### PR TITLE
Remove deprecation of PerformIndexOperations after tester complaint

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PerformIndexOperations.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PerformIndexOperations.h
@@ -31,7 +31,7 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PerformIndexOperations : public API::DataProcessorAlgorithm{
+class DLLExport PerformIndexOperations : public API::DataProcessorAlgorithm {
 public:
   PerformIndexOperations();
   virtual ~PerformIndexOperations();

--- a/Framework/Algorithms/inc/MantidAlgorithms/PerformIndexOperations.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PerformIndexOperations.h
@@ -3,7 +3,6 @@
 
 #include "MantidKernel/System.h"
 #include "MantidAPI/DataProcessorAlgorithm.h"
-#include "MantidAPI/DeprecatedAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -32,8 +31,7 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PerformIndexOperations : public API::DataProcessorAlgorithm,
-                                         public API::DeprecatedAlgorithm {
+class DLLExport PerformIndexOperations : public API::DataProcessorAlgorithm{
 public:
   PerformIndexOperations();
   virtual ~PerformIndexOperations();

--- a/Framework/Algorithms/src/PerformIndexOperations.cpp
+++ b/Framework/Algorithms/src/PerformIndexOperations.cpp
@@ -342,11 +342,6 @@ VecCommands interpret(const std::string &processingInstructions) {
 /** Execute the algorithm.
  */
 void PerformIndexOperations::exec() {
-  g_log.error("PerformIndexOperations has been deprecated. It will be "
-              "removed in the next release of Mantid. The same functionality "
-              "is provided by GroupDetectors-v2. Its GroupingPattern "
-              "property accepts the same syntax as PerformIndexOperations' "
-              "ProcessingInstructions property.");
   MatrixWorkspace_sptr inputWorkspace = this->getProperty("InputWorkspace");
   const std::string processingInstructions =
       this->getProperty("ProcessingInstructions");

--- a/Framework/Algorithms/src/PerformIndexOperations.cpp
+++ b/Framework/Algorithms/src/PerformIndexOperations.cpp
@@ -258,9 +258,7 @@ DECLARE_ALGORITHM(PerformIndexOperations)
 //------------------------------------------------------------------------------
 /** Constructor
  */
-PerformIndexOperations::PerformIndexOperations() {
-  useAlgorithm("GroupDetectors", 2);
-}
+PerformIndexOperations::PerformIndexOperations() {}
 
 //------------------------------------------------------------------------------
 /** Destructor


### PR DESCRIPTION
This just removes the deprecation tag from PerformIndexOperations after feedback from one of our testers that GroupDetectors cannot do all of the things that it allowed.
### Release Notes

Nothing to include for this
### To Test

run PerformIndexOperations you should not get the deprecation warning

fixes #15261
