### PR TITLE
Fix parameter errors display in fit property browser

### DIFF
--- a/MantidQt/MantidWidgets/src/FitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/FitPropertyBrowser.cpp
@@ -1171,7 +1171,7 @@ void FitPropertyBrowser::boolChanged(QtProperty *prop) {
     settings.beginGroup("Mantid/FitBrowser");
     settings.setValue(prop->propertyName(), val);
 
-    if (m_showParamErrors) {
+    if (prop == m_showParamErrors) {
       m_parameterManager->setErrorsEnabled(val);
     }
   } else { // it could be an attribute

--- a/docs/source/release/v3.7.0/ui.rst
+++ b/docs/source/release/v3.7.0/ui.rst
@@ -117,6 +117,8 @@ Bugs Resolved
 
 -  VSI: The TECHNIQUE-DEPENDENT initial view now checks for Spectroscopy before Neutron Diffraction.
 
+-  A bug was fixed in the Fit property browser where the "Plot Difference" and other checkboxes affected the display of parameter errors. Now only the "Show Parameter Errors" box will control this.
+
 -  Plots from tables: the axis labels correspond to the data plotted and not just the first two columns.
 
 -  Plots from tables: the title of the plot is the title of the TableWorkspace rather than the default "Table" (this is useful when several tables and plots are open)


### PR DESCRIPTION
Fix a bug where checking/unchecking "Plot difference", "Plot composite members" etc affected whether parameter errors were shown.

The only option that should control the display of errors is "Show parameter errors".

**To test:**
(build available at `\\olympic\babylon5\Scratch\TomPerkins\PR 15835`)
- Fit some data using the fit property browser
- Note that the errors are shown in parentheses e.g. 
  
  _A_         _0.091 (0.005)_
  _Lambda_ _0.363 (0.024)_
- Uncheck the "Plot difference" box (if checked)
  - Verify the errors _do not_ disappear
- Try other checkboxes in the fit property browser
  - Only "Show parameter errors" should turn errors on and off, the rest should not
- Re-run the fit with "Plot difference" unchecked and verify the difference is not plotted.
- Try the same test with the muon fit property browser:
  - open MuonAnalysis interface and use "Browse" to load a file (e.g. `MUSR00022725.nxs` from system test data)
  - Go to "Data Analysis" tab and fit something (e.g. `ExpDecayOsc`)
  - Do the same test as above with the "Plot difference" checkbox

Fixes #15734

[Release notes](https://github.com/mantidproject/mantid/blob/15734_PlotDifference_errors/docs/source/release/v3.7.0/ui.rst#bugs-resolved) have been updated

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Error display should only be controlled by "Show parameter errors" checkbox
and not by other boxes like "Plot Difference"
