### PR TITLE
Indirect Data Analaysis ConvFit -sqw files causing failure

### DIFF
--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/ConvolutionFitSequential.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/ConvolutionFitSequential.h
@@ -53,7 +53,7 @@ private:
                                               const std::vector<std::string> &);
   std::vector<double> squareVector(std::vector<double>);
   std::vector<double> cloneVector(const std::vector<double> &);
-  API::MatrixWorkspace_sptr convertInputToElasticQ(API::MatrixWorkspace_sptr &,
+  void convertInputToElasticQ(API::MatrixWorkspace_sptr &,
                                                    const std::string &);
   void calculateEISF(API::ITableWorkspace_sptr &);
   std::string convertBackToShort(const std::string &);

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/ConvolutionFitSequential.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/ConvolutionFitSequential.h
@@ -53,8 +53,7 @@ private:
                                               const std::vector<std::string> &);
   std::vector<double> squareVector(std::vector<double>);
   std::vector<double> cloneVector(const std::vector<double> &);
-  void convertInputToElasticQ(API::MatrixWorkspace_sptr &,
-                                                   const std::string &);
+  void convertInputToElasticQ(API::MatrixWorkspace_sptr &, const std::string &);
   void calculateEISF(API::ITableWorkspace_sptr &);
   std::string convertBackToShort(const std::string &);
   std::string convertFuncToShort(const std::string &);

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -464,7 +464,7 @@ void ConvolutionFitSequential::convertInputToElasticQ(
   auto axis = inputWs->getAxis(1);
   if (axis->isSpectra()) {
     auto convSpec = createChildAlgorithm("ConvertSpectrumAxis");
-	// Store in ADS to allow use by PlotPeakByLogValue
+    // Store in ADS to allow use by PlotPeakByLogValue
     convSpec->setAlwaysStoreInADS(true);
     convSpec->setProperty("InputWorkSpace", inputWs);
     convSpec->setProperty("OutputWorkSpace", wsName);
@@ -477,7 +477,7 @@ void ConvolutionFitSequential::convertInputToElasticQ(
       throw std::runtime_error("Input must have axis values of Q");
     }
     auto cloneWs = createChildAlgorithm("CloneWorkspace");
-	// Store in ADS to allow use by PlotPeakByLogValue
+    // Store in ADS to allow use by PlotPeakByLogValue
     cloneWs->setAlwaysStoreInADS(true);
     cloneWs->setProperty("InputWorkspace", inputWs);
     cloneWs->setProperty("OutputWorkspace", wsName);

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -464,7 +464,7 @@ void ConvolutionFitSequential::convertInputToElasticQ(
   auto axis = inputWs->getAxis(1);
   if (axis->isSpectra()) {
     auto convSpec = createChildAlgorithm("ConvertSpectrumAxis");
-    // remains in ADS for use in embedded algorithm call
+	// Store in ADS to allow use by PlotPeakByLogValue
     convSpec->setAlwaysStoreInADS(true);
     convSpec->setProperty("InputWorkSpace", inputWs);
     convSpec->setProperty("OutputWorkSpace", wsName);
@@ -477,7 +477,8 @@ void ConvolutionFitSequential::convertInputToElasticQ(
       throw std::runtime_error("Input must have axis values of Q");
     }
     auto cloneWs = createChildAlgorithm("CloneWorkspace");
-	cloneWs->setAlwaysStoreInADS(true);
+	// Store in ADS to allow use by PlotPeakByLogValue
+    cloneWs->setAlwaysStoreInADS(true);
     cloneWs->setProperty("InputWorkspace", inputWs);
     cloneWs->setProperty("OutputWorkspace", wsName);
     cloneWs->executeAsChildAlg();

--- a/Framework/WorkflowAlgorithms/test/ConvolutionFitSequentialTest.h
+++ b/Framework/WorkflowAlgorithms/test/ConvolutionFitSequentialTest.h
@@ -14,8 +14,6 @@
 
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
-#include <boost/assign/list_of.hpp>
-
 using Mantid::Algorithms::ConvolutionFitSequential;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
@@ -245,10 +243,8 @@ public:
 
   MatrixWorkspace_sptr createGenericWorkspace(const std::string &wsName,
                                               const bool numericAxis) {
-    const auto xData = boost::assign::list_of(1)(2)(3)(4)(5)
-                           .convert_to_container<Mantid::MantidVec>();
-    const auto yData = boost::assign::list_of(0)(1)(3)(1)(0)
-                           .convert_to_container<Mantid::MantidVec>();
+    const std::vector<double> xData{1, 2, 3, 4, 5};
+    const std::vector<double> yData{0, 1, 3, 1, 0};
 
     auto createWorkspace =
         AlgorithmManager::Instance().create("CreateWorkspace");

--- a/Framework/WorkflowAlgorithms/test/ConvolutionFitSequentialTest.h
+++ b/Framework/WorkflowAlgorithms/test/ConvolutionFitSequentialTest.h
@@ -228,15 +228,15 @@ public:
 	// Assert that output is in ADS
     TS_ASSERT_THROWS_NOTHING(
         AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(
-            "SqwWs_conv_1LFixF_s0_to_5_Parameters"));
+            "SqwWs_conv_1LFixF_s0_to_0_Parameters"));
 
     TS_ASSERT_THROWS_NOTHING(
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            "SqwWs_conv_1LFixF_s0_to_5_Result"));
+            "SqwWs_conv_1LFixF_s0_to_0_Result"));
 
     TS_ASSERT_THROWS_NOTHING(
         AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-            "SqwWs_conv_1LFixF_s0_to_5_Workspaces"));
