### PR TITLE
SaveAscii2 fails with non spectrum axis

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveAscii2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveAscii2.h
@@ -78,6 +78,9 @@ private:
   void populateSpectrumNumberMetaData();
   void populateAngleMetaData();
   void populateAllMetaData();
+  bool
+  findElementInUnorderedStringVector(const std::vector<std::string> &vector,
+                                     const std::string &toFind);
 
   /// Map the separator options to their string equivalents
   std::map<std::string, std::string> m_separatorIndex;
@@ -92,6 +95,7 @@ private:
   std::vector<std::string> m_metaData;
   std::map<std::string, std::vector<std::string>> m_metaDataMap;
   spec2index_map m_specToIndexMap;
+
 };
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveAscii2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveAscii2.h
@@ -95,7 +95,6 @@ private:
   std::vector<std::string> m_metaData;
   std::map<std::string, std::vector<std::string>> m_metaDataMap;
   spec2index_map m_specToIndexMap;
-
 };
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -71,9 +71,12 @@ void SaveAscii2::init() {
                   "Character(s) to put in front of comment lines.");
 
   // For the ListValidator
-  std::string spacers[6][2] = {
-      {"CSV", ","},   {"Tab", "\t"},      {"Space", " "},
-      {"Colon", ":"}, {"SemiColon", ";"}, {"UserDefined", "UserDefined"}};
+  std::string spacers[6][2] = {{"CSV", ","},
+                               {"Tab", "\t"},
+                               {"Space", " "},
+                               {"Colon", ":"},
+                               {"SemiColon", ";"},
+                               {"UserDefined", "UserDefined"}};
   std::vector<std::string> sepOptions;
   for (auto &spacer : spacers) {
     std::string option = spacer[0];

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -71,12 +71,9 @@ void SaveAscii2::init() {
                   "Character(s) to put in front of comment lines.");
 
   // For the ListValidator
-  std::string spacers[6][2] = {{"CSV", ","},
-                               {"Tab", "\t"},
-                               {"Space", " "},
-                               {"Colon", ":"},
-                               {"SemiColon", ";"},
-                               {"UserDefined", "UserDefined"}};
+  std::string spacers[6][2] = {
+      {"CSV", ","},   {"Tab", "\t"},      {"Space", " "},
+      {"Colon", ":"}, {"SemiColon", ";"}, {"UserDefined", "UserDefined"}};
   std::vector<std::string> sepOptions;
   for (auto &spacer : spacers) {
     std::string option = spacer[0];
@@ -488,14 +485,14 @@ void SaveAscii2::populateAllMetaData() {
 
 bool SaveAscii2::findElementInUnorderedStringVector(
     const std::vector<std::string> &vector, const std::string &toFind) {
-	auto containsElement = false;
-	for (auto iter = vector.begin(); iter != vector.end(); ++iter) {
-		const auto vectorElement = *iter;
-		if (vectorElement.compare(toFind) == 0) {
-			containsElement = true;
-		}
-	}
-	return containsElement;
+  auto containsElement = false;
+  for (auto iter = vector.begin(); iter != vector.end(); ++iter) {
+    const auto vectorElement = *iter;
+    if (vectorElement.compare(toFind) == 0) {
+      containsElement = true;
+    }
+  }
+  return containsElement;
 }
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -136,7 +136,7 @@ void SaveAscii2::exec() {
     if (containsSpectrumNumber) {
       try {
         m_specToIndexMap = m_ws->getSpectrumToWorkspaceIndexMap();
-      } catch (std::runtime_error e) {
+      } catch (std::runtime_error) {
         throw std::runtime_error("SpectrumNumber is present in "
                                  "SpectrumMetaData but the workspace does not "
                                  "have a SpectrumAxis.");

--- a/Framework/DataHandling/test/SaveAscii2Test.h
+++ b/Framework/DataHandling/test/SaveAscii2Test.h
@@ -277,16 +277,19 @@ public:
 
     // Now make some checks on the content of the file
     std::ifstream in(filename.c_str());
+    int specID;
     std::string header1, header2, header3, separator, comment;
 
     // Test that the first few column headers, separator and first two bins are
     // as expected
-    in >> comment >> header1 >> separator >> header2 >> separator >> header3;
+    in >> comment >> header1 >> separator >> header2 >> separator >> header3 >>
+        specID;
     TS_ASSERT_EQUALS(comment, "#");
     TS_ASSERT_EQUALS(separator, ",");
     TS_ASSERT_EQUALS(header1, "X");
     TS_ASSERT_EQUALS(header2, "Y");
     TS_ASSERT_EQUALS(header3, "E");
+    TS_ASSERT_EQUALS(specID, 1);
 
     in.close();
 
@@ -455,6 +458,19 @@ public:
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
+  }
+
+  void test_fail_spectrum_number_in_meta_data_for_non_spectrum_axis_ws() {
+	  Mantid::DataObjects::Workspace2D_sptr wsToSave;
+	  writeSampleWS(wsToSave, false);
+
+	  SaveAscii2 save;
+	  std::string filename = initSaveAscii2(save);
+
+	  TS_ASSERT_THROWS_NOTHING(save.setProperty("SpectrumMetaData", "SpectrumNumber"));
+	  TS_ASSERT_THROWS_ANYTHING(save.execute());
+
+	  AnalysisDataService::Instance().remove(m_name);
   }
 
   void test_fail_invalid_IndexMin_Max_Overlap() {

--- a/Framework/DataHandling/test/SaveAscii2Test.h
+++ b/Framework/DataHandling/test/SaveAscii2Test.h
@@ -461,16 +461,17 @@ public:
   }
 
   void test_fail_spectrum_number_in_meta_data_for_non_spectrum_axis_ws() {
-	  Mantid::DataObjects::Workspace2D_sptr wsToSave;
-	  writeSampleWS(wsToSave, false);
+    Mantid::DataObjects::Workspace2D_sptr wsToSave;
+    writeSampleWS(wsToSave, false);
 
-	  SaveAscii2 save;
-	  std::string filename = initSaveAscii2(save);
+    SaveAscii2 save;
+    std::string filename = initSaveAscii2(save);
 
-	  TS_ASSERT_THROWS_NOTHING(save.setProperty("SpectrumMetaData", "SpectrumNumber"));
-	  TS_ASSERT_THROWS_ANYTHING(save.execute());
+    TS_ASSERT_THROWS_NOTHING(
+        save.setProperty("SpectrumMetaData", "SpectrumNumber"));
+    TS_ASSERT_THROWS_ANYTHING(save.execute());
 
-	  AnalysisDataService::Instance().remove(m_name);
+    AnalysisDataService::Instance().remove(m_name);
   }
 
   void test_fail_invalid_IndexMin_Max_Overlap() {

--- a/Framework/DataHandling/test/SaveAscii2Test.h
+++ b/Framework/DataHandling/test/SaveAscii2Test.h
@@ -4,9 +4,10 @@
 #include <cxxtest/TestSuite.h>
 #include "MantidDataHandling/SaveAscii2.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidAPI/FrameworkManager.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/Axis.h"
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/TextAxis.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include <fstream>
 #include <Poco/File.h>
@@ -276,8 +277,6 @@ public:
 
     // Now make some checks on the content of the file
     std::ifstream in(filename.c_str());
-    int specID;
-    double qVal, angle;
     std::string header1, header2, header3, separator, comment;
 
     // Test that the first few column headers, separator and first two bins are
@@ -738,8 +737,10 @@ private:
     }
 
     if (!isSpectra) {
-      auto axis = wsToSave->getAxis(1);
-      axis->setUnit("Degrees");
+      auto textAxis = new TextAxis(2);
+      textAxis->setLabel(0, "Test Axis 1");
+      textAxis->setLabel(1, "Test Axis 2");
+      wsToSave->replaceAxis(1, textAxis);
     }
 
     AnalysisDataService::Instance().add(m_name, wsToSave);


### PR DESCRIPTION
SaveAscii2 should now be able to save data if WriteID is checked and the workspace axis is not a spectrum axis. If the workspace does not have a spectrum axis and SpectrumNumebr is in the meta data then an exception is now thrown.

**To test:**
- Run the following script to check that the data is saved with non spectrum axis and writeID:

```
data = CreateWorkspace("1,2,3", "1,2,3", VerticalAxisUnit="Degrees", VerticalAxisValues="1")
SaveAscii(data, "test_saveAscii", WriteSpectrumID=True)
```
- Run the following script to check that the data is not saved when it is not a spectrumaxis and spectrumnumber is in the metadata (error should read: `SpectrumNumber is present in SpectrumMetaData but the workspace does not have a SpectrumAxis`)

```
data = CreateWorkspace("1,2,3", "1,2,3", VerticalAxisUnit="Degrees", VerticalAxisValues="1")
SaveAscii(data, "test_saveAscii", WriteSpectrumID=False, SpectrumMetaData="SpectrumNumber")
```

Fixes #15888

_Does not need to be in the release notes as it is a bugfix to a recently added feature._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
