### PR TITLE
Fix warning: clang-analyzer-security.FloatLoopCounter

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ChebfunBase.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ChebfunBase.h
@@ -5,8 +5,8 @@
 #include "MantidCurveFitting/GSLMatrix.h"
 
 #include <boost/shared_ptr.hpp>
-#include <vector>
 #include <functional>
+#include <vector>
 
 namespace Mantid {
 
@@ -206,10 +206,14 @@ boost::shared_ptr<ChebfunBase> ChebfunBase::bestFitAnyTolerance(
     std::vector<double> &a, double maxA, double tolerance, size_t maxSize) {
   if (tolerance == 0.0)
     tolerance = g_tolerance;
-  for (double tol = tolerance; tol < 0.1; tol *= 100) {
+
+  double tol = tolerance;
+  while (tol < 0.1) {
     auto base = bestFit(start, end, f, p, a, maxA, tol, maxSize);
-    if (base)
+    if (base) {
       return base;
+    }
+    tol *= 100.0;
   }
   return ChebfunBase_sptr();
 }


### PR DESCRIPTION
This fixes a clang-tidy warning in the category clang-analyzer-security.FloatLoopCounter.

While in this case I think the for loop is OK (the constructor sets a minimum value of the tolerance and the loop step is quite large), it is at least as clear when written as a while loop. Keeping the warning level at zero makes it easier to spot potential issues in the future.

No release notes.

testing: code review.
