### PR TITLE
Add algorithm EnggFitDIFCFromPeaks, from EnggFitPeaks

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
@@ -49,8 +49,8 @@ class EnggCalibrateFull(PythonAlgorithm):
                              doc="A table with the detector IDs and calibrated detector positions and "
                              "additional calibration information. The table includes: the old positions "
                              "in V3D format (3D vector with x, y, z values), the new positions in V3D, the "
-                             "new positions in spherical coordinates, the change in L2, and the DIFC and "
-                             "ZERO parameters.")
+                             "new positions in spherical coordinates, the change in L2, and the DIFA, "
+                             "DIFC and TZERO calibration parameters.")
 
         self.declareProperty(ITableWorkspaceProperty("FittedPeaks", "", Direction.Output),
                              doc = "Information on fitted peaks. The table has one row per calibrated "
@@ -149,7 +149,7 @@ class EnggCalibrateFull(PythonAlgorithm):
     def _calculate_calib_positions_tbl(self, ws, indices, expectedPeaksD):
         """
         Makes a table of calibrated positions (and additional parameters). It goes through
-        the detectors of the workspace and calculates the difc and zero parameters by fitting
+        the detectors of the workspace and calculates the DIFC and TZERO parameters by fitting
         peaks, then calculates the coordinates and adds them in the returned table.
 
         @param ws :: input workspace with an instrument definition
@@ -169,7 +169,8 @@ class EnggCalibrateFull(PythonAlgorithm):
         for i in indices:
 
             try:
-                zero, difc, fitted_peaks_table = self._fit_peaks(ws, i, expectedPeaksD)
+                fitted_peaks_table = self._fit_peaks(ws, i, expectedPeaksD)
+                difa, difc, tzero = self._fit_difc_linear(fitted_peaks_table)
             except RuntimeError as re:
                 raise RuntimeError("Severe issue found when trying to fit peaks for the detector with ID %d. "
                                    "This calibration algorithm cannot continue. Please check the expected "
@@ -186,7 +187,7 @@ class EnggCalibrateFull(PythonAlgorithm):
             old_pos = det.getPos()
 
             pos_tbl.addRow([det.getID(), old_pos, new_pos, new_L2, det_2Theta, det_phi,
-                            new_L2-old_L2, difc, zero])
+                            new_L2-old_L2, difa, difc, tzero])
 
             # fitted parameter details as a string for every peak for one detector
             peaks_details = self._build_peaks_details_string(fitted_peaks_table)
@@ -202,7 +203,8 @@ class EnggCalibrateFull(PythonAlgorithm):
         @param wsIndex workspace index of the spectrum to fit
         @param expectedPeaksD :: expected peaks for the fitting, in d-spacing units
 
-        @returns a pair of parameters: difc and zero
+        @returns the peaks parameters in a table as produced by the algorithm
+        EnggFitPeaks
     	"""
         alg = self.createChildAlgorithm('EnggFitPeaks')
         alg.setProperty('InputWorkspace', ws)
@@ -210,11 +212,28 @@ class EnggCalibrateFull(PythonAlgorithm):
         alg.setProperty('ExpectedPeaks', expectedPeaksD)
         alg.execute()
 
-        difc = alg.getProperty('Difc').value
-        zero = alg.getProperty('Zero').value
         fitted_peaks_table = alg.getProperty('FittedPeaks').value
 
-        return (zero, difc, fitted_peaks_table)
+        return fitted_peaks_table
+
+    def _fit_difc_linear(self, fitted_peaks_table):
+        """
+        Fit the DIFC-TZERO curve (line) to the peaks
+
+        @param fitted_peaks_table a table with peaks parameters, expected
+        in the format produced by EnggFitPeaks
+
+        @returns the DIFA, DIFC, TZERO calibration parameters of GSAS
+        """
+        alg = self.createChildAlgorithm('EnggFitDIFCFromPeaks')
+        alg.setProperty('FittedPeaks', fitted_peaks_table)
+        alg.execute()
+
+        difa = alg.getProperty('DIFA').value
+        difc = alg.getProperty('DIFC').value
+        tzero = alg.getProperty('TZERO').value
+
+        return (difa, difc, tzero)
 
     def _create_positions_table(self):
         """
@@ -235,8 +254,9 @@ class EnggCalibrateFull(PythonAlgorithm):
         table.addColumn('float', '2 \\theta')
         table.addColumn('float', '\\phi')
         table.addColumn('float', '\\delta L2 (calibrated - old)')
-        table.addColumn('float', 'difc')
-        table.addColumn('float', 'zero')
+        table.addColumn('float', 'DIFA')
+        table.addColumn('float', 'DIFC')
+        table.addColumn('float', 'TZERO')
 
         return table
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
@@ -1,7 +1,8 @@
 #pylint: disable=no-init,invalid-name
+import math
+
 from mantid.kernel import *
 from mantid.api import *
-import math
 import EnggUtils
 
 class EnggCalibrateFull(PythonAlgorithm):
@@ -139,7 +140,7 @@ class EnggCalibrateFull(PythonAlgorithm):
         rebin_alg.execute()
         result = rebin_alg.getProperty('OutputWorkspace').value
 
-        if result.isDistribution()==False:
+        if not result.isDistribution():
             convert_alg = self.createChildAlgorithm('ConvertToDistribution')
             convert_alg.setProperty('Workspace', result)
             convert_alg.execute()

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitDIFCFromPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitDIFCFromPeaks.py
@@ -104,7 +104,7 @@ class EnggFitDIFCFromPeaks(PythonAlgorithm):
 
         tzero = param_table.cell('Value', 0) # A0
         difc = param_table.cell('Value', 1) # A1
-        difa = 0 # Not fitted, we may add an option for this later on
+        difa = 0.0 # Not fitted, we may add an option for this later on
 
         return (difa, difc, tzero)
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitDIFCFromPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitDIFCFromPeaks.py
@@ -17,9 +17,121 @@ class EnggFitDIFCFromPeaks(PythonAlgorithm):
                 "performing single peak fits.")
 
     def PyInit(self):
-        pass
+
+        self.declareProperty(ITableWorkspaceProperty('FittedPeaks', '', Direction.Input),
+                             doc = "Information on fitted peaks, in the format produced by EnggFitPeaks. "
+                             "The table must contain, for every peak fitted the expected peak value "
+                             "(in d-spacing), and the parameters fitted. The expected values are given "
+                             "in the column labelled 'dSpacing'. When using the back-to-back exponential "
+                             "peak function, the 'X0' column must have the fitted peak center.")
+
+        self.declareProperty('OutParametersTable', '', direction=Direction.Input,
+                             doc = 'Name for a table workspace with the fitted values calculated by '
+                             'this algorithm (DIFC and TZERO calibration parameters) for GSAS. '
+                             'These two parameters are added as two columns in a single row. If not given, '
+                             'the table workspace is not created.')
+
+        self.declareProperty('DIFA', 0.0, direction = Direction.Output,\
+                             doc = 'Fitted DIFA value. This parameter is not effectively considered and it '
+                             'is always zero in this version of the algorithm.')
+
+        self.declareProperty('DIFC', 0.0, direction = Direction.Output,\
+                             doc = "Fitted DIFC calibration parameter")
+
+        self.declareProperty('TZERO', 0.0, direction = Direction.Output,\
+                             doc = "Fitted TZERO calibration parameter")
+
+    def validateInputs(self):
+        errors = dict()
+
+        peaks = self.getProperty('FittedPeaks').value
+
+        # Better than failing to fit the linear function
+        if 1 == peaks.rowCount():
+            errors['FittedPeaks'] = ('Only one peak was given in the input peaks table. This is not enough '
+                                     'to fit the output parameters difc and zero. Please check the list of '
+                                     'expected peaks given and if it is appropriate for the workspace')
+        return errors
 
     def PyExec(self):
-        pass
 
-AlgorithmFactory.subscribe(EnggFitPeaks)
+        peaks = self.getProperty('FittedPeaks').value
+
+        difa, difc, tzero = self._fit_difc_tzero(peaks)
+
+        out_tbl_name = self.getPropertyValue('OutParametersTable')
+        self._produce_outputs(difa, difc, tzero, out_tbl_name)
+
+        self.log().information("Fitted {0} peaks in total. DIFA: {1}, DIFC: {2}, TZERP: {3}".
+                               format(peaks.rowCount(), difa, difc, tzero))
+
+    def _fit_difc_tzero(self, fitted_peaks_table):
+        """
+        Fits a linear function to the dSpacing-TOF relationship and
+        returns the fitted (DIFA=0), DIFC and TZERO values. If the
+        table passed has less than 2 peaks this raises an exception,
+        as it is not possible to fit the difc, zero parameters.
+
+        @param fitted_peaks_table :: table with one row per fitted peak, expecting column 'dSpacing'
+        as x values and column 'X0' as y values.
+
+        @returns DIFA, DIFC and TZERO parameters as defined in GSAS and GSAS-II. The difc and zero
+        parameters are obtained from fitting a linear background (in _fit_dSpacing_to_ToF) to the
+        peaks fitted individually that have been passed in the input table
+
+        """
+
+        num_peaks = fitted_peaks_table.rowCount()
+        if num_peaks < 2:
+            raise ValueError('Cannot fit a linear function with less than two peaks. Got a table of ' +
+                             'peaks with ' + str(num_peaks) + ' peaks')
+
+        convert_tbl_alg = self.createChildAlgorithm('ConvertTableToMatrixWorkspace')
+        convert_tbl_alg.setProperty('InputWorkspace', fitted_peaks_table)
+        convert_tbl_alg.setProperty('ColumnX', 'dSpacing')
+        convert_tbl_alg.setProperty('ColumnY', 'X0')
+        convert_tbl_alg.execute()
+        dSpacingVsTof = convert_tbl_alg.getProperty('OutputWorkspace').value
+
+        # Fit the curve to get linear coefficients of TOF <-> dSpacing relationship for the detector
+        fit_alg = self.createChildAlgorithm('Fit')
+        fit_alg.setProperty('Function', 'name=LinearBackground')
+        fit_alg.setProperty('InputWorkspace', dSpacingVsTof)
+        fit_alg.setProperty('WorkspaceIndex', 0)
+        fit_alg.setProperty('CreateOutput', True)
+        fit_alg.execute()
+        param_table = fit_alg.getProperty('OutputParameters').value
+
+        tzero = param_table.cell('Value', 0) # A0
+        difc = param_table.cell('Value', 1) # A1
+        difa = 0 # Not fitted, we may add an option for this later on
+
+        return (difa, difc, tzero)
+
+    def _produce_outputs(self, difa, difc, tzero, tbl_name):
+        """
+        Fills in the output properties as requested via the input
+        properties. Sets the output difz/difc/tzero values. It can
+        also produces a table with these parameters if required in the
+        inputs.
+
+        @param difa :: the DIFA GSAS parameter as fitted here
+        @param difc :: the DIFC GSAS parameter as fitted here
+        @param tzero :: the TZERO GSAS parameter as fitted here
+        @param tbl_name :: a table name, non-empty if a table workspace
+        should be created with the calibration parameters
+        """
+
+        import EnggUtils
+
+        # mandatory outputs
+        self.setProperty('DIFA', difa)
+        self.setProperty('DIFC', difc)
+        self.setProperty('TZERO', tzero)
+
+        # optional outputs
+        if tbl_name:
+            EnggUtils.generateOutputParTable(tbl_name, difa, difc, tzero)
+            self.log().information("Output parameters added into a table workspace: %s" % tbl_name)
+
+AlgorithmFactory.subscribe(EnggFitDIFCFromPeaks)

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitDIFCFromPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitDIFCFromPeaks.py
@@ -2,8 +2,6 @@
 from mantid.kernel import *
 from mantid.api import *
 
-import math
-
 class EnggFitDIFCFromPeaks(PythonAlgorithm):
 
     def category(self):

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitDIFCFromPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitDIFCFromPeaks.py
@@ -1,0 +1,25 @@
+#pylint: disable=no-init,invalid-name
+from mantid.kernel import *
+from mantid.api import *
+
+import math
+
+class EnggFitDIFCFromPeaks(PythonAlgorithm):
+
+    def category(self):
+        return "Diffraction\\Engineering"
+
+    def name(self):
+        return "EnggFitPeaks"
+
+    def summary(self):
+        return ("The algorithm fits an expected diffraction pattern to a workpace spectrum by "
+                "performing single peak fits.")
+
+    def PyInit(self):
+        pass
+
+    def PyExec(self):
+        pass
+
+AlgorithmFactory.subscribe(EnggFitPeaks)

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
@@ -1,8 +1,8 @@
 #pylint: disable=no-init,invalid-name
+import math
+
 from mantid.kernel import *
 from mantid.api import *
-
-import math
 
 class EnggFitPeaks(PythonAlgorithm):
     EXPECTED_DIM_TYPE = 'Time-of-flight'
@@ -144,9 +144,7 @@ class EnggFitPeaks(PythonAlgorithm):
         @returns a table with parameters for every fitted peak.
 
         """
-        if 2 != len(peaks):
-            raise RuntimeError("Unexpected inconsistency found. This method requires a tuple with the list "
-                               "of found peaks and the list of expected peaks.")
+
         found_peaks = peaks[0]
         fitted_peaks = self._create_fitted_peaks_table(peaks_table_name)
 
@@ -482,9 +480,9 @@ class EnggFitPeaks(PythonAlgorithm):
                 and not math.isnan(fitted_params['B_Err'])
                 and fitted_params['X0_Err'] < (fitted_params['X0'] * 100.0 / self.CENTER_ERROR_LIMIT)
                 and
-                (not 0 == fitted_params['X0_Err'] and not 0 == fitted_params['A_Err'] and
-                 not 0 == fitted_params['B_Err'] and not 0 == fitted_params['S_Err'] and
-                 not 0 == fitted_params['I_Err'])
+                (0 != fitted_params['X0_Err'] and 0 != fitted_params['A_Err'] and
+                 0 != fitted_params['B_Err'] and 0 != fitted_params['S_Err'] and
+                 0 != fitted_params['I_Err'])
                )
 
     def _add_parameters_to_map(self, param_map, param_table):

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
@@ -18,8 +18,8 @@ class EnggFitPeaks(PythonAlgorithm):
         return "EnggFitPeaks"
 
     def summary(self):
