### PR TITLE
Make AlignComponents use method='L-BFGS-B' in scipy.optimize.minimize

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
@@ -280,6 +280,7 @@ class AlignComponents(PythonAlgorithm):
                 else:
                     mask_out = None
                 newZ = minimize(self._minimisation_func_L1, x0=componentZ,
+                                method='L-BFGS-B',
                                 args=(wks_name,
                                       componentName,
                                       firstIndex,
@@ -360,6 +361,7 @@ class AlignComponents(PythonAlgorithm):
                                    self._initialPos[5] + self.getProperty("MaxGammaRotation").value))
 
             results = minimize(self._minimisation_func, x0=x0List,
+                               method='L-BFGS-B',
                                args=(wks_name,
                                      component,
                                      firstIndex,


### PR DESCRIPTION
Older versions of `scipy.optimize.minimize` don't automatically select the correct method to use when bounds are provided. This manually specifies which method it should use.

**To test:**

You can run the unit test for AlignComponents and see that this warning is gone. `ctest -V -R AlignComponents`

Fixes #15426 

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
