### PR TITLE
Computes phonon density of states in the incoherent approximation.

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -8,7 +8,7 @@ from scipy import constants
 def evaluateEbin(Emin, Emax, Ei, strn):
     return [eval(estr) for estr in strn.split(',')]
 
-def evaluateQRange(Qmin, Qmax, string):
+def evaluateQRange(Qmin, Qmax, strn):
     return [eval(qstr) for qstr in strn.split(',')]
 
 

--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -5,11 +5,11 @@ from mantid.simpleapi import *
 import numpy as np
 from scipy import constants
 
-def evaluateEbin(Emin, Emax, Ei, string):
-    return [eval(estr) for estr in string.split(',')]
+def evaluateEbin(Emin, Emax, Ei, strn):
+    return [eval(estr) for estr in strn.split(',')]
 
 def evaluateQRange(Qmin, Qmax, string):
-    return [eval(qstr) for qstr in string.split(',')]
+    return [eval(qstr) for qstr in strn.split(',')]
 
 
 class ComputeIncoherentDOS(PythonAlgorithm):

--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -52,9 +52,9 @@ class ComputeIncoherentDOS(PythonAlgorithm):
                              doc='Sample temperature in Kelvin.')
         self.declareProperty(name='MeanSquareDisplacement', defaultValue=0., validator=FloatBoundedValidator(lower=0),
                              doc='Average mean square displacement in Angstrom^2.')
