### PR TITLE
ALC: set last run directory to the same as selected first run

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
@@ -85,6 +85,7 @@ namespace CustomInterfaces
     void disableAll() override;
     void enableAll() override;
     void checkBoxAutoChanged(int state) override;
+    void handleFirstFileChanged() override;
 
     /// returns the string "Auto"
     std::string autoString() const override { return g_autoString; }

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
@@ -138,6 +138,9 @@ namespace CustomInterfaces
     /// Toggles "auto" mode for last file
     virtual void checkBoxAutoChanged(int state) = 0;
 
+    /// Gets directory from first file and sets last file directory
+    virtual void handleFirstFileChanged() = 0;
+
   signals:
     /// Request to load data
     void loadRequested();

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -32,7 +32,8 @@ ALCDataLoadingView::~ALCDataLoadingView() {
     m_ui.setupUi(m_widget);
     connect(m_ui.load, SIGNAL(clicked()), SIGNAL(loadRequested()));
     connect(m_ui.firstRun, SIGNAL(fileFindingFinished()), SIGNAL(firstRunSelected()));
-
+    connect(m_ui.firstRun, SIGNAL(filesFoundChanged()), this,
+            SLOT(handleFirstFileChanged()));
     connect(m_ui.help, SIGNAL(clicked()), this, SLOT(help()));
     connect(m_ui.lastRunAuto, SIGNAL(stateChanged(int)), this, SLOT(checkBoxAutoChanged(int)));
 
@@ -287,6 +288,17 @@ ALCDataLoadingView::~ALCDataLoadingView() {
       // The search is necessary to clear the validator
       m_ui.lastRun->setFileTextWithSearch(m_currentAutoFile.c_str());
       m_ui.lastRun->setReadOnly(false);
+    }
+  }
+
+  /**
+   * Called when the "first run" file has changed.
+   * Sets the "last run" box to look in the same directory.
+   */
+  void ALCDataLoadingView::handleFirstFileChanged() {
+    QString directory = m_ui.firstRun->getLastDirectory();
+    if (!directory.isEmpty()) {
+      m_ui.lastRun->setLastDirectory(directory);
     }
   }
 

--- a/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -57,6 +57,7 @@ public:
   MOCK_METHOD0(help, void());
   MOCK_METHOD1(checkBoxAutoChanged, void(int));
   MOCK_METHOD1(setCurrentAutoFile, void(const std::string &));
+  MOCK_METHOD0(handleFirstFileChanged, void());
 
   void requestLoading() { emit loadRequested(); }
   void selectFirstRun() { emit firstRunSelected(); }

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
@@ -216,6 +216,10 @@ public:
   void setInstrumentOverride(const QString &instName);
   /// Set the input read-only or not
   void setReadOnly(bool readOnly);
+  /// Get the last directory
+  QString getLastDirectory() { return m_lastDir; }
+  /// Set the last directory
+  void setLastDirectory(const QString &lastDir) { m_lastDir = lastDir; }
 
 signals:
   /// Emitted when the file text changes

--- a/docs/source/release/v3.7.0/muon.rst
+++ b/docs/source/release/v3.7.0/muon.rst
@@ -8,6 +8,11 @@ Muon Analysis
 Interfaces
 ----------
 
+Muon ALC
+########
+
+- The default directory for the last run is now set to the same directory selected for the first run `#15524 <https://github.com/mantidproject/mantid/pull/15524>`_
+
 Muon Analysis
 #############
 


### PR DESCRIPTION
The ALC interface has two file selectors to choose the first and last run files. Previously, after the first file had been selected, clicking "Browse" for the second file would open a dialog in the default directory. This has been changed to open the file browser in the same directory that the first file was selected from.

The change is minor but fixes a small inconvenience that has been raised by users several times.

**To test:**
- Open the muon ALC interface
- Click "Browse" on the first file selector, navigate to any directory and choose a datafile (it doesn't matter what)
- Click "Browse" on the last file selector. Check that the file browser opens in the same directory that you just navigated to in the other file selector.

Fixes #12564

[Release notes](https://github.com/mantidproject/mantid/blob/95b0963e7ba234acb57c8603dd4a04616ec12d8f/docs/source/release/v3.7.0/muon.rst) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
