### PR TITLE
Remove deprecated add function box in Set Column Values

### DIFF
--- a/MantidPlot/src/SetColValuesDialog.cpp
+++ b/MantidPlot/src/SetColValuesDialog.cpp
@@ -80,10 +80,6 @@ SetColValuesDialog::SetColValuesDialog( ScriptingEnv *env, Table* t, Qt::WFlags 
 	}
 
 	QGridLayout *gl1 = new QGridLayout();
-	functions = new QComboBox();
-	gl1->addWidget(functions, 0, 0);
-	btnAddFunction = new QPushButton(tr( "Add function" ));
-	gl1->addWidget(btnAddFunction, 0, 1);
 	boxColumn = new QComboBox();
 	gl1->addWidget(boxColumn, 1, 0);
 	btnAddCol = new QPushButton(tr( "Add column" ));
@@ -141,16 +137,10 @@ SetColValuesDialog::SetColValuesDialog( ScriptingEnv *env, Table* t, Qt::WFlags 
 	setFocusProxy (commands);
 	commands->setFocus();
 
-	functions->insertStringList(scriptingEnv()->mathFunctions(), -1);
-	if (functions->count() > 0)
-		insertExplain(0);
-
-	connect(btnAddFunction, SIGNAL(clicked()),this, SLOT(insertFunction()));
 	connect(btnAddCol, SIGNAL(clicked()),this, SLOT(insertCol()));
 	connect(addCellButton, SIGNAL(clicked()),this, SLOT(insertCell()));
 	connect(btnApply, SIGNAL(clicked()),this, SLOT(apply()));
 	connect(btnCancel, SIGNAL(clicked()),this, SLOT(close()));
-	connect(functions, SIGNAL(activated(int)),this, SLOT(insertExplain(int)));
 	connect(buttonPrev, SIGNAL(clicked()), this, SLOT(prevColumn()));
 	connect(buttonNext, SIGNAL(clicked()), this, SLOT(nextColumn()));
 
@@ -223,16 +213,6 @@ bool SetColValuesDialog::apply()
 	
 	table->setCommand(col, oldFormula);
 	return false;
-}
-
-void SetColValuesDialog::insertExplain(int index)
-{
-	explain->setText(scriptingEnv()->mathFunctionDoc(functions->text(index)));
-}
-
-void SetColValuesDialog::insertFunction()
-{
-  QMessageBox::warning(this, "", "Deprepcated functionality");
 }
 
 void SetColValuesDialog::insertCol()

--- a/MantidPlot/src/SetColValuesDialog.h
+++ b/MantidPlot/src/SetColValuesDialog.h
@@ -61,10 +61,8 @@ private slots:
 	bool apply();
 	void prevColumn();
 	void nextColumn();
-	void insertFunction();
 	void insertCol();
 	void insertCell();
-	void insertExplain(int index);
 	void updateColumn(int sc);
 
 private:
@@ -74,9 +72,7 @@ private:
 	QSize sizeHint() const ;
 	void customEvent( QEvent *e );
 
-    QComboBox* functions;
     QComboBox* boxColumn;
-    QPushButton* btnAddFunction;
     QPushButton* btnAddCol;
     QPushButton* btnCancel;
     QPushButton *buttonPrev;


### PR DESCRIPTION
closes #11598

The functionality has been deprecated for years.  Remove the gui elements.
## release notes

not worth mentioning
## to test
1. open mantidplot
2. File->new->new table
3. Right click on a column and select "Set Column Values"
4. The dialog box should not have a button that says "Add Function"
5. Other than that the box should be functional
