### PR TITLE
Ensure correct units of the workspace that is the output of DPDFReduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -292,6 +292,10 @@ class DPDFreduction(PythonAlgorithm):
         api.ConvertMDHistoToMatrixWorkspace(InputWorkspace=wn_sqeb,
                                             Normalization='NumEventsNormalization', OutputWorkspace=wn_sqes)
 
+        # Ensure correct units
+        api.mtd[wn_sqes].getAxis(0).setUnit("MomentumTransfer")
+        api.mtd[wn_sqes].getAxis(1).setUnit("DeltaE")
+
         # Shift the energy axis, since the reported values should be the center
         # of the bins, instead of the minimum bin boundary
         ws_sqes = api.mtd[wn_sqes]
@@ -308,7 +312,7 @@ class DPDFreduction(PythonAlgorithm):
         # Clean up workspaces from intermediate steps
         if self._clean:
             for name in (wn_van, wn_reduced, wn_ste, wn_van_st, wn_sten,
-                         wn_steni, wn_sqe, wn_sqeb, wn_sqesn):
+                         wn_steni, wn_sqe, wn_sqeb):
                 api.DeleteWorkspace(name)
             if api.mtd.doesExist('PreprocessedDetectorsWS'):
                 api.DeleteWorkspace('PreprocessedDetectorsWS')

--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -91,6 +91,10 @@ class DPDFreduction(PythonAlgorithm):
 
     #pylint: disable=too-many-locals, too-many-branches
     def PyExec(self):
+        # Save current configuration
+        facility = config['default.facility']
+        instrument = config['default.instrument']
+        # Allows searching for ARCS run numbers
         config['default.facility'] = 'SNS'
         config['default.instrument'] = 'ARCS'
         self._runs = self.getProperty('RunNumbers').value
@@ -126,18 +130,24 @@ class DPDFreduction(PythonAlgorithm):
         if datasearch != "On":
             config["datasearch.searcharchive"] = "On"
 
-        # Load several event files into a sinle workspace. The nominal incident
-        # energy should be the same to avoid difference in energy resolution
-        api.Load(Filename=self._runs, OutputWorkspace=wn_data)
+        try:
+            # Load several event files into a sinle workspace. The nominal incident
+            # energy should be the same to avoid difference in energy resolution
+            api.Load(Filename=self._runs, OutputWorkspace=wn_data)
 
-        # Load the vanadium file, assume to be preprocessed, meaning that
-        # for every detector all events whithin a particular wide wavelength
-        # range have been rebinned into a single histogram
-        api.Load(Filename=self._vanfile, OutputWorkspace=wn_van)
+            # Load the vanadium file, assume to be preprocessed, meaning that
+            # for every detector all events whithin a particular wide wavelength
+            # range have been rebinned into a single histogram
+            api.Load(Filename=self._vanfile, OutputWorkspace=wn_van)
 
-        # Load empty can event files, if present
-        if self._ecruns:
-            api.Load(Filename=self._ecruns, OutputWorkspace=wn_ec_data)
+            # Load empty can event files, if present
+            if self._ecruns:
+                api.Load(Filename=self._ecruns, OutputWorkspace=wn_ec_data)
+        finally:
+            # Recover the default configuration
+            config['default.facility'] = facility
+            config['default.instrument'] = instrument
+            config["datasearch.searcharchive"] = datasearch
 
         # Retrieve the mask from the vanadium workspace, and apply it to the data
         # (and empty can, if submitted)
@@ -312,10 +322,9 @@ class DPDFreduction(PythonAlgorithm):
         # Clean up workspaces from intermediate steps
         if self._clean:
             for name in (wn_van, wn_reduced, wn_ste, wn_van_st, wn_sten,
-                         wn_steni, wn_sqe, wn_sqeb):
-                api.DeleteWorkspace(name)
-            if api.mtd.doesExist('PreprocessedDetectorsWS'):
-                api.DeleteWorkspace('PreprocessedDetectorsWS')
+                         wn_steni, wn_sqe, wn_sqeb, wn_sqesn, 'PreprocessedDetectorsWS'):
+                if api.mtd.doesExist(name):
+                    api.DeleteWorkspace(name)
 
         # Ouput some info
         message = '\n******  SOME OUTPUT INFORMATION ***' + \


### PR DESCRIPTION
Description of work.

**To test:**

1.Download vanadium file [van56293.nxs](https://www.dropbox.com/s/tjkw8zwet3lvl8k/van56293.nxs?dl=0) and python script [reduction_test.py](https://www.dropbox.com/s/2wg3013a5nycyh0/reduction_test.py?dl=0).
2. Edit script to change the path of the directory where you saved the vanadium file.
3. Load and execute the python script in the python window of MantidPlot.
4. Verify the units of output workspace `slice_QE`.

Fixes #15588.

No release notes are necessary
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
