### PR TITLE
Improve unit tests for Kernel::Matrix

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/Matrix.h
+++ b/Framework/Kernel/inc/MantidKernel/Matrix.h
@@ -122,9 +122,9 @@ public:
 
   std::vector<T> Diagonal() const; ///< Returns a vector of the diagonal
   Matrix<T>
-  fDiagonal(const std::vector<T> &) const; ///< Forward multiply  D*this
-  Matrix<T>
-  bDiagonal(const std::vector<T> &) const; ///< Backward multiply this*D
+  preMultiplyByDiagonal(const std::vector<T> &) const; ///< pre-multiply D*this
+  Matrix<T> postMultiplyByDiagonal(
+      const std::vector<T> &) const; ///< post-multiply this*D
 
   void setMem(const size_t, const size_t);
 
@@ -139,15 +139,13 @@ public:
   /// Return the number of columns in the matrix
   size_t numCols() const { return ny; }
 
-  /// Return the largest matrix size
+  /// Return the smallest matrix size
   size_t Ssize() const { return (nx > ny) ? ny : nx; }
 
   void swapRows(const size_t, const size_t); ///< Swap rows (first V index)
   void swapCols(const size_t, const size_t); ///< Swap cols (second V index)
 
   T Invert(); ///< LU inversion routine
-  std::vector<T>
-  Faddeev(Matrix<T> &); ///< Polynomanal and inversion by Faddeev method.
   void averSymmetric(); ///< make Matrix symmetric
   int Diagonalise(Matrix<T> &, Matrix<T> &) const; ///< (only Symmetric matrix)
   void sortEigen(Matrix<T> &);                     ///< Sort eigenvectors
@@ -157,7 +155,7 @@ public:
   T factor();            ///< Calculate the factor
   T determinant() const; ///< Calculate the determinant
 
-  int GaussJordan(Matrix<T> &); ///< Create a Gauss-Jordan Invertion
+  void GaussJordan(Matrix<T> &); ///< Create a Gauss-Jordan Inversion
   T compSum() const;
 
   // Check if a rotation matrix

--- a/Framework/Kernel/inc/MantidKernel/Matrix.h
+++ b/Framework/Kernel/inc/MantidKernel/Matrix.h
@@ -145,8 +145,8 @@ public:
   void swapRows(const size_t, const size_t); ///< Swap rows (first V index)
   void swapCols(const size_t, const size_t); ///< Swap cols (second V index)
 
-  T Invert(); ///< LU inversion routine
-  void averSymmetric(); ///< make Matrix symmetric
+  T Invert();                                      ///< LU inversion routine
+  void averSymmetric();                            ///< make Matrix symmetric
   int Diagonalise(Matrix<T> &, Matrix<T> &) const; ///< (only Symmetric matrix)
   void sortEigen(Matrix<T> &);                     ///< Sort eigenvectors
   Matrix<T> Tprime() const;                        ///< Transpose the matrix

