### PR TITLE
Remove unused variables found by cppcheck.

### DIFF
--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -44,8 +44,6 @@ void SaveIsawPeaks::init() {
   declareProperty("AppendFile", false, "Append to file if true.\n"
                                        "If false, new file (default).");
 
-  std::vector<std::string> exts{".peaks", ".integrate"};
-
   declareProperty(new FileProperty("Filename", "", FileProperty::Save,
                                    {".peaks", ".integrate"}),
                   "Path to an ISAW-style peaks or integrate file to save.");

--- a/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
+++ b/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
@@ -191,8 +191,9 @@ void ProcessBackground::init() {
                                               "SelectBackgroundPoints"));
 
   // Output background type.
+  std::vector<std::string> outbkgdtype{"Polynomial", "Chebyshev"};
   auto outbkgdvalidator =
-      boost::make_shared<Kernel::StringListValidator>(bkgdtype);
+      boost::make_shared<Kernel::StringListValidator>(outbkgdtype);
   declareProperty("OutputBackgroundType", "Polynomial", outbkgdvalidator,
                   "Type of background to fit with selected background points.");
   setPropertySettings("OutputBackgroundType",

--- a/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
+++ b/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
@@ -191,7 +191,6 @@ void ProcessBackground::init() {
                                               "SelectBackgroundPoints"));
 
   // Output background type.
-  std::vector<std::string> outbkgdtype{"Polynomial", "Chebyshev"};
   auto outbkgdvalidator =
       boost::make_shared<Kernel::StringListValidator>(bkgdtype);
   declareProperty("OutputBackgroundType", "Polynomial", outbkgdvalidator,

--- a/Framework/MDAlgorithms/src/ConvertCWSDMDtoHKL.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWSDMDtoHKL.cpp
@@ -66,7 +66,6 @@ void ConvertCWSDMDtoHKL::init() {
                       "OutputWorkspace", "", Direction::Output),
                   "Name of the output MDEventWorkspace in HKL-space.");
 
-  std::vector<std::string> exts{".dat"};
   declareProperty(
       new FileProperty("QSampleFileName", "", API::FileProperty::OptionalSave),
       "Name of file for sample sample.");

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -57,9 +57,6 @@ void IntegratePeaksMD2::init() {
                                                            Direction::Input),
                   "An input MDEventWorkspace.");
 
-  std::vector<std::string> propOptions{"Q (lab frame)", "Q (sample frame)",
-                                       "HKL"};
-
   declareProperty(
       new PropertyWithValue<double>("PeakRadius", 1.0, Direction::Input),
       "Fixed radius around each peak position in which to integrate (in the "


### PR DESCRIPTION
This fixes four new [cppcheck warnings](http://builds.mantidproject.org/view/Static%20Analysis/job/cppcheck-1.72/995/cppcheckResult/) found after PR #15104 was merged into master.

The vectors appear to have always been unused, but this was previous obscured by calls to .push_back().
