### PR TITLE
Fix Qt3 warnings in muon interfaces

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -2878,7 +2878,7 @@ void MuonAnalysis::openSequentialFitDialog() {
                     "Error was: ");
     message.append(err.what());
     QMessageBox::critical(this, "Unable to open dialog", message);
-    g_log.error(message.ascii());
+    g_log.error(message.toLatin1().data());
     return;
   } catch (...) {
     QMessageBox::critical(this, "Unable to open dialog",

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataTab.cpp
@@ -80,13 +80,18 @@ void MuonAnalysisFitDataTab::groupFittedWorkspaces(QString workspaceName)
     inputWorkspaces.push_back(wsWorkspace);
   }
 
-  if (inputWorkspaces.size() > 1)
-  {
-    std::string groupName = workspaceName.left(workspaceName.find(';')).toStdString();
+  if (inputWorkspaces.size() > 1) {
+    const std::string groupName = [&workspaceName] {
+      const int index = workspaceName.indexOf(';');
+      if (index != -1) {
+        return workspaceName.left(index).toStdString();
+      } else {
+        return workspaceName.toStdString();
+      }
+    }();
     MuonAnalysisHelper::groupWorkspaces(groupName, inputWorkspaces);
   }
 }
-
 }
 }
 }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisResultTableTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisResultTableTab.cpp
@@ -592,7 +592,7 @@ void MuonAnalysisResultTableTab::populateFittings(
     // Fill values and delete previous old ones.
     if (row < fittedWsList.size()) {
       QTableWidgetItem *item = new QTableWidgetItem(fittedWsList[row]);
-      int color(colors.find(row).data());
+      const int color(colors.find(row).value());
       switch (color) {
       case (1):
         item->setTextColor("red");
@@ -929,7 +929,7 @@ QStringList MuonAnalysisResultTableTab::getSelectedLogs() {
 * @return name :: The name the results table should be created with.
 */
 std::string MuonAnalysisResultTableTab::getFileName() {
-  std::string fileName(m_uiForm.tableName->text());
+  std::string fileName(m_uiForm.tableName->text().toStdString());
 
   if (Mantid::API::AnalysisDataService::Instance().doesExist(fileName)) {
     int choice = QMessageBox::question(


### PR DESCRIPTION
Fix four Qt3 warnings (including one newly introduced one) in muon interfaces.

These were found by http://builds.mantidproject.org/job/master_clean-Qt3-warnings/ .

**To test:**
No changes to unit tests as functionality has not changed.
- Code review: verify functionality is the same
- Turn on `WITH_QT3_SUPPORT_WARNINGS` in CMake and build CustomInterfaces. Verify there are no warnings.

Fixes #15893 

_No release notes necessary_ - change is not visible to users.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
