### PR TITLE
Refactor PeakShape

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/NoShape.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/NoShape.h
@@ -48,6 +48,8 @@ public:
   boost::optional<double> radius(RadiusType) const override {
     return boost::optional<double>{};
   }
+  /// Return the shape name
+  static const std::string noShapeName();
 };
 
 } // namespace DataObjects

--- a/Framework/DataObjects/inc/MantidDataObjects/NoShape.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/NoShape.h
@@ -45,6 +45,9 @@ public:
   std::string shapeName() const override;
   /// Get the coordinate frame
   Kernel::SpecialCoordinateSystem frame() const override;
+  boost::optional<double> radius(RadiusType) const override {
+    return boost::optional<double>{};
+  }
 };
 
 } // namespace DataObjects

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeBase.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeBase.h
@@ -37,6 +37,7 @@ namespace DataObjects {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
+
 class DLLExport PeakShapeBase : public Mantid::Geometry::PeakShape {
 
 public:
@@ -50,8 +51,9 @@ public:
   std::string algorithmName() const override;
   /// Get the version of the algorithm used to make this shape
   int algorithmVersion() const override;
+  enum class RadiusType { Region, BackgroundInner, BackgroundOuter };
   /// Radius
-  virtual double radius() const = 0;
+  virtual double radius(RadiusType type) const = 0;
 
 protected:
   /// Copy constructor

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeBase.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeBase.h
@@ -4,6 +4,7 @@
 #include "MantidKernel/System.h"
 #include "MantidGeometry/Crystal/PeakShape.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
+
 #include <string>
 
 namespace Json {
@@ -51,9 +52,6 @@ public:
   std::string algorithmName() const override;
   /// Get the version of the algorithm used to make this shape
   int algorithmVersion() const override;
-  enum class RadiusType { Region, BackgroundInner, BackgroundOuter };
-  /// Radius
-  virtual double radius(RadiusType type) const = 0;
 
 protected:
   /// Copy constructor

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
@@ -64,8 +64,8 @@ public:
   std::string shapeName() const override;
 
   /// PeakBase interface
-  double radius(RadiusType type = RadiusType::Region) const override;
-
+  boost::optional<double>
+  radius(RadiusType type = RadiusType::Radius) const override;
   static const std::string ellipsoidShapeName();
 
 private:

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
@@ -35,27 +35,23 @@ namespace DataObjects {
 class DLLExport PeakShapeEllipsoid : public PeakShapeBase {
 public:
   /// Constructor
-  PeakShapeEllipsoid(std::vector<Mantid::Kernel::V3D> directions,
-                     std::vector<double> abcRadii,
-                     std::vector<double> abcRadiiBackgroundInner,
-                     std::vector<double> abcRadiiBackgroundOuter,
+  PeakShapeEllipsoid(const std::vector<Mantid::Kernel::V3D> &directions,
+                     const std::vector<double> &abcRadii,
+                     const std::vector<double> &abcRadiiBackgroundInner,
+                     const std::vector<double> &abcRadiiBackgroundOuter,
                      Kernel::SpecialCoordinateSystem frame,
                      std::string algorithmName = std::string(),
                      int algorithmVersion = -1);
-  /// Copy constructor
-  PeakShapeEllipsoid(const PeakShapeEllipsoid &other);
-  /// Assignment operator
-  PeakShapeEllipsoid &operator=(const PeakShapeEllipsoid &other);
   /// Equals operator
   bool operator==(const PeakShapeEllipsoid &other) const;
   /// Get radii
-  std::vector<double> abcRadii() const;
+  const std::vector<double> &abcRadii() const;
   /// Get background inner radii
-  std::vector<double> abcRadiiBackgroundInner() const;
+  const std::vector<double> &abcRadiiBackgroundInner() const;
   /// Get background outer radii
-  std::vector<double> abcRadiiBackgroundOuter() const;
+  const std::vector<double> &abcRadiiBackgroundOuter() const;
   /// Get ellipsoid directions
-  std::vector<Mantid::Kernel::V3D> directions() const;
+  const std::vector<Mantid::Kernel::V3D> &directions() const;
   /// Get ellipsoid directions in a specified frame
   std::vector<Kernel::V3D> getDirectionInSpecificFrame(
       Kernel::Matrix<double> &invertedGoniometerMatrix) const;
@@ -68,7 +64,7 @@ public:
   std::string shapeName() const override;
 
   /// PeakBase interface
-  double radius() const override;
+  double radius(RadiusType type = RadiusType::Region) const override;
 
   static const std::string ellipsoidShapeName();
 

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeSpherical.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeSpherical.h
@@ -55,7 +55,8 @@ public:
   /// Equals operator
   bool operator==(const PeakShapeSpherical &other) const;
   /// Peak radius
-  double radius(RadiusType type = RadiusType::Region) const override;
+  boost::optional<double>
+  radius(RadiusType type = RadiusType::Radius) const override;
   /// Peak outer background radius
   boost::optional<double> backgroundOuterRadius() const;
   /// Peak inner background radius

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeSpherical.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeSpherical.h
@@ -55,7 +55,7 @@ public:
   /// Equals operator
   bool operator==(const PeakShapeSpherical &other) const;
   /// Peak radius
-  double radius() const override;
+  double radius(RadiusType type = RadiusType::Region) const override;
   /// Peak outer background radius
   boost::optional<double> backgroundOuterRadius() const;
   /// Peak inner background radius

--- a/Framework/DataObjects/src/NoShape.cpp
+++ b/Framework/DataObjects/src/NoShape.cpp
@@ -33,9 +33,11 @@ int NoShape::algorithmVersion() const { return -1; }
  * @brief Return the unique shape name associated with this type
  * @return Shape name
  */
-std::string NoShape::shapeName() const { return "none"; }
+std::string NoShape::shapeName() const { return NoShape::noShapeName(); }
 
 Kernel::SpecialCoordinateSystem NoShape::frame() const { return Kernel::None; }
+
+const std::string NoShape::noShapeName() { return "none"; }
 
 } // namespace DataObjects
 } // namespace Mantid

--- a/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
@@ -6,9 +6,10 @@ namespace Mantid {
 namespace DataObjects {
 
 PeakShapeEllipsoid::PeakShapeEllipsoid(
-    std::vector<Kernel::V3D> directions, std::vector<double> abcRadii,
-    std::vector<double> abcRadiiBackgroundInner,
-    std::vector<double> abcRadiiBackgroundOuter,
+    const std::vector<Kernel::V3D> &directions,
+    const std::vector<double> &abcRadii,
+    const std::vector<double> &abcRadiiBackgroundInner,
+    const std::vector<double> &abcRadiiBackgroundOuter,
     Kernel::SpecialCoordinateSystem frame, std::string algorithmName,
     int algorithmVersion)
     : PeakShapeBase(frame, algorithmName, algorithmVersion),
@@ -30,24 +31,6 @@ PeakShapeEllipsoid::PeakShapeEllipsoid(
   }
 }
 
-PeakShapeEllipsoid::PeakShapeEllipsoid(const PeakShapeEllipsoid &other)
-    : PeakShapeBase(other), m_directions(other.directions()),
-      m_abc_radii(other.abcRadii()),
-      m_abc_radiiBackgroundInner(other.abcRadiiBackgroundInner()),
-      m_abc_radiiBackgroundOuter(other.abcRadiiBackgroundOuter()) {}
-
-PeakShapeEllipsoid &PeakShapeEllipsoid::
-operator=(const PeakShapeEllipsoid &other) {
-  if (&other != this) {
-    PeakShapeBase::operator=(other);
-    m_directions = other.directions();
-    m_abc_radii = other.abcRadii();
-    m_abc_radiiBackgroundInner = other.abcRadiiBackgroundInner();
-    m_abc_radiiBackgroundOuter = other.abcRadiiBackgroundOuter();
-  }
-  return *this;
-}
-
 bool PeakShapeEllipsoid::operator==(const PeakShapeEllipsoid &other) const {
   return PeakShapeBase::operator==(other) &&
          other.directions() == this->directions() &&
@@ -56,17 +39,19 @@ bool PeakShapeEllipsoid::operator==(const PeakShapeEllipsoid &other) const {
          other.abcRadiiBackgroundOuter() == this->abcRadiiBackgroundOuter();
 }
 
-std::vector<double> PeakShapeEllipsoid::abcRadii() const { return m_abc_radii; }
+const std::vector<double> &PeakShapeEllipsoid::abcRadii() const {
+  return m_abc_radii;
+}
 
-std::vector<double> PeakShapeEllipsoid::abcRadiiBackgroundInner() const {
+const std::vector<double> &PeakShapeEllipsoid::abcRadiiBackgroundInner() const {
   return m_abc_radiiBackgroundInner;
 }
 
-std::vector<double> PeakShapeEllipsoid::abcRadiiBackgroundOuter() const {
+const std::vector<double> &PeakShapeEllipsoid::abcRadiiBackgroundOuter() const {
   return m_abc_radiiBackgroundOuter;
 }
 
-std::vector<Kernel::V3D> PeakShapeEllipsoid::directions() const {
+const std::vector<Kernel::V3D> &PeakShapeEllipsoid::directions() const {
   return m_directions;
 }
 
@@ -118,7 +103,7 @@ std::string PeakShapeEllipsoid::shapeName() const {
   return PeakShapeEllipsoid::ellipsoidShapeName();
 }
 
-double PeakShapeEllipsoid::radius() const {
+double PeakShapeEllipsoid::radius(RadiusType type) const {
   double radius = m_abc_radii[0];
   for (int8_t i = 1; i < 3; ++i) {
     radius = std::max(radius, m_abc_radii[i]);

--- a/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
@@ -104,19 +104,21 @@ std::string PeakShapeEllipsoid::shapeName() const {
 }
 
 boost::optional<double> PeakShapeEllipsoid::radius(RadiusType type) const {
+  std::vector<double>::const_iterator it;
   switch (type) {
   case (RadiusType::Radius):
-    return boost::optional<double>{
-        *std::max_element(m_abc_radii.cbegin(), m_abc_radii.cend())};
+    it = std::max_element(m_abc_radii.cbegin(), m_abc_radii.cend());
+    break;
   case (RadiusType::OuterRadius):
-    return boost::optional<double>{
-        *std::max_element(m_abc_radiiBackgroundOuter.cbegin(),
-                          m_abc_radiiBackgroundOuter.cend())};
+    it = std::max_element(m_abc_radiiBackgroundOuter.cbegin(),
+                          m_abc_radiiBackgroundOuter.cend());
+    break;
   case (RadiusType::InnerRadius):
-    return boost::optional<double>{
-        *std::max_element(m_abc_radiiBackgroundInner.cbegin(),
-                          m_abc_radiiBackgroundInner.cend())};
+    it = std::max_element(m_abc_radiiBackgroundInner.cbegin(),
+                          m_abc_radiiBackgroundInner.cend());
+    break;
   }
+  return boost::optional<double>{*it};
 }
 
 const std::string PeakShapeEllipsoid::ellipsoidShapeName() {

--- a/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
@@ -103,12 +103,20 @@ std::string PeakShapeEllipsoid::shapeName() const {
   return PeakShapeEllipsoid::ellipsoidShapeName();
 }
 
-double PeakShapeEllipsoid::radius(RadiusType type) const {
-  double radius = m_abc_radii[0];
-  for (int8_t i = 1; i < 3; ++i) {
-    radius = std::max(radius, m_abc_radii[i]);
+boost::optional<double> PeakShapeEllipsoid::radius(RadiusType type) const {
+  switch (type) {
+  case (RadiusType::Radius):
+    return boost::optional<double>{
+        *std::max_element(m_abc_radii.cbegin(), m_abc_radii.cend())};
+  case (RadiusType::OuterRadius):
+    return boost::optional<double>{
+        *std::max_element(m_abc_radiiBackgroundOuter.cbegin(),
+                          m_abc_radiiBackgroundOuter.cend())};
+  case (RadiusType::InnerRadius):
+    return boost::optional<double>{
+        *std::max_element(m_abc_radiiBackgroundInner.cbegin(),
+                          m_abc_radiiBackgroundInner.cend())};
   }
-  return radius;
 }
 
 const std::string PeakShapeEllipsoid::ellipsoidShapeName() {

--- a/Framework/DataObjects/src/PeakShapeSpherical.cpp
+++ b/Framework/DataObjects/src/PeakShapeSpherical.cpp
@@ -86,6 +86,7 @@ bool PeakShapeSpherical::operator==(const PeakShapeSpherical &other) const {
 
 /**
  * @brief Get radius of sphere
+ * @param type Which radius to get.
  * @return radius
  */
 boost::optional<double> PeakShapeSpherical::radius(RadiusType type) const {

--- a/Framework/DataObjects/src/PeakShapeSpherical.cpp
+++ b/Framework/DataObjects/src/PeakShapeSpherical.cpp
@@ -88,7 +88,7 @@ bool PeakShapeSpherical::operator==(const PeakShapeSpherical &other) const {
  * @brief Get radius of sphere
  * @return radius
  */
-double PeakShapeSpherical::radius() const { return m_radius; }
+double PeakShapeSpherical::radius(RadiusType type) const { return m_radius; }
 
 /**
  * @brief Get the background outer radius. The outer radius may not be set, so

--- a/Framework/DataObjects/src/PeakShapeSpherical.cpp
+++ b/Framework/DataObjects/src/PeakShapeSpherical.cpp
@@ -88,7 +88,17 @@ bool PeakShapeSpherical::operator==(const PeakShapeSpherical &other) const {
  * @brief Get radius of sphere
  * @return radius
  */
-double PeakShapeSpherical::radius(RadiusType type) const { return m_radius; }
+boost::optional<double> PeakShapeSpherical::radius(RadiusType type) const {
+
+  switch (type) {
+  case (RadiusType::Radius):
+    return boost::optional<double>{m_radius};
+  case (RadiusType::OuterRadius):
+    return m_backgroundOuterRadius;
+  case (RadiusType::InnerRadius):
+    return m_backgroundInnerRadius;
+  }
+}
 
 /**
  * @brief Get the background outer radius. The outer radius may not be set, so

--- a/Framework/DataObjects/src/PeakShapeSpherical.cpp
+++ b/Framework/DataObjects/src/PeakShapeSpherical.cpp
@@ -91,14 +91,19 @@ bool PeakShapeSpherical::operator==(const PeakShapeSpherical &other) const {
  */
 boost::optional<double> PeakShapeSpherical::radius(RadiusType type) const {
 
+  boost::optional<double> value;
   switch (type) {
   case (RadiusType::Radius):
-    return boost::optional<double>{m_radius};
+    value = boost::optional<double>{m_radius};
+    break;
   case (RadiusType::OuterRadius):
-    return m_backgroundOuterRadius;
+    value = m_backgroundOuterRadius;
+    break;
   case (RadiusType::InnerRadius):
-    return m_backgroundInnerRadius;
+    value = m_backgroundInnerRadius;
+    break;
   }
+  return value;
 }
 
 /**

--- a/Framework/DataObjects/test/MockObjects.h
+++ b/Framework/DataObjects/test/MockObjects.h
@@ -27,7 +27,8 @@ public:
   MOCK_CONST_METHOD0(algorithmName, std::string());
   MOCK_CONST_METHOD0(algorithmVersion, int());
   MOCK_CONST_METHOD0(shapeName, std::string());
-
+  MOCK_CONST_METHOD1(
+      radius, boost::optional<double>(Mantid::Geometry::PeakShape::RadiusType));
   ~MockPeakShape() override {}
 };
 }

--- a/Framework/DataObjects/test/PeakShapeEllipsoidTest.h
+++ b/Framework/DataObjects/test/PeakShapeEllipsoidTest.h
@@ -126,6 +126,17 @@ public:
 
     TSM_ASSERT_EQUALS("Radius should be taken to be the max of the ABC radii",
                       3.0, shape.radius());
+    TSM_ASSERT_EQUALS(
+        "Radius should be taken to be the max of the ABC radii", 3.0,
+        shape.radius(Mantid::Geometry::PeakShape::RadiusType::Radius));
+    TSM_ASSERT_EQUALS(
+        "Radius should be taken to be the max of the ABC BackgroundInner radii",
+        3.0,
+        shape.radius(Mantid::Geometry::PeakShape::RadiusType::InnerRadius));
+    TSM_ASSERT_EQUALS(
+        "Radius should be taken to be the max of the ABC BackgroundOuter radii",
+        3.0,
+        shape.radius(Mantid::Geometry::PeakShape::RadiusType::OuterRadius));
   }
 
   void test_shape_name() {

--- a/Framework/DataObjects/test/PeakShapeSphericalTest.h
+++ b/Framework/DataObjects/test/PeakShapeSphericalTest.h
@@ -60,6 +60,15 @@ public:
                              algorithmVersion);
 
     TS_ASSERT_EQUALS(radius, shape.radius());
+    TS_ASSERT_EQUALS(
+        radius, shape.radius(Mantid::Geometry::PeakShape::RadiusType::Radius));
+    TS_ASSERT_EQUALS(
+        backgroundInnerRadius,
+        shape.radius(Mantid::Geometry::PeakShape::RadiusType::InnerRadius));
+    TS_ASSERT_EQUALS(
+        backgroundOuterRadius,
+        shape.radius(Mantid::Geometry::PeakShape::RadiusType::OuterRadius));
+
     TS_ASSERT_EQUALS(frame, shape.frame());
     TS_ASSERT_EQUALS(algorithmName, shape.algorithmName());
     TS_ASSERT_EQUALS(algorithmVersion, shape.algorithmVersion());

--- a/Framework/DataObjects/test/PeakTest.h
+++ b/Framework/DataObjects/test/PeakTest.h
@@ -19,6 +19,17 @@ using namespace Mantid::DataObjects;
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
 
+namespace boost {
+template <class CharType, class CharTrait>
+std::basic_ostream<CharType, CharTrait> &
+operator<<(std::basic_ostream<CharType, CharTrait> &out,
+           optional<double> const &maybe) {
+  if (maybe)
+    out << maybe;
+  return out;
+}
+}
+
 class PeakTest : public CxxTest::TestSuite {
 private:
   /// Common instrument

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/PeakShape.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/PeakShape.h
@@ -47,6 +47,7 @@ public:
   virtual int algorithmVersion() const = 0;
   /// Shape name
   virtual std::string shapeName() const = 0;
+  /// For selecting different radius types.
   enum RadiusType { Radius = 0, OuterRadius = 1, InnerRadius = 2 };
   /// Radius
   virtual boost::optional<double> radius(RadiusType type) const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/PeakShape.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/PeakShape.h
@@ -1,10 +1,11 @@
 #ifndef MANTID_GEOMETRY_PEAKSHAPE_H_
 #define MANTID_GEOMETRY_PEAKSHAPE_H_
 
-#include "MantidKernel/System.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
-#include <string>
+#include "MantidKernel/System.h"
+#include <boost/optional.hpp>
 #include <boost/shared_ptr.hpp>
+#include <string>
 
 namespace Mantid {
 namespace Geometry {
@@ -46,6 +47,9 @@ public:
   virtual int algorithmVersion() const = 0;
   /// Shape name
   virtual std::string shapeName() const = 0;
+  enum RadiusType { Radius = 0, OuterRadius = 1, InnerRadius = 2 };
+  /// Radius
+  virtual boost::optional<double> radius(RadiusType type) const = 0;
   /// Destructor
   virtual ~PeakShape() = default;
 };

--- a/Framework/Kernel/inc/MantidKernel/StringTokenizer.h
+++ b/Framework/Kernel/inc/MantidKernel/StringTokenizer.h
@@ -73,6 +73,16 @@ public:
   Iterator end() { return m_tokens.end(); }
 
   /** Const iterator referring to first element in the container.
+   * @return a const iterator referring to the first element in the container.
+   */
+  ConstIterator begin() const { return m_tokens.cbegin(); }
+  /** Const iterator referring to the past-the-end element in the container.
+   * @return a const iterator referring to the past-the-end element in the
+   * container.
+   */
+  ConstIterator end() const { return m_tokens.cend(); }
+
+  /** Const iterator referring to first element in the container.
   * @return a const iterator referring to the first element in the container.
   */
   ConstIterator cbegin() const { return m_tokens.cbegin(); }

--- a/MantidQt/SliceViewer/src/PeakViewFactory.cpp
+++ b/MantidQt/SliceViewer/src/PeakViewFactory.cpp
@@ -151,7 +151,7 @@ PeakRepresentation_sptr PeakViewFactory::createPeakRepresentationSphere(
         = dynamic_cast<const Mantid::DataObjects::PeakShapeSpherical &>(shape);
 
     // Get the radius
-    const auto peakRadius = sphericalShape.radius();
+    const auto peakRadius = sphericalShape.radius().value();
 
     // Get the background inner radius. If it does not exist, default to radius.
     const auto backgroundInnerRadiusOptional

--- a/MantidQt/SliceViewer/src/PeakViewFactory.cpp
+++ b/MantidQt/SliceViewer/src/PeakViewFactory.cpp
@@ -151,7 +151,7 @@ PeakRepresentation_sptr PeakViewFactory::createPeakRepresentationSphere(
         = dynamic_cast<const Mantid::DataObjects::PeakShapeSpherical &>(shape);
 
     // Get the radius
-    const auto peakRadius = sphericalShape.radius().value();
+    const auto peakRadius = sphericalShape.radius().get();
 
     // Get the background inner radius. If it does not exist, default to radius.
     const auto backgroundInnerRadiusOptional

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/CMakeLists.txt
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/CMakeLists.txt
@@ -2,7 +2,7 @@ PROJECT(PeaksFilter)
 include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
 ADD_PARAVIEW_PLUGIN(MantidParaViewPeaksFilterSMPlugin "1.0"
 SERVER_MANAGER_XML PeaksFilter.xml
-SERVER_MANAGER_SOURCES vtkPeaksFilter.cxx)
+SERVER_MANAGER_SOURCES vtkPeaksFilter.cxx vtkPeaksFilter.h)
 # Add to the 'VatesParaViewPlugins' group in VS
 set_property( TARGET MantidParaViewPeaksFilterSMPlugin PROPERTY FOLDER "MantidVatesParaViewPlugins")
 

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/PeaksFilter.xml
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/PeaksFilter.xml
@@ -16,7 +16,7 @@
           <DataType value="vtkUnstructuredGrid"/>
         </DataTypeDomain>
       </InputProperty>
-	  <StringVectorProperty name="PeaksWorkspace" command="SetPeaksWorkspace" number_of_elements="1" panel_visibility="never"/>
+	  <StringVectorProperty name="PeaksWorkspace" command="SetPeaksWorkspace" number_of_elements="2" element_types="2 2" panel_visibility="never"/>
     <DoubleVectorProperty name="RadiusNoShape" command="SetRadiusNoShape" number_of_elements="1" default_values="0.5">
       <DoubleRangeDomain name="range" min="0.001" max="10" />
       <Documentation>
@@ -33,10 +33,9 @@
         Set the radius type.
       </Documentation>
     </IntVectorProperty>
-    <StringVectorProperty name="Delimiter" command="SetDelimiter" number_of_elements="1" panel_visibility="never"/>
-	 <DoubleVectorProperty name="MinValue"	command="GetMinValue" information_only="1"/>
+    <DoubleVectorProperty name="MinValue" command="GetMinValue" information_only="1"/>
     <DoubleVectorProperty name="MaxValue" command="GetMaxValue" information_only="1"/>
-	<StringVectorProperty name="Instrument" command="GetInstrument" number_of_elements="1" information_only="1"/>
+    <StringVectorProperty name="Instrument" command="GetInstrument" number_of_elements="1" information_only="1"/>
     </SourceProxy>
   </ProxyGroup>
   <!-- End ScaleWorkspace -->

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.cxx
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.cxx
@@ -22,9 +22,9 @@ vtkStandardNewMacro(vtkPeaksFilter)
 using namespace Mantid::VATES;
 
 vtkPeaksFilter::vtkPeaksFilter()
-    : m_delimiter(";"), m_radiusNoShape(0.5),
-      m_radiusType(Mantid::Geometry::PeakShape::Radius), m_minValue(0.1),
-      m_maxValue(0.1), m_metadataJsonManager(new MetadataJsonManager()),
+    : m_radiusNoShape(0.5), m_radiusType(Mantid::Geometry::PeakShape::Radius),
+      m_minValue(0.1), m_maxValue(0.1),
+      m_metadataJsonManager(new MetadataJsonManager()),
       m_vatesConfigurations(new VatesConfigurations()), m_coordinateSystem(0) {
   this->SetNumberOfInputPorts(1);
   this->SetNumberOfOutputPorts(1);

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.cxx
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.cxx
@@ -1,11 +1,12 @@
 #include "vtkPeaksFilter.h"
-#include "MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h"
+
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IPeaksWorkspace.h"
-#include "MantidVatesAPI/FilteringUpdateProgressAction.h"
 #include "MantidVatesAPI/FieldDataToMetadata.h"
+#include "MantidVatesAPI/FilteringUpdateProgressAction.h"
 #include "MantidVatesAPI/MetadataJsonManager.h"
 #include "MantidVatesAPI/VatesConfigurations.h"
+#include "MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h"
 
 #include <boost/scoped_ptr.hpp>
 
@@ -22,10 +23,10 @@ vtkStandardNewMacro(vtkPeaksFilter)
 using namespace Mantid::VATES;
 
 vtkPeaksFilter::vtkPeaksFilter()
-    : m_radiusNoShape(0.5), m_radiusType(Mantid::Geometry::PeakShape::Radius),
-      m_minValue(0.1), m_maxValue(0.1),
+    : m_radiusNoShape(0.5), m_minValue(0.1), m_maxValue(0.1),
+      m_coordinateSystem(0), m_radiusType(Mantid::Geometry::PeakShape::Radius),
       m_metadataJsonManager(new MetadataJsonManager()),
-      m_vatesConfigurations(new VatesConfigurations()), m_coordinateSystem(0) {
+      m_vatesConfigurations(new VatesConfigurations()) {
   this->SetNumberOfInputPorts(1);
   this->SetNumberOfOutputPorts(1);
 }

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.cxx
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.cxx
@@ -78,7 +78,10 @@ int vtkPeaksFilter::RequestData(vtkInformation*, vtkInformationVector **inputVec
   FilterUpdateProgressAction<vtkPeaksFilter> drawingProgressUpdate(this, "Drawing...");
 
   vtkDataSetToPeaksFilteredDataSet peaksFilter(inputDataSet, outputDataSet);
-  peaksFilter.initialize(peaksWorkspaces, m_radiusNoShape, m_radiusType, m_coordinateSystem);
+  peaksFilter.initialize(
+      peaksWorkspaces, m_radiusNoShape,
+      static_cast<Mantid::DataObjects::PeakShapeBase::RadiusType>(m_radiusType),
+      m_coordinateSystem);
   peaksFilter.execute(drawingProgressUpdate);
   return 1;
 }

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.cxx
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.cxx
@@ -117,8 +117,7 @@ void vtkPeaksFilter::SetPeaksWorkspace(const std::string &peaksWorkspaceName,
                                        const std::string &delimiter) {
   auto tokenizedNames =
       Mantid::Kernel::StringTokenizer(peaksWorkspaceName, delimiter);
-  std::vector<Mantid::API::IPeaksWorkspace_sptr> peaksWorkspaces =
-      getPeaksWorkspaces(tokenizedNames);
+  m_peaksWorkspaces = getPeaksWorkspaces(tokenizedNames);
   this->Modified();
 }
 
@@ -136,9 +135,8 @@ void vtkPeaksFilter::SetRadiusNoShape(double radius)
  * Set the radius type.
  * @param type The type of the radius
  */
-void vtkPeaksFilter::SetRadiusType(
-    Mantid::Geometry::PeakShape::RadiusType type) {
-  m_radiusType = type;
+void vtkPeaksFilter::SetRadiusType(int type) {
+  m_radiusType = static_cast<Mantid::Geometry::PeakShape::RadiusType>(type);
   this->Modified();
 }
 

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
@@ -17,10 +17,10 @@ public:
       ostream &os, vtkIndent indent) override;
   vtkPeaksFilter(const vtkPeaksFilter &) = delete;
   vtkPeaksFilter &operator=(const vtkPeaksFilter &) = delete;
-  void SetPeaksWorkspace(const std::string &peaksWorkspaceName);
+  void SetPeaksWorkspace(const std::string &peaksWorkspaceName,
+                         const std::string &delimiter);
   void SetRadiusNoShape(double radius);
   void SetRadiusType(Mantid::Geometry::PeakShape::RadiusType type);
-  void SetDelimiter(const std::string &delimiter);
   void updateAlgorithmProgress(double progress, const std::string& message);
   double GetMinValue();
   double GetMaxValue();
@@ -34,8 +34,9 @@ protected:
                   vtkInformationVector *) override;
 
 private:
-  std::vector<Mantid::API::IPeaksWorkspace_sptr> getPeaksWorkspaces();
-  Mantid::Kernel::StringTokenizer m_peaksWorkspaceNames;
+  std::vector<Mantid::API::IPeaksWorkspace_sptr>
+  getPeaksWorkspaces(const Mantid::Kernel::StringTokenizer &workspaceNames);
+  std::vector<Mantid::API::IPeaksWorkspace_sptr> m_peaksWorkspaces;
   std::string m_delimiter;
   double m_radiusNoShape;
   Mantid::Geometry::PeakShape::RadiusType m_radiusType;

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
@@ -36,14 +36,14 @@ protected:
 private:
   std::vector<Mantid::API::IPeaksWorkspace_sptr>
   getPeaksWorkspaces(const Mantid::Kernel::StringTokenizer &workspaceNames);
-  std::vector<Mantid::API::IPeaksWorkspace_sptr> m_peaksWorkspaces;
   double m_radiusNoShape;
-  Mantid::Geometry::PeakShape::RadiusType m_radiusType;
   double m_minValue;
   double m_maxValue;
+  int m_coordinateSystem;
+  Mantid::Geometry::PeakShape::RadiusType m_radiusType;
   std::string m_instrument;
+  std::vector<Mantid::API::IPeaksWorkspace_sptr> m_peaksWorkspaces;
   boost::scoped_ptr<Mantid::VATES::MetadataJsonManager> m_metadataJsonManager;
   boost::scoped_ptr<Mantid::VATES::VatesConfigurations> m_vatesConfigurations;
-  int m_coordinateSystem;
 };
 #endif

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
@@ -2,6 +2,7 @@
 #define _VTKPEAKSFILTER_h
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidGeometry/Crystal/PeakShape.h"
+#include "MantidKernel/StringTokenizer.h"
 #include "MantidVatesAPI/MetadataJsonManager.h"
 #include "MantidVatesAPI/VatesConfigurations.h"
 #include "vtkUnstructuredGridAlgorithm.h"
@@ -14,10 +15,12 @@ public:
   static vtkPeaksFilter *New();
   vtkTypeMacro(vtkPeaksFilter, vtkUnstructuredGridAlgorithm) void PrintSelf(
       ostream &os, vtkIndent indent) override;
-  void SetPeaksWorkspace(std::string peaksWorkspaceName);
+  vtkPeaksFilter(const vtkPeaksFilter &) = delete;
+  vtkPeaksFilter &operator=(const vtkPeaksFilter &) = delete;
+  void SetPeaksWorkspace(const std::string &peaksWorkspaceName);
   void SetRadiusNoShape(double radius);
   void SetRadiusType(Mantid::Geometry::PeakShape::RadiusType type);
-  void SetDelimiter(std::string delimiter);
+  void SetDelimiter(const std::string &delimiter);
   void updateAlgorithmProgress(double progress, const std::string& message);
   double GetMinValue();
   double GetMaxValue();
@@ -31,12 +34,8 @@ protected:
                   vtkInformationVector *) override;
 
 private:
-  vtkPeaksFilter(const vtkPeaksFilter&);
-  void operator = (const vtkPeaksFilter&);
-  std::vector<std::string> extractPeakWorkspaceNames();
-  std::vector<Mantid::API::IPeaksWorkspace_sptr>
-  getPeaksWorkspaces(const std::vector<std::string> &peaksWorkspaceNames);
-  std::string m_peaksWorkspaceNames;
+  std::vector<Mantid::API::IPeaksWorkspace_sptr> getPeaksWorkspaces();
+  Mantid::Kernel::StringTokenizer m_peaksWorkspaceNames;
   std::string m_delimiter;
   double m_radiusNoShape;
   Mantid::Geometry::PeakShape::RadiusType m_radiusType;

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
@@ -1,9 +1,10 @@
 #ifndef _VTKPEAKSFILTER_h
 #define _VTKPEAKSFILTER_h
-#include "vtkUnstructuredGridAlgorithm.h"
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
+#include "MantidGeometry/Crystal/PeakShape.h"
 #include "MantidVatesAPI/MetadataJsonManager.h"
 #include "MantidVatesAPI/VatesConfigurations.h"
+#include "vtkUnstructuredGridAlgorithm.h"
 #include <boost/scoped_ptr.hpp>
 #include <string>
 // cppcheck-suppress class_X_Y
@@ -15,7 +16,7 @@ public:
       ostream &os, vtkIndent indent) override;
   void SetPeaksWorkspace(std::string peaksWorkspaceName);
   void SetRadiusNoShape(double radius);
-  void SetRadiusType(int type);
+  void SetRadiusType(Mantid::Geometry::PeakShape::RadiusType type);
   void SetDelimiter(std::string delimiter);
   void updateAlgorithmProgress(double progress, const std::string& message);
   double GetMinValue();
@@ -33,11 +34,12 @@ private:
   vtkPeaksFilter(const vtkPeaksFilter&);
   void operator = (const vtkPeaksFilter&);
   std::vector<std::string> extractPeakWorkspaceNames();
-  std::vector<Mantid::API::IPeaksWorkspace_sptr> getPeaksWorkspaces(std::vector<std::string> peaksWorkspaceNames);
+  std::vector<Mantid::API::IPeaksWorkspace_sptr>
+  getPeaksWorkspaces(const std::vector<std::string> &peaksWorkspaceNames);
   std::string m_peaksWorkspaceNames;
   std::string m_delimiter;
   double m_radiusNoShape;
-  int m_radiusType;
+  Mantid::Geometry::PeakShape::RadiusType m_radiusType;
   double m_minValue;
   double m_maxValue;
   std::string m_instrument;

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
@@ -20,7 +20,7 @@ public:
   void SetPeaksWorkspace(const std::string &peaksWorkspaceName,
                          const std::string &delimiter);
   void SetRadiusNoShape(double radius);
-  void SetRadiusType(Mantid::Geometry::PeakShape::RadiusType type);
+  void SetRadiusType(int type);
   void updateAlgorithmProgress(double progress, const std::string& message);
   double GetMinValue();
   double GetMaxValue();

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
@@ -37,7 +37,6 @@ private:
   std::vector<Mantid::API::IPeaksWorkspace_sptr>
   getPeaksWorkspaces(const Mantid::Kernel::StringTokenizer &workspaceNames);
   std::vector<Mantid::API::IPeaksWorkspace_sptr> m_peaksWorkspaces;
-  std::string m_delimiter;
   double m_radiusNoShape;
   Mantid::Geometry::PeakShape::RadiusType m_radiusType;
   double m_minValue;

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
@@ -48,6 +48,10 @@ namespace VATES
       vtkDataSetToPeaksFilteredDataSet(
           vtkSmartPointer<vtkUnstructuredGrid> input,
           vtkSmartPointer<vtkUnstructuredGrid> output);
+      vtkDataSetToPeaksFilteredDataSet(
+          const vtkDataSetToPeaksFilteredDataSet &) = delete;
+      vtkDataSetToPeaksFilteredDataSet &
+      operator=(const vtkDataSetToPeaksFilteredDataSet &) = delete;
       virtual ~vtkDataSetToPeaksFilteredDataSet();
       /// Set the name of the peaks workspace
       void initialize(
@@ -61,20 +65,23 @@ namespace VATES
       /// Get radius factor
       double getRadiusFactor();
     private:
-      vtkDataSetToPeaksFilteredDataSet& operator=(const vtkDataSetToPeaksFilteredDataSet& other);
       std::vector<std::pair<Mantid::Kernel::V3D, double>>
       getPeaksInfo(const std::vector<Mantid::API::IPeaksWorkspace_sptr>
                        &peaksWorkspaces);
-      void addSinglePeak(Mantid::Geometry::IPeak* peak, const Mantid::Kernel::SpecialCoordinateSystem coordinateSystem, std::vector<std::pair<Mantid::Kernel::V3D, double>>& peaksInfo);
-      vtkSmartPointer<vtkUnstructuredGrid> m_inputData; ///< Data to peak filter
-      vtkSmartPointer<vtkUnstructuredGrid> m_outputData; ///< Peak filtered data
-      std::vector<Mantid::API::IPeaksWorkspace_sptr> m_peaksWorkspaces; ///< A list of peaks workspace names.
-      bool m_isInitialised; ///<Flag if the filter is initialized
+      void addSinglePeak(
+          Mantid::Geometry::IPeak *peak,
+          std::vector<std::pair<Mantid::Kernel::V3D, double>> &peaksInfo);
       double m_radiusNoShape; ///< The radius for peaks with no peak shape.
-      Geometry::PeakShape::RadiusType m_radiusType;
       double m_radiusFactor;///< By how much we want to trim the data set.
       double m_defaultRadius; ///< A default radius.
-      int m_coordinateSystem;///< A coordinate system.
+      Geometry::PeakShape::RadiusType m_radiusType;
+      bool m_isInitialised; ///<Flag if the filter is initialized
+      Mantid::Kernel::SpecialCoordinateSystem
+          m_coordinateSystem; ///< A coordinate system.
+      vtkSmartPointer<vtkUnstructuredGrid> m_inputData; ///< Data to peak filter
+      vtkSmartPointer<vtkUnstructuredGrid> m_outputData; ///< Peak filtered data
+      std::vector<Mantid::API::IPeaksWorkspace_sptr>
+          m_peaksWorkspaces; ///< A list of peaks workspace names.
   };
 }
 }

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
@@ -49,7 +49,7 @@ namespace VATES
           vtkSmartPointer<vtkUnstructuredGrid> input,
           vtkSmartPointer<vtkUnstructuredGrid> output);
       vtkDataSetToPeaksFilteredDataSet(
-          const vtkDataSetToPeaksFilteredDataSet &) = delete;
+          const vtkDataSetToPeaksFilteredDataSet &) = default;
       vtkDataSetToPeaksFilteredDataSet &
       operator=(const vtkDataSetToPeaksFilteredDataSet &) = delete;
       virtual ~vtkDataSetToPeaksFilteredDataSet();

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
@@ -68,9 +68,8 @@ namespace VATES
       std::vector<std::pair<Mantid::Kernel::V3D, double>>
       getPeaksInfo(const std::vector<Mantid::API::IPeaksWorkspace_sptr>
                        &peaksWorkspaces);
-      void addSinglePeak(
-          Mantid::Geometry::IPeak *peak,
-          std::vector<std::pair<Mantid::Kernel::V3D, double>> &peaksInfo);
+      Kernel::V3D getPeakPosition(const Mantid::Geometry::IPeak &peak);
+      double getPeakRadius(const Mantid::Geometry::PeakShape &shape);
       double m_radiusNoShape; ///< The radius for peaks with no peak shape.
       double m_radiusFactor;///< By how much we want to trim the data set.
       double m_defaultRadius; ///< A default radius.

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
@@ -1,9 +1,10 @@
 #ifndef MANTID_VATES_PeaksFilter_H
 #define MANTID_VATES_PeaksFilter_H
 
+#include "MantidAPI/IPeaksWorkspace.h"
+#include "MantidDataObjects/PeakShapeBase.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/V3D.h"
-#include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidVatesAPI/ProgressAction.h"
 #include "vtkSmartPointer.h"
 #include <string>
@@ -51,7 +52,9 @@ namespace VATES
       /// Set the name of the peaks workspace
       void initialize(
           const std::vector<Mantid::API::IPeaksWorkspace_sptr> &peaksWorkspaces,
-          double radiusNoShape, int radiusType, int coordinateSystem);
+          double radiusNoShape,
+          DataObjects::PeakShapeBase::RadiusType radiusType,
+          int coordinateSystem);
       /// Apply the peak filtering
       void execute(ProgressAction& progressUpdating);
       /// Get radius of no shape
@@ -69,7 +72,7 @@ namespace VATES
       std::vector<Mantid::API::IPeaksWorkspace_sptr> m_peaksWorkspaces; ///< A list of peaks workspace names.
       bool m_isInitialised; ///<Flag if the filter is initialized
       double m_radiusNoShape; ///< The radius for peaks with no peak shape.
-      int m_radiusType;
+      DataObjects::PeakShapeBase::RadiusType m_radiusType;
       double m_radiusFactor;///< By how much we want to trim the data set.
       double m_defaultRadius; ///< A default radius.
       int m_coordinateSystem;///< A coordinate system.

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
@@ -49,7 +49,9 @@ namespace VATES
           vtkSmartPointer<vtkUnstructuredGrid> output);
       virtual ~vtkDataSetToPeaksFilteredDataSet();
       /// Set the name of the peaks workspace
-      void initialize(std::vector<Mantid::API::IPeaksWorkspace_sptr> peaksWorkspaces, double radiusNoShape, int radiusType, int coordinateSystem);
+      void initialize(
+          const std::vector<Mantid::API::IPeaksWorkspace_sptr> &peaksWorkspaces,
+          double radiusNoShape, int radiusType, int coordinateSystem);
       /// Apply the peak filtering
       void execute(ProgressAction& progressUpdating);
       /// Get radius of no shape
@@ -58,7 +60,9 @@ namespace VATES
       double getRadiusFactor();
     private:
       vtkDataSetToPeaksFilteredDataSet& operator=(const vtkDataSetToPeaksFilteredDataSet& other);
-      std::vector<std::pair<Mantid::Kernel::V3D, double>> getPeaksInfo(std::vector<Mantid::API::IPeaksWorkspace_sptr> peaksWorkspaces);
+      std::vector<std::pair<Mantid::Kernel::V3D, double>>
+      getPeaksInfo(const std::vector<Mantid::API::IPeaksWorkspace_sptr>
+                       &peaksWorkspaces);
       void addSinglePeak(Mantid::Geometry::IPeak* peak, const Mantid::Kernel::SpecialCoordinateSystem coordinateSystem, std::vector<std::pair<Mantid::Kernel::V3D, double>>& peaksInfo);
       vtkSmartPointer<vtkUnstructuredGrid> m_inputData; ///< Data to peak filter
       vtkSmartPointer<vtkUnstructuredGrid> m_outputData; ///< Peak filtered data

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
@@ -52,8 +52,7 @@ namespace VATES
       /// Set the name of the peaks workspace
       void initialize(
           const std::vector<Mantid::API::IPeaksWorkspace_sptr> &peaksWorkspaces,
-          double radiusNoShape,
-          DataObjects::PeakShapeBase::RadiusType radiusType,
+          double radiusNoShape, Geometry::PeakShape::RadiusType radiusType,
           int coordinateSystem);
       /// Apply the peak filtering
       void execute(ProgressAction& progressUpdating);
@@ -72,7 +71,7 @@ namespace VATES
       std::vector<Mantid::API::IPeaksWorkspace_sptr> m_peaksWorkspaces; ///< A list of peaks workspace names.
       bool m_isInitialised; ///<Flag if the filter is initialized
       double m_radiusNoShape; ///< The radius for peaks with no peak shape.
-      DataObjects::PeakShapeBase::RadiusType m_radiusType;
+      Geometry::PeakShape::RadiusType m_radiusType;
       double m_radiusFactor;///< By how much we want to trim the data set.
       double m_defaultRadius; ///< A default radius.
       int m_coordinateSystem;///< A coordinate system.

--- a/Vates/VatesAPI/src/ConcretePeaksPresenterVsi.cpp
+++ b/Vates/VatesAPI/src/ConcretePeaksPresenterVsi.cpp
@@ -141,7 +141,7 @@ double ConcretePeaksPresenterVsi::getMaxRadius (
   boost::optional<double> radius =
       shape->radius(Mantid::Geometry::PeakShape::Radius);
   if (radius) {
-    return radius.value();
+    return radius.get();
   } else {
     return defaultRadius;
   }

--- a/Vates/VatesAPI/src/ConcretePeaksPresenterVsi.cpp
+++ b/Vates/VatesAPI/src/ConcretePeaksPresenterVsi.cpp
@@ -137,26 +137,11 @@ void ConcretePeaksPresenterVsi::getPeaksInfo(
 double ConcretePeaksPresenterVsi::getMaxRadius (
     Mantid::Geometry::PeakShape_sptr shape) const{
   const double defaultRadius = 1.0;
-  boost::shared_ptr<Mantid::DataObjects::NoShape> nullShape =
-      boost::dynamic_pointer_cast<Mantid::DataObjects::NoShape>(shape);
-  boost::shared_ptr<Mantid::DataObjects::PeakShapeEllipsoid> ellipsoidShape =
-      boost::dynamic_pointer_cast<Mantid::DataObjects::PeakShapeEllipsoid>(
-          shape);
-  boost::shared_ptr<Mantid::DataObjects::PeakShapeSpherical> sphericalShape =
-      boost::dynamic_pointer_cast<Mantid::DataObjects::PeakShapeSpherical>(
-          shape);
 
-  if (nullShape) {
-    return defaultRadius;
-  } else if (ellipsoidShape) {
-    std::vector<double> radius = ellipsoidShape->abcRadii();
-    return *(std::max_element(radius.begin(), radius.end()));
-  } else if (sphericalShape) {
-    if (double radius = sphericalShape->radius()) {
-      return radius;
-    } else {
-      return defaultRadius;
-    }
+  boost::optional<double> radius =
+      shape->radius(Mantid::Geometry::PeakShape::Radius);
+  if (radius) {
+    return radius.value();
   } else {
     return defaultRadius;
   }

--- a/Vates/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
@@ -24,12 +24,13 @@
 #include <vtkFieldData.h>
 
 #include <boost/shared_ptr.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <algorithm>
-#include <cmath>
-
 
 namespace Mantid
 {
@@ -114,19 +115,17 @@ void vtkDataSetToPeaksFilteredDataSet::execute(
     points->GetPoint(i, point);
 
     // Compare to Peaks
-    const size_t numberOfPeaks = peaksInfo.size();
-    // size_t counter = 0;
-    // while (counter < numberOfPeaks) {
-    for (size_t counter = 0; counter < numberOfPeaks; ++counter) {
-      // Calcuate the differnce between the vtkDataSet point and the peak. Needs
+    for (const auto &peak : peaksInfo) {
+      // Calcuate the difference between the vtkDataSet point and the peak.
+      // Needs
       // to be smaller than the radius
+
       double squaredDifference = 0.;
       for (unsigned k = 0; k < 3; k++) {
-        squaredDifference += pow(point[k] - peaksInfo[counter].first[k], 2);
+        squaredDifference += pow(point[k] - peak.first[k], 2);
       }
 
-      if (squaredDifference <=
-          (peaksInfo[counter].second * peaksInfo[counter].second)) {
+      if (squaredDifference <= pow(peak.second, 2)) {
         ids->InsertNextValue(i);
         break;
       }

--- a/Vates/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
@@ -181,7 +181,6 @@ GCC_DIAG_OFF(strict-aliasing)
   /**
    * Add information for a single peak to the peakInfo vector.
    * @param peak The peak from which the information will be extracted.
-   * @param coordinateSystem The coordinate system in which the peaks position should be retrieved.
    * @param peaksInfo A reference to the vector containing peak information.
    */
 void vtkDataSetToPeaksFilteredDataSet::addSinglePeak(

--- a/Vates/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
@@ -190,10 +190,7 @@ void vtkDataSetToPeaksFilteredDataSet::addSinglePeak(
   const Mantid::Geometry::PeakShape &shape = peak->getPeakShape();
   std::string shapeName = shape.shapeName();
 
-  if (shapeName == Mantid::DataObjects::PeakShapeSpherical::sphereShapeName() ||
-      shapeName ==
-          Mantid::DataObjects::PeakShapeEllipsoid::ellipsoidShapeName()) {
-
+  if (shapeName != Mantid::DataObjects::NoShape::noShapeName()) {
     boost::optional<double> rad = shape.radius(m_radiusType);
     if (rad.is_initialized()) {
       radius = rad.get();

--- a/Vates/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToPeaksFilteredDataSet.cpp
@@ -45,8 +45,8 @@ vtkDataSetToPeaksFilteredDataSet::vtkDataSetToPeaksFilteredDataSet(
     vtkSmartPointer<vtkUnstructuredGrid> output)
     : m_inputData(input), m_outputData(output), m_isInitialised(false),
       m_radiusNoShape(0.2),
-      m_radiusType(DataObjects::PeakShapeBase::RadiusType::Radius),
-      m_radiusFactor(2), m_defaultRadius(0.1), m_coordinateSystem(0) {
+      m_radiusType(Geometry::PeakShape::RadiusType::Radius), m_radiusFactor(2),
+      m_defaultRadius(0.1), m_coordinateSystem(0) {
   if (nullptr == input) {
     throw std::runtime_error("Cannot construct "
                              "vtkDataSetToPeaksFilteredDataSet with NULL input "
@@ -71,7 +71,7 @@ vtkDataSetToPeaksFilteredDataSet::~vtkDataSetToPeaksFilteredDataSet() {}
   */
 void vtkDataSetToPeaksFilteredDataSet::initialize(
     const std::vector<Mantid::API::IPeaksWorkspace_sptr> &peaksWorkspaces,
-    double radiusNoShape, DataObjects::PeakShapeBase::RadiusType radiusType,
+    double radiusNoShape, Geometry::PeakShape::RadiusType radiusType,
     int coordinateSystem) {
   m_peaksWorkspaces = peaksWorkspaces;
   m_radiusNoShape = radiusNoShape;

--- a/Vates/VatesAPI/src/vtkPeakMarkerFactory.cpp
+++ b/Vates/VatesAPI/src/vtkPeakMarkerFactory.cpp
@@ -220,7 +220,7 @@ stack.
       if(shape.shapeName() == Mantid::DataObjects::PeakShapeSpherical::sphereShapeName())
       {
         double peakRadius =
-            shape.radius(Mantid::Geometry::PeakShape::Radius).value();
+            shape.radius(Mantid::Geometry::PeakShape::Radius).get();
 
         vtkNew<vtkRegularPolygonSource> polygonSource;
         polygonSource->GeneratePolygonOff();

--- a/Vates/VatesAPI/src/vtkPeakMarkerFactory.cpp
+++ b/Vates/VatesAPI/src/vtkPeakMarkerFactory.cpp
@@ -204,7 +204,7 @@ stack.
       peakDataSet->Allocate(1);
       peakDataSet->SetPoints(peakPoint.GetPointer());
 
-      IPeak & peak = m_workspace->getPeak(i);
+      const IPeak &peak = m_workspace->getPeak(i);
 
       // Choose the dimensionality of the position to show
       V3D pos = getPosition(peak);
@@ -219,8 +219,8 @@ stack.
       // Pick the radius up from the factory if possible, otherwise use the user-provided value.
       if(shape.shapeName() == Mantid::DataObjects::PeakShapeSpherical::sphereShapeName())
       {
-        const Mantid::DataObjects::PeakShapeSpherical& sphericalShape = dynamic_cast<const Mantid::DataObjects::PeakShapeSpherical&>(shape);
-        double peakRadius = sphericalShape.radius();
+        double peakRadius =
+            shape.radius(Mantid::Geometry::PeakShape::Radius).value();
 
         vtkNew<vtkRegularPolygonSource> polygonSource;
         polygonSource->GeneratePolygonOff();

--- a/Vates/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
+++ b/Vates/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
@@ -172,7 +172,9 @@ public:
       peaksContainer.push_back(pw_ptr);
     }
 
-    peaksFilter.initialize(peaksContainer, 0.5, 0, static_cast<int>(coordinateSystem));
+    peaksFilter.initialize(peaksContainer, 0.5,
+                           Mantid::Geometry::PeakShape::RadiusType::Radius,
+                           coordinateSystem);
     FakeProgressAction updateProgress;
     TSM_ASSERT_THROWS_NOTHING("Should execute regularly.", peaksFilter.execute(updateProgress));
   }

--- a/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
@@ -651,8 +651,12 @@ void SplatterPlotView::updatePeaksFilter(pqPipelineSource* filter) {
       throw std::runtime_error("The peaks viewer does not contain a valid peaks workspace.");
     }
 
-    vtkSMPropertyHelper(filter->getProxy(), MantidQt::API::MdConstants::PeaksWorkspace).Set(workspaceNamesConcatentated.c_str());
-    vtkSMPropertyHelper(filter->getProxy(), MantidQt::API::MdConstants::Delimiter).Set(m_peaksWorkspaceNameDelimiter.c_str());
+    vtkSMPropertyHelper(filter->getProxy(),
+                        MantidQt::API::MdConstants::PeaksWorkspace)
+        .Set(0, workspaceNamesConcatentated.c_str());
+    vtkSMPropertyHelper(filter->getProxy(),
+                        MantidQt::API::MdConstants::PeaksWorkspace)
+        .Set(1, m_peaksWorkspaceNameDelimiter.c_str());
     emit this->triggerAccept();
     filter->updatePipeline();
     this->resetCamera();

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -101,6 +101,8 @@ Geometry
 
 The Instrument Definition File syntax has been extended to provide support for a new type of topologically regular, but geometrically irregular form of 2D detectors. This new type of detector available in the IDF is known as a Structured Detector. Information on how to use this new detector type can be found in the :ref:`IDF <InstrumentDefinitionFile>` documentation.
 
+Refactored `PeakShape` to better support arbitrary shapes.
+
 Performance
 -----------
 


### PR DESCRIPTION
Description of work.

This refactors `Mantid::Geometry::PeakShape::radius()` to better support arbitrary shapes without casting back to it's derived type. I also made internal changes to `vtkPeaksFilter` to remove many unnecessary copies.

**To test:**

<!-- Instructions for testing. -->

Open a `MDEventWorkspace` and a `PeaksWorkspace` in the VSI. View the peaks table to activate the PeaksFilter and verify that the points and glyphs still render properly.

This pull request has no related issue.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
