### PR TITLE
Add table to LoadNexusLogs documentation to explain loading

### DIFF
--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -91,7 +91,7 @@ void LoadNexusLogs::init() {
   declareProperty(
       make_unique<PropertyWithValue<bool>>("OverwriteLogs", true,
                                            Direction::Input),
-      "If true then existing logs will be overwritten, if false they will "
+      "If true then some existing logs will be overwritten, if false they will "
       "not.");
   declareProperty(make_unique<PropertyWithValue<std::string>>("NXentryName", "",
                                                               Direction::Input),

--- a/docs/source/algorithms/LoadNexusLogs-v1.rst
+++ b/docs/source/algorithms/LoadNexusLogs-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-The :ref:`LoadNexusLogs <algm-LoadNexusLogs>`
+The **LoadNexusLogs**
 algorithm loads the sample logs from the given `NeXus <http://www.nexusformat.org>`__
 file. The logs are visible from MantidPlot if you right-click on a workspace and
 select "Sample Logs...".
@@ -18,6 +18,45 @@ If you use :ref:`LoadEventNexus <algm-LoadEventNexus>`
 or
 :ref:`LoadISISNexus <algm-LoadISISNexus>`,
 calling this algorithm is not necessary, since it called as a child algorithm.
+
+Data loaded from Nexus File
+###########################
+
+Not all of the nexus file is loaded. This section tells you what is loaded and where it goes in the workspace. 
+Items missing from the Nexus file are simply not loaded.
+
+
++----------------------------------+----------------------------------------------------+---------------------------------------+
+| Description of Data              | Found in Nexus file                                | Placed in Workspace (Workspace2D)     |
+|                                  |                                                    | or output                             |
++==================================+====================================================+=======================================+
+| Log group                        | Each group of class ``IXrunlog`` or ``IXselog``    | See below                             |
+|                                  | or with name ``"DASLogs"`` or ``"framelog"``       |                                       |
+|                                  | (henceforth referred as [LOG])                     |                                       |
++----------------------------------+----------------------------------------------------+---------------------------------------+
+| Periods group                    | Each group of class ``IXperiods``                  | See below                             |
+|                                  | (henceforth referred as [PERIODS])                 |                                       |
++----------------------------------+----------------------------------------------------+---------------------------------------+
+| Time series                      | Each group of class ``NXlog`` or ``NXpositioner``  | Time series in workspace run object   |
+|                                  | within [LOG]                                       |                                       |
++----------------------------------+----------------------------------------------------+---------------------------------------+
+| SE logs                          | Each group of class ``IXseblock``                  | Workspace run object. Item prefixed   |
+|                                  | within [LOG]                                       | with ``selog_``,                      |
+|                                  |                                                    | if name is already in use.            |
++----------------------------------+----------------------------------------------------+---------------------------------------+
+| Periods                          | Each group of class ``IXperiods`` and  name        | ``nperiods`` item in run object,      |
+|                                  | ``"periods"`` within [PERIOD]                      | if it does not already exist          |
++----------------------------------+----------------------------------------------------+---------------------------------------+
+| Start and end times              | Groups ``"start_time"`` and ``"end time"``         | start and end times in run object     |
++----------------------------------+----------------------------------------------------+---------------------------------------+
+| Proton charge                    | Group ``"proton_charge"``, if it exists,           | Proton charge in run object           |
+|                                  | else integration of proton charge time series      | if it does not already exist          |
++----------------------------------+----------------------------------------------------+---------------------------------------+
+| Measurement information          | Group ``"measurement"`` of class ``NXcollection``  | Run object items with name from       |
+|                                  |                                                    | Nexus group prefixed with             |
+|                                  |                                                    | ``measurement_``                      |
++----------------------------------+----------------------------------------------------+---------------------------------------+
+
 
 Usage
 -----

--- a/docs/source/algorithms/LoadNexusLogs-v1.rst
+++ b/docs/source/algorithms/LoadNexusLogs-v1.rst
@@ -28,7 +28,6 @@ Items missing from the Nexus file are simply not loaded.
 
 +----------------------------------+----------------------------------------------------+---------------------------------------+
 | Description of Data              | Found in Nexus file                                | Placed in Workspace (Workspace2D)     |
-|                                  |                                                    | or output                             |
 +==================================+====================================================+=======================================+
 | Log group                        | Each group of class ``IXrunlog`` or ``IXselog``    | See below                             |
 |                                  | or with name ``"DASLogs"`` or ``"framelog"``       |                                       |
@@ -38,16 +37,19 @@ Items missing from the Nexus file are simply not loaded.
 |                                  | (henceforth referred as [PERIODS])                 |                                       |
 +----------------------------------+----------------------------------------------------+---------------------------------------+
 | Time series                      | Each group of class ``NXlog`` or ``NXpositioner``  | Time series in workspace run object   |
-|                                  | within [LOG]                                       |                                       |
+|                                  | within [LOG]                                       | *Only these are affected by the       |
+|                                  |                                                    | OverwriteLogs algorithm property.*    |
 +----------------------------------+----------------------------------------------------+---------------------------------------+
 | SE logs                          | Each group of class ``IXseblock``                  | Workspace run object. Item prefixed   |
 |                                  | within [LOG]                                       | with ``selog_``,                      |
 |                                  |                                                    | if name is already in use.            |
 +----------------------------------+----------------------------------------------------+---------------------------------------+
 | Periods                          | Each group of class ``IXperiods`` and  name        | ``nperiods`` item in run object,      |
-|                                  | ``"periods"`` within [PERIOD]                      | if it does not already exist          |
+|                                  | ``"periods"`` within [PERIODS]                     | if it does not already exist          |
 +----------------------------------+----------------------------------------------------+---------------------------------------+
 | Start and end times              | Groups ``"start_time"`` and ``"end time"``         | start and end times in run object     |
+|                                  |                                                    | *Existing values are always           |
+|                                  |                                                    | overwritten.*                         |
 +----------------------------------+----------------------------------------------------+---------------------------------------+
 | Proton charge                    | Group ``"proton_charge"``, if it exists,           | Proton charge in run object           |
 |                                  | else integration of proton charge time series      | if it does not already exist          |
@@ -55,8 +57,11 @@ Items missing from the Nexus file are simply not loaded.
 | Measurement information          | Group ``"measurement"`` of class ``NXcollection``  | Run object items with name from       |
 |                                  |                                                    | Nexus group prefixed with             |
 |                                  |                                                    | ``measurement_``                      |
+|                                  |                                                    | *Existing values are always           |
+|                                  |                                                    | overwritten.*                         |
 +----------------------------------+----------------------------------------------------+---------------------------------------+
 
+If the nexus file has a ``"proton_log"`` group, then this algorithm will do some event filtering to allow SANS2D files to load.
 
 Usage
 -----


### PR DESCRIPTION
Adding tables to documentation of LoadMuonNexus version 2 to explain what items in the Nexus file go where in the workspace, when the algorithm is executed.

Check that the documentation is a good explanation of what LoadNexusLogs does, particularly for Nexus files that are used in the unit test.

Fixes #15607.

Release notes will be updated when #14940 is done.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
