### PR TITLE
ApplyDeadTimeCorr: add validation for bin size

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ApplyDeadTimeCorr.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ApplyDeadTimeCorr.h
@@ -44,7 +44,7 @@ public:
   const std::string name() const override { return "ApplyDeadTimeCorr"; };
   /// Summary of algorithms purpose
   const std::string summary() const override {
-    return "Apply deadtime correction to each spectra of a workspace.";
+    return "Apply deadtime correction to each spectrum of a workspace.";
   }
 
   /// Algorithm's version for identification
@@ -59,6 +59,8 @@ private:
   void init() override;
   /// Run the algorithm
   void exec() override;
+  /// Validate the inputs
+  std::map<std::string, std::string> validateInputs() override;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/ApplyDeadTimeCorr.cpp
+++ b/Framework/Algorithms/src/ApplyDeadTimeCorr.cpp
@@ -130,5 +130,43 @@ void ApplyDeadTimeCorr::exec() {
   }
 }
 
+/**
+ * Validates input properties:
+ * - input workspace must have all bins the same size (within reasonable error)
+ * @returns :: map of property names to error strings (empty if no error)
+ */
+std::map<std::string, std::string> ApplyDeadTimeCorr::validateInputs() {
+  std::map<std::string, std::string> errors;
+  MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
+  if (inputWS) { // in case input was a WorkspaceGroup
+    const MantidVec &xValues = inputWS->readX(0);
+    const size_t xSize = xValues.size();
+    if (xSize < 2) {
+      errors["InputWorkspace"] = "Input workspace cannot be empty";
+    } else {
+      // average bin width
+      const double dx =
+          (xValues[xSize - 1] - xValues[0]) / static_cast<double>(xSize - 1);
+
+      // Use cumulative errors
+      auto difference = [&xValues, &dx](size_t i) {
+        return std::abs((xValues[i] - xValues[0] - (double)i * dx) / dx);
+      };
+
+      // Check each width against dx
+      constexpr double tolerance = 0.5;
+      for (size_t i = 1; i < xValues.size() - 2; i++) {
+        if (difference(i) > tolerance) {
+          g_log.error() << "dx=" << xValues[i + 1] - xValues[i] << ' ' << dx
+                        << ' ' << i << std::endl;
+          errors["InputWorkspace"] = "Uneven bin widths in input workspace";
+          break;
+        }
+      }
+    }
+  }
+  return errors;
+}
+
 } // namespace Mantid
 } // namespace Algorithms

--- a/Framework/Algorithms/test/ApplyDeadTimeCorrTest.h
+++ b/Framework/Algorithms/test/ApplyDeadTimeCorrTest.h
@@ -60,7 +60,8 @@ public:
     numGoodFrames =
         boost::lexical_cast<double>(run.getProperty("goodfrm")->value());
 
-    MatrixWorkspace_sptr outputWs = applyDeadTime.getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr outputWs =
+        applyDeadTime.getProperty("OutputWorkspace");
     TS_ASSERT(outputWs);
 
     TS_ASSERT_EQUALS(
@@ -146,7 +147,8 @@ public:
     numGoodFrames =
         boost::lexical_cast<double>(run.getProperty("goodfrm")->value());
 
-    MatrixWorkspace_sptr outputWs = applyDeadTime.getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr outputWs =
+        applyDeadTime.getProperty("OutputWorkspace");
     TS_ASSERT(outputWs);
 
     TS_ASSERT_EQUALS(outputWs->dataY(0)[0], inputWs->dataY(0)[0]);
@@ -156,7 +158,7 @@ public:
             (1 -
              inputWs->dataY(14)[40] *
                  (g_deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
-                               numGoodFrames))));
+                                 numGoodFrames))));
     TS_ASSERT_EQUALS(outputWs->dataY(31)[20], inputWs->dataY(31)[20]);
 
     // Should be the same (no dead time associated with it)

