### PR TITLE
Added missing suite methods that slowed down all Kernel tests.

### DIFF
--- a/Framework/Kernel/test/StringTokenizerTest.h
+++ b/Framework/Kernel/test/StringTokenizerTest.h
@@ -195,6 +195,15 @@ private:
   std::size_t m_length = 50000000;
 
 public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static StringTokenizerTestPerformance *createSuite() {
+    return new StringTokenizerTestPerformance();
+  }
+  static void destroySuite(StringTokenizerTestPerformance *suite) {
+    delete suite;
+  }
+
   StringTokenizerTestPerformance() {
     m_bigString = randomString(m_length);
     for (size_t i = 2; i < m_length; i += 10) {


### PR DESCRIPTION
StringTokenizerTestPerformance does lots of work in constructor and did not define `createSuite` or `destroySuite`. As a result all Kernel tests took of the order of 1 second longer.

**To test:**

Check that most tests from Kernel now run in much less than 1 second (as they used to).

No corresponding issue.
No release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
