### PR TITLE
Reduce Pylint warning in Reflectometer files

### DIFF
--- a/scripts/Interface/reduction_gui/widgets/reflectometer/base_ref_reduction.py
+++ b/scripts/Interface/reduction_gui/widgets/reflectometer/base_ref_reduction.py
@@ -515,7 +515,7 @@ class BaseRefWidget(BaseWidget):
                     _y_val = np.nan
                     _y_val = np.nan
 
-            file_number += 1
+            _file_number += 1
 
         # END OF DEBUGGING ONLY
 

--- a/scripts/Interface/reduction_gui/widgets/reflectometer/base_ref_reduction.py
+++ b/scripts/Interface/reduction_gui/widgets/reflectometer/base_ref_reduction.py
@@ -501,7 +501,7 @@ class BaseRefWidget(BaseWidget):
         binning_parameters = _from_q + ',-' + _bin_size + ',' + _bin_max
 
         # DEBUGGING ONLY
-        file_number = 0
+        _file_number = 0
 #        print '=========== BEFORE REBINING =========='
         for ws in scaled_ws_list:
             # print 'file_number: ' , file_number
@@ -1270,7 +1270,7 @@ class BaseRefWidget(BaseWidget):
         """
 
         if not IS_IN_MANTIDPLOT:
-            return
+            return None, None
 
         try:
             f = FileFinder.findRuns("%s%s" % (self.instrument_name, str(file_ctrl.text())))[0]

--- a/scripts/Interface/reduction_gui/widgets/reflectometer/base_ref_reduction.py
+++ b/scripts/Interface/reduction_gui/widgets/reflectometer/base_ref_reduction.py
@@ -1,35 +1,31 @@
-#pylint: disable=too-many-lines,invalid-name,unused-import,bare-except,too-many-arguments
-
-from PyQt4 import QtGui, QtCore
-import reduction_gui.widgets.util as util
+# pylint: disable=too-many-lines,invalid-name,bare-except,too-many-arguments,too-many-branches
 import math
-import os
 import time
 import sys
-import numpy as np
 from functools import partial
+import numpy as np
+from PyQt4 import QtGui, QtCore
+import reduction_gui.widgets.util as util
 from reduction_gui.widgets.base_widget import BaseWidget
-#from launch_peak_back_selection_1d import DesignerMainWindow
+# from launch_peak_back_selection_1d import DesignerMainWindow
 
 IS_IN_MANTIDPLOT = False
 try:
-    import mantidplot
-    import mantid
-    #from MantidFramework import *
-    #mtd.initialise(False)
-    #from mantidsimple import *
+    # from MantidFramework import *
+    # mtd.initialise(False)
+    # from mantidsimple import *
     from mantid.simpleapi import *
     from reduction.instruments.reflectometer import data_manipulation
 
     IS_IN_MANTIDPLOT = True
-except ImportError:
-    pass
+except ImportError, e:
+    logger.error(e.message())
 
 class BaseRefWidget(BaseWidget):
     """
         Base widget for reflectivity interfaces
     """
-    ## Widget name
+    # Widget name
     name = "Data"
     instrument_name = ''
     short_name = ''
@@ -86,26 +82,35 @@ class BaseRefWidget(BaseWidget):
         self._summary.norm_background_to_pixel1.setValidator(QtGui.QIntValidator(self._summary.norm_background_to_pixel1))
 
         # Event connections
-        self.connect(self._summary.data_run_number_edit, QtCore.SIGNAL("returnPressed()"), self.data_run_number_validated)
-        self.connect(self._summary.data_low_res_range_switch, QtCore.SIGNAL("clicked(bool)"), self._data_low_res_clicked)
-        self.connect(self._summary.norm_low_res_range_switch, QtCore.SIGNAL("clicked(bool)"), self._norm_low_res_clicked)
+        self.connect(self._summary.data_run_number_edit, QtCore.SIGNAL("returnPressed()"),
+                     self.data_run_number_validated)
+        self.connect(self._summary.data_low_res_range_switch, QtCore.SIGNAL("clicked(bool)"),
+                     self._data_low_res_clicked)
+        self.connect(self._summary.norm_low_res_range_switch, QtCore.SIGNAL("clicked(bool)"),
+                     self._norm_low_res_clicked)
         self.connect(self._summary.norm_switch, QtCore.SIGNAL("clicked(bool)"), self._norm_clicked)
-        self.connect(self._summary.norm_background_switch, QtCore.SIGNAL("clicked(bool)"), self._norm_background_clicked)
-        self.connect(self._summary.data_background_switch, QtCore.SIGNAL("clicked(bool)"), self._data_background_clicked)
+        self.connect(self._summary.norm_background_switch, QtCore.SIGNAL("clicked(bool)"),
+                     self._norm_background_clicked)
+        self.connect(self._summary.data_background_switch, QtCore.SIGNAL("clicked(bool)"),
+                     self._data_background_clicked)
         self.connect(self._summary.tof_range_switch, QtCore.SIGNAL("clicked(bool)"), self._tof_range_clicked)
         self.connect(self._summary.plot_count_vs_y_btn, QtCore.SIGNAL("clicked()"), self._plot_count_vs_y)
         self.connect(self._summary.plot_count_vs_x_btn, QtCore.SIGNAL("clicked()"), self._plot_count_vs_x)
         self.connect(self._summary.plot_count_vs_y_bck_btn, QtCore.SIGNAL("clicked()"), self._plot_count_vs_y_bck)
 
-        self.connect(self._summary.plot_data_count_vs_x_2d_btn, QtCore.SIGNAL("clicked(bool)"), self._plot_data_count_vs_x_2d)
-        self.connect(self._summary.plot_data_count_vs_tof_2d_btn, QtCore.SIGNAL("clicked(bool)"), self._plot_data_count_vs_tof_2d)
+        self.connect(self._summary.plot_data_count_vs_x_2d_btn, QtCore.SIGNAL("clicked(bool)"),
+                     self._plot_data_count_vs_x_2d)
+        self.connect(self._summary.plot_data_count_vs_tof_2d_btn, QtCore.SIGNAL("clicked(bool)"),
+                     self._plot_data_count_vs_tof_2d)
 
         self.connect(self._summary.norm_count_vs_y_btn, QtCore.SIGNAL("clicked()"), self._norm_count_vs_y)
         self.connect(self._summary.norm_count_vs_x_btn, QtCore.SIGNAL("clicked()"), self._norm_count_vs_x)
         self.connect(self._summary.norm_count_vs_y_bck_btn, QtCore.SIGNAL("clicked()"), self._norm_count_vs_y_bck)
 
-        self.connect(self._summary.plot_norm_count_vs_x_2d_btn, QtCore.SIGNAL("clicked(bool)"), self._plot_norm_count_vs_x_2d)
-        self.connect(self._summary.plot_norm_count_vs_tof_2d_btn, QtCore.SIGNAL("clicked(bool)"), self._plot_norm_count_vs_tof_2d)
+        self.connect(self._summary.plot_norm_count_vs_x_2d_btn, QtCore.SIGNAL("clicked(bool)"),
+                     self._plot_norm_count_vs_x_2d)
+        self.connect(self._summary.plot_norm_count_vs_tof_2d_btn, QtCore.SIGNAL("clicked(bool)"),
+                     self._plot_norm_count_vs_tof_2d)
 
         self.connect(self._summary.plot_tof_btn, QtCore.SIGNAL("clicked()"), self._plot_tof)
         self.connect(self._summary.add_dataset_btn, QtCore.SIGNAL("clicked()"), self._add_data)
@@ -118,7 +123,8 @@ class BaseRefWidget(BaseWidget):
         # Catch edited controls
         call_back = partial(self._edit_event, ctrl=self._summary.data_peak_from_pixel)
         self.connect(self._summary.data_peak_from_pixel, QtCore.SIGNAL("textChanged(QString)"), call_back)
-#        self.connect(self._summary.data_peak_from_pixel, QtCore.SIGNAL("textChanged(QString)"), self.refresh_data_peak_counts_vs_pixel)
+        # self.connect(self._summary.data_peak_from_pixel, QtCore.SIGNAL("textChanged(QString)"),\
+        # self.refresh_data_peak_counts_vs_pixel)
 
         call_back = partial(self._edit_event, ctrl=self._summary.use_sf_config_switch)
         self.connect(self._summary.use_sf_config_switch, QtCore.SIGNAL("clicked()"), call_back)
@@ -155,7 +161,8 @@ class BaseRefWidget(BaseWidget):
         call_back = partial(self._edit_event, ctrl=self._summary.norm_run_number_edit)
         self.connect(self._summary.norm_run_number_edit, QtCore.SIGNAL("textChanged(QString)"), call_back)
         call_back = partial(self._edit_event, ctrl=self._summary.data_run_number_edit)
-        self.connect(self._summary.data_run_number_edit, QtCore.SIGNAL("textChanged(QString)"), self._run_number_changed)
+        self.connect(self._summary.data_run_number_edit, QtCore.SIGNAL("textChanged(QString)"),
+                     self._run_number_changed)
         self.connect(self._summary.data_run_number_edit, QtCore.SIGNAL("returnPressed()"), self._run_number_changed)
         self._run_number_first_edit = True
 
@@ -172,11 +179,11 @@ class BaseRefWidget(BaseWidget):
         call_back = partial(self._edit_event, ctrl=self._summary.log_scale_chk)
         self.connect(self._summary.log_scale_chk, QtCore.SIGNAL("clicked()"), call_back)
 
-        #Incident medium (selection or text changed)
+        # Incident medium (selection or text changed)
         call_back = partial(self._edit_event, ctrl=self._summary.incident_medium_combobox)
         self.connect(self._summary.incident_medium_combobox, QtCore.SIGNAL("editTextChanged(QString)"), call_back)
 
-        #4th column
+        # 4th column
         call_back = partial(self._edit_event, ctrl=self._summary.dq0)
         self.connect(self._summary.dq0, QtCore.SIGNAL("textChanged(QString)"), call_back)
         call_back = partial(self._edit_event, ctrl=self._summary.dq_over_q)
@@ -184,18 +191,19 @@ class BaseRefWidget(BaseWidget):
         call_back = partial(self._edit_event, ctrl=self._summary.fourth_column_switch)
         self.connect(self._summary.fourth_column_switch, QtCore.SIGNAL("clicked()"), call_back)
 
-        #overlap values
+        # overlap values
         call_back = partial(self._edit_event, ctrl=self._summary.overlapValueMeanRadioButton)
         self.connect(self._summary.overlapValueMeanRadioButton, QtCore.SIGNAL("clicked()"), call_back)
         call_back = partial(self._edit_event, ctrl=self._summary.overlapValueLowestErrorRadioButton)
         self.connect(self._summary.overlapValueLowestErrorRadioButton, QtCore.SIGNAL("clicked()"), call_back)
 
-        #name of output file changed
+        # name of output file changed
         call_back = partial(self._edit_event, ctrl=self._summary.cfg_scaling_factor_file_name)
         self.connect(self._summary.cfg_scaling_factor_file_name_browse, QtCore.SIGNAL("clicked()"), call_back)
 
-        #scaling factor configuration file
-        self.connect(self._summary.cfg_scaling_factor_file_name_browse, QtCore.SIGNAL("clicked()"), self.browse_config_file_name)
+        # scaling factor configuration file
+        self.connect(self._summary.cfg_scaling_factor_file_name_browse, QtCore.SIGNAL("clicked()"),
+                     self.browse_config_file_name)
 
         # Output directory
         self._summary.outdir_edit.setText(os.path.expanduser('~'))
@@ -211,7 +219,7 @@ class BaseRefWidget(BaseWidget):
         if not self._settings.debug and not os.path.isdir("/SNS/%s" % self.instrument_name):
             self._summary.auto_reduce_check.hide()
 
-    def getMetadata(self,filename):
+    def getMetadata(self, filename):
         """
         This retrieve the metadata from the data event NeXus filename
         """
@@ -220,27 +228,27 @@ class BaseRefWidget(BaseWidget):
 
         isSi = False
 
-        #mt1 = mtd['tmpWks']
-        #mt_run = mt1.getRun()
+        # mt1 = mtd['tmpWks']
+        # mt_run = mt1.getRun()
         mt_run = tmpWks.getRun()
 
-        #tthd
+        # tthd
         tthd = mt_run.getProperty('tthd').value[0]
 
-        #ths
+        # ths
         ths = mt_run.getProperty('ths').value[0]
 
-        #lambda requested
+        # lambda requested
         lambda_requested = mt_run.getProperty('LambdaRequest').value[0]
 
-        #s1h, s2h, s1w and s2w
+        # s1h, s2h, s1w and s2w
         s1h = mt_run.getProperty('S1VHeight').value[0]
         s1w = mt_run.getProperty('S1HWidth').value[0]
 
         try:
             s2h = mt_run.getProperty('SiVHeight').value[0]
             isSi = True
-        except:
+        except RuntimeError:
             s2h = mt_run.getProperty('S2VHeight').value[0]
 
         try:
@@ -403,15 +411,15 @@ class BaseRefWidget(BaseWidget):
         # calculate the numerator of mean
         dataNum = 0
         for i in range(sz):
-            if not data_array[i] == 0:
-                tmpFactor = float(data_array[i]) / float((pow(error_array[i],2)))
+            if data_array[i] != 0:
+                tmpFactor = float(data_array[i]) / float((pow(error_array[i], 2)))
                 dataNum += tmpFactor
 
         # calculate denominator
         dataDen = 0
         for i in range(sz):
-            if not error_array[i] == 0:
-                tmpFactor = 1./float((pow(error_array[i],2)))
+            if error_array[i] != 0:
+                tmpFactor = 1./float((pow(error_array[i], 2)))
                 dataDen += tmpFactor
 
         if dataDen == 0:
@@ -456,16 +464,19 @@ class BaseRefWidget(BaseWidget):
         data_e = mtd[scaled_ws_list[0]+'_histo'].dataE(0)
 
         # Add in the other histos, averaging the overlaps
-        for i in range(1, len(scaled_ws_list)):
-            data_y_i = mtd[scaled_ws_list[i]+'_histo'].dataY(0)
-            data_e_i = mt[scaled_ws_list[i]+'_histo'].dataE(0)
-            for j in range(len(data_y_i)):
-
-                if data_y[j]>0 and data_y_i[j]>0:
-                    [data_y[j], data_e[j]] = self.weightedMean([data_y[j], data_y_i[j]], [data_e[j], data_e_i[j]])
-                elif (data_y[j] == 0) and (data_y_i[j]>0):
-                    data_y[j] = data_y_i[j]
-                    data_e[j] = data_e_i[j]
+        for scaled_ws in scaled_ws_list:
+            y_val_index = 0
+            data_y_i = mtd[scaled_ws +'_histo'].dataY(0)
+            data_e_i = mtd[scaled_ws+'_histo'].dataE(0)
+            for y_val in data_y_i:
+                y_val_index += 1
+                if data_y[y_val_index] > 0 and y_val > 0:
+                    data_y[y_val_index], data_e[y_val_index] = self.weightedMean([data_y[y_val_index], y_val],
+                                                                                 [data_e[y_val_index],
+                                                                                  data_e_i[y_val_index]])
+                elif (data_y[y_val_index] == 0) and (y_val > 0):
+                    data_y[y_val_index] = y_val
+                    data_e[y_val_index] = data_e_i[y_val_index]
 
         return scaled_ws_list[0]+'_histo'
 
@@ -489,24 +500,24 @@ class BaseRefWidget(BaseWidget):
         _bin_max = str(2)
         binning_parameters = _from_q + ',-' + _bin_size + ',' + _bin_max
 
-        ## DEBUGGING ONLY
+        # DEBUGGING ONLY
         file_number = 0
 #        print '=========== BEFORE REBINING =========='
         for ws in scaled_ws_list:
-#            print 'file_number: ' , file_number
+            # print 'file_number: ' , file_number
             data_y = mtd[ws].dataY(0)
-            data_e = mtd[ws].dataE(0)
+            _data_e = mtd[ws].dataE(0)
 
             # cleanup data 0-> NAN
-            for j in range(len(data_y)):
-#                print '-> data_y[j]: ' , data_y[j] , ' data_e[j]: ' , data_y[j]
-                if data_y[j] < 1e-12:
-                    data_y[j] = np.nan
-                    data_e[j] = np.nan
+            for y_val in data_y:
+                # print '-> data_y[j]: ' , data_y[j] , ' data_e[j]: ' , data_y[j]
+                if y_val < 1e-12:
+                    _y_val = np.nan
+                    _y_val = np.nan
 
-            file_number = file_number + 1
+            file_number += 1
 
-        ## END OF DEBUGGING ONLY
+        # END OF DEBUGGING ONLY
 
         # Convert each histo to histograms and rebin to final binning
         for ws in scaled_ws_list:
@@ -587,7 +598,8 @@ class BaseRefWidget(BaseWidget):
         default_file_name = 'REFL_' + run_number + '_combined_data.txt'
 
         #retrieve name of the output file
-        file_name = QtGui.QFileDialog.getSaveFileName(self, "Select or define a ASCII file name", default_file_name, "(*.txt)")
+        file_name = QtGui.QFileDialog.getSaveFileName(self, "Select or define a ASCII file name", default_file_name,
+                                                      "(*.txt)")
         if str(file_name).strip() == '':
             return
 
@@ -693,15 +705,18 @@ class BaseRefWidget(BaseWidget):
         _unique_list = list(set(list_incident_medium))
 
         self._summary.incident_medium_combobox.clear()
-        for i in range(len(_unique_list)):
-            self._summary.incident_medium_combobox.addItem(str(_unique_list[i]))
+        for entry in _unique_list:
+            self._summary.incident_medium_combobox.addItem(str(entry))
 
     def _run_number_changed(self):
         self._edit_event(ctrl=self._summary.data_run_number_edit)
 
     def _edit_event(self, text=None, ctrl=None):
+        if text is None:
+            text = ""
+            _text = text
         self._summary.edited_warning_label.show()
-        util.set_edited(ctrl,True)
+        util.set_edited(ctrl, True)
 
     def _reset_warnings(self):
         self._summary.edited_warning_label.hide()
@@ -731,7 +746,7 @@ class BaseRefWidget(BaseWidget):
         util.set_edited(self._summary.data_low_res_range_switch, False)
         util.set_edited(self._summary.norm_low_res_range_switch, False)
         util.set_edited(self._summary.norm_switch, False)
-        #util.set_edited(self._summary.tof_range_switch, False)
+        # util.set_edited(self._summary.tof_range_switch, False)
         util.set_edited(self._summary.q_min_edit, False)
         util.set_edited(self._summary.q_step_edit, False)
         util.set_edited(self._summary.cfg_scaling_factor_file_name, False)
@@ -774,7 +789,7 @@ class BaseRefWidget(BaseWidget):
         content += "# Place holder for python script\n"
         content += "file_path = os.path.join(outputDir, '%s_'+runNumber+'.py')\n" % self.instrument_name
         content += "f=open(file_path,'w')\n"
-        content += "f.write(\"runNumber=\%s \% runNumber\\n\")\n"
+        content += r"f.write(\"runNumber=\%s \% runNumber\\n\")\n"
         content += "f.write(\"\"\"%s\"\"\")\n" % reduce_script
         content += "f.close()\n\n"
 
@@ -991,7 +1006,7 @@ class BaseRefWidget(BaseWidget):
             For REFM, this is X
             For REFL, this is Y
         """
