### PR TITLE
Fix goniometer warning where two NaNs detected as not equal

### DIFF
--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -433,7 +433,8 @@ void Run::calculateGoniometerMatrix() {
     const double maxAngle =
         getLogAsSingleValue(axisName, Kernel::Math::Maximum);
     const double angle = getLogAsSingleValue(axisName, Kernel::Math::Mean);
-    if (minAngle != maxAngle) {
+    if (minAngle != maxAngle &&
+        !(boost::math::isnan(minAngle) && boost::math::isnan(maxAngle))) {
       const double lastAngle =
           getLogAsSingleValue(axisName, Kernel::Math::LastValue);
       g_log.warning("Goniometer angle changed in " + axisName + " log from " +


### PR DESCRIPTION
A warning was being given that a goniometer value was changing when using CreateMD, in fact the value was always NaN. Instead of just testing `A != B` it now tests `A != B && !(isnan(A) && isnan(B))`.

**To test:**
Very minor change, code review should suffice and does not need to be in release notes.

<!-- Instructions for testing. -->

Fixes #15740.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
