### PR TITLE
ALC: fix crash when no baseline fitted

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingPresenter.h
@@ -61,17 +61,23 @@ namespace CustomInterfaces
     void onDataChanged();
 
     /// Executed when user clicks "Plot guess"
-    void onPlotGuess();
-
-    // Remove plots from graph
-    void removePlots();
+    void onPlotGuessClicked();
 
   private:
+    /// Plot guess on graph
+    bool plotGuessOnGraph();
+
+    /// Remove plots from graph
+    void removePlots();
+
     /// Associated view
     IALCPeakFittingView* const m_view;
 
     /// Associated model
     IALCPeakFittingModel* const m_model;
+
+    /// Whether guess is currently plotted
+    bool m_guessPlotted;
   };
 
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h
@@ -60,10 +60,6 @@ namespace CustomInterfaces
     IPeakFunction_const_sptr peakPicker() const override;
     void emitFitRequested();
 
-  public:
-    /// Clear guess when a fit is ready
-    void clearGuess() override;
-
   public slots:
 
     void initialize() override;
@@ -78,6 +74,7 @@ namespace CustomInterfaces
     void displayError(const QString &message) override;
     void help() override;
     void plotGuess() override;
+    void changePlotGuessState(bool plotted) override;
 
     // -- End of IALCPeakFitting interface ---------------------------------------------------------
   private:
@@ -95,9 +92,6 @@ namespace CustomInterfaces
 
     /// Peak picker tool - only one on the plot at any given moment
     MantidWidgets::PeakPicker* m_peakPicker;
-
-    /// Whether the guess is currently plotted on the graph
-    bool m_guessPlotted;
   };
 
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCPeakFittingModel.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCPeakFittingModel.h
@@ -66,6 +66,9 @@ namespace CustomInterfaces
 
     /// Signal to inform that data was set
     void dataChanged();
+
+    /// Signal to inform presenter of an error with fitting
+    void errorInModel(const QString &message);
   };
 
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCPeakFittingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCPeakFittingView.h
@@ -56,9 +56,6 @@ namespace CustomInterfaces
     /// @return A peak currently represented by the peak picker
     virtual IPeakFunction_const_sptr peakPicker() const = 0;
 
-    /// Clears any guess from the plot
-    virtual void clearGuess() = 0;
-
   public slots:
     /// Performs any necessary initialization
     virtual void initialize() = 0;
@@ -100,8 +97,11 @@ namespace CustomInterfaces
     /// Opens the Mantid Wiki web page
     virtual void help() = 0;
 
-    /// Changes button text and emits signal
+    /// Emits signal
     virtual void plotGuess() = 0;
+
+    /// Changes button state
+    virtual void changePlotGuessState(bool plotted) = 0;
 
   signals:
     /// Request to perform peak fitting
@@ -117,10 +117,7 @@ namespace CustomInterfaces
     void parameterChanged(const QString &funcIndex, const QString &paramName);
 
     /// Request to plot guess
-    void plotGuessRequested();
-
-    /// Request to remove guess from plot
-    void removeGuessRequested();
+    void plotGuessClicked();
   };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
@@ -67,7 +67,9 @@ namespace CustomInterfaces
       QCoreApplication::processEvents();
     }
     if (!result.error().empty()) {
-      throw std::runtime_error(result.error());
+      QString msg =
+          "Fit algorithm failed.\n\n" + QString(result.error().c_str()) + "\n";
+      emit errorInModel(msg);
     }
 
     m_data = fit->getProperty("OutputWorkspace");

--- a/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingPresenter.cpp
@@ -97,25 +97,28 @@ namespace CustomInterfaces
     }
   }
 
