### PR TITLE
Disable AlignComponents usage example tests because it fails on RHEL6.

### DIFF
--- a/docs/source/algorithms/AlignComponents-v1.rst
+++ b/docs/source/algorithms/AlignComponents-v1.rst
@@ -60,7 +60,7 @@ Usage
 
 **Example - Align the X and Z position of bank26 in POWGEN:**
 
-.. testcode:: position
+.. code-block:: python
 
       LoadCalFile(InstrumentName="PG3",
             CalFilename="PG3_golden.cal",
@@ -81,14 +81,14 @@ Usage
 
 Output:
 
-.. testoutput:: position
+.. code-block:: none
 
     Start position is [1.54436,0.863271,-1.9297]
     Final position is [1.50591,0.863271,-1.92734]
 
 **Example - Align the Y rotation of bank26 and bank46 in POWGEN:**
 
-.. testcode:: rotation
+.. code-block:: python
 
       LoadCalFile(InstrumentName="PG3",
 	    CalFilename="PG3_golden.cal",
@@ -114,7 +114,9 @@ Output:
       print "Final bank26 rotation is [{:.3f}.{:.3f},{:.3f}]".format(bank26Rot[0], bank26Rot[1], bank26Rot[2])
       print "Final bank46 rotation is [{:.3f}.{:.3f},{:.3f}]".format(bank46Rot[0], bank46Rot[1], bank46Rot[2])
 
-.. testoutput:: rotation
+Output:
+
+.. code-block:: none
 
       Start bank26 rotation is [-24.061.0.120,18.016]
       Start bank46 rotation is [-41.092.0.061,17.795]
@@ -123,7 +125,7 @@ Output:
 
 **Example - Align sample position in POWGEN:**
 
-.. testcode:: sample
+.. code-block:: python
 
       LoadCalFile(InstrumentName="PG3",
 	    CalFilename="PG3_golden.cal",
@@ -142,7 +144,9 @@ Output:
             FitSamplePosition=True)
       print "Final sample position is {:.5f}".format(mtd['ws'].getInstrument().getSample().getPos().getZ())
 
-.. testoutput:: sample
+Output:
+
+.. code-block:: none
 
       Start sample position is 0.0
       Final sample position is 0.02826


### PR DESCRIPTION
This disables AlignComponents doctests because it fails on RHEL6 as seen [here.](http://builds.mantidproject.org/job/master_doctests/231/testReport/)

I created another issue #15425 for future me to reimplement these doctests in a way that works for RHEL6.

**To test:**

No testing required, just look at the changes.

Fixes #15394 

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
