### PR TITLE
Fix result table regression in MuonAnalysis and add test

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisHelper.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisHelper.h
@@ -82,6 +82,10 @@ appendTimeSeriesLogs(boost::shared_ptr<Mantid::API::Workspace> toAppend,
                      boost::shared_ptr<Mantid::API::Workspace> resultant,
                      const std::string &logName);
 
+/// Get "run: period" string from workspace name
+MANTIDQT_CUSTOMINTERFACES_DLL QString
+runNumberString(const std::string &workspaceName, const std::string &firstRun);
+
 /**
  * A class which deals with auto-saving the widget values. Widgets are
  * registered and then on any

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisResultTableTab.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisResultTableTab.h
@@ -136,10 +136,6 @@ private:
   std::string getFileName();
   QMap<int,int> getWorkspaceColors(const QStringList& wsList);
   
-  /// Gets "run number: period" string from workspace
-  static QString runNumberString(const std::string &workspaceName,
-                                 const std::string &firstRun);
-
   Ui::MuonAnalysis& m_uiForm;
   int m_numLogsdisplayed;
   

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisResultTableTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisResultTableTab.cpp
@@ -8,11 +8,11 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidKernel/ConfigService.h"
-#include "MantidKernel/StringTokenizer.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 
 #include "MantidQtMantidWidgets/MuonSequentialFitDialog.h"
 #include "MantidQtAPI/UserSubWindow.h"
+#include "MantidQtCustomInterfaces/Muon/MuonAnalysisHelper.h"
 
 #include <boost/shared_ptr.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -423,14 +423,12 @@ void MuonAnalysisResultTableTab::populateLogsAndValues(
     Mantid::Kernel::DateAndTime end = ws->run().endTime();
 
     const std::vector<Property *> &logData = ws->run().getLogData();
-    std::vector<Property *>::const_iterator pEnd = logData.end();
 
-    for (std::vector<Property *>::const_iterator pItr = logData.begin();
-         pItr != pEnd; ++pItr) {
+    for (const auto prop : logData) {
       // Check if is a timeseries log
       if (TimeSeriesProperty<double> *tspd =
-              dynamic_cast<TimeSeriesProperty<double> *>(*pItr)) {
-        QString logFile(QFileInfo((**pItr).name().c_str()).fileName());
+              dynamic_cast<TimeSeriesProperty<double> *>(prop)) {
+        QString logFile(QFileInfo(prop->name().c_str()).fileName());
 
         double value(0.0);
         int count(0);
@@ -457,20 +455,19 @@ void MuonAnalysisResultTableTab::populateLogsAndValues(
         }
       } else // Should be a non-timeseries one
       {
-        QString logName = QString::fromStdString((**pItr).name());
+        QString logName = QString::fromStdString(prop->name());
 
         // Check if we should display it
         if (NON_TIMESERIES_LOGS.contains(logName)) {
           QVariant value;
 
           if (logName == RUN_NUMBER_LOG) { // special case
-            value = runNumberString(wsName, (*pItr)->value());
+            value = MuonAnalysisHelper::runNumberString(wsName, prop->value());
           } else if (auto stringProp =
-                         dynamic_cast<PropertyWithValue<std::string> *>(
-                             *pItr)) {
+                         dynamic_cast<PropertyWithValue<std::string> *>(prop)) {
             value = QString::fromStdString((*stringProp)());
           } else if (auto doubleProp =
-                         dynamic_cast<PropertyWithValue<double> *>(*pItr)) {
+                         dynamic_cast<PropertyWithValue<double> *>(prop)) {
             value = (*doubleProp)();
           } else {
             throw std::runtime_error("Unsupported non-timeseries log type");
@@ -949,41 +946,6 @@ std::string MuonAnalysisResultTableTab::getFileName() {
     }
   }
   return fileName;
-}
-
-/**
- * Uses the format of the workspace name
- * (INST00012345-8; Pair; long; Asym; [1+2-3+4]; #2)
- * to get a string in the format "run number: period"
- * @param workspaceName :: [input] Name of the workspace
- * @param firstRun :: [input] First run number - use this if tokenizing fails
- * @returns Run number/period string
- */
-QString
-MuonAnalysisResultTableTab::runNumberString(const std::string &workspaceName,
-                                            const std::string &firstRun) {
-  std::string periods = "";        // default
-  std::string instRuns = firstRun; // default
-
-  Mantid::Kernel::StringTokenizer tokenizer(
-      workspaceName, ";", Mantid::Kernel::StringTokenizer::TOK_TRIM);
-  const size_t numTokens = tokenizer.count();
-  if (numTokens > 4) { // format is ok
-    instRuns = tokenizer[0];
-    // Remove "INST000" off the start
-    // No muon instruments have numbers in their names
-    size_t numPos = instRuns.find_first_of("123456789");
-    instRuns = instRuns.substr(numPos, instRuns.size());
-    if (numTokens > 5) { // periods included
-      periods = tokenizer[4];
-    }
-  }
-
-  QString ret(instRuns.c_str());
-  if (!periods.empty()) {
-    ret.append(": ").append(periods.c_str());
-  }
-  return ret;
 }
 }
 }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisResultTableTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisResultTableTab.cpp
