### PR TITLE
Changed formula for T0 on CNCS

### DIFF
--- a/docs/source/release/v3.7.0/direct_inelastic.rst
+++ b/docs/source/release/v3.7.0/direct_inelastic.rst
@@ -5,5 +5,10 @@ Direct Inelastic Changes
 .. contents:: Table of Contents
    :local:
 
+Improvements
+------------
+
+- New CNCS formula to calculate T0 accounts for different phasing of the choppers since August 2015
+
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Direct+Inelastic%22>`_
 

--- a/instrument/CNCS_Parameters_1-35154.xml
+++ b/instrument/CNCS_Parameters_1-35154.xml
@@ -191,8 +191,7 @@
 		
 		<!--   formula for t0 calculation. See http://muparser.sourceforge.net/mup_features.html#idDef2 for available operators-->
 		<parameter name="t0_formula" type="string">
-			<!--<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" /> Old formula (valid till august 2015) -->
-            <value val="157.539+ln(incidentEnergy)*(-33.04593+ln(incidentEnergy)*(-8.07523+ln(incidentEnergy)*(2.2143-0.109521767*ln(incidentEnergy))))"/>
+			<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" />
 		</parameter>
 
 		<parameter name="treat-background-as-events" type="string">

--- a/instrument/CNCS_Parameters_20120215-20120313.xml
+++ b/instrument/CNCS_Parameters_20120215-20120313.xml
@@ -191,8 +191,7 @@
 		
 		<!--   formula for t0 calculation. See http://muparser.sourceforge.net/mup_features.html#idDef2 for available operators-->
 		<parameter name="t0_formula" type="string">
-			<!--<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" /> Old formula (valid till august 2015) -->
-            <value val="157.539+ln(incidentEnergy)*(-33.04593+ln(incidentEnergy)*(-8.07523+ln(incidentEnergy)*(2.2143-0.109521767*ln(incidentEnergy))))"/>
+			<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" />
 		</parameter>
 
 		<parameter name="treat-background-as-events" type="string">

--- a/instrument/CNCS_Parameters_20120314_20120816.xml
+++ b/instrument/CNCS_Parameters_20120314_20120816.xml
@@ -191,8 +191,7 @@
 		
 		<!--   formula for t0 calculation. See http://muparser.sourceforge.net/mup_features.html#idDef2 for available operators-->
 		<parameter name="t0_formula" type="string">
-			<!--<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" /> Old formula (valid till august 2015) -->
-            <value val="157.539+ln(incidentEnergy)*(-33.04593+ln(incidentEnergy)*(-8.07523+ln(incidentEnergy)*(2.2143-0.109521767*ln(incidentEnergy))))"/>
+			<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" />
 		</parameter>
 
 		<parameter name="treat-background-as-events" type="string">

--- a/instrument/CNCS_Parameters_20120817_20130814.xml
+++ b/instrument/CNCS_Parameters_20120817_20130814.xml
@@ -191,8 +191,7 @@
 		
 		<!--   formula for t0 calculation. See http://muparser.sourceforge.net/mup_features.html#idDef2 for available operators-->
 		<parameter name="t0_formula" type="string">
-			<!--<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" /> Old formula (valid till august 2015) -->
-            <value val="157.539+ln(incidentEnergy)*(-33.04593+ln(incidentEnergy)*(-8.07523+ln(incidentEnergy)*(2.2143-0.109521767*ln(incidentEnergy))))"/>
+			<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" />
 		</parameter>
 
 		<parameter name="treat-background-as-events" type="string">

--- a/instrument/CNCS_Parameters_20130814_20140131.xml
+++ b/instrument/CNCS_Parameters_20130814_20140131.xml
@@ -191,8 +191,7 @@
 		
 		<!--   formula for t0 calculation. See http://muparser.sourceforge.net/mup_features.html#idDef2 for available operators-->
 		<parameter name="t0_formula" type="string">
-			<!--<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" /> Old formula (valid till august 2015) -->
-            <value val="157.539+ln(incidentEnergy)*(-33.04593+ln(incidentEnergy)*(-8.07523+ln(incidentEnergy)*(2.2143-0.109521767*ln(incidentEnergy))))"/>
+			<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" />
 		</parameter>
 
 		<parameter name="treat-background-as-events" type="string">

--- a/instrument/CNCS_Parameters_20140201_20140807.xml
+++ b/instrument/CNCS_Parameters_20140201_20140807.xml
@@ -191,8 +191,7 @@
 		
 		<!--   formula for t0 calculation. See http://muparser.sourceforge.net/mup_features.html#idDef2 for available operators-->
 		<parameter name="t0_formula" type="string">
-			<!--<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" /> Old formula (valid till august 2015) -->
-            <value val="157.539+ln(incidentEnergy)*(-33.04593+ln(incidentEnergy)*(-8.07523+ln(incidentEnergy)*(2.2143-0.109521767*ln(incidentEnergy))))"/>
+			<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" />
 		</parameter>
 
 		<parameter name="treat-background-as-events" type="string">

--- a/instrument/CNCS_Parameters_20140808-20150129.xml
+++ b/instrument/CNCS_Parameters_20140808-20150129.xml
@@ -191,8 +191,7 @@
 		
 		<!--   formula for t0 calculation. See http://muparser.sourceforge.net/mup_features.html#idDef2 for available operators-->
 		<parameter name="t0_formula" type="string">
-			<!--<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" /> Old formula (valid till august 2015) -->
-            <value val="157.539+ln(incidentEnergy)*(-33.04593+ln(incidentEnergy)*(-8.07523+ln(incidentEnergy)*(2.2143-0.109521767*ln(incidentEnergy))))"/>
+			<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" />
 		</parameter>
 
 		<parameter name="treat-background-as-events" type="string">

--- a/instrument/CNCS_Parameters_20150130-20150731.xml
+++ b/instrument/CNCS_Parameters_20150130-20150731.xml
@@ -191,8 +191,7 @@
 		
 		<!--   formula for t0 calculation. See http://muparser.sourceforge.net/mup_features.html#idDef2 for available operators-->
 		<parameter name="t0_formula" type="string">
-			<!--<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" /> Old formula (valid till august 2015) -->
-            <value val="157.539+ln(incidentEnergy)*(-33.04593+ln(incidentEnergy)*(-8.07523+ln(incidentEnergy)*(2.2143-0.109521767*ln(incidentEnergy))))"/>
+			<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" />
 		</parameter>
 
 		<parameter name="treat-background-as-events" type="string">

--- a/instrument/CNCS_Parameters_35155-44929.xml
+++ b/instrument/CNCS_Parameters_35155-44929.xml
@@ -191,8 +191,7 @@
 		
 		<!--   formula for t0 calculation. See http://muparser.sourceforge.net/mup_features.html#idDef2 for available operators-->
 		<parameter name="t0_formula" type="string">
-			<!--<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" /> Old formula (valid till august 2015) -->
-            <value val="157.539+ln(incidentEnergy)*(-33.04593+ln(incidentEnergy)*(-8.07523+ln(incidentEnergy)*(2.2143-0.109521767*ln(incidentEnergy))))"/>
+			<value val="198.2 * (1.0 + incidentEnergy)^(-0.84098)" />
 		</parameter>
 
 		<parameter name="treat-background-as-events" type="string">


### PR DESCRIPTION
Since August 2015, CNCS changed how they phased choppers. Created parameter files for all IDFs till that date (just copied the old CNCS_Parameters.xml), and changed the T0 formula for the current parameters file.

**To test:**
All unit test, doc tests, and system tests that use CNCS files should pass

Someone at SNS, who has access to old and new CNCS files, should load CNCS files from different SNS cycles. Then run `GetEi` and compare the T0 with the old and new formula.
Here is a simple script to do that:

```
import numpy as np
runs=[103400,132300,154700,163100]
# first 2 runs are before the change

for r in runs:
    w=Load("CNCS_"+str(r))
    start_time=w.getRun()['start_time'].value
    Ei,unused1,unused2,T0=GetEi(w)
    oldT0=198.2 * (1.0 + Ei)**(-0.84098)
    lnEi=np.log(Ei)
    newT0=157.539+lnEi*(-33.04593+lnEi*(-8.07523+lnEi*(2.2143-0.109521767*lnEi)))
    print start_time,Ei,T0,newT0,oldT0
```

<!-- Instructions for testing. -->

Fixes #15636.

RELEASE NOTES: see the changes in the rst file.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
