### PR TITLE
Modified hard-coded detector IDs in FakeISISHistoDAE

### DIFF
--- a/Framework/LiveData/src/FakeISISHistoDAE.cpp
+++ b/Framework/LiveData/src/FakeISISHistoDAE.cpp
@@ -246,7 +246,7 @@ public:
         } else if (command == "UDET") {
           std::vector<int> udet(m_nSpectra + m_nMonitors);
           for (int i = 0; i < static_cast<int>(udet.size()); ++i) {
-            udet[i] = (i+1);
+            udet[i] = (i + 1);
           }
           sendIntArray(udet);
         } else if (command == "SPEC") {

--- a/Framework/LiveData/src/FakeISISHistoDAE.cpp
+++ b/Framework/LiveData/src/FakeISISHistoDAE.cpp
@@ -246,7 +246,7 @@ public:
         } else if (command == "UDET") {
           std::vector<int> udet(m_nSpectra + m_nMonitors);
           for (int i = 0; i < static_cast<int>(udet.size()); ++i) {
-            udet[i] = (1000 + i + 1);
+            udet[i] = (i+1);
           }
           sendIntArray(udet);
         } else if (command == "SPEC") {

--- a/Framework/LiveData/test/ISISHistoDataListenerTest.h
+++ b/Framework/LiveData/test/ISISHistoDataListenerTest.h
@@ -113,13 +113,13 @@ public:
     TS_ASSERT_EQUALS(spec->getSpectrumNo(), 1)
     auto dets = spec->getDetectorIDs();
     TS_ASSERT_EQUALS(dets.size(), 1);
-    TS_ASSERT_EQUALS(*dets.begin(), 1001);
+    TS_ASSERT_EQUALS(*dets.begin(), 1);
 
     spec = ws->getSpectrum(3);
     TS_ASSERT_EQUALS(spec->getSpectrumNo(), 10)
     dets = spec->getDetectorIDs();
     TS_ASSERT_EQUALS(dets.size(), 1);
-    TS_ASSERT_EQUALS(*dets.begin(), 1004);
+    TS_ASSERT_EQUALS(*dets.begin(), 4);
 
     res.wait();
 #else
@@ -217,25 +217,25 @@ public:
     TS_ASSERT_EQUALS(spec->getSpectrumNo(), 1)
     auto dets = spec->getDetectorIDs();
     TS_ASSERT_EQUALS(dets.size(), 1);
-    TS_ASSERT_EQUALS(*dets.begin(), 1001);
+    TS_ASSERT_EQUALS(*dets.begin(), 1);
 
     spec = ws1->getSpectrum(3);
     TS_ASSERT_EQUALS(spec->getSpectrumNo(), 4)
     dets = spec->getDetectorIDs();
     TS_ASSERT_EQUALS(dets.size(), 1);
-    TS_ASSERT_EQUALS(*dets.begin(), 1004);
+    TS_ASSERT_EQUALS(*dets.begin(), 4);
 
     spec = ws2->getSpectrum(0);
     TS_ASSERT_EQUALS(spec->getSpectrumNo(), 1)
     dets = spec->getDetectorIDs();
     TS_ASSERT_EQUALS(dets.size(), 1);
-    TS_ASSERT_EQUALS(*dets.begin(), 1001);
+    TS_ASSERT_EQUALS(*dets.begin(), 1);
 
     spec = ws2->getSpectrum(3);
     TS_ASSERT_EQUALS(spec->getSpectrumNo(), 4)
     dets = spec->getDetectorIDs();
     TS_ASSERT_EQUALS(dets.size(), 1);
-    TS_ASSERT_EQUALS(*dets.begin(), 1004);
+    TS_ASSERT_EQUALS(*dets.begin(), 4);
 
     dae.cancel();
     res.wait();


### PR DESCRIPTION
The hard-coded detector IDs in the FakeISISHistoDAE were modified to correspond to the MUSR detector IDs. This prevented any display of spectra data in the pick tab while running the instrument view in live data mode using FakeISISEventDAE.

**To test:**
- Run the script below. **_N.B**_ This script runs forever unless manually aborted.
- Right-click on the output workspace and select **_Show Instrument**_
- Select the Pick tab in the instrument view. 
- Move the mouse cursor over the instrument. 

``` python
from threading import Thread
import time

def startFakeDAE():
    # This will generate 2000 events roughly every 20ms, so about 50,000 events/sec
    # They will be randomly shared across the 100 spectra
    # and have a time of flight between 10,000 and 20,000
    try:
        FakeISISEventDAE(NPeriods=1,NSpectra=100,Rate=20,NEvents=1000)
    except RuntimeError:
        pass

def captureLive():
    ConfigService.setFacility("TEST_LIVE")

    # start a Live data listener updating every second, that rebins the data
    # and replaces the results each time with those of the last second.
    StartLiveData(Instrument='ISIS_Event', OutputWorkspace='wsOut', UpdateEvery=1,
                  ProcessingAlgorithm='Rebin', ProcessingProperties='Params=10000,1000,20000;PreserveEvents=1',
                  AccumulationMethod='Add', PreserveEvents=True)
#--------------------------------------------------------------------------------------------------

oldFacility = ConfigService.getFacility().name()
thread = Thread(target = startFakeDAE)
thread.start()
time.sleep(2) # give it a small amount of time to get ready
if not thread.is_alive():
    raise RuntimeError("Unable to start FakeDAE")

try:
    captureLive()
except Exception, exc:
    print "Error occurred starting live data"
finally:
    thread.join() # this must get hit

# put back the facility
ConfigService.setFacility(oldFacility)

#get the ouput workspace
wsOut = mtd["wsOut"]
print "The workspace contains %i events" % wsOut.getNumberEvents()
```

Detector info and spectra should be displayed. 

Fixes #15527 

Release notes have not been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
