### PR TITLE
Generate ninja build script if the tool is found

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -170,6 +170,20 @@ if [[ "$BUILDPKG" == true ]]; then
 fi
 
 ###############################################################################
+# Generator
+###############################################################################
+if [ $(command -v ninja) ]; then
+  CMAKE_GENERATOR="-G Ninja"
+elif [ $(command -v ninja-build) ]; then
+  CMAKE_GENERATOR="-G Ninja"
+fi
+if [ -e $BUILD_DIR/CMakeCache.txt ]; then
+  CMAKE_GENERATOR=""
+fi
+echo "CMAKE_GENERATOR ${CMAKE_GENERATOR}"
+exit -1
+
+###############################################################################
 # Work in the build directory
 ###############################################################################
 cd $BUILD_DIR

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -180,8 +180,6 @@ fi
 if [ -e $BUILD_DIR/CMakeCache.txt ]; then
   CMAKE_GENERATOR=""
 fi
-echo "CMAKE_GENERATOR ${CMAKE_GENERATOR}"
-exit -1
 
 ###############################################################################
 # Work in the build directory

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -197,7 +197,7 @@ rm -f *.dmg *.rpm *.deb *.tar.gz
 ###############################################################################
 # CMake configuration
 ###############################################################################
-$SCL_ON_RHEL6 "cmake -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE_VATES=ON -DParaView_DIR=${PARAVIEW_DIR} -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON ${DIST_FLAGS} ${PACKAGINGVARS} .."
+$SCL_ON_RHEL6 "cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE_VATES=ON -DParaView_DIR=${PARAVIEW_DIR} -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON ${DIST_FLAGS} ${PACKAGINGVARS} .."
 
 ###############################################################################
 # Coverity build should exit early


### PR DESCRIPTION
At the developer meeting there was a decision to use ninja to build if it was on the server. This implements that request.

**To test:**

The build servers should keep working with or without ninja installed. This is setup to continue using the existing generator if there is one, but use ninja if there isn't  a `CMakeCache.txt` and `ninja` is installed.

A proper test would involve wiping out a workspace on a build server that has ninja installed and seeing that the build still goes through.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
