### PR TITLE
In Vates subdirectory, tidy up emplace and push_back

### DIFF
--- a/Vates/VatesAPI/inc/MantidVatesAPI/ViewFrustum.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/ViewFrustum.h
@@ -35,13 +35,7 @@ class DLLExport FrustumPlane
 
     std::vector<T> getPlaneCoefficients()
     {
-      std::vector<T> coefficients;
-      coefficients.push_back(m_paramA);
-      coefficients.push_back(m_paramB);
-      coefficients.push_back(m_paramC);
-      coefficients.push_back(m_paramD);
-
-      return coefficients;
+      return {m_paramA, m_paramB, m_paramC, m_paramD};
     }
 
 private:
@@ -100,27 +94,16 @@ class DLLExport ViewFrustum
   {
     const size_t dim = 3;
 
-    std::vector<T> aVec;
-    aVec.push_back(plane1.A());
-    aVec.push_back(plane2.A());
-    aVec.push_back(plane3.A());
+    std::vector<T> aVec{plane1.A(), plane2.A(), plane3.A()};
 
-    std::vector<T> bVec;
-    bVec.push_back(plane1.B());
-    bVec.push_back(plane2.B());
-    bVec.push_back(plane3.B());
+    std::vector<T> bVec{plane1.B(), plane2.B(), plane3.B()};
 
-    std::vector<T> cVec;
-    cVec.push_back(plane1.C());
-    cVec.push_back(plane2.C());
-    cVec.push_back(plane3.C());
+    std::vector<T> cVec{plane1.C(), plane2.C(), plane3.C()};
 
     // The input is Ax+By+Cz+D=0 but we need the form Ax+By+Cz=D
-    std::vector<T> dVec;
     const T factor = -1;
-    dVec.push_back(factor*plane1.D());
-    dVec.push_back(factor*plane2.D());
-    dVec.push_back(factor*plane3.D());
+    std::vector<T> dVec{factor * plane1.D(), factor * plane2.D(),
+                        factor * plane3.D()};
 
     // Get the different matrix permutations
     Mantid::Kernel::Matrix<T> abcMatrix(dim, dim);
@@ -143,10 +126,8 @@ class DLLExport ViewFrustum
     T adcDet = adcMatrix.determinant();
     T abdDet = abdMatrix.determinant();
 
-    std::vector<T> intersection;
-    intersection.push_back(dbcDet/abcDet);
-    intersection.push_back(adcDet/abcDet);
-    intersection.push_back(abdDet/abcDet);
+    std::vector<T> intersection{dbcDet / abcDet, adcDet / abcDet,
+                                abdDet / abcDet};
 
     return intersection;
   }

--- a/Vates/VatesAPI/src/MDHWLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDHWLoadingPresenter.cpp
@@ -62,8 +62,8 @@ void MDHWLoadingPresenter::transposeWs(Mantid::API::IMDHistoWorkspace_sptr &inHi
         nonIntegratedDims.push_back(i);
       }
     }
-    std::vector<int> orderedDims;
-    orderedDims = nonIntegratedDims;
+
+    std::vector<int> orderedDims = nonIntegratedDims;
     orderedDims.insert(orderedDims.end(), integratedDims.begin(),
                        integratedDims.end());
 

