### PR TITLE
Extended cow_ptr to be more like shared_ptr, in particular added support for NULL cow_ptr.

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/cow_ptr.h
+++ b/Framework/Kernel/inc/MantidKernel/cow_ptr.h
@@ -77,7 +77,7 @@ public:
   cow_ptr<DataType> &operator=(const ptr_type &);
 
   /// Returns the stored pointer.
-  DataType *get() const noexcept { return Data.get(); }
+  const DataType *get() const noexcept { return Data.get(); }
 
   /// Checks if *this stores a non-null pointer, i.e. whether get() != nullptr.
   explicit operator bool() const noexcept { return bool(Data); }

--- a/Framework/Kernel/inc/MantidKernel/cow_ptr.h
+++ b/Framework/Kernel/inc/MantidKernel/cow_ptr.h
@@ -68,11 +68,27 @@ public:
   cow_ptr(const ptr_type &resourceSptr);
   explicit cow_ptr(DataType *resourcePtr);
   cow_ptr();
+  /// Constructs a cow_ptr with no managed object, i.e. empty cow_ptr.
+  constexpr cow_ptr(std::nullptr_t) : Data(nullptr) {}
   cow_ptr(const cow_ptr<DataType> &);
   cow_ptr(cow_ptr<DataType> &&) = default;
   cow_ptr<DataType> &operator=(const cow_ptr<DataType> &);
   cow_ptr<DataType> &operator=(cow_ptr<DataType> &&) = default;
   cow_ptr<DataType> &operator=(const ptr_type &);
+
+  /// Returns the stored pointer.
+  DataType *get() const noexcept { return Data.get(); }
+
+  /// Checks if *this stores a non-null pointer, i.e. whether get() != nullptr.
+  explicit operator bool() const noexcept { return bool(Data); }
+
+  /// Returns the number of different shared_ptr instances (this included)
+  /// managing the current object. If there is no managed object, 0 is returned.
+  long use_count() const noexcept { return Data.use_count(); }
+
+  /// Checks if *this is the only shared_ptr instance managing the current
+  /// object, i.e. whether use_count() == 1.
+  bool unique() const noexcept { return Data.unique(); }
 
   const DataType &operator*() const {
     return *Data;
@@ -92,11 +108,7 @@ public:
  */
 template <typename DataType>
 cow_ptr<DataType>::cow_ptr(DataType *resourcePtr)
-    : Data(resourcePtr) {
-  if (resourcePtr == nullptr) {
-    throw std::invalid_argument("cow_ptr source pointer cannot be null");
-  }
-}
+    : Data(resourcePtr) {}
 
 /**
   Constructor : creates new data() object
@@ -171,17 +183,11 @@ template <typename DataType> DataType &cow_ptr<DataType>::access() {
 
 template <typename DataType>
 cow_ptr<DataType>::cow_ptr(ptr_type &&resourceSptr) {
-  if (resourceSptr.get() == nullptr) {
-    throw std::invalid_argument("cow_ptr source pointer cannot be null");
-  }
   this->Data = std::move(resourceSptr);
 }
 
 template <typename DataType>
 cow_ptr<DataType>::cow_ptr(const ptr_type &resourceSptr) {
-  if (resourceSptr.get() == nullptr) {
-    throw std::invalid_argument("cow_ptr source pointer cannot be null");
-  }
   this->Data = resourceSptr;
 }
 


### PR DESCRIPTION
Extended cow_ptr to be more like shared_ptr, in particular added support for NULL cow_ptr. A few (related) missing interface functions from `shared_ptr` were also added to make the interfaces more similar.

**To test:**

Code review.

Fixes #15844.

No release notes

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
