### PR TITLE
MuonAnalysis: Fix bug with trailing space in workspace name

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -471,17 +471,21 @@ std::string MuonAnalysis::getNewAnalysisWSName(ItemType itemType, int tableRow,
     workspaceName << "Logs";
     break;
   }
-  
-  // Period(s)
-  workspaceName << sep << getPeriodLabels();
 
-  // Construct workspace name
+  // Period(s)
+  const auto periods = getPeriodLabels();
+  if (!periods.empty()) {
+    workspaceName << sep << periods;
+  }
+
+  // Version - always "#1" if overwrite is on, otherwise increment
+  workspaceName << sep << "#";
   std::string newName;
   if (isOverwriteEnabled()) {
+    workspaceName << "1"; // Always use #1
     newName = workspaceName.str();
   } else {
     // If overwrite is disabled, need to find unique name for the new workspace
-    workspaceName << sep << "#";
     newName = workspaceName.str();
     std::string uniqueName;
     int plotNum(1);


### PR DESCRIPTION
Removed trailing space from workspace name in MuonAnalysis

Always append a number to the workspace name.
If overwrite is on, this is always `#1`.
If overwrite is off, increment each time (same as before).

This fixes the bug caused when overwrite was on and the data was collected in only one period.
In that case the workspace name ended with a separator "; " and the trailing space was trimmed on passing to the `Fit` algorithm.

**To test:**
- Open interface (Interfaces/Muon/Muon Analysis)
- Load any muon data set (for example `MUSR00024580.nxs` from `\\olympic\babylon5\Scratch\TomPerkins\Data`)
- Go to the "Data Analysis" tab and set up a fit function
- Run the fit.

The fit should complete successfully and you should not see an error message that the workspace can't be found in the ADS.

(MuonAnalysis doesn't have automated tests as the interface is not written in a way that allows this easily.)

Fixes #15814 

_Does not need to be in the release notes_ as the bug was not in the 3.6 release and no users will have seen it - unless they are using the very latest nightly build from 1/4/16!

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
