### PR TITLE
Fix Crash when incorrect credentials are used when logging into ICAT in Refl GUI

### DIFF
--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflMainViewPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflMainViewPresenter.cpp
@@ -1452,13 +1452,24 @@ void ReflMainViewPresenter::search() {
   // This is breaking the abstraction provided by IReflSearcher, but provides a
   // nice usability win
   // If we're not logged into a catalog, prompt the user to do so
-  if (CatalogManager::Instance().getActiveSessions().empty())
-    m_view->showAlgorithmDialog("CatalogLogin");
-
-  auto sessionId =
-      CatalogManager::Instance().getActiveSessions().front()->getSessionId();
-
-  // try {
+  if (CatalogManager::Instance().getActiveSessions().empty()) {
+    try {
+      m_view->showAlgorithmDialog("CatalogLogin");
+    } catch (std::runtime_error &e) {
+      m_view->giveUserCritical("Error Logging in:\n" + std::string(e.what()),
+                               "login failed");
+    }
+  }
+  std::string sessionId;
+  // check to see if we have any active sessions for ICAT
+  if (!CatalogManager::Instance().getActiveSessions().empty()) {
+    // we have an active session, so grab the ID
+    sessionId =
+        CatalogManager::Instance().getActiveSessions().front()->getSessionId();
+  } else {
+    // there are no active sessions, we return here to avoid an exception
+    return;
+  }
   auto algSearch = AlgorithmManager::Instance().create("CatalogGetDataFiles");
   algSearch->initialize();
   algSearch->setChild(true);
@@ -1468,34 +1479,6 @@ void ReflMainViewPresenter::search() {
   algSearch->setProperty("OutputWorkspace", "_ReflSearchResults");
   auto algRunner = m_view->getAlgorithmRunner();
   algRunner->startAlgorithm(algSearch);
-  /*
-  while (!currentAlg->isExecuted())
-  {
-
-  THIS WORKS FUNCTIONALLY BUT YOU NEED TO
-  FIND A BETTER WAY TO SEE IF ALGORITHM
-  HAS BEEN EXECUTED AS THIS STILL INTRODUCES
-  A SERIAL-TYPE LAG
-
-
-
-  }
-  if (currentAlg->isExecuted())
-  {
-  ITableWorkspace_sptr results = currentAlg->getProperty("OutputWorkspace");
-  m_searchModel = ReflSearchModel_sptr(
-  new ReflSearchModel(*getTransferStrategy(), results, searchInstr));
-  m_view->showSearch(m_searchModel);
-  }
-  //ITableWorkspace_sptr results = algSearch->getProperty("OutputWorkspace");
-  //auto results = m_searcher->search(searchString);
-  m_searchModel = ReflSearchModel_sptr(
-  new ReflSearchModel(*getTransferStrategy(), results, searchInstr));
-  m_view->showSearch(m_searchModel);
-  } catch (std::runtime_error &e) {
-  m_view->giveUserCritical("Error running search:\n" + std::string(e.what()),
-  "Search Failed");
-  }*/
 }
 
 void ReflMainViewPresenter::populateSearch(IAlgorithm_sptr searchAlg) {

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflMainViewPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflMainViewPresenter.cpp
@@ -1468,6 +1468,9 @@ void ReflMainViewPresenter::search() {
         CatalogManager::Instance().getActiveSessions().front()->getSessionId();
   } else {
     // there are no active sessions, we return here to avoid an exception
+    m_view->giveUserInfo(
+        "Error Logging in: Please press 'Search' to try again.",
+        "Login Failed");
     return;
   }
   auto algSearch = AlgorithmManager::Instance().create("CatalogGetDataFiles");


### PR DESCRIPTION
There were no checks being performed when the GUI attempts to grab the sessionID of the ICAT active sessions. The check has now been added to see if there are any active sessions before attempting to retrieve the ID of that session. 

**To Test**
- Make sure you have an ICAT login (to check what happens when the correct credentials are entered)
- Load up the ISIS Reflectometry (Polref) interface (`Interfaces > Reflectometry > ISIS Reflectometry (Polref)`)
- In the search table (to the right hand side) change the search instrument to `Polref`
- Change the type from Description to Measurement 
- Enter the Investigation ID `1520249`
- When the ICAT login dialog pops up:
- Enter the wrong credentials and make sure mantid does not crash
- Press `Cancel` and ensure there is no crash
- Close the dialog use the `X` window button and make sure there is no crash
- Enter the correct credentials and search, make sure the search table is populated.

[Release Notes](http://www.mantidproject.org/Release_Notes_3_7_Reflectometry#ISIS_Reflectometry_.28Polref.29)

Fixes #15400
