### PR TITLE
Fix EnggCalibrateFull doc test on RHEL6

### DIFF
--- a/docs/source/algorithms/EnggCalibrateFull-v1.rst
+++ b/docs/source/algorithms/EnggCalibrateFull-v1.rst
@@ -141,8 +141,8 @@ Output:
    det_id = pos_table.column(0)[0]
    pos =  pos_table.column(2)[0]
    print "Det ID:", det_id
-   print "Calibrated position: (%.3f,%.3f,%.3f)" % (pos.getX(),pos.getY(),pos.getZ())
-   print "Got details on the peaks fitted for {:d} detector(s)".format(peaks_info.rowCount())
+   print "Calibrated position: ({0:.3f},{1:.3f},{2:.3f})".format(pos.getX(),pos.getY(),pos.getZ())
+   print "Got details on the peaks fitted for {0:d} detector(s)".format(peaks_info.rowCount())
    print "Was the file created?", os.path.exists(pos_filename)
    with open(pos_filename) as csvf:
       reader = csv.reader(csvf, dialect='excel')


### PR DESCRIPTION
The ancient Python of RHEL6 does not accept format specs without index (`{:d}`) and because of this the doc test is failing in the master_doctests build. This is very minor quick change from `{:d}` to `{0:d}` in a format and print statement, so that it doesn't fail on RHEL6.

**To test:**

Check code changes. The tests had already pass and will pass anyway, as this is an issue with Python 2.6.

No issue number.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
