### PR TITLE
Fix error initializing python with broken files

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/plugins.py
+++ b/Framework/PythonInterface/mantid/kernel/plugins.py
@@ -220,16 +220,18 @@ def contains_newapi_algorithm(filename):
         @returns True if a python algorithm written with the new API
         has been found.
     """
-    alg_found = False
+    alg_found = True
     try:
         with open(filename,'r') as file:
             for line in reversed(file.readlines()):
                 if 'registerPyAlgorithm' in line:
-                    break  # not found
+                    alg_found = False
+                    break
                 if 'AlgorithmFactory.subscribe' in line:
                     alg_found = True
                     break
     except IOError:
-        pass  # something wrong with reading the file
+        # something wrong with reading the file
+        alg_found = False
 
     return alg_found

--- a/Framework/PythonInterface/mantid/kernel/plugins.py
+++ b/Framework/PythonInterface/mantid/kernel/plugins.py
@@ -220,14 +220,16 @@ def contains_newapi_algorithm(filename):
         @returns True if a python algorithm written with the new API
         has been found.
     """
-    file = open(filename,'r')
-    alg_found = True
-    for line in reversed(file.readlines()):
-        if 'registerPyAlgorithm' in line:
-            alg_found = False
-            break
-        if 'AlgorithmFactory.subscribe' in line:
-            alg_found = True
-            break
-    file.close()
+    alg_found = False
+    try:
+        with open(filename,'r') as file:
+            for line in reversed(file.readlines()):
+                if 'registerPyAlgorithm' in line:
+                    break  # not found
+                if 'AlgorithmFactory.subscribe' in line:
+                    alg_found = True
+                    break
+    except IOError:
+        pass  # something wrong with reading the file
+
     return alg_found


### PR DESCRIPTION
Description of work.

**To test:**

The easiest way is to edit an algorithm using emacs, make a change, don't save, and start mantid. Before this change mantid will fail to initialize python. After this change it will.

_There is no related issue_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
