### PR TITLE
Fix Slice Viewer bug where no plot was shown if there are integrated dimensions

### DIFF
--- a/MantidQt/SliceViewer/src/DimensionSliceWidget.cpp
+++ b/MantidQt/SliceViewer/src/DimensionSliceWidget.cpp
@@ -114,6 +114,13 @@ void DimensionSliceWidget::setShownDim(int dim)
   ui.btnY->blockSignals(false);
   /// Slice if dimension is not X or Y AND is not integrated
   bool slicing = (m_shownDim == -1 && !m_dim->getIsIntegrated());
+
+  // Use the minimum slice point for integrated dimensions
+  // otherwise high bin boundary can be selected and no data plotted
+  if (m_dim->getIsIntegrated()) {
+    this->setSlicePoint(m_dim->getMinimum());
+  }
+
   ui.horizontalSlider->setVisible( slicing );
   ui.doubleSpinBox->setVisible( slicing );
   ui.lblUnits->setVisible( slicing );


### PR DESCRIPTION
FIxes #15243 

Should be merged with 3.6 release branch.

This bug affects MDHistoWorkspaces which have integrated dimensions and is a regression from previous release. The slice selecting slider was disabled for integrated dimensions (dimensions which have only a single bin) in #14354, however this can mean it is locked in a position where no data is shown. The fix here is to set the slider to the minimum position for integrated dimensions, which always results in the data being plotted.

**To Test:**

Use the following script to create an MDHistoWorkspace with 2 integrated dimensions and 2 non-integrated dimensions.
Select the non-integrated ones in the slice viewer (the first and last dimension).
You should see something plotted, previous to fix you would see only NaN for the slice.

``` python
# Create a 3D event workspace to test with
ws_mdew = CreateMDWorkspace(Dimensions='4', Extents='-2,2,-2,2,-2,2,-2,2', Names='h,k,l,E',
                       Units='rlu,rlu,rlu,E', SplitInto='12')
FakeMDEventData(ws_mdew, UniformParams='10000', RandomizeSignal='1')
ws_mdew = SliceMD(ws_mdew,AlignedDim0='h,-2,2,12',AlignedDim1='k,-2,2,12',AlignedDim2='l,-2,2,12',AlignedDim3='E,-2,2,12')

# Create projection
proj_id = Projection([1,1,0], [-1,1,0], [0,0,1])
proj_id.setType(0,'r')
proj_id.setType(1,'r')
proj_id.setType(2,'r')
ws_id = proj_id.createWorkspace()

out_md_2d = CutMD(ws_mdew, Projection=ws_id, PBins=([-2,0.05,2],[-1.1,-0.9],[-0.1,0.1],[-2,0.05,2]), NoPix=True)

sv1=plotSlice(out_md_2d,colormin=0.01,colormax=1,normalization=2)
```
