### PR TITLE
SliceView radius of integration is now circular

### DIFF
--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.ui
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -73,8 +82,11 @@
      </item>
      <item>
       <widget class="QCheckBox" name="autoScale">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this flag is disabled, auto scaling on loading&lt;/p&gt;&lt;p&gt;a workspace will be disabled, except for when&lt;/p&gt;&lt;p&gt;the SliceViewer is initially created. This is mainly&lt;/p&gt;&lt;p&gt;relevant for live data workspaces.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
-        <string>Autoscale</string>
+        <string>Autoscale on Load</string>
        </property>
       </widget>
      </item>

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.ui
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.ui
@@ -83,7 +83,7 @@
      <item>
       <widget class="QCheckBox" name="autoScale">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this flag is disabled, auto scaling on loading&lt;/p&gt;&lt;p&gt;a workspace will be disabled, except for when&lt;/p&gt;&lt;p&gt;the SliceViewer is initially created. This is mainly&lt;/p&gt;&lt;p&gt;relevant for live data workspaces.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This flag signals that the color scale range should be set automatically to the current slice range when a workspace is loaded. Note that auto scaling will be applied when a workspace is loaded for the very first time. This option is mainly relevant for live data workspaces, which are continuously being updated and reloaded.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>Autoscale on Load</string>

--- a/MantidQt/SliceViewer/src/PhysicalSphericalPeak.cpp
+++ b/MantidQt/SliceViewer/src/PhysicalSphericalPeak.cpp
@@ -100,7 +100,7 @@ namespace MantidQt
       @param viewHeight : height of the view area in natural coordinates
       @return SphericalPeakPrimites. Information object for rendering.
       */
-      MantidQt::SliceViewer::SphericalPeakPrimitives PhysicalSphericalPeak::draw(const double& windowHeight, const double& windowWidth, const double& viewWidth, const double& viewHeight) const
+      MantidQt::SliceViewer::SphericalPeakPrimitives PhysicalSphericalPeak::draw(const double& windowHeight, const double& windowWidth, const double& viewHeight, const double& viewWidth) const
       {
         SphericalPeakPrimitives drawingObjects = {0, 0, 0, 0, 0,0, 0, Mantid::Kernel::V3D()};
 

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -71,8 +71,8 @@ Checks if the rebinning is in a consistent state, ie if rebin mode is selected a
 is a rebin workspace or there is no rebin workspace and no rebin mode selected.
 The state is inconsistent if rebin mode is selected and there is no workspace.
 */
-  bool isRebinInConsistentState(Mantid::API::IMDWorkspace_sptr rebinnedWS, bool useRebinMode) {
-    return rebinnedWS && useRebinMode;
+  bool isRebinInConsistentState(Mantid::API::IMDWorkspace* rebinnedWS, bool useRebinMode) {
+    return (rebinnedWS != nullptr) && useRebinMode;
   }
 }
 
@@ -755,7 +755,7 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   this->updateDimensionSliceWidgets();
 
   // Only autoscale color bar if box is checked
-  if (m_colorBar->getAutoScale()) {
+  if (!m_firstWorkspaceOpen || m_colorBar->getAutoScale()) {
     // Find the full range. And use it
     findRangeFull();
     m_colorBar->setViewRange(m_colorRangeFull);
@@ -1392,7 +1392,7 @@ void SliceViewer::findRangeSlice() {
   if (m_rebinMode) {
     // If the rebinned state is inconsistent, then we turn off
     // the rebin selection and continue to use the original WS
-    if (!isRebinInConsistentState(m_overlayWS, m_rebinMode)) {
+    if (!isRebinInConsistentState(m_overlayWS.get(), m_rebinMode)) {
       setRebinMode(false);
     } else {
       workspace_used = this->m_overlayWS;

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -74,6 +74,15 @@ The state is inconsistent if rebin mode is selected and there is no workspace.
   bool isRebinInConsistentState(Mantid::API::IMDWorkspace* rebinnedWS, bool useRebinMode) {
     return (rebinnedWS != nullptr) && useRebinMode;
   }
+
+/**
+ * Checks if the colors scale range should be automatically set. We should provide auto scaling
+ * on load if the workspaces is either loaded the first time or if it is explictly selected.
+ */
+  bool shouldAutoScaleForNewlySetWorkspace(bool isFirstWorkspaceOpen, bool isAutoScalingOnLoad) {
+    return !isFirstWorkspaceOpen || isAutoScalingOnLoad;
+  }
+
 }
 
 
@@ -754,9 +763,11 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   // Build up the widgets
   this->updateDimensionSliceWidgets();
 
-  // Only autoscale color bar if box is checked
-  if (!m_firstWorkspaceOpen || m_colorBar->getAutoScale()) {
-    // Find the full range. And use it
+  // This will auto scale the color bar to the current slice when the workspace is
+  // loaded. This always happens when a workspace is loaded for the first time.
+  // For live event data workspaces subsequent updates might not lead to an auto
+  // scaling of the color scale range (if this is explicitly turned off).
+  if (shouldAutoScaleForNewlySetWorkspace(m_firstWorkspaceOpen, m_colorBar->getAutoScale())) {
     findRangeFull();
     m_colorBar->setViewRange(m_colorRangeFull);
     m_colorBar->updateColorMap();

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -65,6 +65,18 @@ using Poco::XML::NodeIterator;
 using Poco::XML::NodeFilter;
 using MantidQt::API::AlgorithmRunner;
 
+namespace {
+/*
+Checks if the rebinning is in a consistent state, ie if rebin mode is selected and there
+is a rebin workspace or there is no rebin workspace and no rebin mode selected.
+The state is inconsistent if rebin mode is selected and there is no workspace.
+*/
+  bool isRebinInConsistentState(Mantid::API::IMDWorkspace_sptr rebinnedWS, bool useRebinMode) {
+    return rebinnedWS && useRebinMode;
+  }
+}
+
+
 namespace MantidQt {
 namespace SliceViewer {
 
@@ -1378,7 +1390,13 @@ part of the workspace */
 void SliceViewer::findRangeSlice() {
   IMDWorkspace_sptr workspace_used = m_ws;
   if (m_rebinMode) {
-    workspace_used = this->m_overlayWS;
+    // If the rebinned state is inconsistent, then we turn off
+    // the rebin selection and continue to use the original WS
+    if (!isRebinInConsistentState(m_overlayWS, m_rebinMode)) {
+      setRebinMode(false);
+    } else {
+      workspace_used = this->m_overlayWS;
+    }
   }
 
   if (!workspace_used)


### PR DESCRIPTION
Fixes #15232  Test by running SCD Event Data Reduction Interface with default settings and TOPAZ_3132.  Then use SliceView with the resulting PeaksWorkspace and make sure the radius of integration is 0.18 in both horizontal and vertical axes.
