### PR TITLE
Correct with sqrt

### DIFF
--- a/Framework/Algorithms/src/PDFFourierTransform.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform.cpp
@@ -166,11 +166,11 @@ void PDFFourierTransform::exec() {
     // nothing to do
   } else if (inputXunit == "dSpacing") {
     // convert the x-units to Q/MomentumTransfer
-    std::transform(inputDQ.begin(), inputDQ.end(), inputQ.begin(),
-                   inputDQ.begin(), std::divides<double>());
     const double PI_2(2. * M_PI);
     std::transform(inputQ.begin(), inputQ.end(), inputQ.begin(),
                    std::bind1st(std::divides<double>(), PI_2));
+    std::transform(inputDQ.begin(), inputDQ.end(), inputQ.begin(),
+                   inputDQ.begin(), std::divides<double>());
 
     // reverse all of the arrays
     std::reverse(inputQ.begin(), inputQ.end());
@@ -321,7 +321,7 @@ void PDFFourierTransform::exec() {
 
     // put the information into the output
     outputY[r_index] = fs * 2 / M_PI;
-    outputE[r_index] = sqrt(error) * 2 / M_PI; // TODO: Wrong!
+    outputE[r_index] = sqrt(error) * 2 / M_PI;
   }
 
   // convert to the correct form of PDF
@@ -344,7 +344,7 @@ void PDFFourierTransform::exec() {
   } else if (pdfType == LITTLE_G_OF_R) {
     const double factor = 1. / (4. * M_PI * rho0);
     for (size_t i = 0; i < outputY.size(); ++i) {
-      // error propogation - assuming uncertainty in r = 0
+      // error propagation - assuming uncertainty in r = 0
       outputE[i] = outputE[i] / outputR[i];
       // transform the data
       outputY[i] = 1. + factor * outputY[i] / outputR[i];
@@ -352,7 +352,7 @@ void PDFFourierTransform::exec() {
   } else if (pdfType == RDF_OF_R) {
     const double factor = 4. * M_PI * rho0;
     for (size_t i = 0; i < outputY.size(); ++i) {
-      // error propogation - assuming uncertainty in r = 0
+      // error propagation - assuming uncertainty in r = 0
       outputE[i] = outputE[i] * outputR[i];
       // transform the data
       outputY[i] = outputR[i] * outputY[i] + factor * outputR[i] * outputR[i];

--- a/Framework/Algorithms/src/PDFFourierTransform.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform.cpp
@@ -316,8 +316,7 @@ void PDFFourierTransform::exec() {
         sinus *= sin(q * rdelta) / (q * rdelta);
       }
       fs += sinus * inputFOfQ[q_index];
-      error +=
-          (sinus * inputDfOfQ[q_index]) * (sinus * inputDfOfQ[q_index]);
+      error += (sinus * inputDfOfQ[q_index]) * (sinus * inputDfOfQ[q_index]);
       // g_log.debug() << "q[" << i << "] = " << q << "  dq = " << deltaq << "
       // S(q) =" << s;
       // g_log.debug() << "  d(gr) = " << temp << "  gr = " << gr << std::endl;

--- a/Framework/Algorithms/src/PDFFourierTransform.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform.cpp
@@ -215,6 +215,10 @@ void PDFFourierTransform::exec() {
   }
   if (soqType == S_OF_Q_MINUS_ONE) {
     g_log.information() << "Multiplying all values by Q\n";
+    // error propagation
+    for (size_t i = 0; i < inputDfOfQ.size(); ++i) {
+      inputDfOfQ[i] = inputQ[i] * inputDfOfQ[i] + inputFOfQ[i] * inputDQ[i];
+    }
     // convert the function
     std::transform(inputFOfQ.begin(), inputFOfQ.end(), inputQ.begin(),
                    inputFOfQ.begin(), std::multiplies<double>());
@@ -313,7 +317,7 @@ void PDFFourierTransform::exec() {
       }
       fs += sinus * inputFOfQ[q_index];
       error +=
-          q * q * (sinus * inputDfOfQ[q_index]) * (sinus * inputDfOfQ[q_index]);
+          (sinus * inputDfOfQ[q_index]) * (sinus * inputDfOfQ[q_index]);
       // g_log.debug() << "q[" << i << "] = " << q << "  dq = " << deltaq << "
       // S(q) =" << s;
       // g_log.debug() << "  d(gr) = " << temp << "  gr = " << gr << std::endl;

--- a/Framework/Algorithms/src/PDFFourierTransform.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform.cpp
@@ -216,7 +216,7 @@ void PDFFourierTransform::exec() {
   if (soqType == S_OF_Q_MINUS_ONE) {
     g_log.information() << "Multiplying all values by Q\n";
     // error propagation
-    //for (size_t i = 0; i < inputDfOfQ.size(); ++i) {
+    // for (size_t i = 0; i < inputDfOfQ.size(); ++i) {
     //  inputDfOfQ[i] = inputQ[i] * inputDfOfQ[i] + inputFOfQ[i] * inputDQ[i];
     //}
     // convert the function

--- a/Framework/Algorithms/src/PDFFourierTransform.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform.cpp
@@ -215,10 +215,6 @@ void PDFFourierTransform::exec() {
   }
   if (soqType == S_OF_Q_MINUS_ONE) {
     g_log.information() << "Multiplying all values by Q\n";
-    // error propagation
-    // for (size_t i = 0; i < inputDfOfQ.size(); ++i) {
-    //  inputDfOfQ[i] = inputQ[i] * inputDfOfQ[i] + inputFOfQ[i] * inputDQ[i];
-    //}
     // convert the function
     std::transform(inputFOfQ.begin(), inputFOfQ.end(), inputQ.begin(),
                    inputFOfQ.begin(), std::multiplies<double>());

--- a/Framework/Algorithms/src/PDFFourierTransform.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform.cpp
@@ -167,11 +167,7 @@ void PDFFourierTransform::exec() {
   } else if (inputXunit == "dSpacing") {
     // convert the x-units to Q/MomentumTransfer
     const double PI_2(2. * M_PI);
-    std::transform(inputQ.begin(), inputQ.end(), inputQ.begin(),
-                   std::bind1st(std::divides<double>(), PI_2));
-    std::transform(inputDQ.begin(), inputDQ.end(), inputQ.begin(),
-                   inputDQ.begin(), std::divides<double>());
-
+    std::for_each(inputQ.begin(), inputQ.end(), [&PI_2](double Q){Q/=PI_2;});
     // reverse all of the arrays
     std::reverse(inputQ.begin(), inputQ.end());
     std::reverse(inputDQ.begin(), inputDQ.end());
@@ -209,8 +205,7 @@ void PDFFourierTransform::exec() {
   if (soqType == S_OF_Q) {
     g_log.information() << "Subtracting one from all values\n";
     // there is no error propagation for subtracting one
-    std::transform(inputFOfQ.begin(), inputFOfQ.end(), inputFOfQ.begin(),
-                   std::bind2nd(std::minus<double>(), 1.));
+    std::for_each(inputFOfQ.begin(), inputFOfQ.end(), [&](double F){--F;});
     soqType = S_OF_Q_MINUS_ONE;
   }
   if (soqType == S_OF_Q_MINUS_ONE) {

--- a/Framework/Algorithms/src/PDFFourierTransform.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform.cpp
@@ -216,9 +216,9 @@ void PDFFourierTransform::exec() {
   if (soqType == S_OF_Q_MINUS_ONE) {
     g_log.information() << "Multiplying all values by Q\n";
     // error propagation
-    for (size_t i = 0; i < inputDfOfQ.size(); ++i) {
-      inputDfOfQ[i] = inputQ[i] * inputDfOfQ[i] + inputFOfQ[i] * inputDQ[i];
-    }
+    //for (size_t i = 0; i < inputDfOfQ.size(); ++i) {
+    //  inputDfOfQ[i] = inputQ[i] * inputDfOfQ[i] + inputFOfQ[i] * inputDQ[i];
+    //}
     // convert the function
     std::transform(inputFOfQ.begin(), inputFOfQ.end(), inputQ.begin(),
                    inputFOfQ.begin(), std::multiplies<double>());
@@ -325,7 +325,7 @@ void PDFFourierTransform::exec() {
 
     // put the information into the output
     outputY[r_index] = fs * 2 / M_PI;
-    outputE[r_index] = error * 2 / M_PI; // TODO: Wrong!
+    outputE[r_index] = sqrt(error) * 2 / M_PI; // TODO: Wrong!
   }
 
   // convert to the correct form of PDF

--- a/Framework/Algorithms/src/PDFFourierTransform.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform.cpp
@@ -168,7 +168,9 @@ void PDFFourierTransform::exec() {
     // convert the x-units to Q/MomentumTransfer
     const double PI_2(2. * M_PI);
     std::for_each(inputQ.begin(), inputQ.end(),
-                  [&PI_2](double Q) { Q /= PI_2; });
+                  [&PI_2](double &Q) { Q /= PI_2; });
+    std::transform(inputDQ.begin(), inputDQ.end(), inputQ.begin(),
+                   inputDQ.begin(), std::divides<double>());
     // reverse all of the arrays
     std::reverse(inputQ.begin(), inputQ.end());
     std::reverse(inputDQ.begin(), inputDQ.end());
@@ -206,7 +208,7 @@ void PDFFourierTransform::exec() {
   if (soqType == S_OF_Q) {
     g_log.information() << "Subtracting one from all values\n";
     // there is no error propagation for subtracting one
-    std::for_each(inputFOfQ.begin(), inputFOfQ.end(), [&](double F) { --F; });
+    std::for_each(inputFOfQ.begin(), inputFOfQ.end(), [](double &F) { F--; });
     soqType = S_OF_Q_MINUS_ONE;
   }
   if (soqType == S_OF_Q_MINUS_ONE) {

--- a/Framework/Algorithms/src/PDFFourierTransform.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform.cpp
@@ -167,7 +167,8 @@ void PDFFourierTransform::exec() {
   } else if (inputXunit == "dSpacing") {
     // convert the x-units to Q/MomentumTransfer
     const double PI_2(2. * M_PI);
-    std::for_each(inputQ.begin(), inputQ.end(), [&PI_2](double Q){Q/=PI_2;});
+    std::for_each(inputQ.begin(), inputQ.end(),
+                  [&PI_2](double Q) { Q /= PI_2; });
     // reverse all of the arrays
     std::reverse(inputQ.begin(), inputQ.end());
     std::reverse(inputDQ.begin(), inputDQ.end());
@@ -205,7 +206,7 @@ void PDFFourierTransform::exec() {
   if (soqType == S_OF_Q) {
     g_log.information() << "Subtracting one from all values\n";
     // there is no error propagation for subtracting one
-    std::for_each(inputFOfQ.begin(), inputFOfQ.end(), [&](double F){--F;});
+    std::for_each(inputFOfQ.begin(), inputFOfQ.end(), [&](double F) { --F; });
     soqType = S_OF_Q_MINUS_ONE;
   }
   if (soqType == S_OF_Q_MINUS_ONE) {

--- a/docs/source/algorithms/PDFFourierTransform-v1.rst
+++ b/docs/source/algorithms/PDFFourierTransform-v1.rst
@@ -21,9 +21,9 @@ References
 ----------
 
 #. B. H. Toby and T. Egami, *Accuracy of Pair Distribution Functions Analysis Appliced to Crystalline and Non-Crystalline Materials*, Acta Cryst. (1992) A**48**, 336-346
-   `doi: 10.1107/S0108767391011327 <http://scripts.iucr.org/cgi-bin/paper?S0108767391011327>`_
+   `doi: 10.1107/S0108767391011327 <http://dx.doi.org/10.1107/S0108767391011327>`_
 #. B.H. Toby and S. Billinge, *Determination of Standard uncertainities in fits to pair distribution functions*  Acta Cryst. (2004) A**60**, 315-317]
-   `doi: 10.1107/S0108767304011754 <http://scripts.iucr.org/cgi-bin/paper?S0108767304011754>`_
+   `doi: 10.1107/S0108767304011754 <http://dx.doi.org/10.1107/S0108767304011754>`_
 
 .. The algorithm itself is able to identify the unit.  -- not any more. TODO:  should be investigated why this has been disabled
 

--- a/docs/source/algorithms/PDFFourierTransform-v1.rst
+++ b/docs/source/algorithms/PDFFourierTransform-v1.rst
@@ -17,11 +17,19 @@ spectral density :math:`S(Q)`, :math:`S(Q)-1`, or :math:`Q[S(Q)-1]`
 The input Workspace spectrum should be in the Q-space (\ **MomentumTransfer**\ ) `units <http://www.mantidproject.org/Units>`_ . 
 (d-spacing is not supported any more. Contact development team to fix that and enable **dSpacing** again)
 
+References
+----------
+
+#. B. H. Toby and T. Egami, *Accuracy of Pair Distribution Functions Analysis Appliced to Crystalline and Non-Crystalline Materials*, Acta Cryst. (1992) A**48**, 336-346
+   `doi: 10.1107/S0108767391011327 <http://scripts.iucr.org/cgi-bin/paper?S0108767391011327>`_
+#. B.H. Toby and S. Billinge, *Determination of Standard uncertainities in fits to pair distribution functions*  Acta Cryst. (2004) A**60**, 315-317]
+   `doi: 10.1107/S0108767304011754 <http://scripts.iucr.org/cgi-bin/paper?S0108767304011754>`_
+
 .. The algorithm itself is able to identify the unit.  -- not any more. TODO:  should be investigated why this has been disabled
 
 
-Output Options:
-###############
+Output Options
+--------------
 
 **G(r)**
 '''''''''

--- a/docs/source/release/v3.7.0/diffraction.rst
+++ b/docs/source/release/v3.7.0/diffraction.rst
@@ -47,6 +47,10 @@ Graphical user interface:
   now view the plot in `dSpacing` instead `ToF`, which enables you to
   rerun the fitting process after selecting peaks from the interface.
 
+Powder Diffraction
+------------------
+
+- :ref:`PDFFourierTransform <algm-PDFFourierTransform>` has been corrected in its calculation of errors.
 
 Imaging
 -------


### PR DESCRIPTION
Errors have been corrected with sqrt. Furthermore, S(Q) channels are assumed independent from each other (justified according to [Toby et al](http://apps.webofknowledge.com/full_record.do?product=UA&search_mode=GeneralSearch&qid=1&SID=3BEpjrIq7tv2K1M79lI&page=1&doc=1))

**To test:**

<!-- Instructions for testing. -->

Fixes #15929

[Release notes](https://github.com/mantidproject/mantid/blob/15929_PDFFourierTransForm_errors/docs/source/release/v3.7.0/diffraction.rst) have been updated
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
