### PR TITLE
CreateTransmissionWorkspaceAuto: fix default ProcessingInstructions

### DIFF
--- a/Framework/Algorithms/src/CreateTransmissionWorkspaceAuto.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspaceAuto.cpp
@@ -144,14 +144,14 @@ void CreateTransmissionWorkspaceAuto::exec() {
       if (start == stop) {
         processing_commands = boost::lexical_cast<std::string>(start);
       } else {
-        processing_commands = boost::lexical_cast<std::string>(start) + "," +
+        processing_commands = boost::lexical_cast<std::string>(start) + ":" +
                               boost::lexical_cast<std::string>(stop);
       }
     } else {
       processing_commands =
           boost::lexical_cast<std::string>(static_cast<int>(
               instrument->getNumberParameter("MultiDetectorStart")[0])) +
-          "," +
+          ":" +
           boost::lexical_cast<std::string>(firstWS->getNumberHistograms() - 1);
     }
   } else {

--- a/Framework/Algorithms/test/CreateTransmissionWorkspaceAutoTest.h
+++ b/Framework/Algorithms/test/CreateTransmissionWorkspaceAutoTest.h
@@ -107,7 +107,7 @@ public:
         vecPropertyHistories, "ProcessingInstructions");
     std::vector<std::string> pointDetectorStartStop;
     boost::split(pointDetectorStartStop, processingInstructions,
-                 boost::is_any_of(","));
+                 boost::is_any_of(":"));
 
     TS_ASSERT_EQUALS(inst->getNumberParameter("LambdaMin").at(0),
                      wavelengthMin);


### PR DESCRIPTION
**Description of work**

`CreateTransmissionWorkspaceAuto` should behave similarly to `ReflectometryReductionOneAuto` in terms of processing instructions: when those are not given, all the spectra should be analyzed.

**To test:**

The following script:

```
offspec = Load(Filename='OFFSPEC00010791.raw', PeriodList='1')

# MultiDetectorAnalysis mode
trans = CreateTransmissionWorkspaceAuto(AnalysisMode='MultiDetectorAnalysis', FirstTransmissionRun=offspec)
IvsQ, IvsLam, theta = ReflectometryReductionOneAuto(InputWorkspace=offspec, AnalysisMode='MultiDetectorAnalysis', FirstTransmissionRun=trans)

# PointDetectorAnalysis mode (default)
trans = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=offspec)
IvsQ, IvsLam, theta = ReflectometryReductionOneAuto(InputWorkspace=offspec,FirstTransmissionRun=trans)
```

should work (make sure you get an error when running it on the master branch. The error you'll get is related to the spectrum maps not matching, the reason is that `ReflectometryReductionOneAuto` was analyzing all the spectra whereas `CreateTransmissionWorkspaceAuto` was analyzing only the first and last spectra).

Fixes #15936.

**Release notes**

I don't think this needs to be mentioned in the release notes. I think scientists are not aware of this issue, as they usually specify processing instructions.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