+            "SqwWs_conv_1LFixF_s0_to_0_Workspaces"));
 
 	AnalysisDataService::Instance().clear();
   }

--- a/Framework/WorkflowAlgorithms/test/ConvolutionFitSequentialTest.h
+++ b/Framework/WorkflowAlgorithms/test/ConvolutionFitSequentialTest.h
@@ -146,7 +146,7 @@ public:
     alg.setProperty("Minimizer", "Levenberg-Marquardt");
     alg.setProperty("MaxIterations", 500);
     TS_ASSERT_THROWS_NOTHING(alg.execute());
-	TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(alg.isExecuted());
 
     // Retrieve and analyse parameter table - Param table does not require
     // further testing as this is tested in the ProcessIndirectFitParameters
@@ -197,13 +197,13 @@ public:
     TS_ASSERT_EQUALS(memberLogs.at(6)->value(), "ReductionWs_");
     TS_ASSERT_EQUALS(memberLogs.at(7)->value(), "1");
 
-	AnalysisDataService::Instance().clear();
+    AnalysisDataService::Instance().clear();
   }
 
   void test_exec_with_sqw_file() {
     auto sqwWs = createGenericWorkspace("SqwWs_", true);
-	auto resWs = createGenericWorkspace("ResolutionWs_", false);
-	auto convFitRes = createGenericWorkspace("__ConvFit_Resolution", false);
+    auto resWs = createGenericWorkspace("ResolutionWs_", false);
+    auto convFitRes = createGenericWorkspace("__ConvFit_Resolution", false);
     Mantid::Algorithms::ConvolutionFitSequential alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     alg.setProperty("InputWorkspace", sqwWs);
@@ -223,9 +223,9 @@ public:
     alg.setProperty("Minimizer", "Levenberg-Marquardt");
     alg.setProperty("MaxIterations", 500);
     TS_ASSERT_THROWS_NOTHING(alg.execute());
-	TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(alg.isExecuted());
 
-	// Assert that output is in ADS
+    // Assert that output is in ADS
     TS_ASSERT_THROWS_NOTHING(
         AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(
             "SqwWs_conv_1LFixF_s0_to_0_Parameters"));
@@ -238,7 +238,7 @@ public:
         AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
             "SqwWs_conv_1LFixF_s0_to_0_Workspaces"));
 
-	AnalysisDataService::Instance().clear();
+    AnalysisDataService::Instance().clear();
   }
 
   //------------------------ Private Functions---------------------------
@@ -250,7 +250,8 @@ public:
     const auto yData = boost::assign::list_of(0)(1)(3)(1)(0)
                            .convert_to_container<Mantid::MantidVec>();
 
