### PR TITLE
Indirect - Additional DRange value added to OSIRISDiffractionReduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
@@ -32,9 +32,9 @@ TIME_REGIME_TO_DRANGE = {
                          13.55e4: DRange( 8.3,  9.5),
                          15.32e4: DRange( 9.4, 10.6),
                          17.09e4: DRange(10.4, 11.6),
-                         18.86e4: DRange(11.0, 12.5)
+                         18.86e4: DRange(11.0, 12.5),
+                         20.63e4: DRange(12.2, 13.8)
 }
-
 
 class DRangeToWorkspaceMap(object):
     """

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -58,6 +58,9 @@ Improvements
     If Emin or Emax are left empty; appropriate values are set automatically, the negative values of Ei are treated as
     positive, appropriate informative pop-up messages displayed for invalid values and minor calculations updates.
 
+- :ref:`OSIRISDiffractionReduction <algm-OSIRISDiffractionReduction>` has an additional DRange added for conversion from time regime.
+
+
 Bugfixes
 --------
 


### PR DESCRIPTION
Additional 12th dRange conversion added to dictionary in OSIRISDiffractionReduction for new time regime.

**To test:**
- Ensure tests pass
- Only requires code review

Fixes #15903.

[Release Notes](https://github.com/mantidproject/mantid/blob/15903_OSIRISDiffRed_additional_dRange/docs/source/release/v3.7.0/indirect_inelastic.rst#improvements)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
