### PR TITLE
Change SaveMD2 to write compressed data from MDHisto

### DIFF
--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -167,21 +167,28 @@ void SaveMD2::doSaveHisto(Mantid::DataObjects::MDHistoWorkspace_sptr ws) {
     size[numDims - 1 - d] = int(dim->getNBins());
   }
 
-  file->makeData("signal", ::NeXus::FLOAT64, size, true);
+  std::vector<int> chunks = size;
+  chunks[0] = 1; // Drop the largest stride for chunking, I don't know
+                 // if this is the best but appears to work
+
+  file->makeCompData("signal", ::NeXus::FLOAT64, size, ::NeXus::LZW, chunks,
+                     true);
   file->putData(ws->getSignalArray());
   file->putAttr("signal", 1);
   file->putAttr("axes", axes_label);
   file->closeData();
 
-  file->makeData("errors_squared", ::NeXus::FLOAT64, size, true);
+  file->makeCompData("errors_squared", ::NeXus::FLOAT64, size, ::NeXus::LZW,
+                     chunks, true);
   file->putData(ws->getErrorSquaredArray());
   file->closeData();
 
-  file->makeData("num_events", ::NeXus::FLOAT64, size, true);
+  file->makeCompData("num_events", ::NeXus::FLOAT64, size, ::NeXus::LZW, chunks,
+                     true);
   file->putData(ws->getNumEventsArray());
   file->closeData();
 
-  file->makeData("mask", ::NeXus::INT8, size, true);
+  file->makeCompData("mask", ::NeXus::INT8, size, ::NeXus::LZW, chunks, true);
   file->putData(ws->getMaskArray());
   file->closeData();
 

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -57,6 +57,7 @@ Improved
 - :ref:`CreateSimulationWorkspace <algm-CreateSimulationWorkspace>` now matches the IDF of the simulation workspace to the IDF of a reference workspace (either Nexus or Raw).
 - :ref:`LoadNexusLogs <algm-LoadNexusLogs>` allows now to load logs from an entry other than the first. :ref:`LoadEventNexus <algm-LoadEventNexus>` now loads the correct logs when an *NXentry* is given 
 - :ref:`FFT <algm-FFT>`: added property *AutoShift* to enable automatic phase correction for workspaces not centred at zero.
+- :ref:`SaveMD <algm-SaveMD>` now writes MDHisto signal arrays as compressed data.
 
 Deprecated
 ##########


### PR DESCRIPTION
SaveMD2 will now write the `signal`, `errors`, `num_events` and `mask` arrays as compressed data. This decreases file size and loading time in particular when most of the data are just zeros/NANs.

**To test:**
- You can load then save a previously saved MDHisto and compared the file size.
- Make sure you can read the new saved file back into Mantid and nothing has changed (`CompareWorkspaces`).

release notes updated

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