-    auto createWorkspace = AlgorithmManager::Instance().create("CreateWorkspace");
+    auto createWorkspace =
+        AlgorithmManager::Instance().create("CreateWorkspace");
     createWorkspace->initialize();
     if (numericAxis) {
       createWorkspace->setProperty("UnitX", "DeltaE");

--- a/Framework/WorkflowAlgorithms/test/ConvolutionFitSequentialTest.h
+++ b/Framework/WorkflowAlgorithms/test/ConvolutionFitSequentialTest.h
@@ -14,6 +14,8 @@
 
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
+#include <boost/assign/list_of.hpp>
+
 using Mantid::Algorithms::ConvolutionFitSequential;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
@@ -118,11 +120,11 @@ public:
   }
 
   //------------------------- Execution cases ---------------------------
-  void test_exec() {
+  void test_exec_with_red_file() {
     const int totalBins = 6;
     auto resWs = create2DWorkspace(5, 1);
     auto redWs = create2DWorkspace(totalBins, 5);
-    createConvitResWorkspace(5, totalBins);
+    createConvFitResWorkspace(5, totalBins);
     AnalysisDataService::Instance().add("ResolutionWs_", resWs);
     AnalysisDataService::Instance().add("ReductionWs_", redWs);
     Mantid::Algorithms::ConvolutionFitSequential alg;
@@ -143,7 +145,8 @@ public:
     alg.setProperty("Convolve", true);
     alg.setProperty("Minimizer", "Levenberg-Marquardt");
     alg.setProperty("MaxIterations", 500);
-    alg.execute();
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+	TS_ASSERT(alg.isExecuted());
 
     // Retrieve and analyse parameter table - Param table does not require
     // further testing as this is tested in the ProcessIndirectFitParameters
@@ -193,9 +196,79 @@ public:
     TS_ASSERT_EQUALS(memberLogs.at(5)->value(), "ConvFit");
     TS_ASSERT_EQUALS(memberLogs.at(6)->value(), "ReductionWs_");
     TS_ASSERT_EQUALS(memberLogs.at(7)->value(), "1");
+
+	AnalysisDataService::Instance().clear();
+  }
+
+  void test_exec_with_sqw_file() {
+    auto sqwWs = createGenericWorkspace("SqwWs_", true);
+	auto resWs = createGenericWorkspace("ResolutionWs_", false);
+	auto convFitRes = createGenericWorkspace("__ConvFit_Resolution", false);
+    Mantid::Algorithms::ConvolutionFitSequential alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    alg.setProperty("InputWorkspace", sqwWs);
+    alg.setProperty("Function",
+                    "name=LinearBackground,A0=0,A1=0,ties=(A0=0.000000,A1=0.0);"
+                    "(composite=Convolution,FixResolution=true,NumDeriv=true;"
+                    "name=Resolution,Workspace=__ConvFit_Resolution,"
+                    "WorkspaceIndex=0;((composite=ProductFunction,NumDeriv="
+                    "false;name=Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0."
+                    "0175)))");
+    alg.setProperty("BackgroundType", "Fixed Flat");
+    alg.setProperty("StartX", 0.0);
+    alg.setProperty("EndX", 5.0);
+    alg.setProperty("SpecMin", 0);
+    alg.setProperty("SpecMax", 0);
+    alg.setProperty("Convolve", true);
+    alg.setProperty("Minimizer", "Levenberg-Marquardt");
+    alg.setProperty("MaxIterations", 500);
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+	TS_ASSERT(alg.isExecuted());
+
+	// Assert that output is in ADS
+    TS_ASSERT_THROWS_NOTHING(
+        AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(
+            "SqwWs_conv_1LFixF_s0_to_5_Parameters"));
+
+    TS_ASSERT_THROWS_NOTHING(
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            "SqwWs_conv_1LFixF_s0_to_5_Result"));
+
+    TS_ASSERT_THROWS_NOTHING(
+        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+            "SqwWs_conv_1LFixF_s0_to_5_Workspaces"));
+
+	AnalysisDataService::Instance().clear();
   }
 
   //------------------------ Private Functions---------------------------