-        return ("The algorithm fits an expected diffraction pattern to a workpace spectrum by "
-                "performing single peak fits.")
+        return ("The algorithm fits an expected diffraction pattern to a spectrum from a workspace "
+                "by fitting one peak at a time (single peak fits).")
 
     def PyInit(self):
         self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", Direction.Input),\
@@ -41,21 +41,9 @@ class EnggFitPeaks(PythonAlgorithm):
         self.setPropertyGroup('ExpectedPeaks', peaks_grp)
         self.setPropertyGroup('ExpectedPeaksFromFile', peaks_grp)
 
-        self.declareProperty('OutParametersTable', '', direction=Direction.Input,
-                             doc = 'Name for a table workspace with the fitted values calculated by '
-                             'this algorithm (Difc and Zero parameters) for GSAS. '
-                             'These two parameters are added as two columns in a single row. If not given, '
-                             'the table workspace is not created.')
-
         self.declareProperty('OutFittedPeaksTable', '', direction=Direction.Input,
                              doc = 'Name for a table workspace with the parameters of the peaks found and '
                              'fitted. If not given, the table workspace is not created.')
-
-        self.declareProperty("Difc", 0.0, direction = Direction.Output,\
-    		doc = "Fitted Difc value")
-
-        self.declareProperty("Zero", 0.0, direction = Direction.Output,\
-    		doc = "Fitted Zero value")
 
         self.declareProperty(ITableWorkspaceProperty("FittedPeaks", "", Direction.Output),
                              doc = "Information on fitted peaks. The table contains, for every peak fitted "
@@ -95,9 +83,11 @@ class EnggFitPeaks(PythonAlgorithm):
                                "expected peaks. " + txt)
 
         peaks_table_name = self.getPropertyValue("OutFittedPeaksTable")
-        difc, zero, fitted_peaks = self._fit_all_peaks(in_wks, wks_index,
-                                                       (found_peaks, expected_peaks_dsp), peaks_table_name)
-        self._produce_outputs(difc, zero, fitted_peaks)
+        fitted_peaks = self._fit_all_peaks(in_wks, wks_index,
+                                           (found_peaks, expected_peaks_dsp), peaks_table_name)
+
+        # mandatory output
+        self.setProperty('FittedPeaks', fitted_peaks)
 
     def _get_default_peaks(self):
         """
@@ -106,31 +96,6 @@ class EnggFitPeaks(PythonAlgorithm):
         import EnggUtils
 
         return EnggUtils.default_ceria_expected_peaks()
-
-    def _produce_outputs(self, difc, zero, fitted_peaks):
-        """
-        Fills in the output properties as requested via the input properties. Sets the output difc, and zero
-        values, and a table workspace with peaks information. It can also produces a table with the difc and
-        zero parameters if this is required in the inputs.
-
-        @param difc :: the difc GSAS parameter as fitted here
-        @param zero :: the zero GSAS parameter as fitted here
-        @param fitted_peaks :: table workspace with peak parameters (one peak per row)
-        """
-
-        import EnggUtils
-
-        # mandatory outputs
-        self.setProperty('Difc', difc)
-        self.setProperty('Zero', zero)
-        self.setProperty('FittedPeaks', fitted_peaks)
-
-        # optional outputs
-        tbl_name = self.getPropertyValue("OutParametersTable")
-        if '' != tbl_name:
-            EnggUtils.generateOutputParTable(tbl_name, difc, zero)
-            self.log().information("Output parameters added into a table workspace: %s" % tbl_name)
-
 
     def _estimate_start_end_fitting_range(self, center, width):
         """
@@ -176,9 +141,7 @@ class EnggFitPeaks(PythonAlgorithm):
                         (in dSpacing units)
         @param peaks_table_name :: name of an (output) table with peaks parameters. If empty, the table is anonymous
 
-        @returns difc and zero parameters and a table with parameters for every fitted peak. The difc and zero
-        parameters are obtained from fitting a linear background (in _fit_dSpacing_to_ToF) to the peaks fitted
-        here individually
+        @returns a table with parameters for every fitted peak.
 
         """
         if 2 != len(peaks):
@@ -241,17 +204,10 @@ class EnggFitPeaks(PythonAlgorithm):
             raise RuntimeError('Could not fit any peak.  Failed to fit peaks with peak type ' +
                                self.PEAK_TYPE + ' even though FindPeaks found ' + str(found_peaks.rowCount()) +
                                ' peaks in principle. See the logs for further details.')
-        # Better than failing to fit the linear function
-        if 1 == fitted_peaks.rowCount():
-            raise RuntimeError('Could find only one peak. This is not enough to fit the output parameters '
-                               'difc and zero. Please check the list of expected peaks given and if it is '
-                               'appropriate for the workspace')
 
-        difc, zero = self._fit_dSpacing_to_ToF(fitted_peaks)
-        self.log().information("Fitted {0} peaks in total. Difc: {1}, Tzero: {2}".
-                               format(fitted_peaks.rowCount(), difc, zero))
+        self.log().information("Fitted {0} peaks in total.".format(fitted_peaks.rowCount()))
 
-        return (difc, zero, fitted_peaks)
+        return fitted_peaks
 
     def _fit_single_peak(self, expected_center, initial_params, wks, wks_index):
         """
@@ -318,44 +274,6 @@ class EnggFitPeaks(PythonAlgorithm):
         find_peaks_alg.execute()
         found_peaks = find_peaks_alg.getProperty('PeaksList').value
         return found_peaks
