### PR TITLE
Fix VSI crash when selecting Scale or Cut Filter when "builtin" node is selected

### DIFF
--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
@@ -145,6 +145,8 @@ public:
   void setColorScaleLock(Mantid::VATES::ColorScaleLock* colorScaleLock);
   QPointer<pqPipelineSource> origSrc; ///< The original source
   QPointer<pqPipelineRepresentation> origRep; ///< The original source representation
+  /// Has active source
+  bool hasActiveSource();
 
 public slots:
   /// Set the color scale back to the original bounds.

--- a/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -229,6 +229,11 @@ void StandardView::render()
 }
 
 void StandardView::onCutButtonClicked() {
+  // check that has active source
+  if (!hasActiveSource()) {
+    return;
+  }
+
   // Apply cut to currently viewed data
   pqObjectBuilder *builder = pqApplicationCore::instance()->getObjectBuilder();
   builder->createFilter("filters", "Cut", this->getPvActiveSrc());
@@ -239,6 +244,11 @@ void StandardView::onCutButtonClicked() {
 }
 
 void StandardView::onScaleButtonClicked() {
+  // check that has active source
+  if (!hasActiveSource()) {
+    return;
+  }
+
   pqObjectBuilder *builder = pqApplicationCore::instance()->getObjectBuilder();
   this->m_scaler = builder->createFilter(
       "filters", "MantidParaViewScaleWorkspace", this->getPvActiveSrc());

--- a/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
@@ -954,6 +954,13 @@ void ViewBase::setAxesGrid(bool on) {
   }
 }
 
+/**
+ * Check if there is an active source available
+ * @returns true if there is an active source else false
+ */
+bool ViewBase::hasActiveSource() {
+  return this->getPvActiveSrc() != nullptr;
+}
 
 } // namespace SimpleGui
 } // namespace Vates


### PR DESCRIPTION
Fixes  #11947 

**Issue**

The pipeline browser in the VSI has an initial node called `builtin` (not sure why it is selectable at all). If this node is selected and subsequently `Cut` or `Scale` is pressed, Mantid used to crash.

The cause of the crash is related to us querrying for an Active Source when there is none (basically, because the `builtin` node is neither a source or a filter). The issue arises [here](https://github.com/mantidproject/mantid/blob/master/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp#L234), when we pass the Active Source (which is `nullptr`) to thect `ObjectBuilder`s `createFilter` method

**Solution**

In the filter callbacks we need to hedge for empty Active Sources and not do anything if we encounter such a situation.
# For Tester:

Please find an Ubunutu installer here:  //olympic/babylon5/Scratch/Anton/VSI/11947

**Release Notes**
- Release note changes can be found [here](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_7_UI_Changes&diff=26317&oldid=26310)

**Implemented Tests**
- Note that this is a VSI GUI bugfix and currently not being unit tested

**Functional Testing**
1. Load a sample workspace into the VSI
2. Select the `builin` node in the pipeline browser (the icon at the beginning of the pipeline).
   - You should see that the properties browser changes its display
3. Now that it is selected. Press `Scale`
   - Confirm that nothing happens, especially that Mantid does not crash
4. Press `Cut`
   - Confirm that nothing happens, especially that Mantid does not crash
