### PR TITLE
Use workspace clone method in algorithms

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CorrectKiKf.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CorrectKiKf.h
@@ -94,10 +94,6 @@ private:
   template <class T>
   void correctKiKfEventHelper(std::vector<T> &events, double efixed,
                               const std::string emodeStr);
-  /// The user selected (input) workspace
-  API::MatrixWorkspace_const_sptr inputWS;
-  /// The output workspace, maybe the same as the input one
-  API::MatrixWorkspace_sptr outputWS;
 };
 
 } // namespace Algorithm

--- a/Framework/Algorithms/src/AlignDetectors.cpp
+++ b/Framework/Algorithms/src/AlignDetectors.cpp
@@ -162,7 +162,6 @@ AlignDetectors::AlignDetectors() : m_numberOfSpectra(0) {
 /// Destructor
 AlignDetectors::~AlignDetectors() { delete this->tofToDmap; }
 
-//-----------------------------------------------------------------------
 void AlignDetectors::init() {
   auto wsValidator = boost::make_shared<CompositeValidator>();
   // Workspace unit must be TOF.
@@ -281,7 +280,6 @@ void setXAxisUnits(API::MatrixWorkspace_sptr outputWS) {
   outputWS->getAxis(0)->unit() = UnitFactory::Instance().create("dSpacing");
 }
 
-//-----------------------------------------------------------------------
 /** Executes the algorithm
  *  @throw Exception::FileError If the calibration file cannot be opened and
  * read successfully
@@ -356,16 +354,12 @@ void AlignDetectors::exec() {
   PARALLEL_CHECK_INTERUPT_REGION
 }
 
-//-----------------------------------------------------------------------
 /**
  * Execute the align detectors algorithm for an event workspace.
  */
 void AlignDetectors::execEvent() {
-  // g_log.information("Processing event workspace");
-
   // the calibration information is already read in at this point
 
-  // convert the input workspace into the event workspace we already know it is
   const MatrixWorkspace_const_sptr matrixInputWS =
       getProperty("InputWorkspace");
 

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -222,18 +222,9 @@ void BinaryOperation::exec() {
             "Contact the developers.");
     } else {
       // You HAVE to copy the data from lhs to to the output!
-
-      // Create a copy of the lhs workspace
-      m_eout = boost::dynamic_pointer_cast<EventWorkspace>(
-          API::WorkspaceFactory::Instance().create(
-              "EventWorkspace", m_elhs->getNumberHistograms(), 2, 1));
-      // Copy geometry, spectra map, etc. over.
-      API::WorkspaceFactory::Instance().initializeFromParent(m_elhs, m_eout,
-                                                             false);
-      // And we copy all the events from the lhs
-      m_eout->copyDataFrom(*m_elhs);
-      // Make sure m_out still points to the same as m_eout;
-      m_out = boost::dynamic_pointer_cast<API::MatrixWorkspace>(m_eout);
+      m_out = MatrixWorkspace_sptr(m_lhs->clone().release());
+      // Make sure m_eout still points to the same as m_out;
+      m_eout = boost::dynamic_pointer_cast<EventWorkspace>(m_out);
     }
 
     // Always clear the MRUs.

--- a/Framework/Algorithms/src/ChangeBinOffset.cpp
+++ b/Framework/Algorithms/src/ChangeBinOffset.cpp
@@ -146,33 +146,17 @@ void ChangeBinOffset::execEvent() {
   g_log.information("Processing event workspace");
 
   const MatrixWorkspace_const_sptr matrixInputWS =
-      this->getProperty("InputWorkspace");
-  EventWorkspace_const_sptr inputWS =
-      boost::dynamic_pointer_cast<const EventWorkspace>(matrixInputWS);
+      getProperty("InputWorkspace");
 
   // generate the output workspace pointer
-  API::MatrixWorkspace_sptr matrixOutputWS =
-      this->getProperty("OutputWorkspace");
-  EventWorkspace_sptr outputWS;
-  if (matrixOutputWS == matrixInputWS)
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
-  else {
-    // Make a brand new EventWorkspace
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        API::WorkspaceFactory::Instance().create(
-            "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
-    // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS,
-                                                           false);
-    // You need to copy over the data as well.
-    outputWS->copyDataFrom((*inputWS));
-
-    // Cast to the matrixOutputWS and save it
-    matrixOutputWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS);
+  API::MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
+  if (matrixOutputWS != matrixInputWS) {
+    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
     this->setProperty("OutputWorkspace", matrixOutputWS);
   }
+  auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
 
-  int64_t numHistograms = static_cast<int64_t>(inputWS->getNumberHistograms());
+  int64_t numHistograms = static_cast<int64_t>(outputWS->getNumberHistograms());
   PARALLEL_FOR1(outputWS)
   for (int64_t i = 0; i < numHistograms; ++i) {
     PARALLEL_START_INTERUPT_REGION

--- a/Framework/Algorithms/src/ChangePulsetime.cpp
+++ b/Framework/Algorithms/src/ChangePulsetime.cpp
@@ -51,15 +51,7 @@ void ChangePulsetime::exec() {
   EventWorkspace_const_sptr in_ws = getProperty("InputWorkspace");
   EventWorkspace_sptr out_ws = getProperty("OutputWorkspace");
   if (!out_ws) {
-    // Make a brand new EventWorkspace
-    out_ws = boost::dynamic_pointer_cast<EventWorkspace>(
-        API::WorkspaceFactory::Instance().create(
-            "EventWorkspace", in_ws->getNumberHistograms(), 2, 1));
-    // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(in_ws, out_ws,
-                                                           false);
-    // You need to copy over the data as well.
-    out_ws->copyDataFrom((*in_ws));
+    out_ws = EventWorkspace_sptr(in_ws->clone().release());
   }
 
   // Either use the given list or use all spectra

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -210,18 +210,7 @@ API::MatrixWorkspace_sptr ConvertUnits::setupOutputWorkspace(
   // the output
   if (outputWS != inputWS) {
     if (m_inputEvents) {
-      // Need to create by name as WorkspaceFactory otherwise spits out
-      // Workspace2D when EventWS passed in
-      outputWS = WorkspaceFactory::Instance().create(
-          "EventWorkspace", inputWS->getNumberHistograms(), 2, 1);
-      // Copy geometry etc. over
-      WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS,
-                                                        false);
-      // Need to copy over the data as well
-      EventWorkspace_const_sptr inputEventWS =
-          boost::dynamic_pointer_cast<const EventWorkspace>(inputWS);
-      boost::dynamic_pointer_cast<EventWorkspace>(outputWS)
-          ->copyDataFrom(*inputEventWS);
+      outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
     } else {
       // Create the output workspace
       outputWS = WorkspaceFactory::Instance().create(inputWS);

--- a/Framework/Algorithms/src/ConvertUnitsUsingDetectorTable.cpp
+++ b/Framework/Algorithms/src/ConvertUnitsUsingDetectorTable.cpp
@@ -223,18 +223,7 @@ API::MatrixWorkspace_sptr ConvertUnitsUsingDetectorTable::setupOutputWorkspace(
   // the output
   if (outputWS != inputWS) {
     if (m_inputEvents) {
-      // Need to create by name as WorkspaceFactory otherwise spits out
-      // Workspace2D when EventWS passed in
-      outputWS = WorkspaceFactory::Instance().create(
-          "EventWorkspace", inputWS->getNumberHistograms(), 2, 1);
-      // Copy geometry etc. over
-      WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS,
-                                                        false);
-      // Need to copy over the data as well
-      EventWorkspace_const_sptr inputEventWS =
-          boost::dynamic_pointer_cast<const EventWorkspace>(inputWS);
-      boost::dynamic_pointer_cast<EventWorkspace>(outputWS)
-          ->copyDataFrom(*inputEventWS);
+      outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
     } else {
       // Create the output workspace
       outputWS = WorkspaceFactory::Instance().create(inputWS);

--- a/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
@@ -109,15 +109,7 @@ void CorelliCrossCorrelate::exec() {
   outputWS = getProperty("OutputWorkspace");
 
   if (outputWS != inputWS) {
-    // Make a brand new EventWorkspace
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        API::WorkspaceFactory::Instance().create(
-            "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
-    // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS,
-                                                           false);
-    // You need to copy over the data as well.
-    outputWS->copyDataFrom((*inputWS));
+    outputWS = EventWorkspace_sptr(inputWS->clone().release());
   }
 
   // Read in chopper sequence from IDF.

--- a/Framework/Algorithms/src/CorrectKiKf.cpp
+++ b/Framework/Algorithms/src/CorrectKiKf.cpp
@@ -53,8 +53,8 @@ void CorrectKiKf::init() {
 
 void CorrectKiKf::exec() {
   // Get the workspaces
-  this->inputWS = this->getProperty("InputWorkspace");
-  this->outputWS = this->getProperty("OutputWorkspace");
+  MatrixWorkspace_const_sptr inputWS = this->getProperty("InputWorkspace");
+  MatrixWorkspace_sptr outputWS = this->getProperty("OutputWorkspace");
 
   // Check if it is an event workspace
   EventWorkspace_const_sptr eventW =
@@ -66,15 +66,15 @@ void CorrectKiKf::exec() {
 
   // If input and output workspaces are not the same, create a new workspace for
   // the output
-  if (this->outputWS != this->inputWS) {
-    this->outputWS = API::WorkspaceFactory::Instance().create(this->inputWS);
+  if (outputWS != inputWS) {
+    outputWS = API::WorkspaceFactory::Instance().create(inputWS);
   }
 
-  const size_t size = this->inputWS->blocksize();
+  const size_t size = inputWS->blocksize();
   // Calculate the number of spectra in this workspace
-  const int numberOfSpectra = static_cast<int>(this->inputWS->size() / size);
+  const int numberOfSpectra = static_cast<int>(inputWS->size() / size);
   API::Progress prog(this, 0.0, 1.0, numberOfSpectra);
-  const bool histogram = this->inputWS->isHistogramData();
+  const bool histogram = inputWS->isHistogramData();
   bool negativeEnergyWarning = false;
 
   const std::string emodeStr = getProperty("EMode");
@@ -83,8 +83,8 @@ void CorrectKiKf::exec() {
   if (efixedProp == EMPTY_DBL()) {
     if (emodeStr == "Direct") {
       // Check if it has been store on the run object for this workspace
-      if (this->inputWS->run().hasProperty("Ei")) {
-        Kernel::Property *eiprop = this->inputWS->run().getProperty("Ei");
+      if (inputWS->run().hasProperty("Ei")) {
+        Kernel::Property *eiprop = inputWS->run().getProperty("Ei");
         efixedProp = boost::lexical_cast<double>(eiprop->value());
         g_log.debug() << "Using stored Ei value " << efixedProp << "\n";
       } else {
@@ -178,7 +178,7 @@ void CorrectKiKf::exec() {
                         << std::endl;
   if ((negativeEnergyWarning) && (efixedProp == EMPTY_DBL()))
     g_log.information() << "Try to set fixed energy" << std::endl;
-  this->setProperty("OutputWorkspace", this->outputWS);
+  this->setProperty("OutputWorkspace", outputWS);
   return;
 }
 
@@ -209,8 +209,8 @@ void CorrectKiKf::execEvent() {
   if (efixedProp == EMPTY_DBL()) {
     if (emodeStr == "Direct") {
       // Check if it has been store on the run object for this workspace
-      if (this->inputWS->run().hasProperty("Ei")) {
-        Kernel::Property *eiprop = this->inputWS->run().getProperty("Ei");
+      if (inputWS->run().hasProperty("Ei")) {
+        Kernel::Property *eiprop = inputWS->run().getProperty("Ei");
         efixedProp = boost::lexical_cast<double>(eiprop->value());
         g_log.debug() << "Using stored Ei value " << efixedProp << "\n";
       } else {

--- a/Framework/Algorithms/src/FilterByXValue.cpp
+++ b/Framework/Algorithms/src/FilterByXValue.cpp
@@ -78,22 +78,13 @@ void FilterByXValue::exec() {
 
   // Check if we're doing thing in-place.
   if (inputWS != outputWS) {
-    // Create a new output workspace if not doing things in place. Preserve
-    // event-ness.
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        WorkspaceFactory::Instance().create("EventWorkspace", numSpec,
-                                            inputWS->blocksize() +
-                                                inputWS->isHistogramData(),
-                                            inputWS->blocksize()));
-    WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS, false);
-    // Copy over the data.
     // TODO: Make this more efficient by only copying over the events that pass
     // the
     // filter rather than copying everything and then removing some. This should
     // entail new methods (e.g. iterators) on EventList as this algorithm
     // shouldn't
     // need to know about the type of the events (e.g. weighted).
-    outputWS->copyDataFrom(*inputWS);
+    outputWS = EventWorkspace_sptr(inputWS->clone().release());
     setProperty("OutputWorkspace", outputWS);
   }
 

--- a/Framework/Algorithms/src/He3TubeEfficiency.cpp
+++ b/Framework/Algorithms/src/He3TubeEfficiency.cpp
@@ -405,42 +405,25 @@ void He3TubeEfficiency::execEvent() {
   this->g_log.information("Processing event workspace");
 
   const API::MatrixWorkspace_const_sptr matrixInputWS =
-      this->getProperty("InputWorkspace");
-  DataObjects::EventWorkspace_const_sptr inputWS =
-      boost::dynamic_pointer_cast<const DataObjects::EventWorkspace>(
-          matrixInputWS);
+      getProperty("InputWorkspace");
 
   // generate the output workspace pointer
-  API::MatrixWorkspace_sptr matrixOutputWS =
-      this->getProperty("OutputWorkspace");
-  DataObjects::EventWorkspace_sptr outputWS;
-  if (matrixOutputWS == matrixInputWS) {
-    outputWS = boost::dynamic_pointer_cast<DataObjects::EventWorkspace>(
-        matrixOutputWS);
-  } else {
-    // Make a brand new EventWorkspace
-    outputWS = boost::dynamic_pointer_cast<DataObjects::EventWorkspace>(
-        API::WorkspaceFactory::Instance().create(
-            "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
-    // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS,
-                                                           false);
-    // You need to copy over the data as well.
-    outputWS->copyDataFrom((*inputWS));
-
-    // Cast to the matrixOutputWS and save it
+  API::MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
+  if (matrixOutputWS != matrixInputWS) {
     matrixOutputWS =
-        boost::dynamic_pointer_cast<API::MatrixWorkspace>(outputWS);
-    this->setProperty("OutputWorkspace", matrixOutputWS);
+        API::MatrixWorkspace_sptr(matrixInputWS->clone().release());
+    setProperty("OutputWorkspace", matrixOutputWS);
   }
+  auto outputWS =
+      boost::dynamic_pointer_cast<DataObjects::EventWorkspace>(matrixOutputWS);
 
-  std::size_t numHistograms = inputWS->getNumberHistograms();
+  std::size_t numHistograms = outputWS->getNumberHistograms();
   this->progress = new API::Progress(this, 0.0, 1.0, numHistograms);
   PARALLEL_FOR1(outputWS)
   for (int i = 0; i < static_cast<int>(numHistograms); ++i) {
     PARALLEL_START_INTERUPT_REGION
 
-    Geometry::IDetector_const_sptr det = inputWS->getDetector(i);
+    Geometry::IDetector_const_sptr det = outputWS->getDetector(i);
     if (det->isMonitor() || det->isMasked()) {
       continue;
     }
@@ -451,7 +434,7 @@ void He3TubeEfficiency::execEvent() {
     } catch (std::out_of_range &) {
       // Parameters are bad so skip correction
       PARALLEL_CRITICAL(deteff_invalid) {
-        this->spectraSkipped.push_back(inputWS->getAxis(1)->spectraNo(i));
+        this->spectraSkipped.push_back(outputWS->getAxis(1)->spectraNo(i));
         outputWS->maskWorkspaceIndex(i);
       }
     }

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -89,6 +89,13 @@ void MaskBins::exec() {
     }
   }
 
+  // Only create the output workspace if it's different to the input one
+  MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
+  if (outputWS != inputWS) {
+    outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
+    setProperty("OutputWorkspace", outputWS);
+  }
+
   //---------------------------------------------------------------------------------
   // Now, determine if the input workspace is actually an EventWorkspace
   EventWorkspace_const_sptr eventW =
@@ -107,20 +114,6 @@ void MaskBins::exec() {
     if (commonBins) {
       const MantidVec &X = inputWS->readX(0);
       this->findIndices(X, startBin, endBin);
-    }
-
-    // Only create the output workspace if it's different to the input one
-    MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
-    if (outputWS != inputWS) {
-      outputWS = WorkspaceFactory::Instance().create(inputWS);
-      setProperty("OutputWorkspace", outputWS);
-
-      // Copy over the data
-      for (size_t wi = 0; wi < outputWS->getNumberHistograms(); ++wi) {
-        outputWS->dataX(wi) = inputWS->readX(wi);
-        outputWS->dataY(wi) = inputWS->readY(wi);
-        outputWS->dataE(wi) = inputWS->readE(wi);
-      }
     }
 
     const int numHists = static_cast<int>(inputWS->getNumberHistograms());
@@ -166,35 +159,11 @@ void MaskBins::exec() {
 /** Execution code for EventWorkspaces
  */
 void MaskBins::execEvent() {
-  MatrixWorkspace_const_sptr inputMatrixWS = getProperty("InputWorkspace");
-  EventWorkspace_const_sptr inputWS =
-      boost::dynamic_pointer_cast<const EventWorkspace>(inputMatrixWS);
-  EventWorkspace_sptr outputWS;
-
-  // Only create the output workspace if it's different to the input one
   MatrixWorkspace_sptr outputMatrixWS = getProperty("OutputWorkspace");
-  if (outputMatrixWS != inputWS) {
-    // Make a brand new EventWorkspace
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        API::WorkspaceFactory::Instance().create(
-            "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
-    // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS,
-                                                           false);
-    // You need to copy over the data as well.
-    outputWS->copyDataFrom((*inputWS));
-
-    // Cast to the matrixOutputWS and save it
-    MatrixWorkspace_sptr matrixOutputWS =
-        boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS);
-    this->setProperty("OutputWorkspace", matrixOutputWS);
-  } else {
-    // Output is same as input
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(outputMatrixWS);
-  }
+  auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(outputMatrixWS);
 
   // set up the progress bar
-  const size_t numHists = inputWS->getNumberHistograms();
+  const size_t numHists = outputWS->getNumberHistograms();
   Progress progress(this, 0.0, 1.0, numHists * 2);
 
   // sort the events

--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -260,15 +260,7 @@ void MergeRuns::execEvent() {
 
   // Create a new output event workspace, by copying the first WS in the list
   EventWorkspace_sptr inputWS = m_inEventWS[0];
-
-  // Make a brand new EventWorkspace
-  EventWorkspace_sptr outWS = boost::dynamic_pointer_cast<EventWorkspace>(
-      API::WorkspaceFactory::Instance().create(
-          "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
-  // Copy geometry over.
-  API::WorkspaceFactory::Instance().initializeFromParent(inputWS, outWS, false);
-  // You need to copy over the data as well.
-  outWS->copyDataFrom((*inputWS));
+  EventWorkspace_sptr outWS(inputWS->clone().release());
 
   int64_t n = m_inEventWS.size() - 1;
   m_progress = new Progress(this, 0.0, 1.0, n);

--- a/Framework/Algorithms/src/ModeratorTzero.cpp
+++ b/Framework/Algorithms/src/ModeratorTzero.cpp
@@ -243,28 +243,14 @@ void ModeratorTzero::execEvent(const std::string &emode) {
 
   const MatrixWorkspace_const_sptr matrixInputWS =
       getProperty("InputWorkspace");
-  EventWorkspace_const_sptr inputWS =
-      boost::dynamic_pointer_cast<const EventWorkspace>(matrixInputWS);
 
   // generate the output workspace pointer
-  const size_t numHists = static_cast<size_t>(inputWS->getNumberHistograms());
-  Mantid::API::MatrixWorkspace_sptr matrixOutputWS =
-      getProperty("OutputWorkspace");
-  EventWorkspace_sptr outputWS;
-  if (matrixOutputWS == matrixInputWS) {
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
-  } else {
-    // Make a brand new EventWorkspace
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        WorkspaceFactory::Instance().create("EventWorkspace", numHists, 2, 1));
-    // Copy geometry over.
-    WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS, false);
-    // You need to copy over the data as well.
-    outputWS->copyDataFrom((*inputWS));
-    // Cast to the matrixOutputWS and save it
-    matrixOutputWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS);
+  API::MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
+  if (matrixOutputWS != matrixInputWS) {
+    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
     setProperty("OutputWorkspace", matrixOutputWS);
   }
+  auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
 
   // Get pointers to sample and source
   IComponent_const_sptr source = m_instrument->getSource();
@@ -274,7 +260,7 @@ void ModeratorTzero::execEvent(const std::string &emode) {
   // calculate tof shift once for all neutrons if emode==Direct
   double t0_direct(-1);
   if (emode == "Direct") {
-    Kernel::Property *eiprop = inputWS->run().getProperty("Ei");
+    Kernel::Property *eiprop = outputWS->run().getProperty("Ei");
     double Ei = boost::lexical_cast<double>(eiprop->value());
     mu::Parser parser;
     parser.DefineVar("incidentEnergy", &Ei); // associate E1 to this parser
@@ -283,6 +269,7 @@ void ModeratorTzero::execEvent(const std::string &emode) {
   }
 
   // Loop over the spectra
+  const size_t numHists = static_cast<size_t>(outputWS->getNumberHistograms());
   Progress prog(this, 0.0, 1.0, numHists); // report progress of algorithm
   PARALLEL_FOR1(outputWS)
   for (int i = 0; i < static_cast<int>(numHists); ++i) {
@@ -296,7 +283,7 @@ void ModeratorTzero::execEvent(const std::string &emode) {
       double L2(-1);  // distance from sample to detector
 
       try {
-        det = inputWS->getDetector(i);
+        det = outputWS->getDetector(i);
         if (det->isMonitor()) {
           // redefine the sample as the monitor
           L1 = source->getDistance(*det);

--- a/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
+++ b/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
@@ -179,29 +179,17 @@ void ModeratorTzeroLinear::execEvent() {
 
   const MatrixWorkspace_const_sptr matrixInputWS =
       getProperty("InputWorkspace");
-  EventWorkspace_const_sptr inputWS =
-      boost::dynamic_pointer_cast<const EventWorkspace>(matrixInputWS);
 
   // generate the output workspace pointer
-  const size_t numHists = inputWS->getNumberHistograms();
   MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
-  EventWorkspace_sptr outputWS;
-  if (matrixOutputWS == matrixInputWS) {
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
-  } else {
-    // Make a brand new EventWorkspace
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        WorkspaceFactory::Instance().create("EventWorkspace", numHists, 2, 1));
-    // Copy geometry over.
-    WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS, false);
-    // You need to copy over the data as well.
-    outputWS->copyDataFrom((*inputWS));
-    // Cast to the matrixOutputWS and save it
-    matrixOutputWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS);
+  if (matrixOutputWS != matrixInputWS) {
+    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
     setProperty("OutputWorkspace", matrixOutputWS);
   }
+  auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
 
   // Loop over the spectra
+  const size_t numHists = outputWS->getNumberHistograms();
   Progress prog(this, 0.0, 1.0, numHists); // report progress of algorithm
   PARALLEL_FOR1(outputWS)
   for (int i = 0; i < static_cast<int>(numHists); ++i) {

--- a/Framework/Algorithms/src/MultipleScatteringCylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/MultipleScatteringCylinderAbsorption.cpp
@@ -157,21 +157,12 @@ void MultipleScatteringCylinderAbsorption::exec() {
   EventWorkspace_sptr in_WSevent =
       boost::dynamic_pointer_cast<EventWorkspace>(in_WS);
   if (in_WSevent) {
-    MatrixWorkspace_sptr out_WS = getProperty("OutputWorkspace");
-    EventWorkspace_sptr out_WSevent =
-        boost::dynamic_pointer_cast<EventWorkspace>(out_WS);
-
     // not in-place so create a new copy
-    if (in_WSevent != out_WSevent) {
-      out_WSevent = boost::dynamic_pointer_cast<EventWorkspace>(
-          API::WorkspaceFactory::Instance().create(
-              "EventWorkspace", in_WSevent->getNumberHistograms(), 2, 1));
-      // Copy geometry over.
-      API::WorkspaceFactory::Instance().initializeFromParent(
-          in_WSevent, out_WSevent, false);
-      // You need to copy over the data as well.
-      out_WSevent->copyDataFrom((*in_WSevent));
+    MatrixWorkspace_sptr out_WS = getProperty("OutputWorkspace");
+    if (in_WS != out_WS) {
+      out_WS = MatrixWorkspace_sptr(in_WS->clone().release());
     }
+    auto out_WSevent = boost::dynamic_pointer_cast<EventWorkspace>(out_WS);
 
     // convert to weighted events
     out_WSevent->switchEventType(API::WEIGHTED_NOTIME);
@@ -207,9 +198,7 @@ void MultipleScatteringCylinderAbsorption::exec() {
     PARALLEL_CHECK_INTERUPT_REGION
 
     // set the output workspace
-    this->setProperty(
-        "OutputWorkspace",
-        boost::dynamic_pointer_cast<MatrixWorkspace>(out_WSevent));
+    setProperty("OutputWorkspace", out_WS);
   } else // histogram case
   {
     // Create the new workspace

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -560,25 +560,16 @@ void NormaliseToMonitor::normaliseBinByBin(
     API::MatrixWorkspace_sptr &outputWorkspace) {
   EventWorkspace_sptr inputEvent =
       boost::dynamic_pointer_cast<EventWorkspace>(inputWorkspace);
-  EventWorkspace_sptr outputEvent =
-      boost::dynamic_pointer_cast<EventWorkspace>(outputWorkspace);
 
   // Only create output workspace if different to input one
   if (outputWorkspace != inputWorkspace) {
     if (inputEvent) {
-      // Make a brand new EventWorkspace
-      outputEvent = boost::dynamic_pointer_cast<EventWorkspace>(
-          API::WorkspaceFactory::Instance().create(
-              "EventWorkspace", inputEvent->getNumberHistograms(), 2, 1));
-      // Copy geometry and data
-      API::WorkspaceFactory::Instance().initializeFromParent(
-          inputEvent, outputEvent, false);
-      outputEvent->copyDataFrom((*inputEvent));
-      outputWorkspace =
-          boost::dynamic_pointer_cast<MatrixWorkspace>(outputEvent);
+      outputWorkspace = MatrixWorkspace_sptr(inputWorkspace->clone().release());
     } else
       outputWorkspace = WorkspaceFactory::Instance().create(inputWorkspace);
   }
+  auto outputEvent =
+      boost::dynamic_pointer_cast<EventWorkspace>(outputWorkspace);
 
   // Get hold of the monitor spectrum
   const MantidVec &monX = m_monitor->readX(0);

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -142,41 +142,16 @@ void Rebin::exec() {
 
   if (eventInputWS != nullptr) {
     //------- EventWorkspace as input -------------------------------------
-    EventWorkspace_sptr eventOutputWS =
-        boost::dynamic_pointer_cast<EventWorkspace>(outputWS);
 
-    if (inPlace && PreserveEvents) {
-      // -------------Rebin in-place, preserving events
-      // ----------------------------------------------
+    if (PreserveEvents) {
+      if (!inPlace) {
+        outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
+      }
+      auto eventOutputWS =
+          boost::dynamic_pointer_cast<EventWorkspace>(outputWS);
       // This only sets the X axis. Actual rebinning will be done upon data
       // access.
       eventOutputWS->setAllX(XValues_new);
-      this->setProperty(
-          "OutputWorkspace",
-          boost::dynamic_pointer_cast<MatrixWorkspace>(eventOutputWS));
-    } else if (!inPlace && PreserveEvents) {
-      // -------- NOT in-place, but you want to keep events for some reason.
-      // ----------------------
-      // Must copy the event workspace to a new EventWorkspace (and bin that).
-
-      // Make a brand new EventWorkspace
-      eventOutputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-          API::WorkspaceFactory::Instance().create(
-              "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
-      // Copy geometry over.
-      API::WorkspaceFactory::Instance().initializeFromParent(
-          inputWS, eventOutputWS, false);
-      // You need to copy over the data as well.
-      eventOutputWS->copyDataFrom((*eventInputWS));
-
-      // This only sets the X axis. Actual rebinning will be done upon data
-      // access.
-      eventOutputWS->setAllX(XValues_new);
-
-      // Cast to the matrixOutputWS and save it
-      this->setProperty(
-          "OutputWorkspace",
-          boost::dynamic_pointer_cast<MatrixWorkspace>(eventOutputWS));
     } else {
       //--------- Different output, OR you're inplace but not preserving Events
       //--- create a Workspace2D -------
@@ -230,10 +205,10 @@ void Rebin::exec() {
         outputWS->getAxis(i)->unit() = inputWS->getAxis(i)->unit();
       outputWS->setYUnit(eventInputWS->YUnit());
       outputWS->setYUnitLabel(eventInputWS->YUnitLabel());
-
-      // Assign it to the output workspace property
-      setProperty("OutputWorkspace", outputWS);
     }
+
+    // Assign it to the output workspace property
+    setProperty("OutputWorkspace", outputWS);
 
   } // END ---- EventWorkspace
 

--- a/Framework/Algorithms/src/RemoveLowResTOF.cpp
+++ b/Framework/Algorithms/src/RemoveLowResTOF.cpp
@@ -118,6 +118,13 @@ void RemoveLowResTOF::exec() {
   else
     m_outputLowResTOF = false;
 
+  // Only create the output workspace if it's different to the input one
+  MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
+  if (outputWS != m_inputWS) {
+    outputWS = MatrixWorkspace_sptr(m_inputWS->clone().release());
+    setProperty("OutputWorkspace", outputWS);
+  }
+
   // go off and do the event version if appropriate
   m_inputEvWS = boost::dynamic_pointer_cast<const EventWorkspace>(m_inputWS);
   if (m_inputEvWS != nullptr) {
@@ -127,24 +134,11 @@ void RemoveLowResTOF::exec() {
 
   // set up the progress bar
   m_progress = new Progress(this, 0.0, 1.0, m_numberOfSpectra);
-  size_t xSize = m_inputWS->dataX(0).size();
-
-  MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
-  if (outputWS != m_inputWS) {
-    outputWS = WorkspaceFactory::Instance().create(m_inputWS, m_numberOfSpectra,
-                                                   xSize, xSize - 1);
-    setProperty("OutputWorkspace", outputWS);
-  }
 
   this->getTminData(false);
 
   for (size_t workspaceIndex = 0; workspaceIndex < m_numberOfSpectra;
        workspaceIndex++) {
-    // copy the data from the input workspace
-    outputWS->dataX(workspaceIndex) = m_inputWS->readX(workspaceIndex);
-    outputWS->dataY(workspaceIndex) = m_inputWS->readY(workspaceIndex);
-    outputWS->dataE(workspaceIndex) = m_inputWS->readE(workspaceIndex);
-
     // calculate where to zero out to
     double tofMin = this->calcTofMin(workspaceIndex);
     const MantidVec &X = m_inputWS->readX(0);
@@ -167,38 +161,15 @@ void RemoveLowResTOF::exec() {
   */
 void RemoveLowResTOF::execEvent() {
   // set up the output workspace
-  MatrixWorkspace_sptr matrixOutW = this->getProperty("OutputWorkspace");
-  DataObjects::EventWorkspace_sptr outW;
-  if (matrixOutW == m_inputWS)
-    outW = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutW);
-  else {
-    outW = boost::dynamic_pointer_cast<EventWorkspace>(
-        API::WorkspaceFactory::Instance().create("EventWorkspace",
-                                                 m_numberOfSpectra, 2, 1));
-    // Copy required stuff from it
-    API::WorkspaceFactory::Instance().initializeFromParent(m_inputWS, outW,
-                                                           false);
-    outW->copyDataFrom((*m_inputEvWS));
-
-    // cast to the matrixoutput workspace and save it
-    matrixOutW = boost::dynamic_pointer_cast<MatrixWorkspace>(outW);
-    this->setProperty("OutputWorkspace", matrixOutW);
-  }
+  MatrixWorkspace_sptr matrixOutW = getProperty("OutputWorkspace");
+  auto outW = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutW);
 
   MatrixWorkspace_sptr matrixLowResW = getProperty("LowResTOFWorkspace");
-  DataObjects::EventWorkspace_sptr lowW;
   if (m_outputLowResTOF) {
-    // Duplicate input workspace to output workspace
-    lowW = boost::dynamic_pointer_cast<DataObjects::EventWorkspace>(
-        API::WorkspaceFactory::Instance().create("EventWorkspace",
-                                                 m_numberOfSpectra, 2, 1));
-    API::WorkspaceFactory::Instance().initializeFromParent(m_inputWS, lowW,
-                                                           false);
-    lowW->copyDataFrom((*m_inputEvWS));
-
-    matrixLowResW = boost::dynamic_pointer_cast<MatrixWorkspace>(lowW);
+    matrixLowResW = MatrixWorkspace_sptr(m_inputWS->clone().release());
     setProperty("LowResTOFWorkspace", matrixLowResW);
   }
+  auto lowW = boost::dynamic_pointer_cast<EventWorkspace>(matrixLowResW);
 
   g_log.debug() << "TOF range was " << m_inputEvWS->getTofMin() << " to "
                 << m_inputEvWS->getTofMax() << " microseconds\n";

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -320,23 +320,14 @@ void ResampleX::exec() {
       boost::dynamic_pointer_cast<const EventWorkspace>(inputWS);
   if (inputEventWS != nullptr) {
     if (m_preserveEvents) {
-      EventWorkspace_sptr outputEventWS =
-          boost::dynamic_pointer_cast<EventWorkspace>(outputWS);
       if (inPlace) {
         g_log.debug() << "Rebinning event workspace in place\n";
       } else {
         g_log.debug() << "Rebinning event workspace out of place\n";
-
-        // copy the event workspace to a new EventWorkspace
-        outputEventWS = boost::dynamic_pointer_cast<EventWorkspace>(
-            API::WorkspaceFactory::Instance().create(
-                "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
-        // copy geometry over.
-        API::WorkspaceFactory::Instance().initializeFromParent(
-            inputEventWS, outputEventWS, false);
-        // copy over the data as well.
-        outputEventWS->copyDataFrom((*inputEventWS));
+        outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
       }
+      auto outputEventWS =
+          boost::dynamic_pointer_cast<EventWorkspace>(outputWS);
 
       if (common_limits) {
         // get the delta from the first since they are all the same
@@ -366,9 +357,7 @@ void ResampleX::exec() {
         PARALLEL_CHECK_INTERUPT_REGION
       }
 
-      this->setProperty(
-          "OutputWorkspace",
-          boost::dynamic_pointer_cast<MatrixWorkspace>(outputEventWS));
+      setProperty("OutputWorkspace", outputEventWS);
     }    // end if (m_preserveEvents)
     else // event workspace -> matrix workspace
     {

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -356,8 +356,6 @@ void ResampleX::exec() {
         }
         PARALLEL_CHECK_INTERUPT_REGION
       }
-
-      setProperty("OutputWorkspace", outputEventWS);
     }    // end if (m_preserveEvents)
     else // event workspace -> matrix workspace
     {
@@ -417,10 +415,9 @@ void ResampleX::exec() {
         outputWS->getAxis(i)->unit() = inputWS->getAxis(i)->unit();
       outputWS->setYUnit(inputEventWS->YUnit());
       outputWS->setYUnitLabel(inputEventWS->YUnitLabel());
-
-      // Assign it to the output workspace property
-      setProperty("OutputWorkspace", outputWS);
     }
+    // Assign it to the output workspace property
+    setProperty("OutputWorkspace", outputWS);
     return;
   } else // (inputeventWS != NULL)
   {

--- a/Framework/Algorithms/src/ScaleX.cpp
+++ b/Framework/Algorithms/src/ScaleX.cpp
@@ -170,36 +170,22 @@ void ScaleX::execEvent() {
   g_log.information("Processing event workspace");
   const MatrixWorkspace_const_sptr matrixInputWS =
       this->getProperty("InputWorkspace");
-  const std::string op = getPropertyValue("Operation");
-  EventWorkspace_const_sptr inputWS =
-      boost::dynamic_pointer_cast<const EventWorkspace>(matrixInputWS);
   // generate the output workspace pointer
-  API::MatrixWorkspace_sptr matrixOutputWS =
-      this->getProperty("OutputWorkspace");
-  EventWorkspace_sptr outputWS;
-  if (matrixOutputWS == matrixInputWS)
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
-  else {
-    // Make a brand new EventWorkspace
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        API::WorkspaceFactory::Instance().create(
-            "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
-    // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS,
-                                                           false);
-    // You need to copy over the data as well.
-    outputWS->copyDataFrom((*inputWS));
-    // Cast to the matrixOutputWS and save it
-    matrixOutputWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS);
-    this->setProperty("OutputWorkspace", matrixOutputWS);
+  API::MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
+  if (matrixOutputWS != matrixInputWS) {
+    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
+    setProperty("OutputWorkspace", matrixOutputWS);
   }
-  int numHistograms = static_cast<int>(inputWS->getNumberHistograms());
+  auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
+
+  const std::string op = getPropertyValue("Operation");
+  int numHistograms = static_cast<int>(outputWS->getNumberHistograms());
   PARALLEL_FOR1(outputWS)
   for (int i = 0; i < numHistograms; ++i) {
     PARALLEL_START_INTERUPT_REGION
     // Do the offsetting
     if ((i >= m_wi_min) && (i <= m_wi_max)) {
-      auto factor = getScaleFactor(inputWS, i);
+      auto factor = getScaleFactor(outputWS, i);
       if (op == "Multiply") {
         outputWS->getEventList(i).scaleTof(factor);
         if (factor < 0) {

--- a/Framework/Algorithms/src/UnaryOperation.cpp
+++ b/Framework/Algorithms/src/UnaryOperation.cpp
@@ -109,37 +109,20 @@ void UnaryOperation::exec() {
 void UnaryOperation::execEvent() {
   g_log.information("Processing event workspace");
 
-  const MatrixWorkspace_const_sptr matrixInputWS =
-      this->getProperty(inputPropName());
-  EventWorkspace_const_sptr inputWS =
-      boost::dynamic_pointer_cast<const EventWorkspace>(matrixInputWS);
+  const MatrixWorkspace_const_sptr matrixInputWS = getProperty(inputPropName());
 
   // generate the output workspace pointer
-  API::MatrixWorkspace_sptr matrixOutputWS =
-      this->getProperty(outputPropName());
-  EventWorkspace_sptr outputWS;
-  if (matrixOutputWS == matrixInputWS) {
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
-  } else {
-    // Make a brand new EventWorkspace
-    outputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        API::WorkspaceFactory::Instance().create(
-            "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
-    // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(inputWS, outputWS,
-                                                           false);
-    // You need to copy over the data as well.
-    outputWS->copyDataFrom((*inputWS));
-
-    // Cast to the matrixOutputWS and save it
-    matrixOutputWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS);
-    this->setProperty("OutputWorkspace", matrixOutputWS);
+  API::MatrixWorkspace_sptr matrixOutputWS = getProperty(outputPropName());
+  if (matrixOutputWS != matrixInputWS) {
+    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
+    setProperty(outputPropName(), matrixOutputWS);
   }
+  auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
 
   // Now fetch any properties defined by concrete algorithm
   retrieveProperties();
 
-  int64_t numHistograms = static_cast<int64_t>(inputWS->getNumberHistograms());
+  int64_t numHistograms = static_cast<int64_t>(outputWS->getNumberHistograms());
   API::Progress prog = API::Progress(this, 0.0, 1.0, numHistograms);
   PARALLEL_FOR1(outputWS)
   for (int64_t i = 0; i < numHistograms; ++i) {
@@ -169,6 +152,7 @@ void UnaryOperation::execEvent() {
   PARALLEL_CHECK_INTERUPT_REGION
 
   outputWS->clearMRU();
+  auto inputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);
   if (inputWS->getNumberEvents() != outputWS->getNumberEvents()) {
     g_log.information() << "Number of events has changed!!!" << std::endl;
   }

--- a/Framework/Algorithms/src/UnwrapSNS.cpp
+++ b/Framework/Algorithms/src/UnwrapSNS.cpp
@@ -188,22 +188,11 @@ void UnwrapSNS::exec() {
 void UnwrapSNS::execEvent() {
   // set up the output workspace
   MatrixWorkspace_sptr matrixOutW = this->getProperty("OutputWorkspace");
-  DataObjects::EventWorkspace_sptr outW;
-  if (matrixOutW == m_inputWS)
-    outW = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutW);
-  else {
-    outW = boost::dynamic_pointer_cast<EventWorkspace>(
-        API::WorkspaceFactory::Instance().create("EventWorkspace",
-                                                 m_numberOfSpectra, 2, 1));
-    // Copy required stuff from it
-    API::WorkspaceFactory::Instance().initializeFromParent(m_inputWS, outW,
-                                                           false);
-    outW->copyDataFrom((*m_inputEvWS));
-
-    // cast to the matrixoutput workspace and save it
-    matrixOutW = boost::dynamic_pointer_cast<MatrixWorkspace>(outW);
-    this->setProperty("OutputWorkspace", matrixOutW);
+  if (matrixOutW == m_inputWS) {
+    matrixOutW = MatrixWorkspace_sptr(m_inputWS->clone().release());
+    setProperty("OutputWorkspace", matrixOutW);
   }
+  auto outW = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutW);
 
   // set up the progress bar
   m_progress = new Progress(this, 0.0, 1.0, m_numberOfSpectra * 2);

--- a/Framework/Algorithms/src/UnwrapSNS.cpp
+++ b/Framework/Algorithms/src/UnwrapSNS.cpp
@@ -188,7 +188,7 @@ void UnwrapSNS::exec() {
 void UnwrapSNS::execEvent() {
   // set up the output workspace
   MatrixWorkspace_sptr matrixOutW = this->getProperty("OutputWorkspace");
-  if (matrixOutW == m_inputWS) {
+  if (matrixOutW != m_inputWS) {
     matrixOutW = MatrixWorkspace_sptr(m_inputWS->clone().release());
     setProperty("OutputWorkspace", matrixOutW);
   }

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -316,29 +316,14 @@ void AlignAndFocusPowder::exec() {
 
   // Now setup the output workspace
   m_outputW = getProperty("OutputWorkspace");
-  if (m_outputW == m_inputW) {
-    if (m_inputEW) {
-      m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
+  if (m_inputEW) {
+    if (m_outputW != m_inputW) {
+      m_outputEW = EventWorkspace_sptr(m_inputEW->clone().release());
     }
+    m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
   } else {
-    if (m_inputEW) {
-      // Make a brand new EventWorkspace
-      m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(
-          WorkspaceFactory::Instance().create(
-              "EventWorkspace", m_inputEW->getNumberHistograms(), 2, 1));
-      // Copy geometry over.
-      WorkspaceFactory::Instance().initializeFromParent(m_inputEW, m_outputEW,
-                                                        false);
-      // You need to copy over the data as well.
-      m_outputEW->copyDataFrom((*m_inputEW));
-
-      // Cast to the matrixOutputWS and save it
-      m_outputW = boost::dynamic_pointer_cast<MatrixWorkspace>(m_outputEW);
-      // m_outputW->setName(getProperty("OutputWorkspace"));
-    } else {
-      // Not-an-event workspace
+    if (m_outputW != m_inputW) {
       m_outputW = WorkspaceFactory::Instance().create(m_inputW);
-      // m_outputW->setName(getProperty("OutputWorkspace"));
     }
   }
 

--- a/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
@@ -169,42 +169,26 @@ void SANSSolidAngleCorrection::exec() {
 
 void SANSSolidAngleCorrection::execEvent() {
   MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
-  EventWorkspace_sptr inputEventWS =
-      boost::dynamic_pointer_cast<EventWorkspace>(inputWS);
-
-  const int numberOfSpectra =
-      static_cast<int>(inputEventWS->getNumberHistograms());
-  Progress progress(this, 0.0, 1.0, inputEventWS->getNumberHistograms());
 
   // generate the output workspace pointer
-  MatrixWorkspace_sptr outputWS = this->getProperty("OutputWorkspace");
-  EventWorkspace_sptr outputEventWS;
-  if (outputWS == inputWS)
-    outputEventWS = boost::dynamic_pointer_cast<EventWorkspace>(outputWS);
-  else {
-    // Make a brand new EventWorkspace
-    outputEventWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        WorkspaceFactory::Instance().create(
-            "EventWorkspace", inputEventWS->getNumberHistograms(), 2, 1));
-    // Copy geometry over.
-    WorkspaceFactory::Instance().initializeFromParent(inputEventWS,
-                                                      outputEventWS, false);
-    // You need to copy over the data as well.
-    outputEventWS->copyDataFrom((*inputEventWS));
-
-    // Cast to the matrixOutputWS and save it
-    outputWS = boost::dynamic_pointer_cast<MatrixWorkspace>(outputEventWS);
-    this->setProperty("OutputWorkspace", outputWS);
+  MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
+  if (outputWS != inputWS) {
+    outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
+    setProperty("OutputWorkspace", outputWS);
   }
+  auto outputEventWS = boost::dynamic_pointer_cast<EventWorkspace>(outputWS);
 
+  const int numberOfSpectra =
+      static_cast<int>(outputEventWS->getNumberHistograms());
+  Progress progress(this, 0.0, 1.0, numberOfSpectra);
   progress.report("Solid Angle Correction");
 
-  PARALLEL_FOR2(inputEventWS, outputEventWS)
+  PARALLEL_FOR1(outputEventWS)
   for (int i = 0; i < numberOfSpectra; i++) {
     PARALLEL_START_INTERUPT_REGION
     IDetector_const_sptr det;
     try {
-      det = inputEventWS->getDetector(i);
+      det = outputEventWS->getDetector(i);
     } catch (Exception::NotFoundError &) {
       g_log.warning() << "Spectrum index " << i
                       << " has no detector assigned to it - discarding"
@@ -224,7 +208,7 @@ void SANSSolidAngleCorrection::execEvent() {
 
     // Compute solid angle correction factor
     const bool is_tube = getProperty("DetectorTubes");
-    const double tanTheta = tan(inputEventWS->detectorTwoTheta(det));
+    const double tanTheta = tan(outputEventWS->detectorTwoTheta(det));
     const double theta_term = sqrt(tanTheta * tanTheta + 1.0);
     double corr;
     if (is_tube) {


### PR DESCRIPTION
Closes #15248.

Code review:
Basically this is a simple change: We replace three existing statements by a call to `Workspace::clone()`. As a consequence we can also get rid of some `dynamic_casts`, so the diff may be a bit harder to understand at some points.
Note that the `clone()` call will be simplified by #12949.

Testing:
No new tests were added, since there is no new functionality. In principle our existing system tests should cover this.
One idea for testing manually: Apply algorithm to an event workspace, and see if both in-place (input == output) and not-in-place still work as expected.

No release notes.
