### PR TITLE
Fix OS X packaging with Poco 1.6

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -66,6 +66,11 @@ library_filenames = ["libboost_regex-mt.dylib",
                      "libssl.dylib",
                      "libcrypto.dylib"]
 
+poco_version = "@POCO_VERSION@".split(".").map(&:to_i)
+if(poco_version[0] > 1 || (poco_version[0] == 1 && poco_version[1] >= 6))
+  library_filenames << "libPocoJSON.dylib"
+end
+
 #This copies the libraries over, then changes permissions and the id from /usr/local/lib to @rpath
 library_filenames.each do |filename|
   if filename.include? "libssl.dylib"


### PR DESCRIPTION
Description of work.

Poco 1.6 adds `libPocoJSON.dylib`, which is required by other Poco libraries we bundle. This adds `libPocoJSON.dylib` to the list of bundled shared libraries.

**To test:**

<!-- Instructions for testing. -->

Review changes and check that the OS X app bundle starts without errors.

This is a small change with no issue number.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