-
+        _is_peak = is_peak
 #        run_number = self._summary.data_run_number_edit.text()
 #        f = FileFinder.findRuns("%s%s" % (self.instrument_name, str(run_number)))[0]
 #
@@ -1027,11 +1042,11 @@ class BaseRefWidget(BaseWidget):
 #        # with the same return code of Qt application
 ##        sys.exit(app.exec_())
 
-        min, max = self._integrated_plot(True,
-                                         self._summary.data_run_number_edit,
-                                         self._summary.data_peak_from_pixel,
-                                         self._summary.data_peak_to_pixel,
-                                         True)
+        _minimum, _maximum = self._integrated_plot(True,
+                                                   self._summary.data_run_number_edit,
+                                                   self._summary.data_peak_from_pixel,
+                                                   self._summary.data_peak_to_pixel,
+                                                   True)
 
     def _plot_count_vs_y_bck(self):
         """
@@ -1041,11 +1056,11 @@ class BaseRefWidget(BaseWidget):
             For REFL, this is Y
         """
 
-        min, max = self._integrated_plot(True,\
-                              self._summary.data_run_number_edit,\
-                              self._summary.data_background_from_pixel1,\
-                              self._summary.data_background_to_pixel1,\
-                              False)
+        _minimum, _maximum = self._integrated_plot(True,
+                                                   self._summary.data_run_number_edit,
+                                                   self._summary.data_background_from_pixel1,
+                                                   self._summary.data_background_to_pixel1,
+                                                   False)
 
     def _plot_count_vs_x(self):
         """
@@ -1054,10 +1069,10 @@ class BaseRefWidget(BaseWidget):
             For REFL, this is X
         """
 
