### PR TITLE
Fix a bug in RangeSelector

### DIFF
--- a/MantidQt/MantidWidgets/src/RangeSelector.cpp
+++ b/MantidQt/MantidWidgets/src/RangeSelector.cpp
@@ -426,5 +426,5 @@ void RangeSelector::verify() {
  */
 bool RangeSelector::inRange(double x)
 {
-  return (x < m_lower || x > m_higher);
+  return (x > m_lower && x < m_higher);
 }


### PR DESCRIPTION
Fixed the test of the mouse cursor being in range.

**To test:**
- Start the multi-dataset fitting interface
- Use the mouse to change the fitting range. It should work

Fixes #15646

No release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