--- a/Framework/Algorithms/test/ApplyDeadTimeCorrTest.h
+++ b/Framework/Algorithms/test/ApplyDeadTimeCorrTest.h
@@ -19,6 +19,9 @@ using namespace Mantid::Algorithms;
 using namespace Mantid::API;
 
 class ApplyDeadTimeCorrTest : public CxxTest::TestSuite {
+private:
+  constexpr static double g_deadValue{-0.00456};
+
 public:
   void testName() {
     ApplyDeadTimeCorr applyDeadTime;
@@ -232,8 +235,6 @@ private:
     TS_ASSERT(data);
     return matrixWS;
   }
-
-  constexpr static double g_deadValue{-0.00456};
 };
 
 #endif /* MANTID_ALGORITHMS_APPLYDEADTIMECORRTEST_H_ */

--- a/Framework/Algorithms/test/ApplyDeadTimeCorrTest.h
+++ b/Framework/Algorithms/test/ApplyDeadTimeCorrTest.h
@@ -19,9 +19,6 @@ using namespace Mantid::Algorithms;
 using namespace Mantid::API;
 
 class ApplyDeadTimeCorrTest : public CxxTest::TestSuite {
-private:
-  constexpr static double g_deadValue{-0.00456};
-
 public:
   void testName() {
     ApplyDeadTimeCorr applyDeadTime;
@@ -72,21 +69,21 @@ public:
         inputWs->dataY(0)[0] /
             (1 -
              inputWs->dataY(0)[0] *
-                 (g_deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
+                 (deadValue() / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
                                  numGoodFrames))));
     TS_ASSERT_EQUALS(
         outputWs->dataY(0)[40],
         inputWs->dataY(0)[40] /
             (1 -
              inputWs->dataY(0)[40] *
-                 (g_deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
+                 (deadValue() / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
                                  numGoodFrames))));
     TS_ASSERT_EQUALS(
         outputWs->dataY(31)[20],
         inputWs->dataY(31)[20] /
             (1 -
              inputWs->dataY(31)[20] *
-                 (g_deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
+                 (deadValue() / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
                                  numGoodFrames))));
 
     TS_ASSERT_DELTA(35.9991, outputWs->dataY(12)[2], 0.001);
@@ -126,7 +123,7 @@ public:
     // Spectrum: 3,6,9,12,15,18,21 .....
     for (int i = 0; i < 7; ++i) {
       Mantid::API::TableRow row = deadTimes->appendRow();
-      row << (i + 1) * 3 << g_deadValue;
+      row << (i + 1) * 3 << deadValue();
     }
 
     //.... Index will therefore be 2,5,8,11,14,17,20
@@ -160,7 +157,7 @@ public:
         inputWs->dataY(14)[40] /
             (1 -
              inputWs->dataY(14)[40] *
-                 (g_deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
+                 (deadValue() / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
                                  numGoodFrames))));
     TS_ASSERT_EQUALS(outputWs->dataY(31)[20], inputWs->dataY(31)[20]);
 
@@ -213,7 +210,7 @@ private:
     deadTimes->addColumn("double", "DeadTime Value");
     for (size_t i = 0; i < numSpectra; i++) {
       Mantid::API::TableRow row = deadTimes->appendRow();
-      row << static_cast<int>(i + 1) << g_deadValue;
+      row << static_cast<int>(i + 1) << deadValue();
     }
     return deadTimes;
   }
@@ -235,6 +232,9 @@ private:
     TS_ASSERT(data);
     return matrixWS;
   }
+
+  /// Test dead time value
+  double deadValue() const { return -0.00456; }
 };
 
 #endif /* MANTID_ALGORITHMS_APPLYDEADTIMECORRTEST_H_ */

