### PR TITLE
Fix dx setter bug

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -284,7 +284,7 @@ public:
   /// Set the specified Dx (X Error) array to point to the given existing array
   virtual void setDx(const std::size_t index,
                      const MantidVecPtr::ptr_type &Dx) {
-    getSpectrum(index)->setX(Dx);
+    getSpectrum(index)->setDx(Dx);
     invalidateCommonBinsFlag();
   }
 

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1320,9 +1320,8 @@ public:
     ws.setDx(workspaceIndexWithDx[2], dxSpec2);
 
     // Assert
-    auto compareValue = [&values](double data, size_t index) {
-      return data == values[index];
-    };
+    auto compareValue =
+        [&values](double data, size_t index) { return data == values[index]; };
     for (auto &index : workspaceIndexWithDx) {
       TSM_ASSERT("Should have x resolution values", ws.hasDx(index));
       TSM_ASSERT_EQUALS("Should have a length of 3", ws.dataDx(index).size(),

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1320,9 +1320,8 @@ public:
     ws.setDx(specNumWithDx[2], dxSpec2);
 
     // Assert
-    auto compareValue = [&values](double data, size_t index) {
-      return data == values[index];
-    };
+    auto compareValue =
+        [&values](double data, size_t index) { return data == values[index]; };
     for (auto &specNum : specNumWithDx) {
       TSM_ASSERT("Should have x resolution values", ws.hasDx(specNum));
       TSM_ASSERT_EQUALS("Should have a length of 3", ws.dataDx(specNum).size(),

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1291,6 +1291,68 @@ public:
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 
+  void test_x_uncertainty_can_be_set() {
+    // Arrange
+    WorkspaceTester ws;
+    const size_t numspec = 4;
+    const size_t j = 3;
+    const size_t k = j;
+    ws.init(numspec, j, k);
+
+    const double value0 = 10;
+    const double value1 = 11;
+    const double value2 = 12;
+
+    Mantid::MantidVec dxSpec0(j, value0);
+    Mantid::MantidVecPtr dxSpec1;
+    auto &spec1 = dxSpec1.access();
+    spec1.resize(j, value1);
+    boost::shared_ptr<Mantid::MantidVec> dxSpec2;
+    for (size_t index = 0; index < j; ++index) {
+      (*dxSpec2).push_back(value2);
+    }
+
+    // Act
+    TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(0));
+    TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(1));
+    TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(2));
+    TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(3));
+
+    ws.setDx(0, dxSpec0);
+    ws.setDx(1, dxSpec1);
+    ws.setDx(2, dxSpec2);
+
+    // Assert
+    TSM_ASSERT("Should have x resolution values", ws.hasDx(0));
+    TSM_ASSERT_EQUALS("Should have a length of 3", ws.dataDx(0).size(), j);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 10", ws.dataDx(0)[0],
+                      value0);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 10", ws.dataDx(0)[1],
+                      value0);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 10", ws.dataDx(0)[2],
+                      value0);
+
+    TSM_ASSERT("Should have x resolution values", ws.hasDx(1));
+    TSM_ASSERT_EQUALS("Should have a length of 3", ws.dataDx(1).size(), j);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.dataDx(1)[0],
+                      value1);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.dataDx(1)[1],
+                      value1);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.dataDx(1)[2],
+                      value1);
+
+    TSM_ASSERT("Should have x resolution values", ws.hasDx(2));
+    TSM_ASSERT_EQUALS("Should have a length of 3", ws.dataDx(2).size(), j);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.dataDx(2)[0],
+                      value2);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.dataDx(2)[1],
+                      value2);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.dataDx(2)[2],
+                      value2);
+
+    TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(4));
+  }
+
 private:
   Mantid::API::MantidImage_sptr createImage(size_t width, size_t height) {
     auto image = new Mantid::API::MantidImage(height);

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1307,11 +1307,8 @@ public:
     Mantid::MantidVecPtr dxSpec1;
     auto &spec1 = dxSpec1.access();
     spec1.resize(j, value1);
-    boost::shared_ptr<Mantid::MantidVec> dxSpec2;
-    for (size_t index = 0; index < j; ++index) {
-      (*dxSpec2).push_back(value2);
-    }
-
+    boost::shared_ptr<Mantid::MantidVec> dxSpec2(
+        new Mantid::MantidVec{value2, value2, value2});
     // Act
     TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(0));
     TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(1));
@@ -1323,6 +1320,7 @@ public:
     ws.setDx(2, dxSpec2);
 
     // Assert
