### PR TITLE
change specid_t to specnum_t it was a source of confusion

### DIFF
--- a/Framework/API/inc/MantidAPI/Axis.h
+++ b/Framework/API/inc/MantidAPI/Axis.h
@@ -87,8 +87,8 @@ public:
   /// Find the index of the given double value
   virtual size_t indexOfValue(const double value) const = 0;
 
-  /// Get the spectrum index
-  virtual specid_t spectraNo(const std::size_t &index) const;
+  /// Get the spectrum number
+  virtual specnum_t spectraNo(const std::size_t &index) const;
 
   /// Get the length of the axis
   virtual std::size_t length() const = 0;

--- a/Framework/API/inc/MantidAPI/IEventList.h
+++ b/Framework/API/inc/MantidAPI/IEventList.h
@@ -24,7 +24,7 @@ public:
   IEventList() {}
 
   /// Constructor
-  IEventList(specid_t specNo) : ISpectrum(specNo) {}
+  IEventList(specnum_t specNo) : ISpectrum(specNo) {}
 
   /// Return the current event type for the list
   virtual Mantid::API::EventType getEventType() const = 0;

--- a/Framework/API/inc/MantidAPI/ILiveListener.h
+++ b/Framework/API/inc/MantidAPI/ILiveListener.h
@@ -135,7 +135,7 @@ public:
    * spectra.
    * @param specList :: A vector with spectra indices.
    */