-        self.declareProperty(name='QSumRange', defaultValue='Qmax/2,Qmax',
+        self.declareProperty(name='QSumRange', defaultValue='0,Qmax',
                              doc='Range in |Q| (in Angstroms^-1) to sum data over.')
-        self.declareProperty(name='EnergyBinning', defaultValue='0,Emax/50,Emax',
+        self.declareProperty(name='EnergyBinning', defaultValue='0,Emax/50,Emax*0.9',
                              doc='Energy binning parameters [Emin, Estep, Emax] in meV.')
         self.declareProperty(name='Wavenumbers', defaultValue=False,
                              doc='Should the output be in Wavenumbers (cm^-1)?')
@@ -179,12 +179,15 @@ class ComputeIncoherentDOS(PythonAlgorithm):
         # Make a 1D (energy dependent) cut
         dos1d = Rebin2D(dos2d, [dq[0], dq[1]-dq[0], dq[1]], dosebin, True, True)
 
+        # Renomalise energy bin size
+        dos1d = dos1d * dosebin[1]
+
         if absunits:
             print "Converting to states/energy"
             # cross-section information is given in barns, but data is in milibarns.
             sigma = atoms[0].neutron()['tot_scatt_xs'] * 1000
             mass = atoms[0].mass
-            dos1d = dos1d * (mass/sigma)
+            dos1d = dos1d * (mass/sigma) * 4 * np.pi
 
         self.setProperty("OutputWorkspace", dos1d)
         DeleteWorkspace(dos2d)

--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -1,0 +1,128 @@
+#pylint: disable = no-init, invalid-name, line-too-long, eval-used, unused-argument
+from mantid.kernel import *
+from mantid.api import *
+from mantid.simpleapi import *
+import numpy as np
+from scipy import constants
+
+def evaluateEbin(Emin, Emax, Ei, string):
+    return [eval(estr) for estr in string.split(',')]
+
+def evaluateQRange(Qmin, Qmax, string):
+    return [eval(qstr) for qstr in string.split(',')]
+
+
+class ComputeIncoherentDOS(PythonAlgorithm):
+    """ Calculates the neutron weighted generalised phonon density of states in the incoherent approximation from a
+        measured powder inelastic neutron scattering spectrum.
+
+    ComputeIncoherentDOS(InputWorkspace = iws, Temperature = T, MeanSquareDisplacement = msd,
+                         QSumRange = qrange, EnergyBinning = ebins, OutputWorkspace = ows)
+
+    Input:
+            iws     -   An input MatrixWorkspace (must contain the reduced powder INS data)
+            T       -   The sample temperature in Kelvin (default: 300 K)
+            msd     -   The average mean-squared displacement of all species in the sample in Angstrom^2 (default: 0.01A^2)
+            qrange  -   Range in |Q| to integrate over (default: 0.5Qmax to Qmax)
+            ebins   -   Energy bins in Energy transfer to rebin the data into (default: 0 to Emax in 50 steps)
+            ows     -   An output spectrum workspace (1D)
+    """
+
+    # By Duc Le (2016)
+    # Based on code in PySlice by Jon Taylor
+
+    def category(self):
+        return 'Inelastic;PythonAlgorithms'
+
+    def name(self):
+        return 'ComputeIncoherentDOS'
+
+    def summary(self):
+        return 'Calculates the neutron weighted generalised phonon density of states in the incoherent approximation from a measured powder INS MatrixWorkspace'
+
+    def PyInit(self):
+        validators = CompositeValidator()
+        validators.add(HistogramValidator(True))
+        validators.add(CommonBinsValidator())
+        validators.add(WorkspaceUnitValidator('MomentumTransfer'))
+        self.declareProperty(MatrixWorkspaceProperty(name='InputWorkspace', defaultValue='', direction=Direction.Input, validator=validators),
+                             doc='Input MatrixWorkspace containing the reduced inelastic neutron spectrum in (Q,E) space.')
+        self.declareProperty(name='Temperature', defaultValue=300., validator=FloatBoundedValidator(lower=0),
+                             doc='Sample temperature in Kelvin.')
+        self.declareProperty(name='MeanSquareDisplacement', defaultValue=0.01, validator=FloatBoundedValidator(lower=0),
+                             doc='Average mean square displacement in Angstrom^2.')
+        self.declareProperty(name='QSumRange', defaultValue='Qmax/2,Qmax',
+                             doc='Range in |Q| (in Angstroms^-1) to sum data over.')
+        self.declareProperty(name='EnergyBinning', defaultValue='0,Emax/50,Emax',
+                             doc='Energy binning parameters [Emin, Estep, Emax] in meV.')
+        self.declareProperty(name='SampleFormula', defaultValue='',
+                             doc='Sample chemical formula, with spaces between elements. E.g. "Al2 O3"')
+        self.declareProperty(MatrixWorkspaceProperty(name='OutputWorkspace', defaultValue='', direction=Direction.Output),
+                             doc='Output workspace name.')
+
+    def PyExec(self):
+        inws = mtd[self.getPropertyValue('InputWorkspace')]
+        Temperature = float(self.getPropertyValue('Temperature'))
+        msd = float(self.getPropertyValue('MeanSquareDisplacement'))
+        QSumRange = self.getPropertyValue('QSumRange')
+        EnergyBinning = self.getPropertyValue('EnergyBinning')
+        SampleFormula = self.getPropertyValue('SampleFormula')
+
+        # (Mantid stores the bin boundaries by default rather than bin centers)
+        qq = inws.getAxis(0).extractValues()
+        qq = (qq[1:len(qq)]+qq[0:len(qq)-1])/2
+        en = inws.getAxis(1).extractValues()
+        en = (en[1:len(en)]+en[0:len(en)-1])/2
+
+        # Checks qrange is valid
+        if QSumRange.count(',') != 1:
+            raise ValueError('QSumRange must be a comma separated string with two values.')
+        try:
+            # Do this in a member function to make sure no other variables can be evaluated other than Emax and Ei.
+            dq = evaluateQRange(min(qq), max(qq), QSumRange)
+        except NameError:
+            raise ValueError('Only the variable ''Qmin'' or ''Qmax'' are allowed in QSumRange.')
+        # Checks energy bins are ok.
+        if EnergyBinning.count(',') != 2:
+            raise ValueError('EnergyBinning must be a comma separated string with three values.')
+        try:
+            ei = inws.getEFixed(1)
+        except RuntimeError:
+            ei = max(en)
+        try:
+            # Do this in a function to make sure no other variables can be evaluated other than Emax and Ei.
+            dosebin = evaluateEbin(min(en), max(en), ei, EnergyBinning)
+        except NameError:
+            raise ValueError('Only the variables ''Emin'', ''Emax'' or ''Ei'' are allowed in EnergyBinning.')
+
+        # Extracts the intensity (y) and errors (e) from inws.
+        y = inws.extractY()
+        e = inws.extractE()
+        # Creates a grid the same size as the intensity (y) array populated by the q and energy values
+        qqgrid = np.tile(np.array(qq), (np.shape(y)[0], 1))
+        engrid = np.transpose(np.tile(np.array(en), (np.shape(y)[1], 1)))
+
+        # Calculates the Debye-Waller and Bose factors from the Temperature and mean-squared displacements
+        DWF = np.exp(-2*(qqgrid**2*msd))
+        idm = np.where(engrid<0)
+        idp = np.where(engrid>=0)
+        expm = np.exp(-engrid[idm]*11.604/Temperature)
+        expp = np.exp(-engrid[idp]*11.604/Temperature)
+        Bose = DWF*0
+        Bose[idm] = expm / (1 - expm)      # n energy gain, phonon annihilation
+        Bose[idp] = expp / (1 - expp) + 1  # n energy loss, phonon creation
+        # Calculates the density of states from S(q,w)
+        y = y * (engrid/qqgrid**2) / (Bose*DWF)
+        e = e * (engrid/qqgrid**2) / (Bose*DWF)
+        # Outputs the calculated density of states to another workspace
+        dos2d = CreateWorkspace(qq, y, e, Nspec=len(en), VerticalAxisUnit='DeltaE', VerticalAxisValues=en,
+                                UnitX='MomentumTransfer', YUnitLabel=ylab, WorkSpaceTitle='Density of States',
+                                ParentWorkspace=inws)
+        # Make a 1D (energy dependent) cut
+        dos1d = Rebin2D(dos2d, [dq[0], dq[1]-dq[0], dq[1]], dosebin, True, True)
+
+        self.setProperty("OutputWorkspace", dos1d)
+        DeleteWorkspace(dos2d)
+        DeleteWorkspace(dos1d)
+
+AlgorithmFactory.subscribe(ComputeIncoherentDOS)

--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -1,7 +1,7 @@
 #pylint: disable = no-init, invalid-name, line-too-long, eval-used, unused-argument, too-many-locals, too-many-branches, too-many-statements
 from mantid.kernel import CompositeValidator, Direction, FloatBoundedValidator
 from mantid.api import mtd, AlgorithmFactory, CommonBinsValidator, HistogramValidator, MatrixWorkspaceProperty, PythonAlgorithm
-from mantid.simpleapi import CreateWorkspace, DeleteWorkspace, Rebin2D
+from mantid.simpleapi import *
 import numpy as np
 from scipy import constants
 

--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -172,12 +172,17 @@ class ComputeIncoherentDOS(PythonAlgorithm):
             yunit = 'DeltaE'
 
         # Outputs the calculated density of states to another workspace
-        dos2d = CreateWorkspace(qq, y, e, Nspec=len(en), VerticalAxisUnit=yunit, VerticalAxisValues=en,
-                                UnitX='MomentumTransfer', YUnitLabel=ylabel, WorkSpaceTitle='Density of States',
-                                ParentWorkspace=inws)
+        dos2d = CloneWorkspace(inws)
+        if iqq == 1:
+            dos2d = Transpose(dos2d)
+        for i in range(len(y)):
+            dos2d.setY(i, y[i,:])
+            dos2d.setE(i, e[i,:])
+        dos2d.setYUnitLabel(ylabel)
 
         # Make a 1D (energy dependent) cut
         dos1d = Rebin2D(dos2d, [dq[0], dq[1]-dq[0], dq[1]], dosebin, True, True)
+        dos1d.setYUnit(yunit)
 
         # Renomalise energy bin size
         dos1d = dos1d * dosebin[1]

--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -53,7 +53,7 @@ class ComputeIncoherentDOS(PythonAlgorithm):
         self.declareProperty(name='MeanSquareDisplacement', defaultValue=0., validator=FloatBoundedValidator(lower=0),
                              doc='Average mean square displacement in Angstrom^2.')
         self.declareProperty(name='QSumRange', defaultValue='0,Qmax',
-                             doc='Range in |Q| (in Angstroms^-1) to sum data over.')
+                             doc='Range in Q (in Angstroms^-1) to sum data over.')
         self.declareProperty(name='EnergyBinning', defaultValue='0,Emax/50,Emax*0.9',
                              doc='Energy binning parameters [Emin, Estep, Emax] in meV.')
         self.declareProperty(name='Wavenumbers', defaultValue=False,

--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -184,9 +184,6 @@ class ComputeIncoherentDOS(PythonAlgorithm):
         dos1d = Rebin2D(dos2d, [dq[0], dq[1]-dq[0], dq[1]], dosebin, True, True)
         dos1d.setYUnit(yunit)
 
-        # Renomalise energy bin size
-        dos1d = dos1d * dosebin[1]
-
         if absunits:
             print "Converting to states/energy"
             # cross-section information is given in barns, but data is in milibarns.

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ComputeIncoherentDOSTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ComputeIncoherentDOSTest.py
@@ -1,0 +1,35 @@
+import unittest
+from mantid.simpleapi import ComputeIncoherentDOS, CreateSampleWorkspace, LoadInstrument, ScaleX, SetSampleMaterial, SofQW, Transpose
+import numpy as np
+
+class ComputeIncoherentDOSTest(unittest.TestCase):
+
+    def test_computeincoherentdos(self):
+        ws = CreateSampleWorkspace()
+        # Will fail unless the input workspace has Q and DeltaE axes.
+        with self.assertRaises(RuntimeError):
+            ws_DOS = ComputeIncoherentDOS(ws)
+        ws = CreateSampleWorkspace(binWidth = 0.1, XMin = 0, XMax = 50, XUnit = 'DeltaE')
+        ws = ScaleX(ws, -25, "Add")
+        with self.assertRaises(RuntimeError):
+            ws_DOS = ComputeIncoherentDOS(ws)
+        LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap = True)
+        ws = SofQW(ws, [0, 0.05, 8], 'Direct', 25)
+        # This should work!
+        ws_DOS = ComputeIncoherentDOS(ws)
+        self.assertEquals(ws_DOS.getAxis(0).getUnit().unitID(), 'DeltaE')
+        self.assertEquals(ws_DOS.getNumberHistograms(), 1)
+        ws = Transpose(ws)
+        ws_DOS = ComputeIncoherentDOS(ws, EnergyBinning = '0, 5, 200', Wavenumbers = True)
+        self.assertEquals(ws_DOS.getAxis(0).getUnit().unitID(), 'DeltaE_inWavenumber')
+        self.assertEquals(ws_DOS.blocksize(), 40)
+        # Check that conversion to states/meV is done
+        SetSampleMaterial(ws, 'Al')
+        ws_DOSn = ComputeIncoherentDOS(ws, EnergyBinning = '0, 5, 200', Wavenumbers = True, StatesPerEnergy = True)
+        self.assertTrue('states' in ws_DOSn.YUnitLabel())
+        material = ws.sample().getMaterial()
+        factor = material.relativeMolecularMass() / (material.totalScatterXSection() * 1000)
+        self.assertAlmostEqual(np.max(ws_DOSn.readY(0)), np.max(ws_DOS.readY(0))*factor, places=4)
+
+if __name__=="__main__":
+    unittest.main()

--- a/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
+++ b/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
@@ -51,24 +51,38 @@ Usage
 
 **ISIS Example**
 
-.. testcode:: ExIsis
+The following code will run a reduction on a MARI (ISIS) dataset and apply
+the algorithm to the reduced data. The datafiles (runs 21334, 21335, 21347) and
+map file 'mari_res2013.map' should be in your path. Run number 21335 is a 
+measurement of a large Aluminium sample from the neutron training course.
 
-    # This is using a generic reduction routine so that automated tests can run
-    # You should use the reductions scripts provided by instrument scientists
+.. code:: python
+
     from Direct import DirectEnergyConversion
     from mantid.simpleapi import *
     rd = DirectEnergyConversion.DirectEnergyConversion('MARI')
-    # Run #21334 on MARI is a measurement of a large Aluminium sample from the neutron
-    # training course.
     ws = rd.convert_to_energy(21334, 21335, 60, [-55,0.05,55], 'mari_res2013.map', 
         monovan_run=21347, sample_mass=106.4, sample_rmm=27, monovan_mapfile='mari_res2013.map')
     ws_sqw = SofQW3(ws, [0,0.1,12], 'Direct', 60)
     SetSampleMaterial(ws_sqw,'Al')
     ws_dos = ComputeIncoherentDOS(ws_sqw, Temperature=5, StatesPerEnergy=True)
 
+**Test Example**
+
+This example uses a generated dataset so that it will run on automated tests
+of the build system where the above datafiles do not exist.
+
+.. testcode:: ExGenerated
+
+    ws = CreateSampleWorkspace(binWidth = 0.1, XMin = 0, XMax = 50, XUnit = 'DeltaE')
+    ws = ScaleX(ws, -25, "Add")
+    LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap = True)
+    ws = SofQW(ws, [0, 0.05, 8], 'Direct', 25)
+    ws_DOS = ComputeIncoherentDOS(ws)
+
 Output
 
