### PR TITLE
Applied clang-tidy readability-inconsistent-declaration-parameter-name fixes

### DIFF
--- a/Framework/API/inc/MantidAPI/ChopperModel.h
+++ b/Framework/API/inc/MantidAPI/ChopperModel.h
@@ -57,7 +57,7 @@ public:
   /// Set the rotation speed in rads/sec
   void setAngularVelocityInHz(const double value);
   /// Set the angular velocity log name
-  void setAngularVelocityLog(const std::string &name);
+  void setAngularVelocityLog(const std::string &logName);
   /// Returns the current angular velocity in rads/sec
   double getAngularVelocity() const;
   /// Sets the chopper jitter sigma value in microseconds. This is the FWHH

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -186,13 +186,13 @@ private:
   /// instrument group open.
   void loadEmbeddedInstrumentInfoNexus(::NeXus::File *file,
                                        std::string &instrumentName,
-                                       std::string &instrumentXML);
+                                       std::string &instrumentXml);
 
   /// Set the instrument given the name and XML leading from IDF file if XML
   /// string is empty
   void setInstumentFromXML(const std::string &nxFilename,
                            std::string &instrumentName,
-                           std::string &instrumentXML);
+                           std::string &instrumentXml);
 
   // Loads the xml from an instrument file with some basic error handling
   std::string loadInstrumentXML(const std::string &filename);

--- a/Framework/API/inc/MantidAPI/FileBackedExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/FileBackedExperimentInfo.h
@@ -38,7 +38,7 @@ class MANTID_API_DLL FileBackedExperimentInfo : public ExperimentInfo {
 public:
   /// Constructor
   FileBackedExperimentInfo(const std::string &filename,
-                           const std::string &path);
+                           const std::string &nxpath);
 
   ExperimentInfo *cloneExperimentInfo() const override;
 

--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -53,8 +53,8 @@ public:
   std::string getFullPath(const std::string &filename,
                           const bool ignoreDirs = false) const;
   std::string getPath(const std::vector<IArchiveSearch_sptr> &archs,
-                      const std::set<std::string> &filename,
-                      const std::vector<std::string> &extensions) const;
+                      const std::set<std::string> &filenames,
+                      const std::vector<std::string> &exts) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
   std::string makeFileName(const std::string &hint,
                            const Kernel::InstrumentInfo &instrument) const;

--- a/Framework/API/inc/MantidAPI/FuncMinimizerFactory.h
+++ b/Framework/API/inc/MantidAPI/FuncMinimizerFactory.h
@@ -53,7 +53,7 @@ class MANTID_API_DLL FuncMinimizerFactoryImpl
 public:
   /// Creates an instance of a minimizer
   boost::shared_ptr<IFuncMinimizer>
-  createMinimizer(const std::string &type) const;
+  createMinimizer(const std::string &str) const;
 
 private:
   friend struct Mantid::Kernel::CreateUsingNew<FuncMinimizerFactoryImpl>;

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -477,11 +477,11 @@ public:
   /// Returns a list of attribute names
   virtual std::vector<std::string> getAttributeNames() const;
   /// Return a value of attribute attName
-  virtual Attribute getAttribute(const std::string &attName) const;
+  virtual Attribute getAttribute(const std::string &name) const;
   /// Set a value to attribute attName
-  virtual void setAttribute(const std::string &attName, const Attribute &);
+  virtual void setAttribute(const std::string &name, const Attribute &);
   /// Check if attribute attName exists
-  virtual bool hasAttribute(const std::string &attName) const;
+  virtual bool hasAttribute(const std::string &name) const;
   /// Set an attribute value
   template <typename T>
   void setAttributeValue(const std::string &attName, const T &value) {
@@ -495,7 +495,7 @@ public:
   virtual void setUpForFit() = 0;
 
   /// Calculate numerical derivatives
-  void calNumericalDeriv(const FunctionDomain &domain, Jacobian &out);
+  void calNumericalDeriv(const FunctionDomain &domain, Jacobian &jacobian);
   /// Set the covariance matrix
   void setCovarianceMatrix(boost::shared_ptr<Kernel::Matrix<double>> covar);
   /// Get the covariance matrix
@@ -525,7 +525,7 @@ protected:
                                 const std::string &description = "") = 0;
 
   /// Convert a value from one unit (inUnit) to unit defined in workspace (ws)
-  double convertValue(double value, Kernel::Unit_sptr &inUnit,
+  double convertValue(double value, Kernel::Unit_sptr &outUnit,
                       boost::shared_ptr<const MatrixWorkspace> ws,
                       size_t wsIndex) const;
 

--- a/Framework/API/inc/MantidAPI/IFunction1D.h
+++ b/Framework/API/inc/MantidAPI/IFunction1D.h
@@ -76,7 +76,7 @@ public:
                             const size_t nData, const size_t order) const;
 
   /// Derivatives of function with respect to active parameters
-  virtual void functionDeriv1D(Jacobian *out, const double *xValues,
+  virtual void functionDeriv1D(Jacobian *jacobian, const double *xValues,
                                const size_t nData);
 
 protected:

--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -126,7 +126,7 @@ public:
       Mantid::Geometry::MDImplicitFunction *function = nullptr) const;
 
   std::string getConvention() const;
-  void setConvention(std::string m_convention);
+  void setConvention(std::string convention);
   std::string changeQConvention();
 
   signal_t getSignalAtVMD(const Mantid::Kernel::VMD &coords,

--- a/Framework/API/inc/MantidAPI/IPowderDiffPeakFunction.h
+++ b/Framework/API/inc/MantidAPI/IPowderDiffPeakFunction.h
@@ -89,7 +89,7 @@ public:
 
   /// Override setting a new value to a parameter by name
   void setParameter(const std::string &name, const double &value,
-                    bool explicitlySe = true) override;
+                    bool explicitlySet = true) override;
 
   /// Check whether a parameter is a profile parameter
   virtual bool hasProfileParameter(std::string paramname);

--- a/Framework/API/inc/MantidAPI/IkedaCarpenterModerator.h
+++ b/Framework/API/inc/MantidAPI/IkedaCarpenterModerator.h
@@ -92,7 +92,7 @@ private:
   /// given fraction of the range
   double areaToTimeFunction(const double fraction) const;
   /// Returns the area of the IKeda-Carpenter function for the given time value
-  double area(const double t) const;
+  double area(const double x) const;
 
   /// The value of the 1/fast decay coefficient
   double m_tau_f;

--- a/Framework/API/inc/MantidAPI/ImplicitFunctionParserFactory.h
+++ b/Framework/API/inc/MantidAPI/ImplicitFunctionParserFactory.h
@@ -51,7 +51,7 @@ public:
   boost::shared_ptr<ImplicitFunctionParser>
   create(const std::string &xmlString) const override;
   ImplicitFunctionParser *
-  createImplicitFunctionParserFromXML(const std::string &configXML) const;
+  createImplicitFunctionParserFromXML(const std::string &functionXML) const;
 
   ImplicitFunctionParser *createImplicitFunctionParserFromXML(
       Poco::XML::Element *functionElement) const;

--- a/Framework/API/inc/MantidAPI/LiveListenerFactory.h
+++ b/Framework/API/inc/MantidAPI/LiveListenerFactory.h
@@ -52,7 +52,7 @@ class MANTID_API_DLL LiveListenerFactoryImpl
 public:
   boost::shared_ptr<ILiveListener>
   create(const std::string &instrumentName, bool connect,
-         const Kernel::IPropertyManager *props = nullptr) const;
+         const Kernel::IPropertyManager *properties = nullptr) const;
   LiveListenerFactoryImpl(const LiveListenerFactoryImpl &) = delete;
   LiveListenerFactoryImpl &operator=(const LiveListenerFactoryImpl &) = delete;
   bool checkConnection(const std::string &instrumentName) const;

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -96,7 +96,7 @@ public:
   /// Does the property exist on the object
   bool hasProperty(const std::string &name) const;
   /// Remove a named property
-  void removeProperty(const std::string &name, bool delproperty = true);
+  void removeProperty(const std::string &name, bool delProperty = true);
   /**
    * Return all of the current properties
    * @returns A vector of the current list of properties

--- a/Framework/API/inc/MantidAPI/MatrixWSIndexCalculator.h
+++ b/Framework/API/inc/MantidAPI/MatrixWSIndexCalculator.h
@@ -55,13 +55,13 @@ public:
 
   /// Determine which histogram an index in a 1D array relates to given the
   /// known blockSize
-  HistogramIndex getHistogramIndex(Index index) const;
+  HistogramIndex getHistogramIndex(Index oneDimIndex) const;
 
   /// Get the bin index.
-  BinIndex getBinIndex(Index index, HistogramIndex histogram) const;
+  BinIndex getBinIndex(Index oneDimIndex, HistogramIndex histogramDimIndex) const;
 
   /// Get the one dimensional index given a histogram and bin index.
-  Index getOneDimIndex(HistogramIndex histogram, BinIndex binIndex) const;
+  Index getOneDimIndex(HistogramIndex histogramIndex, BinIndex binIndex) const;
 
   ////Assignment operator
   MatrixWSIndexCalculator &operator=(const MatrixWSIndexCalculator &other);

--- a/Framework/API/inc/MantidAPI/MatrixWSIndexCalculator.h
+++ b/Framework/API/inc/MantidAPI/MatrixWSIndexCalculator.h
@@ -58,7 +58,8 @@ public:
   HistogramIndex getHistogramIndex(Index oneDimIndex) const;
 
   /// Get the bin index.
-  BinIndex getBinIndex(Index oneDimIndex, HistogramIndex histogramDimIndex) const;
+  BinIndex getBinIndex(Index oneDimIndex,
+                       HistogramIndex histogramDimIndex) const;
 
   /// Get the one dimensional index given a histogram and bin index.
   Index getOneDimIndex(HistogramIndex histogramIndex, BinIndex binIndex) const;

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -366,11 +366,11 @@ public:
                const double &weight = 1.0);
   void flagMasked(const size_t &spectrumIndex, const size_t &binIndex,
                   const double &weight = 1.0);
-  bool hasMaskedBins(const size_t &spectrumIndex) const;
+  bool hasMaskedBins(const size_t &workspaceIndex) const;
   /// Masked bins for each spectrum are stored as a set of pairs containing <bin
   /// index, weight>
   typedef std::map<size_t, double> MaskList;
-  const MaskList &maskedBins(const size_t &spectrumIndex) const;
+  const MaskList &maskedBins(const size_t &workspaceIndex) const;
 
   // Methods handling the internal monitor workspace
   virtual void
@@ -470,7 +470,7 @@ protected:
   MatrixWorkspace(const MatrixWorkspace &other);
 
   MatrixWorkspace(
-      Mantid::Geometry::INearestNeighboursFactory *factory = nullptr);
+      Mantid::Geometry::INearestNeighboursFactory *nnFactory = nullptr);
 
   /// Initialises the workspace. Sets the size and lengths of the arrays. Must
   /// be overloaded.

--- a/Framework/API/inc/MantidAPI/NotebookWriter.h
+++ b/Framework/API/inc/MantidAPI/NotebookWriter.h
@@ -40,7 +40,7 @@ class MANTID_API_DLL NotebookWriter {
 public:
   NotebookWriter();
   virtual ~NotebookWriter() = default;
-  std::string markdownCell(std::string string_array);
+  std::string markdownCell(std::string string_text);
   std::string codeCell(std::string string_code);
   std::string writeNotebook();
 
@@ -51,7 +51,7 @@ private:
   Json::Value buildNotebook();
 
   void markdownCell(Json::Value string_array);
-  void codeCell(Json::Value string_code);
+  void codeCell(Json::Value array_code);
 
   Json::Value m_cell_buffer;
 };

--- a/Framework/API/inc/MantidAPI/Run.h
+++ b/Framework/API/inc/MantidAPI/Run.h
@@ -69,10 +69,10 @@ public:
   integrateProtonCharge(const std::string &logname = "proton_charge") const;
 
   /// Store the given values as a set of histogram bin boundaries
-  void storeHistogramBinBoundaries(const std::vector<double> &energyBins);
+  void storeHistogramBinBoundaries(const std::vector<double> &histoBins);
   /// Returns the bin boundaries for a given value
   std::pair<double, double>
-  histogramBinBoundaries(const double energyValue) const;
+  histogramBinBoundaries(const double value) const;
   /// Returns the vector of bin boundaries
   std::vector<double> getBinBoundaries() const;
 

--- a/Framework/API/inc/MantidAPI/Run.h
+++ b/Framework/API/inc/MantidAPI/Run.h
@@ -71,8 +71,7 @@ public:
   /// Store the given values as a set of histogram bin boundaries
   void storeHistogramBinBoundaries(const std::vector<double> &histoBins);
   /// Returns the bin boundaries for a given value
-  std::pair<double, double>
-  histogramBinBoundaries(const double value) const;
+  std::pair<double, double> histogramBinBoundaries(const double value) const;
   /// Returns the vector of bin boundaries
   std::vector<double> getBinBoundaries() const;
 

--- a/Framework/API/inc/MantidAPI/SpectrumDetectorMapping.h
+++ b/Framework/API/inc/MantidAPI/SpectrumDetectorMapping.h
@@ -69,7 +69,7 @@ public:
   const std::set<detid_t> &
   getDetectorIDsForSpectrumNo(const specnum_t spectrumNo) const;
   const std::set<detid_t> &
-  getDetectorIDsForSpectrumIndex(const size_t index) const;
+  getDetectorIDsForSpectrumIndex(const size_t spectrumIndex) const;
   const sdmap &getMapping() const;
   bool indexIsSpecNumber() const;
 

--- a/Framework/API/inc/MantidAPI/VectorParameterParser.h
+++ b/Framework/API/inc/MantidAPI/VectorParameterParser.h
@@ -53,7 +53,7 @@ template <class VectorValueParameterType>
 class DLLExport VectorParameterParser
     : public Mantid::API::ImplicitFunctionParameterParser {
 public:
-  VectorValueParameterType *parseVectorParameter(std::string value);
+  VectorValueParameterType *parseVectorParameter(std::string sValue);
 
   Mantid::API::ImplicitFunctionParameter *
   createParameter(Poco::XML::Element *parameterElement) override;

--- a/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -82,7 +82,7 @@ public:
   /// Inidicates that the workspace group can be treated as multiperiod.
   bool isMultiperiod() const;
   /// Check if a workspace is included in this group or any nested groups.
-  bool isInGroup(const Workspace &workspace, size_t level = 0) const;
+  bool isInGroup(const Workspace &workspaceToCheck, size_t level = 0) const;
   /// Prints the group to the screen using the logger at debug
   void print() const;
 
@@ -100,7 +100,7 @@ public:
   /// Does a workspace exist within the group
   bool contains(const std::string &wsName) const;
   /// Does a workspace exist within the group
-  bool contains(const Workspace_sptr &wsName) const;
+  bool contains(const Workspace_sptr &workspace) const;
   /// Add the members of the group to the given list
   void reportMembers(std::set<Workspace_sptr> &memberList) const;
   /// Returns the names of workspaces that make up this group. Note that this
@@ -122,11 +122,11 @@ private:
   }
   /// ADS removes a member of this group using this method. It doesn't send
   /// notifications in contrast to remove(name).
-  void removeByADS(const std::string &name);
+  void removeByADS(const std::string &wsName);
   /// Turn ADS observations on/off
   void observeADSNotifications(const bool observeADS);
   /// Check if a workspace is included in any child groups and groups in them.
-  bool isInChildGroup(const Workspace &workspace) const;
+  bool isInChildGroup(const Workspace &workspaceToCheck) const;
   /// Callback when a delete notification is received
   void workspaceDeleteHandle(
       Mantid::API::WorkspacePostDeleteNotification_ptr notice);

--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateDIFC.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateDIFC.h
@@ -47,7 +47,7 @@ private:
 
   /// Calculate the DIFC for every pixel
   void calculate(API::Progress &progress, API::MatrixWorkspace_sptr &outputWs,
-                 DataObjects::OffsetsWorkspace_sptr &offsetsWs, double l1,
+                 DataObjects::OffsetsWorkspace_sptr &offsetsWS, double l1,
                  double beamlineNorm, Kernel::V3D &beamline,
                  Kernel::V3D &samplePos, detid2det_map &allDetectors);
 };

--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateTransmission.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateTransmission.h
@@ -115,7 +115,7 @@ private:
                                           std::vector<double> &coeficients);
   /// Calls the rebin algorithm
   API::MatrixWorkspace_sptr rebin(std::vector<double> &binParams,
-                                  API::MatrixWorkspace_sptr output);
+                                  API::MatrixWorkspace_sptr ws);
   /// Outpus message to log if the detector at the given index is not a monitor
   /// in both input workspaces.
   void logIfNotMonitor(API::MatrixWorkspace_sptr sampleWS,

--- a/Framework/Algorithms/inc/MantidAlgorithms/ChangeTimeZero.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ChangeTimeZero.h
@@ -54,7 +54,7 @@ private:
 
   /// Time shift the log of a double series property
   void shiftTimeInLogForTimeSeries(Mantid::API::MatrixWorkspace_sptr ws,
-                                   Mantid::Kernel::Property *logEntry,
+                                   Mantid::Kernel::Property *prop,
                                    double timeShift) const;
   /// Time shift the log of a string property
   void shiftTimeOfLogForStringProperty(

--- a/Framework/Algorithms/inc/MantidAlgorithms/ConvertSpectrumAxis2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConvertSpectrumAxis2.h
@@ -73,14 +73,14 @@ private:
   /// Execution code
   void exec() override;
   /// Converting to theta.
-  void createThetaMap(API::Progress &progress, const std::string &target,
+  void createThetaMap(API::Progress &progress, const std::string &targetUnit,
                       API::MatrixWorkspace_sptr &inputWS, size_t nHist);
   /// Converting to Q and QSquared
-  void createElasticQMap(API::Progress &progress, const std::string &target,
+  void createElasticQMap(API::Progress &progress, const std::string &targetUnit,
                          API::MatrixWorkspace_sptr &inputWS, size_t nHist);
   /// Creates an output workspace.
   API::MatrixWorkspace_sptr
-  createOutputWorkspace(API::Progress &progress, const std::string &target,
+  createOutputWorkspace(API::Progress &progress, const std::string &targetUnit,
                         API::MatrixWorkspace_sptr &inputWS, size_t nHist,
                         size_t nBins, size_t nxBins);
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
@@ -118,7 +118,7 @@ private:
   calculateRebinParams(const API::MatrixWorkspace_const_sptr workspace) const;
 
   /// Reverses the workspace if X values are in descending order
-  void reverse(API::MatrixWorkspace_sptr workspace);
+  void reverse(API::MatrixWorkspace_sptr WS);
 
   /// For conversions to energy transfer, removes bins corresponding to
   /// inaccessible values

--- a/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnitsUsingDetectorTable.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnitsUsingDetectorTable.h
@@ -70,7 +70,7 @@ private:
   calculateRebinParams(const API::MatrixWorkspace_const_sptr workspace) const;
 
   /// Reverses the workspace if X values are in descending order
-  void reverse(API::MatrixWorkspace_sptr workspace);
+  void reverse(API::MatrixWorkspace_sptr WS);
 
   /// For conversions to energy transfer, removes bins corresponding to
   /// inaccessible values

--- a/Framework/Algorithms/inc/MantidAlgorithms/CorrectKiKf.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CorrectKiKf.h
@@ -87,7 +87,7 @@ private:
   void execEvent();
   /**
    * Execute CorrectKiKf for event lists
-   * @param events the list of events to correct
+   * @param wevector the list of events to correct
    * @param efixed the value of the fixed energy
    * @param emodeStr the energy mode description
    */

--- a/Framework/Algorithms/inc/MantidAlgorithms/CorrectKiKf.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CorrectKiKf.h
@@ -92,7 +92,7 @@ private:
    * @param emodeStr the energy mode description
    */
   template <class T>
-  void correctKiKfEventHelper(std::vector<T> &events, double efixed,
+  void correctKiKfEventHelper(std::vector<T> &wevector, double efixed,
                               const std::string emodeStr);
 };
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/CorrectToFile.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CorrectToFile.h
@@ -75,7 +75,7 @@ private:
   /// Multiply or divide the input workspace as specified by the user
   void doWkspAlgebra(API::MatrixWorkspace_sptr lhs,
                      API::MatrixWorkspace_sptr rhs,
-                     const std::string &operation,
+                     const std::string &algName,
                      API::MatrixWorkspace_sptr &result);
 };
 }

--- a/Framework/Algorithms/inc/MantidAlgorithms/CorrectToFile.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CorrectToFile.h
@@ -74,8 +74,7 @@ private:
   API::MatrixWorkspace_sptr loadInFile(const std::string &corrFile);
   /// Multiply or divide the input workspace as specified by the user
   void doWkspAlgebra(API::MatrixWorkspace_sptr lhs,
-                     API::MatrixWorkspace_sptr rhs,
-                     const std::string &algName,
+                     API::MatrixWorkspace_sptr rhs, const std::string &algName,
                      API::MatrixWorkspace_sptr &result);
 };
 }

--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateTransmissionWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateTransmissionWorkspace.h
@@ -54,11 +54,11 @@ private:
       const MinMax &wavelengthMonitorIntegrationInterval,
       const int &i0MonitorIndex, API::MatrixWorkspace_sptr firstTransmissionRun,
       OptionalMatrixWorkspace_sptr secondTransmissionRun,
-      const OptionalDouble &stitchingStartQ,
-      const OptionalDouble &stitchingDeltaQ,
-      const OptionalDouble &stitchingEndQ,
-      const OptionalDouble &stitchingStartOverlapQ,
-      const OptionalDouble &stitchingEndOverlapQ, const double &wavelengthStep);
+      const OptionalDouble &stitchingStart,
+      const OptionalDouble &stitchingDelta,
+      const OptionalDouble &stitchingEnd,
+      const OptionalDouble &stitchingStartOverlap,
+      const OptionalDouble &stitchingEndOverlap, const double &wavelengthStep);
 
   void init() override;
   void exec() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateTransmissionWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateTransmissionWorkspace.h
@@ -55,8 +55,7 @@ private:
       const int &i0MonitorIndex, API::MatrixWorkspace_sptr firstTransmissionRun,
       OptionalMatrixWorkspace_sptr secondTransmissionRun,
       const OptionalDouble &stitchingStart,
-      const OptionalDouble &stitchingDelta,
-      const OptionalDouble &stitchingEnd,
+      const OptionalDouble &stitchingDelta, const OptionalDouble &stitchingEnd,
       const OptionalDouble &stitchingStartOverlap,
       const OptionalDouble &stitchingEndOverlap, const double &wavelengthStep);
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetectorEfficiencyCor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetectorEfficiencyCor.h
@@ -102,7 +102,7 @@ private:
   /// Retrieve algorithm properties
   void retrieveProperties();
   /// Correct the given spectra index for efficiency