+
+  MatrixWorkspace_sptr createGenericWorkspace(const std::string &wsName,
+                                              const bool numericAxis) {
+    const auto xData = boost::assign::list_of(1)(2)(3)(4)(5)
+                           .convert_to_container<Mantid::MantidVec>();
+    const auto yData = boost::assign::list_of(0)(1)(3)(1)(0)
+                           .convert_to_container<Mantid::MantidVec>();
+
+    auto createWorkspace = AlgorithmManager::Instance().create("CreateWorkspace");
+    createWorkspace->initialize();
+    if (numericAxis) {
+      createWorkspace->setProperty("UnitX", "DeltaE");
+      createWorkspace->setProperty("VerticalAxisUnit", "MomentumTransfer");
+      createWorkspace->setProperty("VerticalAxisValues", "1");
+    } else {
+      createWorkspace->setProperty("UnitX", "DeltaE");
+      createWorkspace->setProperty("VerticalAxisUnit", "SpectraNumber");
+    }
+    createWorkspace->setProperty("DataX", xData);
+    createWorkspace->setProperty("DataY", yData);
+    createWorkspace->setProperty("NSpec", 1);
+    createWorkspace->setPropertyValue("OutputWorkspace", wsName);
+    createWorkspace->execute();
+    MatrixWorkspace_sptr sqwWS =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsName);
+    return sqwWS;
+  }
 
   MatrixWorkspace_sptr create2DWorkspace(int xlen, int ylen) {
     auto ws = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
@@ -235,7 +308,7 @@ public:
     return testWs;
   }
 
-  void createConvitResWorkspace(int totalHist, int totalBins) {
+  void createConvFitResWorkspace(int totalHist, int totalBins) {
     auto convFitRes = WorkspaceFactory::Instance().create(
         "Workspace2D", totalHist + 1, totalBins + 1, totalBins);
     boost::shared_ptr<Mantid::MantidVec> x1(


### PR DESCRIPTION
Fixes #15250

It should now be possible to use `_sqw.nxs` files in the ConvFit interface due to the change in ConvolutionFitSequential to allow it to process workspaces with numerical axes rather than only those with spectrum axis.
An addition unit test has been created in order to test the use of numerical axes workspaces.

**Data for test available from `\\olympic\babylon5\Public\ElliotOram\DataAnalysis\ConvFit\IRIS\New`**
# To Test
- Code review for unit test
  - Ensure the unit test passes on all platforms
## Testing through interface
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit) 
- Sample = `iris26176_graphite002_sqw.nxs`
- Resolution = `iris26173_graphite002_res.nxs`
- Fit Type = `One Lorentzian`
- Click `Run`
- Ensure that the algorithm runs without error
- Ensure that the mini plot is updated with good looking fits 
## Testing with scripts
- The following script can be used to test the changes:

```
SqwWs_ = CreateWorkspace(DataX=[1,2,3,4,5], DataY=[0,1,3,1,0], Nspec=1, UnitX='DeltaE', VerticalAxisUnit='MomentumTransfer', VerticalAxisValues=['1'])
CreateWorkspace(DataX=[1,2,3,4,5], DataY=[0,1,3,1,0], Nspec=1, UnitX='DeltaE', VerticalAxisUnit='MomentumTransfer', VerticalAxisValues=['1'], OutputWorkspace='ResolutionWs_')
CreateWorkspace(DataX=[1,2,3,4,5], DataY=[0,1,3,1,0], Nspec=1, UnitX='DeltaE', VerticalAxisUnit='SpectraNumber', OutputWorkspace='__ConvFit_Resolution')

ConvolutionFitSequential(InputWorkspace=SqwWs_,
                                  Function='name=LinearBackground,A0=0,A1=0,ties=(A0=0.000000,A1=0.0);(composite=Convolution,FixResolution=true,NumDeriv=true;name=Resolution,Workspace=__ConvFit_Resolution,WorkspaceIndex=0;((composite=ProductFunction,NumDeriv=false;name=Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0.0175)))',
                                  BackgroundType='Fixed Flat',
                                  StartX=0.0,
                                  EndX=5.0,
                                  SpecMin=0,
                                  SpecMax=0,
                                  Convolve=True,
                                  Minimizer='Levenberg-Marquardt',
                                  MaxIterations=500)
```
- This should run ConvolutionFitSequentail and produce an `_Parameters`, `_Results` and `_Workspaces` workspace in the ADS (along with the initial input from CreateWorkspace).
