### PR TITLE
Optionally enable Qt3Support warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,10 @@ include ( CommonSetup )
 # Check for Qt (DarwinSetup below needs a variable from this)
 ###########################################################################
 find_package ( Qt4 COMPONENTS QtCore QtGui QtOpenGL QtXml QtSvg Qt3Support REQUIRED )
+option(WITH_QT3_SUPPORT_WARNINGS "Enable warnings about used Qt3Support functions" OFF)
+if(WITH_QT3_SUPPORT_WARNINGS)
+  add_defintions(-DQT3_SUPPORT_WARNINGS)
+endif()
 
 ###########################################################################
 # Find OpenGL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ include ( CommonSetup )
 find_package ( Qt4 COMPONENTS QtCore QtGui QtOpenGL QtXml QtSvg Qt3Support REQUIRED )
 option(WITH_QT3_SUPPORT_WARNINGS "Enable warnings about used Qt3Support functions" OFF)
 if(WITH_QT3_SUPPORT_WARNINGS)
-  add_defintions(-DQT3_SUPPORT_WARNINGS)
+  add_definitions(-DQT3_SUPPORT_WARNINGS)
 endif()
 
 ###########################################################################

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -92,24 +92,6 @@ if [[ $USE_CLANG ]]; then
 fi
 
 ###############################################################################
-# OS X 10.8 setup steps
-###############################################################################
-if [[ $(uname) == 'Darwin' ]] && [[ ! $USE_CLANG ]]; then
-  # Assuming we are using the Intel compiler
-  cd $WORKSPACE
-  ./fetch_Third_Party.sh
-  cd $WORKSPACE
-  # Setup environment variables
-  source /opt/intel/bin/iccvars.sh intel64
-  export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$WORKSPACE/Third_Party/lib/mac64:/Library/Frameworks
-  # Make sure we pick up the Intel compiler
-  export CC=icc
-  export CXX=icpc
-  echo "Using Intel compiler."
-  icpc --version
-fi
-
-###############################################################################
 # Set up the location for the local object store outside of the build and
 # source tree, which can be shared by multiple builds.
 # It defaults to a MantidExternalData directory within the HOME directory.
@@ -136,6 +118,13 @@ fi
 
 if [[ ${NODE_LABELS} == *ubuntu* ]]; then
   ON_UBUNTU=true
+fi
+
+###############################################################################
+# Enable warnings about used Qt3Support functions
+###############################################################################
+if [[ ${JOB_NAME} == *Qt3-warnings* ]]; then
+  DIST_FLAGS="${DIST_FLAGS} -DWITH_QT3SUPPORT_WARNINGS=ON"
 fi
 
 ###############################################################################

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -124,7 +124,7 @@ fi
 # Enable warnings about used Qt3Support functions
 ###############################################################################
 if [[ ${JOB_NAME} == *Qt3-warnings* ]]; then
-  DIST_FLAGS="${DIST_FLAGS} -DWITH_QT3SUPPORT_WARNINGS=ON"
+  DIST_FLAGS="${DIST_FLAGS} -DWITH_QT3_SUPPORT_WARNINGS=ON"
 fi
 
 ###############################################################################


### PR DESCRIPTION
Description of work.

This adds the CMake option `WITH_QT3_SUPPORT_WARNINGS`, which generates a warning whenever a deprecated member function is called. I added a Jenkins build to keep track of these warnings and eliminate new ones.

**To test:**

<!-- Instructions for testing. -->

Check the [master_clean-Qt3-warnings](http://builds.mantidproject.org/job/master_clean-Qt3-warnings/) build.

@mantidproject/gatekeepers: Please change the branch from qt3-warnings to master

This is a small change with no issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
