### PR TITLE
Remove unread std::vector found with cppcheck 1.72

### DIFF
--- a/Framework/MDAlgorithms/src/CreateMD.cpp
+++ b/Framework/MDAlgorithms/src/CreateMD.cpp
@@ -447,8 +447,6 @@ Mantid::API::IMDEventWorkspace_sptr CreateMD::single_run(
 
   std::vector<std::vector<double>> ub_params{alatt, angdeg, u, v};
 
-  std::vector<double> goniometer_params{psi, gl, gs};
-
   if (any_given(ub_params) && !all_given(ub_params)) {
     throw std::invalid_argument(
         "Either specify all of alatt, angledeg, u, v or none of them");


### PR DESCRIPTION
This removes a unread vector that recently appeared as a [warning in cppcheck 1.72](http://builds.mantidproject.org/view/Static%20Analysis/job/cppcheck-1.72/1006/cppcheckResult/source.16/). I think that `std::vector::push_back(...)` was previously making it difficult to determine that this variable wasn't being used. 

no release notes: this is a local variable that isn't exposed to users.

testing & code review: Verify that the local  variable `goniometer_params` is never read. 
