### PR TITLE
Update ParaView version from 5.0.0-RC1 to 5.0.0

### DIFF
--- a/buildconfig/CMake/ParaViewSetup.cmake
+++ b/buildconfig/CMake/ParaViewSetup.cmake
@@ -1,7 +1,7 @@
 # This file will setup some common items that later setups depend on
 
 # Set the version of ParaView that is compatible with the Mantid code base
-set ( COMPATIBLE_PARAVIEW_VERSION "5.0.0-RC1" )
+set ( COMPATIBLE_PARAVIEW_VERSION "5.0.0" )
 
 # Set the name of the OSX application as this tends to be different
 set ( OSX_PARAVIEW_APP "paraview.app" )

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -8,7 +8,7 @@ setlocal enableextensions enabledelayedexpansion
 :: BUILD_THREADS & PARAVIEW_DIR should be set in the configuration of each slave.
 :: CMake, git & git-lfs should be on the PATH
 ::
-:: All nodes currently have PARAVIEW_DIR=4.3.b40280, PARAVIEW_NEXT_DIR=5.0.0-RC1
+:: All nodes currently have PARAVIEW_DIR=4.3.b40280, PARAVIEW_NEXT_DIR=5.0.0
 :: and PARAVIEW_MSVC2015_DIR=4.3.b40280-msvc2015
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 call cmake.exe --version


### PR DESCRIPTION
This updates the `COMPATIBLE_PARAVIEW_VERSION` variable to from v5.0.0-RC1 to v5.0.0.  

This PR updates master. PR #15311 updates the release branch.

testing and code review: I believe this variable is only used to configure a header file. While this was much more important before we bundled ParaView, it still should be correct!
