### PR TITLE
Vesuvio commands to only run system tests on RHEL7 and Windows

### DIFF
--- a/Testing/SystemTests/tests/analysis/VesuvioCommandsTest.py
+++ b/Testing/SystemTests/tests/analysis/VesuvioCommandsTest.py
@@ -48,6 +48,20 @@ def _equal_within_tolerance(expected, actual, tolerance=0.05):
     abs_difference = abs(expected - actual)
     return abs_difference <= abs(tolerance_value)
 
+def skip_due_to_os():
+    """
+    Skip tests on some operating systems
+    Currenty tests are only being run on windows and RHEL7
+    @return true if tests SHOULD be skipped
+    """
+    dist = platform.linux_distribution()
+    is_rhel7 = (('Red Hat' in dist[0]) or ('CentOS' in dist[0])) and (dist[1].startswith('7'))
+    is_windows = (platform.system() == "Windows")
+    if is_rhel7 or is_windows:
+        return False # Tests should not be skipped
+    else:
+        return True # Tests should be skipped
+
 #====================================================================================
 
 class FitSingleSpectrumNoBackgroundTest(stresstesting.MantidStressTest):
@@ -60,14 +74,7 @@ class FitSingleSpectrumNoBackgroundTest(stresstesting.MantidStressTest):
         self._fit_results = fit_tof(runs, flags)
 
     def skipTests(self):
-        # Only run tests on Windows and RHEL7
-        dist = platform.linux_distribution()
-        is_rhel7 =  dist[0] == 'Red Hat Enterprise Linux Workstation' and dist[1] == '7.2'
-        if platform.system() == "Windows" or is_rhel7:
-            return False
-        else:
-            return True
-
+        return skip_due_to_os()
 
     def validate(self):
         self.assertTrue(isinstance(self._fit_results, tuple))
@@ -120,13 +127,7 @@ class SingleSpectrumBackground(stresstesting.MantidStressTest):
         self._fit_results = fit_tof(runs, flags)
 
     def skipTests(self):
-        # Only run tests on Windows and RHEL7
-        dist = platform.linux_distribution()
-        is_rhel7 =  dist[0] == 'Red Hat Enterprise Linux Workstation' and dist[1] == '7.2'
-        if platform.system() == "Windows" or is_rhel7:
-            return False
-        else:
-            return True
+        return skip_due_to_os()
 
     def validate(self):
         self.assertTrue(isinstance(self._fit_results, tuple))
@@ -184,13 +185,7 @@ class BankByBankForwardSpectraNoBackground(stresstesting.MantidStressTest):
         self._fit_results = fit_tof(runs, flags)
 
     def skipTests(self):
-        # Only run tests on Windows and RHEL7
-        dist = platform.linux_distribution()
-        is_rhel7 =  dist[0] == 'Red Hat Enterprise Linux Workstation' and dist[1] == '7.2'
-        if platform.system() == "Windows" or is_rhel7:
-            return False
-        else:
-            return True
+        return skip_due_to_os()
 
     def validate(self):
         self.assertTrue(isinstance(self._fit_results, tuple))
@@ -245,13 +240,7 @@ class SpectraBySpectraForwardSpectraNoBackground(stresstesting.MantidStressTest)
         self._fit_results = fit_tof(runs, flags)
 
     def skipTests(self):
-        # Only run tests on Windows and RHEL7
-        dist = platform.linux_distribution()
-        is_rhel7 =  dist[0] == 'Red Hat Enterprise Linux Workstation' and dist[1] == '7.2'
-        if platform.system() == "Windows" or is_rhel7:
-            return False
-        else:
-            return True
+        return skip_due_to_os()
 
     def validate(self):
         self.assertTrue(isinstance(self._fit_results, tuple))

--- a/Testing/SystemTests/tests/analysis/VesuvioCommandsTest.py
+++ b/Testing/SystemTests/tests/analysis/VesuvioCommandsTest.py
@@ -59,6 +59,16 @@ class FitSingleSpectrumNoBackgroundTest(stresstesting.MantidStressTest):
         runs = "15039-15045"
         self._fit_results = fit_tof(runs, flags)
 
+    def skipTests(self):
+        # Only run tests on Windows and RHEL7
+        dist = platform.linux_distribution()
+        is_rhel7 =  dist[0] == 'Red Hat Enterprise Linux Workstation' and dist[1] == '7.2'
+        if platform.system() == "Windows" or is_rhel7:
+            return False
+        else:
+            return True
+
+
     def validate(self):
         self.assertTrue(isinstance(self._fit_results, tuple))
         self.assertEqual(4, len(self._fit_results))
@@ -108,6 +118,15 @@ class SingleSpectrumBackground(stresstesting.MantidStressTest):
         flags = _create_test_flags(background=True)
         runs = "15039-15045"
         self._fit_results = fit_tof(runs, flags)
+
+    def skipTests(self):
+        # Only run tests on Windows and RHEL7
+        dist = platform.linux_distribution()
+        is_rhel7 =  dist[0] == 'Red Hat Enterprise Linux Workstation' and dist[1] == '7.2'
+        if platform.system() == "Windows" or is_rhel7:
+            return False
+        else:
+            return True
 
     def validate(self):
         self.assertTrue(isinstance(self._fit_results, tuple))
@@ -164,6 +183,15 @@ class BankByBankForwardSpectraNoBackground(stresstesting.MantidStressTest):
         runs = "15039-15045"
         self._fit_results = fit_tof(runs, flags)
 
+    def skipTests(self):
+        # Only run tests on Windows and RHEL7
+        dist = platform.linux_distribution()
+        is_rhel7 =  dist[0] == 'Red Hat Enterprise Linux Workstation' and dist[1] == '7.2'
+        if platform.system() == "Windows" or is_rhel7:
+            return False
+        else:
+            return True
+
     def validate(self):
         self.assertTrue(isinstance(self._fit_results, tuple))
         self.assertEquals(4, len(self._fit_results))
@@ -215,6 +243,15 @@ class SpectraBySpectraForwardSpectraNoBackground(stresstesting.MantidStressTest)
         flags['spectra'] = '143-144'
         runs = "15039-15045"
         self._fit_results = fit_tof(runs, flags)
+
+    def skipTests(self):
+        # Only run tests on Windows and RHEL7
+        dist = platform.linux_distribution()
+        is_rhel7 =  dist[0] == 'Red Hat Enterprise Linux Workstation' and dist[1] == '7.2'
+        if platform.system() == "Windows" or is_rhel7:
+            return False
+        else:
+            return True
 
     def validate(self):
         self.assertTrue(isinstance(self._fit_results, tuple))


### PR DESCRIPTION
The VesuvioCommands system test should now be skipped if the platform is not RHEL7 or windows. _This is a temporary change to ensure the nightly builds are not disrupted._

**To test:**
- Ensure the system tests pass.
- Would be good to have a few people test this to ensure it skips/doesn't skip on various OS

Fixes #15784.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
