### PR TITLE
Fix source tarball to include buildconfig directory

### DIFF
--- a/buildconfig/CMake/CPackLinuxSetup.cmake
+++ b/buildconfig/CMake/CPackLinuxSetup.cmake
@@ -7,8 +7,13 @@ string ( TOLOWER "${CPACK_PACKAGE_NAME}" CPACK_PACKAGE_NAME )
 
 # define the source generators
 set ( CPACK_SOURCE_GENERATOR TGZ )
-set ( CPACK_SOURCE_IGNORE_FILES
-  "${CMAKE_BINARY_DIR};/\\\\.git*;${CPACK_SOURCE_IGNORE_FILES}" )
+set ( CPACK_SOURCE_IGNORE_FILES "/\\\\.git*")
+if (CMAKE_BINARY_DIR MATCHES "^${CMAKE_SOURCE_DIR}/.+")
+  # In-source build add the binary directory to files to ignore for the tarball
+  string (REGEX REPLACE "^${CMAKE_SOURCE_DIR}/([^\\/]+)(.*)\$" "/\\1/" _ignore_dir "${CMAKE_BINARY_DIR}")
+  set (CPACK_SOURCE_IGNORE_FILES "${CPACK_SOURCE_IGNORE_FILES};${_ignore_dir}")
+endif ()
+message("CPACK_SOURCE_IGNORE_FILES = ${CPACK_SOURCE_IGNORE_FILES}")
 
 include (DetermineLinuxDistro)
 
@@ -20,10 +25,10 @@ if ( "${UNIX_DIST}" MATCHES "Ubuntu" )
     execute_process( COMMAND ${DPKG_CMD} --print-architecture
       OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
       OUTPUT_STRIP_TRAILING_WHITESPACE )
-    # according to debian <foo>_<VersionNumber>-<DebianRevisionNumber>_<DebianArchitecture>.deb 
+    # according to debian <foo>_<VersionNumber>-<DebianRevisionNumber>_<DebianArchitecture>.deb
     set( CPACK_PACKAGE_FILE_NAME
-      "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")   
-  endif ( DPKG_CMD ) 
+      "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
+  endif ( DPKG_CMD )
 endif ( "${UNIX_DIST}" MATCHES "Ubuntu" )
 
 #RedHatEnterpriseClient RedHatEnterpriseWorkstation
@@ -41,7 +46,7 @@ if ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" OR "${UNIX_DIST}" MATCHES "Fedora
     elseif ( "${UNIX_DIST}" MATCHES "Fedora" )
       set ( CPACK_RPM_PACKAGE_RELEASE "1.fc${UNIX_RELEASE}" )
     endif ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" )
-    
+
     # If CPACK_SET_DESTDIR is ON then the Prefix doesn't get put in the spec file
     if( CPACK_SET_DESTDIR )
       message ( "Adding \"Prefix:\" line to spec file manually when CPACK_SET_DESTDIR is set")
@@ -53,4 +58,3 @@ if ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" OR "${UNIX_DIST}" MATCHES "Fedora
       "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_RPM_PACKAGE_RELEASE}.${CPACK_RPM_PACKAGE_ARCHITECTURE}" )
   endif ( RPMBUILD_CMD)
 endif ()
-


### PR DESCRIPTION
This fixes the regex expression that was used to exclude the binary directory from the source tarball packaging; which was also accidentally swallowing the `buildconfig` directory.

**To test:**

This needs to be tested on a Linux platform with an in-source build, i.e. if your code is checked out to `~/source/mantid` then the build directory should be `~/source/mantid/build`.

Run cmake with cpack enabled:

```
cd ~/source/mantid
mkdir build
cd build
cmake -DENABLE_CPACK=ON ../
```

and generate the tarball with the following command

```
cpack --config CPackSourceConfig.cmake -D CPACK_PACKAGING_INSTALL_PREFIX=
```

Examine the generated tarball using `tar tzf` and check:
- the `buildconfig` directory is present &
- the `build` directory is **not** present.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

The previous regex was also swalling the buildconfig directory.
