### PR TITLE
Factor out constructor from test_Area_Calls

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Math/Quadrilateral.h
+++ b/Framework/Geometry/inc/MantidGeometry/Math/Quadrilateral.h
@@ -44,11 +44,6 @@ public:
   /// Special constructor for a rectangle
   Quadrilateral(const double lowerX, const double upperX, const double lowerY,
                 const double upperY);
-  /// Copy constructor
-  Quadrilateral(const Quadrilateral &other);
-  /// Copy-assignment operator
-  Quadrilateral &operator=(const Quadrilateral &rhs);
-
   /// Index access.
   const Kernel::V2D &operator[](const size_t index) const override;
   /// Bounds-checked index access

--- a/Framework/Geometry/src/Math/Quadrilateral.cpp
+++ b/Framework/Geometry/src/Math/Quadrilateral.cpp
@@ -28,28 +28,6 @@ Quadrilateral::Quadrilateral(const double lowerX, const double upperX,
 {}
 
 /**
- * Copy constructor
- * @param other :: The object to construct this from
- */
-Quadrilateral::Quadrilateral(const Quadrilateral &other)
-    : ConvexPolygon(), m_lowerLeft(other.m_lowerLeft),
-      m_lowerRight(other.m_lowerRight), m_upperRight(other.m_upperRight),
-      m_upperLeft(other.m_upperLeft) {}
-
-/**
- * @param rhs The source object to copy from
- */
-Quadrilateral &Quadrilateral::operator=(const Quadrilateral &rhs) {
-  if (this != &rhs) {
-    m_lowerLeft = rhs.m_lowerLeft;
-    m_lowerRight = rhs.m_lowerRight;
-    m_upperRight = rhs.m_upperRight;
-    m_upperLeft = rhs.m_upperLeft;
-  }
-  return *this;
-}
-
-/**
  * Return the vertex at the given index
  * @param index :: An index, starting at 0
  * @returns A reference to the polygon at that index
@@ -124,26 +102,22 @@ double Quadrilateral::determinant() const { return 2.0 * area(); }
 
 /// @return The smallest X value for all points
 double Quadrilateral::minX() const {
-  return (m_lowerLeft.X() < m_upperLeft.X()) ? m_lowerLeft.X()
-                                             : m_upperLeft.X();
+  return std::min(m_lowerLeft.X(), m_upperLeft.X());
 }
 
 /// @return The largest X value for all points
 double Quadrilateral::maxX() const {
-  return (m_lowerRight.X() > m_upperRight.X()) ? m_lowerRight.X()
-                                               : m_upperRight.X();
+  return std::max(m_lowerRight.X(), m_upperRight.X());
 }
 
 /// @return The smallest Y value for all points
 double Quadrilateral::minY() const {
-  return (m_lowerLeft.Y() < m_lowerRight.Y()) ? m_lowerLeft.Y()
-                                              : m_lowerRight.Y();
+  return std::min(m_lowerLeft.Y(), m_lowerRight.Y());
 }
 
 /// @return The largest Y value for all points
 double Quadrilateral::maxY() const {
-  return (m_upperLeft.Y() > m_upperRight.Y()) ? m_upperLeft.Y()
-                                              : m_upperRight.Y();
+  return std::max(m_upperLeft.Y(), m_upperRight.Y());
 }
 
 /// @return A new polygon based on the current Quadrilateral

--- a/Framework/Geometry/test/QuadrilateralTest.h
+++ b/Framework/Geometry/test/QuadrilateralTest.h
@@ -156,8 +156,8 @@ public:
     const size_t ntests(50000000);
 
     double totalArea(0.0);
+    Quadrilateral test(V2D(), V2D(2.0, 0.0), V2D(2.0, 1.5), V2D(0.0, 1.5));
     for (size_t i = 0; i < ntests; ++i) {
-      Quadrilateral test(V2D(), V2D(2.0, 0.0), V2D(2.0, 1.5), V2D(0.0, 1.5));
       totalArea += test.area();
     }
   }


### PR DESCRIPTION
Description of work.

I noticed in #15856 that in `GeometryTest.QuadrilateralTestPerformance.test_Area_Calls` much of the time is spent constructing the Quadrilateral object. This constructor can be taken out of the loop so that most of the time is spent within the area() function. Clang does not optimize the loop away.

I also removed a copy constructor and copy assignment operator that is not different from the compiler-generated default and changed a few places to use `std::min` and `std::max` instead of the more confusing ternary conditional operator.

Unfortunately, this does not address the performance drop at commit dc9168c.   

**To test:**

<!-- Instructions for testing. -->

`QuadrilateralTestPerformance` isn't one of unit tests run on the build servers and should be built and run locally.

This is a small change with no issue number

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
