### PR TITLE
SliceView radius of integration is now circular

### DIFF
--- a/MantidQt/SliceViewer/src/PhysicalSphericalPeak.cpp
+++ b/MantidQt/SliceViewer/src/PhysicalSphericalPeak.cpp
@@ -100,7 +100,7 @@ namespace MantidQt
       @param viewHeight : height of the view area in natural coordinates
       @return SphericalPeakPrimites. Information object for rendering.
       */
-      MantidQt::SliceViewer::SphericalPeakPrimitives PhysicalSphericalPeak::draw(const double& windowHeight, const double& windowWidth, const double& viewWidth, const double& viewHeight) const
+      MantidQt::SliceViewer::SphericalPeakPrimitives PhysicalSphericalPeak::draw(const double& windowHeight, const double& windowWidth, const double& viewHeight, const double& viewWidth) const
       {
         SphericalPeakPrimitives drawingObjects = {0, 0, 0, 0, 0,0, 0, Mantid::Kernel::V3D()};
 


### PR DESCRIPTION
Fixes #15232 Test by running SCD Event Data Reduction Interface with default settings and TOPAZ_3132. Then use SliceView with the resulting PeaksWorkspace and make sure the radius of integration is 0.18 in both horizontal and vertical axes.  Same as 15234 for 3.7.
