### PR TITLE
Fix random failures of CrystalFieldTest on RHEL 6

### DIFF
--- a/Framework/CurveFitting/test/Functions/CrystalFieldTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldTest.h
@@ -27,6 +27,7 @@ public:
     DoubleFortranVector bmol(1, 3);
     DoubleFortranVector bext(1, 3);
     ComplexFortranMatrix bkq(0, 6, 0, 6);
+    zeroAllEntries(bmol, bext, bkq);
 
     bkq(2, 0) = 0.3365;
     bkq(2, 2) = 7.4851;
@@ -46,6 +47,7 @@ public:
     DoubleFortranVector bmol(1, 3);
     DoubleFortranVector bext(1, 3);
     ComplexFortranMatrix bkq(0, 6, 0, 6);
+    zeroAllEntries(bmol, bext, bkq);
 
     bmol(1) = 10.;
     bkq(2, 0) = 0.3365;
@@ -66,6 +68,7 @@ public:
     DoubleFortranVector bmol(1, 3);
     DoubleFortranVector bext(1, 3);
     ComplexFortranMatrix bkq(0, 6, 0, 6);
+    zeroAllEntries(bmol, bext, bkq);
 
     bmol(1) = 10.;
     bkq(2, 0) = 0.3365;
@@ -99,6 +102,13 @@ public:
   }
 
 private:
+  void zeroAllEntries(DoubleFortranVector &bmol, DoubleFortranVector &bext,
+                      ComplexFortranMatrix &bkq) {
+    bmol.zero();
+    bext.zero();
+    bkq.zero();
+  }
+
   void doTestEigensystem(DoubleFortranVector &en, ComplexFortranMatrix &wf,
                          ComplexFortranMatrix &ham) {
     const size_t n = en.size();


### PR DESCRIPTION
The CrystalFieldTest is failing intermittently on RHEL 6. This fixes the problem by ensuring that all vectors & matrices are zero initialized before feeding them to the calculation functions.

**To test:**
- Code review and agree that the zero initializers make sense.
- The failures only seem to show up on real hardware and did not manifest on a VM. Try rerunning the pull request build for RHEL 6 a few times. It should always pass.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
