### PR TITLE
Use regex instead of if-else tree.

### DIFF
--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1703,7 +1703,7 @@ template <typename TYPE> void TimeSeriesProperty<TYPE>::countSize() const {
 template <typename TYPE>
 bool TimeSeriesProperty<TYPE>::isTimeString(const std::string &str) {
   boost::regex re("^[0-9]{4}.[0-9]{2}.[0-9]{2}.[0-9]{2}.[0-9]{2}.[0-9]{2}");
-  return boost::regex_match(str.begin(), str.end(), re);
+  return boost::regex_search(str.begin(), str.end(), re);
 }
 
 /**

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -5,10 +5,7 @@
 #include "MantidKernel/TimeSplitter.h"
 #include "MantidKernel/make_unique.h"
 
-#if !(defined __APPLE__ && defined __INTEL_COMPILER)
-#else
-#include <boost/range/algorithm_ext/is_sorted.hpp>
-#endif
+#include <boost/regex.hpp>
 
 using namespace std;
 
@@ -1705,37 +1702,8 @@ template <typename TYPE> void TimeSeriesProperty<TYPE>::countSize() const {
  */
 template <typename TYPE>
 bool TimeSeriesProperty<TYPE>::isTimeString(const std::string &str) {
-  if (str.size() < 19)
-    return false;
-  if (!isdigit(str[0]))
-    return false;
-  if (!isdigit(str[1]))
-    return false;
-  if (!isdigit(str[2]))
-    return false;
-  if (!isdigit(str[3]))
-    return false;
-  if (!isdigit(str[5]))
-    return false;
-  if (!isdigit(str[6]))
-    return false;
-  if (!isdigit(str[8]))
-    return false;
-  if (!isdigit(str[9]))
-    return false;
-  if (!isdigit(str[11]))
-    return false;
-  if (!isdigit(str[12]))
-    return false;
-  if (!isdigit(str[14]))
-    return false;
-  if (!isdigit(str[15]))
-    return false;
-  if (!isdigit(str[17]))
-    return false;
-  if (!isdigit(str[18]))
-    return false;
-  return true;
+  boost::regex re("^[0-9]{4}.[0-9]{2}.[0-9]{2}.[0-9]{2}.[0-9]{2}.[0-9]{2}");
+  return boost::regex_match(str.begin(), str.end(), re);
 }
 
 /**
@@ -1852,12 +1820,7 @@ std::string TimeSeriesProperty<TYPE>::toString() const {
  */
 template <typename TYPE> void TimeSeriesProperty<TYPE>::sort() const {
   if (m_propSortedFlag == TimeSeriesSortStatus::TSUNKNOWN) {
-// Check whether it is sorted or not
-#if !(defined __APPLE__ && defined __INTEL_COMPILER)
     bool sorted = is_sorted(m_values.begin(), m_values.end());
-#else
-    bool sorted = boost::is_sorted(m_values);
-#endif
     if (sorted)
       m_propSortedFlag = TimeSeriesSortStatus::TSSORTED;
     else


### PR DESCRIPTION
Description of work.

Stumbled upon a large if/else tree and tried replacing it with a regular expression. I think the regex is clear enough to justify replacing the current test. 

**To test:**

Code review

<!-- Instructions for testing. -->

This is a small change with no issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
