### PR TITLE
Allow FFT to optionally accept rounding errors in X 

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/FFT.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FFT.h
@@ -58,6 +58,10 @@ private:
   // Overridden Algorithm methods
   void init();
   void exec();
+  /// Perform validation of inputs
+  std::map<std::string, std::string> validateInputs() override;
+  /// Check whether supplied values are evenly spaced
+  bool areBinWidthsUneven(const MantidVec &xValues) const;
 };
 
 } // namespace Algorithm

--- a/Framework/Algorithms/inc/MantidAlgorithms/FFT.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FFT.h
@@ -41,18 +41,18 @@ public:
   /// Default constructor
   FFT() : API::Algorithm(){};
   /// Destructor
-  virtual ~FFT(){};
+  ~FFT() override{};
   /// Algorithm's name for identification overriding a virtual method
-  virtual const std::string name() const { return "FFT"; }
+  const std::string name() const override { return "FFT"; }
   /// Summary of algorithms purpose
-  virtual const std::string summary() const {
+  const std::string summary() const override {
     return "Performs complex Fast Fourier Transform";
   }
 
   /// Algorithm's version for identification overriding a virtual method
-  virtual int version() const { return 1; }
+  int version() const override { return 1; }
   /// Algorithm's category for identification overriding a virtual method
-  virtual const std::string category() const { return "Arithmetic\\FFT"; }
+  const std::string category() const override { return "Arithmetic\\FFT"; }
 
 private:
   // Overridden Algorithm methods

--- a/Framework/Algorithms/inc/MantidAlgorithms/FFT.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FFT.h
@@ -56,8 +56,8 @@ public:
 
 private:
   // Overridden Algorithm methods
-  void init();
-  void exec();
+  void init() override;
+  void exec() override;
   /// Perform validation of inputs
   std::map<std::string, std::string> validateInputs() override;
   /// Check whether supplied values are evenly spaced

--- a/Framework/Algorithms/src/FFT.cpp
+++ b/Framework/Algorithms/src/FFT.cpp
@@ -308,13 +308,13 @@ std::map<std::string, std::string> FFT::validateInputs() {
   // check that the workspace isn't empty
   if (X.size() < 2) {
     errors["InputWorkspace"] = "Input workspace must have at least two values";
-  }
-
-  // Check that the x values are evenly spaced
-  // If accepting rounding errors, just give a warning if bins are different.
-  if (areBinWidthsUneven(X)) {
-    errors["InputWorkspace"] =
-        "X axis must be linear (all bins have same width)";
+  } else {
+    // Check that the x values are evenly spaced
+    // If accepting rounding errors, just give a warning if bins are different.
+    if (areBinWidthsUneven(X)) {
+      errors["InputWorkspace"] =
+          "X axis must be linear (all bins have same width)";
+    }
   }
 
   return errors;

--- a/Framework/Algorithms/src/FFT.cpp
+++ b/Framework/Algorithms/src/FFT.cpp
@@ -346,7 +346,8 @@ bool FFT::areBinWidthsUneven(const MantidVec &xValues) const {
   const double dx = [&] {
     if (acceptXRoundingErrors) {
       // use average bin width
-      return (xValues[xValues.size() - 1] - xValues[0]) / (xValues.size() - 1);
+      return (xValues[xValues.size() - 1] - xValues[0]) /
+             static_cast<double>(xValues.size() - 1);
     } else {
       // use first bin width
       return xValues[1] - xValues[0];
@@ -357,7 +358,7 @@ bool FFT::areBinWidthsUneven(const MantidVec &xValues) const {
   // Otherwise just compare each difference in turn to the tolerance.
   auto difference = [&](size_t i) {
     if (acceptXRoundingErrors) {
-      return std::abs((xValues[i] - xValues[0] - i * dx) / dx);
+      return std::abs((xValues[i] - xValues[0] - (double)i * dx) / dx);
     } else {
       return std::abs(dx - xValues[i + 1] + xValues[i]) / dx;
     }

--- a/Framework/Algorithms/src/FFT.cpp
+++ b/Framework/Algorithms/src/FFT.cpp
@@ -58,6 +58,10 @@ void FFT::init() {
                   "Direction of the transform: forward or backward");
   declareProperty("Shift", 0.0, "Apply an extra phase equal to this quantity "
                                 "times 2*pi to the transform");
+  declareProperty(
+      "AcceptXRoundingErrors", false,
+      "Continue to process the data even if X values are not evenly spaced",
+      Direction::Input);
 }
 
 /** Executes the algorithm
@@ -92,22 +96,6 @@ void FFT::exec() {
       throw std::invalid_argument("Property Imaginary is out of range");
   }
 
-  // check that the workspace isn't empty
-  if (X.size() < 2) {
-    throw std::invalid_argument(
-        "Input workspace must have at least two values");
-  }
-
-  // Check that the x values are evenly spaced
-  const double dx = X[1] - X[0];
-  for (size_t i = 1; i < X.size() - 2; i++)
-    if (std::abs(dx - X[i + 1] + X[i]) / dx > 1e-7) {
-      g_log.error() << "dx=" << X[i + 1] - X[i] << ' ' << dx << ' ' << i
-                    << std::endl;
-      throw std::invalid_argument(
-          "X axis must be linear (all bins have same width)");
-    }
-
   gsl_fft_complex_wavetable *wavetable = gsl_fft_complex_wavetable_alloc(ySize);
   gsl_fft_complex_workspace *workspace = gsl_fft_complex_workspace_alloc(ySize);
 
@@ -126,6 +114,7 @@ void FFT::exec() {
   MatrixWorkspace_sptr outWS =
       WorkspaceFactory::Instance().create(inWS, nOut, xSize, ySize);
 
+  const double dx = X[1] - X[0];
   double df = 1.0 / (dx * ySize);
 
   // Output label
@@ -301,6 +290,88 @@ void FFT::exec() {
   }
 
   setProperty("OutputWorkspace", outWS);
+}
+
+/**
+ * Perform validation of input properties:
+ * - input workspace must not be empty
+ * - X values must be evenly spaced (unless accepting rounding errors)
+ * @returns :: map of property names to errors (empty map if no errors)
+ */
+std::map<std::string, std::string> FFT::validateInputs() {
+  std::map<std::string, std::string> errors;
+
+  MatrixWorkspace_const_sptr inWS = getProperty("InputWorkspace");
+  const int iReal = getProperty("Real");
+  const MantidVec &X = inWS->readX(iReal);
+
+  // check that the workspace isn't empty
+  if (X.size() < 2) {
+    errors["InputWorkspace"] = "Input workspace must have at least two values";
+  }
+
+  // Check that the x values are evenly spaced
+  // If accepting rounding errors, just give a warning if bins are different.
+  if (areBinWidthsUneven(X)) {
+    errors["InputWorkspace"] =
+        "X axis must be linear (all bins have same width)";
+  }
+
+  return errors;
+}
+
+/**
+ * Test input X vector for spacing of values.
+ * In normal use, return true if not evenly spaced (error).
+ * If accepting rounding errors, threshold is more lenient, and don't return an
+ * error but just warn the user.
+ * @param xValues :: [input] Values to check
+ * @returns :: True if unevenly spaced, False if not (or accepting errors)
+ */
+bool FFT::areBinWidthsUneven(const MantidVec &xValues) const {
+  bool widthsUneven = false;
+  const bool acceptXRoundingErrors = getProperty("AcceptXRoundingErrors");
+  const double tolerance = acceptXRoundingErrors ? 0.5 : 1e-7;
+  const double warnValue = 0.1;
+
+  // Width to check against
+  const double dx = [&] {
+    if (acceptXRoundingErrors) {
+      // use average bin width
+      return (xValues[xValues.size() - 1] - xValues[0]) / (xValues.size() - 1);
+    } else {
+      // use first bin width
+      return xValues[1] - xValues[0];
+    }
+  }();
+
+  // Use cumulative errors if we are accepting rounding errors.
+  // Otherwise just compare each difference in turn to the tolerance.
+  auto difference = [&](size_t i) {
+    if (acceptXRoundingErrors) {
+      return std::abs((xValues[i] - xValues[0] - i * dx) / dx);
+    } else {
+      return std::abs(dx - xValues[i + 1] + xValues[i]) / dx;
+    }
+  };
+
+  // Check each width against dx
+  for (size_t i = 1; i < xValues.size() - 2; i++) {
+    const double diff = difference(i);
+    if (diff > tolerance) {
+      // return an actual error
+      g_log.error() << "dx=" << xValues[i + 1] - xValues[i] << ' ' << dx << ' '
+                    << i << std::endl;
+      widthsUneven = true;
+      break;
+    } else if (acceptXRoundingErrors && diff > warnValue) {
+      // just warn the user
+      g_log.warning() << "Bin widths differ by more than " << warnValue * 100
+                      << "% of average." << std::endl;
+    }
+  }
+
+  return widthsUneven;
 }
 
 } // namespace Algorithm

--- a/Framework/Algorithms/test/FFTTest.h
+++ b/Framework/Algorithms/test/FFTTest.h
@@ -439,6 +439,56 @@ public:
     FrameworkManager::Instance().deleteWorkspace("FFT_out");
   }
 
+  // Test that unevenly spaced X values are rejected by default
+  void testUnequalBinWidths_Throws() {
+    const int N = 100;
+    auto inputWS = createWS(N, 0, "uneven_points");
+    Mantid::MantidVec &X = inputWS->dataX(0);
+    double aveX = (X[51] + X[49]) / 2.0;
+    X[50] = aveX + 0.01;
+
+    auto fft = FrameworkManager::Instance().createAlgorithm("FFT");
+    fft->initialize();
+    fft->setProperty("InputWorkspace", inputWS);
+    fft->setPropertyValue("OutputWorkspace", "__NotUsed");
+    fft->setPropertyValue("Real", "0");
+    TS_ASSERT_THROWS(fft->execute(), std::runtime_error);
+
+    FrameworkManager::Instance().deleteWorkspace("FFT_WS_uneven_points");
+  }
+
+  // Test that unevenly spaced X values are accepted if the property is set to
+  // do so
+  void testUnequalBinWidths_acceptRoundingErrors() {
+    const int N = 100;
+    auto inputWS = createWS(N, 0, "uneven_points");
+    Mantid::MantidVec &X = inputWS->dataX(0);
+    double aveX = (X[51] + X[49]) / 2.0;
+    X[50] = aveX + 0.01;
+
+    auto fft = FrameworkManager::Instance().createAlgorithm("FFT");
+    fft->initialize();
+    fft->setProperty("InputWorkspace", inputWS);
+    fft->setPropertyValue("OutputWorkspace", "__NotUsed");
+    fft->setPropertyValue("Real", "0");
+    fft->setProperty("AcceptXRoundingErrors", true);
+    TS_ASSERT_THROWS_NOTHING(fft->execute());
+
+    FrameworkManager::Instance().deleteWorkspace("FFT_WS_uneven_points");
+  }
+
+  // Test that algorithm will not accept an empty input workspace
+  void testEmptyInputWorkspace_Throws() {
+    auto inputWS = createWS(1, 0, "empty");
+    auto fft = FrameworkManager::Instance().createAlgorithm("FFT");
+    fft->initialize();
+    fft->setProperty("InputWorkspace", inputWS);
+    fft->setPropertyValue("OutputWorkspace", "__NotUsed");
+    fft->setPropertyValue("Real", "0");
+    TS_ASSERT_THROWS(fft->execute(), std::runtime_error);
+    FrameworkManager::Instance().deleteWorkspace("FFT_WS_empty");
+  }
+
 private:
   MatrixWorkspace_sptr createWS(int n, int dn, const std::string &name) {
     FrameworkManager::Instance();

--- a/Framework/Algorithms/test/FFTTest.h
+++ b/Framework/Algorithms/test/FFTTest.h
@@ -489,6 +489,45 @@ public:
     FrameworkManager::Instance().deleteWorkspace("FFT_WS_empty");
   }
 
+  void testRealOutOfRange_Throws() {
+    auto inputWS = createWS(100, 0, "real_out_of_range");
+    auto fft = FrameworkManager::Instance().createAlgorithm("FFT");
+    fft->initialize();
+    fft->setProperty("InputWorkspace", inputWS);
+    fft->setPropertyValue("OutputWorkspace", "__NotUsed");
+    fft->setPropertyValue("Real", "100");
+    TS_ASSERT_THROWS(fft->execute(), std::runtime_error);
+    FrameworkManager::Instance().deleteWorkspace("FFT_WS_real_out_of_range");
+  }
+
+  void testImaginaryOutOfRange_Throws() {
+    auto inputWS = createWS(100, 0, "imaginary_out_of_range");
+    auto fft = FrameworkManager::Instance().createAlgorithm("FFT");
+    fft->initialize();
+    fft->setProperty("InputWorkspace", inputWS);
+    fft->setPropertyValue("OutputWorkspace", "__NotUsed");
+    fft->setPropertyValue("Real", "0");
+    fft->setPropertyValue("Imaginary", "100");
+    TS_ASSERT_THROWS(fft->execute(), std::runtime_error);
+    FrameworkManager::Instance().deleteWorkspace(
+        "FFT_WS_imaginary_out_of_range");
+  }
+
+  void testRealImaginarySizeMismatch_Throws() {
+    auto inputWS = createWS(100, 0, "real_mismatch");
+    auto inImagWS = createWS(99, 0, "imag_mismatch");
+    auto fft = FrameworkManager::Instance().createAlgorithm("FFT");
+    fft->initialize();
+    fft->setProperty("InputWorkspace", inputWS);
+    fft->setPropertyValue("OutputWorkspace", "__NotUsed");
+    fft->setPropertyValue("Real", "0");
+    fft->setPropertyValue("Imaginary", "0");
+    fft->setProperty("InputImagWorkspace", inImagWS);
+    TS_ASSERT_THROWS(fft->execute(), std::runtime_error);
+    FrameworkManager::Instance().deleteWorkspace("FFT_WS_real_mismatch");
+    FrameworkManager::Instance().deleteWorkspace("FFT_WS_imag_mismatch");
+  }
+
 private:
   MatrixWorkspace_sptr createWS(int n, int dn, const std::string &name) {
     FrameworkManager::Instance();

--- a/Testing/SystemTests/tests/analysis/MuonFFTTest.py
+++ b/Testing/SystemTests/tests/analysis/MuonFFTTest.py
@@ -1,0 +1,30 @@
+﻿#pylint: disable=no-init,attribute-defined-outside-init
+import stresstesting
+from mantid.simpleapi import *
+from math import pi
+
+class MuonFFTTest(stresstesting.MantidStressTest):
+    '''Tests the FFT algorithm on a MUSR workspace, to check it can cope with rounding errors in X'''
+
+    def runTest(self):
+        Load(Filename='MUSR00022725.nxs', OutputWorkspace='MUSR00022725')
+        CropWorkspace(InputWorkspace='MUSR00022725', OutputWorkspace='MUSR00022725', XMin=0, XMax=4, EndWorkspaceIndex=63)
+
+	# create a PhaseTable with detector information
+	tab = CreateEmptyTableWorkspace()
+	tab.addColumn('int', 'DetID')
+	tab.addColumn('double', 'Phase')
+	tab.addColumn('double', 'Asym')
+	for i in range(0,32):
+	    phi = 2*pi*i/32.
+	    tab.addRow([i + 1, 0.2, phi])
+	for i in range(0,32):
+	    phi = 2*pi*i/32.
+	    tab.addRow([i + 33, 0.2, phi])
+	ows = PhaseQuad(InputWorkspace='MUSR00022725', PhaseTable='tab')
+
+	FFT(ows, Real=0, Imaginary=1, AcceptXRoundingErrors=True, OutputWorkspace='MuonFFTResults')
+
+    def validate(self):
+        self.tolerance = 1E-1
+        return ('MuonFFTResults','MuonFFTMUSR00022725.nxs')

--- a/Testing/SystemTests/tests/analysis/MuonFFTTest.py
+++ b/Testing/SystemTests/tests/analysis/MuonFFTTest.py
@@ -10,20 +10,20 @@ class MuonFFTTest(stresstesting.MantidStressTest):
         Load(Filename='MUSR00022725.nxs', OutputWorkspace='MUSR00022725')
         CropWorkspace(InputWorkspace='MUSR00022725', OutputWorkspace='MUSR00022725', XMin=0, XMax=4, EndWorkspaceIndex=63)
 
-	# create a PhaseTable with detector information
-	tab = CreateEmptyTableWorkspace()
-	tab.addColumn('int', 'DetID')
-	tab.addColumn('double', 'Phase')
-	tab.addColumn('double', 'Asym')
-	for i in range(0,32):
-	    phi = 2*pi*i/32.
-	    tab.addRow([i + 1, 0.2, phi])
-	for i in range(0,32):
-	    phi = 2*pi*i/32.
-	    tab.addRow([i + 33, 0.2, phi])
-	ows = PhaseQuad(InputWorkspace='MUSR00022725', PhaseTable='tab')
+        # create a PhaseTable with detector information
+        tab = CreateEmptyTableWorkspace()
+        tab.addColumn('int', 'DetID')
+        tab.addColumn('double', 'Phase')
+        tab.addColumn('double', 'Asym')
+        for i in range(0,32):
+            phi = 2*pi*i/32.
+            tab.addRow([i + 1, 0.2, phi])
+        for i in range(0,32):
+            phi = 2*pi*i/32.
+            tab.addRow([i + 33, 0.2, phi])
+        ows = PhaseQuad(InputWorkspace='MUSR00022725', PhaseTable='tab')
 
-	FFT(ows, Real=0, Imaginary=1, AcceptXRoundingErrors=True, OutputWorkspace='MuonFFTResults')
+        FFT(ows, Real=0, Imaginary=1, AcceptXRoundingErrors=True, OutputWorkspace='MuonFFTResults')
 
     def validate(self):
         self.tolerance = 1E-1

--- a/Testing/SystemTests/tests/analysis/reference/MuonFFTMUSR00022725.nxs.md5
+++ b/Testing/SystemTests/tests/analysis/reference/MuonFFTMUSR00022725.nxs.md5
@@ -1,0 +1,1 @@
+a063c85be6de5178fd7e7a68ea102eb4

--- a/docs/source/algorithms/FFT-v1.rst
+++ b/docs/source/algorithms/FFT-v1.rst
@@ -65,10 +65,17 @@ The Mantid FFT algorithm returns the complex array :math:`\bar{F}_K` as
 Y values of two spectra in the output workspace, one for the real and
 the other for the imaginary part of the transform. The X values are set
 to the transform frequencies and have the range approximately equal to
-:math:`[-N/L,N/L]`. The actual limits depend sllightly on whether
+:math:`[-N/L,N/L]`. The actual limits depend slightly on whether
 :math:`N` is even or odd and whether the input spectra are histograms or
 point data. The variations are of the order of :math:`\Delta\xi`. The
 zero frequency is always in the bin with index :math:`k=int(N/2)`.
+
+The X values of the input data must be evenly spaced for the FFT algorithm
+to work (all bin widths must be the same). If they contain small rounding
+errors, this requirement can be relaxed by setting the *AcceptXRoundingErrors*
+property, which will continue to process the data even if the spacings between
+different X values are unequal. Large differences in the bin widths will still
+produce a warning.
 
 Example 1
 #########


### PR DESCRIPTION
Resolves #15264 

FFT cannot be run on muon datasets because of rounding errors in X (the algorithm complains the bins are not evenly spaced). Add an option _"AcceptXRoundingErrors"_ (default false) that allows the algorithm to go ahead without the need to rebin first.

As suggested by James, the comparison is done with the average bin width and the user is warned if any width deviates significantly (10%) from this. The algorithm throws an error if there is a really big deviation (50%).

Added unit tests for this new functionality and also for other input validation. Also added a system test to try this out on a real muon dataset, and updated the documentation.

The release notes for 3.7 should be updated once this is merged.

**To test:**
- Code review and ensure all tests pass
- Using `MUSR00022725.nxs` (in the system test data):

``` python
from math import pi
Load(Filename='MUSR00022725.nxs', OutputWorkspace='MUSR00022725')
CropWorkspace(InputWorkspace='MUSR00022725', OutputWorkspace='MUSR00022725', XMin=0, XMax=4, EndWorkspaceIndex=63)

# Create a PhaseTable with some arbitrary detector information
tab = CreateEmptyTableWorkspace()
tab.addColumn('int', 'DetID')
tab.addColumn('double', 'Phase')
tab.addColumn('double', 'Asym')
for i in range(0,32):
    phi = 2*pi*i/32.
    tab.addRow([1, 0.2, phi])
for i in range(0,32):
    phi = 2*pi*i/32.
    tab.addRow([1, 0.2, phi])
ows = PhaseQuad(InputWorkspace='MUSR00022725', PhaseTable='tab')
```

and then verify that

``` python
result = FFT(ows, Real=0, Imaginary=1)
```

fails but

``` python
result = FFT(ows, Real=0, Imaginary=1, AcceptXRoundingErrors=True)
```

works.
