### PR TITLE
Apply processing instructions to transmission run in Reflectometry GUI

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflMainViewPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflMainViewPresenter.h
@@ -4,11 +4,11 @@
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidQtAPI/WorkspaceObserver.h"
 #include "MantidQtCustomInterfaces/DllConfig.h"
-#include "MantidQtCustomInterfaces/Reflectometry/ReflMainView.h"
 #include "MantidQtCustomInterfaces/Reflectometry/IReflPresenter.h"
 #include "MantidQtCustomInterfaces/Reflectometry/IReflSearcher.h"
-#include "MantidQtCustomInterfaces/Reflectometry/ReflTransferStrategy.h"
 #include "MantidQtCustomInterfaces/Reflectometry/QReflTableModel.h"
+#include "MantidQtCustomInterfaces/Reflectometry/ReflMainView.h"
+#include "MantidQtCustomInterfaces/Reflectometry/ReflTransferStrategy.h"
 
 #include <Poco/AutoPtr.h>
 #include <memory>
@@ -83,7 +83,9 @@ protected:
   // get an unused group id
   int getUnusedGroup(std::set<int> ignoredRows = std::set<int>()) const;
   // make a transmission workspace
-  Mantid::API::Workspace_sptr makeTransWS(const std::string &transString);
+  Mantid::API::Workspace_sptr
+  makeTransWS(const std::string &transString,
+              const std::map<std::string, std::string> &optionsMap);
   // Validate rows
   bool rowsValid(std::set<int> rows);
   // Validate a row


### PR DESCRIPTION
In the new ReflectometryGUI, users can specify some input properties in the options column, for instance, they can specify the processing instructions and the analysis mode. When these options are provided they should also be applied to the transmission run. 

**To test:**

Open "Interfaces" > "Reflectometry" > "ISIS Reflectometry (Polref)", and run the interface as in the example below:

![reflguitranssmission](https://cloud.githubusercontent.com/assets/8956985/13426816/ea09fe94-dfa7-11e5-907a-270e7444db7d.png)

Check the output history of the workspace `TRANS_37208_1` and ensure that `ProcessingInstructions` were `400-409` and that the `AnalysisMode` was `MultiDetectorAnalysis`. You should also be able to process the runs without having to set `StrictSpectrumChecking` to `0`.

Fixes #15506

//TODO: Link to [Release notes](http://www.mantidproject.org/Release_Notes_3.7)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
