### PR TITLE
Engg GUI::Enable Fitting tab to Select/Add/Save peaks & zoom-in/out option

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>655</width>
-    <height>671</height>
+    <width>664</width>
+    <height>683</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -360,6 +360,13 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_select_peak">
+          <property name="text">
+           <string>Select Peak</string>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QPushButton" name="pushButton_add_peak">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -70,92 +70,6 @@
         </item>
        </layout>
       </item>
-      <item row="1" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QLabel" name="label_fitting_peaks">
-          <property name="text">
-           <string>Peaks:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_fitting_peaks">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>1</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="readOnly">
-           <bool>false</bool>
-          </property>
-          <property name="placeholderText">
-           <string>Leave Blank To Use Default Expected Peaks</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_fitting_browse_peaks">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Browse</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>238</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_fit">
-          <property name="minimumSize">
-           <size>
-            <width>100</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Fit</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="3" column="0">
-       <spacer name="verticalSpacer_5">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Maximum</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>28</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
       <item row="4" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
@@ -206,6 +120,92 @@
         </item>
        </layout>
       </item>
+      <item row="2" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>238</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_fit">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Fit</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <item>
+         <widget class="QLabel" name="label_fitting_peaks">
+          <property name="text">
+           <string>Peaks:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_fitting_peaks">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="readOnly">
+           <bool>false</bool>
+          </property>
+          <property name="placeholderText">
+           <string>Leave Blank To Use Default Expected Peaks</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_fitting_browse_peaks">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="3" column="0">
+       <spacer name="verticalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Maximum</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>28</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>
@@ -249,14 +249,14 @@
       <string>Preview</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="1">
+      <item row="0" column="3">
        <widget class="QLabel" name="label_qlist_bank">
         <property name="text">
          <string>Bank:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="1" column="0" colspan="3">
        <widget class="QwtPlot" name="dataPlot">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -278,7 +278,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="1" column="3">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
          <widget class="QListWidget" name="listWidget_fitting_bank_preview">
@@ -334,6 +334,57 @@
        </spacer>
       </item>
       <item row="2" column="1">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>187</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_peak_button">
+        <item>
+         <spacer name="horizontalSpacer_17">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>38</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_add_peak">
+          <property name="text">
+           <string>Add Peak</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_save_peak_list">
+          <property name="text">
+           <string>Save Peaks List</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_comboBox_fitting_bank_3">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="3">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -370,6 +370,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="pushButton_add_peak">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="text">
            <string>Add Peak</string>
           </property>
@@ -377,6 +380,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="pushButton_save_peak_list">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
           <property name="text">
            <string>Save Peaks List</string>
           </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -363,6 +363,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="pushButton_select_peak">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="text">
            <string>Select Peak</string>
           </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -172,9 +172,7 @@ public:
   void
   setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) override;
 
-  QPoint getQPoint();
-
-  double getPeakFwhm();
+  double getPeakCentre();
 
   void plotFocusedSpectrum(const std::string &wsName) override;
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -16,6 +16,11 @@
 #include <boost/scoped_ptr.hpp>
 #include <qwt_plot_curve.h>
 
+/// shahroz
+#include "MantidQtMantidWidgets/PeakPicker.h"
+#include "MantidAPI/IPeakFunction.h"
+
+
 // Qt classes forward declarations
 class QMutex;
 
@@ -177,6 +182,14 @@ public:
 
   int currentMultiRunMode() const override { return m_currentRunMode; }
 
+  Mantid::API::IPeakFunction_const_sptr peakPicker() const override;
+
+  /// @shahroz
+  void setPeakPickerEnabled(bool enabled) override;
+
+  // void setPeakPicker(const IPeakFunction_const_sptr &peak) override;
+
+
 private slots:
   /// for buttons, do calibrate, focus, event->histo rebin, and similar
   void loadCalibrationClicked();
@@ -233,6 +246,7 @@ private slots:
   void browsePeaksToFit();
   void fittingListWidgetBank(int idx);
   void setListWidgetBank(int idx);
+
 
   // show the standard Mantid help window with this interface's help
   void openHelpWin();
@@ -325,6 +339,10 @@ private:
 
   /// Loaded data curves
   std::vector<QwtPlotCurve *> m_fittedDataVector;
+
+  /// shahroz
+  /// Peak picker tool - only one on the plot at any given moment
+  MantidWidgets::PeakPicker *m_peakPicker;
 
   /// presenter as in the model-view-presenter
   boost::scoped_ptr<IEnggDiffractionPresenter> m_presenter;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -18,6 +18,7 @@
 
 /// shahroz
 #include "MantidQtMantidWidgets/PeakPicker.h"
+
 #include "MantidAPI/IPeakFunction.h"
 
 
@@ -187,8 +188,9 @@ public:
   /// @shahroz
   void setPeakPickerEnabled(bool enabled) override;
 
-  // void setPeakPicker(const IPeakFunction_const_sptr &peak) override;
+  void setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) override;
 
+  QPoint getQPoint();
 
 private slots:
   /// for buttons, do calibrate, focus, event->histo rebin, and similar
@@ -247,6 +249,8 @@ private slots:
   void fittingListWidgetBank(int idx);
   void setListWidgetBank(int idx);
 
+  /// @shahroz
+  void warningWithXY();
 
   // show the standard Mantid help window with this interface's help
   void openHelpWin();
@@ -312,6 +316,9 @@ private:
   int static m_currentRunMode;
 
   int static m_bank_Id;
+
+  /// @shahroz
+  QPoint static m_plotPos;
 
   /// current calibration produced in the 'Calibration' tab
   std::string m_currentCalibFilename;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -19,6 +19,7 @@
 /// shahroz
 #include "MantidQtMantidWidgets/PeakPicker.h"
 #include "MantidAPI/IPeakFunction.h"
+#include <qwt_plot_zoomer.h>
 
 // Qt classes forward declarations
 class QMutex;
@@ -164,9 +165,6 @@ public:
                          std::vector<QwtPlotCurve *> &dataVector, bool focused);
 
   /// @shahroz
-
-  Mantid::API::IPeakFunction_const_sptr peakPicker() const override;
-
   void setPeakPickerEnabled(bool enabled) override;
 
   void
@@ -255,6 +253,7 @@ private slots:
   void setPeakPick();
   void addPeakToList();
   void savePeakList();
