### PR TITLE
AlignComponents extend sample source fitting to X, Y and Z

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
@@ -251,7 +251,7 @@ class AlignComponents(PythonAlgorithm):
         calWS = api.SortTableWorkspace(calWS, Columns='detid')
         maskWS = self.getProperty("MaskWorkspace").value
 
-        if maskWS != None:
+        if maskWS is not None:
             self._masking = True
             mask = maskWS.extractY().flatten()
 

--- a/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignComponents.py
@@ -237,9 +237,9 @@ class AlignComponents(PythonAlgorithm):
         # Check that a position refinement is selected for sample/source
         if ((self.getProperty("FitSourcePosition").value or
              self.getProperty("FitSamplePosition").value) and
-            not (self.getProperty("Xposition").value or
-                 self.getProperty("Yposition").value or
-                 self.getProperty("Zposition").value)):
+                not (self.getProperty("Xposition").value or
+                     self.getProperty("Yposition").value or
+                     self.getProperty("Zposition").value)):
             issues["Xposition"] = "If fitting source or sample, you must calibrate at least one position parameter."
 
         return issues

--- a/docs/source/algorithms/AlignComponents-v1.rst
+++ b/docs/source/algorithms/AlignComponents-v1.rst
@@ -47,10 +47,11 @@ Fitting Sample/Source
 #####################
 
 When fitting the sample or source position it uses the entire
-instrument and only moves the *Z* position (*i.e.* along the
-beam). You can use a masking workspace to mask part of the instrument
-you don't want to use to align the sample/source position (*e.g.* in
-the *Align sample position in POWGEN* usage example below).
+instrument and moves in the directions that you select. All rotation
+options are ignored. You can use a masking workspace to mask part of
+the instrument you don't want to use to align the sample/source
+position (*e.g.* in the *Align sample position in POWGEN* usage
+example below).
 
 The source and sample positions (in that order) are aligned before an
 components are aligned.
@@ -141,7 +142,8 @@ Output:
       AlignComponents(CalibrationTable="PG3_cal",
             Workspace=ws,
             MaskWorkspace="PG3_mask",
-            FitSamplePosition=True)
+            FitSamplePosition=True,
+	    Zposition=True)
       print "Final sample position is {:.5f}".format(mtd['ws'].getInstrument().getSample().getPos().getZ())
 
 Output:


### PR DESCRIPTION
This allows the sample and source position to be refined not just with the Z position but also X and Y using the translation options.

**To test:**
Try the usage aligning sample position usage example but allowing X, Y and Z to move.

This algorithm was new in this release., so the release notes don't need to be updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