-        min, max = self._integrated_plot(False,
-                                         self._summary.data_run_number_edit,
-                                         self._summary.x_min_edit,
-                                         self._summary.x_max_edit)
+        _minimum, _maximum = self._integrated_plot(False,
+                                                   self._summary.data_run_number_edit,
+                                                   self._summary.x_min_edit,
+                                                   self._summary.x_max_edit)
 
     def _plot_data_count_vs_x_2d(self):
         """
@@ -1071,7 +1086,7 @@ class BaseRefWidget(BaseWidget):
             Will launch the 2d plot for the data of counts vs TOF
         """
 
-        #retrieve name of workspace first
+        # retrieve name of workspace first
         run_number =  self._summary.data_run_number_edit.text()
         file_path = FileFinder.findRuns("%s%s" % (self.instrument_name, str(run_number)))[0]
 
@@ -1136,8 +1151,10 @@ class BaseRefWidget(BaseWidget):
 #            self._summary.x_max_edit.setText("%-d" % int(tofmax))
 
         # mantidplot.app should be used instead of _qti.app (it's just an alias)
-        #mantidplot.app.connect(mantidplot.app.mantidUI, QtCore.SIGNAL("python_peak_back_tof_range_update(double,double,double,double,double,double)"), call_back)
-        #mantidplot.app.connect(mantidplot.app.RefDetectorViewer, QtCore.SIGNAL("python_peak_back_tof_range_update(double,double,double,double,double,double)"), call_back)
+        #mantidplot.app.connect(mantidplot.app.mantidUI, QtCore.SIGNAL("python_peak_back_tof_range_update(double,double,
+        # double,double,double,double)"), call_back)
+        #mantidplot.app.connect(mantidplot.app.RefDetectorViewer, QtCore.SIGNAL("python_peak_back_tof_range_update
+        # (double,double,double,double,double,double)"), call_back)
 
         peak_min = int(self._summary.data_peak_from_pixel.text())
         peak_max = int(self._summary.data_peak_to_pixel.text())