+  void zoomToRange(const QwtDoubleRect &rect);
 
   // show the standard Mantid help window with this interface's help
   void openHelpWin();
@@ -354,6 +353,8 @@ private:
   /// shahroz
   /// Peak picker tool - only one on the plot at any given moment
   MantidWidgets::PeakPicker *m_peakPicker;
+
+  QwtPlotZoomer *m_zoomTool;
 
   /// presenter as in the model-view-presenter
   boost::scoped_ptr<IEnggDiffractionPresenter> m_presenter;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -169,7 +169,7 @@ public:
 
   double getPeakCentre() const;
 
-  void fittingWriteFile(std::string &fileDir);
+  void fittingWriteFile(const std::string &fileDir);
 
   void setZoomTool(bool enabled);
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -163,6 +163,19 @@ public:
   void dataCurvesFactory(std::vector<boost::shared_ptr<QwtData>> &data,
                          std::vector<QwtPlotCurve *> &dataVector, bool focused);
 
+  /// @shahroz
+
+  Mantid::API::IPeakFunction_const_sptr peakPicker() const override;
+
+  void setPeakPickerEnabled(bool enabled) override;
+
+  void
+  setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) override;
+
+  QPoint getQPoint();
+
+  double getPeakFwhm();
+
   void plotFocusedSpectrum(const std::string &wsName) override;
 
   void plotWaterfallSpectrum(const std::string &wsName) override;
@@ -180,15 +193,6 @@ public:
   int currentPlotType() const override { return m_currentType; }
 
   int currentMultiRunMode() const override { return m_currentRunMode; }
-
-  Mantid::API::IPeakFunction_const_sptr peakPicker() const override;
-
-  /// @shahroz
-  void setPeakPickerEnabled(bool enabled) override;
-
-  void setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) override;
-
-  QPoint getQPoint();
 
 private slots:
   /// for buttons, do calibrate, focus, event->histo rebin, and similar
@@ -249,7 +253,8 @@ private slots:
 
   /// @shahroz
   void setPeakPick();
-
+  void addPeakToList();
+  void savePeakList();
 
   // show the standard Mantid help window with this interface's help
   void openHelpWin();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -162,18 +162,18 @@ public:
   void dataCurvesFactory(std::vector<boost::shared_ptr<QwtData>> &data,
                          std::vector<QwtPlotCurve *> &dataVector, bool focused);
 
-  void setPeakPickerEnabled(bool enabled) override;
+  void setPeakPickerEnabled(bool enabled);
 
   void
-  setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) override;
+  setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak);
 
-  double getPeakCentre() const override;
+  double getPeakCentre() const;
 
-  void fittingWriteFile(std::string &fileDir) override;
+  void fittingWriteFile(std::string &fileDir);
 
-  void setZoomTool(bool enabled) override;
+  void setZoomTool(bool enabled);
 
-  void resetView() override;
+  void resetView();
 
   void plotFocusedSpectrum(const std::string &wsName) override;
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -2,9 +2,11 @@
 #define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFRACTIONVIEWQTGUI_H_
 
 #include "MantidQtAPI/UserSubWindow.h"
+#include "MantidAPI/IPeakFunction.h"
 #include "MantidQtCustomInterfaces/DllConfig.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h"
+#include "MantidQtMantidWidgets/PeakPicker.h"
 
 #include "ui_EnggDiffractionQtGUI.h"
 #include "ui_EnggDiffractionQtTabCalib.h"
@@ -15,10 +17,6 @@
 
 #include <boost/scoped_ptr.hpp>
 #include <qwt_plot_curve.h>
-
-/// shahroz
-#include "MantidQtMantidWidgets/PeakPicker.h"
-#include "MantidAPI/IPeakFunction.h"
 #include <qwt_plot_zoomer.h>
 
 // Qt classes forward declarations
@@ -164,7 +162,6 @@ public:
   void dataCurvesFactory(std::vector<boost::shared_ptr<QwtData>> &data,
                          std::vector<QwtPlotCurve *> &dataVector, bool focused);
 
-  /// @shahroz
   void setPeakPickerEnabled(bool enabled) override;
 
   void
@@ -172,11 +169,11 @@ public:
 
   double getPeakCentre() const override;
 
-  void fittingWriteFile(std::string &fileDir);
+  void fittingWriteFile(std::string &fileDir) override;
 
-  void setZoomTool(bool enabled);
+  void setZoomTool(bool enabled) override;
 
-  void resetView();
+  void resetView() override;
 
   void plotFocusedSpectrum(const std::string &wsName) override;
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -18,9 +18,7 @@
 
 /// shahroz
 #include "MantidQtMantidWidgets/PeakPicker.h"
-
 #include "MantidAPI/IPeakFunction.h"
-
 
 // Qt classes forward declarations
 class QMutex;
@@ -250,7 +248,8 @@ private slots:
   void setListWidgetBank(int idx);
 
   /// @shahroz
- // void warningWithXY();
+  void setPeakPick();
+
 
   // show the standard Mantid help window with this interface's help
   void openHelpWin();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -250,7 +250,7 @@ private slots:
   void setListWidgetBank(int idx);
 
   /// @shahroz
-  void warningWithXY();
+ // void warningWithXY();
 
   // show the standard Mantid help window with this interface's help
   void openHelpWin();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -170,9 +170,13 @@ public:
   void
   setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) override;
 
-  double getPeakCentre();
+  double getPeakCentre() const override;
 
   void fittingWriteFile(std::string &fileDir);
+
+  void setZoomTool(bool enabled);
+
+  void resetView();
 
   void plotFocusedSpectrum(const std::string &wsName) override;
 
@@ -248,12 +252,9 @@ private slots:
   void browsePeaksToFit();
   void fittingListWidgetBank(int idx);
   void setListWidgetBank(int idx);
-
-  /// @shahroz
   void setPeakPick();
   void addPeakToList();
   void savePeakList();
-  void zoomToRange(const QwtDoubleRect &rect);
 
   // show the standard Mantid help window with this interface's help
   void openHelpWin();
@@ -320,9 +321,6 @@ private:
 
   int static m_bank_Id;
 
-  /// @shahroz
-  QPoint static m_plotPos;
-
   /// current calibration produced in the 'Calibration' tab
   std::string m_currentCalibFilename;
   /// calibration settings - from/to the 'settings' tab
@@ -350,10 +348,10 @@ private:
   /// Loaded data curves
   std::vector<QwtPlotCurve *> m_fittedDataVector;
 
