### PR TITLE
Document PBins property in CutMD help

### DIFF
--- a/docs/source/algorithms/CutMD-v1.rst
+++ b/docs/source/algorithms/CutMD-v1.rst
@@ -33,6 +33,31 @@ MDHistoWorkspaces
 
 If the input is an :ref:`MDHistoWorkspace <MDHistoWorkspace>` :ref:`algm-BinMD` and :ref:`algm-SliceMD` are not made available as they needto get hold of the original MDEvents associated with an :ref:`MDEventWorkspace <MDWorkspace>` in order to perform the rebinning. As this information is missing from the MDHistoWorkspace images, those operations are forbidden. Instead, a limited subset of the operations are allowed, and are performed via :ref:`algm-IntegrateMDHistoWorkspace`. In this case, the Projection and NoPix properties are ignored. See :ref:`algm-IntegrateMDHistoWorkspace` for how the binning parameters are used.
 
+PBins
+~~~~~
+
+The PBins property is used to specify the binning for each dimension of the output workspace.
+The dimension will be truncated to have extents 'minimum' and 'maximum', with 'stepsize' specifying the size of the bins inbetween.
+(maximum - minimum)/stepsize is rounded down to produce an integer number, greater than or equal to 1, of equally-sized bins between 'minimum' and 'maximum'.
+
+Note that if the output workspace is an MDEventWorkspace (NoPix=False), PBins defines the top-level box structure of the workspace.
+If many events fall within a single box it is split further, see the documentation for :ref:`MDEventWorkspace <MDWorkspace>`.
+
+Each element of the PBins list matches one of three possible formats:
+
++----------------------------------+-------------------------------------------------------+
+| Format                           |                                                       |
++==================================+=======================================================+
+| [minimum, stepsize, maximum]     | The dimension in the output workspace will extend     |
+|                                  | from 'minimum' to 'maximum' with bins of width        |
+|                                  | 'stepsize'.                                           |
++----------------------------------+-------------------------------------------------------+
+| [minimum, maximum]               | A single bin will be created between 'minimum' and    |
+|                                  | 'maximum'.                                            |
++----------------------------------+-------------------------------------------------------+
+| [stepsize]                       | The 'minimum' and 'maximum' are set to the dimension  |
+|                                  | limits; the workspace is not cut in this dimension.   |
++----------------------------------+-------------------------------------------------------+
 
 Creating Projections
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/algorithms/CutMD-v1.rst
+++ b/docs/source/algorithms/CutMD-v1.rst
@@ -33,17 +33,17 @@ MDHistoWorkspaces
 
 If the input is an :ref:`MDHistoWorkspace <MDHistoWorkspace>` :ref:`algm-BinMD` and :ref:`algm-SliceMD` are not made available as they needto get hold of the original MDEvents associated with an :ref:`MDEventWorkspace <MDWorkspace>` in order to perform the rebinning. As this information is missing from the MDHistoWorkspace images, those operations are forbidden. Instead, a limited subset of the operations are allowed, and are performed via :ref:`algm-IntegrateMDHistoWorkspace`. In this case, the Projection and NoPix properties are ignored. See :ref:`algm-IntegrateMDHistoWorkspace` for how the binning parameters are used.
 
-PBins
-~~~~~
+Projection Binning
+~~~~~~~~~~~~~~~~~~
 
-The PBins property is used to specify the binning for each dimension of the output workspace.
+The 'PnBin' property, where n is between 1 and 5, is used to specify the binning for the nth dimension of the output workspace.
 The dimension will be truncated to have extents 'minimum' and 'maximum', with 'stepsize' specifying the size of the bins inbetween.
-(maximum - minimum)/stepsize is rounded down to produce an integer number, greater than or equal to 1, of equally-sized bins between 'minimum' and 'maximum'.
+'(maximum - minimum)/stepsize' is rounded down to produce an integer number, greater than or equal to 1, of equally-sized bins between 'minimum' and 'maximum'.
 
-Note that if the output workspace is an MDEventWorkspace (NoPix=False), PBins defines the top-level box structure of the workspace.
+Note that if the output workspace is an MDEventWorkspace (NoPix=False), these properties define the top-level box structure of the workspace.
 If many events fall within a single box it is split further, see the documentation for :ref:`MDEventWorkspace <MDWorkspace>`.
 
-Each element of the PBins list matches one of three possible formats:
+The PnBin parameters must match one of these three formats:
 
 +----------------------------------+-------------------------------------------------------+
 | Format                           |                                                       |
@@ -58,6 +58,9 @@ Each element of the PBins list matches one of three possible formats:
 | [stepsize]                       | The 'minimum' and 'maximum' are set to the dimension  |
 |                                  | limits; the workspace is not cut in this dimension.   |
 +----------------------------------+-------------------------------------------------------+
+
+For ease of use, when using the python interface only, the 'PBins' keyword can be used in place of separate PnBins properties.
+PBins accepts a tuple, or list, of PnBins parameters. The position in the list determines the dimension it corresponds to. See the Usage_ examples below.
 
 Creating Projections
 ~~~~~~~~~~~~~~~~~~~~
@@ -124,8 +127,8 @@ Workflow
 
 .. diagram:: CutMD-v1_wkflw.dot
 
-Usage
------
+_`Usage`
+--------
 
 **Example - Contrived example using projections:**
 


### PR DESCRIPTION
Documented the PBins property of the CutMD algorithm. Previously it only appeared in code examples, with no explanation.

This is an update to user documentation, it does not need to be in the release notes.

**To test:**
Please build the html documentation and view the `CutMD` algorithm page. Check that the section on the `PBins` property is clear and helpful.

Fixes #15238.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
