### PR TITLE
CMake option enabling link-time optimization with GCC 

### DIFF
--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -43,7 +43,7 @@ endif()
 # Check if we have a new enough version for these flags
 if ( CMAKE_COMPILER_IS_GNUCXX )
   if (NOT (GCC_COMPILER_VERSION VERSION_LESS "5.1"))
-    #set(GNUFLAGS "${GNUFLAGS} -Wsuggest-override -Wsuggest-final-types -Wsuggest-final-methods")
+    set(GNUFLAGS "${GNUFLAGS} -Wsuggest-override -Wsuggest-final-types -Wsuggest-final-methods")
     option(ENABLE_LTO "Enable link-time optimization in release builds" ON)
   else()
     option(ENABLE_LTO "Enable link-time optimization in release builds" OFF)

--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -40,6 +40,13 @@ elseif ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
     set(GNUFLAGS "${GNUFLAGS} -Wno-sign-conversion")
 endif()
 
+# Check if we have a new enough version for these flags
+if ( CMAKE_COMPILER_IS_GNUCXX )
+  if (NOT (GCC_COMPILER_VERSION VERSION_LESS "5.1"))
+    set(GNUFLAGS "${GNUFLAGS} -Wsuggest-override -Wsuggest-final-types -Wsuggest-final-methods")
+  endif()
+endif()
+
 # Add some options for debug build to help the Zoom profiler
 set( CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer" )
 set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer" )

--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -43,8 +43,19 @@ endif()
 # Check if we have a new enough version for these flags
 if ( CMAKE_COMPILER_IS_GNUCXX )
   if (NOT (GCC_COMPILER_VERSION VERSION_LESS "5.1"))
-    set(GNUFLAGS "${GNUFLAGS} -Wsuggest-override -Wsuggest-final-types -Wsuggest-final-methods")
+    #set(GNUFLAGS "${GNUFLAGS} -Wsuggest-override -Wsuggest-final-types -Wsuggest-final-methods")
+    option(ENABLE_LTO "Enable link-time optimization in release builds" ON)
+  else()
+    option(ENABLE_LTO "Enable link-time optimization in release builds" OFF)
   endif()
+  mark_as_advanced(ENABLE_LTO)
+endif()
+
+if(ENABLE_LTO)
+  # Avoid fat lto objects which are reported to double compile time.
+  set(GCC_LTO_FLAGS "-flto -fno-fat-lto-objects -fuse-linker-plugin")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${GCC_LTO_FLAGS}")
+  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${GCC_LTO_FLAGS}")
 endif()
 
 # Add some options for debug build to help the Zoom profiler


### PR DESCRIPTION
### THIS PR DEPENDS ON #15273!

Some of the new GCC 5 flags introduced in PR #15273 are most effective when link-time optimization (LTO) is enabled. This pull request creates an option to enable LTO. 

For earlier GCC versions, it is disabled by default. There appears to be [high memory utilization with GCC 4.8](http://hubicka.blogspot.com/2014/04/linktime-optimization-in-gcc-2-firefox.html). In case someone still wants to try it with GCC 4.8, I left in the additional flags required in that version to produce only the slim object files.

I think better diagnostic information about devirtualization opportunities, improved code quality and much smaller file sizes is worth the tradeoff, but am labeling this core because of the increase in build times. Individual developers building in debug mode will be unaffected and have the option to turn off LTO in release builds. When more build servers are using GCC 5+, we can decide whether to turn it off for PR and other frequently-run jobs.

testing: Please double-check that I have the correct flags set and that they are being passed to both the compiler and linker. Verify that this option can be enabled/disabled. 
