### PR TITLE
Fix logic with max spectra in LoadEventNexus

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -912,7 +912,7 @@ public:
       m_min_id = minSpectraToLoad;
     }
     if (maxSpectraToLoad != emptyInt && m_max_id > maxSpectraToLoad) {
-      if (maxSpectraToLoad > m_min_id) {
+      if (maxSpectraToLoad < m_min_id) {
         // the maximum spectra to load is less than the minimum of this bank
         return;
       }


### PR DESCRIPTION
Fixed the logic with max spectra in LoadEventNexus. The code now matches the comment.

**To test:**
- Look at #15643 for the test
- Check that #14532 hasn't been broken by this fix.

Fixes #15643.

This bug exist in `v3.6.0` so should be included in any future `v3.6` patches.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
