### PR TITLE
Skip history loading for LoadMD

### DIFF
--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -317,8 +317,8 @@ void LoadMD::loadHisto() {
   ws->setCoordinateSystem(m_coordSystem);
 
   // Load the WorkspaceHistory "process"
-  if(this->getProperty("LoadHistory")){
-      ws->history().loadNexus(m_file.get());
+  if (this->getProperty("LoadHistory")) {
+    ws->history().loadNexus(m_file.get());
   }
 
   this->loadAffineMatricies(boost::dynamic_pointer_cast<IMDWorkspace>(ws));
@@ -506,8 +506,8 @@ void LoadMD::doLoad(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   ws->setTitle(title);
 
   // Load the WorkspaceHistory "process"
-  if(this->getProperty("LoadHistory")){
-      ws->history().loadNexus(m_file.get());
+  if (this->getProperty("LoadHistory")) {
+    ws->history().loadNexus(m_file.get());
   }
 
   this->loadAffineMatricies(boost::dynamic_pointer_cast<IMDWorkspace>(ws));

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -106,6 +106,9 @@ void LoadMD::init() {
   setPropertySettings("Memory", make_unique<EnabledWhenProperty>(
                                     "FileBackEnd", IS_EQUAL_TO, "1"));
 
+  declareProperty("LoadHistory", true,
+                  "If true, the workspace history will be loaded");
+
   declareProperty(make_unique<WorkspaceProperty<IMDWorkspace>>(
                       "OutputWorkspace", "", Direction::Output),
                   "Name of the output MDEventWorkspace.");
@@ -314,7 +317,9 @@ void LoadMD::loadHisto() {
   ws->setCoordinateSystem(m_coordSystem);
 
   // Load the WorkspaceHistory "process"
-  ws->history().loadNexus(m_file.get());
+  if(this->getProperty("LoadHistory")){
+      ws->history().loadNexus(m_file.get());
+  }
 
   this->loadAffineMatricies(boost::dynamic_pointer_cast<IMDWorkspace>(ws));
 
@@ -501,7 +506,9 @@ void LoadMD::doLoad(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   ws->setTitle(title);
 
   // Load the WorkspaceHistory "process"
-  ws->history().loadNexus(m_file.get());
+  if(this->getProperty("LoadHistory")){
+      ws->history().loadNexus(m_file.get());
+  }
 
   this->loadAffineMatricies(boost::dynamic_pointer_cast<IMDWorkspace>(ws));
 

--- a/Framework/MDAlgorithms/test/LoadMDTest.h
+++ b/Framework/MDAlgorithms/test/LoadMDTest.h
@@ -771,7 +771,78 @@ public:
 
     AnalysisDataService::Instance().remove("SaveMDAffineTest_ws");
     AnalysisDataService::Instance().remove("SaveMDAffineTestHisto_ws");
-    AnalysisDataService::Instance().remove("OutputWorkspace");
+    AnalysisDataService::Instance().remove("reloaded_affine");
+  }
+
+  void test_loadHistory() {
+    std::string filename("History.nxs");
+    // Make a 4D MDEventWorkspace
+    MDEventWorkspace4Lean::sptr ws =
+        MDEventsTestHelper::makeMDEW<4>(10, 0.0, 10.0, 2);
+    AnalysisDataService::Instance().addOrReplace("HistoryEvTest_ws", ws);
+
+    // Bin data
+    BinMD balg;
+    balg.initialize();
+    balg.setProperty("InputWorkspace", "HistoryEvTest_ws");
+    balg.setProperty("OutputWorkspace", "HistoryHiTest_ws");
+    balg.setProperty("AlignedDim0", "Axis2,0,10,10");
+    balg.setProperty("AlignedDim1", "Axis0,0,10,5");
+    balg.setProperty("AlignedDim2", "Axis1,0,10,5");
+    balg.setProperty("AlignedDim3", "Axis3,0,10,2");
+    balg.execute();
+
+    SaveMD2 alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", "HistoryHiTest_ws");
+    alg.setPropertyValue("Filename", filename);
+    alg.setProperty("MakeFileBacked", "0");
+    alg.execute();
+    TS_ASSERT(alg.isExecuted());
+    std::string this_filename = alg.getProperty("Filename");
+
+    LoadMD loadAlg;
+    loadAlg.initialize();
+    loadAlg.isInitialized();
+    loadAlg.setPropertyValue("Filename", this_filename);
+    loadAlg.setProperty("FileBackEnd", false);
+    loadAlg.setPropertyValue("OutputWorkspace", "withHisto");
+    loadAlg.execute();
+    TS_ASSERT(loadAlg.isExecuted());
+
+    // Check the affine matrix over at a couple of locations
+    MDHistoWorkspace_sptr newWSh =
+        AnalysisDataService::Instance().retrieveWS<MDHistoWorkspace>(
+            "withHisto");
+
+    //BinMD and LoadMD should be in the history
+    TS_ASSERT_EQUALS(newWSh->getHistory().size(),2);
+
+    loadAlg.initialize();
+    loadAlg.isInitialized();
+    loadAlg.setPropertyValue("Filename", this_filename);
+    loadAlg.setProperty("FileBackEnd", false);
+    loadAlg.setPropertyValue("OutputWorkspace", "noHisto");
+    loadAlg.setProperty("LoadHistory",false);
+    loadAlg.execute();
+    TS_ASSERT(loadAlg.isExecuted());
+
+    // Check the affine matrix over at a couple of locations
+    MDHistoWorkspace_sptr newWSnh =
+        AnalysisDataService::Instance().retrieveWS<MDHistoWorkspace>(
+            "noHisto");
+
+    //Only LoadMD should be in the history
+    TS_ASSERT_EQUALS(newWSnh->getHistory().size(),1);
+
+    if (Poco::File(this_filename).exists()) {
+        Poco::File(this_filename).remove();
+    }
+
+    AnalysisDataService::Instance().remove("HistoryEvTest_ws");
+    AnalysisDataService::Instance().remove("HistoryHiTest_ws");
+    AnalysisDataService::Instance().remove("withHisto");
+    AnalysisDataService::Instance().remove("noHisto");
   }
 
   void test_MDEventWorkspace_contains_normalization_flags() {

--- a/Framework/MDAlgorithms/test/LoadMDTest.h
+++ b/Framework/MDAlgorithms/test/LoadMDTest.h
@@ -815,28 +815,27 @@ public:
         AnalysisDataService::Instance().retrieveWS<MDHistoWorkspace>(
             "withHisto");
 
-    //BinMD and LoadMD should be in the history
-    TS_ASSERT_EQUALS(newWSh->getHistory().size(),2);
+    // BinMD and LoadMD should be in the history
+    TS_ASSERT_EQUALS(newWSh->getHistory().size(), 2);
 
     loadAlg.initialize();
     loadAlg.isInitialized();
     loadAlg.setPropertyValue("Filename", this_filename);
     loadAlg.setProperty("FileBackEnd", false);
     loadAlg.setPropertyValue("OutputWorkspace", "noHisto");
-    loadAlg.setProperty("LoadHistory",false);
+    loadAlg.setProperty("LoadHistory", false);
     loadAlg.execute();
     TS_ASSERT(loadAlg.isExecuted());
 
     // Check the affine matrix over at a couple of locations
     MDHistoWorkspace_sptr newWSnh =
-        AnalysisDataService::Instance().retrieveWS<MDHistoWorkspace>(
-            "noHisto");
+        AnalysisDataService::Instance().retrieveWS<MDHistoWorkspace>("noHisto");
 
-    //Only LoadMD should be in the history
-    TS_ASSERT_EQUALS(newWSnh->getHistory().size(),1);
+    // Only LoadMD should be in the history
+    TS_ASSERT_EQUALS(newWSnh->getHistory().size(), 1);
 
     if (Poco::File(this_filename).exists()) {
-        Poco::File(this_filename).remove();
+      Poco::File(this_filename).remove();
     }
 
     AnalysisDataService::Instance().remove("HistoryEvTest_ws");

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -111,6 +111,7 @@ MD Algorithms (VATES CLI)
 -  The box structure of workspaces created with CutMD using NoPix=false now matches that specified by the PnBins properties. Additional box splitting is only allowed if MaxRecursionDepth is set to higher than its default of 1.
 -  XorMD, OrMD and AndMD treat masked bins as zero.
 -  A Gaussian smoothing option has been added to SmoothMD. Note, this currently only supports specifying widths for the smoothing function in units of pixels along the dimensions of the workspace.
+-  LoadMD has an option to skip loading workspace history. This is useful for workspaces created form large number of files, treated separately. 
 
 Geometry
 --------


### PR DESCRIPTION
Added option to skip loading history. 

**To test:**
Load any MD workspace that has some history (say BinMD), with or without the `LoadHistory` option. Show the history, and check if it behaves as expected

Fixes #16051.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
