### PR TITLE
Fix mismatched_iterator warning on coverity-scan.

### DIFF
--- a/Framework/DataHandling/src/LoadMask.cpp
+++ b/Framework/DataHandling/src/LoadMask.cpp
@@ -612,7 +612,7 @@ void LoadMask::parseDetectorIDs(std::string inputstr, bool tomask) {
 
   // 2. Set to data storage
   if (tomask) {
-    mask_detid_single.insert(unmask_detid_single.end(), singles.begin(),
+    mask_detid_single.insert(mask_detid_single.end(), singles.begin(),
                              singles.end());
     for (size_t i = 0; i < pairs.size() / 2; i++) {
       mask_detid_pair_low.push_back(pairs[2 * i]);


### PR DESCRIPTION
This fixes a mismatched_iterator (#1351336) and copy/paste (#1351330) warning in coverity-scan.

Looks like a typo I made in PR #14989. 

no release notes: bug introduces after the v3.6.0 release branch was created.

Can we catch this error in a unit test? It's hard to test undefined behavior, and even harder when it is in a private member function that doesn't return anything. 
