### PR TITLE
In Vates subdirectory, replace iterators with range-based for loops.

### DIFF
--- a/Vates/VatesAPI/src/ViewFrustum.cpp
+++ b/Vates/VatesAPI/src/ViewFrustum.cpp
@@ -83,19 +83,10 @@ namespace VATES
     for (int i = 0; i < 3; ++i)
     {
       std::pair<double, double> minMax(DBL_MAX, -DBL_MAX);
-      for (std::vector<std::vector<double>>::iterator it = frustumPoints.begin(); it != frustumPoints.end(); ++it)
-      {
-        if ((*it)[i] < minMax.first)
-        {
-          minMax.first = (*it)[i];
-        }
-
-        if ((*it)[i] > minMax.second)
-        {
-          minMax.second = (*it)[i];
-        }
+      for (auto &points : frustumPoints) {
+        minMax.first = std::min(minMax.first, points[i]);
+        minMax.second = std::max(minMax.second, points[i]);
       }
-
       extents.push_back(minMax);
     }
 
@@ -111,18 +102,14 @@ namespace VATES
     std::vector<std::pair<double, double>> extents = toExtents();
     
     std::stringstream ss;
-
-    for (std::vector<std::pair<double, double>>::iterator it = extents.begin(); it != extents.end(); ++it)
-    {
-      ss << it->first << "," << it->second;
-
-      if ((it+1)!= extents.end())
-      {
-        ss << ",";
-      }
+    for (const auto &extent : extents) {
+      ss << extent.first << "," << extent.second << ",";
     }
+    auto result = ss.str();
 
-    return ss.str();
+    // remove extra "," at the end of the string.
+    result.pop_back();
+    return result;
   }
 
 }

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
@@ -33,8 +33,9 @@ public:
   void showFullTable();
   void removeTable();
   std::string getConcatenatedWorkspaceNames(std::string delimiter);
-  void updatePeaksWorkspaces(QList<QPointer<pqPipelineSource>> peakSources,
-                             pqPipelineSource *splatSource);
+  void
+  updatePeaksWorkspaces(const QList<QPointer<pqPipelineSource>> &peakSources,
+                        pqPipelineSource *splatSource);
 signals:
   void setRotationToPoint(double x, double y, double z);
 public slots:

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h
@@ -136,7 +136,9 @@ namespace Mantid
 
           pqPipelineSource* goToPipelineBeginning(pqPipelineSource* source);
 
-          bool doesSourceNeedToBeDeleted(std::string sourceName, std::vector<std::string> trackedSources);
+          bool doesSourceNeedToBeDeleted(
+              const std::string &sourceName,
+              const std::vector<std::string> &trackedSources);
       };
 
     } // SimpleGui

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
@@ -81,7 +81,7 @@ public:
   /// Retrieve the current time step.
   virtual double getCurrentTimeStep();
   /// Find the number of true sources in the pipeline.