-  void correctForEfficiency(int64_t spectraIndex);
+  void correctForEfficiency(int64_t spectraIn);
   /// Calculate one over the wave vector for 2 bin bounds
   double calculateOneOverK(double loBinBound, double uppBinBound) const;
   /// Sets the detector geometry cache if necessary

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetectorEfficiencyVariation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetectorEfficiencyVariation.h
@@ -85,8 +85,8 @@ protected:
 
   /// Loads and checks the values passed to the algorithm
   void retrieveProperties(API::MatrixWorkspace_sptr &whiteBeam1,
-                          API::MatrixWorkspace_sptr &whiteBeam2, double &variation,
-                          int &minSpec, int &maxSpec);
+                          API::MatrixWorkspace_sptr &whiteBeam2,
+                          double &variation, int &minSpec, int &maxSpec);
   /// Apply the detector test criterion
   int doDetectorTests(API::MatrixWorkspace_const_sptr counts1,
                       API::MatrixWorkspace_const_sptr counts2,

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetectorEfficiencyVariation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetectorEfficiencyVariation.h
@@ -85,7 +85,7 @@ protected:
 
   /// Loads and checks the values passed to the algorithm
   void retrieveProperties(API::MatrixWorkspace_sptr &whiteBeam1,
-                          API::MatrixWorkspace_sptr &whiteBeam2, double &vari,
+                          API::MatrixWorkspace_sptr &whiteBeam2, double &variation,
                           int &minSpec, int &maxSpec);
   /// Apply the detector test criterion
   int doDetectorTests(API::MatrixWorkspace_const_sptr counts1,

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaks.h
@@ -182,8 +182,8 @@ private:
                      const API::IPeakFunction_sptr peakfunction,
                      const API::IBackgroundFunction_sptr backgroundfunction,
                      const std::vector<double> &vec_fitwindow,
-                     const std::vector<double> &vec_peakrange,
-                     int minGuessFWHM, int maxGuessFWHM, int guessedFWHMStep,
+                     const std::vector<double> &vec_peakrange, int minGuessFWHM,
+                     int maxGuessFWHM, int guessedFWHMStep,
                      int estBackResult = 0);
 
   std::vector<std::string> m_peakParameterNames;

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaks.h
@@ -110,7 +110,7 @@ private:
 
   /// Fit peak confined in a given window (x-min, x-max)
   void fitPeakInWindow(const API::MatrixWorkspace_sptr &input,
-                       const int spectrum, const double centre,
+                       const int spectrum, const double centre_guess,
                        const double xmin, const double xmax);
 
   /// Fit peak by given/guessed FWHM
@@ -163,7 +163,7 @@ private:
   void estimatePeakRange(const MantidVec &vecX, size_t i_centre, size_t i_min,
                          size_t i_max, const double &leftfwhm,
                          const double &rightfwhm,
-                         std::vector<double> &vecpeakrang);
+                         std::vector<double> &vecpeakrange);
 
   /// Estimate peak parameters
   std::string estimatePeakParameters(
@@ -183,7 +183,7 @@ private:
                      const API::IBackgroundFunction_sptr backgroundfunction,
                      const std::vector<double> &vec_fitwindow,
                      const std::vector<double> &vec_peakrange,
-                     int minGuessedFWHM, int maxGuessFWHM, int guessedFWHMStep,
+                     int minGuessFWHM, int maxGuessFWHM, int guessedFWHMStep,
                      int estBackResult = 0);
 
   std::vector<std::string> m_peakParameterNames;

--- a/Framework/Algorithms/inc/MantidAlgorithms/FitPeak.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FitPeak.h
@@ -47,7 +47,7 @@ public:
   void setPeakRange(double xpeakleft, double xpeakright);
 
   /// Set peak width to guess
-  void setupGuessedFWHM(double width, int minfwhm, int maxfwhm, int stepsize,
+  void setupGuessedFWHM(double usrwidth, int minfwhm, int maxfwhm, int stepsize,
                         bool fitwithsteppedfwhm);
 
   void setFitPeakCriteria(bool usepeakpostol, double peakpostol);

--- a/Framework/Algorithms/inc/MantidAlgorithms/GetAllEi.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GetAllEi.h
@@ -67,7 +67,7 @@ private:
   void init() override;
   void exec() override;
   Kernel::Property *getPLogForProperty(const API::MatrixWorkspace_sptr &inputWS,
-                                       const std::string &name);
+                                       const std::string &propertyName);
   void setFilterLog(const API::MatrixWorkspace_sptr &inputWS);
   // former lambda function exposed as not evry compiler support this yet
   bool peakGuess(const API::MatrixWorkspace_sptr &inputWS, size_t index,
@@ -95,12 +95,12 @@ protected: // for testing, private otherwise.
   /**Get energy of monitor peak if one is present*/
   bool findMonitorPeak(const API::MatrixWorkspace_sptr &inputWS, double Ei,
                        const std::vector<size_t> &monsRangeMin,
-                       const std::vector<size_t> &monsRangeMax, double &energy,
-                       double &height, double &width);
+                       const std::vector<size_t> &monsRangeMax, double &position,
+                       double &height, double &twoSigma);
   /**Find indexes of each expected peak intervals */
   void findBinRanges(const MantidVec &eBins, const MantidVec &signal,
-                     const std::vector<double> &guess_energies,
-                     double Eresolution, std::vector<size_t> &irangeMin,
+                     const std::vector<double> &guess_energy,
+                     double eResolution, std::vector<size_t> &irangeMin,
                      std::vector<size_t> &irangeMax,
                      std::vector<bool> &guessValid);
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/GetAllEi.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GetAllEi.h
@@ -95,8 +95,8 @@ protected: // for testing, private otherwise.
   /**Get energy of monitor peak if one is present*/
   bool findMonitorPeak(const API::MatrixWorkspace_sptr &inputWS, double Ei,
                        const std::vector<size_t> &monsRangeMin,
-                       const std::vector<size_t> &monsRangeMax, double &position,
-                       double &height, double &twoSigma);
+                       const std::vector<size_t> &monsRangeMax,
+                       double &position, double &height, double &twoSigma);
   /**Find indexes of each expected peak intervals */
   void findBinRanges(const MantidVec &eBins, const MantidVec &signal,
                      const std::vector<double> &guess_energy,

--- a/Framework/Algorithms/inc/MantidAlgorithms/GetDetOffsetsMultiPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GetDetOffsetsMultiPeaks.h
@@ -129,7 +129,7 @@ private:
                          double &deltaDovD, double &dev_deltaDovD);
 
   FitPeakOffsetResult
-  calculatePeakOffset(const int wi, std::vector<double> &fittedpeakpositions,
+  calculatePeakOffset(const int wi, std::vector<double> &vec_peakPosFitted,
                       std::vector<double> &vec_peakPosRef);
 
   /// Calculate a spectrum's offset by optimizing offset

--- a/Framework/Algorithms/inc/MantidAlgorithms/GetEi2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GetEi2.h
@@ -98,7 +98,7 @@ private:
                                   const double first, const double width,
                                   const double end);
   /// Integrate the point data
-  void integrate(double &integral_value, double &integral_err,
+  void integrate(double &integral_val, double &integral_err,
                  const MantidVec &x, const MantidVec &s, const MantidVec &e,
                  const double xmin, const double xmax) const;
   /// Store the incident energy within the sample object

--- a/Framework/Algorithms/inc/MantidAlgorithms/GetEi2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GetEi2.h
@@ -98,9 +98,9 @@ private:
                                   const double first, const double width,
                                   const double end);
   /// Integrate the point data
-  void integrate(double &integral_val, double &integral_err,
-                 const MantidVec &x, const MantidVec &s, const MantidVec &e,
-                 const double xmin, const double xmax) const;
+  void integrate(double &integral_val, double &integral_err, const MantidVec &x,
+                 const MantidVec &s, const MantidVec &e, const double xmin,
+                 const double xmax) const;
   /// Store the incident energy within the sample object
   void storeEi(const double ei) const;
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/He3TubeEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/He3TubeEfficiency.h
@@ -94,7 +94,7 @@ private:
                        const Geometry::Object *shape) const;
   /// Calculate the detector efficiency
   double detectorEfficiency(const double alpha,
-                            const double scale_fac = 1.0) const;
+                            const double scale_factor = 1.0) const;
   /// Log any errors with spectra that occurred
   void logErrors() const;
   /// Retrieve the detector parameters from workspace or detector properties

--- a/Framework/Algorithms/inc/MantidAlgorithms/Integration.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Integration.h
@@ -82,7 +82,7 @@ private:
   void exec() override;
 
   API::MatrixWorkspace_sptr
-  rangeFilterEventWorkspace(API::MatrixWorkspace_sptr eventWorkspace,
+  rangeFilterEventWorkspace(API::MatrixWorkspace_sptr workspace,
                             double minRange, double maxRange);
 
   /// Get the input workspace

--- a/Framework/Algorithms/inc/MantidAlgorithms/MaxEnt.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MaxEnt.h
@@ -105,8 +105,8 @@ private:
                                              const std::vector<double> &image,
                                              double background);
   // Calculates chi-square by solving the matrix equation A*x = b
-  double calculateChi(const SearchDirections &coeffs, double a,
-                      std::vector<double> &beta);
+  double calculateChi(const SearchDirections &dirs, double a,
+                      std::vector<double> &b);
   // Calculates the SVD of the input matrix A
   std::vector<double> solveSVD(const Kernel::DblMatrix &A,
                                const Kernel::DblMatrix &B);

--- a/Framework/Algorithms/inc/MantidAlgorithms/MedianDetectorTest.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MedianDetectorTest.h
@@ -91,12 +91,12 @@ private:
   /// Calculates the sum of solid angles of detectors for each histogram
   API::MatrixWorkspace_sptr getSolidAngles(int firstSpec, int lastSpec);
   /// Mask the outlier values to get a better median value
-  int maskOutliers(const std::vector<double> median,
+  int maskOutliers(const std::vector<double> medianvec,
                    API::MatrixWorkspace_sptr countsWS,
                    std::vector<std::vector<size_t>> indexmap);
   /// Do the tests and mask those that fail
   int doDetectorTests(const API::MatrixWorkspace_sptr countsWS,
-                      const std::vector<double> median,
+                      const std::vector<double> medianvec,
                       std::vector<std::vector<size_t>> indexmap,
                       API::MatrixWorkspace_sptr maskWS);
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/MonitorEfficiencyCorUser.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MonitorEfficiencyCorUser.h
@@ -38,7 +38,7 @@ private:
   double calculateFormulaValue(const std::string &, double);
   std::string getValFromInstrumentDef(const std::string &);
   void applyMonEfficiency(const size_t numberOfChannels, const MantidVec &yIn,
-                          const MantidVec &eIn, const double coeff,
+                          const MantidVec &eIn, const double effVec,
                           MantidVec &yOut, MantidVec &eOut);
 
   /// The user selected (input) workspace

--- a/Framework/Algorithms/inc/MantidAlgorithms/NormaliseByCurrent.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/NormaliseByCurrent.h
@@ -74,7 +74,7 @@ private:
   void exec() override;
   // Extract the charge value from the logs.
   double
-  extractCharge(boost::shared_ptr<Mantid::API::MatrixWorkspace> inputWs) const;
+  extractCharge(boost::shared_ptr<Mantid::API::MatrixWorkspace> inputWS) const;
 };
 
 } // namespace Algorithm

--- a/Framework/Algorithms/inc/MantidAlgorithms/NormaliseToMonitor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/NormaliseToMonitor.h
@@ -101,7 +101,7 @@ protected: // for testing
                          int &spectra_num);
   API::MatrixWorkspace_sptr
   getMonitorWorkspace(const API::MatrixWorkspace_sptr &inputWorkspace,
-                      int &workspaceIndex);
+                      int &wsID);
   API::MatrixWorkspace_sptr
   extractMonitorSpectrum(const API::MatrixWorkspace_sptr &WS,
                          std::size_t index);

--- a/Framework/Algorithms/inc/MantidAlgorithms/Q1D2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Q1D2.h
@@ -92,7 +92,7 @@ private:
   void getQBinPlus1(const MantidVec &OutQs, const double QToFind,
                     MantidVec::const_iterator &loc) const;
   void normalize(const MantidVec &normSum, const MantidVec &normError2,
-                 MantidVec &YOut, MantidVec &errors) const;
+                 MantidVec &counts, MantidVec &errors) const;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/RadiusSum.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RadiusSum.h
@@ -77,7 +77,7 @@ private:
   double getMaxDistance(const Kernel::V3D &centre,
                         const std::vector<double> &boundary_limits);
 
-  void setUpOutputWorkspace(std::vector<double> &output);
+  void setUpOutputWorkspace(std::vector<double> &values);
 
   int getBinForPixelPos(const Kernel::V3D &pos);
 
@@ -118,7 +118,7 @@ private:
                             (max_radius - min_radius));
   }
 
-  void normalizeOutputByRadius(std::vector<double> &output, double exp_power);
+  void normalizeOutputByRadius(std::vector<double> &values, double exp_power);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/Rebin.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Rebin.h
@@ -92,8 +92,8 @@ protected:
   void init() override;
   void exec() override;
 
-  void propagateMasks(API::MatrixWorkspace_const_sptr inputW,
-                      API::MatrixWorkspace_sptr outputW, int hist);
+  void propagateMasks(API::MatrixWorkspace_const_sptr inputWS,
+                      API::MatrixWorkspace_sptr outputWS, int hist);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne.h
@@ -94,8 +94,7 @@ private:
       const int &i0MonitorIndex, API::MatrixWorkspace_sptr firstTransmissionRun,
       OptionalMatrixWorkspace_sptr secondTransmissionRun,
       const OptionalDouble &stitchingStart,
-      const OptionalDouble &stitchingDelta,
-      const OptionalDouble &stitchingEnd,
+      const OptionalDouble &stitchingDelta, const OptionalDouble &stitchingEnd,
       const OptionalDouble &stitchingStartOverlap,
       const OptionalDouble &stitchingEndOverlap, const double &wavelengthStep,
       const std::string &numeratorProcessingCommands);

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne.h
@@ -56,7 +56,7 @@ public:
   /// Convert to an IvsQ workspace. Performs detector positional corrections
   /// based on the component name and the theta value.
   Mantid::API::MatrixWorkspace_sptr toIvsQ(API::MatrixWorkspace_sptr &toConvert,
-                                           const bool correctPosition,
+                                           const bool bCorrectPosition,
                                            OptionalDouble &thetaInDeg,
                                            const bool isPointDetector);
 
@@ -93,12 +93,12 @@ private:
       const MinMax &wavelengthMonitorIntegrationInterval,
       const int &i0MonitorIndex, API::MatrixWorkspace_sptr firstTransmissionRun,
       OptionalMatrixWorkspace_sptr secondTransmissionRun,
-      const OptionalDouble &stitchingStartQ,
-      const OptionalDouble &stitchingDeltaQ,
-      const OptionalDouble &stitchingEndQ,
-      const OptionalDouble &stitchingStartOverlapQ,
-      const OptionalDouble &stitchingEndOverlapQ, const double &wavelengthStep,
-      const std::string &processingCommands);
+      const OptionalDouble &stitchingStart,
+      const OptionalDouble &stitchingDelta,
+      const OptionalDouble &stitchingEnd,
+      const OptionalDouble &stitchingStartOverlap,
+      const OptionalDouble &stitchingEndOverlap, const double &wavelengthStep,
+      const std::string &numeratorProcessingCommands);
 
   /// Perform transmission correction using either PolynomialCorrection
   /// or ExponentialCorrection.

--- a/Framework/Algorithms/inc/MantidAlgorithms/RemoveBackground.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RemoveBackground.h
@@ -54,10 +54,10 @@ public:
 
   void initialize(const API::MatrixWorkspace_const_sptr &bkgWS,
                   const API::MatrixWorkspace_sptr &sourceWS, int emode,
-                  Kernel::Logger *pLog = nullptr, int nTreads = 1,
+                  Kernel::Logger *pLog = nullptr, int nThreads = 1,
                   bool inPlace = true, bool nullifyNegative = false);
-  void removeBackground(int hist, MantidVec &XValues, MantidVec &y_data,
-                        MantidVec &e_data, int tread_num = 0) const;
+  void removeBackground(int nHist, MantidVec &x_data, MantidVec &y_data,
+                        MantidVec &e_data, int threadNum = 0) const;
 
 private:
   // vector of pointers to the units conversion class for the working workspace;

--- a/Framework/Algorithms/inc/MantidAlgorithms/ResetNegatives.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ResetNegatives.h
@@ -52,7 +52,7 @@ private:
   void pushMinimum(API::MatrixWorkspace_const_sptr minWS,
                    API::MatrixWorkspace_sptr wksp, API::Progress &prog);
   void changeNegatives(API::MatrixWorkspace_const_sptr minWS,
-                       const double value, API::MatrixWorkspace_sptr wksp,
+                       const double spectrumNegativeValues, API::MatrixWorkspace_sptr wksp,
                        API::Progress &prog);
 };
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/ResetNegatives.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ResetNegatives.h
@@ -52,8 +52,8 @@ private:
   void pushMinimum(API::MatrixWorkspace_const_sptr minWS,
                    API::MatrixWorkspace_sptr wksp, API::Progress &prog);
   void changeNegatives(API::MatrixWorkspace_const_sptr minWS,
-                       const double spectrumNegativeValues, API::MatrixWorkspace_sptr wksp,
-                       API::Progress &prog);
+                       const double spectrumNegativeValues,
+                       API::MatrixWorkspace_sptr wksp, API::Progress &prog);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/Stitch1D.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Stitch1D.h
@@ -69,7 +69,7 @@ private:
   /// Get the rebin parameters
   Mantid::MantidVec getRebinParams(Mantid::API::MatrixWorkspace_sptr &lhsWS,
                                    Mantid::API::MatrixWorkspace_sptr &rhsWS,
-                                   const bool scaleRHSWS) const;
+                                   const bool scaleRHS) const;
   /// Perform rebin
   Mantid::API::MatrixWorkspace_sptr
   rebin(Mantid::API::MatrixWorkspace_sptr &input,

--- a/Framework/Algorithms/inc/MantidAlgorithms/TOFSANSResolutionByPixel.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/TOFSANSResolutionByPixel.h
@@ -54,7 +54,7 @@ private:
   void checkInput(Mantid::API::MatrixWorkspace_sptr inWS);
   /// Get the moderator workspace
   Mantid::API::MatrixWorkspace_sptr
-  getModeratorWorkspace(Mantid::API::MatrixWorkspace_sptr inWS);
+  getModeratorWorkspace(Mantid::API::MatrixWorkspace_sptr inputWorkspace);
   /// Create an output workspace
   Mantid::API::MatrixWorkspace_sptr
   setupOutputWorkspace(Mantid::API::MatrixWorkspace_sptr inputWorkspace);

--- a/Framework/Algorithms/inc/MantidAlgorithms/TOFSANSResolutionByPixelCalculator.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/TOFSANSResolutionByPixelCalculator.h
@@ -35,8 +35,8 @@ public:
                                         double lCollim, double l2) const;
   double getSigmaQValue(double moderatorValue,
                         double wavlengthIndependentFactor, double q,
-                        double wavelength, double deltaWavelength,
-                        double l1, double l2) const;
+                        double wavelength, double deltaWavelength, double l1,
+                        double l2) const;
 };
 }
 }

--- a/Framework/Algorithms/inc/MantidAlgorithms/TOFSANSResolutionByPixelCalculator.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/TOFSANSResolutionByPixelCalculator.h
@@ -32,11 +32,11 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 class DLLExport TOFSANSResolutionByPixelCalculator {
 public:
   double getWavelengthIndependentFactor(double r1, double r2, double deltaR,
-                                        double l1, double l2) const;
+                                        double lCollim, double l2) const;
   double getSigmaQValue(double moderatorValue,
                         double wavlengthIndependentFactor, double q,
                         double wavelength, double deltaWavelength,
-                        double lCollim, double l2) const;
+                        double l1, double l2) const;
 };
 }
 }

--- a/Framework/Algorithms/inc/MantidAlgorithms/Transpose.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Transpose.h
@@ -73,8 +73,7 @@ private:
   API::MatrixWorkspace_sptr
   createOutputWorkspace(API::MatrixWorkspace_const_sptr inputWorkspace);
   /// Return the vertical axis on the workspace, throwing if it is not valid
-  API::Axis *
-  getVerticalAxis(API::MatrixWorkspace_const_sptr workspace) const;
+  API::Axis *getVerticalAxis(API::MatrixWorkspace_const_sptr workspace) const;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/Transpose.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Transpose.h
@@ -71,10 +71,10 @@ private:
   void exec() override;
   /// Create the output workspace
   API::MatrixWorkspace_sptr
-  createOutputWorkspace(API::MatrixWorkspace_const_sptr workspace);
+  createOutputWorkspace(API::MatrixWorkspace_const_sptr inputWorkspace);
   /// Return the vertical axis on the workspace, throwing if it is not valid
   API::Axis *
-  getVerticalAxis(API::MatrixWorkspace_const_sptr inputWorkspace) const;
+  getVerticalAxis(API::MatrixWorkspace_const_sptr workspace) const;
 };
 
 } // namespace Algorithms

