### PR TITLE
Removed unused private field m_numOfPeriods from ISISRunLogs.

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/ISISRunLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ISISRunLogs.h
@@ -7,7 +7,7 @@
 
 #include "MantidAPI/Run.h"
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 namespace Mantid {
 namespace DataHandling {
@@ -46,8 +46,7 @@ class DLLExport ISISRunLogs {
 public:
   /// Construct this object using a run that has the required ICP event log
   /// and the number of periods
-  ISISRunLogs(const API::Run &icpRun, const int totalNumPeriods);
-
+  ISISRunLogs(const API::Run &icpRun);
   /// Adds the status log to the this run
   void addStatusLog(API::Run &exptRun);
   /// Adds period related logs
@@ -56,12 +55,9 @@ public:
   void addPeriodLog(const int i, API::Run &exptRun);
 
 private:
-  DISABLE_DEFAULT_CONSTRUCT(ISISRunLogs)
-
+  ISISRunLogs() = delete;
   /// A LogParser object
-  boost::scoped_ptr<Kernel::LogParser> m_logParser;
-  /// The total number of periods in original data file
-  const int m_numOfPeriods;
+  std::unique_ptr<Kernel::LogParser> m_logParser;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/ISISRunLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ISISRunLogs.h
@@ -55,7 +55,6 @@ public:
   void addPeriodLog(const int i, API::Run &exptRun);
 
 private:
-  ISISRunLogs() = delete;
   /// A LogParser object
   std::unique_ptr<Kernel::LogParser> m_logParser;
 };

--- a/Framework/DataHandling/src/ISISRunLogs.cpp
+++ b/Framework/DataHandling/src/ISISRunLogs.cpp
@@ -24,7 +24,7 @@ using Kernel::TimeSeriesProperty;
  */
 ISISRunLogs::ISISRunLogs(const API::Run &icpRun) {
   // ICP event either in form icp_event or icpevent
-  for (const auto &icpLogName : {"icp_event", "icpevent"}) {
+  for (const auto icpLogName : {"icp_event", "icpevent"}) {
     try {
       Kernel::Property *icpLog = icpRun.getLogData(icpLogName);
       m_logParser = Kernel::make_unique<LogParser>(icpLog);

--- a/Framework/DataHandling/src/ISISRunLogs.cpp
+++ b/Framework/DataHandling/src/ISISRunLogs.cpp
@@ -20,7 +20,6 @@ using Kernel::TimeSeriesProperty;
  * Construct using a run that has the required ICP event log
  * Throws if no icp event log exists
  * @param icpRun :: A run containing the ICP event log to parse
- * @param totalNumPeriods :: The total number of periods overall
  */
 ISISRunLogs::ISISRunLogs(const API::Run &icpRun) {
   // ICP event either in form icp_event or icpevent

--- a/Framework/DataHandling/src/ISISRunLogs.cpp
+++ b/Framework/DataHandling/src/ISISRunLogs.cpp
@@ -2,6 +2,7 @@
 #include "MantidDataHandling/ISISRunLogs.h"
 
 #include "MantidKernel/LogFilter.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 
 namespace Mantid {
@@ -21,21 +22,19 @@ using Kernel::TimeSeriesProperty;
  * @param icpRun :: A run containing the ICP event log to parse
  * @param totalNumPeriods :: The total number of periods overall
  */
-ISISRunLogs::ISISRunLogs(const API::Run &icpRun, const int totalNumPeriods)
-    : m_logParser(), m_numOfPeriods(totalNumPeriods) {
+ISISRunLogs::ISISRunLogs(const API::Run &icpRun) {
   // ICP event either in form icp_event or icpevent
-  static const char *icpLogNames[2] = {"icp_event", "icpevent"};
-  for (auto &icpLogName : icpLogNames) {
+  for (const auto &icpLogName : {"icp_event", "icpevent"}) {
     try {
       Kernel::Property *icpLog = icpRun.getLogData(icpLogName);
-      m_logParser.reset(new LogParser(icpLog));
+      m_logParser = Kernel::make_unique<LogParser>(icpLog);
       return;
     } catch (std::runtime_error &) {
     }
   }
   // If it does not exist then pass in a NULL log to indicate that period 1
   // should be assumed
-  m_logParser.reset(new LogParser(nullptr));
+  m_logParser = Kernel::make_unique<LogParser>(nullptr);
 }
 
 /**
@@ -53,12 +52,12 @@ void ISISRunLogs::addStatusLog(API::Run &exptRun) {
  */
 void ISISRunLogs::addPeriodLogs(const int period, API::Run &exptRun) {
   auto periodLog = m_logParser->createPeriodLog(period);
-  LogFilter *logFilter(nullptr);
+  auto logFilter = std::unique_ptr<LogFilter>();
   const TimeSeriesProperty<bool> *maskProp(nullptr);
   try {
     auto runningLog =
         exptRun.getTimeSeriesProperty<bool>(LogParser::statusLogName());
-    logFilter = new LogFilter(runningLog);
+    logFilter = Kernel::make_unique<LogFilter>(runningLog);
   } catch (std::exception &) {
     g_log.warning(
         "Cannot find status log. Logs will be not be filtered by run status");
@@ -75,7 +74,6 @@ void ISISRunLogs::addPeriodLogs(const int period, API::Run &exptRun) {
   // Filter logs if we have anything to filter on
   if (maskProp)
     exptRun.filterByLog(*maskProp);
-  delete logFilter;
 
   exptRun.addProperty(periodLog);
   exptRun.addProperty(m_logParser->createCurrentPeriodLog(period));

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -349,8 +349,7 @@ void LoadISISNexus2::exec() {
       loadPeriodData(firstentry, entry, monitor_workspace, true);
       local_workspace->setMonitorWorkspace(monitor_workspace);
 
-      ISISRunLogs monLogCreator(monitor_workspace->run(),
-                                m_detBlockInfo.numberOfPeriods);
+      ISISRunLogs monLogCreator(monitor_workspace->run());
       monLogCreator.addPeriodLogs(1, monitor_workspace->mutableRun());
 
       const std::string monitorPropBase = "MonitorWorkspace";
@@ -1125,8 +1124,7 @@ void LoadISISNexus2::loadLogs(DataObjects::Workspace2D_sptr &ws,
   ws->populateInstrumentParameters();
 
   // Make log creator object and add the run status log
-  m_logCreator.reset(
-      new ISISRunLogs(ws->run(), m_detBlockInfo.numberOfPeriods));
+  m_logCreator.reset(new ISISRunLogs(ws->run()));
   m_logCreator->addStatusLog(ws->mutableRun());
 }
 

--- a/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -722,8 +722,7 @@ void LoadMuonNexus1::runLoadLog(DataObjects::Workspace2D_sptr localWorkspace) {
   }
 
   auto &run = localWorkspace->mutableRun();
-  int n = static_cast<int>(m_numberOfPeriods);
-  ISISRunLogs runLogs(run, n);
+  ISISRunLogs runLogs(run);
   runLogs.addStatusLog(run);
 }
 
@@ -735,8 +734,7 @@ void LoadMuonNexus1::runLoadLog(DataObjects::Workspace2D_sptr localWorkspace) {
 void LoadMuonNexus1::addPeriodLog(DataObjects::Workspace2D_sptr localWorkspace,
                                   int64_t period) {
   auto &run = localWorkspace->mutableRun();
-  int n = static_cast<int>(m_numberOfPeriods);
-  ISISRunLogs runLogs(run, n);
+  ISISRunLogs runLogs(run);
   if (period == 0) {
     runLogs.addPeriodLogs(1, run);
   } else {

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -630,7 +630,7 @@ void LoadNexusMonitors2::splitMutiPeriodHistrogramData(
   size_t yLength = m_workspace->blocksize() / numPeriods;
   size_t xLength = yLength + 1;
   size_t numSpectra = m_workspace->getNumberHistograms();
-  ISISRunLogs monLogCreator(m_workspace->run(), static_cast<int>(numPeriods));
+  ISISRunLogs monLogCreator(m_workspace->run());
   for (size_t i = 0; i < numPeriods; i++) {
     // create the period workspace
     API::MatrixWorkspace_sptr wsPeriod =

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -730,7 +730,7 @@ void LoadRawHelper::runLoadLog(const std::string &fileName,
   }
   // Make log creator object and add the run status log if we have the
   // appropriate ICP log
-  m_logCreator.reset(new ISISRunLogs(localWorkspace->run(), m_numberOfPeriods));
+  m_logCreator.reset(new ISISRunLogs(localWorkspace->run()));
   m_logCreator->addStatusLog(localWorkspace->mutableRun());
 }
 


### PR DESCRIPTION
This fixes #15392.

No release notes. This addresses a compiler warning found in PR #15327. 

I removed the unused private field `m_numOfPeriods`, and updated the constructor and functions calling it. While working on this class, I also removed all calls to new `new` in favor of `unique_ptr` and `make_unique`

Since there is user-defined constructor, there won't be an implicitly created default constructor. Explicitly deleting it is unnecessary.

code review: Please check I didn't change the behavior of this class.

testing: This file lacks explicit unit tests, but appears to have [100% coverage from other tests.](https://coveralls.io/builds/5141282/source?filename=Framework%2FDataHandling%2Fsrc%2FISISRunLogs.cpp)
