### PR TITLE
Don't modify PATH on importing some system test modules

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISIS_MAPS_DGSReduction.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_MAPS_DGSReduction.py
@@ -1,7 +1,5 @@
 #pylint: disable=invalid-name
 """ Sample MAPS reduction scrip """
-import os
-os.environ["PATH"] = r"c:\Mantid\Code\builds\br_master\bin\Release;" + os.environ["PATH"]
 from Direct.ReductionWrapper import *
 try:
     import reduce_vars as web_var
@@ -97,6 +95,8 @@ class ReduceMAPS(ReductionWrapper):
 
 #----------------------------------------------------------------------------------------------------------------------
 if __name__ == "__main__":
+    import os
+    os.environ["PATH"] = r"c:\Mantid\Code\builds\br_master\bin\Release;" + os.environ["PATH"]
 
     data_root = r'd:\Data\MantidDevArea\Datastore\DataCopies'
     data_dir  = os.path.join(data_root,r'Testing\Data\SystemTest')

--- a/Testing/SystemTests/tests/analysis/ISIS_MERLINReduction.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_MERLINReduction.py
@@ -1,8 +1,5 @@
 ﻿#pylint: disable=invalid-name
 """ Sample MERLIN reduction scrip """
-#import os
-#os.environ["PATH"] = r"c:/Mantid/Code/builds/br_master/bin/Release;"+os.environ["PATH"]
-
 from Direct.ReductionWrapper import *
 try:
     import reduce_vars as web_var
@@ -59,9 +56,10 @@ class ReduceMERLIN(ReductionWrapper):
         ReductionWrapper.__init__(self,'MER',web_var)
 #----------------------------------------------------------------------------------------------------------------------
 
-
-
 if __name__=="__main__":
+    #import os
+    #os.environ["PATH"] = r"c:/Mantid/Code/builds/br_master/bin/Release;"+os.environ["PATH"]
+
     #maps_dir = 'd:/Data/MantidSystemTests/Data'
     #data_dir ='d:/Data/Mantid_Testing/14_11_27'
     #ref_data_dir = 'd:/Data/MantidSystemTests/SystemTests/AnalysisTests/ReferenceResults'


### PR DESCRIPTION
Removes the modification of PATH when importing some system test files. This was causing problems for the system tests running under Jenkins on Ubuntu. This did not affect the other Linux distributions for some reason.

**To test:**

_Needs testing on an Ubuntu system_

Before merging locally you can reproduce the problem by running the following commands:

``` shell
cd build
PATH=/usr/bin:/bin ./systemtest -R CodeConv
```

The tests will fail with a permission denied error.

After merging the code the above snippet should work.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