-  /// shahroz
-  /// Peak picker tool - only one on the plot at any given moment
+  /// Peak picker tool for fitting - only one on the plot at any given moment
   MantidWidgets::PeakPicker *m_peakPicker;
 
+  /// zoom-in/zoom-out tool for fitting
   QwtPlotZoomer *m_zoomTool;
 
   /// presenter as in the model-view-presenter

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -174,6 +174,8 @@ public:
 
   double getPeakCentre();
 
+  void fittingWriteFile(std::string &fileDir);
+
   void plotFocusedSpectrum(const std::string &wsName) override;
 
   void plotWaterfallSpectrum(const std::string &wsName) override;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -432,8 +432,6 @@ public:
 
   /// @shahroz
 
-  virtual Mantid::API::IPeakFunction_const_sptr peakPicker() const = 0;
-
   virtual void setPeakPickerEnabled(bool enabled) = 0;
 
   virtual void setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) = 0;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -436,8 +436,7 @@ public:
 
   virtual void setPeakPickerEnabled(bool enabled) = 0;
 
-  //virtual void setPeakPicker(const IPeakFunction_const_sptr &peak) = 0;
-
+  virtual void setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) = 0;
 
 };
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -430,12 +430,22 @@ public:
                                    const std::string &spectrum,
                                    const std::string &type) = 0;
 
-  /// @shahroz
-
+  /**
+  * Enables the peak picker tool
+  *
+  * @param enabled the values used to set the peak picker tool
+  */
   virtual void setPeakPickerEnabled(bool enabled) = 0;
 
-  virtual void setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) = 0;
+  /**
+  * Used to set the function to the widget
+  *
+  * @param peak is the function which will be applied to the widget
+  */
+  virtual void
+  setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) = 0;
 
+  virtual void
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -6,12 +6,9 @@
 #include <qwt_plot_curve.h>
 #include <QStringList>
 
+#include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffCalibSettings.h"
-
-/// @shahroz
-#include "MantidQtMantidWidgets/PeakPicker.h"
-#include "MantidAPI/IPeakFunction.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -445,7 +442,36 @@ public:
   virtual void
   setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) = 0;
 
-  virtual void
+  /**
+  * The value will be returned when the add peaks button will be
+  * clicked on the GUI
+  *
+  * @return centre value of the peak selected
+  */
+  virtual double getPeakCentre() const = 0;
+
+  /**
+  * The function will take a directory which will be used to
+  * write out a file with expected peaks
+  *
+  * @param fileDir is the directory of the file to write in
+  */
+  virtual void fittingWriteFile(std::string &fileDir) = 0;
+
+  /**
+  * Will be used to enable the zoom in/out feature to
+  * maintain the handling of the GUI
+  *
+  * @param enabled is a bool used to enable or disable GUI
+  */
+  virtual void setZoomTool(bool enabled) = 0;
+
+  /**
+  * Used to reset the view when a plot is fitted on the
+  * the GUI
+  *
+  */
+  virtual void resetView() = 0;
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -427,51 +427,9 @@ public:
                                    const std::string &spectrum,
                                    const std::string &type) = 0;
 
-  /**
-  * Enables the peak picker tool
-  *
-  * @param enabled the values used to set the peak picker tool
-  */
-  virtual void setPeakPickerEnabled(bool enabled) = 0;
 
-  /**
-  * Used to set the function to the widget
-  *
-  * @param peak is the function which will be applied to the widget
-  */
-  virtual void
-  setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) = 0;
 
-  /**
-  * The value will be returned when the add peaks button will be
-  * clicked on the GUI
-  *
-  * @return centre value of the peak selected
-  */
-  virtual double getPeakCentre() const = 0;
 
-  /**
-  * The function will take a directory which will be used to
-  * write out a file with expected peaks
-  *
-  * @param fileDir is the directory of the file to write in
-  */
-  virtual void fittingWriteFile(std::string &fileDir) = 0;
-
-  /**
-  * Will be used to enable the zoom in/out feature to
-  * maintain the handling of the GUI
-  *
-  * @param enabled is a bool used to enable or disable GUI
-  */
-  virtual void setZoomTool(bool enabled) = 0;
-
-  /**
-  * Used to reset the view when a plot is fitted on the
-  * the GUI
-  *
-  */
-  virtual void resetView() = 0;
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -9,6 +9,10 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffCalibSettings.h"
 
+/// @shahroz
+#include "MantidQtMantidWidgets/PeakPicker.h"
+#include "MantidAPI/IPeakFunction.h"
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -425,6 +429,16 @@ public:
   virtual void plotReplacingWindow(const std::string &wsName,
                                    const std::string &spectrum,
                                    const std::string &type) = 0;
+
+  /// @shahroz
+
+  virtual Mantid::API::IPeakFunction_const_sptr peakPicker() const = 0;
+
+  virtual void setPeakPickerEnabled(bool enabled) = 0;
+
+  //virtual void setPeakPicker(const IPeakFunction_const_sptr &peak) = 0;
+
+
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -1288,14 +1288,6 @@ void EnggDiffractionViewQtGUI::setListWidgetBank(int idx) {
   selectBank->setCurrentRow(idx);
 }
 
-void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::warningWithXY() {
-  auto x = getFittingPlotX();
-  auto y = getFittingPlotY();
-
-  userWarning("X and Y value: ", "the X value is:" + std::to_string(x) +
-                                     ". the Y value is: " + std::to_string(y));
-}
-
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {
   QComboBox *inst = m_ui.comboBox_instrument;
   if (!inst)

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -233,8 +233,7 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
 
   // add peak by clicking the button
   connect(m_uiTabFitting.pushButton_select_peak, SIGNAL(released()),
-	  SLOT(setPeakPick()));
-
+          SLOT(setPeakPick()));
 
   m_uiTabFitting.dataPlot->setCanvasBackground(Qt::white);
   m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::xBottom,
@@ -245,8 +244,10 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
   m_uiTabFitting.dataPlot->setAxisFont(QwtPlot::yLeft, font);
 
   // constructor of the peakPicker