--- a/Framework/Algorithms/test/ApplyDeadTimeCorrTest.h
+++ b/Framework/Algorithms/test/ApplyDeadTimeCorrTest.h
@@ -4,13 +4,10 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidDataHandling/LoadMuonNexus2.h"
-#include "MantidDataHandling/LoadInstrument.h"
-#include "MantidDataHandling/GroupDetectors.h"
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidAlgorithms/ApplyDeadTimeCorr.h"
 #include "MantidAPI/Workspace.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidAPI/AnalysisDataService.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -24,53 +21,35 @@ using namespace Mantid::API;
 class ApplyDeadTimeCorrTest : public CxxTest::TestSuite {
 public:
   void testName() {
+    ApplyDeadTimeCorr applyDeadTime;
     TS_ASSERT_EQUALS(applyDeadTime.name(), "ApplyDeadTimeCorr")
   }
 
   void testCategory() {
+    ApplyDeadTimeCorr applyDeadTime;
     TS_ASSERT_EQUALS(applyDeadTime.category(),
                      "Muon;CorrectionFunctions\\EfficiencyCorrections")
   }
 
   void testInit() {
+    ApplyDeadTimeCorr applyDeadTime;
     applyDeadTime.initialize();
     TS_ASSERT(applyDeadTime.isInitialized())
   }
 
   void testExec() {
-    loader.initialize();
-    loader.setPropertyValue("Filename", "emu00006473.nxs");
-    loader.setPropertyValue("OutputWorkspace", "EMU6473");
-    TS_ASSERT_THROWS_NOTHING(loader.execute());
-    TS_ASSERT_EQUALS(loader.isExecuted(), true);
+    MatrixWorkspace_sptr inputWs = loadDataFromFile();
+    auto deadTimes = makeDeadTimeTable(32);
 
-    MatrixWorkspace_sptr inputWs =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("EMU6473");
-
-    boost::shared_ptr<ITableWorkspace> tw(
-        new Mantid::DataObjects::TableWorkspace);
-
-    tw->addColumn("int", "Spectrum Number");
-    tw->addColumn("double", "DeadTime Value");
-
-    // Add data to table
-
-    double deadValue(-0.00456);
-
-    for (int i = 0; i < 32; ++i) {
-      Mantid::API::TableRow row = tw->appendRow();
-      row << i + 1 << deadValue;
-    }
-
-    AnalysisDataService::Instance().add("DeadTimeTable", tw);
-
+    ApplyDeadTimeCorr applyDeadTime;
+    applyDeadTime.initialize();
+    applyDeadTime.setChild(true);
     TS_ASSERT_THROWS_NOTHING(
-        applyDeadTime.setProperty("InputWorkspace", "EMU6473"));
+        applyDeadTime.setProperty("InputWorkspace", inputWs));
     TS_ASSERT_THROWS_NOTHING(
-        applyDeadTime.setProperty("DeadTimeTable", "DeadTimeTable"));
+        applyDeadTime.setProperty("DeadTimeTable", deadTimes));
     TS_ASSERT_THROWS_NOTHING(
-        applyDeadTime.setProperty("OutputWorkspace", "AppliedTest"));
-
+        applyDeadTime.setProperty("OutputWorkspace", "__NotUsed"));
     TS_ASSERT_THROWS_NOTHING(applyDeadTime.execute());
     TS_ASSERT(applyDeadTime.isExecuted());
 
@@ -81,122 +60,82 @@ public:
     numGoodFrames =
         boost::lexical_cast<double>(run.getProperty("goodfrm")->value());
 
-    MatrixWorkspace_sptr outputWs =
-        boost::dynamic_pointer_cast<MatrixWorkspace>(
-            AnalysisDataService::Instance().retrieve("AppliedTest"));
+    MatrixWorkspace_sptr outputWs = applyDeadTime.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWs);
 
     TS_ASSERT_EQUALS(
         outputWs->dataY(0)[0],
         inputWs->dataY(0)[0] /
             (1 -
              inputWs->dataY(0)[0] *
-                 (deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
-                               numGoodFrames))));
+                 (g_deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
+                                 numGoodFrames))));
     TS_ASSERT_EQUALS(
         outputWs->dataY(0)[40],
         inputWs->dataY(0)[40] /
             (1 -
              inputWs->dataY(0)[40] *
-                 (deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
-                               numGoodFrames))));
+                 (g_deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
+                                 numGoodFrames))));
     TS_ASSERT_EQUALS(
         outputWs->dataY(31)[20],
         inputWs->dataY(31)[20] /
             (1 -
              inputWs->dataY(31)[20] *
-                 (deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
-                               numGoodFrames))));
+                 (g_deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
+                                 numGoodFrames))));
 
     TS_ASSERT_DELTA(35.9991, outputWs->dataY(12)[2], 0.001);
     TS_ASSERT_DELTA(4901.5439, outputWs->dataY(20)[14], 0.001);
