### PR TITLE
Speed up Windows installer compression

### DIFF
--- a/buildconfig/CMake/WindowsNSIS.cmake
+++ b/buildconfig/CMake/WindowsNSIS.cmake
@@ -14,6 +14,7 @@ set( CPACK_NSIS_INSTALL_ROOT "C:")
 set( CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}/images\\\\MantidPlot_Icon_32offset.png" )
 set( CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}/images\\\\MantidPlot_Icon_32offset.ico" )
 set( CPACK_NSIS_MUI_UNIICON "${CMAKE_CURRENT_SOURCE_DIR}/images\\\\MantidPlot_Icon_32offset.ico" )
+set( CPACK_NSIS_COMPRESSOR "ZLIB" )
 
 ###########################################################################
 # Deployment type - currently only works for Release!


### PR DESCRIPTION
The NSIS Compressor has been changed to `ZLIB` from `LZMA` during testing this has shown a significant speed increase in building the package and also a faster install time.
# To Test

**THIS MUST BE TESTED ON WINDOWS**
- Run `CMake` with `PACKAGE_DOCS=ON` and `ENABLE_CPACK=ON`
- Install Mantid using the installer that is produced
- Ensure you can run Mantid
- Check that line 38 in `Build\_CPack_Packages\win64\NSIS\project.nsi` states that the compressor is `ZLIB` not `LZMA`
  - `SetCompressor ZLIB`

Fixes #15376 

**Does not need to be in the release notes**

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
