### PR TITLE
Vesuvio - VesuvioCommands check height of peak rather than first/last bin

### DIFF
--- a/Testing/SystemTests/tests/analysis/VesuvioCommandsTest.py
+++ b/Testing/SystemTests/tests/analysis/VesuvioCommandsTest.py
@@ -4,6 +4,7 @@ and that mantid can be imported
 """
 import stresstesting
 import platform
+import numpy as np
 
 from mantid.api import (WorkspaceGroup, MatrixWorkspace)
 from mantid.simpleapi import *
@@ -60,6 +61,15 @@ def _equal_within_tolerance(self, expected, actual, tolerance=0.05):
     tolerance_value = expected * tolerance
     abs_difference = abs(expected - actual)
     self.assertTrue(abs_difference <= abs(tolerance_value))
+
+def _get_maximum_peak_height(workspace, ws_index):
+    """
+    returns the maximum height in y of a given spectrum of a workspace
+    workspace is assumed to be a matrix workspace
+    """
+    y_data = workspace.readY(ws_index)
+    peak_height = np.amax(y_data)
+    return peak_height
 
 #====================================================================================
 
@@ -138,18 +148,14 @@ class SingleSpectrumBackground(stresstesting.MantidStressTest):
 
         index_one_first = -0.0221362198069
         index_one_last = 0.00720728978699
-        index_two_first = 0.00571520523979
-        index_two_last = -0.00211277263055
+	calc_data_height = 0.138704
         if _is_old_boost_version():
             index_one_first = 6.809169e-04
             index_one_last = 7.206634e-03
-            index_two_first = 3.360576e-03
-            index_two_last = -1.431954e-03
 
         _equal_within_tolerance(self, index_one_first, fitted_ws.readY(0)[0])
         _equal_within_tolerance(self, index_one_last, fitted_ws.readY(0)[-1])
-        _equal_within_tolerance(self, index_two_first, fitted_ws.readY(1)[0])
-        _equal_within_tolerance(self, index_two_last, fitted_ws.readY(1)[-1])
+        _equal_within_tolerance(self, calc_data_height, _get_maximum_peak_height(fitted_ws, 1))
 
         fitted_params = self._fit_results[1]
         self.assertTrue(isinstance(fitted_params, MatrixWorkspace))


### PR DESCRIPTION
The VesuvioCommandsTest now checks the maximum height of the calculated data for comparison. This value was seen to be far more consistent across different platforms rather than the first/last bin which were seemingly sensitive to the noisy data at the start and end 

**To test:**
- Ensure the system test `VesuvioCommandsTest` passes ideally checking this on a few different OS. 
  - I have checked this locally on Windows, Centos 6 and Ubuntu 14.04 and it passes

Fixes #15981

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Refs #15981
