### PR TITLE
Make RotateSource doc test less sensitive to platform specific numerical issues

### DIFF
--- a/docs/source/algorithms/RotateSource-v1.rst
+++ b/docs/source/algorithms/RotateSource-v1.rst
@@ -29,8 +29,24 @@ Usage
    # Original positions
    samplePos = ws.getInstrument().getSample().getPos()
    sourcePos = ws.getInstrument().getSource().getPos()
-   print "Original position of the sample: [%.1f, %.1f, %.1f]" % (samplePos.X(), samplePos.Y(), samplePos.Z())
-   print "Original position of the source: [%.1f, %.1f, %.1f]" % (sourcePos.X(), sourcePos.Y(), sourcePos.Z())
+
+   def pos3D_as_str(pos, digits=1, tolerance=1e-7):
+     """
+     Produce a string with a human readable version of a V3D position (x, y, z),
+     from a V3D object, using a fixed limited number of digits (for robust string
+     comparisons).
+     """
+     def nz(value):
+        """ Handles potential issues with +-0 (tiny values) """
+        return 0.0 if abs(value) < tolerance else value
+
+     precision = str(digits)
+     format_str = '[{0:.'+precision+'f}, {1:.'+precision+'f}, {2:.'+precision+'f}]'
+     result = format_str.format(nz(pos.getX()), nz(pos.getY()), nz(pos.getZ()))
+     return result
+
+   print "Original position of the sample: {0}".format(pos3D_as_str(samplePos))
+   print "Original position of the source: {0}".format(pos3D_as_str(sourcePos))
 
    # Move (rotate) the source around X axis
    RotateSource(ws, -90)
@@ -38,8 +54,8 @@ Usage
    # New positions
    samplePos = ws.getInstrument().getSample().getPos()
    sourcePos = ws.getInstrument().getSource().getPos()
-   print "New position of the sample: [%.1f, %.1f, %.1f]" % (samplePos.X(), samplePos.Y(), samplePos.Z())
-   print "New position of the source: [%.1f, %.1f, %.1f]" % (sourcePos.X(), sourcePos.Y(), sourcePos.Z())
+   print "New position of the sample: {0}".format(pos3D_as_str(samplePos))
+   print "New position of the source: {0}".format(pos3D_as_str(sourcePos))
 
 Output:
 
@@ -48,7 +64,7 @@ Output:
    Original position of the sample: [0.0, 0.0, 0.0]
    Original position of the source: [0.0, 0.0, -10.0]
    New position of the sample: [0.0, 0.0, 0.0]
-   New position of the source: [0.0, 10.0, -0.0]
+   New position of the source: [0.0, 10.0, 0.0]
 
 .. categories::
 


### PR DESCRIPTION
Fixes #15203.

Prevents issues with tiny numerical differences.

To test:
- Tests should pass (now this passes on windows debug mode as well)
- Review the change and make sure it is sensible

This is an internal change, so no release note.

In this test all platforms except windows+MSVC+debug produce the output "-0.0" (from -2e-15) in the Z coordinate of the source after rotation.

I'm not very happy that, as in #15204, the test (which is also intended as a simple example) gets a bit obfuscated.
But I didn't find any other way to fix the test given the way we are checking the outputs.
The old expected text pattern looked a bit awkward, as the Z coordinate of the sample became -0.0 from 0.0.