+    // Test dataDx
     TSM_ASSERT("Should have x resolution values", ws.hasDx(0));
     TSM_ASSERT_EQUALS("Should have a length of 3", ws.dataDx(0).size(), j);
     TSM_ASSERT_EQUALS("Should have x resolution values of 10", ws.dataDx(0)[0],
@@ -1343,14 +1341,45 @@ public:
 
     TSM_ASSERT("Should have x resolution values", ws.hasDx(2));
     TSM_ASSERT_EQUALS("Should have a length of 3", ws.dataDx(2).size(), j);
-    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.dataDx(2)[0],
+    TSM_ASSERT_EQUALS("Should have x resolution values of 12", ws.dataDx(2)[0],
                       value2);
-    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.dataDx(2)[1],
+    TSM_ASSERT_EQUALS("Should have x resolution values of 12", ws.dataDx(2)[1],
                       value2);
-    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.dataDx(2)[2],
+    TSM_ASSERT_EQUALS("Should have x resolution values of 12", ws.dataDx(2)[2],
                       value2);
 
-    TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(4));
+    // Test readDx
+    TSM_ASSERT_EQUALS("Should have x resolution values of 10", ws.readDx(0)[0],
+                      value0);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 10", ws.readDx(0)[1],
+                      value0);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 10", ws.readDx(0)[2],
+                      value0);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.readDx(1)[0],
+                      value1);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.readDx(1)[1],
+                      value1);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 11", ws.readDx(1)[2],
+                      value1);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 12", ws.readDx(2)[0],
+                      value2);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 12", ws.readDx(2)[1],
+                      value2);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 12", ws.readDx(2)[2],
+                      value2);
+
+    // RefY
+    auto ref0 = ws.refDx(0);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 10", (*ref0)[0],
+                      value0);
+    auto ref1 = ws.refDx(1);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 11", (*ref1)[1],
+                      value1);
+    auto ref2 = ws.refDx(2);
+    TSM_ASSERT_EQUALS("Should have x resolution values of 12", (*ref2)[2],
+                      value2);
+
+    TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(3));
   }
 
 private:

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1303,7 +1303,7 @@ public:
     ws.init(numspec, j, k);
 
     double values[3] = {10, 11, 17};
-    size_t specNumWithDx[3] = {0, 1, 2};
+    size_t workspaceIndexWithDx[3] = {0, 1, 2};
 
     Mantid::MantidVec dxSpec0(j, values[0]);
     Mantid::MantidVecPtr dxSpec1 =
@@ -1315,34 +1315,35 @@ public:
     for (size_t spec = 0; spec < numspec; ++spec) {
       TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(spec));
     }
-    ws.setDx(specNumWithDx[0], dxSpec0);
-    ws.setDx(specNumWithDx[1], dxSpec1);
-    ws.setDx(specNumWithDx[2], dxSpec2);
+    ws.setDx(workspaceIndexWithDx[0], dxSpec0);
+    ws.setDx(workspaceIndexWithDx[1], dxSpec1);
+    ws.setDx(workspaceIndexWithDx[2], dxSpec2);
 
     // Assert
-    auto compareValue =
-        [&values](double data, size_t index) { return data == values[index]; };
-    for (auto &specNum : specNumWithDx) {
-      TSM_ASSERT("Should have x resolution values", ws.hasDx(specNum));
-      TSM_ASSERT_EQUALS("Should have a length of 3", ws.dataDx(specNum).size(),
+    auto compareValue = [&values](double data, size_t index) {
+      return data == values[index];
+    };
+    for (auto &index : workspaceIndexWithDx) {
+      TSM_ASSERT("Should have x resolution values", ws.hasDx(index));
+      TSM_ASSERT_EQUALS("Should have a length of 3", ws.dataDx(index).size(),
                         j);
-      auto compareValueForSpecificSpectrumNumber =
-          std::bind(compareValue, std::placeholders::_1, specNum);
+      auto compareValueForSpecificWorkspaceIndex =
+          std::bind(compareValue, std::placeholders::_1, index);
 
-      auto &dataDx = ws.dataDx(specNum);
+      auto &dataDx = ws.dataDx(index);
       TSM_ASSERT("dataDx should allow access to the spectrum",
                  std::all_of(std::begin(dataDx), std::end(dataDx),
-                             compareValueForSpecificSpectrumNumber));
+                             compareValueForSpecificWorkspaceIndex));
 
-      auto &readDx = ws.readDx(specNum);
+      auto &readDx = ws.readDx(index);
       TSM_ASSERT("readDx should allow access to the spectrum",
                  std::all_of(std::begin(readDx), std::end(readDx),
-                             compareValueForSpecificSpectrumNumber));
+                             compareValueForSpecificWorkspaceIndex));
 
-      auto &refDx = ws.refDx(specNum);
+      auto &refDx = ws.refDx(index);
       TSM_ASSERT("readDx should allow access to the spectrum",
                  std::all_of(std::begin(*refDx), std::end(*refDx),
-                             compareValueForSpecificSpectrumNumber));
+                             compareValueForSpecificWorkspaceIndex));
     }
 
     TSM_ASSERT("Should not have any x resolution values", !ws.hasDx(3));

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1339,7 +1339,7 @@ public:
                  std::all_of(std::begin(readDx), std::end(readDx),
                              compareValueForSpecificWorkspaceIndex));
 
-      auto &refDx = ws.refDx(index);
+      auto refDx = ws.refDx(index);
       TSM_ASSERT("readDx should allow access to the spectrum",
                  std::all_of(std::begin(*refDx), std::end(*refDx),
                              compareValueForSpecificWorkspaceIndex));


### PR DESCRIPTION
Fixes #15933 

This PR fixes a bug in the `MatrixWorkspace` setters. One of the `setDx` overloads forwarded the request to `setX` instead of `setDx`. This should be fixed. A unit test for the X uncertainty accessor methods was added.

**To test:**
Code review and confirm that test covers the three input scenarios.

<!-- RELEASE NOTES
Not needed, Mantid internal

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
