### PR TITLE
Muon analysis sequential fit: set file finder to correct instrument

### DIFF
--- a/MantidQt/MantidWidgets/src/MuonSequentialFitDialog.cpp
+++ b/MantidQt/MantidWidgets/src/MuonSequentialFitDialog.cpp
@@ -34,6 +34,9 @@ namespace MantidWidgets
     // seq. fit dialog 
     auto fitWS = boost::dynamic_pointer_cast<const MatrixWorkspace>( m_fitPropBrowser->getWorkspace() );
     m_ui.runs->setText( QString::number( fitWS->getRunNumber() ) + "-" );
+    // Set the file finder to the correct instrument (not Mantid's default instrument)
+    auto instName = fitWS->getInstrument()->getName();
+    m_ui.runs->setInstrumentOverride(QString(instName.c_str()));
 
     // TODO: find a better initial one, e.g. previously used
     m_ui.labelInput->setText("Label");


### PR DESCRIPTION
Resolves #15223

_Should be merged into release branch if appropriate (issue discovered during beta test)_

Default behaviour in the sequential fit dialog of Muon Analysis was to use Mantid's default instrument, which is wrong when this differs to the instrument set via the drop-down list on the front tab of the interface. Changed this to use the same instrument as that of the workspace in the fit browser.

**To test:**
- The data from the issue is in `\\olympic\babylon5\Public\TomPerkins` (MUSR 17295-17300)
- Start Mantid and set default instrument to HIFI
- Start Muon Analysis interface and use drop-down list to set instrument to MUSR
- Load `MUSR00017295.nxs`
- Go to data analysis tab and fit something to the data (James used a FlatBackground + MuonFInteraction with `beta` fixed to 1)
- Select Fit / Sequential Fit and type "17295-17300" in the box. Run the fit and verify that the data sets fitted are the intended MUSR data sets rather than HIFI ones.
