### PR TITLE
Remove memory leak in UsageService

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/UsageService.h
+++ b/Framework/Kernel/inc/MantidKernel/UsageService.h
@@ -108,8 +108,8 @@ private:
   /// Send featureUsageReport
   void sendFeatureUsageReport(const bool synchronous);
 
-  int UsageServiceImpl::sendStartupAsyncImpl(const std::string &message);
-  int UsageServiceImpl::sendFeatureAsyncImpl(const std::string &message);
+  int sendStartupAsyncImpl(const std::string &message);
+  int sendFeatureAsyncImpl(const std::string &message);
 
   /// A method to handle the timerCallbacks
   void timerCallback(Poco::Timer &);

--- a/Framework/Kernel/inc/MantidKernel/UsageService.h
+++ b/Framework/Kernel/inc/MantidKernel/UsageService.h
@@ -131,11 +131,10 @@ private:
   mutable std::mutex m_mutex;
   std::string m_application;
 
-  ///Async method for sending startup notifications
+  /// Async method for sending startup notifications
   Poco::ActiveMethod<int, std::string, UsageServiceImpl> m_startupActiveMethod;
-  ///Async method for sending feature notifications
+  /// Async method for sending feature notifications
   Poco::ActiveMethod<int, std::string, UsageServiceImpl> m_featureActiveMethod;
-
 };
 
 /// Forward declaration of a specialisation of SingletonHolder for

--- a/Framework/Kernel/inc/MantidKernel/UsageService.h
+++ b/Framework/Kernel/inc/MantidKernel/UsageService.h
@@ -6,7 +6,7 @@
 
 #include <json/value.h>
 
-#include <Poco/ActiveResult.h>
+#include <Poco/ActiveMethod.h>
 #include <Poco/Timer.h>
 
 #include <queue>
@@ -108,16 +108,14 @@ private:
   /// Send featureUsageReport
   void sendFeatureUsageReport(const bool synchronous);
 
+  int UsageServiceImpl::sendStartupAsyncImpl(const std::string &message);
+  int UsageServiceImpl::sendFeatureAsyncImpl(const std::string &message);
+
   /// A method to handle the timerCallbacks
   void timerCallback(Poco::Timer &);
 
   // generate Json header for feature calls
   ::Json::Value generateFeatureHeader();
-
-  Poco::ActiveResult<int> sendStartupAsync(const std::string &message);
-  int sendStartupAsyncImpl(const std::string &message);
-  Poco::ActiveResult<int> sendFeatureAsync(const std::string &message);
-  int sendFeatureAsyncImpl(const std::string &message);
 
   /// a timer
   Poco::Timer m_timer;
@@ -132,6 +130,12 @@ private:
   bool m_isEnabled;
   mutable std::mutex m_mutex;
   std::string m_application;
+
+  ///Async method for sending startup notifications
+  Poco::ActiveMethod<int, std::string, UsageServiceImpl> m_startupActiveMethod;
+  ///Async method for sending feature notifications
+  Poco::ActiveMethod<int, std::string, UsageServiceImpl> m_featureActiveMethod;
+
 };
 
 /// Forward declaration of a specialisation of SingletonHolder for

