### PR TITLE
Fix remaining modernize-loop-convert warnings

### DIFF
--- a/Framework/API/inc/MantidAPI/BoxController.h
+++ b/Framework/API/inc/MantidAPI/BoxController.h
@@ -297,7 +297,7 @@ public:
 
       const auto &splitTopInto = m_splitTopInto.get();
       size_t numSplitTop =
-          std::accumulate(splitTopInto.begin(), splitTopInto.end(), size_t{1},
+          std::accumulate(splitTopInto.cbegin(), splitTopInto.cend(), size_t{1},
                           std::multiplies<size_t>());
       m_numMDBoxes[depth + 1] += numSplitTop;
     } else {
@@ -322,13 +322,13 @@ public:
 
   /** Return the total number of MD Boxes, irrespective of depth */
   size_t getTotalNumMDBoxes() const {
-    return std::accumulate(m_numMDBoxes.begin(), m_numMDBoxes.end(), size_t{0},
+    return std::accumulate(m_numMDBoxes.cbegin(), m_numMDBoxes.cend(), size_t{0},
                            std::plus<size_t>());
   }
 
   /** Return the total number of MDGridBox'es, irrespective of depth */
   size_t getTotalNumMDGridBoxes() const {
-    return std::accumulate(m_numMDGridBoxes.begin(), m_numMDGridBoxes.end(),
+    return std::accumulate(m_numMDGridBoxes.cbegin(), m_numMDGridBoxes.cend(),
                            size_t{0}, std::plus<size_t>());
   }
 

--- a/Framework/API/inc/MantidAPI/BoxController.h
+++ b/Framework/API/inc/MantidAPI/BoxController.h
@@ -9,6 +9,7 @@
 #include <nexus/NeXusFile.hpp>
 
 #include <boost/optional.hpp>
+#include <numeric>
 #include <vector>
 
 namespace Mantid {
@@ -294,10 +295,10 @@ public:
     // We need to account for optional top level splitting
     if (depth == 0 && m_splitTopInto) {
 
-      size_t numSplitTop = 1;
-      for (size_t d = 0; d < m_splitTopInto.get().size(); d++)
-        numSplitTop *= m_splitTopInto.get()[d];
-
+      const auto &splitTopInto = m_splitTopInto.get();
+      size_t numSplitTop =
+          std::accumulate(splitTopInto.begin(), splitTopInto.end(), size_t{1},
+                          std::multiplies<size_t>());
       m_numMDBoxes[depth + 1] += numSplitTop;
     } else {
       m_numMDBoxes[depth + 1] += m_numSplit;
@@ -321,20 +322,14 @@ public:
 
   /** Return the total number of MD Boxes, irrespective of depth */
   size_t getTotalNumMDBoxes() const {
-    size_t total = 0;
-    for (size_t depth = 0; depth < m_numMDBoxes.size(); depth++) {
-      total += m_numMDBoxes[depth];
-    }
-    return total;
+    return std::accumulate(m_numMDBoxes.begin(), m_numMDBoxes.end(), size_t{0},
+                           std::plus<size_t>());
   }
 
   /** Return the total number of MDGridBox'es, irrespective of depth */
   size_t getTotalNumMDGridBoxes() const {
-    size_t total = 0;
-    for (size_t depth = 0; depth < m_numMDGridBoxes.size(); depth++) {
-      total += m_numMDGridBoxes[depth];
-    }
-    return total;
+    return std::accumulate(m_numMDGridBoxes.begin(), m_numMDGridBoxes.end(),
+                           size_t{0}, std::plus<size_t>());
   }
 
   /** Return the average recursion depth of gridding.

--- a/Framework/API/inc/MantidAPI/BoxController.h
+++ b/Framework/API/inc/MantidAPI/BoxController.h
@@ -322,8 +322,8 @@ public:
 
   /** Return the total number of MD Boxes, irrespective of depth */
   size_t getTotalNumMDBoxes() const {
-    return std::accumulate(m_numMDBoxes.cbegin(), m_numMDBoxes.cend(), size_t{0},
-                           std::plus<size_t>());
+    return std::accumulate(m_numMDBoxes.cbegin(), m_numMDBoxes.cend(),
+                           size_t{0}, std::plus<size_t>());
   }
 
   /** Return the total number of MDGridBox'es, irrespective of depth */

--- a/Framework/API/inc/MantidAPI/FunctionFactory.h
+++ b/Framework/API/inc/MantidAPI/FunctionFactory.h
@@ -134,12 +134,11 @@ const std::vector<std::string> &FunctionFactoryImpl::getFunctionNames() const {
   // Create the entry in the cache and work with it directly
   std::vector<std::string> &typeNames = m_cachedFunctionNames[soughtType];
   const std::vector<std::string> names = this->getKeys();
-  for (const auto &name : names) {
-    boost::shared_ptr<IFunction> func = this->createFunction(name);
-    if (func && dynamic_cast<FunctionType *>(func.get())) {
-      typeNames.push_back(name);
-    }
-  }
+  std::copy_if(names.cbegin(), names.cend(), std::back_inserter(typeNames),
+               [this](const std::string &name) {
+                 boost::shared_ptr<IFunction> func = this->createFunction(name);
+                 return boost::dynamic_pointer_cast<FunctionType>(func);
+               });
   return typeNames;
 }
 

--- a/Framework/API/inc/MantidAPI/FunctionFactory.h
+++ b/Framework/API/inc/MantidAPI/FunctionFactory.h
@@ -137,7 +137,7 @@ const std::vector<std::string> &FunctionFactoryImpl::getFunctionNames() const {
   for (const auto &name : names) {
     boost::shared_ptr<IFunction> func = this->createFunction(name);
     if (func && dynamic_cast<FunctionType *>(func.get())) {
-      typeNames.push_back(std::move(name));
+      typeNames.push_back(name);
     }
   }
   return typeNames;

--- a/Framework/API/inc/MantidAPI/FunctionFactory.h
+++ b/Framework/API/inc/MantidAPI/FunctionFactory.h
@@ -134,10 +134,10 @@ const std::vector<std::string> &FunctionFactoryImpl::getFunctionNames() const {
   // Create the entry in the cache and work with it directly
   std::vector<std::string> &typeNames = m_cachedFunctionNames[soughtType];
   const std::vector<std::string> names = this->getKeys();
-  for (auto it = names.begin(); it != names.end(); ++it) {
-    boost::shared_ptr<IFunction> func = this->createFunction(*it);
+  for (const auto &name : names) {
+    boost::shared_ptr<IFunction> func = this->createFunction(name);
     if (func && dynamic_cast<FunctionType *>(func.get())) {
-      typeNames.push_back(*it);
+      typeNames.push_back(std::move(name));
     }
   }
   return typeNames;

--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.h
@@ -399,22 +399,22 @@ private:
     std::string error;
 
     // Cycle through each workspace in the group ...
-    for (const auto &name : wsGroupNames) {
+    for (const auto &memberWsName : wsGroupNames) {
       boost::shared_ptr<Workspace> memberWs =
-          AnalysisDataService::Instance().retrieve(name);
+          AnalysisDataService::Instance().retrieve(memberWsName);
 
       // Table Workspaces are ignored
       if ("TableWorkspace" == memberWs->id()) {
-        error = "Workspace " + name + " is of type TableWorkspace and "
-                                      "will therefore be ignored as "
-                                      "part of the GroupedWorkspace.";
+        error = "Workspace " + memberWsName + " is of type TableWorkspace and "
+                                              "will therefore be ignored as "
+                                              "part of the GroupedWorkspace.";
 
         g_log.debug() << error << std::endl;
       } else {
         // ... and if it is a workspace of incorrect type, exclude the group by
         // returning an error.
         if (!boost::dynamic_pointer_cast<TYPE>(memberWs)) {
-          error = "Workspace " + name + " is not of type " +
+          error = "Workspace " + memberWsName + " is not of type " +
                   Kernel::PropertyWithValue<boost::shared_ptr<TYPE>>::type() +
                   ".";
 
@@ -425,7 +425,7 @@ private:
         // If it is of the correct type, it may still be invalid. Check.
         else {
           Mantid::API::WorkspaceProperty<TYPE> memberWsProperty(*this);
-          std::string memberError = memberWsProperty.setValue(name);
+          std::string memberError = memberWsProperty.setValue(memberWsName);
           if (!memberError.empty())
             return memberError; // Since if this member is invalid, then the
                                 // whole group is invalid.

--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.h
@@ -399,23 +399,22 @@ private:
     std::string error;
 
     // Cycle through each workspace in the group ...
-    for (auto it = wsGroupNames.begin(); it != wsGroupNames.end(); ++it) {
-      std::string memberWsName = *it;
+    for (const auto &name : wsGroupNames) {
       boost::shared_ptr<Workspace> memberWs =
-          AnalysisDataService::Instance().retrieve(memberWsName);
+          AnalysisDataService::Instance().retrieve(name);
 
       // Table Workspaces are ignored
       if ("TableWorkspace" == memberWs->id()) {
-        error = "Workspace " + memberWsName + " is of type TableWorkspace and "
-                                              "will therefore be ignored as "
-                                              "part of the GroupedWorkspace.";
+        error = "Workspace " + name + " is of type TableWorkspace and "
+                                      "will therefore be ignored as "
+                                      "part of the GroupedWorkspace.";
 
         g_log.debug() << error << std::endl;
       } else {
         // ... and if it is a workspace of incorrect type, exclude the group by
         // returning an error.
         if (!boost::dynamic_pointer_cast<TYPE>(memberWs)) {
-          error = "Workspace " + memberWsName + " is not of type " +
+          error = "Workspace " + name + " is not of type " +
                   Kernel::PropertyWithValue<boost::shared_ptr<TYPE>>::type() +
                   ".";
 
@@ -426,7 +425,7 @@ private:
         // If it is of the correct type, it may still be invalid. Check.
         else {
           Mantid::API::WorkspaceProperty<TYPE> memberWsProperty(*this);
-          std::string memberError = memberWsProperty.setValue(memberWsName);
+          std::string memberError = memberWsProperty.setValue(name);
           if (!memberError.empty())
             return memberError; // Since if this member is invalid, then the
                                 // whole group is invalid.

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -328,17 +328,17 @@ AlgorithmFactoryImpl::getDescriptors(bool includeHidden) const {
   // results vector
   std::vector<Algorithm_descriptor> res;
 
-  for (auto s = sv.cbegin(); s != sv.cend(); ++s) {
-    if (s->empty())
+  for (const auto &s : sv) {
+    if (s.empty())
       continue;
     Algorithm_descriptor desc;
-    size_t i = s->find('|');
+    size_t i = s.find('|');
     if (i == std::string::npos) {
-      desc.name = *s;
+      desc.name = s;
       desc.version = 1;
     } else if (i > 0) {
-      desc.name = s->substr(0, i);
-      std::string vers = s->substr(i + 1);
+      desc.name = s.substr(0, i);
+      std::string vers = s.substr(i + 1);
       desc.version = vers.empty() ? 1 : atoi(vers.c_str());
     } else
       continue;

--- a/Framework/API/src/GroupingLoader.cpp
+++ b/Framework/API/src/GroupingLoader.cpp
@@ -275,9 +275,9 @@ ITableWorkspace_sptr Grouping::toTable() const {
 
   newTable->addColumn("vector_int", "Detectors");
 
-  for (auto it = this->groups.begin(); it != this->groups.end(); ++it) {
+  for (const auto &group : this->groups) {
     TableRow newRow = newTable->appendRow();
-    newRow << Kernel::Strings::parseRange(*it);
+    newRow << Kernel::Strings::parseRange(group);
   }
 
   return newTable;

--- a/Framework/Algorithms/src/DetectorDiagnostic.cpp
+++ b/Framework/Algorithms/src/DetectorDiagnostic.cpp
@@ -634,7 +634,7 @@ DetectorDiagnostic::calculateMedian(const API::MatrixWorkspace_sptr input,
     }
 
     PARALLEL_FOR1(input)
-    for (int i = 0; i < static_cast<int>(hists.size()); ++i) {
+    for (int i = 0; i < static_cast<int>(hists.size()); ++i) { // NOLINT
       PARALLEL_START_INTERUPT_REGION
 
       if (checkForMask) {

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -766,8 +766,7 @@ void FilterEvents::setupCustomizedTOFCorrection() {
   // Apply to m_detTofOffsets and m_detTofShifts
   if (usedetid) {
     // Get vector IDs
-    vector<detid_t> vecDetIDs;
-    vecDetIDs.resize(numhist, 0);
+    vector<detid_t> vecDetIDs(numhist, 0);
     // Set up the detector IDs to vecDetIDs and set up the initial value
     for (size_t i = 0; i < numhist; ++i) {
       // It is assumed that there is one detector per spectra.

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -784,10 +784,7 @@ void FilterEvents::setupCustomizedTOFCorrection() {
               << detids.size() << " detectors.";
         throw runtime_error(errss.str());
       }
-      detid_t detid = 0;
-      for (auto detit = detids.begin(); detit != detids.end(); ++detit)
-        detid = *detit;
-      vecDetIDs[i] = detid;
+      vecDetIDs[i] = *detids.begin();
     }
 
     // Map correction map to list

--- a/Framework/Algorithms/src/GeneratePeaks.cpp
+++ b/Framework/Algorithms/src/GeneratePeaks.cpp
@@ -652,8 +652,8 @@ void GeneratePeaks::getSpectraSet(
   }
 
   specnum_t icount = 0;
-  for (auto pit = m_spectraSet.begin(); pit != m_spectraSet.end(); ++pit) {
-    m_SpectrumMap.emplace(*pit, icount);
+  for (const auto specnum : m_spectraSet) {
+    m_SpectrumMap.emplace(specnum, icount);
     ++icount;
   }
 
@@ -725,9 +725,7 @@ API::MatrixWorkspace_sptr GeneratePeaks::createOutputWorkspace() {
 
     // Only copy the X-values from spectra with peaks specified in the table
     // workspace.
-    for (auto siter = m_spectraSet.begin(); siter != m_spectraSet.end();
-         ++siter) {
-      specnum_t iws = *siter;
+    for (const auto &iws : m_spectraSet) {
       std::copy(inputWS->dataX(iws).begin(), inputWS->dataX(iws).end(),
                 outputWS->dataX(iws).begin());
     }

--- a/Framework/Algorithms/src/IntegrateByComponent.cpp
+++ b/Framework/Algorithms/src/IntegrateByComponent.cpp
@@ -89,7 +89,7 @@ void IntegrateByComponent::exec() {
           integratedWS->getInstrument();
 
       PARALLEL_FOR1(integratedWS)
-      for (int i = 0; i < static_cast<int>(hists.size()); ++i) {
+      for (int i = 0; i < static_cast<int>(hists.size()); ++i) { // NOLINT
         PARALLEL_START_INTERUPT_REGION
 
         const std::set<detid_t> &detids =
@@ -131,7 +131,7 @@ void IntegrateByComponent::exec() {
       }
 
       PARALLEL_FOR1(integratedWS)
-      for (int i = 0; i < static_cast<int>(hists.size()); ++i) {
+      for (int i = 0; i < static_cast<int>(hists.size()); ++i) { // NOLINT
         PARALLEL_START_INTERUPT_REGION
         const std::set<detid_t> &detids =
             integratedWS->getSpectrum(hists[i])

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -175,7 +175,8 @@ void MaskBins::execEvent() {
   if (!this->spectra_list.empty()) {
     // Specific spectra were specified
     PARALLEL_FOR1(outputWS)
-    for (int i = 0; i < static_cast<int>(this->spectra_list.size()); ++i) {
+    for (int i = 0; i < static_cast<int>(this->spectra_list.size());
+         ++i) { // NOLINT
       PARALLEL_START_INTERUPT_REGION
       outputWS->getEventList(this->spectra_list[i]).maskTof(m_startX, m_endX);
       progress.report();

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -175,8 +175,8 @@ void MaskBins::execEvent() {
   if (!this->spectra_list.empty()) {
     // Specific spectra were specified
     PARALLEL_FOR1(outputWS)
-    for (int i = 0; i < static_cast<int>(this->spectra_list.size());
-         ++i) { // NOLINT
+    for (int i = 0; i < static_cast<int>(this->spectra_list.size()); // NOLINT
+         ++i) {
       PARALLEL_START_INTERUPT_REGION
       outputWS->getEventList(this->spectra_list[i]).maskTof(m_startX, m_endX);
       progress.report();

--- a/Framework/Algorithms/src/MedianDetectorTest.cpp
+++ b/Framework/Algorithms/src/MedianDetectorTest.cpp
@@ -251,7 +251,7 @@ int MedianDetectorTest::maskOutliers(
     double median = medianvec[i];
 
     PARALLEL_FOR1(countsWS)
-    for (int j = 0; j < static_cast<int>(hists.size()); ++j) {
+    for (int j = 0; j < static_cast<int>(hists.size()); ++j) { // NOLINT
       const double value = countsWS->readY(hists[j])[0];
       if ((value == 0.) && checkForMask) {
         const std::set<detid_t> &detids =

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -242,8 +242,7 @@ void SumSpectra::doWorkspace2D(MatrixWorkspace_const_sptr localworkspace,
 
   // Loop over spectra
   // for (int i = m_minSpec; i <= m_maxSpec; ++i)
-  for (auto it = this->m_indices.begin(); it != this->m_indices.end(); ++it) {
-    int i = *it;
+  for (auto i : this->m_indices) {
     // Don't go outside the range.
     if ((i >= this->m_numberOfSpectra) || (i < 0)) {
       g_log.error() << "Invalid index " << i
@@ -356,8 +355,7 @@ void SumSpectra::doRebinnedOutput(MatrixWorkspace_sptr outputWorkspace,
 
   // Loop over spectra
   // for (int i = m_minSpec; i <= m_maxSpec; ++i)
-  for (auto it = m_indices.begin(); it != m_indices.end(); ++it) {
-    int i = *it;
+  for (auto i : m_indices) {
     // Don't go outside the range.
     if ((i >= m_numberOfSpectra) || (i < 0)) {
       g_log.error() << "Invalid index " << i
@@ -453,8 +451,7 @@ void SumSpectra::execEvent(EventWorkspace_const_sptr localworkspace,
   size_t numMasked(0);
   size_t numZeros(0);
   // for (int i = m_minSpec; i <= m_maxSpec; ++i)
-  for (auto it = indices.begin(); it != indices.end(); ++it) {
-    int i = *it;
+  for (auto i : indices) {
     // Don't go outside the range.
     if ((i >= m_numberOfSpectra) || (i < 0)) {
       g_log.error() << "Invalid index " << i

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -200,7 +200,7 @@ SumSpectra::getOutputSpecId(MatrixWorkspace_const_sptr localworkspace) {
   int totalSpec = static_cast<int>(localworkspace->getNumberHistograms());
 
   specnum_t temp;
-  for (auto index : this->m_indices) {
+  for (const auto index : this->m_indices) {
     if (index < totalSpec) {
       temp = localworkspace->getSpectrum(index)->getSpectrumNo();
       if (temp < specId)

--- a/Framework/Algorithms/src/UnGroupWorkspace.cpp
+++ b/Framework/Algorithms/src/UnGroupWorkspace.cpp
@@ -16,14 +16,14 @@ void UnGroupWorkspace::init() {
   auto workspaceList = data_store.getObjectNames();
   std::unordered_set<std::string> groupWorkspaceList;
   // Not iterate over, removing all those which are not group workspaces
-  for (auto it = workspaceList.begin(); it != workspaceList.end(); ++it) {
+  for (const auto &name : workspaceList) {
     WorkspaceGroup_const_sptr group =
         boost::dynamic_pointer_cast<const WorkspaceGroup>(
-            data_store.retrieve(*it));
+            data_store.retrieve(name));
     // RNT: VC returns bad pointer after erase
     // if ( !group ) workspaceList.erase(it);
     if (group) {
-      groupWorkspaceList.insert(*it);
+      groupWorkspaceList.insert(name);
     }
   }
   // Declare a text property with the list of group workspaces as its allowed

--- a/Framework/Crystal/inc/MantidCrystal/FindSXPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindSXPeaks.h
@@ -92,8 +92,8 @@ public:
     _intensity += rhs._intensity;
     _Ltot += rhs._Ltot;
     npixels += 1;
-    _spectral.insert(_spectral.end(), rhs._spectral.begin(),
-                     rhs._spectral.end());
+    _spectral.insert(_spectral.end(), rhs._spectral.cbegin(),
+                     rhs._spectral.cend());
     return *this;
   }
   /// Normalise by number of pixels

--- a/Framework/Crystal/inc/MantidCrystal/FindSXPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindSXPeaks.h
@@ -92,8 +92,8 @@ public:
     _intensity += rhs._intensity;
     _Ltot += rhs._Ltot;
     npixels += 1;
-    for (std::size_t i = 0; i < rhs._spectral.size(); i++)
-      _spectral.push_back(rhs._spectral[i]);
+    _spectral.insert(_spectral.end(), rhs._spectral.begin(),
+                     rhs._spectral.end());
     return *this;
   }
   /// Normalise by number of pixels

--- a/Framework/Crystal/src/ConnectedComponentLabeling.cpp
+++ b/Framework/Crystal/src/ConnectedComponentLabeling.cpp
@@ -344,8 +344,8 @@ ClusterMap ConnectedComponentLabeling::calculateDisjointTree(
     // equivalent clusters. Must be done in sequence.
     // Combine cluster maps processed by each thread.
     ClusterRegister clusterRegister;
-    for (auto &parallelClusterMap : parallelClusterMapVec) {
-      for (auto &cluster : parallelClusterMap) {
+    for (const auto &parallelClusterMap : parallelClusterMapVec) {
+      for (const auto &cluster : parallelClusterMap) {
         clusterRegister.add(cluster.first, cluster.second);
       }
     }

--- a/Framework/Crystal/src/ConnectedComponentLabeling.cpp
+++ b/Framework/Crystal/src/ConnectedComponentLabeling.cpp
@@ -440,7 +440,7 @@ ClusterTuple ConnectedComponentLabeling::executeAndFetchClusters(
   }
   // Write each cluster out to the output workspace
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (int i = 0; i < static_cast<int>(keys.size()); ++i) {
+  for (int i = 0; i < static_cast<int>(keys.size()); ++i) { // NOLINT
     clusters[keys[i]]->writeTo(outWS);
   }
 

--- a/Framework/Crystal/src/ConnectedComponentLabeling.cpp
+++ b/Framework/Crystal/src/ConnectedComponentLabeling.cpp
@@ -345,9 +345,8 @@ ClusterMap ConnectedComponentLabeling::calculateDisjointTree(
     // Combine cluster maps processed by each thread.
     ClusterRegister clusterRegister;
     for (auto &parallelClusterMap : parallelClusterMapVec) {
-      for (auto it = parallelClusterMap.begin(); it != parallelClusterMap.end();
-           ++it) {
-        clusterRegister.add(it->first, it->second);
+      for (auto &cluster : parallelClusterMap) {
+        clusterRegister.add(cluster.first, cluster.second);
       }
     }
 

--- a/Framework/Crystal/src/MaskPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/MaskPeaksWorkspace.cpp
@@ -95,7 +95,7 @@ void MaskPeaksWorkspace::exec() {
   // Loop over peaks
   const std::vector<Peak> &peaks = peaksW->getPeaks();
   PARALLEL_FOR3(m_inputW, peaksW, tablews)
-  for (int i = 0; i < static_cast<int>(peaks.size()); i++) {
+  for (int i = 0; i < static_cast<int>(peaks.size()); i++) { // NOLINT
     PARALLEL_START_INTERUPT_REGION
     const Peak &peak = peaks[i];
     // get the peak location on the detector

--- a/Framework/Crystal/src/MaskPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/MaskPeaksWorkspace.cpp
@@ -87,8 +87,7 @@ void MaskPeaksWorkspace::exec() {
 
   // Init a table workspace
   DataObjects::TableWorkspace_sptr tablews =
-      boost::shared_ptr<DataObjects::TableWorkspace>(
-          new DataObjects::TableWorkspace());
+      boost::make_shared<DataObjects::TableWorkspace>();
   tablews->addColumn("double", "XMin");
   tablews->addColumn("double", "XMax");
   tablews->addColumn("str", "SpectraList");

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -1716,9 +1716,7 @@ void SCDCalibratePanels::saveXmlFile(
 
   // write out the detector banks
   for (const auto &Group : Groups) {
-    for (auto it1 = Group.begin(); it1 != Group.end(); ++it1) {
-      string bankName = (*it1);
-
+    for (const auto &bankName : Group) {
       oss3 << "<component-link name=\"" << bankName << "\">" << endl;
 
       boost::shared_ptr<const IComponent> bank =

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -166,9 +166,8 @@ void SaveIsawPeaks::exec() {
              "  CenterY   CenterZ    BaseX    BaseY    BaseZ      UpX      UpY "
              "     UpZ" << std::endl;
       // Here would save each detector...
-      for (auto it = uniqueBanks.begin(); it != uniqueBanks.end(); ++it) {
+      for (const auto bank : uniqueBanks) {
         // Build up the bank name
-        int bank = *it;
         std::ostringstream mess;
         if (bankPart == "bank")
           mess << "bank" << bank;

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -602,7 +602,7 @@ FilterEventsByLogValuePreNexus::setupOutputEventWorkspace() {
   */
 void FilterEventsByLogValuePreNexus::processEventLogs() {
   std::map<PixelType, size_t>::iterator mit;
-  for (auto pid : this->wrongdetids) {
+  for (const auto pid : this->wrongdetids) {
     // Convert Pixel ID to 'wrong detectors ID' map's index
     mit = this->wrongdetidmap.find(pid);
     size_t mindex = mit->second;
@@ -1111,7 +1111,7 @@ void FilterEventsByLogValuePreNexus::procEvents(
                    << "Number of Wrong Detector IDs = " << wrongdetids.size()
                    << "\n";
 
-    for (auto pid : this->wrongdetids) {
+    for (const auto pid : this->wrongdetids) {
       g_log.notice() << "Wrong Detector ID : " << pid << std::endl;
     }
     for (const auto &detidPair : wrongdetidmap) {
@@ -1756,7 +1756,7 @@ void FilterEventsByLogValuePreNexus::filterEvents() {
     for (const auto wrongdetid : this->wrongdetids) {
       g_log.notice() << "Wrong Detector ID : " << wrongdetid << std::endl;
     }
-    for (auto &detidPair : this->wrongdetidmap) {
+    for (const auto &detidPair : this->wrongdetidmap) {
       PixelType tmpid = detidPair.first;
       size_t vindex = detidPair.second;
       g_log.notice() << "Pixel " << tmpid << ":  Total number of events = "

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -1416,7 +1416,8 @@ void FilterEventsByLogValuePreNexus::unmaskVetoEventIndexes() {
   size_t numerror = 0;
 
     PRAGMA_OMP(parallel for schedule(dynamic, 1) )
-    for (int i = 0; i < static_cast<int>(m_vecEventIndex.size()); ++i) {
+    for (int i = 0; i < static_cast<int>(m_vecEventIndex.size());
+         ++i) { // NOLINT
       PARALLEL_START_INTERUPT_REGION
 
       uint64_t eventindex = m_vecEventIndex[i];

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -602,10 +602,8 @@ FilterEventsByLogValuePreNexus::setupOutputEventWorkspace() {
   */
 void FilterEventsByLogValuePreNexus::processEventLogs() {
   std::map<PixelType, size_t>::iterator mit;
-  for (auto pit = this->wrongdetids.begin(); pit != this->wrongdetids.end();
-       ++pit) {
+  for (auto pid : this->wrongdetids) {
     // Convert Pixel ID to 'wrong detectors ID' map's index
-    PixelType pid = *pit;
     mit = this->wrongdetidmap.find(pid);
     size_t mindex = mit->second;
     if (mindex > this->wrongdetid_pulsetimes.size()) {
@@ -1113,15 +1111,12 @@ void FilterEventsByLogValuePreNexus::procEvents(
                    << "Number of Wrong Detector IDs = " << wrongdetids.size()
                    << "\n";
 
-    for (auto wit = this->wrongdetids.begin(); wit != this->wrongdetids.end();
-         ++wit) {
-      g_log.notice() << "Wrong Detector ID : " << *wit << std::endl;
+    for (auto pid : this->wrongdetids) {
+      g_log.notice() << "Wrong Detector ID : " << pid << std::endl;
     }
-    std::map<PixelType, size_t>::iterator git;
-    for (git = this->wrongdetidmap.begin(); git != this->wrongdetidmap.end();
-         ++git) {
-      PixelType tmpid = git->first;
-      size_t vindex = git->second;
+    for (const auto &detidPair : wrongdetidmap) {
+      PixelType tmpid = detidPair.first;
+      size_t vindex = detidPair.second;
       g_log.notice() << "Pixel " << tmpid << ":  Total number of events = "
                      << this->wrongdetid_pulsetimes[vindex].size() << std::endl;
     }
@@ -1362,10 +1357,8 @@ void FilterEventsByLogValuePreNexus::procEventsLinear(
     this->m_numBadEvents += local_numBadEvents;
     this->m_numWrongdetidEvents += local_numWrongdetidEvents;
 
-    for (auto it = local_wrongdetids.begin(); it != local_wrongdetids.end();
-         ++it) {
-      PixelType tmpid = *it;
-      this->wrongdetids.insert(*it);
+    for (auto tmpid : local_wrongdetids) {
+      this->wrongdetids.insert(tmpid);
 
       // Obtain the global map index for this wrong detector ID events entry in
       // local map
@@ -1759,14 +1752,12 @@ void FilterEventsByLogValuePreNexus::filterEvents() {
                    << " microsec; longest TOF: " << m_longestTof << " microsec."
                    << "\n";
 
-    for (auto wit = this->wrongdetids.begin(); wit != this->wrongdetids.end();
-         ++wit) {
-      g_log.notice() << "Wrong Detector ID : " << *wit << std::endl;
+    for (const auto wrongdetid : this->wrongdetids) {
+      g_log.notice() << "Wrong Detector ID : " << wrongdetid << std::endl;
     }
-    for (auto git = this->wrongdetidmap.begin();
-         git != this->wrongdetidmap.end(); ++git) {
-      PixelType tmpid = git->first;
-      size_t vindex = git->second;
+    for (auto &detidPair : this->wrongdetidmap) {
+      PixelType tmpid = detidPair.first;
+      size_t vindex = detidPair.second;
       g_log.notice() << "Pixel " << tmpid << ":  Total number of events = "
                      << this->wrongdetid_pulsetimes[vindex].size() << std::endl;
     }

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -1416,8 +1416,8 @@ void FilterEventsByLogValuePreNexus::unmaskVetoEventIndexes() {
   size_t numerror = 0;
 
     PRAGMA_OMP(parallel for schedule(dynamic, 1) )
-    for (int i = 0; i < static_cast<int>(m_vecEventIndex.size());
-         ++i) { // NOLINT
+    for (int i = 0; i < static_cast<int>(m_vecEventIndex.size()); // NOLINT
+         ++i) {
       PARALLEL_START_INTERUPT_REGION
 
       uint64_t eventindex = m_vecEventIndex[i];

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -514,16 +514,12 @@ LoadBBY::createInstrument(ANSTO::Tar::File &tarFile,
 
   // extract log and hdf file
   const std::vector<std::string> &files = tarFile.files();
-
-  int64_t fileSize = 0;
-  for (auto itr = files.begin(); itr != files.end(); ++itr)
-    if (itr->rfind(".hdf") == itr->length() - 4) {
-      tarFile.select(itr->c_str());
-      fileSize = tarFile.selected_size();
-      break;
-    }
-
-  if (fileSize != 0) {
+  const auto file_it =
+      std::find_if(files.begin(), files.end(), [](const std::string &file) {
+        return file.rfind(".hdf") == file.length() - 4;
+      });
+  if (file_it != files.end()) {
+    tarFile.select(file_it->c_str());
     // extract hdf file into tmp file
     Poco::TemporaryFile hdfFile;
     boost::shared_ptr<FILE> handle(fopen(hdfFile.path().c_str(), "wb"), fclose);
@@ -584,9 +580,9 @@ LoadBBY::createInstrument(ANSTO::Tar::File &tarFile,
 
   // patching
   std::string logContent;
-  for (auto itr = files.begin(); itr != files.end(); ++itr)
-    if (itr->compare("History.log") == 0) {
-      tarFile.select(itr->c_str());
+  for (const auto &file : files)
+    if (file.compare("History.log") == 0) {
+      tarFile.select(file.c_str());
       logContent.resize(tarFile.selected_size());
       tarFile.read(&logContent[0], logContent.size());
       break;

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -514,7 +514,7 @@ LoadBBY::createInstrument(ANSTO::Tar::File &tarFile,
 
   // extract log and hdf file
   const std::vector<std::string> &files = tarFile.files();
-  const auto file_it =
+  auto file_it =
       std::find_if(files.cbegin(), files.cend(), [](const std::string &file) {
         return file.rfind(".hdf") == file.length() - 4;
       });
@@ -579,16 +579,12 @@ LoadBBY::createInstrument(ANSTO::Tar::File &tarFile,
   }
 
   // patching
-  std::string logContent;
-  for (const auto &file : files)
-    if (file.compare("History.log") == 0) {
-      tarFile.select(file.c_str());
-      logContent.resize(tarFile.selected_size());
-      tarFile.read(&logContent[0], logContent.size());
-      break;
-    }
-
-  if (logContent.size() > 0) {
+  file_it = std::find(files.cbegin(), files.cend(), "History.log");
+  if (file_it != files.cend()) {
+    tarFile.select(file_it->c_str());
+    std::string logContent;
+    logContent.resize(tarFile.selected_size());
+    tarFile.read(&logContent[0], logContent.size());
     std::istringstream data(logContent);
     Poco::AutoPtr<Poco::Util::PropertyFileConfiguration> conf(
         new Poco::Util::PropertyFileConfiguration(data));

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -515,7 +515,7 @@ LoadBBY::createInstrument(ANSTO::Tar::File &tarFile,
   // extract log and hdf file
   const std::vector<std::string> &files = tarFile.files();
   const auto file_it =
-      std::find_if(files.begin(), files.end(), [](const std::string &file) {
+      std::find_if(files.cbegin(), files.cend(), [](const std::string &file) {
         return file.rfind(".hdf") == file.length() - 4;
       });
   if (file_it != files.end()) {

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -532,7 +532,7 @@ LoadEventPreNexus2::generateEventDistribtionWorkspace() {
 /** Process imbed logs (marked by bad pixel IDs)
  */
 void LoadEventPreNexus2::processImbedLogs() {
-  for (auto pid : this->wrongdetids) {
+  for (const auto pid : this->wrongdetids) {
     // a. pixel ID -> index
     const auto mit = this->wrongdetidmap.find(pid);
     size_t mindex = mit->second;
@@ -609,7 +609,7 @@ void LoadEventPreNexus2::runLoadInstrument(
   vector<string> eventExts(EVENT_EXTS, EVENT_EXTS + NUM_EXT);
   std::reverse(eventExts.begin(), eventExts.end());
 
-  for (auto &ending : eventExts) {
+  for (const auto &ending : eventExts) {
     size_t pos = instrument.find(ending);
     if (pos != string::npos) {
       instrument = instrument.substr(0, pos);

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -532,12 +532,9 @@ LoadEventPreNexus2::generateEventDistribtionWorkspace() {
 /** Process imbed logs (marked by bad pixel IDs)
  */
 void LoadEventPreNexus2::processImbedLogs() {
-  std::map<PixelType, size_t>::iterator mit;
-  for (auto pit = this->wrongdetids.begin(); pit != this->wrongdetids.end();
-       ++pit) {
+  for (auto pid : this->wrongdetids) {
     // a. pixel ID -> index
-    PixelType pid = *pit;
-    mit = this->wrongdetidmap.find(pid);
+    const auto mit = this->wrongdetidmap.find(pid);
     size_t mindex = mit->second;
     if (mindex > this->wrongdetid_pulsetimes.size()) {
       g_log.error() << "Wrong Index " << mindex << " for Pixel " << pid
@@ -612,8 +609,8 @@ void LoadEventPreNexus2::runLoadInstrument(
   vector<string> eventExts(EVENT_EXTS, EVENT_EXTS + NUM_EXT);
   std::reverse(eventExts.begin(), eventExts.end());
 
-  for (auto &eventExt : eventExts) {
-    size_t pos = instrument.find(eventExt);
+  for (auto &ending : eventExts) {
+    size_t pos = instrument.find(ending);
     if (pos != string::npos) {
       instrument = instrument.substr(0, pos);
       break;

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -280,11 +280,11 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
     }
   }
   try {
-    for (auto itr = dMap.begin(); itr != dMap.end(); ++itr) {
-      run.addLogData(itr->second.release());
+    for (auto &itr : dMap) {
+      run.addLogData(itr.second.release());
     }
-    for (auto sitr = sMap.begin(); sitr != sMap.end(); ++sitr) {
-      run.addLogData(sitr->second.release());
+    for (auto &sitr : sMap) {
+      run.addLogData(sitr.second.release());
     }
   } catch (std::invalid_argument &e) {
     g_log.warning() << e.what();

--- a/Framework/DataHandling/src/LoadVulcanCalFile.cpp
+++ b/Framework/DataHandling/src/LoadVulcanCalFile.cpp
@@ -453,7 +453,7 @@ void LoadVulcanCalFile::processOffsets(
       g_log.information() << "Find inter-bank correction for bank " << bankid
                           << " for special detid " << interbank_detid << ".\n";
 
-      auto offsetiter = map_detoffset.find(interbank_detid);
+      const auto offsetiter = map_detoffset.find(interbank_detid);
       if (offsetiter == map_detoffset.end())
         throw runtime_error("It cannot happen!");
       double interbanklogcorr = offsetiter->second;
@@ -468,7 +468,7 @@ void LoadVulcanCalFile::processOffsets(
 
       detid_t intermodule_detid =
           static_cast<detid_t>((bankid + 1) * NUMBERRESERVEDPERMODULE) - 1;
-      auto offsetiter = map_detoffset.find(intermodule_detid);
+      const auto offsetiter = map_detoffset.find(intermodule_detid);
       if (offsetiter == map_detoffset.end())
         throw runtime_error("It cannot happen!");
       double intermodulelogcorr = offsetiter->second;

--- a/Framework/DataHandling/src/LoadVulcanCalFile.cpp
+++ b/Framework/DataHandling/src/LoadVulcanCalFile.cpp
@@ -441,11 +441,9 @@ void LoadVulcanCalFile::processOffsets(
   g_log.information() << "Number of bankds to process = " << set_bankID.size()
                       << "\n";
   map<int, double> map_bankLogCorr;
-  for (auto biter = set_bankID.begin(); biter != set_bankID.end(); ++biter) {
+  for (const auto bankid : set_bankID) {
     // Locate inter bank and inter pack correction (log)
-    int bankid = *biter;
     double globalfactor = 0.;
-    map<detid_t, double>::iterator offsetiter;
 
     // Inter-bank correction
     if (m_groupingType != VULCAN_OFFSET_BANK) {
@@ -455,7 +453,7 @@ void LoadVulcanCalFile::processOffsets(
       g_log.information() << "Find inter-bank correction for bank " << bankid
                           << " for special detid " << interbank_detid << ".\n";
 
-      offsetiter = map_detoffset.find(interbank_detid);
+      auto offsetiter = map_detoffset.find(interbank_detid);
       if (offsetiter == map_detoffset.end())
         throw runtime_error("It cannot happen!");
       double interbanklogcorr = offsetiter->second;
@@ -470,7 +468,7 @@ void LoadVulcanCalFile::processOffsets(
 
       detid_t intermodule_detid =
           static_cast<detid_t>((bankid + 1) * NUMBERRESERVEDPERMODULE) - 1;
-      offsetiter = map_detoffset.find(intermodule_detid);
+      auto offsetiter = map_detoffset.find(intermodule_detid);
       if (offsetiter == map_detoffset.end())
         throw runtime_error("It cannot happen!");
       double intermodulelogcorr = offsetiter->second;

--- a/Framework/DataHandling/src/PatchBBY.cpp
+++ b/Framework/DataHandling/src/PatchBBY.cpp
@@ -177,9 +177,9 @@ void PatchBBY::exec() {
   bool reset = getProperty("Reset");
   if (reset) {
     int64_t fileSize = 0;
-    for (auto itr = files.begin(); itr != files.end(); ++itr)
-      if (itr->rfind(".hdf") == itr->length() - 4) {
-        tarFile.select(itr->c_str());
+    for (const auto &file : files)
+      if (file.rfind(".hdf") == file.length() - 4) {
+        tarFile.select(file.c_str());
         fileSize = tarFile.selected_size();
         break;
       }

--- a/Framework/DataHandling/src/PatchBBY.cpp
+++ b/Framework/DataHandling/src/PatchBBY.cpp
@@ -177,7 +177,7 @@ void PatchBBY::exec() {
   bool reset = getProperty("Reset");
   if (reset) {
     const auto file_it =
-        std::find_if(files.begin(), files.end(), [](const std::string &file) {
+        std::find_if(files.cbegin(), files.cend(), [](const std::string &file) {
           return file.rfind(".hdf") == file.length() - 4;
         });
     if (file_it != files.end()) {

--- a/Framework/DataHandling/src/PatchBBY.cpp
+++ b/Framework/DataHandling/src/PatchBBY.cpp
@@ -176,15 +176,11 @@ void PatchBBY::exec() {
   // load original values from hdf
   bool reset = getProperty("Reset");
   if (reset) {
-    int64_t fileSize = 0;
-    for (const auto &file : files)
-      if (file.rfind(".hdf") == file.length() - 4) {
-        tarFile.select(file.c_str());
-        fileSize = tarFile.selected_size();
-        break;
-      }
-
-    if (fileSize != 0) {
+    const auto file_it =
+        std::find_if(files.begin(), files.end(), [](const std::string &file) {
+          return file.rfind(".hdf") == file.length() - 4;
+        });
+    if (file_it != files.end()) {
       // extract hdf file into tmp file
       Poco::TemporaryFile hdfFile;
       boost::shared_ptr<FILE> handle(fopen(hdfFile.path().c_str(), "wb"),

--- a/Framework/DataHandling/src/SaveParameterFile.cpp
+++ b/Framework/DataHandling/src/SaveParameterFile.cpp
@@ -167,12 +167,12 @@ void SaveParameterFile::exec() {
   prog.resetNumSteps(static_cast<int64_t>(toSave.size()), 0.6, 1.0);
   // Iterate through all the parameters we want to save and build an XML
   // document out of them.
-  for (auto &compIt : toSave) {
+  for (auto &comp : toSave) {
     if (prog.hasCancellationBeenRequested())
       break;
     prog.report("Saving parameters");
     // Component data
-    const ComponentID cID = compIt.first;
+    const ComponentID cID = comp.first;
     const std::string cFullName = cID->getFullName();
     const IDetector *cDet = dynamic_cast<IDetector *>(cID);
     const detid_t cDetID = (cDet) ? cDet->getID() : 0;
@@ -181,11 +181,10 @@ void SaveParameterFile::exec() {
     if (cDetID != 0)
       file << " id=\"" << cDetID << "\"";
     file << " name=\"" << cFullName << "\">\n";
-    for (auto paramIt = compIt.second.begin(); paramIt != compIt.second.end();
-         ++paramIt) {
-      const std::string pName = paramIt->get<0>();
-      const std::string pType = paramIt->get<1>();
-      const std::string pValue = paramIt->get<2>();
+    for (auto &param : comp.second) {
+      const std::string pName = param.get<0>();
+      const std::string pType = param.get<1>();
+      const std::string pValue = param.get<2>();
 
       // With fitting parameters, we're actually inserting an entire element, as
       // constructed above

--- a/Framework/DataHandling/src/SaveParameterFile.cpp
+++ b/Framework/DataHandling/src/SaveParameterFile.cpp
@@ -167,7 +167,7 @@ void SaveParameterFile::exec() {
   prog.resetNumSteps(static_cast<int64_t>(toSave.size()), 0.6, 1.0);
   // Iterate through all the parameters we want to save and build an XML
   // document out of them.
-  for (auto &comp : toSave) {
+  for (const auto &comp : toSave) {
     if (prog.hasCancellationBeenRequested())
       break;
     prog.report("Saving parameters");
@@ -181,7 +181,7 @@ void SaveParameterFile::exec() {
     if (cDetID != 0)
       file << " id=\"" << cDetID << "\"";
     file << " name=\"" << cFullName << "\">\n";
-    for (auto &param : comp.second) {
+    for (const auto &param : comp.second) {
       const std::string pName = param.get<0>();
       const std::string pType = param.get<1>();
       const std::string pValue = param.get<2>();

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -187,7 +187,7 @@ TMDE(void MDEventWorkspace)::setMinRecursionDepth(size_t minDepth) {
     std::vector<API::IMDNode *> boxes;
     boxes.clear();
     this->getBox()->getBoxes(boxes, depth - 1, false);
-    for (auto box : boxes) {
+    for (const auto box : boxes) {
       MDGridBox<MDE, nd> *gbox = dynamic_cast<MDGridBox<MDE, nd> *>(box);
       if (gbox) {
         // Split ALL the contents.
@@ -456,7 +456,7 @@ TMDE(Mantid::API::ITableWorkspace_sptr MDEventWorkspace)::makeBoxTable(
   this->getBox()->getBoxes(boxes, 1000, false);
   boxes_filtered.reserve(boxes.size());
 
-  for (auto box : boxes) {
+  for (const auto box : boxes) {
     boxes_filtered.push_back(dynamic_cast<MDBoxBase<MDE, nd> *>(box));
   }
 
@@ -803,7 +803,7 @@ TMDE(void MDEventWorkspace)::setMDMasking(
 
     // Apply new masks
     this->data->getBoxes(toMaskBoxes, 10000, true, maskingRegion);
-    for (auto box : toMaskBoxes) {
+    for (const auto box : toMaskBoxes) {
       box->mask();
     }
 
@@ -818,7 +818,7 @@ TMDE(void MDEventWorkspace)::clearMDMasking() {
   std::vector<API::IMDNode *> allBoxes;
   // Clear old masks
   this->data->getBoxes(allBoxes, 10000, true);
-  for (auto box : allBoxes) {
+  for (const auto box : allBoxes) {
     box->unmask();
   }
 }

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -187,8 +187,8 @@ TMDE(void MDEventWorkspace)::setMinRecursionDepth(size_t minDepth) {
     std::vector<API::IMDNode *> boxes;
     boxes.clear();
     this->getBox()->getBoxes(boxes, depth - 1, false);
-    for (size_t i = 0; i < boxes.size(); i++) {
-      MDGridBox<MDE, nd> *gbox = dynamic_cast<MDGridBox<MDE, nd> *>(boxes[i]);
+    for (auto box : boxes) {
+      MDGridBox<MDE, nd> *gbox = dynamic_cast<MDGridBox<MDE, nd> *>(box);
       if (gbox) {
         // Split ALL the contents.
         for (size_t j = 0; j < gbox->getNumChildren(); j++)
@@ -456,9 +456,8 @@ TMDE(Mantid::API::ITableWorkspace_sptr MDEventWorkspace)::makeBoxTable(
   this->getBox()->getBoxes(boxes, 1000, false);
   boxes_filtered.reserve(boxes.size());
 
-  for (size_t i = 0; i < boxes.size(); i++) {
-    MDBoxBase<MDE, nd> *box = dynamic_cast<MDBoxBase<MDE, nd> *>(boxes[i]);
-    boxes_filtered.push_back(box);
+  for (auto box : boxes) {
+    boxes_filtered.push_back(dynamic_cast<MDBoxBase<MDE, nd> *>(box));
   }
 
   // Now sort by ID
@@ -804,8 +803,8 @@ TMDE(void MDEventWorkspace)::setMDMasking(
 
     // Apply new masks
     this->data->getBoxes(toMaskBoxes, 10000, true, maskingRegion);
-    for (size_t i = 0; i < toMaskBoxes.size(); ++i) {
-      toMaskBoxes[i]->mask();
+    for (auto box : toMaskBoxes) {
+      box->mask();
     }
 
     delete maskingRegion;
@@ -819,8 +818,8 @@ TMDE(void MDEventWorkspace)::clearMDMasking() {
   std::vector<API::IMDNode *> allBoxes;
   // Clear old masks
   this->data->getBoxes(allBoxes, 10000, true);
-  for (size_t i = 0; i < allBoxes.size(); ++i) {
-    allBoxes[i]->unmask();
+  for (auto box : allBoxes) {
+    box->unmask();
   }
 }
 

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -71,7 +71,7 @@ public:
 
     std::vector<T> equivalents;
     std::transform(symmetryOperations.begin(), symmetryOperations.end(),
-                   std::inserter(equivalents, equivalents.begin()),
+                   std::back_inserter(equivalents),
                    [&position](const SymmetryOperation &op) {
                      return Geometry::getWrappedVector(op * position);
                    });

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -70,10 +70,11 @@ public:
         getSymmetryOperations();
 
     std::vector<T> equivalents;
-    for (auto it = symmetryOperations.begin(); it != symmetryOperations.end();
-         ++it) {
-      equivalents.push_back(Geometry::getWrappedVector((*it) * position));
-    }
+    std::transform(symmetryOperations.begin(), symmetryOperations.end(),
+                   std::inserter(equivalents, equivalents.begin()),
+                   [&position](const SymmetryOperation &op) {
+                     return Geometry::getWrappedVector(op * position);
+                   });
 
     // Use fuzzy compare with the same condition as V3D::operator==().
     std::sort(equivalents.begin(), equivalents.end(), AtomPositionsLessThan());

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -70,7 +70,8 @@ public:
         getSymmetryOperations();
 
     std::vector<T> equivalents;
-    std::transform(symmetryOperations.begin(), symmetryOperations.end(),
+    equivalents.reserve(symmetryOperations.size());
+    std::transform(symmetryOperations.cbegin(), symmetryOperations.cend(),
                    std::back_inserter(equivalents),
                    [&position](const SymmetryOperation &op) {
                      return Geometry::getWrappedVector(op * position);

--- a/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h
+++ b/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDImplicitFunction.h
@@ -5,6 +5,7 @@
 #include "MantidGeometry/MDGeometry/MDTypes.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Exception.h"
+#include <boost/shared_ptr.hpp>
 #include <vector>
 #include <string>
 

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -2469,9 +2469,8 @@ void InstrumentDefinitionParser::adjust(
   }
 
   // delete all <component> found in pElem
-  for (auto it = allComponentInType.begin(); it != allComponentInType.end();
-       ++it)
-    pElem->removeChild(*it);
+  for (auto comp : allComponentInType)
+    pElem->removeChild(comp);
 }
 
 /// return absolute position of point which is set relative to the

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -2469,7 +2469,7 @@ void InstrumentDefinitionParser::adjust(
   }
 
   // delete all <component> found in pElem
-  for (auto comp : allComponentInType)
+  for (const auto comp : allComponentInType)
     pElem->removeChild(comp);
 }
 

--- a/Framework/Geometry/src/Rendering/GluGeometryRenderer.cpp
+++ b/Framework/Geometry/src/Rendering/GluGeometryRenderer.cpp
@@ -124,8 +124,7 @@ void GluGeometryRenderer::CreateCube(const V3D &Point1, const V3D &Point2,
                  .cross_prod((vertex[row[0]] - vertex[row[2]]));
     normal.normalize();
     glNormal3d(normal[0], normal[1], normal[2]);
-    for (int j = 0; j < 4; j++) {
-      int ij = row[j];
+    for (int ij : row) {
       if (ij == 0)
         glTexCoord2i(0, 0);
       if (ij == 1)

--- a/Framework/Geometry/src/Rendering/GluGeometryRenderer.cpp
+++ b/Framework/Geometry/src/Rendering/GluGeometryRenderer.cpp
@@ -124,7 +124,7 @@ void GluGeometryRenderer::CreateCube(const V3D &Point1, const V3D &Point2,
                  .cross_prod((vertex[row[0]] - vertex[row[2]]));
     normal.normalize();
     glNormal3d(normal[0], normal[1], normal[2]);
-    for (int ij : row) {
+    for (const int ij : row) {
       if (ij == 0)
         glTexCoord2i(0, 0);
       if (ij == 1)

--- a/Framework/Kernel/inc/MantidKernel/DynamicFactory.h
+++ b/Framework/Kernel/inc/MantidKernel/DynamicFactory.h
@@ -218,9 +218,11 @@ public:
   virtual const std::vector<std::string> getKeys() const {
     std::vector<std::string> names;
     names.reserve(_map.size());
-    for (const auto &mapPair : _map) {
-      names.push_back(mapPair.first);
-    }
+    std::transform(
+        _map.begin(), _map.end(), std::back_inserter(names),
+        [](const std::pair<std::string, AbstractFactory *> &mapPair) {
+          return mapPair.first;
+        });
     return names;
   }
 

--- a/Framework/Kernel/inc/MantidKernel/DynamicFactory.h
+++ b/Framework/Kernel/inc/MantidKernel/DynamicFactory.h
@@ -22,6 +22,7 @@
 // std
 #include <cstring>
 #include <functional>
+#include <iterator>
 #include <map>
 #include <vector>
 

--- a/Framework/Kernel/inc/MantidKernel/DynamicFactory.h
+++ b/Framework/Kernel/inc/MantidKernel/DynamicFactory.h
@@ -218,12 +218,9 @@ public:
   virtual const std::vector<std::string> getKeys() const {
     std::vector<std::string> names;
     names.reserve(_map.size());
-
-    typename FactoryMap::const_iterator iter = _map.begin();
-    for (; iter != _map.end(); ++iter) {
-      names.push_back(iter->first);
+    for (const auto &mapPair : _map) {
+      names.push_back(mapPair.first);
     }
-
     return names;
   }
 

--- a/Framework/Kernel/inc/MantidKernel/DynamicFactory.h
+++ b/Framework/Kernel/inc/MantidKernel/DynamicFactory.h
@@ -220,7 +220,7 @@ public:
     std::vector<std::string> names;
     names.reserve(_map.size());
     std::transform(
-        _map.begin(), _map.end(), std::back_inserter(names),
+        _map.cbegin(), _map.cend(), std::back_inserter(names),
         [](const std::pair<std::string, AbstractFactory *> &mapPair) {
           return mapPair.first;
         });

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -155,9 +155,9 @@ void toValue(const std::string &strvalue, std::vector<T> &value) {
 
   value.clear();
   value.reserve(values.count());
-  for (const auto &str : values) {
-    value.push_back(boost::lexical_cast<T>(str));
-  }
+  std::transform(
+      values.begin(), values.end(), std::back_inserter(value),
+      [](const std::string &str) { return boost::lexical_cast<T>(str); });
 }
 
 template <typename T>
@@ -176,9 +176,9 @@ void toValue(const std::string &strvalue, std::vector<std::vector<T>> &value,
                      tokenizer::TOK_IGNORE_EMPTY | tokenizer::TOK_TRIM);
     std::vector<T> vect;
     vect.reserve(values.count());
-    for (auto &value : values)
-      vect.push_back(boost::lexical_cast<T>(value));
-
+    std::transform(
+        values.begin(), values.end(), std::back_inserter(vect),
+        [](const std::string &str) { return boost::lexical_cast<T>(str); });
     value.push_back(std::move(vect));
   }
 }
@@ -270,9 +270,10 @@ inline std::vector<std::string> determineAllowedValues(const OptionalBool &,
   auto enumMap = OptionalBool::enumToStrMap();
   std::vector<std::string> values;
   values.reserve(enumMap.size());
-  for (const auto &str : enumMap) {
-    values.push_back(str.second);
-  }
+  std::transform(enumMap.begin(), enumMap.end(), std::back_inserter(values),
+                 [](const std::pair<OptionalBool::Value, std::string> &str) {
+                   return str.second;
+                 });
   return values;
 }
 }

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -156,7 +156,7 @@ void toValue(const std::string &strvalue, std::vector<T> &value) {
   value.clear();
   value.reserve(values.count());
   std::transform(
-      values.begin(), values.end(), std::back_inserter(value),
+      values.cbegin(), values.cend(), std::back_inserter(value),
       [](const std::string &str) { return boost::lexical_cast<T>(str); });
 }
 
@@ -270,7 +270,7 @@ inline std::vector<std::string> determineAllowedValues(const OptionalBool &,
   auto enumMap = OptionalBool::enumToStrMap();
   std::vector<std::string> values;
   values.reserve(enumMap.size());
-  std::transform(enumMap.begin(), enumMap.end(), std::back_inserter(values),
+  std::transform(enumMap.cbegin(), enumMap.cend(), std::back_inserter(values),
                  [](const std::pair<OptionalBool::Value, std::string> &str) {
                    return str.second;
                  });

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -155,9 +155,8 @@ void toValue(const std::string &strvalue, std::vector<T> &value) {
 
   value.clear();
   value.reserve(values.count());
-
-  for (tokenizer::Iterator it = values.begin(); it != values.end(); ++it) {
-    value.push_back(boost::lexical_cast<T>(*it));
+  for (const auto &str : values) {
+    value.push_back(boost::lexical_cast<T>(str));
   }
 }
 
@@ -172,15 +171,15 @@ void toValue(const std::string &strvalue, std::vector<std::vector<T>> &value,
   value.clear();
   value.reserve(tokens.count());
 
-  for (tokenizer::Iterator oIt = tokens.begin(); oIt != tokens.end(); ++oIt) {
-    tokenizer values(*oIt, innerDelimiter,
+  for (const auto &token : tokens) {
+    tokenizer values(token, innerDelimiter,
                      tokenizer::TOK_IGNORE_EMPTY | tokenizer::TOK_TRIM);
     std::vector<T> vect;
+    vect.reserve(values.count());
+    for (auto &value : values)
+      vect.push_back(boost::lexical_cast<T>(value));
 
-    for (tokenizer::Iterator iIt = values.begin(); iIt != values.end(); ++iIt)
-      vect.push_back(boost::lexical_cast<T>(*iIt));
-
-    value.push_back(vect);
+    value.push_back(std::move(vect));
   }
 }
 
@@ -270,8 +269,9 @@ inline std::vector<std::string> determineAllowedValues(const OptionalBool &,
                                                        const IValidator &) {
   auto enumMap = OptionalBool::enumToStrMap();
   std::vector<std::string> values;
-  for (auto it = enumMap.begin(); it != enumMap.end(); ++it) {
-    values.push_back(it->second);
+  values.reserve(enumMap.size());
+  for (const auto &str : enumMap) {
+    values.push_back(str.second);
   }
   return values;
 }

--- a/Framework/Kernel/inc/MantidKernel/ThreadScheduler.h
+++ b/Framework/Kernel/inc/MantidKernel/ThreadScheduler.h
@@ -190,9 +190,8 @@ public:
   void clear() override {
     m_queueLock.lock();
     // Empty out the queue and delete the pointers!
-    for (std::deque<Task *>::iterator it = m_queue.begin(); it != m_queue.end();
-         it++)
-      delete *it;
+    for (auto &task : m_queue)
+      delete task;
     m_queue.clear();
     m_cost = 0;
     m_costExecuted = 0;
@@ -297,9 +296,8 @@ public:
   void clear() override {
     m_queueLock.lock();
     // Empty out the queue and delete the pointers!
-    for (std::multimap<double, Task *>::iterator it = m_map.begin();
-         it != m_map.end(); it++)
-      delete it->second;
+    for (auto &taskPair : m_map)
+      delete taskPair.second;
     m_map.clear();
     m_cost = 0;
     m_costExecuted = 0;

--- a/Framework/Kernel/inc/MantidKernel/VMD.h
+++ b/Framework/Kernel/inc/MantidKernel/VMD.h
@@ -6,10 +6,6 @@
 #include "MantidKernel/System.h"
 #include "MantidKernel/Tolerance.h"
 #include "MantidKernel/V3D.h"
-#ifndef Q_MOC_RUN
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/trim.hpp>
-#endif
 #include <cstddef>
 #include <sstream>
 #include <stdexcept>

--- a/Framework/Kernel/inc/MantidKernel/VMD.h
+++ b/Framework/Kernel/inc/MantidKernel/VMD.h
@@ -1,11 +1,12 @@
 #ifndef MANTID_KERNEL_VMD_H_
 #define MANTID_KERNEL_VMD_H_
 
-#include "MantidKernel/Strings.h"
 #include "MantidKernel/StringTokenizer.h"
+#include "MantidKernel/Strings.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Tolerance.h"
 #include "MantidKernel/V3D.h"
+#include <algorithm>
 #include <cstddef>
 #include <sstream>
 #include <stdexcept>

--- a/Framework/Kernel/inc/MantidKernel/VMD.h
+++ b/Framework/Kernel/inc/MantidKernel/VMD.h
@@ -247,6 +247,7 @@ public:
       throw std::invalid_argument("nd must be > 0");
     data = new TYPE[nd];
     std::copy(vals.cbegin(), vals.cend(), data);
+  }
 
   //-------------------------------------------------------------------------------------------
   /// Destructor

--- a/Framework/Kernel/inc/MantidKernel/VMD.h
+++ b/Framework/Kernel/inc/MantidKernel/VMD.h
@@ -234,12 +234,12 @@ public:
     boost::split(strs, str, boost::is_any_of(", "));
 
     std::vector<TYPE> vals;
-    for (size_t d = 0; d < strs.size(); d++) {
-      if (!strs[d].empty()) {
+    for (auto &str : strs) {
+      if (!str.empty()) {
         TYPE v;
-        if (!Strings::convert(strs[d], v))
+        if (!Strings::convert(str, v))
           throw std::invalid_argument(
-              "VMDBase: Unable to convert the string '" + strs[d] +
+              "VMDBase: Unable to convert the string '" + str +
               "' to a number.");
         vals.push_back(v);
       }

--- a/Framework/Kernel/inc/MantidKernel/VMD.h
+++ b/Framework/Kernel/inc/MantidKernel/VMD.h
@@ -234,7 +234,7 @@ public:
     boost::split(strs, str, boost::is_any_of(", "));
 
     std::vector<TYPE> vals;
-    for (auto &str : strs) {
+    for (const auto &str : strs) {
       if (!str.empty()) {
         TYPE v;
         if (!Strings::convert(str, v))

--- a/Framework/Kernel/inc/MantidKernel/VMD.h
+++ b/Framework/Kernel/inc/MantidKernel/VMD.h
@@ -2,6 +2,7 @@
 #define MANTID_KERNEL_VMD_H_
 
 #include "MantidKernel/Strings.h"
+#include "MantidKernel/StringTokenizer.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Tolerance.h"
 #include "MantidKernel/V3D.h"
@@ -227,30 +228,25 @@ public:
    * @param str :: string of comma or space-separated numbers for each component
    */
   VMDBase(const std::string &str) {
-    using boost::algorithm::split;
-    using boost::algorithm::is_any_of;
 
-    std::vector<std::string> strs;
-    boost::split(strs, str, boost::is_any_of(", "));
+    StringTokenizer strs(str, ", ", StringTokenizer::TOK_IGNORE_EMPTY);
 
     std::vector<TYPE> vals;
-    for (const auto &str : strs) {
-      if (!str.empty()) {
-        TYPE v;
-        if (!Strings::convert(str, v))
-          throw std::invalid_argument(
-              "VMDBase: Unable to convert the string '" + str +
-              "' to a number.");
-        vals.push_back(v);
-      }
-    }
+    std::transform(strs.cbegin(), strs.cend(), std::back_inserter(vals),
+                   [](const std::string &token) {
+                     TYPE v;
+                     if (!Strings::convert(token, v))
+                       throw std::invalid_argument(
+                           "VMDBase: Unable to convert the string '" + token +
+                           "' to a number.");
+                     return v;
+                   });
+
     nd = vals.size();
     if (nd <= 0)
       throw std::invalid_argument("nd must be > 0");
     data = new TYPE[nd];
-    for (size_t d = 0; d < nd; d++)
-      data[d] = vals[d];
-  }
+    std::copy(vals.cbegin(), vals.cend(), data);
 
   //-------------------------------------------------------------------------------------------
   /// Destructor

--- a/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -362,7 +362,7 @@ void IntegrateMDHistoWorkspace::exec() {
     auto outIterators = outWS->createIterators(nThreads, nullptr);
 
     PARALLEL_FOR_NO_WSP_CHECK()
-    for (int i = 0; i < int(outIterators.size()); ++i) {
+    for (int i = 0; i < int(outIterators.size()); ++i) { // NOLINT
       PARALLEL_START_INTERUPT_REGION
       boost::scoped_ptr<MDHistoWorkspaceIterator> outIterator(
           dynamic_cast<MDHistoWorkspaceIterator *>(outIterators[i]));

--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -329,7 +329,7 @@ void ReplicateMD::exec() {
   auto iterators = outputWS->createIterators(nThreads, nullptr);
 
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (int it = 0; it < int(iterators.size()); ++it) {
+  for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
     PARALLEL_START_INTERUPT_REGION
     auto outIt = std::unique_ptr<MDHistoWorkspaceIterator>(

--- a/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -121,7 +121,7 @@ SmoothMD::hatSmooth(IMDHistoWorkspace_const_sptr toSmooth,
   auto iterators = toSmooth->createIterators(nThreads, nullptr);
 
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (int it = 0; it < int(iterators.size()); ++it) {
+  for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
     PARALLEL_START_INTERUPT_REGION
     boost::scoped_ptr<MDHistoWorkspaceIterator> iterator(

--- a/Framework/MDAlgorithms/src/TransformMD.cpp
+++ b/Framework/MDAlgorithms/src/TransformMD.cpp
@@ -84,7 +84,7 @@ void TransformMD::doTransform(
     API::IMDNode::sortObjByID(boxes);
 
   PARALLEL_FOR_IF(!ws->isFileBacked())
-  for (int i = 0; i < static_cast<int>(boxes.size()); i++) {
+  for (int i = 0; i < static_cast<int>(boxes.size()); i++) { // NOLINT
     PARALLEL_START_INTERUPT_REGION
     MDBoxBase<MDE, nd> *box = dynamic_cast<MDBoxBase<MDE, nd> *>(boxes[i]);
     if (box) {

--- a/Framework/MDAlgorithms/src/TransposeMD.cpp
+++ b/Framework/MDAlgorithms/src/TransposeMD.cpp
@@ -139,7 +139,7 @@ void TransposeMD::exec() {
   auto iterators = inWS->createIterators(nThreads, nullptr);
 
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (int it = 0; it < int(iterators.size()); ++it) {
+  for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
     PARALLEL_START_INTERUPT_REGION
     auto inIterator = std::unique_ptr<IMDIterator>(iterators[it]);

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
@@ -50,7 +50,7 @@ struct MANTID_SINQ_DLL Poldi2DHelper {
     dFractionalOffsets.clear();
     dOffsets.clear();
 
-    for (double offset : offsets) {
+    for (const double offset : offsets) {
       double dEquivalent = Conversions::TOFtoD(offset, distance, sinTheta);
       double rounded = floor(dEquivalent / deltaD + 0.5);
       dOffsets.push_back(static_cast<int>(rounded));

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
@@ -50,8 +50,8 @@ struct MANTID_SINQ_DLL Poldi2DHelper {
     dFractionalOffsets.clear();
     dOffsets.clear();
 
-    for (auto it = offsets.begin(); it != offsets.end(); ++it) {
-      double dEquivalent = Conversions::TOFtoD(*it, distance, sinTheta);
+    for (double offset : offsets) {
+      double dEquivalent = Conversions::TOFtoD(offset, distance, sinTheta);
       double rounded = floor(dEquivalent / deltaD + 0.5);
       dOffsets.push_back(static_cast<int>(rounded));
       dFractionalOffsets.push_back(dEquivalent - rounded * deltaD);

--- a/Framework/SINQ/src/PoldiUtilities/PoldiResidualCorrelationCore.cpp
+++ b/Framework/SINQ/src/PoldiUtilities/PoldiResidualCorrelationCore.cpp
@@ -134,7 +134,8 @@ void PoldiResidualCorrelationCore::correctCountData() const {
   double ratio = sumOfResiduals / numberOfCells;
 
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (int i = 0; i < static_cast<int>(m_detectorElements.size()); ++i) {
+  for (int i = 0; i < static_cast<int>(m_detectorElements.size());
+       ++i) { // NOLINT
     int element = m_detectorElements[i];
     for (int j = 0; j < m_timeBinCount; ++j) {
       addToCountData(element, j, -ratio);

--- a/Framework/SINQ/src/PoldiUtilities/PoldiResidualCorrelationCore.cpp
+++ b/Framework/SINQ/src/PoldiUtilities/PoldiResidualCorrelationCore.cpp
@@ -134,8 +134,8 @@ void PoldiResidualCorrelationCore::correctCountData() const {
   double ratio = sumOfResiduals / numberOfCells;
 
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (int i = 0; i < static_cast<int>(m_detectorElements.size());
-       ++i) { // NOLINT
+  for (int i = 0; i < static_cast<int>(m_detectorElements.size()); // NOLINT
+       ++i) {
     int element = m_detectorElements[i];
     for (int j = 0; j < m_timeBinCount; ++j) {
       addToCountData(element, j, -ratio);


### PR DESCRIPTION
Description of work.

I reran clang-tidy's modernize-loop-convert check on Mantid Framework, letting it make changes, and reviewing the results.  Ignoring files in `GSoapGenerated/*`, this should bring the number of warnings from modernize-loop-convert down to 0.

**To test:**

Review changes to verify that the functionality is the same. 

<!-- Instructions for testing. -->

There is no issue related to this PR.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
