### PR TITLE
ISIS autoconfig file copies multiple user's sample files

### DIFF
--- a/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -350,7 +350,7 @@ class DirectEnergyConversion(object):
         """
         # Support for old reduction interface:
         self.prop_man.set_input_parameters_ignore_nan\
-            (wb_run=wb_run,sample_run=sample_run,incident_energy=ei_guess,energy_bins=rebin,
+            (wb_run=wb_run,sample_run=sample_run,incident_energy=ei_guess,energy_bins=rebin,\
             map_file=map_file,monovan_run=monovan_run,wb_for_monovan_run=wb_for_monovan_run)
         #
         self.prop_man.set_input_parameters(**kwargs)
@@ -791,16 +791,16 @@ class DirectEnergyConversion(object):
                 psp = workspace.getSpectrum(specID)
                 detIDs = psp.getDetectorIDs()
                 for detID in detIDs:
-                    MoveInstrumentComponent(Workspace=workspace,ComponentName= 'Detector',
-                                DetectorID=detID,X=detPos.getX(),Y=detPos.getY(),
+                    MoveInstrumentComponent(Workspace=workspace,ComponentName= 'Detector',\
+                                DetectorID=detID,X=detPos.getX(),Y=detPos.getY(),\
                                 Z=detPos.getZ(),RelativePosition=False)
             wsIDs.append(specID)
 
         if len(spectra_list) == 1:
-            ExtractSingleSpectrum(InputWorkspace=workspace,OutputWorkspace=target_ws_name,
+            ExtractSingleSpectrum(InputWorkspace=workspace,OutputWorkspace=target_ws_name,\
             WorkspaceIndex=wsIDs[0])
         else:
-            SumSpectra(InputWorkspace=workspace,OutputWorkspace=target_ws_name,
+            SumSpectra(InputWorkspace=workspace,OutputWorkspace=target_ws_name,\
             ListOfWorkspaceIndices=wsIDs)
         ws = mtd[target_ws_name]
         sp = ws.getSpectrum(0)
@@ -837,7 +837,7 @@ class DirectEnergyConversion(object):
 
         # Calculate the incident energy
         #Returns: ei,mon1_peak,mon1_index,tzero
-        ei,mon1_peak,mon1_index,_ = \
+        ei,mon1_peak,_,_ = \
             GetEi(InputWorkspace=monitor_ws, Monitor1Spec=ei_mon_spectra[0],
                   Monitor2Spec=ei_mon_spectra[1],
                   EnergyEstimate=ei_guess,FixEi=fix_ei)
@@ -1145,8 +1145,8 @@ class DirectEnergyConversion(object):
                 # Calculate the incident energy and TOF when the particles access Monitor1
                 try:
                     ei,mon1_peak,mon1_index,_ = \
-                    GetEi(InputWorkspace=monitor_ws, Monitor1Spec=mon_1_spec_ID,
-                        Monitor2Spec=mon_2_spec_ID,
+                    GetEi(InputWorkspace=monitor_ws, Monitor1Spec=mon_1_spec_ID,\
+                        Monitor2Spec=mon_2_spec_ID,\
                         EnergyEstimate=ei_guess,FixEi=fix_ei)
                     mon1_det = monitor_ws.getDetector(mon1_index)
                     mon1_pos = mon1_det.getPos()
@@ -1492,7 +1492,7 @@ class DirectEnergyConversion(object):
 --------> Abs norm factors: Sigma^2: {9}
 --------> Abs norm factors: Poisson: {10}
 --------> Abs norm factors: TGP    : {11}\n"""\
