### PR TITLE
Fix Coverity and Qt3Warnings issues from Reflectometry Interface Refactoring

### DIFF
--- a/MantidQt/CustomInterfaces/src/Reflectometry/QReflTableView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QReflTableView.cpp
@@ -359,7 +359,7 @@ std::string QReflTableView::askUserString(const std::string &prompt,
                                           const std::string &defaultValue) {
   bool ok;
   QString text = QInputDialog::getText(
-      QString::fromStdString(title), QString::fromStdString(prompt),
+      this, QString::fromStdString(title), QString::fromStdString(prompt),
       QLineEdit::Normal, QString::fromStdString(defaultValue), &ok);
   if (ok)
     return text.toStdString();

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
@@ -114,10 +114,7 @@ void QtReflMainView::setRowCommands(std::vector<ReflCommand_uptr> rowCommands) {
 /**
 * Clears all the actions (commands)
 */
-void QtReflMainView::clearCommands() {
-
-	m_commands.clear();
-}
+void QtReflMainView::clearCommands() { m_commands.clear(); }
 
 /**
 * Set all possible tranfer methods
@@ -271,7 +268,7 @@ std::string QtReflMainView::askUserString(const std::string &prompt,
                                           const std::string &defaultValue) {
   bool ok;
   QString text = QInputDialog::getText(
-      QString::fromStdString(title), QString::fromStdString(prompt),
+      this, QString::fromStdString(title), QString::fromStdString(prompt),
       QLineEdit::Normal, QString::fromStdString(defaultValue), &ok);
   if (ok)
     return text.toStdString();

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflTableViewPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflTableViewPresenter.cpp
@@ -136,7 +136,7 @@ namespace CustomInterfaces {
 ReflTableViewPresenter::ReflTableViewPresenter(ReflTableView *tableView,
                                                ProgressableView *progressView)
     : WorkspaceObserver(), m_tableView(tableView), m_progressView(progressView),
-      m_tableDirty(false) {
+      m_workspaceReceiver(), m_tableDirty(false) {
 
   // TODO. Select strategy.
   /*
@@ -145,7 +145,7 @@ ReflTableViewPresenter::ReflTableViewPresenter(ReflTableView *tableView,
   UserCatalogInfo catalogInfo(
   ConfigService::Instance().getFacility().catalogInfo(), *catConfigService);
   */
-
+  // Initialise m_workspaceReceiver
   // Initialise options
   initOptions();
 


### PR DESCRIPTION
Description of work.

**To test:**
- Run Qt3Warnings locally by enabling `WITH_QT3_SUPPORT_WARNINGS` option in Cmake
  and Building CustomInterfaces package.
- Ensure that no warnings appear for any cpp files in `../src/Reflectometry/.`
- If you can run Coverity locally then do so (I don't know how to do this). Failing that, merge the PR and wait for the email if Coverity complains about this fix.

Fixes #15819 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