-
-    AnalysisDataService::Instance().remove("EMU6473");
-    AnalysisDataService::Instance().remove("DeadTimeTable");
-    AnalysisDataService::Instance().remove("AppliedTest");
   }
 
   void testDifferentSize() {
-    loader.initialize();
-    loader.setPropertyValue("Filename", "emu00006473.nxs");
-    loader.setPropertyValue("OutputWorkspace", "EMU6473");
-    TS_ASSERT_THROWS_NOTHING(loader.execute());
-    TS_ASSERT_EQUALS(loader.isExecuted(), true);
-
-    MatrixWorkspace_sptr inputWs =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("EMU6473");
-
-    boost::shared_ptr<ITableWorkspace> tw(
-        new Mantid::DataObjects::TableWorkspace);
-
-    tw->addColumn("int", "Spectrum Number");
-    tw->addColumn("double", "DeadTime Value");
-
-    // Add data to table
-
-    const double deadValue(-0.00456);
+    MatrixWorkspace_sptr inputWs = loadDataFromFile();
 
     // Bigger row count than file (expect to fail)
-    for (int i = 0; i < 64; ++i) {
-      Mantid::API::TableRow row = tw->appendRow();
-      row << i + 1 << deadValue;
-    }
+    auto deadTimes = makeDeadTimeTable(64);
 
-    AnalysisDataService::Instance().add("DeadTimeTable", tw);
-
+    ApplyDeadTimeCorr applyDeadTime;
+    applyDeadTime.initialize();
+    applyDeadTime.setChild(true);
     TS_ASSERT_THROWS_NOTHING(
-        applyDeadTime.setProperty("InputWorkspace", "EMU6473"));
+        applyDeadTime.setProperty("InputWorkspace", inputWs));
     TS_ASSERT_THROWS_NOTHING(
-        applyDeadTime.setProperty("DeadTimeTable", "DeadTimeTable"));
+        applyDeadTime.setProperty("DeadTimeTable", deadTimes));
     TS_ASSERT_THROWS_NOTHING(
-        applyDeadTime.setProperty("OutputWorkspace", "AppliedTest"));
-
-    TS_ASSERT_THROWS_NOTHING(applyDeadTime.execute());
-    TS_ASSERT(applyDeadTime.isExecuted());
+        applyDeadTime.setProperty("OutputWorkspace", "__NotUsed"));
+    TS_ASSERT_THROWS(applyDeadTime.execute(), std::logic_error);
 
     // Check new table wasn't created
