### PR TITLE
Create instances of Instrument View from Python

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -655,6 +655,7 @@ include_directories ( ${CMAKE_CURRENT_BINARY_DIR} )
 ###########################################################################
 
 qt4_add_resources ( RES_FILES ${PROJECT_SOURCE_DIR}/images/images.qrc )
+qt4_add_resources ( RES_FILES ${PROJECT_SOURCE_DIR}/images/MantidWidgets.qrc )
 qt4_add_resources ( RES_FILES ${PROJECT_SOURCE_DIR}/images//fonts/fonts.qrc )
 qt4_add_resources ( RES_FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/icons.qrc )
 qt4_add_resources ( RES_FILES ${PROJECT_SOURCE_DIR}/MantidQt/SliceViewer/icons/SliceViewerIcons.qrc )

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -19,6 +19,11 @@ InstrumentWindow::InstrumentWindow(const QString &wsName, const QString &label,
   this->setWidget(m_instrumentWidget);
   confirmClose(parent->confirmCloseInstrWindow);
   resize(m_instrumentWidget->size());
+
+  connect(m_instrumentWidget, SIGNAL(preDeletingHandle()), this,
+          SLOT(closeSafely()));
+  connect(m_instrumentWidget, SIGNAL(clearingHandle()), this,
+          SLOT(closeSafely()));
 }
 
 InstrumentWindow::~InstrumentWindow() {}
@@ -48,46 +53,6 @@ std::string InstrumentWindow::saveToProject(ApplicationWindow *app) {
 
 void InstrumentWindow::selectTab(int tab) {
   return m_instrumentWidget->selectTab(tab);
-}
-
-/**
-* Closes the window if the associated workspace is deleted.
-* @param ws_name :: Name of the deleted workspace.
-* @param workspace_ptr :: Pointer to the workspace to be deleted
-*/
-void InstrumentWindow::preDeleteHandle(
-    const std::string &ws_name,
-    const boost::shared_ptr<Workspace> workspace_ptr) {
-  if (m_instrumentWidget->hasWorkspace(ws_name)) {
-    confirmClose(false);
-    close();
-    return;
-  }
-  Mantid::API::IPeaksWorkspace_sptr pws =
-      boost::dynamic_pointer_cast<Mantid::API::IPeaksWorkspace>(workspace_ptr);
-  if (pws) {
-    m_instrumentWidget->deletePeaksWorkspace(pws);
-    return;
-  }
-}
-
-void InstrumentWindow::afterReplaceHandle(
-    const std::string &wsName, const boost::shared_ptr<Workspace> workspace) {
-  m_instrumentWidget->handleWorkspaceReplacement(wsName, workspace);
-}
-
-void InstrumentWindow::renameHandle(const std::string &oldName,
-                                    const std::string &newName) {
-  if (m_instrumentWidget->hasWorkspace(oldName)) {
-    m_instrumentWidget->renameWorkspace(newName);
-    setWindowTitle(QString("Instrument - ") +
-                   m_instrumentWidget->getWorkspaceName());
-  }
-}
-
-void InstrumentWindow::clearADSHandle() {
-  confirmClose(false);
-  close();
 }
 
 InstrumentWidgetTab *InstrumentWindow::getTab(const QString &title) const {
@@ -136,4 +101,9 @@ void InstrumentWindow::setScaleType(GraphOptions::ScaleType type) {
 
 void InstrumentWindow::setViewType(const QString &type) {
   return m_instrumentWidget->setViewType(type);
+}
+
+void InstrumentWindow::closeSafely() {
+	confirmClose(false);
+	close();
 }

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.h
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.h
@@ -47,17 +47,8 @@ public:
   void setScaleType(GraphOptions::ScaleType);
   void setViewType(const QString &);
 
-private:
-  /// ADS notification handlers
-  virtual void preDeleteHandle(
-      const std::string &ws_name,
-      const boost::shared_ptr<Mantid::API::Workspace> workspace_ptr);
-  virtual void afterReplaceHandle(
-      const std::string &wsName,
-      const boost::shared_ptr<Mantid::API::Workspace> workspace_ptr);
-  virtual void renameHandle(const std::string &oldName,
-                            const std::string &newName);
-  virtual void clearADSHandle();
+public slots:
+  void closeSafely();
 
 private:
 	MantidQt::MantidWidgets::InstrumentWidget *m_instrumentWidget;

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -100,10 +100,8 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 
 /// Required by Qt to use Mantid::API::Workspace_sptr as a parameter type in signals
-Q_DECLARE_METATYPE(Mantid::API::Workspace_sptr)
-  Q_DECLARE_METATYPE(Mantid::API::MatrixWorkspace_sptr)
-  Q_DECLARE_METATYPE(Mantid::API::MatrixWorkspace_const_sptr)
-  Q_DECLARE_METATYPE(std::string)
+Q_DECLARE_METATYPE(Mantid::API::MatrixWorkspace_sptr)
+Q_DECLARE_METATYPE(Mantid::API::MatrixWorkspace_const_sptr)
 
 class MantidUI:public QObject
 {

--- a/MantidQt/API/inc/MantidQtAPI/WorkspaceObserver.h
+++ b/MantidQt/API/inc/MantidQtAPI/WorkspaceObserver.h
@@ -2,10 +2,10 @@
 #define WORKSPACE_OBSERVER_H
 
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/Workspace_fwd.h"
 #include <Poco/NObserver.h>
 #include <QObject>
 #include "DllOption.h"
-#include <MantidAPI\Workspace_fwd.h>
 #include <QMetaType>
 
 

--- a/MantidQt/API/inc/MantidQtAPI/WorkspaceObserver.h
+++ b/MantidQt/API/inc/MantidQtAPI/WorkspaceObserver.h
@@ -5,6 +5,12 @@
 #include <Poco/NObserver.h>
 #include <QObject>
 #include "DllOption.h"
+#include <MantidAPI\Workspace_fwd.h>
+#include <QMetaType>
+
+
+Q_DECLARE_METATYPE(std::string)
+Q_DECLARE_METATYPE(Mantid::API::Workspace_sptr)
 
 //------------------------------------------------
 // Mantid Forward declaration

--- a/MantidQt/API/src/WorkspaceObserver.cpp
+++ b/MantidQt/API/src/WorkspaceObserver.cpp
@@ -4,10 +4,6 @@
 #include "MantidQtAPI/WorkspaceObserver.h"
 #include "MantidAPI/AnalysisDataService.h"
 
-//#include <QMetaType>
-
-
-
 namespace MantidQt
 {
   namespace API
@@ -62,14 +58,6 @@ namespace MantidQt
       m_rename_observed(false), m_clr_observed(false)
     {
       m_proxy = new ObserverCallback(this);
-
-	  static bool registered_addtional_types = false;
-	  if (!registered_addtional_types)
-	  {
-		  registered_addtional_types = true;
-		  qRegisterMetaType<Mantid::API::Workspace_sptr>();
-		  qRegisterMetaType<std::string>();
-	  }
     }
 
     /// Destructor

--- a/MantidQt/API/src/WorkspaceObserver.cpp
+++ b/MantidQt/API/src/WorkspaceObserver.cpp
@@ -4,6 +4,10 @@
 #include "MantidQtAPI/WorkspaceObserver.h"
 #include "MantidAPI/AnalysisDataService.h"
 
+//#include <QMetaType>
+
+
+
 namespace MantidQt
 {
   namespace API
@@ -58,6 +62,14 @@ namespace MantidQt
       m_rename_observed(false), m_clr_observed(false)
     {
       m_proxy = new ObserverCallback(this);
+
+	  static bool registered_addtional_types = false;
+	  if (!registered_addtional_types)
+	  {
+		  registered_addtional_types = true;
+		  qRegisterMetaType<Mantid::API::Workspace_sptr>();
+		  qRegisterMetaType<std::string>();
+	  }
     }
 
     /// Destructor

--- a/MantidQt/MantidWidgets/CMakeLists.txt
+++ b/MantidQt/MantidWidgets/CMakeLists.txt
@@ -273,6 +273,7 @@ qt4_wrap_cpp ( MOCCED_FILES ${MOC_FILES} )
 set ( ALL_SRC ${SRC_FILES} ${MOCCED_FILES} )
 
 qt4_wrap_ui ( UI_HDRS ${UI_FILES} ) 
+qt4_add_resources ( RES_FILES ${PROJECT_SOURCE_DIR}/images/MantidWidgets.qrc )
 
 include_directories ( ${QSCINTILLA_INCLUDE_DIR} )
 add_definitions ( -DQSCINTILLA_DLL )     # Will only have an effect on Windows (as is desired)
@@ -282,7 +283,7 @@ add_definitions ( -DQSCINTILLA_DLL )     # Will only have an effect on Windows (
 add_definitions ( -DIN_MANTIDQT_MANTIDWIDGETS -DQT_QTPROPERTYBROWSER_IMPORT )
 # Use a precompiled header where they are supported
 enable_precompiled_headers( inc/MantidQtMantidWidgets/PrecompiledHeader.h ALL_SRC )
-add_library ( MantidWidgets ${ALL_SRC} ${INC_FILES} ${UI_HDRS} )
+add_library ( MantidWidgets ${ALL_SRC} ${INC_FILES} ${UI_HDRS} ${RES_FILES} )
 
 if (OSX_VERSION VERSION_GREATER 10.8)
   set_target_properties ( MantidWidgets PROPERTIES INSTALL_RPATH "@loader_path/../MacOS")

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
@@ -150,6 +150,8 @@ namespace MantidQt
 			void integrationRangeChanged(double, double);
 			void glOptionChanged(bool);
 			void requestSelectComponent(const QString &);
+			void preDeletingHandle();
+			void clearingHandle();
 
 		protected:
 			/// Implements AlgorithmObserver's finish handler
@@ -273,6 +275,17 @@ namespace MantidQt
 			bool m_blocked;
 			QList<int> m_selectedDetectors;
 			bool m_instrumentDisplayContextMenuOn;
+		private:
+			/// ADS notification handlers
+			virtual void preDeleteHandle(
+				const std::string &ws_name,
+				const boost::shared_ptr<Mantid::API::Workspace> workspace_ptr);
+			virtual void afterReplaceHandle(
+				const std::string &wsName,
+				const boost::shared_ptr<Mantid::API::Workspace> workspace_ptr);
+			virtual void renameHandle(const std::string &oldName,
+				const std::string &newName);
+			virtual void clearADSHandle();
 		};
 
 	}//MantidWidgets

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
@@ -1280,6 +1280,45 @@ namespace MantidQt
 				}
 			}
 		}
+
+		/**
+		* Closes the window if the associated workspace is deleted.
+		* @param ws_name :: Name of the deleted workspace.
+		* @param workspace_ptr :: Pointer to the workspace to be deleted
+		*/
+		void InstrumentWidget::preDeleteHandle(
+			const std::string &ws_name,
+			const boost::shared_ptr<Workspace> workspace_ptr) {
+			if (hasWorkspace(ws_name)) {
+				emit preDeletingHandle();
+				close();
+				return;
+			}
+			Mantid::API::IPeaksWorkspace_sptr pws =
+				boost::dynamic_pointer_cast<Mantid::API::IPeaksWorkspace>(workspace_ptr);
+			if (pws) {
+				deletePeaksWorkspace(pws);
+				return;
+			}
+		}
+
+		void InstrumentWidget::afterReplaceHandle(
+			const std::string &wsName, const boost::shared_ptr<Workspace> workspace) {
+			handleWorkspaceReplacement(wsName, workspace);
+		}
+
+		void InstrumentWidget::renameHandle(const std::string &oldName,
+			const std::string &newName) {
+			if (hasWorkspace(oldName)) {
+				renameWorkspace(newName);
+				setWindowTitle(QString("Instrument - ") + getWorkspaceName());
+			}
+		}
+
+		void InstrumentWidget::clearADSHandle() {
+			emit clearingHandle();
+			close();
+		}
 	}//MantidWidgets
 }//MantidQt
 

