### PR TITLE
Displaying a table no longer removes whitespace characters from string columns

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -5,6 +5,7 @@
 // Includes
 //----------------------------------------------------------------------
 
+#include "MantidDataObjects/DllConfig.h"
 #include "MantidAPI/Column.h"
 #include "MantidKernel/Logger.h"
 
@@ -26,7 +27,7 @@ namespace Mantid {
 
 namespace DataObjects {
 
-template <class T> class TableVector;
+template <class T> class MANTID_DATAOBJECTS_DLL TableVector;
 
 /** \class TableColumn
 

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -5,7 +5,6 @@
 // Includes
 //----------------------------------------------------------------------
 
-#include "MantidDataObjects/DllConfig.h"
 #include "MantidAPI/Column.h"
 #include "MantidKernel/Logger.h"
 
@@ -27,7 +26,7 @@ namespace Mantid {
 
 namespace DataObjects {
 
-template <class T> class MANTID_DATAOBJECTS_DLL TableVector;
+template <class T> class TableVector;
 
 /** \class TableColumn
 
@@ -241,7 +240,14 @@ private:
 
 /// Template specialization for strings so they can contain spaces
 template <>
-void TableColumn<std::string>::read(size_t index, const std::string &text);
+inline void TableColumn<std::string>::read(size_t index,
+                                           const std::string &text) {
+  /* As opposed to other types, assigning strings via a stream does not work if
+   * it contains a whitespace character, so instead the assignment operator is
+   * used.
+   */
+  m_data[index] = text;
+}
 
 /// Read in a string and set the value at the given index
 template <typename Type>

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -238,6 +238,10 @@ private:
   friend class TableWorkspace;
 };
 
+/// Template specialization for strings so they can contain spaces
+template <>
+void TableColumn<std::string>::read(size_t index, const std::string &text);
+
 /// Read in a string and set the value at the given index
 template <typename Type>
 void TableColumn<Type>::read(size_t index, const std::string &text) {

--- a/Framework/DataObjects/src/TableColumn.cpp
+++ b/Framework/DataObjects/src/TableColumn.cpp
@@ -15,14 +15,5 @@ DECLARE_TABLECOLUMN(API::Boolean, bool)
 DECLARE_TABLECOLUMN(std::string, str)
 DECLARE_TABLECOLUMN(Mantid::Kernel::V3D, V3D)
 
-template <>
-void TableColumn<std::string>::read(size_t index, const std::string &text) {
-  /* As opposed to other types, assigning strings via a stream does not work if
-   * it contains a whitespace character, so instead the assignment operator is
-   * used.
-   */
-  m_data[index] = text;
-}
-
 } // namespace DataObjects
 } // namespace Mantid

--- a/Framework/DataObjects/src/TableColumn.cpp
+++ b/Framework/DataObjects/src/TableColumn.cpp
@@ -15,5 +15,14 @@ DECLARE_TABLECOLUMN(API::Boolean, bool)
 DECLARE_TABLECOLUMN(std::string, str)
 DECLARE_TABLECOLUMN(Mantid::Kernel::V3D, V3D)
 
+template <>
+void TableColumn<std::string>::read(size_t index, const std::string &text) {
+  /* As opposed to other types, assigning strings via a stream does not work if
+   * it contains a whitespace character, so instead the assignment operator is
+   * used.
+   */
+  m_data[index] = text;
+}
+
 } // namespace DataObjects
 } // namespace Mantid

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -270,9 +270,14 @@ void MantidTable::cellEdited(int row, int col) {
     return;
   }
 
-  std::string text =
-      d_table->text(row, col).remove(QRegExp("\\s")).toStdString();
+  QString oldText = d_table->text(row, col);
   Mantid::API::Column_sptr c = m_ws->getColumn(col);
+
+  if (c->type() != "str") {
+    oldText.remove(QRegExp("\\s"));
+  }
+
+  std::string text = oldText.toStdString();
 
   // Have the column convert the text to a value internally
   int index = row;
@@ -282,7 +287,8 @@ void MantidTable::cellEdited(int row, int col) {
   // That way, if the string was stupid, it will be reset to the old value.
   std::ostringstream s;
   c->print(index, s);
-  d_table->setText(row, col, QString(s.str().c_str()));
+
+  d_table->setText(row, col, QString::fromStdString(s.str()));
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
With these modifications string columns are allowed to have whitespace characters again. Does not need to be in the release notes.

**To test:**
Try the example provided in the ticket and make sure that whitespace characters are preserved even after the displaying the table. For columns with numeric types whitespace characters should be removed.

Fixes #15960.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