--- a/Vates/VatesAPI/src/SaveMDWorkspaceToVTKImpl.cpp
+++ b/Vates/VatesAPI/src/SaveMDWorkspaceToVTKImpl.cpp
@@ -195,14 +195,13 @@ SaveMDWorkspaceToVTKImpl::translateStringToVisualNormalization(
 }
 
 void SaveMDWorkspaceToVTKImpl::setupMembers() {
-  m_normalizations.insert(
-      std::make_pair("AutoSelect", VisualNormalization::AutoSelect));
-  m_normalizations.insert(
-      std::make_pair("NoNormalization", VisualNormalization::NoNormalization));
-  m_normalizations.insert(std::make_pair(
-      "NumEventsNormalization", VisualNormalization::NumEventsNormalization));
-  m_normalizations.insert(std::make_pair(
-      "VolumeNormalization", VisualNormalization::VolumeNormalization));
+  m_normalizations.emplace("AutoSelect", VisualNormalization::AutoSelect);
+  m_normalizations.emplace("NoNormalization",
+                           VisualNormalization::NoNormalization);
+  m_normalizations.emplace("NumEventsNormalization",
+                           VisualNormalization::NumEventsNormalization);
+  m_normalizations.emplace("VolumeNormalization",
+                           VisualNormalization::VolumeNormalization);
 
   m_thresholds.push_back("IgnoreZerosThresholdRange");
   m_thresholds.push_back("NoThresholdRange");

--- a/Vates/VatesAPI/src/SaveMDWorkspaceToVTKImpl.cpp
+++ b/Vates/VatesAPI/src/SaveMDWorkspaceToVTKImpl.cpp
@@ -203,8 +203,8 @@ void SaveMDWorkspaceToVTKImpl::setupMembers() {
   m_normalizations.emplace("VolumeNormalization",
                            VisualNormalization::VolumeNormalization);
 
-  m_thresholds.push_back("IgnoreZerosThresholdRange");
-  m_thresholds.push_back("NoThresholdRange");
+  m_thresholds.emplace_back("IgnoreZerosThresholdRange");
+  m_thresholds.emplace_back("NoThresholdRange");
 }
 
 std::vector<std::string>

--- a/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
@@ -286,11 +286,7 @@ void vtkDataSetToNonOrthogonalDataSet::createSkewInformation(
   m_skewMat *= scaleMat;
 
   // Setup basis normalisation array
-  // Intel and MSBuild can't handle this
-  // m_basisNorm = {ol.astar(), ol.bstar(), ol.cstar()};
-  m_basisNorm.push_back(ol.astar());
-  m_basisNorm.push_back(ol.bstar());
-  m_basisNorm.push_back(ol.cstar());
+  m_basisNorm = {ol.astar(), ol.bstar(), ol.cstar()};
 
   // Expand matrix to 4 dimensions if necessary
   if (4 == m_numDims) {

--- a/Vates/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
@@ -256,13 +256,14 @@ GCC_DIAG_OFF(strict-aliasing)
     switch(coordinateSystem)
     {
       case(Mantid::Kernel::SpecialCoordinateSystem::HKL):
-        peaksInfo.push_back(std::pair<Mantid::Kernel::V3D, double>(peak->getHKL(), radius*m_radiusFactor));
+        peaksInfo.emplace_back(peak->getHKL(), radius * m_radiusFactor);
         break;
       case(Mantid::Kernel::SpecialCoordinateSystem::QLab):
-        peaksInfo.push_back(std::pair<Mantid::Kernel::V3D, double>(peak->getQLabFrame(), radius*m_radiusFactor));
+        peaksInfo.emplace_back(peak->getQLabFrame(), radius * m_radiusFactor);
         break;
       case(Mantid::Kernel::SpecialCoordinateSystem::QSample):
-        peaksInfo.push_back(std::pair<Mantid::Kernel::V3D, double>(peak->getQSampleFrame(), radius*m_radiusFactor));
+        peaksInfo.emplace_back(peak->getQSampleFrame(),
+                               radius * m_radiusFactor);
         break;
       default:
         throw std::invalid_argument("The special coordinate systems don't match.");

--- a/Vates/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
+++ b/Vates/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
@@ -84,33 +84,10 @@ private:
     }
 
     // Create the coordinate transformation information
-    std::vector<Mantid::coord_t> affMatVals;
-    affMatVals.push_back(1);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(1);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(1);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(1);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(0);
-    affMatVals.push_back(1);
-                      
+    std::vector<Mantid::coord_t> affMatVals{1, 0, 0, 0, 0, 0, 0, 1, 0,
+                                            0, 0, 0, 0, 1, 0, 0, 1, 0,
+                                            0, 0, 0, 0, 0, 0, 1};
+
     CoordTransformAffine affMat(4, 4);
     affMat.setMatrix(Matrix<Mantid::coord_t>(affMatVals));
     if (!forgetAffmat)
@@ -128,15 +105,7 @@ private:
     }
     else
     {
-      wMat.push_back(1);
-      wMat.push_back(1);
-      wMat.push_back(0);
-      wMat.push_back(1);
-      wMat.push_back(-1);
-      wMat.push_back(0);
-      wMat.push_back(0);
-      wMat.push_back(0);
-      wMat.push_back(1);
+      wMat = {1, 1, 0, 1, -1, 0, 0, 0, 1};
     }
 
     if (!forgetWmat)

--- a/Vates/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
+++ b/Vates/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
@@ -67,7 +67,8 @@ private:
   vtkSmartPointer<vtkUnstructuredGrid> makeSplatterSourceGrid() {
     FakeProgressAction progressUpdate;
     MDEventWorkspace3Lean::sptr ws = MDEventsTestHelper::makeMDEW<3>(10, -10.0, 10.0, 1);
-    vtkSplatterPlotFactory factory(ThresholdRange_scptr(new UserDefinedThresholdRange(0, 1)), "signal");
+    vtkSplatterPlotFactory factory(
+        boost::make_shared<const UserDefinedThresholdRange>(0, 1), "signal");
     factory.initialize(ws);
     vtkSmartPointer<vtkDataSet> product;
     TS_ASSERT_THROWS_NOTHING(product = factory.create(progressUpdate));
@@ -211,22 +212,23 @@ public:
     // The actual radius is multiplied by the radius factor.
     double peakRadius = 5;
     Mantid::Kernel::SpecialCoordinateSystem coordinateSystem = Mantid::Kernel::SpecialCoordinateSystem::QSample;
-    Mantid::Geometry::PeakShape_sptr shape(new Mantid::DataObjects::PeakShapeSpherical(peakRadius, coordinateSystem, "test", 1));
+    auto shape = boost::make_shared<Mantid::DataObjects::PeakShapeSpherical>(
+        peakRadius, coordinateSystem, "test", 1);
     boost::shared_ptr<MockPeakFilter> peak =
         boost::make_shared<MockPeakFilter>();
     peak->setPeakShape(shape);
 
-    std::vector<std::pair<boost::shared_ptr<MockPeakFilter>, Mantid::Kernel::V3D>> fakeSinglePeakPeakWorkspaces;
-    fakeSinglePeakPeakWorkspaces.push_back(std::pair<boost::shared_ptr<MockPeakFilter>, Mantid::Kernel::V3D>(peak, coordinate));
+    std::vector<
+        std::pair<boost::shared_ptr<MockPeakFilter>, Mantid::Kernel::V3D>>
+        fakeSinglePeakPeakWorkspaces{{peak, coordinate}};
 
-    std::vector<PeaksFilterDataContainer> peakData;
     PeaksFilterDataContainer data1;
     data1.position = coordinate;
     data1.radius = peakRadius;
     data1.radiusFactor = peaksFilter.getRadiusFactor();
-    peakData.push_back(data1);
+    std::vector<PeaksFilterDataContainer> peakData{data1};
 
-     // Act
+    // Act
     do_test_execute(peaksFilter, fakeSinglePeakPeakWorkspaces, coordinateSystem);
 
     // Assert
@@ -242,18 +244,14 @@ public:
 
     Mantid::Kernel::V3D coordinate(0,0,0);
     double peakRadiusMax = 7;
-    std::vector<double> radii;
-    radii.push_back(peakRadiusMax);
-    radii.push_back(6);
-    radii.push_back(5);
+    std::vector<double> radii{peakRadiusMax, 6, 5};
 
-    std::vector<Mantid::Kernel::V3D> directions;
-    directions.push_back(Mantid::Kernel::V3D(0.0,1.0,0.0));
-    directions.push_back(Mantid::Kernel::V3D(1.0,0.0,0.0));
-    directions.push_back(Mantid::Kernel::V3D(0.0,0.0,1.0));
+    std::vector<Mantid::Kernel::V3D> directions{
+        {0., 1., 0.}, {1., 0., 0.}, {0., 0., 1.}};
 
     Mantid::Kernel::SpecialCoordinateSystem coordinateSystem = Mantid::Kernel::SpecialCoordinateSystem::QSample;
-    Mantid::Geometry::PeakShape_sptr shape(new Mantid::DataObjects::PeakShapeEllipsoid(directions, radii, radii, radii , coordinateSystem, "test", 1));
+    auto shape = boost::make_shared<Mantid::DataObjects::PeakShapeEllipsoid>(
+        directions, radii, radii, radii, coordinateSystem, "test", 1);
     boost::shared_ptr<MockPeakFilter> peak =
         boost::make_shared<MockPeakFilter>();
     peak->setPeakShape(shape);
@@ -286,7 +284,7 @@ public:
 
     Mantid::Kernel::SpecialCoordinateSystem coordinateSystem = Mantid::Kernel::SpecialCoordinateSystem::QSample;
     double radius = peaksFilter.getRadiusNoShape();
-    Mantid::Geometry::PeakShape_sptr shape(new Mantid::DataObjects::NoShape());
+    auto shape = boost::make_shared<Mantid::DataObjects::NoShape>();
     boost::shared_ptr<MockPeakFilter> peak =
         boost::make_shared<MockPeakFilter>();
     peak->setPeakShape(shape);
@@ -318,7 +316,8 @@ public:
     Mantid::Kernel::V3D coordinate(0,0,0);
     double peakRadius = 5;
     Mantid::Kernel::SpecialCoordinateSystem coordinateSystem = Mantid::Kernel::SpecialCoordinateSystem::QSample;
-    Mantid::Geometry::PeakShape_sptr shape(new Mantid::DataObjects::PeakShapeSpherical(peakRadius, coordinateSystem, "test", 1));
+    auto shape = boost::make_shared<Mantid::DataObjects::PeakShapeSpherical>(
+        peakRadius, coordinateSystem, "test", 1);
     boost::shared_ptr<MockPeakFilter> peak =
         boost::make_shared<MockPeakFilter>();
     peak->setPeakShape(shape);
@@ -326,12 +325,12 @@ public:
     // Peak 2
     Mantid::Kernel::V3D coordinate2(12,0,0);
     double peakRadius2 = 5;
-    Mantid::Geometry::PeakShape_sptr shape2(new Mantid::DataObjects::PeakShapeSpherical(peakRadius2, coordinateSystem, "test", 1));
+    auto shape2 = boost::make_shared<Mantid::DataObjects::PeakShapeSpherical>(
+        peakRadius2, coordinateSystem, "test", 1);
     boost::shared_ptr<MockPeakFilter> peak2 =
         boost::make_shared<MockPeakFilter>();
     peak2->setPeakShape(shape2);
 
-    std::vector<PeaksFilterDataContainer> peakData;
     PeaksFilterDataContainer data1;
     data1.position = coordinate;
     data1.radius =peakRadius;
@@ -341,12 +340,11 @@ public:
     data2.radius = peakRadius2;
     data2.radiusFactor = peaksFilter.getRadiusFactor();
 
-    peakData.push_back(data1);
-    peakData.push_back(data2);
+    std::vector<PeaksFilterDataContainer> peakData{data1, data2};
 
-    std::vector<std::pair<boost::shared_ptr<MockPeakFilter>, Mantid::Kernel::V3D>> fakeSinglePeakPeakWorkspaces;
-    fakeSinglePeakPeakWorkspaces.push_back(std::pair<boost::shared_ptr<MockPeakFilter>, Mantid::Kernel::V3D>(peak, coordinate));
-    fakeSinglePeakPeakWorkspaces.push_back(std::pair<boost::shared_ptr<MockPeakFilter>, Mantid::Kernel::V3D>(peak2, coordinate2));
+    std::vector<
+        std::pair<boost::shared_ptr<MockPeakFilter>, Mantid::Kernel::V3D>>
+        fakeSinglePeakPeakWorkspaces{{peak, coordinate}, {peak2, coordinate2}};
 
     // Act
     do_test_execute(peaksFilter, fakeSinglePeakPeakWorkspaces, coordinateSystem);

--- a/Vates/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
+++ b/Vates/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
@@ -68,7 +68,7 @@ private:
     FakeProgressAction progressUpdate;
     MDEventWorkspace3Lean::sptr ws = MDEventsTestHelper::makeMDEW<3>(10, -10.0, 10.0, 1);
     vtkSplatterPlotFactory factory(
-        boost::make_shared<const UserDefinedThresholdRange>(0, 1), "signal");
+        boost::make_shared<UserDefinedThresholdRange>(0, 1), "signal");
     factory.initialize(ws);
     vtkSmartPointer<vtkDataSet> product;
     TS_ASSERT_THROWS_NOTHING(product = factory.create(progressUpdate));

--- a/Vates/VatesSimpleGui/QtWidgets/src/ModeControlWidget.cpp
+++ b/Vates/VatesSimpleGui/QtWidgets/src/ModeControlWidget.cpp
@@ -29,13 +29,6 @@ ModeControlWidget::ModeControlWidget(QWidget *parent) : QWidget(parent)
                    this, SLOT(onThreeSliceViewButtonClicked()));
   QObject::connect(this->ui.splatterPlotButton, SIGNAL(clicked()),
                    this, SLOT(onSplatterPlotViewButtonClicked()));
-
-  // Add the mapping from string to the view enum
-  MantidQt::API::MdConstants mdConstants;
-  mapFromStringToView.insert(std::pair<QString, ModeControlWidget::Views>(mdConstants.getStandardView(), ModeControlWidget::STANDARD));
-  mapFromStringToView.insert(std::pair<QString, ModeControlWidget::Views>(mdConstants.getThreeSliceView(), ModeControlWidget::THREESLICE));
-  mapFromStringToView.insert(std::pair<QString, ModeControlWidget::Views>(mdConstants.getMultiSliceView(), ModeControlWidget::MULTISLICE));
-  mapFromStringToView.insert(std::pair<QString, ModeControlWidget::Views>(mdConstants.getSplatterPlotView(), ModeControlWidget::SPLATTERPLOT));
 }
 
 ModeControlWidget::~ModeControlWidget()

