### PR TITLE
Fix crash in AsymmetryCalc with workspace group

### DIFF
--- a/Framework/Algorithms/src/AsymmetryCalc.cpp
+++ b/Framework/Algorithms/src/AsymmetryCalc.cpp
@@ -55,13 +55,13 @@ std::map<std::string, std::string> AsymmetryCalc::validateInputs() {
     inputWS->getIndicesFromSpectra(forwd, list);
     if (forwd.size() != list.size()) {
       result["ForwardSpectra"] =
-        "Some of the spectra can not be found in the input workspace";
+          "Some of the spectra can not be found in the input workspace";
     }
 
     inputWS->getIndicesFromSpectra(backwd, list);
     if (backwd.size() != list.size()) {
       result["BackwardSpectra"] =
-        "Some of the spectra can not be found in the input workspace";
+          "Some of the spectra can not be found in the input workspace";
     }
   }
   return result;

--- a/Framework/Algorithms/src/AsymmetryCalc.cpp
+++ b/Framework/Algorithms/src/AsymmetryCalc.cpp
@@ -51,19 +51,19 @@ std::map<std::string, std::string> AsymmetryCalc::validateInputs() {
   std::vector<int> backwd = getProperty("BackwardSpectra");
 
   API::MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
-
-  inputWS->getIndicesFromSpectra(forwd, list);
-  if (forwd.size() != list.size()) {
-    result["ForwardSpectra"] =
+  if (inputWS) {
+    inputWS->getIndicesFromSpectra(forwd, list);
+    if (forwd.size() != list.size()) {
+      result["ForwardSpectra"] =
         "Some of the spectra can not be found in the input workspace";
-  }
+    }
 
-  inputWS->getIndicesFromSpectra(backwd, list);
-  if (backwd.size() != list.size()) {
-    result["BackwardSpectra"] =
+    inputWS->getIndicesFromSpectra(backwd, list);
+    if (backwd.size() != list.size()) {
+      result["BackwardSpectra"] =
         "Some of the spectra can not be found in the input workspace";
+    }
   }
-
   return result;
 }
 


### PR DESCRIPTION
Fixes #15402 

If `AsymmetryCalc` is run with a workspace group, the first call to `validateInputs()` results in a null input workspace (as it can't be cast to a `MatrixWorkspace`). Check for null here so that the algorithm can be run with workspace groups.

**To test:**
Test data is at `\\olympic\Babylon5\Scratch\TomPerkins\Data\HIFI00096329.nxs`
1. Replicate the bug:
   - Load the test file
   - Select the group in the workspace window
   - Try to run `AsymmetryCalc` using the GUI algorithms window - Mantid should crash
2. Test the fix:
   - Attempt the same steps and verify that Mantid does not crash
   - The algorithm should run on each individual workspace in the group
   - The results for each workspace should be grouped in the output WorkspaceGroup

Release notes will be updated when the instrument scientists are happy with the fix.
