### PR TITLE
More objects created with `boost::make_shared`

### DIFF
--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1230,7 +1230,7 @@ bool Algorithm::processGroups() {
   for (auto &pureOutputWorkspaceProp : m_pureOutputWorkspaceProps) {
     Property *prop = dynamic_cast<Property *>(pureOutputWorkspaceProp);
     if (prop) {
-      WorkspaceGroup_sptr outWSGrp = WorkspaceGroup_sptr(new WorkspaceGroup());
+      auto outWSGrp = boost::make_shared<WorkspaceGroup>();
       outGroups.push_back(outWSGrp);
       // Put the GROUP in the ADS
       AnalysisDataService::Instance().addOrReplace(prop->value(), outWSGrp);

--- a/Framework/API/src/MDGeometry.cpp
+++ b/Framework/API/src/MDGeometry.cpp
@@ -4,6 +4,7 @@
 #include "MantidGeometry/MDGeometry/MDGeometryXMLBuilder.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
+#include <boost/make_shared.hpp>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
@@ -34,8 +35,8 @@ MDGeometry::MDGeometry(const MDGeometry &other)
   std::vector<Mantid::Geometry::IMDDimension_sptr> dimensions;
   for (size_t d = 0; d < other.getNumDims(); d++) {
     // Copy the dimension
-    MDHistoDimension_sptr dim(
-        new MDHistoDimension(other.getDimension(d).get()));
+    auto dim =
+        boost::make_shared<MDHistoDimension>(other.getDimension(d).get());
     dimensions.push_back(dim);
   }
   this->initGeometry(dimensions);

--- a/Framework/API/src/MultipleExperimentInfos.cpp
+++ b/Framework/API/src/MultipleExperimentInfos.cpp
@@ -100,7 +100,7 @@ void MultipleExperimentInfos::copyExperimentInfos(
   m_expInfos.reserve(other.m_expInfos.size());
   // Do a deep copy of ExperimentInfo's
   for (const auto &expInfo : other.m_expInfos) {
-    ExperimentInfo_sptr copy(new ExperimentInfo(*expInfo));
+    auto copy(boost::make_shared<ExperimentInfo>(*expInfo));
     m_expInfos.push_back(copy);
   }
 }

--- a/Framework/Algorithms/src/ChopData.cpp
+++ b/Framework/Algorithms/src/ChopData.cpp
@@ -162,7 +162,7 @@ void ChopData::exec() {
   }
 
   // Create workspace group that holds output workspaces
-  WorkspaceGroup_sptr wsgroup = WorkspaceGroup_sptr(new WorkspaceGroup());
+  auto wsgroup = boost::make_shared<WorkspaceGroup>();
 
   for (auto &workspace : workspaces) {
     wsgroup->addWorkspace(workspace);

--- a/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
@@ -349,7 +349,7 @@ void CreateGroupingWorkspace::exec() {
     inst = inWS->getInstrument();
   } else {
     Algorithm_sptr childAlg = createChildAlgorithm("LoadInstrument", 0.0, 0.2);
-    MatrixWorkspace_sptr tempWS(new Workspace2D());
+    MatrixWorkspace_sptr tempWS = boost::make_shared<Workspace2D>();
     childAlg->setProperty<MatrixWorkspace_sptr>("Workspace", tempWS);
     childAlg->setPropertyValue("Filename", InstrumentFilename);
     childAlg->setProperty("RewriteSpectraMap",
@@ -388,7 +388,7 @@ void CreateGroupingWorkspace::exec() {
   }
 
   // --------------------------- Create the output --------------------------
-  GroupingWorkspace_sptr outWS(new GroupingWorkspace(inst));
+  auto outWS = boost::make_shared<GroupingWorkspace>(inst);
   this->setProperty("OutputWorkspace", outWS);
 
   // This will get the grouping

--- a/Framework/Algorithms/src/CreateLogTimeCorrection.cpp
+++ b/Framework/Algorithms/src/CreateLogTimeCorrection.cpp
@@ -144,7 +144,7 @@ void CreateLogTimeCorrection::calculateCorrection() {
 /** Write L2 map and correction map to a TableWorkspace
   */
 TableWorkspace_sptr CreateLogTimeCorrection::generateCorrectionTable() {
-  TableWorkspace_sptr tablews(new TableWorkspace());
+  auto tablews = boost::make_shared<TableWorkspace>();
 
   tablews->addColumn("int", "DetectorID");
   tablews->addColumn("double", "Correction");

--- a/Framework/Algorithms/src/CreatePeaksWorkspace.cpp
+++ b/Framework/Algorithms/src/CreatePeaksWorkspace.cpp
@@ -47,7 +47,7 @@ void CreatePeaksWorkspace::init() {
 void CreatePeaksWorkspace::exec() {
   MatrixWorkspace_sptr instWS = getProperty("InstrumentWorkspace");
 
-  PeaksWorkspace_sptr out(new PeaksWorkspace());
+  auto out = boost::make_shared<PeaksWorkspace>();
   setProperty("OutputWorkspace", out);
   int NumberOfPeaks = getProperty("NumberOfPeaks");
 

--- a/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -306,7 +306,7 @@ MatrixWorkspace_sptr CreateSampleWorkspace::createHistogramWorkspace(
   std::transform(y.access().begin(), y.access().end(), e.access().begin(),
                  dblSqrt);
 
-  MatrixWorkspace_sptr retVal(new DataObjects::Workspace2D);
+  MatrixWorkspace_sptr retVal = boost::make_shared<DataObjects::Workspace2D>();
   retVal->initialize(numPixels, numBins + 1, numBins);
   retVal->setInstrument(inst);
 
@@ -331,7 +331,7 @@ EventWorkspace_sptr CreateSampleWorkspace::createEventWorkspace(
   // add one to the number of bins as this is histogram
   int numXBins = numBins + 1;
 
-  EventWorkspace_sptr retVal(new EventWorkspace);
+  auto retVal = boost::make_shared<EventWorkspace>();
   retVal->initialize(numPixels, 1, 1);
 
   retVal->setInstrument(inst);

--- a/Framework/Algorithms/src/DetectorDiagnostic.cpp
+++ b/Framework/Algorithms/src/DetectorDiagnostic.cpp
@@ -523,7 +523,7 @@ DataObjects::MaskWorkspace_sptr
 DetectorDiagnostic::generateEmptyMask(API::MatrixWorkspace_const_sptr inputWS) {
   // Create a new workspace for the results, copy from the input to ensure that
   // we copy over the instrument and current masking
-  DataObjects::MaskWorkspace_sptr maskWS(new DataObjects::MaskWorkspace());
+  auto maskWS = boost::make_shared<DataObjects::MaskWorkspace>();
   maskWS->initialize(inputWS->getNumberHistograms(), 1, 1);
   WorkspaceFactory::Instance().initializeFromParent(inputWS, maskWS, false);
   maskWS->setTitle(inputWS->getTitle());

--- a/Framework/Algorithms/src/EditInstrumentGeometry.cpp
+++ b/Framework/Algorithms/src/EditInstrumentGeometry.cpp
@@ -289,7 +289,7 @@ void EditInstrumentGeometry::exec() {
   }
 
   // Create a new instrument from scratch any way.
-  Geometry::Instrument_sptr instrument(new Geometry::Instrument(name));
+  auto instrument = boost::make_shared<Geometry::Instrument>(name);
   if (!bool(instrument)) {
     stringstream errss;
     errss << "Trying to use a Parametrized Instrument as an Instrument.";

--- a/Framework/Algorithms/src/ExtractMaskToTable.cpp
+++ b/Framework/Algorithms/src/ExtractMaskToTable.cpp
@@ -81,7 +81,7 @@ void ExtractMaskToTable::exec() {
         "XMin or XMax cannot be empty.  XMin must be less than XMax.");
 
   // Create and set up output workspace
-  TableWorkspace_sptr outws(new TableWorkspace());
+  auto outws = boost::make_shared<TableWorkspace>();
   outws->addColumn("double", "XMin");
   outws->addColumn("double", "XMax");
   outws->addColumn("str", "DetectorIDsList");

--- a/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
+++ b/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
@@ -349,8 +349,8 @@ void GetDetOffsetsMultiPeaks::processProperties() {
   // Create output workspaces
   m_outputW = boost::make_shared<OffsetsWorkspace>(m_inputWS->getInstrument());
   m_outputNP = boost::make_shared<OffsetsWorkspace>(m_inputWS->getInstrument());
-  MatrixWorkspace_sptr tempmaskws(
-      new MaskWorkspace(m_inputWS->getInstrument()));
+  MatrixWorkspace_sptr tempmaskws =
+      boost::make_shared<MaskWorkspace>(m_inputWS->getInstrument());
   m_maskWS = tempmaskws;
 
   // Input resolution

--- a/Framework/Algorithms/src/GetDetectorOffsets.cpp
+++ b/Framework/Algorithms/src/GetDetectorOffsets.cpp
@@ -110,9 +110,9 @@ void GetDetectorOffsets::exec() {
 
   int64_t nspec = inputW->getNumberHistograms();
   // Create the output OffsetsWorkspace
-  OffsetsWorkspace_sptr outputW(new OffsetsWorkspace(inputW->getInstrument()));
+  auto outputW = boost::make_shared<OffsetsWorkspace>(inputW->getInstrument());
   // Create the output MaskWorkspace
-  MaskWorkspace_sptr maskWS(new MaskWorkspace(inputW->getInstrument()));
+  auto maskWS = boost::make_shared<MaskWorkspace>(inputW->getInstrument());
   // To get the workspace index from the detector ID
   const detid2index_map pixel_to_wi =
       maskWS->getDetectorIDToWorkspaceIndexMap(true);

--- a/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
+++ b/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
@@ -271,7 +271,7 @@ GetTimeSeriesLogInformation::calculateRelativeTime(double deltatime) {
 /** Generate statistic information table workspace
   */
 TableWorkspace_sptr GetTimeSeriesLogInformation::generateStatisticTable() {
-  TableWorkspace_sptr tablews(new TableWorkspace());
+  auto tablews = boost::make_shared<TableWorkspace>();
 
   tablews->addColumn("str", "Name");
   tablews->addColumn("double", "Value");

--- a/Framework/Algorithms/src/Q1DWeighted.cpp
+++ b/Framework/Algorithms/src/Q1DWeighted.cpp
@@ -334,7 +334,7 @@ void Q1DWeighted::exec() {
   }
 
   // Create workspace group that holds output workspaces
-  WorkspaceGroup_sptr wsgroup = WorkspaceGroup_sptr(new WorkspaceGroup());
+  auto wsgroup = boost::make_shared<WorkspaceGroup>();
 
   for (auto &wedgeWorkspace : wedgeWorkspaces) {
     wsgroup->addWorkspace(wedgeWorkspace);

--- a/Framework/Algorithms/test/CloneWorkspaceTest.h
+++ b/Framework/Algorithms/test/CloneWorkspaceTest.h
@@ -185,7 +185,7 @@ public:
   */
   void test_exec_TableWorkspace() {
     // 1. Create input table workspace
-    TableWorkspace_sptr inpWS(new TableWorkspace());
+    auto inpWS = boost::make_shared<TableWorkspace>();
 
     inpWS->addColumn("str", "Name");
     inpWS->addColumn("double", "Value");

--- a/Framework/Algorithms/test/ExtractMaskToTableTest.h
+++ b/Framework/Algorithms/test/ExtractMaskToTableTest.h
@@ -183,7 +183,7 @@ public:
     AnalysisDataService::Instance().addOrReplace("TestWorkspace2", inputws);
 
     // Create a table workspace to append to
-    TableWorkspace_sptr existtablews(new TableWorkspace());
+    auto existtablews = boost::make_shared<TableWorkspace>();
     existtablews->addColumn("double", "XMin");
     existtablews->addColumn("double", "XMax");
     existtablews->addColumn("str", "DetectorIDsList");
@@ -289,7 +289,7 @@ public:
     AnalysisDataService::Instance().addOrReplace("TestWorkspace2", inputws);
 
     // Create a table workspace to append to
-    TableWorkspace_sptr existtablews(new TableWorkspace());
+    auto existtablews = boost::make_shared<TableWorkspace>();
     existtablews->addColumn("double", "XMin");
     existtablews->addColumn("double", "XMax");
     existtablews->addColumn("str", "DetectorIDsList");

--- a/Framework/Algorithms/test/FilterEventsTest.h
+++ b/Framework/Algorithms/test/FilterEventsTest.h
@@ -964,7 +964,7 @@ public:
     */
   TableWorkspace_sptr createTimeCorrectionTable(MatrixWorkspace_sptr inpws) {
     // 1. Generate an empty table
-    TableWorkspace_sptr corrtable(new TableWorkspace());
+    auto corrtable = boost::make_shared<TableWorkspace>();
     corrtable->addColumn("int", "DetectorID");
     corrtable->addColumn("double", "Correction");
 

--- a/Framework/Algorithms/test/MaskBinsFromTableTest.h
+++ b/Framework/Algorithms/test/MaskBinsFromTableTest.h
@@ -288,7 +288,7 @@ public:
     }
 
     // Generate a TableWorksapce
-    TableWorkspace_sptr tablews(new TableWorkspace());
+    auto tablews = boost::make_shared<TableWorkspace>();
     tablews->addColumn("str", "DetectorIDsList");
     tablews->addColumn("double", "XMin");
     tablews->addColumn("double", "XMax");

--- a/Framework/Crystal/src/ShowPeakHKLOffsets.cpp
+++ b/Framework/Crystal/src/ShowPeakHKLOffsets.cpp
@@ -63,7 +63,6 @@ void ShowPeakHKLOffsets::exec() {
   UBinv.Invert();
   UBinv /= 2 * M_PI;
 
-  // TableWorkspace_sptr Res( new TableWorkspace());
   boost::shared_ptr<ITableWorkspace> Res =
       WorkspaceFactory::Instance().createTable("TableWorkspace");
   Res->setTitle("HKL int offsets for " + Peaks->getName());

--- a/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
@@ -667,7 +667,7 @@ void LeBailFit::execRefineBackground() {
   }
 
   // 5. Output background to table workspace
-  TableWorkspace_sptr outtablews(new TableWorkspace());
+  auto outtablews = boost::make_shared<TableWorkspace>();
   outtablews->addColumn("str", "Name");
   outtablews->addColumn("double", "Value");
   outtablews->addColumn("double", "Error");

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters3.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters3.cpp
@@ -1060,7 +1060,7 @@ bool RefinePowderInstrumentParameters3::doFitFunction(
 TableWorkspace_sptr RefinePowderInstrumentParameters3::genOutputProfileTable(
     map<string, Parameter> parameters, double startchi2, double finalchi2) {
   // 1. Create TableWorkspace
-  TableWorkspace_sptr tablews(new TableWorkspace);
+  auto tablews = boost::make_shared<TableWorkspace>();
 
   tablews->addColumn("str", "Name");
   tablews->addColumn("double", "Value");

--- a/Framework/DataHandling/src/Load.cpp
+++ b/Framework/DataHandling/src/Load.cpp
@@ -726,7 +726,7 @@ API::Workspace_sptr Load::plusWs(Workspace_sptr ws1, Workspace_sptr ws2) {
  */
 API::WorkspaceGroup_sptr
 Load::groupWsList(const std::vector<API::Workspace_sptr> &wsList) {
-  WorkspaceGroup_sptr group = WorkspaceGroup_sptr(new WorkspaceGroup);
+  auto group = boost::make_shared<WorkspaceGroup>();
 
   for (const auto &ws : wsList) {
     WorkspaceGroup_sptr isGroup =

--- a/Framework/DataHandling/src/LoadCalFile.cpp
+++ b/Framework/DataHandling/src/LoadCalFile.cpp
@@ -108,7 +108,7 @@ LoadCalFile::getInstrument3Ways(Algorithm *alg) {
   } else {
     Algorithm_sptr childAlg =
         alg->createChildAlgorithm("LoadInstrument", 0.0, 0.2);
-    MatrixWorkspace_sptr tempWS(new Workspace2D());
+    MatrixWorkspace_sptr tempWS = boost::make_shared<Workspace2D>();
     childAlg->setProperty<MatrixWorkspace_sptr>("Workspace", tempWS);
     childAlg->setPropertyValue("Filename", InstrumentFilename);
     childAlg->setPropertyValue("InstrumentName", InstrumentName);

--- a/Framework/DataHandling/src/LoadCanSAS1D.cpp
+++ b/Framework/DataHandling/src/LoadCanSAS1D.cpp
@@ -129,7 +129,7 @@ void LoadCanSAS1D::exec() {
     outputWork = WS;
     break;
   default:
-    WorkspaceGroup_sptr group(new WorkspaceGroup);
+    auto group = boost::make_shared<WorkspaceGroup>();
     for (unsigned int i = 0; i < numEntries; ++i) {
       std::string runName;
       MatrixWorkspace_sptr newWork = loadEntry(entryList->item(i), runName);

--- a/Framework/DataHandling/src/LoadFullprofResolution.cpp
+++ b/Framework/DataHandling/src/LoadFullprofResolution.cpp
@@ -717,7 +717,7 @@ TableWorkspace_sptr LoadFullprofResolution::genTableWorkspace(
                 << "\n";
 
   // Create TableWorkspace
-  TableWorkspace_sptr tablews(new TableWorkspace());
+  auto tablews = boost::make_shared<TableWorkspace>();
 
   // set columns :
   // Any 2 columns cannot have the same name.

--- a/Framework/DataHandling/src/LoadGSASInstrumentFile.cpp
+++ b/Framework/DataHandling/src/LoadGSASInstrumentFile.cpp
@@ -435,7 +435,7 @@ TableWorkspace_sptr LoadGSASInstrumentFile::genTableWorkspace(
                 << "\n";
 
   // Create TableWorkspace
-  TableWorkspace_sptr tablews(new TableWorkspace());
+  auto tablews = boost::make_shared<TableWorkspace>();
 
   // set columns :
   // Any 2 columns cannot have the same name.

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -436,7 +436,7 @@ void LoadNexusProcessed::exec() {
     m_list = !specListProp->isDefault();
 
     // Load all first level entries
-    WorkspaceGroup_sptr wksp_group(new WorkspaceGroup);
+    auto wksp_group = boost::make_shared<WorkspaceGroup>();
     // This forms the name of the group
     std::string base_name = getPropertyValue("OutputWorkspace");
     // First member of group should be the group itself, for some reason!

--- a/Framework/DataHandling/src/LoadVulcanCalFile.cpp
+++ b/Framework/DataHandling/src/LoadVulcanCalFile.cpp
@@ -614,7 +614,7 @@ Geometry::Instrument_const_sptr LoadVulcanCalFile::getInstrument() {
   Instrument_const_sptr inst;
 
   Algorithm_sptr childAlg = createChildAlgorithm("LoadInstrument", 0.0, 0.2);
-  MatrixWorkspace_sptr tempWS(new Workspace2D());
+  MatrixWorkspace_sptr tempWS = boost::make_shared<Workspace2D>();
   childAlg->setProperty<MatrixWorkspace_sptr>("Workspace", tempWS);
   childAlg->setPropertyValue("InstrumentName", InstrumentName);
   childAlg->setProperty("RewriteSpectraMap",

--- a/Framework/DataHandling/test/SaveGSASInstrumentFileTest.h
+++ b/Framework/DataHandling/test/SaveGSASInstrumentFileTest.h
@@ -183,7 +183,7 @@ public:
   void loadProfileTable(string wsname) {
     // The data befow is from Bank1 in pg60_2011B.irf
 
-    TableWorkspace_sptr tablews(new TableWorkspace);
+    auto tablews = boost::make_shared<TableWorkspace>();
     tablews->addColumn("str", "Name");
     tablews->addColumn("double", "Value_1");
 

--- a/Framework/DataObjects/test/TableWorkspaceTest.h
+++ b/Framework/DataObjects/test/TableWorkspaceTest.h
@@ -649,7 +649,7 @@ public:
   */
   void testGetProperty_const_sptr() {
     const std::string wsName = "InputWorkspace";
-    TableWorkspace_sptr wsInput(new TableWorkspace());
+    auto wsInput = boost::make_shared<TableWorkspace>();
     PropertyManagerHelper manager;
     manager.declareProperty(wsName, wsInput, Mantid::Kernel::Direction::Input);
 
@@ -681,7 +681,7 @@ public:
   */
   void testGetProperty_ITableWS_const_sptr() {
     const std::string wsName = "InputWorkspace";
-    ITableWorkspace_sptr wsInput(new TableWorkspace());
+    ITableWorkspace_sptr wsInput = boost::make_shared<TableWorkspace>();
     PropertyManagerHelper manager;
     manager.declareProperty(wsName, wsInput, Mantid::Kernel::Direction::Input);
 

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -861,8 +861,7 @@ Instrument::getPlottable() const {
 
   } else {
     // Base instrument
-    boost::shared_ptr<std::vector<IObjComponent_const_sptr>> res(
-        new std::vector<IObjComponent_const_sptr>);
+    auto res = boost::make_shared<std::vector<IObjComponent_const_sptr>>();
     res->reserve(m_detectorCache.size() + 10);
     appendPlottable(*this, *res);
     return res;

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -2291,7 +2291,7 @@ InstrumentDefinitionParser::getAppliedCachingOption() const {
 
 void InstrumentDefinitionParser::createNeutronicInstrument() {
   // Create a copy of the instrument
-  Instrument_sptr physical(new Instrument(*m_instrument));
+  auto physical = boost::make_shared<Instrument>(*m_instrument);
   // Store the physical instrument 'inside' the neutronic instrument
   m_instrument->setPhysicalInstrument(physical);
 

--- a/Framework/SINQ/src/InvertMDDim.cpp
+++ b/Framework/SINQ/src/InvertMDDim.cpp
@@ -39,7 +39,7 @@ void InvertMDDim::exec() {
     dimensions.push_back(boost::const_pointer_cast<IMDDimension>(dimi));
   }
 
-  MDHistoWorkspace_sptr outWS(new MDHistoWorkspace(dimensions));
+  auto outWS = boost::make_shared<MDHistoWorkspace>(dimensions);
   outWS->setTo(.0, .0, .0);
 
   int rank = static_cast<int>(inWS->getNumDims());

--- a/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -207,7 +207,7 @@ void LoadFlexiNexus::loadMD(NeXus::File *fin) {
     dimensions.push_back(makeDimension(fin, k, static_cast<int>(inf.dims[k])));
   }
 
-  MDHistoWorkspace_sptr ws(new MDHistoWorkspace(dimensions));
+  auto ws = boost::make_shared<MDHistoWorkspace>(dimensions);
 
   signal_t *dd = ws->getSignalArray();
   signal_t *ddE = ws->getErrorSquaredArray();

--- a/Framework/SINQ/src/PoldiFitPeaks1D.cpp
+++ b/Framework/SINQ/src/PoldiFitPeaks1D.cpp
@@ -84,7 +84,7 @@ void PoldiFitPeaks1D::setPeakFunction(const std::string &peakFunction) {
 
 PoldiPeakCollection_sptr PoldiFitPeaks1D::getInitializedPeakCollection(
     const DataObjects::TableWorkspace_sptr &peakTable) const {
-  PoldiPeakCollection_sptr peakCollection(new PoldiPeakCollection(peakTable));
+  auto peakCollection = boost::make_shared<PoldiPeakCollection>(peakTable);
   peakCollection->setProfileFunctionName(m_profileTemplate);
 
   return peakCollection;
@@ -100,7 +100,7 @@ PoldiFitPeaks1D::getPeakProfile(const PoldiPeak_sptr &poldiPeak) const {
 
   IFunction_sptr clonedBackground = m_backgroundTemplate->clone();
 
-  CompositeFunction_sptr totalProfile(new CompositeFunction);
+  auto totalProfile = boost::make_shared<CompositeFunction>();
   totalProfile->initialize();
   totalProfile->addFunction(clonedProfile);
   totalProfile->addFunction(clonedBackground);
@@ -153,7 +153,7 @@ void PoldiFitPeaks1D::exec() {
 
   Workspace2D_sptr dataWorkspace = getProperty("InputWorkspace");
 
-  WorkspaceGroup_sptr fitPlotGroup(new WorkspaceGroup);
+  auto fitPlotGroup = boost::make_shared<WorkspaceGroup>();
 
   for (size_t i = 0; i < m_peaks->peakCount(); ++i) {
     PoldiPeak_sptr currentPeak = m_peaks->peak(i);

--- a/Framework/SINQ/src/PoldiFitPeaks1D2.cpp
+++ b/Framework/SINQ/src/PoldiFitPeaks1D2.cpp
@@ -182,7 +182,7 @@ void PoldiFitPeaks1D2::setPeakFunction(const std::string &peakFunction) {
 
 PoldiPeakCollection_sptr PoldiFitPeaks1D2::getInitializedPeakCollection(
     const DataObjects::TableWorkspace_sptr &peakTable) const {
-  PoldiPeakCollection_sptr peakCollection(new PoldiPeakCollection(peakTable));
+  auto peakCollection = boost::make_shared<PoldiPeakCollection>(peakTable);
   peakCollection->setProfileFunctionName(m_profileTemplate);
 
   return peakCollection;
@@ -227,7 +227,7 @@ std::vector<RefinedRange_sptr> PoldiFitPeaks1D2::getReducedRanges(
 
 API::IFunction_sptr
 PoldiFitPeaks1D2::getRangeProfile(const RefinedRange_sptr &range, int n) const {
-  CompositeFunction_sptr totalProfile(new CompositeFunction);
+  auto totalProfile = boost::make_shared<CompositeFunction>();
   totalProfile->initialize();
 
   std::vector<PoldiPeak_sptr> peaks = range->getPeaks();

--- a/Framework/SINQ/src/PoldiFitPeaks2D.cpp
+++ b/Framework/SINQ/src/PoldiFitPeaks2D.cpp
@@ -469,7 +469,7 @@ Poldi2DFunction_sptr PoldiFitPeaks2D::getFunctionFromPeakCollection(
 Poldi2DFunction_sptr PoldiFitPeaks2D::getFunctionIndividualPeaks(
     std::string profileFunctionName,
     const PoldiPeakCollection_sptr &peakCollection) const {
-  Poldi2DFunction_sptr mdFunction(new Poldi2DFunction);
+  auto mdFunction = boost::make_shared<Poldi2DFunction>();
 
   for (size_t i = 0; i < peakCollection->peakCount(); ++i) {
     PoldiPeak_sptr peak = peakCollection->peak(i);
@@ -522,7 +522,7 @@ Poldi2DFunction_sptr PoldiFitPeaks2D::getFunctionIndividualPeaks(
 Poldi2DFunction_sptr PoldiFitPeaks2D::getFunctionPawley(
     std::string profileFunctionName,
     const PoldiPeakCollection_sptr &peakCollection) {
-  Poldi2DFunction_sptr mdFunction(new Poldi2DFunction);
+  auto mdFunction = boost::make_shared<Poldi2DFunction>();
 
   boost::shared_ptr<PoldiSpectrumPawleyFunction> poldiPawleyFunction =
       boost::dynamic_pointer_cast<PoldiSpectrumPawleyFunction>(
@@ -979,7 +979,7 @@ IAlgorithm_sptr PoldiFitPeaks2D::calculateSpectrum(
       getNormalizedPeakCollections(peakCollections);
 
   // Create a Poldi2DFunction that collects all sub-functions
-  Poldi2DFunction_sptr mdFunction(new Poldi2DFunction);
+  auto mdFunction = boost::make_shared<Poldi2DFunction>();
 
   // Add one Poldi2DFunction for each peak collection
   for (auto &normalizedPeakCollection : normalizedPeakCollections) {

--- a/Framework/SINQ/src/ProjectMD.cpp
+++ b/Framework/SINQ/src/ProjectMD.cpp
@@ -70,7 +70,7 @@ void ProjectMD::exec() {
     }
   }
 
-  MDHistoWorkspace_sptr outWS(new MDHistoWorkspace(dimensions));
+  auto outWS = boost::make_shared<MDHistoWorkspace>(dimensions);
   outWS->setTo(.0, .0, .0);
 
   memset(targetDim, 0, MAXDIM * sizeof(int));

--- a/Framework/SINQ/src/SINQHMListener.cpp
+++ b/Framework/SINQ/src/SINQHMListener.cpp
@@ -106,7 +106,7 @@ boost::shared_ptr<Workspace> SINQHMListener::extractData() {
     dimensions.push_back(MDHistoDimension_sptr(new MDHistoDimension(
         dimNames[i], dimNames[i], frame, .0, coord_t(dim[i]), dim[i])));
   }
-  MDHistoWorkspace_sptr ws(new MDHistoWorkspace(dimensions));
+  auto ws = boost::make_shared<MDHistoWorkspace>(dimensions);
   ws->setTo(.0, .0, .0);
 
   readHMData(ws);

--- a/Framework/SINQ/src/SINQTranspose3D.cpp
+++ b/Framework/SINQ/src/SINQTranspose3D.cpp
@@ -65,7 +65,7 @@ void SINQTranspose3D::doYXZ(IMDHistoWorkspace_sptr inWS) {
   dimensions.push_back(boost::const_pointer_cast<IMDDimension>(x));
   dimensions.push_back(boost::const_pointer_cast<IMDDimension>(z));
 
-  MDHistoWorkspace_sptr outWS(new MDHistoWorkspace(dimensions));
+  auto outWS = boost::make_shared<MDHistoWorkspace>(dimensions);
 
   inVal = inWS->getSignalArray();
   inErr = inWS->getErrorSquaredArray();
@@ -102,7 +102,7 @@ void SINQTranspose3D::doXZY(IMDHistoWorkspace_sptr inWS) {
   dimensions.push_back(boost::const_pointer_cast<IMDDimension>(z));
   dimensions.push_back(boost::const_pointer_cast<IMDDimension>(y));
 
-  MDHistoWorkspace_sptr outWS(new MDHistoWorkspace(dimensions));
+  auto outWS = boost::make_shared<MDHistoWorkspace>(dimensions);
 
   inVal = inWS->getSignalArray();
   inErr = inWS->getErrorSquaredArray();
@@ -141,7 +141,7 @@ void SINQTranspose3D::doTRICS(IMDHistoWorkspace_sptr inWS) {
   dimensions.push_back(boost::const_pointer_cast<IMDDimension>(z));
   dimensions.push_back(boost::const_pointer_cast<IMDDimension>(y));
 
-  MDHistoWorkspace_sptr outWS(new MDHistoWorkspace(dimensions));
+  auto outWS = boost::make_shared<MDHistoWorkspace>(dimensions);
   outWS->setTo(.0, .0, .0);
 
   inVal = inWS->getSignalArray();
@@ -180,7 +180,7 @@ void SINQTranspose3D::doAMOR(IMDHistoWorkspace_sptr inWS) {
   dimensions.push_back(boost::const_pointer_cast<IMDDimension>(x));
   dimensions.push_back(boost::const_pointer_cast<IMDDimension>(z));
 
-  MDHistoWorkspace_sptr outWS(new MDHistoWorkspace(dimensions));
+  auto outWS = boost::make_shared<MDHistoWorkspace>(dimensions);
   outWS->setTo(.0, .0, .0);
 
   xdim = static_cast<unsigned int>(x->getNBins());

--- a/Framework/SINQ/src/SliceMDHisto.cpp
+++ b/Framework/SINQ/src/SliceMDHisto.cpp
@@ -78,7 +78,7 @@ void SliceMDHisto::exec() {
         arDim->getName(), arDim->getName(), arDim->getMDFrame(),
         arDim->getX(start[k]), arDim->getX(end[k]), end[k] - start[k])));
   }
-  MDHistoWorkspace_sptr outWS(new MDHistoWorkspace(dimensions));
+  auto outWS = boost::make_shared<MDHistoWorkspace>(dimensions);
 
   coord_t *sourceDim =
       reinterpret_cast<coord_t *>(malloc(m_rank * sizeof(coord_t)));

--- a/Framework/SINQ/test/PoldiPeakCollectionTest.h
+++ b/Framework/SINQ/test/PoldiPeakCollectionTest.h
@@ -287,7 +287,7 @@ public:
   void testColumnCheckConsistency() {
     TestablePoldiPeakCollection peaks;
 
-    TableWorkspace_sptr newTable(new TableWorkspace());
+    auto newTable = boost::make_shared<TableWorkspace>();
     peaks.prepareTable(newTable);
 
     TS_ASSERT(peaks.checkColumns(newTable));

--- a/Framework/TestHelpers/src/MDEventsTestHelper.cpp
+++ b/Framework/TestHelpers/src/MDEventsTestHelper.cpp
@@ -65,7 +65,7 @@ EventWorkspace_sptr
 createDiffractionEventWorkspace(int numEvents, int numPixels, int numBins) {
   double binDelta = 10.0;
 
-  EventWorkspace_sptr retVal(new EventWorkspace);
+  auto retVal = boost::make_shared<EventWorkspace>();
   retVal->initialize(numPixels, 1, 1);
 
   // --------- Load the instrument -----------
@@ -349,7 +349,7 @@ Mantid::DataObjects::MDHistoWorkspace_sptr makeFakeMDHistoWorkspaceWithMDFrame(
         " invalid or unsupported number of dimensions given");
 
   ws_sptr->setTo(signal, errorSquared, numEvents);
-  ws_sptr->addExperimentInfo(ExperimentInfo_sptr(new ExperimentInfo()));
+  ws_sptr->addExperimentInfo(boost::make_shared<ExperimentInfo>());
   if (!name.empty())
     AnalysisDataService::Instance().addOrReplace(name, ws_sptr);
   return ws_sptr;

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -76,7 +76,7 @@ Workspace2D_sptr Create1DWorkspaceRand(int size) {
   std::generate(y1.access().begin(), y1.access().end(), randFunc);
   e1.access().resize(size);
   std::generate(e1.access().begin(), e1.access().end(), randFunc);
-  Workspace2D_sptr retVal(new Workspace2D);
+  auto retVal = boost::make_shared<Workspace2D>();
   retVal->initialize(1, size, size);
   retVal->setX(0, x1);
   retVal->setData(0, y1, e1);
@@ -89,7 +89,7 @@ Workspace2D_sptr Create1DWorkspaceConstant(int size, double value,
   x1.access().resize(size, 1);
   y1.access().resize(size, value);
   e1.access().resize(size, error);
-  Workspace2D_sptr retVal(new Workspace2D);
+  auto retVal = boost::make_shared<Workspace2D>();
   retVal->initialize(1, size, size);
   retVal->setX(0, x1);
   retVal->setData(0, y1, e1);
@@ -112,7 +112,7 @@ Workspace2D_sptr Create1DWorkspaceFib(int size) {
   y1.access().resize(size);
   std::generate(y1.access().begin(), y1.access().end(), FibSeries<double>());
   e1.access().resize(size);
-  Workspace2D_sptr retVal(new Workspace2D);
+  auto retVal = boost::make_shared<Workspace2D>();
   retVal->initialize(1, size, size);
   retVal->setX(0, x1);
   retVal->setData(0, y1, e1);
@@ -159,7 +159,7 @@ Create2DWorkspaceWithValues(int64_t nHist, int64_t nBins, bool isHist,
   x1.access().resize(isHist ? nBins + 1 : nBins, xVal);
   y1.access().resize(nBins, yVal);
   e1.access().resize(nBins, eVal);
-  Workspace2D_sptr retVal(new Workspace2D);
+  auto retVal = boost::make_shared<Workspace2D>();
   retVal->initialize(nHist, isHist ? nBins + 1 : nBins, nBins);
   for (int i = 0; i < nHist; i++) {
     retVal->setX(i, x1);
@@ -239,7 +239,7 @@ Workspace2D_sptr maskSpectra(Workspace2D_sptr workspace,
  */
 WorkspaceGroup_sptr CreateWorkspaceGroup(int nEntries, int nHist, int nBins,
                                          const std::string &stem) {
-  WorkspaceGroup_sptr group(new WorkspaceGroup);
+  auto group = boost::make_shared<WorkspaceGroup>();
   AnalysisDataService::Instance().add(stem, group);
   for (int i = 0; i < nEntries; ++i) {
     Workspace2D_sptr ws = Create2DWorkspace(nHist, nBins);
@@ -263,7 +263,7 @@ Workspace2D_sptr Create2DWorkspaceBinned(int nhist, int nbins, double x0,
   for (int i = 0; i < nbins + 1; ++i) {
     x.access()[i] = x0 + i * deltax;
   }
-  Workspace2D_sptr retVal(new Workspace2D);
+  auto retVal = boost::make_shared<Workspace2D>();
   retVal->initialize(nhist, nbins + 1, nbins);
   for (int i = 0; i < nhist; i++) {
     retVal->setX(i, x);
@@ -286,7 +286,7 @@ Workspace2D_sptr Create2DWorkspaceBinned(int nhist, const int numBoundaries,
   for (int i = 0; i < numBoundaries; ++i) {
     x.access()[i] = xBoundaries[i];
   }
-  Workspace2D_sptr retVal(new Workspace2D);
+  auto retVal = boost::make_shared<Workspace2D>();
   retVal->initialize(nhist, numBins + 1, numBins);
   for (int i = 0; i < nhist; i++) {
     retVal->setX(i, x);
@@ -600,15 +600,12 @@ void createInstrumentForWorkspaceWithDistances(
 
 //================================================================================================================
 WorkspaceSingleValue_sptr CreateWorkspaceSingleValue(double value) {
-  WorkspaceSingleValue_sptr retVal(
-      new WorkspaceSingleValue(value, sqrt(value)));
-  return retVal;
+  return boost::make_shared<WorkspaceSingleValue>(value, sqrt(value));
 }
 
 WorkspaceSingleValue_sptr CreateWorkspaceSingleValueWithError(double value,
                                                               double error) {
-  WorkspaceSingleValue_sptr retVal(new WorkspaceSingleValue(value, error));
-  return retVal;
+  return boost::make_shared<WorkspaceSingleValue>(value, error);
 }
 
 /** Perform some finalization on event workspace stuff */
@@ -657,7 +654,7 @@ CreateEventWorkspaceWithStartTime(int numPixels, int numBins, int numEvents,
   // add one to the number of bins as this is histogram
   numBins++;
 
-  EventWorkspace_sptr retVal(new EventWorkspace);
+  auto retVal = boost::make_shared<EventWorkspace>();
   retVal->initialize(numPixels, 1, 1);
 
   // Make fake events
@@ -712,7 +709,7 @@ EventWorkspace_sptr
 CreateGroupedEventWorkspace(std::vector<std::vector<int>> groups, int numBins,
                             double binDelta) {
 
-  EventWorkspace_sptr retVal(new EventWorkspace);
+  auto retVal = boost::make_shared<EventWorkspace>();
   retVal->initialize(1, 2, 1);
 
   for (size_t g = 0; g < groups.size(); g++) {
@@ -749,7 +746,7 @@ CreateGroupedEventWorkspace(std::vector<std::vector<int>> groups, int numBins,
  */
 EventWorkspace_sptr CreateRandomEventWorkspace(size_t numbins, size_t numpixels,
                                                double bin_delta) {
-  EventWorkspace_sptr retVal(new EventWorkspace);
+  auto retVal = boost::make_shared<EventWorkspace>();
   retVal->initialize(numpixels, numbins, numbins - 1);
 
   // and X-axis for references:
@@ -1235,7 +1232,7 @@ RebinnedOutput_sptr CreateRebinnedOutputWorkspace() {
 
 Mantid::DataObjects::PeaksWorkspace_sptr
 createPeaksWorkspace(const int numPeaks, const bool createOrientedLattice) {
-  PeaksWorkspace_sptr peaksWS(new PeaksWorkspace());
+  auto peaksWS = boost::make_shared<PeaksWorkspace>();
   Instrument_sptr inst =
       ComponentCreationHelper::createTestInstrumentRectangular2(1, 10);
   peaksWS->setInstrument(inst);

--- a/Vates/VatesAPI/test/vtkMDHexFactoryTest.h
+++ b/Vates/VatesAPI/test/vtkMDHexFactoryTest.h
@@ -100,7 +100,7 @@ public:
                             VATES::VolumeNormalization);
     factory.setSuccessor(std::move(uniqueSuccessor));
 
-    ITableWorkspace_sptr ws(new Mantid::DataObjects::TableWorkspace);
+    auto ws = boost::make_shared<Mantid::DataObjects::TableWorkspace>();
     TS_ASSERT_THROWS_NOTHING(factory.initialize(ws));
 
     // Need the raw pointer to test assertions here. Object is not yet deleted
@@ -124,7 +124,7 @@ public:
                             VATES::VolumeNormalization);
     factory.setSuccessor(std::move(uniqueSuccessor));
 
-    ITableWorkspace_sptr ws(new Mantid::DataObjects::TableWorkspace);
+    auto ws = boost::make_shared<Mantid::DataObjects::TableWorkspace>();
     TS_ASSERT_THROWS_NOTHING(factory.initialize(ws));
     TS_ASSERT_THROWS_NOTHING(factory.create(progressUpdater));
 
@@ -138,7 +138,7 @@ public:
                             VATES::VolumeNormalization);
     // factory.SetSuccessor(mockSuccessor); No Successor set.
 
-    ITableWorkspace_sptr ws(new Mantid::DataObjects::TableWorkspace);
+    auto ws = boost::make_shared<Mantid::DataObjects::TableWorkspace>();
     TS_ASSERT_THROWS(factory.initialize(ws), std::runtime_error);
   }
 

--- a/Vates/VatesAPI/test/vtkMDLineFactoryTest.h
+++ b/Vates/VatesAPI/test/vtkMDLineFactoryTest.h
@@ -69,7 +69,7 @@ public:
                              Mantid::VATES::VolumeNormalization);
     factory.setSuccessor(std::move(uniqueSuccessor));
 
-    ITableWorkspace_sptr ws(new Mantid::DataObjects::TableWorkspace);
+    auto ws = boost::make_shared<Mantid::DataObjects::TableWorkspace>();
     TS_ASSERT_THROWS_NOTHING(factory.initialize(ws));
     TS_ASSERT_THROWS_NOTHING(factory.create(progressUpdate));
 
@@ -146,7 +146,7 @@ public:
 
   void setUp()
   {
-    boost::shared_ptr<Mantid::DataObjects::MDEventWorkspace<Mantid::DataObjects::MDEvent<1>,1> > input 
+    boost::shared_ptr<Mantid::DataObjects::MDEventWorkspace<Mantid::DataObjects::MDEvent<1>,1> > input
       = MDEventsTestHelper::makeMDEWFull<1>(2, 10, 10, 4000);
     //Rebin it to make it possible to compare cells to bins.
     using namespace Mantid::API;
@@ -178,9 +178,8 @@ public:
     TS_ASSERT(dynamic_cast<vtkUnstructuredGrid *>(product.GetPointer()) !=
               NULL);
     TS_ASSERT_EQUALS(200000, product->GetNumberOfCells());
-    TS_ASSERT_EQUALS(400000, product->GetNumberOfPoints());    
+    TS_ASSERT_EQUALS(400000, product->GetNumberOfPoints());
   }
 };
 
 #endif
-  


### PR DESCRIPTION
This moves more objects to use `boost::make_shared`.

**To test:** If the builds pass, then it is fine.

This does not need to be in the release notes and has no issue.