--- a/Vates/VatesSimpleGui/QtWidgets/src/ModeControlWidget.cpp
+++ b/Vates/VatesSimpleGui/QtWidgets/src/ModeControlWidget.cpp
@@ -29,6 +29,17 @@ ModeControlWidget::ModeControlWidget(QWidget *parent) : QWidget(parent)
                    this, SLOT(onThreeSliceViewButtonClicked()));
   QObject::connect(this->ui.splatterPlotButton, SIGNAL(clicked()),
                    this, SLOT(onSplatterPlotViewButtonClicked()));
+
+  // Add the mapping from string to the view enum
+  MantidQt::API::MdConstants mdConstants;
+  mapFromStringToView.emplace(mdConstants.getStandardView(),
+                              ModeControlWidget::STANDARD);
+  mapFromStringToView.emplace(mdConstants.getThreeSliceView(),
+                              ModeControlWidget::THREESLICE);
+  mapFromStringToView.emplace(mdConstants.getMultiSliceView(),
+                              ModeControlWidget::MULTISLICE);
+  mapFromStringToView.emplace(mdConstants.getSplatterPlotView(),
+                              ModeControlWidget::SPLATTERPLOT);
 }
 
 ModeControlWidget::~ModeControlWidget()

--- a/Vates/VatesSimpleGui/ViewWidgets/src/BackgroundRgbProvider.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/BackgroundRgbProvider.cpp
@@ -53,7 +53,6 @@ namespace Mantid
       std::vector<double> BackgroundRgbProvider::getRgbFromSetting(bool useCurrentBackgroundColor)
       {
         // Set the mantid default here
-        std::vector<double> background;
         QColor userBackground;
 
         if (useCurrentBackgroundColor)
@@ -101,11 +100,8 @@ namespace Mantid
           bVal = defaultBackgroundColor.blue();
         }
 
