### PR TITLE
Fix MantidPlot -x option 

### DIFF
--- a/MantidPlot/src/ScriptingWindow.cpp
+++ b/MantidPlot/src/ScriptingWindow.cpp
@@ -769,8 +769,11 @@ bool ScriptingWindow::shouldEnableAbort() const {
  * active tab will be the one containing the given script.
  * @param filename The name of the newTab to open
  */
-void ScriptingWindow::openUnique(const QString &filename) {
+void ScriptingWindow::openUnique(QString filename) {
   auto openFiles = m_manager->fileNamesToQStringList();
+  // The list of open files contains absolute paths so make sure we have one
+  // here
+  filename = QFileInfo(filename).absFilePath();
   auto position = openFiles.indexOf(filename);
   if (position < 0) {
     m_manager->newTab(openFiles.size(), filename);

--- a/MantidPlot/src/ScriptingWindow.cpp
+++ b/MantidPlot/src/ScriptingWindow.cpp
@@ -765,14 +765,18 @@ bool ScriptingWindow::shouldEnableAbort() const {
 }
 
 /**
- * Opens a script providing a copy is not already open
- * @param newTabName The name of the newTab to open
+ * Opens a script providing a copy is not already open. On exit the
+ * active tab will be the one containing the given script.
+ * @param filename The name of the newTab to open
  */
-void ScriptingWindow::openUnique(const QString &newTabName) {
+void ScriptingWindow::openUnique(const QString &filename) {
   auto openFiles = m_manager->fileNamesToQStringList();
-  auto position = openFiles.contains(newTabName);
-  if (!position) {
-    m_manager->newTab(openFiles.size(), newTabName);
+  auto position = openFiles.indexOf(filename);
+  if (position < 0) {
+    m_manager->newTab(openFiles.size(), filename);
+  } else {
+    // make it the current tab
+    m_manager->setCurrentIndex(position);
   }
 }
 

--- a/MantidPlot/src/ScriptingWindow.h
+++ b/MantidPlot/src/ScriptingWindow.h
@@ -56,7 +56,7 @@ public:
   /// Set whether to accept/reject close events
   void acceptCloseEvent(const bool value);
   /// Opens a script providing a copy is not already open
-  void openUnique(const QString &filename);
+  void openUnique(QString filename);
 
 signals:
   /// Show the scripting language dialog

--- a/MantidPlot/src/ScriptingWindow.h
+++ b/MantidPlot/src/ScriptingWindow.h
@@ -56,7 +56,7 @@ public:
   /// Set whether to accept/reject close events
   void acceptCloseEvent(const bool value);
   /// Opens a script providing a copy is not already open
-  void openUnique(const QString &);
+  void openUnique(const QString &filename);
 
 signals:
   /// Show the scripting language dialog

--- a/docs/source/release/v3.7.0/ui.rst
+++ b/docs/source/release/v3.7.0/ui.rst
@@ -97,6 +97,9 @@ Algorithm Toolbox
 Scripting Window
 ################
 
+- If `MantidPlot` was launched with the `-x` option but the script was already opened by the recent files list then
+  the wrong script would be executed. This bug has been fixed. `#15682 <https://github.com/mantidproject/mantid/issue/15682>`_
+
 Documentation
 #############
 
@@ -112,7 +115,7 @@ Bugs Resolved
 -  VSI: Fix Mantid crash when pressing :ref:`Scale <algm-Scale>` or Cut when "builtin" node
    is selected in Pipeline Browser
 
--  VSI: The TECHNIQUE-DEPENDENT initial view now checks for Spectroscopy before Neutron Diffraction.  
+-  VSI: The TECHNIQUE-DEPENDENT initial view now checks for Spectroscopy before Neutron Diffraction.
 
 SliceViewer Improvements
 ------------------------
@@ -130,12 +133,12 @@ VSI Improvements
 -  The representation of points in the splatter plot was changed from opaque cubes to translucent spheres.
 
 .. figure::  ../../images/VSIPointGaussianRepresentation.png
-   :align: center 
+   :align: center
 
-- The sphere and ellipse wireframes have been simplified so that it is easier to see the enclosed points. 
+- The sphere and ellipse wireframes have been simplified so that it is easier to see the enclosed points.
 
 .. figure:: ../../images/VSIEllipses.png
-    :align: center  
+    :align: center
 
 |
 


### PR DESCRIPTION
Fixes an issue in MantidPlot when passing a script to the `-x` option that was already opened by the recent files list. The correct script is now executed. 

While testing this it was also discovered that if you passed a relative path to the `-x` option and this file was already opened by the recent files list then an extra identical tab was opened. This has also been fixed.

**To test:**
- Create two test files `test-a.py` & `test-b.py` and add the text `print 'running script test-a'` & `print 'running script test-b'` in each file respectively.
- Start MantidPlot first without any arguments, open the script window and open both files in two separate tabs,  `test-a.py` first followed by `test-b.py` second.
- Close MantidPlot.
- Run MantidPlot with `-x`:

``` bash
MantidPlot -x $PWD/test-a.py
```

(For windows use `-x %CD%\test-a.py`)
- The script window should set `test-a.py` as the active tab and execute it. Before the fix `test-b.py` would be executed.

Fixes #15682

Release notes updated in `/docs/source/release/v3.7.0/ui.rst`

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
