### PR TITLE
Remove using namespace in header files.

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
@@ -7,8 +7,6 @@
 #include <boost/math/special_functions/round.hpp>
 #include <cmath>
 
-using namespace Mantid::API;
-
 namespace Mantid {
 namespace DataObjects {
 
@@ -67,7 +65,7 @@ TMDE(MDBox)::MDBox(API::BoxController *const splitter, const uint32_t depth,
  * @param boxID :: id for the given box
  */
 TMDE(MDBox)::MDBox(
-    BoxController_sptr &splitter, const uint32_t depth,
+    API::BoxController_sptr &splitter, const uint32_t depth,
     const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>> &
         extentsVector,
     const size_t nBoxEvents, const size_t boxID)
@@ -85,7 +83,7 @@ TMDE(MDBox)::MDBox(
  * @param boxID :: id for the given box
  */
 TMDE(MDBox)::MDBox(
-    BoxController *const splitter, const uint32_t depth,
+    API::BoxController *const splitter, const uint32_t depth,
     const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>> &
         extentsVector,
     const size_t nBoxEvents, const size_t boxID)
@@ -706,8 +704,8 @@ TMDE(void MDBox)::transformDimensions(std::vector<double> &scaling,
 
 /// Setter for masking the box
 TMDE(void MDBox)::mask() {
-  this->setSignal(MDMaskValue);
-  this->setErrorSquared(MDMaskValue);
+  this->setSignal(API::MDMaskValue);
+  this->setErrorSquared(API::MDMaskValue);
   m_bIsMasked = true;
 }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.tcc
@@ -5,7 +5,7 @@
 #include <limits>
 #include <boost/make_shared.hpp>
 
-using NeXus::File;
+//using NeXus::File;
 
 namespace Mantid {
 namespace DataObjects {

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.tcc
@@ -3,10 +3,6 @@
 #include "MantidDataObjects/MDBoxBase.h"
 #include "MantidDataObjects/MDBoxIterator.h"
 
-using namespace Mantid;
-using namespace Mantid::API;
-using namespace Mantid::Geometry;
-
 namespace Mantid {
 namespace DataObjects {
 
@@ -229,11 +225,11 @@ TMDE(size_t MDBoxIterator)::getDataSize() const { return m_max; }
 TMDE(signal_t MDBoxIterator)::getNormalizedSignal() const {
   // What is our normalization factor?
   switch (m_normalization) {
-  case NoNormalization:
+  case API::NoNormalization:
     return m_current->getSignal();
-  case VolumeNormalization:
+  case API::VolumeNormalization:
     return m_current->getSignal() * m_current->getInverseVolume();
-  case NumEventsNormalization:
+  case API::NumEventsNormalization:
     return m_current->getSignal() / double(m_current->getNPoints());
   }
   return std::numeric_limits<signal_t>::quiet_NaN();
@@ -243,11 +239,11 @@ TMDE(signal_t MDBoxIterator)::getNormalizedSignal() const {
 TMDE(signal_t MDBoxIterator)::getNormalizedError() const {
   // What is our normalization factor?
   switch (m_normalization) {
-  case NoNormalization:
+  case API::NoNormalization:
     return m_current->getError();
-  case VolumeNormalization:
+  case API::VolumeNormalization:
     return m_current->getError() * m_current->getInverseVolume();
-  case NumEventsNormalization:
+  case API::NumEventsNormalization:
     return m_current->getError() / double(m_current->getNPoints());
   }
   return std::numeric_limits<signal_t>::quiet_NaN();

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -34,12 +34,6 @@ GCC_DIAG_OFF(strict-aliasing)
 // clang-format on
 #endif
 
-using namespace Mantid;
-using namespace Mantid::Kernel;
-using namespace Mantid::API;
-using namespace Mantid::Geometry;
-using namespace Mantid::DataObjects;
-
 namespace Mantid {
 namespace DataObjects {
 
@@ -51,10 +45,10 @@ TMDE(MDEventWorkspace)::MDEventWorkspace(
     Mantid::API::MDNormalization preferredNormalization,
     Mantid::API::MDNormalization preferredNormalizationHisto)
     : API::IMDEventWorkspace(), data(nullptr),
-      m_BoxController(new BoxController(nd)),
+      m_BoxController(new API::BoxController(nd)),
       m_displayNormalization(preferredNormalization),
       m_displayNormalizationHisto(preferredNormalizationHisto),
-      m_coordSystem(None) {
+      m_coordSystem(Kernel::None) {
   // First box is at depth 0, and has this default boxController
   data = new MDBox<MDE, nd>(m_BoxController.get(), 0);
 }
@@ -174,10 +168,10 @@ TMDE(uint64_t MDEventWorkspace)::getNPoints() const {
  * @throw std::runtime_error if there is not enough memory for the boxes.
  */
 TMDE(void MDEventWorkspace)::setMinRecursionDepth(size_t minDepth) {
-  BoxController_sptr bc = this->getBoxController();
+  API::BoxController_sptr bc = this->getBoxController();
   double numBoxes = pow(double(bc->getNumSplit()), double(minDepth));
   double memoryToUse = numBoxes * double(sizeof(MDBox<MDE, nd>)) / 1024.0;
-  MemoryStats stats;
+  Kernel::MemoryStats stats;
   if (double(stats.availMem()) < memoryToUse) {
     std::ostringstream mess;
     mess << "Not enough memory available for the given MinRecursionDepth! "
@@ -218,7 +212,7 @@ TMDE(std::vector<coord_t> MDEventWorkspace)::estimateResolution() const {
     size_t finestSplit = 1;
     for (size_t i = 0; i < realDepth; i++)
       finestSplit *= m_BoxController->getSplitInto(d);
-    IMDDimension_const_sptr dim = this->getDimension(d);
+    Geometry::IMDDimension_const_sptr dim = this->getDimension(d);
     // Calculate the bin size at the smallest split amount
     out.push_back((dim->getMaximum() - dim->getMinimum()) /
                   static_cast<coord_t>(finestSplit));
@@ -236,7 +230,7 @@ TMDE(std::vector<Mantid::API::IMDIterator *> MDEventWorkspace)::createIterators(
     size_t suggestedNumCores,
     Mantid::Geometry::MDImplicitFunction *function) const {
   // Get all the boxes in this workspaces
-  std::vector<IMDNode *> boxes;
+  std::vector<API::IMDNode *> boxes;
   // TODO: Should this be leaf only? Depends on most common use case
   if (function)
     this->data->getBoxes(boxes, 10000, true, function);
@@ -254,7 +248,7 @@ TMDE(std::vector<Mantid::API::IMDIterator *> MDEventWorkspace)::createIterators(
     numCores = 1;
 
   // Create one iterator per core, splitting evenly amongst spectra
-  std::vector<IMDIterator *> out;
+  std::vector<API::IMDIterator *> out;
   for (size_t i = 0; i < numCores; i++) {
     size_t begin = (i * numElements) / numCores;
     size_t end = ((i + 1) * numElements) / numCores;
@@ -290,11 +284,11 @@ TMDE(signal_t MDEventWorkspace)::getNormalizedSignal(
   if (box) {
     // What is our normalization factor?
     switch (normalization) {
-    case NoNormalization:
+    case API::NoNormalization:
       return box->getSignal();
-    case VolumeNormalization:
+    case API::VolumeNormalization:
       return box->getSignal() * box->getInverseVolume();
-    case NumEventsNormalization:
+    case API::NumEventsNormalization:
       return box->getSignal() / double(box->getNPoints());
     }
     // Should not reach here
@@ -330,9 +324,9 @@ TMDE(signal_t MDEventWorkspace)::getSignalWithMaskAtCoord(
   // Check if masked
   const API::IMDNode *box = data->getBoxAtCoord(coords);
   if (!box)
-    return MDMaskValue;
+    return API::MDMaskValue;
   if (box->getIsMasked()) {
-    return MDMaskValue;
+    return API::MDMaskValue;
   }
   return getNormalizedSignal(box, normalization);
 }
@@ -452,7 +446,7 @@ bool SortBoxesByID(const BOXTYPE &a, const BOXTYPE &b) {
 /** Create a table of data about the boxes contained */
 TMDE(Mantid::API::ITableWorkspace_sptr MDEventWorkspace)::makeBoxTable(
     size_t start, size_t num) {
-  CPUTimer tim;
+  Kernel::CPUTimer tim;
   UNUSED_ARG(start);
   UNUSED_ARG(num);
 
@@ -604,7 +598,7 @@ TMDE(void MDEventWorkspace)::splitAllIfNeeded(Kernel::ThreadScheduler *ts) {
  * @param ts :: optional ThreadScheduler * that will be used to parallelize
  *        recursive splitting.
  */
-TMDE(void MDEventWorkspace)::splitTrackedBoxes(ThreadScheduler *ts) {
+TMDE(void MDEventWorkspace)::splitTrackedBoxes(Kernel::ThreadScheduler *ts) {
   UNUSED_ARG(ts);
   throw std::runtime_error("Not implemented yet");
   //    // Get a COPY of the vector (to avoid thread-safety issues)
@@ -740,24 +734,24 @@ TMDE(void MDEventWorkspace)::refreshCache() {
  *- 1
  * @param e :: vector of errors for each bin.
  */
-TMDE(IMDWorkspace::LinePlot MDEventWorkspace)
+TMDE(API::IMDWorkspace::LinePlot MDEventWorkspace)
 ::getLinePlot(const Mantid::Kernel::VMD &start, const Mantid::Kernel::VMD &end,
               Mantid::API::MDNormalization normalize) const {
   // TODO: Don't use a fixed number of points later
   size_t numPoints = 500;
 
-  VMD step = (end - start) / double(numPoints - 1);
+  Kernel::VMD step = (end - start) / double(numPoints - 1);
   double stepLength = step.norm();
 
   // This will be the curve as plotted
   LinePlot line;
   for (size_t i = 0; i < numPoints; i++) {
     // Coordinate along the line
-    VMD coord = start + step * double(i);
+    Kernel::VMD coord = start + step * double(i);
 
     // Look for the box at this coordinate
     // const MDBoxBase<MDE,nd> * box = NULL;
-    const IMDNode *box = nullptr;
+    const API::IMDNode *box = nullptr;
 
     if (isInBounds(coord.getBareArray())) {
       box = this->data->getBoxAtCoord(coord.getBareArray());
@@ -767,12 +761,12 @@ TMDE(IMDWorkspace::LinePlot MDEventWorkspace)
           // What is our normalization factor?
           signal_t normalizer = 1.0;
           switch (normalize) {
-          case NoNormalization:
+          case API::NoNormalization:
             break;
-          case VolumeNormalization:
+          case API::VolumeNormalization:
             normalizer = box->getInverseVolume();
             break;
-          case NumEventsNormalization:
+          case API::NumEventsNormalization:
             normalizer = 1.0 / double(box->getNPoints());
             break;
           }
@@ -868,7 +862,7 @@ TMDE(void MDEventWorkspace)::setDisplayNormalizationHisto(
 /**
 Return the preferred normalization preference for subsequent histoworkspaces.
 */
-TMDE(MDNormalization MDEventWorkspace)::displayNormalizationHisto() const {
+TMDE(API::MDNormalization MDEventWorkspace)::displayNormalizationHisto() const {
   return m_displayNormalizationHisto;
 }
 
@@ -884,7 +878,7 @@ TMDE(void MDEventWorkspace)::setDisplayNormalization(
 /**
 Return the preferred normalization to use for visualization.
 */
-TMDE(MDNormalization MDEventWorkspace)::displayNormalization() const {
+TMDE(API::MDNormalization MDEventWorkspace)::displayNormalization() const {
   return m_displayNormalization;
 }
 

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -54,7 +54,6 @@
 #include <limits>
 
 #include <boost/math/special_functions/fpclassify.hpp>
-//using namespace Mantid;
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace MantidQt::API;

--- a/MantidQt/API/src/FilePropertyWidget.cpp
+++ b/MantidQt/API/src/FilePropertyWidget.cpp
@@ -5,7 +5,6 @@
 #include "MantidQtAPI/FileDialogHandler.h"
 
 using namespace Mantid::Kernel;
-//using namespace Mantid::API;
 
 namespace MantidQt
 {


### PR DESCRIPTION
Description of work.

This removes the remaining cases where [`using namespace` is used in a header file.](http://builds.mantidproject.org/view/Static%20Analysis/job/clang_tidy/115/warnings10Result/category.-495837223) The first issue is already fixed in PR #15377.

I found and deleted two other lines were `using namespace` was already commented out.

**To test:**

<!-- Instructions for testing. -->

The build servers should catch any issues.

This PR is not associated with an issue.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
