### PR TITLE
Fix "Plot/Remove guess" getting stuck when changing run (MuonAnalysis)

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -8182,7 +8182,7 @@ void ApplicationWindow::selectMultiPeak(MultiLayer *plot,
     return;
   }
 
-  if (dynamic_cast<Graph *>(plot->activeGraph())->isPiePlot()) {
+  if (plot->activeGraph()->isPiePlot()) {
     QMessageBox::warning(
         this, tr("MantidPlot - Warning"), // Mantid
         tr("This functionality is not available for pie plots!"));

--- a/MantidPlot/src/Mantid/PeakPickerTool.cpp
+++ b/MantidPlot/src/Mantid/PeakPickerTool.cpp
@@ -42,6 +42,8 @@ m_shouldBeNormalised(false)
 {
   d_graph->plotWidget()->canvas()->setCursor(Qt::pointingHandCursor);
 
+  addExistingFits(d_graph->curvesList());
+
   if (d_graph->plotWidget()->curves().size() > 0) {
     // Initialize from the first curve that will work
     auto curvesMap = d_graph->plotWidget()->curves();
@@ -1091,4 +1093,22 @@ bool PeakPickerTool::initializeFromCurve(PlotCurve *curve) {
     }
   }
   return true;
+}
+
+/**
+ * Setup function called from constructor.
+ * Adds any existing fit curves to the list so that
+ * "clear fit curves" will clear *all* fits, including old ones.
+ * Also finds out if a guess is already plotted and updates so
+ * that "plot/remove guess" will work correctly
+ * @param curvesList :: [input] List of names of curves on graph
+ */
+void PeakPickerTool::addExistingFits(const QStringList &curvesList) {
+  for (const auto curveName : curvesList) {
+    if (curveName.contains(QRegExp("Workspace-[Calc|Diff]"))) { // fit
+      m_curveNames.append(curveName);
+    } else if (curveName == "CompositeFunction") { // guess
+      // deal with this
+    }
+  }
 }

--- a/MantidPlot/src/Mantid/PeakPickerTool.cpp
+++ b/MantidPlot/src/Mantid/PeakPickerTool.cpp
@@ -42,7 +42,7 @@ m_shouldBeNormalised(false)
 {
   d_graph->plotWidget()->canvas()->setCursor(Qt::pointingHandCursor);
 
-  addExistingFits(d_graph->curvesList());
+  addExistingFitsAndGuess(d_graph->curvesList());
 
   if (d_graph->plotWidget()->curves().size() > 0) {
     // Initialize from the first curve that will work
@@ -1103,12 +1103,20 @@ bool PeakPickerTool::initializeFromCurve(PlotCurve *curve) {
  * that "plot/remove guess" will work correctly
  * @param curvesList :: [input] List of names of curves on graph
  */
-void PeakPickerTool::addExistingFits(const QStringList &curvesList) {
+void PeakPickerTool::addExistingFitsAndGuess(const QStringList &curvesList) {
+  bool hasGuess = false;
   for (const auto curveName : curvesList) {
     if (curveName.contains(QRegExp("Workspace-[Calc|Diff]"))) { // fit
       m_curveNames.append(curveName);
     } else if (curveName == "CompositeFunction") { // guess
-      // deal with this
+      hasGuess = true;
     }
+  }
+  // Set status of plot guess in fit property browser
+  auto handler = m_fitPropertyBrowser->getHandler();
+  if (handler) {
+    handler->hasPlot() = hasGuess;
+    m_fitPropertyBrowser->setTextPlotGuess(hasGuess ? "Remove guess"
+                                                    : "Plot guess");
   }
 }

--- a/MantidPlot/src/Mantid/PeakPickerTool.h
+++ b/MantidPlot/src/Mantid/PeakPickerTool.h
@@ -189,6 +189,8 @@ private:
 
   // Set up member variables from curve
   bool initializeFromCurve(PlotCurve *curve);
+  // Set up - add names of existing fit curves
+  void addExistingFits(const QStringList &curvesList);
 
   /// Creates a pointer to fitPropertyBrowser
   MantidQt::MantidWidgets::FitPropertyBrowser* m_fitPropertyBrowser;

--- a/MantidPlot/src/Mantid/PeakPickerTool.h
+++ b/MantidPlot/src/Mantid/PeakPickerTool.h
@@ -187,6 +187,9 @@ private:
   // Set the tool tip text
   void setToolTip(const QString& txt);
 
+  // Set up member variables from curve
+  bool initializeFromCurve(PlotCurve *curve);
+
   /// Creates a pointer to fitPropertyBrowser
   MantidQt::MantidWidgets::FitPropertyBrowser* m_fitPropertyBrowser;
 

--- a/MantidPlot/src/Mantid/PeakPickerTool.h
+++ b/MantidPlot/src/Mantid/PeakPickerTool.h
@@ -189,8 +189,8 @@ private:
 
   // Set up member variables from curve
   bool initializeFromCurve(PlotCurve *curve);
-  // Set up - add names of existing fit curves
-  void addExistingFits(const QStringList &curvesList);
+  // Set up - add names of existing fit curves and plot guess status
+  void addExistingFitsAndGuess(const QStringList &curvesList);
 
   /// Creates a pointer to fitPropertyBrowser
   MantidQt::MantidWidgets::FitPropertyBrowser* m_fitPropertyBrowser;

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1807,14 +1807,13 @@ std::string MuonAnalysis::getPeriodLabels() const {
 }
 
 /**
- * plots specific WS spectrum (used by plotPair and plotGroup)
+ * Plots specific WS spectrum (used by plotPair and plotGroup)
+ * This is done with a Python script (there must be a better way!)
  * @param wsName   :: Workspace name
  * @param logScale :: Whether to plot using logarithmic scale
  */
 void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
-  // List of script lines which acquire a window for plotting. The window is
-  // placed to Python
-  // variable named 'w';'
+  // List of script lines which acquire a window and plot in it.
   QStringList acquireWindowScript;
 
   MuonAnalysisOptionTab::NewPlotPolicy policy = m_optionTab->newPlotPolicy();
@@ -1826,28 +1825,70 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   }
 
   QStringList &s = acquireWindowScript; // To keep short
-  s << "ws = mtd['%WSNAME%']";
-  s << "altName = ws.name() + '-1'";
 
-  if (policy == MuonAnalysisOptionTab::PreviousWindow) {
-    s << "ew = graph(altName)";
-    s << "if '%WSNAME%' != '%PREV%' and ew != None:";
-    s << "    ew.close()";
+  // Get the window to plot in (returns window)
+  // ws_name: name of workspace to plot
+  // prev_name: name of currently plotted workspace
+  // use_prev: whether to plot in existing window or new
+  s << "def get_window(ws_name, prev_name, use_prev):";
+  s << "  graph_name = ws_name + '-1'";
+  s << "  if not use_prev:";
+  s << "    return newGraph(graph_name, 0)";
+  s << "  existing = graph(graph_name)";
+  s << "  if existing is not None and ws_name != prev_name:";
+  s << "    existing.close()";
+  s << "  window = graph(prev_name + '-1')";
+  s << "  if window is None:";
+  s << "    window = newGraph(graph_name, 0)";
+  s << "  return window";
+  s << "";
 
-    s << "pw = graph('%PREV%-1')";
-    s << "if pw == None:";
-    s << "  pw = newGraph(altName, 0)";
-  } else if (policy == MuonAnalysisOptionTab::NewWindow) {
-    s << "pw = newGraph(altName, 0)";
-  }
+  // Remove data and difference from given plot (keep fit and guess)
+  s << "def remove_data(window):";
+  s << "  if window is None:";
+  s << "    raise ValueError('No plot to remove data from')";
+  s << "  to_keep = ['Workspace-Calc', 'CompositeFunction']";
+  s << "  layer = window.activeLayer()";
+  s << "  if layer is not None:";
+  s << "    for i in range(0, layer.numCurves()):";
+  s << "      if not any (x in layer.curveTitle(i) for x in to_keep):";
+  s << "        layer.removeCurve(i)";
+  s << "";
 
-  s << "w = plotSpectrum(ws.name(), 0, error_bars = %ERRORS%, type = "
-       "%CONNECT%, window = pw, "
-       "clearWindow = True)";
-  s << "w.setName(altName)";
-  s << "w.setObjectName(ws.name())";
-  s << "w.show()";
-  s << "w.setFocus()";
+  // Plot data in the given window with given options
+  s << "def plot_data(ws_name, errors, connect, window_to_use):";
+  s << "  w = plotSpectrum(ws_name, 0, error_bars = errors, type = connect, "
+       "window = window_to_use)";
+  s << "  w.setName(ws_name + '-1')";
+  s << "  w.setObjectName(ws_name)";
+  s << "  w.show()";
+  s << "  w.setFocus()";
+  s << "  return w";
+  s << "";
+
+  // Format the graph scale, title, legends and colours
+  // Data (most recently added curve) should be black
+  s << "def format_graph(graph, ws_name, log_scale, y_auto, y_min, y_max):";
+  s << "  layer = graph.activeLayer()";
+  s << "  num_curves = layer.numCurves()";
+  s << "  layer.setCurveTitle(num_curves, ws_name)";
+  s << "  layer.setTitle(mtd[ws_name].getTitle())";
+  s << "  for i in range(0, num_curves):";
+  s << "    color = i + 1 if i != num_curves - 1 else 0";
+  s << "    layer.setCurveLineColor(i, color)";
+  s << "  if log_scale:";
+  s << "    layer.logYlinX()";
+  s << "  if y_auto:";
+  s << "    layer.setAutoScale()";
+  s << "  else:";
+  s << "    layer.setAxisScale(Layer.Left, y_min, y_max)";
+  s << "";
+
+  // Plot the data!
+  s << "win = get_window('%WSNAME%', '%PREV%', %USEPREV%)";
+  s << "remove_data(win)";
+  s << "g = plot_data('%WSNAME%', %ERRORS%, %CONNECT%, win)";
+  s << "format_graph(g, '%WSNAME%', %LOGSCALE%, %YAUTO%, '%YMIN%', '%YMAX%')";
 
   QString pyS;
 
@@ -1862,25 +1903,16 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   safeWSName.replace("'", "\'");
   pyS.replace("%WSNAME%", safeWSName);
   pyS.replace("%PREV%", m_currentDataName);
+  pyS.replace("%USEPREV%", policy == MuonAnalysisOptionTab::PreviousWindow
+                               ? "True"
+                               : "False");
   pyS.replace("%ERRORS%", params["ShowErrors"]);
   pyS.replace("%CONNECT%", params["ConnectType"]);
+  pyS.replace("%LOGSCALE%", logScale ? "True" : "False");
+  pyS.replace("%YAUTO%", params["YAxisAuto"]);
+  pyS.replace("%YMIN%", params["YAxisMin"]);
+  pyS.replace("%YMAX%", params["YAxisMax"]);
 
-  // Update titles
-  pyS += "l = w.activeLayer()\n"
-         "l.setCurveTitle(0, ws.name())\n"
-         "l.setTitle(ws.getTitle())\n";
-
-  // Set logarithmic scale if required
-  if (logScale)
-    pyS += "l.logYlinX()\n";
-
-  // Set scaling
-  if (params["YAxisAuto"] == "True") {
-    pyS += "l.setAutoScale()\n";
-  } else {
-    pyS += "l.setAxisScale(Layer.Left, %1, %2)\n";
-    pyS = pyS.arg(params["YAxisMin"]).arg(params["YAxisMax"]);
-  }
   runPythonCode(pyS);
 }
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1986,8 +1986,10 @@ bool MuonAnalysis::plotExists(const QString &wsName) {
 void MuonAnalysis::selectMultiPeak(const QString &wsName) {
   disableAllTools();
 
-  if (!plotExists(wsName))
+  if (!plotExists(wsName)) {
     plotSpectrum(wsName);
+    setCurrentDataName(wsName);
+  }
 
   QString code;
 

--- a/docs/source/release/v3.7.0/muon.rst
+++ b/docs/source/release/v3.7.0/muon.rst
@@ -34,6 +34,7 @@ Muon Analysis
   - *Start* and *End* are the earliest start and latest end
 
 - When the window is resized, all widgets within the window should now resize with it. This enables the interface to be used on smaller screens. `#15382 <https://github.com/mantidproject/mantid/pull/15832>`_
+- "Plot/Remove guess" now deals correctly with the case when a new run is loaded. `#15872 <https://github.com/mantidproject/mantid/pull/15872>`_
 
 Algorithms
 ----------


### PR DESCRIPTION
Fixed a bug in the fitting tab of MuonAnalysis where "Plot/Remove guess" would get stuck saying the wrong thing when a new run was loaded.

Changes made:
- Refactored plotting Python code to keep existing fits and plot guesses, if any, when a new run is loaded. (This is a request from the scientists - see issue). The plot difference is not kept as it relates to the old run's data.
- Add code to `PeakPickerTool` to initialise from the existing graph, in case there are already fits or guesses plotted. This ensures that
  - "Clear fit curves" clears all fits, not just the new ones
  - "Plot/remove guess" displays the correct text

**To test:**
_Data available at `\\olympic\babylon5\Scratch\TomPerkins\Data\MUSR00024580.nxs` and `MUSR00024581.nxs`_
- Open MuonAnalysis interface

**Plotting in previous plot window**
- On _Settings_ tab, set "New plot policy" to "use previous window"
- Back on _Home_ tab, load `MUSR00024580.nxs`
- Go to _Data Analysis_ tab and set up a function. Try flat background + exponential decay.
- Click Display/Plot Guess, then fit
- Go back to _Home_ tab and load the next run.
  - Verify the guess and fit stay on the graph but difference doesn't
- On _Data Analysis_ tab, verify the option under "Display" says "Remove guess" and not "Plot guess", and that it does what it says
- Run a new fit. Check that "Display/Clear fit curves" clears all fit curves, not just the new ones.
- Now change the run using the selector in the "Data" section on this tab.
  - Again check that fits/guess remain when data changes

**Plotting in a new window each time**
- Start again from opening the interface.
- Change the "New plot policy" option on the _Settings_ tab to "create new window"
- Load first dataset and set up the function as above, plot guess and fit.
- Go back to _Home_ tab and load the next run.
  - This time the new run will open in a second window
- On _Data Analysis_ tab, check that the option under "Display" says "Plot guess" - i.e. it's updated for the new graph
- Change the run back using the selector in the "Data" section on this tab. 
  - Check that the option under "Display" turns back to "Remove guess" (and works) 
  - Check that the "Display/Clear fit curves" option works too.
- Also check that the behaviour of the regular fit browser hasn't been affected.

Fixes #15737. 

[Release notes](https://github.com/mantidproject/mantid/blob/15737_plot_guess_fix/docs/source/release/v3.7.0/muon.rst#id3) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
