### PR TITLE
Add loaded main field direction as a log value

### DIFF
--- a/Framework/DataHandling/src/LoadMuonNexus.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus.cpp
@@ -79,7 +79,7 @@ void LoadMuonNexus::init() {
   declareProperty("MainFieldDirection", "Transverse",
                   boost::make_shared<StringListValidator>(FieldOptions),
                   "Output the main field direction if specified in Nexus file "
-                  "(default Transverse)",
+                  "(run/instrument/detector/orientation, default longitudinal)",
                   Direction::Output);
 
   declareProperty("TimeZero", 0.0,

--- a/Framework/DataHandling/test/LoadMuonNexus1Test.h
+++ b/Framework/DataHandling/test/LoadMuonNexus1Test.h
@@ -97,9 +97,14 @@ public:
                      "2006-Nov-21 07:03:08  182.8");
     // check that sample name has been set correctly
     TS_ASSERT_EQUALS(output->sample().getName(), "Cr2.7Co0.3Si");
+
+    // check that the main field direction has been added as a log
+    Property *fieldDirection = output->run().getLogData("main_field_direction");
+    TS_ASSERT(fieldDirection);
+    TS_ASSERT_EQUALS(fieldDirection->value(), "Longitudinal");
   }
 
-  void testTransvereDataset() {
+  void testTransverseDataset() {
     LoadMuonNexus1 nxL;
     if (!nxL.isInitialized())
       nxL.initialize();
@@ -121,6 +126,14 @@ public:
     TS_ASSERT_DELTA(timeZero, 0.55, 0.001);
     double firstgood = nxL.getProperty("FirstGoodData");
     TS_ASSERT_DELTA(firstgood, 0.656, 0.001);
+
+    // Test that the output workspace knows the field direction
+    MatrixWorkspace_sptr output;
+    output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+        outputSpace);
+    Property *fieldDirection = output->run().getLogData("main_field_direction");
+    TS_ASSERT(fieldDirection);
+    TS_ASSERT_EQUALS(fieldDirection->value(), "Transverse");
   }
 
   void testExec2() {

--- a/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -175,7 +175,7 @@ public:
   {
     EXPECT_CALL(*m_view, firstRun()).WillRepeatedly(Return("MUSR00015189.nxs"));
     // Test logs
-    EXPECT_CALL(*m_view, setAvailableLogs(AllOf(Property(&std::vector<std::string>::size, 38),
+    EXPECT_CALL(*m_view, setAvailableLogs(AllOf(Property(&std::vector<std::string>::size, 39),
                                                 Contains("run_number"),
                                                 Contains("sample_magn_field"),
                                                 Contains("Field_Danfysik")))).Times(1);


### PR DESCRIPTION
Add main field direction as a log value in loaded workspace

`LoadMuonNexus-v1` loads the main field direction from the NeXus file and returns it as an output
parameter, but does not add this information to the returned workspace. If this workspace is then
passed as input to other algorithms, they might want to know this information.

For example: MUSR data can have either a longitudinal or transverse field, and 
`CalMuonDetectorPhases` needs to know which so it can load the correct grouping.

The changes in this PR add the field direction as a log value in the loaded workspace, and use this
log in `CalMuonDetectorPhases` - enabling this algorithm to be used on MUSR data (see #15191).

Unit tests added for the loaded log value and its use in `CalMuonDetectorPhases`.

**To test:**
_data in `\\olympic\babylon5\Scratch\TomPerkins\Data\MUSR`_

`MUSR00015189.nxs` has a longitudinal field and `MUSR00022725.nxs` has a transverse field.
- Use `LoadMuonNexus` to load these files and check the log values of the loaded workspaces.
  There should be a log called `main_field_direction` that has the correct value in it.
- Run `CalMuonDetectorPhases` on the loaded workspaces. The algorithm should run to completion and not throw any errors.

Fixes #15296

Does not need to be in the release notes as the situation it resolves was introduced since the last
release.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