-  void ALCPeakFittingPresenter::onFittedPeaksChanged()
-  {
-    if(IFunction_const_sptr fittedPeaks = m_model->fittedPeaks())
-    {
-      auto x = m_model->data()->readX(0);
-      m_view->setFittedCurve(*(ALCHelper::curveDataFromFunction(fittedPeaks, x)));
+  void ALCPeakFittingPresenter::onFittedPeaksChanged() {
+    IFunction_const_sptr fittedPeaks = m_model->fittedPeaks();
+    auto dataWS = m_model->data();
+    if (fittedPeaks && dataWS) {
+      auto x = dataWS->readX(0);
+      m_view->setFittedCurve(
+          *(ALCHelper::curveDataFromFunction(fittedPeaks, x)));
       m_view->setFunction(fittedPeaks);
-    }
-    else
-    {
+    } else {
       m_view->setFittedCurve(*(ALCHelper::emptyCurveData()));
       m_view->setFunction(IFunction_const_sptr());
     }
   }
 
-  void ALCPeakFittingPresenter::onDataChanged()
-  {
-    m_view->setDataCurve(*(ALCHelper::curveDataFromWs(m_model->data(), 0)),
-                         ALCHelper::curveErrorsFromWs(m_model->data(), 0));
+  void ALCPeakFittingPresenter::onDataChanged() {
+    auto dataWS = m_model->data();
+    if (dataWS) {
+      m_view->setDataCurve(*(ALCHelper::curveDataFromWs(m_model->data(), 0)),
+                           ALCHelper::curveErrorsFromWs(m_model->data(), 0));
+    } else {
+      m_view->setDataCurve(*(ALCHelper::emptyCurveData()), Mantid::MantidVec{});
+    }
   }
 
   /**

--- a/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingPresenter.cpp
@@ -30,6 +30,8 @@ namespace CustomInterfaces
     connect(m_model, SIGNAL(dataChanged()), SLOT(onDataChanged()));
     connect(m_view, SIGNAL(plotGuessRequested()), SLOT(onPlotGuess()));
     connect(m_view, SIGNAL(removeGuessRequested()), SLOT(removePlots()));
+    connect(m_model, SIGNAL(errorInModel(const QString &)), m_view,
+            SLOT(displayError(const QString &)));
   }
 
   void ALCPeakFittingPresenter::fit()

--- a/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
@@ -15,7 +15,7 @@ namespace CustomInterfaces
 ALCPeakFittingView::ALCPeakFittingView(QWidget *widget)
     : m_widget(widget), m_ui(), m_dataCurve(new QwtPlotCurve()),
       m_fittedCurve(new QwtPlotCurve()), m_dataErrorCurve(NULL),
-      m_peakPicker(NULL), m_guessPlotted(false) {}
+      m_peakPicker(NULL) {}
 
 ALCPeakFittingView::~ALCPeakFittingView()
 {
@@ -150,38 +150,20 @@ void ALCPeakFittingView::displayError(const QString& message)
 
 void ALCPeakFittingView::emitFitRequested() {
   // Fit requested: reset "plot guess"
-  clearGuess();
   emit fitRequested();
 }
 
 /**
- * Clears fit guess and changes button text
+ * Emit signal that "plot/remove guess" has been clicked
  */
-void ALCPeakFittingView::clearGuess() {
-  m_guessPlotted = false;
-  m_ui.plotGuess->setText("Plot guess");
-}
+void ALCPeakFittingView::plotGuess() { emit plotGuessClicked(); }
 
 /**
- * Changes the text on the "Plot guess" button and emits a signal
- * to plot the guess on the graph
+ * Changes the text on the "Plot guess" button
+ * @param plotted :: [input] Whether guess is plotted or not
  */
-void ALCPeakFittingView::plotGuess() {
-  QString buttonText("Plot guess");
-
-  if (m_guessPlotted) {
-    // Remove the plotted guess
-    emit removeGuessRequested();
-    m_guessPlotted = false;
-  } else {
-    // Plot the guess function, if there is one
-    if (function("") != nullptr) {
-      buttonText = "Remove guess";
-      emit plotGuessRequested();
-      m_guessPlotted = true;
-    }
-  }
-  m_ui.plotGuess->setText(buttonText);
+void ALCPeakFittingView::changePlotGuessState(bool plotted) {
+  m_ui.plotGuess->setText(plotted ? "Remove guess" : "Plot guess");
 }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
@@ -61,6 +61,7 @@ class MockALCPeakFittingModel : public IALCPeakFittingModel
 public:
   void changeFittedPeaks() { emit fittedPeaksChanged(); }
   void changeData() { emit dataChanged(); }
+  void setError(const QString &message) { emit errorInModel(message); }
 
   MOCK_CONST_METHOD0(fittedPeaks, IFunction_const_sptr());
   MOCK_CONST_METHOD0(data, MatrixWorkspace_const_sptr());
@@ -314,6 +315,14 @@ public:
     ON_CALL(*m_view, function(QString(""))).WillByDefault(Return(peaks));
     EXPECT_CALL(*m_view, setFittedCurve(_));
     m_view->plotGuess();
+  }
+
+  /**
+   * Test that errors coming from the model are displayed in the view
+   */
+  void test_displayError() {
+    EXPECT_CALL(*m_view, displayError(QString("Test error")));
+    m_model->setError("Test error");
   }
 };
 

--- a/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
@@ -38,8 +38,7 @@ public:
   {
     emit parameterChanged(funcIndex, paramName);
   }
-  void plotGuess() override { emit plotGuessRequested(); }
-  void clearGuess() override { emit removeGuessRequested(); }
+  void plotGuess() override { emit plotGuessClicked(); }
 
   MOCK_CONST_METHOD1(function, IFunction_const_sptr(QString));
   MOCK_CONST_METHOD0(currentFunctionIndex, boost::optional<QString>());
@@ -54,6 +53,7 @@ public:
   MOCK_METHOD3(setParameter, void(const QString&, const QString&, double));
   MOCK_METHOD1(displayError, void(const QString&));
   MOCK_METHOD0(help, void());
+  MOCK_METHOD1(changePlotGuessState, void(bool));
 };
 
 class MockALCPeakFittingModel : public IALCPeakFittingModel
@@ -130,16 +130,22 @@ public:
     presenter.initialize();
   }
 
