### PR TITLE
Transmission Correction properties enabled in RRO Dialog

### DIFF
--- a/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -234,25 +234,20 @@ void ReflectometryReductionOne::init() {
   setPropertyGroup("StartOverlap", "Transmission");
   setPropertyGroup("EndOverlap", "Transmission");
 
-  // Only do transmission corrections when point detector.
-  setPropertySettings(
-      "FirstTransmissionRun",
-      Kernel::make_unique<Kernel::EnabledWhenProperty>(
-          "AnalysisMode", IS_EQUAL_TO, "PointDetectorAnalysis"));
-  setPropertySettings(
-      "SecondTransmissionRun",
-      Kernel::make_unique<Kernel::EnabledWhenProperty>(
-          "AnalysisMode", IS_EQUAL_TO, "PointDetectorAnalysis"));
-  setPropertySettings(
-      "Params", Kernel::make_unique<Kernel::EnabledWhenProperty>(
-                    "AnalysisMode", IS_EQUAL_TO, "PointDetectorAnalysis"));
-  setPropertySettings(
-      "StartOverlap",
-      Kernel::make_unique<Kernel::EnabledWhenProperty>(
-          "AnalysisMode", IS_EQUAL_TO, "PointDetectorAnalysis"));
-  setPropertySettings(
-      "EndOverlap", Kernel::make_unique<Kernel::EnabledWhenProperty>(
-                        "AnalysisMode", IS_EQUAL_TO, "PointDetectorAnalysis"));
+  // Only ask for transmission parameters when a FirstTranmissionRun has been
+  // provided
+  setPropertySettings("SecondTransmissionRun",
+                      Kernel::make_unique<Kernel::EnabledWhenProperty>(
+                          "FirstTransmissionRun", IS_NOT_DEFAULT));
+  setPropertySettings("Params",
+                      Kernel::make_unique<Kernel::EnabledWhenProperty>(
+                          "FirstTransmissionRun", IS_NOT_DEFAULT));
+  setPropertySettings("StartOverlap",
+                      Kernel::make_unique<Kernel::EnabledWhenProperty>(
+                          "FirstTransmissionRun", IS_NOT_DEFAULT));
+  setPropertySettings("EndOverlap",
+                      Kernel::make_unique<Kernel::EnabledWhenProperty>(
+                          "FirstTransmissionRun", IS_NOT_DEFAULT));
 
   // Only use region of direct beam when in multi-detector analysis mode.
   setPropertySettings(

--- a/docs/source/algorithms/ReflectometryReductionOne-v1.rst
+++ b/docs/source/algorithms/ReflectometryReductionOne-v1.rst
@@ -24,11 +24,12 @@ background normalization will not be performed on the monitors.
 Analysis Modes
 ##############
 
-The default analysis mode is *PointDetectorAnalysis*. Only this mode
-supports Transmission corrections (see below). For PointAnalysisMode the
+The default analysis mode is *PointDetectorAnalysis*. For PointAnalysisMode the
 analysis can be roughly reduced to IvsLam = DetectorWS / sum(I0) /
-TransmissionWS / sum(I0). The normalization by tranmission run(s) is
-optional. If necessary, input workspaces are converted to *Wavelength*
+TransmissionWS / sum(I0). For MultiDetectorAnalysis the analysis can be roughly reduced to 
+IvsLam = DetectorWS / RegionOfDirectBeamWS / sum(I0) / TransmissionWS / sum(I0).
+The normalization by tranmission run(s) is optional.
+If necessary, input workspaces are converted to *Wavelength*
 first via :ref:`algm-ConvertUnits`.
 
 IvsQ is calculated via :ref:`algm-ConvertUnits` into units of
@@ -40,8 +41,8 @@ Theta input value has been provided.
 Transmission Runs
 #################
 
-Transmission correction is a normalization step, which may be applied to
-*PointDetectorAnalysis* reduction.
+Transmission correction is a normalization step, which may be applied to both
+*PointDetectorAnalysis* and *MultiDetectorAnalysis* reduction.
 
 Transmission runs are expected to be in TOF. The spectra numbers in the
 Transmission run workspaces must be the same as those in the Input Run


### PR DESCRIPTION
It was found that if the property for `AnalysisMode` was set to `MultiDetectorAnalysis` in the algorithm dialog for ReflectometryReductionOne then all of the properties associated with Transmission corrections became disabled. A user should be able to apply transmission corrections regardless of what analysis mode they are using however they must provide at least one Transmission run to perform these corrections.

**To test:**
- Load the ReflectometryReductionOne algorithm dialog
- Change the `AnalysisMode` to `PointDetectorAnalysis` and see that the property for `FirstTransmissionRun` is enabled and the rest are disabled within `Transmission` box.
- See that `RegionOfDirectBeam` property is disabled.
- Change the `AnalysisMode` to `MultiDetectorAnalysis` and see that the property for `FirstTransmissionRun` is enabled and the rest are disabled within `Transmission` box.
- See that `RegionOfDirectBeam` property is enabled.
- Close the algorithm dialog.
- Load any MatrixWorkspace into mantid.
- Open the algorithm dialog again.
- Choose an AnalysisMode.
- Select the `FirstTransmissionRun` property to be set to the workspace you previously loaded.
- See that the remaining properties associated with Transmission corrections are now enabled.

Fixes #15498

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
