### PR TITLE
GetDetOffsetsMultiPeaks extend peak functions and minimizer

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/GetDetOffsetsMultiPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GetDetOffsetsMultiPeaks.h
@@ -157,6 +157,7 @@ private:
   /// Peak profile type
   std::string m_peakType;
   /// Criterias for fitting peak
+  std::string m_minimizer;
   double m_maxChiSq;
   double m_minPeakHeight;
   double m_leastMaxObsY;

--- a/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
+++ b/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
@@ -3,6 +3,7 @@
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/FuncMinimizerFactory.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/IBackgroundFunction.h"
@@ -14,6 +15,7 @@
 #include "MantidDataObjects/OffsetsWorkspace.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/ListValidator.h"
+#include "MantidKernel/StartsWithValidator.h"
 #include "MantidKernel/Statistics.h"
 #include "MantidKernel/VectorHelper.h"
 
@@ -123,12 +125,12 @@ DECLARE_ALGORITHM(GetDetOffsetsMultiPeaks)
   */
 GetDetOffsetsMultiPeaks::GetDetOffsetsMultiPeaks()
     : API::Algorithm(), m_inputWS(), m_eventW(), m_isEvent(false), m_backType(),
-      m_peakType(), m_maxChiSq(0.), m_minPeakHeight(0.), m_leastMaxObsY(0.),
-      m_maxOffset(0.), m_peakPositions(), m_fitWindows(), m_inputResolutionWS(),
-      m_hasInputResolution(false), m_minResFactor(0.), m_maxResFactor(0.),
-      m_outputW(), m_outputNP(), m_maskWS(), m_infoTableWS(),
-      m_peakOffsetTableWS(), m_resolutionWS(), m_useFitWindowTable(false),
-      m_vecFitWindow() {}
+      m_peakType(), m_minimizer(), m_maxChiSq(0.), m_minPeakHeight(0.),
+      m_leastMaxObsY(0.), m_maxOffset(0.), m_peakPositions(), m_fitWindows(),
+      m_inputResolutionWS(), m_hasInputResolution(false), m_minResFactor(0.),
+      m_maxResFactor(0.), m_outputW(), m_outputNP(), m_maskWS(),
+      m_infoTableWS(), m_peakOffsetTableWS(), m_resolutionWS(),
+      m_useFitWindowTable(false), m_vecFitWindow() {}
 
 //----------------------------------------------------------------------------------------------
 /** Destructor
@@ -160,7 +162,7 @@ void GetDetOffsetsMultiPeaks::init() {
                   "information for each spectrum. ");
 
   std::vector<std::string> peaktypes =
-    FunctionFactory::Instance().getFunctionNames<API::IPeakFunction>();
+      FunctionFactory::Instance().getFunctionNames<API::IPeakFunction>();
   declareProperty("PeakFunction", "Gaussian",
                   boost::make_shared<StringListValidator>(peaktypes),
                   "Type of peak to fit");
@@ -203,6 +205,13 @@ void GetDetOffsetsMultiPeaks::init() {
       "then "
       "this peak will not be fit.  It is designed for EventWorkspace with "
       "integer counts.");
+
+  std::vector<std::string> minimizerOptions =
+      API::FuncMinimizerFactory::Instance().getKeys();
+  declareProperty("Minimizer", "Levenberg-MarquardtMD",
+                  Kernel::IValidator_sptr(
+                      new Kernel::StartsWithValidator(minimizerOptions)),
+                  "Minimizer to use for fitting peaks.");
 
   // Disable default gsl error handler (which is to call abort!)
   gsl_set_error_handler_off();
@@ -344,6 +353,7 @@ void GetDetOffsetsMultiPeaks::processProperties() {
   // The maximum allowable chisq value for an individual peak fit
   m_maxChiSq = this->getProperty("MaxChiSq");
   m_minPeakHeight = this->getProperty("MinimumPeakHeight");
+  m_minimizer = getPropertyValue("Minimizer");
   m_maxOffset = getProperty("MaxOffset");
   m_leastMaxObsY = getProperty("MinimumPeakHeightObs");
 
@@ -909,6 +919,7 @@ int GetDetOffsetsMultiPeaks::fitSpectra(
   findpeaks->setProperty<int>("MinGuessedPeakWidth", 4);
   findpeaks->setProperty<int>("MaxGuessedPeakWidth", 4);
   findpeaks->setProperty<double>("MinimumPeakHeight", m_minPeakHeight);
+  findpeaks->setProperty<std::string>("Minimizer", m_minimizer);
   findpeaks->setProperty("StartFromObservedPeakCentre", true);
   findpeaks->executeAsChildAlg();
 

--- a/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
+++ b/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
@@ -159,8 +159,8 @@ void GetDetOffsetsMultiPeaks::init() {
                   "Name of the input Tableworkspace containing peak fit window "
                   "information for each spectrum. ");
 
-  std::vector<std::string> peaktypes{"BackToBackExponential", "Gaussian",
-                                     "Lorentzian"};
+  std::vector<std::string> peaktypes =
+    FunctionFactory::Instance().getFunctionNames<API::IPeakFunction>();
   declareProperty("PeakFunction", "Gaussian",
                   boost::make_shared<StringListValidator>(peaktypes),
                   "Type of peak to fit");


### PR DESCRIPTION
This allows GetDetOffsetsMultiPeaks to use any of the peak functions available, where previously it was limited to BackToBackExponential, Gaussian and Lorentzian.

It also allows the minimizer used by FindPeaks to be set to any available.

**To test:**
Try the usage example with the new PeakFunction and Minimizer. E.g. PeakFunction='Voigt', Minimizer="BFGS" Should give similar but slightly different results.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
