### PR TITLE
Fix clang-tidy warning: misc-incorrect-roundings

### DIFF
--- a/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Framework/Algorithms/src/FindPeaks.cpp
@@ -14,10 +14,11 @@
 #include "MantidKernel/StartsWithValidator.h"
 #include "MantidKernel/VectorHelper.h"
 
-#include <boost/algorithm/string.hpp>
-#include <numeric>
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
+#include <boost/algorithm/string.hpp>
+#include <boost/math/special_functions/round.hpp>
+#include <numeric>
 
 #include <fstream>
 
@@ -449,7 +450,7 @@ void FindPeaks::findPeaksUsingMariscotti() {
   // Calculate n1 (Mariscotti eqn. 18)
   const double kz =
       1.22; // This kz corresponds to z=5 & w=0.6*fwhm - see Mariscotti Fig. 8
-  const int n1 = static_cast<int>(std::lround(kz * m_inputPeakFWHM));
+  const int n1 = boost::math::iround(kz * m_inputPeakFWHM);
   // Can't calculate n2 or n3 yet because they need i0
   const int tolerance = getProperty("Tolerance");
 
@@ -563,10 +564,10 @@ void FindPeaks::findPeaksUsingMariscotti() {
           continue;
         }
         // Calculate n2 (Mariscotti eqn. 20)
-        int n2 = abs(static_cast<int>(
-            std::lround(0.5 * (F[i0] / S[i0]) * (n1 + tolerance))));
-        const int n2b = abs(static_cast<int>(
-            std::lround(0.5 * (F[i0] / S[i0]) * (n1 - tolerance))));
+        int n2 = std::abs(
+            boost::math::iround(0.5 * (F[i0] / S[i0]) * (n1 + tolerance)));
+        const int n2b = std::abs(
+            boost::math::iround(0.5 * (F[i0] / S[i0]) * (n1 - tolerance)));
         if (n2b > n2)
           n2 = n2b;
         // Mariscotti eqn. (21)
@@ -576,10 +577,10 @@ void FindPeaks::findPeaksUsingMariscotti() {
           continue;
         }
         // Calculate n3 (Mariscotti eqn. 22)
-        int n3 = abs(static_cast<int>(
-            std::lround((n1 + tolerance) * (1 - 2 * (F[i0] / S[i0])))));
-        const int n3b = abs(static_cast<int>(
-            std::lround((n1 - tolerance) * (1 - 2 * (F[i0] / S[i0])))));
+        int n3 = std::abs(
+            boost::math::iround((n1 + tolerance) * (1 - 2 * (F[i0] / S[i0]))));
+        const int n3b = std::abs(
+            boost::math::iround((n1 - tolerance) * (1 - 2 * (F[i0] / S[i0]))));
         if (n3b < n3)
           n3 = n3b;
         // Mariscotti eqn. (23)

--- a/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Framework/Algorithms/src/FindPeaks.cpp
@@ -449,7 +449,7 @@ void FindPeaks::findPeaksUsingMariscotti() {
   // Calculate n1 (Mariscotti eqn. 18)
   const double kz =
       1.22; // This kz corresponds to z=5 & w=0.6*fwhm - see Mariscotti Fig. 8
-  const int n1 = static_cast<int>(kz * m_inputPeakFWHM + 0.5);
+  const int n1 = static_cast<int>(std::lround(kz * m_inputPeakFWHM));
   // Can't calculate n2 or n3 yet because they need i0
   const int tolerance = getProperty("Tolerance");
 
@@ -563,10 +563,10 @@ void FindPeaks::findPeaksUsingMariscotti() {
           continue;
         }
         // Calculate n2 (Mariscotti eqn. 20)
-        int n2 = abs(
-            static_cast<int>(0.5 * (F[i0] / S[i0]) * (n1 + tolerance) + 0.5));
-        const int n2b = abs(
-            static_cast<int>(0.5 * (F[i0] / S[i0]) * (n1 - tolerance) + 0.5));
+        int n2 = abs(static_cast<int>(
+            std::lround(0.5 * (F[i0] / S[i0]) * (n1 + tolerance))));
+        const int n2b = abs(static_cast<int>(
+            std::lround(0.5 * (F[i0] / S[i0]) * (n1 - tolerance))));
         if (n2b > n2)
           n2 = n2b;
         // Mariscotti eqn. (21)
@@ -577,9 +577,9 @@ void FindPeaks::findPeaksUsingMariscotti() {
         }
         // Calculate n3 (Mariscotti eqn. 22)
         int n3 = abs(static_cast<int>(
-            (n1 + tolerance) * (1 - 2 * (F[i0] / S[i0])) + 0.5));
+            std::lround((n1 + tolerance) * (1 - 2 * (F[i0] / S[i0])))));
         const int n3b = abs(static_cast<int>(
-            (n1 - tolerance) * (1 - 2 * (F[i0] / S[i0])) + 0.5));
+            std::lround((n1 - tolerance) * (1 - 2 * (F[i0] / S[i0])))));
         if (n3b < n3)
           n3 = n3b;
         // Mariscotti eqn. (23)

--- a/Framework/Algorithms/src/GenerateEventsFilter.cpp
+++ b/Framework/Algorithms/src/GenerateEventsFilter.cpp
@@ -601,13 +601,13 @@ void GenerateEventsFilter::setFilterByLogValue(std::string logname) {
       minvaluei = m_intLog->minValue();
       minvalue = static_cast<double>(minvaluei);
     } else
-      minvaluei = static_cast<int>(minvalue + 0.5);
+      minvaluei = static_cast<int>(std::lround(minvalue));
 
     if (maxvalue == EMPTY_DBL()) {
       maxvaluei = m_intLog->maxValue();
       maxvalue = static_cast<double>(maxvaluei);
     } else