-.. testoutput:: ExIsis
+.. testoutput:: ExGenerated
 
 .. categories:: Algorithms Inelastic
 

--- a/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
+++ b/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
@@ -15,10 +15,7 @@ assuming that all scattering is incoherent, using the formula
 (Thermodynamic Properties of Solids, eds. Chaplot, Mittal, Choudhury,
 Chapter 3) for the 1-phonon incoherent scattering function:
 
-:math:`S^{(1)}_{\mathrm{inc}}(Q,E) = 
-   \exp\left(-2\bar{W}(Q)\right) \frac{Q^2}{E} 
-   \langle n+\frac{1}{2}\pm\frac{1}{2} \rangle
-   \left[ \sum_k \frac{\sigma_k^{\mathrm{scatt}}{2m_k} g_k(E) \right]`
+:math:`S^{(1)}_{\mathrm{inc}}(Q,E) = \exp\left(-2\bar{W}(Q)\right) \frac{Q^2}{E} \langle n+\frac{1}{2}\pm\frac{1}{2} \rangle \left[ \sum_k \frac{\sigma_k^{\mathrm{scatt}}}{2m_k} g_k(E) \right]`
 
 where the term in square brackets is the neutron weighted densiy of 
 states which is calculated by this algorithm, and :math:`g_k(E)` is

