### PR TITLE
Don't try to load non-existant state file in reducers

### DIFF
--- a/scripts/Interface/reduction_application.py
+++ b/scripts/Interface/reduction_application.py
@@ -469,12 +469,17 @@ class ReductionGUI(QtGui.QMainWindow, ui.ui_reduction_main.Ui_SANSReduction):
             if isinstance(action, QtGui.QAction):
                 file_path = unicode(action.data())
 
+        # don't try to load if the file doesn't exist
+        if not os.path.exists(file_path):
+            return
+
         # Check whether the file describes the current instrument
         try:
             found_instrument = self._interface.scripter.verify_instrument(file_path)
         except:
-            msg = "The file you attempted to load doesn't have a recognized format.\n\n"
-            msg += "Please make sure it has been produced by this application."
+            msg = "The file you attempted to load doesn't have a recognized format:\n" \
+                  + file_path+"\n\n" \
+                  + "Please make sure it has been produced by this application."
             QtGui.QMessageBox.warning(self, "Error loading reduction parameter file", msg)
             print sys.exc_value
             return
@@ -611,4 +616,3 @@ def start(argv):
 
 if __name__ == '__main__':
     start(argv=sys.argv)
-


### PR DESCRIPTION
When starting a reduction GUI for the first time, the user would get a pop-up warning with the text "The file you attempted to load doesn't have a recognized format. Please make sure it has been produced by this application." This was non-fatal and confusing. It also didn't help the user file the file. This pull-request clarifies what file has issues, and skips loading files that don't exist.

**To test:**
1. Find a GUI that uses the "reducer" framework (e.g. powder diffraction)
2. Remove it's state file in `~/.mantid/???.xml`
3. Start the GUI and see the dialog box
4. Merge the patch and see that the dialog box doesn't appear anymore

_There was no issue associated with this ticket._

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
