### PR TITLE
Enable to FilterEvents to split integer TimeSeriesProperty

### DIFF
--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -1038,14 +1038,14 @@ void FilterEvents::splitLog(EventWorkspace_sptr eventws, std::string logname,
           eventws->mutableRun().getProperty(logname));
 
   if (!dbl_prop && !int_prop) {
-    g_log.warning()
-        << "Log " << logname
-        << " is not TimeSeriesProperty<int> or TimeSeriesProperty<double>. "
-        << "Unable to split."
-        << "\n";
+    std::stringstream errmsg;
+    errmsg << "Log " << logname
+           << " is not TimeSeriesProperty<int> or TimeSeriesProperty<double>. "
+           << "Unable to split.";
+    throw std::runtime_error(errmsg.str());
   } else {
     for (const auto &split : splitters) {
-      g_log.debug() << "[FilterEvents DB1226] Going to filter workspace "
+      g_log.debug() << "Workspace "
                     << eventws->name() << ": "
                     << "log name = " << logname
                     << ", duration = " << split.duration() << " from "
@@ -1063,7 +1063,7 @@ void FilterEvents::splitLog(EventWorkspace_sptr eventws, std::string logname,
 }
 
 //----------------------------------------------------------------------------------------------
-/** Get all filterable logs' names
+/** Get all filterable logs' names (double and integer)
  * @returns Vector of names of logs
  */
 std::vector<std::string> FilterEvents::getTimeSeriesLogNames() {
@@ -1072,10 +1072,15 @@ std::vector<std::string> FilterEvents::getTimeSeriesLogNames() {
   const std::vector<Kernel::Property *> allprop =
       m_eventWS->mutableRun().getProperties();
   for (auto ip : allprop) {
-    Kernel::TimeSeriesProperty<double> *timeprop =
+    // cast to double log and integer log
+    Kernel::TimeSeriesProperty<double> *dbltimeprop =
         dynamic_cast<Kernel::TimeSeriesProperty<double> *>(ip);
-    if (timeprop) {
-      std::string pname = timeprop->name();
+    Kernel::TimeSeriesProperty<int> *inttimeprop =
+        dynamic_cast<Kernel::TimeSeriesProperty<int> *>(ip);
+
+    // append to vector if it is either double TimeSeries or int TimeSeries
+    if (dbltimeprop || inttimeprop) {
+      std::string pname = ip->name();
       lognames.push_back(pname);
     }
   }

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -1045,8 +1045,7 @@ void FilterEvents::splitLog(EventWorkspace_sptr eventws, std::string logname,
     throw std::runtime_error(errmsg.str());
   } else {
     for (const auto &split : splitters) {
-      g_log.debug() << "Workspace "
-                    << eventws->name() << ": "
+      g_log.debug() << "Workspace " << eventws->name() << ": "
                     << "log name = " << logname
                     << ", duration = " << split.duration() << " from "
                     << split.start() << " to " << split.stop() << ".\n";

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -1035,12 +1035,14 @@ void FilterEvents::splitLog(EventWorkspace_sptr eventws, std::string logname,
           eventws->mutableRun().getProperty(logname));
   Kernel::TimeSeriesProperty<int> *int_prop =
       dynamic_cast<Kernel::TimeSeriesProperty<int> *>(
-        eventws->mutableRun().getProperty(logname));
+          eventws->mutableRun().getProperty(logname));
 
   if (!dbl_prop && !int_prop) {
-    g_log.warning() << "Log " << logname
-                    << " is not TimeSeriesProperty<int> or TimeSeriesProperty<double>. "
-                    << "Unable to split." << "\n";
+    g_log.warning()
+        << "Log " << logname
+        << " is not TimeSeriesProperty<int> or TimeSeriesProperty<double>. "
+        << "Unable to split."
+        << "\n";
   } else {
     for (const auto &split : splitters) {
       g_log.debug() << "[FilterEvents DB1226] Going to filter workspace "

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -1029,14 +1029,18 @@ Kernel::TimeSplitterType FilterEvents::generateSplitters(int wsindex) {
  */
 void FilterEvents::splitLog(EventWorkspace_sptr eventws, std::string logname,
                             TimeSplitterType &splitters) {
-  Kernel::TimeSeriesProperty<double> *prop =
+  // cast property to both double TimeSeriesProperty and IntSeriesProperty
+  Kernel::TimeSeriesProperty<double> *dbl_prop =
       dynamic_cast<Kernel::TimeSeriesProperty<double> *>(
           eventws->mutableRun().getProperty(logname));
-  if (!prop) {
+  Kernel::TimeSeriesProperty<int> *int_prop =
+      dynamic_cast<Kernel::TimeSeriesProperty<int> *>(
+        eventws->mutableRun().getProperty(logname));
+
+  if (!dbl_prop && !int_prop) {
     g_log.warning() << "Log " << logname
-                    << " is not TimeSeriesProperty.  Unable to split."
-                    << std::endl;
-    return;
+                    << " is not TimeSeriesProperty<int> or TimeSeriesProperty<double>. "
+                    << "Unable to split." << "\n";
   } else {
     for (const auto &split : splitters) {
       g_log.debug() << "[FilterEvents DB1226] Going to filter workspace "
@@ -1045,9 +1049,13 @@ void FilterEvents::splitLog(EventWorkspace_sptr eventws, std::string logname,
                     << ", duration = " << split.duration() << " from "
                     << split.start() << " to " << split.stop() << ".\n";
     }
-  }
 
-  prop->filterByTimes(splitters);
+    // split log
+    if (dbl_prop)
+      dbl_prop->filterByTimes(splitters);
+    else
+      int_prop->filterByTimes(splitters);
+  }
 
   return;
 }


### PR DESCRIPTION
Fix the bug that FilterEvents does not split integer TimeSeriesProperty sample log.

**To test:**

Run the script found blow to check whether the integer sample logs are split.

```
import numpy as np
import mantid.simpleapi as ms

def add_row2tbl(tbl_wkspc,ln2add,idxa,num_rows):
    """    add a row to a table workspace
    """
    if idxa >=num_rows:
        #addrow
        tbl_wkspc.addRow(ln2add)
    else:
    #modify original row
        for idx2 in xrange(3):
            tbl_wkspc.setCell(idxa,idx2,ln2add[idx2])

binwidth=10
ms.Load(Filename='/SNS/CORELLI/IPTS-15132/nexus/CORELLI_25001.nxs.h5', OutputWorkspace='CORELLI_25001.nxs', LoadMonitors=True)
ms.LoadMask(Instrument='CORELLI', InputFile='/SNS/CORELLI/IPTS-15132/shared/TimeDep_peak100H6T_9K/Mask_100.xml', OutputWorkspace='Mask_in')
ms.MaskDetectors(Workspace='CORELLI_25001.nxs',  MaskedWorkspace='Mask_in')
ms.GenerateEventsFilter(InputWorkspace='CORELLI_25001.nxs', OutputWorkspace='splitter_field', InformationWorkspace='info_field_', UnitOfTime='Nanoseconds', LogName='PM_ADC', MinimumLogValue=28950, MaximumLogValue=29100, LogValueInterval=150, FilterLogValueByChangingDirection='Increase', LogBoundary='Left', TitleOfSplitters='ac_dec')

sf=ms.mtd['splitter_field']
sf_check=ms.CloneWorkspace(sf)
start_array=np.array(sf.column('start'))
diffs=start_array[1:]-start_array[:-1]
maxnum_bins=np.floor(diffs[0]/(binwidth*1e9))
tinc=np.int64(np.arange(maxnum_bins)*10e9)
binnums=range(int(maxnum_bins-1))
row_num=0
num_rows=sf.rowCount()

# create table workspace as splitters
for val in start_array:
    new_starts=val+tinc[:-1]
    new_stops=val+tinc[1:]
    for idx in binnums:
       row_val=[np.long(new_starts[idx]),np.long(new_stops[idx]),idx]
       add_row2tbl(sf,row_val,row_num,num_rows)
       row_num=row_num+1  

# using splitters/table workspace, so the sample logs should be splitted
ms.FilterEvents(InputWorkspace='CORELLI_25001.nxs', SplitterWorkspace=sf, OutputWorkspaceBaseName='split', GroupWorkspaces=True, CorrectionToSample='Elastic', OutputWorkspaceNames='split_unfiltered,split_0,split_1,split_2,split_3,split_4,split_5,split_6,split_7,split_8,split_9,split_10,split_11,split_12,split_13,split_14,split_15,split_16,split_17,split_18,split_19,split_20,split_21,split_22')
```

Fixes #16015.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
