### PR TITLE
Sort members of a WorkspaceGroup by workspace name

### DIFF
--- a/Framework/API/inc/MantidAPI/AnalysisDataService.h
+++ b/Framework/API/inc/MantidAPI/AnalysisDataService.h
@@ -150,6 +150,7 @@ public:
 
   /** @name Methods to work with workspace groups */
   //@{
+  void sortGroupByName(const std::string &groupName);
   void addToGroup(const std::string &groupName, const std::string &wsName);
   void deepRemoveGroup(const std::string &name);
   void removeFromGroup(const std::string &groupName, const std::string &wsName);

--- a/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -62,6 +62,8 @@ public:
 
   /// The collection itself is considered to take up no space
   size_t getMemorySize() const override { return 0; }
+  /// Sort the internal data structure according to member name
+  void sortMembersByName();
   /// Adds a workspace to the group.
   void addWorkspace(Workspace_sptr workspace);
   /// Return the number of entries within the group
@@ -88,6 +90,11 @@ public:
 
   /// @name Wrapped ADS calls
   //@{
+
+  /// Invokes the ADS to sort group members by orkspace name
+  void sortByName() {
+    AnalysisDataService::Instance().sortGroupByName(this->name());
+  }
 
   /// Adds a workspace to the group.
   void add(const std::string &wsName) {

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -164,6 +164,20 @@ void AnalysisDataServiceImpl::remove(const std::string &name) {
 }
 
 /**
+ * Sort members by Workspace name. The group must be in the ADS.
+ * @param groupName :: A group name.
+ */
+void AnalysisDataServiceImpl::sortGroupByName(const std::string &groupName) {
+  WorkspaceGroup_sptr group = retrieveWS<WorkspaceGroup>(groupName);
+  if (!group) {
+    throw std::runtime_error("Workspace " + groupName +
+                             " is not a workspace group.");
+  }
+  group->sortMembersByName();
+  notificationCenter.postNotification(new GroupUpdatedNotification(groupName));
+}
+
+/**
  * Add a workspace to a group. The group and the workspace must be in the ADS.
  * @param groupName :: A group name.
  * @param wsName :: Name of a workspace to add to the group.

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -86,6 +86,18 @@ bool WorkspaceGroup::isInChildGroup(const Workspace &workspaceToCheck) const {
 }
 
 /**
+ * Sort members by Workspace name
+ */
+void WorkspaceGroup::sortMembersByName(){
+  if( this->size()==0){
+    return;
+  }
+  std::sort(m_workspaces.begin(), m_workspaces.end(),
+    [](const Workspace_sptr &w1, const Workspace_sptr &w2) {
+    return (w1->name() < w2->name());} );
+}
+
+/**
  * Adds a workspace to the group. The workspace does not have to be in the ADS
  * @param workspace :: A shared pointer to a workspace to add. If the workspace
  * already exists give a warning.

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -88,13 +88,14 @@ bool WorkspaceGroup::isInChildGroup(const Workspace &workspaceToCheck) const {
 /**
  * Sort members by Workspace name
  */
-void WorkspaceGroup::sortMembersByName(){
-  if( this->size()==0){
+void WorkspaceGroup::sortMembersByName() {
+  if (this->size() == 0) {
     return;
   }
   std::sort(m_workspaces.begin(), m_workspaces.end(),
-    [](const Workspace_sptr &w1, const Workspace_sptr &w2) {
-    return (w1->name() < w2->name());} );
+            [](const Workspace_sptr &w1, const Workspace_sptr &w2) {
+              return (w1->name() < w2->name());
+            });
 }
 
 /**

--- a/Framework/API/test/WorkspaceGroupTest.h
+++ b/Framework/API/test/WorkspaceGroupTest.h
@@ -84,6 +84,7 @@ private:
   }
 
 public:
+
   void test_toString_Produces_Expected_String() {
     WorkspaceGroup_sptr group = makeGroup();
 
@@ -92,6 +93,25 @@ public:
                                  " -- ws1\n"
                                  " -- ws2\n";
     TS_ASSERT_EQUALS(expected, group->toString());
+  }
+
+  void test_sortByName() {
+    WorkspaceGroup_sptr group = makeGroup();
+    AnalysisDataService::Instance().rename("ws0", "ws3");
+    AnalysisDataService::Instance().sortGroupByName("group");
+    const std::string expected = "WorkspaceGroup\n"
+                                 " -- ws1\n"
+                                 " -- ws2\n"
+                                 " -- ws3\n";
+    TS_ASSERT_EQUALS(expected, group->toString());
+    AnalysisDataService::Instance().rename("ws1", "ws5");
+    const std::string expected2 = "WorkspaceGroup\n"
+                                  " -- ws2\n"
+                                  " -- ws3\n"
+                                  " -- ws5\n";
+    group->sortMembersByName();
+    TS_ASSERT_EQUALS(expected2, group->toString());
+    AnalysisDataService::Instance().clear();
   }
 
   void test_add() {

--- a/Framework/API/test/WorkspaceGroupTest.h
+++ b/Framework/API/test/WorkspaceGroupTest.h
@@ -84,7 +84,6 @@ private:
   }
 
 public:
-
   void test_toString_Produces_Expected_String() {
     WorkspaceGroup_sptr group = makeGroup();
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
@@ -21,6 +21,8 @@ void export_WorkspaceGroup() {
                WorkspaceGroup::contains,
            (arg("self"), arg("workspace")),
            "Returns true if the given name is in the group")
+      .def("sortByName", &WorkspaceGroup::sortByName, (arg("self")),
+           "Sort members by name")
       .def("add", &WorkspaceGroup::add, (arg("self"), arg("workspace_name")),
            "Add a name to the group")
       .def("size", &WorkspaceGroup::size, arg("self"),

--- a/Framework/PythonInterface/test/python/mantid/api/WorkspaceGroupTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/WorkspaceGroupTest.py
@@ -87,5 +87,18 @@ class WorkspaceGroupTest(unittest.TestCase):
         mtd.remove('grouped_1')
         mtd.remove('grouped_2')
 
+    def test_sortByName(self):
+        run_algorithm('CreateSingleValuedWorkspace', OutputWorkspace="w1")
+        run_algorithm('CreateSingleValuedWorkspace', OutputWorkspace="w4")
+        run_algorithm('GroupWorkspaces',InputWorkspaces='w4,w1',
+                      OutputWorkspace='group')
+        group = mtd['group']
+        names = ' '.join(list(group.getNames()))
+        self.assertTrue("w4 w1"==names)
+        group.sortByName()
+        names = ' '.join(list(group.getNames()))
+        self.assertTrue("w1 w4"==names)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -5,6 +5,14 @@ Framework Changes
 .. contents:: Table of Contents
    :local:
 
+API
+---
+
+Improved
+########
+
+- A sorting members by name method was added to :ref:`WorkspaceGroup <WorkspaceGroup>`.
+
 Algorithms
 ----------
 


### PR DESCRIPTION
A method to sort by name the members of a WorkspaceGroup has been implemented, and exposed to python. Unit tests have been implemented in the C++ (WorkspaceGrouTest.cpp) and python (WorkspaceGroupTest.py) tests.

**To test:**
load into the python window of MantidPlot the following lines, then execute the two blocks sequentially

```
w5= CreateEmptyTableWorkspace()
group=GroupWorkspaces("w5")
w2 = CreateEmptyTableWorkspace()
group.add("w2")
group.sortByName()

group.remove("w2")
w3=CreateSingleValuedWorkspace()
group.add("w3")
group.add("w2")
group.sortByName()
```

Fixes #16037.

[Release notes](https://github.com/mantidproject/mantid/blob/16037_WorkspaceGroup_SortByName/docs/source/release/v3.7.0/framework.rst#api) have been updated

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
