### PR TITLE
Optimize vtkSplatterPlotFactory

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
@@ -413,10 +413,10 @@ TMDE(void MDGridBox)::getBoxes(std::vector<API::IMDNode *> &outBoxes,
   if (!leafOnly)
     outBoxes.push_back(this);
 
-  if (this->getDepth() + 1 <= maxDepth) {
-    for (size_t i = 0; i < numBoxes; i++) {
+  if (this->getDepth() < maxDepth) {
+    for(API::IMDNode * child: m_Children){
       // Recursively go deeper, if needed
-      m_Children[i]->getBoxes(outBoxes, maxDepth, leafOnly);
+      child->getBoxes(outBoxes, maxDepth, leafOnly);
     }
   } else {
     // Oh, we reached the max depth and want only leaves.
@@ -450,7 +450,7 @@ TMDE(void MDGridBox)::getBoxes(std::vector<API::IMDNode *> &outBoxes,
   if (!leafOnly)
     outBoxes.push_back(this);
 
-  if (this->getDepth() + 1 <= maxDepth) {
+  if (this->getDepth() < maxDepth) {
     // OK, let's look for children that are either touching or completely
     // contained by the implicit function.
 

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkSplatterPlotFactory.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkSplatterPlotFactory.h
@@ -175,8 +175,7 @@ private:
   boost::scoped_ptr<VatesConfigurations> m_vatesConfigurations;
 
   /// Sort boxes by normalized signal value
-  virtual void sortBoxesByDecreasingSignal(SigFuncIMDNodePtr getSignalFunction,
-                                           const bool VERBOSE) const;
+  virtual void sortBoxesByDecreasingSignal(const bool VERBOSE) const;
 };
 }
 }

--- a/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
+++ b/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
@@ -76,6 +76,7 @@ template <typename MDE, size_t nd>
 void vtkSplatterPlotFactory::doCreate(
     typename MDEventWorkspace<MDE, nd>::sptr ws) const {
   bool VERBOSE = true;
+  CPUTimer tim;
   // Acquire a scoped read-only lock to the workspace (prevent segfault
   // from algos modifying ws)
   ReadLock lock(*ws);
@@ -89,7 +90,6 @@ void vtkSplatterPlotFactory::doCreate(
   if (new_name != m_wsName || m_buildSortedList) {
     // First we get all the boxes, up to the given depth; with or wo the
     // slice function
-    CPUTimer tim;
 
     m_sortedBoxes.clear();
     if (this->slice) {
@@ -142,7 +142,6 @@ void vtkSplatterPlotFactory::doCreate(
 
   if (VERBOSE) {
     std::cout << "numPoints                 = " << numPoints << std::endl;
-    // std::cout << "num boxes in all          = " << boxes.size() << std::endl;
     std::cout << "num boxes above zero      = " << m_sortedBoxes.size()
               << std::endl;
     std::cout << "num boxes to use          = " << num_boxes_to_use
@@ -209,8 +208,7 @@ void vtkSplatterPlotFactory::doCreate(
   if (VERBOSE) {
     std::cout << "Recorded data for all points" << std::endl;
     std::cout << "numPoints = " << numPoints << std::endl;
-    // std::cout << tim << " to create " << pointIndex << " points." <<
-    // std::endl;
+    std::cout << tim << " to create " << pointIndex << " points." << std::endl;
   }
 
   pointsArray->Resize(pointIndex);
@@ -310,9 +308,9 @@ void vtkSplatterPlotFactory::doCreateMDHisto(
   size_t index = 0;
 
   for (int z = 0; z < nBinsZ; z++) {
-    in[2] = (minZ + static_cast<coord_t>(z + 0.5f) * incrementZ);
+    in[2] = (minZ + (static_cast<coord_t>(z) + 0.5f) * incrementZ);
     for (int y = 0; y < nBinsY; y++) {
-      in[1] = (minY + static_cast<coord_t>(y + 0.5f) * incrementY);
+      in[1] = (minY + (static_cast<coord_t>(y) + 0.5f) * incrementY);
       for (int x = 0; x < nBinsX; x++) {
         // Get the signalScalar
         signalScalar = this->extractScalarSignal(workspace, do4D, x, y, z);
@@ -322,7 +320,7 @@ void vtkSplatterPlotFactory::doCreateMDHisto(
         if (!Mantid::VATES::isSpecial(static_cast<double>(signalScalar)) &&
             m_thresholdRange->inRange(signalScalar) &&
             (signalScalar > static_cast<signal_t>(0.0))) {
-          in[0] = (minX + static_cast<coord_t>(x + 0.5f) * incrementX);
+          in[0] = (minX + (static_cast<coord_t>(x) + 0.5f) * incrementX);
           // Create the transformed value if required
           if (transform) {
             transform->apply(in, out);

--- a/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
+++ b/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
@@ -220,7 +220,6 @@ void vtkSplatterPlotFactory::doCreate(
 
 /**
  * Sort the boxes by their normalized signal in decreasing order
- * @param getSignalFunction : the function to use to get the signal
  * @param VERBOSE : if true then print when sorting happens
  */
 void vtkSplatterPlotFactory::sortBoxesByDecreasingSignal(

--- a/Vates/VatesAPI/test/vtkSplatterPlotFactoryTest.h
+++ b/Vates/VatesAPI/test/vtkSplatterPlotFactoryTest.h
@@ -113,8 +113,9 @@ public:
     FakeProgressAction progressUpdate;
 
     MDEventWorkspace3Lean::sptr ws =
-        MDEventsTestHelper::makeMDEW<3>(400, 0.0, 100.0, 1);
-    vtkSplatterPlotFactory factory(ThresholdRange_scptr(new UserDefinedThresholdRange(0, 1)), "signal");
+        MDEventsTestHelper::makeMDEW<3>(10, 0.0, 10.0, 1);
+    vtkSplatterPlotFactory factory(
+        boost::make_shared<UserDefinedThresholdRange>(0, 1), "signal");
     factory.initialize(ws);
     vtkSmartPointer<vtkDataSet> product;
 
@@ -127,7 +128,7 @@ public:
 
     // New sizes for splatter plot test, after changing the way the points 
     // are selected, 5/28/2013
-    const size_t expected_n_points = 200;
+    const size_t expected_n_points = 50;
     const size_t expected_n_cells = 0;
 
     const size_t expected_n_signals = expected_n_points;

--- a/Vates/VatesAPI/test/vtkSplatterPlotFactoryTest.h
+++ b/Vates/VatesAPI/test/vtkSplatterPlotFactoryTest.h
@@ -112,7 +112,8 @@ public:
   {
     FakeProgressAction progressUpdate;
 
-    MDEventWorkspace3Lean::sptr ws = MDEventsTestHelper::makeMDEW<3>(10, 0.0, 10.0, 1);
+    MDEventWorkspace3Lean::sptr ws =
+        MDEventsTestHelper::makeMDEW<3>(400, 0.0, 100.0, 1);
     vtkSplatterPlotFactory factory(ThresholdRange_scptr(new UserDefinedThresholdRange(0, 1)), "signal");
     factory.initialize(ws);
     vtkSmartPointer<vtkDataSet> product;
@@ -126,7 +127,7 @@ public:
 
     // New sizes for splatter plot test, after changing the way the points 
     // are selected, 5/28/2013
-    const size_t expected_n_points = 50;
+    const size_t expected_n_points = 200;
     const size_t expected_n_cells = 0;
 
     const size_t expected_n_signals = expected_n_points;


### PR DESCRIPTION
Description of work.

This eliminates constructing a container of boxes multiple times, eliminates an unnecessary `dynamic_cast` and uses the erase-remove idiom instead of constructing a second container. There are also a few places where I tried to make the code cleaner.

**To test:**

<!-- Instructions for testing. -->

Load a MDWorkspace in the VSI and switch to the SplatterPlot. Changing the number of points should be at least as responsive as before.

I used `test_3DWorkspace()` with more points to profile `vtkSplatterPlotFactory::create`

This is a small change with no issue number

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
