### PR TITLE
Fix clang warnings on OS X.

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/MaxEnt/MaxentEntropyPositiveValues.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MaxEnt/MaxentEntropyPositiveValues.h
@@ -34,10 +34,6 @@ namespace Algorithms {
 */
 class MANTID_ALGORITHMS_DLL MaxentEntropyPositiveValues : public MaxentEntropy {
 public:
-  // Constructor
-  MaxentEntropyPositiveValues() = default;
-  // Destructor
-  virtual ~MaxentEntropyPositiveValues() = default;
   // First derivative
   double getDerivative(double value) override;
   // Second derivative

--- a/Framework/LiveData/test/ADARAPacketTest.h
+++ b/Framework/LiveData/test/ADARAPacketTest.h
@@ -175,7 +175,7 @@ protected:
   // The test class will handle everything from there.
   using ADARA::Parser::rxPacket;
 #define DEFINE_RX_PACKET(PktType)                                              \
-  virtual bool rxPacket(const PktType &pkt) {                                  \
+  bool rxPacket(const PktType &pkt) override {                                 \
     m_pkt.reset(new PktType(pkt));                                             \
     return false;                                                              \
   }

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadSQW2.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadSQW2.h
@@ -43,21 +43,21 @@ namespace MDAlgorithms {
 class DLLExport LoadSQW2 : public API::IFileLoader<Kernel::FileDescriptor> {
 public:
   LoadSQW2();
-  ~LoadSQW2();
+  ~LoadSQW2() override;
 
-  virtual const std::string name() const;
-  virtual int version() const;
-  virtual const std::string category() const;
-  virtual const std::string summary() const;
-  virtual int confidence(Kernel::FileDescriptor &descriptor) const;
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+  int confidence(Kernel::FileDescriptor &descriptor) const override;
 
 private:
   /// Local typedef for
   typedef DataObjects::MDEventWorkspace<DataObjects::MDEvent<4>, 4>
       SQWWorkspace;
 
-  void init();
-  void exec();
+  void init() override;
+  void exec() override;
   void cacheInputs();
   void initFileReader();
   int32_t readMainHeader();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -104,7 +104,7 @@ public:
 
   std::string currentCalibSpecNos() const override;
 
-  std::string currentCalibCustomisedBankName() const;
+  std::string currentCalibCustomisedBankName() const override;
 
   void newCalibLoaded(const std::string &vanadiumNo, const std::string &ceriaNo,
                       const std::string &fname) override;

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/CompositePeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/CompositePeaksPresenter.h
@@ -47,13 +47,13 @@ public:
     /*Do nothing*/
   }
   /// Get the foreground colour. This should never be used on the composite
-  PeakViewColor getForegroundPeakViewColor( ) const {
+  PeakViewColor getForegroundPeakViewColor() const override {
     std::runtime_error("Error: Trying to access getForegroundPeaViewColor on a"
                        "composite presenter");
     return PeakViewColor();
   }
   /// Get the background colour corresponding to the workspace
-  PeakViewColor getBackgroundPeakViewColor() const {
+  PeakViewColor getBackgroundPeakViewColor() const override {
     std::runtime_error("Error: Trying to access getBackgroundPeaViewColor on a"
                        "composite presenter");
     return PeakViewColor();

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/NullPeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/NullPeaksPresenter.h
@@ -26,10 +26,10 @@ public:
   }
   void setBackgroundColor(const PeakViewColor) override { /*Do nothing*/
   }
-  PeakViewColor getBackgroundPeakViewColor() const {
+  PeakViewColor getBackgroundPeakViewColor() const override {
     return PeakViewColor();
   }
-  PeakViewColor getForegroundPeakViewColor() const {
+  PeakViewColor getForegroundPeakViewColor() const override {
     return PeakViewColor();
   }
   std::string getTransformName() const override { return ""; }


### PR DESCRIPTION
Description of work.

This fixes `-Winconsistent-missing-override` warnings on OS X when building with Xcode 7 or later. I also addressed warnings from clang-tidy's`modernize-use-override`.

**To test:**

Code review and verifying the builds pass should be sufficient.

<!-- Instructions for testing. -->

This is a small change with no issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
