### PR TITLE
Pass a const reference instead of a shared_ptr.

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -5,9 +5,9 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
 
-#include "MantidGeometry/Instrument_fwd.h"
-#include "MantidGeometry/IDetector_fwd.h"
 #include "MantidAPI/SpectraDetectorTypes.h"
+#include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/Instrument_fwd.h"
 
 #include "MantidKernel/DeltaEMode.h"
 

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -92,8 +92,8 @@ public:
   /**@name Instrument queries */
   //@{
   Geometry::IDetector_const_sptr getDetector(const size_t workspaceIndex) const;
-  double detectorTwoTheta(Geometry::IDetector_const_sptr det) const;
-  double detectorSignedTwoTheta(Geometry::IDetector_const_sptr det) const;
+  double detectorTwoTheta(const Geometry::IDetector &det) const;
+  double detectorSignedTwoTheta(const Geometry::IDetector &det) const;
 
   //@}
 

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -945,7 +945,7 @@ void IFunction::convertValue(std::vector<double> &values,
     double l2(-1.0), twoTheta(0.0);
     if (!det->isMonitor()) {
       l2 = det->getDistance(*sample);
-      twoTheta = ws->detectorTwoTheta(det);
+      twoTheta = ws->detectorTwoTheta(*det);
     } else // If this is a monitor then make l1+l2 = source-detector distance
            // and twoTheta=0
     {

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -32,7 +32,7 @@ using Kernel::V3D;
 namespace {
 /// static logger
 Kernel::Logger g_log("MatrixWorkspace");
-static constexpr double rad2deg = 180. / M_PI;
+constexpr double rad2deg = 180. / M_PI;
 }
 
 const std::string MatrixWorkspace::xDimensionId = "xDimension";

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -32,6 +32,7 @@ using Kernel::V3D;
 namespace {
 /// static logger
 Kernel::Logger g_log("MatrixWorkspace");
+static constexpr double rad2deg = 180. / M_PI;
 }
 
 const std::string MatrixWorkspace::xDimensionId = "xDimension";
@@ -790,10 +791,10 @@ MatrixWorkspace::getDetector(const size_t workspaceIndex) const {
 *  @throws InstrumentDefinitionError if source or sample is missing, or they are
 * in the same place
 */
-double MatrixWorkspace::detectorSignedTwoTheta(
-    Geometry::IDetector_const_sptr det) const {
-  Instrument_const_sptr instrument = getInstrument();
+double
+MatrixWorkspace::detectorSignedTwoTheta(const Geometry::IDetector &det) const {
 
+  Instrument_const_sptr instrument = getInstrument();
   Geometry::IComponent_const_sptr source = instrument->getSource();
   Geometry::IComponent_const_sptr sample = instrument->getSample();
   if (source == nullptr || sample == nullptr) {
@@ -812,7 +813,7 @@ double MatrixWorkspace::detectorSignedTwoTheta(
   // Get the instrument up axis.
   const V3D &instrumentUpAxis =
       instrument->getReferenceFrame()->vecPointingUp();
-  return det->getSignedTwoTheta(samplePos, beamLine, instrumentUpAxis);
+  return det.getSignedTwoTheta(samplePos, beamLine, instrumentUpAxis);
 }
 
 /** Returns the 2Theta scattering angle for a detector
@@ -822,10 +823,10 @@ double MatrixWorkspace::detectorSignedTwoTheta(
 *  @throws InstrumentDefinitionError if source or sample is missing, or they are
 * in the same place
 */
-double
-MatrixWorkspace::detectorTwoTheta(Geometry::IDetector_const_sptr det) const {
-  Geometry::IComponent_const_sptr source = getInstrument()->getSource();
-  Geometry::IComponent_const_sptr sample = getInstrument()->getSample();
+double MatrixWorkspace::detectorTwoTheta(const Geometry::IDetector &det) const {
+  Instrument_const_sptr instrument = this->getInstrument();
+  Geometry::IComponent_const_sptr source = instrument->getSource();
+  Geometry::IComponent_const_sptr sample = instrument->getSample();
   if (source == nullptr || sample == nullptr) {
     throw Kernel::Exception::InstrumentDefinitionError(
         "Instrument not sufficiently defined: failed to get source and/or "
@@ -840,7 +841,7 @@ MatrixWorkspace::detectorTwoTheta(Geometry::IDetector_const_sptr det) const {
         "Source and sample are at same position!");
   }
 
-  return det->getTwoTheta(samplePos, beamLine);
+  return det.getTwoTheta(samplePos, beamLine);
 }
 
 //---------------------------------------------------------------------------------------
@@ -1693,7 +1694,7 @@ void MatrixWorkspace::saveSpectraMapNexus(
           Kernel::V3D pos = det->getPos() - sample_pos;
           pos.getSpherical(R, Theta, Phi);
           R = det->getDistance(*sample);
-          Theta = this->detectorTwoTheta(det) * 180.0 / M_PI;
+          Theta = this->detectorTwoTheta(*det) * rad2deg;
         } catch (...) {
           R = 0.;
           Theta = 0.;

--- a/Framework/API/test/GeometryInfoTest.h
+++ b/Framework/API/test/GeometryInfoTest.h
@@ -123,8 +123,8 @@ public:
   // removed at some point.
   void test_getTwoThetaLegacy() {
     auto info = GeometryInfo(*m_factory, *(m_workspace.getSpectrum(2)));
-    TS_ASSERT_EQUALS(info.getTwoTheta(),
-                     m_workspace.detectorTwoTheta(info.getDetector()));
+    auto det = info.getDetector();
+    TS_ASSERT_EQUALS(info.getTwoTheta(), m_workspace.detectorTwoTheta(*det));
   }
 
   void test_getSignedTwoTheta() {
@@ -143,8 +143,9 @@ public:
   // be removed at some point.
   void test_getSignedTwoThetaLegacy() {
     auto info = GeometryInfo(*m_factory, *(m_workspace.getSpectrum(2)));
+    auto det = info.getDetector();
     TS_ASSERT_EQUALS(info.getSignedTwoTheta(),
-                     m_workspace.detectorSignedTwoTheta(info.getDetector()));
+                     m_workspace.detectorSignedTwoTheta(*det));
   }
 
 private:

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1339,7 +1339,7 @@ public:
       auto detector = m_workspace.getDetector(i);
       result += L1;
       result += detector->getDistance(*sample);
-      result += m_workspace.detectorTwoTheta(detector);
+      result += m_workspace.detectorTwoTheta(*detector);
     }
     // We are computing an using the result to fool the optimizer.
     TS_ASSERT_DELTA(result, 5214709.740869, 1e-6);

--- a/Framework/Algorithms/inc/MantidAlgorithms/SofQCommon.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SofQCommon.h
@@ -21,11 +21,11 @@ struct SofQCommon {
   // Constructor
   SofQCommon() : m_emode(0), m_efixedGiven(false), m_efixed(0.0) {}
   // init the class parameters, defined above
-  void initCachedValues(API::MatrixWorkspace_const_sptr workspace,
+  void initCachedValues(const API::MatrixWorkspace &workspace,
                         API::Algorithm *const hostAlgorithm);
 
   /// Get the efixed value for the given detector
-  double getEFixed(Geometry::IDetector_const_sptr det) const;
+  double getEFixed(const Geometry::IDetector &det) const;
 };
 }
 }

--- a/Framework/Algorithms/inc/MantidAlgorithms/SofQWPolygon.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SofQWPolygon.h
@@ -88,7 +88,7 @@ private:
   /// Init variables cache base on the given workspace
   void initCachedValues(API::MatrixWorkspace_const_sptr workspace);
   /// Init the theta index
-  void initThetaCache(API::MatrixWorkspace_const_sptr workspace);
+  void initThetaCache(const API::MatrixWorkspace &workspace);
 
   SofQCommon m_EmodeProperties;
   //---------------------------------------------------------------------------------

--- a/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
+++ b/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
@@ -122,8 +122,7 @@ void ApplyTransmissionCorrection::exec() {
     MantidVec &YOut = corrWS->dataY(i);
     MantidVec &EOut = corrWS->dataE(i);
 
-    const double exp_term =
-        (1.0 / cos(inputWS->detectorTwoTheta(det)) + 1.0) / 2.0;
+    const double exp_term = 0.5 / cos(inputWS->detectorTwoTheta(*det)) + 0.5;
     for (int j = 0; j < static_cast<int>(inputWS->readY(0).size()); j++) {
       if (!thetaDependent) {
         YOut[j] = 1.0 / TrIn[j];

--- a/Framework/Algorithms/src/ConvertAxesToRealSpace.cpp
+++ b/Framework/Algorithms/src/ConvertAxesToRealSpace.cpp
@@ -152,9 +152,9 @@ void ConvertAxesToRealSpace::exec() {
         } else if (axisSelection == "phi") {
           axisValue = phi;
         } else if (axisSelection == "2theta") {
-          axisValue = inputWs->detectorTwoTheta(det);
+          axisValue = inputWs->detectorTwoTheta(*det);
         } else if (axisSelection == "signed2theta") {
-          axisValue = inputWs->detectorSignedTwoTheta(det);
+          axisValue = inputWs->detectorSignedTwoTheta(*det);
         }
 
         if (axisIndex == 0) {

--- a/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
@@ -27,6 +27,10 @@ using namespace Kernel;
 using namespace API;
 using namespace Geometry;
 
+namespace {
+constexpr double rad2deg = 180. / M_PI;
+}
+
 void ConvertSpectrumAxis::init() {
   // Validator for Input Workspace
   auto wsVal = boost::make_shared<CompositeValidator>();
@@ -101,7 +105,7 @@ void ConvertSpectrumAxis::exec() {
       IDetector_const_sptr detector = inputWS->getDetector(i);
       double twoTheta, l1val, l2;
       if (!detector->isMonitor()) {
-        twoTheta = inputWS->detectorTwoTheta(detector);
+        twoTheta = inputWS->detectorTwoTheta(*detector);
         l2 = detector->getDistance(*sample);
         l1val = l1;
         efixed = getEfixed(detector, inputWS, emode); // get efixed
@@ -121,7 +125,7 @@ void ConvertSpectrumAxis::exec() {
   } else {
     // Set up binding to memeber funtion. Avoids condition as part of loop over
     // nHistograms.
-    boost::function<double(IDetector_const_sptr)> thetaFunction;
+    boost::function<double(const IDetector &)> thetaFunction;
     if (unitTarget.compare("signed_theta") == 0) {
       thetaFunction =
           boost::bind(&MatrixWorkspace::detectorSignedTwoTheta, inputWS, _1);
@@ -135,7 +139,7 @@ void ConvertSpectrumAxis::exec() {
       try {
         IDetector_const_sptr det = inputWS->getDetector(i);
         // Invoke relevant member function.
-        indexMap.emplace(thetaFunction(det) * 180.0 / M_PI, i);
+        indexMap.emplace(thetaFunction(*det) * rad2deg, i);
       } catch (Exception::NotFoundError &) {
         if (!warningGiven)
           g_log.warning("The instrument definition is incomplete - spectra "

--- a/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
@@ -115,7 +115,7 @@ void ConvertSpectrumAxis2::createThetaMap(API::Progress &progress,
                                           size_t nHist) {
   // Set up binding to member funtion. Avoids condition as part of loop over
   // nHistograms.
-  boost::function<double(IDetector_const_sptr)> thetaFunction;
+  boost::function<double(const IDetector &)> thetaFunction;
   if (targetUnit.compare("signed_theta") == 0 ||
       targetUnit.compare("SignedTheta") == 0) {
     thetaFunction =
@@ -131,7 +131,7 @@ void ConvertSpectrumAxis2::createThetaMap(API::Progress &progress,
     try {
       IDetector_const_sptr det = inputWS->getDetector(i);
       // Invoke relevant member function.
-      m_indexMap.emplace(thetaFunction(det) * 180.0 / M_PI, i);
+      m_indexMap.emplace(thetaFunction(*det) * rad2deg, i);
     } catch (Exception::NotFoundError &) {
       if (!warningGiven)
         g_log.warning("The instrument definition is incomplete - spectra "
@@ -167,7 +167,7 @@ void ConvertSpectrumAxis2::createElasticQMap(API::Progress &progress,
     IDetector_const_sptr detector = inputWS->getDetector(i);
     double twoTheta(0.0), efixed(0.0);
     if (!detector->isMonitor()) {
-      twoTheta = inputWS->detectorTwoTheta(detector) / 2.0;
+      twoTheta = 0.5 * inputWS->detectorTwoTheta(*detector);
       efixed = getEfixed(detector, inputWS, emode); // get efixed
     } else {
       twoTheta = 0.0;

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -418,7 +418,7 @@ void ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUnit,
   bool bUseSignedVersion =
       (!parameters.empty()) &&
       find(parameters.begin(), parameters.end(), "Always") != parameters.end();
-  function<double(IDetector_const_sptr)> thetaFunction =
+  function<double(const IDetector &)> thetaFunction =
       bUseSignedVersion
           ? bind(&MatrixWorkspace::detectorSignedTwoTheta, outputWS, _1)
           : bind(&MatrixWorkspace::detectorTwoTheta, outputWS, _1);
@@ -437,7 +437,7 @@ void ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUnit,
       if (!det->isMonitor()) {
         l2 = det->getDistance(*sample);
         // The scattering angle for this detector (in radians).
-        twoTheta = thetaFunction(det);
+        twoTheta = thetaFunction(*det);
         // If an indirect instrument, try getting Efixed from the geometry
         if (emode == 2) // indirect
         {

--- a/Framework/Algorithms/src/EstimateResolutionDiffraction.cpp
+++ b/Framework/Algorithms/src/EstimateResolutionDiffraction.cpp
@@ -226,7 +226,7 @@ void EstimateResolutionDiffraction::estimateDetectorResolution() {
     double centraltof = (m_L1 + l2) / m_centreVelocity;
 
     // Angle
-    double twotheta = m_inputWS->detectorTwoTheta(det);
+    double twotheta = m_inputWS->detectorTwoTheta(*det);
     double theta = 0.5 * twotheta;
 
     // double solidangle = m_solidangleWS->readY(i)[0];

--- a/Framework/Algorithms/src/LorentzCorrection.cpp
+++ b/Framework/Algorithms/src/LorentzCorrection.cpp
@@ -104,7 +104,7 @@ void LorentzCorrection::exec() {
     if (!detector)
       continue;
 
-    const double twoTheta = inWS->detectorTwoTheta(detector);
+    const double twoTheta = inWS->detectorTwoTheta(*detector);
     const double sinTheta = std::sin(twoTheta / 2);
     double sinThetaSq = sinTheta * sinTheta;
 

--- a/Framework/Algorithms/src/MultipleScatteringCylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/MultipleScatteringCylinderAbsorption.cpp
@@ -179,7 +179,7 @@ void MultipleScatteringCylinderAbsorption::exec() {
         throw std::runtime_error("Failed to find detector");
       if (det->isMasked())
         continue;
-      const double tth_rad = out_WSevent->detectorTwoTheta(det);
+      const double tth_rad = out_WSevent->detectorTwoTheta(*det);
 
       EventList &eventList = out_WSevent->getEventList(index);
       vector<double> tof_vec, y_vec, err_vec;
@@ -214,7 +214,7 @@ void MultipleScatteringCylinderAbsorption::exec() {
         throw std::runtime_error("Failed to find detector");
       if (det->isMasked())
         continue;
-      const double tth_rad = in_WS->detectorTwoTheta(det);
+      const double tth_rad = in_WS->detectorTwoTheta(*det);
 
       MantidVec tof_vec = in_WS->readX(index);
       MantidVec y_vec = in_WS->readY(index);

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -595,7 +595,7 @@ void Q1D2::convertWavetoQ(const size_t wsInd, const bool doGravity,
     // Calculate the Q values for the current spectrum, using Q =
     // 4*pi*sin(theta)/lambda
     const double factor =
-        2.0 * FOUR_PI * sin(m_dataWS->detectorTwoTheta(det) / 2.0);
+        2.0 * FOUR_PI * sin(m_dataWS->detectorTwoTheta(*det) * 0.5);
     for (; waves != end; ++Qs, ++waves) {
       // the HistogramValidator at the start should ensure that we have one more
       // bin on the input wavelengths

--- a/Framework/Algorithms/src/Q1DWeighted.cpp
+++ b/Framework/Algorithms/src/Q1DWeighted.cpp
@@ -118,7 +118,7 @@ void Q1DWeighted::exec() {
   const V3D samplePos = inputWS->getInstrument()->getSample()->getPos();
 
   const int xLength = static_cast<int>(inputWS->readX(0).size());
-  const double fmp = 4.0 * M_PI;
+  constexpr double fmp = 4.0 * M_PI;
 
   // Set up the progress reporting object
   Progress progress(this, 0.0, 1.0, numSpec * (xLength - 1));
@@ -212,7 +212,7 @@ void Q1DWeighted::exec() {
                        nSubPixels;
         double sub_x = pixelSizeX *
                        (floor(static_cast<double>(isub) / nSubPixels) -
-                        (nSubPixels - 1.0) / 2.0) /
+                        (nSubPixels - 1.0) * 0.5) /
                        nSubPixels;
 
         // Find the position of this sub-pixel in real space and compute Q
@@ -220,7 +220,7 @@ void Q1DWeighted::exec() {
         // use:
         //     double sinTheta = sin( inputWS->detectorTwoTheta(*det)/2.0 );
         V3D pos = det->getPos() - V3D(sub_x, sub_y, 0.0);
-        double sinTheta = sin(pos.angle(beamLine) / 2.0);
+        double sinTheta = sin(0.5 * pos.angle(beamLine));
         double factor = fmp * sinTheta;
         double q = factor * 2.0 / (XIn[j] + XIn[j + 1]);
         int iq = 0;
@@ -275,13 +275,13 @@ void Q1DWeighted::exec() {
               // only over a forward-going cone
               if (isCone)
                 center_angle *= 2.0;
-              center_angle += M_PI / 180.0 * wedgeOffset;
+              center_angle += deg2rad * wedgeOffset;
               V3D sub_pix = V3D(pos.X(), pos.Y(), 0.0);
               double angle = fabs(sub_pix.angle(
                   V3D(cos(center_angle), sin(center_angle), 0.0)));
-              if (angle < M_PI / 180.0 * wedgeAngle / 2.0 ||
+              if (angle < deg2rad * wedgeAngle * 0.5 ||
                   (!isCone &&
-                   fabs(M_PI - angle) < M_PI / 180.0 * wedgeAngle / 2.0)) {
+                   fabs(M_PI - angle) < deg2rad * wedgeAngle * 0.5)) {
                 wedge_lambda_iq[iWedge][iq] += YIn[j] * w;
                 wedge_lambda_iq_err[iWedge][iq] += w * w * EIn[j] * EIn[j];
                 wedge_XNorm[iWedge][iq] += w;

--- a/Framework/Algorithms/src/Q1DWeighted.cpp
+++ b/Framework/Algorithms/src/Q1DWeighted.cpp
@@ -218,7 +218,7 @@ void Q1DWeighted::exec() {
         // Find the position of this sub-pixel in real space and compute Q
         // For reference - in the case where we don't use sub-pixels, simply
         // use:
-        //     double sinTheta = sin( inputWS->detectorTwoTheta(det)/2.0 );
+        //     double sinTheta = sin( inputWS->detectorTwoTheta(*det)/2.0 );
         V3D pos = det->getPos() - V3D(sub_x, sub_y, 0.0);
         double sinTheta = sin(pos.angle(beamLine) / 2.0);
         double factor = fmp * sinTheta;

--- a/Framework/Algorithms/src/Qxy.cpp
+++ b/Framework/Algorithms/src/Qxy.cpp
@@ -162,7 +162,7 @@ void Qxy::exec() {
     double phi = atan2(detPos.Y(), detPos.X());
     double a = cos(phi);
     double b = sin(phi);
-    double sinTheta = sin(inputWorkspace->detectorTwoTheta(det) / 2.0);
+    double sinTheta = sin(inputWorkspace->detectorTwoTheta(*det) * 0.5);
 
     // Get references to the data for this spectrum
     const MantidVec &X = inputWorkspace->readX(i);

--- a/Framework/Algorithms/src/RemoveBins.cpp
+++ b/Framework/Algorithms/src/RemoveBins.cpp
@@ -288,7 +288,7 @@ void RemoveBins::calculateDetectorPosition(const int &index, double &l1,
   if (!det->isMonitor()) {
     l2 = det->getDistance(*sample);
     // The scattering angle for this detector (in radians).
-    twoTheta = m_inputWorkspace->detectorTwoTheta(det);
+    twoTheta = m_inputWorkspace->detectorTwoTheta(*det);
   } else // If this is a monitor then make l1+l2 = source-detector distance and
          // twoTheta=0
   {

--- a/Framework/Algorithms/src/SofQCommon.cpp
+++ b/Framework/Algorithms/src/SofQCommon.cpp
@@ -11,7 +11,7 @@ namespace Algorithms {
  *@param hostAlgorithm :: the pointer to SofQ algorithm hosting the base class.
  *This algorithm expects to have EMode and EFixed properties attached to it.
 */
-void SofQCommon::initCachedValues(API::MatrixWorkspace_const_sptr workspace,
+void SofQCommon::initCachedValues(const API::MatrixWorkspace &workspace,
                                   API::Algorithm *const hostAlgorithm) {
   // Retrieve the emode & efixed properties
   const std::string emode = hostAlgorithm->getProperty("EMode");
@@ -29,8 +29,8 @@ void SofQCommon::initCachedValues(API::MatrixWorkspace_const_sptr workspace,
     // If GetEi was run then it will have been stored in the workspace, if not
     // the user will need to enter one
     if (m_efixed == 0.0) {
-      if (workspace->run().hasProperty("Ei")) {
-        Kernel::Property *p = workspace->run().getProperty("Ei");
+      if (workspace.run().hasProperty("Ei")) {
+        Kernel::Property *p = workspace.run().getProperty("Ei");
         Kernel::PropertyWithValue<double> *eiProp =
             dynamic_cast<Kernel::PropertyWithValue<double> *>(p);
         if (!eiProp)
@@ -60,7 +60,7 @@ void SofQCommon::initCachedValues(API::MatrixWorkspace_const_sptr workspace,
  * @param det A pointer to a detector object
  * @return The value of efixed
  */
-double SofQCommon::getEFixed(Geometry::IDetector_const_sptr det) const {
+double SofQCommon::getEFixed(const Geometry::IDetector &det) const {
   double efixed(0.0);
   if (m_emode == 1) // Direct
   {
@@ -70,10 +70,10 @@ double SofQCommon::getEFixed(Geometry::IDetector_const_sptr det) const {
     if (m_efixedGiven)
       efixed = m_efixed; // user provided a value
     else {
-      std::vector<double> param = det->getNumberParameter("EFixed");
+      std::vector<double> param = det.getNumberParameter("EFixed");
       if (param.empty())
         throw std::runtime_error(
-            "Cannot find EFixed parameter for component \"" + det->getName() +
+            "Cannot find EFixed parameter for component \"" + det.getName() +
             "\". This is required in indirect mode. Please check the IDF "
             "contains these values.");
       efixed = param[0];

--- a/Framework/Algorithms/src/SofQWCentre.cpp
+++ b/Framework/Algorithms/src/SofQWCentre.cpp
@@ -106,7 +106,7 @@ void SofQWCentre::exec() {
   std::vector<specnum_t> specNumberMapping;
   std::vector<detid_t> detIDMapping;
 
-  m_EmodeProperties.initCachedValues(inputWorkspace, this);
+  m_EmodeProperties.initCachedValues(*inputWorkspace, this);
   int emode = m_EmodeProperties.m_emode;
 
   // Get a pointer to the instrument contained in the workspace
@@ -145,7 +145,7 @@ void SofQWCentre::exec() {
       if (spectrumDet->isMonitor())
         continue;
 
-      const double efixed = m_EmodeProperties.getEFixed(spectrumDet);
+      const double efixed = m_EmodeProperties.getEFixed(*spectrumDet);
 
       // For inelastic scattering the simple relationship q=4*pi*sinTheta/lambda
       // does not hold. In order to

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -87,7 +87,7 @@ void SofQWNormalisedPolygon::exec() {
       new API::Progress(this, 0.0, 1.0, nreports));
 
   // Compute input caches
-  m_EmodeProperties.initCachedValues(inputWS, this);
+  m_EmodeProperties.initCachedValues(*inputWS, this);
 
   std::vector<double> par =
       inputWS->getInstrument()->getNumberParameter("detector-neighbour-offset");
@@ -129,7 +129,7 @@ void SofQWNormalisedPolygon::exec() {
     const double phiLower = phi - phiHalfWidth;
     const double phiUpper = phi + phiHalfWidth;
 
-    const double efixed = m_EmodeProperties.getEFixed(detector);
+    const double efixed = m_EmodeProperties.getEFixed(*detector);
     const specnum_t specNo = inputWS->getSpectrum(i)->getSpectrumNo();
     std::stringstream logStream;
     for (size_t j = 0; j < nEnergyBins; ++j) {
@@ -245,7 +245,7 @@ void SofQWNormalisedPolygon::initAngularCachesNonPSD(
       det = workspace->getDetector(i);
       // Check to see if there is an EFixed, if not skip it
       try {
-        m_EmodeProperties.getEFixed(det);
+        m_EmodeProperties.getEFixed(*det);
       } catch (std::runtime_error &) {
         det.reset();
       }
@@ -262,8 +262,7 @@ void SofQWNormalisedPolygon::initAngularCachesNonPSD(
       this->m_thetaWidths[i] = -1.0;
       continue;
     }
-    const double theta = workspace->detectorTwoTheta(det);
-    this->m_theta[i] = theta;
+    this->m_theta[i] = workspace->detectorTwoTheta(*det);
 
     /**
      * Determine width from shape geometry. A group is assumed to contain
@@ -330,7 +329,7 @@ void SofQWNormalisedPolygon::initAngularCachesPSD(
     double phiWidth = -DBL_MAX;
 
     // Find theta and phi widths
-    double theta = workspace->detectorTwoTheta(detector);
+    double theta = workspace->detectorTwoTheta(*detector);
     double phi = detector->getPhi();
 
     specnum_t deltaPlus1 = inSpec + 1;
@@ -344,7 +343,7 @@ void SofQWNormalisedPolygon::initAngularCachesPSD(
       if (spec == deltaPlus1 || spec == deltaMinus1 || spec == deltaPlusT ||
           spec == deltaMinusT) {
         DetConstPtr detector_n = workspace->getDetector(spec - 1);
-        double theta_n = workspace->detectorTwoTheta(detector_n) / 2.0;
+        double theta_n = workspace->detectorTwoTheta(*detector_n) * 0.5;
         double phi_n = detector_n->getPhi();
 
         double dTheta = std::fabs(theta - theta_n);

--- a/Framework/Algorithms/src/TOFSANSResolution.cpp
+++ b/Framework/Algorithms/src/TOFSANSResolution.cpp
@@ -151,8 +151,8 @@ void TOFSANSResolution::exec() {
 
     // Multiplicative factor to go from lambda to Q
     // Don't get fooled by the function name...
-    const double theta = reducedWS->detectorTwoTheta(det);
-    const double factor = 4.0 * M_PI * sin(theta / 2.0);
+    const double theta = reducedWS->detectorTwoTheta(*det);
+    const double factor = 4.0 * M_PI * sin(0.5 * theta);
 
     const MantidVec &XIn = reducedWS->readX(i);
     const MantidVec &YIn = reducedWS->readY(i);

--- a/Framework/Algorithms/src/TOFSANSResolutionByPixel.cpp
+++ b/Framework/Algorithms/src/TOFSANSResolutionByPixel.cpp
@@ -162,8 +162,8 @@ void TOFSANSResolutionByPixel::exec() {
 
     // Multiplicative factor to go from lambda to Q
     // Don't get fooled by the function name...
-    const double theta = inWS->detectorTwoTheta(det);
-    double sinTheta = sin(theta / 2.0);
+    const double theta = inWS->detectorTwoTheta(*det);
+    double sinTheta = sin(0.5 * theta);
     double factor = 4.0 * M_PI * sinTheta;
 
     const MantidVec &xIn = inWS->readX(i);

--- a/Framework/Algorithms/src/VesuvioL1ThetaResolution.cpp
+++ b/Framework/Algorithms/src/VesuvioL1ThetaResolution.cpp
@@ -386,8 +386,7 @@ void VesuvioL1ThetaResolution::calculateDetector(
                 << "detHeight=" << detHeight << std::endl;
 
   // Scattering angle in rad
-  const double theta =
-      m_instWorkspace->detectorTwoTheta(IDetector_const_sptr(detector));
+  const double theta = m_instWorkspace->detectorTwoTheta(*detector);
   if (theta == 0.0)
     return;
 

--- a/Framework/Algorithms/test/LorentzCorrectionTest.h
+++ b/Framework/Algorithms/test/LorentzCorrectionTest.h
@@ -30,9 +30,9 @@ private:
     const Mantid::MantidVec &xData = ws->readX(0);
 
     auto detector = ws->getDetector(0);
-    double twotheta = ws->detectorTwoTheta(detector);
-    double lam = (xData[bin_index] + xData[bin_index + 1]) / 2;
-    double weight = std::sin(twotheta / 2);
+    double twotheta = ws->detectorTwoTheta(*detector);
+    double lam = 0.5 * (xData[bin_index] + xData[bin_index + 1]);
+    double weight = std::sin(0.5 * twotheta);
     weight = weight * weight;
     weight = weight / (lam * lam * lam * lam);
     return weight;

--- a/Framework/CurveFitting/src/Algorithms/ConvertToYSpace.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvertToYSpace.cpp
@@ -78,7 +78,7 @@ DetectorParams ConvertToYSpace::getDetectorParameters(
   detpar.l1 = sample->getDistance(*source);
   detpar.l2 = det->getDistance(*sample);
   detpar.pos = det->getPos();
-  detpar.theta = ws->detectorTwoTheta(det);
+  detpar.theta = ws->detectorTwoTheta(*det);
   detpar.t0 = ConvertToYSpace::getComponentParameter(det, pmap, "t0") *
               1e-6; // Convert to seconds
   detpar.efixed = ConvertToYSpace::getComponentParameter(det, pmap, "efixed");

--- a/Framework/CurveFitting/src/Functions/DiffRotDiscreteCircle.cpp
+++ b/Framework/CurveFitting/src/Functions/DiffRotDiscreteCircle.cpp
@@ -182,7 +182,7 @@ void InelasticDiffRotDiscreteCircle::setWorkspace(
 
     try {
       double efixed = workspace->getEFixed(det);
-      double usignTheta = workspace->detectorTwoTheta(det) / 2.0;
+      double usignTheta = 0.5 * workspace->detectorTwoTheta(*det);
 
       double q = Mantid::Kernel::UnitConversion::run(usignTheta, efixed);
 

--- a/Framework/CurveFitting/src/Functions/DiffSphere.cpp
+++ b/Framework/CurveFitting/src/Functions/DiffSphere.cpp
@@ -292,7 +292,7 @@ void InelasticDiffSphere::setWorkspace(
 
     try {
       double efixed = workspace->getEFixed(det);
-      double usignTheta = workspace->detectorTwoTheta(det) / 2.0;
+      double usignTheta = 0.5 * workspace->detectorTwoTheta(*det);
 
       double q = Mantid::Kernel::UnitConversion::run(usignTheta, efixed);
 

--- a/Framework/DataHandling/src/AppendGeometryToSNSNexus.cpp
+++ b/Framework/DataHandling/src/AppendGeometryToSNSNexus.cpp
@@ -227,7 +227,7 @@ void AppendGeometryToSNSNexus::exec() {
                   pixel_id.push_back(det->getID());
                   distance.push_back(det->getDistance(*sample));
                   azimuthal_angle.push_back(det->getPhi());
-                  polar_angle.push_back(ws->detectorTwoTheta(det));
+                  polar_angle.push_back(ws->detectorTwoTheta(*det));
                 }
 
                 // Write Pixel ID to file

--- a/Framework/DataHandling/src/FindDetectorsPar.cpp
+++ b/Framework/DataHandling/src/FindDetectorsPar.cpp
@@ -192,7 +192,7 @@ void FindDetectorsPar::setOutputTable() {
 }
 
 // Constant for converting Radians to Degrees
-const double rad2deg = 180.0 / M_PI;
+constexpr double rad2deg = 180.0 / M_PI;
 
 /** method calculates an angle closest to the initial one taken on a ring
   * e.g. given inital angle 179 deg and another one -179 closest one to 179 is

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -421,7 +421,7 @@ void SaveAscii2::populateQMetaData() {
     const auto detector = m_ws->getDetector(workspaceIndex);
     double twoTheta(0.0), efixed(0.0);
     if (!detector->isMonitor()) {
-      twoTheta = m_ws->detectorTwoTheta(detector) / 2.0;
+      twoTheta = 0.5 * m_ws->detectorTwoTheta(*detector);
       try {
         efixed = m_ws->getEFixed(detector);
       } catch (std::runtime_error) {
@@ -463,8 +463,9 @@ void SaveAscii2::populateAngleMetaData() {
     const auto specNo = m_ws->getSpectrum(i)->getSpectrumNo();
     const auto workspaceIndex = m_specToIndexMap[specNo];
     auto det = m_ws->getDetector(workspaceIndex);
-    const auto two_theta = m_ws->detectorTwoTheta(det);
-    const auto angleInDeg = two_theta * (180 / M_PI);
+    const auto two_theta = m_ws->detectorTwoTheta(*det);
+    constexpr double rad2deg = 180. / M_PI;
+    const auto angleInDeg = two_theta * rad2deg;
     const auto angleInDegStr = boost::lexical_cast<std::string>(angleInDeg);
     angles.push_back(angleInDegStr);
   }

--- a/Framework/DataHandling/src/SaveFocusedXYE.cpp
+++ b/Framework/DataHandling/src/SaveFocusedXYE.cpp
@@ -328,5 +328,6 @@ void SaveFocusedXYE::getFocusedPos(Mantid::API::MatrixWorkspace_const_sptr wksp,
   l1 = source->getDistance(*sample);
   Geometry::IDetector_const_sptr det = wksp->getDetector(spectrum);
   l2 = det->getDistance(*sample);
-  tth = wksp->detectorTwoTheta(det) * 180. / M_PI;
+  constexpr double rad2deg = 180. / M_PI;
+  tth = wksp->detectorTwoTheta(*det) * rad2deg;
 }

--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -122,10 +122,10 @@ void getFocusedPos(MatrixWorkspace_const_sptr wksp, const int spectrum,
     throw std::runtime_error(errss.str());
   }
   l2 = det->getDistance(*sample);
-  tth = wksp->detectorTwoTheta(det);
+  tth = wksp->detectorTwoTheta(*det);
 
-  difc = ((2.0 * PhysicalConstants::NeutronMass * sin(tth / 2.0) * (l1 + l2)) /
-          (PhysicalConstants::h * 1e4));
+  difc = ((2.0 * PhysicalConstants::NeutronMass * sin(tth * 0.5) * (l1 + l2)) /
+          (PhysicalConstants::h * 1.e4));
 
   return;
 }

--- a/Framework/DataHandling/test/GenerateGroupingPowderTest.h
+++ b/Framework/DataHandling/test/GenerateGroupingPowderTest.h
@@ -71,8 +71,8 @@ public:
       TS_ASSERT_EQUALS(phi, 0);
       TS_ASSERT_DELTA(dx, r * step * Geometry::deg2rad, 0.01);
       TS_ASSERT_EQUALS(dy, 0.01);
-      tth = ws->detectorTwoTheta(ws->getInstrument()->getDetector(detID)) *
-            Geometry::rad2deg;
+      auto det = ws->getInstrument()->getDetector(detID);
+      tth = ws->detectorTwoTheta(*det) * Geometry::rad2deg;
       TS_ASSERT_LESS_THAN(tth, static_cast<double>(i + 1) * step);
       TS_ASSERT_LESS_THAN(static_cast<double>(i) * step, tth);
     }

--- a/Framework/DataObjects/src/ReflectometryTransform.cpp
+++ b/Framework/DataObjects/src/ReflectometryTransform.cpp
@@ -235,7 +235,7 @@ DetectorAngularCache initAngularCaches(const MatrixWorkspace *const workspace) {
       continue;
     }
     // We have to convert theta from radians to degrees
-    const double theta = workspace->detectorSignedTwoTheta(det) * 180.0 / M_PI;
+    const double theta = workspace->detectorSignedTwoTheta(*det) * rad2deg;
     thetas[i] = theta;
     /**
      * Determine width from shape geometry. A group is assumed to contain

--- a/Framework/Kernel/src/Quat.cpp
+++ b/Framework/Kernel/src/Quat.cpp
@@ -798,7 +798,7 @@ Quat::getEulerAngles(const std::string &convention = "XYZ") const {
   V3D axis3(0, 0, 0);
   axis3[last] = 1.0;
 
-  const double rad2deg = 180.0 / M_PI;
+  constexpr double rad2deg = 180.0 / M_PI;
 
   angles[2] = atan2(s3, c3) * rad2deg;
 

--- a/Framework/Kernel/src/V3D.cpp
+++ b/Framework/Kernel/src/V3D.cpp
@@ -345,7 +345,7 @@ double &V3D::operator[](const size_t Index) {
  *  @param phi ::   Returns the phi (azimuthal) angle in degrees
  */
 void V3D::getSpherical(double &R, double &theta, double &phi) const {
-  const double rad2deg = 180.0 / M_PI;
+  constexpr double rad2deg = 180.0 / M_PI;
   R = norm();
   theta = 0.0;
   if (R != 0.0)

--- a/Framework/MDAlgorithms/src/PreprocessDetectorsToMD.cpp
+++ b/Framework/MDAlgorithms/src/PreprocessDetectorsToMD.cpp
@@ -275,7 +275,7 @@ void PreprocessDetectorsToMD::processDetectorsPositions(
     detIDMap[liveDetectorsCount] = i;
     L2[liveDetectorsCount] = spDet->getDistance(*sample);
 
-    double polar = inputWS->detectorTwoTheta(spDet);
+    double polar = inputWS->detectorTwoTheta(*spDet);
     double azim = spDet->getPhi();
     TwoTheta[liveDetectorsCount] = polar;
     Azimuthal[liveDetectorsCount] = azim;

--- a/Framework/MDAlgorithms/src/Quantification/CachedExperimentInfo.cpp
+++ b/Framework/MDAlgorithms/src/Quantification/CachedExperimentInfo.cpp
@@ -185,7 +185,7 @@ void CachedExperimentInfo::initCaches(
                                 boost::lexical_cast<std::string>(det->getID()));
   }
 
-  const double rad2deg = 180. / M_PI;
+  constexpr double rad2deg = 180. / M_PI;
   const double thetaInDegs = twoTheta() * rad2deg;
   const double phiInDegs = phi() * rad2deg;
 

--- a/Framework/MDAlgorithms/test/SaveMD2Test.h
+++ b/Framework/MDAlgorithms/test/SaveMD2Test.h
@@ -17,14 +17,6 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using namespace Mantid::MDAlgorithms;
 
-class SaveMD2Tester : public SaveMD2 {
-public:
-  void saveExperimentInfos(::NeXus::File *const file,
-                           IMDEventWorkspace_const_sptr ws) {
-    this->saveExperimentInfos(file, ws);
-  }
-};
-
 /** Note: See the LoadMDTest class
  * for a more thorough test that does
  * a round-trip.

--- a/Framework/MDAlgorithms/test/SaveMDTest.h
+++ b/Framework/MDAlgorithms/test/SaveMDTest.h
@@ -16,14 +16,6 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using namespace Mantid::MDAlgorithms;
 
-class SaveMDTester : public SaveMD {
-public:
-  void saveExperimentInfos(::NeXus::File *const file,
-                           IMDEventWorkspace_const_sptr ws) {
-    this->saveExperimentInfos(file, ws);
-  }
-};
-
 /** Note: See the LoadMDTest class
  * for a more thorough test that does
  * a round-trip.

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -182,8 +182,6 @@ Mantid::API::Run &getSampleDetailsDeprecated(MatrixWorkspace &self) {
 void export_MatrixWorkspace() {
   /// Typedef to remove const qualifier on input detector shared_ptr. See
   /// Policies/RemoveConst.h for more details
-  typedef double (MatrixWorkspace::*getDetectorSignature)(
-      Mantid::Geometry::IDetector_sptr det) const;
 
   class_<MatrixWorkspace, boost::python::bases<ExperimentInfo, IMDWorkspace>,
          boost::noncopyable>("MatrixWorkspace", no_init)
@@ -198,12 +196,10 @@ void export_MatrixWorkspace() {
                (arg("self"), arg("xvalue"), arg("workspaceIndex")),
                "Returns the index of the bin containing the given xvalue. The "
                "workspace_index is optional [default=0]"))
-      .def("detectorTwoTheta",
-           (getDetectorSignature)&MatrixWorkspace::detectorTwoTheta,
+      .def("detectorTwoTheta", &MatrixWorkspace::detectorTwoTheta,
            (arg("self"), arg("det")),
            "Returns the two theta value for a given detector")
-      .def("detectorSignedTwoTheta",
-           (getDetectorSignature)&MatrixWorkspace::detectorSignedTwoTheta,
+      .def("detectorSignedTwoTheta", &MatrixWorkspace::detectorSignedTwoTheta,
            (arg("self"), arg("det")),
            "Returns the signed two theta value for given detector")
       .def("getSpectrum", (ISpectrum * (MatrixWorkspace::*)(const size_t)) &

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -1311,7 +1311,7 @@ void processDetectorsPositions(const API::MatrixWorkspace_const_sptr &inputWS,
     detIDMap[liveDetectorsCount] = i;
     L2[liveDetectorsCount] = spDet->getDistance(*sample);
 
-    double polar = inputWS->detectorTwoTheta(spDet);
+    double polar = inputWS->detectorTwoTheta(*spDet);
     double azim = spDet->getPhi();
     TwoTheta[liveDetectorsCount] = polar;
     Azimuthal[liveDetectorsCount] = azim;

--- a/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
@@ -140,7 +140,7 @@ void SANSSolidAngleCorrection::exec() {
 
     // Compute solid angle correction factor
     const bool is_tube = getProperty("DetectorTubes");
-    const double tanTheta = tan(inputWS->detectorTwoTheta(det));
+    const double tanTheta = tan(inputWS->detectorTwoTheta(*det));
     const double theta_term = sqrt(tanTheta * tanTheta + 1.0);
     double corr;
     if (is_tube) {
@@ -204,7 +204,7 @@ void SANSSolidAngleCorrection::execEvent() {
 
     // Compute solid angle correction factor
     const bool is_tube = getProperty("DetectorTubes");
-    const double tanTheta = tan(outputEventWS->detectorTwoTheta(det));
+    const double tanTheta = tan(outputEventWS->detectorTwoTheta(*det));
     const double theta_term = sqrt(tanTheta * tanTheta + 1.0);
     double corr;
     if (is_tube) {

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -1235,8 +1235,8 @@ Table *MantidUI::createDetectorTable(
       // Need to get R, theta through these methods to be correct for grouped
       // detectors
       R = det->getDistance(*sample);
-      theta = showSignedTwoTheta ? ws->detectorSignedTwoTheta(det)
-                                 : ws->detectorTwoTheta(det);
+      theta = showSignedTwoTheta ? ws->detectorSignedTwoTheta(*det)
+                                 : ws->detectorTwoTheta(*det);
       theta *= 180.0 / M_PI; // To degrees
       QString isMonitor = det->isMonitor() ? "yes" : "no";
 
@@ -1252,7 +1252,7 @@ Table *MantidUI::createDetectorTable(
         try {
           // Get unsigned theta and efixed value
           double efixed = ws->getEFixed(det);
-          double usignTheta = ws->detectorTwoTheta(det) / 2.0;
+          double usignTheta = ws->detectorTwoTheta(*det) * 0.5;
 
           double q = Mantid::Kernel::UnitConversion::run(usignTheta, efixed);
           colValues << QVariant(q);

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflMainViewPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflMainViewPresenter.cpp
@@ -108,7 +108,7 @@ void ReflMainViewPresenter::pushCommands() {
 
   // The expected number of commands
   const size_t nCommands = 26;
-  auto commands = std::move(m_tablePresenter->publishCommands());
+  auto commands = m_tablePresenter->publishCommands();
   if (commands.size() != nCommands) {
     throw std::runtime_error("Invalid list of commands");
   }

--- a/MantidQt/SpectrumViewer/src/MatrixWSDataSource.cpp
+++ b/MantidQt/SpectrumViewer/src/MatrixWSDataSource.cpp
@@ -282,12 +282,12 @@ std::vector<std::string> MatrixWSDataSource::getInfoList(double x, double y) {
       l2 = l2 - l1;
     } else {
       l2 = det->getDistance(*m_sample);
-      two_theta = m_matWs->detectorTwoTheta(det);
+      two_theta = m_matWs->detectorTwoTheta(*det);
       azi = det->getPhi();
     }
     SVUtils::PushNameValue("L2", 8, 4, l2, list);
-    SVUtils::PushNameValue("TwoTheta", 8, 2, two_theta * 180. / M_PI, list);
-    SVUtils::PushNameValue("Azimuthal", 8, 2, azi * 180. / M_PI, list);
+    SVUtils::PushNameValue("TwoTheta", 8, 2, two_theta * deg2rad, list);
+    SVUtils::PushNameValue("Azimuthal", 8, 2, azi * deg2rad, list);
 
     /* For now, only support diffractometers and monitors. */
     /* We need a portable way to determine emode and */


### PR DESCRIPTION
Description of work.

This changes `MatrixWorkspace::detectorTwoTheta(...)` and `MatrixWorkspace::detectorSignedTwoTheta(...)` so that they accept a reference to `Geometry::IDetector` and avoid unnecessarily incrementing/decrementing a shared_ptr. This clarifies that neither function assumes (shared) ownership of the detector and, if this function is called in a tight loop, may improve performance. 

**To test:**

<!-- Instructions for testing. -->

This is a small change with no issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
