### PR TITLE
Estimate width of peak using the data

### DIFF
--- a/MantidPlot/src/Mantid/PeakPickerTool.cpp
+++ b/MantidPlot/src/Mantid/PeakPickerTool.cpp
@@ -432,16 +432,22 @@ void PeakPickerTool::addPeak(double c,double h)
   MantidQt::MantidWidgets::PropertyHandler* handler = m_fitPropertyBrowser->addFunction(fnName);
   if (!handler || !handler->pfun()) return;
   handler->setCentre(c);
-  double width = handler->fwhm();
-  if (width == 0 && m_width != 0.0)
+  //if previous width was set use that
+  if (handler->fwhm() == 0 && m_width != 0.0)
   {
     handler->setFwhm(m_width);
   }
-  if (handler->fwhm() > 0.)
+  handler->calcBase();
+  // if no width still try to estimate
+  if (handler->fwhm() == 0.)
   {
-    handler->calcBase();
+    double w = handler->EstimateFwhm();
+    if (w > 0) {
+      handler->setFwhm(w);
+    }
   }
   handler->setHeight(h);
+
 }
 
 // Give new centre and height to the current peak

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/PropertyHandler.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/PropertyHandler.h
@@ -154,6 +154,8 @@ public:
   void setBase(const double& b){m_base = b;}
   void calcBase();//< caclulate baseline from workspace data
   void calcBaseAll();//< calc baseline for all peaks in the function
+  /// Estimate the FwHM for a peak
+  double EstimateFwhm() const;
 
   double height()const;
   double centre()const;
@@ -164,7 +166,6 @@ public:
   void fix(const QString& parName);
   void removeTie(QtProperty* prop);
   void removeTie(const QString& propName);
-
   void addConstraint(QtProperty* parProp,bool lo,bool up,double loBound,double upBound);
   void removeConstraint(QtProperty* parProp);
 

--- a/MantidQt/MantidWidgets/src/PropertyHandler.cpp
+++ b/MantidQt/MantidWidgets/src/PropertyHandler.cpp
@@ -1106,8 +1106,8 @@ double PropertyHandler::EstimateFwhm() const
     size_t wi = m_browser->workspaceIndex();
     const Mantid::MantidVec &X = ws->readX(wi);
     const Mantid::MantidVec &Y = ws->readY(wi);
-    int n = static_cast<int>(Y.size()) - 1;
-    if (m_ci < 0 || m_ci > n) {
+    size_t n = Y.size() - 1;
+    if (m_ci < 0 || m_ci > static_cast<int>(n)) {
       fwhm = 0.;
     }
     else {

--- a/MantidQt/MantidWidgets/src/PropertyHandler.cpp
+++ b/MantidQt/MantidWidgets/src/PropertyHandler.cpp
@@ -1094,6 +1094,55 @@ void PropertyHandler::removeTie(const QString &parName) {
 }
 
 /**
+ Create a simple estimate of the full width half maximum
+ @returns and estimate of the peak width, or 0 if an error occurs
+*/
+double PropertyHandler::EstimateFwhm() const
+{
+  double fwhm = 0.;
+  auto ws = boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(
+    m_browser->getWorkspace());
+  if (ws) {
+    size_t wi = m_browser->workspaceIndex();
+    const Mantid::MantidVec &X = ws->readX(wi);
+    const Mantid::MantidVec &Y = ws->readY(wi);
+    int n = static_cast<int>(Y.size()) - 1;
+    if (m_ci < 0 || m_ci > n) {
+      fwhm = 0.;
+    }
+    else {
+      double halfHeight = ((Y[m_ci] - m_base)/2.) + m_base;
+      //walk to the right
+      size_t rightHwhmIndex = m_ci;
+      while (rightHwhmIndex < n) {
+        if (Y[rightHwhmIndex++] <= halfHeight)
+        {
+          break;
+        }
+      }
+
+      //walk to the left
+      size_t leftHwhmIndex = m_ci;
+      while (leftHwhmIndex > 0) {
+        if (Y[leftHwhmIndex--] <= halfHeight) {
+          break;
+        }
+      }
+
+      fwhm = fabs(X[rightHwhmIndex] - X[leftHwhmIndex]);
+
+      //apply a maximum limitation if larger than the fitting region
+      double fitRange = m_browser->endX() - m_browser->startX();
+      if (fwhm > fitRange)
+      {
+        //set to 10% of fitting region
+        fwhm = fitRange*0.1;
+      }
+    }  
+  }
+  return fwhm;
+}
+/**
  * Calculate m_base: the baseline level under the peak (if this function is a
  * peak and auto background is on)
  */


### PR DESCRIPTION
Gets a better initial guess of the peak width by walking down the data.  Should not interfere with current approaches, only steps in if the width would otherwise be 0.

**To test:**

<!-- Instructions for testing. -->

Fixes #15911 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

re #15911