-
-    def _fit_dSpacing_to_ToF(self, fitted_peaksTable):
-        """
-        Fits a linear background to the dSpacing <-> TOF relationship and returns fitted difc
-        and zero values. If the table passed has less than 2 peaks this raises an exception, as it
-        is not possible to fit the difc, zero parameters.
-
-        @param fitted_peaksTable :: table with one row per fitted peak, expecting column 'dSpacing'
-        as x values and column 'X0' as y values.
-
-        @return the pair of difc and zero values fitted to the peaks.
-    	"""
-
-        num_peaks = fitted_peaksTable.rowCount()
-        if num_peaks < 2:
-            raise ValueError('Cannot fit a linear function with less than two peaks. Got a table of ' +
-                             'peaks with ' + str(num_peaks) + ' peaks')
-
-        convert_tbl_alg = self.createChildAlgorithm('ConvertTableToMatrixWorkspace')
-        convert_tbl_alg.setProperty('InputWorkspace', fitted_peaksTable)
-        convert_tbl_alg.setProperty('ColumnX', 'dSpacing')
-        convert_tbl_alg.setProperty('ColumnY', 'X0')
-        convert_tbl_alg.execute()
-        dSpacingVsTof = convert_tbl_alg.getProperty('OutputWorkspace').value
-
-    	# Fit the curve to get linear coefficients of TOF <-> dSpacing relationship for the detector
-        fit_alg = self.createChildAlgorithm('Fit')
-        fit_alg.setProperty('Function', 'name=LinearBackground')
-        fit_alg.setProperty('InputWorkspace', dSpacingVsTof)
-        fit_alg.setProperty('WorkspaceIndex', 0)
-        fit_alg.setProperty('CreateOutput', True)
-        fit_alg.execute()
-        param_table = fit_alg.getProperty('OutputParameters').value
-
-        zero = param_table.cell('Value', 0) # A0
-        difc = param_table.cell('Value', 1) # A1
-
-        return (difc, zero)
 
     def _expected_peaks_in_ToF(self, expectedPeaks, in_wks, wks_index):
         """

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -26,6 +26,7 @@ set ( TEST_PY_FILES
   DSFinterpTest.py
   EnggCalibrateFullTest.py
   EnggCalibrateTest.py
+  EnggFitDIFCFromPeaksTest.py
   EnggFitPeaksTest.py
   EnggFocusTest.py
   EnggVanadiumCorrectionsTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateFullTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateFullTest.py
@@ -73,7 +73,6 @@ class EnggCalibrateFullTest(unittest.TestCase):
         # for testing purposes. A test with real (much larger) data that produces
         # a correct fit is included in system tests
         tbl_name = 'det_peaks_tbl'
-        det_peaks_tbl = CreateEmptyTableWorkspace()
         self.assertRaises(RuntimeError,
                           EnggCalibrateFull,
                           InputWorkspace=self.__class__._data_ws, Bank=2,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
@@ -1,8 +1,7 @@
+import sys
 import unittest
 from mantid.api import *
 import mantid.simpleapi as sapi
-
-import sys
 
 class EnggCalibrateTest(unittest.TestCase):
 
@@ -83,7 +82,12 @@ class EnggCalibrateTest(unittest.TestCase):
                                                          VanIntegrationWorkspace=self.__class__._van_integ_tbl,
                                                          VanCurvesWorkspace=self.__class__._van_curves_ws,
                                                          ExpectedPeaks=[1.6, 1.1, 1.8], Bank='2')
-        except RuntimeError as ere:
+            self.assertEquals(difa, 0)
+            self.assertGreater(difc, 0)
+            self.assertLess(abs(zero), 1000)
+            self.assertEquals(peaks.rowCount(), 3)
+
+        except RuntimeError:
             pass
 
     def test_runs_ok_with_bad_peaks_file(self):
@@ -100,7 +104,12 @@ class EnggCalibrateTest(unittest.TestCase):
                                                          ExpectedPeaks=[-4, 40, 323],
                                                          ExpectedPeaksFromFile=filename,
                                                          Bank='2')
-        except RuntimeError as ere:
+            self.assertEquals(difa, 0)
+            self.assertGreater(difc, 0)
+            self.assertLess(abs(zero), 1000)
+            self.assertEquals(peaks.rowCount(), 3)
+
+        except RuntimeError:
             pass
 
     def check_3peaks_values(self, difa, difc, zero):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
@@ -79,10 +79,10 @@ class EnggCalibrateTest(unittest.TestCase):
         Checks normal operation.
         """
         try:
-            difc, zero, peaks = sapi.EnggCalibrate(InputWorkspace=self.__class__._data_ws,
-                                                   VanIntegrationWorkspace=self.__class__._van_integ_tbl,
-                                                   VanCurvesWorkspace=self.__class__._van_curves_ws,
-                                                   ExpectedPeaks=[1.6, 1.1, 1.8], Bank='2')
+            difa, difc, zero, peaks = sapi.EnggCalibrate(InputWorkspace=self.__class__._data_ws,
+                                                         VanIntegrationWorkspace=self.__class__._van_integ_tbl,
+                                                         VanCurvesWorkspace=self.__class__._van_curves_ws,
+                                                         ExpectedPeaks=[1.6, 1.1, 1.8], Bank='2')
         except RuntimeError as ere:
             pass
 
@@ -93,17 +93,19 @@ class EnggCalibrateTest(unittest.TestCase):
         # This file has: 1.6, 1.1, 1.8 (as the test above)
         filename = 'EnginX_3_expected_peaks_unittest.csv'
         try:
-            difc, zero, peaks = sapi.EnggCalibrate(InputWorkspace=self.__class__._data_ws,
-                                                   VanIntegrationWorkspace=self.__class__._van_integ_tbl,
-                                                   VanCurvesWorkspace=self.__class__._van_curves_ws,
-                                                   # nonsense, but FromFile should prevail
-                                                   ExpectedPeaks=[-4, 40, 323],
-                                                   ExpectedPeaksFromFile=filename,
-                                                   Bank='2')
+            difa, difc, zero, peaks = sapi.EnggCalibrate(InputWorkspace=self.__class__._data_ws,
+                                                         VanIntegrationWorkspace=self.__class__._van_integ_tbl,
+                                                         VanCurvesWorkspace=self.__class__._van_curves_ws,
+                                                         # nonsense, but FromFile should prevail
+                                                         ExpectedPeaks=[-4, 40, 323],
+                                                         ExpectedPeaksFromFile=filename,
+                                                         Bank='2')
         except RuntimeError as ere:
             pass
 
-    def check_3peaks_values(self, difc, zero):
+    def check_3peaks_values(self, difa, difc, zero):
+        self.assertEquals(difa, 0)
+
         # There are platform specific differences in final parameter values
         # For example in earlier versions, debian: 369367.57492582797; win7: 369242.28850305633
         # osx were ~0.995% different (18920.539474 instead of 18485.223143) in the best case but can
@@ -118,7 +120,7 @@ class EnggCalibrateTest(unittest.TestCase):
 
         # assertLess would be nice, but only available in unittest >= 2.7
         self.assertTrue(abs((expected_difc-difc)/expected_difc) < difc_err_epsilon,
-                        "Difc (%f) is too far from its expected value (%f)" %(difc, expected_difc))
+                        "DIFC (%f) is too far from its expected value (%f)" %(difc, expected_difc))
 
         # especially this zero parameter is extremely platform dependent/sensitive
         # Examples:
@@ -130,7 +132,7 @@ class EnggCalibrateTest(unittest.TestCase):
         zero_err_epsilon = 0.2
 
         self.assertTrue(abs((expected_zero-zero)/expected_zero) < zero_err_epsilon,
-                        "Zero (%f) is too far from its expected value (%f)" %(zero, expected_zero))
+                        "TZERO (%f) is too far from its expected value (%f)" %(zero, expected_zero))
 
 
 if __name__ == '__main__':

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitDIFCFromPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitDIFCFromPeaksTest.py
@@ -8,7 +8,127 @@ class EnggFitDIFCFromPeaksTest(unittest.TestCase):
         """
         Handle in/out property issues appropriately.
         """
-        pass
+        # No InputWorkspace property (required)
+        self.assertRaises(RuntimeError,
+                          EnggFitDIFCFromPeaks,
+                          OutParametersTable='param_table')
+
+        table = CreateEmptyTableWorkspace(OutputWorkspace='some_tbl_name')
+        # This property doesn't belong here
+        self.assertRaises(RuntimeError,
+                          EnggFitDIFCFromPeaks,
+                          FittedPeaks=table,
+                          ExpectedPeaks='0.6, 0.9')
+
+    def test_2peaks_runs_ok(self):
+        """
+        Tests fitting DIFC/TZERO on a couple of peaks from EnggFitPeaks.
+        """
+
+        peak_def1 = "name=BackToBackExponential, I=15000, A=1, B=1.7, X0=15000, S=100"
+        peak_def2 = "name=BackToBackExponential, I=8000, A=1, B=1.7, X0=20000, S=300"
+        sws = CreateSampleWorkspace(Function="User Defined",
+                                    UserDefinedFunction=peak_def1 + ";" + peak_def2,
+                                    NumBanks=1, BankPixelWidth=1,
+                                    XMin=5000, XMax=30000,
+                                    BinWidth=25)
+        EditInstrumentGeometry(Workspace=sws, L2=[1.5], Polar=[90], PrimaryFlightPath=50)
+
+        peaksTblName = 'test_fit_peaks_table'
+        ep1 = 0.83
+        ep2 = 1.09
+        test_fit_peaks_table = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2],
+                                            OutFittedPeaksTable=peaksTblName)
+
+        paramsTblName = 'test_difc_zero_table'
+        difa, difc, zero = EnggFitDIFCFromPeaks(FittedPeaks=test_fit_peaks_table,
+                                                OutParametersTable=paramsTblName)
+
+
+        self.assertEquals(difa, 0)
+
+        pTable = mtd[paramsTblName]
+        self.assertEquals(pTable.rowCount(), 1)
+        self.assertEquals(pTable.columnCount(), 3)
+
+        self.assertEquals(test_fit_peaks_table.rowCount(), 2)
+
+        # fitting results on some platforms (OSX) are different by ~0.07%
+        expected_difc = 19229.3699679
+        self.assertTrue(self._approxRelErrorLessThan(difc, expected_difc, 5e-3))
+        expected_zero = -948.449062995
+        self.assertTrue(self._approxRelErrorLessThan(zero, expected_zero, 5e-3))
+
+        # values in the table should also be good within epsilon
+        self.assertTrue(self._approxRelErrorLessThan(pTable.cell(0,1), expected_difc, 5e-3))
+        self.assertTrue(self._approxRelErrorLessThan(pTable.cell(0,2), expected_zero, 5e-3))
+
+    def test_runs_ok_3peaks(self):
+        """
+        Tests fitting DIFC/TZERO on three clean peaks
+        """
+
+        peak_def1 = "name=BackToBackExponential, I=15000, A=1, B=1.7, X0=15000, S=100"
+        peak_def2 = "name=BackToBackExponential, I=8000, A=1, B=1.2, X0=20000, S=800"
+        peak_def3 = "name=BackToBackExponential, I=10000, A=1, B=0.9, X0=25000, S=350"
+        sws = CreateSampleWorkspace(Function="User Defined",
+                                    UserDefinedFunction=
+                                    peak_def1 + ";" + peak_def2 + ";" + peak_def3,
+                                    NumBanks=1, BankPixelWidth=1,
+                                    XMin=5000, XMax=30000,
+                                    BinWidth=25)
+        EditInstrumentGeometry(Workspace=sws, L2=[1.5], Polar=[90], PrimaryFlightPath=50)
+
+        peaksTblName = 'test_fit_peaks_table'
+        ep1 = 0.83
+        ep2 = 1.09
+        ep3 = 1.4
+        test_fit_peaks_table = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2, ep3],
+                                                              OutFittedPeaksTable=peaksTblName)
+
+        paramsTblName = 'test_difc_zero_table'
+        difa, difc, zero = EnggFitDIFCFromPeaks(FittedPeaks=test_fit_peaks_table,
+                                                OutParametersTable=paramsTblName)
+
+        self.assertEquals(difa, 0)
+
+        pTable = mtd[paramsTblName]
+        self.assertEquals(pTable.rowCount(), 1)
+        self.assertEquals(pTable.columnCount(), 3)
+
+        self.assertEquals(test_fit_peaks_table.rowCount(), 3)
+        self.assertEquals(3, len(test_fit_peaks_table.column('dSpacing')))
+        self.assertEquals(3, len(test_fit_peaks_table.column('X0')))
+        self.assertEquals(3, len(test_fit_peaks_table.column('A')))
+        self.assertEquals(3, len(test_fit_peaks_table.column('S')))
+
+        expected_difc = 17500.7287679
+        # assertLess would be nices, but only available in unittest >= 2.7
+        self.assertTrue(self._approxRelErrorLessThan(difc, expected_difc, 5e-3))
+        expected_zero = 658.544128868
+        self.assertTrue(self._approxRelErrorLessThan(zero, expected_zero, 5e-3))
+
+    def _approxRelErrorLessThan(self, val, ref, epsilon):
+        """
+        Checks that a value 'val' does not defer from a reference value 'ref' by 'epsilon'
+        or more . This plays the role of assertAlmostEqual, assertLess, etc. which are not
+        available in some ancient unittest versions.
+
+        @param val :: value obtained from a calculation or algorithm
+        @param ref :: (expected) reference value
+        @param epsilon :: comparison epsilon (error tolerance)
+
+        @returns if val differs from ref by less than epsilon
+        """
+        if 0 == ref:
+            return False
+
+        approx_comp = (abs((ref-val)/ref) < epsilon)
+        if not approx_comp:
+            print ("Failed approximate comparison between value {0} and reference value "
+                   "{1}, with epsilon {2}".format(val, ref, epsilon))
+
+        return approx_comp
 
 
 if __name__ == '__main__':

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitDIFCFromPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitDIFCFromPeaksTest.py
@@ -1,0 +1,15 @@
+import unittest
+from mantid.simpleapi import *
+from mantid.api import *
+
+class EnggFitDIFCFromPeaksTest(unittest.TestCase):
+
+    def test_wrong_properties(self):
+        """
+        Handle in/out property issues appropriately.
+        """
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitDIFCFromPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitDIFCFromPeaksTest.py
@@ -84,7 +84,7 @@ class EnggFitDIFCFromPeaksTest(unittest.TestCase):
         ep2 = 1.09
         ep3 = 1.4
         test_fit_peaks_table = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2, ep3],
