### PR TITLE
Plots from tables: axis labels, title, auto-update

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -11964,10 +11964,7 @@ void ApplicationWindow::connectMultilayerPlot(MultiLayer *g) {
 void ApplicationWindow::connectTable(Table *w) {
   connect(w->table(), SIGNAL(itemSelectionChanged()), this,
           SLOT(customColumnActions()));
-  connect(w, SIGNAL(removedCol(const QString &)), this,
-          SLOT(removeCurves(const QString &)));
-  connect(w, SIGNAL(modifiedData(Table *, const QString &)), this,
-          SLOT(updateCurves(Table *, const QString &)));
+  setUpdateCurvesFromTable(w, true);
   connect(w, SIGNAL(optionsDialog()), this, SLOT(showColumnOptionsDialog()));
   connect(w, SIGNAL(colValuesDialog()), this, SLOT(showColumnValuesDialog()));
   connect(w, SIGNAL(showContextMenu(bool)), this,
@@ -11978,6 +11975,27 @@ void ApplicationWindow::connectTable(Table *w) {
           this, SLOT(newTable(const QString &, int, int, const QString &)));
 
   w->confirmClose(confirmCloseTable);
+}
+
+/**
+ * Connect or disconnect the auto-update of curves from a table
+ * @param table :: [input] Table to connect/disconnect signal from
+ * @param on :: [bool] True to turn auto-update on, false to turn off
+ */
+void ApplicationWindow::setUpdateCurvesFromTable(Table *table, bool on) {
+  if (table) { // If no table, nothing to do
+    if (on) {
+      connect(table, SIGNAL(removedCol(const QString &)), this,
+              SLOT(removeCurves(const QString &)));
+      connect(table, SIGNAL(modifiedData(Table *, const QString &)), this,
+              SLOT(updateCurves(Table *, const QString &)));
+    } else {
+      disconnect(table, SIGNAL(removedCol(const QString &)), this,
+                 SLOT(removeCurves(const QString &)));
+      disconnect(table, SIGNAL(modifiedData(Table *, const QString &)), this,
+                 SLOT(updateCurves(Table *, const QString &)));
+    }
+  }
 }
 
 void ApplicationWindow::setAppColors(const QColor &wc, const QColor &pc,

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -2792,6 +2792,10 @@ MultiLayer *ApplicationWindow::multilayerPlot(
   if (!autoscale2DPlots)
     ag->enableAutoscaling(false);
 
+  // Set graph title to the same as the table
+  if (auto mantidTable = dynamic_cast<MantidTable *>(w)) {
+    ag->setTitle(mantidTable->getWorkspaceName().c_str());
+  }
   QApplication::restoreOverrideCursor();
   return g;
 }

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -431,6 +431,8 @@ public slots:
   void customizeTables(const QColor& bgColor,const QColor& textColor,
     const QColor& headerColor,const QFont& textFont,
     const QFont& headerFont, bool showComments);
+  /// Turn on/off auto-update of curves from table
+  void setUpdateCurvesFromTable(Table *table, bool on);
 
   void importASCII();
   void importASCII(const QStringList& files, int import_mode, const QString& local_column_separator, int local_ignored_lines, bool local_rename_columns,

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -3026,8 +3026,20 @@ void Graph::updateScale() {
     setXAxisTitle(mantidCurve->mantidData()->getXAxisLabel());
     setYAxisTitle(mantidCurve->mantidData()->getYAxisLabel());
   } else if (dataCurve && dataCurve->table()) {
-    setXAxisTitle(dataCurve->table()->colLabel(0));
-    setYAxisTitle(dataCurve->table()->colLabel(1).section(".", 0, 0));
+    auto xTitle = dataCurve->xColumnName();
+    auto yTitle = dataCurve->title().text();
+    // X, Y labels in form "Table-1_axisTitle" so split on '_'
+    auto cleanTitle = [](const QString &title) {
+      if (title.contains(QRegExp("^Table")) && title.contains('_')) {
+        return title.section('_', 1);
+      } else {
+        return title;
+      }
+    };
+    xTitle = cleanTitle(xTitle);
+    yTitle = cleanTitle(yTitle);
+    setXAxisTitle(xTitle);
+    setYAxisTitle(yTitle);
   }
 
   Spectrogram *spec = spectrogram();

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -88,9 +88,10 @@ void MantidTable::fillTable() {
     return;
   }
 
-  // temporarily allow resizing
+  // temporarily allow resizing and disable graph auto-update
   d_table->blockResizing(false);
   d_table->blockSignals(true);
+  applicationWindow()->setUpdateCurvesFromTable(this, false);
 
   setNumRows(0);
   setNumCols(0);
@@ -151,9 +152,11 @@ void MantidTable::fillTable() {
     setColumnWidth(i, maxWidth);
   }
 
-  // block resizing
+  // block resizing and turn auto-update back on
   d_table->blockResizing(true);
   d_table->blockSignals(false);
+  applicationWindow()->setUpdateCurvesFromTable(this, true);
+  this->notifyChanges();
 }
 
 /**

--- a/MantidPlot/src/PlotCurve.cpp
+++ b/MantidPlot/src/PlotCurve.cpp
@@ -404,7 +404,8 @@ bool DataCurve::updateData(Table *t, const QString &colName) {
                        colName != d_labels_column))
     return false;
 
-  loadData();
+  // Update data with all rows in table
+  setFullRange();
   return true;
 }
 

--- a/docs/source/release/v3.7.0/ui.rst
+++ b/docs/source/release/v3.7.0/ui.rst
@@ -117,6 +117,12 @@ Bugs Resolved
 
 -  VSI: The TECHNIQUE-DEPENDENT initial view now checks for Spectroscopy before Neutron Diffraction.
 
+-  Plots from tables: the axis labels correspond to the data plotted and not just the first two columns.
+
+-  Plots from tables: the title of the plot is the title of the TableWorkspace rather than the default "Table" (this is useful when several tables and plots are open)
+
+-  Plots from tables auto-update when the TableWorkspace is replaced in the ADS. If extra rows are added then the new points are added to the graph.
+
 SliceViewer Improvements
 ------------------------
 


### PR DESCRIPTION
Fixed three issues involved in plotting graphs from tables in MantidPlot as requested by scientists.

These are:
1.  **Axis labels**  
     Axis labels on the new graph correspond to the chosen X and Y, rather than just being the titles    of the first two columns. 
2.  **Graph title**  
    The title of the graph is the name of the TableWorkspace rather than the generic "Table".  
    This is particularly useful when plotting graphs from several different tables.
3.  **Auto-update**  
    When the TableWorkspace is replaced in the ADS, the GUI table updates itself. (This happened before, no change to this).  
   Any graphs based on that table should now update too, rather than just going blank as happened before.  
   The use case for this is the "Create Table" button on the MuonAnalysis result table tab - see issue.

Although this was requested by muon scientists, the changes should be general.

**To test:**
-  Use the following to create a new table in MantidPlot:
  
  ``` python
  tab = CreateEmptyTableWorkspace()
  tab.addColumn("int", "run_number", 6)  
  tab.addColumn("int", "sample_temp", 1)  
  tab.addColumn("double", "f0.A0", 2)        
  tab.addColumn("double", "f0.A0Error", 5) 
  tab.addRow([17295, 20, 50, 1])
  tab.addRow([17296, 30, 60, 1])
  tabl = importTableWorkspace('tab', True)
  ```
-  Highlight the X, Y, YErr columns and right-click. Select a "Plot" option.
  - Verify axis labels are `sample_temp` (X) and `f0.A0` (Y), not `run_number` and `sample_temp`
  - Verify the graph title is _tab_ rather than _Table_
- Edit a point programmatically and see it change on the graph to check this functionality isn't broken:

``` python
tabl.setCell(3, 2, 55)
tabl.notifyChanges()
```
-  Replace the table with a bigger one _that has the same columns_ and verify the graph now has four points (may need to rescale) and doesn't go blank:

``` python
tab = CreateEmptyTableWorkspace()
tab.addColumn("int", "run_number", 6)  
tab.addColumn("int", "sample_temp", 1)  
tab.addColumn("double", "f0.A0", 2)        
tab.addColumn("double", "f0.A0Error", 5)
tab.addRow([17295, 20, 50, 1])
tab.addRow([17296, 30, 60, 1])
tab.addRow([17297, 40, 70, 1])
tab.addRow([17298, 50, 70, 1])
```
-  Replace the table with one with different columns. The graph should go blank.

``` python
tab = CreateEmptyTableWorkspace()
tab.addColumn("int", "run_number", 6)  
tab.addColumn("int", "something_else", 1)  # this has changed
tab.addColumn("double", "f0.A0", 2)        
tab.addColumn("double", "f0.A0Error", 5)
tab.addRow([17295, 20, 50, 1])
tab.addRow([17296, 30, 60, 1])
tab.addRow([17297, 40, 70, 1])
tab.addRow([17298, 50, 70, 1])
```

Fixes #15226 

[Release notes](https://github.com/mantidproject/mantid/blob/cb30e35a1565f8ac8afb868e930a3f8f599e25bd/docs/source/release/v3.7.0/ui.rst#bugs-resolved) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