@@ -1147,9 +1164,12 @@ class BaseRefWidget(BaseWidget):
         tof_max = int(self._summary.data_to_tof.text())
 
         import mantidqtpython
-        self.ref_det_view = mantidqtpython.MantidQt.RefDetectorViewer.RefMatrixWSImageView(ws_output_base, peak_min, peak_max, back_min, back_max, tof_min, tof_max)
+        self.ref_det_view = mantidqtpython.MantidQt.RefDetectorViewer.RefMatrixWSImageView(ws_output_base, peak_min,
+                                                                                           peak_max, back_min, back_max,
+                                                                                           tof_min, tof_max)
         QtCore.QObject.connect(self.ref_det_view.getConnections(),
-                               QtCore.SIGNAL("peak_back_tof_range_update(double,double, double,double,double,double)"), self.call_back)
+                               QtCore.SIGNAL("peak_back_tof_range_update(double,double, double,double,double,double)"),
+                               self.call_back)
 
 
     def call_back(self, peakmin, peakmax, backmin, backmax, tofmin, tofmax):
@@ -1196,10 +1216,10 @@ class BaseRefWidget(BaseWidget):
 
 #        dmw = DesignerMainWindow(self, 'norm')
 #        dmw.show()
-        min, max = self._integrated_plot(True,
-                                         self._summary.norm_run_number_edit,
-                                         self._summary.norm_peak_from_pixel,
-                                         self._summary.norm_peak_to_pixel)
+        _minimum, _maximum = self._integrated_plot(True,
+                                                   self._summary.norm_run_number_edit,
+                                                   self._summary.norm_peak_from_pixel,
+                                                   self._summary.norm_peak_to_pixel)
 
     def _norm_count_vs_y_bck(self):
 
@@ -1210,10 +1230,10 @@ class BaseRefWidget(BaseWidget):
 
     def _norm_count_vs_x(self):
 
