### PR TITLE
Algorithm refactoring --- example for first steps

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -19,6 +19,7 @@ set ( SRC_FILES
 	src/ApplyTransmissionCorrection.cpp
 	src/AsymmetryCalc.cpp
 	src/AverageLogData.cpp
+        src/BasicInstrumentInfo.cpp
 	src/BinaryOperateMasks.cpp
 	src/BinaryOperation.cpp
 	src/CalMuonDeadTime.cpp
@@ -298,6 +299,7 @@ set ( INC_FILES
 	inc/MantidAlgorithms/ApplyTransmissionCorrection.h
 	inc/MantidAlgorithms/AsymmetryCalc.h
 	inc/MantidAlgorithms/AverageLogData.h
+	inc/MantidAlgorithms/BasicInstrumentInfo.h
 	inc/MantidAlgorithms/BinaryOperateMasks.h
 	inc/MantidAlgorithms/BinaryOperation.h
 	inc/MantidAlgorithms/CalMuonDeadTime.h
@@ -589,6 +591,7 @@ set ( TEST_FILES
 	ApplyTransmissionCorrectionTest.h
 	AsymmetryCalcTest.h
 	AverageLogDataTest.h
+	BasicInstrumentInfoTest.h
 	BinaryOperateMasksTest.h
 	BinaryOperationTest.h
 	CalMuonDeadTimeTest.h

--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -133,6 +133,7 @@ set ( SRC_FILES
 	src/GenerateIPythonNotebook.cpp
 	src/GeneratePeaks.cpp
 	src/GeneratePythonScript.cpp
+        src/GeometryInfo.cpp
 	src/GetAllEi.cpp
 	src/GetDetOffsetsMultiPeaks.cpp
 	src/GetDetectorOffsets.cpp
@@ -414,6 +415,7 @@ set ( INC_FILES
 	inc/MantidAlgorithms/GenerateIPythonNotebook.h
 	inc/MantidAlgorithms/GeneratePeaks.h
 	inc/MantidAlgorithms/GeneratePythonScript.h
+        inc/MantidAlgorithms/GeometryInfo.h
 	inc/MantidAlgorithms/GetAllEi.h
 	inc/MantidAlgorithms/GetDetOffsetsMultiPeaks.h
 	inc/MantidAlgorithms/GetDetectorOffsets.h
@@ -700,6 +702,7 @@ set ( TEST_FILES
 	GenerateIPythonNotebookTest.h
 	GeneratePeaksTest.h
 	GeneratePythonScriptTest.h
+        GeometryInfoTest.h
 	GetAllEiTest.h
 	GetDetOffsetsMultiPeaksTest.h
 	GetDetectorOffsetsTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/ApplyTransmissionCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ApplyTransmissionCorrection.h
@@ -4,7 +4,7 @@
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/SpectrumAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -42,10 +42,10 @@ namespace Algorithms {
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport ApplyTransmissionCorrection : public API::Algorithm {
+class DLLExport ApplyTransmissionCorrection : public SpectrumAlgorithm {
 public:
   /// (Empty) Constructor
-  ApplyTransmissionCorrection() : API::Algorithm() {}
+  ApplyTransmissionCorrection() : SpectrumAlgorithm() {}
   /// Virtual destructor
   virtual ~ApplyTransmissionCorrection() {}
   /// Algorithm's name

--- a/Framework/Algorithms/inc/MantidAlgorithms/BasicInstrumentInfo.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BasicInstrumentInfo.h
@@ -3,6 +3,8 @@
 
 #include <boost/shared_ptr.hpp>
 
+#include "MantidKernel/V3D.h"
+
 namespace Mantid {
 
 namespace Geometry {
@@ -23,11 +25,17 @@ public:
   const Geometry::Instrument &getInstrument() const;
   const Geometry::IComponent &getSource() const;
   const Geometry::IComponent &getSample() const;
+  Kernel::V3D getSourcePos() const;
+  Kernel::V3D getSamplePos() const;
+  double getL1() const;
 
 private:
   boost::shared_ptr<const Geometry::Instrument> m_instrument;
   boost::shared_ptr<const Geometry::IComponent> m_source;
   boost::shared_ptr<const Geometry::IComponent> m_sample;
+  Kernel::V3D m_sourcePos;
+  Kernel::V3D m_samplePos;
+  double m_L1;
 };
 }
 }

--- a/Framework/Algorithms/inc/MantidAlgorithms/BasicInstrumentInfo.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BasicInstrumentInfo.h
@@ -1,0 +1,35 @@
+#ifndef MANTID_ALGORITHMS_BASICINSTRUMENT_INFO_H_
+#define MANTID_ALGORITHMS_BASICINSTRUMENT_INFO_H_
+
+#include <boost/shared_ptr.hpp>
+
+namespace Mantid {
+
+namespace Geometry {
+class Instrument;
+class IComponent;
+}
+
+namespace API {
+class MatrixWorkspace;
+}
+
+namespace Algorithms {
+
+class BasicInstrumentInfo {
+public:
+  BasicInstrumentInfo(const API::MatrixWorkspace &workspace);
+
+  const Geometry::Instrument &getInstrument() const;
+  const Geometry::IComponent &getSource() const;
+  const Geometry::IComponent &getSample() const;
+
+private:
+  boost::shared_ptr<const Geometry::Instrument> m_instrument;
+  boost::shared_ptr<const Geometry::IComponent> m_source;
+  boost::shared_ptr<const Geometry::IComponent> m_sample;
+};
+}
+}
+
+#endif /* MANTID_ALGORITHMS_BASICINSTRUMENT_INFO_H_ */

--- a/Framework/Algorithms/inc/MantidAlgorithms/BasicInstrumentInfo.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BasicInstrumentInfo.h
@@ -4,6 +4,7 @@
 #include <boost/shared_ptr.hpp>
 
 #include "MantidKernel/V3D.h"
+#include "MantidAlgorithms/DllConfig.h"
 
 namespace Mantid {
 
@@ -18,7 +19,7 @@ class MatrixWorkspace;
 
 namespace Algorithms {
 
-class BasicInstrumentInfo {
+class MANTID_ALGORITHMS_DLL BasicInstrumentInfo {
 public:
   BasicInstrumentInfo(const API::MatrixWorkspace &workspace);
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/GeometryInfo.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GeometryInfo.h
@@ -16,7 +16,7 @@ class ISpectrum;
 
 namespace Algorithms {
 
-class GeometryInfo {
+class MANTID_ALGORITHMS_DLL GeometryInfo {
 public:
   GeometryInfo(const BasicInstrumentInfo &instrument_info,
                const API::ISpectrum &spectrum);

--- a/Framework/Algorithms/inc/MantidAlgorithms/GeometryInfo.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GeometryInfo.h
@@ -1,0 +1,39 @@
+#ifndef MANTID_ALGORITHMS_GEOMETRYINFO_H_
+#define MANTID_ALGORITHMS_GEOMETRYINFO_H_
+
+#include "MantidAlgorithms/BasicInstrumentInfo.h"
+
+namespace Mantid {
+
+namespace Geometry {
+class Instrument;
+class IDetector;
+}
+
+namespace API {
+class ISpectrum;
+}
+
+namespace Algorithms {
+
+class GeometryInfo {
+public:
+  GeometryInfo(const BasicInstrumentInfo &instrument_info,
+               const API::ISpectrum &spectrum);
+
+  bool isMonitor() const;
+  bool isMasked() const;
+  double getL1() const;
+  double getL2() const;
+  double getTwoTheta() const;
+  double getSignedTwoTheta() const;
+  boost::shared_ptr<const Geometry::IDetector> getDetector() const;
+
+private:
+  const BasicInstrumentInfo &m_instrument_info;
+  boost::shared_ptr<const Geometry::IDetector> m_detector;
+};
+}
+}
+
+#endif /*MANTID_ALGORITHMS_GEOMETRYINFO_H_*/

--- a/Framework/Algorithms/inc/MantidAlgorithms/Getters.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Getters.h
@@ -1,0 +1,27 @@
+#ifndef MANTID_ALGORITHMS_GETTERS_H_
+#define MANTID_ALGORITHMS_GETTERS_H_
+
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAlgorithms/GeometryInfo.h"
+
+namespace Mantid {
+namespace Algorithms {
+namespace Getters {
+static auto isMonitor = std::mem_fn(&GeometryInfo::isMonitor);
+static auto isMasked = std::mem_fn(&GeometryInfo::isMasked);
+static auto twoTheta = std::mem_fn(&GeometryInfo::getTwoTheta);
+static auto constX = std::mem_fn(&API::MatrixWorkspace::readX);
+static auto x = std::mem_fn(
+    (std::vector<double> & (API::MatrixWorkspace::*)(const std::size_t)) &
+    API::MatrixWorkspace::dataX);
+static auto y = std::mem_fn(
+    (std::vector<double> & (API::MatrixWorkspace::*)(const std::size_t)) &
+    API::MatrixWorkspace::dataY);
+static auto e = std::mem_fn(
+    (std::vector<double> & (API::MatrixWorkspace::*)(const std::size_t)) &
+    API::MatrixWorkspace::dataE);
+}
+}
+}
+
+#endif /*MANTID_ALGORITHMS_GETTERS_H_*/

--- a/Framework/Algorithms/inc/MantidAlgorithms/SpectrumAlgorithm.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpectrumAlgorithm.h
@@ -1,0 +1,70 @@
+#ifndef MANTID_ALGORITHMS_SPECTRUMALGORITHM_H_
+#define MANTID_ALGORITHMS_SPECTRUMALGORITHM_H_
+
+#include <tuple>
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/Getters.h"
+#include "MantidAlgorithms/GeometryInfo.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+class MANTID_API_DLL SpectrumAlgorithm : public API::Algorithm {
+public:
+  virtual ~SpectrumAlgorithm() override = default;
+
+private:
+  // 3 little helpers for generating a sequence 1,2,3,.... Used for extracting
+  // arguments from tuple.
+  template <int...> struct seq {};
+  template <int N, int... S> struct gens : gens<N - 1, N - 1, S...> {};
+  template <int... S> struct gens<0, S...> { typedef seq<S...> type; };
+
+  template <class WS, class T1, int... S1, class T2, int... S2, class T3,
+            int... S3, class OP>
+  void for_each(const WS &inputWorkspace, T1 inputGetters, seq<S1...>,
+                T2 geometryGetters, seq<S2...>, WS &outputWorkspace,
+                T3 outputGetters, seq<S3...>, const OP &operation) {
+    auto count = static_cast<int64_t>(inputWorkspace.getNumberHistograms());
+    API::Progress progress(this, 0.0, 1.0, count);
+    BasicInstrumentInfo info(inputWorkspace);
+
+    PARALLEL_FOR2((&inputWorkspace), (&outputWorkspace))
+    for (int i = 0; i < count; ++i) {
+      PARALLEL_START_INTERUPT_REGION
+      try {
+        GeometryInfo geom(info, *(inputWorkspace.getSpectrum(i)));
+        operation(std::get<S1>(inputGetters)(inputWorkspace, i)...,
+                  std::get<S2>(geometryGetters)(geom)...,
+                  std::get<S3>(outputGetters)(outputWorkspace, i)...);
+      } catch (Kernel::Exception::NotFoundError &) {
+        g_log.warning() << "Spectrum index " << i
+                        << " has no detector assigned to it -- skipping"
+                        << std::endl;
+      }
+      progress.report(name());
+      PARALLEL_END_INTERUPT_REGION
+    }
+    PARALLEL_CHECK_INTERUPT_REGION
+  }
+
+protected:
+  template <class WS, class... Args1, class... Args2, class... Args3, class OP>
+  void for_each(const WS &inputWorkspace, std::tuple<Args1...> inputGetters,
+                std::tuple<Args2...> geometryGetters, WS &outputWorkspace,
+                std::tuple<Args3...> outputGetters, const OP &operation) {
+    for_each(inputWorkspace, inputGetters,
+             typename gens<sizeof...(Args1)>::type(), geometryGetters,
+             typename gens<sizeof...(Args2)>::type(), outputWorkspace,
+             outputGetters, typename gens<sizeof...(Args3)>::type(), operation);
+  }
+};
+
+/// Typedef for a shared pointer to a SpectrumAlgorithm
+typedef boost::shared_ptr<SpectrumAlgorithm> SpectrumAlgorithm_sptr;
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /*MANTID_ALGORITHMS_SPECTRUMALGORITHM_H_*/

--- a/Framework/Algorithms/inc/MantidAlgorithms/SpectrumAlgorithm.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpectrumAlgorithm.h
@@ -10,7 +10,7 @@
 namespace Mantid {
 namespace Algorithms {
 
-class MANTID_API_DLL SpectrumAlgorithm : public API::Algorithm {
+class MANTID_ALGORITHMS_DLL SpectrumAlgorithm : public API::Algorithm {
 public:
   virtual ~SpectrumAlgorithm() override = default;
 

--- a/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
+++ b/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
@@ -49,6 +49,43 @@ void ApplyTransmissionCorrection::init() {
       "If true, a theta-dependent transmission correction will be applied.");
 }
 
+class ApplyTransmissionCorrectionToSpectrum {
+public:
+  ApplyTransmissionCorrectionToSpectrum(const std::vector<double> &TrIn,
+                                        const std::vector<double> &ETrIn,
+                                        const bool thetaDependent)
+      : m_TrIn(TrIn), m_ETrIn(ETrIn), m_thetaDependent(thetaDependent) {}
+
+  void operator()(const std::vector<double> &inX, bool isMonitor, bool isMasked,
+                  double twoTheta, std::vector<double> &outX,
+                  std::vector<double> &outY, std::vector<double> &outE) const {
+    // Copy over the X data
+    outX = inX;
+
+    // Skip if we have a monitor or if the detector is masked.
+    if (isMonitor || isMasked)
+      return;
+
+    // Compute theta-dependent transmission term for each wavelength bin
+    const double exp_term = (1.0 / cos(twoTheta) + 1.0) / 2.0;
+    for (int j = 0; j < static_cast<int>(inX.size() - 1); j++) {
+      if (!m_thetaDependent) {
+        outY[j] = 1.0 / m_TrIn[j];
+        outE[j] = std::fabs(m_ETrIn[j] * m_TrIn[j] * m_TrIn[j]);
+      } else {
+        outE[j] =
+            std::fabs(m_ETrIn[j] * exp_term / pow(m_TrIn[j], exp_term + 1.0));
+        outY[j] = 1.0 / pow(m_TrIn[j], exp_term);
+      }
+    }
+  }
+
+private:
+  const std::vector<double> &m_TrIn;
+  const std::vector<double> &m_ETrIn;
+  const bool m_thetaDependent;
+};
+
 void ApplyTransmissionCorrection::exec() {
   // Check whether we only need to divided the workspace by
   // the transmission.
@@ -81,61 +118,14 @@ void ApplyTransmissionCorrection::exec() {
     ETrIn = transWS->readE(0);
   }
 
-  const int numHists = static_cast<int>(inputWS->getNumberHistograms());
-  Progress progress(this, 0.0, 1.0, numHists);
-
   // Create a Workspace2D to match the intput workspace
   MatrixWorkspace_sptr corrWS = WorkspaceFactory::Instance().create(inputWS);
 
-  // Loop through the spectra and apply correction
-  PARALLEL_FOR2(inputWS, corrWS)
-  for (int i = 0; i < numHists; i++) {
-    PARALLEL_START_INTERUPT_REGION
-
-    IDetector_const_sptr det;
-    try {
-      det = inputWS->getDetector(i);
-    } catch (Exception::NotFoundError &) {
-      g_log.warning() << "Spectrum index " << i
-                      << " has no detector assigned to it - discarding"
-                      << std::endl;
-      // Catch if no detector. Next line tests whether this happened - test
-      // placed
-      // outside here because Mac Intel compiler doesn't like 'continue' in a
-      // catch
-      // in an openmp block.
-    }
-    // If no detector found, skip onto the next spectrum
-    if (!det)
-      continue;
-
-    // Copy over the X data
-    corrWS->dataX(i) = inputWS->readX(i);
-
-    // Skip if we have a monitor or if the detector is masked.
-    if (det->isMonitor() || det->isMasked())
-      continue;
-
-    // Compute theta-dependent transmission term for each wavelength bin
-    MantidVec &YOut = corrWS->dataY(i);
-    MantidVec &EOut = corrWS->dataE(i);
-
-    const double exp_term =
-        (1.0 / cos(inputWS->detectorTwoTheta(det)) + 1.0) / 2.0;
-    for (int j = 0; j < static_cast<int>(inputWS->readY(0).size()); j++) {
-      if (!thetaDependent) {
-        YOut[j] = 1.0 / TrIn[j];
-        EOut[j] = std::fabs(ETrIn[j] * TrIn[j] * TrIn[j]);
-      } else {
-        EOut[j] = std::fabs(ETrIn[j] * exp_term / pow(TrIn[j], exp_term + 1.0));
-        YOut[j] = 1.0 / pow(TrIn[j], exp_term);
-      }
-    }
-
-    progress.report("Applying Transmission Correction");
-    PARALLEL_END_INTERUPT_REGION
-  }
-  PARALLEL_CHECK_INTERUPT_REGION
+  ApplyTransmissionCorrectionToSpectrum apply(TrIn, ETrIn, thetaDependent);
+  this->for_each(
+      *inputWS, std::make_tuple(Getters::constX),
+      std::make_tuple(Getters::isMonitor, Getters::isMasked, Getters::twoTheta),
+      *corrWS, std::make_tuple(Getters::x, Getters::y, Getters::e), apply);
 
   outputWS = inputWS * corrWS;
   setProperty("OutputWorkspace", outputWS);

--- a/Framework/Algorithms/src/BasicInstrumentInfo.cpp
+++ b/Framework/Algorithms/src/BasicInstrumentInfo.cpp
@@ -27,16 +27,10 @@ const Geometry::IComponent &BasicInstrumentInfo::getSample() const {
   return *m_sample;
 }
 
-Kernel::V3D BasicInstrumentInfo::getSourcePos() const {
-  return m_sourcePos;
-}
+Kernel::V3D BasicInstrumentInfo::getSourcePos() const { return m_sourcePos; }
 
-Kernel::V3D BasicInstrumentInfo::getSamplePos() const {
-  return m_samplePos;
-}
+Kernel::V3D BasicInstrumentInfo::getSamplePos() const { return m_samplePos; }
 
-double BasicInstrumentInfo::getL1() const {
-  return m_L1;
-}
+double BasicInstrumentInfo::getL1() const { return m_L1; }
 }
 }

--- a/Framework/Algorithms/src/BasicInstrumentInfo.cpp
+++ b/Framework/Algorithms/src/BasicInstrumentInfo.cpp
@@ -1,0 +1,27 @@
+#include "MantidAlgorithms/BasicInstrumentInfo.h"
+
+#include "MantidAPI/MatrixWorkspace.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+BasicInstrumentInfo::BasicInstrumentInfo(const API::MatrixWorkspace &workspace)
+    : m_instrument(workspace.getInstrument()) {
+  // TODO: Create these only when needed (thread-safe via atomics)
+  m_source = m_instrument->getSource();
+  m_sample = m_instrument->getSample();
+}
+
+const Geometry::Instrument &BasicInstrumentInfo::getInstrument() const {
+  return *m_instrument;
+}
+
+const Geometry::IComponent &BasicInstrumentInfo::getSource() const {
+  return *m_source;
+}
+
+const Geometry::IComponent &BasicInstrumentInfo::getSample() const {
+  return *m_sample;
+}
+}
+}

--- a/Framework/Algorithms/src/BasicInstrumentInfo.cpp
+++ b/Framework/Algorithms/src/BasicInstrumentInfo.cpp
@@ -10,6 +10,9 @@ BasicInstrumentInfo::BasicInstrumentInfo(const API::MatrixWorkspace &workspace)
   // TODO: Create these only when needed (thread-safe via atomics)
   m_source = m_instrument->getSource();
   m_sample = m_instrument->getSample();
+  m_sourcePos = m_source->getPos();
+  m_samplePos = m_sample->getPos();
+  m_L1 = getSource().getDistance(getSample());
 }
 
 const Geometry::Instrument &BasicInstrumentInfo::getInstrument() const {
@@ -22,6 +25,18 @@ const Geometry::IComponent &BasicInstrumentInfo::getSource() const {
 
 const Geometry::IComponent &BasicInstrumentInfo::getSample() const {
   return *m_sample;
+}
+
+Kernel::V3D BasicInstrumentInfo::getSourcePos() const {
+  return m_sourcePos;
+}
+
+Kernel::V3D BasicInstrumentInfo::getSamplePos() const {
+  return m_samplePos;
+}
+
+double BasicInstrumentInfo::getL1() const {
+  return m_L1;
 }
 }
 }

--- a/Framework/Algorithms/src/GeometryInfo.cpp
+++ b/Framework/Algorithms/src/GeometryInfo.cpp
@@ -35,9 +35,7 @@ bool GeometryInfo::isMonitor() const { return m_detector->isMonitor(); }
 
 bool GeometryInfo::isMasked() const { return m_detector->isMasked(); }
 
-double GeometryInfo::getL1() const {
-  return m_instrument_info.getL1();
-}
+double GeometryInfo::getL1() const { return m_instrument_info.getL1(); }
 
 double GeometryInfo::getL2() const {
   if (!isMonitor()) {

--- a/Framework/Algorithms/src/GeometryInfo.cpp
+++ b/Framework/Algorithms/src/GeometryInfo.cpp
@@ -36,9 +36,7 @@ bool GeometryInfo::isMonitor() const { return m_detector->isMonitor(); }
 bool GeometryInfo::isMasked() const { return m_detector->isMasked(); }
 
 double GeometryInfo::getL1() const {
-  auto &source = m_instrument_info.getSource();
-  auto &sample = m_instrument_info.getSample();
-  return source.getDistance(sample);
+  return m_instrument_info.getL1();
 }
 
 double GeometryInfo::getL2() const {
@@ -53,12 +51,8 @@ double GeometryInfo::getL2() const {
 }
 
 double GeometryInfo::getTwoTheta() const {
-  auto &source = m_instrument_info.getSource();
-  auto &sample = m_instrument_info.getSample();
-
-  // TODO move these to BasicInstrumentInfo
-  const Kernel::V3D samplePos = sample.getPos();
-  const Kernel::V3D beamLine = samplePos - source.getPos();
+  const Kernel::V3D samplePos = m_instrument_info.getSamplePos();
+  const Kernel::V3D beamLine = samplePos - m_instrument_info.getSourcePos();
 
   if (beamLine.nullVector()) {
     throw Kernel::Exception::InstrumentDefinitionError(
@@ -69,12 +63,8 @@ double GeometryInfo::getTwoTheta() const {
 }
 
 double GeometryInfo::getSignedTwoTheta() const {
-  auto &source = m_instrument_info.getSource();
-  auto &sample = m_instrument_info.getSample();
-
-  // TODO move these to BasicInstrumentInfo
-  const Kernel::V3D samplePos = sample.getPos();
-  const Kernel::V3D beamLine = samplePos - source.getPos();
+  const Kernel::V3D samplePos = m_instrument_info.getSamplePos();
+  const Kernel::V3D beamLine = samplePos - m_instrument_info.getSourcePos();
 
   if (beamLine.nullVector()) {
     throw Kernel::Exception::InstrumentDefinitionError(

--- a/Framework/Algorithms/src/GeometryInfo.cpp
+++ b/Framework/Algorithms/src/GeometryInfo.cpp
@@ -1,0 +1,93 @@
+#include "MantidAlgorithms/GeometryInfo.h"
+
+#include "MantidAPI/ISpectrum.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/DetectorGroup.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+GeometryInfo::GeometryInfo(const BasicInstrumentInfo &instrument_info,
+                           const API::ISpectrum &spectrum)
+    : m_instrument_info(instrument_info) {
+  const std::set<detid_t> &dets = spectrum.getDetectorIDs();
+
+  const size_t ndets = dets.size();
+  if (ndets == 1) {
+    // If only 1 detector for the spectrum number, just return it
+    m_detector = m_instrument_info.getInstrument().getDetector(*dets.begin());
+  } else if (ndets == 0) {
+    throw Kernel::Exception::NotFoundError("MatrixWorkspace::getDetector(): No "
+                                           "detectors for this workspace "
+                                           "index.",
+                                           "");
+  } else {
+    // Else need to construct a DetectorGroup and use that
+    std::vector<Geometry::IDetector_const_sptr> dets_ptr =
+        m_instrument_info.getInstrument().getDetectors(dets);
+    m_detector = Geometry::IDetector_const_sptr(
+        new Geometry::DetectorGroup(dets_ptr, false));
+  }
+}
+
+bool GeometryInfo::isMonitor() const { return m_detector->isMonitor(); }
+
+bool GeometryInfo::isMasked() const { return m_detector->isMasked(); }
+
+double GeometryInfo::getL1() const {
+  auto &source = m_instrument_info.getSource();
+  auto &sample = m_instrument_info.getSample();
+  return source.getDistance(sample);
+}
+
+double GeometryInfo::getL2() const {
+  if (!isMonitor()) {
+    auto &sample = m_instrument_info.getSample();
+    return m_detector->getDistance(sample);
+  } else {
+    // If this is a monitor then make l1+l2 = source-detector distance
+    auto &source = m_instrument_info.getSource();
+    return m_detector->getDistance(source) - getL1();
+  }
+}
+
+double GeometryInfo::getTwoTheta() const {
+  auto &source = m_instrument_info.getSource();
+  auto &sample = m_instrument_info.getSample();
+
+  // TODO move these to BasicInstrumentInfo
+  const Kernel::V3D samplePos = sample.getPos();
+  const Kernel::V3D beamLine = samplePos - source.getPos();
+
+  if (beamLine.nullVector()) {
+    throw Kernel::Exception::InstrumentDefinitionError(
+        "Source and sample are at same position!");
+  }
+
+  return m_detector->getTwoTheta(samplePos, beamLine);
+}
+
+double GeometryInfo::getSignedTwoTheta() const {
+  auto &source = m_instrument_info.getSource();
+  auto &sample = m_instrument_info.getSample();
+
+  // TODO move these to BasicInstrumentInfo
+  const Kernel::V3D samplePos = sample.getPos();
+  const Kernel::V3D beamLine = samplePos - source.getPos();
+
+  if (beamLine.nullVector()) {
+    throw Kernel::Exception::InstrumentDefinitionError(
+        "Source and sample are at same position!");
+  }
+  // Get the instrument up axis.
+  const Kernel::V3D &instrumentUpAxis =
+      m_instrument_info.getInstrument().getReferenceFrame()->vecPointingUp();
+  return m_detector->getSignedTwoTheta(samplePos, beamLine, instrumentUpAxis);
+}
+
+boost::shared_ptr<const Geometry::IDetector> GeometryInfo::getDetector() const {
+  return m_detector;
+}
+}
+}

--- a/Framework/Algorithms/test/BasicInstrumentInfoTest.h
+++ b/Framework/Algorithms/test/BasicInstrumentInfoTest.h
@@ -1,0 +1,52 @@
+#ifndef MANTID_ALGORITHMS_BASICINSTRUMENTINFOTEST_H_
+#define MANTID_ALGORITHMS_BASICINSTRUMENTINFOTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidAlgorithms/BasicInstrumentInfo.h"
+
+using namespace Mantid;
+using namespace Mantid::API;
+using namespace Mantid::Algorithms;
+using namespace Mantid::DataObjects;
+
+class BasicInstrumentInfoTest : public CxxTest::TestSuite {
+public:
+  static BasicInstrumentInfoTest *createSuite() {
+    return new BasicInstrumentInfoTest();
+  }
+  static void destroySuite(BasicInstrumentInfoTest *suite) { delete suite; }
+
+  BasicInstrumentInfoTest() {
+    workspace = WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument(
+        1, 2, false);
+  }
+
+  void test_constructor() {
+    TS_ASSERT_THROWS_NOTHING(BasicInstrumentInfo(*workspace));
+  }
+
+  void test_getInstrument() {
+    auto info = BasicInstrumentInfo(*workspace);
+    // This might fail if we get a null instrument, so we test for throw. Since
+    // workspace->getInstrument() creates a copy of the instrument there is no
+    // point in attempting to verify that the pointer is "correct".
+    TS_ASSERT_THROWS_NOTHING(info.getInstrument());
+  }
+
+  void test_getSource() {
+    auto info = BasicInstrumentInfo(*workspace);
+    TS_ASSERT_THROWS_NOTHING(info.getSource());
+  }
+
+  void test_getSample() {
+    auto info = BasicInstrumentInfo(*workspace);
+    TS_ASSERT_THROWS_NOTHING(info.getSample());
+  }
+
+private:
+  EventWorkspace_sptr workspace;
+};
+
+#endif /* MANTID_ALGORITHMS_BASICINSTRUMENTINFOTEST_H_ */

--- a/Framework/Algorithms/test/BasicInstrumentInfoTest.h
+++ b/Framework/Algorithms/test/BasicInstrumentInfoTest.h
@@ -19,8 +19,8 @@ public:
   static void destroySuite(BasicInstrumentInfoTest *suite) { delete suite; }
 
   BasicInstrumentInfoTest() {
-    workspace = WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument(
-        1, 2, false);
+    workspace = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
+        1, 1, false);
   }
 
   void test_constructor() {
@@ -45,8 +45,23 @@ public:
     TS_ASSERT_THROWS_NOTHING(info.getSample());
   }
 
+  void test_getSourcePos() {
+    auto info = BasicInstrumentInfo(*workspace);
+    TS_ASSERT_EQUALS(info.getSourcePos(), Kernel::V3D(-20.0,0.0,0.0));
+  }
+
+  void test_getSamplePos() {
+    auto info = BasicInstrumentInfo(*workspace);
+    TS_ASSERT_EQUALS(info.getSamplePos(), Kernel::V3D(0.0,0.0,0.0));
+  }
+
+  void test_getL1() {
+    auto info = BasicInstrumentInfo(*workspace);
+    TS_ASSERT_EQUALS(info.getL1(), 20.0);
+  }
+
 private:
-  EventWorkspace_sptr workspace;
+  Workspace2D_sptr workspace;
 };
 
 #endif /* MANTID_ALGORITHMS_BASICINSTRUMENTINFOTEST_H_ */

--- a/Framework/Algorithms/test/BasicInstrumentInfoTest.h
+++ b/Framework/Algorithms/test/BasicInstrumentInfoTest.h
@@ -24,7 +24,7 @@ public:
   }
 
   void test_constructor() {
-    TS_ASSERT_THROWS_NOTHING(BasicInstrumentInfo(*workspace));
+    TS_ASSERT_THROWS_NOTHING(BasicInstrumentInfo info(*workspace));
   }
 
   void test_getInstrument() {

--- a/Framework/Algorithms/test/BasicInstrumentInfoTest.h
+++ b/Framework/Algorithms/test/BasicInstrumentInfoTest.h
@@ -47,12 +47,12 @@ public:
 
   void test_getSourcePos() {
     auto info = BasicInstrumentInfo(*workspace);
-    TS_ASSERT_EQUALS(info.getSourcePos(), Kernel::V3D(-20.0,0.0,0.0));
+    TS_ASSERT_EQUALS(info.getSourcePos(), Kernel::V3D(-20.0, 0.0, 0.0));
   }
 
   void test_getSamplePos() {
     auto info = BasicInstrumentInfo(*workspace);
-    TS_ASSERT_EQUALS(info.getSamplePos(), Kernel::V3D(0.0,0.0,0.0));
+    TS_ASSERT_EQUALS(info.getSamplePos(), Kernel::V3D(0.0, 0.0, 0.0));
   }
 
   void test_getL1() {

--- a/Framework/Algorithms/test/GeometryInfoTest.h
+++ b/Framework/Algorithms/test/GeometryInfoTest.h
@@ -1,0 +1,135 @@
+#ifndef MANTID_ALGORITHMS_GEOMETRYINFOTEST_H_
+#define MANTID_ALGORITHMS_GEOMETRYINFOTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidAlgorithms/GeometryInfo.h"
+
+using namespace Mantid;
+using namespace Mantid::API;
+using namespace Mantid::Algorithms;
+using namespace Mantid::DataObjects;
+
+class GeometryInfoTest : public CxxTest::TestSuite {
+public:
+  static GeometryInfoTest *createSuite() { return new GeometryInfoTest(); }
+  static void destroySuite(GeometryInfoTest *suite) { delete suite; }
+
+  GeometryInfoTest()
+      : workspace(WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
+            5, 1, true, true)),
+        m_instrument_info(*workspace) {}
+
+  void test_constructor() {
+    TS_ASSERT_THROWS_NOTHING(
+        GeometryInfo(m_instrument_info, *(workspace->getSpectrum(0))));
+  }
+
+  void test_isMonitor() {
+    TS_ASSERT_EQUALS(GeometryInfo(m_instrument_info,
+                                  *(workspace->getSpectrum(0))).isMonitor(),
+                     false);
+    TS_ASSERT_EQUALS(GeometryInfo(m_instrument_info,
+                                  *(workspace->getSpectrum(1))).isMonitor(),
+                     false);
+    TS_ASSERT_EQUALS(GeometryInfo(m_instrument_info,
+                                  *(workspace->getSpectrum(2))).isMonitor(),
+                     false);
+    TS_ASSERT_EQUALS(GeometryInfo(m_instrument_info,
+                                  *(workspace->getSpectrum(3))).isMonitor(),
+                     true);
+    TS_ASSERT_EQUALS(GeometryInfo(m_instrument_info,
+                                  *(workspace->getSpectrum(4))).isMonitor(),
+                     true);
+  }
+
+  void test_isMasked() {
+    auto ws = WorkspaceCreationHelper::maskSpectra(workspace, {0, 3});
+    auto instrument_info = BasicInstrumentInfo(*ws);
+    TS_ASSERT_EQUALS(
+        GeometryInfo(instrument_info, *(ws->getSpectrum(0))).isMasked(), true);
+    TS_ASSERT_EQUALS(
+        GeometryInfo(instrument_info, *(ws->getSpectrum(1))).isMasked(), false);
+    TS_ASSERT_EQUALS(
+        GeometryInfo(instrument_info, *(ws->getSpectrum(2))).isMasked(), false);
+    TS_ASSERT_EQUALS(
+        GeometryInfo(instrument_info, *(ws->getSpectrum(3))).isMasked(), true);
+    TS_ASSERT_EQUALS(
+        GeometryInfo(instrument_info, *(ws->getSpectrum(4))).isMasked(), false);
+  }
+
+  void test_getL1() {
+    auto info = GeometryInfo(m_instrument_info, *(workspace->getSpectrum(0)));
+    TS_ASSERT_EQUALS(info.getL1(), 20.0);
+  }
+
+  void test_getL2() {
+    double x2 = 5.0 * 5.0;
+    double y2 = 2.0 * 2.0 * 0.05 * 0.05;
+    TS_ASSERT_EQUALS(
+        GeometryInfo(m_instrument_info, *(workspace->getSpectrum(0))).getL2(),
+        sqrt(x2 + 1 * 1 * y2));
+    TS_ASSERT_EQUALS(
+        GeometryInfo(m_instrument_info, *(workspace->getSpectrum(1))).getL2(),
+        sqrt(x2 + 0 * 0 * y2));
+    TS_ASSERT_EQUALS(
+        GeometryInfo(m_instrument_info, *(workspace->getSpectrum(2))).getL2(),
+        sqrt(x2 + 1 * 1 * y2));
+    TS_ASSERT_EQUALS(
+        GeometryInfo(m_instrument_info, *(workspace->getSpectrum(3))).getL2(),
+        -9.0);
+    TS_ASSERT_EQUALS(
+        GeometryInfo(m_instrument_info, *(workspace->getSpectrum(4))).getL2(),
+        -2.0);
+  }
+
+  void test_getTwoTheta() {
+    TS_ASSERT_DELTA(GeometryInfo(m_instrument_info,
+                                 *(workspace->getSpectrum(0))).getTwoTheta(),
+                    0.0199973, 1e-6);
+    TS_ASSERT_DELTA(GeometryInfo(m_instrument_info,
+                                 *(workspace->getSpectrum(1))).getTwoTheta(),
+                    0.0, 1e-6);
+    TS_ASSERT_DELTA(GeometryInfo(m_instrument_info,
+                                 *(workspace->getSpectrum(2))).getTwoTheta(),
+                    0.0199973, 1e-6);
+  }
+
+  // Legacy test via the workspace method detectorTwoTheta(), which might be
+  // removed at some point.
+  void test_getTwoThetaLegacy() {
+    auto info = GeometryInfo(m_instrument_info, *(workspace->getSpectrum(2)));
+    TS_ASSERT_EQUALS(info.getTwoTheta(),
+                     workspace->detectorTwoTheta(info.getDetector()));
+  }
+
+  void test_getSignedTwoTheta() {
+    TS_ASSERT_DELTA(
+        GeometryInfo(m_instrument_info, *(workspace->getSpectrum(0)))
+            .getSignedTwoTheta(),
+        -0.0199973, 1e-6);
+    TS_ASSERT_DELTA(
+        GeometryInfo(m_instrument_info, *(workspace->getSpectrum(1)))
+            .getSignedTwoTheta(),
+        0.0, 1e-6);
+    TS_ASSERT_DELTA(
+        GeometryInfo(m_instrument_info, *(workspace->getSpectrum(2)))
+            .getSignedTwoTheta(),
+        0.0199973, 1e-6);
+  }
+
+  // Legacy test via the workspace method detectorSignedTwoTheta(), which might
+  // be removed at some point.
+  void test_getSignedTwoThetaLegacy() {
+    auto info = GeometryInfo(m_instrument_info, *(workspace->getSpectrum(2)));
+    TS_ASSERT_EQUALS(info.getSignedTwoTheta(),
+                     workspace->detectorSignedTwoTheta(info.getDetector()));
+  }
+
+private:
+  Workspace2D_sptr workspace;
+  BasicInstrumentInfo m_instrument_info;
+};
+
+#endif /* MANTID_ALGORITHMS_GEOMETRYINFOTEST_H_ */


### PR DESCRIPTION
This is a first example for:
- An `Algorithm::for_each` that loops over all spectra.
- The use of a new small helper class `GeometryInfo`.

Please comment!

Note that I am considering the following changes:
- Make `BasicInstrumentInfo` a factory for `GeometryInfo`.
- `ApplyTransmissionCorrection` can be further simplified by using `Workspace::clone()` (as a side effect, this seems to speed up the tests of the algorithm by 2x).
- Checks for `isMonitor` and `isMasked` are very frequent, we can provide a variant of `for_each` that does that automatically.
- Rename `SpectrumAlgorithm` and other bits.

TODOs:
- Doxygen
- Comments that explain how the variadic template stuff works
