### PR TITLE
Fix for Slice Viewer crash when peak is added in area of no coverage

### DIFF
--- a/MantidQt/SliceViewer/src/ConcretePeaksPresenter.cpp
+++ b/MantidQt/SliceViewer/src/ConcretePeaksPresenter.cpp
@@ -580,7 +580,16 @@ bool ConcretePeaksPresenter::addPeakAt(double plotCoordsPointX,
   alg->initialize();
   alg->setProperty("Workspace", peaksWS);
   alg->setProperty("HKL", std::vector<double>(hkl));
-  alg->execute();
+
+
+// Execute the algorithm
+try {
+    alg->execute();
+} catch (...) {
+    g_log.warning("ConcretePeaksPresenter: Could not add the peak. Make sure "
+                  "that it is added within a valid workspace region");
+}
+
 
   // Reproduce the views. Proxy representations recreated for all peaks.
   this->produceViews();
@@ -593,6 +602,7 @@ bool ConcretePeaksPresenter::addPeakAt(double plotCoordsPointX,
   this->informOwnerUpdate();
 
   return alg->isExecuted();
+
 }
 
 bool ConcretePeaksPresenter::hasPeakAddMode() const {


### PR DESCRIPTION
Fixes #15162

Please see [here](https://github.com/mantidproject/mantid/issues/15162#issuecomment-182376955) for an issue description and suggested solution.

As mentioned in the link above the issue arises from a negative `qbeam` with:

``` cpp
  const double qBeam = q.scalar_prod(refBeamDir) * qSign; 
```

where q is the center of the peak in reciprocal space. This means that back-scattering components are not allowed (??).

@OwenArnold : 
- Does it make sense that qBeam cannot be negative and if so, why?
# For testing:

Please find an installer, a sample workspace and a corresponding peaks workspace here: TODO
1. Load the workspace into the Slice Viewer
2. Drag and drop the peaks workspace onto the SliceViewer
3. Slect the `Add peaks` feature
4. Start adding peaks on the centre of the workspace
   - Confirm that everything is OK
5. Add a peak on the outer right edge of the workspace (i got the issue there). You might have to try several areas.
   - Confirm that Mantid does not terminate.
   - Confirm that an error message is displayed instead
   - Confirm that no peak is generated