-        min, max = self._integrated_plot(False,
-                                         self._summary.norm_run_number_edit,
-                                         self._summary.norm_x_min_edit,
-                                         self._summary.norm_x_max_edit)
+        _minimum, _maximum = self._integrated_plot(False,
+                                                   self._summary.norm_run_number_edit,
+                                                   self._summary.norm_x_min_edit,
+                                                   self._summary.norm_x_max_edit)
 
     def _plot_norm_count_vs_x_2d(self):
         """
@@ -1269,17 +1289,17 @@ class BaseRefWidget(BaseWidget):
             if self.short_name == "REFM":
                 is_pixel_y = not is_pixel_y
 
-            min, max = data_manipulation.counts_vs_pixel_distribution(f, is_pixel_y=is_pixel_y,
-                                                                      callback=call_back,
-                                                                      range_min=range_min,
-                                                                      range_max=range_max,
-                                                                      high_res=is_high_res,
-                                                                      instrument=self.short_name,
-                                                                      isPeak=isPeak)
+            minimum, maximum = data_manipulation.counts_vs_pixel_distribution(f, is_pixel_y=is_pixel_y,
+                                                                              callback=call_back,
+                                                                              range_min=range_min,
+                                                                              range_max=range_max,
+                                                                              high_res=is_high_res,
+                                                                              instrument=self.short_name,
+                                                                              isPeak=isPeak)
 
-            return min, max
-        except:
-            pass
+            return minimum, maximum
+        except IOError, e:
+            logger.error("Could not find file: " + e.filename())
 
     def _plot_tof(self):
         if not IS_IN_MANTIDPLOT:
@@ -1414,7 +1434,8 @@ class BaseRefWidget(BaseWidget):
         else:
             for item in state.data_sets:
                 if item is not None:
-                    item_widget = QtGui.QListWidgetItem(unicode(str(','.join([str(i) for i in item.data_files]))), self._summary.angle_list)
+                    item_widget = QtGui.QListWidgetItem(unicode(str(','.join([str(i) for i in item.data_files]))),
+                                                        self._summary.angle_list)
                     item_widget.setData(QtCore.Qt.UserRole, item)
 
         if len(state.data_sets)>0:
@@ -1439,8 +1460,8 @@ class BaseRefWidget(BaseWidget):
         self._summary.incident_medium_combobox.clear()
         _incident_medium_str = str(state.incident_medium_list[0])
         _list = _incident_medium_str.split(',')
-        for i in range(len(_list)):
-            self._summary.incident_medium_combobox.addItem(str(_list[i]))
+        for item in _list:
+            self._summary.incident_medium_combobox.addItem(str(item))
         self._summary.incident_medium_combobox.setCurrentIndex(state.incident_medium_index_selected)
 
         #Peak from/to pixels

--- a/scripts/Interface/reduction_gui/widgets/reflectometer/launch_peak_back_selection_1d.py
+++ b/scripts/Interface/reduction_gui/widgets/reflectometer/launch_peak_back_selection_1d.py
@@ -1,13 +1,6 @@
-#pylint: disable=invalid-name
+# pylint: disable=invalid-name, too-many-instance-attributes, too-many-arguments
 # used to parse files more easily
 from __future__ import with_statement
-
-# numpy module
-import numpy as np
-
-# for command-line arguments
-import sys
-
 # Qt4 bindings for core Qt functionalities (non-GUI)
 from PyQt4 import QtCore
 # python Qt4 bindings for GUI objects
@@ -15,17 +8,17 @@ from PyQt4 import QtGui
 
 from mantid.simpleapi import *
 
-#blue
+# blue
 CSS_PEAK = """QLineEdit {
                    background-color: #54f3f5;
                 }"""
 
-#red
+# red
 CSS_BACK = """QLineEdit{
                    background-color: #f53535;
                 }"""
 
-#green
+# green
 CSS_LOWRES = """QLineEdit{
                    background-color: #a7f6a1;
                 }"""
@@ -44,7 +37,7 @@ class DesignerMainWindow(QtGui.QMainWindow):
     _lowresToValue = 6.
     drs = []
     parent = None
-    dataType = 'data'  #'data' or 'norm'
+    dataType = 'data'  # 'data' or 'norm'
     x1=None
     x2=None
     y1=None
@@ -82,22 +75,23 @@ class DesignerMainWindow(QtGui.QMainWindow):
         self.y2 = mt2.readY(0)[:]
 
         self.dataType = type
+        _summary = parent._summary
         if type == 'data':
-            self._peakFromValue=float(parent._summary.data_peak_from_pixel.text())
-            self._peakToValue=float(parent._summary.data_peak_to_pixel.text())
-            self._backFromValue=float(parent._summary.data_background_from_pixel1.text())
-            self._backToValue=float(parent._summary.data_background_to_pixel1.text())
-            self._lowresFromValue=float(parent._summary.x_min_edit.text())
-            self._lowresToValue=float(parent._summary.x_max_edit.text())
+            self._peakFromValue = float(_summary.data_peak_from_pixel.text())
+            self._peakToValue = float(_summary.data_peak_to_pixel.text())
+            self._backFromValue = float(_summary.data_background_from_pixel1.text())
+            self._backToValue = float(_summary.data_background_to_pixel1.text())
+            self._lowresFromValue = float(_summary.x_min_edit.text())
+            self._lowresToValue = float(_summary.x_max_edit.text())
         else:
-            self._peakFromValue=float(parent._summary.norm_peak_from_pixel.text())
-            self._peakToValue=float(parent._summary.norm_peak_to_pixel.text())
-            self._backFromValue=float(parent._summary.norm_background_from_pixel1.text())
-            self._backToValue=float(parent._summary.norm_background_to_pixel1.text())
-            self._lowresFromValue=float(parent._summary.norm_x_min_edit.text())
-            self._lowresToValue=float(parent._summary.norm_x_max_edit.text())
+            self._peakFromValue = float(_summary.norm_peak_from_pixel.text())
+            self._peakToValue = float(_summary.norm_peak_to_pixel.text())
+            self._backFromValue = float(_summary.norm_background_from_pixel1.text())
+            self._backToValue = float(_summary.norm_background_to_pixel1.text())
+            self._lowresFromValue = float(_summary.norm_x_min_edit.text())
+            self._lowresToValue = float(_summary.norm_x_max_edit.text())
 
-        #initialization of the superclass
+        # initialization of the superclass
         super(DesignerMainWindow, self).__init__(parent)
         self.parent = parent
 
@@ -107,19 +101,19 @@ class DesignerMainWindow(QtGui.QMainWindow):
         self.create_menu()
         self.create_main_frame()
 
-        #peak text fields
+        # peak text fields
         QtCore.QObject.connect(self.peakFrom, QtCore.SIGNAL("returnPressed()"), self.update_plot)
         QtCore.QObject.connect(self.peakTo, QtCore.SIGNAL("returnPressed()"), self.update_plot)
 
-        #back text fields
+        # back text fields
         QtCore.QObject.connect(self.backFrom, QtCore.SIGNAL("returnPressed()"), self.update_plot)
         QtCore.QObject.connect(self.backTo, QtCore.SIGNAL("returnPressed()"), self.update_plot)
 
-        #lowres text fields
+        # lowres text fields
         QtCore.QObject.connect(self.lowresFrom, QtCore.SIGNAL("returnPressed()"), self.update_plot)
         QtCore.QObject.connect(self.lowresTo, QtCore.SIGNAL("returnPressed()"), self.update_plot)
 
-        #linear and log axis
+        # linear and log axis
         QtCore.QObject.connect(self.linear, QtCore.SIGNAL("clicked()"), self.update_linear_selection_mode)
         QtCore.QObject.connect(self.log, QtCore.SIGNAL("clicked()"), self.update_log_selection_mode)
 
@@ -358,7 +352,6 @@ class DesignerMainWindow(QtGui.QMainWindow):
 
     def tmp_plot_data(self, refresh=False):
         """ just for testing, display random data """
-
         if refresh:
             for rect in self.drs:
                 rect._refresh()
@@ -369,7 +362,7 @@ class DesignerMainWindow(QtGui.QMainWindow):
             def __init__(self, rect, type, super, parent):
                 self.rect = rect
                 self.xpress = None
-                self.type = type #peak_from, peak_to, back_from, back_to...
+                self.type = type  # peak_from, peak_to, back_from, back_to...
                 self.super = super
                 self.parent = parent
 
@@ -384,34 +377,38 @@ class DesignerMainWindow(QtGui.QMainWindow):
 
             def on_press(self, event):
                 'on button press we will see if the mouse is over us and store some data'
-                if event.inaxes != self.rect.axes: return
+                if event.inaxes != self.rect.axes:
+                    return
 
-                contains, attrd = self.rect.contains(event)
-                if not contains: return
+                contains, _attrd = self.rect.contains(event)
+                if not contains:
+                    return
                 self.xpress = event.xdata
 
             def on_motion(self, event):
-                'on motion we will move the rect if the mouse is over us'
-                if self.xpress is None: return
-                if event.inaxes != self.rect.axes: return
+                """on motion we will move the rect if the mouse is over us"""
+                if self.xpress is None:
+                    return
+                if event.inaxes != self.rect.axes:
+                    return
                 x0 = event.xdata
                 _x0_format = '{0:.2f}'.format(x0)
                 _x0_parent_format = str(int(round(x0)))
-
+                _summary = self.parent._summary
                 if self.super.dataType == 'data':
-                    parent_data_peak_from = self.parent._summary.data_peak_from_pixel
-                    parent_data_peak_to = self.parent._summary.data_peak_to_pixel
-                    parent_back_peak_from = self.parent._summary.data_background_from_pixel1
-                    parent_back_peak_to = self.parent._summary.data_background_to_pixel1
-                    parent_x_min = self.parent._summary.x_min_edit
-                    parent_x_max = self.parent._summary.x_max_edit
+                    parent_data_peak_from = _summary.data_peak_from_pixel
+                    parent_data_peak_to = _summary.data_peak_to_pixel
+                    parent_back_peak_from = _summary.data_background_from_pixel1
+                    parent_back_peak_to = _summary.data_background_to_pixel1
+                    parent_x_min = _summary.x_min_edit
+                    parent_x_max = _summary.x_max_edit
                 else:
-                    parent_data_peak_from = self.parent._summary.norm_peak_from_pixel
-                    parent_data_peak_to = self.parent._summary.norm_peak_to_pixel
-                    parent_back_peak_from = self.parent._summary.norm_background_from_pixel1
-                    parent_back_peak_to = self.parent._summary.norm_background_to_pixel1
-                    parent_x_min = self.parent._summary.norm_x_min_edit
-                    parent_x_max = self.parent._summary.norm_x_max_edit
+                    parent_data_peak_from = _summary.norm_peak_from_pixel
+                    parent_data_peak_to = _summary.norm_peak_to_pixel
+                    parent_back_peak_from = _summary.norm_background_from_pixel1
+                    parent_back_peak_to = _summary.norm_background_to_pixel1
+                    parent_x_min = _summary.norm_x_min_edit
+                    parent_x_max = _summary.norm_x_max_edit
 
                 if self.type == 'peak_from':
                     self.super.peakFrom.setText(_x0_format)
@@ -452,7 +449,8 @@ class DesignerMainWindow(QtGui.QMainWindow):
                 self.rect.figure.canvas.draw()
 
             def on_release(self, event):
-                'on release we reset the press data'
+                """on release we reset the press data"""
+                _event = event
                 self.xpress = None
                 self.rect.figure.canvas.draw()
 
@@ -464,7 +462,7 @@ class DesignerMainWindow(QtGui.QMainWindow):
 
         parent = self.parent
 
-        #top plot will be for peak and background selection
+        # top plot will be for peak and background selection
         axes = self.fig.add_subplot(211)
 
         x = self.x1
@@ -473,9 +471,9 @@ class DesignerMainWindow(QtGui.QMainWindow):
         bLinear = self.linear.isChecked()
 
         if bLinear:
-            line, = axes.plot(x,y,color='black')
+            _line, = axes.plot(x, y, color='black')
         else:
-            line, = axes.semilogy(x,y,color='black')
+            _line, = axes.semilogy(x, y, color='black')
 
         ymax=max(y)
 
@@ -484,7 +482,7 @@ class DesignerMainWindow(QtGui.QMainWindow):
         else:
             ymin = 1
 
-        #peak cursor
+        # peak cursor
         peakx1 = self._peakFromValue
         self.peakFrom.setText(str(peakx1))
         peakx2 = self._peakToValue
@@ -509,7 +507,7 @@ class DesignerMainWindow(QtGui.QMainWindow):
             dr.connect()
             self.drs.append(dr)
 
-        #back cursor
+        # back cursor
         backx1 = self._backFromValue
         self.backFrom.setText(str(backx1))
         backx2 = self._backToValue
@@ -541,9 +539,9 @@ class DesignerMainWindow(QtGui.QMainWindow):
         y = self.y2
 
         if bLinear:
-            line2, = axes2.plot(x,y,color='black')
+            _line2, = axes2.plot(x,y,color='black')
         else:
-            line2, = axes2.semilogy(x,y,color='black')
+            _line2, = axes2.semilogy(x,y,color='black')
 
         ymax=max(y)
         if bLinear:

--- a/scripts/Interface/reduction_gui/widgets/reflectometer/launch_peak_back_selection_1d.py
+++ b/scripts/Interface/reduction_gui/widgets/reflectometer/launch_peak_back_selection_1d.py
@@ -312,11 +312,11 @@ class DesignerMainWindow(QtGui.QMainWindow):
     def select_file(self):
         """ opens a file select dialog """
         # open the dialog and get the selected file
-        file = QtGui.QFileDialog.getOpenFileName()
+        file_to_open = QtGui.QFileDialog.getOpenFileName()
         # if a file is selected
-        if file:
+        if file_to_open:
             # update the lineEdit text with the selected filename
-            self.mpllineEdit.setText(file)
+            self.mpllineEdit.setText(file_to_open)
 
     def parse_file(self, filename):
         """ parse a text file to extract letters frequencies """
@@ -328,7 +328,7 @@ class DesignerMainWindow(QtGui.QMainWindow):
         with open(filename) as f:
             for line in f:
                 for char in line:
-                    #counts only letters
+                    # counts only letters
                     if ord(char.lower()) in range(97, 122+1):
                         letters[char.lower()] += 1
 
@@ -336,7 +336,7 @@ class DesignerMainWindow(QtGui.QMainWindow):
         k = sorted(letters.keys())
         v = [letters[ki] for ki in k]
 
-        return k,v
+        return k, v
 
     def update_plot(self):
         """ retrieve the value of the peak/back/lowres and save it