--- a/Framework/Kernel/src/Matrix.cpp
+++ b/Framework/Kernel/src/Matrix.cpp
@@ -150,7 +150,6 @@ Matrix<T>::Matrix(const Matrix<T> &A, const size_t nrow, const size_t ncol)
   @param ncol :: number of column to miss
 */
 {
-  // Note:: nx,ny zeroed so setMem always works
   if (nrow > nx)
     throw Kernel::Exception::IndexError(nrow, A.nx,
                                         "Matrix::Constructor without col");
@@ -558,7 +557,7 @@ void Matrix<T>::deleteMem()
   @param b :: number of columns
 */
 template <typename T> void Matrix<T>::setMem(const size_t a, const size_t b) {
-  if (a == nx && b == ny)
+  if (a == nx && b == ny && V != nullptr)
     return;
 
   deleteMem();
@@ -691,19 +690,18 @@ void Matrix<T>::rotate(const double tau, const double s, const int i,
 }
 
 template <typename T>
-Matrix<T> Matrix<T>::fDiagonal(const std::vector<T> &Dvec) const
+Matrix<T> Matrix<T>::preMultiplyByDiagonal(const std::vector<T> &Dvec) const
 /**
-  Calculate the forward diagonal product.
-  Construct a matrix based on  Dvec * This,
-  where Dvec is made into a diagonal matrix.
+  Creates a diagonal matrix D from the given vector Dvec and
+  PRE-multiplies the matrix by it (i.e. D * M).
   @param Dvec :: diagonal matrix (just centre points)
   @return D*this
 */
 {
-  // Note:: nx,ny zeroed so setMem always works
   if (Dvec.size() != nx) {
     std::ostringstream cx;
-    cx << "Matrix::fDiagonal Size: " << Dvec.size() << " " << nx << " " << ny;
+    cx << "Matrix::preMultiplyByDiagonal Size: " << Dvec.size() << " " << nx
+       << " " << ny;
     throw std::runtime_error(cx.str());
   }
   Matrix<T> X(Dvec.size(), ny);
@@ -716,17 +714,14 @@ Matrix<T> Matrix<T>::fDiagonal(const std::vector<T> &Dvec) const
 }
 
 template <typename T>
-Matrix<T> Matrix<T>::bDiagonal(const std::vector<T> &Dvec) const
+Matrix<T> Matrix<T>::postMultiplyByDiagonal(const std::vector<T> &Dvec) const
 /**
-  Calculate the backward diagonal product.
-  Construct a matrix based on
-  This * Dvec, where Dvec is made into a diagonal
-  matrix.
+  Creates a diagonal matrix D from the given vector Dvec and
+  POST-multiplies the matrix by it (i.e. M * D).
   @param Dvec :: diagonal matrix (just centre points)
   @return this*D
 */
 {
-  // Note:: nx,ny zeroed so setMem always works
   if (Dvec.size() != ny) {
     std::ostringstream cx;
     cx << "Error Matrix::bDiaognal size:: " << Dvec.size() << " " << nx << " "
@@ -816,28 +811,31 @@ Matrix<T> &Matrix<T>::Transpose()
 }
 
 template <>
-int Matrix<int>::GaussJordan(Kernel::Matrix<int> &)
+void Matrix<int>::GaussJordan(Kernel::Matrix<int> &)
 /**
   Not valid for Integer
-  @return zero
+  @throw std::invalid_argument
 */
 {
-  return 0;
+  throw std::invalid_argument(
+      "Gauss-Jordan inversion not valid for integer matrix");
 }
 
 template <typename T>
-int Matrix<T>::GaussJordan(Matrix<T> &B)
+void Matrix<T>::GaussJordan(Matrix<T> &B)
 /**
-  Invert this Matrix and solve the
-  form such that if A.x=B then  solve to generate x.
-  This requires that B is B[A.nx][Any]
-  The result is placed back in B
-  @return the calculation result
+  Invert this matrix in place using Gauss-Jordan elimination.
+  Matrix will be replaced by its inverse.
+  @param B :: [input, output] Must have same dimensions as A. Returned as
+  identity matrix. (?)
+  @throw std::invalid_argument on input error
+  @throw std::runtime_error if singular
  */
 {
   // check for input errors
-  if (nx != ny || B.nx != nx)
-    return -1;
+  if (nx != ny || B.nx != nx) {
+    throw std::invalid_argument("Matrix not square, or sizes do not match");
+  }
 
   // pivoted rows
   std::vector<int> pivoted(nx);
@@ -876,8 +874,7 @@ int Matrix<T>::GaussJordan(Matrix<T> &B)
     indxcol[i] = static_cast<int>(icol);
 
     if (V[icol][icol] == 0.0) {
-      std::cerr << "Error doing G-J elem on a singular matrix" << std::endl;
-      return 1;
+      throw std::runtime_error("Error doing G-J elem on a singular matrix");
     }
     const T pivDiv = T(1.0) / V[icol][icol];
     V[icol][icol] = 1;
@@ -910,51 +907,6 @@ int Matrix<T>::GaussJordan(Matrix<T> &B)
       }
     }
   }
-  return 0;
-}
-
-template <typename T>
-std::vector<T> Matrix<T>::Faddeev(Matrix<T> &InvOut)
-/**
-  Return the polynominal for the matrix
-  and the inverse.
-  The polynomial is such that
-  \f[
-    det(sI-A)=s^n+a_{n-1}s^{n-1} \dots +a_0
-  \f]
-  @param InvOut ::: output
-  @return Matrix self Polynomial (low->high coefficient order)
-*/
-{
-  if (nx != ny)
-    throw Kernel::Exception::MisMatch<size_t>(nx, ny, "Matrix::Faddev(Matrix)");
-
-  Matrix<T> &A(*this);
-  Matrix<T> B(A);
-  Matrix<T> Ident(nx, ny);
-  Ident.identityMatrix();
-
-  T tVal = B.Trace(); // Trace of the matrix
-  std::vector<T> Poly;
-  Poly.push_back(1);
-  Poly.push_back(tVal);
-
-  for (size_t i = 0; i < nx - 2;
-       i++) // skip first (just copy) and last (to keep B-1)
-  {
-    B = A * B - Ident * tVal;
-    tVal = B.Trace();
-    Poly.push_back(tVal / static_cast<T>(i + 1));
-  }
-  // Last on need to keep B;
-  InvOut = B;
-  B = A * B - Ident * tVal;
-  tVal = B.Trace();
-  Poly.push_back(tVal / static_cast<T>(nx));
-
-  InvOut -= Ident * (-Poly[nx - 1]);
-  InvOut /= Poly.back();
-  return Poly;
 }
 
 template <typename T>

