### PR TITLE
Clang warnings in Kernel/Math/Optimization reduced

### DIFF
--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -7,7 +7,7 @@
 #include <sstream>
 
 #ifdef __clang__
-#ifndef __OSX__
+#ifndef __APPLE__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored                                               \
     "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"

--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -1,3 +1,9 @@
+#pragma clang diagnostic ignored "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
+#pragma clang diagnostic ignored "-Wreadability-named-parameter"
+#pragma clang diagnostic ignored "-Wcppcoreguidelines-pro-bounds-array-to-pointer-decay"
+#pragma clang diagnostic ignored "-Wreadability-braces-around-statements"
+#pragma clang diagnostic ignored "-Wllvm-namespace-comment"
+
 #include "MantidKernel/Math/Optimization/SLSQPMinimizer.h"
 #include "MantidKernel/Exception.h"
 
@@ -17,7 +23,7 @@ int slsqp_(int *m, int *meq, int *la, int *n, double *x, double *xl, double *xu,
            double *f, double *c__, double *g, double *a, double *acc, int *iter,
            int *mode, double *w, int *l_w__, int *jw, int *l_jw__);
 ///@endcond
-}
+}// namespace
 
 /**
  * Perform the minimization using the SLSQP routine
@@ -3008,8 +3014,8 @@ L40:
 
 ///@endcond
 
-} // <anonymous>
+} // namespace
 
 } // namespace Math
-}
-} // namespace Mantid::Kernel
+} // namespace Kernel
+} // namespace Mantid

--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -1,5 +1,3 @@
-#pragma clang diagnostic ignored "-Wall"
-
 #include "MantidKernel/Math/Optimization/SLSQPMinimizer.h"
 #include "MantidKernel/Exception.h"
 
@@ -7,6 +5,11 @@
 #include <cmath>
 #include <cassert>
 #include <sstream>
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
+#endif
 
 namespace Mantid {
 namespace Kernel {
@@ -3015,3 +3018,7 @@ L40:
 } // namespace Math
 } // namespace Kernel
 } // namespace Mantid
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif

--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -1,6 +1,8 @@
-#pragma clang diagnostic ignored "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
+#pragma clang diagnostic ignored                                               \
+    "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
 #pragma clang diagnostic ignored "-Wreadability-named-parameter"
-#pragma clang diagnostic ignored "-Wcppcoreguidelines-pro-bounds-array-to-pointer-decay"
+#pragma clang diagnostic ignored                                               \
+    "-Wcppcoreguidelines-pro-bounds-array-to-pointer-decay"
 #pragma clang diagnostic ignored "-Wreadability-braces-around-statements"
 #pragma clang diagnostic ignored "-Wllvm-namespace-comment"
 
@@ -23,7 +25,7 @@ int slsqp_(int *m, int *meq, int *la, int *n, double *x, double *xl, double *xu,
            double *f, double *c__, double *g, double *a, double *acc, int *iter,
            int *mode, double *w, int *l_w__, int *jw, int *l_jw__);
 ///@endcond
-}// namespace
+} // namespace
 
 /**
  * Perform the minimization using the SLSQP routine

--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -7,11 +7,11 @@
 #include <sstream>
 
 #ifdef __clang__
-	#ifndef __APPLE__
-		#pragma clang diagnostic push
-		#pragma clang diagnostic ignored                                               \
-			"-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
-	#endif
+#ifndef __APPLE__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored                                               \
+    "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
+#endif
 #endif
 
 namespace Mantid {
@@ -3023,7 +3023,7 @@ L40:
 } // namespace Mantid
 
 #ifndef __APPLE__
-	#ifdef __clang__
-		#pragma clang diagnostic pop
-	#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #endif

--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -7,9 +7,11 @@
 #include <sstream>
 
 #ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored                                               \
-    "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
+	#ifndef __OSX__
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored                                               \
+			"-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
+	#endif
 #endif
 
 namespace Mantid {

--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -7,11 +7,11 @@
 #include <sstream>
 
 #ifdef __clang__
-	#ifndef __OSX__
-		#pragma clang diagnostic push
-		#pragma clang diagnostic ignored                                               \
-			"-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
-	#endif
+#ifndef __OSX__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored                                               \
+    "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
+#endif
 #endif
 
 namespace Mantid {

--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -7,11 +7,11 @@
 #include <sstream>
 
 #ifdef __clang__
-#ifndef __APPLE__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored                                               \
-    "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
-#endif
+	#ifndef __APPLE__
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored                                               \
+			"-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
+	#endif
 #endif
 
 namespace Mantid {
@@ -3022,6 +3022,8 @@ L40:
 } // namespace Kernel
 } // namespace Mantid
 
-#ifdef __clang__
-#pragma clang diagnostic pop
+#ifndef __APPLE__
+	#ifdef __clang__
+		#pragma clang diagnostic pop
+	#endif
 #endif

--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -8,7 +8,8 @@
 
 #ifdef __clang__
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
+#pragma clang diagnostic ignored                                               \
+    "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
 #endif
 
 namespace Mantid {

--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -1,10 +1,4 @@
-#pragma clang diagnostic ignored                                               \
-    "-Wcppcoreguidelines-pro-bounds-pointer-arithmetic"
-#pragma clang diagnostic ignored "-Wreadability-named-parameter"
-#pragma clang diagnostic ignored                                               \
-    "-Wcppcoreguidelines-pro-bounds-array-to-pointer-decay"
-#pragma clang diagnostic ignored "-Wreadability-braces-around-statements"
-#pragma clang diagnostic ignored "-Wllvm-namespace-comment"
+#pragma clang diagnostic ignored "-Wall"
 
 #include "MantidKernel/Math/Optimization/SLSQPMinimizer.h"
 #include "MantidKernel/Exception.h"


### PR DESCRIPTION
Resolves #15351 
### Changes

The file SLSQPMinimizer contained several clang warnings related to the use of pointer arithmetic (>600). Since this file was generated using f2c as a direct translation from fortran code, these errors have been ignored.
### Testing

Code review
