### PR TITLE
 Python Export for Unit::quickConversion

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
@@ -1,6 +1,7 @@
 #include "MantidKernel/Unit.h"
 
 #include <boost/python/class.hpp>
+#include <boost/python/tuple.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
 using Mantid::Kernel::Unit;
@@ -27,16 +28,23 @@ const std::string deprecatedLabel(Unit &self) {
              "'unit.label()' is deprecated, use 'str(unit.symbol())' instead.");
   return self.label().ascii();
 }
+
+template <class T>
+tuple quickConversionWrapper(Unit &self, const T &destUnitName) {
+  double wavelengthFactor = 0;
+  double wavelengthPower = 0;
+  bool converted =
+      self.quickConversion(destUnitName, wavelengthFactor, wavelengthPower);
+  if (!converted) {
+    throw std::runtime_error("Quick conversion is not possible for " +
+                             std::string(self.unitID()) +
+                             " to the desired unit.");
+  }
+  return boost::python::make_tuple<double>(wavelengthFactor, wavelengthPower);
+}
 }
 
 void export_Unit() {
-  // Function pointer typedef
-  // Unit version
-  typedef bool (Unit::*UnitVersion)(const Unit &destination, double &factor,
-                                    double &power) const;
-  // String version
-  typedef bool (Unit::*StringVersion)(std::string destUnitName, double &factor,
-                                      double &power) const;
 
   register_ptr_to_python<boost::shared_ptr<Unit>>();
 
@@ -55,12 +63,12 @@ void export_Unit() {
       .def("unitID", &Unit::unitID, arg("self"),
            "Returns the string ID of the unit. This may/may not match "
            "its name")
-      .def("quickConversion", (StringVersion)&Unit::quickConversion,
-           (arg("destUnitName"), arg("factor"), arg("power")),
+      .def("quickConversion", &quickConversionWrapper<Unit>,
+           (arg("self"), arg("destUnitName")),
            "Check whether the unit can be converted to another via a "
            "simple factor")
-      .def("quickConversion", (UnitVersion)&Unit::quickConversion,
-           (arg("destination"), arg("factor"), arg("power")),
+      .def("quickConversion", &quickConversionWrapper<std::string>,
+           (arg("self"), arg("destination")),
            "Check whether the unit can be converted to another via a "
            "simple factor");
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
@@ -30,6 +30,14 @@ const std::string deprecatedLabel(Unit &self) {
 }
 
 void export_Unit() {
+  // Function pointer typedef
+  // Unit version
+  typedef bool (Unit::*UnitVersion)(const Unit &destination, double &factor,
+                                    double &power) const;
+  // String version
+  typedef bool (Unit::*StringVersion)(std::string destUnitName, double &factor,
+                                      double &power) const;
+
   register_ptr_to_python<boost::shared_ptr<Unit>>();
 
   class_<Unit, boost::noncopyable>("Unit", no_init)
@@ -44,7 +52,15 @@ void export_Unit() {
       .def("symbol", &Unit::label, arg("self"),
            "Returns a UnitLabel object that holds "
            "information on the symbol to use for unit")
-      .def(
-          "unitID", &Unit::unitID, arg("self"),
-          "Returns the string ID of the unit. This may/may not match its name");
+      .def("unitID", &Unit::unitID, arg("self"),
+           "Returns the string ID of the unit. This may/may not match "
+           "its name")
+      .def("quickConversion", (StringVersion)&Unit::quickConversion,
+           (arg("destUnitName"), arg("factor"), arg("power")),
+           "Check whether the unit can be converted to another via a "
+           "simple factor")
+      .def("quickConversion", (UnitVersion)&Unit::quickConversion,
+           (arg("destination"), arg("factor"), arg("power")),
+           "Check whether the unit can be converted to another via a "
+           "simple factor");
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
@@ -36,7 +36,7 @@ tuple quickConversionWrapper(Unit &self, const T &destUnitName) {
   bool converted =
       self.quickConversion(destUnitName, wavelengthFactor, wavelengthPower);
   if (!converted) {
-    throw std::runtime_error("Quick conversion is not possible for " +
+    throw std::runtime_error("Quick conversion is not possible from unit:" +
                              std::string(self.unitID()) +
                              " to the desired unit.");
   }

--- a/Framework/PythonInterface/test/python/mantid/kernel/UnitsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/UnitsTest.py
@@ -27,10 +27,14 @@ class UnitsTest(unittest.TestCase):
         self.assertEquals(power, -0.5)
 
 # -------------  Failure cases  -------------------
-    def test_failure_quick_conversion_failure_with_bad_input(self):
+    def test_failure_quick_conversion_failure_with_same_input(self):
         energy = UnitFactory.Instance().create("Energy")
-        self.assertRaises(RuntimeError, energy.quickConversion(100))
-
+        try:
+            energy.quickConversion("Energy")
+        except RuntimeError:
+            pass
+        except:
+            self.fail('unexpected error.')
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/kernel/UnitsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/UnitsTest.py
@@ -29,12 +29,8 @@ class UnitsTest(unittest.TestCase):
 # -------------  Failure cases  -------------------
     def test_failure_quick_conversion_failure_with_same_input(self):
         energy = UnitFactory.Instance().create("Energy")
-        try:
-            energy.quickConversion("Energy")
-        except RuntimeError:
-            pass
-        except:
-            self.fail('unexpected error.')
+        self.assertRaises(RuntimeError, energy.quickConversion, "Energy")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/kernel/UnitsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/UnitsTest.py
@@ -13,5 +13,24 @@ class UnitsTest(unittest.TestCase):
         self.assertEquals("K", label_unit.label())
         self.assertTrue(isinstance(label_unit.symbol(), UnitLabel))
 
+    def test_quick_conversion_with_string_input(self):
+        energy = UnitFactory.Instance().create("Energy")
+        factor, power = energy.quickConversion("Wavelength")
+        self.assertAlmostEquals(factor, 9.04456756843)
+        self.assertEquals(power, -0.5)
+
+    def test_quick_conversion_with_unit_input(self):
+        energy = UnitFactory.Instance().create("Energy")
+        wavelength = UnitFactory.Instance().create("Wavelength")
+        factor, power = energy.quickConversion(wavelength)
+        self.assertAlmostEquals(factor, 9.04456756843)
+        self.assertEquals(power, -0.5)
+
+# -------------  Failure cases  -------------------
+    def test_failure_quick_conversion_failure_with_bad_input(self):
+        energy = UnitFactory.Instance().create("Energy")
+        self.assertRaises(RuntimeError, energy.quickConversion(100))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -118,6 +118,9 @@ Improved
 Python
 ------
 
+- It is now possible to use the unit.quickConversion(destinationUnit) functionality in python. If it is possible to convert one unit to another using a multiplication by a constant, this will return the factor and power required for the multiplication.
+
+
 Python Algorithms
 #################
 


### PR DESCRIPTION
It is now possible to use `unit.quickConversion(destination)` in python

**To test:**
- Ensure the tests pass
- Open the scripting window in Mantid and try this script:

```
energy = UnitFactory.Instance().create("Energy")
wavelength = UnitFactory.Instance().create("Wavelength")
factor, power = energy.quickConversion("Wavelength")
print factor
print power
factor, power = energy.quickConversion(wavelength)
print factor
print power
#factor, power = energy.quickConversion("Not a Real Unit")
print factor
print power
#factor, power = energy.quickConversion(1.111)
print factor
print power
```
- This should be sufficient to test that the change is working..

Fixes #15751.

[Release Notes](https://github.com/mantidproject/mantid/blob/15751_python_export_for_quick_conversion/docs/source/release/v3.7.0/framework.rst#python)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