--- a/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
+++ b/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
@@ -1,0 +1,60 @@
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+Computes the phonon density of states from an inelastic neutron 
+scattering measurement of a powder or polycrystalline sample,
+assuming that all scattering is incoherent, using the formula 
+(Thermodynamic Properties of Solids, eds. Chaplot, Mittal, Choudhury,
+Chapter 3) for the 1-phonon incoherent scattering function:
+
+:math:`S^{(1)}_{\mathrm{inc}}(Q,E) = 
+   \exp\left(-2\bar{W}(Q)\right) \frac{Q^2}{E} 
+   \langle n+\frac{1}{2}\pm\frac{1}{2} \rangle
+   \left[ \sum_k \frac{\sigma_k^{\mathrm{scatt}}{2m_k} g_k(E) \right]`
+
+where the term in square brackets is the neutron weighted densiy of 
+states which is calculated by this algorithm, and :math:`g_k(E)` is
+the partial density of states for each component (element or isotope)
+:math:`k` in the material. :math:`m_k` is the relative atomic mass of the
+component.
+
+The average Debye-Waller factor :math:`\exp\left(-2\bar{W}(Q)\right)` is
+calculated using an average mean-square displacement :math:`\langle u \rangle`,
+using :math:`W=Q^2\langle u\rangle/2`. 
+
+Restrictions on the Input Workspace
+###################################
+
+The input workspace must have units of Momentum Transfer and
+contain histogram data with common binning on all spectra.
+
+Usage
+-----
+
+.. include:: ../usagedata-note.txt
+
+**ISIS Example**
+
+.. testcode:: ExIsis
+
+    # The MARIReduction_Sample file can be found in the User scripts repository
+    # under direct_inelastic/mari
+    import MARIReduction_Sample
+    # Data is from a measurement of Aluminium pellets on Mari during a neutron training course
+    MARIReduction_Sample.iliad_mari(20228,60,19717,20383,25,27)
+    MAR20228_DOS = ComputeIncoherentDOS('MAR20228_SQW',T=300,MeanSquareDisplacement=0.01)
+
+Output
+
+.. testoutput:: ExIsis
+
+.. categories:: Algorithms Inelastic
+

