### PR TITLE
Replace critical region in cow_ptr by std::mutex/lock_guard for better performance

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/cow_ptr.h
+++ b/Framework/Kernel/inc/MantidKernel/cow_ptr.h
@@ -8,6 +8,7 @@
 #include <boost/make_shared.hpp>
 #endif
 
+#include <mutex>
 #include <vector>
 
 namespace Mantid {
@@ -60,9 +61,12 @@ public:
 
 private:
   ptr_type Data; ///< Real object Ptr
+  std::mutex copyMutex;
 
 public:
   cow_ptr();
+  cow_ptr(const cow_ptr<DataType> &);
+  cow_ptr<DataType> &operator=(const cow_ptr<DataType> &);
   cow_ptr<DataType> &operator=(const ptr_type &);
 
   const DataType &operator*() const {
@@ -85,6 +89,30 @@ cow_ptr<DataType>::cow_ptr()
     : Data(boost::make_shared<DataType>()) {}
 
 /**
+  Copy constructor : double references the data object
+  @param A :: object to copy
+*/
+// Note: Need custom implementation, since std::mutex is not copyable.
+template <typename DataType>
+cow_ptr<DataType>::cow_ptr(const cow_ptr<DataType> &A)
+    : Data(A.Data) {}
+
+/**
+  Assignment operator : double references the data object
+  maybe drops the old reference.
+  @param A :: object to copy
+  @return *this
+*/
+// Note: Need custom implementation, since std::mutex is not copyable.
+template <typename DataType>
+cow_ptr<DataType> &cow_ptr<DataType>::operator=(const cow_ptr<DataType> &A) {
+  if (this != &A) {
+    Data = A.Data;
+  }
+  return *this;
+}
+
+/**
   Assignment operator : double references the data object
   maybe drops the old reference.
   @param A :: object to copy
@@ -105,18 +133,14 @@ cow_ptr<DataType> &cow_ptr<DataType>::operator=(const ptr_type &A) {
   @return new copy of *this, if required
 */
 template <typename DataType> DataType &cow_ptr<DataType>::access() {
-  // Use a double-check for sharing so that we only
-  // enter the critical region if absolutely necessary
+  // Use a double-check for sharing so that we only acquire the lock if
+  // absolutely necessary
   if (!Data.unique()) {
-    PARALLEL_CRITICAL(cow_ptr_access) {
-      // Check again because another thread may have taken copy
-      // and dropped reference count since previous check
-      if (!Data.unique()) {
-        ptr_type oldData = Data;
-        Data.reset();
-        Data = ptr_type(new DataType(*oldData));
-      }
-    }
+    std::lock_guard<std::mutex> lock{copyMutex};
+    // Check again because another thread may have taken copy and dropped
+    // reference count since previous check
+    if (!Data.unique())
+      Data = boost::make_shared<DataType>(*Data);
   }
 
   return *Data;

--- a/Framework/Kernel/inc/MantidKernel/cow_ptr.h
+++ b/Framework/Kernel/inc/MantidKernel/cow_ptr.h
@@ -66,7 +66,9 @@ private:
 public:
   cow_ptr();
   cow_ptr(const cow_ptr<DataType> &);
+  cow_ptr(cow_ptr<DataType> &&) = default;
   cow_ptr<DataType> &operator=(const cow_ptr<DataType> &);
+  cow_ptr<DataType> &operator=(cow_ptr<DataType> &&) = default;
   cow_ptr<DataType> &operator=(const ptr_type &);
 
   const DataType &operator*() const {

--- a/Framework/Kernel/src/Atom.cpp
+++ b/Framework/Kernel/src/Atom.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <sstream>
+#include <stdexcept>
 #include "MantidKernel/Atom.h"
 #include "MantidKernel/PhysicalConstants.h"
 #include <boost/math/special_functions/fpclassify.hpp>

--- a/Framework/Kernel/src/NeutronAtom.cpp
+++ b/Framework/Kernel/src/NeutronAtom.cpp
@@ -5,6 +5,7 @@
 #include "MantidKernel/PhysicalConstants.h"
 #include <algorithm>
 #include <sstream>
+#include <stdexcept>
 #include <boost/math/special_functions/fpclassify.hpp>
 
 namespace Mantid {


### PR DESCRIPTION
The class `cow_ptr` is used for the histogram data (`X`, `Y`, and `E`) in our matrix workspaces to provide a copy-on-write mechanism. Before these changes this copy was made thread-safe via a critical region (OpenMP). However, this basically corresponds to a global lock, i.e., if thread 1 copies spectrum 42, thread 2 cannot at the same time copy spectrum 13.
This PR adds a `std::mutex` variable to `cow_ptr`. The critical region is replaced with a `std::lock_guard` based on this mutex, i.e., we now have a local lock and different sprectra can be copied at the same time.

This may potentially yield significant speed-up for algorithms that work with, e.g., `Workspace2D`.

**To test:**

Code review.
No corresponding issue.
There may be changes to the release note in case we notice a significant speed-up for certain algorithms. I suggest we update the release notes at a later point, once we had a look at our performance tests.

[Release notes](/docs/source/release/)

<!-- Replace with a link above to the updated file or state "Does not need to be in the release notes." -->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
