### PR TITLE
Fix system test PearlPowderDiffractionScriptTest on rhel6

### DIFF
--- a/Testing/SystemTests/tests/analysis/PearlPowderDiffractionScriptTest.py
+++ b/Testing/SystemTests/tests/analysis/PearlPowderDiffractionScriptTest.py
@@ -131,13 +131,14 @@ class LoadTests(unittest.TestCase):
         self.assertAlmostEqual(3.39159292684e-05, van14.readY(0)[187], places=DIFF_PLACES)
 
     def test_rdata_workspace(self):
+        expected_title = "glucose+Pb 6 tns in ZTA anvils"
         for i in range(1, 15, 3):
             rfile = mtd["rdata" + str(i)]
             self.assertTrue(isinstance(rfile, MatrixWorkspace))
             self.assertEquals(1, rfile.getNumberHistograms())
             self.assertEquals(4310, rfile.blocksize())
-            self.assertIn("glucose+Pb 6 tns in ZTA anvils", rfile.getTitle())
-
+            # Not using assertIn - not supported on rhel6 (python 2.6)
+            self.assertTrue(expected_title in rfile.getTitle())
             van_file = mtd["van" + str(i)]
             self.assertAlmostEquals(van_file.readX(0)[i], rfile.readX(0)[i], places=DIFF_PLACES)
 
@@ -145,7 +146,7 @@ class LoadTests(unittest.TestCase):
         self.assertTrue(isinstance(focus_file, MatrixWorkspace))
         self.assertEquals(14, focus_file.getNumberHistograms())
         self.assertEquals(4310, focus_file.blocksize())
-        self.assertIn("glucose+Pb 6 tns in ZTA anvils", rfile.getTitle())
+        self.assertTrue(expected_title in focus_file.getTitle())
 
     def test_mod_files(self):
         mod_group_table = mtd["PRL92476_92479"]


### PR DESCRIPTION
This system test is failing on rhel6: http://builds.mantidproject.org/job/master_systemtests-rhel6/158/#showFailuresLink.
Replaces `assertIn(a, b)` which is only supported in Python>= 2.7 (see table here: https://docs.python.org/2.7/library/unittest.html#test-cases) with `assertTrue(a in b)`. RHEL 6 has Python 2.6 so many of the special asserts of that table cannot be used safely in our system tests. Note this also changes `rfile` to `focus_file` in the second modified assert where I'd guess that was the intention.

**To test:**
- check that system tests (still) pass and that you're happy with the code changes

No issue number for this quick fix.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