--- a/scripts/Interface/reduction_gui/widgets/reflectometer/refl_data_simple.py
+++ b/scripts/Interface/reduction_gui/widgets/reflectometer/refl_data_simple.py
@@ -1,16 +1,13 @@
-#pylint: disable=too-many-lines
-#pylint: disable=invalid-name
-from PyQt4 import QtGui, uic, QtCore
-import reduction_gui.widgets.util as util
+# pylint: disable=too-many-lines, invalid-name, too-many-arguments
 import math
-import os
 import time
 import sys
 from functools import partial
+import reduction_gui.widgets.util as util
+from PyQt4 import QtGui, QtCore
 from reduction_gui.reduction.reflectometer.refl_data_script import DataSets as REFLDataSets
 from reduction_gui.reduction.reflectometer.refm_data_script import DataSets as REFMDataSets
 from reduction_gui.reduction.reflectometer.refl_data_series import DataSeries
-from reduction_gui.settings.application_settings import GeneralSettings
 from reduction_gui.widgets.base_widget import BaseWidget
 import ui.reflectometer.ui_data_refl_simple
 
@@ -19,16 +16,15 @@ try:
     import mantidplot
     from mantid.simpleapi import *
     from reduction.instruments.reflectometer import data_manipulation
-
     IS_IN_MANTIDPLOT = True
-except:
-    pass
+except ImportError, e:
+    logger.error(e.message())
 
 class DataReflWidget(BaseWidget):
     """
         Widget that present instrument details to the user
     """
-    ## Widget name
+    # Widget name
     name = "Data"
     instrument_name = 'REF_L'
     short_name = 'REFL'
@@ -169,8 +165,8 @@ class DataReflWidget(BaseWidget):
         call_back = partial(self._edit_event, ctrl=self._summary.data_run_number_edit)
         self.connect(self._summary.data_run_number_edit, QtCore.SIGNAL("textChanged(QString)"), self._run_number_changed)
         self._run_number_first_edit = True
-        #call_back = partial(self._edit_event, ctrl=self._summary.log_scale_chk)
-        #self.connect(self._summary.log_scale_chk, QtCore.SIGNAL("clicked()"), call_back)
+        # call_back = partial(self._edit_event, ctrl=self._summary.log_scale_chk)
+        # self.connect(self._summary.log_scale_chk, QtCore.SIGNAL("clicked()"), call_back)
 
         call_back = partial(self._edit_event, ctrl=self._summary.det_angle_edit)
         self.connect(self._summary.det_angle_edit, QtCore.SIGNAL("textChanged(QString)"), call_back)
@@ -246,8 +242,9 @@ class DataReflWidget(BaseWidget):
         self._edit_event(ctrl=self._summary.data_run_number_edit)
 
     def _edit_event(self, text=None, ctrl=None):
+        _text = text
         self._summary.edited_warning_label.show()
-        util.set_edited(ctrl,True)
+        util.set_edited(ctrl, True)
 
     def _reset_warnings(self):
         self._summary.edited_warning_label.hide()
@@ -345,14 +342,15 @@ class DataReflWidget(BaseWidget):
 
     def _update_scattering_angle(self):
         if not self._summary.angle_radio.isChecked():
+
             dangle = util._check_and_get_float_line_edit(self._summary.det_angle_edit)
             dangle0 = util._check_and_get_float_line_edit(self._summary.det_angle_offset_edit)
             direct_beam_pix = util._check_and_get_float_line_edit(self._summary.direct_pixel_edit)
             ref_pix = util._check_and_get_float_line_edit(self._summary.center_pix_edit)
-            PIXEL_SIZE = 0.0007 # m
+            PIXEL_SIZE = 0.0007  # m
 
             delta = (dangle-dangle0)*math.pi/180.0/2.0\
-                + ((direct_beam_pix-ref_pix)*PIXEL_SIZE)/ (2.0*self._detector_distance)
+                + ((direct_beam_pix-ref_pix)*PIXEL_SIZE) / (2.0*self._detector_distance)
 
             scattering_angle = delta*180.0/math.pi
             scattering_angle_str = "%4.3g" % scattering_angle
@@ -404,7 +402,7 @@ class DataReflWidget(BaseWidget):
             self._summary.q_min_label.hide()
             self._summary.q_min_unit_label.hide()
 
-            #TODO: allow log binning
+            # TODO: allow log binning
             self._summary.log_scale_chk.hide()
 
     def _create_auto_reduce_template(self):
@@ -418,9 +416,9 @@ class DataReflWidget(BaseWidget):
         content += "if (os.environ.has_key(\"MANTIDPATH\")):\n"
         content += "    del os.environ[\"MANTIDPATH\"]\n"
         content += "sys.path.insert(0,'/opt/mantidnightly/bin')\n"
-        script += "import mantid\n"
-        script += "from mantid.simpleapi import *\n"
-        script += "from mantid.kernel import ConfigService\n"
+        reduce_script += "import mantid\n"
+        reduce_script += "from mantid.simpleapi import *\n"
+        reduce_script += "from mantid.kernel import ConfigService\n"
 
         content += "eventFileAbs=sys.argv[1]\n"
         content += "outputDir=sys.argv[2]\n\n"
