### PR TITLE
Implement string trimming for properties

### DIFF
--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.h
@@ -208,6 +208,9 @@ public:
   */
   std::string setValue(const std::string &value) override {
     m_workspaceName = value;
+    if (Kernel::PropertyWithValue<boost::shared_ptr<TYPE>>::autoTrim()) {
+      boost::trim(m_workspaceName);
+    }
     // Try and get the workspace from the ADS, but don't worry if we can't
     try {
       Kernel::PropertyWithValue<boost::shared_ptr<TYPE>>::m_value =

--- a/Framework/API/test/WorkspacePropertyTest.h
+++ b/Framework/API/test/WorkspacePropertyTest.h
@@ -319,6 +319,27 @@ public:
     TS_ASSERT_EQUALS(p1.value(), "");
   }
 
+  void test_trimmming() {
+    // trimming on
+    Workspace_sptr ws1 =
+        WorkspaceFactory::Instance().create("WorkspacePropertyTest", 1, 1, 1);
+    AnalysisDataService::Instance().add("space1", ws1);
+    WorkspaceProperty<Workspace> p1("workspace1", "", Direction::Input);
+    p1.setValue("  space1\t\n");
+    TS_ASSERT_EQUALS(p1.value(), "space1");
+
+    // turn trimming off
+    Workspace_sptr ws2 =
+        WorkspaceFactory::Instance().create("WorkspacePropertyTest", 1, 1, 1);
+    AnalysisDataService::Instance().add("  space1\t\n", ws2);
+    WorkspaceProperty<Workspace> p2("workspace1", "", Direction::Input);
+    p2.setAutoTrim(false);
+    p2.setValue("  space1\t\n");
+    TS_ASSERT_EQUALS(p2.value(), "  space1\t\n");
+
+    AnalysisDataService::Instance().clear();
+  }
+
 private:
   WorkspaceProperty<Workspace> *wsp1;
   WorkspaceProperty<Workspace> *wsp2;

--- a/Framework/Algorithms/src/GenerateIPythonNotebook.cpp
+++ b/Framework/Algorithms/src/GenerateIPythonNotebook.cpp
@@ -40,6 +40,7 @@ void GenerateIPythonNotebook::init() {
   declareProperty("NotebookText", std::string(""),
                   "Saves the history of the workspace to a variable.",
                   Direction::Output);
+  getPointerToProperty("NotebookText")->setAutoTrim(false);
 
   declareProperty("UnrollAll", false,
                   "Unroll all algorithms to show just their child algorithms.",

--- a/Framework/DataHandling/src/SaveAscii.cpp
+++ b/Framework/DataHandling/src/SaveAscii.cpp
@@ -76,6 +76,7 @@ void SaveAscii::init() {
       make_unique<PropertyWithValue<std::string>>("CustomSeparator", "",
                                                   Direction::Input),
       "If present, will override any specified choice given to Separator.");
+  getPointerToProperty("CustomSeparator")->setAutoTrim(false);
 
   setPropertySettings("CustomSeparator",
                       make_unique<VisibleWhenProperty>("Separator", IS_EQUAL_TO,

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -96,7 +96,7 @@ void SaveAscii2::init() {
   setPropertySettings("CustomSeparator",
                       make_unique<VisibleWhenProperty>("Separator", IS_EQUAL_TO,
                                                        "UserDefined"));
-
+  getPointerToProperty("CustomSeparator")->setAutoTrim(false);
   declareProperty("ColumnHeader", true,
                   "If true, put column headers into file. ");
 

--- a/Framework/DataHandling/src/SaveCSV.cpp
+++ b/Framework/DataHandling/src/SaveCSV.cpp
@@ -66,9 +66,11 @@ void SaveCSV::init() {
       "Separator", ",",
       "The separator that will go between the numbers on a line in the\n"
       "output file (default ',')");
+  getPointerToProperty("Separator")->setAutoTrim(false);
   declareProperty("LineSeparator", "\n",
                   "The string to place at the end of lines (default new line\n"
                   "character)");
+  getPointerToProperty("LineSeparator")->setAutoTrim(false);
   declareProperty(
       make_unique<PropertyWithValue<bool>>("SaveXerrors", false,
                                            Direction::Input),

--- a/Framework/DataHandling/test/RawFileInfoTest.h
+++ b/Framework/DataHandling/test/RawFileInfoTest.h
@@ -38,8 +38,7 @@ private:
 
     // Check the output parameters are what we expect
     std::string title = alg.getProperty("RunTitle");
-    TS_ASSERT_EQUALS(title,
-                     std::string("direct beam"));
+    TS_ASSERT_EQUALS(title, std::string("direct beam"));
     std::string header = alg.getProperty("RunHeader");
     TS_ASSERT_EQUALS(header,
                      std::string("LOQ 48127 LOQ team & SANS Xpre direct beam   "

--- a/Framework/DataHandling/test/RawFileInfoTest.h
+++ b/Framework/DataHandling/test/RawFileInfoTest.h
@@ -39,8 +39,7 @@ private:
     // Check the output parameters are what we expect
     std::string title = alg.getProperty("RunTitle");
     TS_ASSERT_EQUALS(title,
-                     std::string("direct beam                                  "
-                                 "                                   "));
+                     std::string("direct beam"));
     std::string header = alg.getProperty("RunHeader");
     TS_ASSERT_EQUALS(header,
                      std::string("LOQ 48127 LOQ team & SANS Xpre direct beam   "

--- a/Framework/Kernel/inc/MantidKernel/Property.h
+++ b/Framework/Kernel/inc/MantidKernel/Property.h
@@ -182,6 +182,9 @@ public:
   /// @return the group this property belongs to
   const std::string &getGroup() { return m_group; }
 
+  bool autoTrim() const;
+  void setAutoTrim(const bool& setting);
+
 protected:
   /// Constructor
   Property(const std::string &name, const std::type_info &type,
@@ -217,6 +220,9 @@ private:
 
   /// Flag whether to save input values
   bool m_remember;
+
+  /// Flag to determine if string inputs to the property should be automatically trimmed of whitespace
+  bool m_autotrim;
 };
 
 /// Compares this to another property for equality

--- a/Framework/Kernel/inc/MantidKernel/Property.h
+++ b/Framework/Kernel/inc/MantidKernel/Property.h
@@ -183,7 +183,7 @@ public:
   const std::string &getGroup() { return m_group; }
 
   bool autoTrim() const;
-  void setAutoTrim(const bool& setting);
+  void setAutoTrim(const bool &setting);
 
 protected:
   /// Constructor
@@ -221,7 +221,8 @@ private:
   /// Flag whether to save input values
   bool m_remember;
 
-  /// Flag to determine if string inputs to the property should be automatically trimmed of whitespace
+  /// Flag to determine if string inputs to the property should be automatically
+  /// trimmed of whitespace
   bool m_autotrim;
 };
 

--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -9,16 +9,18 @@
 namespace Mantid {
 namespace Kernel {
 
-/** Constructor
- *  @param name :: The name of the property
- *  @param type :: The type of the property
- *  @param direction :: Whether this is a Direction::Input, Direction::Output or
- * Direction::InOut (Input & Output) property
- */
+
+  /** Constructor
+   *  @param name :: The name of the property
+   *  @param type :: The type of the property
+   *  @param direction :: Whether this is a Direction::Input, Direction::Output or
+   * Direction::InOut (Input & Output) property
+   */
 Property::Property(const std::string &name, const std::type_info &type,
                    const unsigned int direction)
     : m_name(name), m_documentation(""), m_typeinfo(&type),
-      m_direction(direction), m_units(""), m_group(""), m_remember(true) {
+      m_direction(direction), m_units(""), m_group(""), m_remember(true),
+      m_autotrim(true) {
   // Make sure a random int hasn't been passed in for the direction
   // Property & PropertyWithValue destructors will be called in this case
   if (m_direction > 2)
@@ -31,7 +33,7 @@ Property::Property(const Property &right)
     : m_name(right.m_name), m_documentation(right.m_documentation),
       m_typeinfo(right.m_typeinfo), m_direction(right.m_direction),
       m_units(right.m_units), m_group(right.m_group),
-      m_remember(right.m_remember) {
+      m_remember(right.m_remember), m_autotrim(right.m_autotrim) {
   if (right.m_settings)
     m_settings.reset(right.m_settings->clone());
 }
@@ -383,6 +385,21 @@ std::string getUnmangledTypeName(const std::type_info &type) {
   return type.name();
 }
 
+/**
+* Returns if the property is set to  automatically trim string unput values of whitespace
+* @returns True/False
+*/
+bool Property::autoTrim() const {
+  return m_autotrim;
+}
+
+/**
+* Sets if the property is set to  automatically trim string unput values of whitespace
+* @param setting The new setting value
+*/
+void Property::setAutoTrim(const bool& setting) {
+  m_autotrim = setting;
+}
 } // namespace Kernel
 
 } // namespace Mantid

--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -9,13 +9,12 @@
 namespace Mantid {
 namespace Kernel {
 
-
-  /** Constructor
-   *  @param name :: The name of the property
-   *  @param type :: The type of the property
-   *  @param direction :: Whether this is a Direction::Input, Direction::Output or
-   * Direction::InOut (Input & Output) property
-   */
+/** Constructor
+ *  @param name :: The name of the property
+ *  @param type :: The type of the property
+ *  @param direction :: Whether this is a Direction::Input, Direction::Output or
+ * Direction::InOut (Input & Output) property
+ */
 Property::Property(const std::string &name, const std::type_info &type,
                    const unsigned int direction)
     : m_name(name), m_documentation(""), m_typeinfo(&type),
@@ -386,20 +385,18 @@ std::string getUnmangledTypeName(const std::type_info &type) {
 }
 
 /**
-* Returns if the property is set to  automatically trim string unput values of whitespace
+* Returns if the property is set to  automatically trim string unput values of
+* whitespace
 * @returns True/False
 */
-bool Property::autoTrim() const {
-  return m_autotrim;
-}
+bool Property::autoTrim() const { return m_autotrim; }
 
 /**
-* Sets if the property is set to  automatically trim string unput values of whitespace
+* Sets if the property is set to  automatically trim string unput values of
+* whitespace
 * @param setting The new setting value
 */
-void Property::setAutoTrim(const bool& setting) {
-  m_autotrim = setting;
-}
+void Property::setAutoTrim(const bool &setting) { m_autotrim = setting; }
 } // namespace Kernel
 
 } // namespace Mantid

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -712,7 +712,7 @@ public:
     // test assignment with string literal
     *sProp = "  value with whitespace\t\t \r\n";
     TSM_ASSERT_EQUALS("Assignment string literal has not been trimmed",
-      sProp->value(), trimmedStringWithWhitespace);
+                      sProp->value(), trimmedStringWithWhitespace);
   }
 
   void test_trimming_integer_property() {

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -685,6 +685,47 @@ public:
     }
   }
 
+  void test_trimming_string_property()
+  {
+    std::string stringWithWhitespace = "  value with whitespace\t\t \r\n";
+    std::string trimmedStringWithWhitespace = "value with whitespace";
+    sProp->setValue(stringWithWhitespace);
+    TSM_ASSERT_EQUALS("Input value has not been trimmed", sProp->value(), trimmedStringWithWhitespace);
+
+    //turn trimming off
+    sProp->setAutoTrim(false);
+    TSM_ASSERT_EQUALS("Auto trim is not turned off", sProp->autoTrim(), false);
+
+    sProp->setValue(stringWithWhitespace);
+    TSM_ASSERT_EQUALS("Input value has been trimmed when it should not", sProp->value(), stringWithWhitespace);
+
+    //turn trimming on
+    sProp->setAutoTrim(true);
+    TSM_ASSERT_EQUALS("Auto trim is not turned on", sProp->autoTrim(), true);
+
+    //test assignment
+    *sProp = stringWithWhitespace;
+    TSM_ASSERT_EQUALS("Assignment input value has not been trimmed", sProp->value(), trimmedStringWithWhitespace);
+  }
+
+  void test_trimming_integer_property() {
+    std::string stringWithWhitespace = "  1243\t\t \r\n";
+    std::string trimmedStringWithWhitespace = "1243";
+    iProp->setValue(stringWithWhitespace);
+    TSM_ASSERT_EQUALS("Input value has not been trimmed", iProp->value(), trimmedStringWithWhitespace);
+
+    //turn trimming off
+    iProp->setAutoTrim(false);
+    TSM_ASSERT_EQUALS("Auto trim is not turned off", iProp->autoTrim(), false);
+
+    iProp->setValue(stringWithWhitespace);
+    TSM_ASSERT_EQUALS("Input value should still appear trimmed for an integer", iProp->value(), trimmedStringWithWhitespace);
+
+    //turn trimming on
+    iProp->setAutoTrim(true);
+    TSM_ASSERT_EQUALS("Auto trim is not turned on", iProp->autoTrim(), true);
+
+  }
 private:
   PropertyWithValue<int> *iProp;
   PropertyWithValue<double> *dProp;

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -708,6 +708,11 @@ public:
     *sProp = stringWithWhitespace;
     TSM_ASSERT_EQUALS("Assignment input value has not been trimmed",
                       sProp->value(), trimmedStringWithWhitespace);
+
+    // test assignment with string literal
+    *sProp = "  value with whitespace\t\t \r\n";
+    TSM_ASSERT_EQUALS("Assignment string literal has not been trimmed",
+      sProp->value(), trimmedStringWithWhitespace);
   }
 
   void test_trimming_integer_property() {

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -685,47 +685,51 @@ public:
     }
   }
 
-  void test_trimming_string_property()
-  {
+  void test_trimming_string_property() {
     std::string stringWithWhitespace = "  value with whitespace\t\t \r\n";
     std::string trimmedStringWithWhitespace = "value with whitespace";
     sProp->setValue(stringWithWhitespace);
-    TSM_ASSERT_EQUALS("Input value has not been trimmed", sProp->value(), trimmedStringWithWhitespace);
+    TSM_ASSERT_EQUALS("Input value has not been trimmed", sProp->value(),
+                      trimmedStringWithWhitespace);
 
-    //turn trimming off
+    // turn trimming off
     sProp->setAutoTrim(false);
     TSM_ASSERT_EQUALS("Auto trim is not turned off", sProp->autoTrim(), false);
 
     sProp->setValue(stringWithWhitespace);
-    TSM_ASSERT_EQUALS("Input value has been trimmed when it should not", sProp->value(), stringWithWhitespace);
+    TSM_ASSERT_EQUALS("Input value has been trimmed when it should not",
+                      sProp->value(), stringWithWhitespace);
 
-    //turn trimming on
+    // turn trimming on
     sProp->setAutoTrim(true);
     TSM_ASSERT_EQUALS("Auto trim is not turned on", sProp->autoTrim(), true);
 
-    //test assignment
+    // test assignment
     *sProp = stringWithWhitespace;
-    TSM_ASSERT_EQUALS("Assignment input value has not been trimmed", sProp->value(), trimmedStringWithWhitespace);
+    TSM_ASSERT_EQUALS("Assignment input value has not been trimmed",
+                      sProp->value(), trimmedStringWithWhitespace);
   }
 
   void test_trimming_integer_property() {
     std::string stringWithWhitespace = "  1243\t\t \r\n";
     std::string trimmedStringWithWhitespace = "1243";
     iProp->setValue(stringWithWhitespace);
-    TSM_ASSERT_EQUALS("Input value has not been trimmed", iProp->value(), trimmedStringWithWhitespace);
+    TSM_ASSERT_EQUALS("Input value has not been trimmed", iProp->value(),
+                      trimmedStringWithWhitespace);
 
-    //turn trimming off
+    // turn trimming off
     iProp->setAutoTrim(false);
     TSM_ASSERT_EQUALS("Auto trim is not turned off", iProp->autoTrim(), false);
 
     iProp->setValue(stringWithWhitespace);
-    TSM_ASSERT_EQUALS("Input value should still appear trimmed for an integer", iProp->value(), trimmedStringWithWhitespace);
+    TSM_ASSERT_EQUALS("Input value should still appear trimmed for an integer",
+                      iProp->value(), trimmedStringWithWhitespace);
 
-    //turn trimming on
+    // turn trimming on
     iProp->setAutoTrim(true);
     TSM_ASSERT_EQUALS("Auto trim is not turned on", iProp->autoTrim(), true);
-
   }
+
 private:
   PropertyWithValue<int> *iProp;
   PropertyWithValue<double> *dProp;

--- a/Framework/MDAlgorithms/src/ConvertToMDParent.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMDParent.cpp
@@ -129,6 +129,7 @@ void ConvertToMDParent::init() {
       "without quotes) or empty (possible from script only) "
       "to force the workspace recalculation each time the algorithm is "
       "invoked.*");
+  getPointerToProperty("PreprocDetectorsWS")->setAutoTrim(false);
 
   declareProperty(
       make_unique<PropertyWithValue<bool>>("UpdateMasks", false,

--- a/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
@@ -265,7 +265,7 @@ class OSIRISMultiFileReduction(ISISIndirectInelasticReduction):
         ISISIndirectInelasticReduction.__init__(self)
         self.instr_name = 'OSIRIS'
         self.detector_range = [963, 1004]
-        self.data_files = ['OSIRIS00106550.raw',' OSIRIS00106551.raw']
+        self.data_files = ['OSIRIS00106550.raw','OSIRIS00106551.raw']
         self.rebin_string = None
 
     def get_reference_files(self):

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -8,6 +8,10 @@ Framework Changes
 Algorithms
 ----------
 
+Properties
+##########
+-  String properties of algoithms are now trimmed of whitespace by default before being used by the algorithm.  So "  My filename   " will be trimmed to "My filename".
+
 New
 ###
 

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -229,7 +229,7 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},
         if verbose:
             sanslog.notice(createColetteScript(run, format, reduced, centreit, plotresults, filename))
         # Rename the final workspace
-        final_name = run['output_as']
+        final_name = run['output_as'].strip()
         if final_name == '':
             final_name = reduced
 


### PR DESCRIPTION
Makes properties trim whitespace from the ends of strings when setting.  This can be disabled using the setAutoTrim method.  This will mean that " " is correctly interpreted as "" (empty string) for default and mandatory validator purposes.

There are a few instances where this is used to define a separator in algorithms and for these the autotrim has been turned off.

**To test:**
1. Check all unit and system tests pass
2. Pick an algorithm that accepts a string property and enter various options with and without leading and trailing whitespace.
3. Check that the mandatory validator complains if " " a space is entered as a valid value

Fixes #13676 

**Release Notes:**
docs/source/release/v3.7.0/framework.rst

Algorithms ->Properties

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

re #13676
