### PR TITLE
Dereference tcmalloc symlink at build time

### DIFF
--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -125,8 +125,14 @@ elseif ( "${UNIX_DIST}" MATCHES "Ubuntu" )
 endif()
 
 ############################################################################
-# MantidPlot launcher script
+# Launcher scripts
 ############################################################################
+# The scripts need tcmalloc to be resolved to the runtime library as the plain
+# .so symlink is only present when a -dev/-devel package is present
+if ( TCMALLOC_FOUND )
+  get_filename_component ( TCMALLOC_RUNTIME_LIB ${TCMALLOC_LIBRARIES} REALPATH )
+endif ()
+
 # Local dev version
 set ( EXTRA_LDPATH "${ParaView_DIR}/lib" )
 set ( MANTIDPLOT_EXEC MantidPlot )

--- a/buildconfig/CMake/Packaging/launch_mantidplot.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidplot.sh.in
@@ -9,7 +9,7 @@ SCRIPTFILE=$(readlink -f "$0")
 INSTALLDIR=$(echo $SCRIPTFILE | sed -r -e 's|^(.*)/(.*)$|\1|g') #.* is greedy and eats up until the final slash
 
 # Define extra libraries and load paths
-LOCAL_PRELOAD=`readlink --no-newline --canonicalize-existing @TCMALLOC_LIBRARIES@`
+LOCAL_PRELOAD=@TCMALLOC_RUNTIME_LIB@
 if [ -n "${LD_PRELOAD}" ]; then
     LOCAL_PRELOAD=${LOCAL_PRELOAD}:${LD_PRELOAD}
 fi

--- a/buildconfig/CMake/Packaging/mantidpython.in
+++ b/buildconfig/CMake/Packaging/mantidpython.in
@@ -14,7 +14,7 @@ else
 fi
 
 # Define extra libraries and load paths
-LOCAL_PRELOAD=`readlink --no-newline --canonicalize-existing @TCMALLOC_LIBRARIES@`
+LOCAL_PRELOAD=@TCMALLOC_RUNTIME_LIB@
 if [ -n "${LD_PRELOAD}" ]; then
     LOCAL_PRELOAD=${LOCAL_PRELOAD}:${LD_PRELOAD}
 fi


### PR DESCRIPTION
This changes the launch scripts for Linux systems so that the `tcmalloc` library is found at build time. This removes the requirement that the plain `.so` symlink be present on the user system as this is only installed with the `-dev` or `-devel` packages.

**To test:**

Run cmake and check the contents of both `bin/launch_mantidplot.sh` & `bin/mantidpython`. The LD_PRELOAD line should point a versioned tcmalloc library that exists on the system 

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
