### PR TITLE
Fix Engin-X system test on windows

### DIFF
--- a/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
+++ b/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
@@ -18,7 +18,7 @@ def rel_err_less_delta(val, ref, epsilon):
         return False
     check = (abs((ref-val)/ref) < epsilon)
     if not check:
-        print ("Val '{0}' differs from ref '{1}' by more than required epsilon '{2}'"
+        print ("Value '{0}' differs from reference '{1}' by more than required epsilon '{2}' (relative)"
                .format(val, ref, epsilon))
 
     return check
@@ -233,16 +233,19 @@ class EnginXCalibrateFullThenCalibrateTest(stresstesting.MantidStressTest):
             self.assertEquals(cell_val[-2:], '}}')
 
         # this will be used as a comparison delta in relative terms (percentage)
-        exdelta = exdelta_special = 1e-5
+        exdelta = exdelta_special = exdelta_tzero = 1e-5
         # Mac fitting tests produce differences for some reason.
         import sys
         if "darwin" == sys.platform:
             exdelta = 1e-2
             # Some tests need a bigger delta
-            exdelta_special = 1e-1
+            exdelta_tzero = exdelta_special = 1e-1
         if "win32" == sys.platform:
             exdelta = 5e-4 # this is needed especially for the zero parameter (error >=1e-4)
             exdelta_special = exdelta
+            # tzero is particularly sensitive on windows, but 2% looks acceptable considering we're
+            # not using all the peaks (for speed), and that the important parameter, DIFC, is ok.
+            exdelta_tzero = 2e-2
 
         # Note that the reference values are given with 12 digits more for reference than
         # for assert-comparison purposes (comparisons are not that picky, by far)
@@ -260,14 +263,14 @@ class EnginXCalibrateFullThenCalibrateTest(stresstesting.MantidStressTest):
         self.assertTrue(rel_err_less_delta(self.difc, 18403.4516907, exdelta_special),
                         "difc parameter for bank 1 is not what was expected, got: %f" % self.difc)
         if "darwin" != sys.platform:
-            self.assertTrue(rel_err_less_delta(self.zero, 5.23928765686, exdelta),
+            self.assertTrue(rel_err_less_delta(self.zero, 5.23928765686, exdelta_tzero),
                             "zero parameter for bank 1 is not what was expected, got: %f" % self.zero)
 
         # Bank 2
         self.assertTrue(rel_err_less_delta(self.difc_b2, 18388.8780161, exdelta_special),
                         "difc parameter for bank 2 is not what was expected, got: %f" % self.difc_b2)
         if "darwin" != sys.platform:
-            self.assertTrue(rel_err_less_delta(self.zero_b2, -4.35573786169, exdelta_special),
+            self.assertTrue(rel_err_less_delta(self.zero_b2, -4.35573786169, exdelta_tzero),
                             "zero parameter for bank 2 is not what was expected, got: %f" % self.zero_b2)
 
         # === peaks used to fit the difc and zero parameters ===

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -55,7 +55,7 @@ def read_in_expected_peaks(filename, expectedGiven):
 
         if not exPeakArray:
             # "File could not be read. Defaults in alternative option used."
-            if [] == expectedGiven:
+            if not expectedGiven:
                 raise ValueError("Could not read any peaks from the file given in 'ExpectedPeaksFromFile: '" +
                                  filename + "', and no expected peaks were given in the property "
                                  "'ExpectedPeaks' either. Cannot continue without a list of expected peaks.")


### PR DESCRIPTION
Increases the error tolerance for some comparisons.

**To test:**

Check changes (the tolerance for some comparisons has been increased when on windows).

I can't seem to make it fail on my windows 7 machine which really puzzles me.
I've observed slight differences between the windows 7 master build and the windows 10 master build (which fails in the same comparison).
The tolerance is modified so that it should be more than sufficient for the build servers.

If you run this locally I strongly advise using `-lnotice` or higher unless you want to be flooded with messages (slow down as well). To run only this test only you can use the option `-R EnggCalibrationTest.EnginXCalibrateFullThenCalib` with `runSystemsTests.py`.

Fixes #15626.

"Does not need to be in the release notes." 

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
