### PR TITLE
Adding compiler flags introduced in GCC 5.1

### DIFF
--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -40,6 +40,13 @@ elseif ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
     set(GNUFLAGS "${GNUFLAGS} -Wno-sign-conversion")
 endif()
 
+# Check if we have a new enough version for these flags
+if ( CMAKE_COMPILER_IS_GNUCXX )
+  if (NOT (GCC_COMPILER_VERSION VERSION_LESS "5.1"))
+    set(GNUFLAGS "${GNUFLAGS} -Wsuggest-override -Wsuggest-final-types -Wsuggest-final-methods")
+  endif()
+endif()
+
 # Add some options for debug build to help the Zoom profiler
 set( CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer" )
 set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer" )


### PR DESCRIPTION
This is to facilitate [maintenance task # 6](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html).

This PR adds the flags `-Wsuggest-override`, `-Wsuggest-final-types` and `-Wsuggest-final-methods` to all builds using GCC 5.1 or later. More information on these flags is below. This PR shouldn't introduce new warnings on any currently supported builds, but will make the warnings visible on our fedora 23 and arch linux build servers, where they can be more efficiently addressed by the development team. 

testing: Trying building this branch on a machine with GCC 5.1 or later.

`-Wsuggest-override`
Warn about overriding virtual functions that are not marked with the override keyword.

`-Wsuggest-final-types`
Warn about types with virtual methods where code quality would be improved if the type were declared with the C++11 final specifier, or, if possible, declared in an anonymous namespace. This allows GCC to more aggressively devirtualize the polymorphic calls. This warning is more effective with link time optimization, where the information about the class hierarchy graph is more complete. 

`-Wsuggest-final-methods` 
Warn about virtual methods where code quality would be improved if the method were declared with the C++11 final specifier, or, if possible, its type were declared in an anonymous namespace or with the final specifier. This warning is more effective with link time optimization, where the information about the class hierarchy graph is more complete. It is recommended to first consider suggestions of -Wsuggest-final-types and then rebuild with new annotations. 