-        background.push_back(static_cast<double>(rVal));
-        background.push_back(static_cast<double>(gVal));
-        background.push_back(static_cast<double>(bVal));
-
-        return background;
+        return {static_cast<double>(rVal), static_cast<double>(gVal),
+                static_cast<double>(bVal)};
       }
 
       void BackgroundRgbProvider::update()

--- a/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -618,26 +618,22 @@ void MdViewerWidget::removeAllRebinning(ModeControlWidget::Views view) {
   pqServer *server = pqActiveObjects::instance().activeServer();
   pqServerManagerModel *smModel =
       pqApplicationCore::instance()->getServerManagerModel();
-  QList<pqPipelineSource *> sources =
+  const QList<pqPipelineSource *> sources =
       smModel->findItems<pqPipelineSource *>(server);
 
   // We need to record all true sources, The filters will be removed in the
   // removeRebinning step
   // Hence the iterator will not point to a valid object anymore.
   QList<pqPipelineSource *> sourcesToAlter;
-
-  for (QList<pqPipelineSource *>::Iterator source = sources.begin();
-       source != sources.end(); ++source) {
-    const QString srcProxyName = (*source)->getProxy()->GetXMLGroup();
-
+  foreach (pqPipelineSource *source, sources) {
+    const QString srcProxyName = source->getProxy()->GetXMLGroup();
     if (srcProxyName == QString("sources")) {
-      sourcesToAlter.push_back(*source);
+      sourcesToAlter.push_back(source);
     }
   }
 
-  for (QList<pqPipelineSource *>::Iterator source = sourcesToAlter.begin();
-       source != sourcesToAlter.end(); ++source) {
-    removeRebinning(*source, false, view);
+  foreach (pqPipelineSource *source, sourcesToAlter) {
+    removeRebinning(source, false, view);
   }
 }
 

--- a/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
@@ -396,11 +396,13 @@ namespace Mantid
             inputWorkspace = m_rebinnedWorkspaceAndSourceToOriginalWorkspace[createKeyPairForSource(source)];
             outputWorkspace = m_tempPrefix + inputWorkspace + algorithmType + m_tempPostfix;
             // Keep track of the old rebinned workspace and source
-            m_newRebinnedWorkspacePairBuffer.insert(std::pair<std::string, std::pair<std::string, pqPipelineSource*>>(workspaceName, std::pair<std::string, pqPipelineSource*>(outputWorkspace, source)));
+            m_newRebinnedWorkspacePairBuffer.emplace(
+                workspaceName, std::make_pair(outputWorkspace, source));
           }
         }
         // Record the workspaces
-        m_newWorkspacePairBuffer.insert(std::pair<std::string, std::pair<std::string, pqPipelineSource*>>(inputWorkspace, std::pair<std::string, pqPipelineSource*>(outputWorkspace, source)));
+        m_newWorkspacePairBuffer.emplace(
+            inputWorkspace, std::make_pair(outputWorkspace, source));
         m_inputSource= source;
       }
 


### PR DESCRIPTION
Description of work.

This just cleans up several places in the Vates subdirectory where C++11 allows us to write less verbose code.

**To test:**

Code review

<!-- Instructions for testing. -->

There is no issue associated with this PR

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
