### PR TITLE
Fix hyperlink to BSpline page in CubicSpline documentation

### DIFF
--- a/docs/source/fitfunctions/CubicSpline.rst
+++ b/docs/source/fitfunctions/CubicSpline.rst
@@ -16,7 +16,7 @@ First and second derivatives from the spline can be calculated by using
 the derivative1D function.
 
 A CubicSpline is a polynomial function :math:`f(x)` of order 3, defined between an interval :math:`a \leqslant x \leqslant b`.
-When using CubicSplines for interpolation or for fitting, we essentially chain `Basis-Splines <<http://docs.mantidproject.org/nightly/fitfunctions/BSpline.html>`__ 
+When using CubicSplines for interpolation or for fitting, we essentially chain `BSplines <http://docs.mantidproject.org/nightly/fitfunctions/BSpline.html>`__ 
 of order 3 together so that each spline passes through the breakpoints in that interval.
 
 A Cubic Spline is a specific case of `BSpline <http://docs.mantidproject.org/nightly/fitfunctions/BSpline.html>`__


### PR DESCRIPTION
A typo involving an extra "<" character was causing the hyperlink to the BSpline documentation to fail.

**To test:**
- Ensure that hyperlink works correctly now by building qt-help and viewing the resulting cubic spline html page
- Compare this with the current [CubicSpline Doc](http://docs.mantidproject.org/nightly/fitfunctions/CubicSpline.html) 
- Ensure all tests pass

Fixes #15769.

No need to update release notes for such a minor change.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
