### PR TITLE
Reorder check for initial view

### DIFF
--- a/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -838,10 +838,10 @@ MdViewerWidget::getViewForInstrument(const std::string &instrumentName) const {
 
     if (techniques.count("Single Crystal Diffraction") > 0) {
       associatedView = mdConstants.getSplatterPlotView();
-    } else if (techniques.count("Neutron Diffraction") > 0) {
-      associatedView = mdConstants.getSplatterPlotView();
     } else if (checkIfTechniqueContainsKeyword(techniques, "Spectroscopy")) {
       associatedView = mdConstants.getMultiSliceView();
+    } else if (techniques.count("Neutron Diffraction") > 0) {
+      associatedView = mdConstants.getSplatterPlotView();
     } else {
       associatedView = mdConstants.getStandardView();
     }

--- a/docs/source/release/v3.7.0/ui.rst
+++ b/docs/source/release/v3.7.0/ui.rst
@@ -112,6 +112,8 @@ Bugs Resolved
 -  VSI: Fix Mantid crash when pressing :ref:`Scale <algm-Scale>` or Cut when "builtin" node
    is selected in Pipeline Browser
 
+-  VSI: The TECHNIQUE-DEPENDENT initial view now checks for Spectroscopy before Neutron Diffraction.  
+
 SliceViewer Improvements
 ------------------------
 


### PR DESCRIPTION
Description of work.

The VSI was checking the [Facilities.xml](https://github.com/mantidproject/mantid/blob/master/instrument/Facilities.xml) file for `Neutron Diffraction` before `Spectroscopy`. The PR reverses that order so that instruments like SEQUOIA, CNCS and ARCS will initially open in the multi-slice view.

**To test:**

Verify that data from a spectroscopy instrument opens in the multi-slice view.

<!-- Instructions for testing. -->

Fixes #15726.

Wiki changes:
http://www.mantidproject.org/index.php?title=VatesSimpleInterface_v2&diff=26416&oldid=26074

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
