### PR TITLE
Improve LR log names

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRDirectBeamSort.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRDirectBeamSort.py
@@ -31,7 +31,7 @@ class CompareTwoNXSDataForSFcalculator(object):
             self.resultComparison = compare1
             return
 
-        compare2 = self.compareParameter('vATT', 'ascending')
+        compare2 = self.compareParameter('vAtt', 'ascending')
         if compare2 != 0:
             self.resultComparison = compare2
             return
@@ -170,7 +170,6 @@ class LRDirectBeamSort(PythonAlgorithm):
             if len(g) == 0:
                 continue
             runs = [r.getRunNumber() for r in g]
-            logger.notice(str(runs))
 
             direct_beam_runs = []
             peak_ranges = []
@@ -203,7 +202,7 @@ class LRDirectBeamSort(PythonAlgorithm):
                 else:
                     low_res = [0, number_of_pixels_x]
 
-                att = run.getRun().getProperty('vATT').value[0]-1
+                att = run.getRun().getProperty('vAtt').value[0]-1
                 direct_beam_runs.append(run.getRunNumber())
                 peak_ranges.append(int(peak[0]))
                 peak_ranges.append(int(peak[1]))
@@ -232,6 +231,7 @@ class LRDirectBeamSort(PythonAlgorithm):
             summary += "TOF: %s\n\n" % tof_range
 
             # Compute the scaling factors
+            logger.notice("Computing scaling factors for %s" % str(direct_beam_runs))
             LRScalingFactors(DirectBeamRuns=direct_beam_runs,
                              TOFRange=tof_range, TOFSteps=tof_steps,
                              SignalPeakPixelRange=peak_ranges,

--- a/Framework/PythonInterface/plugins/algorithms/LRDirectBeamSort.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRDirectBeamSort.py
@@ -1,16 +1,12 @@
 #pylint: disable=no-init,invalid-name
-import math
-import time
-import numpy as np
 import mantid
 from mantid.api import *
 from mantid.simpleapi import *
 from mantid.kernel import *
-import logging
 
 class CompareTwoNXSDataForSFcalculator(object):
     """
-        will return -1, 0 or 1 according to the position of the nexusToPosition in relation to the 
+        will return -1, 0 or 1 according to the position of the nexusToPosition in relation to the
         nexusToCompareWith based on the following criteria
         #1: number of attenuators (ascending order)
         #2: lambda requested (descending order)
@@ -58,9 +54,9 @@ class CompareTwoNXSDataForSFcalculator(object):
             resultLessThan = 1
             resultMoreThan = -1
 
-        if (_paramNexusToPosition < _paramNexusToCompareWith):
+        if _paramNexusToPosition < _paramNexusToCompareWith:
             return resultLessThan
-        elif (_paramNexusToPosition > _paramNexusToCompareWith):
+        elif _paramNexusToPosition > _paramNexusToCompareWith:
             return resultMoreThan
         else:
             return 0
@@ -74,7 +70,7 @@ def sorter_function(r1, r2):
     """
     return CompareTwoNXSDataForSFcalculator(r2, r1).result()
 
-     
+
 class LRDirectBeamSort(PythonAlgorithm):
 
     def category(self):
@@ -140,7 +136,7 @@ class LRDirectBeamSort(PythonAlgorithm):
 
     def _compute_scaling_factors(self, lr_data_sorted):
         """
-            If we need to compute the scaling factors, group the runs by their wavelength request 
+            If we need to compute the scaling factors, group the runs by their wavelength request
             @param lr_data_sorted: ordered list of workspaces
         """
         group_list = []
@@ -155,7 +151,7 @@ class LRDirectBeamSort(PythonAlgorithm):
                 if len(current_group)>0:
                     group_list.append(current_group)
                 current_group = []
-    
+
             current_group.append(r)
 
         # Add in the last group
@@ -169,7 +165,6 @@ class LRDirectBeamSort(PythonAlgorithm):
         for g in group_list:
             if len(g) == 0:
                 continue
-            runs = [r.getRunNumber() for r in g]
 
             direct_beam_runs = []
             peak_ranges = []

--- a/Framework/PythonInterface/plugins/algorithms/LRScalingFactors.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRScalingFactors.py
@@ -65,6 +65,7 @@ class LRScalingFactors(PythonAlgorithm):
         self.declareProperty("FrontSlitName", "S1", doc="Name of the front slit")
         self.declareProperty("BackSlitName", "Si", doc="Name of the back slit")
         self.declareProperty("TOFSteps", 500.0, doc="TOF step size")
+        self.declareProperty("SlitTolerance", 0.02, doc="Tolerance for matching slit positions")
         self.declareProperty(FileProperty("ScalingFactorFile","",
                                           action=FileAction.Save,
                                           extensions=['cfg']))
@@ -102,7 +103,7 @@ class LRScalingFactors(PythonAlgorithm):
         self.wavelength_tolerance = 0.2
 
         # Slit settings tolerance
-        self.tolerance = 0.02
+        self.tolerance = self.getProperty("SlitTolerance").value
 
         # Scaling factor output
         self.scaling_factors = []
@@ -236,7 +237,7 @@ class LRScalingFactors(PythonAlgorithm):
         if self.have_attenuator_info:
             return self.attenuators[run_index]
         else:
-            return int(workspace.getRun().getProperty('vATT').value[0]-1)
+            return int(workspace.getRun().getProperty('vAtt').value[0]-1)
 
     def get_valid_pixel_range(self, property_name, number_of_runs):
         """

--- a/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
@@ -75,6 +75,7 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
         self.declareProperty("AngleOffsetError", 0.0, doc="Angle offset error (degrees)")
         self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", Direction.Output), "Output workspace")
         self.declareProperty("ScalingFactorFile", "", doc="Scaling factor configuration file")
+        self.declareProperty("SlitTolerance", 0.02, doc="Tolerance for matching slit positions")
         self.declareProperty("SlitsWidthFlag", True,
                              doc="Looking for perfect match of slits width when using Scaling Factor file")
         self.declareProperty("IncidentMediumSelected", "", doc="Incident medium used for those runs")
@@ -92,7 +93,7 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
     def PyExec(self):
         # The old reduction code had a tolerance value for matching the
         # slit parameters to get the scaling factors
-        self.TOLERANCE = 0.020
+        self.TOLERANCE = self.getProperty("SlitTolerance").value
 
         # DATA
         dataRunNumbers = self.getProperty("RunNumbers").value

--- a/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
@@ -334,9 +334,9 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
         tthd_units = run_object.getProperty('tthd').units
 
         # Make sure we have radians
-        if thi_units == 'degree':
+        if thi_units.lower().startswith('deg'):
             thi_value *= math.pi / 180.0
-        if tthd_units == 'degree':
+        if tthd_units.lower().startswith('deg'):
             tthd_value *= math.pi / 180.0
 
         theta = math.fabs(tthd_value - thi_value) / 2.


### PR DESCRIPTION
Since the LR DAS upgrade started, a couple of minor issues were noticed:

1- Although Mantid doesn't seem to be case sensitive, the correct name of the attenuator log is "vAtt", not "vATT".

2- The new DAS writes the angle logs as "deg" instead of "degree". Make the algorithm a little more flexible to accommodate both.

3- Another issue we have seen while setting up was that the slit position tolerance wasn't matching the instrument. Make the slit tolerance a parameter.

To test: Make sure the system tests still pass. Code review the changes.

No release note info needed. All the info needed is in this PR, there is no additional Issue.
