### PR TITLE
SumSpectra: fix algorithm for weighted case

### DIFF
--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -297,9 +297,9 @@ void SumSpectra::doWorkspace2D(MatrixWorkspace_const_sptr localworkspace,
   if (m_calculateWeightedSum) {
     numZeros = 0;
     for (size_t i = 0; i < Weight.size(); i++) {
-      if (nZeros[i] == 0)
-        YSum[i] *= double(numSpectra) / Weight[i];
-      else
+      if (numSpectra > nZeros[i])
+        YSum[i] *= double(numSpectra - nZeros[i]) / Weight[i];
+      if (nZeros[i] != 0)
         numZeros += nZeros[i];
     }
   }
@@ -416,9 +416,9 @@ void SumSpectra::doRebinnedOutput(MatrixWorkspace_sptr outputWorkspace,
   if (m_calculateWeightedSum) {
     numZeros = 0;
     for (size_t i = 0; i < Weight.size(); i++) {
-      if (nZeros[i] == 0)
-        YSum[i] *= double(numSpectra) / Weight[i];
-      else
+      if (numSpectra > nZeros[i])
+        YSum[i] *= double(numSpectra - nZeros[i]) / Weight[i];
+      if (nZeros[i] != 0)
         numZeros += nZeros[i];
     }
   }

--- a/Framework/Algorithms/test/SumSpectraTest.h
+++ b/Framework/Algorithms/test/SumSpectraTest.h
@@ -26,6 +26,8 @@ public:
                                                                      102, true);
     this->inputSpace->instrumentParameters().addBool(
         inputSpace->getDetector(1).get(), "masked", true);
+
+    inputSpace->dataE(5)[38] = 0.0;
   }
 
   ~SumSpectraTest() { AnalysisDataService::Instance().clear(); }
@@ -306,7 +308,7 @@ public:
                      output2D->run().getLogData("NumAllSpectra")->value())
     TS_ASSERT_EQUALS(boost::lexical_cast<std::string>(1),
                      output2D->run().getLogData("NumMaskSpectra")->value())
-    TS_ASSERT_EQUALS(boost::lexical_cast<std::string>(0),
+    TS_ASSERT_EQUALS(boost::lexical_cast<std::string>(1),
                      output2D->run().getLogData("NumZeroSpectra")->value())
 
     size_t nSignals = nTestHist - 3;
@@ -315,7 +317,7 @@ public:
     TS_ASSERT_EQUALS(x[50], inputSpace->readX(0)[50]);
     TS_ASSERT_EQUALS(x[100], inputSpace->readX(0)[100]);
     TS_ASSERT_DELTA(y[7], double(nSignals) * y0[7], 1.e-6);
-    TS_ASSERT_DELTA(y[38], double(nSignals) * y0[38], 1.e-6);
+    TS_ASSERT_DELTA(y[38], double(nSignals - 1) * y0[38], 1.e-6);
     TS_ASSERT_DELTA(y[72], double(nSignals) * y0[72], 1.e-6);
     TS_ASSERT_DELTA(e[28], std::sqrt(double(nSignals)) * e0[28], 0.00001);
     TS_ASSERT_DELTA(e[47], std::sqrt(double(nSignals)) * e0[47], 0.00001);

--- a/Framework/Algorithms/test/SumSpectraTest.h
+++ b/Framework/Algorithms/test/SumSpectraTest.h
@@ -320,6 +320,7 @@ public:
     TS_ASSERT_DELTA(y[38], double(nSignals - 1) * y0[38], 1.e-6);
     TS_ASSERT_DELTA(y[72], double(nSignals) * y0[72], 1.e-6);
     TS_ASSERT_DELTA(e[28], std::sqrt(double(nSignals)) * e0[28], 0.00001);
+    TS_ASSERT_DELTA(e[38], std::sqrt(double(nSignals - 1)) * e0[38], 0.00001);
     TS_ASSERT_DELTA(e[47], std::sqrt(double(nSignals)) * e0[47], 0.00001);
     TS_ASSERT_DELTA(e[99], std::sqrt(double(nSignals)) * e0[99], 0.00001);
 

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -40,6 +40,7 @@ Improved
 -  When plotting a workspace that had been normalized by bin widths, the y-axis unit label was incorrect.
    An appropriate labelling has now been implemented
   `#15398 <https://github.com/mantidproject/mantid/pull/15398>`_
+-  :ref:`SumSpectra <algm-SumSpectra>` fixed broken scaling of bins for the `WeightedSum=true` case.
 
 Deprecated
 ##########


### PR DESCRIPTION
This fixes the bug which causes completely wrong results for `SumSpectra` when `WeightedSum` is enabled.

**To test:**

<!-- Instructions for testing. -->

Code review.
Make sure the test case given in the issue now gives a better result.

Fixes #15525 .

[Release notes](https://github.com/mantidproject/mantid/blob/870eac1b70348cd96af9d0b9bc3920b6e20655f6/docs/source/release/v3.7.0/framework.rst)

<!-- Replace with a link above to the updated file or state "Does not need to be in the release notes." -->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