--- a/MantidQt/Python/mantidqt.sip
+++ b/MantidQt/Python/mantidqt.sip
@@ -26,7 +26,6 @@
 %End
 
 %InitialisationCode
-/*registerMetaTypes();*/
 qRegisterMetaType<Mantid::API::Workspace_sptr>();
 qRegisterMetaType<std::string>();
 %End

--- a/MantidQt/Python/mantidqt.sip
+++ b/MantidQt/Python/mantidqt.sip
@@ -21,6 +21,15 @@
 %Import QtGui/QtGuimod.sip
 %Include qwttypes.sip
 
+%ModuleHeaderCode
+#include <MantidQtAPI/WorkspaceObserver.h>
+%End
+
+%InitialisationCode
+/*registerMetaTypes();*/
+qRegisterMetaType<Mantid::API::Workspace_sptr>();
+qRegisterMetaType<std::string>();
+%End
 /***************************************************************************/
 /**************** Exceptions ***********************************************/
 /***************************************************************************/

--- a/images/MantidWidgets.qrc
+++ b/images/MantidWidgets.qrc
@@ -1,0 +1,25 @@
+<RCC>
+    <qresource prefix="/PickTools">
+        <file>zoom.png</file>
+        <file>selection-tube.png</file>
+        <file>selection-box.png</file>
+        <file>selection-circle.png</file>
+        <file>selection-pointer.png</file>
+        <file>selection-text.png</file>
+        <file>selection-peak.png</file>
+        <file>selection-peaks.png</file>
+        <file>selection-edit.png</file>
+        <file>eraser.png</file>
+        <file>selection-box-ring.png</file>
+        <file>selection-circle-ring.png</file>
+        <file>brush.png</file>
+    </qresource>
+    <qresource prefix="/MaskTools">
+        <file>selection-circle.png</file>
+        <file>selection-box.png</file>
+        <file>selection-box-ring.png</file>
+        <file>selection-circle-ring.png</file>
+        <file>selection-edit.png</file>
+        <file>brush.png</file>
+    </qresource>
+</RCC>

