### PR TITLE
Use _WIN32 macro definition.

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadANSTOHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadANSTOHelper.h
@@ -123,7 +123,7 @@ public:
 
 class FastReadOnlyFile {
 private:
-#ifdef WIN32
+#ifdef _WIN32
   HANDLE m_handle;
 #else
   FILE *m_handle;

--- a/Framework/DataHandling/src/LoadANSTOHelper.cpp
+++ b/Framework/DataHandling/src/LoadANSTOHelper.cpp
@@ -139,7 +139,7 @@ void EventAssigner::addEventImpl(size_t id, double tof) {
 }
 
 // FastReadOnlyFile
-#ifdef WIN32
+#ifdef _WIN32
 FastReadOnlyFile::FastReadOnlyFile(const char *filename) {
   m_handle = CreateFileA(filename, GENERIC_READ, FILE_SHARE_READ, NULL,
                          OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);

--- a/Framework/DataHandling/test/FindDetectorsParTest.h
+++ b/Framework/DataHandling/test/FindDetectorsParTest.h
@@ -317,7 +317,7 @@ public:
     // TS_ASSERT_EQUALS(3,descr.data_start_position._Fpos);
     TS_ASSERT_EQUALS(2, descr.nData_records);
     TS_ASSERT_EQUALS(6, descr.nData_blocks);
-#ifdef WIN32
+#ifdef _WIN32
     TS_ASSERT_EQUALS(char(0x0A), descr.line_end);
 #else
 //  TS_ASSERT_EQUALS(char(0x0A),descr.line_end);
@@ -350,7 +350,7 @@ public:
     // TS_ASSERT_EQUALS(3,descr.data_start_position._Fpos);
     TS_ASSERT_EQUALS(3, descr.nData_records);
     TS_ASSERT_EQUALS(6, descr.nData_blocks);
-#ifdef WIN32
+#ifdef _WIN32
     TS_ASSERT_EQUALS(char(0x0A), descr.line_end);
 #else
 //  TS_ASSERT_EQUALS(char(0x0A),descr.line_end);
@@ -382,7 +382,7 @@ public:
     // TS_ASSERT_EQUALS(3,descr.data_start_position._Fpos);
     TS_ASSERT_EQUALS(3, descr.nData_records);
     TS_ASSERT_EQUALS(7, descr.nData_blocks);
-#ifdef WIN32
+#ifdef _WIN32
     TS_ASSERT_EQUALS(char(0x0A), descr.line_end);
 #else
 //   TS_ASSERT_EQUALS(char(0x0A),descr.line_end);

--- a/Framework/ICat/test/CatalogDownloadDataFilesTest.h
+++ b/Framework/ICat/test/CatalogDownloadDataFilesTest.h
@@ -24,7 +24,7 @@ public:
    * skip all tests if internet/server is down.
    */
   bool skipTests() override {
-#ifdef WIN32
+#ifdef _WIN32
     // I don't know how to get exit status from windows.
     return false;
 #else

--- a/Framework/Kernel/inc/MantidKernel/ANN/ANN.h
+++ b/Framework/Kernel/inc/MantidKernel/ANN/ANN.h
@@ -77,7 +77,7 @@
 #pragma warning(disable : 4100)
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 //----------------------------------------------------------------------
 // For Microsoft Visual C++, externally accessible symbols must be
 // explicitly indicated with DLL_API, which is somewhat like "extern."

--- a/MantidPlot/src/zlib123/minigzip.c
+++ b/MantidPlot/src/zlib123/minigzip.c
@@ -59,8 +59,8 @@
 #  endif
 #endif
 
-#ifndef WIN32 /* unlink already in stdio.h for WIN32 */
-  extern int unlink OF((const char *));
+#ifndef _WIN32 /* unlink already in stdio.h for _WIN32 */
+extern int unlink OF((const char *));
 #else
 #pragma warning(disable: 4996)
 #endif

--- a/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceModel.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceModel.cpp
@@ -9,7 +9,7 @@
 
 #include <QMutex>
 
-#ifndef WIN32
+#ifndef _WIN32
 // This is exclusively for kill/waitpid (interim solution, see below)
 #include <signal.h>
 #include <sys/wait.h>
@@ -514,7 +514,7 @@ void TomographyIfaceModel::checkDataPathsSet() const {
  * @return running status
  */
 bool TomographyIfaceModel::processIsRunning(int pid) {
-#ifdef WIN32
+#ifdef _WIN32
   HANDLE handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pid);
   DWORD code;
   BOOL rc = GetExitCodeProcess(handle, &code);

--- a/MantidQt/MantidWidgets/src/InstrumentView/GLObject.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/GLObject.cpp
@@ -1,4 +1,4 @@
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 #include "MantidQtMantidWidgets/InstrumentView/GLObject.h"

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentTreeModel.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentTreeModel.cpp
@@ -1,6 +1,6 @@
 #include "MantidQtMantidWidgets/InstrumentView/InstrumentTreeModel.h"
 #include "MantidQtMantidWidgets/InstrumentView/InstrumentActor.h"
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 #include "MantidKernel/Exception.h"

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentTreeWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentTreeWidget.cpp
@@ -1,6 +1,6 @@
 #include "MantidQtMantidWidgets/InstrumentView/InstrumentTreeWidget.h"
 #include "MantidQtMantidWidgets/InstrumentView/InstrumentActor.h"
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 #include "MantidKernel/Exception.h"

--- a/MantidQt/MantidWidgets/src/InstrumentView/MantidGLWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/MantidGLWidget.cpp
@@ -1,4 +1,4 @@
- #ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 #include "MantidQtMantidWidgets/InstrumentView/MantidGLWidget.h"

--- a/MantidQt/MantidWidgets/src/InstrumentView/Projection3D.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/Projection3D.cpp
@@ -1,4 +1,4 @@
- #ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #endif
 #include "MantidQtMantidWidgets/InstrumentView/Projection3D.h"

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -8,7 +8,7 @@ set (SYSTEM_PACKAGE_TARGET RUNTIME)
 ###########################################################################
 # Compiler options.
 ###########################################################################
-add_definitions ( -DWIN32 -D_WINDOWS -DMS_VISUAL_STUDIO )
+add_definitions ( -D_WINDOWS -DMS_VISUAL_STUDIO )
 add_definitions ( -D_USE_MATH_DEFINES -DNOMINMAX )
 add_definitions ( -DGSL_DLL -DJSON_DLL )
 add_definitions ( -DPOCO_NO_UNWINDOWS )


### PR DESCRIPTION
Description of work.

This changes most cases using the nonstandard `WIN32` macro definition to use the the `_WIN32` macro defined by Visual Studio. I didn't change `Framework/ICat/inc/MantidICat/GSoap/stdsoap2.h` because it has its own logic for defining `WIN32`. 

Below is the VTK post and merge request that got me thinking about this.
http://public.kitware.com/pipermail/vtk-developers/2016-April/033394.html
https://msdn.microsoft.com/en-us/library/b0084kay.aspx
https://gitlab.kitware.com/vtk/vtk/merge_requests/1358

**To test:**

<!-- Instructions for testing. -->

Verify Mantid still builds on Windows.

This is a small change with no issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
