### PR TITLE
Fix EQSANSLoad to work with Poco 1.6

### DIFF
--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -769,7 +769,7 @@ void EQSANSLoad::exec() {
   // Rebin so all the wavelength bins are aligned
   const bool preserveEvents = getProperty("PreserveEvents");
   const double wl_step = getProperty("WavelengthStep");
-  
+
   const double wl_min_rounded = round(wl_min * 100.0) / 100.0;
   const double wl_max_rounded = round(wl_combined_max * 100.0) / 100.0;
   std::string params = Poco::NumberFormatter::format(wl_min_rounded, 2) + "," +

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -336,8 +336,8 @@ void EQSANSLoad::moveToBeamCenter() {
   if (isEmpty(m_center_x) || isEmpty(m_center_y)) {
     EQSANSInstrument::getDefaultBeamCenter(dataWS, m_center_x, m_center_y);
     g_log.information() << "Setting beam center to ["
-                        << Poco::NumberFormatter::format(m_center_x, 1) << ", "
-                        << Poco::NumberFormatter::format(m_center_y, 1) << "]"
+                        << m_center_x << ", "
+                        << m_center_y << "]"
                         << std::endl;
     return;
   }
@@ -380,8 +380,8 @@ void EQSANSLoad::moveToBeamCenter() {
   dataWS->mutableRun().addProperty("beam_center_x", m_center_x, "pixel", true);
   dataWS->mutableRun().addProperty("beam_center_y", m_center_y, "pixel", true);
   m_output_message += "   Beam center: " +
-                      Poco::NumberFormatter::format(m_center_x, 1) + ", " +
-                      Poco::NumberFormatter::format(m_center_y, 1) + "\n";
+                      Poco::NumberFormatter::format(m_center_x) + ", " +
+                      Poco::NumberFormatter::format(m_center_y) + "\n";
 }
 
 /// Read a config file
@@ -430,8 +430,8 @@ void EQSANSLoad::readConfigFile(const std::string &filePath) {
   dataWS->mutableRun().addProperty("high_tof_cut", m_high_TOF_cut,
                                    "microsecond", true);
   m_output_message +=
-      "   Discarding lower " + Poco::NumberFormatter::format(m_low_TOF_cut, 1) +
-      " and upper " + Poco::NumberFormatter::format(m_high_TOF_cut, 1) +
+      "   Discarding lower " + Poco::NumberFormatter::format(m_low_TOF_cut) +
+      " and upper " + Poco::NumberFormatter::format(m_high_TOF_cut) +
       " microsec\n";
 
   if (m_moderator_position != 0) {
@@ -638,7 +638,7 @@ void EQSANSLoad::exec() {
     g_log.information() << "Moving moderator to " << m_moderator_position
                         << std::endl;
     m_output_message += "   Moderator position: " +
-                        Poco::NumberFormatter::format(m_moderator_position, 3) +
+                        Poco::NumberFormatter::format(m_moderator_position) +
                         " m\n";
     mvAlg = createChildAlgorithm("MoveInstrumentComponent", 0.4, 0.45);
     mvAlg->setProperty<MatrixWorkspace_sptr>("Workspace", dataWS);
@@ -721,8 +721,8 @@ void EQSANSLoad::exec() {
                                      true);
     wl_combined_max = wl_max;
     m_output_message += "   Wavelength range: " +
-                        Poco::NumberFormatter::format(wl_min, 1) + " - " +
-                        Poco::NumberFormatter::format(wl_max, 1);
+                        Poco::NumberFormatter::format(wl_min) + " - " +
+                        Poco::NumberFormatter::format(wl_max);
     if (frame_skipping) {
       const double wl_min2 = tofAlg->getProperty("WavelengthMinFrame2");
       const double wl_max2 = tofAlg->getProperty("WavelengthMaxFrame2");
@@ -731,8 +731,8 @@ void EQSANSLoad::exec() {
                                        "Angstrom", true);
       dataWS->mutableRun().addProperty("wavelength_max_frame2", wl_max2,
                                        "Angstrom", true);
-      m_output_message += " and " + Poco::NumberFormatter::format(wl_min2, 1) +
-                          " - " + Poco::NumberFormatter::format(wl_max2, 1) +
+      m_output_message += " and " + Poco::NumberFormatter::format(wl_min2) +
+                          " - " + Poco::NumberFormatter::format(wl_max2) +
                           " Angstrom\n";
     } else
       m_output_message += " Angstrom\n";
@@ -771,9 +771,13 @@ void EQSANSLoad::exec() {
   // Rebin so all the wavelength bins are aligned
   const bool preserveEvents = getProperty("PreserveEvents");
   const double wl_step = getProperty("WavelengthStep");
-  std::string params = Poco::NumberFormatter::format(wl_min, 2) + "," +
-                       Poco::NumberFormatter::format(wl_step, 2) + "," +
-                       Poco::NumberFormatter::format(wl_combined_max, 2);
+  
+  const double wl_min_rounded = round(wl_min*100.0)/100.0;
+  const double wl_max_rounded = round(wl_combined_max*100.0)/100.0;
+  std::string params = Poco::NumberFormatter::format(wl_min_rounded, 2) + "," +
+                       Poco::NumberFormatter::format(wl_step) + "," +
+                       Poco::NumberFormatter::format(wl_max_rounded, 2);
+  g_log.information() << "Rebin parameters: " << params << std::endl;
   IAlgorithm_sptr rebinAlg = createChildAlgorithm("Rebin", 0.71, 0.72);
   rebinAlg->setProperty<MatrixWorkspace_sptr>("InputWorkspace", dataWS);
   if (preserveEvents)

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -335,10 +335,8 @@ void EQSANSLoad::moveToBeamCenter() {
   // default beam center
   if (isEmpty(m_center_x) || isEmpty(m_center_y)) {
     EQSANSInstrument::getDefaultBeamCenter(dataWS, m_center_x, m_center_y);
-    g_log.information() << "Setting beam center to ["
-                        << m_center_x << ", "
-                        << m_center_y << "]"
-                        << std::endl;
+    g_log.information() << "Setting beam center to [" << m_center_x << ", "
+                        << m_center_y << "]" << std::endl;
     return;
   }
 
@@ -772,8 +770,8 @@ void EQSANSLoad::exec() {
   const bool preserveEvents = getProperty("PreserveEvents");
   const double wl_step = getProperty("WavelengthStep");
   
-  const double wl_min_rounded = round(wl_min*100.0)/100.0;
-  const double wl_max_rounded = round(wl_combined_max*100.0)/100.0;
+  const double wl_min_rounded = round(wl_min * 100.0) / 100.0;
+  const double wl_max_rounded = round(wl_combined_max * 100.0) / 100.0;
   std::string params = Poco::NumberFormatter::format(wl_min_rounded, 2) + "," +
                        Poco::NumberFormatter::format(wl_step) + "," +
                        Poco::NumberFormatter::format(wl_max_rounded, 2);


### PR DESCRIPTION
EQSANSLoad round up the wavelength values to the second digit when rebinning.
It does that using Poco::NumberFormatter::format.

That function changed in Poco 1.6. It used to round up the numbers up to the specified digit. Now it just truncates.

The fix is to round up by hand and not trust the formatter.

I've also removed the number of digits parameter from _format_ calls. Those are only used in log messages, except for the one _Rebin_ call.

**To test:**
1. Make sure the system tests run.

Fixes #15387.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
