### PR TITLE
Apply changes suggested by clang-tidy performance-faster-string-find

### DIFF
--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -131,7 +131,7 @@ std::string AlgorithmFactoryImpl::createName(const std::string &name,
 */
 std::pair<std::string, int>
 AlgorithmFactoryImpl::decodeName(const std::string &mangledName) const {
-  std::string::size_type seperatorPosition = mangledName.find("|");
+  std::string::size_type seperatorPosition = mangledName.find('|');
   if (seperatorPosition == std::string::npos) {
     throw std::invalid_argument(
         "Cannot decode a Name string without a \"|\" (bar) character ");

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -37,7 +37,7 @@ Mantid::Kernel::Logger g_log("FileFinder");
  * @returns true if extension contains a "*", else false.
  */
 bool containsWildCard(const std::string &ext) {
-  return std::string::npos != ext.find("*");
+  return std::string::npos != ext.find('*');
 }
 }
 

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -29,7 +29,7 @@ Mantid::Kernel::Logger g_log("MultipleFileProperty");
  * a "*" wild card in the file extension string passed to it.
  */
 bool doesNotContainWildCard(const std::string &ext) {
-  return std::string::npos == ext.find("*");
+  return std::string::npos == ext.find('*');
 }
 } // anonymous namespace
 

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -308,7 +308,7 @@ bool WorkspaceGroup::areNamesSimilar() const {
   for (const auto &workspace : m_workspaces) {
     const std::string wsName = (*workspace).name();
     // Find the last underscore _
-    std::size_t pos = wsName.find_last_of("_");
+    std::size_t pos = wsName.find_last_of('_');
     // No underscore = not similar
     if (pos == std::string::npos)
       return false;

--- a/Framework/API/src/WorkspaceHistory.cpp
+++ b/Framework/API/src/WorkspaceHistory.cpp
@@ -392,18 +392,18 @@ WorkspaceHistory::parseAlgorithmHistory(const std::string &rawData) {
   for (size_t index = static_cast<size_t>(PARAMS) + 1; index < nlines;
        ++index) {
     const std::string line = info[index];
-    std::string::size_type colon = line.find(":");
-    std::string::size_type comma = line.find(",");
+    std::string::size_type colon = line.find(':');
+    std::string::size_type comma = line.find(',');
     // Each colon has a space after it
     std::string prop_name = line.substr(colon + 2, comma - colon - 2);
-    colon = line.find(":", comma);
+    colon = line.find(':', comma);
     comma = line.find(", Default?", colon);
     std::string prop_value = line.substr(colon + 2, comma - colon - 2);
-    colon = line.find(":", comma);
+    colon = line.find(':', comma);
     comma = line.find(", Direction", colon);
     std::string is_def = line.substr(colon + 2, comma - colon - 2);
-    colon = line.find(":", comma);
-    comma = line.find(",", colon);
+    colon = line.find(':', comma);
+    comma = line.find(',', colon);
     std::string direction = line.substr(colon + 2, comma - colon - 2);
     unsigned int direc(Mantid::Kernel::Direction::asEnum(direction));
     alg_hist.addProperty(prop_name, prop_value, (is_def[0] == 'Y'), direc);

--- a/Framework/Algorithms/src/FitPeak.cpp
+++ b/Framework/Algorithms/src/FitPeak.cpp
@@ -1493,7 +1493,7 @@ std::string FitPeak::parseFunctionTypeFull(const std::string &fullstring,
 
   size_t n = std::count(fullstring.begin(), fullstring.end(), '(');
   if (n > 0) {
-    peaktype = fullstring.substr(0, fullstring.find("("));
+    peaktype = fullstring.substr(0, fullstring.find('('));
     boost::algorithm::trim(peaktype);
     defaultparorder = true;
   } else {

--- a/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -475,7 +475,7 @@ void PlotAsymmetryByLogValue::parseRunNames(std::string &firstFN,
                                             std::string &fnExt, int &fnZeros) {
 
   // Parse first run's name
-  std::string firstExt = firstFN.substr(firstFN.find_last_of("."));
+  std::string firstExt = firstFN.substr(firstFN.find_last_of('.'));
   firstFN.erase(firstFN.size() - 4);
 
   std::string firstBase = firstFN;
@@ -489,7 +489,7 @@ void PlotAsymmetryByLogValue::parseRunNames(std::string &firstFN,
   firstFN.erase(0, firstBase.size());
 
   // Parse last run's name
-  std::string lastExt = lastFN.substr(lastFN.find_last_of("."));
+  std::string lastExt = lastFN.substr(lastFN.find_last_of('.'));
   lastFN.erase(lastFN.size() - 4);
 
   std::string lastBase = lastFN;

--- a/Framework/CurveFitting/src/Algorithms/CalculateGammaBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/CalculateGammaBackground.cpp
@@ -423,7 +423,7 @@ void CalculateGammaBackground::calculateTofSpectrum(
 void CalculateGammaBackground::retrieveInputs() {
   m_inputWS = getProperty("InputWorkspace");
   m_profileFunction = getPropertyValue("ComptonFunction");
-  if (m_profileFunction.find(";") == std::string::npos) // not composite
+  if (m_profileFunction.find(';') == std::string::npos) // not composite
   {
     m_profileFunction = "composite=CompositeFunction;" + m_profileFunction;
   }

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -106,8 +106,8 @@ static string getRunnumber(const string &filename) {
   if (runnumber.find("neutron") >= string::npos)
     return "0";
 
-  std::size_t left = runnumber.find("_");
-  std::size_t right = runnumber.find("_", left + 1);
+  std::size_t left = runnumber.find('_');
+  std::size_t right = runnumber.find('_', left + 1);
 
   return runnumber.substr(left + 1, right - left - 1);
 }
@@ -788,7 +788,7 @@ void FilterEventsByLogValuePreNexus::runLoadInstrument(
   }
 
   // determine the instrument parameter file
-  size_t pos = instrument.rfind("_"); // get rid of the run number
+  size_t pos = instrument.rfind('_'); // get rid of the run number
   instrument = instrument.substr(0, pos);
 
   // do the actual work

--- a/Framework/DataHandling/src/GenerateGroupingPowder.cpp
+++ b/Framework/DataHandling/src/GenerateGroupingPowder.cpp
@@ -138,7 +138,7 @@ void GenerateGroupingPowder::exec() {
       std::copy(groups.at(i).begin(), groups.at(i).end(),
                 std::ostream_iterator<size_t>(textvalue, ","));
       std::string text = textvalue.str();
-      size_t found = text.rfind(",");
+      size_t found = text.rfind(',');
       if (found != std::string::npos) {
         text.erase(found, 1); // erase the last comma
       }

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -1409,12 +1409,12 @@ void GroupDetectors2::translateInstructions(const std::string &instructions,
 
     // Look for the various operators in the string. If one is found then
     // do the necessary translation into groupings.
-    if (groupStr.find("+") != std::string::npos) {
+    if (groupStr.find('+') != std::string::npos) {
       // add a group with the given spectra
       translateAdd(groupStr, outGroups);
-    } else if (groupStr.find("-") != std::string::npos) {
+    } else if (groupStr.find('-') != std::string::npos) {
       translateSumRange(groupStr, outGroups);
-    } else if (groupStr.find(":") != std::string::npos) {
+    } else if (groupStr.find(':') != std::string::npos) {
       translateRange(groupStr, outGroups);
     } else if (!groupStr.empty()) {
       // contains no instructions, just add this spectrum as a new group

--- a/Framework/DataHandling/src/LoadEventPreNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus.cpp
@@ -265,8 +265,8 @@ string getRunnumber(const string &filename) {
   if (runnumber.find("neutron") >= string::npos)
     return "0";
 
-  std::size_t left = runnumber.find("_");
-  std::size_t right = runnumber.find("_", left + 1);
+  std::size_t left = runnumber.find('_');
+  std::size_t right = runnumber.find('_', left + 1);
 
   return runnumber.substr(left + 1, right - left - 1);
 }
@@ -372,9 +372,9 @@ void LoadEventPreNexus::runLoadInstrument(const std::string &eventfilename,
                                           MatrixWorkspace_sptr localWorkspace) {
   // determine the instrument parameter file
   string instrument = Poco::Path(eventfilename).getFileName();
-  size_t pos = instrument.rfind("_");   // get rid of 'event.dat'
-  pos = instrument.rfind("_", pos - 1); // get rid of 'neutron'
-  pos = instrument.rfind("_", pos - 1); // get rid of the run number
+  size_t pos = instrument.rfind('_');   // get rid of 'event.dat'
+  pos = instrument.rfind('_', pos - 1); // get rid of 'neutron'
+  pos = instrument.rfind('_', pos - 1); // get rid of the run number
   instrument = instrument.substr(0, pos);
 
   // do the actual work

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -107,8 +107,8 @@ static string getRunnumber(const string &filename) {
   if (runnumber.find("neutron") >= string::npos)
     return "0";
 
-  std::size_t left = runnumber.find("_");
-  std::size_t right = runnumber.find("_", left + 1);
+  std::size_t left = runnumber.find('_');
+  std::size_t right = runnumber.find('_', left + 1);
 
   return runnumber.substr(left + 1, right - left - 1);
 }
@@ -621,7 +621,7 @@ void LoadEventPreNexus2::runLoadInstrument(
   }
 
   // determine the instrument parameter file
-  size_t pos = instrument.rfind("_"); // get rid of the run number
+  size_t pos = instrument.rfind('_'); // get rid of the run number
   instrument = instrument.substr(0, pos);
 
   // do the actual work

--- a/Framework/DataHandling/src/LoadFullprofResolution.cpp
+++ b/Framework/DataHandling/src/LoadFullprofResolution.cpp
@@ -291,9 +291,9 @@ int LoadFullprofResolution::getProfNumber(const vector<string> &lines) {
   if (lines[1].find("NPROF") != string::npos) {
     // Split line to get the NPROF number
     size_t nStart = lines[1].find("NPROF");
-    size_t nEq = lines[1].find("=", nStart);
+    size_t nEq = lines[1].find('=', nStart);
     size_t nEnd = lines[1].find(
-        " ", nStart); // Assume the NRPOF number is followed by space
+        ' ', nStart); // Assume the NRPOF number is followed by space
     if (nEq == string::npos || nEnd == string::npos)
       return (-1);
     size_t nNumber = nEq + 1;

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1728,11 +1728,11 @@ bool UDlesserExecCount(NXClassInfo elem1, NXClassInfo elem2) {
   std::string::size_type index1, index2;
   std::string num1, num2;
   // find the number after "_" in algorithm name ( eg:MantidAlogorthm_1)
-  index1 = elem1.nxname.find("_");
+  index1 = elem1.nxname.find('_');
   if (index1 != std::string::npos) {
     num1 = elem1.nxname.substr(index1 + 1, elem1.nxname.length() - index1);
   }
-  index2 = elem2.nxname.find("_");
+  index2 = elem2.nxname.find('_');
   if (index2 != std::string::npos) {
     num2 = elem2.nxname.substr(index2 + 1, elem2.nxname.length() - index2);
   }

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -1166,7 +1166,7 @@ LoadRawHelper::searchForLogFiles(const std::string &pathToRawFile) {
   std::string l_filenamePart =
       Poco::Path(l_path.path()).getFileName(); // get filename part only
   if (isAscii(pathToRawFile) &&
-      l_filenamePart.rfind("_") != std::string::npos) {
+      l_filenamePart.rfind('_') != std::string::npos) {
     // then we will assume that the file is an ISIS log file
     potentialLogFiles.insert(pathToRawFile);
   } else {
@@ -1256,7 +1256,7 @@ LoadRawHelper::getLogFilenamesfromADS(const std::string &pathToRawFile) {
   std::string logFile;
   std::set<std::string> logfilesList;
   Poco::Path logpath(pathToRawFile);
-  size_t pos = pathToRawFile.find_last_of("/");
+  size_t pos = pathToRawFile.find_last_of('/');
   if (pos == std::string::npos) {
     pos = pathToRawFile.find_last_of("\\");
   }
@@ -1265,7 +1265,7 @@ LoadRawHelper::getLogFilenamesfromADS(const std::string &pathToRawFile) {
   }
   while (Mantid::Kernel::Strings::extractToEOL(adstream, str)) {
     std::string fileName;
-    pos = str.find("*");
+    pos = str.find('*');
     if (pos == std::string::npos)
       continue;
     fileName = str.substr(pos + 1, str.length() - pos);

--- a/Framework/DataHandling/src/LoadSINQFocus.cpp
+++ b/Framework/DataHandling/src/LoadSINQFocus.cpp
@@ -122,7 +122,7 @@ void LoadSINQFocus::setInstrumentName(NeXus::NXEntry &entry) {
   }
   m_instrumentName =
       m_loader.getStringFromNexusPath(entry, m_instrumentPath + "/name");
-  size_t pos = m_instrumentName.find(" ");
+  size_t pos = m_instrumentName.find(' ');
   m_instrumentName = m_instrumentName.substr(0, pos);
 }
 

--- a/Framework/DataHandling/src/LoadSpiceAscii.cpp
+++ b/Framework/DataHandling/src/LoadSpiceAscii.cpp
@@ -522,9 +522,9 @@ std::string LoadSpiceAscii::processDateString(const std::string &rawdate,
   std::string month("");
   std::string day("");
   for (size_t i = 0; i < 3; ++i) {
-    if (formatterms[i].find("Y") != std::string::npos)
+    if (formatterms[i].find('Y') != std::string::npos)
       year = dateterms[i];
-    else if (formatterms[i].find("M") != std::string::npos) {
+    else if (formatterms[i].find('M') != std::string::npos) {
       month = dateterms[i];
       if (month.size() == 1)
         month = "0" + month;

--- a/Framework/DataHandling/src/SaveFocusedXYE.cpp
+++ b/Framework/DataHandling/src/SaveFocusedXYE.cpp
@@ -74,7 +74,7 @@ void SaveFocusedXYE::exec() {
     std::string directory = path.parent().toString();
     std::string name = path.getFileName();
 
-    std::size_t pos = name.find_first_of(".");
+    std::size_t pos = name.find_first_of('.');
     if (pos != std::string::npos) // Remove the extension
     {
       ext = name.substr(pos + 1, name.npos);

--- a/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
+++ b/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
@@ -368,7 +368,7 @@ void SaveOpenGenieAscii::applyEnginxFormat(const std::string fourspc) {
   std::string SpecNumberField = getProperty("SpecNumberField");
   // while field is not empty
   if (SpecNumberField != "") {
-    if (SpecNumberField.std::string::find("-") != std::string::npos) {
+    if (SpecNumberField.std::string::find('-') != std::string::npos) {
       std::string specNum = "spec_no";
 
       auto specNumOut = ("  \"" + specNum + "\"" + "\n" + fourspc + typeStr +

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -94,9 +94,9 @@ public:
   TableColumn() {
     int length = sizeof(Type);
     std::string name = std::string(typeid(Type).name());
-    if ((name.find("i") != std::string::npos) ||
-        (name.find("l") != std::string::npos) ||
-        (name.find("x") != std::string::npos)) {
+    if ((name.find('i') != std::string::npos) ||
+        (name.find('l') != std::string::npos) ||
+        (name.find('x') != std::string::npos)) {
       if (length == 4) {
         this->m_type = "int";
       }
@@ -104,13 +104,13 @@ public:
         this->m_type = "int64";
       }
     }
-    if (name.find("f") != std::string::npos) {
+    if (name.find('f') != std::string::npos) {
       this->m_type = "float";
     }
-    if (name.find("d") != std::string::npos) {
+    if (name.find('d') != std::string::npos) {
       this->m_type = "double";
     }
-    if (name.find("u") != std::string::npos) {
+    if (name.find('u') != std::string::npos) {
       if (length == 4) {
         this->m_type = "uint32_t";
       }

--- a/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
+++ b/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
@@ -118,8 +118,8 @@ bool BoxControllerNeXusIO::openFile(const std::string &fileName,
 
   std::lock_guard<std::mutex> _lock(m_fileMutex);
   m_ReadOnly = true;
-  if (mode.find("w") != std::string::npos ||
-      mode.find("W") != std::string::npos) {
+  if (mode.find('w') != std::string::npos ||
+      mode.find('W') != std::string::npos) {
     m_ReadOnly = false;
   }
 

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -1931,10 +1931,10 @@ void InstrumentDefinitionParser::setLogfile(
     std::string tie = "";
 
     if (type.compare("fitting") == 0) {
-      size_t found = paramName.find(":");
+      size_t found = paramName.find(':');
       if (found != std::string::npos) {
         // check that only one : in name
-        size_t index = paramName.find(":", found + 1);
+        size_t index = paramName.find(':', found + 1);
         if (index != std::string::npos) {
           g_log.error()
               << "Fitting <parameter> in instrument definition file defined "

--- a/Framework/Geometry/src/Instrument/Parameter.cpp
+++ b/Framework/Geometry/src/Instrument/Parameter.cpp
@@ -18,7 +18,7 @@ ParameterFactory::FactoryMap ParameterFactory::s_map;
    is returned.
 */
 std::string Parameter::getShortDescription() const {
-  size_t pos = m_description.find(".");
+  size_t pos = m_description.find('.');
   if (pos == std::string::npos) {
     return std::string(m_description);
   } else {

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -75,7 +75,7 @@ Logger g_log("ConfigService");
 std::vector<std::string> splitPath(const std::string &path) {
   std::vector<std::string> splitted;
 
-  if (path.find(";") == std::string::npos) { // don't bother tokenizing
+  if (path.find(';') == std::string::npos) { // don't bother tokenizing
     splitted.push_back(path);
   } else {
     int options = Mantid::Kernel::StringTokenizer::TOK_TRIM +
@@ -1226,7 +1226,7 @@ std::string getValueFromStdOut(const std::string &orig,
   }
   start += key.size();
 
-  size_t stop = orig.find("\n", start);
+  size_t stop = orig.find('\n', start);
   if (stop == std::string::npos) {
     return std::string();
   }

--- a/Framework/Kernel/src/DateAndTime.cpp
+++ b/Framework/Kernel/src/DateAndTime.cpp
@@ -460,7 +460,7 @@ void DateAndTime::setFromISO8601(const std::string str, bool displayLogs) {
   // the
   // string to always denote the full timestamp so we check for a colon and if
   // it is not present then throw an exception.
-  if (time.find(":") == std::string::npos)
+  if (time.find(':') == std::string::npos)
     throw std::invalid_argument("Error interpreting string '" + str +
                                 "' as a date/time.");
   try {

--- a/Framework/Kernel/src/InstrumentInfo.cpp
+++ b/Framework/Kernel/src/InstrumentInfo.cpp
@@ -238,7 +238,7 @@ void InstrumentInfo::fillLiveData(const Poco::XML::Element *elem) {
           << m_name << "\n";
     }
     // Check for a colon, which would suggest that a host & port are present
-    else if (m_liveDataAddress.find(":") == std::string::npos) {
+    else if (m_liveDataAddress.find(':') == std::string::npos) {
       g_log.warning() << "Live data address for " << m_name
                       << " appears not to have both host and port specified.\n";
     }

--- a/Framework/Kernel/src/MultiFileNameParser.cpp
+++ b/Framework/Kernel/src/MultiFileNameParser.cpp
@@ -274,7 +274,7 @@ void Parser::split() {
   // combinations of special characters, for example double commas.)
 
   // Get the extension, if there is one.
-  size_t lastDot = m_multiFileName.find_last_of(".");
+  size_t lastDot = m_multiFileName.find_last_of('.');
   if (lastDot != std::string::npos)
     m_extString = m_multiFileName.substr(lastDot);
 
@@ -285,7 +285,7 @@ void Parser::split() {
 
   // If the directory contains an instance of a comma, then the string is
   // a comma separated list of single *full* file names to load.
-  if (std::string::npos != m_dirString.find(","))
+  if (std::string::npos != m_dirString.find(','))
     throw std::runtime_error("Unable to parse.");
 
   // Slice off the directory and extension.

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -331,7 +331,7 @@ int isEmpty(const std::string &A) {
 void stripComment(std::string &A) {
   std::string::size_type posA = A.find("$ ");
   std::string::size_type posB = A.find("# ");
-  std::string::size_type posC = A.find("!");
+  std::string::size_type posC = A.find('!');
   if (posA > posB)
     posA = posB;
   if (posA > posC)

--- a/Framework/Kernel/src/UserStringParser.cpp
+++ b/Framework/Kernel/src/UserStringParser.cpp
@@ -21,7 +21,7 @@ UserStringParser::parse(const std::string &userString) {
   std::vector<std::vector<unsigned int>> numbers;
   // first separate commas
   std::vector<std::string> commaseparatedstrings;
-  if (userString.find(",") != std::string::npos) {
+  if (userString.find(',') != std::string::npos) {
     commaseparatedstrings = separateComma(userString);
   }
   if (!commaseparatedstrings.empty()) {

--- a/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
+++ b/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
@@ -160,19 +160,19 @@ void SlicingAlgorithm::makeBasisVectorFromString(const std::string &str) {
   // Special case: accept dimension names [x,y,z]
   if (input[0] == '[') {
     // Find the name at the closing []
-    size_t n = input.find_first_of("]", 1);
+    size_t n = input.find_first_of(']', 1);
     if (n == std::string::npos)
       throw std::invalid_argument(
           "No closing ] character in the dimension name of : " + str);
     // Find the comma after the name
-    n_first_comma = input.find_first_of(",", n);
+    n_first_comma = input.find_first_of(',', n);
     if (n_first_comma == std::string::npos)
       throw std::invalid_argument(
           "No comma after the closing ] character in the dimension string: " +
           str);
   } else
     // Find the comma after the name
-    n_first_comma = input.find_first_of(",");
+    n_first_comma = input.find_first_of(',');
 
   if (n_first_comma == std::string::npos)
     throw std::invalid_argument("No comma in the dimension string: " + str);
@@ -464,7 +464,7 @@ void SlicingAlgorithm::makeAlignedDimensionFromString(const std::string &str) {
     // Find the 3rd comma from the end
     size_t n = std::string::npos;
     for (size_t i = 0; i < 3; i++) {
-      n = input.find_last_of(",", n);
+      n = input.find_last_of(',', n);
       if (n == std::string::npos)
         throw std::invalid_argument("Wrong number of values (4 are expected) "
                                     "in the dimensions string: " +

--- a/Framework/RemoteAlgorithms/src/SCARFTomoReconstruction.cpp
+++ b/Framework/RemoteAlgorithms/src/SCARFTomoReconstruction.cpp
@@ -1088,7 +1088,7 @@ SCARFTomoReconstruction::buildUploadBody(const std::string &boundary,
   std::string upName = filename;
   std::replace(upName.begin(), upName.end(), '\\', '/');
   // discard up to last / (path)
-  upName = upName.substr(upName.rfind("/") + 1);
+  upName = upName.substr(upName.rfind('/') + 1);
 
   // BLOCK: start and encode destination directory like this:
   // --4k89ogja023oh1-gkdfk903jf9wngmujfs95m
@@ -1321,9 +1321,9 @@ const std::string SCARFTomoReconstruction::checkDownloadOutputFile(
 const std::string
 SCARFTomoReconstruction::filterPACFilename(const std::string PACName) const {
   // discard up to last / (path)
-  std::string name = PACName.substr(PACName.rfind("/") + 1);
+  std::string name = PACName.substr(PACName.rfind('/') + 1);
   // remove trailing parameters
-  size_t ast = name.find("*");
+  size_t ast = name.find('*');
   name.replace(ast, std::string::npos, "");
   return name;
 }

--- a/Framework/RemoteJobManagers/src/LSFJobManager.cpp
+++ b/Framework/RemoteJobManagers/src/LSFJobManager.cpp
@@ -1096,9 +1096,9 @@ LSFJobManager::checkDownloadOutputFile(const std::string &localPath,
 const std::string
 LSFJobManager::filterPACFilename(const std::string &PACName) const {
   // discard up to last / (path)
-  std::string name = PACName.substr(PACName.rfind("/") + 1);
+  std::string name = PACName.substr(PACName.rfind('/') + 1);
   // remove trailing parameters
-  size_t ast = name.find("*");
+  size_t ast = name.find('*');
   if (std::string::npos != ast)
     name.replace(ast, std::string::npos, "");
   return name;

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -858,7 +858,7 @@ void ScriptRepositoryImpl::upload(const std::string &file_path,
       // get exception from the read_json parser
       std::string server_reply_str;
       server_reply_str = server_reply.str();
-      size_t pos = server_reply_str.rfind("}");
+      size_t pos = server_reply_str.rfind('}');
       if (pos != std::string::npos)
         answer << std::string(server_reply_str.begin(),
                               server_reply_str.begin() + pos + 1);
@@ -1179,7 +1179,7 @@ std::string ScriptRepositoryImpl::doDeleteRemoteFile(
       server_reply_str = server_reply.str();
       // remove the status message from the end of the reply,
       // in order not to get exception from the read_json parser
-      size_t pos = server_reply_str.rfind("}");
+      size_t pos = server_reply_str.rfind('}');
       if (pos != std::string::npos)
         answer << std::string(server_reply_str.begin(),
                               server_reply_str.begin() + pos + 1);
@@ -1698,7 +1698,7 @@ bool ScriptRepositoryImpl::isEntryValid(const std::string &path) {
 }
 
 std::string ScriptRepositoryImpl::getParentFolder(const std::string &file) {
-  size_t pos = file.rfind("/");
+  size_t pos = file.rfind('/');
   if (pos == file.npos) {
     return "";
   }

--- a/Framework/TestHelpers/src/BoxControllerDummyIO.cpp
+++ b/Framework/TestHelpers/src/BoxControllerDummyIO.cpp
@@ -90,8 +90,8 @@ bool BoxControllerDummyIO::openFile(const std::string &fileName,
 
   m_ReadOnly = true;
   ;
-  if (mode.find("w") != std::string::npos ||
-      mode.find("W") != std::string::npos) {
+  if (mode.find('w') != std::string::npos ||
+      mode.find('W') != std::string::npos) {
     m_ReadOnly = false;
   }
 

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -162,7 +162,7 @@ void ConvolutionFitSequential::exec() {
 
   // Output workspace name
   std::string outputWsName = inputWs->getName();
-  pos = outputWsName.rfind("_");
+  pos = outputWsName.rfind('_');
   if (pos != std::string::npos) {
     outputWsName = outputWsName.substr(0, pos + 1);
   }
@@ -381,7 +381,7 @@ ConvolutionFitSequential::findValuesFromFunction(const std::string &function) {
   auto startPos = function.rfind("name=");
   if (startPos != std::string::npos) {
     fitType = function.substr(startPos, function.size());
-    auto nextPos = fitType.find_first_of(",");
+    auto nextPos = fitType.find_first_of(',');
     fitType = fitType.substr(5, nextPos - 5);
     functionName = fitType;
     if (fitType.compare("Lorentzian") == 0) {
@@ -598,7 +598,7 @@ void ConvolutionFitSequential::calculateEISF(
 std::string
 ConvolutionFitSequential::convertBackToShort(const std::string &original) {
   std::string result = original.substr(0, 3);
-  auto pos = original.find(" ");
+  auto pos = original.find(' ');
   if (pos != std::string::npos) {
     result += original.at(pos + 1);
   }

--- a/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
@@ -199,12 +199,12 @@ void ProcessIndirectFitParameters::exec() {
 std::vector<std::string>
 ProcessIndirectFitParameters::listToVector(std::string &commaList) {
   auto listVector = std::vector<std::string>();
-  auto pos = commaList.find(",");
+  auto pos = commaList.find(',');
   while (pos != std::string::npos) {
     std::string nextItem = commaList.substr(0, pos);
     listVector.push_back(nextItem);
     commaList = commaList.substr(pos + 1, commaList.size());
-    pos = commaList.find(",");
+    pos = commaList.find(',');
   }
   if (commaList.compare("") != 0) {
     listVector.push_back(commaList);


### PR DESCRIPTION
Description of work.

This applies changes suggested by clang-tidy's [performance-faster-string-find](http://builds.mantidproject.org/view/Static%20Analysis/job/clang_tidy/119/warnings10Result/category.885322990/). Specifically, it replaces string literals (`const char *`) with a single `char`.

**To test:**

<!-- Instructions for testing. -->

Check that the changes seem reasonable and that the builds still pass.

This is a small change with no issue number.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