-  unsigned int getNumSources();
+  long long getNumSources();
   /// Get the active ParaView source.
   pqPipelineSource *getPvActiveSrc();
   /**

--- a/Vates/VatesSimpleGui/ViewWidgets/src/AutoScaleRangeGenerator.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/AutoScaleRangeGenerator.cpp
@@ -133,11 +133,10 @@ namespace SimpleGui
     pqView* activeView = pqActiveObjects::instance().activeView();
 
     // Check all sources for the maximum and minimum value
-    for (QList<pqPipelineSource *>::iterator source = sources.begin();
-         source != sources.end(); ++source)
-    {
+    foreach (pqPipelineSource *source, sources) {
       // Check if the pipeline representation of the source for the active view is visible
-      pqDataRepresentation* representation = (*source)->getRepresentation(activeView);
+      pqDataRepresentation *representation =
+          source->getRepresentation(activeView);
 
       if (representation)
       {
@@ -145,7 +144,7 @@ namespace SimpleGui
 
         if (isVisible)
         {
-          setMinBufferAndMaxBuffer((*source), minValueBuffer, maxValueBuffer);
+          setMinBufferAndMaxBuffer(source, minValueBuffer, maxValueBuffer);
 
           if (initialSetting || maxValueBuffer > maxValue)
           {

--- a/Vates/VatesSimpleGui/ViewWidgets/src/AutoScaleRangeGenerator.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/AutoScaleRangeGenerator.cpp
@@ -128,7 +128,7 @@ namespace SimpleGui
 
     bool initialSetting = true;
 
-    QList<pqPipelineSource *> sources = getAllPVSources();
+    const QList<pqPipelineSource *> sources = getAllPVSources();
 
     pqView* activeView = pqActiveObjects::instance().activeView();
 

--- a/Vates/VatesSimpleGui/ViewWidgets/src/ColorUpdater.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/ColorUpdater.cpp
@@ -98,14 +98,16 @@ void ColorUpdater::colorScaleChange(double min, double max)
     // Update for all sources and all reps
     pqServer *server = pqActiveObjects::instance().activeServer();
     pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-    QList<pqPipelineSource *> sources = smModel->findItems<pqPipelineSource *>(server);
+    const QList<pqPipelineSource *> sources =
+        smModel->findItems<pqPipelineSource *>(server);
 
     // For all sources
     foreach (pqPipelineSource *source, sources) {
-      QList<pqView *> views = source->getViews();
+      const QList<pqView *> views = source->getViews();
       // For all views
       foreach (pqView *view, views) {
-        QList<pqDataRepresentation *> reps = source->getRepresentations(view);
+        const QList<pqDataRepresentation *> reps =
+            source->getRepresentations(view);
         // For all representations
         foreach (pqDataRepresentation *rep, reps) {
           this->updateLookupTable(rep);
@@ -166,15 +168,16 @@ void ColorUpdater::logScale(int state)
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel =
       pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources =
+  const QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
 
   // For all sources
   foreach (pqPipelineSource *source, sources) {
-    QList<pqView *> views = source->getViews();
+    const QList<pqView *> views = source->getViews();
     // For all views
     foreach (pqView *view, views) {
-      QList<pqDataRepresentation *> reps = source->getRepresentations(view);
+      const QList<pqDataRepresentation *> reps =
+          source->getRepresentations(view);
       // For all representations
       foreach (pqDataRepresentation *rep, reps) {
         // Set the logarithmic (linear) scale

--- a/Vates/VatesSimpleGui/ViewWidgets/src/ColorUpdater.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/ColorUpdater.cpp
@@ -99,22 +99,16 @@ void ColorUpdater::colorScaleChange(double min, double max)
     pqServer *server = pqActiveObjects::instance().activeServer();
     pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
     QList<pqPipelineSource *> sources = smModel->findItems<pqPipelineSource *>(server);
-    QList<pqPipelineSource *>::Iterator source;
 
     // For all sources
-    for(QList<pqPipelineSource*>::iterator source = sources.begin(); source != sources.end(); ++source)
-    {
-      QList<pqView*> views = (*source)->getViews();
-
+    foreach (pqPipelineSource *source, sources) {
+      QList<pqView *> views = source->getViews();
       // For all views
-      for (QList<pqView*>::iterator view = views.begin(); view != views.end(); ++view)
-      {
-        QList<pqDataRepresentation*> reps =  (*source)->getRepresentations((*view));
-
+      foreach (pqView *view, views) {
+        QList<pqDataRepresentation *> reps = source->getRepresentations(view);
         // For all representations
-        for (QList<pqDataRepresentation*>::iterator rep = reps.begin(); rep != reps.end(); ++rep)
-        {
-          this->updateLookupTable(*rep);
+        foreach (pqDataRepresentation *rep, reps) {
+          this->updateLookupTable(rep);
         }
       }
     }
@@ -174,34 +168,28 @@ void ColorUpdater::logScale(int state)
       pqApplicationCore::instance()->getServerManagerModel();
   QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
-  QList<pqPipelineSource *>::Iterator source;
 
   // For all sources
-  for (QList<pqPipelineSource *>::iterator source = sources.begin();
-       source != sources.end(); ++source) {
-    QList<pqView *> views = (*source)->getViews();
-
+  foreach (pqPipelineSource *source, sources) {
+    QList<pqView *> views = source->getViews();
     // For all views
-    for (QList<pqView *>::iterator view = views.begin(); view != views.end();
-         ++view) {
-      QList<pqDataRepresentation *> reps =
-          (*source)->getRepresentations((*view));
-
+    foreach (pqView *view, views) {
+      QList<pqDataRepresentation *> reps = source->getRepresentations(view);
       // For all representations
-      for (QList<pqDataRepresentation *>::iterator rep = reps.begin();
-           rep != reps.end(); ++rep) {
+      foreach (pqDataRepresentation *rep, reps) {
         // Set the logarithmic (linear) scale
-        auto lut = (*rep)->getLookupTable();
+        auto lut = rep->getLookupTable();
         if (lut) {
           pqSMAdaptor::setElementProperty(
-              (*rep)->getLookupTable()->getProxy()->GetProperty("UseLogScale"),
+              rep->getLookupTable()->getProxy()->GetProperty("UseLogScale"),
               this->m_logScaleState);
-          if (m_logScaleState)
+          if (m_logScaleState) {
             vtkSMTransferFunctionProxy::MapControlPointsToLogSpace(
-                (*rep)->getLookupTable()->getProxy());
-          else
+                rep->getLookupTable()->getProxy());
+          } else {
             vtkSMTransferFunctionProxy::MapControlPointsToLinearSpace(
-                (*rep)->getLookupTable()->getProxy());
+                rep->getLookupTable()->getProxy());
+          }
         }
       }
     }

--- a/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -1365,7 +1365,7 @@ void MdViewerWidget::setDestroyedListener() {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel =
       pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources =
+  const QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
 
   // Attach the destroyd signal of all sources to the viewbase.

--- a/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -1341,7 +1341,7 @@ void MdViewerWidget::preDeleteHandle(const std::string &wsName,
 
   pqPipelineSource *src = this->currentView->hasWorkspace(wsName.c_str());
   if (NULL != src) {
-    unsigned int numSources = this->currentView->getNumSources();
+    long long numSources = this->currentView->getNumSources();
     if (numSources > 1) {
       pqObjectBuilder *builder =
           pqApplicationCore::instance()->getObjectBuilder();
@@ -1369,9 +1369,8 @@ void MdViewerWidget::setDestroyedListener() {
       smModel->findItems<pqPipelineSource *>(server);
 
   // Attach the destroyd signal of all sources to the viewbase.
-  for (QList<pqPipelineSource *>::iterator source = sources.begin();
-       source != sources.end(); ++source) {
-    QObject::connect((*source), SIGNAL(destroyed()), this->currentView,
+  foreach (pqPipelineSource *source, sources) {
+    QObject::connect(source, SIGNAL(destroyed()), this->currentView,
                      SLOT(onSourceDestroyed()), Qt::UniqueConnection);
   }
 }

--- a/Vates/VatesSimpleGui/ViewWidgets/src/PeaksTabWidget.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/PeaksTabWidget.cpp
@@ -42,15 +42,12 @@ PeaksTabWidget::~PeaksTabWidget() {}
  */
 void PeaksTabWidget::setupMvc(
     std::map<std::string, std::vector<bool>> visiblePeaks) {
-  for (std::vector<Mantid::API::IPeaksWorkspace_sptr>::iterator it =
-           m_ws.begin();
-       it != m_ws.end(); ++it) {
+  for (const auto &ws : m_ws) {
     // Create new tab
-    std::string name((*it)->getName().c_str());
-
+    const std::string &name = ws->getName();
     // Get visible peaks
-    if (visiblePeaks.count((*it)->getName()) > 0) {
-      addNewTab(*it, name, visiblePeaks[(*it)->getName()]);
+    if (visiblePeaks.count(name) > 0) {
+      addNewTab(ws, name, visiblePeaks[name]);
     }
   }
 }

--- a/Vates/VatesSimpleGui/ViewWidgets/src/PeaksTableControllerVsi.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/PeaksTableControllerVsi.cpp
@@ -215,7 +215,7 @@ void PeaksTableControllerVsi::updatePeakWorkspaceColor() {
     pqServer *server = pqActiveObjects::instance().activeServer();
     pqServerManagerModel *smModel =
         pqApplicationCore::instance()->getServerManagerModel();
-    QList<pqPipelineSource *> sources =
+    const QList<pqPipelineSource *> sources =
         smModel->findItems<pqPipelineSource *>(server);
     foreach (pqPipelineSource *src, sources) {
       // Make sure that the source is a peak workspace
@@ -545,7 +545,7 @@ PeaksTableControllerVsi::getConcatenatedWorkspaceNames(std::string delimiter) {
  * @param splatSource The splatterplot source
  */
 void PeaksTableControllerVsi::updatePeaksWorkspaces(
-    QList<QPointer<pqPipelineSource>> peakSources,
+    const QList<QPointer<pqPipelineSource>> &peakSources,
     pqPipelineSource *splatSource) {
   // Check if the presenters exist and which need to be added
   std::vector<std::string> peaksWorkspaceNames;

--- a/Vates/VatesSimpleGui/ViewWidgets/src/PeaksTableControllerVsi.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/PeaksTableControllerVsi.cpp
@@ -189,13 +189,11 @@ std::map<std::string, QColor> PeaksTableControllerVsi::getColors() {
 
   std::vector<Mantid::API::IPeaksWorkspace_sptr> peakWs =
       m_presenter->getPeaksWorkspaces();
-  for (std::vector<Mantid::API::IPeaksWorkspace_sptr>::iterator it =
-           peakWs.begin();
-       it != peakWs.end(); ++it) {
+  for (auto it = peakWs.begin(); it != peakWs.end(); ++it) {
     const int pos = static_cast<int>(std::distance(peakWs.begin(), it));
     QColor color = m_peakPalette.foregroundIndexToColour(pos);
     const std::string name = (*it)->getName();
-    colors.insert(std::pair<std::string, QColor>(name, color));
+    colors.emplace(name, color);
   }
 
   return colors;
@@ -207,9 +205,7 @@ std::map<std::string, QColor> PeaksTableControllerVsi::getColors() {
 void PeaksTableControllerVsi::updatePeakWorkspaceColor() {
   std::vector<Mantid::API::IPeaksWorkspace_sptr> peakWs =
       m_presenter->getPeaksWorkspaces();
-  for (std::vector<Mantid::API::IPeaksWorkspace_sptr>::iterator it =
-           peakWs.begin();
-       it != peakWs.end(); ++it) {
+  for (auto it = peakWs.begin(); it != peakWs.end(); ++it) {
     const int pos = static_cast<int>(std::distance(peakWs.begin(), it));
     QColor color = m_peakPalette.foregroundIndexToColour(pos);
     const std::string name = (*it)->getName();
@@ -221,14 +217,12 @@ void PeaksTableControllerVsi::updatePeakWorkspaceColor() {
         pqApplicationCore::instance()->getServerManagerModel();
     QList<pqPipelineSource *> sources =
         smModel->findItems<pqPipelineSource *>(server);
-    for (QList<pqPipelineSource *>::iterator src = sources.begin();
-         src != sources.end(); ++src) {
+    foreach (pqPipelineSource *src, sources) {
       // Make sure that the source is a peak workspace
-
-      std::string xmlName((*src)->getProxy()->GetXMLName());
+      std::string xmlName(src->getProxy()->GetXMLName());
       if ((xmlName.find("Peaks Source") != std::string::npos)) {
         std::string workspaceName(
-            vtkSMPropertyHelper((*src)->getProxy(), "WorkspaceName")
+            vtkSMPropertyHelper(src->getProxy(), "WorkspaceName")
                 .GetAsString());
         if (workspaceName == name) {
           int r = color.red();
@@ -240,10 +234,9 @@ void PeaksTableControllerVsi::updatePeakWorkspaceColor() {
           double blue = static_cast<double>(b) / 255.0;
 
           pqDataRepresentation *rep =
-              (*src)
-                  ->getRepresentation(pqActiveObjects::instance().activeView());
-           pqPipelineRepresentation *pipelineRepresentation =
-               qobject_cast<pqPipelineRepresentation *>(rep);
+              src->getRepresentation(pqActiveObjects::instance().activeView());
+          pqPipelineRepresentation *pipelineRepresentation =
+              qobject_cast<pqPipelineRepresentation *>(rep);
           pipelineRepresentation->getProxy()->UpdatePropertyInformation();
 
           vtkSMDoubleVectorProperty *prop =
@@ -560,10 +553,9 @@ void PeaksTableControllerVsi::updatePeaksWorkspaces(
   std::vector<pqPipelineSource *> nonTrackedWorkspaces;
   std::vector<std::string> trackedWorkspaceNames =
       m_presenter->getPeaksWorkspaceNames();
-  for (QList<QPointer<pqPipelineSource>>::Iterator it = peakSources.begin();
-       it != peakSources.end(); ++it) {
+  foreach (QPointer<pqPipelineSource> it, peakSources) {
     std::string workspaceName(
-        vtkSMPropertyHelper((*it)->getProxy(), "WorkspaceName").GetAsString());
+        vtkSMPropertyHelper(it->getProxy(), "WorkspaceName").GetAsString());
 
     peaksWorkspaceNames.push_back(workspaceName);
 
@@ -572,16 +564,14 @@ void PeaksTableControllerVsi::updatePeaksWorkspaces(
                                             workspaceName));
 
     if (count == 0) {
-      nonTrackedWorkspaces.push_back(*it);
+      nonTrackedWorkspaces.push_back(it);
     }
   }
 
   if (splatSource) {
     // Add the workspaces which are missing in the presenter
-    for (std::vector<pqPipelineSource *>::iterator it =
-             nonTrackedWorkspaces.begin();
-         it != nonTrackedWorkspaces.end(); ++it) {
-      addWorkspace(*it, splatSource);
+    for (pqPipelineSource *ws : nonTrackedWorkspaces) {
+      addWorkspace(ws, splatSource);
     }
   }
 
@@ -620,7 +610,7 @@ void PeaksTableControllerVsi::setPeakSourceColorToDefault() {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
   QList<pqPipelineSource *> sources = smModel->findItems<pqPipelineSource *>(server);
-  for (QList<pqPipelineSource *>::iterator src = sources.begin(); src != sources.end(); ++src) {
+  for (auto src = sources.begin(); src != sources.end(); ++src) {
 
     std::string xmlName((*src)->getProxy()->GetXMLName());
     if ((xmlName.find("Peaks Source") != std::string::npos)) {

--- a/Vates/VatesSimpleGui/ViewWidgets/src/PeaksTableControllerVsi.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/PeaksTableControllerVsi.cpp
@@ -553,18 +553,17 @@ void PeaksTableControllerVsi::updatePeaksWorkspaces(
   std::vector<pqPipelineSource *> nonTrackedWorkspaces;
   std::vector<std::string> trackedWorkspaceNames =
       m_presenter->getPeaksWorkspaceNames();
-  foreach (QPointer<pqPipelineSource> it, peakSources) {
+  foreach (QPointer<pqPipelineSource> source, peakSources) {
     std::string workspaceName(
-        vtkSMPropertyHelper(it->getProxy(), "WorkspaceName").GetAsString());
+        vtkSMPropertyHelper(source->getProxy(), "WorkspaceName").GetAsString());
 
     peaksWorkspaceNames.push_back(workspaceName);
 
-    int count = static_cast<int>(std::count(trackedWorkspaceNames.begin(),
-                                            trackedWorkspaceNames.end(),
-                                            workspaceName));
+    auto count = std::count(trackedWorkspaceNames.begin(),
+                            trackedWorkspaceNames.end(), workspaceName);
 
     if (count == 0) {
-      nonTrackedWorkspaces.push_back(it);
+      nonTrackedWorkspaces.push_back(source);
     }
   }
 

--- a/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
@@ -326,16 +326,15 @@ namespace Mantid
         pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
         QList<pqPipelineSource *> sources = smModel->findItems<pqPipelineSource *>(server);
 
-        for (QList<pqPipelineSource*>::Iterator source = sources.begin(); source != sources.end(); ++source)
-        {
-          pqPipelineFilter* filter = qobject_cast<pqPipelineFilter*>(*source);
+        foreach (pqPipelineSource *source, sources) {
+          pqPipelineFilter *filter = qobject_cast<pqPipelineFilter *>(source);
           if (!filter)
           {
-            std::string sourceName((*source)->getProxy()->GetGlobalIDAsString());
+            std::string sourceName(source->getProxy()->GetGlobalIDAsString());
 
             if (doesSourceNeedToBeDeleted(sourceName, linkedSources))
             {
-              sourcesToBeDeleted.push_back(*source);
+              sourcesToBeDeleted.push_back(source);
             }
           }
         }
@@ -348,17 +347,14 @@ namespace Mantid
        * @param sourceName the name of the source which we want to check
        * @param trackedSources a list of tracked sources which need to be deleted
        */
-      bool RebinnedSourcesManager::doesSourceNeedToBeDeleted(std::string sourceName, std::vector<std::string> trackedSources)
-      {
-        for (std::vector<std::string>::iterator it = trackedSources.begin(); it != trackedSources.end(); ++it)
-        {
-          if (!sourceName.empty() && *it == sourceName)
-          {
-            return true;
-          }
-        }
+      bool RebinnedSourcesManager::doesSourceNeedToBeDeleted(
+          const std::string &sourceName,
+          const std::vector<std::string> &trackedSources) {
+        if (sourceName.empty())
+          return false;
 
-        return false;
+        return std::find(trackedSources.cbegin(), trackedSources.cend(),
+                         sourceName) != trackedSources.cend();
       }
 
       /**
@@ -578,11 +574,15 @@ namespace Mantid
             throw std::runtime_error("Original source for rebinned source could not be found.");
           }
 
-          std::string originalWorkspaceName = m_newWorkspacePairBuffer.begin()->first;
-          std::string rebinnedWorkspaceName = m_newWorkspacePairBuffer.begin()->second.first;
+          const std::string &originalWorkspaceName =
+              m_newWorkspacePairBuffer.begin()->first;
+          const std::string &rebinnedWorkspaceName =
+              m_newWorkspacePairBuffer.begin()->second.first;
 
-          std::pair<std::string, std::string> key = std::pair<std::string, std::string>(rebinnedWorkspaceName, getSourceName(source));
-          m_rebinnedWorkspaceAndSourceToOriginalWorkspace.insert(std::pair<std::pair<std::string, std::string>, std::string>(key, originalWorkspaceName));
+          std::pair<std::string, std::string> key(rebinnedWorkspaceName,
+                                                  getSourceName(source));
+          m_rebinnedWorkspaceAndSourceToOriginalWorkspace.emplace(
+              key, originalWorkspaceName);
 
           // Record the rebinned source
           m_rebinnedSource = source;
@@ -608,34 +608,26 @@ namespace Mantid
         std::vector<std::pair<std::string, std::string>> toBeUntracked;
 
         // Compare all registered sources to all loaded sources,
-        for (std::map<std::pair<std::string, std::string>, std::string>::iterator it = m_rebinnedWorkspaceAndSourceToOriginalWorkspace.begin();
-             it != m_rebinnedWorkspaceAndSourceToOriginalWorkspace.end(); ++it)
-        {
-          std::string registeredSourceName = it->first.second;
+        for (const auto &wsPair :
+             m_rebinnedWorkspaceAndSourceToOriginalWorkspace) {
+          const std::string &registeredSourceName = wsPair.first.second;
 
-          QList<pqPipelineSource*>::Iterator source = sources.begin();
-
-          // Find the source which matches the registered source
-          while(source != sources.end())
-          {
-            if (registeredSourceName == getSourceName(*source))
-            {
-              break;
-            }
-            ++source;
-          }
+          auto source = std::find_if(
+              sources.begin(), sources.end(),
+              [this, &registeredSourceName](pqPipelineSource *src) {
+                return registeredSourceName == getSourceName(src);
+              });
 
           // If there was no matching source then mark it to be untracked
           if (source == sources.end())
           {
-            toBeUntracked.push_back(it->first);
+            toBeUntracked.push_back(wsPair.first);
           }
         }
 
         // Finally untrack all sources which need it
-        for (std::vector<std::pair<std::string, std::string>>::iterator key = toBeUntracked.begin(); key != toBeUntracked.end(); ++key)
-        {
-          untrackWorkspaces(*key);
+        for (const auto &key : toBeUntracked) {
+          untrackWorkspaces(key);
         }
       }
 

--- a/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
@@ -324,7 +324,8 @@ namespace Mantid
 
         pqServer *server = pqActiveObjects::instance().activeServer();
         pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-        QList<pqPipelineSource *> sources = smModel->findItems<pqPipelineSource *>(server);
+        const QList<pqPipelineSource *> sources =
+            smModel->findItems<pqPipelineSource *>(server);
 
         foreach (pqPipelineSource *source, sources) {
           pqPipelineFilter *filter = qobject_cast<pqPipelineFilter *>(source);

--- a/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
@@ -374,7 +374,7 @@ void SplatterPlotView::destroyPeakSources()
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqObjectBuilder *builder = pqApplicationCore::instance()->getObjectBuilder();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources =
+  const QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
 
   foreach (pqPipelineSource *source, sources) {
@@ -551,12 +551,12 @@ void SplatterPlotView::onPeakSourceDestroyed()
   for (auto it = m_peaksSource.begin(); it != m_peaksSource.end();) {
     pqServer *server = pqActiveObjects::instance().activeServer();
     pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-    QList<pqPipelineSource *> sources =
+    const QList<pqPipelineSource *> sources =
         smModel->findItems<pqPipelineSource *>(server);
 
     auto foundSource = std::find(sources.begin(), sources.end(), *it);
 
-    if (foundSource != sources.end()) {
+    if (foundSource == sources.end()) {
       it = m_peaksSource.erase(it);
     } else {
       ++it;

--- a/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
@@ -374,15 +374,12 @@ void SplatterPlotView::destroyPeakSources()
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqObjectBuilder *builder = pqApplicationCore::instance()->getObjectBuilder();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources;
-  QList<pqPipelineSource *>::Iterator source;
-  sources = smModel->findItems<pqPipelineSource *>(server);
+  QList<pqPipelineSource *> sources =
+      smModel->findItems<pqPipelineSource *>(server);
 
-  for (source = sources.begin(); source != sources.end(); ++source)
-  {
-    if (this->isPeaksWorkspace(*source))
-    {
-      builder->destroy(*source);
+  foreach (pqPipelineSource *source, sources) {
+    if (this->isPeaksWorkspace(source)) {
+      builder->destroy(source);
     }
   }
 
@@ -551,23 +548,17 @@ void SplatterPlotView::onPeakSourceDestroyed()
 {
   // For each peak Source check if there is a "true" source available.
   // If it is not availble then remove it from the peakSource storage.
-  for (QList<QPointer<pqPipelineSource>>::Iterator it = m_peaksSource.begin(); it != m_peaksSource.end();) {
+  for (auto it = m_peaksSource.begin(); it != m_peaksSource.end();) {
     pqServer *server = pqActiveObjects::instance().activeServer();
     pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-    QList<pqPipelineSource *> sources;
-    sources = smModel->findItems<pqPipelineSource *>(server);
+    QList<pqPipelineSource *> sources =
+        smModel->findItems<pqPipelineSource *>(server);
 
-    bool foundSource = false;
-    for (QList<pqPipelineSource *>::iterator src = sources.begin(); src != sources.end(); ++src) {
-      if ((*src) == (*it)) {
-        foundSource = true;
-      }
-    }
+    auto foundSource = std::find(sources.begin(), sources.end(), *it);
 
-    if (!foundSource) {
-      it = m_peaksSource.erase(it); 
-    } 
-    else {
+    if (foundSource != sources.end()) {
+      it = m_peaksSource.erase(it);
+    } else {
       ++it;
     }
   }

--- a/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -333,7 +333,8 @@ void StandardView::setRebinAndUnbinButtons()
 
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources = smModel->findItems<pqPipelineSource *>(server);
+  const QList<pqPipelineSource *> sources =
+      smModel->findItems<pqPipelineSource *>(server);
 
   foreach (pqPipelineSource *source, sources) {
     if (isInternallyRebinnedWorkspace(source)) {

--- a/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -335,17 +335,12 @@ void StandardView::setRebinAndUnbinButtons()
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
   QList<pqPipelineSource *> sources = smModel->findItems<pqPipelineSource *>(server);
 
-  for (QList<pqPipelineSource *>::iterator source = sources.begin(); source != sources.end(); ++source)
-  {
-    if (isInternallyRebinnedWorkspace(*source))
-    {
+  foreach (pqPipelineSource *source, sources) {
+    if (isInternallyRebinnedWorkspace(source)) {
       ++numberOfInternallyRebinnedWorkspaces;
-    } else if (isMDHistoWorkspace(*source))
-    {
+    } else if (isMDHistoWorkspace(source)) {
       ++numberOfTrueMDHistoWorkspaces;
-    }
-    else if (isPeaksWorkspace(*source))
-    {
+    } else if (isPeaksWorkspace(source)) {
       ++numberOfPeakWorkspaces;
     }
   }

--- a/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
@@ -107,7 +107,7 @@ void ViewBase::destroyFilter(const QString &name)
 {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources =
+  const QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
 
   QSet<pqPipelineSource*> toDelete;
@@ -437,7 +437,7 @@ void ViewBase::updateAnimationControls()
 long long ViewBase::getNumSources() {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources =
+  const QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
 
   return std::count_if(
@@ -716,7 +716,7 @@ bool ViewBase::hasFilter(const QString &name)
 {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources =
+  const QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
   foreach (pqPipelineSource *source, sources) {
     const QString sourceName = source->getSMName();
@@ -765,7 +765,7 @@ bool ViewBase::hasWorkspaceType(const QString &wsTypeName)
 {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources =
+  const QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
   bool hasWsType = false;
   foreach (pqPipelineSource *source, sources) {
@@ -847,7 +847,8 @@ void ViewBase::onSourceDestroyed()
 void ViewBase::destroyAllSourcesInView() {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources = smModel->findItems<pqPipelineSource *>(server);
+  const QList<pqPipelineSource *> sources =
+      smModel->findItems<pqPipelineSource *>(server);
 
   // Out of all pqPipelineSources, find the "true" sources, which were
   // created by a Source Plugin, i.e. MDEW Source, MDHW Source, PeakSource
@@ -899,7 +900,7 @@ void ViewBase::setVisibilityListener()
   // Set the connection to listen to a visibility change of the representation.
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources =
+  const QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
 
   // Attach the visibilityChanged signal for all sources.
@@ -920,7 +921,7 @@ void ViewBase::removeVisibilityListener() {
     // Set the connection to listen to a visibility change of the representation.
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources =
+  const QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
 
   // Attach the visibilityChanged signal for all sources.

--- a/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
@@ -107,16 +107,14 @@ void ViewBase::destroyFilter(const QString &name)
 {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources;
-  QList<pqPipelineSource *>::Iterator source;
-  sources = smModel->findItems<pqPipelineSource *>(server);
+  QList<pqPipelineSource *> sources =
+      smModel->findItems<pqPipelineSource *>(server);
+
   QSet<pqPipelineSource*> toDelete;
-  for (source = sources.begin(); source != sources.end(); ++source)
-  {
-    const QString sourceName = (*source)->getSMName();
-    if (sourceName.startsWith(name))
-    {
-    toDelete.insert(*source);
+  foreach (pqPipelineSource *source, sources) {
+    const QString sourceName = source->getSMName();
+    if (sourceName.startsWith(name)) {
+      toDelete.insert(source);
     }
   }
   pqDeleteReaction::deleteSources(toDelete);
@@ -409,7 +407,7 @@ void ViewBase::checkViewOnSwitch()
 void ViewBase::updateAnimationControls()
 {
   pqPipelineSource *src = this->getPvActiveSrc();
-  unsigned int numSrcs = this->getNumSources();
+  long long numSrcs = this->getNumSources();
   if (this->isPeaksWorkspace(src))
   {
     if (1 == numSrcs)
@@ -436,23 +434,16 @@ void ViewBase::updateAnimationControls()
  * returns the total count of those present;
  * @return the number of true pipeline sources
  */
-unsigned int ViewBase::getNumSources()
-{
-  unsigned int count = 0;
+long long ViewBase::getNumSources() {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources;
-  QList<pqPipelineSource *>::Iterator source;
-  sources = smModel->findItems<pqPipelineSource *>(server);
-  for (source = sources.begin(); source != sources.end(); ++source)
-  {
-    const QString srcProxyName = (*source)->getProxy()->GetXMLGroup();
-    if (srcProxyName == QString("sources"))
-    {
-      count++;
-    }
-  }
-  return count;
+  QList<pqPipelineSource *> sources =
+      smModel->findItems<pqPipelineSource *>(server);
+
+  return std::count_if(
+      sources.begin(), sources.end(), [](const pqPipelineSource *source) {
+        return strcmp(source->getProxy()->GetXMLGroup(), "sources") == 0;
+      });
 }
 
 /**
@@ -725,12 +716,10 @@ bool ViewBase::hasFilter(const QString &name)
 {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources;
-  QList<pqPipelineSource *>::Iterator source;
-  sources = smModel->findItems<pqPipelineSource *>(server);
-  for (source = sources.begin(); source != sources.end(); ++source)
-  {
-    const QString sourceName = (*source)->getSMName();
+  QList<pqPipelineSource *> sources =
+      smModel->findItems<pqPipelineSource *>(server);
+  foreach (pqPipelineSource *source, sources) {
+    const QString sourceName = source->getSMName();
     if (sourceName.startsWith(name))
     {
       return true;
@@ -749,18 +738,17 @@ pqPipelineSource *ViewBase::hasWorkspace(const QString &name)
 {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources;
-  QList<pqPipelineSource *>::Iterator source;
-  sources = smModel->findItems<pqPipelineSource *>(server);
-  for (source = sources.begin(); source != sources.end(); ++source)
-  {
-    QString wsName(vtkSMPropertyHelper((*source)->getProxy(),
-                                       "WorkspaceName", true).GetAsString());
+  QList<pqPipelineSource *> sources =
+      smModel->findItems<pqPipelineSource *>(server);
+  foreach (pqPipelineSource *source, sources) {
+    QString wsName(
+        vtkSMPropertyHelper(source->getProxy(), "WorkspaceName", true)
+            .GetAsString());
     if (!wsName.isEmpty())
     {
       if (wsName == name)
       {
-        return (*source);
+        return source;
       }
     }
   }
@@ -777,18 +765,17 @@ bool ViewBase::hasWorkspaceType(const QString &wsTypeName)
 {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources;
-  QList<pqPipelineSource *>::Iterator source;
-  sources = smModel->findItems<pqPipelineSource *>(server);
+  QList<pqPipelineSource *> sources =
+      smModel->findItems<pqPipelineSource *>(server);
   bool hasWsType = false;
-  for (source = sources.begin(); source != sources.end(); ++source)
-  {
-    QString wsType(vtkSMPropertyHelper((*source)->getProxy(),
-                                       "WorkspaceTypeName", true).GetAsString());
+  foreach (pqPipelineSource *source, sources) {
+    QString wsType(
+        vtkSMPropertyHelper(source->getProxy(), "WorkspaceTypeName", true)
+            .GetAsString());
 
     if (wsType.isEmpty())
     {
-      wsType = (*source)->getSMName();
+      wsType = source->getSMName();
     }
     hasWsType = wsType.contains(wsTypeName);
     if (hasWsType)
@@ -865,16 +852,16 @@ void ViewBase::destroyAllSourcesInView() {
   // Out of all pqPipelineSources, find the "true" sources, which were
   // created by a Source Plugin, i.e. MDEW Source, MDHW Source, PeakSource
   QList<pqPipelineSource*> trueSources;
-  for (QList<pqPipelineSource *>::iterator source = sources.begin(); source != sources.end(); ++source) {
-    if (!qobject_cast<pqPipelineFilter*>(*source)) {
-      trueSources.push_back(*source);
+  foreach (pqPipelineSource *source, sources) {
+    if (!qobject_cast<pqPipelineFilter *>(source)) {
+      trueSources.push_back(source);
     }
   }
 
   // For each true source, go to the end of the pipeline and destroy it on the way back
   // to the start. This assumes linear pipelines.
-  for (QList<pqPipelineSource *>::iterator trueSource = trueSources.begin(); trueSource != trueSources.end(); ++trueSource) {
-    destroySinglePipeline(*trueSource);
+  foreach (pqPipelineSource *trueSource, trueSources) {
+    destroySinglePipeline(trueSource);
   }
 }
 
@@ -912,15 +899,17 @@ void ViewBase::setVisibilityListener()
   // Set the connection to listen to a visibility change of the representation.
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources;
-  sources = smModel->findItems<pqPipelineSource *>(server);
+  QList<pqPipelineSource *> sources =
+      smModel->findItems<pqPipelineSource *>(server);
 
   // Attach the visibilityChanged signal for all sources.
-  for (QList<pqPipelineSource *>::iterator source = sources.begin(); source != sources.end(); ++source)
-  {
-    QObject::connect((*source), SIGNAL(visibilityChanged(pqPipelineSource*, pqDataRepresentation*)),
-                     this, SLOT(onVisibilityChanged(pqPipelineSource*, pqDataRepresentation*)),
-                     Qt::UniqueConnection);
+  foreach (pqPipelineSource *source, sources) {
+    QObject::connect(
+        source,
+        SIGNAL(visibilityChanged(pqPipelineSource *, pqDataRepresentation *)),
+        this,
+        SLOT(onVisibilityChanged(pqPipelineSource *, pqDataRepresentation *)),
+        Qt::UniqueConnection);
   }
 }
 
@@ -931,14 +920,16 @@ void ViewBase::removeVisibilityListener() {
     // Set the connection to listen to a visibility change of the representation.
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel = pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources;
-  sources = smModel->findItems<pqPipelineSource *>(server);
+  QList<pqPipelineSource *> sources =
+      smModel->findItems<pqPipelineSource *>(server);
 
   // Attach the visibilityChanged signal for all sources.
-  for (QList<pqPipelineSource *>::iterator source = sources.begin(); source != sources.end(); ++source)
-  {
-    QObject::disconnect((*source), SIGNAL(visibilityChanged(pqPipelineSource*, pqDataRepresentation*)),
-                         this, SLOT(onVisibilityChanged(pqPipelineSource*, pqDataRepresentation*)));
+  foreach (pqPipelineSource *source, sources) {
+    QObject::disconnect(
+        source,
+        SIGNAL(visibilityChanged(pqPipelineSource *, pqDataRepresentation *)),
+        this,
+        SLOT(onVisibilityChanged(pqPipelineSource *, pqDataRepresentation *)));
   }
 }
 


### PR DESCRIPTION
Description of work.

While working on other issues, I found several places in the Vates subdirectory where a range-based for loop would be shorter and clearer than a for loop with iterators. For `Qlist` and `Qset` I used Qt's `foreach` macro to avoid potential [performance issues](http://www.dvratil.cz/2015/06/qt-containers-and-c11-range-based-loops/).

CompositePeaksPresenterVsi was already refactored in PR #15678. Those changes are NOT included here.

**To test:**

<!-- Instructions for testing. -->

Check that I didn't significantly change the behavior of any of these member functions. 

This PR has no associated issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
