### PR TITLE
Fix compiler warning in ObjCompAssemblyActor for debug build

### DIFF
--- a/MantidQt/MantidWidgets/src/InstrumentView/ObjCompAssemblyActor.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/ObjCompAssemblyActor.cpp
@@ -28,7 +28,7 @@ namespace MantidQt
 
           ObjCompAssembly_const_sptr objAss = getObjCompAssembly();
           mNumberOfDetectors = objAss->nelements();
-          assert(m_n == mNumberOfDetectors);
+          assert(static_cast<size_t>(m_n) == mNumberOfDetectors);
           m_data = new unsigned char[m_n * 3];
           m_pick_data = new unsigned char[m_n * 3];
           for (size_t i = 0; i < getNumberOfDetectors(); ++i) {


### PR DESCRIPTION
Fix a compiler warning in debug mode

**To test:**

Compile in debug mode using `gcc`

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
