### PR TITLE
Indirect Data Analysis Jump Fit - Remove Load button from JumpFit UI

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
@@ -31,8 +31,8 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="loadLabelText" stdset="0">
-        <string>Plot</string>
+       <property name="showLoad" stdset="0">
+         <bool>false</bool>
        </property>
        <property name="workspaceSuffixes" stdset="0">
         <stringlist>

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -21,6 +21,7 @@ Jump Fit
 ~~~~~~~~
 
 - The interface now has the option to plot a guess of what the fit will look like before running the algorithm.
+- The Plot button is no longer present in the interface as it is no longer used.
 
 Improvements
 ------------


### PR DESCRIPTION
The Load button has been removed from the JumpFit UI
# To test
- Open JumpFit (Interfaces > Indirect > Data Analysis > JumpFit)
- Observe that the `Plot` button is no longer in the top right corner of the interface.
  - The interface used to look like this:
    ![image](https://cloud.githubusercontent.com/assets/13132128/13633386/98a8417e-e5e6-11e5-965c-95dd37588ad0.png)
- It will now look the same but with no button in the top right labelled `Plot`

Fixes #15492 

**[Release notes](https://github.com/mantidproject/mantid/pull/15621/files?short_path=8f6fe6e#diff-8f6fe6e661f2504b69d18f4089286657)**

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Refs #15492
