### PR TITLE
Set either Content-Length or Transfer-Encoding HTTP headers, not both.

### DIFF
--- a/Framework/Kernel/src/InternetHelper.cpp
+++ b/Framework/Kernel/src/InternetHelper.cpp
@@ -104,16 +104,18 @@ void InternetHelper::createRequest(Poco::URI &uri) {
   }
 
   m_request->set("User-Agent", "MANTID");
-  if (m_contentLength > 0) {
+  if (m_method == "POST") {
+    // HTTP states that the 'Content-Length' header should not be included
+    // if the 'Transfer-Encoding' header is set. UNKNOWN_CONTENT_LENGTH
+    // indicates to Poco to remove the header field
+    m_request->setContentLength(HTTPMessage::UNKNOWN_CONTENT_LENGTH);
+    m_request->setChunkedTransferEncoding(true);
+  } else if (m_contentLength > 0) {
     m_request->setContentLength(m_contentLength);
   }
 
   for (auto &header : m_headers) {
     m_request->set(header.first, header.second);
-  }
-
-  if (m_method == "POST") {
-    m_request->setChunkedTransferEncoding(true);
   }
 }
 

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -83,6 +83,12 @@ Python
 Python Algorithms
 #################
 
+
+Script Repository
+-----------------
+
+- A bug has been fixed that caused uploads to fail with some incorrectly configured proxy servers.
+
 |
 
 Full list of
@@ -90,4 +96,3 @@ Full list of
 and
 `Python <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Python%22>`__
 changes on GitHub
-


### PR DESCRIPTION
Removes `Content-Length` header if `Transfer-Encoding: chunked` is set on POST in `InternetHelper`.

**To test:**

This will need to be tested at ISIS as it is the only place where the original problem manifests itself. On your current version of the codebase first convince youself that the problem exists by following the steps in the #15685. 

After merging the fix you should be able to follow the steps and successfully upload a file to the script repository from ISIS.

Fixes #15685.

[Release Notes](https://github.com/mantidproject/mantid/blob/f0bf7a3786cda4bab5195da82c6dde875e5257b9/docs/source/release/v3.7.0/framework.rst)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Servers should handle the case of both appearing in a header but it
would appear that some are not so graceful...
Refs #15685