-      maxvaluei = static_cast<int>(maxvalue + 0.5);
+      maxvaluei = static_cast<int>(std::lround(maxvalue));
 
     if (minvalue > maxvalue) {
       stringstream errmsg;
@@ -1449,7 +1449,7 @@ void GenerateEventsFilter::processIntegerValueFilter(int minvalue, int maxvalue,
     if (isEmpty(deltadbl))
       delta = maxvalue - minvalue + 1;
     else
-      delta = static_cast<int>(deltadbl + 0.5);
+      delta = static_cast<int>(std::lround(deltadbl));
 
     if (delta <= 0) {
       stringstream errss;

--- a/Framework/Algorithms/src/GenerateEventsFilter.cpp
+++ b/Framework/Algorithms/src/GenerateEventsFilter.cpp
@@ -12,6 +12,8 @@
 #include "MantidKernel/VisibleWhenProperty.h"
 #include "MantidKernel/ArrayProperty.h"
 
+#include <boost/math/special_functions/round.hpp>
+
 using namespace Mantid;
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
@@ -601,13 +603,13 @@ void GenerateEventsFilter::setFilterByLogValue(std::string logname) {
       minvaluei = m_intLog->minValue();
       minvalue = static_cast<double>(minvaluei);
     } else
-      minvaluei = static_cast<int>(std::lround(minvalue));
+      minvaluei = boost::math::iround(minvalue);
 
     if (maxvalue == EMPTY_DBL()) {
       maxvaluei = m_intLog->maxValue();
       maxvalue = static_cast<double>(maxvaluei);
     } else
-      maxvaluei = static_cast<int>(std::lround(maxvalue));
+      maxvaluei = boost::math::iround(maxvalue);
 
     if (minvalue > maxvalue) {
       stringstream errmsg;
@@ -1449,7 +1451,7 @@ void GenerateEventsFilter::processIntegerValueFilter(int minvalue, int maxvalue,
     if (isEmpty(deltadbl))
       delta = maxvalue - minvalue + 1;
     else
-      delta = static_cast<int>(std::lround(deltadbl));
+      delta = boost::math::iround(deltadbl);
 
     if (delta <= 0) {
       stringstream errss;

--- a/Framework/Crystal/src/FindUBUsingIndexedPeaks.cpp
+++ b/Framework/Crystal/src/FindUBUsingIndexedPeaks.cpp
@@ -15,8 +15,6 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using namespace Mantid::Geometry;
 
-#define round(x) ((x) >= 0 ? (int)((x) + 0.5) : (int)((x)-0.5))
-
 //--------------------------------------------------------------------------
 /** Constructor
  */
@@ -66,7 +64,8 @@ void FindUBUsingIndexedPeaks::exec() {
                                              // just check for (0,0,0)
     {
       q_vectors.push_back(peaks[i].getQSampleFrame());
-      hkl_vectors.emplace_back(round(hkl[0]), round(hkl[1]), round(hkl[2]));
+      hkl_vectors.emplace_back(std::round(hkl[0]), std::round(hkl[1]),
+                               std::round(hkl[2]));
       indexed_count++;
     }
   }

--- a/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
+++ b/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
@@ -934,8 +934,8 @@ void IntegratePeakTimeSlices::FindPlane(V3D &center, V3D &xvec, V3D &yvec,
 
   panel1->getBoundingBox(B);
 
-  NROWS = static_cast<int>((B.yMax() - B.yMin()) / pixHeighty + .5);
-  NCOLS = static_cast<int>((B.xMax() - B.xMin()) / pixWidthx + .5);
+  NROWS = static_cast<int>(std::lround((B.yMax() - B.yMin()) / pixHeighty));
+  NCOLS = static_cast<int>(std::lround((B.xMax() - B.xMin()) / pixWidthx));
 }
 
 /**
@@ -1004,7 +1004,7 @@ std::vector<double> DataModeHandler::InitValues(double Varx, double Vary,
   double x = 1;
   if (sigy * NstdY < 7 && sigy * NstdY >= 0) // is close to row edge
   {
-    x = probs[static_cast<int>(sigy * NstdY + .5)];
+    x = probs[std::lround(sigy * NstdY)];
     if (sigy < 0)
       x = 1 - x;
     double My2 = StatBase[IStartRow];
@@ -1015,7 +1015,7 @@ std::vector<double> DataModeHandler::InitValues(double Varx, double Vary,
   double x1 = 1;
   if (sigx * NstdX < 7 && sigx * NstdX > 0) // is close to x edge
   {
-    x1 = probs[static_cast<int>(sigx * NstdX + .5)];
+    x1 = probs[std::lround(sigx * NstdX)];
     if (sigx < 0)
       x1 = 1 - x1;
     double Mx2 = StatBase[IStartCol];

--- a/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
+++ b/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
@@ -16,9 +16,9 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/Workspace2D.h"
-//#include "MantidGeometry/Surfaces/Surface.h"
 
-//#include <boost/random/poisson_distribution.hpp>
+#include <boost/math/special_functions/round.hpp>
+
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
@@ -934,8 +934,8 @@ void IntegratePeakTimeSlices::FindPlane(V3D &center, V3D &xvec, V3D &yvec,
 
   panel1->getBoundingBox(B);
 
-  NROWS = static_cast<int>(std::lround((B.yMax() - B.yMin()) / pixHeighty));
-  NCOLS = static_cast<int>(std::lround((B.xMax() - B.xMin()) / pixWidthx));
+  NROWS = boost::math::iround((B.yMax() - B.yMin()) / pixHeighty);
+  NCOLS = boost::math::iround((B.xMax() - B.xMin()) / pixWidthx);
 }
 
 /**

--- a/Framework/Crystal/src/MaskPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/MaskPeaksWorkspace.cpp
@@ -10,6 +10,8 @@
 #include "MantidKernel/VectorHelper.h"
 #include "MantidKernel/ArrayProperty.h"
 
+#include <boost/math/special_functions/round.hpp>
+
 namespace Mantid {
 namespace Crystal {
 
@@ -100,8 +102,8 @@ void MaskPeaksWorkspace::exec() {
     // get the peak location on the detector
     double col = peak.getCol();
     double row = peak.getRow();
-    int xPeak = static_cast<int>(std::lround(col)) - 1;
-    int yPeak = static_cast<int>(std::lround(row)) - 1;
+    int xPeak = boost::math::iround(col) - 1;
+    int yPeak = boost::math::iround(row) - 1;
     g_log.debug() << "Generating information for peak at x=" << xPeak
                   << " y=" << yPeak << "\n";
 

--- a/Framework/Crystal/src/MaskPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/MaskPeaksWorkspace.cpp
@@ -100,8 +100,8 @@ void MaskPeaksWorkspace::exec() {
     // get the peak location on the detector
     double col = peak.getCol();
     double row = peak.getRow();
-    int xPeak = int(col + 0.5) - 1;
-    int yPeak = int(row + 0.5) - 1;
+    int xPeak = static_cast<int>(std::lround(col)) - 1;
+    int yPeak = static_cast<int>(std::lround(row)) - 1;
     g_log.debug() << "Generating information for peak at x=" << xPeak
                   << " y=" << yPeak << "\n";
 

--- a/Framework/Crystal/src/PeakHKLErrors.cpp
+++ b/Framework/Crystal/src/PeakHKLErrors.cpp
@@ -372,7 +372,7 @@ void PeakHKLErrors::function1D(double *out, const double *xValues,
 
   double ChiSqTot = 0.0;
   for (size_t i = 0; i < nData; i += 3) {
-    int peakNum = static_cast<int>(.5 + xValues[i]);
+    int peakNum = static_cast<int>(std::lround(xValues[i]));
     IPeak &peak_old = Peaks->getPeak(peakNum);
 
     int runNum = peak_old.getRunNumber();
@@ -469,7 +469,7 @@ void PeakHKLErrors::functionDeriv1D(Jacobian *out, const double *xValues,
                         parameterIndex(std::string("SampleZOffset"))};
 
   for (size_t i = 0; i < nData; i += 3) {
-    int peakNum = static_cast<int>(.5 + xValues[i]);
+    int peakNum = static_cast<int>(std::lround(xValues[i]));
     IPeak &peak_old = Peaks->getPeak(peakNum);
     Peak peak =
         SCDPanelErrors::createNewPeak(peak_old, instNew, 0, peak_old.getL1());

--- a/Framework/Crystal/src/PeakHKLErrors.cpp
+++ b/Framework/Crystal/src/PeakHKLErrors.cpp
@@ -12,6 +12,8 @@
 #include "MantidCrystal/PeakHKLErrors.h"
 #include "MantidCrystal/SCDPanelErrors.h"
 
+#include <boost/math/special_functions/round.hpp>
+
 using namespace Mantid::DataObjects;
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -372,7 +374,7 @@ void PeakHKLErrors::function1D(double *out, const double *xValues,
 
   double ChiSqTot = 0.0;
   for (size_t i = 0; i < nData; i += 3) {
-    int peakNum = static_cast<int>(std::lround(xValues[i]));
+    int peakNum = boost::math::iround(xValues[i]);
     IPeak &peak_old = Peaks->getPeak(peakNum);
 
     int runNum = peak_old.getRunNumber();
@@ -469,7 +471,7 @@ void PeakHKLErrors::functionDeriv1D(Jacobian *out, const double *xValues,
                         parameterIndex(std::string("SampleZOffset"))};
 
   for (size_t i = 0; i < nData; i += 3) {
-    int peakNum = static_cast<int>(std::lround(xValues[i]));
+    int peakNum = boost::math::iround(xValues[i]);
     IPeak &peak_old = Peaks->getPeak(peakNum);
     Peak peak =
         SCDPanelErrors::createNewPeak(peak_old, instNew, 0, peak_old.getL1());

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -16,6 +16,7 @@
 #include "MantidKernel/VisibleWhenProperty.h"
 
 #include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/math/special_functions/round.hpp>
 
 namespace Mantid {
 namespace Crystal {
@@ -144,8 +145,8 @@ void PeakIntegration::exec() {
     double row = peak.getRow();
 
     // Average integer postion
-    int XPeak = static_cast<int>(std::lround(col));
-    int YPeak = static_cast<int>(std::lround(row));
+    int XPeak = boost::math::iround(col);
+    int YPeak = boost::math::iround(row);
 
     double TOFPeakd = peak.getTOF();
     std::string bankName = peak.getBankName();

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -144,8 +144,8 @@ void PeakIntegration::exec() {
     double row = peak.getRow();
 
     // Average integer postion
-    int XPeak = int(col + 0.5);
-    int YPeak = int(row + 0.5);
+    int XPeak = static_cast<int>(std::lround(col));
+    int YPeak = static_cast<int>(std::lround(row));
 
     double TOFPeakd = peak.getTOF();
     std::string bankName = peak.getBankName();

--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -137,7 +137,7 @@ void PredictFractionalPeaks::exec() {
   int N = NPeaks;
   if (includePeaksInRange) {
     N = static_cast<int>(
-        (Hmax - Hmin + 1) * (Kmax - Kmin + 1) * (Lmax - Lmin + 1) + .5);
+        std::lround((Hmax - Hmin + 1) * (Kmax - Kmin + 1) * (Lmax - Lmin + 1)));
     N = max<int>(100, N);
   }
   IPeak &peak0 = Peaks->getPeak(0);
@@ -188,9 +188,9 @@ void PredictFractionalPeaks::exec() {
               ErrPos = 2;
               vector<int> SavPk;
               SavPk.push_back(RunNumber);
-              SavPk.push_back(static_cast<int>(floor(1000 * hkl1[0] + .5)));
-              SavPk.push_back(static_cast<int>(floor(1000 * hkl1[1] + .5)));
-              SavPk.push_back(static_cast<int>(floor(1000 * hkl1[2] + .5)));
+              SavPk.push_back(static_cast<int>(lround(1000.0 * hkl1[0])));
+              SavPk.push_back(static_cast<int>(lround(1000.0 * hkl1[1])));
+              SavPk.push_back(static_cast<int>(lround(1000.0 * hkl1[2])));
 
               // TODO keep list sorted so searching is faster?
               auto it =

--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -12,7 +12,8 @@
 #include "MantidKernel/ArrayLengthValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
 
-//#include "MantidKernel/Strings.h"
+#include <boost/math/special_functions/round.hpp>
+
 namespace Mantid {
 using namespace Mantid::DataObjects;
 using namespace Mantid::API;
@@ -136,8 +137,8 @@ void PredictFractionalPeaks::exec() {
 
   int N = NPeaks;
   if (includePeaksInRange) {
-    N = static_cast<int>(
-        std::lround((Hmax - Hmin + 1) * (Kmax - Kmin + 1) * (Lmax - Lmin + 1)));
+    N = boost::math::iround((Hmax - Hmin + 1) * (Kmax - Kmin + 1) *
+                            (Lmax - Lmin + 1));
     N = max<int>(100, N);
   }
   IPeak &peak0 = Peaks->getPeak(0);
@@ -186,11 +187,10 @@ void PredictFractionalPeaks::exec() {
 
             if (Qs[2] > 0 && peak->findDetector()) {
               ErrPos = 2;
-              vector<int> SavPk;
-              SavPk.push_back(RunNumber);
-              SavPk.push_back(static_cast<int>(lround(1000.0 * hkl1[0])));
-              SavPk.push_back(static_cast<int>(lround(1000.0 * hkl1[1])));
-              SavPk.push_back(static_cast<int>(lround(1000.0 * hkl1[2])));
+              vector<int> SavPk{RunNumber,
+                                boost::math::iround(1000.0 * hkl1[0]),
+                                boost::math::iround(1000.0 * hkl1[1]),
+                                boost::math::iround(1000.0 * hkl1[2])};
 
               // TODO keep list sorted so searching is faster?
               auto it =

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -13,6 +13,8 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidNexus/NexusClasses.h"
 
+#include <boost/math/special_functions/round.hpp>
+
 #include <Poco/AutoPtr.h>
 #include <Poco/TemporaryFile.h>
 #include <Poco/Util/PropertyFileConfiguration.h>
@@ -541,8 +543,8 @@ LoadBBY::createInstrument(ANSTO::Tar::File &tarFile,
       if (loadNXDataSet(entry, "monitor/bm1_counts", tmp_int32))
         instrumentInfo.bm_counts = tmp_int32;
       if (loadNXDataSet(entry, "instrument/att_pos", tmp_float))
-        instrumentInfo.att_pos = static_cast<int32_t>(
-            std::lround(tmp_float)); // [1.0, 2.0, ..., 5.0]
+        instrumentInfo.att_pos =
+            boost::math::iround(tmp_float); // [1.0, 2.0, ..., 5.0]
 
       if (loadNXDataSet(entry, "instrument/master_chopper_freq", tmp_float))
         instrumentInfo.period_master = 1.0 / tmp_float * 1.0e6;
@@ -597,8 +599,7 @@ LoadBBY::createInstrument(ANSTO::Tar::File &tarFile,
     if (conf->hasProperty("bm1_counts"))
       instrumentInfo.bm_counts = conf->getInt("bm1_counts");
     if (conf->hasProperty("att_pos"))
-      instrumentInfo.att_pos =
-          static_cast<int32_t>(std::lround(conf->getDouble("att_pos")));
+      instrumentInfo.att_pos = boost::math::iround(conf->getDouble("att_pos"));
 
     if (conf->hasProperty("master_chopper_freq"))
       instrumentInfo.period_master =

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -541,8 +541,8 @@ LoadBBY::createInstrument(ANSTO::Tar::File &tarFile,
       if (loadNXDataSet(entry, "monitor/bm1_counts", tmp_int32))
         instrumentInfo.bm_counts = tmp_int32;
       if (loadNXDataSet(entry, "instrument/att_pos", tmp_float))
-        instrumentInfo.att_pos =
-            static_cast<int32_t>(tmp_float + 0.5f); // [1.0, 2.0, ..., 5.0]
+        instrumentInfo.att_pos = static_cast<int32_t>(
+            std::lround(tmp_float)); // [1.0, 2.0, ..., 5.0]
 
       if (loadNXDataSet(entry, "instrument/master_chopper_freq", tmp_float))
         instrumentInfo.period_master = 1.0 / tmp_float * 1.0e6;
@@ -598,7 +598,7 @@ LoadBBY::createInstrument(ANSTO::Tar::File &tarFile,
       instrumentInfo.bm_counts = conf->getInt("bm1_counts");
     if (conf->hasProperty("att_pos"))
       instrumentInfo.att_pos =
-          static_cast<int32_t>(conf->getDouble("att_pos") + 0.5f);
+          static_cast<int32_t>(std::lround(conf->getDouble("att_pos")));
 
     if (conf->hasProperty("master_chopper_freq"))
       instrumentInfo.period_master =

--- a/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -1,12 +1,13 @@
 #include "MantidDataObjects/MDHistoWorkspaceIterator.h"
-#include "MantidKernel/System.h"
-#include "MantidKernel/VMD.h"
-#include "MantidKernel/Utils.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
+#include "MantidKernel/System.h"
+#include "MantidKernel/Utils.h"
+#include "MantidKernel/VMD.h"
 #include <algorithm>
-#include <utility>
+#include <boost/math/special_functions/round.hpp>
 #include <functional>
 #include <numeric>
+#include <utility>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -276,7 +276,7 @@ MDHistoWorkspaceIterator::jumpToNearest(const VMD &fromLocation) {
   coord_t sqDiff = 0;
   for (size_t d = 0; d < m_nd; ++d) {
     coord_t dExact = getDExact(fromLocation[d], m_origin[d], m_binWidth[d]);
-    size_t dRound = size_t(dExact + 0.5); // Round to nearest bin edge.
+    size_t dRound = std::lround(dExact); // Round to nearest bin edge.
     sqDiff += (dExact - coord_t(dRound)) * (dExact - coord_t(dRound)) *
               m_binWidth[d] * m_binWidth[d];
     indexes[d] = dRound;

--- a/Framework/Geometry/src/Crystal/IndexingUtils.cpp
+++ b/Framework/Geometry/src/Crystal/IndexingUtils.cpp
@@ -1008,17 +1008,17 @@ double IndexingUtils::ScanFor_UB(DblMatrix &UB,
     for (const auto &q_vector : q_vectors) {
       q_vec = q_vector / (2.0 * M_PI);
       dot_prod = a_dir_temp.scalar_prod(q_vec);
-      nearest_int = std::lround(dot_prod);
+      nearest_int = std::round(dot_prod);
       error = dot_prod - nearest_int;
       sum_sq_error += error * error;
 
       dot_prod = b_dir_temp.scalar_prod(q_vec);
-      nearest_int = std::lround(dot_prod);
+      nearest_int = std::round(dot_prod);
       error = dot_prod - nearest_int;
       sum_sq_error += error * error;
 
       dot_prod = c_dir_temp.scalar_prod(q_vec);
-      nearest_int = std::lround(dot_prod);
+      nearest_int = std::round(dot_prod);
       error = dot_prod - nearest_int;
       sum_sq_error += error * error;
     }
@@ -2401,7 +2401,7 @@ std::vector<V3D> IndexingUtils::MakeHemisphereDirections(int n_steps) {
       theta_step = 2. * M_PI + 1.; // use one vector at the pole
       n_theta = 1;
     } else {
-      theta_step = 2. * M_PI / n_theta;
+      theta_step = 2. * M_PI / static_cast<double>(n_theta);
     }
 
     // use half the equator to avoid vectors that are the negatives of other

--- a/Framework/Geometry/src/Crystal/IndexingUtils.cpp
+++ b/Framework/Geometry/src/Crystal/IndexingUtils.cpp
@@ -916,7 +916,7 @@ double IndexingUtils::ScanFor_UB(DblMatrix &UB,
   V3D b_dir;
   V3D c_dir;
 
-  long num_a_steps = std::lround(90.0 / degrees_per_step);
+  double num_a_steps = std::round(90.0 / degrees_per_step);
   double gamma_radians = gamma * DEG_TO_RAD;
 
   long num_b_steps = std::lround(4.0 * sin(gamma_radians) * num_a_steps);
@@ -932,7 +932,7 @@ double IndexingUtils::ScanFor_UB(DblMatrix &UB,
 
   double error;
   double dot_prod;
-  long nearest_int;
+  double nearest_int;
   int max_indexed = 0;
   V3D q_vec;
   // first select those directions
@@ -959,19 +959,19 @@ double IndexingUtils::ScanFor_UB(DblMatrix &UB,
         bool indexes_peak = true;
         q_vec = q_vector / (2.0 * M_PI);
         dot_prod = a_dir_temp.scalar_prod(q_vec);
-        nearest_int = std::lround(dot_prod);
+        nearest_int = std::round(dot_prod);
         error = fabs(dot_prod - nearest_int);
         if (error > required_tolerance)
           indexes_peak = false;
         else {
           dot_prod = b_dir_temp.scalar_prod(q_vec);
-          nearest_int = std::lround(dot_prod);
+          nearest_int = std::round(dot_prod);
           error = fabs(dot_prod - nearest_int);
           if (error > required_tolerance)
             indexes_peak = false;
           else {
             dot_prod = c_dir_temp.scalar_prod(q_vec);
-            nearest_int = std::lround(dot_prod);
+            nearest_int = std::round(dot_prod);
             error = fabs(dot_prod - nearest_int);
             if (error > required_tolerance)
               indexes_peak = false;
@@ -1070,7 +1070,7 @@ size_t IndexingUtils::ScanFor_Directions(std::vector<V3D> &directions,
   double error;
   double fit_error;
   double dot_prod;
-  long nearest_int;
+  double nearest_int;
   int max_indexed = 0;
   V3D q_vec;
   // first, make hemisphere of possible directions
@@ -1097,7 +1097,7 @@ size_t IndexingUtils::ScanFor_Directions(std::vector<V3D> &directions,
       for (const auto &q_vector : q_vectors) {
         q_vec = q_vector / (2.0 * M_PI);
         dot_prod = dir_temp.scalar_prod(q_vec);
-        nearest_int = std::lround(dot_prod);
+        nearest_int = std::round(dot_prod);
         error = fabs(dot_prod - nearest_int);
         if (error <= required_tolerance)
           num_indexed++;
@@ -1797,7 +1797,7 @@ void IndexingUtils::DiscardDuplicates(std::vector<V3D> &new_list,
             NumberIndexed_1D(temp[i], q_vectors, required_tolerance);
         if (num_indexed > max_indexed) {
           max_indexed = num_indexed;
-          max_i = i;
+          max_i = static_cast<long>(i);
         }
       }
 
@@ -2269,9 +2269,9 @@ int IndexingUtils::GetIndexedPeaks_3D(
     hkl(projected_h, projected_k, projected_l);
 
     if (ValidIndex(hkl, required_tolerance)) {
-      long h_int = std::lround(projected_h);
-      long k_int = std::lround(projected_k);
-      long l_int = std::lround(projected_l);
+      double h_int = std::round(projected_h);
+      double k_int = std::round(projected_k);
+      double l_int = std::round(projected_l);
 
       double h_error = fabs(projected_h - h_int);
       double k_error = fabs(projected_k - k_int);

--- a/Framework/Geometry/src/Crystal/IndexingUtils.cpp
+++ b/Framework/Geometry/src/Crystal/IndexingUtils.cpp
@@ -1083,7 +1083,7 @@ size_t IndexingUtils::ScanFor_Directions(std::vector<V3D> &directions,
   // in some direction, keeping the shortest vector
   // for each direction where the max peaks are indexed
   double delta_d = 0.1f;
-  long n_steps = std::lround(1 + (max_d - min_d) / delta_d);
+  long n_steps = std::lround(1.0 + (max_d - min_d) / delta_d);
 
   std::vector<V3D> selected_dirs;
   V3D dir_temp;

--- a/Framework/Geometry/src/Crystal/IndexingUtils.cpp
+++ b/Framework/Geometry/src/Crystal/IndexingUtils.cpp
@@ -21,10 +21,9 @@ using Mantid::Kernel::Matrix;
 using Mantid::Kernel::DblMatrix;
 using Mantid::Kernel::Quat;
 
-#define round(x) ((x) >= 0 ? (int)((x) + 0.5) : (int)((x)-0.5))
 namespace {
-const double DEG_TO_RAD = M_PI / 180.;
-const double RAD_TO_DEG = 180. / M_PI;
+const constexpr double DEG_TO_RAD = M_PI / 180.;
+const constexpr double RAD_TO_DEG = 180. / M_PI;
 }
 
 /**
@@ -169,7 +168,7 @@ double IndexingUtils::Find_UB(DblMatrix &UB, const std::vector<V3D> &q_vectors,
   size_t count = 0;
   while (num_initial < sorted_qs.size()) {
     count++;
-    num_initial = round(1.5 * (double)(num_initial + 3));
+    num_initial = std::lround(1.5 * static_cast<double>(num_initial + 3));
     // add 3, in case we started with
     // a very small number of peaks!
     if (num_initial >= sorted_qs.size())
@@ -370,7 +369,7 @@ double IndexingUtils::Find_UB(DblMatrix &UB, const std::vector<V3D> &q_vectors,
   Matrix<double> temp_UB(3, 3, false);
   double fit_error = 0;
   while (num_initial < sorted_qs.size()) {
-    num_initial = round(1.5 * (double)num_initial + 3);
+    num_initial = std::lround(1.5 * static_cast<double>(num_initial + 3));
     // add 3, in case we started with
     // a very small number of peaks!
     if (num_initial >= sorted_qs.size())
@@ -917,12 +916,13 @@ double IndexingUtils::ScanFor_UB(DblMatrix &UB,
   V3D b_dir;
   V3D c_dir;
 
-  int num_a_steps = round(90.0 / degrees_per_step);
+  long num_a_steps = std::lround(90.0 / degrees_per_step);
   double gamma_radians = gamma * DEG_TO_RAD;
 
-  int num_b_steps = round(4 * sin(gamma_radians) * num_a_steps);
+  long num_b_steps = std::lround(4.0 * sin(gamma_radians) * num_a_steps);
 
-  std::vector<V3D> a_dir_list = MakeHemisphereDirections(num_a_steps);
+  std::vector<V3D> a_dir_list =
+      MakeHemisphereDirections(static_cast<int>(num_a_steps));
 
   std::vector<V3D> b_dir_list;
 
@@ -932,7 +932,7 @@ double IndexingUtils::ScanFor_UB(DblMatrix &UB,
 
   double error;
   double dot_prod;
-  int nearest_int;
+  long nearest_int;
   int max_indexed = 0;
   V3D q_vec;
   // first select those directions
@@ -946,7 +946,8 @@ double IndexingUtils::ScanFor_UB(DblMatrix &UB,
     a_dir_temp = V3D(a_dir_temp);
     a_dir_temp *= a;
 
-    b_dir_list = MakeCircleDirections(num_b_steps, a_dir_temp, gamma);
+    b_dir_list =
+        MakeCircleDirections(static_cast<int>(num_b_steps), a_dir_temp, gamma);
 
     for (auto &b_dir_num : b_dir_list) {
       b_dir_temp = b_dir_num;
@@ -958,19 +959,19 @@ double IndexingUtils::ScanFor_UB(DblMatrix &UB,
         bool indexes_peak = true;
         q_vec = q_vector / (2.0 * M_PI);
         dot_prod = a_dir_temp.scalar_prod(q_vec);
-        nearest_int = round(dot_prod);
+        nearest_int = std::lround(dot_prod);
         error = fabs(dot_prod - nearest_int);
         if (error > required_tolerance)
           indexes_peak = false;
         else {
           dot_prod = b_dir_temp.scalar_prod(q_vec);
-          nearest_int = round(dot_prod);
+          nearest_int = std::lround(dot_prod);
           error = fabs(dot_prod - nearest_int);
           if (error > required_tolerance)
             indexes_peak = false;
           else {
             dot_prod = c_dir_temp.scalar_prod(q_vec);
-            nearest_int = round(dot_prod);
+            nearest_int = std::lround(dot_prod);
             error = fabs(dot_prod - nearest_int);
             if (error > required_tolerance)
               indexes_peak = false;
@@ -997,27 +998,27 @@ double IndexingUtils::ScanFor_UB(DblMatrix &UB,
   // now, for each such direction, find
   // the one that indexes closes to
   // integer values
-  double min_error = 1e50;
+  double min_error = 1.0e50;
   for (size_t dir_num = 0; dir_num < selected_a_dirs.size(); dir_num++) {
     a_dir_temp = selected_a_dirs[dir_num];
     b_dir_temp = selected_b_dirs[dir_num];
     c_dir_temp = selected_c_dirs[dir_num];
 
-    double sum_sq_error = 0;
+    double sum_sq_error = 0.0;
     for (const auto &q_vector : q_vectors) {
       q_vec = q_vector / (2.0 * M_PI);
       dot_prod = a_dir_temp.scalar_prod(q_vec);
-      nearest_int = round(dot_prod);
+      nearest_int = std::lround(dot_prod);
       error = dot_prod - nearest_int;
       sum_sq_error += error * error;
 
       dot_prod = b_dir_temp.scalar_prod(q_vec);
-      nearest_int = round(dot_prod);
+      nearest_int = std::lround(dot_prod);
       error = dot_prod - nearest_int;
       sum_sq_error += error * error;
 
       dot_prod = c_dir_temp.scalar_prod(q_vec);
-      nearest_int = round(dot_prod);
+      nearest_int = std::lround(dot_prod);
       error = dot_prod - nearest_int;
       sum_sq_error += error * error;
     }
@@ -1069,12 +1070,12 @@ size_t IndexingUtils::ScanFor_Directions(std::vector<V3D> &directions,
   double error;
   double fit_error;
   double dot_prod;
-  int nearest_int;
+  long nearest_int;
   int max_indexed = 0;
   V3D q_vec;
   // first, make hemisphere of possible directions
   // with specified resolution.
-  int num_steps = round(90.0 / degrees_per_step);
+  int num_steps = static_cast<int>(std::lround(90.0 / degrees_per_step));
   std::vector<V3D> full_list = MakeHemisphereDirections(num_steps);
   // Now, look for possible real-space unit cell edges
   // by checking for vectors with length between
@@ -1082,7 +1083,7 @@ size_t IndexingUtils::ScanFor_Directions(std::vector<V3D> &directions,
   // in some direction, keeping the shortest vector
   // for each direction where the max peaks are indexed
   double delta_d = 0.1f;
-  int n_steps = round(1 + (max_d - min_d) / delta_d);
+  long n_steps = std::lround(1 + (max_d - min_d) / delta_d);
 
   std::vector<V3D> selected_dirs;
   V3D dir_temp;
@@ -1096,7 +1097,7 @@ size_t IndexingUtils::ScanFor_Directions(std::vector<V3D> &directions,
       for (const auto &q_vector : q_vectors) {
         q_vec = q_vector / (2.0 * M_PI);
         dot_prod = dir_temp.scalar_prod(q_vec);
-        nearest_int = round(dot_prod);
+        nearest_int = std::lround(dot_prod);
         error = fabs(dot_prod - nearest_int);
         if (error <= required_tolerance)
           num_indexed++;
@@ -1196,7 +1197,7 @@ size_t IndexingUtils::FFTScanFor_Directions(std::vector<V3D> &directions,
 
   // first, make hemisphere of possible directions
   // with specified resolution.
-  int num_steps = round(90.0 / degrees_per_step);
+  int num_steps = static_cast<int>(std::lround(90.0 / degrees_per_step));
   std::vector<V3D> full_list = MakeHemisphereDirections(num_steps);
 
   // find the maximum magnitude of Q to set range
@@ -1790,13 +1791,13 @@ void IndexingUtils::DiscardDuplicates(std::vector<V3D> &new_list,
       // now scan through temp list to
       int max_indexed = 0; // find the one that indexes most
 
-      int max_i = -1;
+      long max_i = -1;
       for (size_t i = 0; i < temp.size(); i++) {
         int num_indexed =
             NumberIndexed_1D(temp[i], q_vectors, required_tolerance);
         if (num_indexed > max_indexed) {
           max_indexed = num_indexed;
-          max_i = static_cast<int>(i);
+          max_i = i;
         }
       }
 
@@ -1822,7 +1823,7 @@ void IndexingUtils::DiscardDuplicates(std::vector<V3D> &new_list,
 void IndexingUtils::RoundHKLs(std::vector<V3D> &hkl_list) {
   for (auto &entry : hkl_list) {
     for (size_t i = 0; i < 3; i++) {
-      entry[i] = static_cast<double>(round(entry[i]));
+      entry[i] = std::round(entry[i]);
     }
   }
 }
@@ -2033,8 +2034,7 @@ int IndexingUtils::NumberIndexed_1D(const V3D &direction,
 
   for (const auto &q_vector : q_vectors) {
     double proj_value = direction.scalar_prod(q_vector) / (2.0 * M_PI);
-    int nearest_int = round(proj_value);
-    double error = fabs(proj_value - nearest_int);
+    double error = fabs(proj_value - std::round(proj_value));
     if (error <= tolerance) {
       count++;
     }
@@ -2134,9 +2134,9 @@ int IndexingUtils::CalculateMillerIndices(const DblMatrix &UB,
     if (ValidIndex(hkl, tolerance)) {
       count++;
       miller_indices.emplace_back(hkl);
-      h_error = fabs(round(hkl[0]) - hkl[0]);
-      k_error = fabs(round(hkl[1]) - hkl[1]);
-      l_error = fabs(round(hkl[2]) - hkl[2]);
+      h_error = std::abs(std::round(hkl[0]) - hkl[0]);
+      k_error = std::abs(std::round(hkl[1]) - hkl[1]);
+      l_error = std::abs(std::round(hkl[2]) - hkl[2]);
       ave_error += h_error + k_error + l_error;
     } else
       miller_indices.emplace_back(0, 0, 0);
@@ -2197,12 +2197,12 @@ int IndexingUtils::GetIndexedPeaks_1D(const V3D &direction,
 
   for (const auto &q_vector : q_vectors) {
     double proj_value = direction.scalar_prod(q_vector) / (2.0 * M_PI);
-    int nearest_int = round(proj_value);
+    double nearest_int = std::round(proj_value);
     double error = fabs(proj_value - nearest_int);
     if (error < required_tolerance) {
       fit_error += error * error;
       indexed_qs.push_back(q_vector);
-      index_vals.push_back(nearest_int);
+      index_vals.push_back(static_cast<int>(nearest_int));
       num_indexed++;
     }
   }
@@ -2269,9 +2269,9 @@ int IndexingUtils::GetIndexedPeaks_3D(
     hkl(projected_h, projected_k, projected_l);
 
     if (ValidIndex(hkl, required_tolerance)) {
-      int h_int = round(projected_h);
-      int k_int = round(projected_k);
-      int l_int = round(projected_l);
+      long h_int = std::lround(projected_h);
+      long k_int = std::lround(projected_k);
+      long l_int = std::lround(projected_l);
 
       double h_error = fabs(projected_h - h_int);
       double k_error = fabs(projected_k - k_int);
@@ -2346,7 +2346,7 @@ int IndexingUtils::GetIndexedPeaks(const DblMatrix &UB,
 
     if (ValidIndex(hkl, required_tolerance)) {
       for (int i = 0; i < 3; i++) {
-        error = hkl[i] - round(hkl[i]);
+        error = hkl[i] - std::round(hkl[i]);
         fit_error += error * error;
       }
 
@@ -2394,7 +2394,7 @@ std::vector<V3D> IndexingUtils::MakeHemisphereDirections(int n_steps) {
     double phi = static_cast<double>(iPhi) * angle_step;
     double r = sin(phi);
 
-    int n_theta = static_cast<int>(2. * M_PI * r / angle_step + 0.5);
+    long n_theta = std::lround(2. * M_PI * r / angle_step);
 
     double theta_step;
     if (n_theta == 0) {            // n = ( 0, 1, 0 ).  Just
@@ -2532,7 +2532,6 @@ int IndexingUtils::SelectDirection(V3D &best_direction,
         "SelectDirection(): List of possible directions has zero length");
   }
 
-  int nearest_int;
   double error;
   double min_sum_sq_error = 1.0e100;
 
@@ -2541,8 +2540,7 @@ int IndexingUtils::SelectDirection(V3D &best_direction,
     direction /= plane_spacing;
     for (const auto &q_vector : q_vectors) {
       double dot_product = direction.scalar_prod(q_vector) / (2.0 * M_PI);
-      nearest_int = round(dot_product);
-      error = fabs(dot_product - nearest_int);
+      error = fabs(dot_product - std::round(dot_product));
       sum_sq_error += error * error;
     }
 
@@ -2555,8 +2553,7 @@ int IndexingUtils::SelectDirection(V3D &best_direction,
   int num_indexed = 0;
   for (const auto &q_vector : q_vectors) {
     double proj_value = best_direction.scalar_prod(q_vector) / (2.0 * M_PI);
-    nearest_int = round(proj_value);
-    error = fabs(proj_value - nearest_int);
+    error = fabs(proj_value - std::round(proj_value));
     if (error < required_tolerance)
       num_indexed++;
   }

--- a/Framework/Kernel/src/V3D.cpp
+++ b/Framework/Kernel/src/V3D.cpp
@@ -730,14 +730,13 @@ void V3D::loadNexus(::NeXus::File *file, const std::string &name) {
   *  As crystallographical coordinate sytem is based on 3 integers, eps is used
   *as accuracy to convert into integers
 */
-#define DINT(x) std::fabs((x) - double(size_t((x) + 0.5)))
 double nearInt(double val, double eps, double mult) {
   if (val > 0) {
     if (val < 1) {
       mult /= val;
     } else {
-      if (DINT(val) > eps) {
-        mult *= (double(size_t(val / eps) + 1) * eps / val);
+      if (std::abs(val - std::round(val)) > eps) {
+        mult *= std::ceil(val / eps) * eps / val;
       }
     }
   }
@@ -779,12 +778,12 @@ double V3D::toMillerIndexes(double eps) {
   mult = nearInt(ay, eps, mult);
   mult = nearInt(az, eps, mult);
 
-  size_t iax = size_t(ax * mult / eps + 0.5);
-  size_t iay = size_t(ay * mult / eps + 0.5);
-  size_t iaz = size_t(az * mult / eps + 0.5);
+  size_t iax = std::lround(ax * mult / eps);
+  size_t iay = std::lround(ay * mult / eps);
+  size_t iaz = std::lround(az * mult / eps);
 
   size_t div = boost::math::gcd(iax, boost::math::gcd(iay, iaz));
-  mult /= (double(div) * eps);
+  mult /= (static_cast<double>(div) * eps);
   x *= mult;
   y *= mult;
   z *= mult;

--- a/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -164,8 +164,8 @@ void setMinMaxBins(Mantid::coord_t &pMin, Mantid::coord_t &pMax,
   pMax = snappedPMax;
 
   // Bins
-  numberOfBins = static_cast<size_t>(
-      (pMax - pMin) / width + 0.5); // round up to a whole number of bins.
+  numberOfBins =
+      std::lround((pMax - pMin) / width); // round up to a whole number of bins.
 }
 }
 

--- a/Framework/MDAlgorithms/src/MDTransfAxisNames.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfAxisNames.cpp
@@ -93,7 +93,7 @@ std::string makeAxisName(const Kernel::V3D &Dir,
 }
 std::string DLLExport sprintfd(const double data, const double eps) {
   // truncate to eps decimal points
-  float dist = static_cast<float>(std::round(data / eps) * eps);
+  double dist = std::round(data / eps) * eps;
   return boost::str(boost::format("%d") % dist);
 }
 

--- a/Framework/MDAlgorithms/src/MDTransfAxisNames.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfAxisNames.cpp
@@ -93,7 +93,7 @@ std::string makeAxisName(const Kernel::V3D &Dir,
 }
 std::string DLLExport sprintfd(const double data, const double eps) {
   // truncate to eps decimal points
-  float dist = float((int(data / eps + 0.5)) * eps);
+  float dist = static_cast<float>(std::round(data / eps) * eps);
   return boost::str(boost::format("%d") % dist);
 }
 


### PR DESCRIPTION
Description of work.

This removes the warnings found by clang-tidy's [misc-incorrect-rounding](http://clang.llvm.org/extra/clang-tidy/checks/misc-incorrect-roundings.html). Where possible, I tried to remove `static_cast<int>`.

**To test:**

<!-- Instructions for testing. -->

Please check that the behavior hasn't changed.

[std::round & std::lround documentation](http://www.cplusplus.com/reference/cmath/lround/)

[boost::math::iround documentation](http://www.boost.org/doc/libs/1_60_0/libs/math/doc/html/math_toolkit/rounding/round.html)

[warnings on the clang-tidy build](http://builds.mantidproject.org/view/Static%20Analysis/job/clang_tidy/115/warnings10Result/category.-1521249066/)

This PR is not associated with an issue.

Fortunately, this didn't change any test results and does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