--- a/Framework/Kernel/test/MatrixTest.h
+++ b/Framework/Kernel/test/MatrixTest.h
@@ -685,7 +685,7 @@ public:
     makeMatrix(mat);
     mat.normVert();
     const std::string expected("0.137361 0.549442 0.824163 0.408248 0.408248 "
-                         "0.816497 0.57735 0.11547 -0.80829 ");
+                               "0.816497 0.57735 0.11547 -0.80829 ");
     TS_ASSERT_EQUALS(mat.str(), expected);
     TS_ASSERT_DELTA(std::sqrt(mat[0][0] * mat[0][0] + mat[0][1] * mat[0][1] +
                               mat[0][2] * mat[0][2]),

--- a/Framework/Kernel/test/MatrixTest.h
+++ b/Framework/Kernel/test/MatrixTest.h
@@ -751,6 +751,7 @@ public:
     mat.setMem(5, 5);
     double x = 0;
     TS_ASSERT_THROWS_NOTHING(x = mat[4][4]);
+    (void)x; // fixes compiler warning
   }
 
   void testSize() {

--- a/Framework/Kernel/test/MatrixTest.h
+++ b/Framework/Kernel/test/MatrixTest.h
@@ -476,8 +476,9 @@ public:
   void testConstructorTwoVectors() {
     const std::vector<int> vecA{1, 2, 3}, vecB{4, 5, 6};
     IntMatrix mat(vecA, vecB);
-    for (int iRow = 0; iRow < vecA.size(); iRow++) {
-      for (int iCol = 0; iCol < vecA.size(); iCol++) {
+    const int nRowsCols = static_cast<int>(vecA.size());
+    for (int iRow = 0; iRow < nRowsCols; iRow++) {
+      for (int iCol = 0; iCol < nRowsCols; iCol++) {
         const int expected = vecA[iRow] * vecB[iCol];
         TS_ASSERT_EQUALS(mat.item(iRow, iCol), expected);
       }
@@ -748,7 +749,8 @@ public:
   void testSetMem() {
     DblMatrix mat(3, 3);
     mat.setMem(5, 5);
-    TS_ASSERT_THROWS_NOTHING(double x = mat[4][4]);
+    double x = 0;
+    TS_ASSERT_THROWS_NOTHING(x = mat[4][4]);
   }
 
   void testSize() {

--- a/Framework/Kernel/test/MatrixTest.h
+++ b/Framework/Kernel/test/MatrixTest.h
@@ -16,6 +16,7 @@
 using Mantid::Kernel::Matrix;
 using Mantid::Kernel::DblMatrix;
 using Mantid::Kernel::V3D;
+using Mantid::Kernel::IntMatrix;
 
 class MatrixTest : public CxxTest::TestSuite {
 
@@ -38,23 +39,23 @@ public:
   Test that a matrix can be inverted
   */
   void testInvert() {
+    // 3x3
     Matrix<double> A(3, 3);
-
-    A[0][0] = 1.0;
-    A[1][0] = 3.0;
-    A[0][1] = 4.0;
-    A[0][2] = 6.0;
-    A[2][0] = 5.0;
-    A[1][1] = 3.0;
-    A[2][1] = 1.0;
-    A[1][2] = 6.0;
-    A[2][2] = -7.0;
-
+    makeMatrix(A);
     TS_ASSERT_DELTA(A.Invert(), 105.0, 1e-5);
+
+    // 1x1
     Matrix<double> B(1, 1);
     B[0][0] = 2.;
     TS_ASSERT_DELTA(B.Invert(), 2, 1e-5);
     TS_ASSERT_DELTA(B[0][0], 0.5, 1e-5);
+
+    // 2x2
+    std::vector<double> data{1, 2, 3, 4}, expected{-2, 1, 1.5, -0.5};
+    DblMatrix C(data);
+    TS_ASSERT_DELTA(C.Invert(), -2, 1e-5);
+    DblMatrix expectedInverse(expected);
+    TS_ASSERT(C == expectedInverse);
   }
 
   void testIdent() {
@@ -159,6 +160,16 @@ public:
     Eval *= Diag;
     Eval *= EvalT;
     TS_ASSERT(Eval == A);
+  }
+
+  /// Can't diagonalise a non-square or non-symmetric matrix
+  void testDiagonaliseThrows() {
+    DblMatrix notSquare(2, 3);
+    const std::vector<double> data{1, 2, 3, 4};
+    DblMatrix notSymm(data);
+    DblMatrix eigenVectors, eigenValues;
+    TS_ASSERT_EQUALS(0, notSquare.Diagonalise(eigenVectors, eigenValues));
+    TS_ASSERT_EQUALS(0, notSymm.Diagonalise(eigenVectors, eigenValues));
   }
 
   void testFromVectorThrows() {
@@ -391,37 +402,425 @@ public:
     }
   }
 
+  /// Tests both V3D and std::vector
   void testMultiplicationWithVector() {
     DblMatrix M = boost::lexical_cast<DblMatrix>(
         "Matrix(3,3)-0.23,0.55,5.22,2.96,4.2,0.1,-1.453,3.112,-2.34");
 
     V3D v(2.3, 4.5, -0.45);
+    std::vector<double> stdvec(v);
 
     V3D nv = M * v;
+    std::vector<double> stdNewVec = M * stdvec;
 
     // Results from octave.
     TS_ASSERT_DELTA(nv.X(), -0.403000000000000, 1e-15);
     TS_ASSERT_DELTA(nv.Y(), 25.663000000000000, 1e-15);
     TS_ASSERT_DELTA(nv.Z(), 11.715100000000003, 1e-15);
+    TS_ASSERT_DELTA(stdNewVec[0], -0.403000000000000, 1e-15);
+    TS_ASSERT_DELTA(stdNewVec[1], 25.663000000000000, 1e-15);
+    TS_ASSERT_DELTA(stdNewVec[2], 11.715100000000003, 1e-15);
 
     DblMatrix M4(4, 4, true);
     TS_ASSERT_THROWS(M4.operator*(v),
+                     Mantid::Kernel::Exception::MisMatch<size_t>);
+    TS_ASSERT_THROWS(M4.operator*(stdvec),
                      Mantid::Kernel::Exception::MisMatch<size_t>);
 
     DblMatrix M23 = boost::lexical_cast<DblMatrix>(
         "Matrix(2,3)-0.23,0.55,5.22,2.96,4.2,0.1");
     TS_ASSERT_THROWS_NOTHING(M23.operator*(v));
+    TS_ASSERT_THROWS_NOTHING(M23.operator*(stdvec));
 
     nv = M23 * v;
+    stdNewVec = M23 * stdvec;
 
     TS_ASSERT_DELTA(nv.X(), -0.403000000000000, 1e-15);
     TS_ASSERT_DELTA(nv.Y(), 25.663000000000000, 1e-15);
     TS_ASSERT_EQUALS(nv.Z(), 0);
+    TS_ASSERT_DELTA(stdNewVec[0], -0.403000000000000, 1e-15);
+    TS_ASSERT_DELTA(stdNewVec[1], 25.663000000000000, 1e-15);
+    TS_ASSERT_EQUALS(stdNewVec.size(), 2);
 
     DblMatrix M43 = boost::lexical_cast<DblMatrix>(
         "Matrix(4,3)-0.23,0.55,5.22,2.96,4.2,0.1,-0.23,0.55,5.22,2.96,4.2,0.1");
     TS_ASSERT_THROWS(M43.operator*(v),
-                     Mantid::Kernel::Exception::MisMatch<size_t>);
+                     Mantid::Kernel::Exception::MisMatch<size_t>); // V3D only
+  }
+
+  /// Test that the constructor taking preset sizes returns a zero matrix
+  void testConstructorPresetSizes() {
+    constexpr int nRows(2), nCols(3);
+    IntMatrix mat(nRows, nCols);
+    for (int iRow = 0; iRow < nRows; iRow++) {
+      for (int iCol = 0; iCol < nCols; iCol++) {
+        TS_ASSERT_EQUALS(mat.item(iRow, iCol), 0);
+      }
+    }
+  }
+
+  /// Test that the 'make identity' option in the preset size constructor works
+  void testConstructorPresetSizes_makeIdentity() {
+    constexpr int nRowsCols(2);
+    constexpr bool makeIdentity(true);
+    IntMatrix mat(nRowsCols, nRowsCols, makeIdentity);
+    for (int iRow = 0; iRow < nRowsCols; iRow++) {
+      for (int iCol = 0; iCol < nRowsCols; iCol++) {
+        const int expected = iRow == iCol ? 1 : 0;
+        TS_ASSERT_EQUALS(mat.item(iRow, iCol), expected);
+      }
+    }
+  }
+
+  /// Constructor multiplying two vectors
+  void testConstructorTwoVectors() {
+    const std::vector<int> vecA{1, 2, 3}, vecB{4, 5, 6};
+    IntMatrix mat(vecA, vecB);
+    for (int iRow = 0; iRow < vecA.size(); iRow++) {
+      for (int iCol = 0; iCol < vecA.size(); iCol++) {
+        const int expected = vecA[iRow] * vecB[iCol];
+        TS_ASSERT_EQUALS(mat.item(iRow, iCol), expected);
+      }
+    }
+  }
+
+  /// Constructor with missing row or column
+  void testConstructorMissingRowColumn() {
+    constexpr int nRows(4), nCols(4), missingRow(3), missingCol(1);
+    const std::vector<double> data{1, 86,  2, 3, 4,  55,  5,  6,
+                                   7, -25, 8, 9, 42, -33, 15, 0};
+    DblMatrix original(data);
+    TS_ASSERT_THROWS(DblMatrix badMat(original, nRows + 1, missingCol),
+                     Mantid::Kernel::Exception::IndexError);
+    TS_ASSERT_THROWS(DblMatrix badMat(original, missingRow, nCols + 1),
+                     Mantid::Kernel::Exception::IndexError);
+    DblMatrix mat(original, missingRow, missingCol);
+    checkMatrixHasExpectedValuesForSquareMatrixTest(mat);
+  }
+
+  void testCopyConstructor() {
+    const std::vector<double> data{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    DblMatrix original(data);
+    DblMatrix copy(original);
+    checkMatrixHasExpectedValuesForSquareMatrixTest(copy);
+  }
+
+  void testAssignment() {
+    const std::vector<double> data{1, 2, 3, 4, 5, 6, 7, 8, 9};
+    DblMatrix original(data);
+    DblMatrix copy = original;
+    checkMatrixHasExpectedValuesForSquareMatrixTest(copy);
+  }
+
+  /// Test + and +=
+  void testAddition() {
+    const std::vector<double> data{0, 2, 3, 4, 4, 6, 7, 8, 8};
+    DblMatrix mat(data);
+    DblMatrix ident(3, 3);
+    ident.identityMatrix();
+    DblMatrix plus = mat + ident;
+    checkMatrixHasExpectedValuesForSquareMatrixTest(plus);
+    mat += ident;
+    checkMatrixHasExpectedValuesForSquareMatrixTest(mat);
+  }
+
+  /// Test - and -=
+  void testSubtraction() {
+    const std::vector<double> data{2, 2, 3, 4, 6, 6, 7, 8, 10};
+    DblMatrix mat(data);
+    DblMatrix ident(3, 3);
+    ident.identityMatrix();
+    DblMatrix minus = mat - ident;
+    checkMatrixHasExpectedValuesForSquareMatrixTest(minus);
+    mat -= ident;
+    checkMatrixHasExpectedValuesForSquareMatrixTest(mat);
+  }
+
+  /// Test * and *=
+  void testMultiplicationByMatrix() {
+    const std::vector<int> dataA{1, 2, 3, 4}, dataB{5, 6, 7, 8};
+    IntMatrix matA(dataA), matB(dataB);
+    IntMatrix multiplied = matA * matB;
+    TS_ASSERT_EQUALS(multiplied[0][0], 19);
+    TS_ASSERT_EQUALS(multiplied[0][1], 22);
+    TS_ASSERT_EQUALS(multiplied[1][0], 43);
+    TS_ASSERT_EQUALS(multiplied[1][1], 50);
+    matA *= matB;
+    TS_ASSERT_EQUALS(matA[0][0], 19);
+    TS_ASSERT_EQUALS(matA[0][1], 22);
+    TS_ASSERT_EQUALS(matA[1][0], 43);
+    TS_ASSERT_EQUALS(matA[1][1], 50);
+  }
+
+  /// Test * and *=
+  void testMultiplicationByConstant() {
+    const std::vector<int> data{1, 2, 3, 4};
+    IntMatrix mat(data);
+    IntMatrix multiplied = mat * 2;
+    TS_ASSERT_EQUALS(multiplied[0][0], 2);
+    TS_ASSERT_EQUALS(multiplied[0][1], 4);
+    TS_ASSERT_EQUALS(multiplied[1][0], 6);
+    TS_ASSERT_EQUALS(multiplied[1][1], 8);
+    mat *= 2;
+    TS_ASSERT_EQUALS(mat[0][0], 2);
+    TS_ASSERT_EQUALS(mat[0][1], 4);
+    TS_ASSERT_EQUALS(mat[1][0], 6);
+    TS_ASSERT_EQUALS(mat[1][1], 8);
+  }
+
+  void testDivisionByConstant() {
+    const std::vector<double> data{2, 4, 6, 8, 10, 12, 14, 16, 18};
+    DblMatrix mat(data);
+    mat /= 2.0;
+    checkMatrixHasExpectedValuesForSquareMatrixTest(mat);
+  }
+
+  void testComparisonOperators() {
+    constexpr int nRowsCols(3);
+    DblMatrix mat(nRowsCols, nRowsCols);
+    makeMatrix(mat);
+    // self-comparison
+    TS_ASSERT_EQUALS(mat < mat, false);
+    TS_ASSERT_EQUALS(mat >= mat, true);
+    // wrong size
+    DblMatrix wrong(nRowsCols - 1, nRowsCols);
+    TS_ASSERT_EQUALS(mat < wrong, false);
+    TS_ASSERT_EQUALS(mat >= wrong, false);
+    // less than
+    DblMatrix less(mat);
+    for (int iRow = 0; iRow < nRowsCols; iRow++) {
+      for (int iCol = 0; iCol < nRowsCols; iCol++) {
+        less[iRow][iCol] = mat[iRow][iCol] - 1;
+      }
+    }
+    TS_ASSERT_EQUALS(mat < less, false);
+    TS_ASSERT_EQUALS(less < mat, true);
+    TS_ASSERT_EQUALS(mat >= less, true);
+    TS_ASSERT_EQUALS(less >= mat, false);
+    // greater than
+    DblMatrix greater(mat);
+    for (int iRow = 0; iRow < nRowsCols; iRow++) {
+      for (int iCol = 0; iCol < nRowsCols; iCol++) {
+        greater[iRow][iCol] = mat[iRow][iCol] + 1;
+      }
+    }
+    TS_ASSERT_EQUALS(mat < greater, true);
+    TS_ASSERT_EQUALS(greater < mat, false);
+    TS_ASSERT_EQUALS(mat >= greater, false);
+    TS_ASSERT_EQUALS(greater >= mat, true);
+  }
+
+  void testWrite() {
+    std::ostringstream os;
+    DblMatrix mat(3, 3);
+    makeMatrix(mat);
+    mat.write(os, 10);
+    std::string output = os.str();
+    std::string expected = "1.000000e+00  4.000000e+00  6.000000e+00  "
+                           "\n3.000000e+00  3.000000e+00  6.000000e+00  "
+                           "\n5.000000e+00  1.000000e+00  -7.000000e+00  \n";
+    TS_ASSERT_EQUALS(output, expected);
+  }
+
+  void testToString() {
+    DblMatrix mat(3, 3);
+    makeMatrix(mat);
+    std::string output = mat.str();
+    std::string expected = "1 4 6 3 3 6 5 1 -7 ";
+    TS_ASSERT_EQUALS(output, expected);
+  }
+
+  void testToVector() {
+    constexpr int nRowsCols(3);
+    DblMatrix mat(nRowsCols, nRowsCols);
+    makeMatrix(mat);
+    std::vector<double> converted = mat.getVector();
+    std::vector<double> implicit(mat);
+    int iVectorIndex(0);
+    for (int iRow = 0; iRow < nRowsCols; iRow++) {
+      for (int iCol = 0; iCol < nRowsCols; iCol++) {
+        TS_ASSERT_EQUALS(converted[iVectorIndex], mat[iRow][iCol]);
+        TS_ASSERT_EQUALS(implicit[iVectorIndex], mat[iRow][iCol]);
+        iVectorIndex++;
+      }
+    }
+  }
+
+  void testSetColumn() {
+    const std::vector<double> data{1, -2, 3, 4, -5, 6, 7, -8, 9};
+    const std::vector<double> newCol{2, 5, 8};
+    DblMatrix mat(data);
+    size_t badCol(3), goodCol(1);
+    TS_ASSERT_THROWS(mat.setColumn(badCol, newCol), std::invalid_argument);
+    mat.setColumn(goodCol, newCol);
+    checkMatrixHasExpectedValuesForSquareMatrixTest(mat);
+  }
+
+  void testSetRow() {
+    const std::vector<double> data{1, 2, 3, 4, 5, 6, -7, -8, -9};
+    const std::vector<double> newRow{7, 8, 9};
+    DblMatrix mat(data);
+    size_t badRow(3), goodRow(2);
+    TS_ASSERT_THROWS(mat.setRow(badRow, newRow), std::invalid_argument);
+    mat.setRow(goodRow, newRow);
+    checkMatrixHasExpectedValuesForSquareMatrixTest(mat);
+  }
+
+  void testZeroMatrix() {
+    constexpr int nRowCol(3);
+    DblMatrix mat(nRowCol, nRowCol);
+    makeMatrix(mat);
+    TS_ASSERT_DIFFERS(mat[0][0], 0);
+    mat.zeroMatrix();
+    for (int iRow = 0; iRow < nRowCol; iRow++) {
+      for (int iCol = 0; iCol < nRowCol; iCol++) {
+        TS_ASSERT_EQUALS(mat[iRow][iCol], 0);
+      }
+    }
+  }
+
+  void testNormVert() {
+    constexpr int nRowCol(3);
+    DblMatrix mat(nRowCol, nRowCol);
+    makeMatrix(mat);
+    mat.normVert();
+    const std::string expected("0.137361 0.549442 0.824163 0.408248 0.408248 "
+                         "0.816497 0.57735 0.11547 -0.80829 ");
+    TS_ASSERT_EQUALS(mat.str(), expected);
+    TS_ASSERT_DELTA(std::sqrt(mat[0][0] * mat[0][0] + mat[0][1] * mat[0][1] +
+                              mat[0][2] * mat[0][2]),
+                    1.0, 0.001);
+    TS_ASSERT_DELTA(std::sqrt(mat[1][0] * mat[1][0] + mat[1][1] * mat[1][1] +
+                              mat[1][2] * mat[1][2]),
+                    1.0, 0.001);
+    TS_ASSERT_DELTA(std::sqrt(mat[2][0] * mat[2][0] + mat[2][1] * mat[2][1] +
+                              mat[2][2] * mat[2][2]),
+                    1.0, 0.001);
+  }
+
+  void testTrace() {
+    constexpr int nRowCol(3);
+    DblMatrix mat(nRowCol, nRowCol);
+    makeMatrix(mat);
+    double trace = mat.Trace();
+    double expected = 0;
+    for (int i = 0; i < nRowCol; i++) {
+      expected += mat[i][i];
+    }
+    TS_ASSERT_EQUALS(trace, expected);
+  }
+
+  void testDiagonal() {
+    constexpr int nRowCol(3);
+    DblMatrix mat(nRowCol, nRowCol);
+    makeMatrix(mat);
+    std::vector<double> diag = mat.Diagonal();
+    TS_ASSERT_EQUALS(diag.size(), nRowCol);
+    for (int i = 0; i < nRowCol; i++) {
+      TS_ASSERT_EQUALS(diag[i], mat[i][i]);
+    }
+  }
+
+  void testPreMultiplyDiagonal() {
+    const std::vector<double> dataA{1, 2, 3, 4}, dataDiag{5, 6},
+        dataBad{5, 6, 7};
+    DblMatrix mat(dataA);
+    TS_ASSERT_THROWS(mat.preMultiplyByDiagonal(dataBad), std::runtime_error);
+    DblMatrix result = mat.preMultiplyByDiagonal(dataDiag);
+    TS_ASSERT_EQUALS(result[0][0], 5);
+    TS_ASSERT_EQUALS(result[0][1], 10);
+    TS_ASSERT_EQUALS(result[1][0], 18);
+    TS_ASSERT_EQUALS(result[1][1], 24);
+  }
+
+  void testPostMultiplyDiagonal() {
+    const std::vector<double> dataA{1, 2, 3, 4}, dataDiag{5, 6},
+        dataBad{5, 6, 7};
+    DblMatrix mat(dataA);
+    TS_ASSERT_THROWS(mat.postMultiplyByDiagonal(dataBad), std::runtime_error);
+    DblMatrix result = mat.postMultiplyByDiagonal(dataDiag);
+    TS_ASSERT_EQUALS(result[0][0], 5);
+    TS_ASSERT_EQUALS(result[0][1], 12);
+    TS_ASSERT_EQUALS(result[1][0], 15);
+    TS_ASSERT_EQUALS(result[1][1], 24);
+  }
+
+  void testSetMem() {
+    DblMatrix mat(3, 3);
+    mat.setMem(5, 5);
+    TS_ASSERT_THROWS_NOTHING(double x = mat[4][4]);
+  }
+
+  void testSize() {
+    constexpr size_t nRows(5), nCols(4);
+    DblMatrix mat(nRows, nCols);
+    auto size = mat.size();
+    TS_ASSERT_EQUALS(nRows, size.first);
+    TS_ASSERT_EQUALS(nCols, size.second);
+    TS_ASSERT_EQUALS(std::min(nRows, nCols), mat.Ssize());
+  }
+
+  void testAverageSymmetric() {
+    const std::vector<double> data{1, 2, 3, 4}, expected{1, 2.5, 2.5, 4};
+    DblMatrix mat(data), expectedResult(expected);
+    mat.averSymmetric();
+    TS_ASSERT(mat == expectedResult);
+  }
+
+  void testDeterminant() {
+    DblMatrix mat(3, 3);
+    makeMatrix(mat);
+    double det = mat.determinant();
+    TS_ASSERT_EQUALS(det, 105);
+  }
+
+  /// Test Gauss-Jordan factorisation
+  void testFactor() {
+    DblMatrix mat(3, 3);
+    makeMatrix(mat);
+    TS_ASSERT_EQUALS(mat.factor(), 105);
+    const std::vector<double> expectedData{6, 1, 4, 0, 2, -1, 0, 0, 8.75};
+    DblMatrix expected(expectedData);
+    TS_ASSERT(mat == expected);
+  }
+
+  // Test inverting a matrix using Gauss-Jordan method
+  void testGaussJordan() {
+    constexpr size_t nRowsCols(3);
+    DblMatrix mat(nRowsCols, nRowsCols);
+    makeMatrix(mat);
+    DblMatrix B(nRowsCols, nRowsCols);
+    makeMatrix(B);
+    DblMatrix expected(mat);
+    expected.Invert();
+    mat.GaussJordan(B);
+    // test the two inverses agree
+    TS_ASSERT(mat == expected);
+    // B should be an identity matrix
+    for (size_t iRow = 0; iRow < nRowsCols; iRow++) {
+      for (size_t iCol = 0; iCol < nRowsCols; iCol++) {
+        TS_ASSERT_EQUALS(B[iRow][iCol], iRow == iCol ? 1 : 0);
+      }
+    }
+  }
+
+  // sum of squares of all elements
+  void testCompSum() {
+    DblMatrix mat(3, 3);
+    makeMatrix(mat);
+    double result = mat.compSum();
+    TS_ASSERT_EQUALS(result, 182);
+  }
+
+  // test orthogonality - rotations and non-rotational matrices
+  void testIsOrthogonal() {
+    const std::vector<double> rotationData{0, -1, 1, 0},
+        nonRotationData{0, 1, 1, 0};
+    DblMatrix rotation(rotationData), reflection(nonRotationData);
+    TS_ASSERT(rotation.isRotation());
+    TS_ASSERT(rotation.isOrthogonal());
+    TS_ASSERT(!reflection.isRotation());
+    TS_ASSERT(reflection.isOrthogonal());
   }
 
 private:


### PR DESCRIPTION
Resolves #13998

Adds unit tests to `Kernel::Matrix` so that all public methods should be covered. 

**To test:**
- Code review (verify that code coverage is sufficient)
- Vandalise `Kernel::Matrix` and see if any tests fail (they should) - deleting lines, changing booleans, row indices etc