-                                                              OutFittedPeaksTable=peaksTblName)
+                                            OutFittedPeaksTable=peaksTblName)
 
         paramsTblName = 'test_difc_zero_table'
         difa, difc, zero = EnggFitDIFCFromPeaks(FittedPeaks=test_fit_peaks_table,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
@@ -145,8 +145,7 @@ class EnggFitPeaksTest(unittest.TestCase):
 
     def test_fails_ok_1peak(self):
         """
-        Tests fitting a single peak, which should raise because we need at least 2 peaks to
-        fit two parameters: difc and zero
+        Tests fitting a single peak, which should raise
         """
         peak_def = "name=BackToBackExponential, I=15000, A=1, B=1.2, X0=10000, S=400"
         sws = CreateSampleWorkspace(Function="User Defined",
@@ -176,14 +175,12 @@ class EnggFitPeaksTest(unittest.TestCase):
         peaksTblName = 'test_fit_peaks_table'
         ep1 = 0.4
         ep2 = 1.09
-        paramsTblName = 'test_difc_zero_table'
 
         # will fail to fit the first peak (too far off initial guess)
         try:
-            difc, zero, test_fit_peaks_table = EnggFitPeaks(sws,
-                                                            WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2],
-                                                            OutFittedPeaksTable=peaksTblName,
-                                                            OutParametersTable=paramsTblName)
+            test_fit_peaks_table = EnggFitPeaks(sws,
+                                                WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2],
+                                                OutFittedPeaksTable=peaksTblName)
         except RuntimeError as rex:
             print ("Failed (as expected) to fit the first peak (too far off the initial "
                    "guess), with RuntimeError: {0}".format(str(rex)))
@@ -205,26 +202,10 @@ class EnggFitPeaksTest(unittest.TestCase):
         peaksTblName = 'test_fit_peaks_table'
         ep1 = 0.83
         ep2 = 1.09
-        paramsTblName = 'test_difc_zero_table'
-        difc, zero, test_fit_peaks_table = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2],
-                                                        OutFittedPeaksTable=peaksTblName,
-                                                        OutParametersTable=paramsTblName)
+        test_fit_peaks_table = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2],
+                                            OutFittedPeaksTable=peaksTblName)
 
         self.assertEquals(test_fit_peaks_table.rowCount(), 2)
-
-        pTable = mtd[paramsTblName]
-        self.assertEquals(pTable.rowCount(), 1)
-        self.assertEquals(pTable.columnCount(), 2)
-
-        # fitting results on some platforms (OSX) are different by ~0.07%
-        expected_difc = 19229.3699679
-        self.assertTrue(self._approxRelErrorLessThan(difc, expected_difc, 5e-3))
-        expected_zero = -948.449062995
-        self.assertTrue(self._approxRelErrorLessThan(zero, expected_zero, 5e-3))
-
-        # values in the table should also be good within epsilon
-        self.assertTrue(self._approxRelErrorLessThan(pTable.cell(0,0), expected_difc, 5e-3))
-        self.assertTrue(self._approxRelErrorLessThan(pTable.cell(0,1), expected_zero, 5e-3))
 
         # check 'OutFittedPeaksTable' table workspace
         self._check_outputs_ok(peaksTblName, 2, ep1, -1.5602448495e-06,
@@ -250,20 +231,14 @@ class EnggFitPeaksTest(unittest.TestCase):
         ep1 = 0.83
         ep2 = 1.09
         ep3 = 1.4
-        difc, zero, test_fit_peaks_table = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2, ep3],
-                                                        OutFittedPeaksTable=peaksTblName)
+        test_fit_peaks_table = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2, ep3],
+                                            OutFittedPeaksTable=peaksTblName)
 
         self.assertEquals(test_fit_peaks_table.rowCount(), 3)
         self.assertEquals(3, len(test_fit_peaks_table.column('dSpacing')))
         self.assertEquals(3, len(test_fit_peaks_table.column('X0')))
         self.assertEquals(3, len(test_fit_peaks_table.column('A')))
         self.assertEquals(3, len(test_fit_peaks_table.column('S')))
-
-        expected_difc = 17500.7287679
-        # assertLess would be nices, but only available in unittest >= 2.7
-        self.assertTrue(self._approxRelErrorLessThan(difc, expected_difc, 5e-3))
-        expected_zero = 658.544128868
-        self.assertTrue(self._approxRelErrorLessThan(zero, expected_zero, 5e-3))
 
         # check 'OutFittedPeaksTable' table workspace
         self._check_outputs_ok(peaksTblName, 3, ep1, -0.000162978436217,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
@@ -67,12 +67,12 @@ class EnggFitPeaksTest(unittest.TestCase):
 
         return approx_comp
 
-    def _check_outputs_ok(self, tblName, numPeaks, cell00, cell01, cell10, cell14):
+    def _check_outputs_ok(self, tbl_name, num_peaks, cell00, cell01, cell10, cell14):
         """
         Checks that we get the expected types and values in the outputs.
 
-        @param tblName :: name of the table of peaks that should have been created
-        @param numPeaks :: number of peaks that should be found in the table
+        @param tbl_name :: name of the table of peaks that should have been created
+        @param num_peaks :: number of peaks that should be found in the table
         @param cell00 :: expected (good) value for cell(0,0)
         @param cell11 :: expected (good) value for cell(0,1)
         @param cell11 :: expected (good) value for cell(1,0)
@@ -80,22 +80,22 @@ class EnggFitPeaksTest(unittest.TestCase):
         """
 
         # it has ben created
-        tbl = mtd[tblName]
-        self.assertEquals(tbl.getName(), tblName)
+        tbl = mtd[tbl_name]
+        self.assertEquals(tbl.getName(), tbl_name)
         self.assertTrue(isinstance(tbl, ITableWorkspace),
                         'The output workspace of fitted peaks should be a table workspace.')
 
         # number of peaks
-        self.assertEquals(tbl.rowCount(), numPeaks)
+        self.assertEquals(tbl.rowCount(), num_peaks)
         # number of parameters for every peak
-        colNames = ['dSpacing',
+        col_names = ['dSpacing',
                     'A0', 'A0_Err', 'A1', 'A1_Err', 'X0', 'X0_Err', 'A', 'A_Err',
                     'B', 'B_Err', 'S', 'S_Err', 'I', 'I_Err',
                     'Chi']
-        self.assertEquals(tbl.columnCount(), len(colNames))
+        self.assertEquals(tbl.columnCount(), len(col_names))
 
         # expected columns
-        self.assertEquals(tbl.getColumnNames(), colNames)
+        self.assertEquals(tbl.getColumnNames(), col_names)
 
         # some values
         # note approx comparison - fitting results differences of ~5% between glinux/win/osx

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
@@ -67,18 +67,17 @@ class EnggFitPeaksTest(unittest.TestCase):
 
         return approx_comp
 
-    def _check_outputs_ok(self, tbl_name, num_peaks, cell00, cell01, cell10, cell14):
+    def _check_outputs_ok(self, tbl_name, num_peaks, cells):
         """
         Checks that we get the expected types and values in the outputs.
 
         @param tbl_name :: name of the table of peaks that should have been created
         @param num_peaks :: number of peaks that should be found in the table
-        @param cell00 :: expected (good) value for cell(0,0)
-        @param cell11 :: expected (good) value for cell(0,1)
-        @param cell11 :: expected (good) value for cell(1,0)
-        @param cell14 :: expected (good) value for cell(1,4)
+        @param cells :: list of expected (good) values for several cells:
+        cell(0,0), cell(0,1), cell(1,0), cell(1,4)
         """
 
+        cell00, cell01, cell10, cell14 = cells
         # it has ben created
         tbl = mtd[tbl_name]
         self.assertEquals(tbl.getName(), tbl_name)
@@ -89,9 +88,9 @@ class EnggFitPeaksTest(unittest.TestCase):
         self.assertEquals(tbl.rowCount(), num_peaks)
         # number of parameters for every peak
         col_names = ['dSpacing',
-                    'A0', 'A0_Err', 'A1', 'A1_Err', 'X0', 'X0_Err', 'A', 'A_Err',
-                    'B', 'B_Err', 'S', 'S_Err', 'I', 'I_Err',
-                    'Chi']
+                     'A0', 'A0_Err', 'A1', 'A1_Err', 'X0', 'X0_Err', 'A', 'A_Err',
+                     'B', 'B_Err', 'S', 'S_Err', 'I', 'I_Err',
+                     'Chi']
         self.assertEquals(tbl.columnCount(), len(col_names))
 
         # expected columns
@@ -181,6 +180,7 @@ class EnggFitPeaksTest(unittest.TestCase):
             test_fit_peaks_table = EnggFitPeaks(sws,
                                                 WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2],
                                                 OutFittedPeaksTable=peaksTblName)