-  // XXX: Being a QwtPlotItem, should get deleted when m_ui.plot gets deleted (auto-delete option)
-  m_peakPicker = new MantidWidgets::PeakPicker(m_uiTabFitting.dataPlot, Qt::red);
+  // XXX: Being a QwtPlotItem, should get deleted when m_ui.plot gets deleted
+  // (auto-delete option)
+  m_peakPicker =
+      new MantidWidgets::PeakPicker(m_uiTabFitting.dataPlot, Qt::red);
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabSettings() {
@@ -765,6 +766,35 @@ void EnggDiffractionViewQtGUI::dataCurvesFactory(
   data.clear();
 }
 
+/// @shahroz
+Mantid::API::IPeakFunction_const_sptr
+EnggDiffractionViewQtGUI::peakPicker() const {
+  return m_peakPicker->peak();
+}
+
+void EnggDiffractionViewQtGUI::setPeakPickerEnabled(bool enabled) {
+  m_peakPicker->setEnabled(enabled);
+  m_peakPicker->setVisible(enabled);
+  m_uiTabFitting.dataPlot->replot(); // PeakPicker might get hidden/shown
+}
+
+void EnggDiffractionViewQtGUI::setPeakPicker(
+    const IPeakFunction_const_sptr &peak) {
+  m_peakPicker->setPeak(peak);
+  m_uiTabFitting.dataPlot->replot();
+}
+
+QPoint EnggDiffractionViewQtGUI::getQPoint() {
+  auto pos = m_uiTabFitting.dataPlot->pos();
+  return pos;
+}
+
+double EnggDiffractionViewQtGUI::getPeakFwhm() {
+  auto peak = m_peakPicker->peak();
+  auto fwhm = peak->fwhm();
+  3 return fwhm;
+}
+
 void EnggDiffractionViewQtGUI::plotFocusedSpectrum(const std::string &wsName) {
   std::string pyCode =
       "win=plotSpectrum('" + wsName + "', 0, error_bars=False, type=0)";
@@ -905,29 +935,6 @@ std::string EnggDiffractionViewQtGUI::askExistingCalibFilename() {
 void EnggDiffractionViewQtGUI::loadCalibrationClicked() {
   m_presenter->notify(IEnggDiffractionPresenter::LoadExistingCalib);
 }
-
-Mantid::API::IPeakFunction_const_sptr
-EnggDiffractionViewQtGUI::peakPicker() const {
-  return m_peakPicker->peak();
-}
-
-void EnggDiffractionViewQtGUI::setPeakPickerEnabled(bool enabled) {
-  m_peakPicker->setEnabled(enabled);
-  m_peakPicker->setVisible(enabled);
-  m_uiTabFitting.dataPlot->replot(); // PeakPicker might get hidden/shown
-}
-
-void EnggDiffractionViewQtGUI::setPeakPicker(
-    const IPeakFunction_const_sptr &peak) {
-  m_peakPicker->setPeak(peak);
-  m_uiTabFitting.dataPlot->replot();
-}
-
-QPoint EnggDiffractionViewQtGUI::getQPoint() {
-  auto pos = m_uiTabFitting.dataPlot->pos();
-  return pos;
-}
-
 
 void EnggDiffractionViewQtGUI::calibrateClicked() {
   m_presenter->notify(IEnggDiffractionPresenter::CalcCalib);
@@ -1298,13 +1305,19 @@ void EnggDiffractionViewQtGUI::setListWidgetBank(int idx) {
   selectBank->setCurrentRow(idx);
 }
 
-void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::setPeakPick()
-{
-	auto bk2bk = FunctionFactory::Instance().createFunction("BackToBackExponential");
-	auto bk2bkFunc = boost::dynamic_pointer_cast<IPeakFunction>(bk2bk);
-	
-	setPeakPicker(bk2bkFunc);
-	setPeakPickerEnabled(true);
+void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::setPeakPick() {
+  auto bk2bk =
+      FunctionFactory::Instance().createFunction("BackToBackExponential");
+  auto bk2bkFunc = boost::dynamic_pointer_cast<IPeakFunction>(bk2bk);
+  // set the peak to BackToBackExponential function
+  setPeakPicker(bk2bkFunc);
+  setPeakPickerEnabled(true);
+}
+
+void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::addPeakToList() {}
+
+void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::savePeakList() {
+  // call function in EnggPresenter..
 }
 
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -66,7 +66,7 @@ const std::string EnggDiffractionViewQtGUI::m_settingsGroup =
 EnggDiffractionViewQtGUI::EnggDiffractionViewQtGUI(QWidget *parent)
     : UserSubWindow(parent), IEnggDiffractionView(), m_currentInst("ENGINX"),
       m_currentCalibFilename(""), m_focusedDataVector(), m_fittedDataVector(),
-      m_presenter(NULL) {}
+      m_peakPicker(NULL), m_presenter(NULL) {}
 
 EnggDiffractionViewQtGUI::~EnggDiffractionViewQtGUI() {
   for (auto curves : m_focusedDataVector) {
@@ -233,6 +233,9 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
   QFont font("MS Shell Dlg 2", 8);
   m_uiTabFitting.dataPlot->setAxisFont(QwtPlot::xBottom, font);
   m_uiTabFitting.dataPlot->setAxisFont(QwtPlot::yLeft, font);
+
+  m_peakPicker = new MantidWidgets::PeakPicker(m_uiTabFitting.dataPlot, Qt::red);
+
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabSettings() {
@@ -892,6 +895,26 @@ void EnggDiffractionViewQtGUI::loadCalibrationClicked() {
   m_presenter->notify(IEnggDiffractionPresenter::LoadExistingCalib);
 }
 
+
+Mantid::API::IPeakFunction_const_sptr EnggDiffractionViewQtGUI::peakPicker() const
+{
+	return m_peakPicker->peak();
+}
+
+void EnggDiffractionViewQtGUI::setPeakPickerEnabled(bool enabled)
+{
+	m_peakPicker->setEnabled(enabled);
+	m_peakPicker->setVisible(enabled);
+	m_uiTabFitting.dataPlot->replot(); // PeakPicker might get hidden/shown
+}
+
+/*
+void EnggDiffractionViewQtGUI::setPeakPicker(const IPeakFunction_const_sptr &peak)
+{
+	m_peakPicker->setPeak(peak);
+	m_uiTabFitting.dataPlot->replot();
+}
+*/
 void EnggDiffractionViewQtGUI::calibrateClicked() {
   m_presenter->notify(IEnggDiffractionPresenter::CalcCalib);
 }

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -235,6 +235,9 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
   connect(m_uiTabFitting.pushButton_select_peak, SIGNAL(released()),
           SLOT(setPeakPick()));
 
+  connect(m_uiTabFitting.pushButton_add_peak, SIGNAL(released()),
+          SLOT(addPeakToList()));
+
   m_uiTabFitting.dataPlot->setCanvasBackground(Qt::white);
   m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::xBottom,
                                         "Time-of-flight (us)");
@@ -784,15 +787,10 @@ void EnggDiffractionViewQtGUI::setPeakPicker(
   m_uiTabFitting.dataPlot->replot();
 }
 
-QPoint EnggDiffractionViewQtGUI::getQPoint() {
-  auto pos = m_uiTabFitting.dataPlot->pos();
-  return pos;
-}
-
-double EnggDiffractionViewQtGUI::getPeakFwhm() {
+double EnggDiffractionViewQtGUI::getPeakCentre() {
   auto peak = m_peakPicker->peak();
-  auto fwhm = peak->fwhm();
-  3 return fwhm;
+  auto centre = peak->centre();
+  return centre;
 }
 
 void EnggDiffractionViewQtGUI::plotFocusedSpectrum(const std::string &wsName) {
@@ -1314,7 +1312,25 @@ void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::setPeakPick() {
   setPeakPickerEnabled(true);
 }
 
-void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::addPeakToList() {}
+void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::addPeakToList() {
+
+  auto peakCentre = getPeakCentre();
+
+  auto strPeakCentre = boost::lexical_cast<std::string>(peakCentre);
+
+  auto curExpPeaksList = m_uiTabFitting.lineEdit_fitting_peaks->text();
+
+  std::string expPeakStr = curExpPeaksList.toStdString();
+
+  std::size_t found = expPeakStr.find_last_of(", ");
+  if (found) {
+    QString comma = ", ";
+    curExpPeaksList.append(comma + QString::fromStdString(strPeakCentre));
+  } else {
+    curExpPeaksList.append(QString::fromStdString(strPeakCentre));
+  }
+  m_uiTabFitting.lineEdit_fitting_peaks->setText(curExpPeaksList);
+}
 
 void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::savePeakList() {
   // call function in EnggPresenter..

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -777,8 +777,9 @@ void EnggDiffractionViewQtGUI::dataCurvesFactory(
 
   m_uiTabFitting.dataPlot->replot();
   m_zoomTool->setZoomBase();
-  // enable zoom after the plotting on graph
+  // enable zoom & select peak btn after the plotting on graph
   setZoomTool(true);
+  m_uiTabFitting.pushButton_select_peak->setEnabled(true);
   data.clear();
 }
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -254,6 +254,8 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
   // (auto-delete option)
   m_peakPicker =
       new MantidWidgets::PeakPicker(m_uiTabFitting.dataPlot, Qt::red);
+
+  setPeakPickerEnabled(false);
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabSettings() {
@@ -1323,22 +1325,29 @@ void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::setPeakPick() {
 
 void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::addPeakToList() {
 
-  auto peakCentre = getPeakCentre();
+	if (m_peakPicker->isEnabled()) {
+		auto peakCentre = getPeakCentre();
 
-  auto strPeakCentre = boost::lexical_cast<std::string>(peakCentre);
+		std::stringstream stream;
+		stream << std::fixed << std::setprecision(4) << peakCentre;
+		auto strPeakCentre = stream.str();
 
-  auto curExpPeaksList = m_uiTabFitting.lineEdit_fitting_peaks->text();
+		auto curExpPeaksList = m_uiTabFitting.lineEdit_fitting_peaks->text();
 
-  std::string expPeakStr = curExpPeaksList.toStdString();
+		if (!curExpPeaksList.isEmpty()) {
 
-  std::size_t found = expPeakStr.find_last_of(", ");
-  if (found) {
-    QString comma = ", ";
-    curExpPeaksList.append(comma + QString::fromStdString(strPeakCentre));
-  } else {
-    curExpPeaksList.append(QString::fromStdString(strPeakCentre));
-  }
-  m_uiTabFitting.lineEdit_fitting_peaks->setText(curExpPeaksList);
+			std::string expPeakStr = curExpPeaksList.toStdString();
+			std::size_t found = (expPeakStr.find_last_of(", ") || expPeakStr.find_last_of(","));
+			if (found) {
+				QString comma = ", ";
+				curExpPeaksList.append(comma + QString::fromStdString(strPeakCentre));
+			}
+			else {
+				curExpPeaksList.append(QString::fromStdString(strPeakCentre));
+			}
+			m_uiTabFitting.lineEdit_fitting_peaks->setText(curExpPeaksList);
+		}
+	}
 }
 
 void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::savePeakList() {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -25,6 +25,9 @@ using namespace MantidQt::CustomInterfaces;
 
 #include <qwt_symbol.h>
 
+/// shahroz
+
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -205,9 +208,6 @@ void EnggDiffractionViewQtGUI::doSetupTabPreproc() {
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabFitting() {
-  // constructor of the peakPicker
-  m_peakPicker =
-      new MantidWidgets::PeakPicker(m_uiTabFitting.dataPlot, Qt::red);
 
   connect(m_uiTabFitting.pushButton_fitting_browse_run_num, SIGNAL(released()),
           this, SLOT(browseFitFocusedRun()));
@@ -231,6 +231,12 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
   connect(m_uiTabFitting.listWidget_fitting_bank_preview,
           SIGNAL(currentRowChanged(int)), this, SLOT(setBankIdComboBox(int)));
 
+  // add peak by clicking the button
+  connect(m_uiTabFitting.pushButton_add_peak, SIGNAL(released()),
+	  SLOT(enablePeakPick()));
+
+  //connect(m_peakPicker, SIGNAL(changed()), 
+
   m_uiTabFitting.dataPlot->setCanvasBackground(Qt::white);
   m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::xBottom,
                                         "Time-of-flight (us)");
@@ -238,6 +244,12 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
   QFont font("MS Shell Dlg 2", 8);
   m_uiTabFitting.dataPlot->setAxisFont(QwtPlot::xBottom, font);
   m_uiTabFitting.dataPlot->setAxisFont(QwtPlot::yLeft, font);
+
+  // constructor of the peakPicker
+  // XXX: Being a QwtPlotItem, should get deleted when m_ui.plot gets deleted (auto-delete option)
+  m_peakPicker = new MantidWidgets::PeakPicker(m_uiTabFitting.dataPlot, Qt::red);
+  /// shahroz : causing crash
+  setPeakPickerEnabled(true);
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabSettings() {
@@ -919,6 +931,7 @@ QPoint EnggDiffractionViewQtGUI::getQPoint() {
   return pos;
 }
 
+
 void EnggDiffractionViewQtGUI::calibrateClicked() {
   m_presenter->notify(IEnggDiffractionPresenter::CalcCalib);
 }
@@ -1286,6 +1299,15 @@ void EnggDiffractionViewQtGUI::setListWidgetBank(int idx) {
 
   QListWidget *selectBank = m_uiTabFitting.listWidget_fitting_bank_preview;
   selectBank->setCurrentRow(idx);
+}
+
+void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::enablePeakPick()
+{
+	auto ourFunc = FunctionFactory::Instance().createFunction("BackToBackExponential");
+	auto backtoback = boost::dynamic_pointer_cast<IPeakFunction>(ourFunc);
+	
+	setPeakPicker(backtoback);
+	setPeakPickerEnabled(true);
 }
 
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -26,7 +26,7 @@ using namespace MantidQt::CustomInterfaces;
 #include <qwt_symbol.h>
 
 /// shahroz
-
+#include "MantidAPI/FunctionFactory.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -232,10 +232,9 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
           SIGNAL(currentRowChanged(int)), this, SLOT(setBankIdComboBox(int)));
 
   // add peak by clicking the button
-  connect(m_uiTabFitting.pushButton_add_peak, SIGNAL(released()),
-	  SLOT(enablePeakPick()));
+  connect(m_uiTabFitting.pushButton_select_peak, SIGNAL(released()),
+	  SLOT(setPeakPick()));
 
-  //connect(m_peakPicker, SIGNAL(changed()), 
 
   m_uiTabFitting.dataPlot->setCanvasBackground(Qt::white);
   m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::xBottom,
@@ -248,8 +247,6 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
   // constructor of the peakPicker
   // XXX: Being a QwtPlotItem, should get deleted when m_ui.plot gets deleted (auto-delete option)
   m_peakPicker = new MantidWidgets::PeakPicker(m_uiTabFitting.dataPlot, Qt::red);
-  /// shahroz : causing crash
-  setPeakPickerEnabled(true);
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabSettings() {
@@ -1301,12 +1298,12 @@ void EnggDiffractionViewQtGUI::setListWidgetBank(int idx) {
   selectBank->setCurrentRow(idx);
 }
 
-void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::enablePeakPick()
+void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::setPeakPick()
 {
-	auto ourFunc = FunctionFactory::Instance().createFunction("BackToBackExponential");
-	auto backtoback = boost::dynamic_pointer_cast<IPeakFunction>(ourFunc);
+	auto bk2bk = FunctionFactory::Instance().createFunction("BackToBackExponential");
+	auto bk2bkFunc = boost::dynamic_pointer_cast<IPeakFunction>(bk2bk);
 	
-	setPeakPicker(backtoback);
+	setPeakPicker(bk2bkFunc);
 	setPeakPickerEnabled(true);
 }
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -259,7 +259,6 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
       QwtPicker::AlwaysOff, m_uiTabFitting.dataPlot->canvas());
   m_zoomTool->setRubberBandPen(QPen(Qt::black));
   setZoomTool(false);
-
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabSettings() {
@@ -747,7 +746,7 @@ void EnggDiffractionViewQtGUI::dataCurvesFactory(
 
   if (dataVector.size() > 0)
     dataVector.clear();
-	resetView();
+  resetView();
 
   // dark colours could be removed so the colored peaks stand out more
   const std::array<QColor, 16> QPenList{
@@ -807,25 +806,23 @@ double EnggDiffractionViewQtGUI::getPeakCentre() const {
 }
 
 void EnggDiffractionViewQtGUI::fittingWriteFile(std::string &fileDir) {
-  auto outfile = std::ofstream(fileDir);
+  auto outfile = std::ofstream(fileDir.c_str());
   auto expPeaks = m_uiTabFitting.lineEdit_fitting_peaks->text();
   outfile << expPeaks.toStdString();
 }
 
-void EnggDiffractionViewQtGUI::setZoomTool(bool enabled)
-{
-	m_zoomTool->setEnabled(enabled);
+void EnggDiffractionViewQtGUI::setZoomTool(bool enabled) {
+  m_zoomTool->setEnabled(enabled);
 }
 
-void EnggDiffractionViewQtGUI::resetView()
-{
-	// Resets the view to a sensible default
-	// Auto scale the axis
-	m_uiTabFitting.dataPlot->setAxisAutoScale(QwtPlot::xBottom);
-	m_uiTabFitting.dataPlot->setAxisAutoScale(QwtPlot::yLeft);
+void EnggDiffractionViewQtGUI::resetView() {
+  // Resets the view to a sensible default
+  // Auto scale the axis
+  m_uiTabFitting.dataPlot->setAxisAutoScale(QwtPlot::xBottom);
+  m_uiTabFitting.dataPlot->setAxisAutoScale(QwtPlot::yLeft);
 
-	// Set this as the default zoom level
-	m_zoomTool->setZoomBase(true);
+  // Set this as the default zoom level
+  m_zoomTool->setZoomBase(true);
 }
 
 void EnggDiffractionViewQtGUI::plotFocusedSpectrum(const std::string &wsName) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -784,6 +784,8 @@ void EnggDiffractionViewQtGUI::setPeakPickerEnabled(bool enabled) {
   m_peakPicker->setEnabled(enabled);
   m_peakPicker->setVisible(enabled);
   m_uiTabFitting.dataPlot->replot(); // PeakPicker might get hidden/shown
+  m_uiTabFitting.pushButton_add_peak->setEnabled(enabled);
+  m_uiTabFitting.pushButton_select_peak->setEnabled(!enabled);
 }
 
 void EnggDiffractionViewQtGUI::setPeakPicker(
@@ -1325,29 +1327,30 @@ void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::setPeakPick() {
 
 void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::addPeakToList() {
 
-	if (m_peakPicker->isEnabled()) {
-		auto peakCentre = getPeakCentre();
+  if (m_peakPicker->isEnabled()) {
+    auto peakCentre = getPeakCentre();
 
-		std::stringstream stream;
-		stream << std::fixed << std::setprecision(4) << peakCentre;
-		auto strPeakCentre = stream.str();
+    std::stringstream stream;
+    stream << std::fixed << std::setprecision(4) << peakCentre;
+    auto strPeakCentre = stream.str();
 
-		auto curExpPeaksList = m_uiTabFitting.lineEdit_fitting_peaks->text();
+    auto curExpPeaksList = m_uiTabFitting.lineEdit_fitting_peaks->text();
 
-		if (!curExpPeaksList.isEmpty()) {
+    if (!curExpPeaksList.isEmpty()) {
 
-			std::string expPeakStr = curExpPeaksList.toStdString();
-			std::size_t found = (expPeakStr.find_last_of(", ") || expPeakStr.find_last_of(","));
-			if (found) {
-				QString comma = ", ";
-				curExpPeaksList.append(comma + QString::fromStdString(strPeakCentre));
-			}
-			else {
-				curExpPeaksList.append(QString::fromStdString(strPeakCentre));
-			}
-			m_uiTabFitting.lineEdit_fitting_peaks->setText(curExpPeaksList);
-		}
-	}
+      std::string expPeakStr = curExpPeaksList.toStdString();
+      std::string lastTwoChr = expPeakStr.substr(expPeakStr.size() - 2);
+      auto lastChr = expPeakStr.back();
+      char comma = ',';
+      if (lastChr == comma || lastTwoChr == ", ") {
+        curExpPeaksList.append(QString::fromStdString(" " + strPeakCentre));
+      } else {
+        QString comma = ", ";
+        curExpPeaksList.append(comma + QString::fromStdString(strPeakCentre));
+      }
+      m_uiTabFitting.lineEdit_fitting_peaks->setText(curExpPeaksList);
+    }
+  }
 }
 
 void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::savePeakList() {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -805,10 +805,16 @@ double EnggDiffractionViewQtGUI::getPeakCentre() const {
   return centre;
 }
 
-void EnggDiffractionViewQtGUI::fittingWriteFile(std::string &fileDir) {
-  auto outfile = std::ofstream(fileDir.c_str());
-  auto expPeaks = m_uiTabFitting.lineEdit_fitting_peaks->text();
-  outfile << expPeaks.toStdString();
+void EnggDiffractionViewQtGUI::fittingWriteFile(const std::string &fileDir) {
+  auto *stream_c_str = fileDir.c_str();
+  auto outfile = std::ofstream(stream_c_str);
+  if (!outfile) {
+    userWarning("File not found",
+                "File " + fileDir + " , could not be found. Please try again!");
+  } else {
+    auto expPeaks = m_uiTabFitting.lineEdit_fitting_peaks->text();
+    outfile << expPeaks.toStdString();
+  }
 }
 
 void EnggDiffractionViewQtGUI::setZoomTool(bool enabled) {
@@ -1389,7 +1395,7 @@ void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::savePeakList() {
     if (path.isEmpty()) {
       return;
     }
-    std::string strPath = path.toStdString();
+    const std::string strPath = path.toStdString();
     fittingWriteFile(strPath);
   } catch (...) {
     userWarning("Unable to save the peaks file: ",

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -806,8 +806,7 @@ double EnggDiffractionViewQtGUI::getPeakCentre() const {
 }
 
 void EnggDiffractionViewQtGUI::fittingWriteFile(const std::string &fileDir) {
-  auto *stream_c_str = fileDir.c_str();
-  auto outfile = std::ofstream(stream_c_str);
+  std::ofstream outfile(fileDir.c_str());
   if (!outfile) {
     userWarning("File not found",
                 "File " + fileDir + " , could not be found. Please try again!");

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -35,6 +35,7 @@ int EnggDiffractionViewQtGUI::m_currentType = 0;
 int EnggDiffractionViewQtGUI::m_currentRunMode = 0;
 int EnggDiffractionViewQtGUI::m_currentCropCalibBankName = 0;
 int EnggDiffractionViewQtGUI::m_bank_Id = 0;
+QPoint EnggDiffractionViewQtGUI::m_plotPos = QPoint(0, 0);
 
 const std::string EnggDiffractionViewQtGUI::g_iparmExtStr =
     "GSAS instrument parameters, IPARM file: PRM, PAR, IPAR, IPARAM "
@@ -204,6 +205,10 @@ void EnggDiffractionViewQtGUI::doSetupTabPreproc() {
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabFitting() {
+  // constructor of the peakPicker
+  m_peakPicker =
+      new MantidWidgets::PeakPicker(m_uiTabFitting.dataPlot, Qt::red);
+
   connect(m_uiTabFitting.pushButton_fitting_browse_run_num, SIGNAL(released()),
           this, SLOT(browseFitFocusedRun()));
 
@@ -233,9 +238,6 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
   QFont font("MS Shell Dlg 2", 8);
   m_uiTabFitting.dataPlot->setAxisFont(QwtPlot::xBottom, font);
   m_uiTabFitting.dataPlot->setAxisFont(QwtPlot::yLeft, font);
-
-  m_peakPicker = new MantidWidgets::PeakPicker(m_uiTabFitting.dataPlot, Qt::red);
-
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabSettings() {
@@ -895,26 +897,28 @@ void EnggDiffractionViewQtGUI::loadCalibrationClicked() {
   m_presenter->notify(IEnggDiffractionPresenter::LoadExistingCalib);
 }
 
-
-Mantid::API::IPeakFunction_const_sptr EnggDiffractionViewQtGUI::peakPicker() const
-{
-	return m_peakPicker->peak();
+Mantid::API::IPeakFunction_const_sptr
+EnggDiffractionViewQtGUI::peakPicker() const {
+  return m_peakPicker->peak();
 }
 
-void EnggDiffractionViewQtGUI::setPeakPickerEnabled(bool enabled)
-{
-	m_peakPicker->setEnabled(enabled);
-	m_peakPicker->setVisible(enabled);
-	m_uiTabFitting.dataPlot->replot(); // PeakPicker might get hidden/shown
+void EnggDiffractionViewQtGUI::setPeakPickerEnabled(bool enabled) {
+  m_peakPicker->setEnabled(enabled);
+  m_peakPicker->setVisible(enabled);
+  m_uiTabFitting.dataPlot->replot(); // PeakPicker might get hidden/shown
 }
 
-/*
-void EnggDiffractionViewQtGUI::setPeakPicker(const IPeakFunction_const_sptr &peak)
-{
-	m_peakPicker->setPeak(peak);
-	m_uiTabFitting.dataPlot->replot();
+void EnggDiffractionViewQtGUI::setPeakPicker(
+    const IPeakFunction_const_sptr &peak) {
+  m_peakPicker->setPeak(peak);
+  m_uiTabFitting.dataPlot->replot();
 }
-*/
+
+QPoint EnggDiffractionViewQtGUI::getQPoint() {
+  auto pos = m_uiTabFitting.dataPlot->pos();
+  return pos;
+}
+
 void EnggDiffractionViewQtGUI::calibrateClicked() {
   m_presenter->notify(IEnggDiffractionPresenter::CalcCalib);
 }
@@ -1282,6 +1286,14 @@ void EnggDiffractionViewQtGUI::setListWidgetBank(int idx) {
 
   QListWidget *selectBank = m_uiTabFitting.listWidget_fitting_bank_preview;
   selectBank->setCurrentRow(idx);
+}
+
+void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::warningWithXY() {
+  auto x = getFittingPlotX();
+  auto y = getFittingPlotY();
+
+  userWarning("X and Y value: ", "the X value is:" + std::to_string(x) +
+                                     ". the Y value is: " + std::to_string(y));
 }
 
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {

--- a/docs/source/interfaces/Engineering_Diffraction.rst
+++ b/docs/source/interfaces/Engineering_Diffraction.rst
@@ -323,7 +323,7 @@ workspaces window:
 
 Preview
 ^^^^^^^
-Once the fitting process has completed and the you are able to view a
+Once the fitting process has completed and you are able to view a
 focused workspace with listed expected peaks on the data plot, Select
 Peak button should should also be enabled.
 By clicking Select Peak button the peak picker tool can be activated.

--- a/docs/source/interfaces/Engineering_Diffraction.rst
+++ b/docs/source/interfaces/Engineering_Diffraction.rst
@@ -290,6 +290,8 @@ Focused Run #:
   directory can be set in the :ref:`setting-Engineering_Diffraction-ref`
   tab under the *Focusing settings* section.
 
+.. _ExpectedPeaks-Engineering_Diffraction-ref:
+
 Peaks:
   A list of dSpacing values to be translated into TOF to find expected
   peaks. These peaks can be manually written or imported by selecting a
@@ -304,6 +306,9 @@ tab plots the focused workspace in the background in black, whereas the
 expected peaks plotted in various colours over lapping the focused
 workspace peaks.
 
+Within the :ref:`Preview-Engineering_Diffraction-ref` section user is
+able to zoom-in or zoom-out as well as select, add and save peaks.
+
 The interface will also generate workspaces that can be inspected in the
 workspaces window:
 
@@ -313,6 +318,29 @@ workspaces window:
    so the fitted data can be compared with focused data
 3. The *engggui_fitting_single_peaks* workspace within each workspace
    index representing individual expected peak.
+
+.. _Preview-Engineering_Diffraction-ref:
+
+Preview
+^^^^^^^
+Once the fitting process has completed and the you are able to view a
+focused workspace with listed expected peaks on the data plot, Select
+Peak button should should also be enabled.
+By clicking Select Peak button the peak picker tool can be activated.
+To select a peak simply hold *Shift* key and left-click on the graph
+near the peak's center.
+
+To get help selecting the center of the peak, you may set the peak
+width by left-click and drag horizontally, while holding *Ctrl* key
+as well. User may also zoom-in to the graph by holding left-click
+and dragging on the plot, whereas zoom-out by simple left-click on
+the plot.
+
+When user is satisfied with the center position of the peak, you may
+add the selected peak to :ref:`ExpectedPeaks-Engineering_Diffraction-ref`
+list by clicking Add Peak button. User may rerun Fit process with
+the new selected peaks or save the peaks list as *CSV* file by clicking
+Save Peak List button.
 
 .. _setting-Engineering_Diffraction-ref:
 

--- a/docs/source/release/v3.7.0/diffraction.rst
+++ b/docs/source/release/v3.7.0/diffraction.rst
@@ -22,6 +22,11 @@ Engineering Diffraction
   The pastern is specified by providing a list of dSpacing values where Bragg peaks are expected. The algorithm
   :ref:`EnggFitPeaks<algm-EnggFitPeaks>` used in the background fit peaks in those areas using a peak fitting function.
 
+- Improvements to the :ref:`Preview-Engineering_Diffraction-ref` section
+  for Fitting tab, the zoom-in or zoom-out feature on to the data plot
+  is enabled. As well as option to select peak, add peak or save peaks
+  from the data plot is now supported.
+
 Imaging
 -------
 


### PR DESCRIPTION
**Description of work.**

This branch improves the `Preview` section from the `Fitting tab`, upon completion of Fitting process, an option to `select`, `add` and `save` peak from the data plot of the focused workspace will be enabled. The peaks selected will be added to the `Peak` text-field so it can be utilised to either rerun `Fit` or save the peaks as _CSV_ file. The branch also supports option to `zoom-in` or `zoom-out` of the data plot once plots have been fitted, more details description can be found in documentation file.

**To test:**
Files can be found at: `\\olympic\Babylon5\Public\Shahroz\`
Select a focused file to Fit : `ENGINX_241391_focused_texture_bank_3.nxs`
Add peaks: `3.1243,2.7057,1.9132` _or leave blank_
Check with empty plot:
 `Select Peak` and `Add Peak` buttons are disabled
 `Zoom-in` feature is disabled
Click `Fit`

Once Fit process completed:
1. Test the `zoom-in` feature
   `zoom-in` by left click and drag on plot
   `zoom-out` by right click on plot
2. Click `Select Peak` button
   This should enable the `peak picking tool`
   Test feature by holding `shift` key and `left click` on graph
   Increase the width of the tool by using `Ctrl` key and dragging horizontally
3. Once centre of peak selected:
   Click `Add Peak` button
   Which should add the selected peak to `Peaks` text-field 
   The integer should be to 4 d.p.
   _(Units are required to be changed to dSpacing)_ #15766
   Unless it can be `Fit` again to plot
   or
4. Peaks can be saved as `.csv` file by clicking `Save Peak List` button

Documentation update
Code Check

<!-- Instructions for testing. -->

Fixes #15765.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

[Release Notes](https://github.com/mantidproject/mantid/blob/15ab5125dc809b610c34fb059b2cd449178fc6f0/docs/source/release/v3.7.0/diffraction.rst)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
