### PR TITLE
MuonAnalysis: fix current data for ARGUS

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -136,6 +136,11 @@ void MuonAnalysis::initLayout() {
   if (userFacility != "ISIS")
     m_uiForm.loadCurrent->setDisabled(true);
 
+// Load current run only works on Windows
+#ifndef _WIN32
+  m_uiForm.loadCurrent->setDisabled(true);
+#endif
+
   // If facility if not supported by the interface - show a warning, but still
   // open it
   if (supportedFacilities.find(userFacility) == supportedFacilities.end()) {
@@ -764,34 +769,8 @@ void MuonAnalysis::runGroupTablePlotButton() {
 void MuonAnalysis::runLoadCurrent() {
   QString instname = m_uiForm.instrSelector->currentText().toUpper();
 
-  // If Argus data then simple
-  if (instname == "ARGUS") {
-    QString argusDAE =
-        "\\\\ndw828\\argusdata\\current cycle\\nexus\\argus0000000.nxs";
-    Poco::File l_path(argusDAE.toStdString());
-    try {
-      if (!l_path.exists()) {
-        QMessageBox::warning(this, "Mantid - MuonAnalysis",
-                             QString("Can't load ARGUS Current data since\n") +
-                                 argusDAE + QString("\n") +
-                                 QString("does not seem to exist"));
-        return;
-      }
-    } catch (Poco::Exception &) {
-      QMessageBox::warning(this, "MantidPlot - MuonAnalysis",
-                           "Can't read from the selected directory, either the "
-                           "computer you are trying"
-                           "\nto access is down or your computer is not "
-                           "currently connected to the network.");
-      return;
-    }
-    m_uiForm.mwRunFiles->setUserInput(argusDAE);
-    m_uiForm.mwRunFiles->setText("CURRENT RUN");
-    return;
-  }
-
   if (instname == "EMU" || instname == "HIFI" || instname == "MUSR" ||
-      instname == "CHRONUS") {
+      instname == "CHRONUS" || instname == "ARGUS") {
     QString instDirectory = instname;
     if (instname == "CHRONUS")
       instDirectory = "NDW1030";


### PR DESCRIPTION
"Load current data" button now works the same for all instruments - removed the special case for ARGUS as `ndw828` no longer exists. Now ARGUS loads current data in the same way as other muon instruments at ISIS.

Also disabled the "load current data" button on non-Windows platforms, as it doesn't work there. 

This is required by scientists to set up computers for the Muon training school happening soon.
### To test:

**Tester will need a Windows PC and ISIS network access**
- Open the MuonAnalysis interface
- Set instrument as ARGUS from the drop-down list
- Click "Load current data" button
- Some data should be loaded
- No error message should be shown

(The data loaded might look strange, this is because detectors 10-16 are bad and should be excluded.)

Fixes #15469 

[Release notes](http://www.mantidproject.org/Release_Notes_3_7_MuonAnalysis#Muon_Analysis) have been updated
- [x] Notify the scientists when there is a build with this fix in place.
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