+            self.assertEquals(test_fit_peaks_table.rowCount(), 1)
         except RuntimeError as rex:
             print ("Failed (as expected) to fit the first peak (too far off the initial "
                    "guess), with RuntimeError: {0}".format(str(rex)))
@@ -208,8 +208,8 @@ class EnggFitPeaksTest(unittest.TestCase):
         self.assertEquals(test_fit_peaks_table.rowCount(), 2)
 
         # check 'OutFittedPeaksTable' table workspace
-        self._check_outputs_ok(peaksTblName, 2, ep1, -1.5602448495e-06,
-                               ep2, 1.723902507582676e-07)
+        self._check_outputs_ok(peaksTblName, 2, [ep1, -1.5602448495e-06,
+                                                 ep2, 1.723902507582676e-07])
 
     def test_runs_ok_3peaks(self):
         """
@@ -241,8 +241,8 @@ class EnggFitPeaksTest(unittest.TestCase):
         self.assertEquals(3, len(test_fit_peaks_table.column('S')))
 
         # check 'OutFittedPeaksTable' table workspace
-        self._check_outputs_ok(peaksTblName, 3, ep1, -0.000162978436217,
-                               ep2, 3.94317157133e-05)
+        self._check_outputs_ok(peaksTblName, 3, [ep1, -0.000162978436217,
+                                                 ep2, 3.94317157133e-05])
 
 
 if __name__ == '__main__':

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFocusTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFocusTest.py
@@ -28,8 +28,8 @@ class EnggFocusTest(unittest.TestCase):
             # Note the pre-calculated file instead of the too big vanadium run
             # self.__class__._van_ws = LoadNexus("ENGINX00236516.nxs", OutputWorkspace='ENGIN-X_test_vanadium_ws')
             self.__class__._van_curves_ws = LoadNexus(Filename=
-                                               'ENGINX_precalculated_vanadium_run000236516_bank_curves.nxs',
-                                               OutputWorkspace='ENGIN-X_vanadium_curves_test_ws')
+                                                      'ENGINX_precalculated_vanadium_run000236516_bank_curves.nxs',
+                                                      OutputWorkspace='ENGIN-X_vanadium_curves_test_ws')
         if not self.__class__._van_integ_tbl:
             self.__class__._van_integ_tbl = LoadNexus(Filename=
                                                       'ENGINX_precalculated_vanadium_run000236516_integration.nxs',
@@ -79,38 +79,38 @@ class EnggFocusTest(unittest.TestCase):
                           InputWorkspace=self.__class__._data_ws, DetectorPositions=tbl,
                           SpectrumNumbers='999999999999999', OutputWorkspace='nop')
 
-    def _check_output_ok(self, ws, ws_name='', y_dim_max=1, yvalues=None):
+    def _check_output_ok(self, wks, ws_name='', y_dim_max=1, yvalues=None):
         """
         Checks expected types, values, etc. of an output workspace from EnggFocus.
         """
 
-        self.assertTrue(isinstance(ws, MatrixWorkspace),
+        self.assertTrue(isinstance(wks, MatrixWorkspace),
                         'Output workspace should be a matrix workspace.')
-        self.assertEqual(ws.name(), ws_name)
-        self.assertEqual(ws.getTitle(), 'yscan;y=250.210')
-        self.assertEqual(ws.isHistogramData(), True)
-        self.assertEqual(ws.isDistribution(), True)
-        self.assertEqual(ws.getNumberHistograms(), 1)
-        self.assertEqual(ws.blocksize(), 98)
-        self.assertEqual(ws.getNEvents(), 98)
-        self.assertEqual(ws.getNumDims(), 2)
-        self.assertEqual(ws.YUnit(), 'Counts')
-        dimX = ws.getXDimension()
+        self.assertEqual(wks.name(), ws_name)
+        self.assertEqual(wks.getTitle(), 'yscan;y=250.210')
+        self.assertEqual(wks.isHistogramData(), True)
+        self.assertEqual(wks.isDistribution(), True)
+        self.assertEqual(wks.getNumberHistograms(), 1)
+        self.assertEqual(wks.blocksize(), 98)
+        self.assertEqual(wks.getNEvents(), 98)
+        self.assertEqual(wks.getNumDims(), 2)
+        self.assertEqual(wks.YUnit(), 'Counts')
+        dimX = wks.getXDimension()
         self.assertAlmostEqual( dimX.getMaximum(), 36938.078125)
         self.assertEqual(dimX.getName(), 'Time-of-flight')
         self.assertEqual(dimX.getUnits(), 'microsecond')
-        dimY = ws.getYDimension()
+        dimY = wks.getYDimension()
         self.assertEqual(dimY.getMaximum(), y_dim_max)
         self.assertEqual(dimY.getName(), 'Spectrum')
         self.assertEqual(dimY.getUnits(), '')
 
-        if None == yvalues:
+        if yvalues is None:
             raise ValueError("No y-vals provided for test")
         xvals = [10861.958645540433, 12192.372902418168, 13522.787159295902,
                  14853.201416173637, 24166.101214317776, 34809.415269339654]
-        for i, bin in enumerate([0, 5, 10, 15, 50, 90]):
-            self.assertAlmostEqual( ws.readX(0)[bin], xvals[i])
-            self.assertAlmostEqual( ws.readY(0)[bin], yvalues[i])
+        for i, bin_idx in enumerate([0, 5, 10, 15, 50, 90]):
+            self.assertAlmostEqual(wks.readX(0)[bin_idx], xvals[i])
+            self.assertAlmostEqual(wks.readY(0)[bin_idx], yvalues[i])
 
 
     def test_runs_ok(self):
@@ -124,7 +124,7 @@ class EnggFocusTest(unittest.TestCase):
                         VanCurvesWorkspace=self.__class__._van_curves_ws,
                         Bank='1', OutputWorkspace=out_name)
 
-        self._check_output_ok(ws=out, ws_name=out_name, y_dim_max=1, yvalues=self._expected_yvals_bank1)
+        self._check_output_ok(wks=out, ws_name=out_name, y_dim_max=1, yvalues=self._expected_yvals_bank1)
 
     def test_runs_ok_north(self):
         """
@@ -137,7 +137,7 @@ class EnggFocusTest(unittest.TestCase):
                         VanCurvesWorkspace=self.__class__._van_curves_ws,
                         Bank='North', OutputWorkspace=out_name)
 
-        self._check_output_ok(ws=out, ws_name=out_name, y_dim_max=1, yvalues=self._expected_yvals_bank1)
+        self._check_output_ok(wks=out, ws_name=out_name, y_dim_max=1, yvalues=self._expected_yvals_bank1)
 
     def test_runs_ok_indices(self):
         """
@@ -150,7 +150,7 @@ class EnggFocusTest(unittest.TestCase):
                             SpectrumNumbers='1-1200',
                             OutputWorkspace=out_idx_name)
 
-        self._check_output_ok(ws=out_idx, ws_name=out_idx_name, y_dim_max=1,
+        self._check_output_ok(wks=out_idx, ws_name=out_idx_name, y_dim_max=1,
                               yvalues=self._expected_yvals_bank1)
 
     def test_runs_ok_indices_split3(self):
@@ -163,7 +163,7 @@ class EnggFocusTest(unittest.TestCase):
                             VanCurvesWorkspace=self.__class__._van_curves_ws,
                             SpectrumNumbers='1-100, 101-500, 400-1200',
                             OutputWorkspace=out_idx_name)
-        self._check_output_ok(ws=out_idx, ws_name=out_idx_name, y_dim_max=1,
+        self._check_output_ok(wks=out_idx, ws_name=out_idx_name, y_dim_max=1,
                               yvalues=self._expected_yvals_bank1)
 
     def test_runs_ok_bank2(self):
@@ -177,7 +177,7 @@ class EnggFocusTest(unittest.TestCase):
                               VanIntegrationWorkspace=self.__class__._van_integ_tbl,
                               OutputWorkspace=out_name)
 
-        self._check_output_ok(ws=out_bank2, ws_name=out_name, y_dim_max=1201,
+        self._check_output_ok(wks=out_bank2, ws_name=out_name, y_dim_max=1201,
                               yvalues=self._expected_yvals_bank2)
 
     def test_runs_ok_bank_south(self):
@@ -190,7 +190,7 @@ class EnggFocusTest(unittest.TestCase):
                                    VanCurvesWorkspace=self.__class__._van_curves_ws,
                                    Bank='South', OutputWorkspace=out_name)
 
-        self._check_output_ok(ws=out_bank_south, ws_name=out_name, y_dim_max=1201,
+        self._check_output_ok(wks=out_bank_south, ws_name=out_name, y_dim_max=1201,
                               yvalues=self._expected_yvals_bank2)
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggVanadiumCorrectionsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggVanadiumCorrectionsTest.py
@@ -23,13 +23,13 @@ class EnggVanadiumCorrectionsTest(unittest.TestCase):
             # Note the pre-calculated file instead of the too big vanadium run
             # self.__class__._van_ws = LoadNexus("ENGINX00236516.nxs", OutputWorkspace='ENGIN-X_test_vanadium_ws')
             self.__class__._van_curves_ws = sapi.LoadNexus(Filename=
-                                                 'ENGINX_precalculated_vanadium_run000236516_bank_curves.nxs',
-                                                 OutputWorkspace='ENGIN-X_vanadium_curves_test_ws')
+                                                           'ENGINX_precalculated_vanadium_run000236516_bank_curves.nxs',
+                                                           OutputWorkspace='ENGIN-X_vanadium_curves_test_ws')
 
         if not self.__class__._van_integ_tbl:
             self.__class__._van_integ_tbl = sapi.LoadNexus(Filename=
-                                                 'ENGINX_precalculated_vanadium_run000236516_integration.nxs',
-                                                 OutputWorkspace='ENGIN-X_vanadium_integ_test_ws')
+                                                           'ENGINX_precalculated_vanadium_run000236516_integration.nxs',
+                                                           OutputWorkspace='ENGIN-X_vanadium_integ_test_ws')
 
     def test_issues_with_properties(self):
         """
@@ -92,20 +92,20 @@ class EnggVanadiumCorrectionsTest(unittest.TestCase):
                           IntegrationWorkspace=self.__class__._van_integ_tbl,
                           CurvesWorkspace=self.__class__._van_curves_ws)
 