--- a/images/images.qrc
+++ b/images/images.qrc
@@ -54,27 +54,4 @@
         <file>MantidPlot_Python_Icon_32x32.png</file>
         <file>Circle_cog_48x48.png</file>
     </qresource>
-    <qresource prefix="/PickTools">
-        <file>zoom.png</file>
-        <file>selection-tube.png</file>
-        <file>selection-box.png</file>
-        <file>selection-circle.png</file>
-        <file>selection-pointer.png</file>
-        <file>selection-text.png</file>
-        <file>selection-peak.png</file>
-        <file>selection-peaks.png</file>
-        <file>selection-edit.png</file>
-        <file>eraser.png</file>
-        <file>selection-box-ring.png</file>
-        <file>selection-circle-ring.png</file>
-        <file>brush.png</file>
-    </qresource>
-    <qresource prefix="/MaskTools">
-        <file>selection-circle.png</file>
-        <file>selection-box.png</file>
-        <file>selection-box-ring.png</file>
-        <file>selection-circle-ring.png</file>
-        <file>selection-edit.png</file>
-        <file>brush.png</file>
-    </qresource>
 </RCC>


### PR DESCRIPTION
Fixes #15132 
### Changes

The Instrument View can now be instantiated from python as a stand-alone QWidget.
- [x] [Release Notes](http://www.mantidproject.org/ReleaseNotes_3_7_UI_Changes#Instrument_View) updated.
### Testing
- Code Review
- Run the following script from python (not mantidplot). I used dreampie with a startup script to configure the environment. I ran the script below which launches fake live data acquisition with the instrument view. Whenever the live output workspace is updated, the instrument view is updated.

**Start-up script**

For Windows:

``` sh
@echo off
::
:: Sets up the environment configured for Mantid by CMake and
:: starts DreamPie

:: Assume the buildenv.bat script exists and is in the same directory
call %~dp0buildenv.bat
set PYTHONPATH=%~dp0bin\Debug
set PATH=%PYTHONPATH%;%PATH%
:: Start DreamPie
Path\To\Your\\dreampie.exe --hide-console-window "%PYTHONHOME%\python.exe"
```

For OSX

``` bash
export PYTHONPATH=/Applications/MantidPlot.app/Contents/MacOS/
python {path_to_following_script} &
```

**python script**

``` python
from threading import Thread
import time
import sys
import PyQt4
import mantid.simpleapi as simpleapi
import mantidqtpython as mpy

ConfigService = simpleapi.ConfigService
def startFakeEventDAE():
    # This will generate 2000 events roughly every 20ms, so about 50,000 events/sec
    # They will be randomly shared across the 100 spectra
    # and have a time of flight between 10,000 and 20,000
    try:
        simpleapi.FakeISISEventDAE(NPeriods=1,NSpectra=100,Rate=20,NEvents=1000)
    except RuntimeError:
        pass

def captureLive():
    ConfigService.setFacility("TEST_LIVE")

    # start a Live data listener updating every second, that rebins the data
    # and replaces the results each time with those of the last second.
    simpleapi.StartLiveData(Instrument='ISIS_Event', OutputWorkspace='wsOut', UpdateEvery=0.5,
                  ProcessingAlgorithm='Rebin', ProcessingProperties='Params=10000,1000,20000;PreserveEvents=1',
                  AccumulationMethod='Add', PreserveEvents=True)


#--------------------------------------------------------------------------------------------------
InstrumentWidget = mpy.MantidQt.MantidWidgets.InstrumentWidget
app = PyQt4.QtGui.QApplication(sys.argv)

eventThread = Thread(target = startFakeEventDAE)
eventThread.start()

while not eventThread.is_alive():
    time.sleep(2) # give it a small amount of time to get ready


facility = ConfigService.getFacility()

try:
    captureLive()

    iw = InstrumentWidget("wsOut")
    iw.show()
    app.exec_()
finally:
    # put back the facility
    ConfigService.setFacility(facility)
```
