### PR TITLE
Fix alloc-dealloc-mismatch caught by address sanitizer.

### DIFF
--- a/Vates/VatesAPI/src/vtkMDLineFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDLineFactory.cpp
@@ -118,7 +118,7 @@ vtkMDLineFactory::create(ProgressAction &progressUpdating) const {
         useBox[iBox] = true;
         signals->InsertNextValue(static_cast<float>(signal_normalized));
 
-        auto coords = std::unique_ptr<coord_t>(
+        auto coords = std::unique_ptr<coord_t[]>(
             it->getVertexesArray(nVertexes, nNonIntegrated, masks.get()));
 
         // Iterate through all coordinates. Candidate for speed improvement.

--- a/Vates/VatesAPI/src/vtkMDQuadFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDQuadFactory.cpp
@@ -114,7 +114,7 @@ vtkMDQuadFactory::create(ProgressAction &progressUpdating) const {
         useBox[iBox] = true;
         signals->InsertNextValue(static_cast<float>(signal));
 
-        auto coords = std::unique_ptr<coord_t>(
+        auto coords = std::unique_ptr<coord_t[]>(
             it->getVertexesArray(nVertexes, nNonIntegrated, masks.get()));
 
         // Iterate through all coordinates. Candidate for speed improvement.


### PR DESCRIPTION
Description of work.

This fixes two alloc-dealloc-mismatch errosr caused by `unique_ptr<coord_t>` calling  `delete` instead of `delete[]`. Changing the type from `coord_t` to `coord_t[]` should fix this. 

**To test:**

<!-- Instructions for testing. -->

Code review is sufficient.

This is a small change with no issue number

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
