### PR TITLE
Remove release() call that's no longer necessary

### DIFF
--- a/Framework/Algorithms/src/AlignDetectors.cpp
+++ b/Framework/Algorithms/src/AlignDetectors.cpp
@@ -371,7 +371,7 @@ void AlignDetectors::execEvent() {
   // generate the output workspace pointer
   API::MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
   if (matrixOutputWS != matrixInputWS) {
-    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
+    matrixOutputWS = matrixInputWS->clone();
     this->setProperty("OutputWorkspace", matrixOutputWS);
   }
   auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -226,7 +226,7 @@ void BinaryOperation::exec() {
             "Contact the developers.");
     } else {
       // You HAVE to copy the data from lhs to to the output!
-      m_out = MatrixWorkspace_sptr(m_lhs->clone().release());
+      m_out = m_lhs->clone();
       // Make sure m_eout still points to the same as m_out;
       m_eout = boost::dynamic_pointer_cast<EventWorkspace>(m_out);
     }

--- a/Framework/Algorithms/src/ChangeBinOffset.cpp
+++ b/Framework/Algorithms/src/ChangeBinOffset.cpp
@@ -33,7 +33,7 @@ void ChangeBinOffset::exec() {
   const MatrixWorkspace_sptr inputW = getProperty("InputWorkspace");
   MatrixWorkspace_sptr outputW = getProperty("OutputWorkspace");
   if (outputW != inputW) {
-    outputW = MatrixWorkspace_sptr(inputW->clone().release());
+    outputW = inputW->clone();
     setProperty("OutputWorkspace", outputW);
   }
 

--- a/Framework/Algorithms/src/ChangePulsetime.cpp
+++ b/Framework/Algorithms/src/ChangePulsetime.cpp
@@ -53,7 +53,7 @@ void ChangePulsetime::exec() {
   EventWorkspace_const_sptr in_ws = getProperty("InputWorkspace");
   EventWorkspace_sptr out_ws = getProperty("OutputWorkspace");
   if (!out_ws) {
-    out_ws = EventWorkspace_sptr(in_ws->clone().release());
+    out_ws = in_ws->clone();
   }
 
   // Either use the given list or use all spectra

--- a/Framework/Algorithms/src/CloneWorkspace.cpp
+++ b/Framework/Algorithms/src/CloneWorkspace.cpp
@@ -37,7 +37,7 @@ void CloneWorkspace::exec() {
 
   if (inputMatrix || iTableWS) {
     // Workspace::clone() is polymorphic, we can use the same for all types
-    Workspace_sptr outputWS(inputWorkspace->clone().release());
+    Workspace_sptr outputWS(inputWorkspace->clone());
     setProperty("OutputWorkspace", outputWS);
   } else if (inputMD) {
     // Call the CloneMDWorkspace algo to handle MDEventWorkspace

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -212,7 +212,7 @@ API::MatrixWorkspace_sptr ConvertUnits::setupOutputWorkspace(
   // If input and output workspaces are NOT the same, create a new workspace for
   // the output
   if (outputWS != inputWS) {
-    outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
+    outputWS = inputWS->clone();
   }
 
   if (!m_inputEvents && m_distribution) {

--- a/Framework/Algorithms/src/ConvertUnitsUsingDetectorTable.cpp
+++ b/Framework/Algorithms/src/ConvertUnitsUsingDetectorTable.cpp
@@ -226,7 +226,7 @@ API::MatrixWorkspace_sptr ConvertUnitsUsingDetectorTable::setupOutputWorkspace(
   // If input and output workspaces are NOT the same, create a new workspace for
   // the output
   if (outputWS != inputWS) {
-    outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
+    outputWS = inputWS->clone();
   }
 
   if (!m_inputEvents && m_distribution) {

--- a/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
@@ -111,7 +111,7 @@ void CorelliCrossCorrelate::exec() {
   outputWS = getProperty("OutputWorkspace");
 
   if (outputWS != inputWS) {
-    outputWS = EventWorkspace_sptr(inputWS->clone().release());
+    outputWS = inputWS->clone();
   }
 
   // Read in chopper sequence from IDF.

--- a/Framework/Algorithms/src/CorrectKiKf.cpp
+++ b/Framework/Algorithms/src/CorrectKiKf.cpp
@@ -201,7 +201,7 @@ void CorrectKiKf::execEvent() {
   // generate the output workspace pointer
   API::MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
   if (matrixOutputWS != matrixInputWS) {
-    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
+    matrixOutputWS = matrixInputWS->clone();
     setProperty("OutputWorkspace", matrixOutputWS);
   }
   auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);

--- a/Framework/Algorithms/src/FilterByXValue.cpp
+++ b/Framework/Algorithms/src/FilterByXValue.cpp
@@ -85,7 +85,7 @@ void FilterByXValue::exec() {
     // entail new methods (e.g. iterators) on EventList as this algorithm
     // shouldn't
     // need to know about the type of the events (e.g. weighted).
-    outputWS = EventWorkspace_sptr(inputWS->clone().release());
+    outputWS = inputWS->clone();
     setProperty("OutputWorkspace", outputWS);
   }
 

--- a/Framework/Algorithms/src/He3TubeEfficiency.cpp
+++ b/Framework/Algorithms/src/He3TubeEfficiency.cpp
@@ -416,8 +416,7 @@ void He3TubeEfficiency::execEvent() {
   // generate the output workspace pointer
   API::MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
   if (matrixOutputWS != matrixInputWS) {
-    matrixOutputWS =
-        API::MatrixWorkspace_sptr(matrixInputWS->clone().release());
+    matrixOutputWS = matrixInputWS->clone();
     setProperty("OutputWorkspace", matrixOutputWS);
   }
   auto outputWS =

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -94,7 +94,7 @@ void MaskBins::exec() {
   // Only create the output workspace if it's different to the input one
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
   if (outputWS != inputWS) {
-    outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
+    outputWS = inputWS->clone();
     setProperty("OutputWorkspace", outputWS);
   }
 

--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -264,7 +264,7 @@ void MergeRuns::execEvent() {
 
   // Create a new output event workspace, by copying the first WS in the list
   EventWorkspace_sptr inputWS = m_inEventWS[0];
-  EventWorkspace_sptr outWS(inputWS->clone().release());
+  EventWorkspace_sptr outWS(inputWS->clone());
 
   int64_t n = m_inEventWS.size() - 1;
   m_progress = new Progress(this, 0.0, 1.0, n);

--- a/Framework/Algorithms/src/ModeratorTzero.cpp
+++ b/Framework/Algorithms/src/ModeratorTzero.cpp
@@ -249,7 +249,7 @@ void ModeratorTzero::execEvent(const std::string &emode) {
   // generate the output workspace pointer
   API::MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
   if (matrixOutputWS != matrixInputWS) {
-    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
+    matrixOutputWS = matrixInputWS->clone();
     setProperty("OutputWorkspace", matrixOutputWS);
   }
   auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);

--- a/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
+++ b/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
@@ -185,7 +185,7 @@ void ModeratorTzeroLinear::execEvent() {
   // generate the output workspace pointer
   MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
   if (matrixOutputWS != matrixInputWS) {
-    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
+    matrixOutputWS = matrixInputWS->clone();
     setProperty("OutputWorkspace", matrixOutputWS);
   }
   auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);

--- a/Framework/Algorithms/src/MultipleScatteringCylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/MultipleScatteringCylinderAbsorption.cpp
@@ -163,7 +163,7 @@ void MultipleScatteringCylinderAbsorption::exec() {
     // not in-place so create a new copy
     MatrixWorkspace_sptr out_WS = getProperty("OutputWorkspace");
     if (in_WS != out_WS) {
-      out_WS = MatrixWorkspace_sptr(in_WS->clone().release());
+      out_WS = in_WS->clone();
     }
     auto out_WSevent = boost::dynamic_pointer_cast<EventWorkspace>(out_WS);
 

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -566,7 +566,7 @@ void NormaliseToMonitor::normaliseBinByBin(
   // Only create output workspace if different to input one
   if (outputWorkspace != inputWorkspace) {
     if (inputEvent) {
-      outputWorkspace = MatrixWorkspace_sptr(inputWorkspace->clone().release());
+      outputWorkspace = inputWorkspace->clone();
     } else
       outputWorkspace = WorkspaceFactory::Instance().create(inputWorkspace);
   }

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -147,7 +147,7 @@ void Rebin::exec() {
 
     if (PreserveEvents) {
       if (!inPlace) {
-        outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
+        outputWS = inputWS->clone();
       }
       auto eventOutputWS =
           boost::dynamic_pointer_cast<EventWorkspace>(outputWS);

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -542,7 +542,7 @@ ReflectometryReductionOneAuto::sumOverTransmissionGroup(
   // We used .release because clone() will return a unique_ptr.
   // we need to release the ownership of the pointer so that it
   // can be cast into a shared_ptr of type Workspace.
-  Workspace_sptr transmissionRunSum(transGroup->getItem(0)->clone().release());
+  Workspace_sptr transmissionRunSum(transGroup->getItem(0)->clone());
 
   // make a variable to store the overall total of the summation
   MatrixWorkspace_sptr total;

--- a/Framework/Algorithms/src/RemoveLowResTOF.cpp
+++ b/Framework/Algorithms/src/RemoveLowResTOF.cpp
@@ -123,7 +123,7 @@ void RemoveLowResTOF::exec() {
   // Only create the output workspace if it's different to the input one
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
   if (outputWS != m_inputWS) {
-    outputWS = MatrixWorkspace_sptr(m_inputWS->clone().release());
+    outputWS = m_inputWS->clone();
     setProperty("OutputWorkspace", outputWS);
   }
 
@@ -168,7 +168,7 @@ void RemoveLowResTOF::execEvent() {
 
   MatrixWorkspace_sptr matrixLowResW = getProperty("LowResTOFWorkspace");
   if (m_outputLowResTOF) {
-    matrixLowResW = MatrixWorkspace_sptr(m_inputWS->clone().release());
+    matrixLowResW = m_inputWS->clone();
     setProperty("LowResTOFWorkspace", matrixLowResW);
   }
   auto lowW = boost::dynamic_pointer_cast<EventWorkspace>(matrixLowResW);

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -327,7 +327,7 @@ void ResampleX::exec() {
         g_log.debug() << "Rebinning event workspace in place\n";
       } else {
         g_log.debug() << "Rebinning event workspace out of place\n";
-        outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
+        outputWS = inputWS->clone();
       }
       auto outputEventWS =
           boost::dynamic_pointer_cast<EventWorkspace>(outputWS);

--- a/Framework/Algorithms/src/Scale.cpp
+++ b/Framework/Algorithms/src/Scale.cpp
@@ -51,7 +51,7 @@ void Scale::exec() {
 
     if (outputWS == inputWS) {
       if (hasDx) {
-        bufferWS = MatrixWorkspace_sptr(inputWS->clone().release());
+        bufferWS = inputWS->clone();
       }
       inputWS *= factor;
     } else {
@@ -63,7 +63,7 @@ void Scale::exec() {
 
     if (outputWS == inputWS) {
       if (hasDx) {
-        bufferWS = MatrixWorkspace_sptr(inputWS->clone().release());
+        bufferWS = inputWS->clone();
       }
       inputWS += factor;
     } else {

--- a/Framework/Algorithms/src/ScaleX.cpp
+++ b/Framework/Algorithms/src/ScaleX.cpp
@@ -176,7 +176,7 @@ void ScaleX::execEvent() {
   // generate the output workspace pointer
   API::MatrixWorkspace_sptr matrixOutputWS = getProperty("OutputWorkspace");
   if (matrixOutputWS != matrixInputWS) {
-    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
+    matrixOutputWS = matrixInputWS->clone();
     setProperty("OutputWorkspace", matrixOutputWS);
   }
   auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);

--- a/Framework/Algorithms/src/UnaryOperation.cpp
+++ b/Framework/Algorithms/src/UnaryOperation.cpp
@@ -116,7 +116,7 @@ void UnaryOperation::execEvent() {
   // generate the output workspace pointer
   API::MatrixWorkspace_sptr matrixOutputWS = getProperty(outputPropName());
   if (matrixOutputWS != matrixInputWS) {
-    matrixOutputWS = MatrixWorkspace_sptr(matrixInputWS->clone().release());
+    matrixOutputWS = matrixInputWS->clone();
     setProperty(outputPropName(), matrixOutputWS);
   }
   auto outputWS = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);

--- a/Framework/Algorithms/src/UnwrapSNS.cpp
+++ b/Framework/Algorithms/src/UnwrapSNS.cpp
@@ -191,7 +191,7 @@ void UnwrapSNS::execEvent() {
   // set up the output workspace
   MatrixWorkspace_sptr matrixOutW = this->getProperty("OutputWorkspace");
   if (matrixOutW != m_inputWS) {
-    matrixOutW = MatrixWorkspace_sptr(m_inputWS->clone().release());
+    matrixOutW = m_inputWS->clone();
     setProperty("OutputWorkspace", matrixOutW);
   }
   auto outW = boost::dynamic_pointer_cast<EventWorkspace>(matrixOutW);

--- a/Framework/Algorithms/test/Q1D2Test.h
+++ b/Framework/Algorithms/test/Q1D2Test.h
@@ -626,8 +626,8 @@ void createQResolutionWorkspace(Mantid::API::MatrixWorkspace_sptr &qResolution,
                                 double value1, double value2) {
   // The q resolution workspace is almost the same to the input workspace,
   // except for the y value, we set all Y values to 1
-  qResolution = Mantid::API::MatrixWorkspace_sptr(input->clone().release());
-  alteredInput = Mantid::API::MatrixWorkspace_sptr(input->clone().release());
+  qResolution = input->clone();
+  alteredInput = input->clone();
 
   // Populate Y with Value1
   for (size_t i = 0; i < qResolution->getNumberHistograms(); ++i) {

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -73,7 +73,7 @@ void CentroidPeaks::integrate() {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutPeaksWorkspace");
   if (peakWS != inPeakWS)
-    peakWS.reset(inPeakWS->clone().release());
+    peakWS = inPeakWS->clone();
 
   /// Radius to use around peaks
   int PeakRadius = getProperty("PeakRadius");
@@ -209,7 +209,7 @@ void CentroidPeaks::integrateEvent() {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutPeaksWorkspace");
   if (peakWS != inPeakWS)
-    peakWS.reset(inPeakWS->clone().release());
+    peakWS = inPeakWS->clone();
 
   /// Radius to use around peaks
   int PeakRadius = getProperty("PeakRadius");

--- a/Framework/Crystal/src/CombinePeaksWorkspaces.cpp
+++ b/Framework/Crystal/src/CombinePeaksWorkspaces.cpp
@@ -81,7 +81,7 @@ void CombinePeaksWorkspaces::exec() {
   }
 
   // Copy the first workspace to our output workspace
-  PeaksWorkspace_sptr output(LHSWorkspace->clone().release());
+  PeaksWorkspace_sptr output(LHSWorkspace->clone());
   // Get hold of the peaks in the second workspace
   auto &rhsPeaks = RHSWorkspace->getPeaks();
 

--- a/Framework/Crystal/src/ConnectedComponentLabeling.cpp
+++ b/Framework/Crystal/src/ConnectedComponentLabeling.cpp
@@ -61,7 +61,7 @@ size_t calculateMaxClusters(IMDHistoWorkspace const *const ws,
  */
 boost::shared_ptr<Mantid::API::IMDHistoWorkspace>
 cloneInputWorkspace(IMDHistoWorkspace_sptr &inWS) {
-  IMDHistoWorkspace_sptr outWS(inWS->clone().release());
+  IMDHistoWorkspace_sptr outWS(inWS->clone());
 
   // Initialize to zero.
   PARALLEL_FOR_NO_WSP_CHECK()

--- a/Framework/Crystal/src/DiffPeaksWorkspaces.cpp
+++ b/Framework/Crystal/src/DiffPeaksWorkspaces.cpp
@@ -74,7 +74,7 @@ void DiffPeaksWorkspaces::exec() {
   }
 
   // Copy the first workspace to our output workspace
-  PeaksWorkspace_sptr output(LHSWorkspace->clone().release());
+  PeaksWorkspace_sptr output(LHSWorkspace->clone());
   // Get hold of the peaks in the second workspace
   auto &rhsPeaks = RHSWorkspace->getPeaks();
   // Get hold of the peaks in the first workspace as we'll need to examine them

--- a/Framework/Crystal/src/IntegratePeaksHybrid.cpp
+++ b/Framework/Crystal/src/IntegratePeaksHybrid.cpp
@@ -164,7 +164,7 @@ void IntegratePeaksHybrid::exec() {
   const double peakOuterRadius = getProperty("BackgroundOuterRadius");
   const double halfPeakOuterRadius = peakOuterRadius / 2;
   if (peakWS != inPeakWS) {
-    peakWS = IPeaksWorkspace_sptr(inPeakWS->clone().release());
+    peakWS = inPeakWS->clone();
   }
 
   {

--- a/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
+++ b/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
@@ -120,7 +120,7 @@ void IntegratePeaksUsingClusters::exec() {
   IPeaksWorkspace_sptr inPeakWS = getProperty("PeaksWorkspace");
   IPeaksWorkspace_sptr peakWS = getProperty("OutputWorkspace");
   if (peakWS != inPeakWS) {
-    peakWS = IPeaksWorkspace_sptr(inPeakWS->clone().release());
+    peakWS = inPeakWS->clone();
   }
 
   {

--- a/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
+++ b/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
@@ -149,8 +149,7 @@ void OptimizeCrystalPlacement::exec() {
   PeaksWorkspace_sptr OutPeaks = getProperty("ModifiedPeaksWorkspace");
 
   if (Peaks != OutPeaks) {
-    boost::shared_ptr<PeaksWorkspace> X(Peaks->clone().release());
-    OutPeaks = X;
+    OutPeaks = Peaks->clone();
   }
 
   std::vector<int> NOoptimizeRuns = getProperty("KeepGoniometerFixedfor");

--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -120,7 +120,7 @@ void OptimizeLatticeForCellType::exec() {
   }
   // finally do the optimization
   for (auto &i_run : runWS) {
-    DataObjects::PeaksWorkspace_sptr peakWS(i_run->clone().release());
+    DataObjects::PeaksWorkspace_sptr peakWS(i_run->clone());
     AnalysisDataService::Instance().addOrReplace("_peaks", peakWS);
     const DblMatrix UB = peakWS->sample().getOrientedLattice().getUB();
     std::vector<double> lat(6);

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -75,7 +75,7 @@ void PeakIntegration::exec() {
   /// Output peaks workspace, create if needed
   PeaksWorkspace_sptr peaksW = getProperty("OutPeaksWorkspace");
   if (peaksW != inPeaksW)
-    peaksW.reset(inPeaksW->clone().release());
+    peaksW = inPeaksW->clone();
 
   double qspan = 0.12;
   m_IC = getProperty("IkedaCarpenterTOF");

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -116,7 +116,7 @@ void SaveHKL::exec() {
   // HKL will be overwritten by equivalent HKL but never seen by user
   PeaksWorkspace_sptr peaksW = getProperty("OutputWorkspace");
   if (peaksW != ws)
-    peaksW.reset(ws->clone().release());
+    peaksW = ws->clone();
   double scaleFactor = getProperty("ScalePeaks");
   double dMin = getProperty("MinDSpacing");
   double wlMin = getProperty("MinWavelength");

--- a/Framework/Crystal/src/SortHKL.cpp
+++ b/Framework/Crystal/src/SortHKL.cpp
@@ -302,7 +302,7 @@ PeaksWorkspace_sptr SortHKL::getOutputPeaksWorkspace(
     const PeaksWorkspace_sptr &inputPeaksWorkspace) const {
   PeaksWorkspace_sptr outputPeaksWorkspace = getProperty("OutputWorkspace");
   if (outputPeaksWorkspace != inputPeaksWorkspace) {
-    outputPeaksWorkspace.reset(inputPeaksWorkspace->clone().release());
+    outputPeaksWorkspace = inputPeaksWorkspace->clone();
   }
 
   return outputPeaksWorkspace;

--- a/Framework/Crystal/src/SortPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/SortPeaksWorkspace.cpp
@@ -92,7 +92,7 @@ void SortPeaksWorkspace::exec() {
     inputWS->getColumn(columnToSortBy);
 
     if (inputWS != outputWS) {
-      outputWS = boost::shared_ptr<PeaksWorkspace>(inputWS->clone().release());
+      outputWS = inputWS->clone();
     }
 
     // Perform the sorting.

--- a/Framework/Crystal/src/TOFExtinction.cpp
+++ b/Framework/Crystal/src/TOFExtinction.cpp
@@ -70,7 +70,7 @@ void TOFExtinction::exec() {
   /// Output peaks workspace, create if needed
   PeaksWorkspace_sptr peaksW = getProperty("OutputWorkspace");
   if (peaksW != inPeaksW)
-    peaksW.reset(inPeaksW->clone().release());
+    peaksW = inPeaksW->clone();
 
   const Kernel::Material *m_sampleMaterial =
       &(inPeaksW->sample().getMaterial());

--- a/Framework/Crystal/test/IndexSXPeaksTest.h
+++ b/Framework/Crystal/test/IndexSXPeaksTest.h
@@ -55,7 +55,7 @@ public:
               double dTolerance = 0.01) {
 
     // Take a copy of the original peaks workspace.
-    PeaksWorkspace_sptr local(m_masterPeaks->clone().release());
+    PeaksWorkspace_sptr local(m_masterPeaks->clone());
     // Clear the copies hkl values with some invalid values so that we'll know
     // if we fail.
     for (int i = 0; i < nPixels; i++) {
@@ -114,7 +114,7 @@ public:
   }
 
   void test_colinearPeaksThrows() {
-    PeaksWorkspace_sptr temp(m_masterPeaks->clone().release());
+    PeaksWorkspace_sptr temp(m_masterPeaks->clone());
 
     for (int i = 0; i < m_masterPeaks->getNumberPeaks(); i++) {
       IPeak &peak = m_masterPeaks->getPeak(i);

--- a/Framework/DataHandling/src/SortTableWorkspace.cpp
+++ b/Framework/DataHandling/src/SortTableWorkspace.cpp
@@ -90,7 +90,7 @@ void SortTableWorkspace::exec() {
     crt->second = (*asc) != 0;
   }
 
-  API::ITableWorkspace_sptr outputWS(ws->clone().release());
+  API::ITableWorkspace_sptr outputWS(ws->clone());
   outputWS->sort(criteria);
   setProperty("OutputWorkspace", outputWS);
 }

--- a/Framework/DataObjects/test/RebinnedOutputTest.h
+++ b/Framework/DataObjects/test/RebinnedOutputTest.h
@@ -29,7 +29,7 @@ public:
   }
 
   void testClone() {
-    RebinnedOutput_sptr cloned(ws->clone().release());
+    RebinnedOutput_sptr cloned(ws->clone());
 
     // Swap ws with cloned pointer, such that we can reuse existing tests.
     ws.swap(cloned);

--- a/Framework/DataObjects/test/TableWorkspaceTest.h
+++ b/Framework/DataObjects/test/TableWorkspaceTest.h
@@ -305,7 +305,7 @@ public:
     tw.getColumn(1)->cell<std::string>(0) = "b";
     tw.getColumn(2)->cell<std::string>(0) = "c";
 
-    boost::scoped_ptr<TableWorkspace> cloned(tw.clone().release());
+    std::unique_ptr<TableWorkspace> cloned(tw.clone());
 
     // Check clone is same as original.
     TS_ASSERT_EQUALS(tw.columnCount(), cloned->columnCount());

--- a/Framework/DataObjects/test/Workspace2DTest.h
+++ b/Framework/DataObjects/test/Workspace2DTest.h
@@ -55,7 +55,7 @@ public:
   }
 
   void testClone() {
-    Workspace2D_sptr cloned(ws->clone().release());
+    Workspace2D_sptr cloned(ws->clone());
 
     // Swap ws with cloned pointer, such that we can reuse existing tests.
     ws.swap(cloned);

--- a/Framework/MDAlgorithms/src/CentroidPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/CentroidPeaksMD.cpp
@@ -83,7 +83,7 @@ void CentroidPeaksMD::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutputWorkspace");
   if (peakWS != inPeakWS)
-    peakWS.reset(inPeakWS->clone().release());
+    peakWS = inPeakWS->clone();
 
   std::string CoordinatesToUseStr = getPropertyValue("CoordinatesToUse");
   int CoordinatesToUse = ws->getSpecialCoordinateSystem();

--- a/Framework/MDAlgorithms/src/CentroidPeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/CentroidPeaksMD2.cpp
@@ -77,7 +77,7 @@ void CentroidPeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutputWorkspace");
   if (peakWS != inPeakWS)
-    peakWS.reset(inPeakWS->clone().release());
+    peakWS = inPeakWS->clone();
 
   int CoordinatesToUse = ws->getSpecialCoordinateSystem();
 

--- a/Framework/MDAlgorithms/src/CloneMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/CloneMDWorkspace.cpp
@@ -109,7 +109,7 @@ void CloneMDWorkspace::doClone(
                       boost::dynamic_pointer_cast<IMDWorkspace>(outWS));
   } else {
     // Perform the clone in memory.
-    IMDWorkspace_sptr outWS(ws->clone().release());
+    IMDWorkspace_sptr outWS(ws->clone());
     setProperty("OutputWorkspace", outWS);
   }
 }
@@ -128,7 +128,7 @@ void CloneMDWorkspace::exec() {
     CALL_MDEVENT_FUNCTION(this->doClone, inWS);
   } else if (inHistoWS) {
     // Polymorphic clone().
-    IMDWorkspace_sptr outWS(inHistoWS->clone().release());
+    IMDWorkspace_sptr outWS(inHistoWS->clone());
     // And set to the output. Easy.
     this->setProperty("OutputWorkspace", outWS);
   } else {

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
@@ -341,7 +341,7 @@ void IntegrateEllipsoids::exec() {
   Mantid::DataObjects::PeaksWorkspace_sptr peak_ws =
       getProperty("OutputWorkspace");
   if (peak_ws != in_peak_ws) {
-    peak_ws.reset(in_peak_ws->clone().release());
+    peak_ws = in_peak_ws->clone();
   }
 
   // get UBinv and the list of

--- a/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -319,8 +319,8 @@ void IntegrateMDHistoWorkspace::exec() {
   if (emptyCount == pbins.size()) {
     // No work to do.
     g_log.information(this->name() + " Direct clone of input.");
-    this->setProperty("OutputWorkspace", boost::shared_ptr<IMDHistoWorkspace>(
-                                             inWS->clone().release()));
+    this->setProperty("OutputWorkspace",
+                      boost::shared_ptr<IMDHistoWorkspace>(inWS->clone()));
   } else {
 
     /* Create the output workspace in the right shape. This allows us to iterate

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
@@ -165,7 +165,7 @@ void IntegratePeaksMD::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutputWorkspace");
   if (peakWS != inPeakWS)
-    peakWS.reset(inPeakWS->clone().release());
+    peakWS = inPeakWS->clone();
 
   /// Value of the CoordinatesToUse property.
   std::string CoordinatesToUseStr = getPropertyValue("CoordinatesToUse");

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -175,7 +175,7 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutputWorkspace");
   if (peakWS != inPeakWS)
-    peakWS.reset(inPeakWS->clone().release());
+    peakWS = inPeakWS->clone();
   // This only fails in the unit tests which say that MaskBTP is not registered
   try {
     runMaskDetectors(inPeakWS, "Tube", "edges");

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -257,7 +257,7 @@ MDHistoWorkspace_sptr MDNormDirectSC::binInputWS() {
  */
 void MDNormDirectSC::createNormalizationWS(const MDHistoWorkspace &dataWS) {
   // Copy the MDHisto workspace, and change signals and errors to 0.
-  m_normWS.reset(dataWS.clone().release());
+  m_normWS = dataWS.clone();
   m_normWS->setTo(0., 0., 0.);
 }
 

--- a/Framework/MDAlgorithms/src/MDNormSCD.cpp
+++ b/Framework/MDAlgorithms/src/MDNormSCD.cpp
@@ -226,7 +226,7 @@ MDHistoWorkspace_sptr MDNormSCD::binInputWS() {
  */
 void MDNormSCD::createNormalizationWS(const MDHistoWorkspace &dataWS) {
   // Copy the MDHisto workspace, and change signals and errors to 0.
-  m_normWS.reset(dataWS.clone().release());
+  m_normWS = dataWS.clone();
   m_normWS->setTo(0., 0., 0.);
 }
 

--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -318,7 +318,7 @@ void ReplicateMD::exec() {
       findReplicationDimension(*shapeWS, *transposedDataWS);
 
   // Create the output workspace from the shape.
-  MDHistoWorkspace_sptr outputWS(shapeWS->clone().release());
+  MDHistoWorkspace_sptr outputWS(shapeWS->clone());
   auto outIt = std::unique_ptr<MDHistoWorkspaceIterator>(
       dynamic_cast<MDHistoWorkspaceIterator *>(outputWS->createIterator()));
 

--- a/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -111,7 +111,7 @@ SmoothMD::hatSmooth(IMDHistoWorkspace_const_sptr toSmooth,
   uint64_t nPoints = toSmooth->getNPoints();
   Progress progress(this, 0, 1, size_t(double(nPoints) * 1.1));
   // Create the output workspace.
-  IMDHistoWorkspace_sptr outWS(toSmooth->clone().release());
+  IMDHistoWorkspace_sptr outWS(toSmooth->clone());
   progress.reportIncrement(
       size_t(double(nPoints) * 0.1)); // Report ~10% progress
 

--- a/Framework/SINQ/test/PoldiPeakCollectionTest.h
+++ b/Framework/SINQ/test/PoldiPeakCollectionTest.h
@@ -164,7 +164,7 @@ public:
 
     TS_ASSERT_EQUALS(collection.intensityType(), PoldiPeakCollection::Maximum);
 
-    TableWorkspace_sptr newDummy(m_dummyData->clone().release());
+    TableWorkspace_sptr newDummy(m_dummyData->clone());
     newDummy->logs()->addProperty<std::string>("IntensityType", "Integral");
 
     PoldiPeakCollection otherCollection(newDummy);
@@ -173,7 +173,7 @@ public:
   }
 
   void testIntensityTypeRecoveryConversion() {
-    TableWorkspace_sptr newDummy(m_dummyData->clone().release());
+    TableWorkspace_sptr newDummy(m_dummyData->clone());
     newDummy->logs()->addProperty<std::string>("IntensityType", "Integral");
 
     PoldiPeakCollection collection(newDummy);
@@ -223,7 +223,7 @@ public:
   }
 
   void testUnitCellFromLogs() {
-    TableWorkspace_sptr newDummy(m_dummyData->clone().release());
+    TableWorkspace_sptr newDummy(m_dummyData->clone());
 
     UnitCell cell(1, 2, 3, 90, 91, 92);
     newDummy->logs()->addProperty<std::string>("UnitCell", unitCellToStr(cell));
@@ -248,7 +248,7 @@ public:
   }
 
   void testGetPointGroupStringFromLog() {
-    TableWorkspace_sptr newDummy(m_dummyData->clone().release());
+    TableWorkspace_sptr newDummy(m_dummyData->clone());
     newDummy->logs()->addProperty<std::string>("PointGroup", "SomeString");
 
     TestablePoldiPeakCollection peaks;

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -323,7 +323,7 @@ void AlignAndFocusPowder::exec() {
   m_outputW = getProperty("OutputWorkspace");
   if (m_inputEW) {
     if (m_outputW != m_inputW) {
-      m_outputEW = EventWorkspace_sptr(m_inputEW->clone().release());
+      m_outputEW = m_inputEW->clone();
     }
     m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
   } else {

--- a/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
@@ -169,7 +169,7 @@ void SANSSolidAngleCorrection::execEvent() {
   // generate the output workspace pointer
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
   if (outputWS != inputWS) {
-    outputWS = MatrixWorkspace_sptr(inputWS->clone().release());
+    outputWS = inputWS->clone();
     setProperty("OutputWorkspace", outputWS);
   }
   auto outputEventWS = boost::dynamic_pointer_cast<EventWorkspace>(outputWS);

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflTableViewPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflTableViewPresenter.cpp
@@ -1130,8 +1130,7 @@ Press changes to the same item in the ADS
 */
 void ReflTableViewPresenter::saveTable() {
   if (!m_wsName.empty()) {
-    AnalysisDataService::Instance().addOrReplace(
-        m_wsName, boost::shared_ptr<ITableWorkspace>(m_ws->clone().release()));
+    AnalysisDataService::Instance().addOrReplace(m_wsName, m_ws->clone());
     m_tableDirty = false;
   } else {
     saveTableAs();
@@ -1197,8 +1196,7 @@ void ReflTableViewPresenter::openTable() {
 
   // We create a clone of the table for live editing. The original is not
   // updated unless we explicitly save.
-  ITableWorkspace_sptr newTable =
-      boost::shared_ptr<ITableWorkspace>(origTable->clone().release());
+  ITableWorkspace_sptr newTable = origTable->clone();
   try {
     validateModel(newTable);
     m_ws = newTable;


### PR DESCRIPTION
Description of work.

This removes a workaround for boost < 1.53. Since boost 1.53 is now our minimum version, we can construct a `boost::shared_ptr` from a `std::unique_ptr` and no longer need to use `.release()`.

**To test:**

<!-- Instructions for testing. -->

The build servers should catch most issues, 

Fixes #12949.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
