### PR TITLE
LR: Add wavelength offset property

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -43,6 +43,7 @@ class LRAutoReduction(PythonAlgorithm):
         # ---------------------------------------------------------------------
 
         self.declareProperty("ScalingFactorTOFStep", 200.0, "Bin width in TOF for fitting scaling factors")
+        self.declareProperty("WavelengthOffset", 0.0, doc="Wavelength offset used for TOF range determination")
         self.declareProperty("ScalingWavelengthCutoff", 10.0, "Wavelength above which the scaling factors are assumed to be one")
         self.declareProperty("FindPeaks", False, "Find reflectivity peaks instead of using the template values")
         self.declareProperty("ForceSequenceNumber", 0, "Force the sequence number value if it's not available")
@@ -358,8 +359,9 @@ class LRAutoReduction(PythonAlgorithm):
         m = 1.675e-27  # kg
         wl = self.event_data.getRun().getProperty('LambdaRequest').value[0]
         chopper_speed = self.event_data.getRun().getProperty('SpeedRequest1').value[0]
-        tof_min = source_detector_distance / h * m * (wl + 0.5 * 60.0 / chopper_speed - 1.7 * 60.0 / chopper_speed) * 1e-4
-        tof_max = source_detector_distance / h * m * (wl + 0.5 * 60.0 / chopper_speed + 1.7 * 60.0 / chopper_speed) * 1e-4
+        wl_offset = self.getProperty("WavelengthOffset").value
+        tof_min = source_detector_distance / h * m * (wl + wl_offset * 60.0 / chopper_speed - 1.7 * 60.0 / chopper_speed) * 1e-4
+        tof_max = source_detector_distance / h * m * (wl + wl_offset * 60.0 / chopper_speed + 1.7 * 60.0 / chopper_speed) * 1e-4
         return [tof_min, tof_max]
 
 

--- a/Framework/PythonInterface/plugins/algorithms/LRDirectBeamSort.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRDirectBeamSort.py
@@ -95,6 +95,7 @@ class LRDirectBeamSort(PythonAlgorithm):
         self.declareProperty("ComputeScalingFactors", True, direction=Direction.Input,
                              doc="If True, the scaling factors will be computed")
         self.declareProperty("TOFSteps", 200.0, doc="TOF bin width")
+        self.declareProperty("WavelengthOffset", 0.0, doc="Wavelength offset used for TOF range determination")
         self.declareProperty("IncidentMedium", "Air", doc="Name of the incident medium")
         self.declareProperty(FileProperty("ScalingFactorFile","",
                                           action=FileAction.OptionalSave,
@@ -219,8 +220,9 @@ class LRDirectBeamSort(PythonAlgorithm):
             m = 1.675e-27  # kg
             wl = g[0].getRun().getProperty('LambdaRequest').value[0]
             chopper_speed = g[0].getRun().getProperty('SpeedRequest1').value[0]
-            tof_min = source_detector_distance / h * m * (wl + 0.5*60.0/chopper_speed - 1.7*60.0/chopper_speed) * 1e-4
-            tof_max = source_detector_distance / h * m * (wl + 0.5*60.0/chopper_speed + 1.7*60.0/chopper_speed) * 1e-4
+            wl_offset = self.getProperty("WavelengthOffset").value
+            tof_min = source_detector_distance / h * m * (wl + wl_offset*60.0/chopper_speed - 1.7*60.0/chopper_speed) * 1e-4
+            tof_max = source_detector_distance / h * m * (wl + wl_offset*60.0/chopper_speed + 1.7*60.0/chopper_speed) * 1e-4
             tof_range = [tof_min, tof_max]
 
             summary += "TOF: %s\n\n" % tof_range


### PR DESCRIPTION
Since upgrading the LR DAS, the wavelength selection has been adjusted so that an offset in the code is no longer necessary. Move the offset in LRAutoreduce and LRDirectBeamSort to an algorithm property with a default value of zero.

**To test:**
1. Review the code.
 The code that read `0.5*60.0/chopper_speed` should now be replaced with `offset*60.0/chopper_speed` where offset is a property.
2. Make sure the system tests pass.

There is no Issue for this fix. All the info is here.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
