### PR TITLE
Engg GUI:: customised bank name & output names fixes + other improvements

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -189,10 +189,12 @@ private:
                   size_t bank, const std::string &specNos,
                   const std::string &dgFile);
 
-  void loadOrCalcVanadiumWorkspaces(
-      const std::string &vanNo, const std::string &inputDirCalib,
-      Mantid::API::ITableWorkspace_sptr &vanIntegWS,
-      Mantid::API::MatrixWorkspace_sptr &vanCurvesWS, bool forceRecalc);
+  void
+  loadOrCalcVanadiumWorkspaces(const std::string &vanNo,
+                               const std::string &inputDirCalib,
+                               Mantid::API::ITableWorkspace_sptr &vanIntegWS,
+                               Mantid::API::MatrixWorkspace_sptr &vanCurvesWS,
+                               bool forceRecalc, const std::string specNos);
 
   void findPrecalcVanadiumCorrFilenames(const std::string &vanNo,
                                         const std::string &inputDirCalib,
@@ -203,7 +205,8 @@ private:
   void loadVanadiumPrecalcWorkspaces(
       const std::string &preIntegFilename, const std::string &preCurvesFilename,
       Mantid::API::ITableWorkspace_sptr &vanIntegWS,
-      Mantid::API::MatrixWorkspace_sptr &vanCurvesWS, const std::string &vanNo);
+      Mantid::API::MatrixWorkspace_sptr &vanCurvesWS, const std::string &vanNo,
+      const std::string specNos);
 
   void calcVanadiumWorkspaces(const std::string &vanNo,
                               Mantid::API::ITableWorkspace_sptr &vanIntegWS,
@@ -250,13 +253,15 @@ private:
   Poco::Path outFilesDir(std::string addToDir);
 
   // generates appropriate names for table workspaces
-  std::string outFitParamsTblNameGenerator(const std::string specNos, size_t bank_i) const;
+  std::string outFitParamsTblNameGenerator(const std::string specNos,
+                                           size_t bank_i) const;
 
   std::string DifcZeroWorkspaceFactory(
       const std::vector<double> &difc, const std::vector<double> &tzero,
       const std::string &specNo, const std::string &customisedBankName) const;
 
-  std::string plotDifcZeroWorkspace(const std::string &customisedBankName) const;
+  std::string
+  plotDifcZeroWorkspace(const std::string &customisedBankName) const;
 
   /// string to use for ENGINX file names (as a prefix, etc.)
   const static std::string g_enginxStr;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -250,13 +250,13 @@ private:
   Poco::Path outFilesDir(std::string addToDir);
 
   // generates appropriate names for table workspaces
-  std::string outFitParamsTblNameGenerator(std::string specNos, size_t bank_i);
+  std::string outFitParamsTblNameGenerator(const std::string specNos, size_t bank_i) const;
 
-  std::string DifcZeroWorkspaceFactory(const std::vector<double> &difc,
-                                       const std::vector<double> &tzero,
-                                       const std::string &specNo) const;
+  std::string DifcZeroWorkspaceFactory(
+      const std::vector<double> &difc, const std::vector<double> &tzero,
+      const std::string &specNo, const std::string &customisedBankName) const;
 
-  std::string plotDifcZeroWorkspace() const;
+  std::string plotDifcZeroWorkspace(const std::string &customisedBankName) const;
 
   /// string to use for ENGINX file names (as a prefix, etc.)
   const static std::string g_enginxStr;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>575</width>
-    <height>629</height>
+    <width>595</width>
+    <height>640</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -220,8 +220,48 @@
      <property name="checked">
       <bool>false</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_7">
-      <item row="1" column="0">
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <widget class="QLabel" name="label_vanadium_num_2">
+          <property name="text">
+           <string>Calibration sample #:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_14">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_cropped_run_num" native="true">
+          <property name="text" stdset="0">
+           <string/>
+          </property>
+          <property name="readOnly" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="label" stdset="0">
+           <string>Run #:</string>
+          </property>
+          <property name="multipleFiles" stdset="0">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_10">
         <item>
          <spacer name="horizontalSpacer_15">
@@ -264,77 +304,7 @@
         </item>
        </layout>
       </item>
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QLabel" name="label_vanadium_num_2">
-          <property name="text">
-           <string>Calibration sample #:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_14">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>98</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_cropped_run_num" native="true">
-          <property name="text" stdset="0">
-           <string/>
-          </property>
-          <property name="readOnly" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="label" stdset="0">
-           <string>Run #:</string>
-          </property>
-          <property name="multipleFiles" stdset="0">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="3" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_12">
-        <item>
-         <spacer name="horizontalSpacer_16">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_new_cropped_calib">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Calibrate</string>
-          </property>
-          <property name="autoDefault">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
+      <item row="2" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_11">
         <item>
          <widget class="QLabel" name="label_cropped_spec_ids">
@@ -367,6 +337,66 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_14">
+        <item>
+         <spacer name="horizontalSpacer_22">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>248</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_cropped_customise_bank">
+          <property name="text">
+           <string>Customise Bank Name:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_customise_bank_name">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="4" column="0">
+       <spacer name="horizontalSpacer_19">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>473</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="4" column="1">
+       <widget class="QPushButton" name="pushButton_new_cropped_calib">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Calibrate</string>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -278,7 +278,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Cropped</string>
+           <string>cropped</string>
           </property>
          </widget>
         </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -310,7 +310,7 @@
          <widget class="QComboBox" name="comboBox_calib_cropped_bank_name">
           <item>
            <property name="text">
-            <string>Enable Spectrum-IDs</string>
+            <string>Enable Spectrum-Nos</string>
            </property>
           </item>
           <item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -332,7 +332,7 @@
         <item>
          <widget class="QLabel" name="label_cropped_spec_ids">
           <property name="text">
-           <string>Spectrum IDs:</string>
+           <string>Spectrum Numbers:</string>
           </property>
          </widget>
         </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -221,41 +221,64 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
+      <item row="4" column="1">
+       <widget class="QPushButton" name="pushButton_new_cropped_calib">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Calibrate</string>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <spacer name="horizontalSpacer_19">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>473</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_14">
         <item>
-         <widget class="QLabel" name="label_vanadium_num_2">
-          <property name="text">
-           <string>Calibration sample #:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_14">
+         <spacer name="horizontalSpacer_22">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>98</width>
+            <width>248</width>
             <height>20</height>
            </size>
           </property>
          </spacer>
         </item>
         <item>
-         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_cropped_run_num" native="true">
-          <property name="text" stdset="0">
-           <string/>
+         <widget class="QLabel" name="label_cropped_customise_bank">
+          <property name="text">
+           <string>Customise Bank Name:</string>
           </property>
-          <property name="readOnly" stdset="0">
-           <bool>false</bool>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_customise_bank_name">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="label" stdset="0">
-           <string>Run #:</string>
-          </property>
-          <property name="multipleFiles" stdset="0">
-           <bool>true</bool>
+          <property name="text">
+           <string>Cropped</string>
           </property>
          </widget>
         </item>
@@ -338,65 +361,45 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="0" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_14">
+      <item row="0" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
         <item>
-         <spacer name="horizontalSpacer_22">
+         <widget class="QLabel" name="label_vanadium_num_2">
+          <property name="text">
+           <string>Calibration sample #:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_14">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>248</width>
+            <width>98</width>
             <height>20</height>
            </size>
           </property>
          </spacer>
         </item>
         <item>
-         <widget class="QLabel" name="label_cropped_customise_bank">
-          <property name="text">
-           <string>Customise Bank Name:</string>
+         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_cropped_run_num" native="true">
+          <property name="text" stdset="0">
+           <string/>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_cropped_customise_bank_name">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>1</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+          <property name="readOnly" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="label" stdset="0">
+           <string>Run #:</string>
+          </property>
+          <property name="multipleFiles" stdset="0">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
        </layout>
-      </item>
-      <item row="4" column="0">
-       <spacer name="horizontalSpacer_19">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>473</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="4" column="1">
-       <widget class="QPushButton" name="pushButton_new_cropped_calib">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Calibrate</string>
-        </property>
-        <property name="autoDefault">
-         <bool>false</bool>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -211,7 +211,7 @@
         <item>
          <widget class="QLabel" name="label_cropped_spec_ids">
           <property name="text">
-           <string>Spectrum IDs:</string>
+           <string>Spectrum Numbers:</string>
           </property>
          </widget>
         </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -97,6 +97,8 @@ public:
 
   std::string currentCalibSpecNos() const;
 
+  std::string currentCalibCustomisedBankName() const;
+
   void newCalibLoaded(const std::string &vanadiumNo, const std::string &ceriaNo,
                       const std::string &fname);
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -126,11 +126,19 @@ public:
 
   /**
   * customised spec will be passed via specID text field for the
-  * calibrartion process to be carried out
+  * cropped calibrartion process to be carried out
   *
   * @return which format should to applied for plotting data
   */
   virtual std::string currentCalibSpecNos() const = 0;
+
+  /**
+  * customised bank name will be passed with spectrumIDs to
+  * save workspace and file with particular bank name
+  *
+  * @return string which will be used to generate bank name
+  */
+  virtual std::string currentCalibCustomisedBankName() const = 0;
 
   /**
   * Selected plot data representation will be applied, which will

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1798,9 +1798,14 @@ void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
       // when south bank is selected while cropped calib
       saveOpenGenie(curvesWSName, "1201-2400", "South", vanNo);
     } else {
+
       // when spectrumIDs are provided
-      const std::string CustomisedBankName =
-          m_view->currentCalibCustomisedBankName();
+      std::string CustomisedBankName = m_view->currentCalibCustomisedBankName();
+
+      // assign default value if empty string passed
+      if (CustomisedBankName.empty())
+        CustomisedBankName = "cropped";
+
       saveOpenGenie(curvesWSName, specNos, CustomisedBankName, vanNo);
     }
   } else {
@@ -2153,8 +2158,9 @@ void EnggDiffractionPresenter::plotCalibWorkspace(std::vector<double> difc,
     }
 
     // Get the Customised Bank Name text-ield string from qt
-    const std::string CustomisedBankName =
-        m_view->currentCalibCustomisedBankName();
+    std::string CustomisedBankName = m_view->currentCalibCustomisedBankName();
+    if (CustomisedBankName.empty())
+      CustomisedBankName = "cropped";
     const std::string pythonCode =
         DifcZeroWorkspaceFactory(difc, tzero, specNos, CustomisedBankName) +
         plotDifcZeroWorkspace(CustomisedBankName);
@@ -2488,7 +2494,7 @@ std::string EnggDiffractionPresenter::outFitParamsTblNameGenerator(
       // Get the Customised Bank Name text-ield string from qt
       std::string CustomisedBankName = m_view->currentCalibCustomisedBankName();
 
-      if (CustomisedBankName == "")
+      if (CustomisedBankName.empty())
         outFitParamsTblName = "engggui_calibration_bank_cropped";
       else
         outFitParamsTblName = "engggui_calibration_bank_" + CustomisedBankName;

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1797,13 +1797,18 @@ void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
   // algCurves->getProperty("OutputWorkspace");
   vanCurvesWS = ADS.retrieveWS<MatrixWorkspace>(curvesWSName);
 
+  const std::string specNosBank1 = "1-2000";
+  const std::string specNosBank2 = "1201-2400";
+  const std::string northBank = "North";
+  const std::string southBank = "South";
+
   if (specNos != "") {
-    if (specNos == "North") {
+    if (specNos == northBank) {
       // when north bank is selected while cropped calib
-      saveOpenGenie(curvesWSName, "1-1200", "North", vanNo);
-    } else if (specNos == "South") {
+      saveOpenGenie(curvesWSName, specNosBank1, northBank, vanNo);
+    } else if (specNos == southBank) {
       // when south bank is selected while cropped calib
-      saveOpenGenie(curvesWSName, "1201-2400", "South", vanNo);
+      saveOpenGenie(curvesWSName, specNosBank2, southBank, vanNo);
     } else {
 
       // when spectrumIDs are provided
@@ -1817,8 +1822,8 @@ void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
     }
   } else {
     // when full calibration is carried; saves both banks
-    saveOpenGenie(curvesWSName, "1-1200", "North", vanNo);
-    saveOpenGenie(curvesWSName, "1201-2400", "South", vanNo);
+    saveOpenGenie(curvesWSName, specNosBank1, northBank, vanNo);
+    saveOpenGenie(curvesWSName, specNosBank2, southBank, vanNo);
   }
 }
 
@@ -2316,8 +2321,8 @@ void EnggDiffractionPresenter::saveOpenGenie(const std::string inputWorkspace,
             " Please check also the log messages for details.";
     throw;
   }
-  g_log.notice() << "Saved focused workspace as file: " << saveDir.toString()
-                 << std::endl;
+  g_log.notice() << "Saves OpenGenieAscii (.his) file written as: "
+                 << saveDir.toString() << std::endl;
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1792,11 +1792,19 @@ void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
 
   if (specNos != "") {
     if (specNos == "North") {
+      // when north bank is selected while cropped calib
       saveOpenGenie(curvesWSName, "1-1200", "North", vanNo);
     } else if (specNos == "South") {
+      // when south bank is selected while cropped calib
       saveOpenGenie(curvesWSName, "1201-2400", "South", vanNo);
+    } else {
+      // when spectrumIDs are provided
+      const std::string CustomisedBankName =
+          m_view->currentCalibCustomisedBankName();
+      saveOpenGenie(curvesWSName, specNos, CustomisedBankName, vanNo);
     }
   } else {
+    // when full calibration is carried; saves both banks
     saveOpenGenie(curvesWSName, "1-1200", "North", vanNo);
     saveOpenGenie(curvesWSName, "1201-2400", "South", vanNo);
   }

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -227,6 +227,7 @@ void EnggDiffractionPresenter::ProcessCropCalib() {
     g_calibCropIdentifier = "Bank";
 
   } else if (specIdNum == BankMode::SPECIDS) {
+    g_calibCropIdentifier = "SpectrumNumbers";
     specId = m_view->currentCalibSpecNos();
   }
 
@@ -953,12 +954,12 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
       alg->setProperty("InputWorkspace", ceriaWS);
       alg->setProperty("VanIntegrationWorkspace", vanIntegWS);
       alg->setProperty("VanCurvesWorkspace", vanCurvesWS);
-      if (specNumUsed)
+      if (specNumUsed) {
         alg->setPropertyValue(g_calibCropIdentifier,
                               boost::lexical_cast<std::string>(specNos));
-      else
+      } else {
         alg->setPropertyValue("Bank", boost::lexical_cast<std::string>(i + 1));
-
+      }
       const std::string outFitParamsTblName =
           outFitParamsTblNameGenerator(specNos, i);
       alg->setPropertyValue("FittedPeaks", outFitParamsTblName);

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -2456,8 +2456,14 @@ EnggDiffractionPresenter::outFitParamsTblNameGenerator(std::string specNos,
       outFitParamsTblName = "engggui_calibration_bank_1";
     else if (specNos == "South")
       outFitParamsTblName = "engggui_calibration_bank_2";
-    else
-      outFitParamsTblName = "engggui_calibration_bank_cropped";
+    else {
+      std::string CustomisedBankName = m_view->currentCalibCustomisedBankName();
+
+      if (CustomisedBankName == "")
+        outFitParamsTblName = "engggui_calibration_bank_cropped";
+      else
+        outFitParamsTblName = "engggui_calibration_bank_" + CustomisedBankName;
+    }
   } else {
     outFitParamsTblName = "engggui_calibration_bank_" +
                           boost::lexical_cast<std::string>(bank_i + 1);

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -961,7 +961,6 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
 
       const std::string outFitParamsTblName =
           outFitParamsTblNameGenerator(specNos, i);
-      const std::string customisedBankName = outFitParamsTblName;
       alg->setPropertyValue("FittedPeaks", outFitParamsTblName);
       alg->setPropertyValue("OutputParametersTableName", outFitParamsTblName);
       alg->execute();
@@ -1631,6 +1630,10 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
 *
 * @param forceRecalc whether to calculate Vanadium corrections even
 * if the files of pre-calculated results are found
+*
+*
+* @param specNos string carrying cropped calib info: spectra to use
+* when cropped calibrating.
 */
 void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
     const std::string &vanNo, const std::string &inputDirCalib,
@@ -1763,6 +1766,9 @@ void EnggDiffractionPresenter::findPrecalcVanadiumCorrFilenames(
 *
 * @param vanNo the Vanadium run number used for the openGenieAscii
 * output label
+*
+* @param specNos string carrying cropped calib info: spectra to use
+* when cropped calibrating.
 */
 void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
     const std::string &preIntegFilename, const std::string &preCurvesFilename,
@@ -2349,6 +2355,7 @@ std::string EnggDiffractionPresenter::outFileNameFactory(
 * @param difc vector containing constants difc value of each bank
 * @param tzero vector containing constants tzero value of each bank
 * @param specNo used to set range for Calibration Cropped
+* @param customisedBankName used to set the file and workspace name
 *
 * @return string with a python script
 */
@@ -2419,6 +2426,8 @@ std::string EnggDiffractionPresenter::DifcZeroWorkspaceFactory(
 
 /**
 * Plot the workspace with difc/zero acordding to selected bank
+*
+* @param customisedBankName used to set the file and workspace name
 *
 * @return string with a python script which will merge with
 *

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -981,6 +981,11 @@ std::string EnggDiffractionViewQtGUI::currentCalibSpecNos() const {
   return m_uiTabCalib.lineEdit_cropped_spec_ids->text().toStdString();
 }
 
+std::string EnggDiffractionViewQtGUI::currentCalibCustomisedBankName() const {
+  return m_uiTabCalib.lineEdit_cropped_customise_bank_name->text()
+      .toStdString();
+}
+
 void EnggDiffractionViewQtGUI::multiRunModeChanged(int /*idx*/) {
   QComboBox *plotType = m_uiTabFocus.comboBox_Multi_Runs;
   if (!plotType)

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -260,6 +260,12 @@ void EnggDiffractionViewQtGUI::readSettings() {
 
   m_uiTabCalib.comboBox_calib_cropped_bank_name->setCurrentIndex(0);
 
+  m_uiTabCalib.lineEdit_cropped_spec_ids->setText(
+      qs.value("user-params-calib-cropped-spectrum-nos", "").toString());
+
+  m_uiTabCalib.lineEdit_cropped_customise_bank_name->setText(
+      qs.value("user-params-calib-cropped-customise-name", "").toString());
+
   m_uiTabCalib.checkBox_PlotData_Calib->setChecked(
       qs.value("user-param-calib-plot-data", true).toBool());
 
@@ -367,6 +373,12 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
 
   qs.setValue("user-params-calib-cropped-group-checkbox",
               m_uiTabCalib.groupBox_calib_cropped->isChecked());
+
+  qs.setValue("user-params-calib-cropped-spectrum-nos",
+              m_uiTabCalib.lineEdit_cropped_spec_ids->text());
+
+  qs.setValue("user-params-calib-cropped-customise-name",
+              m_uiTabCalib.lineEdit_cropped_customise_bank_name->text());
 
   qs.setValue("user-param-calib-plot-data",
               m_uiTabCalib.checkBox_PlotData_Calib->isChecked());
@@ -956,10 +968,13 @@ void EnggDiffractionViewQtGUI::calibSpecIdChanged(int /*idx*/) {
 }
 
 void EnggDiffractionViewQtGUI::enableSpecIds() {
-  if (m_currentCropCalibBankName == 0)
+  if (m_currentCropCalibBankName == 0) {
     m_uiTabCalib.lineEdit_cropped_spec_ids->setEnabled(true);
-  else
+    m_uiTabCalib.lineEdit_cropped_customise_bank_name->setEnabled(true);
+  } else {
     m_uiTabCalib.lineEdit_cropped_spec_ids->setDisabled(true);
+    m_uiTabCalib.lineEdit_cropped_customise_bank_name->setDisabled(true);
+  }
 }
 
 std::string EnggDiffractionViewQtGUI::currentCalibSpecNos() const {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -264,7 +264,8 @@ void EnggDiffractionViewQtGUI::readSettings() {
       qs.value("user-params-calib-cropped-spectrum-nos", "").toString());
 
   m_uiTabCalib.lineEdit_cropped_customise_bank_name->setText(
-      qs.value("user-params-calib-cropped-customise-name", "").toString());
+      qs.value("user-params-calib-cropped-customise-name", "cropped")
+          .toString());
 
   m_uiTabCalib.checkBox_PlotData_Calib->setChecked(
       qs.value("user-param-calib-plot-data", true).toBool());

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -438,6 +438,8 @@ public:
     EXPECT_CALL(mockView, currentCalibSpecNos())
         .Times(1)
         .WillOnce(Return(specid));
+	EXPECT_CALL(mockView, currentCalibCustomisedBankName())
+		.Times(0);
 
     // No warnings/error pop-ups: some exception(s) are thrown (because there
     // are missing settings and/or files) but these must be caught
@@ -554,6 +556,9 @@ public:
         .Times(2)
         .WillRepeatedly(Return(specid));
 
+	EXPECT_CALL(mockView, currentCalibCustomisedBankName())
+		.Times(0);
+
     const std::string filename =
         "UNKNOWNINST_" + vanNo + "_" + ceriaNo + "_" + "foo.prm";
     EXPECT_CALL(mockView,
@@ -608,6 +613,9 @@ public:
     EXPECT_CALL(mockView, currentCalibSpecNos())
         .Times(2)
         .WillRepeatedly(Return(specid));
+
+	EXPECT_CALL(mockView, currentCalibCustomisedBankName())
+		.Times(0);
 
     // No errors/warnings
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -56,6 +56,9 @@ public:
   // std::string currentCalibSpecNos
   MOCK_CONST_METHOD0(currentCalibSpecNos, std::string());
 
+  // std::string currentCalibCustomisedBankName
+  MOCK_CONST_METHOD0(currentCalibCustomisedBankName, std::string());
+
   // int currentPlotType
   MOCK_CONST_METHOD0(currentPlotType, int());
 

--- a/docs/source/interfaces/Engineering_Diffraction.rst
+++ b/docs/source/interfaces/Engineering_Diffraction.rst
@@ -81,10 +81,12 @@ Calibration sample #
 Bank Name:
   This parameter is only required when Cropped Calibration is being
   carried out. The bank name can be selected from a drop down list with
-  option of North and South, which are equivalently to 1 and 2
-  respectively. The Bank Name drop down list is set to `Enable Spectrum-IDs`
-  by default. This option cannot be used together with Spectrum IDs,
-  as they overlap.
+  option of "North" and "South", which are equivalently to 1 and 2
+  respectively. However the Bank Name drop down list is set to
+  "Enable Spectrum-IDs" by default. This option cannot be used together
+  with Spectrum IDs, as they overlap. For the convenience of users, the
+  GUI will only enable SpectrumIDs and Customise Bank Name text-fields
+  when Bank Name drop down list is set to "Enable Spectrum-IDs"
 
 SpectrumIDs:
   This parameter is only required when Cropped Calibration is being
@@ -93,6 +95,13 @@ SpectrumIDs:
   others will be ignored. This option cannot be used together with
   Bank Name, as they overlap. You may also give multiple ranges, for
   example: "0-100", or "0-9", "150-750".
+
+Customise Bank Name:
+  This parameter is only required when Cropped Calibration is being
+  carried out with SpectrumIDs, the parameter will set the workspace
+  and .his file name according to this Bank Name provided by the user.
+  However if the user does not provide a personalised name, the
+  interface will use "cropped" as a default bank name.
 
 The calibration process depends on several additional parameters and
 settings which can be modified in the *Settings* section (tab), see


### PR DESCRIPTION
Customised bank name can now be set while carrying out cropped calibration along with SpectrumIDs, the parameter will set the workspace and .his file name according to provided bank name. Also enables GUI to only write out the appropriate _OpenGenie_ `.his` files and file names. The python script which is passed to plot the calibration output made compatible with personalised bank name. Pull Request also includes checks for the Customise Bank Name in the presenter test and documentation updates. 
## **To test:**
- _Code Check_
- Check _EnggDiffractionPresenterTest_ passes
### **Test 1**

<!-- Instructions for testing. -->

Interface->Engineering Diffraction Analysis->Calibration
Enter RB Number: `123456`

Enable `Cropped Calibration`:

Calibration sample: `241391`
Bank Name: `Enable Spectrum-IDs`
- Check SpectrumIDs and Customise Bank Name text-field are disabled when Bank Name not `Enable Spectrum-IDs`

Spectrum IDs: `1-100`
Customise Bank Name: `Mantid`
Click **Calibrate** button below

Output:

Total of 5 output workspace  & two with the following name:
1.  `engggui_calibration_bank_Mantid`
2.  `engggui_difc_zero_peaks_Mantid`

Total of two plotted graph and one with the title name:
`Engg Gui Difc Zero Peaks Mantid`

In the following repository: `C:\EnginX_Mantid\User\1234\Calibration\`
You should be able to find single file name:
`ob+ENGINX_236516_Mantid_bank.his`

Open the `ob+ENGINX_236516_Mantid_bank.his` with notepad:
Search for _spec_no_ and check that the following text is found within the `.his` file:

```
   "spec_no"
    String
    "1-100"
```

---
### **Test 2**

Interface->Engineering Diffraction Analysis->Calibration
Enter RB Number: `123456`

Enable `Cropped Calibration`
Calibration sample: `241391`
Bank Name: `North`

Click **Calibrate** button below

_Once The Process Has Completed:_

Carry out **Test 1** again and the following error should not be displayed at any point:

```
The calibration calculations failed. Some input properties were not valid. See log messages for details. 
The cablibration did not finish correctly.
```

Fixes #15337 

[Release notes](http://www.mantidproject.org/ReleaseNotes_3_7_Diffraction#Engineering_Diffraction)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