--- a/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
+++ b/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
@@ -30,6 +30,14 @@ The average Debye-Waller factor :math:`\exp\left(-2\bar{W}(Q)\right)` is
 calculated using an average mean-square displacement :math:`\langle u \rangle`,
 using :math:`W=Q^2\langle u\rangle/2`. 
 
+If the data has been normalised to a Vanadium standard measurement, the
+output of this algorithm is the neutron weighted density of states in
+milibarns/steradians per formula unit per meV (or per cm^-1). If the sample
+material has been set and is found to be a pure element, then an additional
+option will be enabled to calculate the DOS in states per meV (states per 
+cm^-1) by dividing by the scattering cross-section and multiplying by the
+relative atomic mass.
+
 Restrictions on the Input Workspace
 ###################################
 

--- a/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
+++ b/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
@@ -53,12 +53,18 @@ Usage
 
 .. testcode:: ExIsis
 
-    # The MARIReduction_Sample file can be found in the User scripts repository
-    # under direct_inelastic/mari
-    import MARIReduction_Sample
-    # Data is from a measurement of Aluminium pellets on Mari during a neutron training course
-    MARIReduction_Sample.iliad_mari(20228,60,19717,20383,25,27)
-    MAR20228_DOS = ComputeIncoherentDOS('MAR20228_SQW',T=300,MeanSquareDisplacement=0.01)
+    # This is using a generic reduction routine so that automated tests can run
+    # You should use the reductions scripts provided by instrument scientists
+    from Direct import DirectEnergyConversion
+    from mantid.simpleapi import *
+    rd = DirectEnergyConversion.DirectEnergyConversion('MARI')
+    # Run #21334 on MARI is a measurement of a large Aluminium sample from the neutron
+    # training course.
+    ws = rd.convert_to_energy(21334, 21335, 60, [-55,0.05,55], 'mari_res2013.map', 
+        monovan_run=21347, sample_mass=106.4, sample_rmm=27, monovan_mapfile='mari_res2013.map')
+    ws_sqw = SofQW3(ws, [0,0.1,12], 'Direct', 60)
+    SetSampleMaterial(ws_sqw,'Al')
+    ws_dos = ComputeIncoherentDOS(ws_sqw, Temperature=5, StatesPerEnergy=True)
 
 Output
 