-    TS_ASSERT(!(AnalysisDataService::Instance().doesExist("AppliedTest")));
-
-    AnalysisDataService::Instance().remove("EMU6473");
-    AnalysisDataService::Instance().remove("DeadTimeTable");
+    MatrixWorkspace_sptr output = applyDeadTime.getProperty("OutputWorkspace");
+    TS_ASSERT(!output);
   }
 
   void testSelectedSpectrum() {
-    loader.initialize();
-    loader.setPropertyValue("Filename", "emu00006473.nxs");
-    loader.setPropertyValue("OutputWorkspace", "EMU6473");
-    TS_ASSERT_THROWS_NOTHING(loader.execute());
-    TS_ASSERT_EQUALS(loader.isExecuted(), true);
+    MatrixWorkspace_sptr inputWs = loadDataFromFile();
 
-    MatrixWorkspace_sptr inputWs =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("EMU6473");
-
-    boost::shared_ptr<ITableWorkspace> tw(
-        new Mantid::DataObjects::TableWorkspace);
-
-    tw->addColumn("int", "Spectrum Number");
-    tw->addColumn("double", "DeadTime Value");
-
-    // Add data to table
-
-    const double deadValue(-0.00456);
+    boost::shared_ptr<ITableWorkspace> deadTimes =
+        boost::make_shared<Mantid::DataObjects::TableWorkspace>();
+    deadTimes->addColumn("int", "Spectrum Number");
+    deadTimes->addColumn("double", "DeadTime Value");
 
     // Spectrum: 3,6,9,12,15,18,21 .....
     for (int i = 0; i < 7; ++i) {
-      Mantid::API::TableRow row = tw->appendRow();
-      row << (i + 1) * 3 << deadValue;
+      Mantid::API::TableRow row = deadTimes->appendRow();
+      row << (i + 1) * 3 << g_deadValue;
     }
 
     //.... Index will therefore be 2,5,8,11,14,17,20
 
-    AnalysisDataService::Instance().add("DeadTimeTable", tw);
-
+    ApplyDeadTimeCorr applyDeadTime;
+    applyDeadTime.initialize();
+    applyDeadTime.setChild(true);
     TS_ASSERT_THROWS_NOTHING(
-        applyDeadTime.setProperty("InputWorkspace", "EMU6473"));
+        applyDeadTime.setProperty("InputWorkspace", inputWs));
     TS_ASSERT_THROWS_NOTHING(
-        applyDeadTime.setProperty("DeadTimeTable", "DeadTimeTable"));
+        applyDeadTime.setProperty("DeadTimeTable", deadTimes));
     TS_ASSERT_THROWS_NOTHING(
-        applyDeadTime.setProperty("OutputWorkspace", "AppliedTest"));
-
+        applyDeadTime.setProperty("OutputWorkspace", "__NotUsed"));
     TS_ASSERT_THROWS_NOTHING(applyDeadTime.execute());
     TS_ASSERT(applyDeadTime.isExecuted());
 
@@ -207,9 +146,8 @@ public:
     numGoodFrames =
         boost::lexical_cast<double>(run.getProperty("goodfrm")->value());
 
-    MatrixWorkspace_sptr outputWs =
-        boost::dynamic_pointer_cast<MatrixWorkspace>(
-            AnalysisDataService::Instance().retrieve("AppliedTest"));
+    MatrixWorkspace_sptr outputWs = applyDeadTime.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWs);
 
     TS_ASSERT_EQUALS(outputWs->dataY(0)[0], inputWs->dataY(0)[0]);
     TS_ASSERT_EQUALS(
@@ -217,7 +155,7 @@ public:
         inputWs->dataY(14)[40] /
             (1 -
              inputWs->dataY(14)[40] *
-                 (deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
+                 (g_deadValue / ((inputWs->dataX(0)[1] - inputWs->dataX(0)[0]) *
                                numGoodFrames))));
     TS_ASSERT_EQUALS(outputWs->dataY(31)[20], inputWs->dataY(31)[20]);
 
@@ -226,10 +164,6 @@ public:
 
     // Should be new value (dead time applied based on spectrum number)
     TS_ASSERT_DELTA(4901.5439, outputWs->dataY(20)[14], 0.001);
-
-    AnalysisDataService::Instance().remove("EMU6473");
-    AnalysisDataService::Instance().remove("DeadTimeTable");
-    AnalysisDataService::Instance().remove("AppliedTest");
   }
 
   /// Test algorithm rejects an input workspace with uneven bin widths