@@ -953,7 +953,7 @@ std::string MuonAnalysisResultTableTab::getFileName() {
 
 /**
  * Uses the format of the workspace name
- * (INST00012345-8; Pair; long; Asym; 1+2-3+4; #2)
+ * (INST00012345-8; Pair; long; Asym; [1+2-3+4]; #2)
  * to get a string in the format "run number: period"
  * @param workspaceName :: [input] Name of the workspace
  * @param firstRun :: [input] First run number - use this if tokenizing fails
@@ -967,13 +967,16 @@ MuonAnalysisResultTableTab::runNumberString(const std::string &workspaceName,
 
   Mantid::Kernel::StringTokenizer tokenizer(
       workspaceName, ";", Mantid::Kernel::StringTokenizer::TOK_TRIM);
-  if (tokenizer.count() > 4) {
+  const size_t numTokens = tokenizer.count();
+  if (numTokens > 4) { // format is ok
     instRuns = tokenizer[0];
-    periods = tokenizer[4];
     // Remove "INST000" off the start
     // No muon instruments have numbers in their names
     size_t numPos = instRuns.find_first_of("123456789");
     instRuns = instRuns.substr(numPos, instRuns.size());
+    if (numTokens > 5) { // periods included
+      periods = tokenizer[4];
+    }
   }
 
   QString ret(instRuns.c_str());

--- a/MantidQt/CustomInterfaces/test/MuonAnalysisHelperTest.h
+++ b/MantidQt/CustomInterfaces/test/MuonAnalysisHelperTest.h
@@ -273,6 +273,30 @@ public:
     TS_ASSERT_EQUALS(6, prop->valueAsCorrectMap().size());
   }
 
+  void test_runNumberString_singlePeriod() {
+    doTestRunNumberString("15189", false);
+  }
+
+  void test_runNumberString_multiPeriod() {
+    doTestRunNumberString("15189", true);
+  }
+
+  void test_runNumberString_singlePeriod_runRange() {
+    doTestRunNumberString("15189-91", false);
+  }
+
+  void test_runNumberString_singlePeriod_runRangeNonContinuous() {
+    doTestRunNumberString("15189-90, 15192", false);
+  }
+
+  void test_runNumberString_multiPeriod_runRange() {
+    doTestRunNumberString("15189-91", true);
+  }
+
+  void test_runNumberString_multiPeriod_runRangeNonContinuous() {
+    doTestRunNumberString("15189-90, 15192", true);
+  }
+
 private:
   // Creates a single-point workspace with instrument and runNumber set
   Workspace_sptr createWs(const std::string &instrName, int runNumber) {
@@ -321,6 +345,30 @@ private:
         Mantid::Kernel::make_unique<TimeSeriesProperty<double>>(logName);
     prop->addValues(times, values);
     matrixWS->mutableRun().addLogData(std::move(prop));
+  }
+
+  void doTestRunNumberString(const std::string &runs, bool multiPeriod) {
+    // create workspace name
+    const std::string sep("; ");
+    std::ostringstream wsName;
+    wsName << "MUSR000" << runs << sep; // MUSR00012345-8
+    wsName << "Pair" << sep;
+    wsName << "long" << sep;
+    wsName << "Asym" << sep;
+    if (multiPeriod) {
+      wsName << "1+2-3+4" << sep;
+    }
+    wsName << "#1";
+
+    // create expected output
+    QString expected = QString::fromStdString(runs);
+    if (multiPeriod) {
+      expected.append(": 1+2-3+4");
+    }
+
+    // test
+    const QString result = runNumberString(wsName.str(), runs);
+    TS_ASSERT_EQUALS(expected, result);
   }
 };
 


### PR DESCRIPTION
Fixed a bug where the period label was being set wrongly for single-period data.
To prevent the bug reoccuring, refactored the method into a helper class and added tests.

The tested method generates a run/period label from the workspace name. (The function that generates the workspace name itself has not been refactored out and tested because it is closely coupled to the UI. However, this is anticipated to be done as part of the ongoing work for #15518, so testing this has been left until then.)

**To test:**
- _Code review:_ satisfy yourself that the unit tests cover the functionality and expose the bug
- Can also be tested with the files in `\\olympic\babylon5\Scratch\TomPerkins\Data\MUSR`:  
  - Open MuonAnalysis interface and set instrument to MUSR. Make sure data files are in your search path.
  - Type a single run number or a range in the box to load, e.g. "15189-91" or "24580". `MUSR00024580` and `MUSR00024581` are single-period and `MUSR00015189-91` are multi-period.
  - Go to Data Analysis tab and fit something (doesn't matter what)
  - Go to Results Table tab and click "Create Table"
  - The first column in the generated table should have the run number only for single-period data, and 'run number: period' for multiperiod data.

Fixes #16003. 

Does not need to be in the release notes as the bug is not in release 3.6.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