--- a/Framework/Crystal/inc/MantidCrystal/ConnectedComponentLabeling.h
+++ b/Framework/Crystal/inc/MantidCrystal/ConnectedComponentLabeling.h
@@ -64,7 +64,7 @@ class DLLExport ConnectedComponentLabeling {
 
 public:
   /// Constructor
-  ConnectedComponentLabeling(const size_t &id = 1,
+  ConnectedComponentLabeling(const size_t &startId = 1,
                              const boost::optional<int> nThreads = boost::none);
 
   /// Getter for the start label id
@@ -95,7 +95,7 @@ private:
   /// Calculate the disjoint element tree across the image.
   ConnectedComponentMappingTypes::ClusterMap
   calculateDisjointTree(Mantid::API::IMDHistoWorkspace_sptr ws,
-                        BackgroundStrategy *const strategy,
+                        BackgroundStrategy *const baseStrategy,
                         Mantid::API::Progress &progress) const;
 
   /// Start labeling index

--- a/Framework/Crystal/inc/MantidCrystal/HardThresholdBackground.h
+++ b/Framework/Crystal/inc/MantidCrystal/HardThresholdBackground.h
@@ -36,7 +36,7 @@ class DLLExport HardThresholdBackground : public BackgroundStrategy {
 public:
   /// Contructor
   HardThresholdBackground(const double thresholdSignal,
-                          const Mantid::API::MDNormalization normalisation);
+                          const Mantid::API::MDNormalization normalization);
 
   /// Overriden isBackground
   bool isBackground(Mantid::API::IMDIterator *iterator) const override;

--- a/Framework/Crystal/inc/MantidCrystal/IndexSXPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/IndexSXPeaks.h
@@ -173,7 +173,7 @@ public:
 
 private:
   // Helper method to cull potential hkls off each peak.
-  void cullHKLs(std::vector<PeakCandidate> &peaksCandidates,
+  void cullHKLs(std::vector<PeakCandidate> &peakCandidates,
                 Mantid::Geometry::UnitCell &unitcell);
   // Helper method used to check that not all peaks are colinear.
   void validateNotColinear(std::vector<PeakCandidate> &peakCandidates) const;

--- a/Framework/Crystal/inc/MantidCrystal/IntegratePeakTimeSlices.h
+++ b/Framework/Crystal/inc/MantidCrystal/IntegratePeakTimeSlices.h
@@ -115,9 +115,9 @@ public:
       EdgeY = newsize;
   }
 
-  void CalcVariancesFromData(double background, double row, double col,
-                             double &Varx, double &Vary, double &Varxy,
-                             std::vector<double> &ParameterValues);
+  void CalcVariancesFromData(double background, double meanx, double meany,
+                             double &Varxx, double &Varxy, double &Varyy,
+                             std::vector<double> &StatBase);
 
   bool IsEnoughData(const double *ParameterValues, Kernel::Logger &);
 
@@ -143,7 +143,7 @@ public:
 
   bool CalcVariances();
 
-  std::vector<double> GetParams(double background);
+  std::vector<double> GetParams(double b);
 
   double StatBaseVals(int index) {
     if (index < 0 || index >= (int)StatBase.size())
@@ -308,12 +308,12 @@ private:
   /**
    *  Tests several starting points in the Marquardt algorithm then calls Fit.
    */
-  void PreFit(API::MatrixWorkspace_sptr &Data, double &chisq, bool &done,
+  void PreFit(API::MatrixWorkspace_sptr &Data, double &chisqOverDOF, bool &done,
               std::vector<std::string> &names, std::vector<double> &params,
               std::vector<double> &errs, double lastRow, double lastCol,
               double neighborRadius);
 
-  void Fit(API::MatrixWorkspace_sptr &Data, double &chisq, bool &done,
+  void Fit(API::MatrixWorkspace_sptr &Data, double &chisqOverDOF, bool &done,
            std::vector<std::string> &names, std::vector<double> &params,
            std::vector<double> &errs, double lastRow, double lastCol,
            double neighborRadius);
@@ -322,12 +322,12 @@ private:
 
   bool isGoodFit(std::vector<double> const &params,
                  std::vector<double> const &errs,
-                 std::vector<std::string> const &names, double chisq);
+                 std::vector<std::string> const &names, double chisqOverDOF);
   // returns last row added
   int UpdateOutputWS(DataObjects::TableWorkspace_sptr &TabWS, const int dir,
                      const double chan, std::vector<double> const &params,
                      std::vector<double> const &errs,
-                     std::vector<std::string> const &names, const double chisq,
+                     std::vector<std::string> const &names, const double Chisq,
                      const double time, std::string spec_idList);
 
   void updatePeakInformation(std::vector<double> const &params,
@@ -336,7 +336,7 @@ private:
                              double &TotVariance, double &TotIntensity,
                              double const TotSliceIntensity,
                              double const TotSliceVariance,
-                             double const chisqdivDOF, const int ncelss);
+                             double const chisqdivDOF, const int ncells);
 
   void updateStats(const double intensity, const double variance,
                    const double row, const double col,
@@ -348,7 +348,7 @@ private:
   double CalculateIsawIntegrateError(const double background,
                                      const double backError,
                                      const double ChiSqOverDOF,
-                                     const double TotIntensity,
+                                     const double TotVariance,
                                      const int ncells);
 
   void FindPlane(Kernel::V3D &center, Kernel::V3D &xvec, Kernel::V3D &yvec,

--- a/Framework/Crystal/inc/MantidCrystal/PeaksInRegion.h
+++ b/Framework/Crystal/inc/MantidCrystal/PeaksInRegion.h
@@ -55,7 +55,7 @@ private:
   bool
   pointOutsideAnyExtents(const Mantid::Kernel::V3D &testPoint) const override;
   bool
-  pointInsideAllExtents(const Mantid::Kernel::V3D &testPoints,
+  pointInsideAllExtents(const Mantid::Kernel::V3D &testPoint,
                         const Mantid::Kernel::V3D &peakCenter) const override;
   void checkTouchPoint(const Mantid::Kernel::V3D &touchPoint,
                        const Mantid::Kernel::V3D &normal,

--- a/Framework/Crystal/inc/MantidCrystal/PeaksIntersection.h
+++ b/Framework/Crystal/inc/MantidCrystal/PeaksIntersection.h
@@ -53,7 +53,7 @@ protected:
   void initBaseProperties();
 
   /// Run the algorithm.
-  void executePeaksIntersection(const bool checkExtents = true);
+  void executePeaksIntersection(const bool checkPeakExtents = true);
 
   /// Get the peak radius.
   double getPeakRadius() const;

--- a/Framework/Crystal/inc/MantidCrystal/PeaksOnSurface.h
+++ b/Framework/Crystal/inc/MantidCrystal/PeaksOnSurface.h
@@ -55,7 +55,7 @@ private:
   bool
   pointOutsideAnyExtents(const Mantid::Kernel::V3D &testPoint) const override;
   bool
-  pointInsideAllExtents(const Mantid::Kernel::V3D &testPoints,
+  pointInsideAllExtents(const Mantid::Kernel::V3D &testPoint,
                         const Mantid::Kernel::V3D &peakCenter) const override;
   void checkTouchPoint(const Mantid::Kernel::V3D &touchPoint,
                        const Mantid::Kernel::V3D &normal,
@@ -80,7 +80,7 @@ private:
 bool DLLExport lineIntersectsSphere(const Mantid::Kernel::V3D &line,
                                     const Mantid::Kernel::V3D &lineStart,
                                     const Mantid::Kernel::V3D &peakCenter,
-                                    const double peakRadiusSQ);
+                                    const double peakRadius);
 
 } // namespace Crystal
 } // namespace Mantid

--- a/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
@@ -54,7 +54,7 @@ private:
       std::vector<Kernel::V3D> &possibleHKLs) const;
 
   void fillPossibleHKLsUsingPeaksWorkspace(
-      const DataObjects::PeaksWorkspace_sptr &possibleHKLWorkspace,
+      const DataObjects::PeaksWorkspace_sptr &peaksWorkspace,
       std::vector<Kernel::V3D> &possibleHKLs) const;
 
   void setStructureFactorCalculatorFromSample(const API::Sample &sample);

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels.h
@@ -106,7 +106,7 @@ public:
    *the
    *                        NewInstrument's parameter map.
    *
-   *   @param RotateCenters Rotate the centers of the panels(the same amount)
+   *   @param RotCenters Rotate the centers of the panels(the same amount)
    *with the
    *                        rotation of panels around their center
    */

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels.h
@@ -116,7 +116,7 @@ public:
       Kernel::V3D const pos, Kernel::Quat const rot, double const DetWScale,
       double const DetHtScale,
       boost::shared_ptr<const Geometry::ParameterMap> const pmapOld,
-      bool RotateCenters);
+      bool RotCenters);
 
   /**
    * *  Updates the ParameterMap for NewInstrument to reflect the position of

--- a/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
@@ -64,9 +64,9 @@ public:
      *
      *
      */
-  SCDPanelErrors(DataObjects::PeaksWorkspace_sptr &pwk, std::string &BankNames,
-                 double a, double b, double c, double alpha, double beta,
-                 double gamma, double tolerance);
+  SCDPanelErrors(DataObjects::PeaksWorkspace_sptr &pwk, std::string &Component_name,
+                 double ax, double bx, double cx, double alphax, double betax,
+                 double gammax, double tolerance1);
 
   ~SCDPanelErrors() override;
 

--- a/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
@@ -64,9 +64,9 @@ public:
      *
      *
      */
-  SCDPanelErrors(DataObjects::PeaksWorkspace_sptr &pwk, std::string &Component_name,
-                 double ax, double bx, double cx, double alphax, double betax,
-                 double gammax, double tolerance1);
+  SCDPanelErrors(DataObjects::PeaksWorkspace_sptr &pwk,
+                 std::string &Component_name, double ax, double bx, double cx,
+                 double alphax, double betax, double gammax, double tolerance1);
 
   ~SCDPanelErrors() override;
 

--- a/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
@@ -46,7 +46,8 @@ public:
   /**
      * Constructor
      * @param pwk       - The PeaksWorkspace
-     * @param Component_name - The comma separated list of bank names for which this
+     * @param Component_name - The comma separated list of bank names for which
+    *this
     *Function
      *                     this Function calculates the associated errors in
     *qx,qy,qz

--- a/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
@@ -46,17 +46,17 @@ public:
   /**
      * Constructor
      * @param pwk       - The PeaksWorkspace
-     * @param BankNames - The comma separated list of bank names for which this
+     * @param Component_name - The comma separated list of bank names for which this
     *Function
      *                     this Function calculates the associated errors in
     *qx,qy,qz
-     * @param a         - The a lattice parameter
-     * @param b         - The b lattice parameter
-     * @param c         - The c lattice parameter
-     * @param alpha     - The alpha lattice parameter in degrees
-     * @param beta      - The beta lattice parameter in degrees
-     * @param gamma     - The gamma lattice parameter in degrees
-     * @param tolerance - The maximum distance a peak's h value, k value and
+     * @param ax         - The a lattice parameter
+     * @param bx         - The b lattice parameter
+     * @param cx         - The c lattice parameter
+     * @param alphax     - The alpha lattice parameter in degrees
+     * @param betax      - The beta lattice parameter in degrees
+     * @param gammax     - The gamma lattice parameter in degrees
+     * @param tolerance1 - The maximum distance a peak's h value, k value and
     *lvalue are
      *                    from an integer to be considered indexed. Outside of
     *this

--- a/Framework/Crystal/inc/MantidCrystal/TOFExtinction.h
+++ b/Framework/Crystal/inc/MantidCrystal/TOFExtinction.h
@@ -60,7 +60,7 @@ private:
   /// Run the algorithm;
   void exec() override;
   double getEg(double mosaic);
-  double getEgLaue(double Eb, double twoth, double wl, double divBeam,
+  double getEgLaue(double Eg, double twoth, double wl, double divBeam,
                    double betaBeam);
   double getXqt(double Eg, double cellV, double wl, double twoth, double tbar,
                 double fsq);

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CalculateMSVesuvio.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CalculateMSVesuvio.h
@@ -114,7 +114,7 @@ private:
   // single-event helpers
   Kernel::V3D generateSrcPos(const double l1) const;
   double generateE0(const double l1, const double t2, double &weight) const;
-  double generateTOF(const double gaussTOF, const double dtof,
+  double generateTOF(const double en0, const double dtof,
                      const double dl1) const;
   bool generateScatter(const Kernel::V3D &startPos, const Kernel::V3D &direc,
                        double &weight, Kernel::V3D &scatterPt) const;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvertToYSpace.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvertToYSpace.h
@@ -82,9 +82,8 @@ public:
                         const std::string &name);
   /// Convert single time value to Y,Q & Ei values
   static void calculateY(double &yspace, double &qspace, double &ei,
-                         const double mass, const double tsec,
-                         const double k1, const double v1,
-                         const DetectorParams &detpar);
+                         const double mass, const double tsec, const double k1,
+                         const double v1, const DetectorParams &detpar);
 
 private:
   void init() override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvertToYSpace.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvertToYSpace.h
@@ -82,7 +82,7 @@ public:
                         const std::string &name);
   /// Convert single time value to Y,Q & Ei values
   static void calculateY(double &yspace, double &qspace, double &ei,
-                         const double mass, const double tmicro,
+                         const double mass, const double tsec,
                          const double k1, const double v1,
                          const DetectorParams &detpar);
 
@@ -91,7 +91,7 @@ private:
   void exec() override;
 
   /// Perform the conversion to Y-space
-  bool convert(const size_t i);
+  bool convert(const size_t index);
   /// Check and store appropriate input data
   void retrieveInputs();
   /// Create the output workspace

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/FitPowderDiffPeaks.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/FitPowderDiffPeaks.h
@@ -287,13 +287,15 @@ private:
             double guessedfwhm);
 
   /// Fit background-removed peak by Gaussian
-  bool doFitGaussianPeak(DataObjects::Workspace2D_sptr dataws, size_t workspaceindex,
-                         double in_center, double leftfwhm, double rightfwhm,
-                         double &center, double &sigma, double &height);
+  bool doFitGaussianPeak(DataObjects::Workspace2D_sptr dataws,
+                         size_t workspaceindex, double in_center,
+                         double leftfwhm, double rightfwhm, double &center,
+                         double &sigma, double &height);
 
   /// Create a Workspace2D for fitted peaks (pattern)
   DataObjects::Workspace2D_sptr
-  genOutputFittedPatternWorkspace(std::vector<double> pattern, int workspaceindex);
+  genOutputFittedPatternWorkspace(std::vector<double> pattern,
+                                  int workspaceindex);
 
   /// Calcualte the value of a single peak in a given range.
   void calculate1PeakGroup(std::vector<size_t> peakindexes,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/FitPowderDiffPeaks.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/FitPowderDiffPeaks.h
@@ -100,7 +100,7 @@ private:
 
   /// Import instrument parameters from (input) table workspace
   void importInstrumentParameterFromTable(
-      DataObjects::TableWorkspace_sptr m_profileTable);
+      DataObjects::TableWorkspace_sptr parameterWS);
 
   /// Import Bragg peak table workspace
   void
@@ -125,7 +125,7 @@ private:
   bool
   fitSinglePeakRobust(Functions::BackToBackExponential_sptr peak,
                       Functions::BackgroundFunction_sptr backgroundfunction,
-                      double leftdev, double rightdev,
+                      double peakleftbound, double peakrightbound,
                       std::map<std::string, double> rightpeakparammap,
                       double &finalchi2);
 
@@ -287,13 +287,13 @@ private:
             double guessedfwhm);
 
   /// Fit background-removed peak by Gaussian
-  bool doFitGaussianPeak(DataObjects::Workspace2D_sptr dataws, size_t m_wsIndex,
+  bool doFitGaussianPeak(DataObjects::Workspace2D_sptr dataws, size_t workspaceindex,
                          double in_center, double leftfwhm, double rightfwhm,
                          double &center, double &sigma, double &height);
 
   /// Create a Workspace2D for fitted peaks (pattern)
   DataObjects::Workspace2D_sptr
-  genOutputFittedPatternWorkspace(std::vector<double> pattern, int m_wsIndex);
+  genOutputFittedPatternWorkspace(std::vector<double> pattern, int workspaceindex);
 
   /// Calcualte the value of a single peak in a given range.
   void calculate1PeakGroup(std::vector<size_t> peakindexes,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters.h
@@ -146,7 +146,7 @@ private:
   // double calculateDspaceValue(std::vector<int> hkl, double lattice);
 
   /// Calcualte value n for thermal neutron peak profile
-  void calculateThermalNeutronSpecial(API::IFunction_sptr mFunction,
+  void calculateThermalNeutronSpecial(API::IFunction_sptr m_Function,
                                       std::vector<double> vec_d,
                                       std::vector<double> &vec_n);
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/LevenbergMarquardtMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/LevenbergMarquardtMinimizer.h
@@ -50,7 +50,7 @@ public:
   std::string name() const override { return "Levenberg-Marquardt"; }
 
   /// Initialize minimizer, i.e. pass a function to minimize.
-  void initialize(API::ICostFunction_sptr function,
+  void initialize(API::ICostFunction_sptr costFunction,
                   size_t maxIterations = 0) override;
   /// Do one iteration.
   bool iterate(size_t) override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BackToBackExponential.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BackToBackExponential.h
@@ -72,7 +72,7 @@ public:
   const std::string category() const override { return "Peak"; }
   void function1D(double *out, const double *xValues,
                   const size_t nData) const override;
-  void functionDeriv1D(API::Jacobian *out, const double *xValues,
+  void functionDeriv1D(API::Jacobian *jacobian, const double *xValues,
                        const size_t nData) override;
 
 protected:

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ChebfunBase.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ChebfunBase.h
@@ -169,7 +169,7 @@ private:
                              std::vector<double> &p) const;
   /// Calculate function values at odd-valued indices of the base x-points
   std::vector<double> fitOdd(const API::IFunction &f,
-                             std::vector<double> &p) const;
+                             std::vector<double> &pEven) const;
   /// Test an array of Chebyshev coefficients for convergence
   static bool hasConverged(const std::vector<double> &a, double maxA,
                            double tolerance, size_t shift = 0);

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonProfile.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonProfile.h
@@ -58,7 +58,7 @@ public:
   /// Cache a copy of the workspace pointer and pull out the parameters
   void
   setMatrixWorkspace(boost::shared_ptr<const API::MatrixWorkspace> workspace,
-                     size_t wi, double startX, double endX) override;
+                     size_t wsIndex, double startX, double endX) override;
 
   /// Pre-calculate the Y-space values with specified resolution parameters
   void cacheYSpaceValues(const std::vector<double> &tseconds,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonScatteringCountRate.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonScatteringCountRate.h
@@ -57,9 +57,8 @@ private:
   void updateCMatrixValues() const;
 
   /// Cache reference to workspace for use in setupForFit
-  void
-  setMatrixWorkspace(boost::shared_ptr<const API::MatrixWorkspace> matrix,
-                     size_t wsIndex, double startX, double endX) override;
+  void setMatrixWorkspace(boost::shared_ptr<const API::MatrixWorkspace> matrix,
+                          size_t wsIndex, double startX, double endX) override;
   /// Cache ptrs to the individual profiles and their parameters
   void cacheFunctions();
   /// Cache ptr to the individual profile and its parameters

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonScatteringCountRate.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonScatteringCountRate.h
@@ -58,15 +58,15 @@ private:
 
   /// Cache reference to workspace for use in setupForFit
   void
-  setMatrixWorkspace(boost::shared_ptr<const API::MatrixWorkspace> workspace,
-                     size_t wi, double startX, double endX) override;
+  setMatrixWorkspace(boost::shared_ptr<const API::MatrixWorkspace> matrix,
+                     size_t wsIndex, double startX, double endX) override;
   /// Cache ptrs to the individual profiles and their parameters
   void cacheFunctions();
   /// Cache ptr to the individual profile and its parameters
   void cacheComptonProfile(const boost::shared_ptr<ComptonProfile> &profile,
                            const size_t paramsOffset);
   /// Cache parameters positions for background function
-  void cacheBackground(const API::IFunction1D_sptr &profile,
+  void cacheBackground(const API::IFunction1D_sptr &function1D,
                        const size_t paramsOffset);
   /// Set up the constraint matrices
   void createConstraintMatrices(const std::vector<double> &xValues);

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DiffRotDiscreteCircle.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DiffRotDiscreteCircle.h
@@ -109,7 +109,7 @@ public:
                                 const API::IFunction::Attribute &defaultValue);
 
   /// Override parent definition
-  void setAttribute(const std::string &attName, const Attribute &att) override;
+  void setAttribute(const std::string &name, const Attribute &att) override;
 
 private:
   boost::shared_ptr<ElasticDiffRotDiscreteCircle> m_elastic;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DiffSphere.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DiffSphere.h
@@ -153,7 +153,7 @@ public:
                                 const API::IFunction::Attribute &defaultValue);
 
   /// Override parent definition
-  void setAttribute(const std::string &attName, const Attribute &att) override;
+  void setAttribute(const std::string &name, const Attribute &att) override;
 
   /// overwrite IFunction base class method, which declare function parameters
   void init() override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GramCharlierComptonProfile.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GramCharlierComptonProfile.h
@@ -57,7 +57,7 @@ private:
   /// Returns the indices of the intensity parameters
   std::vector<size_t> intensityParameterIndices() const override;
   /// Fill in the columns of the matrix for this mass
-  size_t fillConstraintMatrix(Kernel::DblMatrix &cmatrix, const size_t index,
+  size_t fillConstraintMatrix(Kernel::DblMatrix &cmatrix, const size_t start,
                               const std::vector<double> &errors) const override;
   /// Compute the sum for all Hermite polynomial coefficents
   void massProfile(double *result, const size_t nData) const override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/NeutronBk2BkExpConvPVoigt.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/NeutronBk2BkExpConvPVoigt.h
@@ -60,7 +60,7 @@ public:
 
   /// Override setting a new value to a parameter by name
   void setParameter(const std::string &name, const double &value,
-                    bool explicitlySe = true) override;
+                    bool explicitlySet = true) override;
 
   /// Set peak's height
   // virtual void setHeight(const double h);

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/TabulatedFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/TabulatedFunction.h
@@ -104,7 +104,7 @@ private:
   void clear() const;
 
   /// Evaluate the function for a list of arguments and given scaling factor
-  void eval(double scaling, double shift, double xscale, double *out,
+  void eval(double scaling, double xshift, double xscale, double *out,
             const double *xValues, const size_t nData) const;
 
   /// Fill in the x and y value containers (m_xData and m_yData)

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpConvPVoigt.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpConvPVoigt.h
@@ -90,7 +90,7 @@ public:
 
   /// Override setting a new value to a parameter by name
   void setParameter(const std::string &name, const double &value,
-                    bool explicitlySe = true) override;
+                    bool explicitlySet = true) override;
 
   /// Set peak's height
   // virtual void setHeight(const double h);

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/VesuvioResolution.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/VesuvioResolution.h
@@ -82,7 +82,7 @@ public:
   /// Cache a copy of the workspace pointer and pull out the parameters
   void
   setMatrixWorkspace(boost::shared_ptr<const API::MatrixWorkspace> workspace,
-                     size_t wi, double startX, double endX) override;
+                     size_t wsIndex, double startX, double endX) override;
   /// Pre-calculate the resolution components values
   void cacheResolutionComponents(const Algorithms::DetectorParams &detpar,
                                  const ResolutionParams &respar);
@@ -90,7 +90,7 @@ public:
   void disableLogging() { m_log.setEnabled(false); }
   /// Compute Voigt function
   void voigtApprox(std::vector<double> &voigt,
-                   const std::vector<double> &yspace, const double lorentzPos,
+                   const std::vector<double> &xValues, const double lorentzPos,
                    const double lorentzAmp, const double lorentzWidth,
                    const double gaussWidth) const;
   /// Compute Voigt function with cached values

--- a/Framework/CurveFitting/inc/MantidCurveFitting/IFittingAlgorithm.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/IFittingAlgorithm.h
@@ -63,7 +63,7 @@ private:
   virtual void execConcrete() = 0;
 
   void afterPropertySet(const std::string &propName) override;
-  void addWorkspace(const std::string &workspaceNameProperty,
+  void addWorkspace(const std::string &workspacePropertyName,
                     bool addProperties = true);
   /// Read domain type property and cache the value
   void setDomainType();

--- a/Framework/CurveFitting/inc/MantidCurveFitting/MultiDomainCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/MultiDomainCreator.h
@@ -48,7 +48,7 @@ public:
 
   /// Create a domain from the input workspace
   void createDomain(boost::shared_ptr<API::FunctionDomain> &domain,
-                    boost::shared_ptr<API::FunctionValues> &values,
+                    boost::shared_ptr<API::FunctionValues> &ivalues,
                     size_t i0 = 0) override;
   /// Create the output workspace
   boost::shared_ptr<API::Workspace> createOutputWorkspace(

--- a/Framework/DataHandling/inc/MantidDataHandling/AppendGeometryToSNSNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AppendGeometryToSNSNexus.h
@@ -70,7 +70,7 @@ private:
 
   /// Load logs from the NeXus file
   static bool runLoadNexusLogs(const std::string &nexusFileName,
-                               API::MatrixWorkspace_sptr localWorkspaceName,
+                               API::MatrixWorkspace_sptr localWorkspace,
                                Algorithm *alg);
 
   /// Are we going to make a copy of the NeXus file to operate on ?

--- a/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
@@ -109,7 +109,7 @@ public:
   DataObjects::EventList *getEventListPtr(size_t i);
   void populateInstrumentParameters();
   void setTitle(std::string title);
-  void applyFilter(boost::function<void(API::MatrixWorkspace_sptr)> filter);
+  void applyFilter(boost::function<void(API::MatrixWorkspace_sptr)> func);
   virtual bool threadSafe() const;
 };
 

--- a/Framework/DataHandling/inc/MantidDataHandling/FindDetectorsPar.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/FindDetectorsPar.h
@@ -191,7 +191,7 @@ private:
 
   // calculate generic detectors parameters:
   void calcDetPar(const Geometry::IDetector_const_sptr &spDet,
-                  const Kernel::V3D &GroupCenter, DetParameters &Detector);
+                  const Kernel::V3D &Observer, DetParameters &Detector);
 
   /// if ASCII file is selected as the datasource, this structure describes the
   /// type of this file.
@@ -269,7 +269,7 @@ public:
         m_nComponents(0) {}
   void addDetInfo(const Geometry::IDetector_const_sptr &spDet,
                   const Kernel::V3D &Observer);
-  void returnAvrgDetPar(DetParameters &det);
+  void returnAvrgDetPar(DetParameters &avrgDet);
 
   void setUseSpherical(bool shouldWe = true) { m_useSphericalSizes = shouldWe; }
 

--- a/Framework/DataHandling/inc/MantidDataHandling/ISISRunLogs.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ISISRunLogs.h
@@ -52,7 +52,7 @@ public:
   /// Adds period related logs
   void addPeriodLogs(const int period, API::Run &exptRun);
   /// Add 'period i' log.
-  void addPeriodLog(const int i, API::Run &exptRun);
+  void addPeriodLog(const int period, API::Run &exptRun);
 
 private:
   /// A LogParser object

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -120,7 +120,7 @@ public:
   template <typename T>
   static boost::shared_ptr<BankPulseTimes> runLoadNexusLogs(
       const std::string &nexusfilename, T localWorkspace, Algorithm &alg,
-      bool returnpulsetimes, int &size_t,
+      bool returnpulsetimes, int &nPeriods,
       std::unique_ptr<const Kernel::TimeSeriesProperty<int>> &periodLog);
 
   template <typename T>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadFullprofResolution.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadFullprofResolution.h
@@ -145,7 +145,8 @@ private:
   void parseResolutionStrings(std::map<std::string, double> &parammap,
                               const std::vector<std::string> &lines,
                               const bool useFileBankIDs, int bankid,
-                              int startlineindex, int endlineindex, int profNumber);
+                              int startlineindex, int endlineindex,
+                              int profNumber);
 
   void parseBankLine(std::string line, double &cwl, int &bankid);
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadFullprofResolution.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadFullprofResolution.h
@@ -69,7 +69,7 @@ public:
   /// Put parameters into a matrix workspace
   static void putParametersIntoWorkspace(const API::Column_const_sptr,
                                          API::MatrixWorkspace_sptr ws,
-                                         int profNumber,
+                                         int nProf,
                                          std::string &parameterXMLString);
 
   /// Add an Ikeda-Carpenter PV ALFBE parameter
@@ -118,7 +118,7 @@ public:
   /// Create Bank to Workspace Correspondence
   static void createBankToWorkspaceMap(const std::vector<int> &banks,
                                        const std::vector<int> &workspaces,
-                                       std::map<int, size_t> &WorkpsaceOfBank);
+                                       std::map<int, size_t> &workspaceOfBank);
 
   /// Place to store the row numbers
   static std::map<std::string, size_t> m_rowNumbers;
@@ -137,15 +137,15 @@ private:
 
   /// Scan imported file for bank information
   void scanBanks(const std::vector<std::string> &lines,
-                 const bool useBankIDsInFile, std::vector<int> &banks,
+                 const bool useFileBankIDs, std::vector<int> &banks,
                  std::map<int, int> &bankstartindexmap,
                  std::map<int, int> &bankendindexmap);
 
   /// Parse .irf file to a map
   void parseResolutionStrings(std::map<std::string, double> &parammap,
                               const std::vector<std::string> &lines,
-                              const bool useBankIDsInFile, int bankid,
-                              int startlineindex, int endlineindex, int nProf);
+                              const bool useFileBankIDs, int bankid,
+                              int startlineindex, int endlineindex, int profNumber);
 
   void parseBankLine(std::string line, double &cwl, int &bankid);
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
@@ -74,7 +74,7 @@ public:
 private:
   void recurseAndAddNexusFieldsToWsRun(NXhandle nxfileID, API::Run &runDetails,
                                        std::string &parent_name,
-                                       std::string &parent_class, int indent);
+                                       std::string &parent_class, int level);
 };
 }
 // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadIDFFromNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadIDFFromNexus.h
@@ -96,7 +96,7 @@ private:
   /// Load Parameter File specified by full pathname into given workspace,
   /// return success
   bool loadParameterFile(const std::string &fullPathName,
-                         const API::MatrixWorkspace_sptr workspace);
+                         const API::MatrixWorkspace_sptr localWorkspace);
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
@@ -136,7 +136,7 @@ private:
   void exec() override;
   // Validate the optional input properties
   void checkOptionalProperties(
-      const std::map<int64_t, std::string> &ExcludedMonitors);
+      const std::map<int64_t, std::string> &SpectraExcluded);
   /// Prepare a vector of SpectraBlock structures to simplify loading
   size_t
   prepareSpectraBlocks(std::map<int64_t, std::string> &monitors,
@@ -165,7 +165,7 @@ private:
   void loadBlock(Mantid::NeXus::NXDataSetTyped<int> &data, int64_t blocksize,
                  int64_t period, int64_t start, int64_t &hist,
                  int64_t &spec_num,
-                 DataObjects::Workspace2D_sptr &localWorkspace);
+                 DataObjects::Workspace2D_sptr &local_workspace);
 
   // Create period logs
   void createPeriodLogs(int64_t period,
@@ -176,7 +176,7 @@ private:
   void buildSpectraInd2SpectraNumMap(
       bool range_supplied, int64_t range_min, int64_t range_max,
       const std::vector<int64_t> &spec_list,
-      const std::map<int64_t, std::string> &ExcludedMonitors);
+      const std::map<int64_t, std::string> &SpectraExcluded);
 
   /// The name and path of the input file
   std::string m_filename;
@@ -241,7 +241,7 @@ private:
       NeXus::NXEntry &entry, boost::shared_array<int> &spectrum_index,
       int64_t ndets, int64_t n_vms_compat_spectra,
       std::map<int64_t, std::string> &monitors, bool excludeMonitors,
-      bool separateMonitors, std::map<int64_t, std::string> &ExcludedMonitors);
+      bool separateMonitors, std::map<int64_t, std::string> &OvelapMonitors);
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadInstrument.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadInstrument.h
@@ -109,7 +109,7 @@ private:
 
   /// Search directory for Parameter file, return full path name if found, else
   /// "".
-  std::string getFullPathParamIDF(std::string directory);
+  std::string getFullPathParamIDF(std::string directoryName);
 
   /// The name and path of the input file
   std::string m_filename;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadLog.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadLog.h
@@ -115,7 +115,7 @@ private:
   std::string stringToLower(std::string strToConvert);
 
   /// Checks if the file is an ASCII file
-  bool isAscii(const std::string &filenamePart);
+  bool isAscii(const std::string &filename);
 
   /// Check if first 19 characters of a string is data-time string according to
   /// yyyy-mm-ddThh:mm:ss
@@ -123,7 +123,7 @@ private:
 
   /// Checks if a log file name was provided (e.g. through setPropertyValue). If
   /// not it creates one based on provided path.
-  std::string extractLogName(const std::vector<std::string> &logFileName);
+  std::string extractLogName(const std::vector<std::string> &logName);
 
   /// Check for SNS-style text file
   bool SNSTextFormatColumns(const std::string &str,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
@@ -87,7 +87,7 @@ private:
 
   /// Create the workspace name if it's part of a group workspace
   std::string buildWorkspaceName(const std::string &name,
-                                 const std::string &base_name, int64_t wsIndex,
+                                 const std::string &baseName, int64_t wsIndex,
                                  bool commonStem);
 
   /// Add an index to the name if it already exists in the workspace
@@ -154,7 +154,7 @@ private:
   void getWordsInString(const std::string &words3, std::string &w1,
                         std::string &w2, std::string &w3);
   /// Splits a string of exactly four words into the separate words
-  void getWordsInString(const std::string &words3, std::string &w1,
+  void getWordsInString(const std::string &words4, std::string &w1,
                         std::string &w2, std::string &w3, std::string &w4);
 
   /// Read the bin masking information
@@ -202,7 +202,7 @@ private:
   Mantid::API::Workspace_sptr doAccelleratedMultiPeriodLoading(
       Mantid::NeXus::NXRoot &root, const std::string &entryName,
       Mantid::API::MatrixWorkspace_sptr &tempMatrixWorkspace,
-      const int64_t nWorkspaceEntries, const int64_t i);
+      const int64_t nWorkspaceEntries, const int64_t p);
 
   /// Does the current workspace have uniform binning
   bool m_shared_bins;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
@@ -88,12 +88,12 @@ public:
                                         API::Algorithm *const pAlgo);
   /// creates monitor workspace
   static void createMonitorWorkspace(DataObjects::Workspace2D_sptr &monws_sptr,
-                                     DataObjects::Workspace2D_sptr &ws_sptr,
+                                     DataObjects::Workspace2D_sptr &normalws_sptr,
                                      API::WorkspaceGroup_sptr &mongrp_sptr,
                                      const int64_t mwsSpecs,
                                      const int64_t nwsSpecs,
                                      const int64_t numberOfPeriods,
-                                     const int64_t lenthIn, std::string title,
+                                     const int64_t lengthIn, std::string title,
                                      API::Algorithm *const pAlg);
   /// creates  shared pointer to group workspace
   static API::WorkspaceGroup_sptr createGroupWorkspace();
@@ -141,8 +141,8 @@ protected:
   void ioRaw(FILE *file, bool from_file);
 
   /// reads data
-  bool readData(FILE *file, int histToRead);
-  bool readData(FILE *file, int64_t histToRead);
+  bool readData(FILE *file, int hist);
+  bool readData(FILE *file, int64_t hist);
 
   // Constructs the time channel (X) vector(s)
   std::vector<boost::shared_ptr<MantidVec>>
@@ -203,7 +203,7 @@ protected:
                                specnum_t &normalwsSpecs,
                                specnum_t &monitorwsSpecs);
   /// load the spectra
-  void loadSpectra(FILE *file, const int &period, const int &m_total_specs,
+  void loadSpectra(FILE *file, const int &period, const int &total_specs,
                    DataObjects::Workspace2D_sptr ws_sptr,
                    std::vector<boost::shared_ptr<MantidVec>>);
 
@@ -250,15 +250,15 @@ private:
 
   /// Search for the log files in the workspace, and output their names as a
   /// set.
-  std::list<std::string> searchForLogFiles(const std::string &fileName);
+  std::list<std::string> searchForLogFiles(const std::string &pathToRawFile);
   /// Extract the log name from the path to the specific log file.
   std::string extractLogName(const std::string &path);
   /// Checks if the file is an ASCII file
-  bool isAscii(const std::string &filenamePart);
+  bool isAscii(const std::string &filename);
   /// if  alternate data stream named checksum exists for the raw file
   bool adsExists(const std::string &pathToFile);
   /// returns the list of log files from ADS checksum
-  std::set<std::string> getLogFilenamesfromADS(const std::string &pathToFile);
+  std::set<std::string> getLogFilenamesfromADS(const std::string &pathToRawFile);
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
@@ -87,14 +87,13 @@ public:
                                         bool &bexcludeMonitors,
                                         API::Algorithm *const pAlgo);
   /// creates monitor workspace
-  static void createMonitorWorkspace(DataObjects::Workspace2D_sptr &monws_sptr,
-                                     DataObjects::Workspace2D_sptr &normalws_sptr,
-                                     API::WorkspaceGroup_sptr &mongrp_sptr,
-                                     const int64_t mwsSpecs,
-                                     const int64_t nwsSpecs,
-                                     const int64_t numberOfPeriods,
-                                     const int64_t lengthIn, std::string title,
-                                     API::Algorithm *const pAlg);
+  static void
+  createMonitorWorkspace(DataObjects::Workspace2D_sptr &monws_sptr,
+                         DataObjects::Workspace2D_sptr &normalws_sptr,
+                         API::WorkspaceGroup_sptr &mongrp_sptr,
+                         const int64_t mwsSpecs, const int64_t nwsSpecs,
+                         const int64_t numberOfPeriods, const int64_t lengthIn,
+                         std::string title, API::Algorithm *const pAlg);
   /// creates  shared pointer to group workspace
   static API::WorkspaceGroup_sptr createGroupWorkspace();
 
@@ -258,7 +257,8 @@ private:
   /// if  alternate data stream named checksum exists for the raw file
   bool adsExists(const std::string &pathToFile);
   /// returns the list of log files from ADS checksum
-  std::set<std::string> getLogFilenamesfromADS(const std::string &pathToRawFile);
+  std::set<std::string>
+  getLogFilenamesfromADS(const std::string &pathToRawFile);
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSwans.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSwans.h
@@ -51,7 +51,7 @@ private:
   std::vector<double> loadMetaData();
   void setMetaDataAsWorkspaceProperties(const std::vector<double> &metadata);
   void loadDataIntoTheWorkspace(
-      const std::map<uint32_t, std::vector<uint32_t>> &pos_tof_map);
+      const std::map<uint32_t, std::vector<uint32_t>> &eventMap);
   void setTimeAxis();
   void loadInstrument();
   void placeDetectorInSpace();

--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessDasNexusLog.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessDasNexusLog.h
@@ -54,7 +54,7 @@ private:
   void exec() override;
 
   void convertToAbsoluteTime(API::MatrixWorkspace_sptr ws, std::string logname,
-                             std::vector<Kernel::DateAndTime> &abstimeve,
+                             std::vector<Kernel::DateAndTime> &abstimevec,
                              std::vector<double> &orderedtofs);
 
   void writeLogtoFile(API::MatrixWorkspace_sptr ws, std::string logname,

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveDiffCal.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveDiffCal.h
@@ -56,7 +56,7 @@ private:
   void writeIntFieldFromSVWS(H5::Group &group, const std::string &name,
                              DataObjects::SpecialWorkspace2D_const_sptr ws);
   void generateDetidToIndex();
-  bool tableHasColumn(const std::string name) const;
+  bool tableHasColumn(const std::string ColumnName) const;
 
   std::size_t m_numValues;
   API::ITableWorkspace_sptr m_calibrationWS;

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessed.h
@@ -93,7 +93,7 @@ private:
                           const std::string &propertyValue,
                           int perioidNum) override;
   /// execute the algorithm.
-  void doExec(Mantid::API::Workspace_sptr workspace,
+  void doExec(Mantid::API::Workspace_sptr inputWorkspace,
               Mantid::NeXus::NexusFileIO_sptr &nexusFile,
               const bool keepFile = false,
               NeXus::NexusFileIO::optional_size_t entryNumber =

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveVTK.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveVTK.h
@@ -85,9 +85,9 @@ private:
   void checkOptionalProperties();
 
   /// Write a histogram to the file
-  void writeVTKPiece(std::ostream &outXML, const std::vector<double> &dataX,
-                     const std::vector<double> &dataY,
-                     const std::vector<double> &dataE, int index) const;
+  void writeVTKPiece(std::ostream &outVTP, const std::vector<double> &xValue,
+                     const std::vector<double> &yValue,
+                     const std::vector<double> &errors, int index) const;
 
   /// The x-axis minimum
   double m_Xmin;

--- a/Framework/DataHandling/inc/MantidDataHandling/SetScalingPSD.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SetScalingPSD.h
@@ -96,7 +96,7 @@ private:
   /// An integer option controlling the scaling method
   int m_scalingOption;
   bool processScalingFile(const std::string &scalingFile,
-                          std::vector<Kernel::V3D> &truePos);
+                          std::vector<Kernel::V3D> &truepos);
   API::MatrixWorkspace_sptr m_workspace; ///< Pointer to the workspace
   // void runMoveInstrumentComp(const int& detIndex, const Kernel::V3D& shift);
 

--- a/Framework/DataHandling/src/LoadRaw/isisraw.h
+++ b/Framework/DataHandling/src/LoadRaw/isisraw.h
@@ -347,7 +347,7 @@ public:
   ISISRAW(ISISCRPT_STRUCT *crpt, bool doUpdateFromCRPT);
   int updateFromCRPT();
 
-  virtual int ioRAW(FILE *file, bool from_file, bool do_data = true);
+  virtual int ioRAW(FILE *file, bool from_file, bool read_data = true);
   int ioRAW(FILE *file, HDR_STRUCT *s, int len, bool from_file);
   int ioRAW(FILE *file, ADD_STRUCT *s, int len, bool from_file);
   int ioRAW(FILE *file, USER_STRUCT *s, int len, bool from_file);
@@ -360,15 +360,15 @@ public:
   int ioRAW(FILE *file, DDES_STRUCT *s, int len, bool from_file);
   int ioRAW(FILE *file, LOG_STRUCT *s, int len, bool from_file);
   int ioRAW(FILE *file, LOG_LINE *s, int len, bool from_file);
-  int ioRAW(FILE *file, char *val, int len, bool from_file);
-  int ioRAW(FILE *file, int *val, int len, bool from_file);
-  int ioRAW(FILE *file, uint32_t *val, int len, bool from_file);
-  int ioRAW(FILE *file, float *val, int len, bool from_file);
+  int ioRAW(FILE *file, char *s, int len, bool from_file);
+  int ioRAW(FILE *file, int *s, int len, bool from_file);
+  int ioRAW(FILE *file, uint32_t *s, int len, bool from_file);
+  int ioRAW(FILE *file, float *s, int len, bool from_file);
   // allocate
-  int ioRAW(FILE *file, char **val, int len, bool from_file);
-  int ioRAW(FILE *file, int **val, int len, bool from_file);
-  int ioRAW(FILE *file, uint32_t **val, int len, bool from_file);
-  int ioRAW(FILE *file, float **val, int len, bool from_file);
+  int ioRAW(FILE *file, char **s, int len, bool from_file);
+  int ioRAW(FILE *file, int **s, int len, bool from_file);
+  int ioRAW(FILE *file, uint32_t **s, int len, bool from_file);
+  int ioRAW(FILE *file, float **s, int len, bool from_file);
   int ioRAW(FILE *file, SE_STRUCT **s, int len, bool from_file);
   int ioRAW(FILE *file, DDES_STRUCT **s, int len, bool from_file);
   int ioRAW(FILE *file, LOG_LINE **s, int len, bool from_file);

--- a/Framework/DataHandling/src/LoadRaw/isisraw2.h
+++ b/Framework/DataHandling/src/LoadRaw/isisraw2.h
@@ -10,7 +10,7 @@ public:
   ISISRAW2();
   ~ISISRAW2() override;
 
-  int ioRAW(FILE *file, bool from_file, bool do_data = true) override;
+  int ioRAW(FILE *file, bool from_file, bool read_data = true) override;
 
   void skipData(FILE *file, int i);
   bool readData(FILE *file, int i);

--- a/Framework/DataObjects/inc/MantidDataObjects/BoxControllerNeXusIO.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/BoxControllerNeXusIO.h
@@ -159,8 +159,7 @@ private:
   void saveGenericBlock(const std::vector<Type> &DataBlock,
                         const uint64_t blockPosition) const;
   template <typename Type>
-  void loadGenericBlock(std::vector<Type> &Block,
-                        const uint64_t blockPosition,
+  void loadGenericBlock(std::vector<Type> &Block, const uint64_t blockPosition,
                         const size_t nPoints) const;
 };
 }

--- a/Framework/DataObjects/inc/MantidDataObjects/BoxControllerNeXusIO.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/BoxControllerNeXusIO.h
@@ -41,7 +41,7 @@ namespace DataObjects {
 */
 class DLLExport BoxControllerNeXusIO : public API::IBoxControllerIO {
 public:
-  BoxControllerNeXusIO(API::BoxController *const theBC);
+  BoxControllerNeXusIO(API::BoxController *const bc);
 
   ///@return true if the file to write events is opened and false otherwise
   bool isOpened() const override { return m_File != nullptr; }
@@ -69,9 +69,9 @@ public:
   ~BoxControllerNeXusIO() override;
   // Auxiliary functions. Used to change default state of this object which is
   // not fully supported. Should be replaced by some IBoxControllerIO factory
-  void setDataType(const size_t coordSize,
+  void setDataType(const size_t blockSize,
                    const std::string &typeName) override;
-  void getDataType(size_t &coordSize, std::string &typeName) const override;
+  void getDataType(size_t &CoordSize, std::string &typeName) const override;
   //------------------------------------------------------------------------------------------------------------------------
   // Auxiliary functions (non-virtual, used for testing)
   int64_t getNDataColums() const { return m_BlockSize[1]; }
@@ -159,9 +159,9 @@ private:
   void saveGenericBlock(const std::vector<Type> &DataBlock,
                         const uint64_t blockPosition) const;
   template <typename Type>
-  void loadGenericBlock(std::vector<Type> &DataBlock,
+  void loadGenericBlock(std::vector<Type> &Block,
                         const uint64_t blockPosition,
-                        const size_t blockSize) const;
+                        const size_t nPoints) const;
 };
 }
 }

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -82,7 +82,7 @@ public:
 
   ~EventList() override;
 
-  void createFromHistogram(const ISpectrum *spec, bool GenerateZeros,
+  void createFromHistogram(const ISpectrum *inSpec, bool GenerateZeros,
                            bool GenerateMultipleEvents, int MaxEventsPerBin);
 
   EventList &operator=(const EventList &);
@@ -391,7 +391,7 @@ private:
 
   template <class T>
   static typename std::vector<T>::const_iterator
-  findFirstPulseEvent(const std::vector<T> &events, const double seek_tof);
+  findFirstPulseEvent(const std::vector<T> &events, const double seek_pulsetime);
 
   template <class T>
   typename std::vector<T>::const_iterator
@@ -496,7 +496,7 @@ private:
   template <class T>
   std::string splitByFullTimeVectorSplitterHelper(
       const std::vector<int64_t> &vectimes, const std::vector<int> &vecgroups,
-      std::map<int, EventList *> outputs, typename std::vector<T> &events,
+      std::map<int, EventList *> outputs, typename std::vector<T> &vecEvents,
       bool docorrection, double toffactor, double tofshift) const;
   template <class T>
   static void multiplyHelper(std::vector<T> &events, const double value,

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -391,7 +391,8 @@ private:
 
   template <class T>
   static typename std::vector<T>::const_iterator
-  findFirstPulseEvent(const std::vector<T> &events, const double seek_pulsetime);
+  findFirstPulseEvent(const std::vector<T> &events,
+                      const double seek_pulsetime);
 
   template <class T>
   typename std::vector<T>::const_iterator

--- a/Framework/DataObjects/inc/MantidDataObjects/Events.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Events.h
@@ -121,10 +121,10 @@ public:
   WeightedEvent(double time_of_flight);
 
   /// Constructor, full
-  WeightedEvent(double time_of_flight,
+  WeightedEvent(double tof,
                 const Mantid::Kernel::DateAndTime pulsetime, double weight,
                 double errorSquared);
-  WeightedEvent(double time_of_flight,
+  WeightedEvent(double tof,
                 const Mantid::Kernel::DateAndTime pulsetime, float weight,
                 float errorSquared);
 
@@ -135,7 +135,7 @@ public:
 
   WeightedEvent();
 
-  bool operator==(const WeightedEvent &other) const;
+  bool operator==(const WeightedEvent &rhs) const;
   bool equals(const WeightedEvent &rhs, const double tolTof,
               const double tolWeight, const int64_t tolPulse) const;
 
@@ -181,9 +181,9 @@ public:
   WeightedEventNoTime(double time_of_flight);
 
   /// Constructor, full
-  WeightedEventNoTime(double time_of_flight, double weight,
+  WeightedEventNoTime(double tof, double weight,
                       double errorSquared);
-  WeightedEventNoTime(double time_of_flight, float weight, float errorSquared);
+  WeightedEventNoTime(double tof, float weight, float errorSquared);
 
   WeightedEventNoTime(double tof, const Mantid::Kernel::DateAndTime pulsetime,
                       double weight, double errorSquared);
@@ -199,9 +199,9 @@ public:
 
   WeightedEventNoTime();
 
-  bool operator==(const WeightedEventNoTime &other) const;
+  bool operator==(const WeightedEventNoTime &rhs) const;
   bool operator<(const WeightedEventNoTime &rhs) const;
-  bool operator<(const double rhs) const;
+  bool operator<(const double rhs_tof) const;
   bool equals(const WeightedEventNoTime &rhs, const double tolTof,
               const double tolWeight) const;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/Events.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Events.h
@@ -121,12 +121,10 @@ public:
   WeightedEvent(double time_of_flight);
 
   /// Constructor, full
-  WeightedEvent(double tof,
-                const Mantid::Kernel::DateAndTime pulsetime, double weight,
-                double errorSquared);
-  WeightedEvent(double tof,
-                const Mantid::Kernel::DateAndTime pulsetime, float weight,
-                float errorSquared);
+  WeightedEvent(double tof, const Mantid::Kernel::DateAndTime pulsetime,
+                double weight, double errorSquared);
+  WeightedEvent(double tof, const Mantid::Kernel::DateAndTime pulsetime,
+                float weight, float errorSquared);
 
   WeightedEvent(const TofEvent &, double weight, double errorSquared);
   WeightedEvent(const TofEvent &, float weight, float errorSquared);
@@ -181,8 +179,7 @@ public:
   WeightedEventNoTime(double time_of_flight);
 
   /// Constructor, full
-  WeightedEventNoTime(double tof, double weight,
-                      double errorSquared);
+  WeightedEventNoTime(double tof, double weight, double errorSquared);
   WeightedEventNoTime(double tof, float weight, float errorSquared);
 
   WeightedEventNoTime(double tof, const Mantid::Kernel::DateAndTime pulsetime,

--- a/Framework/DataObjects/inc/MantidDataObjects/FractionalRebinning.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/FractionalRebinning.h
@@ -55,7 +55,7 @@ MANTID_DATAOBJECTS_DLL bool
 getIntersectionRegion(API::MatrixWorkspace_const_sptr outputWS,
                       const std::vector<double> &verticalAxis,
                       const Geometry::Quadrilateral &inputQ, size_t &qstart,
-                      size_t &qend, size_t &en_start, size_t &en_end);
+                      size_t &qend, size_t &x_start, size_t &x_end);
 
 /// Compute sqrt of errors and put back in bin width division if necessary
 MANTID_DATAOBJECTS_DLL void

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBox.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBox.h
@@ -221,7 +221,7 @@ private:
   /// one with the boxController;
   MDBox(const MDBox &);
   /// common part of mdBox constructor
-  void initMDBox(const size_t numEvents);
+  void initMDBox(const size_t nBoxEvents);
 
 public:
   /// Typedef for a shared pointer to a MDBox

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.h
@@ -46,10 +46,10 @@ TMDE_CLASS
 class DLLExport MDBoxBase : public Mantid::API::IMDNode {
 public:
   //-----------------------------------------------------------------------------------------------
-  MDBoxBase(Mantid::API::BoxController *const BoxController = nullptr,
+  MDBoxBase(Mantid::API::BoxController *const boxController = nullptr,
             const uint32_t depth = 0, const size_t boxID = UNDEF_SIZET);
 
-  MDBoxBase(Mantid::API::BoxController *const BoxController,
+  MDBoxBase(Mantid::API::BoxController *const boxController,
             const uint32_t depth, const size_t boxID,
             const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>> &
                 extentsVector);

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
@@ -67,7 +67,7 @@ public:
 
   uint64_t restoreBoxTree(std::vector<API::IMDNode *> &Boxes,
                           API::BoxController_sptr &bc, bool FileBackEnd,
-                          bool NoFileInfo = false);
+                          bool BoxStructureOnly = false);
 
   /*** this function tries to set file positions of the boxes to
         make data physically located close to each other to be as close as
@@ -128,7 +128,7 @@ public:
   static ::NeXus::File *createOrOpenMDWSgroup(const std::string &fileName,
                                               int &nDims,
                                               const std::string &WSEventType,
-                                              bool readOnly, bool &exist);
+                                              bool readOnly, bool &alreadyExists);
   // save each experiment info into its own NeXus group within an existing
   // opened group
   static void saveExperimentInfos(::NeXus::File *const file,

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
@@ -128,7 +128,8 @@ public:
   static ::NeXus::File *createOrOpenMDWSgroup(const std::string &fileName,
                                               int &nDims,
                                               const std::string &WSEventType,
-                                              bool readOnly, bool &alreadyExists);
+                                              bool readOnly,
+                                              bool &alreadyExists);
   // save each experiment info into its own NeXus group within an existing
   // opened group
   static void saveExperimentInfos(::NeXus::File *const file,

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.h
@@ -47,7 +47,7 @@ public:
 
   MDGridBox(MDBox<MDE, nd> *box);
 
-  MDGridBox(const MDGridBox<MDE, nd> &box,
+  MDGridBox(const MDGridBox<MDE, nd> &other,
             Mantid::API::BoxController *const otherBC);
 
   ~MDGridBox() override;
@@ -109,12 +109,12 @@ public:
   API::IMDNode *getChild(size_t index) override;
   void setChild(size_t index, MDGridBox<MDE, nd> *newChild);
 
-  void setChildren(const std::vector<API::IMDNode *> &boxes,
+  void setChildren(const std::vector<API::IMDNode *> &otherBoxes,
                    const size_t indexStart, const size_t indexEnd) override;
 
-  void getBoxes(std::vector<API::IMDNode *> &boxes, size_t maxDepth,
+  void getBoxes(std::vector<API::IMDNode *> &outBoxes, size_t maxDepth,
                 bool leafOnly) override;
-  void getBoxes(std::vector<API::IMDNode *> &boxes, size_t maxDepth,
+  void getBoxes(std::vector<API::IMDNode *> &outBoxes, size_t maxDepth,
                 bool leafOnly,
                 Mantid::Geometry::MDImplicitFunction *function) override;
 
@@ -242,7 +242,7 @@ private:
   size_t getLinearIndex(size_t *indices) const;
 
   size_t computeSizesFromSplit();
-  void fillBoxShell(const size_t tot, const coord_t inverseVolume);
+  void fillBoxShell(const size_t tot, const coord_t ChildInverseVolume);
   /**private default copy constructor as the only correct constructor is the one
    * with box controller */
   MDGridBox(const MDGridBox<MDE, nd> &box);

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -96,12 +96,12 @@ public:
   void subtract(const MDHistoWorkspace &b);
   void subtract(const signal_t signal, const signal_t error);
 
-  MDHistoWorkspace &operator*=(const MDHistoWorkspace &b);
-  void multiply(const MDHistoWorkspace &b);
+  MDHistoWorkspace &operator*=(const MDHistoWorkspace &b_ws);
+  void multiply(const MDHistoWorkspace &b_ws);
   void multiply(const signal_t signal, const signal_t error);
 
-  MDHistoWorkspace &operator/=(const MDHistoWorkspace &b);
-  void divide(const MDHistoWorkspace &b);
+  MDHistoWorkspace &operator/=(const MDHistoWorkspace &b_ws);
+  void divide(const MDHistoWorkspace &b_ws);
   void divide(const signal_t signal, const signal_t error);
 
   void log(double filler = 0.0);

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -31,11 +31,11 @@ public:
   Peak(Geometry::Instrument_const_sptr m_inst, Mantid::Kernel::V3D QSampleFrame,
        Mantid::Kernel::Matrix<double> goniometer,
        boost::optional<double> detectorDistance = boost::optional<double>());
-  Peak(Geometry::Instrument_const_sptr m_inst, int m_DetectorID,
+  Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
        double m_Wavelength);
-  Peak(Geometry::Instrument_const_sptr m_inst, int m_DetectorID,
+  Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
        double m_Wavelength, Mantid::Kernel::V3D HKL);
-  Peak(Geometry::Instrument_const_sptr m_inst, int m_DetectorID,
+  Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
        double m_Wavelength, Mantid::Kernel::V3D HKL,
        Mantid::Kernel::Matrix<double> goniometer);
   Peak(Geometry::Instrument_const_sptr m_inst, double scattering,
@@ -61,10 +61,10 @@ public:
   bool findDetector() override;
 
   int getRunNumber() const override;
-  void setRunNumber(int m_RunNumber) override;
+  void setRunNumber(int m_runNumber) override;
 
   double getMonitorCount() const override;
-  void setMonitorCount(double m_MonitorCount) override;
+  void setMonitorCount(double m_monitorCount) override;
 
   double getH() const override;
   double getK() const override;
@@ -73,7 +73,7 @@ public:
   void setH(double m_H) override;
   void setK(double m_K) override;
   void setL(double m_L) override;
-  void setBankName(std::string m_BankName);
+  void setBankName(std::string m_bankName);
   void setHKL(double H, double K, double L) override;
   void setHKL(Mantid::Kernel::V3D HKL) override;
   void resetHKL();
@@ -98,21 +98,21 @@ public:
 
   double getInitialEnergy() const override;
   double getFinalEnergy() const override;
-  void setInitialEnergy(double m_InitialEnergy) override;
-  void setFinalEnergy(double m_FinalEnergy) override;
+  void setInitialEnergy(double m_initialEnergy) override;
+  void setFinalEnergy(double m_finalEnergy) override;
 
   double getIntensity() const override;
   double getSigmaIntensity() const override;
 
-  void setIntensity(double m_Intensity) override;
-  void setSigmaIntensity(double m_SigmaIntensity) override;
+  void setIntensity(double m_intensity) override;
+  void setSigmaIntensity(double m_sigmaIntensity) override;
 
   double getBinCount() const override;
-  void setBinCount(double m_BinCount) override;
+  void setBinCount(double m_binCount) override;
 
   Mantid::Kernel::Matrix<double> getGoniometerMatrix() const override;
   void setGoniometerMatrix(
-      Mantid::Kernel::Matrix<double> m_GoniometerMatrix) override;
+      Mantid::Kernel::Matrix<double> goniometerMatrix) override;
 
   std::string getBankName() const override;
   int getRow() const override;
@@ -122,7 +122,7 @@ public:
   double getL1() const override;
   double getL2() const override;
 
-  double getValueByColName(const std::string &name) const;
+  double getValueByColName(const std::string &name_in) const;
 
   /// Get the peak shape.
   const Mantid::Geometry::PeakShape &getPeakShape() const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -111,8 +111,8 @@ public:
   void setBinCount(double m_binCount) override;
 
   Mantid::Kernel::Matrix<double> getGoniometerMatrix() const override;
-  void setGoniometerMatrix(
-      Mantid::Kernel::Matrix<double> goniometerMatrix) override;
+  void
+  setGoniometerMatrix(Mantid::Kernel::Matrix<double> goniometerMatrix) override;
 
   std::string getBankName() const override;
   int getRow() const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
@@ -36,9 +36,9 @@ class DLLExport PeakShapeEllipsoid : public PeakShapeBase {
 public:
   /// Constructor
   PeakShapeEllipsoid(std::vector<Mantid::Kernel::V3D> directions,
-                     std::vector<double> abcRadius,
-                     std::vector<double> abcBackgroundInnerRadius,
-                     std::vector<double> abcBackgroundOuterRadius,
+                     std::vector<double> abcRadii,
+                     std::vector<double> abcRadiiBackgroundInner,
+                     std::vector<double> abcRadiiBackgroundOuter,
                      Kernel::SpecialCoordinateSystem frame,
                      std::string algorithmName = std::string(),
                      int algorithmVersion = -1);

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -106,7 +106,7 @@ public:
   Peak &getPeak(int peakNum) override;
   const Peak &getPeak(int peakNum) const override;
 
-  Geometry::IPeak *createPeak(Kernel::V3D QFrame,
+  Geometry::IPeak *createPeak(Kernel::V3D QLabFrame,
                               boost::optional<double> detectorDistance =
                                   boost::optional<double>()) const override;
   std::vector<std::pair<std::string, std::string>>

--- a/Framework/DataObjects/inc/MantidDataObjects/ReflectometryTransform.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/ReflectometryTransform.h
@@ -91,7 +91,7 @@ public:
 
   /// Execuate transformation using normalised polynomial binning
   Mantid::API::MatrixWorkspace_sptr executeNormPoly(
-      Mantid::API::MatrixWorkspace_const_sptr inputWs,
+      Mantid::API::MatrixWorkspace_const_sptr inputWS,
       boost::shared_ptr<Mantid::DataObjects::TableWorkspace> &vertexes,
       bool dumpVertexes, std::string outputDimensions) const;
 
@@ -107,14 +107,14 @@ public:
 
 /// Create a new x-axis for the output workspace
 MANTID_DATAOBJECTS_DLL MantidVec
-createXAxis(Mantid::API::MatrixWorkspace *const ws, const double gradQx,
+createXAxis(Mantid::API::MatrixWorkspace *const ws, const double gradX,
             const double cxToUnit, const size_t nBins,
             const std::string &caption, const std::string &units);
 
 /// Create a new y(vertical)-axis for the output workspace
 MANTID_DATAOBJECTS_DLL void
 createVerticalAxis(Mantid::API::MatrixWorkspace *const ws,
-                   const MantidVec &xAxisVec, const double gradQz,
+                   const MantidVec &xAxisVec, const double gradY,
                    const double cyToUnit, const size_t nBins,
                    const std::string &caption, const std::string &units);
 

--- a/Framework/DataObjects/src/ReflectometryTransform.cpp
+++ b/Framework/DataObjects/src/ReflectometryTransform.cpp
@@ -416,7 +416,7 @@ IMDHistoWorkspace_sptr ReflectometryTransform::executeMDNormPoly(
 
 /**
  * Execution path for NormalisedPolygon Rebinning
- * @param inputWs : Workspace to be rebinned
+ * @param inputWS : Workspace to be rebinned
  * @param vertexes : TableWorkspace for debugging purposes
  * @param dumpVertexes : determines whether vertexes will be written to for
  * debugging purposes or not

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IndexingUtils.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IndexingUtils.h
@@ -190,7 +190,7 @@ public:
                                     const std::vector<Kernel::V3D> &q_vectors,
                                     double tolerance,
                                     std::vector<Kernel::V3D> &miller_indices,
-                                    double &average_error);
+                                    double &ave_error);
 
   /// Get lists of indices and Qs for peaks indexed in the specified direction
   static int GetIndexedPeaks_1D(const Kernel::V3D &direction,

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/ReducedCell.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/ReducedCell.h
@@ -82,13 +82,13 @@ public:
   static const std::string R_CENTERED() { return "R"; }
 
 private:
-  void init(size_t form_num, double a_a, double b_b, double c_c, double b_c,
+  void init(size_t f_num, double a_a, double b_b, double c_c, double b_c,
             double a_c, double a_b);
   void foot_note_b(double a_a, double a_c);
   void foot_note_c(double b_b, double b_c);
   void foot_note_d(double c_c, double b_c);
   void foot_note_e(double a_a, double c_c, double a_c);
-  void foot_note_f(double b_b, double c_c, double a_c);
+  void foot_note_f(double b_b, double c_c, double b_c);
   void premultiply(size_t index);
   std::vector<double> norm_vals(const ReducedCell &info) const;
 

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroupFactory.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroupFactory.h
@@ -246,7 +246,7 @@ public:
 protected:
   std::string
   getTransformedSymbolOrthorhombic(const std::string &hmSymbol,
-                                   const std::string &transformations) const;
+                                   const std::string &transformation) const;
 
   SpaceGroup_const_sptr getPrototype(const std::string &hmSymbol);
   void subscribe(const AbstractSpaceGroupGenerator_sptr &generator);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -148,7 +148,7 @@ public:
   size_t numMonitors() const;
 
   /// Get the bounding box for this component and store it in the given argument
-  void getBoundingBox(BoundingBox &boundingBox) const override;
+  void getBoundingBox(BoundingBox &assemblyBox) const override;
 
   /// Get pointers to plottable components
   boost::shared_ptr<const std::vector<IObjComponent_const_sptr>>
@@ -238,7 +238,7 @@ public:
 
   void setFilename(const std::string &filename);
   const std::string &getFilename() const;
-  void setXmlText(const std::string &filename);
+  void setXmlText(const std::string &XmlText);
   const std::string &getXmlText() const;
 
   /// Set reference Frame

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/CompAssembly.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/CompAssembly.h
@@ -96,7 +96,7 @@ public:
   const Kernel::Quat getRotation() const override;
 
   /// Get the bounding box for this component and store it in the given argument
-  void getBoundingBox(BoundingBox &boundingBox) const override;
+  void getBoundingBox(BoundingBox &assemblyBox) const override;
 
   //! Print information about all children
   void printChildren(std::ostream &) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentHelper.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentHelper.h
@@ -61,7 +61,7 @@ MANTID_GEOMETRY_DLL void moveComponent(const IComponent &comp,
 MANTID_GEOMETRY_DLL void rotateComponent(const IComponent &comp,
                                          ParameterMap &pmap,
                                          const Kernel::Quat &rot,
-                                         const TransformType positionType);
+                                         const TransformType rotType);
 
 MANTID_GEOMETRY_DLL Geometry::Instrument_sptr
 createMinimalInstrument(const Mantid::Kernel::V3D &sourcePos,

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
@@ -51,7 +51,7 @@ public:
   /// Constructor for parametrized version
   Detector(const Detector *base, const ParameterMap *map);
   Detector(const std::string &name, int id, IComponent *parent);
-  Detector(const std::string &name, int it, boost::shared_ptr<Object> shape,
+  Detector(const std::string &name, int id, boost::shared_ptr<Object> shape,
            IComponent *parent);
   // functions inherited from IObjectComponent
   Component *clone() const override { return new Detector(*this); }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -82,7 +82,7 @@ public:
   /// Add/overwrite any parameters specified in instrument with param values
   /// specified in <component-link> XML elements
   void setComponentLinks(boost::shared_ptr<Geometry::Instrument> &instrument,
-                         Poco::XML::Element *pElem,
+                         Poco::XML::Element *pRootElem,
                          Kernel::ProgressBase *progress = nullptr);
 
   std::string getMangledName();
@@ -154,7 +154,7 @@ private:
   };
 
   /// Method for populating IdList
-  void populateIdList(Poco::XML::Element *pElem, IdList &idList);
+  void populateIdList(Poco::XML::Element *pE, IdList &idList);
 
   std::vector<std::string>
   buildExcludeList(const Poco::XML::Element *const location);
@@ -232,7 +232,7 @@ private:
 
   /// Write out a cache file.
   CachingOption writeAndApplyCache(IDFObject_const_sptr firstChoiceCache,
-                                   IDFObject_const_sptr usedCache);
+                                   IDFObject_const_sptr fallBackCache);
 
   /// This method returns the parent appended which its child components and
   /// also name of type of the last child component

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/NearestNeighbours.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/NearestNeighbours.h
@@ -55,13 +55,13 @@ public:
   /// Constructor with an instrument and a spectra map
   NearestNeighbours(boost::shared_ptr<const Instrument> instrument,
                     const ISpectrumDetectorMapping &spectraMap,
-                    bool ignoreMasked = true);
+                    bool ignoreMaskedDetectors = true);
 
   /// Constructor with an instrument and a spectra map and number of neighbours
   NearestNeighbours(int nNeighbours,
                     boost::shared_ptr<const Instrument> instrument,
                     const ISpectrumDetectorMapping &spectraMap,
-                    bool ignoreMasked = true);
+                    bool ignoreMaskedDetectors = true);
 
   // Neighbouring spectra by radius
   std::map<specnum_t, Mantid::Kernel::V3D>

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -149,7 +149,7 @@ public:
   }
   /// Method for adding a parameter providing shared pointer to it. The class
   /// stores share pointer and increment ref count to it
-  void add(const IComponent *comp, const boost::shared_ptr<Parameter> &param,
+  void add(const IComponent *comp, const boost::shared_ptr<Parameter> &par,
            const std::string *const pDescription = nullptr);
 
   /** @name Helper methods for adding and updating parameter types  */

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/RectangularDetectorPixel.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/RectangularDetectorPixel.h
@@ -52,7 +52,7 @@ public:
   /// Constructor for parametrized version
   RectangularDetectorPixel(const RectangularDetectorPixel *base,
                            const ParameterMap *map);
-  RectangularDetectorPixel(const std::string &name, int it,
+  RectangularDetectorPixel(const std::string &name, int id,
                            boost::shared_ptr<Object> shape, IComponent *parent,
                            RectangularDetector *panel, size_t row, size_t col);
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ReferenceFrame.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ReferenceFrame.h
@@ -45,7 +45,7 @@ public:
   ReferenceFrame();
   /// Constructor
   ReferenceFrame(PointingAlong up, PointingAlong alongBeam,
-                 Handedness handedNess, std::string origin);
+                 Handedness handedness, std::string origin);
   /// Gets the pointing up direction
   PointingAlong pointingUp() const;
   /// Gets the beam pointing along direction

--- a/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDBoxImplicitFunction.h
+++ b/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDBoxImplicitFunction.h
@@ -51,7 +51,7 @@ public:
 
   double
   fraction(const std::vector<boost::tuple<Mantid::coord_t, Mantid::coord_t>> &
-               extents) const;
+               boxExtents) const;
 
 private:
   void construct(const Mantid::Kernel::VMD &min,

--- a/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDGeometryXMLBuilder.h
+++ b/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDGeometryXMLBuilder.h
@@ -53,7 +53,7 @@ public:
   ~MDGeometryBuilderXML();
 
   /// Add a dimension that is neither considered x, y, z or t.
-  bool addOrdinaryDimension(IMDDimension_const_sptr dimension) const;
+  bool addOrdinaryDimension(IMDDimension_const_sptr dimensionToAdd) const;
 
   /// Add many ordinary dimensions.
   void addManyOrdinaryDimensions(VecIMDDimension_sptr manyDims) const;

--- a/Framework/Geometry/inc/MantidGeometry/Math/PolygonEdge.h
+++ b/Framework/Geometry/inc/MantidGeometry/Math/PolygonEdge.h
@@ -94,7 +94,7 @@ crossingPoint(const PolygonEdge &edgeOne, const PolygonEdge &edgeTwo,
               Kernel::V2D &crossPoint);
 /// Return if the edges aim at each other
 MANTID_GEOMETRY_DLL bool edgeAimsAt(const PolygonEdge &a, const PolygonEdge &b,
-                                    PointClassification pclass,
+                                    PointClassification aclass,
                                     PolygonEdge::Orientation crossType);
 
 } // namespace Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Objects/InstrumentRayTracer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/InstrumentRayTracer.h
@@ -57,8 +57,8 @@ public:
   InstrumentRayTracer(Instrument_const_sptr instrument);
   /// Trace a given track from the instrument source in the given direction
   /// and compile a list of results that this track intersects.
-  void trace(const Kernel::V3D &direction) const;
-  void traceFromSample(const Kernel::V3D &direction) const;
+  void trace(const Kernel::V3D &dir) const;
+  void traceFromSample(const Kernel::V3D &dir) const;
   /// Get the results of the intersection tests that have been updated
   /// since the previous call to trace
   Links getResults() const;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/Object.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/Object.h
@@ -143,9 +143,9 @@ public:
   /// Return cached value of axis-aligned bounding box
   const BoundingBox &getBoundingBox() const;
   /// Define axis-aligned bounding box
-  void defineBoundingBox(const double &xmax, const double &ymax,
-                         const double &zmax, const double &xmin,
-                         const double &ymin, const double &zmin);
+  void defineBoundingBox(const double &xMax, const double &yMax,
+                         const double &zMax, const double &xMin,
+                         const double &yMin, const double &zMin);
   /// Set a null bounding box for this object
   void setNullBoundingBox();
   // find internal point to object

--- a/Framework/Geometry/inc/MantidGeometry/Objects/Rules.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/Rules.h
@@ -266,7 +266,7 @@ public:
   int type() const override { return 0; } ///< Effective name
 
   void setKeyN(const int Ky); ///< set keyNumber
-  void setKey(const boost::shared_ptr<Surface> &key);
+  void setKey(const boost::shared_ptr<Surface> &Spoint);
   bool isValid(const Kernel::V3D &) const override;
   bool isValid(const std::map<int, int> &) const override;
   int getSign() const { return sign; } ///< Get Sign

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/CacheGeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/CacheGeometryHandler.h
@@ -56,7 +56,7 @@ private:
       Triangulator; ///< Geometry generator to triangulate Object
 
 public:
-  CacheGeometryHandler(IObjComponent *comp);            ///< Constructor
+  CacheGeometryHandler(IObjComponent *comp);           ///< Constructor
   CacheGeometryHandler(boost::shared_ptr<Object> obj); ///< Constructor
   CacheGeometryHandler(Object *obj);                   ///< Constructor
   boost::shared_ptr<GeometryHandler> clone() const override;

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/CacheGeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/CacheGeometryHandler.h
@@ -56,7 +56,7 @@ private:
       Triangulator; ///< Geometry generator to triangulate Object
 
 public:
-  CacheGeometryHandler(IObjComponent *obj);            ///< Constructor
+  CacheGeometryHandler(IObjComponent *comp);            ///< Constructor
   CacheGeometryHandler(boost::shared_ptr<Object> obj); ///< Constructor
   CacheGeometryHandler(Object *obj);                   ///< Constructor
   boost::shared_ptr<GeometryHandler> clone() const override;

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryHandler.h
@@ -72,7 +72,7 @@ private:
   GEOMETRY_TYPE
   type; ///< the type of the geometry eg CUBOID,CYLINDER,CONE,SPHERE
 public:
-  GluGeometryHandler(IObjComponent *obj);            ///< Constructor
+  GluGeometryHandler(IObjComponent *comp);            ///< Constructor
   GluGeometryHandler(boost::shared_ptr<Object> obj); ///< Constructor
   GluGeometryHandler(Object *obj);                   ///< Constructor
   boost::shared_ptr<GeometryHandler> clone() const override;

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryHandler.h
@@ -72,7 +72,7 @@ private:
   GEOMETRY_TYPE
   type; ///< the type of the geometry eg CUBOID,CYLINDER,CONE,SPHERE
 public:
-  GluGeometryHandler(IObjComponent *comp);            ///< Constructor
+  GluGeometryHandler(IObjComponent *comp);           ///< Constructor
   GluGeometryHandler(boost::shared_ptr<Object> obj); ///< Constructor
   GluGeometryHandler(Object *obj);                   ///< Constructor
   boost::shared_ptr<GeometryHandler> clone() const override;

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/OCGeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/OCGeometryHandler.h
@@ -55,7 +55,7 @@ private:
   OCGeometryGenerator *
       Triangulator; ///< Geometry generator to triangulate Object
 public:
-  OCGeometryHandler(IObjComponent *comp);            ///< Constructor
+  OCGeometryHandler(IObjComponent *comp);           ///< Constructor
   OCGeometryHandler(boost::shared_ptr<Object> obj); ///< Constructor
   OCGeometryHandler(Object *obj);                   ///< Constructor
   boost::shared_ptr<GeometryHandler>

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/OCGeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/OCGeometryHandler.h
@@ -55,7 +55,7 @@ private:
   OCGeometryGenerator *
       Triangulator; ///< Geometry generator to triangulate Object
 public:
-  OCGeometryHandler(IObjComponent *obj);            ///< Constructor
+  OCGeometryHandler(IObjComponent *comp);            ///< Constructor
   OCGeometryHandler(boost::shared_ptr<Object> obj); ///< Constructor
   OCGeometryHandler(Object *obj);                   ///< Constructor
   boost::shared_ptr<GeometryHandler>

--- a/Framework/Geometry/src/Objects/InstrumentRayTracer.cpp
+++ b/Framework/Geometry/src/Objects/InstrumentRayTracer.cpp
@@ -45,7 +45,7 @@ InstrumentRayTracer::InstrumentRayTracer(Instrument_const_sptr instrument)
  * performance reasons the
  * results are accumulated within the object and can be returned using
  * getResults.
- * @param direction :: A directional vector. The starting point is defined by
+ * @param dir :: A directional vector. The starting point is defined by
  * the instrument source.
  */
 void InstrumentRayTracer::trace(const V3D &dir) const {
@@ -62,7 +62,7 @@ void InstrumentRayTracer::trace(const V3D &dir) const {
  * performance reasons the
  * results are accumulated within the object and can be returned using
  * getResults.
- * @param direction :: A directional vector. The starting point is defined by
+ * @param dir :: A directional vector. The starting point is defined by
  * the instrument source.
  */
 void InstrumentRayTracer::traceFromSample(const V3D &dir) const {

--- a/Framework/ICat/inc/MantidICat/CatalogSearchParam.h
+++ b/Framework/ICat/inc/MantidICat/CatalogSearchParam.h
@@ -92,7 +92,7 @@ public:
   /// Get the investigation id.
   const std::string &getInvestigationId() const;
   /// Saves the start/end date times to time_t value.
-  time_t getTimevalue(const std::string &sDate);
+  time_t getTimevalue(const std::string &inputDate);
 
 private:
   /// start run number

--- a/Framework/ICat/inc/MantidICat/GSoap/stdsoap2.h
+++ b/Framework/ICat/inc/MantidICat/GSoap/stdsoap2.h
@@ -2552,13 +2552,13 @@ SOAP_FMAC1 int SOAP_FMAC2 soap_dime_forward(struct soap *, unsigned char **,
 SOAP_FMAC1 int SOAP_FMAC2
 soap_pointer_lookup_id(struct soap *, void *p, int t, struct soap_plist **);
 SOAP_FMAC1 int SOAP_FMAC2
-soap_pointer_lookup(struct soap *, const void *p, int t, struct soap_plist **);
+soap_pointer_lookup(struct soap *, const void *p, int type, struct soap_plist **);
 SOAP_FMAC1 int SOAP_FMAC2 soap_pointer_enter(struct soap *, const void *p,
                                              const struct soap_array *a, int n,
-                                             int t, struct soap_plist **);
+                                             int type, struct soap_plist **);
 SOAP_FMAC1 int SOAP_FMAC2
 soap_array_pointer_lookup(struct soap *, const void *p,
-                          const struct soap_array *a, int n, int t,
+                          const struct soap_array *a, int n, int type,
                           struct soap_plist **);
 SOAP_FMAC1 int SOAP_FMAC2 soap_embed(struct soap *soap, const void *p,
                                      const struct soap_array *a, int n,
@@ -2622,7 +2622,7 @@ SOAP_FMAC1 void *SOAP_FMAC2 soap_id_lookup(struct soap *, const char *id,
                                            void **p, int t, size_t n,
                                            unsigned int k);
 SOAP_FMAC1 void *SOAP_FMAC2
-soap_id_forward(struct soap *, const char *id, void *p, size_t len, int st,
+soap_id_forward(struct soap *, const char *href, void *p, size_t len, int st,
                 int tt, size_t n, unsigned int k,
                 void (*fcopy)(struct soap *, int, int, void *, size_t,
                               const void *, size_t));
@@ -2701,7 +2701,7 @@ soap_element_null(struct soap *, const char *tag, int id, const char *type);
 SOAP_FMAC1 int SOAP_FMAC2 soap_element_nil(struct soap *, const char *tag);
 SOAP_FMAC1 int SOAP_FMAC2
 soap_element_id(struct soap *, const char *tag, int id, const void *p,
-                const struct soap_array *a, int d, const char *type, int n);
+                const struct soap_array *a, int n, const char *type, int t);
 SOAP_FMAC1 int SOAP_FMAC2 soap_element_result(struct soap *, const char *tag);
 SOAP_FMAC1 void SOAP_FMAC2 soap_check_result(struct soap *, const char *tag);
 SOAP_FMAC1 int SOAP_FMAC2 soap_element_end_out(struct soap *, const char *tag);
@@ -2792,7 +2792,7 @@ SOAP_FMAC1 int SOAP_FMAC2 soap_recv_header(struct soap *);
 
 SOAP_FMAC1 int SOAP_FMAC2 soap_response(struct soap *, int);
 
-SOAP_FMAC1 int SOAP_FMAC2 soap_send_empty_response(struct soap *, int status);
+SOAP_FMAC1 int SOAP_FMAC2 soap_send_empty_response(struct soap *, int httpstatuscode);
 SOAP_FMAC1 int SOAP_FMAC2 soap_recv_empty_response(struct soap *);
 
 SOAP_FMAC1 int SOAP_FMAC2 soap_send_fault(struct soap *);

--- a/Framework/ICat/inc/MantidICat/GSoap/stdsoap2.h
+++ b/Framework/ICat/inc/MantidICat/GSoap/stdsoap2.h
@@ -2551,8 +2551,8 @@ SOAP_FMAC1 int SOAP_FMAC2 soap_dime_forward(struct soap *, unsigned char **,
 #ifndef WITH_NOIDREF
 SOAP_FMAC1 int SOAP_FMAC2
 soap_pointer_lookup_id(struct soap *, void *p, int t, struct soap_plist **);
-SOAP_FMAC1 int SOAP_FMAC2
-soap_pointer_lookup(struct soap *, const void *p, int type, struct soap_plist **);
+SOAP_FMAC1 int SOAP_FMAC2 soap_pointer_lookup(struct soap *, const void *p,
+                                              int type, struct soap_plist **);
 SOAP_FMAC1 int SOAP_FMAC2 soap_pointer_enter(struct soap *, const void *p,
                                              const struct soap_array *a, int n,
                                              int type, struct soap_plist **);
@@ -2792,7 +2792,8 @@ SOAP_FMAC1 int SOAP_FMAC2 soap_recv_header(struct soap *);
 
 SOAP_FMAC1 int SOAP_FMAC2 soap_response(struct soap *, int);
 
-SOAP_FMAC1 int SOAP_FMAC2 soap_send_empty_response(struct soap *, int httpstatuscode);
+SOAP_FMAC1 int SOAP_FMAC2
+soap_send_empty_response(struct soap *, int httpstatuscode);
 SOAP_FMAC1 int SOAP_FMAC2 soap_recv_empty_response(struct soap *);
 
 SOAP_FMAC1 int SOAP_FMAC2 soap_send_fault(struct soap *);

--- a/Framework/ICat/inc/MantidICat/ICat3/ICat3Catalog.h
+++ b/Framework/ICat/inc/MantidICat/ICat3/ICat3Catalog.h
@@ -69,9 +69,9 @@ public:
   /// get investigationtypes list
   virtual void listInvestigationTypes(std::vector<std::string> &invstTypes);
   /// get file location strings
-  virtual const std::string getFileLocation(const long long &fileid);
+  virtual const std::string getFileLocation(const long long &fileID);
   /// get urls
-  virtual const std::string getDownloadURL(const long long &fileid);
+  virtual const std::string getDownloadURL(const long long &fileID);
   /// get URL of where to PUT (publish) files.
   virtual const std::string
   getUploadURL(const std::string &investigationID,

--- a/Framework/ICat/inc/MantidICat/ICat3/ICat3Helper.h
+++ b/Framework/ICat/inc/MantidICat/ICat3/ICat3Helper.h
@@ -49,12 +49,12 @@ public:
                ICat3::ns1__searchByAdvancedResponse &response);
 
   /// calls getInvestigationIncludes api's
-  void getDataFiles(long long invId, ICat3::ns1__investigationInclude include,
+  void getDataFiles(long long invstId, ICat3::ns1__investigationInclude include,
                     API::ITableWorkspace_sptr &responsews_sptr);
 
   /// this method calls Icat api getInvestigationIncludes and returns datasets
   /// for the given investigation id.
-  void doDataSetsSearch(long long invId,
+  void doDataSetsSearch(long long invstId,
                         ICat3::ns1__investigationInclude include,
                         API::ITableWorkspace_sptr &responsews_sptr);
 

--- a/Framework/Kernel/inc/MantidKernel/BinFinder.h
+++ b/Framework/Kernel/inc/MantidKernel/BinFinder.h
@@ -31,7 +31,7 @@ class MANTID_KERNEL_DLL BinFinder {
 public:
   BinFinder(const std::vector<double> &binParams);
 
-  int bin(double value);
+  int bin(double x);
 
   int lastBinIndex();
 

--- a/Framework/Kernel/inc/MantidKernel/ComputeResourceInfo.h
+++ b/Framework/Kernel/inc/MantidKernel/ComputeResourceInfo.h
@@ -48,7 +48,7 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 class MANTID_KERNEL_DLL ComputeResourceInfo {
 public:
   /// constructor - from facility info and the element for this resource
-  ComputeResourceInfo(const FacilityInfo *f, const Poco::XML::Element *elem);
+  ComputeResourceInfo(const FacilityInfo *fac, const Poco::XML::Element *elem);
 
   /// Equality operator
   bool operator==(const ComputeResourceInfo &rhs) const;

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -145,7 +145,7 @@ public:
   void launchProcess(const std::string &programFilePath,
                      const std::vector<std::string> &programArguments) const;
   /// Sets a configuration property
-  void setString(const std::string &keyName, const std::string &keyValue);
+  void setString(const std::string &key, const std::string &value);
   // Searches for a configuration property and returns its value
   template <typename T> int getValue(const std::string &keyName, T &out);
   /// Return the local properties filename.
@@ -212,7 +212,7 @@ public:
   //@}
 
   /// Load facility information from instrumentDir/Facilities.xml file
-  void updateFacilities(const std::string &facilityName = "");
+  void updateFacilities(const std::string &fName = "");
   /// Get the list of facilities
   const std::vector<FacilityInfo *> getFacilities() const;
   /// Get the list of facility names

--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -90,10 +90,10 @@ public:
   DateAndTime operator-(const time_duration &td) const;
   DateAndTime &operator-=(const time_duration &td);
 
-  DateAndTime operator+(const double seconds) const;
-  DateAndTime &operator+=(const double seconds);
-  DateAndTime operator-(const double seconds) const;
-  DateAndTime &operator-=(const double seconds);
+  DateAndTime operator+(const double sec) const;
+  DateAndTime &operator+=(const double sec);
+  DateAndTime operator-(const double sec) const;
+  DateAndTime &operator-=(const double sec);
 
   time_duration operator-(const DateAndTime &rhs) const;
 
@@ -101,8 +101,8 @@ public:
   static DateAndTime getCurrentTime();
   static DateAndTime maximum();
   static DateAndTime minimum();
-  static double secondsFromDuration(time_duration td);
-  static time_duration durationFromSeconds(double seconds);
+  static double secondsFromDuration(time_duration duration);
+  static time_duration durationFromSeconds(double duration);
   static int64_t nanosecondsFromDuration(const time_duration &td);
   static int64_t nanosecondsFromSeconds(double sec);
   static time_duration durationFromNanoseconds(int64_t dur);

--- a/Framework/Kernel/inc/MantidKernel/DiskBuffer.h
+++ b/Framework/Kernel/inc/MantidKernel/DiskBuffer.h
@@ -84,7 +84,7 @@ public:
   void objectDeleted(ISaveable *item);
 
   // Free space map methods
-  void freeBlock(uint64_t const pos, uint64_t const fileSize);
+  void freeBlock(uint64_t const pos, uint64_t const size);
   void defragFreeBlocks();
 
   // Allocating

--- a/Framework/Kernel/inc/MantidKernel/Exception.h
+++ b/Framework/Kernel/inc/MantidKernel/Exception.h
@@ -118,7 +118,7 @@ private:
   std::string outMessage;
 
 public:
-  FileError(const std::string &Description, const std::string &FileName);
+  FileError(const std::string &Desc, const std::string &FName);
   FileError(const FileError &A);
   /// Assignment operator
   FileError &operator=(const FileError &A);

--- a/Framework/Kernel/inc/MantidKernel/FilteredTimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/FilteredTimeSeriesProperty.h
@@ -41,7 +41,7 @@ public:
   /// Construct with a source time series & a filter property
   FilteredTimeSeriesProperty(TimeSeriesProperty<HeldType> *seriesProp,
                              const TimeSeriesProperty<bool> &filterProp,
-                             const bool transferOwnserhip = false);
+                             const bool transferOwnership = false);
   /// Destructor
   ~FilteredTimeSeriesProperty() override;
 

--- a/Framework/Kernel/inc/MantidKernel/LogParser.h
+++ b/Framework/Kernel/inc/MantidKernel/LogParser.h
@@ -119,7 +119,7 @@ private:
   CommandMap createCommandMap(bool newStyle) const;
 
   /// Try to parse period data.
-  void tryParsePeriod(const std::string &com, const DateAndTime &time,
+  void tryParsePeriod(const std::string &scom, const DateAndTime &time,
                       std::istringstream &idata,
                       Kernel::TimeSeriesProperty<int> *const periods);
 };

--- a/Framework/Kernel/inc/MantidKernel/MagneticIon.h
+++ b/Framework/Kernel/inc/MantidKernel/MagneticIon.h
@@ -20,8 +20,8 @@ struct MANTID_KERNEL_DLL MagneticIon {
   /// Default constructor
   MagneticIon();
   /// Construct the Ion with data
-  MagneticIon(const char *symbol, const uint16_t charge, const double j0[8],
-              const double j2[8], const double j4[8], const double j6[8]);
+  MagneticIon(const char *symbol, const uint16_t charge, const double j0i[8],
+              const double j2i[8], const double j4i[8], const double j6i[8]);
 
   /// Returns the value of the form factor for the given J/L
   double analyticalFormFactor(const double qsqr, const uint16_t j,

--- a/Framework/Kernel/inc/MantidKernel/Matrix.h
+++ b/Framework/Kernel/inc/MantidKernel/Matrix.h
@@ -111,11 +111,11 @@ public:
     return tmp;
   }
   //
-  void setColumn(const size_t nCol, const std::vector<T> &newColumn);
+  void setColumn(const size_t nCol, const std::vector<T> &newCol);
   void setRow(const size_t nRow, const std::vector<T> &newRow);
   void zeroMatrix(); ///< Set the matrix to zero
   void identityMatrix();
-  void setRandom(size_t seedValue = 0, double rMin = -1,
+  void setRandom(size_t seed = 0, double rMin = -1,
                  double rMax = 1); ///< initialize random matrix;
   void normVert();                 ///< Vertical normalisation
   T Trace() const;                 ///< Trace of the matrix

--- a/Framework/Kernel/inc/MantidKernel/MersenneTwister.h
+++ b/Framework/Kernel/inc/MantidKernel/MersenneTwister.h
@@ -65,7 +65,7 @@ public:
   /// Destructor
   ~MersenneTwister() override;
   /// Set the random number seed
-  void setSeed(const size_t seed) override;
+  void setSeed(const size_t seedValue) override;
   /// Sets the range of the subsequent calls to next
   void setRange(const double start, const double end) override;
   /// Generate the next random number in the sequence within the given range,

--- a/Framework/Kernel/inc/MantidKernel/Quat.h
+++ b/Framework/Kernel/inc/MantidKernel/Quat.h
@@ -58,7 +58,7 @@ public:
   // * Construct a Quat between two vectors;
   // * The angle between them is defined differently from usual if vectors are
   // not unit or the same length vectors, so quat would be not consistent
-  Quat(const V3D &vec1, const V3D &vec2);
+  Quat(const V3D &src, const V3D &des);
   Quat(const V3D &rX, const V3D &rY, const V3D &rZ);
   //! Set quaternion form an angle in degrees and an axis
   Quat(const double _deg, const V3D &_axis);
@@ -72,8 +72,8 @@ public:
 
   void set(const double ww, const double aa, const double bb, const double cc);
   void setAngleAxis(const double _deg, const V3D &_axis);
-  void getAngleAxis(double &_deg, double &_axis1, double &_axis2,
-                    double &axis3) const;
+  void getAngleAxis(double &_deg, double &_ax0, double &_ax1,
+                    double &_ax2) const;
   std::vector<double> getEulerAngles(const std::string &convention) const;
   /// Set the rotation (both don't change rotation axis)
   void setRotation(const double deg);
@@ -94,7 +94,7 @@ public:
   //! Convert quaternion rotation to an OpenGL matrix [4x4] matrix
   //! stored as an linear array of 16 double
   //! The function glRotated must be called
-  void GLMatrix(double *glmat) const;
+  void GLMatrix(double *mat) const;
   //! returns the rotation matrix defined by this quaternion as an 9-point
   // vector representing M33 matrix
   //! (m33 is not used at the moment), if check_normalisation selected, verify
@@ -105,7 +105,7 @@ public:
   void setQuat(double[16]);
   //! Convert usual 3D rotation matrix into quat; Will throw if matirix is not
   // rotational;
-  void setQuat(const DblMatrix &RotMat);
+  void setQuat(const DblMatrix &rMat);
   //! Rotate a vector
   void rotate(V3D &) const;
 

--- a/Framework/Kernel/inc/MantidKernel/ThreadPool.h
+++ b/Framework/Kernel/inc/MantidKernel/ThreadPool.h
@@ -49,7 +49,7 @@ namespace Kernel {
 class MANTID_KERNEL_DLL ThreadPool final {
 public:
   ThreadPool(ThreadScheduler *scheduler = new ThreadSchedulerFIFO(),
-             size_t numCores = 0, ProgressBase *prog = nullptr);
+             size_t numThreads = 0, ProgressBase *prog = nullptr);
 
   ~ThreadPool();
 

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -325,7 +325,7 @@ private:
 /// statistics.
 double DLLExport
 filterByStatistic(TimeSeriesProperty<double> const *const propertyToFilter,
-                  Kernel::Math::StatisticType statistic_type);
+                  Kernel::Math::StatisticType statisticType);
 
 } // namespace Kernel
 } // namespace Mantid

--- a/Framework/Kernel/inc/MantidKernel/Unit.h
+++ b/Framework/Kernel/inc/MantidKernel/Unit.h
@@ -93,8 +93,8 @@ public:
    *  @param delta ::    Not currently used
    */
   void toTOF(std::vector<double> &xdata, std::vector<double> &ydata,
-             const double &l1, const double &l2, const double &twoTheta,
-             const int &emode, const double &efixed, const double &delta);
+             const double &_l1, const double &_l2, const double &_twoTheta,
+             const int &_emode, const double &_efixed, const double &_delta);
 
   /** Convert from the concrete unit to time-of-flight. TOF is in microseconds.
    *  @param xvalue ::   A single X-value to convert
@@ -127,8 +127,8 @@ public:
    *  @param delta ::    Not currently used
    */
   void fromTOF(std::vector<double> &xdata, std::vector<double> &ydata,
-               const double &l1, const double &l2, const double &twoTheta,
-               const int &emode, const double &efixed, const double &delta);
+               const double &_l1, const double &_l2, const double &_twoTheta,
+               const int &_emode, const double &_efixed, const double &_delta);
 
   /** Convert from the time-of-flight to the concrete unit. TOF is in
    * microseconds.
@@ -498,7 +498,7 @@ public:
   const std::string caption() const override { return "Momentum"; }
   const UnitLabel label() const override;
 
-  double singleToTOF(const double x) const override;
+  double singleToTOF(const double ki) const override;
   double singleFromTOF(const double tof) const override;
   void init() override;
   Unit *clone() const override;

--- a/Framework/Kernel/inc/MantidKernel/Unit.h
+++ b/Framework/Kernel/inc/MantidKernel/Unit.h
@@ -83,14 +83,14 @@ public:
    *  @param xdata ::    The array of X data to be converted
    *  @param ydata ::    Not currently used (ConvertUnits passes an empty
    * vector)
-   *  @param l1 ::       The source-sample distance (in metres)
-   *  @param l2 ::       The sample-detector distance (in metres)
-   *  @param twoTheta :: The scattering angle (in radians)
-   *  @param emode ::    The energy mode (0=elastic, 1=direct geometry,
+   *  @param _l1 ::       The source-sample distance (in metres)
+   *  @param _l2 ::       The sample-detector distance (in metres)
+   *  @param _twoTheta :: The scattering angle (in radians)
+   *  @param _emode ::    The energy mode (0=elastic, 1=direct geometry,
    * 2=indirect geometry)
-   *  @param efixed ::   Value of fixed energy: EI (emode=1) or EF (emode=2) (in
+   *  @param _efixed ::   Value of fixed energy: EI (emode=1) or EF (emode=2) (in
    * meV)
-   *  @param delta ::    Not currently used
+   *  @param _delta ::    Not currently used
    */
   void toTOF(std::vector<double> &xdata, std::vector<double> &ydata,
              const double &_l1, const double &_l2, const double &_twoTheta,
@@ -117,14 +117,14 @@ public:
    *  @param xdata ::    The array of X data to be converted
    *  @param ydata ::    Not currently used (ConvertUnits passes an empty
    * vector)
-   *  @param l1 ::       The source-sample distance (in metres)
-   *  @param l2 ::       The sample-detector distance (in metres)
-   *  @param twoTheta :: The scattering angle (in radians)
-   *  @param emode ::    The energy mode (0=elastic, 1=direct geometry,
+   *  @param _l1 ::       The source-sample distance (in metres)
+   *  @param _l2 ::       The sample-detector distance (in metres)
+   *  @param _twoTheta :: The scattering angle (in radians)
+   *  @param _emode ::    The energy mode (0=elastic, 1=direct geometry,
    * 2=indirect geometry)
-   *  @param efixed ::   Value of fixed energy: EI (emode=1) or EF (emode=2) (in
+   *  @param _efixed ::   Value of fixed energy: EI (emode=1) or EF (emode=2) (in
    * meV)
-   *  @param delta ::    Not currently used
+   *  @param _delta ::    Not currently used
    */
   void fromTOF(std::vector<double> &xdata, std::vector<double> &ydata,
                const double &_l1, const double &_l2, const double &_twoTheta,

--- a/Framework/Kernel/inc/MantidKernel/Unit.h
+++ b/Framework/Kernel/inc/MantidKernel/Unit.h
@@ -88,7 +88,8 @@ public:
    *  @param _twoTheta :: The scattering angle (in radians)
    *  @param _emode ::    The energy mode (0=elastic, 1=direct geometry,
    * 2=indirect geometry)
-   *  @param _efixed ::   Value of fixed energy: EI (emode=1) or EF (emode=2) (in
+   *  @param _efixed ::   Value of fixed energy: EI (emode=1) or EF (emode=2)
+   * (in
    * meV)
    *  @param _delta ::    Not currently used
    */
@@ -122,7 +123,8 @@ public:
    *  @param _twoTheta :: The scattering angle (in radians)
    *  @param _emode ::    The energy mode (0=elastic, 1=direct geometry,
    * 2=indirect geometry)
-   *  @param _efixed ::   Value of fixed energy: EI (emode=1) or EF (emode=2) (in
+   *  @param _efixed ::   Value of fixed energy: EI (emode=1) or EF (emode=2)
+   * (in
    * meV)
    *  @param _delta ::    Not currently used
    */

--- a/Framework/Kernel/inc/MantidKernel/UserStringParser.h
+++ b/Framework/Kernel/inc/MantidKernel/UserStringParser.h
@@ -68,7 +68,7 @@ private:
   /// separate delimiter string from input string and return a vector of numbers
   /// created from the separated string
   std::vector<unsigned int> separateDelimiters(const std::string &input,
-                                               const std::string &symbol);
+                                               const std::string &delimiters);
 
   /// converts a string to int.
   unsigned int toUInt(const std::string &input);
@@ -77,7 +77,7 @@ private:
 
   /// This method removes the separator string from the input string and
   /// converts the tokens to unisgned int
-  void Tokenize(const std::string &input, const std::string &separator,
+  void Tokenize(const std::string &input, const std::string &delimiter,
                 unsigned int &start, unsigned int &end, unsigned int &step);
 
   /// convert the string into numbers

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -75,7 +75,7 @@ MANTID_KERNEL_DLL std::vector<NumT>
 splitStringIntoVector(std::string listString);
 
 MANTID_KERNEL_DLL int getBinIndex(const std::vector<double> &bins,
-                                  const double X);
+                                  const double value);
 // Linearly interpolate between a set of Y values. Assumes the values are set
 // for the calculated nodes
 MANTID_KERNEL_DLL void linearlyInterpolateY(const std::vector<double> &x,
@@ -87,9 +87,9 @@ MANTID_KERNEL_DLL void linearlyInterpolateY(const std::vector<double> &x,
 MANTID_KERNEL_DLL void
 smoothInRange(const std::vector<double> &input, std::vector<double> &output,
               double avrgInterval,
-              std::vector<double> const *const binBoundaris = nullptr,
+              std::vector<double> const *const binBndrs = nullptr,
               size_t startIndex = 0, size_t endIndex = 0,
-              std::vector<double> *const outputBinBoundaries = nullptr);
+              std::vector<double> *const outBins = nullptr);
 
 //-------------------------------------------------------------------------------------
 /** Return the length of the vector (in the physical sense),

--- a/Framework/Kernel/src/Math/ChebyshevPolyFit.cpp
+++ b/Framework/Kernel/src/Math/ChebyshevPolyFit.cpp
@@ -17,9 +17,9 @@ class ChebyshevPolyFitImpl {
 public:
   explicit ChebyshevPolyFitImpl(const size_t order) : m_order(order) {}
 
-  std::vector<double> fit(const std::vector<double> &xs,
-                          const std::vector<double> &ys,
-                          const std::vector<double> &wgts);
+  std::vector<double> fit(const std::vector<double> &x,
+                          const std::vector<double> &y,
+                          const std::vector<double> &w);
 
 private:
   const size_t m_order;

--- a/Framework/Kernel/src/Unit.cpp
+++ b/Framework/Kernel/src/Unit.cpp
@@ -135,7 +135,16 @@ void Unit::initialize(const double &_l1, const double &_l2,
 }
 
 //---------------------------------------------------------------------------------------
-/** Perform the conversion to TOF on a vector of data */
+/** Perform the conversion to TOF on a vector of data 
+@param xdata
+@param ydata
+@param _l1
+@param _l2
+@param _twoTheta
+@param _emode
+@param _efixed
+@param _delta
+*/
 void Unit::toTOF(std::vector<double> &xdata, std::vector<double> &ydata,
                  const double &_l1, const double &_l2, const double &_twoTheta,
                  const int &_emode, const double &_efixed,
@@ -147,7 +156,15 @@ void Unit::toTOF(std::vector<double> &xdata, std::vector<double> &ydata,
     xdata[i] = this->singleToTOF(xdata[i]);
 }
 
-/** Convert a single value to TOF */
+/** Convert a single value to TOF 
+@param xvalue
+@param l1
+@param l2
+@param twoTheta
+@param emode
+@param efixed
+@param delta
+*/
 double Unit::convertSingleToTOF(const double xvalue, const double &l1,
                                 const double &l2, const double &twoTheta,
                                 const int &emode, const double &efixed,
@@ -157,7 +174,16 @@ double Unit::convertSingleToTOF(const double xvalue, const double &l1,
 }
 
 //---------------------------------------------------------------------------------------
-/** Perform the conversion to TOF on a vector of data */
+/** Perform the conversion to TOF on a vector of data
+@param xdata
+@param ydata
+@param _l1
+@param _l2
+@param _twoTheta
+@param _emode
+@param _efixed
+@param _delta
+*/
 void Unit::fromTOF(std::vector<double> &xdata, std::vector<double> &ydata,
                    const double &_l1, const double &_l2,
                    const double &_twoTheta, const int &_emode,
@@ -169,7 +195,15 @@ void Unit::fromTOF(std::vector<double> &xdata, std::vector<double> &ydata,
     xdata[i] = this->singleFromTOF(xdata[i]);
 }
 
-/** Convert a single value from TOF */
+/** Convert a single value from TOF 
+@param xvalue
+@param l1
+@param l2
+@param twoTheta
+@param emode
+@param efixed
+@param delta
+*/
 double Unit::convertSingleFromTOF(const double xvalue, const double &l1,
                                   const double &l2, const double &twoTheta,
                                   const int &emode, const double &efixed,

--- a/Framework/Kernel/src/Unit.cpp
+++ b/Framework/Kernel/src/Unit.cpp
@@ -135,7 +135,7 @@ void Unit::initialize(const double &_l1, const double &_l2,
 }
 
 //---------------------------------------------------------------------------------------
-/** Perform the conversion to TOF on a vector of data 
+/** Perform the conversion to TOF on a vector of data
 @param xdata
 @param ydata
 @param _l1
@@ -156,7 +156,7 @@ void Unit::toTOF(std::vector<double> &xdata, std::vector<double> &ydata,
     xdata[i] = this->singleToTOF(xdata[i]);
 }
 
-/** Convert a single value to TOF 
+/** Convert a single value to TOF
 @param xvalue
 @param l1
 @param l2
@@ -195,7 +195,7 @@ void Unit::fromTOF(std::vector<double> &xdata, std::vector<double> &ydata,
     xdata[i] = this->singleFromTOF(xdata[i]);
 }
 
-/** Convert a single value from TOF 
+/** Convert a single value from TOF
 @param xvalue
 @param l1
 @param l2

--- a/Framework/Kernel/src/Unit.cpp
+++ b/Framework/Kernel/src/Unit.cpp
@@ -136,14 +136,6 @@ void Unit::initialize(const double &_l1, const double &_l2,
 
 //---------------------------------------------------------------------------------------
 /** Perform the conversion to TOF on a vector of data
-@param xdata
-@param ydata
-@param _l1
-@param _l2
-@param _twoTheta
-@param _emode
-@param _efixed
-@param _delta
 */
 void Unit::toTOF(std::vector<double> &xdata, std::vector<double> &ydata,
                  const double &_l1, const double &_l2, const double &_twoTheta,
@@ -175,14 +167,6 @@ double Unit::convertSingleToTOF(const double xvalue, const double &l1,
 
 //---------------------------------------------------------------------------------------
 /** Perform the conversion to TOF on a vector of data
-@param xdata
-@param ydata
-@param _l1
-@param _l2
-@param _twoTheta
-@param _emode
-@param _efixed
-@param _delta
 */
 void Unit::fromTOF(std::vector<double> &xdata, std::vector<double> &ydata,
                    const double &_l1, const double &_l2,

--- a/Framework/LiveData/inc/MantidLiveData/ADARA/ADARAParser.h
+++ b/Framework/LiveData/inc/MantidLiveData/ADARA/ADARAParser.h
@@ -23,7 +23,7 @@ namespace ADARA {
 class DLLExport Parser {
 public:
   /// Constructor
-  Parser(uint32_t inital_buffer_size = 1024 * 1024,
+  Parser(uint32_t initial_buffer_size = 1024 * 1024,
          uint32_t max_pkt_size = 8 * 1024 * 1024);
 
   /// Destructor

--- a/Framework/LiveData/src/LoadDAE/idc.h
+++ b/Framework/LiveData/src/LoadDAE/idc.h
@@ -37,11 +37,11 @@ extern "C" {
 #endif
 
 /** Open a DAE connection on host*/
-int IDCopen(const char *host, int mode, int options, idc_handle_t *fh,
+int IDCopen(const char *host, int mode, int options, idc_handle_t *pfh,
             uint16_t port = ISISDS_PORT);
 
 /** Close a DAE connection */
-int IDCclose(idc_handle_t *fh);
+int IDCclose(idc_handle_t *pfh);
 
 /* The A versions of the functions allocate memory, the other need to be passed
  * a pre-allocated array */

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/AccumulateMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/AccumulateMD.h
@@ -37,7 +37,7 @@ filterToNew(std::vector<std::string> &input_data,
 
 /// Check if the named data source is in the vector of data currently in the
 /// workspace
-bool appearsInCurrentData(const std::string &input_data,
+bool appearsInCurrentData(const std::string &data_source,
                           std::vector<std::string> &current_data);
 
 /// Return a vector of the names of files and workspaces which have been

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDHistoWS.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDHistoWS.h
@@ -70,7 +70,7 @@ private:
   void estimateThreadWork(size_t nThreads, size_t specSize,
                           size_t nPointsToProcess);
   // the function does a chunk of work. Expected to run on a thread.
-  size_t conversionChunk(size_t job_ID) override;
+  size_t conversionChunk(size_t startSpectra) override;
 };
 
 } // endNamespace MDAlgorithms

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDSelector.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDSelector.h
@@ -45,7 +45,7 @@ public:
   /// (possibly, in a future) some workspace properties
   boost::shared_ptr<ConvToMDBase>
   convSelector(API::MatrixWorkspace_sptr inputWS,
-               boost::shared_ptr<ConvToMDBase> &currentSptr) const;
+               boost::shared_ptr<ConvToMDBase> &currentSolver) const;
 };
 } // end MDAlgorithms Namespace
 } // end Mantid Namespace

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToDiffractionMDWorkspace2.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToDiffractionMDWorkspace2.h
@@ -53,7 +53,7 @@ protected: // for testing
   // method to convert the value of the target frame specified for the
   // ConvertToDiffractionMDWorksapce  into the properties names of the
   // ConvertToMD
-  void convertFramePropertyNames(const std::string &ConvToDifrWSPropName,
+  void convertFramePropertyNames(const std::string &TargFrame,
                                  std::string &TargFrameName,
                                  std::string &ScalingName);
   // method to convert the extents specified for the

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToMD.h
@@ -90,9 +90,9 @@ protected: // for testing, otherwise private:
   createNewMDWorkspace(const MDAlgorithms::MDWSDescription &targWSDescr);
 
   bool buildTargetWSDescription(API::IMDEventWorkspace_sptr spws,
-                                const std::string &Q_mod_req,
-                                const std::string &dEModeRequested,
-                                const std::vector<std::string> &other_dim_names,
+                                const std::string &QModReq,
+                                const std::string &dEModReq,
+                                const std::vector<std::string> &otherDimNames,
                                 std::vector<double> &dimMin,
                                 std::vector<double> &dimMax,
                                 const std::string &QFrame,

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToMDMinMaxLocal.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToMDMinMaxLocal.h
@@ -46,9 +46,9 @@ public:
   int version() const override { return 1; }
 
 protected: // for testing
-  void findMinMaxValues(MDWSDescription &targWSDescr,
-                        MDTransfInterface *const qTransf,
-                        Kernel::DeltaEMode::Type dEMode,
+  void findMinMaxValues(MDWSDescription &WSDescription,
+                        MDTransfInterface *const pQtransf,
+                        Kernel::DeltaEMode::Type iEMode,
                         std::vector<double> &MinValues,
                         std::vector<double> &MaxValues);
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToMDParent.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertToMDParent.h
@@ -63,7 +63,7 @@ protected:
   DataObjects::TableWorkspace_const_sptr preprocessDetectorsPositions(
       const Mantid::API::MatrixWorkspace_const_sptr &InWS2D,
       const std::string &dEModeRequested, bool updateMasks,
-      const std::string &preproc_detectorsWSName);
+      const std::string &OutWSName);
   DataObjects::TableWorkspace_sptr runPreprocessDetectorsToMDChildUpdatingMasks(
       const Mantid::API::MatrixWorkspace_const_sptr &InWS2D,
       const std::string &OutWSName, const std::string &dEModeRequested,

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/DisplayNormalizationSetter.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/DisplayNormalizationSetter.h
@@ -35,21 +35,21 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 class DLLExport DisplayNormalizationSetter {
 public:
-  void operator()(Mantid::API::IMDWorkspace_sptr workspace,
-                  const Mantid::API::MatrixWorkspace_sptr &workspaceToCheck,
+  void operator()(Mantid::API::IMDWorkspace_sptr mdWorkspace,
+                  const Mantid::API::MatrixWorkspace_sptr &underlyingWorkspace,
                   bool isQ = false,
                   const Mantid::Kernel::DeltaEMode::Type &mode =
                       Mantid::Kernel::DeltaEMode::Elastic);
 
 private:
   void setNormalizationMDEvent(
-      Mantid::API::IMDWorkspace_sptr workspace,
+      Mantid::API::IMDWorkspace_sptr mdWorkspace,
       const Mantid::API::MatrixWorkspace_sptr &underlyingWorkspace,
       bool isQ = false, const Mantid::Kernel::DeltaEMode::Type &mode =
                             Mantid::Kernel::DeltaEMode::Elastic);
 
   void applyNormalizationMDEvent(
-      Mantid::API::IMDWorkspace_sptr workspace,
+      Mantid::API::IMDWorkspace_sptr mdWorkspace,
       Mantid::API::MDNormalization displayNormalization,
       Mantid::API::MDNormalization displayNormalizationHisto);
 };

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -108,7 +108,7 @@ private:
 
   /// Form a map key for the specified q_vector.
   int64_t getHklKey(Mantid::Kernel::V3D const &q_vector);
-  int64_t getHklKey2(Mantid::Kernel::V3D const &q_vector);
+  int64_t getHklKey2(Mantid::Kernel::V3D const &hkl);
 
   /// Add an event to the vector of events for the closest h,k,l
   void addEvent(std::pair<double, Mantid::Kernel::V3D> event_Q, bool hkl_integ);

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD.h
@@ -47,7 +47,7 @@ private:
   Mantid::API::IMDEventWorkspace_sptr inWS;
 
   /// Calculate if this Q is on a detector
-  bool detectorQ(Mantid::Kernel::V3D QLabFrame, double PeakRadius);
+  bool detectorQ(Mantid::Kernel::V3D QLabFrame, double r);
 
   /// Instrument reference
   Geometry::Instrument_const_sptr inst;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD2.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksMD2.h
@@ -48,7 +48,7 @@ private:
 
   /// Calculate if this Q is on a detector
   void calculateE1(Geometry::Instrument_const_sptr inst);
-  double detectorQ(Mantid::Kernel::V3D QLabFrame, double PeakRadius);
+  double detectorQ(Mantid::Kernel::V3D QLabFrame, double r);
   void runMaskDetectors(Mantid::DataObjects::PeaksWorkspace_sptr peakWS,
                         std::string property, std::string values);
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/InvalidParameterParser.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/InvalidParameterParser.h
@@ -47,7 +47,7 @@ public:
   Mantid::API::ImplicitFunctionParameter *
   createParameter(Poco::XML::Element *parameterElement) override;
   void setSuccessorParser(
-      Mantid::API::ImplicitFunctionParameterParser *paramParser) override;
+      Mantid::API::ImplicitFunctionParameterParser *parser) override;
 
 protected:
   ImplicitFunctionParameterParser::SuccessorType m_successor;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadILLAsciiHelper.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadILLAsciiHelper.h
@@ -42,7 +42,7 @@ namespace MDAlgorithms {
 
 class ILLParser {
 public:
-  ILLParser(const std::string &filename);
+  ILLParser(const std::string &filepath);
   virtual ~ILLParser();
   void parse();
   void showHeader();

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadSQW.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadSQW.h
@@ -62,19 +62,19 @@ struct dataPositions {
   // the helper methods
   /// Block 1:  Main_header: Parse SQW main data header
   void parse_sqw_main_header(
-      std::ifstream &stream); // Legacy - candidate for removal
+      std::ifstream &dataStream); // Legacy - candidate for removal
   /// Block 2: Header: Parse header of single SPE file
   std::streamoff parse_component_header(
-      std::ifstream &stream,
+      std::ifstream &dataStream,
       std::streamoff start_location); // Legacy -candidate for removal
   /// Block 3: Detpar: parse positions of the contributed detectors. These
   /// detectors have to be the same for all contributing spe files
   std::streamoff parse_sqw_detpar(
-      std::ifstream &stream,
+      std::ifstream &dataStream,
       std::streamoff start_location); // Legacy - candidate for removal
   /// Block 4: Data: parse positions of the data fields
   void
-  parse_data_locations(std::ifstream &stream, std::streamoff data_start,
+  parse_data_locations(std::ifstream &dataStream, std::streamoff data_start,
                        std::vector<size_t> &nBins,
                        uint64_t &nDataPoints); // Legacy - candidate for removal
 };

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDEventWSWrapper.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDEventWSWrapper.h
@@ -71,9 +71,9 @@ public:
   API::IMDEventWorkspace_sptr createEmptyMDWS(const MDWSDescription &WSD);
   /// add the data to the internal workspace. The workspace has to exist and be
   /// initiated
-  void addMDData(std::vector<float> &sig_err, std::vector<uint16_t> &run_index,
-                 std::vector<uint32_t> &det_id, std::vector<coord_t> &Coord,
-                 size_t data_size) const;
+  void addMDData(std::vector<float> &sigErr, std::vector<uint16_t> &runIndex,
+                 std::vector<uint32_t> &detId, std::vector<coord_t> &Coord,
+                 size_t dataSize) const;
   /// releases the shared pointer to the MD workspace, stored by the class and
   /// makes the class instance undefined;
   void releaseWorkspace();
@@ -121,8 +121,8 @@ private:
   // internal function tempates to generate as function of dimensions and
   // assightn to function pointers
   template <size_t nd>
-  void addMDDataND(float *sig_err, uint16_t *run_index, uint32_t *det_id,
-                   coord_t *Coord, size_t data_size) const;
+  void addMDDataND(float *sigErr, uint16_t *runIndex, uint32_t *detId,
+                   coord_t *Coord, size_t dataSize) const;
   template <size_t nd>
   void addAndTraceMDDataND(float *sig_err, uint16_t *run_index,
                            uint32_t *det_id, coord_t *Coord,

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfAxisNames.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfAxisNames.h
@@ -56,9 +56,9 @@ public:
   /// function returns default dimension id-s for different Q and dE modes,
   /// defined by this class
   std::vector<std::string>
-  getDefaultDimIDQ3D(Kernel::DeltaEMode::Type dEmode) const;
+  getDefaultDimIDQ3D(Kernel::DeltaEMode::Type dEMode) const;
   std::vector<std::string>
-  getDefaultDimIDModQ(Kernel::DeltaEMode::Type dEmode) const;
+  getDefaultDimIDModQ(Kernel::DeltaEMode::Type dEMode) const;
 
   // constructor
   MDTransfAxisNames();
@@ -70,8 +70,8 @@ private:
 };
 /** function to build mslice-like axis name from the vector, which describes
  * crystallographic direction along this axis*/
-std::string DLLExport makeAxisName(const Kernel::V3D &vector,
-                                   const std::vector<std::string> &Q1Names);
+std::string DLLExport makeAxisName(const Kernel::V3D &Dir,
+                                   const std::vector<std::string> &QNames);
 /**creates string representation of the number with accuracy, cpecified by eps*/
 std::string DLLExport sprintfd(const double data, const double eps);
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfAxisNames.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfAxisNames.h
@@ -70,8 +70,8 @@ private:
 };
 /** function to build mslice-like axis name from the vector, which describes
  * crystallographic direction along this axis*/
-std::string DLLExport makeAxisName(const Kernel::V3D &Dir,
-                                   const std::vector<std::string> &QNames);
+std::string DLLExport
+makeAxisName(const Kernel::V3D &Dir, const std::vector<std::string> &QNames);
 /**creates string representation of the number with accuracy, cpecified by eps*/
 std::string DLLExport sprintfd(const double data, const double eps);
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
@@ -55,8 +55,8 @@ public:
 
   bool calcGenericVariables(std::vector<coord_t> &Coord, size_t nd) override;
   bool calcYDepCoordinates(std::vector<coord_t> &Coord, size_t i) override;
-  bool calcMatrixCoord(const double &x, std::vector<coord_t> &Coord, double &signal,
-                       double &ErrSq) const override;
+  bool calcMatrixCoord(const double &x, std::vector<coord_t> &Coord,
+                       double &signal, double &ErrSq) const override;
   // constructor;
   MDTransfModQ();
   /* clone method allowing to provide the copy of the particular class */

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfModQ.h
@@ -55,8 +55,8 @@ public:
 
   bool calcGenericVariables(std::vector<coord_t> &Coord, size_t nd) override;
   bool calcYDepCoordinates(std::vector<coord_t> &Coord, size_t i) override;
-  bool calcMatrixCoord(const double &k0, std::vector<coord_t> &Coord, double &s,
-                       double &err) const override;
+  bool calcMatrixCoord(const double &x, std::vector<coord_t> &Coord, double &signal,
+                       double &ErrSq) const override;
   // constructor;
   MDTransfModQ();
   /* clone method allowing to provide the copy of the particular class */
@@ -64,7 +64,7 @@ public:
   //
   void initialize(const MDWSDescription &ConvParams) override;
 
-  std::vector<double> getExtremumPoints(const double xMin, const double xMax,
+  std::vector<double> getExtremumPoints(const double eMin, const double eMax,
                                         size_t det_num) const override;
 
   // WARNING!!!! THESE METHODS ARE USED BEFORE INITIALIZE IS EXECUTED SO THEY
@@ -76,24 +76,24 @@ public:
      input workspace*/
   unsigned int
   getNMatrixDimensions(Kernel::DeltaEMode::Type mode,
-                       API::MatrixWorkspace_const_sptr Sptr =
+                       API::MatrixWorkspace_const_sptr inWS =
                            API::MatrixWorkspace_const_sptr()) const override;
   /**function returns units ID-s which this transformation prodiuces its ouptut.
      It is Momentum and Momentum and DelteE in inelastic modes */
   std::vector<std::string>
   outputUnitID(Kernel::DeltaEMode::Type dEmode,
-               API::MatrixWorkspace_const_sptr Sptr =
+               API::MatrixWorkspace_const_sptr inWS =
                    API::MatrixWorkspace_const_sptr()) const override;
   /**the default dimID-s in ModQ mode are |Q| and dE if necessary */
   std::vector<std::string>
   getDefaultDimID(Kernel::DeltaEMode::Type dEmode,
-                  API::MatrixWorkspace_const_sptr Sptr =
+                  API::MatrixWorkspace_const_sptr inWS =
                       API::MatrixWorkspace_const_sptr()) const override;
   /**  returns the units, the transformation expects for input workspace to be
    * expressed in. */
   const std::string
   inputUnitID(Kernel::DeltaEMode::Type dEmode,
-              API::MatrixWorkspace_const_sptr Sptr =
+              API::MatrixWorkspace_const_sptr inWS =
                   API::MatrixWorkspace_const_sptr()) const override;
   void setDisplayNormalization(
       Mantid::API::IMDWorkspace_sptr mdWorkspace,
@@ -138,10 +138,10 @@ protected:
 private:
   /// how to transform workspace data in elastic case
   inline bool calcMatrixCoordElastic(const double &k0,
-                                     std::vector<coord_t> &Coored) const;
+                                     std::vector<coord_t> &Coord) const;
   /// how to transform workspace data in inelastic case
-  inline bool calcMatrixCoordInelastic(const double &DeltaE,
-                                       std::vector<coord_t> &Coored) const;
+  inline bool calcMatrixCoordInelastic(const double &E_tr,
+                                       std::vector<coord_t> &Coord) const;
 };
 
 } // End MDAlgorighms namespace

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfNoQ.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfNoQ.h
@@ -50,7 +50,7 @@ public:
   // calc target coordinates interface:
   bool calcGenericVariables(std::vector<coord_t> &Coord, size_t nd) override;
   bool calcYDepCoordinates(std::vector<coord_t> &Coord, size_t i) override;
-  bool calcMatrixCoord(const double &k0, std::vector<coord_t> &Coord, double &s,
+  bool calcMatrixCoord(const double &X, std::vector<coord_t> &Coord, double &s,
                        double &err) const override;
   // constructor;
   MDTransfNoQ();

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
@@ -51,7 +51,7 @@ public:
   /// list)
   const std::string transfID() const override; // {return "Q3D"; }
   bool calcYDepCoordinates(std::vector<coord_t> &Coord, size_t i) override;
-  bool calcMatrixCoord(const double &X, std::vector<coord_t> &Coord, double &s,
+  bool calcMatrixCoord(const double &x, std::vector<coord_t> &Coord, double &s,
                        double &err) const override;
   // constructor;
   MDTransfQ3D();
@@ -72,18 +72,18 @@ public:
      input workspace*/
   unsigned int
   getNMatrixDimensions(Kernel::DeltaEMode::Type mode,
-                       API::MatrixWorkspace_const_sptr Sptr =
+                       API::MatrixWorkspace_const_sptr inWS =
                            API::MatrixWorkspace_const_sptr()) const override;
   /**function returns units ID-s which this transformation prodiuces its ouptut.
      It is Momentum and Momentum and DelteE in inelastic modes */
   std::vector<std::string>
   outputUnitID(Kernel::DeltaEMode::Type dEmode,
-               API::MatrixWorkspace_const_sptr Sptr =
+               API::MatrixWorkspace_const_sptr inWS =
                    API::MatrixWorkspace_const_sptr()) const override;
   /**the default dimID-s in Q3D mode are Q1,Q2,Q3 and dE if necessary */
   std::vector<std::string>
   getDefaultDimID(Kernel::DeltaEMode::Type dEmode,
-                  API::MatrixWorkspace_const_sptr Sptr =
+                  API::MatrixWorkspace_const_sptr inWS =
                       API::MatrixWorkspace_const_sptr()) const override;
 
 protected:
@@ -107,11 +107,11 @@ protected:
 private:
   /// how to transform workspace data in elastic case
   inline bool calcMatrixCoord3DElastic(const double &k0,
-                                       std::vector<coord_t> &Coored, double &s,
-                                       double &err) const;
+                                       std::vector<coord_t> &Coord, double &signal,
+                                       double &errSq) const;
   /// how to transform workspace data in inelastic case
-  inline bool calcMatrixCoord3DInelastic(const double &DeltaE,
-                                         std::vector<coord_t> &Coored) const;
+  inline bool calcMatrixCoord3DInelastic(const double &E_tr,
+                                         std::vector<coord_t> &Coord) const;
 };
 
 } // End MDAlgorighms namespace

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
@@ -107,8 +107,8 @@ protected:
 private:
   /// how to transform workspace data in elastic case
   inline bool calcMatrixCoord3DElastic(const double &k0,
-                                       std::vector<coord_t> &Coord, double &signal,
-                                       double &errSq) const;
+                                       std::vector<coord_t> &Coord,
+                                       double &signal, double &errSq) const;
   /// how to transform workspace data in inelastic case
   inline bool calcMatrixCoord3DInelastic(const double &E_tr,
                                          std::vector<coord_t> &Coord) const;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDWSDescription.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDWSDescription.h
@@ -119,17 +119,17 @@ public: // for the time being
   void buildFromMDWS(const API::IMDEventWorkspace_const_sptr &pWS);
   /// copy some parameters from the input workspace, as target md WS do not have
   /// all information about the algorithm.
-  void setUpMissingParameters(const MDWSDescription &SourceMatrixWorkspace);
+  void setUpMissingParameters(const MDWSDescription &SourceMatrWS);
 
   /// method builds MD Event ws description from a matrix workspace and the
   /// transformations, requested to be performed on the workspace
   void buildFromMatrixWS(const API::MatrixWorkspace_sptr &pWS,
                          const std::string &QMode, const std::string dEMode,
-                         const std::vector<std::string> &dimProperyNames =
+                         const std::vector<std::string> &dimPropertyNames =
                              std::vector<std::string>());
 
   /// compare two descriptions and select the complimentary result.
-  void checkWSCorresponsMDWorkspace(MDWSDescription &NewMDWorkspace);
+  void checkWSCorresponsMDWorkspace(MDWSDescription &NewMDWorkspaceD);
 
   void setMinMax(const std::vector<double> &minVal,
                  const std::vector<double> &maxVal);
@@ -148,7 +148,7 @@ public: // for the time being
   /** function extracts the coordinates from additional workspace properties and
    * places them to AddCoord vector for further usage*/
   static void fillAddProperties(Mantid::API::MatrixWorkspace_const_sptr inWS2D,
-                                const std::vector<std::string> &dimProperyNames,
+                                const std::vector<std::string> &dimPropertyNames,
                                 std::vector<coord_t> &AddCoord);
 
   static boost::shared_ptr<Geometry::OrientedLattice>
@@ -165,7 +165,7 @@ public: // for the time being
   Geometry::MDFrame_uptr getFrame(size_t d) const;
 
   /// sets number of bins each dimension is split
-  void setNumBins(const std::vector<int> &nBins);
+  void setNumBins(const std::vector<int> &nBins_toSplit);
 
 protected: // until MDWSDesctiptionDepricatedExist
   /// the variable which describes the number of the dimensions, in the target
@@ -201,7 +201,7 @@ protected: // until MDWSDesctiptionDepricatedExist
   //********************* internal helpers
   /// helper function to resize all vectors, responsible for MD dimensions in
   /// one go
-  void resizeDimDescriptions(unsigned int Dims, size_t nBins = 10);
+  void resizeDimDescriptions(unsigned int nDimensions, size_t nBins = 10);
 
 private:
   /// Coordinate system.

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDWSDescription.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDWSDescription.h
@@ -147,9 +147,10 @@ public: // for the time being
                                         const std::vector<double> &maxVal);
   /** function extracts the coordinates from additional workspace properties and
    * places them to AddCoord vector for further usage*/
-  static void fillAddProperties(Mantid::API::MatrixWorkspace_const_sptr inWS2D,
-                                const std::vector<std::string> &dimPropertyNames,
-                                std::vector<coord_t> &AddCoord);
+  static void
+  fillAddProperties(Mantid::API::MatrixWorkspace_const_sptr inWS2D,
+                    const std::vector<std::string> &dimPropertyNames,
+                    std::vector<coord_t> &AddCoord);
 
   static boost::shared_ptr<Geometry::OrientedLattice>
   getOrientedLattice(Mantid::API::MatrixWorkspace_const_sptr inWS2D);

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDWSTransform.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDWSTransform.h
@@ -92,7 +92,7 @@ public:
   /// transformation types defined by the class
   void setQ3DDimensionsNames(MDAlgorithms::MDWSDescription &TargWSDescription,
                              CnvrtToMD::TargetFrame FrameID,
-                             CnvrtToMD::CoordScaling scaling) const;
+                             CnvrtToMD::CoordScaling ScaleID) const;
   /// construct meaningful dimension names for ModQ case and different
   /// transformation types defined by the class;
   void setModQDimensionsNames(MDAlgorithms::MDWSDescription &TargWSDescription,
@@ -128,7 +128,7 @@ protected: // for testing
   /// Q-conversion modes;
   Kernel::DblMatrix
   buildQTrahsf(MDAlgorithms::MDWSDescription &TargWSDescription,
-               CnvrtToMD::CoordScaling scaling, bool UnitUB = false) const;
+               CnvrtToMD::CoordScaling ScaleID, bool UnitUB = false) const;
   /// build orthogonal coordinate around two input vecotors u and v expressed in
   /// rlu;
   // std::vector<Kernel::V3D> buildOrtho3D(const Kernel::DblMatrix &BM,const
@@ -137,7 +137,7 @@ protected: // for testing
   std::vector<double>
   getTransfMatrix(MDAlgorithms::MDWSDescription &TargWSDescription,
                   CnvrtToMD::TargetFrame FrameID,
-                  CnvrtToMD::CoordScaling &scaling) const;
+                  CnvrtToMD::CoordScaling &ScaleID) const;
 
   CnvrtToMD::TargetFrame
   findTargetFrame(MDAlgorithms::MDWSDescription &TargWSDescription) const;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Quantification/ForegroundModel.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Quantification/ForegroundModel.h
@@ -75,7 +75,7 @@ public:
 
   /// Set a reference to the convolved fitting function. Needed as we need a
   /// default constructor
-  void setFunctionUnderMinimization(const API::IFunction &fitFunction);
+  void setFunctionUnderMinimization(const API::IFunction &fittingFunction);
   /// Declares the parameters
   void declareParameters() override;
   /// Called when an attribute value is set

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Quantification/Models/MullerAnsatz.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Quantification/Models/MullerAnsatz.h
@@ -39,7 +39,7 @@ public:
   enum MagneticFFDirection { NormalTo_a, NormalTo_b, NormalTo_c, Isotropic };
 
   /// Calculates the intensity for the model for the current parameters.
-  double scatteringIntensity(const API::ExperimentInfo &exptDescr,
+  double scatteringIntensity(const API::ExperimentInfo &exptSetup,
                              const std::vector<double> &point) const override;
   /// Called when an attribute is set
   void setAttribute(const std::string &name,

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Quantification/Models/QCoordinate.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Quantification/Models/QCoordinate.h
@@ -51,7 +51,7 @@ private:
   /// Returns the type of model
   ModelType modelType() const override { return Broad; }
   /// Calculates the intensity for the model for the current parameters.
-  double scatteringIntensity(const API::ExperimentInfo &exptDescr,
+  double scatteringIntensity(const API::ExperimentInfo &exptSetup,
                              const std::vector<double> &point) const override;
 
   /// Which coordinate has been chosen

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Quantification/Models/Strontium122.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Quantification/Models/Strontium122.h
@@ -45,7 +45,7 @@ private:
   /// Returns the type of model
   ModelType modelType() const override { return Broad; }
   /// Calculates the intensity for the model for the current parameters.
-  double scatteringIntensity(const API::ExperimentInfo &exptDescr,
+  double scatteringIntensity(const API::ExperimentInfo &exptSetup,
                              const std::vector<double> &point) const override;
 
   /// Twin type attribute

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Quantification/Resolution/TobyFitResolutionModel.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Quantification/Resolution/TobyFitResolutionModel.h
@@ -65,7 +65,7 @@ public:
   TobyFitResolutionModel();
   /// Construct with a model pointer & a pointer to the fitting function
   TobyFitResolutionModel(const API::IFunctionMD &fittedFunction,
-                         const std::string &fgModelName);
+                         const std::string &fgModel);
   /// Destructor
   ~TobyFitResolutionModel() override;
 
@@ -99,7 +99,7 @@ private:
 
   /// Map integration variables to perturbed values in Q-E space
   void calculatePerturbedQE(const CachedExperimentInfo &observation,
-                            const QOmegaPoint &eventPoint) const;
+                            const QOmegaPoint &qOmega) const;
   /// Return true if it is time to check for convergence of the
   /// current sigma value
   bool checkForConvergence(const int step) const;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/UnitsConversionHelper.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/UnitsConversionHelper.h
@@ -74,7 +74,7 @@ class DLLExport UnitsConversionHelper {
 public:
   UnitsConversionHelper();
   void initialize(const MDWSDescription &targetWSDescr,
-                  const std::string &units_to, bool forceViaTOF = false);
+                  const std::string &unitsTo, bool forceViaTOF = false);
   void initialize(const std::string &unitsFrom, const std::string &unitsTo,
                   const DataObjects::TableWorkspace_const_sptr &DetWS,
                   int Emode, bool forceViaTOF = false);

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -376,7 +376,7 @@ int64_t Integrate3DEvents::getHklKey(int h, int k, int l) {
  *  h,k,l by UBinv and the map key is then formed from those rounded h,k,l
  *  values.
  *
- *  @param q_vector  The q_vector to be mapped to h,k,l
+ *  @param hkl  The q_vector to be mapped to h,k,l
  */
 int64_t Integrate3DEvents::getHklKey2(V3D const &hkl) {
   int h = boost::math::iround<double>(hkl[0]);

--- a/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
+++ b/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
@@ -88,8 +88,8 @@ public:
 
   void readFromFile(const std::string &filename); ///< read histogram data
   void readLogData(const std::string &filename);  ///< read log data
-  void getTimeChannels(float *timechannels,
-                       const int &len) const; ///< get time bin boundaries
+  void getTimeChannels(float *timebnds,
+                       const int &nbnds) const; ///< get time bin boundaries
                                               /// return sample name
   std::string getSampleName() const { return nexus_samplename; };
   int numberOfLogs() const; ///< Number of NXlog sections read from file

--- a/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
+++ b/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
@@ -90,7 +90,7 @@ public:
   void readLogData(const std::string &filename);  ///< read log data
   void getTimeChannels(float *timebnds,
                        const int &nbnds) const; ///< get time bin boundaries
-                                              /// return sample name
+                                                /// return sample name
   std::string getSampleName() const { return nexus_samplename; };
   int numberOfLogs() const; ///< Number of NXlog sections read from file
   int getLogLength(const int i) const;       ///< Lenght of i'th log

--- a/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
@@ -86,11 +86,11 @@ public:
 
   /// write table workspace
   int writeNexusTableWorkspace(
-      const API::ITableWorkspace_const_sptr &localworkspace,
+      const API::ITableWorkspace_const_sptr &itableworkspace,
       const char *group_name) const;
 
   int writeNexusProcessedDataEvent(
-      const DataObjects::EventWorkspace_const_sptr &localworkspace);
+      const DataObjects::EventWorkspace_const_sptr &ws);
 
   int writeNexusProcessedDataEventCombined(
       const DataObjects::EventWorkspace_const_sptr &ws,
@@ -110,7 +110,7 @@ public:
   /// find size of open entry data section
   int getWorkspaceSize(int &numberOfSpectra, int &numberOfChannels,
                        int &numberOfXpoints, bool &uniformBounds,
-                       std::string &axesNames, std::string &yUnits) const;
+                       std::string &axesUnits, std::string &yUnits) const;
   /// read X values for one (or the generic if uniform) spectra
   int getXValues(MantidVec &xValues, const int &spectra) const;
   /// read values and errors for spectra
@@ -217,7 +217,7 @@ private:
 
   /// Writes given vector column to the currently open Nexus file
   template <typename VecType, typename ElemType>
-  void writeNexusVectorColumn(API::Column_const_sptr column,
+  void writeNexusVectorColumn(API::Column_const_sptr col,
                               const std::string &columnName, int nexusType,
                               const std::string &interpret_as) const;
 

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -574,7 +574,7 @@ size_t getSizeOf(const Kernel::V3D &) { return 3; }
 
 /**
  * Writes given vector column to the currently open Nexus file.
- * @param column     :: Column to write
+ * @param col     :: Column to write
  * @param columnName :: Name of NXdata to write to
  * @param nexusType  :: Nexus type to use to store data
  * @param interpret_as   :: Name of the type to use for "interpret_as" attribute

--- a/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/SCARFTomoReconstruction.h
+++ b/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/SCARFTomoReconstruction.h
@@ -79,7 +79,7 @@ protected:
   /// method that deals with the actual HTTP(S) connection (convenient to
   /// mock up all inet messaging)
   virtual int doSendRequestGetResponse(
-      const std::string &url, std::ostream &response,
+      const std::string &url, std::ostream &rss,
       const StringToStringMap &headers = StringToStringMap(),
       const std::string &method = std::string(), const std::string &body = "");
 
@@ -91,7 +91,7 @@ private:
   // helper for the submit request
   std::string buildSubmitBody(const std::string &appName,
                               const std::string &boundary,
-                              const std::string &inputFiles,
+                              const std::string &inputFile,
                               const std::string &inputArgs,
                               const std::string &jobName);
 
@@ -106,7 +106,7 @@ private:
 
   /// fill in output properties with job status and info
   void genOutputStatusInfo(const std::string &resp,
-                           const std::string &jobID = std::string());
+                           const std::string &jobIDFilter = std::string());
 
   /// Job sequence number (from here, nothing to do with the job id on the
   /// cluster)

--- a/Framework/RemoteJobManagers/inc/MantidRemoteJobManagers/LSFJobManager.h
+++ b/Framework/RemoteJobManagers/inc/MantidRemoteJobManagers/LSFJobManager.h
@@ -88,7 +88,7 @@ protected:
   /// method that deals with the actual HTTP(S) connection (convenient to
   /// mock up all inet messaging)
   virtual int doSendRequestGetResponse(
-      const Poco::URI &uri, std::ostream &response,
+      const Poco::URI &uri, std::ostream &rss,
       const StringToStringMap &headers = StringToStringMap(),
       const std::string &method = std::string(),
       const std::string &body = "") const;
@@ -156,7 +156,7 @@ private:
   /// fill in output properties with job status and info
   std::vector<IRemoteJobManager::RemoteJobInfo>
   genOutputStatusInfo(const std::string &resp,
-                      const std::string &jobID = std::string()) const;
+                      const std::string &jobIDFilter = std::string()) const;
 
   void getOneJobFile(const std::string &jobId, const std::string &remotePath,
                      const std::string &localPath, const Token &t);

--- a/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
+++ b/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
@@ -85,21 +85,21 @@ class SCRIPT_DLL_EXPORT ScriptRepositoryImpl : public ScriptRepository {
   Repository repo;
 
 public:
-  ScriptRepositoryImpl(const std::string &local_repository = std::string(),
-                       const std::string &remote_url = std::string());
+  ScriptRepositoryImpl(const std::string &local_rep = std::string(),
+                       const std::string &remote = std::string());
 
   void connect(const std::string &server) override;
 
-  void install(const std::string &local_path) override;
+  void install(const std::string &path) override;
 
-  ScriptInfo info(const std::string &path) override;
-  const std::string &description(const std::string &path) override;
+  ScriptInfo info(const std::string &input_path) override;
+  const std::string &description(const std::string &input_path) override;
 
   std::vector<std::string> listFiles() override;
 
-  void download(const std::string &file_path) override;
+  void download(const std::string &input_path) override;
 
-  SCRIPTSTATUS fileStatus(const std::string &file_path) override;
+  SCRIPTSTATUS fileStatus(const std::string &input_path) override;
 
   void upload(const std::string &file_path, const std::string &comment,
               const std::string &author, const std::string &email) override;
@@ -116,7 +116,7 @@ public:
 
   std::string ignorePatterns(void) override;
 
-  int setAutoUpdate(const std::string &path, bool option = true) override;
+  int setAutoUpdate(const std::string &input_path, bool option = true) override;
 
   /// @deprecated Should avoid this, it is not in the design file.
   std::string localRepository() const { return local_repository; }
@@ -178,7 +178,7 @@ private:
 
   std::string ignoreregex;
 
-  std::string getParentFolder(const std::string &entry);
+  std::string getParentFolder(const std::string &file);
 };
 
 } // namespace API

--- a/Framework/TestHelpers/inc/MantidTestHelpers/BoxControllerDummyIO.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/BoxControllerDummyIO.h
@@ -48,8 +48,7 @@ namespace MantidTestHelpers {
 */
 class DLLExport BoxControllerDummyIO : public Mantid::API::IBoxControllerIO {
 public:
-  BoxControllerDummyIO(const Mantid::API::BoxController *theBC);
-
+  BoxControllerDummyIO(const Mantid::API::BoxController *bc
   ///@return true if the file to write events is opened and false otherwise
   bool isOpened() const override { return (m_isOpened); }
   /// get the full file name of the file used for IO operations
@@ -81,9 +80,9 @@ public:
   ~BoxControllerDummyIO() override;
   // Auxiliary functions. Used to change default state of this object which is
   // not fully supported. Should be replaced by some IBoxControllerIO factory
-  void setDataType(const size_t coordSize,
+  void setDataType(const size_t blockSize,
                    const std::string &typeName) override;
-  void getDataType(size_t &coordSize, std::string &typeName) const override;
+  void getDataType(size_t &CoordSize, std::string &typeName) const override;
 
   // Auxiliary functions (non-virtual, used at testing)
   int64_t getNDataColums() const { return 2; }

--- a/Framework/TestHelpers/inc/MantidTestHelpers/BoxControllerDummyIO.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/BoxControllerDummyIO.h
@@ -48,7 +48,7 @@ namespace MantidTestHelpers {
 */
 class DLLExport BoxControllerDummyIO : public Mantid::API::IBoxControllerIO {
 public:
-  BoxControllerDummyIO(const Mantid::API::BoxController *bc
+  BoxControllerDummyIO(const Mantid::API::BoxController *bc);
   ///@return true if the file to write events is opened and false otherwise
   bool isOpened() const override { return (m_isOpened); }
   /// get the full file name of the file used for IO operations

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
@@ -113,7 +113,7 @@ createDetectorGroupWithNCylindricalDetectorsWithGaps(unsigned int nDet = 4,
  */
 boost::shared_ptr<Mantid::Geometry::DetectorGroup>
 createRingOfCylindricalDetectors(const double R_min = 4.5,
-                                 const double R_max = 5, const double z = 4);
+                                 const double R_max = 5, const double z000000000000000 = 4);
 /**
  * Create a group of two monitors
  */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
@@ -113,7 +113,8 @@ createDetectorGroupWithNCylindricalDetectorsWithGaps(unsigned int nDet = 4,
  */
 boost::shared_ptr<Mantid::Geometry::DetectorGroup>
 createRingOfCylindricalDetectors(const double R_min = 4.5,
-                                 const double R_max = 5, const double z000000000000000 = 4);
+                                 const double R_max = 5,
+                                 const double z000000000000000 = 4);
 /**
  * Create a group of two monitors
  */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
@@ -95,11 +95,11 @@ Mantid::DataObjects::Workspace2D_sptr Create1DWorkspaceFib(int size);
 Mantid::DataObjects::Workspace2D_sptr
 Create1DWorkspaceConstantWithXerror(int size, double value, double error,
                                     double xError);
-Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace(int nHist, int nBins);
+Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace(int nhist, int numBoundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundaries);
 Mantid::DataObjects::Workspace2D_sptr
 Create2DWorkspaceWhereYIsWorkspaceIndex(int nhist, int numBoundaries);
 Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace123(
-    int64_t nHist, int64_t nBin, bool isHist = false,
+    int64_t nHist, int64_t nBinsssssssssssss, bool isHist = false,
     const std::set<int64_t> &maskedWorkspaceIndices = std::set<int64_t>());
 Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace154(
     int64_t nHist, int64_t nBins, bool isHist = false,
@@ -121,7 +121,7 @@ Mantid::API::WorkspaceGroup_sptr CreateWorkspaceGroup(int nEntries, int nHist,
  * Filled with Y = 2.0 and E = sqrt(2.0)w
  */
 Mantid::DataObjects::Workspace2D_sptr
-Create2DWorkspaceBinned(int nHist, int nBins, double x0 = 0.0,
+Create2DWorkspaceBinned(int nhist, int nbins, double x0 = 0.0,
                         double deltax = 1.0);
 
 /** Create a 2D workspace with this many histograms and bins. The bins are
@@ -129,7 +129,7 @@ Create2DWorkspaceBinned(int nHist, int nBins, double x0 = 0.0,
  * Filled with Y = 2.0 and E = sqrt(2.0)w
  */
 Mantid::DataObjects::Workspace2D_sptr
-Create2DWorkspaceBinned(int nHist, const int nBins, const double xBoundaries[]);
+Create2DWorkspaceBinned(int nhist, const int numBoundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundaries, const double xBoundaries[]);
 
 /**
  * Creates a 2D workspace from taking the function values from the input
@@ -184,7 +184,7 @@ void addNoise(Mantid::API::MatrixWorkspace_sptr ws, double noise,
  * Data filled with: Y: 2.0, E: sqrt(2.0), X: nbins of width 1 starting at 0
  */
 Mantid::DataObjects::Workspace2D_sptr create2DWorkspaceWithFullInstrument(
-    int nHist, int nBins, bool includeMonitors = false,
+    int nhist, int nbins, bool includeMonitors = false,
     bool startYNegative = false, bool isHistogram = true,
     const std::string &instrumentName = std::string("testInst"));
 
@@ -295,7 +295,7 @@ createProcessedWorkspaceWithCylComplexInstrument(
 
 // Create a workspace with all components needed for inelastic analysis;
 Mantid::API::MatrixWorkspace_sptr createProcessedInelasticWS(
-    const std::vector<double> &L2, const std::vector<double> &ploar,
+    const std::vector<double> &L2, const std::vector<double> &polar,
     const std::vector<double> &azimutal, size_t numBins = 4, double Emin = -10,
     double Emax = 10, double Ei = 11);
 

--- a/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
@@ -95,7 +95,9 @@ Mantid::DataObjects::Workspace2D_sptr Create1DWorkspaceFib(int size);
 Mantid::DataObjects::Workspace2D_sptr
 Create1DWorkspaceConstantWithXerror(int size, double value, double error,
                                     double xError);
-Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace(int nhist, int numBoundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundaries);
+Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace(
+    int nhist,
+    int numBoundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundaries);
 Mantid::DataObjects::Workspace2D_sptr
 Create2DWorkspaceWhereYIsWorkspaceIndex(int nhist, int numBoundaries);
 Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace123(
@@ -128,8 +130,11 @@ Create2DWorkspaceBinned(int nhist, int nbins, double x0 = 0.0,
  * assumed to be non-uniform and given by the input array
  * Filled with Y = 2.0 and E = sqrt(2.0)w
  */
-Mantid::DataObjects::Workspace2D_sptr
-Create2DWorkspaceBinned(int nhist, const int numBoundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundaries, const double xBoundaries[]);
+Mantid::DataObjects::Workspace2D_sptr Create2DWorkspaceBinned(
+    int nhist,
+    const int
+        numBoundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundariesundaries,
+    const double xBoundaries[]);
 
 /**
  * Creates a 2D workspace from taking the function values from the input


### PR DESCRIPTION
Applied the clang-tidy fixes on the mantid Framework source for the readability-inconsistent-declaration-parameter-name warning.

**To test:**

Code review and ensure all unit tests pass.

Fixes #15487 .

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