-    def _check_corrected_ws(self, ws):
-        self.assertEqual(ws.getAxis(0).getUnit().unitID(), 'TOF')
-        self.assertEqual(ws.getAxis(1).getUnit().unitID(), 'Label')
-        self.assertEqual(ws.getNumberHistograms(), self.NUM_SPEC)
+    def _check_corrected_ws(self, wks):
+        self.assertEqual(wks.getAxis(0).getUnit().unitID(), 'TOF')
+        self.assertEqual(wks.getAxis(1).getUnit().unitID(), 'Label')
+        self.assertEqual(wks.getNumberHistograms(), self.NUM_SPEC)
 
-    def _check_integ_ws(self, ws):
-        self.assertTrue(isinstance(ws, ITableWorkspace),
+    def _check_integ_ws(self, wks):
+        self.assertTrue(isinstance(wks, ITableWorkspace),
                         'The integration workspace should be a table workspace.')
-        self.assertEqual(ws.columnCount(), 1)
-        self.assertEqual(ws.rowCount(), self.NUM_SPEC)
+        self.assertEqual(wks.columnCount(), 1)
+        self.assertEqual(wks.rowCount(), self.NUM_SPEC)
 
-    def _check_curves_ws(self, ws):
-        self.assertTrue(0 == ws.getNumberHistograms() % 3)
-        self.assertTrue(isinstance(ws, MatrixWorkspace),
+    def _check_curves_ws(self, wks):
+        self.assertTrue(0 == wks.getNumberHistograms() % 3)
+        self.assertTrue(isinstance(wks, MatrixWorkspace),
                         'The integration workspace should be a matrix workspace.')
 
     def test_runs_ok_when_reusing_precalculated(self):
@@ -133,10 +133,10 @@ class EnggVanadiumCorrectionsTest(unittest.TestCase):
         sample_ws = self.__class__._data_ws
         integ_ws_name = 'calc_integ_ws'
         curves_ws_name = 'calc_curves_ws'
-        out = sapi.EnggVanadiumCorrections(Workspace=sample_ws,
-                                           VanadiumWorkspace=self.__class__._van_ws,
-                                           IntegrationWorkspace=integ_ws_name,
-                                           CurvesWorkspace=curves_ws_name)
+        sapi.EnggVanadiumCorrections(Workspace=sample_ws,
+                                     VanadiumWorkspace=self.__class__._van_ws,
+                                     IntegrationWorkspace=integ_ws_name,
+                                     CurvesWorkspace=curves_ws_name)
 
         self._check_corrected_ws(sample_ws)
         self._check_integ_ws(integ_ws_name)

--- a/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
+++ b/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
@@ -150,6 +150,8 @@ class EnginXCalibrateFullThenCalibrateTest(stresstesting.MantidStressTest):
     def __init__(self):
         stresstesting.MantidStressTest.__init__(self)
         # difc and zero parameters for GSAS
+        self.difa = -1
+        self.difa_b2 = -1
         self.difc = -1
         self.difc_b2 = -1
         self.zero_b2 = -1
@@ -189,32 +191,33 @@ class EnginXCalibrateFullThenCalibrateTest(stresstesting.MantidStressTest):
         self.peaks_info = peaks_params
 
         # Bank 1
-        self.difc, self.zero, tbl = EnggCalibrate(InputWorkspace = long_calib_ws,
-                                                  VanadiumWorkspace = van_ws,
-                                                  Bank = '1',
-                                                  ExpectedPeaks =
-                                                  '2.7057,1.9132,1.6316,1.5621,1.3528,0.9566',
-                                                  DetectorPositions = self.pos_table)
+        self.difa, self.difc, self.zero, tbl = EnggCalibrate(InputWorkspace = long_calib_ws,
+                                                             VanadiumWorkspace = van_ws,
+                                                             Bank = '1',
+                                                             ExpectedPeaks =
+                                                             '2.7057,1.9132,1.6316,1.5621,1.3528,0.9566',
+                                                             DetectorPositions = self.pos_table)
         self.peaks = tbl.column('dSpacing')
         self.peaks_fitted = tbl.column('X0')
 
         # Bank 2
-        self.difc_b2, self.zero_b2, tbl_b2 = EnggCalibrate(InputWorkspace = long_calib_ws,
-                                                           VanadiumWorkspace = van_ws,
-                                                           Bank = '2',
-                                                           ExpectedPeaks =
-                                                           '2.7057,1.9132,1.6316,1.5621,1.3528,0.9566',
-                                                           DetectorPositions = self.pos_table)
+        self.difa_b2, self.difc_b2, self.zero_b2, tbl_b2 = EnggCalibrate(InputWorkspace = long_calib_ws,
+                                                                         VanadiumWorkspace = van_ws,
+                                                                         Bank = '2',
+                                                                         ExpectedPeaks =
+                                                                         '2.7057,1.9132,1.6316,1.5621,1.3528,0.9566',
+                                                                         DetectorPositions = self.pos_table)
         self.peaks_b2 = tbl_b2.column('dSpacing')
         self.peaks_fitted_b2 = tbl_b2.column('X0')
 
     def validate(self):
         # === check detector positions table produced by EnggCalibrateFull
         self.assertTrue(self.pos_table)
-        self.assertEquals(self.pos_table.columnCount(), 9)
+        self.assertEquals(self.pos_table.columnCount(), 10)
         self.assertEquals(self.pos_table.rowCount(), 1200)
         self.assertEquals(self.pos_table.cell(88, 0), 100089)   # det ID
         self.assertEquals(self.pos_table.cell(200, 0), 101081)  # det ID
+        self.assertEquals(self.pos_table.cell(88, 0), 100089)   # det ID
 
         # The output table of peak parameters has the expected structure
         self.assertEquals(self.peaks_info.rowCount(), 1200)
@@ -231,6 +234,9 @@ class EnginXCalibrateFullThenCalibrateTest(stresstesting.MantidStressTest):
             self.assertTrue(isinstance(cell_val, str))
             self.assertEquals(cell_val[0:11], '{"1": {"A":')
             self.assertEquals(cell_val[-2:], '}}')
+
+        self.assertEquals(self.difa, 0)
+        self.assertEquals(self.difa_b2, 0)
 
         # this will be used as a comparison delta in relative terms (percentage)
         exdelta = exdelta_special = exdelta_tzero = 1e-5
@@ -254,8 +260,9 @@ class EnginXCalibrateFullThenCalibrateTest(stresstesting.MantidStressTest):
         #self.assertDelta(self.pos_table.cell(100, 3), 1.49010562897, delta)
         self.assertTrue(rel_err_less_delta(self.pos_table.cell(400, 4), 1.65264105797, exdelta))
         self.assertTrue(rel_err_less_delta(self.pos_table.cell(200, 5), -0.296705961227, exdelta))
-        self.assertTrue(rel_err_less_delta(self.pos_table.cell(610, 7), 18603.7597656, exdelta))
-        self.assertTrue(rel_err_less_delta(self.pos_table.cell(1199, 8), -5.62454175949, exdelta_special))
+        self.assertEquals(self.pos_table.cell(133, 7), 0)   # DIFA
+        self.assertTrue(rel_err_less_delta(self.pos_table.cell(610, 8), 18603.7597656, exdelta))
+        self.assertTrue(rel_err_less_delta(self.pos_table.cell(1199, 9), -5.62454175949, exdelta_special))
 
         # === check difc, zero parameters for GSAS produced by EnggCalibrate
 

--- a/docs/source/algorithms/EnggCalibrate-v1.rst
+++ b/docs/source/algorithms/EnggCalibrate-v1.rst
@@ -23,19 +23,21 @@ also perform corrections with Vanadium data.
 
 Then this algorithm calls :ref:`algm-EnggFitPeaks` (as a child
 algorithm) which through a sequence of peak fits determines a linear
-relationship between dSpacing and measured TOF values in terms of DIFC
-and ZERO values and provides the these parameters to the Calibrate
-algorithm.
+relationship between dSpacing and measured TOF values in terms of
+DIFA, DIFC and TZERO values and provides the these parameters to the
+Calibrate algorithm.
 
 This algorithm provides an indirect calibration of the sample
-position, that is, a calibration returned in terms of Difc and Zero
-rather than an actual new sample position (hence the reason for
+position, that is, a calibration returned in terms of DIFA, DIFC and
+ZERO rather than an actual new sample position (hence the reason for
 'indirect').
 
-The parameters DIFC and ZERO are returned and can be retrieved as
-output properties as well. If a name is given in
+The parameters DIFA, DIFC and ZERO are returned and can be retrieved
+as output properties as well. If a name is given in
 OutputParametersTableName the algorithm also produces a table
 workspace with that name, containing the two output parameters.
+Presently the DIFA parameter is always set to zero (see
+:ref:`algm-EnggFitDIFCFromPeaks`).
 
 The script EnggUtils included with Mantid can produce a GSAS
 parameters file for the ENGIN-X instrument, given the DIFC and ZERO

--- a/docs/source/algorithms/EnggCalibrate-v1.rst
+++ b/docs/source/algorithms/EnggCalibrate-v1.rst
@@ -69,16 +69,16 @@ Usage
    van_integ_ws = Load('ENGINX_precalculated_vanadium_run000236516_integration.nxs')
    van_curves_ws = Load('ENGINX_precalculated_vanadium_run000236516_bank_curves.nxs')
 
-   Difc1, Zero1, peaks1 = EnggCalibrate(InputWorkspace=ws_name,
-                                        VanIntegrationWorkspace=van_integ_ws,
-                                        VanCurvesWorkspace=van_curves_ws,
-                                        ExpectedPeaks=[1.097, 2.1], Bank='1',
-                                        OutputParametersTableName=out_tbl_name)
+   difa1, Difc1, Zero1, peaks1 = EnggCalibrate(InputWorkspace=ws_name,
+                                               VanIntegrationWorkspace=van_integ_ws,
+                                               VanCurvesWorkspace=van_curves_ws,
+                                               ExpectedPeaks=[1.097, 2.1], Bank='1',
+                                               OutputParametersTableName=out_tbl_name)
 
-   Difc2, Zero2, peaks2 = EnggCalibrate(InputWorkspace=ws_name,
-                                        VanIntegrationWorkspace=van_integ_ws,
-                                        VanCurvesWorkspace=van_curves_ws,
-                                        ExpectedPeaks=[1.097, 2.1], Bank='2')
+   Difa1, Difc2, Zero2, peaks2 = EnggCalibrate(InputWorkspace=ws_name,
+                                               VanIntegrationWorkspace=van_integ_ws,
+                                               VanCurvesWorkspace=van_curves_ws,
+                                               ExpectedPeaks=[1.097, 2.1], Bank='2')
 
    # You can produce an instrument parameters (iparam) file for GSAS.
    # Note that this is very specific to ENGIN-X
@@ -86,11 +86,12 @@ Usage
    import EnggUtils
    EnggUtils.write_ENGINX_GSAS_iparam_file(GSAS_iparm_fname, [Difc1, Difc2], [Zero1, Zero2])
 
-   print "Difc1: %.2f" % (Difc1)
-   print "Zero1: %.2f" % (Zero1)
+   print "DIFA1: %.2f" % (Difa1)
+   print "DIFC1: %.2f" % (Difc1)
+   print "TZERO1: %.2f" % (Zero1)
    tbl = mtd[out_tbl_name]
    print "The output table has %d row(s)" % tbl.rowCount()
-   print "Parameters from the table, Difc1: %.2f, Zero1: %.2f" % (tbl.cell(0,0), tbl.cell(0,1))
+   print "Parameters from the table, DIFC1: %.2f, ZERO1: %.2f" % (tbl.cell(0,1), tbl.cell(0,2))
    import os
    print "Output GSAS iparam file was written?", os.path.exists(GSAS_iparm_fname)
    print "Number of lines of the GSAS iparam file:", sum(1 for line in open(GSAS_iparm_fname))
@@ -108,9 +109,10 @@ Output:
 
 .. testoutput:: ExampleCalib
 
-   Difc1: 18400.19
-   Zero1: -2.06
+   DIFA1: 0.00
+   DIFC1: 18400.19
+   TZERO1: -2.06
    The output table has 1 row(s)
-   Parameters from the table, Difc1: 18400.19, Zero1: -2.06
+   Parameters from the table, DIFC1: 18400.19, ZERO1: -2.06
    Output GSAS iparam file was written? True
    Number of lines of the GSAS iparam file: 35

--- a/docs/source/algorithms/EnggCalibrateFull-v1.rst
+++ b/docs/source/algorithms/EnggCalibrateFull-v1.rst
@@ -19,8 +19,8 @@ Description
 Allows to calibrate or correct for variations in detector position
 parameters. It does this by fitting the peaks for each of the selected
 bank's detector indices, (using :ref:`algm-EnggFitPeaks` as a child
-algorithm) and using the resulting difc values to calibrate the
-detector positions.
+algorithm) and using the resulting DIFC (GSAS calibration parameter)
+values to calibrate the detector positions.
 
 This algorithm produces a table with calibration information,
 including calibrated or corrected positions and parameters. This
@@ -35,8 +35,8 @@ The output table has one row per detector where each row gives the
 original position before calibration (as a V3D point, x-y-z values),
 the new calibrated position (as V3D) and the calibrated spherical
 co-ordinates (L2, :math:`2 \theta`, :math:`\phi`). It also gives the
-variation in the L2 position, and the 'difc' and 'zero' calibration
-parameters.
+variation in the L2 position, and the 'DIFA', 'DIFC' and 'TZERO'
+calibration parameters as used in GSAS and other Mantid algorithms.
 
 The result of the calibration (the output table given in
 OutDetPosTable) is accepted by both :ref:`algm-EnggCalibrate` and
@@ -47,14 +47,14 @@ to apply the calibration calculated by this algorithm on any other
 workspace by using the algorithm :ref:`algm-ApplyCalibration`.
 
 In the output table the calibrated positions for every detector are
-found by calculating the *L2* values from the *difc* values as
+found by calculating the *L2* values from the *DIFC* values as
 follows:
 
-.. math:: L2 = \left(\frac{Difc} { 252.816 * 2 * sin \left(\frac{2\theta} {2.0}\right)}\right) - 50
+.. math:: L2 = \left(\frac{DIFC} { 252.816 * 2 * sin \left(\frac{2\theta} {2.0}\right)}\right) - 50
 
-where the *difc* values are obtained from the fitting of expected
+where the *DIFC* values are obtained from the fitting of expected
 peaks. See the algorithm :ref:`algm-EnggFitPeaks` for details on how
-*difc* and other calibration parameters are calculated.
+*DIFC* and other calibration parameters are calculated.
 
 This algorithm expects as input/output workspace the *long*
 calibration run, which provides a decent pattern for every detector or
@@ -76,7 +76,7 @@ Usage
 
 .. include:: ../usagedata-note.txt
 
-**Example - Calculate corrected positions, and difc and zero, for Engg:**
+**Example - Calculate corrected positions, using the DIFC parameter, for the EnginX instrument:**
 
 .. testcode:: ExCalFull
 

--- a/docs/source/algorithms/EnggFitDIFCFromPeaks-v1.rst
+++ b/docs/source/algorithms/EnggFitDIFCFromPeaks-v1.rst
@@ -9,11 +9,78 @@
 Description
 -----------
 
+.. warning::
 
+   This algorithm is being developed for a specific instrument. It
+   might undergo significant changes, should instrument scientists
+   decide to do so.
 
-**Example - Fitting two peaks:**
+Finds the calibration parameters DIFC and TZERO (as defined in GSAS)
+from a list of peaks fitted to a diffraction pattern. The peaks can be
+fitted to a Mantid workspace spectrum using the algorithm
+:ref:`EnggFitPeaks <algm-EnggFitPeaks>` which produces a table with
+parameter values for peaks in time-of-flight (TOF, see
+:ref:`UnitFactory <algm-UnitFactory>`). The table is the essential
+input to this algorithm.
+
+This algorithm fits the adjusted peak time-of-fligth value positions
+that are fitted against expected dSpacing values (d) according to the
+expression:
+
+.. math:: TOF = DIFC*d + TZERO
+
+The calibration parameters TZERO and DIFC can then be used within the
+GSAS program or in other Mantid algorithms (see :ref:`EnggCalibrate
+<algm-EnggCalibrate>` and :ref:`EnggCalibrateFull
+<algm-EnggCalibrateFull>`).  These parameters are returned and can be
+retrieved as output properties as well. The DIFA coefficient
+(quadratic term on d) is not considered and is fixed to zero in this
+version of the algorithm.
+
+If a name is given in OutParametersTable this algorithm also produces
+a table workspace with that name, containing the parameters fitted
+(DIFA, DIFC, TZERO).
+
+Usage
+-----
+
+**Example - Fitting DIFC parameter with two peaks:**
 
 .. testcode:: ExTwoPeaks
+
+   # Two BackB2Back exponential peaks
+   peak1 = "name=BackToBackExponential,I=6000,A=1,B=0.5,X0=15000,S=250"
+   peak2 = "name=BackToBackExponential,I=5000,A=1,B=0.7,X0=35000,S=300"
+
+   # Create workpsace with the above peaks and a single detector pixel
+   ws = CreateSampleWorkspace(Function="User Defined",
+                              UserDefinedFunction=peak1 + ";" + peak2,
+                              NumBanks=1,
+                              BankPixelWidth=1,
+                              XMin=6000,
+                              XMax=45000,
+                              BinWidth=10)
+
+   # Update instrument geometry to something that would allow converting to some sane dSpacing values
+   EditInstrumentGeometry(Workspace = ws, L2 = [1.5], Polar = [90], PrimaryFlightPath = 50)
+
+   # Run the algorithm. Defaults are shown below. Files entered must be in .csv format and if both ExpectedPeaks and ExpectedPeaksFromFile are entered, the latter will be used.
+
+   peaks_tbl = EnggFitPeaks(ws, 0, [0.8, 1.9])
+   out_tbl_name = 'difc_from_peaks'
+   difa, difc, zero = EnggFitDIFCFromPeaks(FittedPeaks=peaks_tbl, OutParametersTable=out_tbl_name)
+
+   # Print the results
+   print "Difc: %.1f" % difc
+   print "Zero: %.1f" % zero
+   tbl = mtd[out_tbl_name]
+   print "The output table has %d row(s)" % tbl.rowCount()
+   print "Parameters from the table, Difc: %.1f, Zero: %.1f" % (tbl.cell(0,0), tbl.cell(0,1))
+   print "Number of peaks fitted: {0}".format(peaks_tbl.rowCount())
+   print "First peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[0])
+   print "First fitted peak center (ToF): {0:.1f}".format(peaks_tbl.column('X0')[0])
+   print "Second peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[1])
+   print "Second fitted peak center (ToF): {0:.1f}".format(peaks_tbl.column('X0')[1])
 
 Output:
 
@@ -32,7 +99,6 @@ Output:
    First fitted peak center (ToF): 15006.0
    Second peak expected (dSpacing): 1.9
    Second fitted peak center (ToF): 35006.0
-
 
 .. categories::
 

--- a/docs/source/algorithms/EnggFitDIFCFromPeaks-v1.rst
+++ b/docs/source/algorithms/EnggFitDIFCFromPeaks-v1.rst
@@ -68,11 +68,12 @@ Usage
 
    peaks_tbl = EnggFitPeaks(ws, 0, [0.8, 1.9])
    out_tbl_name = 'difc_from_peaks'
-   difa, difc, zero = EnggFitDIFCFromPeaks(FittedPeaks=peaks_tbl, OutParametersTable=out_tbl_name)
+   difa, difc, tzero = EnggFitDIFCFromPeaks(FittedPeaks=peaks_tbl, OutParametersTable=out_tbl_name)
 
    # Print the results
-   print "Difc: %.1f" % difc
-   print "Zero: %.1f" % zero
+   print "DIFA: %.1f" % difa
+   print "DIFC: %.1f" % difc
+   print "TZERO: %.1f" % tzero
    tbl = mtd[out_tbl_name]
    print "The output table has %d row(s)" % tbl.rowCount()
    print "Parameters from the table, DIFA: %.1f, DIFC: %.1f, TZERO: %.1f" % (tbl.cell(0,0), tbl.cell(0,1), tbl.cell(0,2))
@@ -90,8 +91,9 @@ Output:
 
 .. testoutput:: ExTwoPeaks
 
-   Difc: 18181.8
-   Zero: 460.5
+   DIFA: 0.0
+   DIFC: 18181.8
+   TZERO: 460.5
    The output table has 1 row(s)
    Parameters from the table, DIFA: 0.0, DIFC: 18181.8, TZERO: 460.5
    Number of peaks fitted: 2

--- a/docs/source/algorithms/EnggFitDIFCFromPeaks-v1.rst
+++ b/docs/source/algorithms/EnggFitDIFCFromPeaks-v1.rst
@@ -75,7 +75,7 @@ Usage
    print "Zero: %.1f" % zero
    tbl = mtd[out_tbl_name]
    print "The output table has %d row(s)" % tbl.rowCount()
-   print "Parameters from the table, Difc: %.1f, Zero: %.1f" % (tbl.cell(0,0), tbl.cell(0,1))
+   print "Parameters from the table, DIFA: %.1f, DIFC: %.1f, TZERO: %.1f" % (tbl.cell(0,0), tbl.cell(0,1), tbl.cell(0,2))
    print "Number of peaks fitted: {0}".format(peaks_tbl.rowCount())
    print "First peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[0])
    print "First fitted peak center (ToF): {0:.1f}".format(peaks_tbl.column('X0')[0])
@@ -93,7 +93,7 @@ Output:
    Difc: 18181.8
    Zero: 460.5
    The output table has 1 row(s)
-   Parameters from the table, Difc: 18181.8, Zero: 460.5
+   Parameters from the table, DIFA: 0.0, DIFC: 18181.8, TZERO: 460.5
    Number of peaks fitted: 2
    First peak expected (dSpacing): 0.8
    First fitted peak center (ToF): 15006.0

--- a/docs/source/algorithms/EnggFitDIFCFromPeaks-v1.rst
+++ b/docs/source/algorithms/EnggFitDIFCFromPeaks-v1.rst
@@ -1,0 +1,39 @@
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+
+
+**Example - Fitting two peaks:**
+
+.. testcode:: ExTwoPeaks
+
+Output:
+
+.. testcleanup:: ExTwoPeaks
+
+   DeleteWorkspace(out_tbl_name)
+
+.. testoutput:: ExTwoPeaks
+
+   Difc: 18181.8
+   Zero: 460.5
+   The output table has 1 row(s)
+   Parameters from the table, Difc: 18181.8, Zero: 460.5
+   Number of peaks fitted: 2
+   First peak expected (dSpacing): 0.8
+   First fitted peak center (ToF): 15006.0
+   Second peak expected (dSpacing): 1.9
+   Second fitted peak center (ToF): 35006.0
+
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/EnggFitPeaks-v1.rst
+++ b/docs/source/algorithms/EnggFitPeaks-v1.rst
@@ -16,27 +16,19 @@ Description
    instrument scientists decide to do so.
 
 
-Fits a series of single peak to a spectrum with an expected
+Fits a series of single peaks to a spectrum with an expected
 diffraction pattern.  The pattern is specified by providing a list of
-dSpacing values where Bragg peaks are expected. The algorithm then
-fits peaks in those areas using a peak fitting function. The dSpacing
-values for ExpectedPeaks are then converted to time-of-flight (TOF)
-(as in the Mantid :ref:`ConvertUnits <algm-ConvertUnits>`
-algorithm). Expected dSpacing values can be given as an input string
-or in a file with values separated by commas.
+dSpacing values where Bragg peaks are expected. These expected values
+are used as initial peak positions when fitting the peaks. The
+expected dSpacing values can be given as an input string or in a file
+with values separated by commas.
 
-These values are used as start peak position in fit. It is these
-adjusted peak TOF value positions that are fitted against
-ExpectedPeaks dSpacing values according to:
-
-
-.. math:: TOF = DIFC*d + TZERO
-
-
-TZERO and DIFC can then be used within the GSAS program.  The
-parameters DIFC and ZERO are returned and can be retrieved as output
-properties as well. The DIFA coefficient (quadratic term on d) is not
-considered in this version of the algorithm.
+The peaks are fitted one at a time. The dSpacing values given in the
+property ExpectedPeaks are then converted to time-of-flight (TOF) (as
+in the Mantid :ref:`ConvertUnits <algm-ConvertUnits>` algorithm).
+After the conversion of units, the algorithm tries to fit (in
+time-of-flight) a peak in the neighborhood of every expected peak
+using a peak shape or function.
 
 This algorithm currently fits (single) peaks of type
 :ref:`Back2BackExponential <func-Back2BackExponential>`. Other
@@ -45,16 +37,15 @@ simpler :ref:`Gaussian <func-Gaussian>` or the more complex
 :ref:`Bk2BkExpConvPV <func-Bk2BkExpConvPV` or :ref:`IkedaCarpenterPV
 <func-IkedaCarpenterPV>`). To produce an initial guess for the peak
 function parameters this algorithm uses the :ref:`FindPeaks
-<algm-FindPeaks>` algorithm.
+<algm-FindPeaks>` algorithm starting from the expected peaks list
+given in the inputs.
 
-If a name is given in OutParametersTable this algorithm also produces
-a table workspace with that name, containing the two fitted (DIFC,
-ZERO) parameters. The algorithm produces an output table workspace
-with information about the peaks fitted. The table has one row per
-peak and several columns for the different fitted parameters (and the
-errors of these parameters). If a name is given in the input
-OutFittedPeaksTable, the table will be available in the "analysis data
-service" (workspaces window) with that name.
+The algorithm produces an output table workspace with information
+about the peaks fitted. The table has one row per peak and several
+columns for the different fitted parameters (and the errors of these
+parameters). If a name is given in the input OutFittedPeaksTable, the
+table will be available in the "analysis data service" (workspaces
+window) with that name.
 
 Usage
 -----
@@ -81,16 +72,10 @@ Usage
 
    # Run the algorithm. Defaults are shown below. Files entered must be in .csv format and if both ExpectedPeaks and ExpectedPeaksFromFile are entered, the latter will be used.
 
-   out_tbl_name = 'peaks'
-   difc, zero, peaks_tbl = EnggFitPeaks(ws, 0, [0.8, 1.9], OutParametersTable=out_tbl_name)
+   peaks_tbl = EnggFitPeaks(ws, 0, [0.8, 1.9])
 
 
    # Print the results
-   print "Difc: %.1f" % difc
-   print "Zero: %.1f" % zero
-   tbl = mtd[out_tbl_name]
-   print "The output table has %d row(s)" % tbl.rowCount()
-   print "Parameters from the table, Difc: %.1f, Zero: %.1f" % (tbl.cell(0,0), tbl.cell(0,1))
    print "Number of peaks fitted: {0}".format(peaks_tbl.rowCount())
    print "First peak expected (dSpacing): {0}".format(peaks_tbl.column('dSpacing')[0])
    print "First fitted peak center (ToF): {0:.1f}".format(peaks_tbl.column('X0')[0])
@@ -101,14 +86,10 @@ Output:
 
 .. testcleanup:: ExTwoPeaks
 
-   DeleteWorkspace(out_tbl_name)
+   DeleteWorkspace(peaks_tbl)
 
 .. testoutput:: ExTwoPeaks
 
-   Difc: 18181.8
-   Zero: 460.5
-   The output table has 1 row(s)
-   Parameters from the table, Difc: 18181.8, Zero: 460.5
    Number of peaks fitted: 2
    First peak expected (dSpacing): 0.8
    First fitted peak center (ToF): 15006.0

--- a/docs/source/release/v3.7.0/diffraction.rst
+++ b/docs/source/release/v3.7.0/diffraction.rst
@@ -15,6 +15,11 @@ Crystal Improvements
 Engineering Diffraction
 -----------------------
 
+- New algorithm added: EnggFitDIFCFromPeaks, which forks from the old EnggFitPeaks. EnggFitPeaks modified to
+  fit peaks but not calibration parameters.
+
+Graphical user interface:
+
 - Vanadium Curves and Ceria Peaks graphs are plotted once basic and cropped calibration process has been carried out
 - Customise Bank Name text-field will set the workspace and .his file name according to this Bank Name
   provided by the user for Cropped Calibration

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -20,6 +20,9 @@ New
    :ref:`GetDetOffsetsMultiPeaks <algm-GetDetOffsetsMultiPeaks>`, :ref:`CalibrateRectangularDetectors <algm-CalibrateRectangularDetectors>`, *et al* and
    minimizes the difference between the *DIFC* of the instrument and
    calibration by moving and rotating instrument components.
+- :ref:`EnggFitDIFCFromPeaks <algm-AlignComponents>` fits GSAS calibration
+  parameters (DIFA, DIFC, TZERO) from peaks fitted using
+  :ref:`EnggFitPeaks <algm-EnggFitPeaks>`.
 
 Renamed
 #######

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -65,7 +65,7 @@ def read_in_expected_peaks(filename, expectedGiven):
             expectedPeaksD = sorted(exPeakArray)
 
     else:
-        if [] == expectedGiven:
+        if 0 == expectedGiven.size:
             raise ValueError("No expected peaks were given in the property 'ExpectedPeaks', "
                              "could not get default expected peaks, and 'ExpectedPeaksFromFile' "
                              "was not given either. Cannot continout without a list of expected peaks.")
@@ -196,17 +196,19 @@ def getDetIDsForBank(bank):
 
     return detIDs
 
-def  generateOutputParTable(name, difc, zero):
+def  generateOutputParTable(name, difa, difc, tzero):
     """
     Produces a table workspace with the two fitted calibration parameters
 
     @param name :: the name to use for the table workspace that is created here
-    @param difc :: difc calibration parameter
-    @param zero :: zero calibration parameter
+    @param difa :: DIFA calibration parameter (GSAS parameter)
+    @param difc :: DIFC calibration parameter
+    @param tzero :: TZERO calibration parameter
     """
     tbl = sapi.CreateEmptyTableWorkspace(OutputWorkspace=name)
-    tbl.addColumn('double', 'difc')
-    tbl.addColumn('double', 'zero')
+    tbl.addColumn('double', 'DIFA')
+    tbl.addColumn('double', 'DIFZ')
+    tbl.addColumn('double', 'TZERO')
     tbl.addRow([float(difc), float(zero)])
 
 def applyVanadiumCorrections(parent, ws, indices, vanWS, vanIntegWS, vanCurvesWS):

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -209,7 +209,7 @@ def  generateOutputParTable(name, difa, difc, tzero):
     tbl.addColumn('double', 'DIFA')
     tbl.addColumn('double', 'DIFZ')
     tbl.addColumn('double', 'TZERO')
-    tbl.addRow([float(difc), float(zero)])
+    tbl.addRow([float(difa), float(difc), float(tzero)])
 
 def applyVanadiumCorrections(parent, ws, indices, vanWS, vanIntegWS, vanCurvesWS):
     """


### PR DESCRIPTION
Introduces EnggFitDIFCFromPeaks, from splitting EnggFitPeaks which now
does strictly peak fitting but no fitting of calibration parameters, as required for the new single peak fitting functionality and GUI.

**To test:**
- Ensure that all relevant tests pass (the unit, doc and system tests for Engg algorithms have been updated and extended).
- Check that the documentation for the new algorithm reads well.
- EnggFitPeaks is used from the Engg GUI (presenter, fit peaks) which should still work well. It didn't need any changes
  as it only uses the peaks information and not the DIFC, etc. parameters.

Fixes #15768

Release notes: https://github.com/mantidproject/mantid/commit/e48b4f9379f2038db9857dd68770d4cec29859ce

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