--- a/Framework/Kernel/src/UsageService.cpp
+++ b/Framework/Kernel/src/UsageService.cpp
@@ -290,7 +290,7 @@ int UsageServiceImpl::sendReport(const std::string &message,
   try {
     Kernel::InternetHelper helper;
     std::stringstream responseStream;
-    helper.setTimeout(2);
+    helper.setTimeout(20);
     helper.setBody(message);
     status = helper.sendRequest(url, responseStream);
   } catch (Mantid::Kernel::Exception::InternetError &e) {

--- a/Framework/Kernel/src/UsageService.cpp
+++ b/Framework/Kernel/src/UsageService.cpp
@@ -8,7 +8,8 @@
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/ParaViewVersion.h"
 
-#include <Poco/ActiveMethod.h>
+#include <Poco/ActiveResult.h>
+
 #include <json/json.h>
 
 namespace Mantid {
@@ -68,7 +69,9 @@ bool FeatureUsage::operator<(const FeatureUsage &r) const {
 UsageServiceImpl::UsageServiceImpl()
     : m_timer(), m_timerTicks(0), m_timerTicksTarget(0), m_FeatureQueue(),
       m_FeatureQueueSizeThreshold(50), m_isEnabled(false), m_mutex(),
-      m_application("python") {
+      m_application("python"),
+      m_startupActiveMethod(this, &UsageServiceImpl::sendStartupAsyncImpl),
+      m_featureActiveMethod(this, &UsageServiceImpl::sendFeatureAsyncImpl) {
   setInterval(60);
 }
 
@@ -140,8 +143,7 @@ void UsageServiceImpl::sendStartupReport() {
     std::string message = this->generateStartupMessage();
 
     // send the report
-    // sendReport(message, STARTUP_URL);
-    Poco::ActiveResult<int> result = this->sendStartupAsync(message);
+    Poco::ActiveResult<int> result = m_startupActiveMethod(message);
   } catch (std::exception &ex) {
     g_log.debug() << "Send startup usage failure. " << ex.what() << std::endl;
   }
@@ -150,12 +152,11 @@ void UsageServiceImpl::sendStartupReport() {
 void UsageServiceImpl::sendFeatureUsageReport(const bool synchronous = false) {
   try {
     std::string message = this->generateFeatureUsageMessage();
-    // g_log.debug() << "FeatureUsage to send\n" << message << std::endl;
     if (!message.empty()) {
       if (synchronous) {
         sendFeatureAsyncImpl(message);
       } else {
-        Poco::ActiveResult<int> result = this->sendFeatureAsync(message);
+        Poco::ActiveResult<int> result = m_featureActiveMethod(message);
       }
     }
 
@@ -270,26 +271,11 @@ std::string UsageServiceImpl::generateFeatureUsageMessage() {
 /**
 * Asynchronous execution
 */
-Poco::ActiveResult<int>
-UsageServiceImpl::sendStartupAsync(const std::string &message) {
-  auto sendAsync = new Poco::ActiveMethod<int, std::string, UsageServiceImpl>(
-      this, &UsageServiceImpl::sendStartupAsyncImpl);
-  return (*sendAsync)(message);
-}
 
 /**Async method for sending startup messages
 */
 int UsageServiceImpl::sendStartupAsyncImpl(const std::string &message) {
   return this->sendReport(message, STARTUP_URL);
-}
-
-/**Async method for sending feature messages
-*/
-Poco::ActiveResult<int>
-UsageServiceImpl::sendFeatureAsync(const std::string &message) {
-  auto sendAsync = new Poco::ActiveMethod<int, std::string, UsageServiceImpl>(
-      this, &UsageServiceImpl::sendFeatureAsyncImpl);
-  return (*sendAsync)(message);
 }
 
 /**Async method for sending feature messages


### PR DESCRIPTION
Description of work.

Changed the ownership of the active method objects to class owned to prevent memory leaks.

**To test:**
1. The testing at the moment would be better performed outside of ISIS as the networks configuration is causing all usage reporting to fail. This is the error message you would see from the log at ISIS (it happens before and after the change.

```
  NetworkProxyWin failed to find the proxy information. It will attempt without proxy. Could not find the  proxy for this url (Error code :87).
  Call to "http://reports.mantidproject.org/api/usage" responded with 0
  InternetError: Connection and request failed Timeout 
```
1. Check that Mantid still sends usage reports
2. You can do this in python using 
   `python
   UsageService.setEnabled(True)
   UsageService.registerStartup()
   UsageService.flush()
   `
3. You can check the latest calls to the usage service here
   http://reports.mantidproject.org/api/usage

Fixes #15591 

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