-  virtual void setSpectra(const std::vector<specid_t> &specList) {
+  virtual void setSpectra(const std::vector<specnum_t> &specList) {
     (void)specList;
   }
 

--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -47,7 +47,7 @@ namespace API {
 class DLLExport ISpectrum {
 public:
   ISpectrum();
-  ISpectrum(const specid_t specNo);
+  ISpectrum(const specnum_t specNo);
   ISpectrum(const ISpectrum &other);
   virtual ~ISpectrum();
 
@@ -112,9 +112,9 @@ public:
   void clearDetectorIDs();
 
   // ---------------------------------------------------------
-  specid_t getSpectrumNo() const;
+  specnum_t getSpectrumNo() const;
 
-  void setSpectrumNo(specid_t num);
+  void setSpectrumNo(specnum_t num);
 
   // ---------------------------------------------------------
   virtual void lockData() const;
@@ -126,7 +126,7 @@ public:
 
 protected:
   /// The spectrum number of this spectrum
-  specid_t m_specNo;
+  specnum_t m_specNo;
 
   /// Set of the detector IDs associated with this spectrum
   std::set<detid_t> detectorIDs;

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -103,18 +103,18 @@ public:
   /// Causes the nearest neighbours map to be rebuilt
   void rebuildNearestNeighbours();
   /// Query the NearestNeighbours object for a detector
-  std::map<specid_t, Mantid::Kernel::V3D>
+  std::map<specnum_t, Mantid::Kernel::V3D>
   getNeighbours(const Geometry::IDetector *comp, const double radius = 0.0,
                 const bool ignoreMaskedDetectors = false) const;
   /// Query the NearestNeighbours object for a given spectrum index using a
   /// search radius
-  std::map<specid_t, Mantid::Kernel::V3D>
-  getNeighbours(specid_t spec, const double radius,
+  std::map<specnum_t, Mantid::Kernel::V3D>
+  getNeighbours(specnum_t spec, const double radius,
                 const bool ignoreMaskedDetectors = false) const;
   /// Query the NearestNeighbours object for a given spectrum index using the
   /// direct number of nearest neighbours
-  std::map<specid_t, Mantid::Kernel::V3D>
-  getNeighboursExact(specid_t spec, const int nNeighbours,
+  std::map<specnum_t, Mantid::Kernel::V3D>
+  getNeighboursExact(specnum_t spec, const int nNeighbours,
                      const bool ignoreMaskedDetectors = false) const;
   //@}
 
@@ -131,14 +131,14 @@ public:
   getDetectorIDToWorkspaceIndexVector(std::vector<size_t> &out, detid_t &offset,
                                       bool throwIfMultipleDets = false) const;
   virtual void getSpectrumToWorkspaceIndexVector(std::vector<size_t> &out,
-                                                 specid_t &offset) const;
-  void getIndicesFromSpectra(const std::vector<specid_t> &spectraList,
+                                                 specnum_t &offset) const;
+  void getIndicesFromSpectra(const std::vector<specnum_t> &spectraList,
                              std::vector<size_t> &indexList) const;
-  size_t getIndexFromSpectrumNumber(const specid_t specNo) const;
+  size_t getIndexFromSpectrumNumber(const specnum_t specNo) const;
   void getIndicesFromDetectorIDs(const std::vector<detid_t> &detIdList,
                                  std::vector<size_t> &indexList) const;
   void getSpectraFromDetectorIDs(const std::vector<detid_t> &detIdList,
-                                 std::vector<specid_t> &spectraList) const;
+                                 std::vector<specnum_t> &spectraList) const;
 
   bool hasGroupedDetectors() const;
 

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -131,409 +131,498 @@ public:
   getDetectorIDToWorkspaceIndexVector(detid_t &offset,
                                       bool throwIfMultipleDets = false) const;
                         std::vector<specnum_t> &spectraList) const;
-  virtual std::vector<size_t>
-  getSpectrumToWorkspaceIndexVector(specnum_t &offset) const;
-  std::vector<size_t>
-  getIndicesFromSpectra(const std::vector<specnum_t> &spectraList) const;
-  size_t getIndexFromSpectrumNumber(const specnum_t specNo) const;
-  std::vector<size_t>
-  getIndicesFromDetectorIDs(const std::vector<detid_t> &detIdList) const;
-  std::vector<specnum_t>
-  getSpectraFromDetectorIDs(const std::vector<detid_t> &detIdList) const;
-
-
-  bool hasGroupedDetectors() const;
-
-  /// Get the footprint in memory in bytes.
-  size_t getMemorySize() const override;
-  virtual size_t getMemorySizeForXAxes() const;
-
-  // Section required for iteration
-  /// Returns the number of single indexable items in the workspace
-  virtual std::size_t size() const = 0;
-  /// Returns the size of each block of data returned by the dataY accessors
-  virtual std::size_t blocksize() const = 0;
-  /// Returns the number of histograms in the workspace
-  virtual std::size_t getNumberHistograms() const = 0;
-
-  /// Sets MatrixWorkspace title
-  void setTitle(const std::string &) override;
-  /// Gets MatrixWorkspace title (same as Run object run_title property)
-  const std::string getTitle() const override;
-
-  virtual Kernel::DateAndTime getFirstPulseTime() const;
-  Kernel::DateAndTime getLastPulseTime() const;
-
-  /// Returns the bin index for a given X value of a given workspace index
-  size_t binIndexOf(const double xValue, const std::size_t = 0) const;
-
-  //----------------------------------------------------------------------
-  // DATA ACCESSORS
-  //----------------------------------------------------------------------
-
-  /// Return the underlying ISpectrum ptr at the given workspace index.
-  virtual ISpectrum *getSpectrum(const size_t index) = 0;
-
-  /// Return the underlying ISpectrum ptr (const version) at the given workspace
-  /// index.
-  virtual const ISpectrum *getSpectrum(const size_t index) const = 0;
-
-  // Methods for getting read-only access to the data.
-  // Just passes through to the virtual dataX/Y/E function (const version)
-  /// Returns a read-only (i.e. const) reference to the specified X array
-  /// @param index :: workspace index to retrieve.
-  const MantidVec &readX(std::size_t const index) const {
-    return getSpectrum(index)->dataX();
-  }
-  /// Returns a read-only (i.e. const) reference to the specified Y array
-  /// @param index :: workspace index to retrieve.
-  const MantidVec &readY(std::size_t const index) const {
-    return getSpectrum(index)->dataY();
-  }
-  /// Returns a read-only (i.e. const) reference to the specified E array
-  /// @param index :: workspace index to retrieve.
-  const MantidVec &readE(std::size_t const index) const {
-    return getSpectrum(index)->dataE();
-  }
-  /// Returns a read-only (i.e. const) reference to the specified X error array
-  /// @param index :: workspace index to retrieve.
-  const MantidVec &readDx(size_t const index) const {
-    return getSpectrum(index)->dataDx();
-  }
-
-  /// Returns the x data
-  virtual MantidVec &dataX(const std::size_t index) {
-    invalidateCommonBinsFlag();
-    return getSpectrum(index)->dataX();
-  }
-  /// Returns the y data
-  virtual MantidVec &dataY(const std::size_t index) {
-    return getSpectrum(index)->dataY();
-  }
-  /// Returns the error data
-  virtual MantidVec &dataE(const std::size_t index) {
-    return getSpectrum(index)->dataE();
-  }
-  /// Returns the x error data
-  virtual MantidVec &dataDx(const std::size_t index) {
-    return getSpectrum(index)->dataDx();
-  }
-
-  /// Returns the x data const
-  virtual const MantidVec &dataX(const std::size_t index) const {
-    return getSpectrum(index)->dataX();
-  }
-  /// Returns the y data const
-  virtual const MantidVec &dataY(const std::size_t index) const {
-    return getSpectrum(index)->dataY();
-  }
-  /// Returns the error const
-  virtual const MantidVec &dataE(const std::size_t index) const {
-    return getSpectrum(index)->dataE();
-  }
-  /// Returns the error const
-  virtual const MantidVec &dataDx(const std::size_t index) const {
-    return getSpectrum(index)->dataDx();
-  }
-
-  virtual double getXMin() const;
-  virtual double getXMax() const;
-  virtual void getXMinMax(double &xmin, double &xmax) const;
-
-  /// Returns a pointer to the x data
-  virtual Kernel::cow_ptr<MantidVec> refX(const std::size_t index) const {
-    return getSpectrum(index)->ptrX();
-  }
-
-  /// Returns a pointer to the dX  (X Error) data
-  virtual Kernel::cow_ptr<MantidVec> refDx(const std::size_t index) const {
-    return getSpectrum(index)->ptrDx();
-  }
-
-  /// Set the specified X array to point to the given existing array
-  virtual void setX(const std::size_t index, const MantidVec &X) {
-    getSpectrum(index)->setX(X);
-    invalidateCommonBinsFlag();
-  }
-
-  /// Set the specified X array to point to the given existing array
-  virtual void setX(const std::size_t index, const MantidVecPtr &X) {
-    getSpectrum(index)->setX(X);
-    invalidateCommonBinsFlag();
-  }
-
-  /// Set the specified X array to point to the given existing array
-  virtual void setX(const std::size_t index, const MantidVecPtr::ptr_type &X) {
-    getSpectrum(index)->setX(X);
-    invalidateCommonBinsFlag();
-  }
-
-  /// Set the specified Dx (X Error) array to point to the given existing array
-  virtual void setDx(const std::size_t index, const MantidVec &Dx) {
-    getSpectrum(index)->setDx(Dx);
-    invalidateCommonBinsFlag();
-  }
-
-  /// Set the specified Dx (X Error) array to point to the given existing array
-  virtual void setDx(const std::size_t index, const MantidVecPtr &Dx) {
-    getSpectrum(index)->setDx(Dx);
-    invalidateCommonBinsFlag();
-  }
-
-  /// Set the specified Dx (X Error) array to point to the given existing array
-  virtual void setDx(const std::size_t index,
-                     const MantidVecPtr::ptr_type &Dx) {
-    getSpectrum(index)->setX(Dx);
-    invalidateCommonBinsFlag();
-  }
-
-  /** Sets the data in the workspace
-  @param index :: the workspace index to set.
-  @param Y :: Y vector  */
-  virtual void setData(const std::size_t index, const MantidVecPtr &Y) {
-    getSpectrum(index)->setData(Y);
-  }
-
-  /** Sets the data in the workspace
-  @param index :: the workspace index to set.
-  @param Y :: Y vector
-  @param E :: Error vector   */
-  virtual void setData(const std::size_t index, const MantidVecPtr &Y,
-                       const MantidVecPtr &E) {
-    getSpectrum(index)->setData(Y, E);
-  }
-
-  /** Sets the data in the workspace
-  @param index :: the workspace index to set.
-  @param Y :: Y vector
-  @param E :: Error vector   */
-  virtual void setData(const std::size_t index, const MantidVecPtr::ptr_type &Y,
-                       const MantidVecPtr::ptr_type &E) {
-    getSpectrum(index)->setData(Y, E);
-  }
-
-  /**
-   * Probes if DX (X Error) values were set on a particular spectrum
-   * @param index: the spectrum index
-   */
-  virtual bool hasDx(const std::size_t index) const {
-    return getSpectrum(index)->hasDx();
-  }
-
-  /// Generate the histogram or rebin the existing histogram.
-  virtual void generateHistogram(const std::size_t index, const MantidVec &X,
-                                 MantidVec &Y, MantidVec &E,
-                                 bool skipError = false) const = 0;
-
-  /// Return a vector with the integrated counts for all spectra withing the
-  /// given range
-  virtual void getIntegratedSpectra(std::vector<double> &out, const double minX,
-                                    const double maxX,
-                                    const bool entireRange) const;
-
-  /// Return an index in the X vector for an x-value close to a given value
-  std::pair<size_t, double> getXIndex(size_t i, double x, bool isLeft = true,
-                                      size_t start = 0) const;
-
-  //----------------------------------------------------------------------
-
-  int axes() const;
-  virtual Axis *getAxis(const std::size_t &axisIndex) const;
-  void replaceAxis(const std::size_t &axisIndex, Axis *const newAxis);
-
-  /// Returns true if the workspace contains data in histogram form (as opposed
-  /// to point-like)
-  virtual bool isHistogramData() const;
-
-  /// Returns true if the workspace contains has common X bins
-  virtual bool isCommonBins() const;
-
-  std::string YUnit() const;
-  void setYUnit(const std::string &newUnit);
-  std::string YUnitLabel() const;
-  void setYUnitLabel(const std::string &newLabel);
-
-  /// Are the Y-values dimensioned?
-  const bool &isDistribution() const;
-  bool &isDistribution(bool newValue);
-
-  /// Mask a given workspace index, setting the data and error values to zero
-  void maskWorkspaceIndex(const std::size_t index);
-
-  // Methods to set and access masked bins
-  void maskBin(const size_t &workspaceIndex, const size_t &binIndex,
-               const double &weight = 1.0);
-  void flagMasked(const size_t &spectrumIndex, const size_t &binIndex,
-                  const double &weight = 1.0);
-  bool hasMaskedBins(const size_t &spectrumIndex) const;
-  /// Masked bins for each spectrum are stored as a set of pairs containing <bin
-  /// index, weight>
-  typedef std::map<size_t, double> MaskList;
-  const MaskList &maskedBins(const size_t &spectrumIndex) const;
-
-  // Methods handling the internal monitor workspace
-  virtual void
-  setMonitorWorkspace(const boost::shared_ptr<MatrixWorkspace> &monitorWS);
-  boost::shared_ptr<MatrixWorkspace> monitorWorkspace() const;
-
-  void saveInstrumentNexus(::NeXus::File *file) const;
-  void loadInstrumentNexus(::NeXus::File *file);
-  void saveSpectraMapNexus(
-      ::NeXus::File *file, const std::vector<int> &spec,
-      const ::NeXus::NXcompression compression = ::NeXus::LZW) const;
-
-  //=====================================================================================
-  // MD Geometry methods
-  //=====================================================================================
-  size_t getNumDims() const override;
-  boost::shared_ptr<const Mantid::Geometry::IMDDimension>
-  getDimension(size_t index) const override;
-  boost::shared_ptr<const Mantid::Geometry::IMDDimension>
-  getDimensionWithId(std::string id) const override;
-  //=====================================================================================
-  // End MD Geometry methods
-  //=====================================================================================
-
-  //=====================================================================================
-  // IMDWorkspace methods
-  //=====================================================================================
-
-  /// Gets the number of points available on the workspace.
-  uint64_t getNPoints() const override;
-  /// Get the number of points available on the workspace.
-  uint64_t getNEvents() const override { return this->getNPoints(); }
-  /// Dimension id for x-dimension.
-  static const std::string xDimensionId;
-  /// Dimensin id for y-dimension.
-  static const std::string yDimensionId;
-  /// Generate a line plot through the matrix workspace.
-  LinePlot getLinePlot(const Mantid::Kernel::VMD &start,
-                       const Mantid::Kernel::VMD &end,
-                       Mantid::API::MDNormalization normalize) const override;
-  /// Get the signal at a coordinate in the workspace.
-  signal_t getSignalAtCoord(
-      const coord_t *coords,
-      const Mantid::API::MDNormalization &normalization) const override;
-  /// Get the signal at a coordinate in the workspace
-  signal_t getSignalWithMaskAtCoord(
-      const coord_t *coords,
-      const Mantid::API::MDNormalization &normalization) const override;
-  /// Create iterators. Partitions the iterators according to the number of
-  /// cores.
-  std::vector<IMDIterator *> createIterators(
-      size_t suggestedNumCores = 1,
-      Mantid::Geometry::MDImplicitFunction *function = nullptr) const override;
-
-  /// Apply masking.
-  void
-  setMDMasking(Mantid::Geometry::MDImplicitFunction *maskingRegion) override;
-  /// Clear exsting masking.
-  void clearMDMasking() override;
-
-  /// @return the special coordinate system used if any.
-  Mantid::Kernel::SpecialCoordinateSystem
-  getSpecialCoordinateSystem() const override;
-
-  //=====================================================================================
-  // End IMDWorkspace methods
-  //=====================================================================================
-
-  //=====================================================================================
-  // Image methods
-  //=====================================================================================
-
-  /// Get start and end x indices for images
-  std::pair<size_t, size_t> getImageStartEndXIndices(size_t i, double startX,
-                                                     double endX) const;
-  /// Create an image of Ys.
-  MantidImage_sptr getImageY(size_t start = 0, size_t stop = 0,
-                             size_t width = 0, double startX = EMPTY_DBL(),
-                             double endX = EMPTY_DBL()) const;
-  /// Create an image of Es.
-  MantidImage_sptr getImageE(size_t start = 0, size_t stop = 0,
-                             size_t width = 0, double startX = EMPTY_DBL(),
-                             double endX = EMPTY_DBL()) const;
-  /// Copy the data (Y's) from an image to this workspace.
-  virtual void setImageY(const MantidImage &image, size_t start = 0,
-                         bool parallelExecution = true);
-  /// Copy the data from an image to this workspace's errors.
-  virtual void setImageE(const MantidImage &image, size_t start = 0,
-                         bool parallelExecution = true);
-
-  //=====================================================================================
-  // End image methods
-  //=====================================================================================
-
-protected:
-  /// Protected copy constructor. May be used by childs for cloning.
-  MatrixWorkspace(const MatrixWorkspace &other);
-  /// Protected copy assignment operator. Assignment not implemented.
-  MatrixWorkspace &operator=(const MatrixWorkspace &other);
-
-  MatrixWorkspace(
-      Mantid::Geometry::INearestNeighboursFactory *factory = nullptr);
-
-  /// Initialises the workspace. Sets the size and lengths of the arrays. Must
-  /// be overloaded.
-  virtual void init(const std::size_t &NVectors, const std::size_t &XLength,
-                    const std::size_t &YLength) = 0;
-
-  /// Invalidates the commons bins flag.  This is generally called when a method
-  /// could allow the X values to be changed.
-  void invalidateCommonBinsFlag() { m_isCommonBinsFlagSet = false; }
-
-  /// A vector of pointers to the axes for this workspace
-  std::vector<Axis *> m_axes;
-
-private:
-  MatrixWorkspace *doClone() const override = 0;
-
-  /// Create an MantidImage instance.
-  MantidImage_sptr
-  getImage(const MantidVec &(MatrixWorkspace::*read)(std::size_t const) const,
-           size_t start, size_t stop, size_t width, size_t indexStart,
-           size_t indexEnd) const;
-  /// Copy data from an image.
-  void setImage(MantidVec &(MatrixWorkspace::*dataVec)(const std::size_t),
-                const MantidImage &image, size_t start, bool parallelExecution);
-
-  /// Has this workspace been initialised?
-  bool m_isInitialized;
-
-  /// The unit for the data values (e.g. Counts)
-  std::string m_YUnit;
-  /// A text label for use when plotting spectra
-  std::string m_YUnitLabel;
-  /// Flag indicating whether the Y-values are dimensioned. False by default
-  bool m_isDistribution;
-
-  /// Flag indicating whether the m_isCommonBinsFlag has been set. False by
-  /// default
-  mutable bool m_isCommonBinsFlagSet;
-  /// Flag indicating whether the data has common bins. False by default
-  mutable bool m_isCommonBinsFlag;
-
-  /// The set of masked bins in a map keyed on spectrum index
-  std::map<int64_t, MaskList> m_masks;
-
-  /// A workspace holding monitor data relating to the main data in the
-  /// containing workspace (null if none).
-  boost::shared_ptr<MatrixWorkspace> m_monitorWorkspace;
-
-protected:
-  /// Assists conversions to and from 2D histogram indexing to 1D indexing.
-  MatrixWSIndexCalculator m_indexCalculator;
-
-  /// Scoped pointer to NearestNeighbours factory
-  boost::scoped_ptr<Mantid::Geometry::INearestNeighboursFactory>
-      m_nearestNeighboursFactory;
-
-  /// Shared pointer to NearestNeighbours object
-  mutable boost::shared_ptr<Mantid::Geometry::INearestNeighbours>
-      m_nearestNeighbours;
-
-  /// Getter for the dimension id based on the axis.
-  std::string getDimensionIdFromAxis(const int &axisIndex) const;
+                        virtual std::vector<size_t>
+                        getSpectrumToWorkspaceIndexVector(
+                            specnum_t &offset) const;
+                        std::vector<size_t> getIndicesFromSpectra(
+                            const std::vector<specnum_t> &spectraList) const;
+                        size_t getIndexFromSpectrumNumber(
+                            const specnum_t specNo) const;
+                        std::vector<size_t> getIndicesFromDetectorIDs(
+                            const std::vector<detid_t> &detIdList) const;
+                        std::vector<specnum_t> getSpectraFromDetectorIDs(
+                            const std::vector<detid_t> &detIdList) const;
+
+                        bool hasGroupedDetectors() const;
+
+                        /// Get the footprint in memory in bytes.
+                        size_t getMemorySize() const override;
+                        virtual size_t getMemorySizeForXAxes() const;
+
+                        // Section required for iteration
+                        /// Returns the number of single indexable items in the
+                        /// workspace
+                        virtual std::size_t size() const = 0;
+                        /// Returns the size of each block of data returned by
+                        /// the dataY accessors
+                        virtual std::size_t blocksize() const = 0;
+                        /// Returns the number of histograms in the workspace
+                        virtual std::size_t getNumberHistograms() const = 0;
+
+                        /// Sets MatrixWorkspace title
+                        void setTitle(const std::string &) override;
+                        /// Gets MatrixWorkspace title (same as Run object
+                        /// run_title property)
+                        const std::string getTitle() const override;
+
+                        virtual Kernel::DateAndTime getFirstPulseTime() const;
+                        Kernel::DateAndTime getLastPulseTime() const;
+
+                        /// Returns the bin index for a given X value of a given
+                        /// workspace index
+                        size_t binIndexOf(const double xValue,
+                                          const std::size_t = 0) const;
+
+                        //----------------------------------------------------------------------
+                        // DATA ACCESSORS
+                        //----------------------------------------------------------------------
+
+                        /// Return the underlying ISpectrum ptr at the given
+                        /// workspace index.
+                        virtual ISpectrum *getSpectrum(const size_t index) = 0;
+
+                        /// Return the underlying ISpectrum ptr (const version)
+                        /// at the given workspace
+                        /// index.
+                        virtual const ISpectrum *
+                        getSpectrum(const size_t index) const = 0;
+
+                        // Methods for getting read-only access to the data.
+                        // Just passes through to the virtual dataX/Y/E function
+                        // (const version)
+                        /// Returns a read-only (i.e. const) reference to the
+                        /// specified X array
+                        /// @param index :: workspace index to retrieve.
+                        const MantidVec &readX(std::size_t const index) const {
+                          return getSpectrum(index)->dataX();
+                        }
+                        /// Returns a read-only (i.e. const) reference to the
+                        /// specified Y array
+                        /// @param index :: workspace index to retrieve.
+                        const MantidVec &readY(std::size_t const index) const {
+                          return getSpectrum(index)->dataY();
+                        }
+                        /// Returns a read-only (i.e. const) reference to the
+                        /// specified E array
+                        /// @param index :: workspace index to retrieve.
+                        const MantidVec &readE(std::size_t const index) const {
+                          return getSpectrum(index)->dataE();
+                        }
+                        /// Returns a read-only (i.e. const) reference to the
+                        /// specified X error array
+                        /// @param index :: workspace index to retrieve.
+                        const MantidVec &readDx(size_t const index) const {
+                          return getSpectrum(index)->dataDx();
+                        }
+
+                        /// Returns the x data
+                        virtual MantidVec &dataX(const std::size_t index) {
+                          invalidateCommonBinsFlag();
+                          return getSpectrum(index)->dataX();
+                        }
+                        /// Returns the y data
+                        virtual MantidVec &dataY(const std::size_t index) {
+                          return getSpectrum(index)->dataY();
+                        }
+                        /// Returns the error data
+                        virtual MantidVec &dataE(const std::size_t index) {
+                          return getSpectrum(index)->dataE();
+                        }
+                        /// Returns the x error data
+                        virtual MantidVec &dataDx(const std::size_t index) {
+                          return getSpectrum(index)->dataDx();
+                        }
+
+                        /// Returns the x data const
+                        virtual const MantidVec &
+                        dataX(const std::size_t index) const {
+                          return getSpectrum(index)->dataX();
+                        }
+                        /// Returns the y data const
+                        virtual const MantidVec &
+                        dataY(const std::size_t index) const {
+                          return getSpectrum(index)->dataY();
+                        }
+                        /// Returns the error const
+                        virtual const MantidVec &
+                        dataE(const std::size_t index) const {
+                          return getSpectrum(index)->dataE();
+                        }
+                        /// Returns the error const
+                        virtual const MantidVec &
+                        dataDx(const std::size_t index) const {
+                          return getSpectrum(index)->dataDx();
+                        }
+
+                        virtual double getXMin() const;
+                        virtual double getXMax() const;
+                        virtual void getXMinMax(double &xmin,
+                                                double &xmax) const;
+
+                        /// Returns a pointer to the x data
+                        virtual Kernel::cow_ptr<MantidVec>
+                        refX(const std::size_t index) const {
+                          return getSpectrum(index)->ptrX();
+                        }
+
+                        /// Returns a pointer to the dX  (X Error) data
+                        virtual Kernel::cow_ptr<MantidVec>
+                        refDx(const std::size_t index) const {
+                          return getSpectrum(index)->ptrDx();
+                        }
+
+                        /// Set the specified X array to point to the given
+                        /// existing array
+                        virtual void setX(const std::size_t index,
+                                          const MantidVec &X) {
+                          getSpectrum(index)->setX(X);
+                          invalidateCommonBinsFlag();
+                        }
+
+                        /// Set the specified X array to point to the given
+                        /// existing array
+                        virtual void setX(const std::size_t index,
+                                          const MantidVecPtr &X) {
+                          getSpectrum(index)->setX(X);
+                          invalidateCommonBinsFlag();
+                        }
+
+                        /// Set the specified X array to point to the given
+                        /// existing array
+                        virtual void setX(const std::size_t index,
+                                          const MantidVecPtr::ptr_type &X) {
+                          getSpectrum(index)->setX(X);
+                          invalidateCommonBinsFlag();
+                        }
+
+                        /// Set the specified Dx (X Error) array to point to the
+                        /// given existing array
+                        virtual void setDx(const std::size_t index,
+                                           const MantidVec &Dx) {
+                          getSpectrum(index)->setDx(Dx);
+                          invalidateCommonBinsFlag();
+                        }
+
+                        /// Set the specified Dx (X Error) array to point to the
+                        /// given existing array
+                        virtual void setDx(const std::size_t index,
+                                           const MantidVecPtr &Dx) {
+                          getSpectrum(index)->setDx(Dx);
+                          invalidateCommonBinsFlag();
+                        }
+
+                        /// Set the specified Dx (X Error) array to point to the
+                        /// given existing array
+                        virtual void setDx(const std::size_t index,
+                                           const MantidVecPtr::ptr_type &Dx) {
+                          getSpectrum(index)->setX(Dx);
+                          invalidateCommonBinsFlag();
+                        }
+
+                        /** Sets the data in the workspace
+                        @param index :: the workspace index to set.
+                        @param Y :: Y vector  */
+                        virtual void setData(const std::size_t index,
+                                             const MantidVecPtr &Y) {
+                          getSpectrum(index)->setData(Y);
+                        }
+
+                        /** Sets the data in the workspace
+                        @param index :: the workspace index to set.
+                        @param Y :: Y vector
+                        @param E :: Error vector   */
+                        virtual void setData(const std::size_t index,
+                                             const MantidVecPtr &Y,
+                                             const MantidVecPtr &E) {
+                          getSpectrum(index)->setData(Y, E);
+                        }
+
+                        /** Sets the data in the workspace
+                        @param index :: the workspace index to set.
+                        @param Y :: Y vector
+                        @param E :: Error vector   */
+                        virtual void setData(const std::size_t index,
+                                             const MantidVecPtr::ptr_type &Y,
+                                             const MantidVecPtr::ptr_type &E) {
+                          getSpectrum(index)->setData(Y, E);
+                        }
+
+                        /**
+                         * Probes if DX (X Error) values were set on a
+                         * particular spectrum
+                         * @param index: the spectrum index
+                         */
+                        virtual bool hasDx(const std::size_t index) const {
+                          return getSpectrum(index)->hasDx();
+                        }
+
+                        /// Generate the histogram or rebin the existing
+                        /// histogram.
+                        virtual void
+                        generateHistogram(const std::size_t index,
+                                          const MantidVec &X, MantidVec &Y,
+                                          MantidVec &E,
+                                          bool skipError = false) const = 0;
+
+                        /// Return a vector with the integrated counts for all
+                        /// spectra withing the
+                        /// given range
+                        virtual void getIntegratedSpectra(
+                            std::vector<double> &out, const double minX,
+                            const double maxX, const bool entireRange) const;
+
+                        /// Return an index in the X vector for an x-value close
+                        /// to a given value
+                        std::pair<size_t, double>
+                        getXIndex(size_t i, double x, bool isLeft = true,
+                                  size_t start = 0) const;
+
+                        //----------------------------------------------------------------------
+
+                        int axes() const;
+                        virtual Axis *
+                        getAxis(const std::size_t &axisIndex) const;
+                        void replaceAxis(const std::size_t &axisIndex,
+                                         Axis *const newAxis);
+
+                        /// Returns true if the workspace contains data in
+                        /// histogram form (as opposed
+                        /// to point-like)
+                        virtual bool isHistogramData() const;
+
+                        /// Returns true if the workspace contains has common X
+                        /// bins
+                        virtual bool isCommonBins() const;
+
+                        std::string YUnit() const;
+                        void setYUnit(const std::string &newUnit);
+                        std::string YUnitLabel() const;
+                        void setYUnitLabel(const std::string &newLabel);
+
+                        /// Are the Y-values dimensioned?
+                        const bool &isDistribution() const;
+                        bool &isDistribution(bool newValue);
+
+                        /// Mask a given workspace index, setting the data and
+                        /// error values to zero
+                        void maskWorkspaceIndex(const std::size_t index);
+
+                        // Methods to set and access masked bins
+                        void maskBin(const size_t &workspaceIndex,
+                                     const size_t &binIndex,
+                                     const double &weight = 1.0);
+                        void flagMasked(const size_t &spectrumIndex,
+                                        const size_t &binIndex,
+                                        const double &weight = 1.0);
+                        bool hasMaskedBins(const size_t &spectrumIndex) const;
+                        /// Masked bins for each spectrum are stored as a set of
+                        /// pairs containing <bin
+                        /// index, weight>
+                        typedef std::map<size_t, double> MaskList;
+                        const MaskList &
+                        maskedBins(const size_t &spectrumIndex) const;
+
+                        // Methods handling the internal monitor workspace
+                        virtual void setMonitorWorkspace(
+                            const boost::shared_ptr<MatrixWorkspace> &
+                                monitorWS);
+                        boost::shared_ptr<MatrixWorkspace>
+                        monitorWorkspace() const;
+
+                        void saveInstrumentNexus(::NeXus::File *file) const;
+                        void loadInstrumentNexus(::NeXus::File *file);
+                        void saveSpectraMapNexus(
+                            ::NeXus::File *file, const std::vector<int> &spec,
+                            const ::NeXus::NXcompression compression =
+                                ::NeXus::LZW) const;
+
+                        //=====================================================================================
+                        // MD Geometry methods
+                        //=====================================================================================
+                        size_t getNumDims() const override;
+                        boost::shared_ptr<const Mantid::Geometry::IMDDimension>
+                        getDimension(size_t index) const override;
+                        boost::shared_ptr<const Mantid::Geometry::IMDDimension>
+                        getDimensionWithId(std::string id) const override;
+                        //=====================================================================================
+                        // End MD Geometry methods
+                        //=====================================================================================
+
+                        //=====================================================================================
+                        // IMDWorkspace methods
+                        //=====================================================================================
+
+                        /// Gets the number of points available on the
+                        /// workspace.
+                        uint64_t getNPoints() const override;
+                        /// Get the number of points available on the workspace.
+                        uint64_t getNEvents() const override {
+                          return this->getNPoints();
+                        }
+                        /// Dimension id for x-dimension.
+                        static const std::string xDimensionId;
+                        /// Dimensin id for y-dimension.
+                        static const std::string yDimensionId;
+                        /// Generate a line plot through the matrix workspace.
+                        LinePlot getLinePlot(const Mantid::Kernel::VMD &start,
+                                             const Mantid::Kernel::VMD &end,
+                                             Mantid::API::MDNormalization
+                                                 normalize) const override;
+                        /// Get the signal at a coordinate in the workspace.
+                        signal_t
+                        getSignalAtCoord(const coord_t *coords,
+                                         const Mantid::API::MDNormalization &
+                                             normalization) const override;
+                        /// Get the signal at a coordinate in the workspace
+                        signal_t getSignalWithMaskAtCoord(
+                            const coord_t *coords,
+                            const Mantid::API::MDNormalization &normalization)
+                            const override;
+                        /// Create iterators. Partitions the iterators according
+                        /// to the number of
+                        /// cores.
+                        std::vector<IMDIterator *> createIterators(
+                            size_t suggestedNumCores = 1,
+                            Mantid::Geometry::MDImplicitFunction *function =
+                                nullptr) const override;
+
+                        /// Apply masking.
+                        void setMDMasking(Mantid::Geometry::MDImplicitFunction *
+                                              maskingRegion) override;
+                        /// Clear exsting masking.
+                        void clearMDMasking() override;
+
+                        /// @return the special coordinate system used if any.
+                        Mantid::Kernel::SpecialCoordinateSystem
+                        getSpecialCoordinateSystem() const override;
+
+                        //=====================================================================================
+                        // End IMDWorkspace methods
+                        //=====================================================================================
+
+                        //=====================================================================================
+                        // Image methods
+                        //=====================================================================================
+
+                        /// Get start and end x indices for images
+                        std::pair<size_t, size_t>
+                        getImageStartEndXIndices(size_t i, double startX,
+                                                 double endX) const;
+                        /// Create an image of Ys.
+                        MantidImage_sptr
+                        getImageY(size_t start = 0, size_t stop = 0,
+                                  size_t width = 0, double startX = EMPTY_DBL(),
+                                  double endX = EMPTY_DBL()) const;
+                        /// Create an image of Es.
+                        MantidImage_sptr
+                        getImageE(size_t start = 0, size_t stop = 0,
+                                  size_t width = 0, double startX = EMPTY_DBL(),
+                                  double endX = EMPTY_DBL()) const;
+                        /// Copy the data (Y's) from an image to this workspace.
+                        virtual void setImageY(const MantidImage &image,
+                                               size_t start = 0,
+                                               bool parallelExecution = true);
+                        /// Copy the data from an image to this workspace's
+                        /// errors.
+                        virtual void setImageE(const MantidImage &image,
+                                               size_t start = 0,
+                                               bool parallelExecution = true);
+
+                        //=====================================================================================
+                        // End image methods
+                        //=====================================================================================
+
+                      protected:
+                        /// Protected copy constructor. May be used by childs
+                        /// for cloning.
+                        MatrixWorkspace(const MatrixWorkspace &other);
+                        /// Protected copy assignment operator. Assignment not
+                        /// implemented.
+                        MatrixWorkspace &
+                        operator=(const MatrixWorkspace &other);
+
+                        MatrixWorkspace(
+                            Mantid::Geometry::INearestNeighboursFactory *
+                                factory = nullptr);
+
+                        /// Initialises the workspace. Sets the size and lengths
+                        /// of the arrays. Must
+                        /// be overloaded.
+                        virtual void init(const std::size_t &NVectors,
+                                          const std::size_t &XLength,
+                                          const std::size_t &YLength) = 0;
+
+                        /// Invalidates the commons bins flag.  This is
+                        /// generally called when a method
+                        /// could allow the X values to be changed.
+                        void invalidateCommonBinsFlag() {
+                          m_isCommonBinsFlagSet = false;
+                        }
+
+                        /// A vector of pointers to the axes for this workspace
+                        std::vector<Axis *> m_axes;
+
+                      private:
+                        MatrixWorkspace *doClone() const override = 0;
+
+                        /// Create an MantidImage instance.
+                        MantidImage_sptr
+                        getImage(const MantidVec &(MatrixWorkspace::*read)(
+                                     std::size_t const) const,
+                                 size_t start, size_t stop, size_t width,
+                                 size_t indexStart, size_t indexEnd) const;
+                        /// Copy data from an image.
+                        void setImage(MantidVec &(MatrixWorkspace::*dataVec)(
+                                          const std::size_t),
+                                      const MantidImage &image, size_t start,
+                                      bool parallelExecution);
+
+                        /// Has this workspace been initialised?
+                        bool m_isInitialized;
+
+                        /// The unit for the data values (e.g. Counts)
+                        std::string m_YUnit;
+                        /// A text label for use when plotting spectra
+                        std::string m_YUnitLabel;
+                        /// Flag indicating whether the Y-values are
+                        /// dimensioned. False by default
+                        bool m_isDistribution;
+
+                        /// Flag indicating whether the m_isCommonBinsFlag has
+                        /// been set. False by
+                        /// default
+                        mutable bool m_isCommonBinsFlagSet;
+                        /// Flag indicating whether the data has common bins.
+                        /// False by default
+                        mutable bool m_isCommonBinsFlag;
+
+                        /// The set of masked bins in a map keyed on spectrum
+                        /// index
+                        std::map<int64_t, MaskList> m_masks;
+
+                        /// A workspace holding monitor data relating to the
+                        /// main data in the
+                        /// containing workspace (null if none).
+                        boost::shared_ptr<MatrixWorkspace> m_monitorWorkspace;
+
+                      protected:
+                        /// Assists conversions to and from 2D histogram
+                        /// indexing to 1D indexing.
+                        MatrixWSIndexCalculator m_indexCalculator;
+
+                        /// Scoped pointer to NearestNeighbours factory
+                        boost::scoped_ptr<
+                            Mantid::Geometry::INearestNeighboursFactory>
+                            m_nearestNeighboursFactory;
+
+                        /// Shared pointer to NearestNeighbours object
+                        mutable boost::shared_ptr<
+                            Mantid::Geometry::INearestNeighbours>
+                            m_nearestNeighbours;
+
+                        /// Getter for the dimension id based on the axis.
+                        std::string
+                        getDimensionIdFromAxis(const int &axisIndex) const;
 };
 
 /// shared pointer to the matrix workspace base class

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -130,499 +130,409 @@ public:
   virtual std::vector<size_t>
   getDetectorIDToWorkspaceIndexVector(detid_t &offset,
                                       bool throwIfMultipleDets = false) const;
-                        std::vector<specnum_t> &spectraList) const;
-                        virtual std::vector<size_t>
-                        getSpectrumToWorkspaceIndexVector(
-                            specnum_t &offset) const;
-                        std::vector<size_t> getIndicesFromSpectra(
-                            const std::vector<specnum_t> &spectraList) const;
-                        size_t getIndexFromSpectrumNumber(
-                            const specnum_t specNo) const;
-                        std::vector<size_t> getIndicesFromDetectorIDs(
-                            const std::vector<detid_t> &detIdList) const;
-                        std::vector<specnum_t> getSpectraFromDetectorIDs(
-                            const std::vector<detid_t> &detIdList) const;
 
-                        bool hasGroupedDetectors() const;
+  virtual std::vector<size_t>
+  getSpectrumToWorkspaceIndexVector(specnum_t &offset) const;
+  std::vector<size_t>
+  getIndicesFromSpectra(const std::vector<specnum_t> &spectraList) const;
+  size_t getIndexFromSpectrumNumber(const specnum_t specNo) const;
+  std::vector<size_t>
+  getIndicesFromDetectorIDs(const std::vector<detid_t> &detIdList) const;
+  std::vector<specnum_t>
+  getSpectraFromDetectorIDs(const std::vector<detid_t> &detIdList) const;
 
-                        /// Get the footprint in memory in bytes.
-                        size_t getMemorySize() const override;
-                        virtual size_t getMemorySizeForXAxes() const;
+  bool hasGroupedDetectors() const;
 
-                        // Section required for iteration
-                        /// Returns the number of single indexable items in the
-                        /// workspace
-                        virtual std::size_t size() const = 0;
-                        /// Returns the size of each block of data returned by
-                        /// the dataY accessors
-                        virtual std::size_t blocksize() const = 0;
-                        /// Returns the number of histograms in the workspace
-                        virtual std::size_t getNumberHistograms() const = 0;
+  /// Get the footprint in memory in bytes.
+  size_t getMemorySize() const override;
+  virtual size_t getMemorySizeForXAxes() const;
 
-                        /// Sets MatrixWorkspace title
-                        void setTitle(const std::string &) override;
-                        /// Gets MatrixWorkspace title (same as Run object
-                        /// run_title property)
-                        const std::string getTitle() const override;
+  // Section required for iteration
+  /// Returns the number of single indexable items in the workspace
+  virtual std::size_t size() const = 0;
+  /// Returns the size of each block of data returned by the dataY accessors
+  virtual std::size_t blocksize() const = 0;
+  /// Returns the number of histograms in the workspace
+  virtual std::size_t getNumberHistograms() const = 0;
 
-                        virtual Kernel::DateAndTime getFirstPulseTime() const;
-                        Kernel::DateAndTime getLastPulseTime() const;
+  /// Sets MatrixWorkspace title
+  void setTitle(const std::string &) override;
+  /// Gets MatrixWorkspace title (same as Run object run_title property)
+  const std::string getTitle() const override;
 
-                        /// Returns the bin index for a given X value of a given
-                        /// workspace index
-                        size_t binIndexOf(const double xValue,
-                                          const std::size_t = 0) const;
+  virtual Kernel::DateAndTime getFirstPulseTime() const;
+  Kernel::DateAndTime getLastPulseTime() const;
 
-                        //----------------------------------------------------------------------
-                        // DATA ACCESSORS
-                        //----------------------------------------------------------------------
+  /// Returns the bin index for a given X value of a given workspace index
+  size_t binIndexOf(const double xValue, const std::size_t = 0) const;
 
-                        /// Return the underlying ISpectrum ptr at the given
-                        /// workspace index.
-                        virtual ISpectrum *getSpectrum(const size_t index) = 0;
+  //----------------------------------------------------------------------
+  // DATA ACCESSORS
+  //----------------------------------------------------------------------
 
-                        /// Return the underlying ISpectrum ptr (const version)
-                        /// at the given workspace
-                        /// index.
-                        virtual const ISpectrum *
-                        getSpectrum(const size_t index) const = 0;
+  /// Return the underlying ISpectrum ptr at the given workspace index.
+  virtual ISpectrum *getSpectrum(const size_t index) = 0;
 
-                        // Methods for getting read-only access to the data.
-                        // Just passes through to the virtual dataX/Y/E function
-                        // (const version)
-                        /// Returns a read-only (i.e. const) reference to the
-                        /// specified X array
-                        /// @param index :: workspace index to retrieve.
-                        const MantidVec &readX(std::size_t const index) const {
-                          return getSpectrum(index)->dataX();
-                        }
-                        /// Returns a read-only (i.e. const) reference to the
-                        /// specified Y array
-                        /// @param index :: workspace index to retrieve.
-                        const MantidVec &readY(std::size_t const index) const {
-                          return getSpectrum(index)->dataY();
-                        }
-                        /// Returns a read-only (i.e. const) reference to the
-                        /// specified E array
-                        /// @param index :: workspace index to retrieve.
-                        const MantidVec &readE(std::size_t const index) const {
-                          return getSpectrum(index)->dataE();
-                        }
-                        /// Returns a read-only (i.e. const) reference to the
-                        /// specified X error array
-                        /// @param index :: workspace index to retrieve.
-                        const MantidVec &readDx(size_t const index) const {
-                          return getSpectrum(index)->dataDx();
-                        }
+  /// Return the underlying ISpectrum ptr (const version) at the given workspace
+  /// index.
+  virtual const ISpectrum *getSpectrum(const size_t index) const = 0;
 
-                        /// Returns the x data
-                        virtual MantidVec &dataX(const std::size_t index) {
-                          invalidateCommonBinsFlag();
-                          return getSpectrum(index)->dataX();
-                        }
-                        /// Returns the y data
-                        virtual MantidVec &dataY(const std::size_t index) {
-                          return getSpectrum(index)->dataY();
-                        }
-                        /// Returns the error data
-                        virtual MantidVec &dataE(const std::size_t index) {
-                          return getSpectrum(index)->dataE();
-                        }
-                        /// Returns the x error data
-                        virtual MantidVec &dataDx(const std::size_t index) {
-                          return getSpectrum(index)->dataDx();
-                        }
+  // Methods for getting read-only access to the data.
+  // Just passes through to the virtual dataX/Y/E function (const version)
+  /// Returns a read-only (i.e. const) reference to the specified X array
+  /// @param index :: workspace index to retrieve.
+  const MantidVec &readX(std::size_t const index) const {
+    return getSpectrum(index)->dataX();
+  }
+  /// Returns a read-only (i.e. const) reference to the specified Y array
+  /// @param index :: workspace index to retrieve.
+  const MantidVec &readY(std::size_t const index) const {
+    return getSpectrum(index)->dataY();
+  }
+  /// Returns a read-only (i.e. const) reference to the specified E array
+  /// @param index :: workspace index to retrieve.
+  const MantidVec &readE(std::size_t const index) const {
+    return getSpectrum(index)->dataE();
+  }
+  /// Returns a read-only (i.e. const) reference to the specified X error array
+  /// @param index :: workspace index to retrieve.
+  const MantidVec &readDx(size_t const index) const {
+    return getSpectrum(index)->dataDx();
+  }
 
-                        /// Returns the x data const
-                        virtual const MantidVec &
-                        dataX(const std::size_t index) const {
-                          return getSpectrum(index)->dataX();
-                        }
-                        /// Returns the y data const
-                        virtual const MantidVec &
-                        dataY(const std::size_t index) const {
-                          return getSpectrum(index)->dataY();
-                        }
-                        /// Returns the error const
-                        virtual const MantidVec &
-                        dataE(const std::size_t index) const {
-                          return getSpectrum(index)->dataE();
-                        }
-                        /// Returns the error const
-                        virtual const MantidVec &
-                        dataDx(const std::size_t index) const {
-                          return getSpectrum(index)->dataDx();
-                        }
+  /// Returns the x data
+  virtual MantidVec &dataX(const std::size_t index) {
+    invalidateCommonBinsFlag();
+    return getSpectrum(index)->dataX();
+  }
+  /// Returns the y data
+  virtual MantidVec &dataY(const std::size_t index) {
+    return getSpectrum(index)->dataY();
+  }
+  /// Returns the error data
+  virtual MantidVec &dataE(const std::size_t index) {
+    return getSpectrum(index)->dataE();
+  }
+  /// Returns the x error data
+  virtual MantidVec &dataDx(const std::size_t index) {
+    return getSpectrum(index)->dataDx();
+  }
 
-                        virtual double getXMin() const;
-                        virtual double getXMax() const;
-                        virtual void getXMinMax(double &xmin,
-                                                double &xmax) const;
+  /// Returns the x data const
+  virtual const MantidVec &dataX(const std::size_t index) const {
+    return getSpectrum(index)->dataX();
+  }
+  /// Returns the y data const
+  virtual const MantidVec &dataY(const std::size_t index) const {
+    return getSpectrum(index)->dataY();
+  }
+  /// Returns the error const
+  virtual const MantidVec &dataE(const std::size_t index) const {
+    return getSpectrum(index)->dataE();
+  }
+  /// Returns the error const
+  virtual const MantidVec &dataDx(const std::size_t index) const {
+    return getSpectrum(index)->dataDx();
+  }
 
-                        /// Returns a pointer to the x data
-                        virtual Kernel::cow_ptr<MantidVec>
-                        refX(const std::size_t index) const {
-                          return getSpectrum(index)->ptrX();
-                        }
+  virtual double getXMin() const;
+  virtual double getXMax() const;
+  virtual void getXMinMax(double &xmin, double &xmax) const;
 
-                        /// Returns a pointer to the dX  (X Error) data
-                        virtual Kernel::cow_ptr<MantidVec>
-                        refDx(const std::size_t index) const {
-                          return getSpectrum(index)->ptrDx();
-                        }
+  /// Returns a pointer to the x data
+  virtual Kernel::cow_ptr<MantidVec> refX(const std::size_t index) const {
+    return getSpectrum(index)->ptrX();
+  }
 
-                        /// Set the specified X array to point to the given
-                        /// existing array
-                        virtual void setX(const std::size_t index,
-                                          const MantidVec &X) {
-                          getSpectrum(index)->setX(X);
-                          invalidateCommonBinsFlag();
-                        }
+  /// Returns a pointer to the dX  (X Error) data
+  virtual Kernel::cow_ptr<MantidVec> refDx(const std::size_t index) const {
+    return getSpectrum(index)->ptrDx();
+  }
 
-                        /// Set the specified X array to point to the given
-                        /// existing array
-                        virtual void setX(const std::size_t index,
-                                          const MantidVecPtr &X) {
-                          getSpectrum(index)->setX(X);
-                          invalidateCommonBinsFlag();
-                        }
+  /// Set the specified X array to point to the given existing array
+  virtual void setX(const std::size_t index, const MantidVec &X) {
+    getSpectrum(index)->setX(X);
+    invalidateCommonBinsFlag();
+  }
 
-                        /// Set the specified X array to point to the given
-                        /// existing array
-                        virtual void setX(const std::size_t index,
-                                          const MantidVecPtr::ptr_type &X) {
-                          getSpectrum(index)->setX(X);
-                          invalidateCommonBinsFlag();
-                        }
+  /// Set the specified X array to point to the given existing array
+  virtual void setX(const std::size_t index, const MantidVecPtr &X) {
+    getSpectrum(index)->setX(X);
+    invalidateCommonBinsFlag();
+  }
 
-                        /// Set the specified Dx (X Error) array to point to the
-                        /// given existing array
-                        virtual void setDx(const std::size_t index,
-                                           const MantidVec &Dx) {
-                          getSpectrum(index)->setDx(Dx);
-                          invalidateCommonBinsFlag();
-                        }
+  /// Set the specified X array to point to the given existing array
+  virtual void setX(const std::size_t index, const MantidVecPtr::ptr_type &X) {
+    getSpectrum(index)->setX(X);
+    invalidateCommonBinsFlag();
+  }
 
-                        /// Set the specified Dx (X Error) array to point to the
-                        /// given existing array
-                        virtual void setDx(const std::size_t index,
-                                           const MantidVecPtr &Dx) {
-                          getSpectrum(index)->setDx(Dx);
-                          invalidateCommonBinsFlag();
-                        }
+  /// Set the specified Dx (X Error) array to point to the given existing array
+  virtual void setDx(const std::size_t index, const MantidVec &Dx) {
+    getSpectrum(index)->setDx(Dx);
+    invalidateCommonBinsFlag();
+  }
 
-                        /// Set the specified Dx (X Error) array to point to the
-                        /// given existing array
-                        virtual void setDx(const std::size_t index,
-                                           const MantidVecPtr::ptr_type &Dx) {
-                          getSpectrum(index)->setX(Dx);
-                          invalidateCommonBinsFlag();
-                        }
+  /// Set the specified Dx (X Error) array to point to the given existing array
+  virtual void setDx(const std::size_t index, const MantidVecPtr &Dx) {
+    getSpectrum(index)->setDx(Dx);
+    invalidateCommonBinsFlag();
+  }
 
-                        /** Sets the data in the workspace
-                        @param index :: the workspace index to set.
-                        @param Y :: Y vector  */
-                        virtual void setData(const std::size_t index,
-                                             const MantidVecPtr &Y) {
-                          getSpectrum(index)->setData(Y);
-                        }
+  /// Set the specified Dx (X Error) array to point to the given existing array
+  virtual void setDx(const std::size_t index,
+                     const MantidVecPtr::ptr_type &Dx) {
+    getSpectrum(index)->setX(Dx);
+    invalidateCommonBinsFlag();
+  }
 
-                        /** Sets the data in the workspace
-                        @param index :: the workspace index to set.
-                        @param Y :: Y vector
-                        @param E :: Error vector   */
-                        virtual void setData(const std::size_t index,
-                                             const MantidVecPtr &Y,
-                                             const MantidVecPtr &E) {
-                          getSpectrum(index)->setData(Y, E);
-                        }
+  /** Sets the data in the workspace
+  @param index :: the workspace index to set.
+  @param Y :: Y vector  */
+  virtual void setData(const std::size_t index, const MantidVecPtr &Y) {
+    getSpectrum(index)->setData(Y);
+  }
 
-                        /** Sets the data in the workspace
-                        @param index :: the workspace index to set.
-                        @param Y :: Y vector
-                        @param E :: Error vector   */
-                        virtual void setData(const std::size_t index,
-                                             const MantidVecPtr::ptr_type &Y,
-                                             const MantidVecPtr::ptr_type &E) {
-                          getSpectrum(index)->setData(Y, E);
-                        }
+  /** Sets the data in the workspace
+  @param index :: the workspace index to set.
+  @param Y :: Y vector
+  @param E :: Error vector   */
+  virtual void setData(const std::size_t index, const MantidVecPtr &Y,
+                       const MantidVecPtr &E) {
+    getSpectrum(index)->setData(Y, E);
+  }
 
-                        /**
-                         * Probes if DX (X Error) values were set on a
-                         * particular spectrum
-                         * @param index: the spectrum index
-                         */
-                        virtual bool hasDx(const std::size_t index) const {
-                          return getSpectrum(index)->hasDx();
-                        }
+  /** Sets the data in the workspace
+  @param index :: the workspace index to set.
+  @param Y :: Y vector
+  @param E :: Error vector   */
+  virtual void setData(const std::size_t index, const MantidVecPtr::ptr_type &Y,
+                       const MantidVecPtr::ptr_type &E) {
+    getSpectrum(index)->setData(Y, E);
+  }
 
-                        /// Generate the histogram or rebin the existing
-                        /// histogram.
-                        virtual void
-                        generateHistogram(const std::size_t index,
-                                          const MantidVec &X, MantidVec &Y,
-                                          MantidVec &E,
-                                          bool skipError = false) const = 0;
+  /**
+   * Probes if DX (X Error) values were set on a particular spectrum
+   * @param index: the spectrum index
+   */
+  virtual bool hasDx(const std::size_t index) const {
+    return getSpectrum(index)->hasDx();
+  }
 
-                        /// Return a vector with the integrated counts for all
-                        /// spectra withing the
-                        /// given range
-                        virtual void getIntegratedSpectra(
-                            std::vector<double> &out, const double minX,
-                            const double maxX, const bool entireRange) const;
+  /// Generate the histogram or rebin the existing histogram.
+  virtual void generateHistogram(const std::size_t index, const MantidVec &X,
+                                 MantidVec &Y, MantidVec &E,
+                                 bool skipError = false) const = 0;
 
-                        /// Return an index in the X vector for an x-value close
-                        /// to a given value
-                        std::pair<size_t, double>
-                        getXIndex(size_t i, double x, bool isLeft = true,
-                                  size_t start = 0) const;
+  /// Return a vector with the integrated counts for all spectra withing the
+  /// given range
+  virtual void getIntegratedSpectra(std::vector<double> &out, const double minX,
+                                    const double maxX,
+                                    const bool entireRange) const;
 
-                        //----------------------------------------------------------------------
+  /// Return an index in the X vector for an x-value close to a given value
+  std::pair<size_t, double> getXIndex(size_t i, double x, bool isLeft = true,
+                                      size_t start = 0) const;
 
-                        int axes() const;
-                        virtual Axis *
-                        getAxis(const std::size_t &axisIndex) const;
-                        void replaceAxis(const std::size_t &axisIndex,
-                                         Axis *const newAxis);
+  //----------------------------------------------------------------------
 
-                        /// Returns true if the workspace contains data in
-                        /// histogram form (as opposed
-                        /// to point-like)
-                        virtual bool isHistogramData() const;
+  int axes() const;
+  virtual Axis *getAxis(const std::size_t &axisIndex) const;
+  void replaceAxis(const std::size_t &axisIndex, Axis *const newAxis);
 
-                        /// Returns true if the workspace contains has common X
-                        /// bins
-                        virtual bool isCommonBins() const;
+  /// Returns true if the workspace contains data in histogram form (as opposed
+  /// to point-like)
+  virtual bool isHistogramData() const;
 
-                        std::string YUnit() const;
-                        void setYUnit(const std::string &newUnit);
-                        std::string YUnitLabel() const;
-                        void setYUnitLabel(const std::string &newLabel);
+  /// Returns true if the workspace contains has common X bins
+  virtual bool isCommonBins() const;
 
-                        /// Are the Y-values dimensioned?
-                        const bool &isDistribution() const;
-                        bool &isDistribution(bool newValue);
+  std::string YUnit() const;
+  void setYUnit(const std::string &newUnit);
+  std::string YUnitLabel() const;
+  void setYUnitLabel(const std::string &newLabel);
 
-                        /// Mask a given workspace index, setting the data and
-                        /// error values to zero
-                        void maskWorkspaceIndex(const std::size_t index);
+  /// Are the Y-values dimensioned?
+  const bool &isDistribution() const;
+  bool &isDistribution(bool newValue);
 
-                        // Methods to set and access masked bins
-                        void maskBin(const size_t &workspaceIndex,
-                                     const size_t &binIndex,
-                                     const double &weight = 1.0);
-                        void flagMasked(const size_t &spectrumIndex,
-                                        const size_t &binIndex,
-                                        const double &weight = 1.0);
-                        bool hasMaskedBins(const size_t &spectrumIndex) const;
-                        /// Masked bins for each spectrum are stored as a set of
-                        /// pairs containing <bin
-                        /// index, weight>
-                        typedef std::map<size_t, double> MaskList;
-                        const MaskList &
-                        maskedBins(const size_t &spectrumIndex) const;
+  /// Mask a given workspace index, setting the data and error values to zero
+  void maskWorkspaceIndex(const std::size_t index);
 
-                        // Methods handling the internal monitor workspace
-                        virtual void setMonitorWorkspace(
-                            const boost::shared_ptr<MatrixWorkspace> &
-                                monitorWS);
-                        boost::shared_ptr<MatrixWorkspace>
-                        monitorWorkspace() const;
+  // Methods to set and access masked bins
+  void maskBin(const size_t &workspaceIndex, const size_t &binIndex,
+               const double &weight = 1.0);
+  void flagMasked(const size_t &spectrumIndex, const size_t &binIndex,
+                  const double &weight = 1.0);
+  bool hasMaskedBins(const size_t &spectrumIndex) const;
+  /// Masked bins for each spectrum are stored as a set of pairs containing <bin
+  /// index, weight>
+  typedef std::map<size_t, double> MaskList;
+  const MaskList &maskedBins(const size_t &spectrumIndex) const;
 
-                        void saveInstrumentNexus(::NeXus::File *file) const;
-                        void loadInstrumentNexus(::NeXus::File *file);
-                        void saveSpectraMapNexus(
-                            ::NeXus::File *file, const std::vector<int> &spec,
-                            const ::NeXus::NXcompression compression =
-                                ::NeXus::LZW) const;
+  // Methods handling the internal monitor workspace
+  virtual void
+  setMonitorWorkspace(const boost::shared_ptr<MatrixWorkspace> &monitorWS);
+  boost::shared_ptr<MatrixWorkspace> monitorWorkspace() const;
 
-                        //=====================================================================================
-                        // MD Geometry methods
-                        //=====================================================================================
-                        size_t getNumDims() const override;
-                        boost::shared_ptr<const Mantid::Geometry::IMDDimension>
-                        getDimension(size_t index) const override;
-                        boost::shared_ptr<const Mantid::Geometry::IMDDimension>
-                        getDimensionWithId(std::string id) const override;
-                        //=====================================================================================
-                        // End MD Geometry methods
-                        //=====================================================================================
+  void saveInstrumentNexus(::NeXus::File *file) const;
+  void loadInstrumentNexus(::NeXus::File *file);
+  void saveSpectraMapNexus(
+      ::NeXus::File *file, const std::vector<int> &spec,
+      const ::NeXus::NXcompression compression = ::NeXus::LZW) const;
 
-                        //=====================================================================================
-                        // IMDWorkspace methods
-                        //=====================================================================================
+  //=====================================================================================
+  // MD Geometry methods
+  //=====================================================================================
+  size_t getNumDims() const override;
+  boost::shared_ptr<const Mantid::Geometry::IMDDimension>
+  getDimension(size_t index) const override;
+  boost::shared_ptr<const Mantid::Geometry::IMDDimension>
+  getDimensionWithId(std::string id) const override;
+  //=====================================================================================
+  // End MD Geometry methods
+  //=====================================================================================
 
-                        /// Gets the number of points available on the
-                        /// workspace.
-                        uint64_t getNPoints() const override;
-                        /// Get the number of points available on the workspace.
-                        uint64_t getNEvents() const override {
-                          return this->getNPoints();
-                        }
-                        /// Dimension id for x-dimension.
-                        static const std::string xDimensionId;
-                        /// Dimensin id for y-dimension.
-                        static const std::string yDimensionId;
-                        /// Generate a line plot through the matrix workspace.
-                        LinePlot getLinePlot(const Mantid::Kernel::VMD &start,
-                                             const Mantid::Kernel::VMD &end,
-                                             Mantid::API::MDNormalization
-                                                 normalize) const override;
-                        /// Get the signal at a coordinate in the workspace.
-                        signal_t
-                        getSignalAtCoord(const coord_t *coords,
-                                         const Mantid::API::MDNormalization &
-                                             normalization) const override;
-                        /// Get the signal at a coordinate in the workspace
-                        signal_t getSignalWithMaskAtCoord(
-                            const coord_t *coords,
-                            const Mantid::API::MDNormalization &normalization)
-                            const override;
-                        /// Create iterators. Partitions the iterators according
-                        /// to the number of
-                        /// cores.
-                        std::vector<IMDIterator *> createIterators(
-                            size_t suggestedNumCores = 1,
-                            Mantid::Geometry::MDImplicitFunction *function =
-                                nullptr) const override;
+  //=====================================================================================
+  // IMDWorkspace methods
+  //=====================================================================================
 
-                        /// Apply masking.
-                        void setMDMasking(Mantid::Geometry::MDImplicitFunction *
-                                              maskingRegion) override;
-                        /// Clear exsting masking.
-                        void clearMDMasking() override;
+  /// Gets the number of points available on the workspace.
+  uint64_t getNPoints() const override;
+  /// Get the number of points available on the workspace.
+  uint64_t getNEvents() const override { return this->getNPoints(); }
+  /// Dimension id for x-dimension.
+  static const std::string xDimensionId;
+  /// Dimensin id for y-dimension.
+  static const std::string yDimensionId;
+  /// Generate a line plot through the matrix workspace.
+  LinePlot getLinePlot(const Mantid::Kernel::VMD &start,
+                       const Mantid::Kernel::VMD &end,
+                       Mantid::API::MDNormalization normalize) const override;
+  /// Get the signal at a coordinate in the workspace.
+  signal_t getSignalAtCoord(
+      const coord_t *coords,
+      const Mantid::API::MDNormalization &normalization) const override;
+  /// Get the signal at a coordinate in the workspace
+  signal_t getSignalWithMaskAtCoord(
+      const coord_t *coords,
+      const Mantid::API::MDNormalization &normalization) const override;
+  /// Create iterators. Partitions the iterators according to the number of
+  /// cores.
+  std::vector<IMDIterator *> createIterators(
+      size_t suggestedNumCores = 1,
+      Mantid::Geometry::MDImplicitFunction *function = nullptr) const override;
 
-                        /// @return the special coordinate system used if any.
-                        Mantid::Kernel::SpecialCoordinateSystem
-                        getSpecialCoordinateSystem() const override;
+  /// Apply masking.
+  void
+  setMDMasking(Mantid::Geometry::MDImplicitFunction *maskingRegion) override;
+  /// Clear exsting masking.
+  void clearMDMasking() override;
 
-                        //=====================================================================================
-                        // End IMDWorkspace methods
-                        //=====================================================================================
+  /// @return the special coordinate system used if any.
+  Mantid::Kernel::SpecialCoordinateSystem
+  getSpecialCoordinateSystem() const override;
 
-                        //=====================================================================================
-                        // Image methods
-                        //=====================================================================================
+  //=====================================================================================
+  // End IMDWorkspace methods
+  //=====================================================================================
 
-                        /// Get start and end x indices for images
-                        std::pair<size_t, size_t>
-                        getImageStartEndXIndices(size_t i, double startX,
-                                                 double endX) const;
-                        /// Create an image of Ys.
-                        MantidImage_sptr
-                        getImageY(size_t start = 0, size_t stop = 0,
-                                  size_t width = 0, double startX = EMPTY_DBL(),
-                                  double endX = EMPTY_DBL()) const;
-                        /// Create an image of Es.
-                        MantidImage_sptr
-                        getImageE(size_t start = 0, size_t stop = 0,
-                                  size_t width = 0, double startX = EMPTY_DBL(),
-                                  double endX = EMPTY_DBL()) const;
-                        /// Copy the data (Y's) from an image to this workspace.
-                        virtual void setImageY(const MantidImage &image,
-                                               size_t start = 0,
-                                               bool parallelExecution = true);
-                        /// Copy the data from an image to this workspace's
-                        /// errors.
-                        virtual void setImageE(const MantidImage &image,
-                                               size_t start = 0,
-                                               bool parallelExecution = true);
+  //=====================================================================================
+  // Image methods
+  //=====================================================================================
 
-                        //=====================================================================================
-                        // End image methods
-                        //=====================================================================================
+  /// Get start and end x indices for images
+  std::pair<size_t, size_t> getImageStartEndXIndices(size_t i, double startX,
+                                                     double endX) const;
+  /// Create an image of Ys.
+  MantidImage_sptr getImageY(size_t start = 0, size_t stop = 0,
+                             size_t width = 0, double startX = EMPTY_DBL(),
+                             double endX = EMPTY_DBL()) const;
+  /// Create an image of Es.
+  MantidImage_sptr getImageE(size_t start = 0, size_t stop = 0,
+                             size_t width = 0, double startX = EMPTY_DBL(),
+                             double endX = EMPTY_DBL()) const;
+  /// Copy the data (Y's) from an image to this workspace.
+  virtual void setImageY(const MantidImage &image, size_t start = 0,
+                         bool parallelExecution = true);
+  /// Copy the data from an image to this workspace's errors.
+  virtual void setImageE(const MantidImage &image, size_t start = 0,
+                         bool parallelExecution = true);
 
-                      protected:
-                        /// Protected copy constructor. May be used by childs
-                        /// for cloning.
-                        MatrixWorkspace(const MatrixWorkspace &other);
-                        /// Protected copy assignment operator. Assignment not
-                        /// implemented.
-                        MatrixWorkspace &
-                        operator=(const MatrixWorkspace &other);
+  //=====================================================================================
+  // End image methods
+  //=====================================================================================
 
-                        MatrixWorkspace(
-                            Mantid::Geometry::INearestNeighboursFactory *
-                                factory = nullptr);
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  MatrixWorkspace(const MatrixWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  MatrixWorkspace &operator=(const MatrixWorkspace &other);
 
-                        /// Initialises the workspace. Sets the size and lengths
-                        /// of the arrays. Must
-                        /// be overloaded.
-                        virtual void init(const std::size_t &NVectors,
-                                          const std::size_t &XLength,
-                                          const std::size_t &YLength) = 0;
+  MatrixWorkspace(
+      Mantid::Geometry::INearestNeighboursFactory *factory = nullptr);
 
-                        /// Invalidates the commons bins flag.  This is
-                        /// generally called when a method
-                        /// could allow the X values to be changed.
-                        void invalidateCommonBinsFlag() {
-                          m_isCommonBinsFlagSet = false;
-                        }
+  /// Initialises the workspace. Sets the size and lengths of the arrays. Must
+  /// be overloaded.
+  virtual void init(const std::size_t &NVectors, const std::size_t &XLength,
+                    const std::size_t &YLength) = 0;
 
-                        /// A vector of pointers to the axes for this workspace
-                        std::vector<Axis *> m_axes;
+  /// Invalidates the commons bins flag.  This is generally called when a method
+  /// could allow the X values to be changed.
+  void invalidateCommonBinsFlag() { m_isCommonBinsFlagSet = false; }
 
-                      private:
-                        MatrixWorkspace *doClone() const override = 0;
+  /// A vector of pointers to the axes for this workspace
+  std::vector<Axis *> m_axes;
 
-                        /// Create an MantidImage instance.
-                        MantidImage_sptr
-                        getImage(const MantidVec &(MatrixWorkspace::*read)(
-                                     std::size_t const) const,
-                                 size_t start, size_t stop, size_t width,
-                                 size_t indexStart, size_t indexEnd) const;
-                        /// Copy data from an image.
-                        void setImage(MantidVec &(MatrixWorkspace::*dataVec)(
-                                          const std::size_t),
-                                      const MantidImage &image, size_t start,
-                                      bool parallelExecution);
+private:
+  MatrixWorkspace *doClone() const override = 0;
 
-                        /// Has this workspace been initialised?
-                        bool m_isInitialized;
+  /// Create an MantidImage instance.
+  MantidImage_sptr
+  getImage(const MantidVec &(MatrixWorkspace::*read)(std::size_t const) const,
+           size_t start, size_t stop, size_t width, size_t indexStart,
+           size_t indexEnd) const;
+  /// Copy data from an image.
+  void setImage(MantidVec &(MatrixWorkspace::*dataVec)(const std::size_t),
+                const MantidImage &image, size_t start, bool parallelExecution);
 
-                        /// The unit for the data values (e.g. Counts)
-                        std::string m_YUnit;
-                        /// A text label for use when plotting spectra
-                        std::string m_YUnitLabel;
-                        /// Flag indicating whether the Y-values are
-                        /// dimensioned. False by default
-                        bool m_isDistribution;
+  /// Has this workspace been initialised?
+  bool m_isInitialized;
 
-                        /// Flag indicating whether the m_isCommonBinsFlag has
-                        /// been set. False by
-                        /// default
-                        mutable bool m_isCommonBinsFlagSet;
-                        /// Flag indicating whether the data has common bins.
-                        /// False by default
-                        mutable bool m_isCommonBinsFlag;
+  /// The unit for the data values (e.g. Counts)
+  std::string m_YUnit;
+  /// A text label for use when plotting spectra
+  std::string m_YUnitLabel;
+  /// Flag indicating whether the Y-values are dimensioned. False by default
+  bool m_isDistribution;
 
-                        /// The set of masked bins in a map keyed on spectrum
-                        /// index
-                        std::map<int64_t, MaskList> m_masks;
+  /// Flag indicating whether the m_isCommonBinsFlag has been set. False by
+  /// default
+  mutable bool m_isCommonBinsFlagSet;
+  /// Flag indicating whether the data has common bins. False by default
+  mutable bool m_isCommonBinsFlag;
 
-                        /// A workspace holding monitor data relating to the
-                        /// main data in the
-                        /// containing workspace (null if none).
-                        boost::shared_ptr<MatrixWorkspace> m_monitorWorkspace;
+  /// The set of masked bins in a map keyed on spectrum index
+  std::map<int64_t, MaskList> m_masks;
 
-                      protected:
-                        /// Assists conversions to and from 2D histogram
-                        /// indexing to 1D indexing.
-                        MatrixWSIndexCalculator m_indexCalculator;
+  /// A workspace holding monitor data relating to the main data in the
+  /// containing workspace (null if none).
+  boost::shared_ptr<MatrixWorkspace> m_monitorWorkspace;
 
-                        /// Scoped pointer to NearestNeighbours factory
-                        boost::scoped_ptr<
-                            Mantid::Geometry::INearestNeighboursFactory>
-                            m_nearestNeighboursFactory;
+protected:
+  /// Assists conversions to and from 2D histogram indexing to 1D indexing.
+  MatrixWSIndexCalculator m_indexCalculator;
 
-                        /// Shared pointer to NearestNeighbours object
-                        mutable boost::shared_ptr<
-                            Mantid::Geometry::INearestNeighbours>
-                            m_nearestNeighbours;
+  /// Scoped pointer to NearestNeighbours factory
+  boost::scoped_ptr<Mantid::Geometry::INearestNeighboursFactory>
+      m_nearestNeighboursFactory;
 
-                        /// Getter for the dimension id based on the axis.
-                        std::string
-                        getDimensionIdFromAxis(const int &axisIndex) const;
+  /// Shared pointer to NearestNeighbours object
+  mutable boost::shared_ptr<Mantid::Geometry::INearestNeighbours>
+      m_nearestNeighbours;
+
+  /// Getter for the dimension id based on the axis.
+  std::string getDimensionIdFromAxis(const int &axisIndex) const;
 };
 
 /// shared pointer to the matrix workspace base class

--- a/Framework/API/inc/MantidAPI/SpectraAxis.h
+++ b/Framework/API/inc/MantidAPI/SpectraAxis.h
@@ -61,7 +61,7 @@ public:
   bool operator==(const Axis &) const override;
   std::string label(const std::size_t &index) const override;
 
-  specid_t spectraNo(const std::size_t &index) const override;
+  specnum_t spectraNo(const std::size_t &index) const override;
   // Get a map that contains the spectra index as the key and the index in the
   // array as teh value
   void getSpectraIndexMap(spec2index_map &) const;

--- a/Framework/API/inc/MantidAPI/SpectraDetectorTypes.h
+++ b/Framework/API/inc/MantidAPI/SpectraDetectorTypes.h
@@ -15,12 +15,12 @@ namespace Mantid {
 
 #ifndef HAS_UNORDERED_MAP_H
 /// Map with key = spectrum number, value = workspace index
-typedef std::map<specid_t, size_t> spec2index_map;
+typedef std::map<specnum_t, size_t> spec2index_map;
 /// Map with key = detector ID, value = workspace index
 typedef std::map<detid_t, size_t> detid2index_map;
 #else
 /// Map with key = spectrum number, value = workspace index
-typedef std::tr1::unordered_map<specid_t, size_t> spec2index_map;
+typedef std::tr1::unordered_map<specnum_t, size_t> spec2index_map;
 /// Map with key = detector ID, value = workspace index
 typedef std::tr1::unordered_map<detid_t, size_t> detid2index_map;
 #endif

--- a/Framework/API/inc/MantidAPI/SpectrumDetectorMapping.h
+++ b/Framework/API/inc/MantidAPI/SpectrumDetectorMapping.h
@@ -50,34 +50,34 @@ class MatrixWorkspace;
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 class MANTID_API_DLL SpectrumDetectorMapping {
-  typedef std::unordered_map<specid_t, std::set<detid_t>> sdmap;
+  typedef std::unordered_map<specnum_t, std::set<detid_t>> sdmap;
 
 public:
   explicit SpectrumDetectorMapping(const MatrixWorkspace *const workspace,
                                    bool useSpecNoIndex = true);
   SpectrumDetectorMapping(
-      const std::vector<specid_t> &spectrumNumbers,
+      const std::vector<specnum_t> &spectrumNumbers,
       const std::vector<detid_t> &detectorIDs,
       const std::vector<detid_t> &ignoreDetIDs = std::vector<detid_t>());
-  SpectrumDetectorMapping(const specid_t *const spectrumNumbers,
+  SpectrumDetectorMapping(const specnum_t *const spectrumNumbers,
                           const detid_t *const detectorIDs,
                           size_t arrayLengths);
   SpectrumDetectorMapping();
   virtual ~SpectrumDetectorMapping();
 
-  std::set<specid_t> getSpectrumNumbers() const;
+  std::set<specnum_t> getSpectrumNumbers() const;
   const std::set<detid_t> &
-  getDetectorIDsForSpectrumNo(const specid_t spectrumNo) const;
+  getDetectorIDsForSpectrumNo(const specnum_t spectrumNo) const;
   const std::set<detid_t> &
   getDetectorIDsForSpectrumIndex(const size_t index) const;
   const sdmap &getMapping() const;
   bool indexIsSpecNumber() const;
 
 private:
-  void fillMapFromArray(const specid_t *const spectrumNumbers,
+  void fillMapFromArray(const specnum_t *const spectrumNumbers,
                         const detid_t *const detectorIDs,
                         const size_t arrayLengths);
-  void fillMapFromVector(const std::vector<specid_t> &spectrumNumbers,
+  void fillMapFromVector(const std::vector<specnum_t> &spectrumNumbers,
                          const std::vector<detid_t> &detectorIDs,
                          const std::vector<detid_t> &ignoreDetIDs);
 

--- a/Framework/API/src/Axis.cpp
+++ b/Framework/API/src/Axis.cpp
@@ -63,7 +63,7 @@ double Axis::getValue(const std::size_t &index,
  *  @return The spectrum number as an int
  *  @throw  domain_error If this method is called on a numeric axis
  */
-specid_t Axis::spectraNo(const std::size_t &index) const {
+specnum_t Axis::spectraNo(const std::size_t &index) const {
   UNUSED_ARG(index)
   throw std::domain_error("Cannot call spectraNo() on a non-spectra axis.");
 }

--- a/Framework/API/src/ISpectrum.cpp
+++ b/Framework/API/src/ISpectrum.cpp
@@ -13,7 +13,7 @@ ISpectrum::ISpectrum()
 /** Constructor with spectrum number
  * @param specNo :: spectrum # of the spectrum
  */
-ISpectrum::ISpectrum(const specid_t specNo)
+ISpectrum::ISpectrum(const specnum_t specNo)
     : m_specNo(specNo), detectorIDs(), refX(), refDx(), m_hasDx(false) {}
 
 //----------------------------------------------------------------------------------------------
@@ -212,11 +212,11 @@ std::set<detid_t> &ISpectrum::getDetectorIDs() { return this->detectorIDs; }
 
 // ---------------------------------------------------------
 /// @return the spectrum number of this spectrum
-specid_t ISpectrum::getSpectrumNo() const { return m_specNo; }
+specnum_t ISpectrum::getSpectrumNo() const { return m_specNo; }
 
 /** Sets the the spectrum number of this spectrum
  * @param num :: the spectrum number of this spectrum */
-void ISpectrum::setSpectrumNo(specid_t num) { m_specNo = num; }
+void ISpectrum::setSpectrumNo(specnum_t num) { m_specNo = num; }
 
 // ---------------------------------------------------------
 /** Lock access to the data so that it does not get deleted while reading.

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -224,7 +224,7 @@ void MatrixWorkspace::rebuildSpectraMapping(const bool includeMonitors) {
       // The detector ID
       const detid_t detId = *it;
       // By default: Spectrum number = index +  1
-      const specid_t specNo = specid_t(index + 1);
+      const specnum_t specNo = specnum_t(index + 1);
 
       if (index < this->getNumberHistograms()) {
         ISpectrum *spec = getSpectrum(index);
@@ -288,7 +288,7 @@ void MatrixWorkspace::rebuildNearestNeighbours() {
 *be ignored. True to ignore detectors.
 * @return map of DetectorID to distance for the nearest neighbours
 */
-std::map<specid_t, V3D>
+std::map<specnum_t, V3D>
 MatrixWorkspace::getNeighbours(const Geometry::IDetector *comp,
                                const double radius,
                                const bool ignoreMaskedDetectors) const {
@@ -296,7 +296,7 @@ MatrixWorkspace::getNeighbours(const Geometry::IDetector *comp,
     buildNearestNeighbours(ignoreMaskedDetectors);
   }
   // Find the spectrum number
-  std::vector<specid_t> spectra;
+  std::vector<specnum_t> spectra;
   this->getSpectraFromDetectorIDs(std::vector<detid_t>(1, comp->getID()),
                                   spectra);
   if (spectra.empty()) {
@@ -305,7 +305,7 @@ MatrixWorkspace::getNeighbours(const Geometry::IDetector *comp,
                                            "detector",
                                            comp->getID());
   }
-  std::map<specid_t, V3D> neighbours =
+  std::map<specnum_t, V3D> neighbours =
       m_nearestNeighbours->neighboursInRadius(spectra[0], radius);
   return neighbours;
 }
@@ -319,13 +319,13 @@ MatrixWorkspace::getNeighbours(const Geometry::IDetector *comp,
 *be ignored. True to ignore detectors.
 * @return map of DetectorID to distance for the nearest neighbours
 */
-std::map<specid_t, V3D>
-MatrixWorkspace::getNeighbours(specid_t spec, const double radius,
+std::map<specnum_t, V3D>
+MatrixWorkspace::getNeighbours(specnum_t spec, const double radius,
                                bool ignoreMaskedDetectors) const {
   if (!m_nearestNeighbours) {
     buildNearestNeighbours(ignoreMaskedDetectors);
   }
-  std::map<specid_t, V3D> neighbours =
+  std::map<specnum_t, V3D> neighbours =
       m_nearestNeighbours->neighboursInRadius(spec, radius);
   return neighbours;
 }
@@ -339,8 +339,8 @@ MatrixWorkspace::getNeighbours(specid_t spec, const double radius,
 *be ignored. True to ignore detectors.
 * @return map of DetectorID to distance for the nearest neighbours
 */
-std::map<specid_t, V3D>
-MatrixWorkspace::getNeighboursExact(specid_t spec, const int nNeighbours,
+std::map<specnum_t, V3D>
+MatrixWorkspace::getNeighboursExact(specnum_t spec, const int nNeighbours,
                                     bool ignoreMaskedDetectors) const {
   if (!m_nearestNeighbours) {
     SpectrumDetectorMapping spectraMap(this);
@@ -348,7 +348,7 @@ MatrixWorkspace::getNeighboursExact(specid_t spec, const int nNeighbours,
         nNeighbours, this->getInstrument(), spectraMap.getMapping(),
         ignoreMaskedDetectors));
   }
-  std::map<specid_t, V3D> neighbours = m_nearestNeighbours->neighbours(spec);
+  std::map<specnum_t, V3D> neighbours = m_nearestNeighbours->neighbours(spec);
   return neighbours;
 }
 
@@ -383,7 +383,7 @@ spec2index_map MatrixWorkspace::getSpectrumToWorkspaceIndexMap() const {
 *vector.
 */
 void MatrixWorkspace::getSpectrumToWorkspaceIndexVector(
-    std::vector<size_t> &out, specid_t &offset) const {
+    std::vector<size_t> &out, specnum_t &offset) const {
   SpectraAxis *ax = dynamic_cast<SpectraAxis *>(this->m_axes[1]);
   if (!ax)
     throw std::runtime_error("MatrixWorkspace::getSpectrumToWorkspaceIndexMap: "
@@ -391,14 +391,14 @@ void MatrixWorkspace::getSpectrumToWorkspaceIndexVector(
                              "generate a map.");
 
   // Find the min/max spectra IDs
-  specid_t min = std::numeric_limits<specid_t>::max(); // So that any number
+  specnum_t min = std::numeric_limits<specnum_t>::max(); // So that any number
                                                        // will be less than this
-  specid_t max = -std::numeric_limits<specid_t>::max(); // So that any number
+  specnum_t max = -std::numeric_limits<specnum_t>::max(); // So that any number
                                                         // will be greater than
                                                         // this
   size_t length = ax->length();
   for (size_t i = 0; i < length; i++) {
-    specid_t spec = ax->spectraNo(i);
+    specnum_t spec = ax->spectraNo(i);
     if (spec < min)
       min = spec;
     if (spec > max)
@@ -413,7 +413,7 @@ void MatrixWorkspace::getSpectrumToWorkspaceIndexVector(
 
   // Make the vector
   for (size_t i = 0; i < length; i++) {
-    specid_t spec = ax->spectraNo(i);
+    specnum_t spec = ax->spectraNo(i);
     out[spec + offset] = i;
   }
 }
@@ -545,7 +545,7 @@ void MatrixWorkspace::getDetectorIDToWorkspaceIndexVector(
 *not a Workspace2D)
 */
 void MatrixWorkspace::getIndicesFromSpectra(
-    const std::vector<specid_t> &spectraList,
+    const std::vector<specnum_t> &spectraList,
     std::vector<size_t> &indexList) const {
   // Clear the output index list
   indexList.clear();
@@ -571,7 +571,7 @@ void MatrixWorkspace::getIndicesFromSpectra(
 * @throw runtime_error if not found.
 */
 size_t
-MatrixWorkspace::getIndexFromSpectrumNumber(const specid_t specNo) const {
+MatrixWorkspace::getIndexFromSpectrumNumber(const specnum_t specNo) const {
   for (size_t i = 0; i < this->getNumberHistograms(); ++i) {
     if (this->getSpectrum(i)->getSpectrumNo() == specNo)
       return i;
@@ -624,14 +624,14 @@ void MatrixWorkspace::getIndicesFromDetectorIDs(
 */
 void MatrixWorkspace::getSpectraFromDetectorIDs(
     const std::vector<detid_t> &detIdList,
-    std::vector<specid_t> &spectraList) const {
+    std::vector<specnum_t> &spectraList) const {
 
   spectraList.clear();
 
   // Try every detector in the list
   for (auto detId : detIdList) {
     bool foundDet = false;
-    specid_t foundSpecNum = 0;
+    specnum_t foundSpecNum = 0;
 
     // Go through every histogram
     for (size_t i = 0; i < this->getNumberHistograms(); i++) {

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -390,10 +390,10 @@ MatrixWorkspace::getSpectrumToWorkspaceIndexVector(specnum_t &offset) const {
 
   // Find the min/max spectra IDs
   specnum_t min = std::numeric_limits<specnum_t>::max(); // So that any number
-                                                       // will be less than this
+  // will be less than this
   specnum_t max = -std::numeric_limits<specnum_t>::max(); // So that any number
-                                                        // will be greater than
-                                                        // this
+  // will be greater than
+  // this
   size_t length = ax->length();
   for (size_t i = 0; i < length; i++) {
     specnum_t spec = ax->spectraNo(i);

--- a/Framework/API/src/SpectraAxis.cpp
+++ b/Framework/API/src/SpectraAxis.cpp
@@ -84,7 +84,7 @@ void SpectraAxis::setValue(const std::size_t &index, const double &value) {
 /**
  * Finds the index of the given value on the axis
  * @param value A value on the axis. It is treated as a spectrum number and cast
- * to specid_t on input
+ * to specnum_t on input
  * @return The index closest to given value
  * @throws std::out_of_range if the value is out of range of the axis
  */
@@ -109,7 +109,7 @@ size_t SpectraAxis::indexOfValue(const double value) const {
  *  @return The spectrum number as an int
  *  @throw  IndexError If the index requested is not in the range of this axis
  */
-specid_t SpectraAxis::spectraNo(const std::size_t &index) const {
+specnum_t SpectraAxis::spectraNo(const std::size_t &index) const {
   if (index >= length()) {
     throw Kernel::Exception::IndexError(index, length() - 1,
                                         "SpectraAxis: Index out of range.");

--- a/Framework/API/src/SpectrumDetectorMapping.cpp
+++ b/Framework/API/src/SpectrumDetectorMapping.cpp
@@ -34,7 +34,7 @@ SpectrumDetectorMapping::SpectrumDetectorMapping(
  * are not of equal length
  */
 SpectrumDetectorMapping::SpectrumDetectorMapping(
-    const std::vector<specid_t> &spectrumNumbers,
+    const std::vector<specnum_t> &spectrumNumbers,
     const std::vector<detid_t> &detectorIDs,
     const std::vector<detid_t> &ignoreDetIDs)
     : m_indexIsSpecNo(true) {
@@ -51,7 +51,7 @@ SpectrumDetectorMapping::SpectrumDetectorMapping(
  *  @throws std::invalid_argument if a null array pointer is passed in
  */
 SpectrumDetectorMapping::SpectrumDetectorMapping(
-    const specid_t *const spectrumNumbers, const detid_t *const detectorIDs,
+    const specnum_t *const spectrumNumbers, const detid_t *const detectorIDs,
     size_t arrayLengths)
     : m_indexIsSpecNo(true) {
   if (spectrumNumbers == nullptr || detectorIDs == nullptr) {
@@ -64,7 +64,7 @@ SpectrumDetectorMapping::SpectrumDetectorMapping(
 
 /// Called by the c-array constructors to do the actual filling
 void SpectrumDetectorMapping::fillMapFromArray(
-    const specid_t *const spectrumNumbers, const detid_t *const detectorIDs,
+    const specnum_t *const spectrumNumbers, const detid_t *const detectorIDs,
     const size_t arrayLengths) {
   for (size_t i = 0; i < arrayLengths; ++i) {
     m_mapping[spectrumNumbers[i]].insert(detectorIDs[i]);
@@ -73,7 +73,7 @@ void SpectrumDetectorMapping::fillMapFromArray(
 
 /// Called by the vector constructors to do the actual filling
 void SpectrumDetectorMapping::fillMapFromVector(
-    const std::vector<specid_t> &spectrumNumbers,
+    const std::vector<specnum_t> &spectrumNumbers,
     const std::vector<detid_t> &detectorIDs,
     const std::vector<detid_t> &ignoreDetIDs) {
   std::set<detid_t> ignoreIDs(ignoreDetIDs.begin(), ignoreDetIDs.end());
@@ -92,8 +92,8 @@ SpectrumDetectorMapping::SpectrumDetectorMapping()
 SpectrumDetectorMapping::~SpectrumDetectorMapping() {}
 
 /// @returns An ordered set of the unique spectrum numbers
-std::set<specid_t> SpectrumDetectorMapping::getSpectrumNumbers() const {
-  std::set<specid_t> specs;
+std::set<specnum_t> SpectrumDetectorMapping::getSpectrumNumbers() const {
+  std::set<specnum_t> specs;
   auto itend = m_mapping.end();
   for (auto it = m_mapping.begin(); it != itend; ++it) {
     specs.insert(it->first);
@@ -102,7 +102,7 @@ std::set<specid_t> SpectrumDetectorMapping::getSpectrumNumbers() const {
 }
 
 const std::set<detid_t> &SpectrumDetectorMapping::getDetectorIDsForSpectrumNo(
-    const specid_t spectrumNo) const {
+    const specnum_t spectrumNo) const {
   if (!m_indexIsSpecNo)
     throw std::runtime_error("Indicies are in spectrum index, not number.");
   return m_mapping.at(spectrumNo);

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -123,7 +123,8 @@ public:
     const size_t nhist(10);
     testWS.initialize(nhist, 1, 1);
     for (size_t i = 0; i < testWS.getNumberHistograms(); i++) {
-      TS_ASSERT_EQUALS(testWS.getSpectrum(i)->getSpectrumNo(), specnum_t(i + 1));
+      TS_ASSERT_EQUALS(testWS.getSpectrum(i)->getSpectrumNo(),
+                       specnum_t(i + 1));
       TS_ASSERT(testWS.getSpectrum(i)->hasDetectorID(detid_t(i)));
     }
   }

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -124,7 +124,7 @@ public:
     const size_t nhist(10);
     testWS.initialize(nhist, 1, 1);
     for (size_t i = 0; i < testWS.getNumberHistograms(); i++) {
-      TS_ASSERT_EQUALS(testWS.getSpectrum(i)->getSpectrumNo(), specid_t(i + 1));
+      TS_ASSERT_EQUALS(testWS.getSpectrum(i)->getSpectrumNo(), specnum_t(i + 1));
       TS_ASSERT(testWS.getSpectrum(i)->hasDetectorID(detid_t(i)));
     }
   }
@@ -133,7 +133,7 @@ public:
     WorkspaceTester testWS;
     testWS.initialize(3, 1, 1);
 
-    specid_t specs[] = {1, 2, 2, 3};
+    specnum_t specs[] = {1, 2, 2, 3};
     detid_t detids[] = {10, 99, 20, 30};
     TS_ASSERT_THROWS_NOTHING(
         testWS.updateSpectraUsing(SpectrumDetectorMapping(specs, detids, 4)));

--- a/Framework/API/test/SpectrumDetectorMappingTest.h
+++ b/Framework/API/test/SpectrumDetectorMappingTest.h
@@ -43,7 +43,7 @@ public:
   }
 
   void test_vector_constructor_unequal_lengths() {
-    TS_ASSERT_THROWS(SpectrumDetectorMapping(std::vector<specid_t>(2),
+    TS_ASSERT_THROWS(SpectrumDetectorMapping(std::vector<specnum_t>(2),
                                              std::vector<detid_t>(1)),
                      std::invalid_argument);
   }
@@ -64,7 +64,7 @@ public:
 
   void test_vector_constructor_uses_all_spectra_by_default() {
     // Empty is fine for the input
-    std::vector<specid_t> specs;
+    std::vector<specnum_t> specs;
     std::vector<detid_t> detids;
     SpectrumDetectorMapping map(specs, detids);
     TS_ASSERT(map.getMapping().empty());
@@ -84,7 +84,7 @@ public:
 
   void test_vector_constructor_ignores_detectors_in_ignore_list() {
     const int ndets = 5;
-    std::vector<specid_t> specs(ndets, 0);
+    std::vector<specnum_t> specs(ndets, 0);
     std::vector<detid_t> detids(ndets, 0);
     for (int i = 0; i < ndets; ++i) {
       specs[i] = i + 1;
@@ -112,7 +112,7 @@ public:
   }
 
   void test_array_constructor_null_inputs() {
-    specid_t specs[2];
+    specnum_t specs[2];
     detid_t detids[2];
     TS_ASSERT_THROWS(SpectrumDetectorMapping(NULL, detids, 10),
                      std::invalid_argument);
@@ -121,7 +121,7 @@ public:
   }
 
   void test_array_constructor() {
-    specid_t specs[] = {1, 2, 2, 3};
+    specnum_t specs[] = {1, 2, 2, 3};
     detid_t detids[] = {10, 99, 20, 30};
 
     SpectrumDetectorMapping map(specs, detids, 4);
@@ -129,7 +129,7 @@ public:
   }
 
   void test_getSpectrumNumbers() {
-    specid_t specs[] = {5, 4, 4, 3};
+    specnum_t specs[] = {5, 4, 4, 3};
     detid_t detids[] = {10, 99, 20, 30};
 
     SpectrumDetectorMapping map(specs, detids, 4);

--- a/Framework/Algorithms/inc/MantidAlgorithms/GeneratePeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GeneratePeaks.h
@@ -71,7 +71,7 @@ private:
   void processTableColumnNames();
 
   void importPeaksFromTable(
-      std::map<specid_t, std::vector<std::pair<double, API::IFunction_sptr>>> &
+      std::map<specnum_t, std::vector<std::pair<double, API::IFunction_sptr>>> &
           functionmap);
 
   /// Import peak and background function parameters from vector
@@ -80,7 +80,7 @@ private:
 
   /// Generate peaks in output data workspaces
   void generatePeaks(
-      const std::map<specid_t,
+      const std::map<specnum_t,
                      std::vector<std::pair<double, API::IFunction_sptr>>> &
           functionmap,
       API::MatrixWorkspace_sptr dataWS);
@@ -117,11 +117,11 @@ private:
   std::vector<double> m_vecBkgdParamValues;
 
   /// Spectrum map from full spectra workspace to partial spectra workspace
-  std::map<specid_t, specid_t> m_SpectrumMap;
+  std::map<specnum_t, specnum_t> m_SpectrumMap;
 
   /// Set of spectra (workspace indexes) in the original workspace that contain
   /// peaks to generate
-  std::set<specid_t> m_spectraSet;
+  std::set<specnum_t> m_spectraSet;
 
   /// Flag to use automatic background (???)
   bool m_useAutoBkgd;

--- a/Framework/Algorithms/inc/MantidAlgorithms/GetEi.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GetEi.h
@@ -83,12 +83,12 @@ private:
   void init() override;
   void exec() override;
 
-  void getGeometry(API::MatrixWorkspace_const_sptr WS, specid_t mon0Spec,
-                   specid_t mon1Spec, double &monitor0Dist,
+  void getGeometry(API::MatrixWorkspace_const_sptr WS, specnum_t mon0Spec,
+                   specnum_t mon1Spec, double &monitor0Dist,
                    double &monitor1Dist) const;
   std::vector<size_t> getMonitorSpecIndexs(API::MatrixWorkspace_const_sptr WS,
-                                           specid_t specNum1,
-                                           specid_t specNum2) const;
+                                           specnum_t specNum1,
+                                           specnum_t specNum2) const;
   double timeToFly(double s, double E_KE) const;
   double getPeakCentre(API::MatrixWorkspace_const_sptr WS,
                        const int64_t monitIn, const double peakTime);

--- a/Framework/Algorithms/inc/MantidAlgorithms/He3TubeEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/He3TubeEfficiency.h
@@ -120,7 +120,7 @@ private:
   /// Sample position
   Kernel::V3D samplePos;
   /// The spectra numbers that were skipped
-  std::vector<specid_t> spectraSkipped;
+  std::vector<specnum_t> spectraSkipped;
   /// Algorithm progress keeper
   API::Progress *progress;
 };

--- a/Framework/Algorithms/inc/MantidAlgorithms/SmoothNeighbours.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SmoothNeighbours.h
@@ -12,7 +12,7 @@
 
 namespace Mantid {
 namespace Algorithms {
-typedef std::map<specid_t, Mantid::Kernel::V3D> SpectraDistanceMap;
+typedef std::map<specnum_t, Mantid::Kernel::V3D> SpectraDistanceMap;
 
 /*
 Filters spectra detector list by radius.
@@ -41,7 +41,7 @@ public:
         unfiltered.begin(), unfiltered.end(),
         std::inserter(neighbSpectra, neighbSpectra.end()),
         [cutoff](
-            const std::pair<specid_t, Mantid::Kernel::V3D> &spectraDistance) {
+            const std::pair<specnum_t, Mantid::Kernel::V3D> &spectraDistance) {
           return spectraDistance.second.norm() <= cutoff;
         });
     return neighbSpectra;

--- a/Framework/Algorithms/inc/MantidAlgorithms/SpatialGrouping.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpatialGrouping.h
@@ -78,11 +78,11 @@ private:
   void exec() override;
 
   /// expand our search out to the next neighbours along
-  bool expandNet(std::map<specid_t, Mantid::Kernel::V3D> &nearest,
-                 specid_t spec, const size_t &noNeighbours,
+  bool expandNet(std::map<specnum_t, Mantid::Kernel::V3D> &nearest,
+                 specnum_t spec, const size_t &noNeighbours,
                  const Mantid::Geometry::BoundingBox &bbox);
   /// sort by distance
-  void sortByDistance(std::map<specid_t, Mantid::Kernel::V3D> &nearest,
+  void sortByDistance(std::map<specnum_t, Mantid::Kernel::V3D> &nearest,
                       const size_t &noNeighbours);
   /// create expanded bounding box for our purposes
   void createBox(boost::shared_ptr<const Geometry::IDetector> det,
@@ -91,9 +91,9 @@ private:
   void growBox(double &min, double &max, const double &factor);
 
   /// map of detectors in the instrument
-  std::map<specid_t, boost::shared_ptr<const Geometry::IDetector>> m_detectors;
+  std::map<specnum_t, boost::shared_ptr<const Geometry::IDetector>> m_detectors;
   /// flag which detectors are included in a group already
-  std::set<specid_t> m_included;
+  std::set<specnum_t> m_included;
   /// first and last values for each group
   std::vector<std::vector<int>> m_groups;
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -91,10 +91,10 @@ private:
   void exec() override;
   void execEvent(DataObjects::EventWorkspace_const_sptr localworkspace,
                  std::set<int> &indices);
-  specid_t getOutputSpecId(API::MatrixWorkspace_const_sptr localworkspace);
+  specnum_t getOutputSpecId(API::MatrixWorkspace_const_sptr localworkspace);
 
   /// The output spectrum id
-  specid_t m_outSpecId;
+  specnum_t m_outSpecId;
   /// The spectrum to start the integration from
   int m_minSpec;
   /// The spectrum to finish the integration at

--- a/Framework/Algorithms/inc/MantidAlgorithms/WorkspaceJoiners.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/WorkspaceJoiners.h
@@ -57,8 +57,8 @@ protected:
   using Mantid::API::Algorithm::validateInputs;
   void validateInputs(API::MatrixWorkspace_const_sptr ws1,
                       API::MatrixWorkspace_const_sptr ws2);
-  void getMinMax(API::MatrixWorkspace_const_sptr ws, specid_t &min,
-                 specid_t &max);
+  void getMinMax(API::MatrixWorkspace_const_sptr ws, specnum_t &min,
+                 specnum_t &max);
 
   /// Abstract method to be implemented in concrete algorithm classes
   virtual void fixSpectrumNumbers(API::MatrixWorkspace_const_sptr ws1,

--- a/Framework/Algorithms/src/AppendSpectra.cpp
+++ b/Framework/Algorithms/src/AppendSpectra.cpp
@@ -126,12 +126,12 @@ void AppendSpectra::exec() {
 void AppendSpectra::fixSpectrumNumbers(API::MatrixWorkspace_const_sptr ws1,
                                        API::MatrixWorkspace_const_sptr ws2,
                                        API::MatrixWorkspace_sptr output) {
-  specid_t ws1min;
-  specid_t ws1max;
+  specnum_t ws1min;
+  specnum_t ws1max;
   getMinMax(ws1, ws1min, ws1max);
 
-  specid_t ws2min;
-  specid_t ws2max;
+  specnum_t ws2min;
+  specnum_t ws2max;
   getMinMax(ws2, ws2min, ws2max);
 
   // is everything possibly ok?
@@ -141,7 +141,7 @@ void AppendSpectra::fixSpectrumNumbers(API::MatrixWorkspace_const_sptr ws1,
   // change the axis by adding the maximum existing spectrum number to the
   // current value
   for (size_t i = 0; i < output->getNumberHistograms(); i++)
-    output->getSpectrum(i)->setSpectrumNo(specid_t(i));
+    output->getSpectrum(i)->setSpectrumNo(specnum_t(i));
 }
 
 void AppendSpectra::combineLogs(const API::Run &lhs, const API::Run &rhs,

--- a/Framework/Algorithms/src/AsymmetryCalc.cpp
+++ b/Framework/Algorithms/src/AsymmetryCalc.cpp
@@ -114,7 +114,7 @@ void AsymmetryCalc::exec() {
     tmpWS = inputWS;
 
     // get workspace indices from spectra ids for forward and backward
-    std::vector<specid_t> specIDs(2);
+    std::vector<specnum_t> specIDs(2);
     specIDs[0] = forward;
     specIDs[1] = backward;
     std::vector<size_t> indices;

--- a/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -116,12 +116,12 @@ void ConjoinWorkspaces::checkForOverlap(API::MatrixWorkspace_const_sptr ws1,
                                         bool checkSpectra) const {
   // Loop through the first workspace adding all the spectrum numbers & UDETS to
   // a set
-  std::set<specid_t> spectra;
+  std::set<specnum_t> spectra;
   std::set<detid_t> detectors;
   const size_t &nhist1 = ws1->getNumberHistograms();
   for (size_t i = 0; i < nhist1; ++i) {
     const ISpectrum *spec = ws1->getSpectrum(i);
-    const specid_t spectrum = spec->getSpectrumNo();
+    const specnum_t spectrum = spec->getSpectrumNo();
     spectra.insert(spectrum);
     const std::set<detid_t> &dets = spec->getDetectorIDs();
     std::set<detid_t>::const_iterator it;
@@ -135,7 +135,7 @@ void ConjoinWorkspaces::checkForOverlap(API::MatrixWorkspace_const_sptr ws1,
   const size_t &nhist2 = ws2->getNumberHistograms();
   for (size_t j = 0; j < nhist2; ++j) {
     const ISpectrum *spec = ws2->getSpectrum(j);
-    const specid_t spectrum = spec->getSpectrumNo();
+    const specnum_t spectrum = spec->getSpectrumNo();
     if (checkSpectra) {
       if (spectrum > 0 && spectra.find(spectrum) != spectra.end()) {
         g_log.error()
@@ -185,23 +185,23 @@ void ConjoinWorkspaces::fixSpectrumNumbers(API::MatrixWorkspace_const_sptr ws1,
     return;
 
   // is everything possibly ok?
-  specid_t min;
-  specid_t max;
+  specnum_t min;
+  specnum_t max;
   getMinMax(output, min, max);
-  if (max - min >= static_cast<specid_t>(
+  if (max - min >= static_cast<specnum_t>(
                        output->getNumberHistograms())) // nothing to do then
     return;
 
   // information for remapping the spectra numbers
-  specid_t ws1min;
-  specid_t ws1max;
+  specnum_t ws1min;
+  specnum_t ws1max;
   getMinMax(ws1, ws1min, ws1max);
 
   // change the axis by adding the maximum existing spectrum number to the
   // current value
   for (size_t i = ws1->getNumberHistograms(); i < output->getNumberHistograms();
        i++) {
-    specid_t origid;
+    specnum_t origid;
     origid = output->getSpectrum(i)->getSpectrumNo();
     output->getSpectrum(i)->setSpectrumNo(origid + ws1max);
   }

--- a/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -314,7 +314,7 @@ MatrixWorkspace_sptr CreateSampleWorkspace::createHistogramWorkspace(
     retVal->setX(wi, x);
     retVal->setData(wi, y, e);
     retVal->getSpectrum(wi)->setDetectorID(detid_t(start_at_pixelID + wi));
-    retVal->getSpectrum(wi)->setSpectrumNo(specid_t(wi + 1));
+    retVal->getSpectrum(wi)->setSpectrumNo(specnum_t(wi + 1));
   }
 
   return retVal;

--- a/Framework/Algorithms/src/FindDeadDetectors.cpp
+++ b/Framework/Algorithms/src/FindDeadDetectors.cpp
@@ -97,7 +97,7 @@ void FindDeadDetectors::exec() {
     } else {
       ++countSpec;
       y = deadValue;
-      const specid_t specNo = spec->getSpectrumNo();
+      const specnum_t specNo = spec->getSpectrumNo();
       // Write the spectrum number to file
       file << i << " " << specNo;
       // Get the list of detectors for this spectrum and iterate over

--- a/Framework/Algorithms/src/GeneratePeaks.cpp
+++ b/Framework/Algorithms/src/GeneratePeaks.cpp
@@ -153,7 +153,7 @@ void GeneratePeaks::exec() {
   setProperty("OutputWorkspace", outputWS);
 
   // Generate peaks
-  std::map<specid_t, std::vector<std::pair<double, API::IFunction_sptr>>>
+  std::map<specnum_t, std::vector<std::pair<double, API::IFunction_sptr>>>
       functionmap;
   if (m_useFuncParamWS)
     importPeaksFromTable(functionmap);
@@ -228,8 +228,8 @@ void GeneratePeaks::processAlgProperties(std::string &peakfunctype,
   // One and only one peak
   if (!m_useFuncParamWS) {
     m_wsIndex = getProperty("WorkspaceIndex");
-    m_spectraSet.insert(static_cast<specid_t>(m_wsIndex));
-    m_SpectrumMap.emplace(static_cast<specid_t>(m_wsIndex), 0);
+    m_spectraSet.insert(static_cast<specnum_t>(m_wsIndex));
+    m_SpectrumMap.emplace(static_cast<specnum_t>(m_wsIndex), 0);
   }
 
   return;
@@ -241,7 +241,7 @@ void GeneratePeaks::processAlgProperties(std::string &peakfunctype,
  * spectrum
   */
 void GeneratePeaks::importPeaksFromTable(
-    std::map<specid_t, std::vector<std::pair<double, API::IFunction_sptr>>> &
+    std::map<specnum_t, std::vector<std::pair<double, API::IFunction_sptr>>> &
         functionmap) {
   size_t numpeaks = m_funcParamWS->rowCount();
   size_t icolchi2 = m_funcParamWS->columnCount() - 1;
@@ -253,7 +253,7 @@ void GeneratePeaks::importPeaksFromTable(
     g_log.warning("There is no background function specified. ");
 
   // Create data structure for all peaks functions
-  std::map<specid_t,
+  std::map<specnum_t,
            std::vector<std::pair<double, API::IFunction_sptr>>>::iterator
       mapiter;
 
@@ -326,7 +326,7 @@ void GeneratePeaks::importPeaksFromTable(
     mapiter = functionmap.find(wsindex);
     if (mapiter == functionmap.end()) {
       std::vector<std::pair<double, API::IFunction_sptr>> tempvector;
-      std::pair<std::map<specid_t, std::vector<std::pair<
+      std::pair<std::map<specnum_t, std::vector<std::pair<
                                        double, API::IFunction_sptr>>>::iterator,
                 bool> ret;
       ret = functionmap.emplace(wsindex, tempvector);
@@ -428,18 +428,18 @@ void GeneratePeaks::importPeakFromVector(
   * @param dataWS :: output matrix workspace
   */
 void GeneratePeaks::generatePeaks(
-    const std::map<specid_t,
+    const std::map<specnum_t,
                    std::vector<std::pair<double, API::IFunction_sptr>>> &
         functionmap,
     API::MatrixWorkspace_sptr dataWS) {
   // Calcualte function
-  std::map<specid_t,
+  std::map<specnum_t,
            std::vector<std::pair<double, API::IFunction_sptr>>>::const_iterator
       mapiter;
   for (mapiter = functionmap.begin(); mapiter != functionmap.end(); ++mapiter) {
     // Get spec id and translated to wsindex in the output workspace
-    specid_t specid = mapiter->first;
-    specid_t wsindex;
+    specnum_t specid = mapiter->first;
+    specnum_t wsindex;
     if (m_newWSFromParent)
       wsindex = specid;
     else
@@ -639,7 +639,7 @@ void GeneratePeaks::getSpectraSet(
 
   for (size_t ipk = 0; ipk < numpeaks; ipk++) {
     // Spectrum
-    specid_t specid = static_cast<specid_t>((*col)[ipk]);
+    specnum_t specid = static_cast<specnum_t>((*col)[ipk]);
     m_spectraSet.insert(specid);
 
     std::stringstream outss;
@@ -647,8 +647,8 @@ void GeneratePeaks::getSpectraSet(
     g_log.debug(outss.str());
   }
 
-  std::set<specid_t>::iterator pit;
-  specid_t icount = 0;
+  std::set<specnum_t>::iterator pit;
+  specnum_t icount = 0;
   for (pit = m_spectraSet.begin(); pit != m_spectraSet.end(); ++pit) {
     m_SpectrumMap.emplace(*pit, icount);
     ++icount;
@@ -720,11 +720,11 @@ API::MatrixWorkspace_sptr GeneratePeaks::createOutputWorkspace() {
         inputWS, inputWS->getNumberHistograms(), inputWS->dataX(0).size(),
         inputWS->dataY(0).size());
 
-    std::set<specid_t>::iterator siter;
+    std::set<specnum_t>::iterator siter;
     // Only copy the X-values from spectra with peaks specified in the table
     // workspace.
     for (siter = m_spectraSet.begin(); siter != m_spectraSet.end(); ++siter) {
-      specid_t iws = *siter;
+      specnum_t iws = *siter;
       std::copy(inputWS->dataX(iws).begin(), inputWS->dataX(iws).end(),
                 outputWS->dataX(iws).begin());
     }
@@ -792,11 +792,11 @@ GeneratePeaks::createDataWorkspace(std::vector<double> binparameters) {
     std::copy(xarray.begin(), xarray.end(), ws->dataX(ip).begin());
 
   // Set spectrum numbers
-  std::map<specid_t, specid_t>::iterator spiter;
+  std::map<specnum_t, specnum_t>::iterator spiter;
   for (spiter = m_SpectrumMap.begin(); spiter != m_SpectrumMap.end();
        ++spiter) {
-    specid_t specid = spiter->first;
-    specid_t wsindex = spiter->second;
+    specnum_t specid = spiter->first;
+    specnum_t wsindex = spiter->second;
     g_log.debug() << "Build WorkspaceIndex-Spectrum  " << wsindex << " , "
                   << specid << "\n";
     ws->getSpectrum(wsindex)->setSpectrumNo(specid);

--- a/Framework/Algorithms/src/GeneratePeaks.cpp
+++ b/Framework/Algorithms/src/GeneratePeaks.cpp
@@ -326,8 +326,9 @@ void GeneratePeaks::importPeaksFromTable(
     mapiter = functionmap.find(wsindex);
     if (mapiter == functionmap.end()) {
       std::vector<std::pair<double, API::IFunction_sptr>> tempvector;
-      std::pair<std::map<specnum_t, std::vector<std::pair<
-                                       double, API::IFunction_sptr>>>::iterator,
+      std::pair<std::map<specnum_t,
+                         std::vector<std::pair<double, API::IFunction_sptr>>>::
+                    iterator,
                 bool> ret;
       ret = functionmap.emplace(wsindex, tempvector);
       mapiter = ret.first;

--- a/Framework/Algorithms/src/GetAllEi.cpp
+++ b/Framework/Algorithms/src/GetAllEi.cpp
@@ -878,9 +878,9 @@ GetAllEi::buildWorkspaceToFit(const API::MatrixWorkspace_sptr &inputWS,
   // at this stage all properties are validated so its safe to access them
   // without
   // additional checks.
-  specid_t specNum1 = getProperty("Monitor1SpecID");
+  specnum_t specNum1 = getProperty("Monitor1SpecID");
   wsIndex0 = inputWS->getIndexFromSpectrumNumber(specNum1);
-  specid_t specNum2 = getProperty("Monitor2SpecID");
+  specnum_t specNum2 = getProperty("Monitor2SpecID");
   size_t wsIndex1 = inputWS->getIndexFromSpectrumNumber(specNum2);
   auto pSpectr1 = inputWS->getSpectrum(wsIndex0);
   auto pSpectr2 = inputWS->getSpectrum(wsIndex1);
@@ -1242,7 +1242,7 @@ std::map<std::string, std::string> GetAllEi::validateInputs() {
                           "Rebin input workspace first.";
   }
 
-  specid_t specNum1 = getProperty("Monitor1SpecID");
+  specnum_t specNum1 = getProperty("Monitor1SpecID");
   try {
     inputWS->getIndexFromSpectrumNumber(specNum1);
   } catch (std::runtime_error &) {
@@ -1250,7 +1250,7 @@ std::map<std::string, std::string> GetAllEi::validateInputs() {
         "Input workspace does not contain spectra with ID: " +
         boost::lexical_cast<std::string>(specNum1);
   }
-  specid_t specNum2 = getProperty("Monitor2SpecID");
+  specnum_t specNum2 = getProperty("Monitor2SpecID");
   try {
     inputWS->getIndexFromSpectrumNumber(specNum2);
   } catch (std::runtime_error &) {

--- a/Framework/Algorithms/src/GetEi.cpp
+++ b/Framework/Algorithms/src/GetEi.cpp
@@ -81,8 +81,8 @@ void GetEi::init() {
 */
 void GetEi::exec() {
   MatrixWorkspace_const_sptr inWS = getProperty("InputWorkspace");
-  const specid_t mon1Spec = getProperty("Monitor1Spec");
-  const specid_t mon2Spec = getProperty("Monitor2Spec");
+  const specnum_t mon1Spec = getProperty("Monitor1Spec");
+  const specnum_t mon2Spec = getProperty("Monitor2Spec");
   double dist2moni0 = -1, dist2moni1 = -1;
   getGeometry(inWS, mon1Spec, mon2Spec, dist2moni0, dist2moni1);
 
@@ -149,8 +149,8 @@ void GetEi::exec() {
 * passed to this function second
 *  @throw NotFoundError if no detector is found for the detector ID given
 */
-void GetEi::getGeometry(API::MatrixWorkspace_const_sptr WS, specid_t mon0Spec,
-                        specid_t mon1Spec, double &monitor0Dist,
+void GetEi::getGeometry(API::MatrixWorkspace_const_sptr WS, specnum_t mon0Spec,
+                        specnum_t mon1Spec, double &monitor0Dist,
                         double &monitor1Dist) const {
   const IComponent_const_sptr source = WS->getInstrument()->getSource();
 
@@ -208,15 +208,15 @@ void GetEi::getGeometry(API::MatrixWorkspace_const_sptr WS, specid_t mon0Spec,
 * in the workspace
 */
 std::vector<size_t> GetEi::getMonitorSpecIndexs(
-    API::MatrixWorkspace_const_sptr WS, specid_t specNum1,
-    specid_t specNum2) const { // getting spectra numbers from detector IDs is
+    API::MatrixWorkspace_const_sptr WS, specnum_t specNum1,
+    specnum_t specNum2) const { // getting spectra numbers from detector IDs is
                                // hard because the map works the other way,
                                // getting index numbers from spectra numbers has
                                // the same problem and we are about to do both
   std::vector<size_t> specInds;
 
   // get the index number of the histogram for the first monitor
-  std::vector<specid_t> specNumTemp(&specNum1, &specNum1 + 1);
+  std::vector<specnum_t> specNumTemp(&specNum1, &specNum1 + 1);
   WS->getIndicesFromSpectra(specNumTemp, specInds);
   if (specInds.size() != 1) { // the monitor spectrum isn't present in the
                               // workspace, we can't continue from here

--- a/Framework/Algorithms/src/GetEi.cpp
+++ b/Framework/Algorithms/src/GetEi.cpp
@@ -236,7 +236,7 @@ std::vector<size_t> GetEi::getMonitorSpecIndexs(
     throw Exception::NotFoundError("GetEi::getMonitorSpecIndexs()", specNum2);
   }
 
-  wsInds.push_back(specIndexTemp[0]);
+  wsInds.push_back(specNumTemp[0]);
   return wsInds;
 }
 /** Uses E_KE = mv^2/2 and s = vt to calculate the time required for a neutron

--- a/Framework/Algorithms/src/GetEi.cpp
+++ b/Framework/Algorithms/src/GetEi.cpp
@@ -210,9 +210,9 @@ void GetEi::getGeometry(API::MatrixWorkspace_const_sptr WS, specnum_t mon0Spec,
 std::vector<size_t> GetEi::getMonitorSpecIndexs(
     API::MatrixWorkspace_const_sptr WS, specnum_t specNum1,
     specnum_t specNum2) const { // getting spectra numbers from detector IDs is
-                               // hard because the map works the other way,
-                               // getting index numbers from spectra numbers has
-                               // the same problem and we are about to do both
+                                // hard because the map works the other way,
+  // getting index numbers from spectra numbers has
+  // the same problem and we are about to do both
 
   // get the index number of the histogram for the first monitor
 
@@ -220,7 +220,7 @@ std::vector<size_t> GetEi::getMonitorSpecIndexs(
   auto wsInds = WS->getIndicesFromSpectra(specNumTemp);
 
   if (wsInds.size() != 1) { // the monitor spectrum isn't present in the
-                              // workspace, we can't continue from here
+                            // workspace, we can't continue from here
     g_log.error() << "Couldn't find the first monitor spectrum, number "
                   << specNum1 << std::endl;
     throw Exception::NotFoundError("GetEi::getMonitorSpecIndexs()", specNum1);
@@ -230,7 +230,7 @@ std::vector<size_t> GetEi::getMonitorSpecIndexs(
   specNumTemp[0] = specNum2;
   auto wsIndexTemp = WS->getIndicesFromSpectra(specNumTemp);
   if (wsIndexTemp.size() != 1) { // the monitor spectrum isn't present in the
-                                   // workspace, we can't continue from here
+                                 // workspace, we can't continue from here
     g_log.error() << "Couldn't find the second monitor spectrum, number "
                   << specNum2 << std::endl;
     throw Exception::NotFoundError("GetEi::getMonitorSpecIndexs()", specNum2);

--- a/Framework/Algorithms/src/GetEi2.cpp
+++ b/Framework/Algorithms/src/GetEi2.cpp
@@ -148,9 +148,9 @@ void GetEi2::exec() {
  *  @return The calculated incident energy
  */
 double GetEi2::calculateEi(const double initial_guess) {
-  const specid_t monitor1_spec = getProperty("Monitor1Spec");
-  const specid_t monitor2_spec = getProperty("Monitor2Spec");
-  specid_t mon1 = monitor1_spec, mon2 = monitor2_spec;
+  const specnum_t monitor1_spec = getProperty("Monitor1Spec");
+  const specnum_t monitor2_spec = getProperty("Monitor2Spec");
+  specnum_t mon1 = monitor1_spec, mon2 = monitor2_spec;
 
   const ParameterMap &pmap = m_input_ws->constInstrumentParameters();
   Instrument_const_sptr instrument = m_input_ws->getInstrument();
@@ -187,13 +187,13 @@ double GetEi2::calculateEi(const double initial_guess) {
   if (mon1 == EMPTY_INT()) {
     par = pmap.getRecursive(instrument->getChild(0).get(), "ei-mon1-spec");
     if (par) {
-      mon1 = boost::lexical_cast<specid_t>(par->asString());
+      mon1 = boost::lexical_cast<specnum_t>(par->asString());
     }
   }
   if (mon2 == EMPTY_INT()) {
     par = pmap.getRecursive(instrument->getChild(0).get(), "ei-mon2-spec");
     if (par) {
-      mon2 = boost::lexical_cast<specid_t>(par->asString());
+      mon2 = boost::lexical_cast<specnum_t>(par->asString());
     }
   }
   if ((mon1 == EMPTY_INT()) || (mon2 == EMPTY_INT())) {
@@ -201,7 +201,7 @@ double GetEi2::calculateEi(const double initial_guess) {
         "Could not determine spectrum number to use. Try to set it explicitly");
   }
   // Covert spectrum numbers to workspace indices
-  std::vector<specid_t> spec_nums(2, mon1);
+  std::vector<specnum_t> spec_nums(2, mon1);
   spec_nums[1] = mon2;
   std::vector<size_t> mon_indices;
   mon_indices.reserve(2);

--- a/Framework/Algorithms/src/MuonGroupDetectors.cpp
+++ b/Framework/Algorithms/src/MuonGroupDetectors.cpp
@@ -127,7 +127,7 @@ void MuonGroupDetectors::exec() {
     outWS->dataX(groupIndex) = inWS->dataX(wsIndices.front());
 
     outWS->getSpectrum(groupIndex)
-        ->setSpectrumNo(static_cast<specid_t>(groupIndex + 1));
+        ->setSpectrumNo(static_cast<specnum_t>(groupIndex + 1));
   }
 
   setProperty("OutputWorkspace", outWS);

--- a/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -39,7 +39,7 @@ std::string createWorkspaceIndexListFromDetectorWorkspace(
   auto spectrumMap = originWS->getSpectrumToWorkspaceIndexMap();
   auto it = spectrumMap.begin();
   std::stringstream result;
-  specid_t specId = (*it).first;
+  specnum_t specId = (*it).first;
   result << static_cast<int>(hostWS->getIndexFromSpectrumNumber(specId));
   ++it;
   for (; it != spectrumMap.end(); ++it) {

--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -375,7 +375,7 @@ void SmoothNeighbours::findNeighboursUbiqutious() {
       continue; // skip missing detector
     }
 
-    specid_t inSpec = inWS->getSpectrum(wi)->getSpectrumNo();
+    specnum_t inSpec = inWS->getSpectrum(wi)->getSpectrumNo();
 
     // Step one - Get the number of specified neighbours
     SpectraDistanceMap insideGrid =
@@ -396,7 +396,7 @@ void SmoothNeighbours::findNeighboursUbiqutious() {
 
     // Convert from spectrum numbers to workspace indices
     for (auto &specDistance : neighbSpectra) {
-      specid_t spec = specDistance.first;
+      specnum_t spec = specDistance.first;
 
       // Use the weighting strategy to calculate the weight.
       double weight = WeightedSum->weightAt(specDistance.second);

--- a/Framework/Algorithms/src/SofQWCentre.cpp
+++ b/Framework/Algorithms/src/SofQWCentre.cpp
@@ -103,7 +103,7 @@ void SofQWCentre::exec() {
   setProperty("OutputWorkspace", outputWorkspace);
 
   // Holds the spectrum-detector mapping
-  std::vector<specid_t> specNumberMapping;
+  std::vector<specnum_t> specNumberMapping;
   std::vector<detid_t> detIDMapping;
 
   m_EmodeProperties.initCachedValues(inputWorkspace, this);

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -16,7 +16,7 @@
 namespace Mantid {
 namespace Algorithms {
 // Setup typedef for later use
-typedef std::map<specid_t, Mantid::Kernel::V3D> SpectraDistanceMap;
+typedef std::map<specnum_t, Mantid::Kernel::V3D> SpectraDistanceMap;
 typedef Geometry::IDetector_const_sptr DetConstPtr;
 
 // Register the algorithm into the AlgorithmFactory
@@ -78,7 +78,7 @@ void SofQWNormalisedPolygon::exec() {
   const size_t nHistos = inputWS->getNumberHistograms();
 
   // Holds the spectrum-detector mapping
-  std::vector<specid_t> specNumberMapping;
+  std::vector<specnum_t> specNumberMapping;
   std::vector<detid_t> detIDMapping;
 
   // Progress reports & cancellation
@@ -130,7 +130,7 @@ void SofQWNormalisedPolygon::exec() {
     const double phiUpper = phi + phiHalfWidth;
 
     const double efixed = m_EmodeProperties.getEFixed(detector);
-    const specid_t specNo = inputWS->getSpectrum(i)->getSpectrumNo();
+    const specnum_t specNo = inputWS->getSpectrum(i)->getSpectrumNo();
     std::stringstream logStream;
     for (size_t j = 0; j < nEnergyBins; ++j) {
       m_progress->report("Computing polygon intersections");
@@ -321,7 +321,7 @@ void SofQWNormalisedPolygon::initAngularCachesPSD(
     m_progress->report("Calculating detector angular widths");
     DetConstPtr detector = workspace->getDetector(i);
     g_log.debug() << "Current histogram: " << i << std::endl;
-    specid_t inSpec = workspace->getSpectrum(i)->getSpectrumNo();
+    specnum_t inSpec = workspace->getSpectrum(i)->getSpectrumNo();
     SpectraDistanceMap neighbours =
         workspace->getNeighboursExact(inSpec, numNeighbours, true);
 
@@ -334,13 +334,13 @@ void SofQWNormalisedPolygon::initAngularCachesPSD(
     double theta = workspace->detectorTwoTheta(detector);
     double phi = detector->getPhi();
 
-    specid_t deltaPlus1 = inSpec + 1;
-    specid_t deltaMinus1 = inSpec - 1;
-    specid_t deltaPlusT = inSpec + this->m_detNeighbourOffset;
-    specid_t deltaMinusT = inSpec - this->m_detNeighbourOffset;
+    specnum_t deltaPlus1 = inSpec + 1;
+    specnum_t deltaMinus1 = inSpec - 1;
+    specnum_t deltaPlusT = inSpec + this->m_detNeighbourOffset;
+    specnum_t deltaMinusT = inSpec - this->m_detNeighbourOffset;
 
     for (auto &neighbour : neighbours) {
-      specid_t spec = neighbour.first;
+      specnum_t spec = neighbour.first;
       g_log.debug() << "Neighbor ID: " << spec << std::endl;
       if (spec == deltaPlus1 || spec == deltaMinus1 || spec == deltaPlusT ||
           spec == deltaMinusT) {

--- a/Framework/Algorithms/src/SofQWPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWPolygon.cpp
@@ -60,7 +60,7 @@ void SofQWPolygon::exec() {
   const MantidVec &X = inputWS->readX(0);
 
   // Holds the spectrum-detector mapping
-  std::vector<specid_t> specNumberMapping;
+  std::vector<specnum_t> specNumberMapping;
   std::vector<detid_t> detIDMapping;
 
   // Select the calculate Q method based on the mode

--- a/Framework/Algorithms/src/SpatialGrouping.cpp
+++ b/Framework/Algorithms/src/SpatialGrouping.cpp
@@ -88,7 +88,7 @@ void SpatialGrouping::exec() {
     // The detector
     Mantid::Geometry::IDetector_const_sptr &det = detector.second;
     // The spectrum number of the detector
-    specid_t specNo = detector.first;
+    specnum_t specNo = detector.first;
 
     // We are not interested in Monitors and we don't want them to be included
     // in
@@ -127,7 +127,7 @@ void SpatialGrouping::exec() {
     group.push_back(specNo);
 
     // Add all the nearest neighbors
-    std::map<specid_t, Mantid::Kernel::V3D>::iterator nrsIt;
+    std::map<specnum_t, Mantid::Kernel::V3D>::iterator nrsIt;
     for (nrsIt = nearest.begin(); nrsIt != nearest.end(); ++nrsIt) {
       m_included.insert(nrsIt->first);
       group.push_back(nrsIt->first);
@@ -200,20 +200,20 @@ void SpatialGrouping::exec() {
 * @return true if neighbours were found matching the parameters, false otherwise
 */
 bool SpatialGrouping::expandNet(
-    std::map<specid_t, Mantid::Kernel::V3D> &nearest, specid_t spec,
+    std::map<specnum_t, Mantid::Kernel::V3D> &nearest, specnum_t spec,
     const size_t &noNeighbours, const Mantid::Geometry::BoundingBox &bbox) {
   const size_t incoming = nearest.size();
 
   Mantid::Geometry::IDetector_const_sptr det = m_detectors[spec];
 
-  std::map<specid_t, Mantid::Kernel::V3D> potentials;
+  std::map<specnum_t, Mantid::Kernel::V3D> potentials;
 
   // Special case for first run for this detector
   if (incoming == 0) {
     potentials = inputWorkspace->getNeighbours(det.get());
   } else {
     for (auto &nrsIt : nearest) {
-      std::map<specid_t, Mantid::Kernel::V3D> results;
+      std::map<specnum_t, Mantid::Kernel::V3D> results;
       results = inputWorkspace->getNeighbours(m_detectors[nrsIt.first].get());
       for (auto &result : results) {
         potentials[result.first] = result.second;

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -188,16 +188,16 @@ void SumSpectra::exec() {
  * @param localworkspace The workspace to use.
  * @return The minimum spectrum id for all the spectra being summed.
  */
-specid_t
+specnum_t
 SumSpectra::getOutputSpecId(MatrixWorkspace_const_sptr localworkspace) {
   // initial value
-  specid_t specId =
+  specnum_t specId =
       localworkspace->getSpectrum(*(this->m_indices.begin()))->getSpectrumNo();
 
   // the total number of spectra
   int totalSpec = static_cast<int>(localworkspace->getNumberHistograms());
 
-  specid_t temp;
+  specnum_t temp;
   for (auto index : this->m_indices) {
     if (index < totalSpec) {
       temp = localworkspace->getSpectrum(index)->getSpectrumNo();

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -254,9 +254,9 @@ void WorkspaceJoiners::validateInputs(API::MatrixWorkspace_const_sptr ws1,
  * @param min The minimum id (output).
  * @param max The maximum id (output).
  */
-void WorkspaceJoiners::getMinMax(MatrixWorkspace_const_sptr ws, specid_t &min,
-                                 specid_t &max) {
-  specid_t temp;
+void WorkspaceJoiners::getMinMax(MatrixWorkspace_const_sptr ws, specnum_t &min,
+                                 specnum_t &max) {
+  specnum_t temp;
   size_t length = ws->getNumberHistograms();
   // initial values
   min = max = ws->getSpectrum(0)->getSpectrumNo();

--- a/Framework/Algorithms/test/AppendSpectraTest.h
+++ b/Framework/Algorithms/test/AppendSpectraTest.h
@@ -203,7 +203,7 @@ public:
     TS_ASSERT_EQUALS(out->blocksize(), numBins);
 
     for (size_t wi = 0; wi < out->getNumberHistograms(); wi++) {
-      TS_ASSERT_EQUALS(out->getSpectrum(wi)->getSpectrumNo(), specid_t(wi));
+      TS_ASSERT_EQUALS(out->getSpectrum(wi)->getSpectrumNo(), specnum_t(wi));
       TS_ASSERT(!out->getSpectrum(wi)->getDetectorIDs().empty());
       for (size_t x = 0; x < out->blocksize(); x++)
         TS_ASSERT_DELTA(out->readY(wi)[x], 2.0, 1e-5);

--- a/Framework/Algorithms/test/ConjoinWorkspacesTest.h
+++ b/Framework/Algorithms/test/ConjoinWorkspacesTest.h
@@ -163,7 +163,7 @@ public:
     TS_ASSERT(!conj.isExecuted());
 
     // Adjust second workspace
-    Mantid::specid_t start =
+    Mantid::specnum_t start =
         ws1->getSpectrum(numPixels - 1)->getSpectrumNo() + 10;
     for (int i = 0; i < 5; ++i) {
       Mantid::API::ISpectrum *spec = ws2->getSpectrum(i);

--- a/Framework/Algorithms/test/CountEventsInPulsesTest.h
+++ b/Framework/Algorithms/test/CountEventsInPulsesTest.h
@@ -280,7 +280,7 @@ public:
       } else {
         /// Regular detector
         DataObjects::EventList &events = eventWS->getOrAddEventList(wsindex);
-        events.setSpectrumNo(static_cast<specid_t>(wsindex + 1));
+        events.setSpectrumNo(static_cast<specnum_t>(wsindex + 1));
         events.clearDetectorIDs();
         events.addDetectorID(it->first);
 

--- a/Framework/Algorithms/test/ExtractSingleSpectrumTest.h
+++ b/Framework/Algorithms/test/ExtractSingleSpectrumTest.h
@@ -106,7 +106,7 @@ private:
     return extractor->getProperty("OutputWorkspace");
   }
 
-  void do_Spectrum_Tests(MatrixWorkspace_sptr outputWS, const specid_t specID,
+  void do_Spectrum_Tests(MatrixWorkspace_sptr outputWS, const specnum_t specID,
                          const detid_t detID) {
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
     const Mantid::API::ISpectrum *spectrum(NULL);

--- a/Framework/Algorithms/test/IntegrationTest.h
+++ b/Framework/Algorithms/test/IntegrationTest.h
@@ -17,7 +17,7 @@ using namespace Mantid::Kernel;
 using namespace Mantid::Algorithms;
 using namespace Mantid::DataObjects;
 using Mantid::MantidVec;
-using Mantid::specid_t;
+using Mantid::specnum_t;
 
 class IntegrationTest : public CxxTest::TestSuite {
 public:
@@ -264,7 +264,7 @@ public:
       TS_ASSERT_DELTA(Y[0], 20.0, 1e-6);
       TS_ASSERT_DELTA(E[0], sqrt(20.0), 1e-6);
       // Correct spectra etc?
-      specid_t specNo = output2D->getSpectrum(i)->getSpectrumNo();
+      specnum_t specNo = output2D->getSpectrum(i)->getSpectrumNo();
       TS_ASSERT_EQUALS(specNo, StartWorkspaceIndex + i);
       TS_ASSERT(output2D->getSpectrum(i)->hasDetectorID(specNo));
     }

--- a/Framework/Algorithms/test/ReflectometryReductionOneTest.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneTest.h
@@ -44,9 +44,9 @@ public:
     size_t workspaceIndexToKeep1 = 1;
     const int monitorIndex = 0;
 
-    specid_t specId1 =
+    specnum_t specId1 =
         toConvert->getSpectrum(workspaceIndexToKeep1)->getSpectrumNo();
-    specid_t monitorSpecId =
+    specnum_t monitorSpecId =
         toConvert->getSpectrum(monitorIndex)->getSpectrumNo();
 
     // Define one spectra to keep

--- a/Framework/Algorithms/test/SANSCollimationLengthEstimatorTest.h
+++ b/Framework/Algorithms/test/SANSCollimationLengthEstimatorTest.h
@@ -151,7 +151,7 @@ Mantid::API::MatrixWorkspace_sptr createTestWorkspace(
 
   // Link workspace with detector
   for (size_t i = 0; i < nhist; ++i) {
-    const Mantid::specid_t specID = static_cast<Mantid::specid_t>(id + i);
+    const Mantid::specnum_t specID = static_cast<Mantid::specnum_t>(id + i);
     auto *spec = ws2d->getSpectrum(i);
     spec->setSpectrumNo(specID);
     spec->clearDetectorIDs();

--- a/Framework/Algorithms/test/SofQWNormalisedPolygonTest.h
+++ b/Framework/Algorithms/test/SofQWNormalisedPolygonTest.h
@@ -77,8 +77,8 @@ public:
 
     for (size_t i = 0; i < nspectra; ++i) {
       const auto *spectrum = result->getSpectrum(i);
-      Mantid::specid_t specNoActual = spectrum->getSpectrumNo();
-      Mantid::specid_t specNoExpected = static_cast<Mantid::specid_t>(i + 1);
+      Mantid::specnum_t specNoActual = spectrum->getSpectrumNo();
+      Mantid::specnum_t specNoExpected = static_cast<Mantid::specnum_t>(i + 1);
       TS_ASSERT_EQUALS(specNoExpected, specNoActual);
       TS_ASSERT_EQUALS(expectedIDs[i], spectrum->getDetectorIDs());
     }

--- a/Framework/Algorithms/test/SofQWPolygonTest.h
+++ b/Framework/Algorithms/test/SofQWPolygonTest.h
@@ -75,8 +75,8 @@ public:
 
     for (size_t i = 0; i < nspectra; ++i) {
       const auto *spectrum = result->getSpectrum(i);
-      Mantid::specid_t specNoActual = spectrum->getSpectrumNo();
-      Mantid::specid_t specNoExpected = static_cast<Mantid::specid_t>(i + 1);
+      Mantid::specnum_t specNoActual = spectrum->getSpectrumNo();
+      Mantid::specnum_t specNoExpected = static_cast<Mantid::specnum_t>(i + 1);
       TS_ASSERT_EQUALS(specNoExpected, specNoActual);
       TS_ASSERT_EQUALS(expectedIDs[i], spectrum->getDetectorIDs());
     }

--- a/Framework/Algorithms/test/TOFSANSResolutionByPixelTest.h
+++ b/Framework/Algorithms/test/TOFSANSResolutionByPixelTest.h
@@ -172,7 +172,7 @@ Mantid::API::MatrixWorkspace_sptr createTestWorkspace(
 
   // Link workspace with detector
   for (size_t i = 0; i < nhist; ++i) {
-    const Mantid::specid_t specID = static_cast<Mantid::specid_t>(id + i);
+    const Mantid::specnum_t specID = static_cast<Mantid::specnum_t>(id + i);
     auto *spec = ws2d->getSpectrum(i);
     spec->setSpectrumNo(specID);
     spec->clearDetectorIDs();

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CalculateGammaBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CalculateGammaBackground.h
@@ -117,7 +117,7 @@ private:
   /// The number of peaks in spectrum
   size_t m_npeaks;
   /// List of spectra numbers whose background sum is to be reversed
-  std::set<specid_t> m_reversed;
+  std::set<specnum_t> m_reversed;
 
   /// Sample position
   Kernel::V3D m_samplePos;

--- a/Framework/CurveFitting/src/Algorithms/CalculateGammaBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/CalculateGammaBackground.cpp
@@ -42,9 +42,9 @@ double DEG2RAD = M_PI / 180.0;
 /// Wavelength of absorption (30603e-24 * 6e19). Constant came from VMS
 double ABSORB_WAVELENGTH = 1.83618;
 /// Start of forward scattering spectrum numbers (inclusive)
-specid_t FORWARD_SCATTER_SPECMIN = 135;
+specnum_t FORWARD_SCATTER_SPECMIN = 135;
 /// End of forward scattering spectrum numbers (inclusive)
-specid_t FORWARD_SCATTER_SPECMAX = 198;
+specnum_t FORWARD_SCATTER_SPECMAX = 198;
 }
 
 //--------------------------------------------------------------------------------------------------------
@@ -155,7 +155,7 @@ bool CalculateGammaBackground::calculateBackground(const size_t inputIndex,
 
   try {
     const auto *inSpec = m_inputWS->getSpectrum(inputIndex);
-    const specid_t spectrumNo(inSpec->getSpectrumNo());
+    const specnum_t spectrumNo(inSpec->getSpectrumNo());
     m_backgroundWS->getSpectrum(outputIndex)->copyInfoFrom(*inSpec);
     m_correctedWS->getSpectrum(outputIndex)->copyInfoFrom(*inSpec);
 
@@ -449,7 +449,7 @@ void CalculateGammaBackground::retrieveInputs() {
 
   // Spectrum numbers whose calculation of background from foils is reversed
   m_reversed.clear();
-  for (specid_t i = 143; i < 199; ++i) {
+  for (specnum_t i = 143; i < 199; ++i) {
     if ((i >= 143 && i <= 150) || (i >= 159 && i <= 166) ||
         (i >= 175 && i <= 182) || (i >= 191 && i <= 198))
       m_reversed.insert(i);

--- a/Framework/CurveFitting/test/Functions/ComptonProfileTestHelpers.h
+++ b/Framework/CurveFitting/test/Functions/ComptonProfileTestHelpers.h
@@ -86,7 +86,7 @@ createTestWorkspace(const size_t nhist, const double x0, const double x1,
 
   // Link workspace with detector
   for (size_t i = 0; i < nhist; ++i) {
-    const Mantid::specid_t specID = static_cast<Mantid::specid_t>(id + i);
+    const Mantid::specnum_t specID = static_cast<Mantid::specnum_t>(id + i);
     auto *spec = ws2d->getSpectrum(i);
     spec->setSpectrumNo(specID);
     spec->clearDetectorIDs();

--- a/Framework/DataHandling/inc/MantidDataHandling/CreateSimulationWorkspace.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/CreateSimulationWorkspace.h
@@ -76,7 +76,7 @@ private:
   /// Pointer to the new workspace
   API::MatrixWorkspace_sptr m_outputWS;
   /// List of detector groupings
-  std::map<specid_t, std::set<detid_t>> m_detGroups;
+  std::map<specnum_t, std::set<detid_t>> m_detGroups;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
@@ -75,7 +75,7 @@ public:
   void setWidth(const float flag);
   void setSpectrumNumbersFromUniqueSpectra(const std::set<int> uniqueSpectra);
   void setSpectrumNumberForAllPeriods(const size_t spectrumNumber,
-                                      const specid_t specid);
+                                      const specnum_t specid);
   void setDetectorIdsForAllPeriods(const size_t spectrumNumber,
                                    const detid_t id);
 
@@ -92,10 +92,10 @@ public:
 
   DataObjects::EventList &getEventList(const std::size_t workspace_index);
   void getSpectrumToWorkspaceIndexVector(std::vector<size_t> &out,
-                                         Mantid::specid_t &offset) const;
+                                         Mantid::specnum_t &offset) const;
 
   void getDetectorIDToWorkspaceIndexVector(std::vector<size_t> &out,
-                                           Mantid::specid_t &offset,
+                                           Mantid::specnum_t &offset,
                                            bool dothrow) const;
   Kernel::DateAndTime getFirstPulseTime() const;
   void setAllX(Kernel::cow_ptr<MantidVec> &x);

--- a/Framework/DataHandling/inc/MantidDataHandling/GroupDetectors2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/GroupDetectors2.h
@@ -154,7 +154,7 @@ private:
 
   /// used to store the lists of WORKSPACE INDICES that will be grouped, the
   /// keys are not used
-  typedef std::map<specid_t, std::vector<size_t>> storage_map;
+  typedef std::map<specnum_t, std::vector<size_t>> storage_map;
 
   /// An estimate of the percentage of the algorithm runtimes that has been
   /// completed

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
@@ -140,7 +140,7 @@ private:
   /// Prepare a vector of SpectraBlock structures to simplify loading
   size_t
   prepareSpectraBlocks(std::map<int64_t, std::string> &monitors,
-                       const std::map<int64_t, specid_t> &specInd2specNum_map,
+                       const std::map<int64_t, specnum_t> &specInd2specNum_map,
                        const DataBlock &LoadBlock);
   /// Run LoadInstrument as a ChildAlgorithm
   void runLoadInstrument(DataObjects::Workspace2D_sptr &);
@@ -203,7 +203,7 @@ private:
   /// if true, a spectra list or range of spectra is supplied
   bool m_load_selected_spectra;
   /// map of spectra Index to spectra Number (spectraID)
-  std::map<int64_t, specid_t> m_specInd2specNum_map;
+  std::map<int64_t, specnum_t> m_specInd2specNum_map;
   /// spectra Number to detector ID (multi)map
   API::SpectrumDetectorMapping m_spec2det_map;
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus.h
@@ -115,13 +115,13 @@ protected:
   /// Have the spectrum_min/max properties been set?
   bool m_interval;
   /// The value of the spectrum_list property
-  std::vector<specid_t> m_spec_list;
+  std::vector<specnum_t> m_spec_list;
   /// The value of the spectrum_min property
   int64_t m_spec_min;
   /// The value of the spectrum_max property
   int64_t m_spec_max;
   /// The group which each detector belongs to in order
-  std::vector<specid_t> m_groupings;
+  std::vector<specnum_t> m_groupings;
 
 private:
   /// Overwrites Algorithm method.

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h
@@ -100,7 +100,7 @@ protected:
   void exec() override;
 
 private:
-  void loadData(size_t hist, specid_t &i, specid_t specNo,
+  void loadData(size_t hist, specnum_t &i, specnum_t specNo,
                 MuonNexusReader &nxload, const int64_t lengthIn,
                 DataObjects::Workspace2D_sptr localWorkspace);
   void runLoadMappingTable(DataObjects::Workspace2D_sptr);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusMonitors2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusMonitors2.h
@@ -77,7 +77,7 @@ private:
   /// Fix the detector numbers if the defaults are not correct
   void fixUDets(boost::scoped_array<Mantid::detid_t> &det_ids,
                 ::NeXus::File &file,
-                const boost::scoped_array<Mantid::specid_t> &spec_ids,
+                const boost::scoped_array<Mantid::specnum_t> &spec_ids,
                 const size_t nmonitors) const;
 
   /// Load the logs

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRaw3.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRaw3.h
@@ -70,8 +70,8 @@ private:
   void exec() override;
 
   /// returns true if the given spectrum is a monitor
-  bool isMonitor(const std::vector<specid_t> &monitorIndexes,
-                 specid_t spectrumNum);
+  bool isMonitor(const std::vector<specnum_t> &monitorIndexes,
+                 specnum_t spectrumNum);
 
   /// validate workspace sizes
   void validateWorkspaceSizes(bool bexcludeMonitors, bool bseparateMonitors,
@@ -80,7 +80,7 @@ private:
 
   /// creates output workspace, monitors excluded from this workspace
   void excludeMonitors(FILE *file, const int &period,
-                       const std::vector<specid_t> &monitorList,
+                       const std::vector<specnum_t> &monitorList,
                        DataObjects::Workspace2D_sptr ws_sptr);
 
   /// creates output workspace whcih includes monitors
@@ -90,7 +90,7 @@ private:
   /// creates two output workspaces none normal workspace and separate one for
   /// monitors
   void separateMonitors(FILE *file, const int64_t &period,
-                        const std::vector<specid_t> &monitorList,
+                        const std::vector<specnum_t> &monitorList,
                         DataObjects::Workspace2D_sptr ws_sptr,
                         DataObjects::Workspace2D_sptr mws_sptr);
 
@@ -113,7 +113,7 @@ private:
   std::string m_filename;
 
   /// The number of spectra in the raw file
-  specid_t m_numberOfSpectra;
+  specnum_t m_numberOfSpectra;
   /// Allowed values for the cache property
   std::vector<std::string> m_cache_options;
   /// A map for storing the time regime for each spectrum

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRawBin0.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRawBin0.h
@@ -101,7 +101,7 @@ private:
   std::string m_filename;
 
   /// The number of spectra in the raw file
-  specid_t m_numberOfSpectra;
+  specnum_t m_numberOfSpectra;
   /// number of time regime
   int64_t m_noTimeRegimes;
 
@@ -118,7 +118,7 @@ private:
   boost::shared_ptr<Kernel::Property> m_perioids;
 
   /// total number of specs
-  specid_t m_total_specs;
+  specnum_t m_total_specs;
   /// time channel vector
   std::vector<boost::shared_ptr<MantidVec>> m_timeChannelsVec;
 };

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
@@ -130,7 +130,7 @@ protected:
   /// Reads title from the isisraw class
   void readTitle(FILE *file, std::string &title);
   /// reads workspace parameters like number of histograms,size of vectors etc
-  void readworkspaceParameters(specid_t &numberOfSpectra, int &numberOfPeriods,
+  void readworkspaceParameters(specnum_t &numberOfSpectra, int &numberOfPeriods,
                                int64_t &lengthIn, int64_t &noTimeRegimes);
 
   /// skips histrogram data from raw file.
@@ -165,14 +165,14 @@ protected:
                         DataObjects::Workspace2D_sptr local_workspace);
 
   /// gets the monitor spectrum list from the workspace
-  std::vector<specid_t>
+  std::vector<specnum_t>
   getmonitorSpectrumList(const API::SpectrumDetectorMapping &mapping);
 
   /// This method sets the raw file data to workspace vectors
   void setWorkspaceData(
       DataObjects::Workspace2D_sptr newWorkspace,
       const std::vector<boost::shared_ptr<MantidVec>> &timeChannelsVec,
-      int64_t wsIndex, specid_t nspecNum, int64_t noTimeRegimes,
+      int64_t wsIndex, specnum_t nspecNum, int64_t noTimeRegimes,
       int64_t lengthIn, int64_t binStart);
 
   /// ISISRAW class instance which does raw file reading. Shared pointer to
@@ -197,11 +197,11 @@ protected:
   /// Validates the optional 'spectra to read' properties, if they have been set
   void checkOptionalProperties();
   /// calculate workspace size
-  specid_t calculateWorkspaceSize();
+  specnum_t calculateWorkspaceSize();
   /// calculate workspace sizes if separate or exclude monitors are selected
-  void calculateWorkspacesizes(const std::vector<specid_t> &monitorSpecList,
-                               specid_t &normalwsSpecs,
-                               specid_t &monitorwsSpecs);
+  void calculateWorkspacesizes(const std::vector<specnum_t> &monitorSpecList,
+                               specnum_t &normalwsSpecs,
+                               specnum_t &monitorwsSpecs);
   /// load the spectra
   void loadSpectra(FILE *file, const int &period, const int &m_total_specs,
                    DataObjects::Workspace2D_sptr ws_sptr,
@@ -212,11 +212,11 @@ protected:
   /// Have the spectrum_min/max properties been set?
   bool m_interval;
   /// The value of the spectrum_list property
-  std::vector<specid_t> m_spec_list;
+  std::vector<specnum_t> m_spec_list;
   /// The value of the spectrum_min property
-  specid_t m_spec_min;
+  specnum_t m_spec_min;
   /// The value of the spectrum_max property
-  specid_t m_spec_max;
+  specnum_t m_spec_max;
   /// The number of periods in the raw file
   int m_numberOfPeriods;
 
@@ -229,21 +229,21 @@ private:
   /// Allowed values for the cache property
   std::vector<std::string> m_cache_options;
   /// A map for storing the time regime for each spectrum
-  std::map<specid_t, specid_t> m_specTimeRegimes;
+  std::map<specnum_t, specnum_t> m_specTimeRegimes;
   /// The current value of the progress counter
   double m_prog;
 
   /// number of spectra
-  specid_t m_numberOfSpectra;
+  specnum_t m_numberOfSpectra;
 
   /// a vector holding the indexes of monitors
-  std::vector<specid_t> m_monitordetectorList;
+  std::vector<specnum_t> m_monitordetectorList;
 
   /// boolean for list spectra options
   bool m_bmspeclist;
 
   /// the total nuumber of spectra
-  specid_t m_total_specs;
+  specnum_t m_total_specs;
 
   /// A ptr to the log creator
   boost::scoped_ptr<ISISRunLogs> m_logCreator;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRawSpectrum0.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRawSpectrum0.h
@@ -90,7 +90,7 @@ private:
   std::string m_filename;
 
   /// The number of spectra in the raw file
-  specid_t m_numberOfSpectra;
+  specnum_t m_numberOfSpectra;
 
   /// Allowed values for the cache property
   std::vector<std::string> m_cache_options;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadTOFRawNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadTOFRawNexus.h
@@ -102,7 +102,7 @@ protected:
   size_t m_numBins;
 
   /// Interval of chunk
-  specid_t m_spec_min, m_spec_max;
+  specnum_t m_spec_min, m_spec_max;
 
   /// Name of the 'data' field to load (depending on Signal)
   std::string m_dataField;

--- a/Framework/DataHandling/inc/MantidDataHandling/MaskDetectors.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/MaskDetectors.h
@@ -84,7 +84,7 @@ private:
   void exec() override;
   void execPeaks(DataObjects::PeaksWorkspace_sptr WS);
   void fillIndexListFromSpectra(std::vector<size_t> &indexList,
-                                const std::vector<specid_t> &spectraList,
+                                const std::vector<specnum_t> &spectraList,
                                 const API::MatrixWorkspace_sptr WS);
   void appendToIndexListFromWS(std::vector<size_t> &indexList,
                                const API::MatrixWorkspace_sptr maskedWorkspace);

--- a/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
+++ b/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
@@ -180,7 +180,7 @@ void CreateSimulationWorkspace::createOneToOneMapping() {
   for (size_t i = 0; i < nhist; ++i) {
     std::set<detid_t> group;
     group.insert(detids[i]);
-    m_detGroups.emplace(static_cast<specid_t>(i + 1), group);
+    m_detGroups.emplace(static_cast<specnum_t>(i + 1), group);
   }
 }
 
@@ -306,7 +306,7 @@ void CreateSimulationWorkspace::applyDetectorMapping() {
   for (auto &detGroup : m_detGroups) {
     ISpectrum *spectrum = m_outputWS->getSpectrum(wsIndex);
     spectrum->setSpectrumNo(
-        static_cast<specid_t>(wsIndex + 1)); // Ensure a contiguous mapping
+        static_cast<specnum_t>(wsIndex + 1)); // Ensure a contiguous mapping
     spectrum->clearDetectorIDs();
     spectrum->addDetectorIDs(detGroup.second);
     ++wsIndex;

--- a/Framework/DataHandling/src/EventWorkspaceCollection.cpp
+++ b/Framework/DataHandling/src/EventWorkspaceCollection.cpp
@@ -171,7 +171,7 @@ void EventWorkspaceCollection::setSpectrumNumbersFromUniqueSpectra(
 }
 
 void EventWorkspaceCollection::setSpectrumNumberForAllPeriods(
-    const size_t spectrumNumber, const specid_t specid) {
+    const size_t spectrumNumber, const specnum_t specid) {
   for (auto &ws : m_WsVec) {
     auto spec = ws->getSpectrum(spectrumNumber);
     spec->setSpectrumNo(specid);
@@ -217,11 +217,11 @@ EventWorkspaceCollection::getEventList(const std::size_t workspace_index) {
 }
 
 void EventWorkspaceCollection::getSpectrumToWorkspaceIndexVector(
-    std::vector<size_t> &out, Mantid::specid_t &offset) const {
+    std::vector<size_t> &out, Mantid::specnum_t &offset) const {
   return m_WsVec[0]->getSpectrumToWorkspaceIndexVector(out, offset);
 }
 void EventWorkspaceCollection::getDetectorIDToWorkspaceIndexVector(
-    std::vector<size_t> &out, Mantid::specid_t &offset, bool dothrow) const {
+    std::vector<size_t> &out, Mantid::specnum_t &offset, bool dothrow) const {
   return m_WsVec[0]->getDetectorIDToWorkspaceIndexVector(out, offset, dothrow);
 }
 

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -847,7 +847,7 @@ void FilterEventsByLogValuePreNexus::procEvents(
       EventList &spec = workspace->getOrAddEventList(workspaceIndex);
       spec.addDetectorID(it->first);
       // Start the spectrum number at 1
-      spec.setSpectrumNo(specid_t(workspaceIndex + 1));
+      spec.setSpectrumNo(specnum_t(workspaceIndex + 1));
       workspaceIndex += 1;
     }
   }
@@ -2223,7 +2223,7 @@ size_t FilterEventsByLogValuePreNexus::padOutEmptyPixels(
       // EventList & spec = workspace->getOrAddEventList(workspaceIndex);
       // spec.addDetectorID(it->first);
       // Start the spectrum number at 1
-      // spec.setSpectrumNo(specid_t(workspaceIndex+1));
+      // spec.setSpectrumNo(specnum_t(workspaceIndex+1));
       workspaceIndex += 1;
     }
   }
@@ -2251,7 +2251,7 @@ void FilterEventsByLogValuePreNexus::setupPixelSpectrumMap(
       EventList &spec = eventws->getOrAddEventList(workspaceIndex);
       spec.addDetectorID(det.first);
       // Start the spectrum number at 1
-      spec.setSpectrumNo(specid_t(workspaceIndex + 1));
+      spec.setSpectrumNo(specnum_t(workspaceIndex + 1));
     }
   }
 

--- a/Framework/DataHandling/src/GroupDetectors.cpp
+++ b/Framework/DataHandling/src/GroupDetectors.cpp
@@ -29,7 +29,7 @@ void GroupDetectors::init() {
       "The name of the workspace2D on which to perform the algorithm");
 
   declareProperty(
-      new ArrayProperty<specid_t>("SpectraList"),
+      new ArrayProperty<specnum_t>("SpectraList"),
       "An array containing a list of the indexes of the spectra to combine\n"
       "(DetectorList and WorkspaceIndexList are ignored if this is set)");
 
@@ -51,7 +51,7 @@ void GroupDetectors::exec() {
   const MatrixWorkspace_sptr WS = getProperty("Workspace");
 
   std::vector<size_t> indexList = getProperty("WorkspaceIndexList");
-  std::vector<specid_t> spectraList = getProperty("SpectraList");
+  std::vector<specnum_t> spectraList = getProperty("SpectraList");
   const std::vector<detid_t> detectorList = getProperty("DetectorList");
 
   // Could create a Validator to replace the below
@@ -89,7 +89,7 @@ void GroupDetectors::exec() {
 
   const size_t vectorSize = WS->blocksize();
 
-  const specid_t firstIndex = static_cast<specid_t>(indexList[0]);
+  const specnum_t firstIndex = static_cast<specnum_t>(indexList[0]);
   ISpectrum *firstSpectrum = WS->getSpectrum(firstIndex);
   MantidVec &firstY = WS->dataY(firstIndex);
 

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -63,7 +63,7 @@ void GroupDetectors2::init() {
                   "Describes how this algorithm should group the detectors. "
                   "See full instruction list.");
   declareProperty(
-      new ArrayProperty<specid_t>("SpectraList"),
+      new ArrayProperty<specnum_t>("SpectraList"),
       "An array containing a list of the spectrum numbers to combine\n"
       "(DetectorList and WorkspaceIndexList are ignored if this is set)");
   declareProperty(new ArrayProperty<detid_t>("DetectorList"),
@@ -327,7 +327,7 @@ void GroupDetectors2::getGroups(API::MatrixWorkspace_const_sptr workspace,
   }
 
   // manually specified grouping
-  const std::vector<specid_t> spectraList = getProperty("SpectraList");
+  const std::vector<specnum_t> spectraList = getProperty("SpectraList");
   const std::vector<detid_t> detectorList = getProperty("DetectorList");
   const std::vector<size_t> indexList = getProperty("WorkspaceIndexList");
 
@@ -636,7 +636,7 @@ void GroupDetectors2::processGroupingWorkspace(
     std::vector<size_t> tempv;
     tempv.assign(targetWSIndexSet.begin(), targetWSIndexSet.end());
     m_GroupSpecInds.insert(
-        std::make_pair(static_cast<specid_t>(groupid), tempv));
+        std::make_pair(static_cast<specnum_t>(groupid), tempv));
   }
 
   return;
@@ -704,7 +704,7 @@ void GroupDetectors2::processMatrixWorkspace(
       std::vector<size_t> tempv;
       tempv.assign(targetWSIndexSet.begin(), targetWSIndexSet.end());
       m_GroupSpecInds.insert(
-          std::make_pair(static_cast<specid_t>(groupid), tempv));
+          std::make_pair(static_cast<specnum_t>(groupid), tempv));
     }
   }
 
@@ -854,7 +854,7 @@ void GroupDetectors2::readSpectraIndexes(std::string line,
 
     std::vector<size_t>::const_iterator specN = specNums.begin();
     for (; specN != specNums.end(); ++specN) {
-      specid_t spectrumNum = static_cast<specid_t>(*specN);
+      specnum_t spectrumNum = static_cast<specnum_t>(*specN);
       spec2index_map::const_iterator ind = specs2index.find(spectrumNum);
       if (ind == specs2index.end()) {
         g_log.debug() << name() << ": spectrum number " << spectrumNum

--- a/Framework/DataHandling/src/LoadAscii.cpp
+++ b/Framework/DataHandling/src/LoadAscii.cpp
@@ -237,7 +237,7 @@ API::Workspace_sptr LoadAscii::readData(std::ifstream &file) const {
     if (haveXErrors)
       localWorkspace->dataDx(i) = spectra[i].dataDx();
     // Just have spectrum number start at 1 and count up
-    localWorkspace->getSpectrum(i)->setSpectrumNo(static_cast<specid_t>(i) + 1);
+    localWorkspace->getSpectrum(i)->setSpectrumNo(static_cast<specnum_t>(i) + 1);
   }
   return localWorkspace;
 }

--- a/Framework/DataHandling/src/LoadAscii.cpp
+++ b/Framework/DataHandling/src/LoadAscii.cpp
@@ -237,7 +237,8 @@ API::Workspace_sptr LoadAscii::readData(std::ifstream &file) const {
     if (haveXErrors)
       localWorkspace->dataDx(i) = spectra[i].dataDx();
     // Just have spectrum number start at 1 and count up
-    localWorkspace->getSpectrum(i)->setSpectrumNo(static_cast<specnum_t>(i) + 1);
+    localWorkspace->getSpectrum(i)
+        ->setSpectrumNo(static_cast<specnum_t>(i) + 1);
   }
   return localWorkspace;
 }

--- a/Framework/DataHandling/src/LoadAscii2.cpp
+++ b/Framework/DataHandling/src/LoadAscii2.cpp
@@ -215,7 +215,7 @@ void LoadAscii2::writeToWorkspace(API::MatrixWorkspace_sptr &localWorkspace,
           ->setSpectrumNo(m_spectra[i].getSpectrumNo());
     } else {
       localWorkspace->getSpectrum(i)
-          ->setSpectrumNo(static_cast<specid_t>(i) + 1);
+          ->setSpectrumNo(static_cast<specnum_t>(i) + 1);
     }
   }
 }

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1383,11 +1383,11 @@ void LoadEventNexus::makeMapToEventLists(std::vector<std::vector<T>> &vectors) {
   if (this->event_id_is_spec) {
     // Find max spectrum no
     Axis *ax1 = m_ws->getAxis(1);
-    specid_t maxSpecNo =
-        -std::numeric_limits<specid_t>::max(); // So that any number will be
+    specnum_t maxSpecNo =
+        -std::numeric_limits<specnum_t>::max(); // So that any number will be
                                                // greater than this
     for (size_t i = 0; i < ax1->length(); i++) {
-      specid_t spec = ax1->spectraNo(i);
+      specnum_t spec = ax1->spectraNo(i);
       if (spec > maxSpecNo)
         maxSpecNo = spec;
     }
@@ -2488,7 +2488,7 @@ bool LoadEventNexus::loadSpectraMapping(const std::string &filename,
       std::vector<int32_t>::const_iterator it =
           std::find(udet.begin(), udet.end(), id);
       if (it != udet.end()) {
-        const specid_t &specNo = spec[it - udet.begin()];
+        const specnum_t &specNo = spec[it - udet.begin()];
         m_ws->setSpectrumNumberForAllPeriods(i, specNo);
         m_ws->setDetectorIdsForAllPeriods(i, id);
       }

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1385,7 +1385,7 @@ void LoadEventNexus::makeMapToEventLists(std::vector<std::vector<T>> &vectors) {
     Axis *ax1 = m_ws->getAxis(1);
     specnum_t maxSpecNo =
         -std::numeric_limits<specnum_t>::max(); // So that any number will be
-                                               // greater than this
+                                                // greater than this
     for (size_t i = 0; i < ax1->length(); i++) {
       specnum_t spec = ax1->spectraNo(i);
       if (spec > maxSpecNo)

--- a/Framework/DataHandling/src/LoadEventPreNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus.cpp
@@ -467,7 +467,7 @@ void LoadEventPreNexus::procEvents(
       EventList &spec = workspace->getOrAddEventList(workspaceIndex);
       spec.addDetectorID(it->first);
       // Start the spectrum number at 1
-      spec.setSpectrumNo(specid_t(workspaceIndex + 1));
+      spec.setSpectrumNo(specnum_t(workspaceIndex + 1));
       workspaceIndex += 1;
     }
   }

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -717,7 +717,7 @@ void LoadEventPreNexus2::procEvents(
       EventList &spec = workspace->getOrAddEventList(workspaceIndex);
       spec.addDetectorID(it->first);
       // Start the spectrum number at 1
-      spec.setSpectrumNo(specid_t(workspaceIndex + 1));
+      spec.setSpectrumNo(specnum_t(workspaceIndex + 1));
       workspaceIndex += 1;
     }
   }

--- a/Framework/DataHandling/src/LoadGSS.cpp
+++ b/Framework/DataHandling/src/LoadGSS.cpp
@@ -414,7 +414,7 @@ API::MatrixWorkspace_sptr LoadGSS::loadGSASFile(const std::string &filename,
 
     // Reset spectrum number if
     if (useBankAsSpectrum) {
-      specid_t specno = static_cast<specid_t>(detectorIDs[i]);
+      specnum_t specno = static_cast<specnum_t>(detectorIDs[i]);
       outputWorkspace->getSpectrum(i)->setSpectrumNo(specno);
     }
   }

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -540,7 +540,7 @@ void LoadISISNexus2::checkOptionalProperties(
       // combine spectra numbers from ranges and the list
       if (spec_list.size() > 0) {
         for (int64_t i = spec_min; i < spec_max + 1; i++) {
-          specid_t spec_num = static_cast<specid_t>(i);
+          specnum_t spec_num = static_cast<specnum_t>(i);
           // remove excluded spectra now rather then inserting it here and
           // removing later
           if (SpectraExcluded.find(spec_num) == SpectraExcluded.end())
@@ -587,10 +587,10 @@ void LoadISISNexus2::buildSpectraInd2SpectraNumMap(
     auto start_point = spec_list.begin();
     for (auto it = start_point; it != spec_list.end(); it++) {
 
-      specid_t spec_num = static_cast<specid_t>(*it);
+      specnum_t spec_num = static_cast<specnum_t>(*it);
       if (SpectraExcluded.find(spec_num) == SpectraExcluded.end()) {
         m_specInd2specNum_map.insert(
-            std::pair<int64_t, specid_t>(ic, spec_num));
+            std::pair<int64_t, specnum_t>(ic, spec_num));
         ic++;
       }
     }
@@ -598,10 +598,10 @@ void LoadISISNexus2::buildSpectraInd2SpectraNumMap(
     if (range_supplied) {
       ic = 0;
       for (int64_t i = range_min; i < range_max + 1; i++) {
-        specid_t spec_num = static_cast<specid_t>(i);
+        specnum_t spec_num = static_cast<specnum_t>(i);
         if (SpectraExcluded.find(spec_num) == SpectraExcluded.end()) {
           m_specInd2specNum_map.insert(
-              std::pair<int64_t, specid_t>(ic, spec_num));
+              std::pair<int64_t, specnum_t>(ic, spec_num));
           ic++;
         }
       }
@@ -629,7 +629,7 @@ bool compareSpectraBlocks(const LoadISISNexus2::SpectraBlock &block1,
 */
 size_t LoadISISNexus2::prepareSpectraBlocks(
     std::map<int64_t, std::string> &monitors,
-    const std::map<int64_t, specid_t> &specInd2specNum_map,
+    const std::map<int64_t, specnum_t> &specInd2specNum_map,
     const DataBlock &LoadBlock) {
   std::vector<int64_t> includedMonitors;
   // fill in the data block descriptor vector
@@ -758,9 +758,9 @@ void LoadISISNexus2::loadPeriodData(
 
       if (update_spectra2det_mapping) {
         // local_workspace->getAxis(1)->setValue(hist_index,
-        // static_cast<specid_t>(it->first));
+        // static_cast<specnum_t>(it->first));
         auto spec = local_workspace->getSpectrum(hist_index);
-        specid_t specID = m_specInd2specNum_map.at(hist_index);
+        specnum_t specID = m_specInd2specNum_map.at(hist_index);
         spec->setDetectorIDs(
             m_spec2det_map.getDetectorIDsForSpectrumNo(specID));
         spec->setSpectrumNo(specID);
@@ -858,9 +858,9 @@ void LoadISISNexus2::loadBlock(NXDataSetTyped<int> &data, int64_t blocksize,
     local_workspace->setX(hist, m_tof_data);
     if (m_load_selected_spectra) {
       // local_workspace->getAxis(1)->setValue(hist,
-      // static_cast<specid_t>(spec_num));
+      // static_cast<specnum_t>(spec_num));
       auto spec = local_workspace->getSpectrum(hist);
-      specid_t specID = m_specInd2specNum_map.at(hist);
+      specnum_t specID = m_specInd2specNum_map.at(hist);
       // set detectors corresponding to spectra Number
       spec->setDetectorIDs(m_spec2det_map.getDetectorIDsForSpectrumNo(specID));
       // set correct spectra Number

--- a/Framework/DataHandling/src/LoadMuonNexus.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus.cpp
@@ -58,7 +58,7 @@ void LoadMuonNexus::init() {
                   mustBePositive, "Index of last spectrum to read\n"
                                   "(default the last spectrum)");
 
-  declareProperty(new ArrayProperty<specid_t>("SpectrumList"),
+  declareProperty(new ArrayProperty<specnum_t>("SpectrumList"),
                   "Array, or comma separated list, of indexes of spectra to\n"
                   "load");
   declareProperty("AutoGroup", false,
@@ -113,9 +113,9 @@ void LoadMuonNexus::checkOptionalProperties() {
 
   // Check validity of spectra list property, if set
   if (m_list) {
-    const specid_t minlist =
+    const specnum_t minlist =
         *min_element(m_spec_list.begin(), m_spec_list.end());
-    const specid_t maxlist =
+    const specnum_t maxlist =
         *max_element(m_spec_list.begin(), m_spec_list.end());
     if (maxlist > m_numberOfSpectra || minlist == 0) {
       g_log.error("Invalid list of spectra");

--- a/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -255,9 +255,9 @@ void LoadMuonNexus1::exec() {
     size_t counter = 0;
     for (int64_t i = m_spec_min; i < m_spec_max; ++i) {
       // Shift the histogram to read if we're not in the first period
-      specid_t histToRead =
-          static_cast<specid_t>(i - 1 + period * nxload.t_nsp1);
-      specid_t specNo = static_cast<specid_t>(i);
+      specnum_t histToRead =
+          static_cast<specnum_t>(i - 1 + period * nxload.t_nsp1);
+      specnum_t specNo = static_cast<specnum_t>(i);
       loadData(counter, histToRead, specNo, nxload, lengthIn - 1,
                localWorkspace); // added -1 for NeXus
       counter++;
@@ -266,9 +266,9 @@ void LoadMuonNexus1::exec() {
     // Read in the spectra in the optional list parameter, if set
     if (m_list) {
       for (auto specid : m_spec_list) {
-        specid_t histToRead =
-            static_cast<specid_t>(specid - 1 + period * nxload.t_nsp1);
-        specid_t specNo = static_cast<specid_t>(specid);
+        specnum_t histToRead =
+            static_cast<specnum_t>(specid - 1 + period * nxload.t_nsp1);
+        specnum_t specNo = static_cast<specnum_t>(specid);
         loadData(counter, histToRead, specNo, nxload, lengthIn - 1,
                  localWorkspace);
         counter++;
@@ -597,7 +597,7 @@ LoadMuonNexus1::createDetectorGroupingTable(std::vector<int> specToLoad,
 *  @param localWorkspace :: A pointer to the workspace in which the data will be
 * stored
 */
-void LoadMuonNexus1::loadData(size_t hist, specid_t &i, specid_t specNo,
+void LoadMuonNexus1::loadData(size_t hist, specnum_t &i, specnum_t specNo,
                               MuonNexusReader &nxload, const int64_t lengthIn,
                               DataObjects::Workspace2D_sptr localWorkspace) {
   // Read in a spectrum

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -260,7 +260,8 @@ void LoadNexusMonitors2::exec() {
   }
 
   // a temporary place to put the spectra/detector numbers
-  boost::scoped_array<specnum_t> spectra_numbers(new specnum_t[m_monitor_count]);
+  boost::scoped_array<specnum_t> spectra_numbers(
+      new specnum_t[m_monitor_count]);
   boost::scoped_array<detid_t> detector_numbers(new detid_t[m_monitor_count]);
 
   API::Progress prog3(this, 0.6, 1.0, m_monitor_count);
@@ -517,10 +518,10 @@ bool LoadNexusMonitors2::allMonitorsHaveHistoData(
  * @param spec_ids :: An array of spectrum numbers that the monitors have
  * @param nmonitors :: The size of the det_ids and spec_ids arrays
  */
-void LoadNexusMonitors2::fixUDets(boost::scoped_array<detid_t> &det_ids,
-                                  ::NeXus::File &file,
-                                  const boost::scoped_array<specnum_t> &spec_ids,
-                                  const size_t nmonitors) const {
+void LoadNexusMonitors2::fixUDets(
+    boost::scoped_array<detid_t> &det_ids, ::NeXus::File &file,
+    const boost::scoped_array<specnum_t> &spec_ids,
+    const size_t nmonitors) const {
   try {
     file.openGroup("isis_vms_compat", "IXvms");
   } catch (::NeXus::Exception &) {

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -171,7 +171,7 @@ void LoadNexusMonitors2::exec() {
       } else {
         numHistMon += 1;
         if (inner_entries.find("monitor_number") != inner_entries.end()) {
-          specid_t monitorNo;
+          specnum_t monitorNo;
           file.openData("monitor_number");
           file.getData(&monitorNo);
           file.closeData();
@@ -260,7 +260,7 @@ void LoadNexusMonitors2::exec() {
   }
 
   // a temporary place to put the spectra/detector numbers
-  boost::scoped_array<specid_t> spectra_numbers(new specid_t[m_monitor_count]);
+  boost::scoped_array<specnum_t> spectra_numbers(new specnum_t[m_monitor_count]);
   boost::scoped_array<detid_t> detector_numbers(new detid_t[m_monitor_count]);
 
   API::Progress prog3(this, 0.6, 1.0, m_monitor_count);
@@ -283,7 +283,7 @@ void LoadNexusMonitors2::exec() {
     file.openGroup(monitorNames[i], "NXmonitor");
 
     // Check if the spectra index is there
-    specid_t spectrumNo(static_cast<specid_t>(i + 1));
+    specnum_t spectrumNo(static_cast<specnum_t>(i + 1));
     try {
       file.openData("spectrum_index");
       file.getData(&spectrumNo);
@@ -519,7 +519,7 @@ bool LoadNexusMonitors2::allMonitorsHaveHistoData(
  */
 void LoadNexusMonitors2::fixUDets(boost::scoped_array<detid_t> &det_ids,
                                   ::NeXus::File &file,
-                                  const boost::scoped_array<specid_t> &spec_ids,
+                                  const boost::scoped_array<specnum_t> &spec_ids,
                                   const size_t nmonitors) const {
   try {
     file.openGroup("isis_vms_compat", "IXvms");

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1658,7 +1658,7 @@ void LoadNexusProcessed::readInstrumentGroup(
     if (spectraInfo.hasSpectra) {
       spectrum = spectraInfo.spectraNumbers[i - 1];
     } else if (haveSpectraAxis && !m_axis1vals.empty()) {
-      spectrum = static_cast<specid_t>(m_axis1vals[i - 1]);
+      spectrum = static_cast<specnum_t>(m_axis1vals[i - 1]);
     } else {
       spectrum = i + 1;
     }

--- a/Framework/DataHandling/src/LoadRaw3.cpp
+++ b/Framework/DataHandling/src/LoadRaw3.cpp
@@ -51,7 +51,7 @@ void LoadRaw3::init() {
       "The number of the last spectrum to read. Only used if explicitly\n"
       "set.");
   declareProperty(
-      new ArrayProperty<specid_t>("SpectrumList"),
+      new ArrayProperty<specnum_t>("SpectrumList"),
       "A comma-separated list of individual spectra to read.  Only used if\n"
       "explicitly set.");
   declareProperty(
@@ -157,9 +157,9 @@ void LoadRaw3::exec() {
   WorkspaceGroup_sptr ws_grp = createGroupWorkspace();
   WorkspaceGroup_sptr monitorws_grp;
   DataObjects::Workspace2D_sptr monitorWorkspace;
-  specid_t normalwsSpecs = 0;
-  specid_t monitorwsSpecs = 0;
-  std::vector<specid_t> monitorSpecList;
+  specnum_t normalwsSpecs = 0;
+  specnum_t monitorwsSpecs = 0;
+  std::vector<specnum_t> monitorSpecList;
 
   if (bincludeMonitors) {
     setWorkspaceProperty("OutputWorkspace", title, ws_grp, localWorkspace,
@@ -312,14 +312,14 @@ void LoadRaw3::exec() {
  *@param ws_sptr :: shared pointer to workspace
  */
 void LoadRaw3::excludeMonitors(FILE *file, const int &period,
-                               const std::vector<specid_t> &monitorList,
+                               const std::vector<specnum_t> &monitorList,
                                DataObjects::Workspace2D_sptr ws_sptr) {
   int64_t histCurrent = -1;
   int64_t wsIndex = 0;
   double histTotal = static_cast<double>(m_total_specs * m_numberOfPeriods);
   // loop through the spectra
-  for (specid_t i = 1; i <= m_numberOfSpectra; ++i) {
-    specid_t histToRead = i + period * (m_numberOfSpectra + 1);
+  for (specnum_t i = 1; i <= m_numberOfSpectra; ++i) {
+    specnum_t histToRead = i + period * (m_numberOfSpectra + 1);
     if ((i >= m_spec_min && i < m_spec_max) ||
         (m_list &&
          find(m_spec_list.begin(), m_spec_list.end(), i) !=
@@ -367,7 +367,7 @@ void LoadRaw3::includeMonitors(FILE *file, const int64_t &period,
   int64_t wsIndex = 0;
   double histTotal = static_cast<double>(m_total_specs * m_numberOfPeriods);
   // loop through spectra
-  for (specid_t i = 1; i <= m_numberOfSpectra; ++i) {
+  for (specnum_t i = 1; i <= m_numberOfSpectra; ++i) {
     int64_t histToRead = i + period * (m_numberOfSpectra + 1);
     if ((i >= m_spec_min && i < m_spec_max) ||
         (m_list &&
@@ -407,7 +407,7 @@ void LoadRaw3::includeMonitors(FILE *file, const int64_t &period,
  */
 
 void LoadRaw3::separateMonitors(FILE *file, const int64_t &period,
-                                const std::vector<specid_t> &monitorList,
+                                const std::vector<specnum_t> &monitorList,
                                 DataObjects::Workspace2D_sptr ws_sptr,
                                 DataObjects::Workspace2D_sptr mws_sptr) {
   int64_t histCurrent = -1;
@@ -415,7 +415,7 @@ void LoadRaw3::separateMonitors(FILE *file, const int64_t &period,
   int64_t mwsIndex = 0;
   double histTotal = static_cast<double>(m_total_specs * m_numberOfPeriods);
   // loop through spectra
-  for (specid_t i = 1; i <= m_numberOfSpectra; ++i) {
+  for (specnum_t i = 1; i <= m_numberOfSpectra; ++i) {
     int64_t histToRead = i + period * (m_numberOfSpectra + 1);
     if ((i >= m_spec_min && i < m_spec_max) ||
         (m_list &&
@@ -458,7 +458,7 @@ void LoadRaw3::separateMonitors(FILE *file, const int64_t &period,
  * @param period :: period number
  */
 void LoadRaw3::skipPeriod(FILE *file, const int64_t &period) {
-  for (specid_t i = 1; i <= m_numberOfSpectra; ++i) {
+  for (specnum_t i = 1; i <= m_numberOfSpectra; ++i) {
     int64_t histToRead = i + period * (m_numberOfSpectra + 1);
     skipData(file, histToRead);
   }
@@ -548,10 +548,10 @@ void LoadRaw3::validateWorkspaceSizes(bool bexcludeMonitors,
  *  @param spectrumNum ::  the requested spectrum number
  *  @return true if it's a monitor
  */
-bool LoadRaw3::isMonitor(const std::vector<specid_t> &monitorIndexes,
-                         specid_t spectrumNum) {
+bool LoadRaw3::isMonitor(const std::vector<specnum_t> &monitorIndexes,
+                         specnum_t spectrumNum) {
   bool bMonitor;
-  std::vector<specid_t>::const_iterator itr;
+  std::vector<specnum_t>::const_iterator itr;
   itr = find(monitorIndexes.begin(), monitorIndexes.end(), spectrumNum);
   (itr != monitorIndexes.end()) ? (bMonitor = true) : (bMonitor = false);
   return bMonitor;

--- a/Framework/DataHandling/src/LoadRawBin0.cpp
+++ b/Framework/DataHandling/src/LoadRawBin0.cpp
@@ -45,7 +45,7 @@ void LoadRawBin0::init() {
   declareProperty("SpectrumMax", EMPTY_INT(), mustBePositive,
                   "The number of the last spectrum to read.");
   declareProperty(
-      new ArrayProperty<specid_t>("SpectrumList"),
+      new ArrayProperty<specnum_t>("SpectrumList"),
       "A comma-separated list of individual spectra to read.  Only used if "
       "explicitly set.");
 }
@@ -135,7 +135,7 @@ void LoadRawBin0::exec() {
         period * (static_cast<int64_t>(m_numberOfSpectra) + 1);
     skipData(file, periodTimesNSpectraP1);
     int64_t wsIndex = 0;
-    for (specid_t i = 1; i <= m_numberOfSpectra; ++i) {
+    for (specnum_t i = 1; i <= m_numberOfSpectra; ++i) {
       int64_t histToRead = i + periodTimesNSpectraP1;
       if ((i >= m_spec_min && i < m_spec_max) ||
           (m_list &&

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -172,12 +172,12 @@ void LoadRawHelper::setRunNumber(API::Run &run) {
  * @param lengthIn :: size of workspace vectors
  * @param noTimeRegimes :: number of time regime.
  */
-void LoadRawHelper::readworkspaceParameters(specid_t &numberOfSpectra,
+void LoadRawHelper::readworkspaceParameters(specnum_t &numberOfSpectra,
                                             int &numberOfPeriods,
                                             int64_t &lengthIn,
                                             int64_t &noTimeRegimes) {
   // Read in the number of spectra in the RAW file
-  m_numberOfSpectra = numberOfSpectra = static_cast<specid_t>(isisRaw->t_nsp1);
+  m_numberOfSpectra = numberOfSpectra = static_cast<specnum_t>(isisRaw->t_nsp1);
   // Read the number of periods in this file
   numberOfPeriods = isisRaw->t_nper;
   // Read the number of time channels (i.e. bins) from the RAW file
@@ -384,7 +384,7 @@ void LoadRawHelper::setWorkspaceProperty(const std::string &propertyName,
 void LoadRawHelper::setWorkspaceData(
     DataObjects::Workspace2D_sptr newWorkspace,
     const std::vector<boost::shared_ptr<MantidVec>> &timeChannelsVec,
-    int64_t wsIndex, specid_t nspecNum, int64_t noTimeRegimes, int64_t lengthIn,
+    int64_t wsIndex, specnum_t nspecNum, int64_t noTimeRegimes, int64_t lengthIn,
     int64_t binStart) {
   if (!newWorkspace)
     return;
@@ -423,9 +423,9 @@ void LoadRawHelper::setWorkspaceData(
  *  @param mapping The spectrum number to detector mapping
  *  @return monitorSpecList The spectrum numbers of the monitors
  */
-std::vector<specid_t>
+std::vector<specnum_t>
 LoadRawHelper::getmonitorSpectrumList(const SpectrumDetectorMapping &mapping) {
-  std::vector<specid_t> spectrumIndices;
+  std::vector<specnum_t> spectrumIndices;
 
   if (!m_monitordetectorList.empty()) {
     const auto &map = mapping.getMapping();
@@ -599,7 +599,7 @@ void LoadRawHelper::runLoadInstrument(
     }
     // Debugging code??
     m_monitordetectorList = loadInst->getProperty("MonitorList");
-    std::vector<specid_t>::const_iterator itr;
+    std::vector<specnum_t>::const_iterator itr;
     for (itr = m_monitordetectorList.begin();
          itr != m_monitordetectorList.end(); ++itr) {
       g_log.debug() << "Monitor detector id is " << (*itr) << std::endl;
@@ -626,7 +626,7 @@ void LoadRawHelper::runLoadInstrumentFromRaw(
         "Unable to successfully run LoadInstrumentFromRaw Child Algorithm");
   }
   m_monitordetectorList = loadInst->getProperty("MonitorList");
-  std::vector<specid_t>::const_iterator itr;
+  std::vector<specnum_t>::const_iterator itr;
   for (itr = m_monitordetectorList.begin(); itr != m_monitordetectorList.end();
        ++itr) {
     g_log.debug() << "Monitor dtector id is " << (*itr) << std::endl;
@@ -947,8 +947,8 @@ void LoadRawHelper::checkOptionalProperties() {
  * properties
  * @return the size of the workspace (number of spectra)
  */
-specid_t LoadRawHelper::calculateWorkspaceSize() {
-  specid_t total_specs(0);
+specnum_t LoadRawHelper::calculateWorkspaceSize() {
+  specnum_t total_specs(0);
   if (m_interval || m_list) {
     if (m_interval) {
       if (m_spec_min != 1 && m_spec_max == 1)
@@ -969,7 +969,7 @@ specid_t LoadRawHelper::calculateWorkspaceSize() {
       }
       if (m_spec_list.size() == 0)
         m_list = false;
-      total_specs += static_cast<specid_t>(m_spec_list.size());
+      total_specs += static_cast<specnum_t>(m_spec_list.size());
       m_total_specs = total_specs;
     }
   } else {
@@ -988,10 +988,10 @@ specid_t LoadRawHelper::calculateWorkspaceSize() {
 /// @param normalwsSpecs :: the spectra for the detector workspace
 /// @param monitorwsSpecs :: the spectra for the monitor workspace
 void LoadRawHelper::calculateWorkspacesizes(
-    const std::vector<specid_t> &monitorSpecList, specid_t &normalwsSpecs,
-    specid_t &monitorwsSpecs) {
+    const std::vector<specnum_t> &monitorSpecList, specnum_t &normalwsSpecs,
+    specnum_t &monitorwsSpecs) {
   if (!m_interval && !m_bmspeclist) {
-    monitorwsSpecs = static_cast<specid_t>(monitorSpecList.size());
+    monitorwsSpecs = static_cast<specnum_t>(monitorSpecList.size());
     normalwsSpecs = m_total_specs - monitorwsSpecs;
     g_log.debug()
         << "normalwsSpecs   when m_interval  & m_bmspeclist are  false is  "
@@ -1000,7 +1000,7 @@ void LoadRawHelper::calculateWorkspacesizes(
   } else if (m_interval || m_bmspeclist) {
     if (m_interval) {
       int msize = 0;
-      std::vector<specid_t>::const_iterator itr1;
+      std::vector<specnum_t>::const_iterator itr1;
       for (itr1 = monitorSpecList.begin(); itr1 != monitorSpecList.end();
            ++itr1) {
         if (*itr1 >= m_spec_min && *itr1 < m_spec_max)
@@ -1014,7 +1014,7 @@ void LoadRawHelper::calculateWorkspacesizes(
     }
     if (m_bmspeclist) {
       if (m_interval) {
-        std::vector<specid_t>::iterator itr;
+        std::vector<specnum_t>::iterator itr;
         for (itr = m_spec_list.begin();
              itr != m_spec_list.end();) { // if  the m_spec_list elements are in
                                           // the range between m_spec_min &
@@ -1031,9 +1031,9 @@ void LoadRawHelper::calculateWorkspacesizes(
         } else { // at this point there are monitors in the list which are not
                  // in the min& max range
           // so find those  monitors  count and calculate the workspace specs
-          std::vector<specid_t>::const_iterator itr;
-          std::vector<specid_t>::const_iterator monitr;
-          specid_t monCounter = 0;
+          std::vector<specnum_t>::const_iterator itr;
+          std::vector<specnum_t>::const_iterator monitr;
+          specnum_t monCounter = 0;
           for (itr = m_spec_list.begin(); itr != m_spec_list.end(); ++itr) {
             monitr = find(monitorSpecList.begin(), monitorSpecList.end(), *itr);
             if (monitr != monitorSpecList.end())
@@ -1047,9 +1047,9 @@ void LoadRawHelper::calculateWorkspacesizes(
         }
       }      // end if loop for m_interval
       else { // if only List true
-        specid_t mSize = 0;
-        std::vector<specid_t>::const_iterator itr;
-        std::vector<specid_t>::const_iterator monitr;
+        specnum_t mSize = 0;
+        std::vector<specnum_t>::const_iterator itr;
+        std::vector<specnum_t>::const_iterator monitr;
         for (itr = m_spec_list.begin(); itr != m_spec_list.end(); ++itr) {
           monitr = find(monitorSpecList.begin(), monitorSpecList.end(), *itr);
           if (monitr != monitorSpecList.end()) {
@@ -1080,7 +1080,7 @@ void LoadRawHelper::loadSpectra(
   const int64_t periodTimesNSpectraP1 =
       period * (static_cast<int64_t>(m_numberOfSpectra) + 1);
   // loop through spectra
-  for (specid_t i = 1; i <= m_numberOfSpectra; ++i) {
+  for (specnum_t i = 1; i <= m_numberOfSpectra; ++i) {
     int64_t histToRead = i + periodTimesNSpectraP1;
     if ((i >= m_spec_min && i < m_spec_max) ||
         (m_list &&

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -384,8 +384,8 @@ void LoadRawHelper::setWorkspaceProperty(const std::string &propertyName,
 void LoadRawHelper::setWorkspaceData(
     DataObjects::Workspace2D_sptr newWorkspace,
     const std::vector<boost::shared_ptr<MantidVec>> &timeChannelsVec,
-    int64_t wsIndex, specnum_t nspecNum, int64_t noTimeRegimes, int64_t lengthIn,
-    int64_t binStart) {
+    int64_t wsIndex, specnum_t nspecNum, int64_t noTimeRegimes,
+    int64_t lengthIn, int64_t binStart) {
   if (!newWorkspace)
     return;
   typedef double (*uf)(double);

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -50,7 +50,7 @@ void LoadTOFRawNexus::init() {
       "spectrum_max is set.");
   declareProperty(
       new PropertyWithValue<specnum_t>("SpectrumMax", Mantid::EMPTY_INT(),
-                                      mustBePositive),
+                                       mustBePositive),
       "The number of the last spectrum to read. Only used if explicitly\n"
       "set.");
 }

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -45,11 +45,11 @@ void LoadTOFRawNexus::init() {
   auto mustBePositive = boost::make_shared<BoundedValidator<int>>();
   mustBePositive->setLower(1);
   declareProperty(
-      new PropertyWithValue<specid_t>("SpectrumMin", 1, mustBePositive),
+      new PropertyWithValue<specnum_t>("SpectrumMin", 1, mustBePositive),
       "The index number of the first spectrum to read.  Only used if\n"
       "spectrum_max is set.");
   declareProperty(
-      new PropertyWithValue<specid_t>("SpectrumMax", Mantid::EMPTY_INT(),
+      new PropertyWithValue<specnum_t>("SpectrumMax", Mantid::EMPTY_INT(),
                                       mustBePositive),
       "The number of the last spectrum to read. Only used if explicitly\n"
       "set.");
@@ -250,7 +250,7 @@ void LoadTOFRawNexus::countPixels(const std::string &nexusfilename,
 pixel_id.end();)
 {
   detid_t pixelID = *it;
-  specid_t wi = static_cast<specid_t>((*id_to_wi)[pixelID]);
+  specnum_t wi = static_cast<specnum_t>((*id_to_wi)[pixelID]);
   // spectrum is just wi+1
   if (wi+1 < m_spec_min || wi+1 > m_spec_max) pixel_id.erase(it);
   else ++it;
@@ -259,17 +259,17 @@ pixel_id.end();)
 namespace {
 // Check the numbers supplied are not in the range and erase the ones that are
 struct range_check {
-  range_check(specid_t min, specid_t max, detid2index_map id_to_wi)
+  range_check(specnum_t min, specnum_t max, detid2index_map id_to_wi)
       : m_min(min), m_max(max), m_id_to_wi(id_to_wi) {}
 
-  bool operator()(specid_t x) {
-    specid_t wi = static_cast<specid_t>((m_id_to_wi)[x]);
+  bool operator()(specnum_t x) {
+    specnum_t wi = static_cast<specnum_t>((m_id_to_wi)[x]);
     return (wi + 1 < m_min || wi + 1 > m_max);
   }
 
 private:
-  specid_t m_min;
-  specid_t m_max;
+  specnum_t m_min;
+  specnum_t m_max;
   detid2index_map m_id_to_wi;
 };
 }
@@ -428,7 +428,7 @@ void LoadTOFRawNexus::loadBank(const std::string &nexusfilename,
 
     // Set the basic info of that spectrum
     ISpectrum *spec = WS->getSpectrum(wi);
-    spec->setSpectrumNo(specid_t(wi + 1));
+    spec->setSpectrumNo(specnum_t(wi + 1));
     spec->setDetectorID(pixel_id[i - iPart]);
     // Set the shared X pointer
     spec->setX(X);

--- a/Framework/DataHandling/src/MaskDetectors.cpp
+++ b/Framework/DataHandling/src/MaskDetectors.cpp
@@ -37,7 +37,7 @@ void MaskDetectors::init() {
       new WorkspaceProperty<Workspace>("Workspace", "", Direction::InOut),
       "The name of the input and output workspace on which to perform the "
       "algorithm.");
-  declareProperty(new ArrayProperty<specid_t>("SpectraList"),
+  declareProperty(new ArrayProperty<specnum_t>("SpectraList"),
                   "An ArrayProperty containing a list of spectra to mask");
   declareProperty(
       new ArrayProperty<detid_t>("DetectorList"),
@@ -85,7 +85,7 @@ void MaskDetectors::exec() {
   MaskWorkspace_sptr isMaskWS = boost::dynamic_pointer_cast<MaskWorkspace>(WS);
 
   std::vector<size_t> indexList = getProperty("WorkspaceIndexList");
-  std::vector<specid_t> spectraList = getProperty("SpectraList");
+  std::vector<specnum_t> spectraList = getProperty("SpectraList");
   const std::vector<detid_t> detectorList = getProperty("DetectorList");
   const MatrixWorkspace_sptr prevMasking = getProperty("MaskedWorkspace");
 
@@ -284,7 +284,7 @@ void MaskDetectors::execPeaks(PeaksWorkspace_sptr WS) {
  * @param WS :: The input workspace to be masked
  */
 void MaskDetectors::fillIndexListFromSpectra(
-    std::vector<size_t> &indexList, const std::vector<specid_t> &spectraList,
+    std::vector<size_t> &indexList, const std::vector<specnum_t> &spectraList,
     const API::MatrixWorkspace_sptr WS) {
   // Convert the vector of properties into a set for easy searching
   std::set<int64_t> spectraSet(spectraList.begin(), spectraList.end());
@@ -293,7 +293,7 @@ void MaskDetectors::fillIndexListFromSpectra(
   indexList.reserve(WS->getNumberHistograms());
 
   for (int i = 0; i < static_cast<int>(WS->getNumberHistograms()); ++i) {
-    const specid_t currentSpec = WS->getSpectrum(i)->getSpectrumNo();
+    const specnum_t currentSpec = WS->getSpectrum(i)->getSpectrumNo();
     if (spectraSet.find(currentSpec) != spectraSet.end()) {
       indexList.push_back(i);
     }

--- a/Framework/DataHandling/src/SaveRKH.cpp
+++ b/Framework/DataHandling/src/SaveRKH.cpp
@@ -153,11 +153,11 @@ void SaveRKH::write1D() {
     const auto &ydata = m_workspace->readY(i);
     const auto &edata = m_workspace->readE(i);
 
-    specid_t specid(0);
+    specnum_t specid(0);
     try {
       specid = m_workspace->getSpectrum(i)->getSpectrumNo();
     } catch (...) {
-      specid = static_cast<specid_t>(i + 1);
+      specid = static_cast<specnum_t>(i + 1);
     }
 
     auto hasDx = m_workspace->hasDx(i);

--- a/Framework/DataHandling/test/GroupDetectorsTest.h
+++ b/Framework/DataHandling/test/GroupDetectorsTest.h
@@ -21,7 +21,7 @@ using namespace Mantid::API;
 using namespace Mantid::Geometry;
 using namespace Mantid::DataObjects;
 using Mantid::detid_t;
-using Mantid::specid_t;
+using Mantid::specnum_t;
 
 class GroupDetectorsTest : public CxxTest::TestSuite {
 public:
@@ -75,7 +75,7 @@ public:
 
     TS_ASSERT_EQUALS(props[1]->name(), "SpectraList")
     TS_ASSERT(props[1]->isDefault())
-    TS_ASSERT(dynamic_cast<ArrayProperty<specid_t> *>(props[1]))
+    TS_ASSERT(dynamic_cast<ArrayProperty<specnum_t> *>(props[1]))
 
     TS_ASSERT_EQUALS(props[2]->name(), "DetectorList")
     TS_ASSERT(props[2]->isDefault())

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -717,7 +717,7 @@ public:
     }
     // Make sure that the spectraNo are equal for all child workspaces.
     auto isFirstChildWorkspace = true;
-    std::vector<Mantid::specid_t> specids;
+    std::vector<Mantid::specnum_t> specids;
 
     for (size_t i = 0; i < outGroup->size(); ++i) {
       EventWorkspace_sptr ws =

--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -331,7 +331,6 @@ public:
     TS_ASSERT_EQUALS(*(ws->getSpectrum(1)->getDetectorIDs().begin()), 10);
     TS_ASSERT(ws->getSpectrum(1)->hasDetectorID(10));
 
-
     Mantid::specnum_t offset;
     auto spectNum2WSInd = ws->getSpectrumToWorkspaceIndexVector(offset);
 
@@ -382,7 +381,6 @@ public:
     TS_ASSERT_EQUALS(ws->getSpectrum(17 - 9)->getSpectrumNo(), 18);
     TS_ASSERT_EQUALS(ws->readY(18 - 9)[1], 1.);
     TS_ASSERT_EQUALS(ws->getSpectrum(18 - 9)->getSpectrumNo(), 19);
-
 
     Mantid::specnum_t offset;
     auto spectNum2WSInd = ws->getSpectrumToWorkspaceIndexVector(offset);

--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -332,7 +332,7 @@ public:
     TS_ASSERT(ws->getSpectrum(1)->hasDetectorID(10));
 
     std::vector<size_t> spectNum2WSInd;
-    Mantid::specid_t offset;
+    Mantid::specnum_t offset;
     ws->getSpectrumToWorkspaceIndexVector(spectNum2WSInd, offset);
     TS_ASSERT_EQUALS(38 + offset + 1, spectNum2WSInd.size());
     size_t sample[] = {5,  10, 11, 12, 13, 14, 15, 16,
@@ -383,7 +383,7 @@ public:
     TS_ASSERT_EQUALS(ws->getSpectrum(18 - 9)->getSpectrumNo(), 19);
 
     std::vector<size_t> spectNum2WSInd;
-    Mantid::specid_t offset;
+    Mantid::specnum_t offset;
     ws->getSpectrumToWorkspaceIndexVector(spectNum2WSInd, offset);
     TS_ASSERT_EQUALS(20 + offset + 1, spectNum2WSInd.size());
     size_t sample[] = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};

--- a/Framework/DataHandling/test/LoadMaskTest.h
+++ b/Framework/DataHandling/test/LoadMaskTest.h
@@ -113,11 +113,11 @@ public:
    */
   void test_ISISFormat() {
     // 1. Generate masking files
-    std::vector<specid_t> singlespectra;
+    std::vector<specnum_t> singlespectra;
     singlespectra.push_back(35);
     singlespectra.push_back(1001);
     singlespectra.push_back(2001);
-    std::vector<specid_t> pairspectra;
+    std::vector<specnum_t> pairspectra;
     pairspectra.push_back(1002);
     pairspectra.push_back(1005);
     pairspectra.push_back(37);
@@ -327,8 +327,8 @@ public:
    */
   ScopedFileHelper::ScopedFile
   genISISMaskingFile(std::string maskfilename,
-                     std::vector<specid_t> singlespectra,
-                     std::vector<specid_t> pairspectra) {
+                     std::vector<specnum_t> singlespectra,
+                     std::vector<specnum_t> pairspectra) {
     std::stringstream ss;
 
     // 1. Single spectra

--- a/Framework/DataHandling/test/MaskDetectorsTest.h
+++ b/Framework/DataHandling/test/MaskDetectorsTest.h
@@ -22,7 +22,7 @@ using namespace Mantid::DataObjects;
 using namespace Mantid::Geometry;
 using Mantid::MantidVecPtr;
 using Mantid::detid_t;
-using Mantid::specid_t;
+using Mantid::specnum_t;
 
 class MaskDetectorsTest : public CxxTest::TestSuite {
 public:
@@ -118,7 +118,7 @@ public:
 
     TS_ASSERT_EQUALS(props[1]->name(), "SpectraList");
     TS_ASSERT(props[1]->isDefault());
-    TS_ASSERT(dynamic_cast<ArrayProperty<specid_t> *>(props[1]));
+    TS_ASSERT(dynamic_cast<ArrayProperty<specnum_t> *>(props[1]));
 
     TS_ASSERT_EQUALS(props[2]->name(), "DetectorList");
     TS_ASSERT(props[2]->isDefault());

--- a/Framework/DataHandling/test/SaveNXSPETest.h
+++ b/Framework/DataHandling/test/SaveNXSPETest.h
@@ -157,7 +157,7 @@ private:
     for (size_t j = 0; j < inputWS->getNumberHistograms(); ++j) {
       // Just set the spectrum number to match the index
       inputWS->getSpectrum(j)
-          ->setSpectrumNo(static_cast<Mantid::specid_t>(j + 1));
+          ->setSpectrumNo(static_cast<Mantid::specnum_t>(j + 1));
     }
 
     // mask the detector

--- a/Framework/DataHandling/test/UpdateInstrumentFromFileTest.h
+++ b/Framework/DataHandling/test/UpdateInstrumentFromFileTest.h
@@ -245,7 +245,7 @@ private:
 
     for (size_t i = 0; i < nhist; ++i) {
       ISpectrum *spec = ws->getSpectrum(0);
-      spec->setSpectrumNo(static_cast<Mantid::specid_t>(i + 1));
+      spec->setSpectrumNo(static_cast<Mantid::specnum_t>(i + 1));
       spec->clearDetectorIDs();
       spec->addDetectorID(static_cast<Mantid::detid_t>(i + 1));
     }

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -70,7 +70,7 @@ class DLLExport EventList : public Mantid::API::IEventList {
 public:
   EventList();
 
-  EventList(EventWorkspaceMRU *mru, specid_t specNo);
+  EventList(EventWorkspaceMRU *mru, specnum_t specNo);
 
   EventList(const EventList &rhs);
 

--- a/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -79,7 +79,7 @@ public:
   /** sets the monitorWorkspace indexlist
     @param mList :: a vector holding the monitor workspace indexes
   */
-  void setMonitorList(std::vector<specid_t> &mList) { m_monitorList = mList; }
+  void setMonitorList(std::vector<specnum_t> &mList) { m_monitorList = mList; }
 
   /// Copy the data (Y's) from an image to this workspace.
   void setImageY(const API::MantidImage &image, size_t start = 0,
@@ -107,7 +107,7 @@ protected:
   std::size_t m_noVectors;
 
   /// a vector holding workspace index of monitors in the workspace
-  std::vector<specid_t> m_monitorList;
+  std::vector<specnum_t> m_monitorList;
 
   /// A vector that holds the 1D histograms
   std::vector<Mantid::API::ISpectrum *> data;

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -129,7 +129,7 @@ EventList::EventList()
  * @param mru :: pointer to the MRU of the parent EventWorkspace
  * @param specNo :: the spectrum number for the event list
  */
-EventList::EventList(EventWorkspaceMRU *mru, specid_t specNo)
+EventList::EventList(EventWorkspaceMRU *mru, specnum_t specNo)
     : IEventList(specNo), eventType(TOF), order(UNSORTED), mru(mru),
       m_lockedMRU(false) {}
 

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -86,7 +86,7 @@ void EventWorkspace::init(const std::size_t &NVectors,
   data.resize(m_noVectors, nullptr);
   // Make sure SOMETHING exists for all initialized spots.
   for (size_t i = 0; i < m_noVectors; i++)
-    data[i] = new EventList(mru, specid_t(i));
+    data[i] = new EventList(mru, specnum_t(i));
 
   // Set each X vector to have one bin of 0 & extremely close to zero
   MantidVecPtr xVals;
@@ -522,7 +522,7 @@ EventWorkspace::getOrAddEventList(const std::size_t workspace_index) {
     // Increase the size of the eventlist lists.
     for (size_t wi = old_size; wi <= workspace_index; wi++) {
       // Need to make a new one!
-      auto newel = new EventList(mru, specid_t(wi));
+      auto newel = new EventList(mru, specnum_t(wi));
       // Add to list
       this->data.push_back(newel);
     }
@@ -549,7 +549,7 @@ void EventWorkspace::resizeTo(const std::size_t numSpectra) {
   data.resize(numSpectra);
   m_noVectors = numSpectra;
   for (size_t i = 0; i < numSpectra; ++i) {
-    data[i] = new EventList(mru, static_cast<specid_t>(i + 1));
+    data[i] = new EventList(mru, static_cast<specnum_t>(i + 1));
   }
 
   // Put on a default set of X vectors, with one bin of 0 & extremely close to

--- a/Framework/DataObjects/src/ReflectometryTransform.cpp
+++ b/Framework/DataObjects/src/ReflectometryTransform.cpp
@@ -462,7 +462,7 @@ MatrixWorkspace_sptr ReflectometryTransform::executeNormPoly(
   const size_t nBins = inputWS->blocksize();
 
   // Holds the spectrum-detector mapping
-  std::vector<specid_t> specNumberMapping;
+  std::vector<specnum_t> specNumberMapping;
   std::vector<detid_t> detIDMapping;
   // Create a table for the output if we want to debug vertex positioning
   addColumnHeadings(vertexes, outputDimensions);

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -85,7 +85,7 @@ void Workspace2D::init(const std::size_t &NVectors, const std::size_t &XLength,
     // Y,E arrays populated
     spec->setData(t2, t2);
     // Default spectrum number = starts at 1, for workspace index 0.
-    spec->setSpectrumNo(specid_t(i + 1));
+    spec->setSpectrumNo(specnum_t(i + 1));
     spec->setDetectorID(detid_t(i + 1));
   }
 

--- a/Framework/Geometry/inc/MantidGeometry/IDTypes.h
+++ b/Framework/Geometry/inc/MantidGeometry/IDTypes.h
@@ -7,8 +7,8 @@
 
 namespace Mantid {
 
-/// Typedef for a spectrum ID
-typedef int32_t specid_t;
+/// Typedef for a spectrum Number
+typedef int32_t specnum_t;
 
 /// Typedef for a detector ID
 typedef int32_t detid_t;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/INearestNeighbours.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/INearestNeighbours.h
@@ -21,7 +21,7 @@ namespace Geometry {
 class Instrument;
 class IComponent;
 
-typedef std::unordered_map<specid_t, std::set<detid_t>>
+typedef std::unordered_map<specnum_t, std::set<detid_t>>
     ISpectrumDetectorMapping;
 
 /**
@@ -56,12 +56,12 @@ public:
   virtual ~INearestNeighbours(){};
 
   // Neighbouring spectra by radius
-  virtual std::map<specid_t, Mantid::Kernel::V3D>
-  neighboursInRadius(specid_t spectrum, double radius = 0.0) const = 0;
+  virtual std::map<specnum_t, Mantid::Kernel::V3D>
+  neighboursInRadius(specnum_t spectrum, double radius = 0.0) const = 0;
 
   // Neighbouring spectra by exact number of neighbours
-  virtual std::map<specid_t, Mantid::Kernel::V3D>
-  neighbours(specid_t spectrum) const = 0;
+  virtual std::map<specnum_t, Mantid::Kernel::V3D>
+  neighbours(specnum_t spectrum) const = 0;
 };
 }
 }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/NearestNeighbours.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/NearestNeighbours.h
@@ -67,16 +67,16 @@ public:
   ~NearestNeighbours() override{};
 
   // Neighbouring spectra by radius
-  std::map<specid_t, Mantid::Kernel::V3D>
-  neighboursInRadius(specid_t spectrum, double radius = 0.0) const override;
+  std::map<specnum_t, Mantid::Kernel::V3D>
+  neighboursInRadius(specnum_t spectrum, double radius = 0.0) const override;
 
   // Neighbouring spectra by
-  std::map<specid_t, Mantid::Kernel::V3D>
-  neighbours(specid_t spectrum) const override;
+  std::map<specnum_t, Mantid::Kernel::V3D>
+  neighbours(specnum_t spectrum) const override;
 
 protected:
   /// Get the spectra associated with all in the instrument
-  std::map<specid_t, IDetector_const_sptr>
+  std::map<specnum_t, IDetector_const_sptr>
   getSpectraDetectors(boost::shared_ptr<const Instrument> instrument,
                       const ISpectrumDetectorMapping &spectraMap);
 
@@ -94,15 +94,15 @@ private:
   /// Vertex descriptor object for Graph
   typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
   /// map object of int to Graph Vertex descriptor
-  typedef std::unordered_map<specid_t, Vertex> MapIV;
+  typedef std::unordered_map<specnum_t, Vertex> MapIV;
 
   /// Construct the graph based on the given number of neighbours and the
   /// current instument and spectra-detector mapping
   void build(const int noNeighbours);
   /// Query the graph for the default number of nearest neighbours to specified
   /// detector
-  std::map<specid_t, Mantid::Kernel::V3D>
-  defaultNeighbours(const specid_t spectrum) const;
+  std::map<specnum_t, Mantid::Kernel::V3D>
+  defaultNeighbours(const specnum_t spectrum) const;
   /// The current number of nearest neighbours
   int m_noNeighbours;
   /// The largest value of the distance to a nearest neighbour

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -4,7 +4,7 @@
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/IDetector.h"
-#include "MantidGeometry/IDTypes.h" //For specid_t
+#include "MantidGeometry/IDTypes.h" //For specnum_t
 #include "MantidGeometry/Instrument/Parameter.h"
 #include "MantidGeometry/Instrument/ParameterFactory.h"
 #include "MantidGeometry/Objects/BoundingBox.h"

--- a/Framework/Geometry/src/Instrument/NearestNeighbours.cpp
+++ b/Framework/Geometry/src/Instrument/NearestNeighbours.cpp
@@ -53,8 +53,8 @@ NearestNeighbours::NearestNeighbours(
  * @param spectrum :: Spectrum ID of the central pixel
  * @return map of Detector ID's to distance
  */
-std::map<specid_t, V3D>
-NearestNeighbours::neighbours(const specid_t spectrum) const {
+std::map<specnum_t, V3D>
+NearestNeighbours::neighbours(const specnum_t spectrum) const {
   return defaultNeighbours(spectrum);
 }
 
@@ -66,8 +66,8 @@ NearestNeighbours::neighbours(const specid_t spectrum) const {
  * @return map of Detector ID's to distance
  * @throw NotFoundError if component is not recognised as a detector
  */
-std::map<specid_t, V3D>
-NearestNeighbours::neighboursInRadius(const specid_t spectrum,
+std::map<specnum_t, V3D>
+NearestNeighbours::neighboursInRadius(const specnum_t spectrum,
                                       const double radius) const {
   // If the radius is stupid then don't let it continue as well be stuck forever
   if (radius < 0.0 || radius > 10.0) {
@@ -75,7 +75,7 @@ NearestNeighbours::neighboursInRadius(const specid_t spectrum,
         "NearestNeighbours::neighbours - Invalid radius parameter.");
   }
 
-  std::map<specid_t, V3D> result;
+  std::map<specnum_t, V3D> result;
   if (radius == 0.0) {
     const int eightNearest = 8;
     if (m_noNeighbours != eightNearest) {
@@ -104,7 +104,7 @@ NearestNeighbours::neighboursInRadius(const specid_t spectrum,
   m_radius = radius;
 
   std::map<detid_t, V3D> nearest = defaultNeighbours(spectrum);
-  for (std::map<specid_t, V3D>::const_iterator cit = nearest.begin();
+  for (std::map<specnum_t, V3D>::const_iterator cit = nearest.begin();
        cit != nearest.end(); ++cit) {
     if (cit->second.norm() <= radius) {
       result[cit->first] = cit->second;
@@ -122,7 +122,7 @@ NearestNeighbours::neighboursInRadius(const specid_t spectrum,
  * the graph
  */
 void NearestNeighbours::build(const int noNeighbours) {
-  std::map<specid_t, IDetector_const_sptr> spectraDets =
+  std::map<specnum_t, IDetector_const_sptr> spectraDets =
       getSpectraDetectors(m_instrument, m_spectraMap);
   if (spectraDets.empty()) {
     throw std::runtime_error(
@@ -149,11 +149,11 @@ void NearestNeighbours::build(const int noNeighbours) {
   ANNpointArray dataPoints = annAllocPts(nspectra, 3);
   MapIV pointNoToVertex;
 
-  std::map<specid_t, IDetector_const_sptr>::const_iterator detIt;
+  std::map<specnum_t, IDetector_const_sptr>::const_iterator detIt;
   int pointNo = 0;
   for (detIt = spectraDets.begin(); detIt != spectraDets.end(); ++detIt) {
     IDetector_const_sptr detector = detIt->second;
-    const specid_t spectrum = detIt->first;
+    const specnum_t spectrum = detIt->first;
     V3D pos = detector->getPos() / (*m_scale);
     dataPoints[pointNo][0] = pos.X();
     dataPoints[pointNo][1] = pos.Y();
@@ -215,18 +215,18 @@ void NearestNeighbours::build(const int noNeighbours) {
  * @return map of detID to distance
  * @throw NotFoundError if detector ID is not recognised
  */
-std::map<specid_t, V3D>
-NearestNeighbours::defaultNeighbours(const specid_t spectrum) const {
+std::map<specnum_t, V3D>
+NearestNeighbours::defaultNeighbours(const specnum_t spectrum) const {
   auto vertex = m_specToVertex.find(spectrum);
 
   if (vertex != m_specToVertex.end()) {
-    std::map<specid_t, V3D> result;
+    std::map<specnum_t, V3D> result;
     std::pair<Graph::adjacency_iterator, Graph::adjacency_iterator> adjacent =
         boost::adjacent_vertices(vertex->second, m_graph);
     Graph::adjacency_iterator adjIt;
     for (adjIt = adjacent.first; adjIt != adjacent.second; adjIt++) {
       Vertex nearest = (*adjIt);
-      specid_t nrSpec = specid_t(m_vertexID[nearest]);
+      specnum_t nrSpec = specnum_t(m_vertexID[nearest]);
       std::pair<Graph::edge_descriptor, bool> nrEd =
           boost::edge(vertex->second, nearest, m_graph);
       result[nrSpec] = m_edgeLength[nrEd.first];
@@ -244,10 +244,10 @@ NearestNeighbours::defaultNeighbours(const specid_t spectrum) const {
  * @param spectraMap :: A reference to the spectra map
  * @returns A map of spectra number to detector pointer
  */
-std::map<specid_t, IDetector_const_sptr> NearestNeighbours::getSpectraDetectors(
+std::map<specnum_t, IDetector_const_sptr> NearestNeighbours::getSpectraDetectors(
     boost::shared_ptr<const Instrument> instrument,
     const ISpectrumDetectorMapping &spectraMap) {
-  std::map<specid_t, IDetector_const_sptr> spectra;
+  std::map<specnum_t, IDetector_const_sptr> spectra;
   if (spectraMap.empty())
     return spectra;
   auto cend = spectraMap.cend();

--- a/Framework/Geometry/src/Instrument/NearestNeighbours.cpp
+++ b/Framework/Geometry/src/Instrument/NearestNeighbours.cpp
@@ -244,7 +244,8 @@ NearestNeighbours::defaultNeighbours(const specnum_t spectrum) const {
  * @param spectraMap :: A reference to the spectra map
  * @returns A map of spectra number to detector pointer
  */
-std::map<specnum_t, IDetector_const_sptr> NearestNeighbours::getSpectraDetectors(
+std::map<specnum_t, IDetector_const_sptr>
+NearestNeighbours::getSpectraDetectors(
     boost::shared_ptr<const Instrument> instrument,
     const ISpectrumDetectorMapping &spectraMap) {
   std::map<specnum_t, IDetector_const_sptr> spectra;

--- a/Framework/Geometry/test/NearestNeighboursTest.h
+++ b/Framework/Geometry/test/NearestNeighboursTest.h
@@ -26,9 +26,9 @@ using Mantid::Kernel::V3D;
 class NearestNeighboursTest : public CxxTest::TestSuite {
 public:
   static ISpectrumDetectorMapping
-  buildSpectrumDetectorMapping(const specid_t start, const specid_t end) {
-    std::unordered_map<specid_t, std::set<detid_t>> map;
-    for (specid_t i = start; i <= end; ++i) {
+  buildSpectrumDetectorMapping(const specnum_t start, const specnum_t end) {
+    std::unordered_map<specnum_t, std::set<detid_t>> map;
+    for (specnum_t i = start; i <= end; ++i) {
       map[i].insert(i);
     }
     return map;
@@ -45,7 +45,7 @@ private:
         : NearestNeighbours(instrument, spectraMap, ignoreMasked) {}
 
     // Direct access to intermdiate spectra detectors
-    std::map<specid_t, IDetector_const_sptr> getSpectraDetectors() {
+    std::map<specnum_t, IDetector_const_sptr> getSpectraDetectors() {
       return NearestNeighbours::getSpectraDetectors(m_instrument, m_spectraMap);
     }
   };
@@ -69,7 +69,7 @@ public:
 
     // Check distances calculated in NearestNeighbours compare with those using
     // getDistance on component
-    std::map<specid_t, V3D> distances = nn.neighbours(14);
+    std::map<specnum_t, V3D> distances = nn.neighbours(14);
 
     // We should have 8 neighbours when not specifying a range.
     TS_ASSERT_EQUALS(expectedNeighboursNumber, distances.size());
@@ -108,8 +108,8 @@ public:
 
     // Check distances calculated in NearestNeighbours compare with those using
     // getDistance on component
-    std::map<specid_t, V3D> distances = nn.neighbours(5);
-    std::map<specid_t, V3D>::iterator distIt;
+    std::map<specnum_t, V3D> distances = nn.neighbours(5);
+    std::map<specnum_t, V3D>::iterator distIt;
 
     // We should have 8 neighbours when not specifying a range.
     TS_ASSERT_EQUALS(distances.size(), 8);
@@ -163,10 +163,10 @@ public:
             m_instrument->getComponentByName("bank1"));
     boost::shared_ptr<const Detector> det = bank1->getAtXY(2, 3);
     TS_ASSERT(det);
-    std::map<specid_t, V3D> nb;
+    std::map<specnum_t, V3D> nb;
 
     // Too close!
-    specid_t spec =
+    specnum_t spec =
         256 + 2 * 16 + 3; // This gives the spectrum number for this detector
     nb = nn.neighboursInRadius(spec, 0.003);
     TS_ASSERT_EQUALS(nb.size(), 0);
@@ -186,7 +186,7 @@ public:
     ParameterMap_sptr pmap(new ParameterMap());
 
     // Mask the first 5 detectors
-    for (Mantid::specid_t i = 1; i < 3; i++) {
+    for (Mantid::specnum_t i = 1; i < 3; i++) {
       if (const Geometry::ComponentID det =
               instrument->getDetector(*spectramap.at(i).begin())
                   ->getComponentID()) {

--- a/Framework/LiveData/inc/MantidLiveData/ISISHistoDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISISHistoDataListener.h
@@ -64,8 +64,8 @@ public:
   int runNumber() const override;
 
 private:
-  void setSpectra(const std::vector<specid_t> &specList) override;
-  void setPeriods(const std::vector<specid_t> &periodList);
+  void setSpectra(const std::vector<specnum_t> &specList) override;
+  void setPeriods(const std::vector<specnum_t> &periodList);
   int getInt(const std::string &par) const;
   std::string getString(const std::string &par) const;
   void getFloatArray(const std::string &par, std::vector<float> &arr,
@@ -107,10 +107,10 @@ private:
   std::vector<int> m_numberOfBins;
 
   /// list of spectra to read or empty to read all
-  std::vector<specid_t> m_specList;
+  std::vector<specnum_t> m_specList;
 
   /// list of periods to read or empty to read all
-  std::vector<specid_t> m_periodList;
+  std::vector<specnum_t> m_periodList;
 
   /// Store the bin boundaries for each time regime
   std::vector<boost::shared_ptr<MantidVec>> m_bins;

--- a/Framework/LiveData/inc/MantidLiveData/ISISLiveEventDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISISLiveEventDataListener.h
@@ -134,7 +134,7 @@ public:
    * spectra.
    * @param specList :: A vector with spectra indices.
    */
-  void setSpectra(const std::vector<specid_t> &specList) override {
+  void setSpectra(const std::vector<specnum_t> &specList) override {
     (void)specList;
   }
 

--- a/Framework/LiveData/src/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISISHistoDataListener.cpp
@@ -48,7 +48,7 @@ Kernel::Logger g_log("ISISHistoDataListener");
 ISISHistoDataListener::ISISHistoDataListener()
     : ILiveListener(), isInitilized(false), m_daeHandle(nullptr),
       m_numberOfPeriods(0), m_totalNumberOfSpectra(0), m_timeRegime(-1) {
-  declareProperty(new Kernel::ArrayProperty<specid_t>("SpectraList"),
+  declareProperty(new Kernel::ArrayProperty<specnum_t>("SpectraList"),
                   "An optional list of spectra to load. If blank, all "
                   "available spectra will be loaded.");
 
@@ -104,7 +104,7 @@ bool ISISHistoDataListener::connect(const Poco::Net::SocketAddress &address) {
   g_log.information() << "Number of periods " << m_numberOfPeriods << std::endl;
 
   // Set the spectra list to load
-  std::vector<specid_t> spectra = getProperty("SpectraList");
+  std::vector<specnum_t> spectra = getProperty("SpectraList");
   if (!spectra.empty()) {
     setSpectra(spectra);
   }
@@ -286,7 +286,7 @@ std::string ISISHistoDataListener::getString(const std::string &par) const {
  * spectra.
   * @param specList :: A vector with spectra indices.
   */
-void ISISHistoDataListener::setSpectra(const std::vector<specid_t> &specList) {
+void ISISHistoDataListener::setSpectra(const std::vector<specnum_t> &specList) {
   // after listener has created its first workspace the spectra numbers cannot
   // be changed
   if (!isInitilized) {
@@ -299,7 +299,7 @@ void ISISHistoDataListener::setSpectra(const std::vector<specid_t> &specList) {
   * @param periodList :: A vector with period numbers.
   */
 void ISISHistoDataListener::setPeriods(
-    const std::vector<specid_t> &periodList) {
+    const std::vector<specnum_t> &periodList) {
   // after listener has created its first workspace the period numbers cannot be
   // changed
   if (!isInitilized) {
@@ -384,9 +384,9 @@ void ISISHistoDataListener::calculateIndicesForReading(
   } else {
     // combine consecutive spectra but don't exceed the maxNumberOfSpectra
     size_t i0 = 0;
-    specid_t spec = m_specList[i0];
+    specnum_t spec = m_specList[i0];
     for (size_t i = 1; i < m_specList.size(); ++i) {
-      specid_t next = m_specList[i];
+      specnum_t next = m_specList[i];
       if (next - m_specList[i - 1] > 1 ||
           static_cast<int>(i - i0) >= maxNumberOfSpectra) {
         int n = static_cast<int>(i - i0);
@@ -434,7 +434,7 @@ void ISISHistoDataListener::getData(int period, int index, int count,
     workspace->setX(wi, m_bins[m_timeRegime]);
     MantidVec &y = workspace->dataY(wi);
     MantidVec &e = workspace->dataE(wi);
-    workspace->getSpectrum(wi)->setSpectrumNo(index + static_cast<specid_t>(i));
+    workspace->getSpectrum(wi)->setSpectrumNo(index + static_cast<specnum_t>(i));
     size_t shift = i * (numberOfBins + 1) + 1;
     y.assign(dataBuffer.begin() + shift, dataBuffer.begin() + shift + y.size());
     std::transform(y.begin(), y.end(), e.begin(), dblSqrt);

--- a/Framework/LiveData/src/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISISHistoDataListener.cpp
@@ -434,7 +434,8 @@ void ISISHistoDataListener::getData(int period, int index, int count,
     workspace->setX(wi, m_bins[m_timeRegime]);
     MantidVec &y = workspace->dataY(wi);
     MantidVec &e = workspace->dataE(wi);
-    workspace->getSpectrum(wi)->setSpectrumNo(index + static_cast<specnum_t>(i));
+    workspace->getSpectrum(wi)
+        ->setSpectrumNo(index + static_cast<specnum_t>(i));
     size_t shift = i * (numberOfBins + 1) + 1;
     y.assign(dataBuffer.begin() + shift, dataBuffer.begin() + shift + y.size());
     std::transform(y.begin(), y.end(), e.begin(), dblSqrt);

--- a/Framework/LiveData/src/StartLiveData.cpp
+++ b/Framework/LiveData/src/StartLiveData.cpp
@@ -68,7 +68,7 @@ void StartLiveData::init() {
       "one chunk.");
 
   // Properties used with ISISHistoDataListener
-  declareProperty(new ArrayProperty<specid_t>("SpectraList"),
+  declareProperty(new ArrayProperty<specnum_t>("SpectraList"),
                   "An optional list of spectra to load. If blank, all "
                   "available spectra will be loaded. Applied to ISIS histogram"
                   " data only.");

--- a/Framework/LiveData/test/ISISHistoDataListenerTest.h
+++ b/Framework/LiveData/test/ISISHistoDataListenerTest.h
@@ -46,9 +46,9 @@ public:
 
     Kernel::PropertyManager props;
     props.declareProperty(
-        new Kernel::ArrayProperty<specid_t>("SpectraList", ""));
+        new Kernel::ArrayProperty<specnum_t>("SpectraList", ""));
     int s[] = {1, 2, 3, 10, 11, 95, 96, 97, 98, 99, 100};
-    std::vector<specid_t> specs;
+    std::vector<specnum_t> specs;
     specs.assign(s, s + 11);
     props.setProperty("SpectraList", specs);
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -18,7 +18,7 @@
 
 using namespace Mantid::API;
 using Mantid::Kernel::Unit_sptr;
-using Mantid::specid_t;
+using Mantid::specnum_t;
 using namespace boost::python;
 
 namespace {

--- a/Framework/SINQ/inc/MantidSINQ/SINQHMListener.h
+++ b/Framework/SINQ/inc/MantidSINQ/SINQHMListener.h
@@ -56,7 +56,7 @@ public:
   ILiveListener::RunStatus runStatus() override;
   int runNumber() const override { return 0; }
 
-  void setSpectra(const std::vector<Mantid::specid_t> &specList) override;
+  void setSpectra(const std::vector<Mantid::specnum_t> &specList) override;
 
 private:
   Poco::Net::HTTPClientSession httpcon;

--- a/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -168,7 +168,7 @@ void LoadFlexiNexus::load2DWorkspace(NeXus::File *fin) {
     ws->setX(wsIndex, xData);
     // Xtof		ws->getAxis(1)->spectraNo(i)= i;
     ws->getSpectrum(wsIndex)
-        ->setSpectrumNo(static_cast<specid_t>(yData[wsIndex]));
+        ->setSpectrumNo(static_cast<specnum_t>(yData[wsIndex]));
     ws->getSpectrum(wsIndex)
         ->setDetectorID(static_cast<detid_t>(yData[wsIndex]));
   }

--- a/Framework/SINQ/src/MDHistoToWorkspace2D.cpp
+++ b/Framework/SINQ/src/MDHistoToWorkspace2D.cpp
@@ -98,7 +98,7 @@ void MDHistoToWorkspace2D::recurseData(IMDHistoWorkspace_sptr inWS,
     }
     outWS->setX(m_currentSpectra, xData);
     outWS->getSpectrum(m_currentSpectra)
-        ->setSpectrumNo(static_cast<specid_t>(m_currentSpectra));
+        ->setSpectrumNo(static_cast<specnum_t>(m_currentSpectra));
     m_currentSpectra++;
   } else {
     // recurse deeper

--- a/Framework/SINQ/src/SINQHMListener.cpp
+++ b/Framework/SINQ/src/SINQHMListener.cpp
@@ -115,7 +115,7 @@ boost::shared_ptr<Workspace> SINQHMListener::extractData() {
 }
 
 void SINQHMListener::setSpectra(
-    const std::vector<Mantid::specid_t> & /*specList*/) {
+    const std::vector<Mantid::specnum_t> & /*specList*/) {
   /**
    * Nothing to do: we always go for the full data.
    * SINQHM would do subsampling but this cannot easily

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeGmockObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeGmockObjects.h
@@ -32,12 +32,12 @@ public:
 };
 
 // Helper typedef and type for mocking NearestNeighbour map usage.
-typedef std::map<Mantid::specid_t, Mantid::Kernel::V3D> SpectrumDistanceMap;
+typedef std::map<Mantid::specnum_t, Mantid::Kernel::V3D> SpectrumDistanceMap;
 class MockNearestNeighbours : public Mantid::Geometry::INearestNeighbours {
 public:
   MOCK_CONST_METHOD2(neighboursInRadius,
-                     SpectrumDistanceMap(specid_t spectrum, double radius));
-  MOCK_CONST_METHOD1(neighbours, SpectrumDistanceMap(specid_t spectrum));
+                     SpectrumDistanceMap(specnum_t spectrum, double radius));
+  MOCK_CONST_METHOD1(neighbours, SpectrumDistanceMap(specnum_t spectrum));
   MOCK_METHOD0(die, void());
   virtual ~MockNearestNeighbours() { die(); }
 };

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -41,7 +41,7 @@ using namespace Mantid;
 class SpectrumTester : public ISpectrum {
 public:
   SpectrumTester() : ISpectrum() {}
-  SpectrumTester(const specid_t specNo) : ISpectrum(specNo) {}
+  SpectrumTester(const specnum_t specNo) : ISpectrum(specNo) {}
 
   virtual void setData(const MantidVec &Y) { data = Y; }
   virtual void setData(const MantidVec &Y, const MantidVec &E) {
@@ -109,7 +109,7 @@ public:
       vec[i].dataY().resize(k, 1.0);
       vec[i].dataE().resize(k, 1.0);
       vec[i].addDetectorID(detid_t(i));
-      vec[i].setSpectrumNo(specid_t(i + 1));
+      vec[i].setSpectrumNo(specnum_t(i + 1));
     }
 
     // Put an 'empty' axis in to test the getAxis method

--- a/Framework/TestHelpers/src/SANSInstrumentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/SANSInstrumentCreationHelper.cpp
@@ -20,7 +20,7 @@
  *****************************************************/
 
 using Mantid::detid_t;
-using Mantid::specid_t;
+using Mantid::specnum_t;
 using namespace Mantid::Geometry;
 using namespace Mantid::API;
 using Mantid::DataObjects::Workspace2D_sptr;
@@ -125,7 +125,7 @@ void SANSInstrumentCreationHelper::runLoadMappingTable(
   // Monitor: IDs start at 1 and increment by 1
   for (size_t i = 0; i < nMonitors; i++) {
     // std::cout << "SANS instrument monitor number " << i << std::endl;
-    workspace->getSpectrum(wi)->setSpectrumNo(specid_t(wi));
+    workspace->getSpectrum(wi)->setSpectrumNo(specnum_t(wi));
     workspace->getSpectrum(wi)->setDetectorID(detid_t(wi + 1));
     wi++;
   }
@@ -133,7 +133,7 @@ void SANSInstrumentCreationHelper::runLoadMappingTable(
   // Detector pixels
   for (size_t ix = 0; ix < nXbins; ix++) {
     for (size_t iy = 0; iy < nYbins; iy++) {
-      workspace->getSpectrum(wi)->setSpectrumNo(specid_t(wi));
+      workspace->getSpectrum(wi)->setSpectrumNo(specnum_t(wi));
       workspace->getSpectrum(wi)
           ->setDetectorID(detid_t(1000000 + iy * 1000 + ix));
       wi++;

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -373,7 +373,7 @@ create2DWorkspaceWithRectangularInstrument(int numBanks, int numPixels,
   ws->getAxis(0)->setUnit("dSpacing");
   for (size_t wi = 0; wi < ws->getNumberHistograms(); wi++) {
     ws->getSpectrum(wi)->setDetectorID(detid_t(numPixels * numPixels + wi));
-    ws->getSpectrum(wi)->setSpectrumNo(specid_t(wi));
+    ws->getSpectrum(wi)->setSpectrumNo(specnum_t(wi));
   }
 
   return ws;
@@ -1026,7 +1026,7 @@ createEventWorkspace3(Mantid::DataObjects::EventWorkspace_const_sptr sourceWS,
           outputWS->getOrAddEventList(workspaceIndex);
       spec.addDetectorID(it->first);
       // Start the spectrum number at 1
-      spec.setSpectrumNo(specid_t(workspaceIndex + 1));
+      spec.setSpectrumNo(specnum_t(workspaceIndex + 1));
       workspaceIndex += 1;
     }
   }

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
@@ -100,7 +100,7 @@ private:
   /// Call edit instrument geometry
   API::MatrixWorkspace_sptr editInstrument(API::MatrixWorkspace_sptr ws,
                                            std::vector<double> polars,
-                                           std::vector<specid_t> specids,
+                                           std::vector<specnum_t> specids,
                                            std::vector<double> l2s,
                                            std::vector<double> phis);
   void convertOffsetsToCal(DataObjects::OffsetsWorkspace_sptr &offsetsWS);

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -662,7 +662,7 @@ void AlignAndFocusPowder::exec() {
   */
 API::MatrixWorkspace_sptr AlignAndFocusPowder::editInstrument(
     API::MatrixWorkspace_sptr ws, std::vector<double> polars,
-    std::vector<specid_t> specids, std::vector<double> l2s,
+    std::vector<specnum_t> specids, std::vector<double> l2s,
     std::vector<double> phis) {
   g_log.information() << "running EditInstrumentGeometry\n";
 
@@ -782,10 +782,10 @@ AlignAndFocusPowder::conjoinWorkspaces(API::MatrixWorkspace_sptr ws1,
   // Get information from ws1: maximum spectrum number, and store original
   // spectrum IDs
   size_t nspec1 = ws1->getNumberHistograms();
-  specid_t maxspecid1 = 0;
-  std::vector<specid_t> origspecids;
+  specnum_t maxspecid1 = 0;
+  std::vector<specnum_t> origspecids;
   for (size_t i = 0; i < nspec1; ++i) {
-    specid_t tmpspecid = ws1->getSpectrum(i)->getSpectrumNo();
+    specnum_t tmpspecid = ws1->getSpectrum(i)->getSpectrumNo();
     origspecids.push_back(tmpspecid);
     if (tmpspecid > maxspecid1)
       maxspecid1 = tmpspecid;
@@ -812,7 +812,7 @@ AlignAndFocusPowder::conjoinWorkspaces(API::MatrixWorkspace_sptr ws1,
 
   // FIXED : Restore the original spectrum IDs to spectra from ws1
   for (size_t i = 0; i < nspec1; ++i) {
-    specid_t tmpspecid = outws->getSpectrum(i)->getSpectrumNo();
+    specnum_t tmpspecid = outws->getSpectrum(i)->getSpectrumNo();
     outws->getSpectrum(i)->setSpectrumNo(origspecids[i]);
 
     g_log.information() << "[DBx540] Conjoined spectrum " << i
@@ -824,7 +824,7 @@ AlignAndFocusPowder::conjoinWorkspaces(API::MatrixWorkspace_sptr ws1,
   // Rename spectrum number
   if (offset >= 1) {
     for (size_t i = 0; i < nspec2; ++i) {
-      specid_t newspecid = maxspecid1 + static_cast<specid_t>((i) + offset);
+      specnum_t newspecid = maxspecid1 + static_cast<specnum_t>((i) + offset);
       outws->getSpectrum(nspec1 + i)->setSpectrumNo(newspecid);
       // ISpectrum* spec = outws->getSpectrum(nspec1+i);
       // if (spec)

--- a/Framework/WorkflowAlgorithms/src/DgsConvertToEnergyTransfer.cpp
+++ b/Framework/WorkflowAlgorithms/src/DgsConvertToEnergyTransfer.cpp
@@ -154,10 +154,10 @@ void DgsConvertToEnergyTransfer::exec() {
 
   double incidentEnergy = 0.0;
   double monPeak = 0.0;
-  specid_t eiMon1Spec =
-      static_cast<specid_t>(reductionManager->getProperty("Monitor1SpecId"));
-  specid_t eiMon2Spec =
-      static_cast<specid_t>(reductionManager->getProperty("Monitor2SpecId"));
+  specnum_t eiMon1Spec =
+      static_cast<specnum_t>(reductionManager->getProperty("Monitor1SpecId"));
+  specnum_t eiMon2Spec =
+      static_cast<specnum_t>(reductionManager->getProperty("Monitor2SpecId"));
 
   if ("SNS" == facility) {
     // SNS wants to preserve events until the last
@@ -251,8 +251,8 @@ void DgsConvertToEnergyTransfer::exec() {
     getei->executeAsChildAlg();
 
     monPeak = getei->getProperty("FirstMonitorPeak");
-    const specid_t monIndex =
-        static_cast<const specid_t>(getei->getProperty("FirstMonitorIndex"));
+    const specnum_t monIndex =
+        static_cast<const specnum_t>(getei->getProperty("FirstMonitorIndex"));
     // Why did the old way get it from the log?
     incidentEnergy = getei->getProperty("IncidentEnergy");
 

--- a/Framework/WorkflowAlgorithms/src/DgsPreprocessData.cpp
+++ b/Framework/WorkflowAlgorithms/src/DgsPreprocessData.cpp
@@ -124,7 +124,7 @@ void DgsPreprocessData::exec() {
           "MonitorIntRangeHigh", reductionManager, "norm-mon1-max", inputWS);
       rangeMax += rangeOffset;
 
-      specid_t monSpec = static_cast<specid_t>(
+      specnum_t monSpec = static_cast<specnum_t>(
           inputWS->getInstrument()->getNumberParameter("norm-mon1-spec")[0]);
       if ("ISIS" == facility) {
         norm->setProperty("MonitorSpectrum", monSpec);

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -1236,7 +1236,7 @@ Table* MantidUI::createDetectorTable(const QString & wsName, const Mantid::API::
     try
     {
       ISpectrum *spectrum = ws->getSpectrum(wsIndex);
-      Mantid::specid_t specNo = spectrum->getSpectrumNo();
+      Mantid::specnum_t specNo = spectrum->getSpectrumNo();
       QString detIds("");
       const auto & ids  = spectrum->getDetectorIDs();
       size_t ndets = ids.size();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSDiagnostics.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSDiagnostics.h
@@ -154,13 +154,13 @@ private:
   void disableDetectorGroupBoxes(bool bStatus);
    
   /// minimum and maximum spectrum ids for detector 
-  void minandMaxSpectrumIds(const std::vector<Mantid::specid_t>& specList,QString& minSpec, QString& maxSpec);
+  void minandMaxSpectrumIds(const std::vector<Mantid::specnum_t>& specList,QString& minSpec, QString& maxSpec);
 
   /// get workspaceIndexes from spectrum list
-  void getWorkspaceIndexes(const Mantid::API::MatrixWorkspace_sptr& mws_sptr,const std::vector<Mantid::specid_t>& specList,
+  void getWorkspaceIndexes(const Mantid::API::MatrixWorkspace_sptr& mws_sptr,const std::vector<Mantid::specnum_t>& specList,
                                               QString& startWSIndex,QString& endWSIndex);
   ///get spectra list from workspace.
-  void getSpectraList(const Mantid::API::MatrixWorkspace_sptr& mws_sptr,const Mantid::detid_t detNum,std::vector<Mantid::specid_t>&specList);
+  void getSpectraList(const Mantid::API::MatrixWorkspace_sptr& mws_sptr,const Mantid::detid_t detNum,std::vector<Mantid::specnum_t>&specList);
 
   /// get detector name
  const  QString getDetectorName(int index);

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -490,7 +490,7 @@ std::vector<std::string> ISISEnergyTransfer::getSaveFormats() {
  * performed.
  */
 void ISISEnergyTransfer::plotRaw() {
-  using Mantid::specid_t;
+  using Mantid::specnum_t;
   using MantidQt::API::BatchAlgorithmRunner;
 
   if (!m_uiForm.dsRunFiles->isValid()) {
@@ -574,8 +574,8 @@ void ISISEnergyTransfer::plotRaw() {
   BatchAlgorithmRunner::AlgorithmRuntimeProps inputFromRebin;
   inputFromRebin["InputWorkspace"] = name;
 
-  std::vector<specid_t> detectorList;
-  for (specid_t i = detectorMin; i <= detectorMax; i++)
+  std::vector<specnum_t> detectorList;
+  for (specnum_t i = detectorMin; i <= detectorMax; i++)
     detectorList.push_back(i);
 
   if (m_uiForm.ckBackgroundRemoval->isChecked()) {

--- a/MantidQt/CustomInterfaces/src/Muon/IO_MuonGrouping.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/IO_MuonGrouping.cpp
@@ -249,7 +249,7 @@ MatrixWorkspace_sptr groupWorkspace(MatrixWorkspace_const_sptr ws,
     *(outWs->getSpectrum(gi)) = *(grouped->getSpectrum(0));
 
     // Update spectrum number
-    outWs->getSpectrum(gi)->setSpectrumNo(static_cast<specid_t>(gi));
+    outWs->getSpectrum(gi)->setSpectrumNo(static_cast<specnum_t>(gi));
 
     // Copy to the output workspace
     outWs->dataY(gi) = grouped->readY(0);

--- a/MantidQt/CustomInterfaces/src/SANSDiagnostics.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSDiagnostics.cpp
@@ -11,7 +11,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/optional.hpp>
 
-using Mantid::specid_t;
+using Mantid::specnum_t;
 using Mantid::detid_t;
 
 namespace MantidQt
@@ -420,7 +420,7 @@ namespace MantidQt
     * @param detNum number used to identify detector
     * @param specList  -list of spectrum
     */
-    void SANSDiagnostics::getSpectraList(const Mantid::API::MatrixWorkspace_sptr& mws_sptr,const detid_t detNum,std::vector<specid_t>&specList)
+    void SANSDiagnostics::getSpectraList(const Mantid::API::MatrixWorkspace_sptr& mws_sptr,const detid_t detNum,std::vector<specnum_t>&specList)
     {
       // This metod was wrong ticket #2470. The solution here will cause the system not to perform very well. 
       // The best option would be put this information inside the DetectorDetails
@@ -484,10 +484,10 @@ namespace MantidQt
     * @param minSpec - minimum spectrum number
     * @param maxSpec - maximum spectrum number
     */
-    void SANSDiagnostics::minandMaxSpectrumIds(const std::vector<specid_t>& specList,QString& minSpec, QString& maxSpec)
+    void SANSDiagnostics::minandMaxSpectrumIds(const std::vector<specnum_t>& specList,QString& minSpec, QString& maxSpec)
     {      
-      specid_t spec_min =*std::min_element(specList.begin(),specList.end());
-      specid_t spec_max=*std::max_element(specList.begin(),specList.end());
+      specnum_t spec_min =*std::min_element(specList.begin(),specList.end());
+      specnum_t spec_max=*std::max_element(specList.begin(),specList.end());
     
       std::string s_min,s_max;
       try
@@ -523,7 +523,7 @@ namespace MantidQt
     */
 
     void SANSDiagnostics::getWorkspaceIndexes(const Mantid::API::MatrixWorkspace_sptr& mws_sptr,
-                                              const std::vector<specid_t>& specList,
+                                              const std::vector<specnum_t>& specList,
                                               QString& startWSIndex,QString& endWSIndex)
     {      
             
@@ -679,7 +679,7 @@ namespace MantidQt
       {
         return;
       }
-      std::vector<specid_t> specList;
+      std::vector<specnum_t> specList;
       getSpectraList(mws_sptr,detNum,specList);
       minandMaxSpectrumIds(specList,minSpec,maxSpec);
       if(!isValidSpectra(minSpec,maxSpec))
@@ -726,7 +726,7 @@ namespace MantidQt
         return;
       }
 
-      std::vector<specid_t> specList;
+      std::vector<specnum_t> specList;
       getSpectraList(mws_sptr,detNum,specList);
       minandMaxSpectrumIds(specList,minSpec,maxSpec);
 
@@ -771,7 +771,7 @@ namespace MantidQt
         return;
       }
 
-      std::vector<specid_t> specList;
+      std::vector<specnum_t> specList;
       getSpectraList(mws_sptr,detNum,specList);
       minandMaxSpectrumIds(specList,minSpec,maxSpec);
       QString wsStartIndex, wsEndIndex;
@@ -1106,7 +1106,7 @@ namespace MantidQt
         return;
       }
       
-      std::vector<specid_t> specList;
+      std::vector<specnum_t> specList;
       getSpectraList(mws_sptr,detNum,specList);
       minandMaxSpectrumIds(specList,minSpec,maxSpec);
        
@@ -1150,7 +1150,7 @@ namespace MantidQt
         return;
       }
 
-      std::vector<specid_t> specList;
+      std::vector<specnum_t> specList;
       getSpectraList(mws_sptr,detNum,specList);
       minandMaxSpectrumIds(specList,minSpec,maxSpec);
       if(!isValidSpectra(minSpec,maxSpec))
@@ -1191,7 +1191,7 @@ namespace MantidQt
         return;
       }
             
-      std::vector<specid_t> specList;
+      std::vector<specnum_t> specList;
       //get spectrum list from detector ids
       getSpectraList(mws_sptr,detNum,specList);
       // get maximum and minimum spectrum ids

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -1677,7 +1677,7 @@ void SANSRunWindow::setGeometryDetails() {
 
   // Moderator-monitor distance is common to LOQ and SANS2D.
   size_t monitorWsIndex = 0;
-  const specid_t monitorSpectrum = m_uiForm.monitor_spec->text().toInt();
+  const specnum_t monitorSpectrum = m_uiForm.monitor_spec->text().toInt();
   try {
     monitorWsIndex = monitorWs->getIndexFromSpectrumNumber(monitorSpectrum);
   } catch (std::runtime_error &) {


### PR DESCRIPTION
Change specid_t to specnum_t it was a source of confusion as there is no spec thing as a spectrum ID, and it made people think of spectrum index.

A simple change that affects many files, so has been done a a PR on it's own

**To test:**
1. all tests and builds must pass

This is specifically re, not fixes as more changes will come
re #15450

"Does not need to be in the release notes."

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

re #15450