--- a/docs/source/release/v3.7.0/direct_inelastic.rst
+++ b/docs/source/release/v3.7.0/direct_inelastic.rst
@@ -18,3 +18,8 @@ Crystal Field
 FOCUS fortran program that fits crystal field parameters is being translated into Mantid (C++ and python).
 The release notes on this work will go here.
 
+Phonon DOS
+----------
+
+The old PySlice routine to compute the phonon DOS from powder data using the incoherent approximation has
+been ported and is now a Mantid Python Algorithm :ref:`ComputeIncoherentDOS <algm-ComputeIncoherentDOS`


### PR DESCRIPTION
This is a python algorithm to compute the phonon density of states from a powder S(q,w) dataset. In this case, all the scattering can be treated as incoherent (the coherent scattering averaged over all angles in a powder is similar to the isotropic incoherent scattering) and a simple formula can be applied to derive the neutron weighted partial density of states. The theory is partly detailed in the documentation rst.

It only operates on histogram workspaces with one axis being momentum transfer (Q) and one being energy transfer (in either meV or cm). By default it outputs the DOS g(E) in meV but can be specified to output in wavenumbers (cm^-1).

**To test:**

By constructing a (Q,w) workspace

```
ws = CreateSampleWorkspace(binWidth = 0.1, XMin = 0, XMax = 50, XUnit = 'DeltaE')
ws = ScaleX(ws, -25, "Add")
LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap = True)
ws = SofQW(ws, [0, 0.05, 8], 'Direct', 25)
ws_DOS = ComputeIncoherentDOS(ws)
```

Alternatively, with a datafile (note the datafiles should be accessible in the archive, but the mapfile might need to be copied somewhere accessible. It is here: https://svn.isis.rl.ac.uk/InstrumentFiles/trunk/mari/mari_res2013.map 
The following uses a measurement of Aluminium on MARI at ISIS.

```
from Direct import DirectEnergyConversion
rd = DirectEnergyConversion.DirectEnergyConversion('MARI')
ws = rd.convert_to_energy(21334, 21335, 60, [-55,0.05,55], 'mari_res2013.map', 
    monovan_run=21347, sample_mass=106.4, sample_rmm=27, monovan_mapfile='mari_res2013.map')
ws_sqw = SofQW3(ws, [0,0.1,12], 'Direct', 60)
SetSampleMaterial(ws_sqw,'Al')
ws_dos = ComputeIncoherentDOS(ws_sqw, Temperature=5, StatesPerEnergy=True)

```

Compare to the data here: http://journals.aps.org/prb/abstract/10.1103/PhysRevB.77.024301
Too high by a factor of around 3, which I haven't figured out why... 
Possibly from the Debye-Waller factor. Or possibly due to multiple scattering.

<!-- Instructions for testing. -->

Fixes #15843.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
