### PR TITLE
Script output window prevent pasting from the middle mouse button

### DIFF
--- a/MantidPlot/src/ScriptOutputDisplay.cpp
+++ b/MantidPlot/src/ScriptOutputDisplay.cpp
@@ -55,6 +55,15 @@ void ScriptOutputDisplay::mouseMoveEvent(QMouseEvent * e)
   this->setReadOnly(false);
 }
 
+/** Mouse move press handler - overridden to prevent middle mouse button clicks from pasting on linux
+* @param e the mouse move event
+*/
+void ScriptOutputDisplay::mousePressEvent(QMouseEvent * e) {
+  this->setReadOnly(true);
+  QTextEdit::mousePressEvent(e);
+  this->setReadOnly(false);
+}
+
 void ScriptOutputDisplay::wheelEvent(QWheelEvent *e) {
     if (e->modifiers() & Qt::ControlModifier) {
         const int delta = e->delta();

--- a/MantidPlot/src/ScriptOutputDisplay.cpp
+++ b/MantidPlot/src/ScriptOutputDisplay.cpp
@@ -55,10 +55,10 @@ void ScriptOutputDisplay::mouseMoveEvent(QMouseEvent * e)
   this->setReadOnly(false);
 }
 
-/** Mouse move press handler - overridden to prevent middle mouse button clicks from pasting on linux
+/** Mouse move release handler - overridden to prevent middle mouse button clicks from pasting on linux
 * @param e the mouse move event
 */
-void ScriptOutputDisplay::mousePressEvent(QMouseEvent * e) {
+void ScriptOutputDisplay::mouseReleaseEvent(QMouseEvent * e) {
   this->setReadOnly(true);
   QTextEdit::mousePressEvent(e);
   this->setReadOnly(false);

--- a/MantidPlot/src/ScriptOutputDisplay.h
+++ b/MantidPlot/src/ScriptOutputDisplay.h
@@ -25,7 +25,7 @@ public:
   //squash dragging ability
   void mouseMoveEvent(QMouseEvent *e) override;
   //prevent middle mouse clicks from pasting
-  void mousePressEvent(QMouseEvent *e) override;
+  void mouseReleaseEvent(QMouseEvent *e) override;
   /// capture ctrl_up or down to zoom
   void wheelEvent(QWheelEvent *e) override;
   //sets the zoom to a specific level

--- a/MantidPlot/src/ScriptOutputDisplay.h
+++ b/MantidPlot/src/ScriptOutputDisplay.h
@@ -24,6 +24,8 @@ public:
   void keyPressEvent(QKeyEvent *event) override;
   //squash dragging ability
   void mouseMoveEvent(QMouseEvent *e) override;
+  //prevent middle mouse clicks from pasting
+  void mousePressEvent(QMouseEvent *e) override;
   /// capture ctrl_up or down to zoom
   void wheelEvent(QWheelEvent *e) override;
   //sets the zoom to a specific level


### PR DESCRIPTION
Prevented the ability to paste into the script window output pane using the middle mouse button.

This is done by temporarily making the control readonly while the mouse press event is processed.

**To test:**
This needs to be tested on linux (or possibly mac)
1. Startup the script window.
2. run some code so you have some output in the script window.
3. copy some text into the clipboard
4. use the middle mouse button to paste into the script output window.
5. check the rest of the mouse button interactions work as expected on the output window.

Fixes #15736 .
#### RELEASE NOTES

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
