### PR TITLE
Undefine poco macro with the same name.

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
+++ b/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
@@ -42,7 +42,15 @@
 
 // things to make the macros clearer
 #define GCC_DIAG_STR(s) #s
+// undefine definition from Poco 1.6
+#ifdef GCC_DIAG_JOINSTR
+#undef GCC_DIAG_JOINSTR
+#endif
 #define GCC_DIAG_JOINSTR(x, y) GCC_DIAG_STR(x##y)
+// undefine definition from Poco 1.6
+#ifdef GCC_DIAG_DO_PRAGMA
+#undef GCC_DIAG_DO_PRAGMA
+#endif
 #define GCC_DIAG_DO_PRAGMA(x) _Pragma(#x)
 #define GCC_DIAG_PRAGMA(x) GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
 


### PR DESCRIPTION
Description of work.

Building with poco 1.6.1 on RHEL7 generates errors that both `GCC_DIAG_JOINSTR` and `GCC_DIAG_DO_PRAGMA` are redefined. While this [issue appears to have been fixed upstream](https://github.com/pocoproject/poco/blob/develop/Foundation/include/Poco/Platform_POSIX.h), they still exist in the current release version.

This PR checks if either of the macros `GCC_DIAG_JOINSTR` or `GCC_DIAG_DO_PRAGMA` are defined before we define them.

Undefining these macros after including any poco header requires substantially more code changes with minimal benefit. 

**To test:**

<!-- Instructions for testing. -->

Build on a machine with gcc and poco 1.6 and verify there are no warnings. 

This is a small PR with no issue number

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
