### PR TITLE
Modified class_maker.py for better subfolder support.

### DIFF
--- a/buildconfig/class_maker.py
+++ b/buildconfig/class_maker.py
@@ -24,7 +24,7 @@ def write_header(subproject, classname, filename, args):
     f = open(filename, 'w')
 
     subproject_upper = subproject.upper()
-    guard = "MANTID_%s_%s_H_" % (subproject_upper, classname.upper())
+    guard = "MANTID_%s_%s%s_H_" % (subproject_upper, args.subfolder.replace('/', '_').upper(), classname.upper())
 
     # Create an Algorithm header; will not use it if not an algo
     algorithm_header = """
@@ -177,7 +177,8 @@ def write_test(subproject, classname, filename, args):
     print "Writing test file to %s" % filename
     f = open(filename, 'w')
 
-    guard = "MANTID_%s_%sTEST_H_" % (subproject.upper(), classname.upper())
+    guard = "MANTID_%s_%s%sTEST_H_" % (subproject.upper(), args.subfolder.replace('/', '_').upper(), classname.upper())
+    testclassname = args.subfolder.translate(None, '/') + classname
     algorithm_test = """
   void test_Init()
   {
@@ -241,7 +242,7 @@ public:
 
 #endif /* %s */""" % (
           guard, guard, subproject, args.subfolder, classname,
-          subproject, classname, classname, classname, classname, classname,
+          subproject, classname, testclassname, testclassname, testclassname, testclassname,
           algorithm_test, guard)
     f.write(s)
     f.close()
@@ -317,7 +318,7 @@ def generate(subproject, classname, overwrite, args):
 
     headerfile = os.path.join(basedir, "inc", header_folder, args.subfolder + classname + ".h")
     sourcefile = os.path.join(basedir, "src", args.subfolder + classname + ".cpp")
-    testfile = os.path.join(basedir, "test", classname + "Test.h")
+    testfile = os.path.join(basedir, "test", args.subfolder + classname + "Test.h")
     #up two from the subproject basedir and then docs\source\algorithms
     mantiddir = os.path.dirname(os.path.dirname(basedir))
     rstfile = os.path.join(mantiddir, "docs", "source", "algorithms", classname + "-v1.rst")

--- a/buildconfig/cmakelists_utils.py
+++ b/buildconfig/cmakelists_utils.py
@@ -138,7 +138,7 @@ def add_to_cmake(subproject, classname, args, subfolder):
     if args.cpp:
         lines = redo_cmake_section(lines, "SRC_FILES", "src/" + subfolder + classname + ".cpp")
     if args.test:
-        lines = redo_cmake_section(lines, "TEST_FILES", classname + "Test.h")
+        lines = redo_cmake_section(lines, "TEST_FILES", subfolder + classname + "Test.h")
 
     f = open(cmake_path, 'w')
     text = "\n".join(lines)


### PR DESCRIPTION
Previous problems for subfolders (option `--subfolder`):
- include guards did not include subfolder name (in header and test)
- test file not placed in subfolder
- test name did not contain subfolder name

All this leads to potential naming clashes.

**To test:**

The changes here are a suggestion, please comment on whether you think they make sense:
- include guards are now, e.g., `MANTID_KERNEL_SUBFOLDER_CLASSNAME_H_`
- tests are placed in subfolders
- test names are `SubfolderClassnameTest`

Known issues:

`move_class.py` currently does not support moving _from_ the new style. Moves should automatically give the new style paths, however. Unless we intend to move all tests to their subdirectories, fixing `move_class.py` for support of both styles seems awkward and error prone, so I decided to leave it alone for now.

To test:
- make class
- make class in subfolder
- move existing class
- make sure the output files in all cases are ok

No corresponding issue.
No release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
