### PR TITLE
Fix clang-tidy warnings that have crept into Framework.

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BivariateNormal.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BivariateNormal.h
@@ -140,10 +140,7 @@ public:
   }
 
   bool hasAttribute(const std::string &attName) const override {
-    if (attName == std::string("CalcVariances"))
-      return true;
-
-    return false;
+    return attName.compare("CalcVariances") == 0;
   }
 
   bool CalcVxx, CalcVyy, CalcVxy;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadANSTOHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadANSTOHelper.h
@@ -88,7 +88,7 @@ protected:
   double m_tofMax;
 
   // methods
-  virtual void addEventImpl(size_t id, double tof); // override
+  void addEventImpl(size_t id, double tof) override;
 
 public:
   // construction
@@ -110,7 +110,7 @@ protected:
   std::vector<EventVector_pt> &m_eventVectors;
 
   // methods
-  virtual void addEventImpl(size_t id, double tof) override;
+  void addEventImpl(size_t id, double tof) override;
 
 public:
   // construction

--- a/Framework/DataHandling/inc/MantidDataHandling/PatchBBY.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/PatchBBY.h
@@ -45,23 +45,19 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 
 class DLLExport PatchBBY : public API::Algorithm {
 public:
-  // construction
-  PatchBBY() {}
-  virtual ~PatchBBY() {}
-
   // description
-  virtual int version() const override { return 1; }
-  virtual const std::string name() const override { return "PatchBBY"; }
-  virtual const std::string category() const override { return "DataHandling"; }
-  virtual const std::string summary() const override {
+  int version() const override { return 1; }
+  const std::string name() const override { return "PatchBBY"; }
+  const std::string category() const override { return "DataHandling"; }
+  const std::string summary() const override {
     return "Patches a BilBy data file.";
   }
 
 protected:
   // initialisation
-  virtual void init() override;
+  void init() override;
   // execution
-  virtual void exec() override;
+  void exec() override;
 };
 
 } // DataHandling

--- a/Framework/DataHandling/src/LoadANSTOHelper.cpp
+++ b/Framework/DataHandling/src/LoadANSTOHelper.cpp
@@ -388,7 +388,7 @@ bool File::append(const std::string &path, const std::string &name,
   std::unique_ptr<FILE, decltype(&fclose)> handle(fopen(path.c_str(), "rb+"),
                                                   fclose);
 
-  bool good = handle != NULL;
+  bool good = handle != nullptr;
   int64_t lastHeaderPosition = 0;
   int64_t targetPosition = -1;
 

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -380,9 +380,7 @@ public:
 
     std::string foundName;
     svc_it it = findNameWithCaseSearch(name, foundName);
-    if (it != datamap.end())
-      return true;
-    return false;
+    return it != datamap.end();
   }
 
   /// Return the number of objects stored by the data service

--- a/Framework/Kernel/inc/MantidKernel/PropertyHistory.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHistory.h
@@ -77,11 +77,8 @@ public:
 
   /// this is required for boost.python
   bool operator==(const PropertyHistory &other) const {
-    if (name() == other.name() && value() == other.value() &&
-        type() == other.type() && isDefault() == other.isDefault()) {
-      return true;
-    }
-    return false;
+    return name() == other.name() && value() == other.value() &&
+           type() == other.type() && isDefault() == other.isDefault();
   }
 
 private:

--- a/Framework/LiveData/src/ADARA/ADARAPackets.cpp
+++ b/Framework/LiveData/src/ADARA/ADARAPackets.cpp
@@ -667,9 +667,9 @@ DetectorBankSetsPkt::DetectorBankSetsPkt(const uint8_t *data, uint32_t len)
       msg += " payload_len=";
       msg += boost::lexical_cast<std::string>(m_payload_len);
       delete[] m_sectionOffsets;
-      m_sectionOffsets = (uint32_t *)NULL;
+      m_sectionOffsets = nullptr;
       delete[] m_after_banks_offset;
-      m_after_banks_offset = (uint32_t *)NULL;
+      m_after_banks_offset = nullptr;
       throw invalid_packet(msg);
     } else if (m_version > ADARA::PacketType::DETECTOR_BANK_SETS_VERSION &&
                m_payload_len < ((sectionOffset + baseSectionOffsetNoBanks) *
@@ -714,9 +714,9 @@ DetectorBankSetsPkt::DetectorBankSetsPkt(const uint8_t *data, uint32_t len)
     msg += " payload_len=";
     msg += boost::lexical_cast<std::string>(m_payload_len);
     delete[] m_sectionOffsets;
-    m_sectionOffsets = (uint32_t *)NULL;
+    m_sectionOffsets = nullptr;
     delete[] m_after_banks_offset;
-    m_after_banks_offset = (uint32_t *)NULL;
+    m_after_banks_offset = nullptr;
     throw invalid_packet(msg);
   } else if (m_version > ADARA::PacketType::DETECTOR_BANK_SETS_VERSION &&
              m_payload_len < (sectionOffset * sizeof(uint32_t))) {

--- a/Framework/TestHelpers/inc/MantidTestHelpers/BoxControllerDummyIO.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/BoxControllerDummyIO.h
@@ -54,7 +54,7 @@ public:
   /// get the full file name of the file used for IO operations
   const std::string &getFileName() const override { return m_fileName; }
   /**Return the size of the NeXus data block used in NeXus data array*/
-  size_t getDataChunk() const { return 1; }
+  size_t getDataChunk() const override { return 1; }
 
   bool openFile(const std::string &fileName, const std::string &mode) override;
   void saveBlock(const std::vector<float> & /* DataBlock */,


### PR DESCRIPTION
This fixes a few [clang-tidy warnings that currently appear in Framework](http://builds.mantidproject.org/view/Static%20Analysis/job/clang-tidy_fixed/18/warnings10Result/). It should address all remaining warnings in the categories `modernize-use-nullptr`, `modernize-use-override`, and `readability-simplify-boolean-expr`.

no release notes.

code review: Check that the changes made sense.

testing: Check if the builds pass.