-  void test_fitEmptyFunction()
-  {
-    ON_CALL(*m_view, function(QString(""))).WillByDefault(Return(IFunction_const_sptr()));
-    EXPECT_CALL(*m_view, displayError(QString("Couldn't fit an empty function"))).Times(1);
+  void test_fitEmptyFunction() {
+    auto ws = WorkspaceCreationHelper::Create2DWorkspace123(1, 3);
+    ON_CALL(*m_model, data()).WillByDefault(Return(ws));
+    ON_CALL(*m_view, function(QString("")))
+        .WillByDefault(Return(IFunction_const_sptr()));
+    EXPECT_CALL(*m_view,
+                displayError(QString("Couldn't fit with empty function/data")))
+        .Times(1);
 
     m_view->requestFit();
   }
 
-  void test_fit()
-  {
+  void test_fit() {
+    auto ws = WorkspaceCreationHelper::Create2DWorkspace123(1, 3);
+    ON_CALL(*m_model, data()).WillByDefault(Return(ws));
+
     IFunction_sptr peaks = createGaussian(1,2,3);
 
     ON_CALL(*m_view, function(QString(""))).WillByDefault(Return(peaks));
@@ -286,14 +292,6 @@ public:
   }
 
   /**
-   * Test that clearing the guess from the view removes the fitted curve
-   */
-  void test_clearGuess() {
-    EXPECT_CALL(*m_view, setFittedCurve(Property(&QwtData::size, 0)));
-    m_view->clearGuess();
-  }
-
-  /**
    * Test that clicking "Plot guess" with no function set plots nothing
    */
   void test_plotGuess_noFunction() {
@@ -306,6 +304,18 @@ public:
   }
 
   /**
+   * Test that clicking "Plot guess" with no data plots nothing
+   * (and doesn't crash)
+   */
+  void test_plotGuess_noData() {
+    ON_CALL(*m_model, data()).WillByDefault(Return(nullptr));
+    IFunction_sptr peaks = createGaussian(1, 2, 3);
+    ON_CALL(*m_view, function(QString(""))).WillByDefault(Return(peaks));
+    EXPECT_CALL(*m_view, setFittedCurve(Property(&QwtData::size, 0)));
+    TS_ASSERT_THROWS_NOTHING(m_view->plotGuess());
+  }
+
+  /**
    * Test that "Plot guess" with a function set plots a function
    */
   void test_plotGuess() {
@@ -315,6 +325,15 @@ public:
     ON_CALL(*m_view, function(QString(""))).WillByDefault(Return(peaks));
     EXPECT_CALL(*m_view, setFittedCurve(_));
     m_view->plotGuess();
+  }
+
+  /**
+   * Test that plotting a guess, then clicking again, clears the guess
+   */
+  void test_plotGuessAndThenClear() {
+    test_plotGuess();
+    EXPECT_CALL(*m_view, setFittedCurve(Property(&QwtData::size, 0)));
+    m_view->plotGuess(); // click again i.e. "Remove guess"
   }
 
   /**


### PR DESCRIPTION
Fix a crash and/or confusing error seen when baseline fitting skipped

The ALC interface has 3 stages: load data, remove baseline, fit peaks.
If no baseline is fitted in the second step and the user just clicks "next", the fit peaks step opens with no data. 
In this case, clicking "Fit" gives a confusing error `Enter a name for the Input/InOut workspace` and clicking "Plot Guess" just crashes the interface.

Added checks for null data so that the error messages shown are more sensible.
Refactored "Plot guess" functionality to deal with failure better.
Added tests to cover the situation here.
Also, if an error occurs in the fit, show a dialog rather than passing the exception on to cause a crash.

At the next meeting with muon scientists, will discuss whether to add an option to skip background fitting, or whether they are happy with the existing manual workaround of fitting a flat background fixed to zero. (see #15691)

**To test:**
- Open the ALC interface (Interfaces/Muons/ALC)
- Use "Browse" buttons by "First" and "Last" boxes to select start and end files (example: `\\olympic\babylon5\Scratch\TomPerkins\Data\ALC`)
- Click "Load" near the bottom of the screen to load the data
- Click "Baseline modelling" (bottom right) to move to baseline removal step. Don't fit any baseline, just click "Peak fitting" to move on to the peak fitting step.
- Right-click in the box to add a function
- Check that trying to fit a function, or clicking "plot guess", doesn't cause a crash, and that the error messages shown clearly reflect the cause of the error (that no data is present).

Fixes #15681.

**Release notes:**

I haven't updated the release notes for now. Not fitting a baseline still doesn't work, this PR just commutes the resulting crash to an error message. After discussing with the scientists, if a "no baseline" option is put in, release notes will be updated at that point.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