@@ -268,20 +202,36 @@ private:
    * @returns :: Dead time table
    */
   boost::shared_ptr<ITableWorkspace> makeDeadTimeTable(size_t numSpectra) {
-    constexpr static double deadValue(-0.00456);
     boost::shared_ptr<ITableWorkspace> deadTimes =
         boost::make_shared<Mantid::DataObjects::TableWorkspace>();
     deadTimes->addColumn("int", "Spectrum Number");
     deadTimes->addColumn("double", "DeadTime Value");
     for (size_t i = 0; i < numSpectra; i++) {
       Mantid::API::TableRow row = deadTimes->appendRow();
-      row << static_cast<int>(i + 1) << deadValue;
+      row << static_cast<int>(i + 1) << g_deadValue;
     }
     return deadTimes;
   }
 
-  ApplyDeadTimeCorr applyDeadTime;
-  Mantid::DataHandling::LoadMuonNexus2 loader;
+  /**
+   * Loads data from the test data file
+   * @returns :: Workspace with loaded data
+   */
+  MatrixWorkspace_sptr loadDataFromFile() {
+    Mantid::DataHandling::LoadMuonNexus2 loader;
+    loader.initialize();
+    loader.setChild(true);
+    loader.setPropertyValue("Filename", "emu00006473.nxs");
+    loader.setPropertyValue("OutputWorkspace", "__NotUsed");
+    TS_ASSERT_THROWS_NOTHING(loader.execute());
+    TS_ASSERT_EQUALS(loader.isExecuted(), true);
+    Workspace_sptr data = loader.getProperty("OutputWorkspace");
+    auto matrixWS = boost::dynamic_pointer_cast<MatrixWorkspace>(data);
+    TS_ASSERT(data);
+    return matrixWS;
+  }
+
+  constexpr static double g_deadValue{-0.00456};
 };
 
 #endif /* MANTID_ALGORITHMS_APPLYDEADTIMECORRTEST_H_ */

--- a/docs/source/algorithms/ApplyDeadTimeCorr-v1.rst
+++ b/docs/source/algorithms/ApplyDeadTimeCorr-v1.rst
@@ -29,6 +29,10 @@ where
 1. Integer type, containing spectrum number (not index)
 2. Double type, containing :math:`t_{dead}` value of the spectrum
 
+It is assumed that all bins in the *InputWorkspace* are the same 
+size (to within reasonable rounding error). 
+If they are not, the algorithm will exit with an error.
+
 Usage
 -----
 


### PR DESCRIPTION
`ApplyDeadTimeCorr` assumes that all bins are the same size. This assumption was not documented previously, and the input workspace was not checked to ensure that this was the case.

Added validation of the input workspace. The algorithm will accept small rounding errors in X, but throw out large variations in the bin width. 

Added a test with uneven bins and refactored the existing tests (since they were dependent on the run order and used the ADS).

Added a note to the algorithm documentation that the bins must be evenly spaced.

There is now similar validation of bin size in `ApplyDeadTimeCorr`, `FFT` and `MaxEnt` - and possibly others that I don't know about. This should be extracted into a common validator if possible (outside the scope of this issue, will create a new issue for it: #15659).

**To test:**
- Check that the new test covers the behaviour with uneven bins, and catches the regression if the fix is undone.
- Check that the algorithm still copes with real data (muon data can contain small rounding errors in X - `ApplyDeadTimeCorr` should still run with no error as long as the bins are equally sized discounting these errors). 
  Example: (file is in the unit test data folder)

``` python
Load(Filename='MUSR00022725.nxs', OutputWorkspace='MUSR00022725', DeadTimeTable='deadtimes')
ApplyDeadTimeCorr(InputWorkspace='MUSR00022725', DeadTimeTable='deadtimes', OutputWorkspace='corrected')

```
- Try loading a muon data file in the MuonAnalysis interface. Use the dropdown "Dead Time Correction" to switch between _None_ and _From Data File_. Correction should be applied without errors appearing in the log (the difference may be hard to see depending on the file used, a good one is `EMU00034998.nxs` from `\\olympic\babylon5\Scratch\TomPerkins\Data`).

Fixes #15538 

 _"Release notes do not need to be updated"_ since behaviour is the same from the user's perspective - the algorithm did not accept uneven bins before and it still doesn't (there is just more validation now). 

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
