### PR TITLE
Run cleanup functions after system test completes

### DIFF
--- a/Testing/SystemTests/lib/systemtests/stresstesting.py
+++ b/Testing/SystemTests/lib/systemtests/stresstesting.py
@@ -567,6 +567,7 @@ sys.path.append('{1}')
 from {2} import {3}
 systest = {3}()
 systest.execute()
+systest.cleanup()
 sys.exit(systest.returnValidationCode({4}))'''
         return code.format(TESTING_FRAMEWORK_DIR, self._test_dir, self._modname,
                            self._test_cls_name, TestRunner.VALIDATION_FAIL_CODE)

--- a/Testing/SystemTests/lib/systemtests/stresstesting.py
+++ b/Testing/SystemTests/lib/systemtests/stresstesting.py
@@ -567,8 +567,9 @@ sys.path.append('{1}')
 from {2} import {3}
 systest = {3}()
 systest.execute()
+exitcode = systest.returnValidationCode({4})
 systest.cleanup()
-sys.exit(systest.returnValidationCode({4}))'''
+sys.exit(exitcode)'''
         return code.format(TESTING_FRAMEWORK_DIR, self._test_dir, self._modname,
                            self._test_cls_name, TestRunner.VALIDATION_FAIL_CODE)
 


### PR DESCRIPTION
The `cleanup` method on the system tests was not being executed after a recent [refactor](https://github.com/mantidproject/mantid/commit/4d4e94523cc1dba98d8b1b33bd367709f124bec1#diff-5247c1f456dfe545c21d1a44924ad807R572).

**To test:**

Run the `MDWorkpaceTests` system test. The `merged.nxs` file should be gone after the test completes.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