-                .format(ws_name,minmax[0],minmax[1],nhist,sum(signal),sum(error),izerc,scale_factor,
+                .format(ws_name,minmax[0],minmax[1],nhist,sum(signal),sum(error),izerc,scale_factor,\
                           norm_factor['LibISIS'],norm_factor['SigSq'],norm_factor['Poisson'],norm_factor['TGP'])
             log_value = log_value + log1_value
             propman.log(log_value,'error')

--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -36,8 +36,8 @@ class UserProperties(object):
         if args[0] is None:
             return
         if len(args) == 1:
-            input = str(args[0])
-            param = input.split()
+            input_str = str(args[0])
+            param = input_str.split()
             self._user_id = param[0]
             if len(param) == 5:
                 self.set_user_properties(param[1], param[2], param[3], param[4])
@@ -160,13 +160,13 @@ class UserProperties(object):
            consisting of string RB and string representation of
            RB number e.g. RB1510324,
            used on the date specified
-        """        
+        """
         return os.path.basename(self._rb_dirs[exp_date])
     #
     def get_rb_dir(self,exp_date):
-        """Returns full name name of user's RB folder correspinding to the 
+        """Returns full name name of user's RB folder correspinding to the
            experiment, with the data provided.
-        """        
+        """
         return self._rb_dirs[exp_date]
 
     @property
@@ -285,12 +285,12 @@ class UserProperties(object):
         if not isinstance(rb_folder_or_id, str):
             raise RuntimeError("RB Folder {0} should be a string".format(rb_folder_or_id))
         else:
-            base, rbf = os.path.split(rb_folder_or_id)
+            f_path, rbf = os.path.split(rb_folder_or_id)
             if len(rbf) != 9:
                 try:
                     rbf = int(rbf)
                     rbf = "RB{0:07}".format(rbf)
-                    rb_folder_or_id = os.path.join(base, rbf)
+                    rb_folder_or_id = os.path.join(f_path, rbf)
                 except ValueError:
                     raise RuntimeError(
                         "RB Folder {0} should be a string containing RB number at the end".format(rb_folder_or_id))
@@ -337,13 +337,13 @@ class MantidConfigDirectInelastic(object):
     """
     # pylint: disable=too-many-instance-attributes
     # It has as many as parameters describing ISIS configuration.
-    def __init__(self, mantid='/opt/Mantid/', home='/home/', \
+    def __init__(self, mantid='/opt/Mantid/', home_dir='/home/', \
                  script_repo='/opt/UserScripts/', \
                  map_mask_folder='/usr/local/mprogs/InstrumentFiles/'):
         """Initialize generic config variables and variables specific to a server"""
 
         self._mantid_path = str(mantid)
-        self._home_path = str(home)
+        self._home_path = str(home_dir)
         self._script_repo = str(script_repo)
         self._map_mask_folder = str(map_mask_folder)
         # check if all necessary server folders specified as class parameters are present
@@ -449,10 +449,10 @@ class MantidConfigDirectInelastic(object):
         else:
             return False
             #
-    
+    #
     def get_user_file_description(self,instr_name=None):
         """returbs full file name (with path) for an xml file which describes
-           files, which should be copied to a user. 
+           files, which should be copied to a user.
 
            If instrument name is known or provided, function
            calculates this name wrt. the location of the file in the Mantid user
@@ -830,7 +830,7 @@ class MantidConfigDirectInelastic(object):
         self.make_map_mask_links(user_path)
 
         users_cycles = self._user.get_all_cycles()
-                                       
+        #
         for cycle in users_cycles:
             instr = self._user.get_instrument(cycle)
             self.copy_reduction_sample(self.get_user_file_description(instr),cycle)
@@ -930,7 +930,7 @@ if __name__ == "__main__":
     rb_user_folder = os.path.join(mcf._home_path, user.userID)
     user.rb_dir = rb_user_folder
     if not user.rb_dir_exist:
-        print "RB folder {0} for user {1} should exist and be accessible to configure this user".format(user.rb_dir,
+        print "RB folder {0} for user {1} should exist and be accessible to configure this user".format(user.rb_dir,\
                                                                                                         user.userID)
         exit()
     # Configure user

--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -283,7 +283,9 @@ class UserProperties(object):
 
         return instrument, start_date, cycle, rb_folder_or_id, rb_exist
 
-
+    def get_all_instruments(self):
+        """ Return list of all instruments, user is working on during this cycle"""
+        return mcf._user._instrument.values()
 #
 # --------------------------------------------------------------------#
 #

--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -564,7 +564,7 @@ class MantidConfigDirectInelastic(object):
         file_time = time.mktime(start_date.timetuple())
         os.utime(output_file, (file_time, file_time))
 
-    def _get_file_attributes(self, file_node):
+    def _get_file_attributes(self, file_node,cycle=None):
         """processes xml file_node to retrieve file attributes to copy """
 
         source_file = file_node.getAttribute("file_name")
@@ -577,7 +577,7 @@ class MantidConfigDirectInelastic(object):
         else:
             if "$" in target_file:
                 target_file = self._user.replace_variables(target_file)
-        full_source, full_target = self._fullpath_to_copy(source_file, target_file)
+        full_source, full_target = self._fullpath_to_copy(source_file, target_file,cycle)
 
         return (full_source, full_target)
 
@@ -633,7 +633,7 @@ class MantidConfigDirectInelastic(object):
         # go through all files in the description and define file copying operations
         for file_node in files_to_copy:
             # retrieve file attributes or its default values if the attributes are missing
-            input_file, output_file = self._get_file_attributes(file_node)
+            input_file, output_file = self._get_file_attributes(file_node,cycle_id)
             if input_file is None:
                 continue
 

--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -136,6 +136,40 @@ class UserProperties(object):
             return None
 
     @property
+    def rb_dir(self):
+        """return rb folder used in last actual instrument"""
+        if self._recent_dateID:
+            return self._rb_dirs[self._recent_dateID]
+        else:
+            raise RuntimeError("User's experiment date is not defined. User undefined")
+
+    @rb_dir.setter
+    def rb_dir(self, user_home_path):
+        """Set user's rb-folder path"""
+        rb_path = self.rb_folder
+        full_path = os.path.join(user_home_path, rb_path)
+        if os.path.exists(full_path) and os.path.isdir(full_path):
+            self._rb_dirs[self._recent_dateID] = full_path
+            self._rb_exist[self._recent_dateID] = True
+        else:
+            pass
+
+
+    def get_rb_num(self,exp_date):
+        """Returns short name of user's RB folder
+           consisting of string RB and string representation of
+           RB number e.g. RB1510324,
+           used on the date specified
+        """        
+        return os.path.basename(self._rb_dirs[exp_date])
+    #
+    def get_rb_dir(self,exp_date):
+        """Returns full name name of user's RB folder correspinding to the 
+           experiment, with the data provided.
+        """        
+        return self._rb_dirs[exp_date]
+
+    @property
     def rb_id(self):
         """the same as rb_folder:
            returns string with RB and string representation of
@@ -161,25 +195,10 @@ class UserProperties(object):
         else:
             raise RuntimeError("User's experiment date is not defined. User undefined")
             #
+    def get_instrument(self,cycle_date_id):
+        """Return the instrument, used in the cycle with the date specified"""
+        return self._instrument[cycle_date_id]
 
-    @property
-    def rb_dir(self):
-        """return rb folder used in last actual instrument"""
-        if self._recent_dateID:
-            return self._rb_dirs[self._recent_dateID]
-        else:
-            raise RuntimeError("User's experiment date is not defined. User undefined")
-
-    @rb_dir.setter
-    def rb_dir(self, user_home_path):
-        """Set user's rb-folder path"""
-        rb_path = self.rb_folder
-        full_path = os.path.join(user_home_path, rb_path)
-        if os.path.exists(full_path) and os.path.isdir(full_path):
-            self._rb_dirs[self._recent_dateID] = full_path
-            self._rb_exist[self._recent_dateID] = True
-        else:
-            pass
 
     #
     @property
@@ -285,7 +304,11 @@ class UserProperties(object):
 
     def get_all_instruments(self):
         """ Return list of all instruments, user is working on during this cycle"""
-        return mcf._user._instrument.values()
+        return self._instrument.values()
+    def get_all_cycles(self):
+        """Return list of all cycles the user participates in"""
+        return self._instrument.keys()
+
 #
 # --------------------------------------------------------------------#
 #
@@ -426,14 +449,19 @@ class MantidConfigDirectInelastic(object):
         else:
             return False
             #
+    
+    def get_user_file_description(self,instr_name=None):
+        """returbs full file name (with path) for an xml file which describes
+           files, which should be copied to a user. 
 
-    @property
-    def user_file_description(self):
-        """defines full file name (with path) for an xml file which describes
-           files, which should be copied to a user
+           If instrument name is known or provided, function
+           calculates this name wrt. the location of the file in the Mantid user
+           script repository.
         """
         if self._user:
-            return os.path.join(self._script_repo, 'direct_inelastic', self._user.instrument,
+            if not instr_name:
+                instr_name =  self._user.instrument
+            return os.path.join(self._script_repo, 'direct_inelastic',instr_name,
                                 self._user_files_descr)
         else:
             return self._user_files_descr
@@ -459,11 +487,15 @@ class MantidConfigDirectInelastic(object):
             return False
             #
 
-    def _fullpath_to_copy(self, short_source_file=None, short_target_file=None):
+    def _fullpath_to_copy(self, short_source_file=None, short_target_file=None,cycle_id=None):
         """Append full path to source and target files """
 
-        InstrName = self._user.instrument
-        rb_folder = self._user.rb_dir
+        if cycle_id:
+            InstrName = self._user.get_instrument(cycle_id)
+            rb_folder = self._user.get_rb_dir(cycle_id)
+        else:
+            InstrName = self._user.instrument
+            rb_folder = self._user.rb_dir
         if short_source_file is None:
             short_source_file = self._sample_reduction_file(InstrName)
         if short_target_file is None:
@@ -477,15 +509,16 @@ class MantidConfigDirectInelastic(object):
         return full_source, full_target
 
     #
-    def copy_reduction_sample(self, users_file_description=None):
+    def copy_reduction_sample(self, user_file_description=None,cycle_id=None):
         """copy sample reduction scripts from Mantid script repository
            to user folder.
         """
-        if users_file_description is None:
-            users_file_description = self._user_files_descr
-        info_to_copy = self._parse_user_files_description(users_file_description)
-        for info in info_to_copy:
-            self._copy_user_file_job(info[0], info[1], info[2])
+        if user_file_description is None:
+            user_file_description = self.get_user_file_description()
+
+        info_to_copy = self._parse_user_files_description(user_file_description,cycle_id)
+        for source_file,dest_file,subst_list in info_to_copy:
+            self._copy_user_file_job(source_file,dest_file,subst_list)
 
     def _copy_and_parse_user_file(self, input_file, output_file, replacemets_list):
         """Method processes file provided for user and replaces list of keywords, describing user
@@ -577,7 +610,7 @@ class MantidConfigDirectInelastic(object):
             dest = self._user.replace_variables(dest)
         return (source, dest)
 
-    def _parse_user_files_description(self, job_description_file):
+    def _parse_user_files_description(self, job_description_file,cycle_id=None):
         """ Method parses xml file used to describe files to provide to user"""
 
         # mainly for debugging purposes
@@ -591,7 +624,7 @@ class MantidConfigDirectInelastic(object):
         try:
             domObj = minidom.parse(job_description_file)
         except Exception:
-            input_file, output_file = self._fullpath_to_copy()
+            input_file, output_file = self._fullpath_to_copy(None,None,cycle_id)
             filenames_to_copy.append((input_file, output_file, None))
             return filenames_to_copy
 
@@ -655,10 +688,10 @@ class MantidConfigDirectInelastic(object):
                 raise RuntimeError("self.init_user(val) has to have val of UserProperty type only and got")
         else:
             theUser.userID = fedIDorUser
-        #
-        # pylint: disable=W0212
-        # bad practice but I need all instruments, not the current one
-        for instr in theUser._instrument.values():
+
+        # check if all users instruments are inelastic instruments. (script works for inelastic only)
+        users_instruments = theUser.get_all_instruments()
+        for instr in users_instruments:
             if not self.is_inelastic(instr):
                 raise RuntimeError('Instrument {0} is not among acceptable instruments'.format(instrument))
         self._user = theUser
@@ -794,10 +827,15 @@ class MantidConfigDirectInelastic(object):
             pass
         if platform.system() != 'Windows':
             os.system('chown -R {0}:{0} {1}'.format(self._fedid, config_path))
-
-        self.copy_reduction_sample(self.user_file_description)
-        #
         self.make_map_mask_links(user_path)
+
+        users_cycles = self._user.get_all_cycles()
+                                       
+        for cycle in users_cycles:
+            instr = self._user.get_instrument(cycle)
+            self.copy_reduction_sample(self.get_user_file_description(instr),cycle)
+        #
+
 
     #
     def make_map_mask_links(self, user_path):

--- a/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/scripts/test/ISISDirecInelasticConfigTest.py
@@ -480,8 +480,6 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         # clean up
         if os.path.exists(os.path.join(self.userRootDir,'.mantid')):
             shutil.rmtree(os.path.join(self.userRootDir,'.mantid'),ignore_errors=True)
-        if os.path.exists(rbdir1):
-            shutil.rmtree(rbdir1,ignore_errors=True)
         if os.path.exists(rbdir2):
             shutil.rmtree(rbdir2,ignore_errors=True)
         if os.path.exists(rbdir3):
@@ -491,9 +489,9 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
 
 if __name__=="__main__":
-   test = ISISDirectInelasticConfigTest('test_copy_multiplpe_ucf')
-   test._set_up()
-   test.run()
-   test._tear_down()
+   #test = ISISDirectInelasticConfigTest('test_copy_multiplpe_ucf')
+   #test._set_up()
+   #test.run()
+   #test._tear_down()
 
-   #unittest.main()
+   unittest.main()

--- a/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/scripts/test/ISISDirecInelasticConfigTest.py
@@ -486,6 +486,54 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
             shutil.rmtree(rbdir3,ignore_errors=True)
         #
 
+    def test_copy_multiplpe_instr(self):
+        # script verifies the presence of a folder, not its contents.
+        # for the script to work, let's run it on default save directory
+        MantidDir = os.path.split(os.path.realpath(__file__))[0]
+        HomeRootDir = self.get_save_dir()
+        mcf = MantidConfigDirectInelastic(MantidDir,HomeRootDir,self.UserScriptRepoDir,self.MapMaskDir)
+
+        user = UserProperties(self.userID)
+        user.set_user_properties(self.instrument,self.rbdir,self.cycle,self.start_date)
+
+
+        rbnum2='RB1999000'
+
+        targetDir = self.get_save_dir()
+        rbdir2 = os.path.join(targetDir,self.userID,rbnum2)
+        if not os.path.exists(rbdir2):
+            os.makedirs(rbdir2)
+        user.set_user_properties('MERLIN',rbdir2,'CYCLE20151','20150508')
+
+    
+        # clear up the previous
+        if os.path.exists(os.path.join(self.userRootDir,'.mantid')):
+            shutil.rmtree(os.path.join(self.userRootDir,'.mantid'))
+
+
+        mcf.init_user(user)
+        # Generate fake test files to copy to test users
+        self.makeFakeSourceReductionFile(mcf)
+
+        mcf.generate_config()
+        #
+        # Check sample reduction files
+        #
+        # Sample file for MERLIN:
+        rbdir1 = self.rbdir
+        mer_file = os.path.join(rbdir1,'MERLINReduction_2015_1.py')
+        self.assertTrue(os.path.isfile(mer_file))
+        mar_file = os.path.join(rbdir2,'MERLINReduction_2015_1.py')
+        self.assertTrue(os.path.isfile(mar_file))
+
+        #--------------------------------------------------------------------
+        # clean up
+        if os.path.exists(os.path.join(self.userRootDir,'.mantid')):
+            shutil.rmtree(os.path.join(self.userRootDir,'.mantid'),ignore_errors=True)
+        if os.path.exists(rbdir2):
+            shutil.rmtree(rbdir2,ignore_errors=True)
+        #
+
 
 
 if __name__=="__main__":

--- a/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/scripts/test/ISISDirecInelasticConfigTest.py
@@ -458,69 +458,34 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
 
         mcf.init_user(user)
-
+        # Generate fake test files to copy to test users
         self.makeFakeSourceReductionFile(mcf)
-        self.assertEqual(len(mcf._dynamic_configuration),6)
-        self.assertEqual(mcf._dynamic_configuration[1],'default.instrument=MERLIN')
 
         mcf.generate_config()
 
-        config_file = os.path.join(self.userRootDir,'.mantid','Mantid.user.properties')
-        self.assertTrue(os.path.exists(os.path.join(self.userRootDir,'.mantid')))
-        self.assertTrue(os.path.exists(config_file))
 
-        self.assertTrue(mcf.config_need_replacing(config_file))
-        start_date = user.start_date
-        date_in_apast=datetime.date(start_date.year,start_date.month,start_date.day-1)
-        time_in_a_past = time.mktime(date_in_apast.timetuple())
-        os.utime(config_file,(time_in_a_past,time_in_a_past))
-        self.assertFalse(mcf.config_need_replacing(config_file))
-        #--------------------------------------------------------------------
-        user1ID = 'tuf299966'
-        user1RootDir = os.path.join(self.get_save_dir(),user1ID)
-        if not os.path.exists(user1RootDir):
-            os.makedirs(user1RootDir)
         #
-        user1 = UserProperties(user1ID)
-        user1.set_user_properties('MARI',rbdir2,'CYCLE20991','20990124')
-
-        mcf.init_user(user1)
-        source_file = self.makeFakeSourceReductionFile(mcf)
-
-        mcf.generate_config()
-        self.assertEqual(len(mcf._dynamic_configuration),6)
-        self.assertEqual(mcf._dynamic_configuration[1],'default.instrument=MARI')
-        config_file = os.path.join(self.userRootDir,'.mantid','Mantid.user.properties')
-        self.assertTrue(os.path.exists(os.path.join(user1RootDir,'.mantid')))
-        self.assertTrue(os.path.exists(config_file))
+        # Check sample reduction files
         #
-        # Check sample reduction file
-        #
-        full_rb_path = rbdir2
-        cycle_id = user1.cycleID
-        instr = user1.instrument
-        target_file = mcf._target_reduction_file(instr,cycle_id)
-        full_target_file = os.path.join(full_rb_path,target_file)
-        self.assertTrue(os.path.exists(full_target_file))
-        # Fresh target file should always be replaced
-        self.assertTrue(mcf.script_need_replacing(full_target_file))
-        # modify target file access time:
-        access_time = os.path.getmtime(full_target_file)
-        now = time.time()
-        os.utime(full_target_file,(access_time ,now))
-        # should not replace modified target file
-        self.assertFalse(mcf.script_need_replacing(full_target_file))
+        # Sample file for MERLIN:
+        rbdir1 = self.rbdir
+        mer_file = os.path.join(rbdir1,'MERLINReduction_2015_1.py')
+        self.assertTrue(os.path.isfile(mer_file))
+        mar_file = os.path.join(rbdir2,'MARIReduction_2015_1.py')
+        self.assertTrue(os.path.isfile(mar_file))
+        maps_file = os.path.join(rbdir3,'MAPSReduction_2015_1.py')
+        self.assertTrue(os.path.isfile(maps_file))
 
         #--------------------------------------------------------------------
         # clean up
         if os.path.exists(os.path.join(self.userRootDir,'.mantid')):
             shutil.rmtree(os.path.join(self.userRootDir,'.mantid'),ignore_errors=True)
+        if os.path.exists(rbdir1):
+            shutil.rmtree(rbdir1,ignore_errors=True)
         if os.path.exists(rbdir2):
             shutil.rmtree(rbdir2,ignore_errors=True)
         if os.path.exists(rbdir3):
             shutil.rmtree(rbdir3,ignore_errors=True)
-        if os.path.exists(user1RootDir):
-            shutil.rmtree(user1RootDir,ignore_errors=True)
         #
 
 

--- a/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/scripts/test/ISISDirecInelasticConfigTest.py
@@ -1,9 +1,11 @@
 ﻿import os
+import sys
 import unittest
 import shutil
 import datetime
 import time
 import platform
+#sys.path.append(r'c:\Mantid\_builds\br_master\bin\Release')
 from mantid import config
 from Direct.ISISDirecInelasticConfig import UserProperties,MantidConfigDirectInelastic
 
@@ -69,21 +71,31 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
     def makeFakeSourceReductionFile(self,mcf,contents=None):
 
-        instr_name = mcf._user.instrument
+        all_instr_names = mcf._user.get_all_instruments()
+        all_files = []
+        for instr in all_instr_names:
+            instr_name = instr
 
-        file_path = os.path.join(self.UserScriptRepoDir,'direct_inelastic',instr_name.upper())
-        if not os.path.exists(file_path):
-            os.makedirs(file_path)
+            file_path = os.path.join(self.UserScriptRepoDir,'direct_inelastic',instr_name.upper())
+            if not os.path.exists(file_path):
+                os.makedirs(file_path)
         
-        file_name = mcf._sample_reduction_file(instr_name)
-        full_file = os.path.join(file_path,file_name)
-        if os.path.isfile(full_file):
-            os.remove(full_file)
-        fh=open(full_file,'w')
-        fh.write('#Test reduction file\n')
-        fh.write('Contents={0}'.format(contents))
-        fh.close()
-        return full_file
+            file_name = mcf._sample_reduction_file(instr_name)
+            all_files.append(file_name)
+            full_file = os.path.join(file_path,file_name)
+            if os.path.isfile(full_file):
+                os.remove(full_file)
+            fh=open(full_file,'w')
+            fh.write('#Test reduction file\n')
+            if contents is None:
+                fh.write('Contents=Fake_reduction_file_for_{0}'.format(instr_name))
+            else:
+                fh.write('Contents={0}'.format(contents))
+            fh.close()
+        if len(all_files) > 1:
+            return all_files
+        else:
+            return full_file
 
 
     def _tear_down(self):
@@ -240,7 +252,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
         mcf.init_user(user)
 
-        fake_source=self.makeFakeSourceReductionFile(mcf)
+        self.makeFakeSourceReductionFile(mcf)
         self.assertEqual(len(mcf._dynamic_configuration),6)
         self.assertEqual(mcf._dynamic_configuration[1],'default.instrument=MERLIN')
 
@@ -415,13 +427,108 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         rb_folder1 = user3.rb_dir
         self.assertEqual(rb_folder,rb_folder1)
 
+    def test_copy_multiplpe_ucf(self):
+        # script verifies the presence of a folder, not its contents.
+        # for the script to work, let's run it on default save directory
+        MantidDir = os.path.split(os.path.realpath(__file__))[0]
+        HomeRootDir = self.get_save_dir()
+        mcf = MantidConfigDirectInelastic(MantidDir,HomeRootDir,self.UserScriptRepoDir,self.MapMaskDir)
+
+        user = UserProperties(self.userID)
+        user.set_user_properties(self.instrument,self.rbdir,self.cycle,self.start_date)
+
+
+        rbnum2='RB1999000'
+
+        targetDir = self.get_save_dir()
+        rbdir2 = os.path.join(targetDir,self.userID,rbnum2)
+        if not os.path.exists(rbdir2):
+            os.makedirs(rbdir2)
+        user.set_user_properties('MARI',rbdir2,'CYCLE20001','20000124')
+
+        rbnum3='RB1204000'
+        rbdir3 = os.path.join(targetDir,self.userID,rbnum3)
+        if not os.path.exists(rbdir3):
+            os.makedirs(rbdir3)
+        user.set_user_properties('MAPS',rbdir3,'CYCLE20044','20041207')
+
+        # clear up the previous
+        if os.path.exists(os.path.join(self.userRootDir,'.mantid')):
+            shutil.rmtree(os.path.join(self.userRootDir,'.mantid'))
+
+
+        mcf.init_user(user)
+
+        self.makeFakeSourceReductionFile(mcf)
+        self.assertEqual(len(mcf._dynamic_configuration),6)
+        self.assertEqual(mcf._dynamic_configuration[1],'default.instrument=MERLIN')
+
+        mcf.generate_config()
+
+        config_file = os.path.join(self.userRootDir,'.mantid','Mantid.user.properties')
+        self.assertTrue(os.path.exists(os.path.join(self.userRootDir,'.mantid')))
+        self.assertTrue(os.path.exists(config_file))
+
+        self.assertTrue(mcf.config_need_replacing(config_file))
+        start_date = user.start_date
+        date_in_apast=datetime.date(start_date.year,start_date.month,start_date.day-1)
+        time_in_a_past = time.mktime(date_in_apast.timetuple())
+        os.utime(config_file,(time_in_a_past,time_in_a_past))
+        self.assertFalse(mcf.config_need_replacing(config_file))
+        #--------------------------------------------------------------------
+        user1ID = 'tuf299966'
+        user1RootDir = os.path.join(self.get_save_dir(),user1ID)
+        if not os.path.exists(user1RootDir):
+            os.makedirs(user1RootDir)
+        #
+        user1 = UserProperties(user1ID)
+        user1.set_user_properties('MARI',rbdir2,'CYCLE20991','20990124')
+
+        mcf.init_user(user1)
+        source_file = self.makeFakeSourceReductionFile(mcf)
+
+        mcf.generate_config()
+        self.assertEqual(len(mcf._dynamic_configuration),6)
+        self.assertEqual(mcf._dynamic_configuration[1],'default.instrument=MARI')
+        config_file = os.path.join(self.userRootDir,'.mantid','Mantid.user.properties')
+        self.assertTrue(os.path.exists(os.path.join(user1RootDir,'.mantid')))
+        self.assertTrue(os.path.exists(config_file))
+        #
+        # Check sample reduction file
+        #
+        full_rb_path = rbdir2
+        cycle_id = user1.cycleID
+        instr = user1.instrument
+        target_file = mcf._target_reduction_file(instr,cycle_id)
+        full_target_file = os.path.join(full_rb_path,target_file)
+        self.assertTrue(os.path.exists(full_target_file))
+        # Fresh target file should always be replaced
+        self.assertTrue(mcf.script_need_replacing(full_target_file))
+        # modify target file access time:
+        access_time = os.path.getmtime(full_target_file)
+        now = time.time()
+        os.utime(full_target_file,(access_time ,now))
+        # should not replace modified target file
+        self.assertFalse(mcf.script_need_replacing(full_target_file))
+
+        #--------------------------------------------------------------------
+        # clean up
+        if os.path.exists(os.path.join(self.userRootDir,'.mantid')):
+            shutil.rmtree(os.path.join(self.userRootDir,'.mantid'),ignore_errors=True)
+        if os.path.exists(rbdir2):
+            shutil.rmtree(rbdir2,ignore_errors=True)
+        if os.path.exists(rbdir3):
+            shutil.rmtree(rbdir3,ignore_errors=True)
+        if os.path.exists(user1RootDir):
+            shutil.rmtree(user1RootDir,ignore_errors=True)
+        #
 
 
 
 if __name__=="__main__":
-   #test = ISISDirectInelasticConfigTest('test_UserProperties')
-   #test._set_up()
-   #test.run()
-   #test._tear_down()
+   test = ISISDirectInelasticConfigTest('test_copy_multiplpe_ucf')
+   test._set_up()
+   test.run()
+   test._tear_down()
 
-   unittest.main()
+   #unittest.main()


### PR DESCRIPTION
Solves #15970 -- see details in the ticket description. 

ISIS direct inelastic users configuration script was copying sample reduction files for main experiment user only despite all experiments were added to the user profile. 

This is not-satisfactory for express experiments as no main user exist for this experiment, so after the changes, autoconfiguration script copies sample files for each experiment a user participates in. 

**To test:**
Test by code review. 

No much additional testing is necessary and actually possible as it relies and needs very specific computer configuration, provided by isiscompute. In addition to that, I've already deployed the script on isiscompute where it belongs and it works fine. The changes illustrated by two new unit tests, which verifies that for a user, participating in three experiments three configuration files were copied to three user' RB folders.

Changes are small and I hope obvious though clogged by pylint changes -- unfortunately can not do anything about it -- it does not let me further without decreasing pylint count.

<!-- RELEASE NOTES
*Does not need to be in the release notes, as changes are trivial, and all necessary files will magically appear within uses folders -- the expected behaviour.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
