### PR TITLE
Improved GeometryInfoFactory: does not require source and sample

### DIFF
--- a/Framework/API/src/GeometryInfoFactory.cpp
+++ b/Framework/API/src/GeometryInfoFactory.cpp
@@ -9,6 +9,8 @@ namespace API {
 
 GeometryInfoFactory::GeometryInfoFactory(const MatrixWorkspace &workspace)
     : m_workspace(workspace), m_instrument(workspace.getInstrument()) {
+  // Note: This does not seem possible currently (the instrument objects is
+  // always allocated, even if it is empty), so this will not fail.
   if (!m_instrument)
     throw std::runtime_error("Workspace " + workspace.getName() +
                              " does not contain an instrument!");

--- a/Framework/API/test/GeometryInfoFactoryTest.h
+++ b/Framework/API/test/GeometryInfoFactoryTest.h
@@ -27,18 +27,12 @@ public:
     const std::string instrumentName("SimpleFakeInstrument");
     InstrumentCreationHelper::addFullInstrumentToWorkspace(
         m_workspace, includeMonitors, startYNegative, instrumentName);
+
+    m_workspaceNoInstrument.init(numberOfHistograms, numberOfBins, numberOfBins - 1);
   }
 
   void test_constructor() {
     TS_ASSERT_THROWS_NOTHING(GeometryInfoFactory factory(m_workspace));
-  }
-
-  void test_constructor_no_instrument() {
-    WorkspaceTester ws;
-    size_t numberOfHistograms = 1;
-    size_t numberOfBins = 1;
-    ws.init(numberOfHistograms, numberOfBins, numberOfBins - 1);
-    TS_ASSERT_THROWS(GeometryInfoFactory factory(ws), std::runtime_error);
   }
 
   void test_create() {
@@ -79,8 +73,34 @@ public:
     TS_ASSERT_EQUALS(factory.getL1(), 20.0);
   }
 
+  void test_getSource_no_instrument() {
+    GeometryInfoFactory factory(m_workspaceNoInstrument);
+    TS_ASSERT_THROWS(factory.getSource(), std::runtime_error);
+  }
+
+  void test_getSourcePos_no_instrument() {
+    GeometryInfoFactory factory(m_workspaceNoInstrument);
+    TS_ASSERT_THROWS(factory.getSourcePos(), std::runtime_error);
+  }
+
+  void test_getSample_no_instrument() {
+    GeometryInfoFactory factory(m_workspaceNoInstrument);
+    TS_ASSERT_THROWS(factory.getSample(), std::runtime_error);
+  }
+
+  void test_getSamplePos_no_instrument() {
+    GeometryInfoFactory factory(m_workspaceNoInstrument);
+    TS_ASSERT_THROWS(factory.getSamplePos(), std::runtime_error);
+  }
+
+  void test_getL1_no_instrument() {
+    GeometryInfoFactory factory(m_workspaceNoInstrument);
+    TS_ASSERT_THROWS(factory.getL1(), std::runtime_error);
+  }
+
 private:
   WorkspaceTester m_workspace;
+  WorkspaceTester m_workspaceNoInstrument;
 };
 
 class GeometryInfoFactoryTestPerformance : public CxxTest::TestSuite {

--- a/Framework/API/test/GeometryInfoFactoryTest.h
+++ b/Framework/API/test/GeometryInfoFactoryTest.h
@@ -42,12 +42,12 @@ public:
   }
 
   void test_create() {
-    auto factory = GeometryInfoFactory(m_workspace);
+    GeometryInfoFactory factory(m_workspace);
     TS_ASSERT_THROWS_NOTHING(factory.create(0).getDetector());
   }
 
   void test_getInstrument() {
-    auto factory = GeometryInfoFactory(m_workspace);
+    GeometryInfoFactory factory(m_workspace);
     // This might fail if we get a null instrument, so we test for throw. Since
     // workspace->getInstrument() creates a copy of the instrument there is no
     // point in attempting to verify that the pointer is "correct".
@@ -55,27 +55,27 @@ public:
   }
 
   void test_getSource() {
-    auto factory = GeometryInfoFactory(m_workspace);
+    GeometryInfoFactory factory(m_workspace);
     TS_ASSERT_THROWS_NOTHING(factory.getSource());
   }
 
   void test_getSample() {
-    auto factory = GeometryInfoFactory(m_workspace);
+    GeometryInfoFactory factory(m_workspace);
     TS_ASSERT_THROWS_NOTHING(factory.getSample());
   }
 
   void test_getSourcePos() {
-    auto factory = GeometryInfoFactory(m_workspace);
+    GeometryInfoFactory factory(m_workspace);
     TS_ASSERT_EQUALS(factory.getSourcePos(), Kernel::V3D(-20.0, 0.0, 0.0));
   }
 
   void test_getSamplePos() {
-    auto factory = GeometryInfoFactory(m_workspace);
+    GeometryInfoFactory factory(m_workspace);
     TS_ASSERT_EQUALS(factory.getSamplePos(), Kernel::V3D(0.0, 0.0, 0.0));
   }
 
   void test_getL1() {
-    auto factory = GeometryInfoFactory(m_workspace);
+    GeometryInfoFactory factory(m_workspace);
     TS_ASSERT_EQUALS(factory.getL1(), 20.0);
   }
 

--- a/Framework/API/test/GeometryInfoFactoryTest.h
+++ b/Framework/API/test/GeometryInfoFactoryTest.h
@@ -28,7 +28,8 @@ public:
     InstrumentCreationHelper::addFullInstrumentToWorkspace(
         m_workspace, includeMonitors, startYNegative, instrumentName);
 
-    m_workspaceNoInstrument.init(numberOfHistograms, numberOfBins, numberOfBins - 1);
+    m_workspaceNoInstrument.init(numberOfHistograms, numberOfBins,
+                                 numberOfBins - 1);
   }
 
   void test_constructor() {

--- a/Framework/API/test/GeometryInfoTest.h
+++ b/Framework/API/test/GeometryInfoTest.h
@@ -66,7 +66,7 @@ public:
   }
 
   void test_isMasked() {
-    auto factory = GeometryInfoFactory(m_workspace);
+    GeometryInfoFactory factory(m_workspace);
     TS_ASSERT_EQUALS(
         GeometryInfo(*m_factory, *(m_workspace.getSpectrum(0))).isMasked(),
         true);

--- a/Framework/Algorithms/test/RemoveBackgroundTest.h
+++ b/Framework/Algorithms/test/RemoveBackgroundTest.h
@@ -96,12 +96,6 @@ public:
     TSM_ASSERT_THROWS("Should throw if background is not 1 or equal to source",
                       bgRemoval.initialize(bkgWS, SourceWS, 0),
                       std::invalid_argument);
-
-    auto sourceWS = WorkspaceCreationHelper::Create2DWorkspace(5, 10);
-    sourceWS->getAxis(0)->setUnit("TOF");
-    TSM_ASSERT_THROWS(
-        "Should throw if source workspace does not have proper instrument",
-        bgRemoval.initialize(BgWS, sourceWS, 0), std::runtime_error);
   }
 
   void testBackgroundHelper() {


### PR DESCRIPTION
GeometryInfoFactory gets source and sample only on demand.

This makes it possible to use GeometryInfoFactory also in algorithms that do not have a workspace with a complete instrument. Previously the construction of the factory would fail in that case.

**To test:**

Just code-review.

No corresponding issue.
No release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