@@ -435,7 +433,7 @@ class DataReflWidget(BaseWidget):
         content += "# Place holder for python script\n"
         content += "file_path = os.path.join(outputDir, '%s_'+runNumber+'.py')\n" % self.instrument_name
         content += "f=open(file_path,'w')\n"
-        content += "f.write(\"runNumber=\%s \% runNumber\\n\")\n"
+        content += r"f.write(\"runNumber=\%s \% runNumber\\n\")\n"
         content += "f.write(\"\"\"%s\"\"\")\n" % reduce_script
         content += "f.close()\n\n"
 
@@ -496,9 +494,9 @@ class DataReflWidget(BaseWidget):
                     f.write(content)
                     f.close()
                     QtGui.QMessageBox.information(self, "Automated reduction script saved",\
-                                           "The automated reduction script has been updated")
-                except:
-                    _report_error()
+                                                        "The automated reduction script has been updated")
+                except IOError, fileError:
+                    _report_error("Failed to open file: " + fileError.filename())
             else:
                 _report_error("You do not have permissions to write to %s." % sns_path)
         else:
@@ -517,7 +515,7 @@ class DataReflWidget(BaseWidget):
             self._summary.auto_reduce_btn.hide()
 
     def _remove_item(self):
-        if self._summary.angle_list.count()==0:
+        if self._summary.angle_list.count() == 0:
             return
         self._summary.angle_list.setEnabled(False)
         self._summary.remove_btn.setEnabled(False)
@@ -633,7 +631,7 @@ class DataReflWidget(BaseWidget):
         self._summary.tof_max_label.setEnabled(is_checked)
         self._summary.data_to_tof.setEnabled(is_checked)
         self._summary.tof_max_label2.setEnabled(is_checked)
-        #self._summary.plot_tof_btn.setEnabled(is_checked)
+        # self._summary.plot_tof_btn.setEnabled(is_checked)
         self._edit_event(None, self._summary.tof_range_switch)
 
     def _geometry_correction_clicked(self, is_checked):
@@ -649,13 +647,13 @@ class DataReflWidget(BaseWidget):
             For REFM, this is X
             For REFL, this is Y
         """
-        min, max = self._integrated_plot(True,
-                                         self._summary.data_run_number_edit,
-                                         self._summary.data_peak_from_pixel,
-                                         self._summary.data_peak_to_pixel)
-        self._summary.data_peak_from_pixel_estimate.setText(str(int(math.ceil(min))))
-        self._summary.data_peak_to_pixel_estimate.setText(str(int(math.ceil(max))))
-        self._summary.ref_pix_estimate.setText("%4.1f" % ((max+min)/2.0))
+        _is_peak = is_peak
+        minimum, maximum = self._integrated_plot(True, self._summary.data_run_number_edit,\
+                                                self._summary.data_peak_from_pixel,\
+                                                self._summary.data_peak_to_pixel)
+        self._summary.data_peak_from_pixel_estimate.setText(str(int(math.ceil(minimum))))
+        self._summary.data_peak_to_pixel_estimate.setText(str(int(math.ceil( maximum))))
+        self._summary.ref_pix_estimate.setText("%4.1f" % ((maximum+minimum)/2.0))
         util.set_tiny(self._summary.data_peak_from_pixel_estimate)
         util.set_tiny(self._summary.data_peak_to_pixel_estimate)
         util.set_tiny(self._summary.ref_pix_estimate)
@@ -678,38 +676,38 @@ class DataReflWidget(BaseWidget):
             For REFM, this is Y
             For REFL, this is X
         """
