### PR TITLE
Fixing bug in validation of characterization run numbers

### DIFF
--- a/scripts/Interface/reduction_gui/reduction/diffraction/diffraction_run_setup_script.py
+++ b/scripts/Interface/reduction_gui/reduction/diffraction/diffraction_run_setup_script.py
@@ -222,32 +222,20 @@ class RunSetupScript(BaseScriptElement):
             self.finalunits = BaseScriptElement.getStringElement(instrument_dom,\
                     "finaldataunits", default=RunSetupScript.finalunits)
 
-            tempint = BaseScriptElement.getStringElement(instrument_dom,\
+            self.bkgdrunnumber = BaseScriptElement.getStringElement(instrument_dom,\
                     "backgroundnumber", default=RunSetupScript.bkgdrunnumber)
-            try:
-                self.bkgdrunnumber = int(tempint)
-            except ValueError:
-                self.bkgdrunnumber = None
             tempbool = BaseScriptElement.getStringElement(instrument_dom,\
                     "disablebackgroundcorrection", default=str(int(RunSetupScript.disablebkgdcorrection)))
             self.disablebkgdcorrection = bool(int(tempbool))
 
-            tempint = BaseScriptElement.getStringElement(instrument_dom,\
+            self.vanrunnumber = BaseScriptElement.getStringElement(instrument_dom,\
                     "vanadiumnumber", default=RunSetupScript.vanrunnumber)
-            try:
-                self.vanrunnumber = int(tempint)
-            except ValueError:
-                self.vanrunnumber = ""
             tempbool = BaseScriptElement.getStringElement(instrument_dom,\
                     "disablevanadiumcorrection", default=str(int(RunSetupScript.disablevancorrection)))
             self.disablevancorrection = bool(int(tempbool))
 
-            tempint = BaseScriptElement.getStringElement(instrument_dom,\
+            self.vanbkgdrunnumber = BaseScriptElement.getStringElement(instrument_dom,\
                     "vanadiumbackgroundnumber", default=RunSetupScript.vanbkgdrunnumber)
-            try:
-                self.vanbkgdrunnumber = int(tempint)
-            except ValueError:
-                self.vanbkgdrunnumber = None
             tempbool = BaseScriptElement.getStringElement(instrument_dom,\
                     "disablevanadiumbackgroundcorrection", default=str(int(RunSetupScript.disablevanbkgdcorrection)))
             self.disablevanbkgdcorrection = bool(int(tempbool))

--- a/scripts/Interface/reduction_gui/widgets/diffraction/diffraction_run_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/diffraction/diffraction_run_setup.py
@@ -21,6 +21,10 @@ try:
 except:
     pass
 
+def generateRegExpValidator(widget, expression):
+    rx = QtCore.QRegExp(expression)
+    return QtGui.QRegExpValidator(rx, widget)
+
 class RunSetupWidget(BaseWidget):
     """ Widget that presents run setup including sample run, optional vanadium run and etc.
     """
@@ -103,21 +107,13 @@ class RunSetupWidget(BaseWidget):
         self._content.resamplex_edit.setEnabled(False)
 
         # Constraints/Validator
-        # Integers
-        iv0 = QtGui.QIntValidator(self._content.emptyrun_edit)
-        iv0.setBottom(0)
+        iv0 = generateRegExpValidator(self._content.emptyrun_edit, "[\d,-]*")
         self._content.emptyrun_edit.setValidator(iv0)
 
-        iv1 = QtGui.QIntValidator(self._content.vanrun_edit)
-        iv1.setBottom(0)
+        iv1 = generateRegExpValidator(self._content.vanrun_edit, "[\d,-]*")
         self._content.vanrun_edit.setValidator(iv1)
 
-        # iv2 = QtGui.QIntValidator(self._content.vannoiserun_edit)
-        # iv2.setBottom(0)
-        # self._content.vannoiserun_edit.setValidator(iv2)
-
-        iv3 = QtGui.QIntValidator(self._content.vanbkgdrun_edit)
-        iv3.setBottom(0)
+        iv3 = generateRegExpValidator(self._content.vanbkgdrun_edit, "[\d,-]*")
         self._content.vanbkgdrun_edit.setValidator(iv3)
 
         siv = QtGui.QIntValidator(self._content.resamplex_edit)
@@ -176,11 +172,13 @@ class RunSetupWidget(BaseWidget):
             @param state: RunSetupScript object
         """
         self._content.runnumbers_edit.setText(state.runnumbers)
+        self._content.runnumbers_edit.setValidator(generateRegExpValidator(self._content.runnumbers_edit, "[\d,-]*"))
+
         self._content.calfile_edit.setText(state.calibfilename)
         self._content.lineEdit_expIniFile.setText(state.exp_ini_file_name)
         self._content.charfile_edit.setText(state.charfilename)
         self._content.sum_checkbox.setChecked(state.dosum)
-        # Set binning type (logarithm or linear) 
+        # Set binning type (logarithm or linear)
         bintype_index = 1
         if state.doresamplex is True:
             # resample x
@@ -221,15 +219,15 @@ class RunSetupWidget(BaseWidget):
 
         # Background correction
         if state.bkgdrunnumber is not None and state.bkgdrunnumber != "":
-            self._content.emptyrun_edit.setText(str(int(state.bkgdrunnumber)))
+            self._content.emptyrun_edit.setText(state.bkgdrunnumber)
         self._content.disablebkgdcorr_chkbox.setChecked(state.disablebkgdcorrection)
         # Vanadium correction
         if state.vanrunnumber is not None and state.vanrunnumber != "":
-            self._content.vanrun_edit.setText(str(abs(int(state.vanrunnumber))))
+            self._content.vanrun_edit.setText(state.vanrunnumber)
         self._content.disablevancorr_chkbox.setChecked(state.disablevancorrection)
         # Vanadium background correction
         if state.vanbkgdrunnumber is not None and state.vanbkgdrunnumber != "":
-            self._content.vanbkgdrun_edit.setText(str(int(state.vanbkgdrunnumber)))
+            self._content.vanbkgdrun_edit.setText(state.vanbkgdrunnumber)
         self._content.disablevanbkgdcorr_chkbox.setChecked(state.disablevanbkgdcorrection)
 
         # self._content.vannoiserun_edit.setText(str(state.vannoiserunnumber))

--- a/scripts/Interface/reduction_gui/widgets/diffraction/diffraction_run_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/diffraction/diffraction_run_setup.py
@@ -2,10 +2,8 @@
 ################################################################################
 # This is my first attempt to make a tab from quasi-scratch
 ################################################################################
-from PyQt4 import QtGui, uic, QtCore
-from functools import partial
+from PyQt4 import QtGui, QtCore
 from reduction_gui.widgets.base_widget import BaseWidget
-import reduction_gui.widgets.util as util
 from mantid.kernel import Logger
 
 from reduction_gui.reduction.diffraction.diffraction_run_setup_script import RunSetupScript
@@ -107,13 +105,14 @@ class RunSetupWidget(BaseWidget):
         self._content.resamplex_edit.setEnabled(False)
 
         # Constraints/Validator
-        iv0 = generateRegExpValidator(self._content.emptyrun_edit, "[\d,-]*")
+        expression = r'[\d,-]*'
+        iv0 = generateRegExpValidator(self._content.emptyrun_edit, expression)
         self._content.emptyrun_edit.setValidator(iv0)
 
-        iv1 = generateRegExpValidator(self._content.vanrun_edit, "[\d,-]*")
+        iv1 = generateRegExpValidator(self._content.vanrun_edit, expression)
         self._content.vanrun_edit.setValidator(iv1)
 
-        iv3 = generateRegExpValidator(self._content.vanbkgdrun_edit, "[\d,-]*")
+        iv3 = generateRegExpValidator(self._content.vanbkgdrun_edit, expression)
         self._content.vanbkgdrun_edit.setValidator(iv3)
 
         siv = QtGui.QIntValidator(self._content.resamplex_edit)
@@ -172,7 +171,7 @@ class RunSetupWidget(BaseWidget):
             @param state: RunSetupScript object
         """
         self._content.runnumbers_edit.setText(state.runnumbers)
-        self._content.runnumbers_edit.setValidator(generateRegExpValidator(self._content.runnumbers_edit, "[\d,-]*"))
+        self._content.runnumbers_edit.setValidator(generateRegExpValidator(self._content.runnumbers_edit, r'[\d,-]*'))
 
         self._content.calfile_edit.setText(state.calibfilename)
         self._content.lineEdit_expIniFile.setText(state.exp_ini_file_name)
@@ -265,7 +264,7 @@ class RunSetupWidget(BaseWidget):
             s.doresamplex = True
             try:
                 s.resamplex = int(self._content.resamplex_edit.text())
-            except ValueError as e:
+            except ValueError:
                 raise RuntimeError('ResampleX parameter is not given!')
 
             if s.resamplex < 0 and bintypestr.startswith('Linear'):


### PR DESCRIPTION
The various characterization runs in the "Powder Diffraction Reduction" GUI did not accept more than 9 characters.  The fields are labeled:
- "Empty Run Correction"
- "Vanadium Run Correction"
- Vanadium Background Run Correction"

**To test:**

Bring up the GUI and try entering various collections of runs into the interface. You don't need to run, just fill it in then "save" and "export". Also try restarting mantid and see that the values are read back into the interface.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- Is the code of an acceptable quality?
- Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- Do changes function as described? Add comments below that describe the tests performed?
- How do the changes handle unexpected situations, e.g. bad input?
- Has the relevant documentation been added/updated?
- Is user-facing documentation written in a user-friendly manner?
- Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