-        min, max = self._integrated_plot(False,
-                                         self._summary.data_run_number_edit,
-                                         self._summary.x_min_edit,
+        minimum, maximum = self._integrated_plot(False,\
+                                         self._summary.data_run_number_edit,\
+                                         self._summary.x_min_edit,\
                                          self._summary.x_max_edit)
-        self._summary.x_min_estimate.setText(str(int(math.ceil(min))))
-        self._summary.x_max_estimate.setText(str(int(math.ceil(max))))
+        self._summary.x_min_estimate.setText(str(int(math.ceil(minimum))))
+        self._summary.x_max_estimate.setText(str(int(math.ceil(maximum))))
         util.set_tiny(self._summary.x_min_estimate)
         util.set_tiny(self._summary.x_max_estimate)
 
     def _norm_count_vs_y(self):
-        min, max = self._integrated_plot(True,
-                                         self._summary.norm_run_number_edit,
-                                         self._summary.norm_peak_from_pixel,
+        minimum, maximum = self._integrated_plot(True,\
+                                         self._summary.norm_run_number_edit,\
+                                         self._summary.norm_peak_from_pixel,\
                                          self._summary.norm_peak_to_pixel)
-        self._summary.norm_peak_from_pixel_estimate.setText(str(int(math.ceil(min))))
-        self._summary.norm_peak_to_pixel_estimate.setText(str(int(math.ceil(max))))
+        self._summary.norm_peak_from_pixel_estimate.setText(str(int(math.ceil(minimum))))
+        self._summary.norm_peak_to_pixel_estimate.setText(str(int(math.ceil(maximum))))
         util.set_tiny(self._summary.norm_peak_from_pixel_estimate)
         util.set_tiny(self._summary.norm_peak_to_pixel_estimate)
 
     def _norm_count_vs_y_bck(self):
-        self._integrated_plot(True,
-                              self._summary.norm_run_number_edit,
-                              self._summary.norm_background_from_pixel1,
+        self._integrated_plot(True,\
+                              self._summary.norm_run_number_edit,\
+                              self._summary.norm_background_from_pixel1,\
                               self._summary.norm_background_to_pixel1)
 
     def _norm_count_vs_x(self):
-        min, max = self._integrated_plot(False,
-                                         self._summary.norm_run_number_edit,
-                                         self._summary.norm_x_min_edit,
+        minimum, maximum = self._integrated_plot(False,\
+                                         self._summary.norm_run_number_edit,\
+                                         self._summary.norm_x_min_edit,\
                                          self._summary.norm_x_max_edit)
-        self._summary.norm_xmin_estimate.setText(str(int(math.ceil(min))))
-        self._summary.norm_xmax_estimate.setText(str(int(math.ceil(max))))
+        self._summary.norm_xmin_estimate.setText(str(int(math.ceil(minimum))))
+        self._summary.norm_xmax_estimate.setText(str(int(math.ceil(maximum))))
         util.set_tiny(self._summary.norm_xmin_estimate)
         util.set_tiny(self._summary.norm_xmax_estimate)
 
@@ -749,14 +747,14 @@ class DataReflWidget(BaseWidget):
             if self.short_name == "REFM":
                 is_pixel_y = not is_pixel_y
 
-            min, max = data_manipulation.counts_vs_pixel_distribution(f, is_pixel_y=is_pixel_y,
-                                                                      callback=call_back,
-                                                                      range_min=range_min,
-                                                                      range_max=range_max,
-                                                                      high_res=is_high_res,
-                                                                      instrument=self.short_name)
-            return min, max
-        except:
+            minimum, maximum = data_manipulation.counts_vs_pixel_distribution(f, is_pixel_y=is_pixel_y,
+                                                                              callback=call_back,
+                                                                              range_min=range_min,
+                                                                              range_max=range_max,
+                                                                              high_res=is_high_res,
+                                                                              instrument=self.short_name)
+            return minimum, maximum
+        except IOError:
             pass
 
     def _plot_tof(self):
@@ -775,7 +773,7 @@ class DataReflWidget(BaseWidget):
             data_manipulation.tof_distribution(f, call_back,
                                                range_min=range_min,
                                                range_max=range_max)
-        except:
+        except IOError:
             pass
 
     def _add_data(self):
@@ -826,7 +824,7 @@ class DataReflWidget(BaseWidget):
 
                 self._sangle_parameter = logs["SANGLE"]
                 self._detector_distance = logs["DET_DISTANCE"]
-            except:
+            except IOError:
                 # Could not read in the parameters, skip.
                 msg = "No data set was found for run %s\n\n" % run_entry
                 msg += "Make sure that your data directory was added to the "
@@ -837,11 +835,11 @@ class DataReflWidget(BaseWidget):
             self._summary.waiting_label.hide()
 
     def _angle_changed(self):
-        if self._summary.angle_list.count()==0:
+        if self._summary.angle_list.count() == 0:
             return
         self._summary.angle_list.setEnabled(False)
         self._summary.remove_btn.setEnabled(False)
-        current_item =  self._summary.angle_list.currentItem()
+        current_item = self._summary.angle_list.currentItem()
         if current_item is not None:
             state = current_item.data(QtCore.Qt.UserRole)
             self.set_editing_state(state)
@@ -892,31 +890,31 @@ class DataReflWidget(BaseWidget):
 
     def set_editing_state(self, state):
 
-        #Peak from/to pixels
+        # Peak from/to pixels
         self._summary.data_peak_from_pixel.setText(str(state.DataPeakPixels[0]))
         self._summary.data_peak_to_pixel.setText(str(state.DataPeakPixels[1]))
 
-        #data low resolution range
+        # data low resolution range
         self._summary.data_low_res_range_switch.setChecked(state.data_x_range_flag)
         self._summary.x_min_edit.setText(str(state.data_x_range[0]))
         self._summary.x_max_edit.setText(str(state.data_x_range[1]))
         self._data_low_res_clicked(state.data_x_range_flag)
 
-        #norm low resolution range
+        # norm low resolution range
         self._summary.norm_low_res_range_switch.setChecked(state.norm_x_range_flag)
         self._summary.norm_x_min_edit.setText(str(state.norm_x_range[0]))
         self._summary.norm_x_max_edit.setText(str(state.norm_x_range[1]))
         self._norm_low_res_clicked(state.data_x_range_flag)
 
-        #Background flag
+        # Background flag
         self._summary.data_background_switch.setChecked(state.DataBackgroundFlag)
         self._data_background_clicked(state.DataBackgroundFlag)
 
-        #Background from/to pixels
+        # Background from/to pixels
         self._summary.data_background_from_pixel1.setText(str(state.DataBackgroundRoi[0]))
         self._summary.data_background_to_pixel1.setText(str(state.DataBackgroundRoi[1]))
 
-        #from TOF and to TOF
+        # from TOF and to TOF
         self._summary.data_from_tof.setText(str(int(state.DataTofRange[0])))
         self._summary.data_to_tof.setText(str(int(state.DataTofRange[1])))
         self._summary.tof_range_switch.setChecked(state.TofRangeFlag)
@@ -947,7 +945,7 @@ class DataReflWidget(BaseWidget):
         self._summary.norm_background_from_pixel1.setText(str(state.NormBackgroundRoi[0]))
         self._summary.norm_background_to_pixel1.setText(str(state.NormBackgroundRoi[1]))
 
-        #normalization flag
+        # normalization flag
         self._summary.norm_switch.setChecked(state.NormFlag)
         self._norm_clicked(state.NormFlag)
 
@@ -1032,7 +1030,7 @@ class DataReflWidget(BaseWidget):
         else:
             m = REFMDataSets()
 
-        #Peak from/to pixels
+        # Peak from/to pixels
         m.DataPeakPixels = [int(self._summary.data_peak_from_pixel.text()),
                             int(self._summary.data_peak_to_pixel.text())]
 
@@ -1044,15 +1042,15 @@ class DataReflWidget(BaseWidget):
                           int(self._summary.norm_x_max_edit.text())]
         m.norm_x_range_flag = self._summary.norm_low_res_range_switch.isChecked()
 
-        #Background flag
+        # Background flag
         m.DataBackgroundFlag = self._summary.data_background_switch.isChecked()
 
-        #Background from/to pixels
+        # Background from/to pixels
         roi1_from = int(self._summary.data_background_from_pixel1.text())
         roi1_to = int(self._summary.data_background_to_pixel1.text())
         m.DataBackgroundRoi = [roi1_from, roi1_to, 0, 0]
 
-        #from TOF and to TOF
+        # from TOF and to TOF
         from_tof = float(self._summary.data_from_tof.text())
         to_tof = float(self._summary.data_to_tof.text())
         m.DataTofRange = [from_tof, to_tof]
@@ -1069,17 +1067,17 @@ class DataReflWidget(BaseWidget):
         m.NormPeakPixels = [int(self._summary.norm_peak_from_pixel.text()),
                             int(self._summary.norm_peak_to_pixel.text())]
 
-        #Background flag
+        # Background flag
         m.NormBackgroundFlag = self._summary.norm_background_switch.isChecked()
 
-        #Background from/to pixels
+        # Background from/to pixels
         roi1_from = int(self._summary.norm_background_from_pixel1.text())
         roi1_to = int(self._summary.norm_background_to_pixel1.text())
         m.NormBackgroundRoi = [roi1_from, roi1_to]
 
-        #m.q_min = float(self._summary.q_min_edit.text())
-        #m.q_step = float(self._summary.q_step_edit.text())
-        #if self._summary.log_scale_chk.isChecked():
+        # m.q_min = float(self._summary.q_min_edit.text())
+        # m.q_step = float(self._summary.q_step_edit.text())
+        # if self._summary.log_scale_chk.isChecked():
         #    m.q_step = -m.q_step
 
         # Scattering angle

--- a/scripts/Interface/reduction_gui/widgets/reflectometer/refl_data_simple.py
+++ b/scripts/Interface/reduction_gui/widgets/reflectometer/refl_data_simple.py
@@ -402,7 +402,7 @@ class DataReflWidget(BaseWidget):
             self._summary.q_min_label.hide()
             self._summary.q_min_unit_label.hide()
 
-            # TODO: allow log binning
+            # to-do: allow log binning
             self._summary.log_scale_chk.hide()
 
     def _create_auto_reduce_template(self):

--- a/scripts/Interface/reduction_gui/widgets/reflectometer/refl_data_simple.py
+++ b/scripts/Interface/reduction_gui/widgets/reflectometer/refl_data_simple.py
@@ -729,7 +729,7 @@ class DataReflWidget(BaseWidget):
             @param max_ctrl: control widget containing the range maximum
         """
         if not IS_IN_MANTIDPLOT:
-            return
+            return None, None
 
         try:
             f = FileFinder.findRuns("%s%s" % (self.instrument_name, str(file_ctrl.text())))[0]


### PR DESCRIPTION
This PR attempts to reduce the Pylint warnings produced by the files in `scripts/interfaces/reduction_gui/widgets/reflectometer`, whilst maintaining their current functionality.
- [x] `launch_peak_back_selection_1d.py`
- [x] `refl_data_simple.py`
- [x] `base_ref_reduction.py`

**To test:**
- Make sure that all builds pass
- Ensure that code changes are clean and make sense
- Ensure that the files in question have a reduced amount of warnings on the Pylint Violations list.

<!-- Instructions for testing. -->

Fixes #15169.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
