### PR TITLE
systemtest.bat not showing failures on Windows

### DIFF
--- a/buildconfig/CMake/Packaging/mantidpython.bat.in
+++ b/buildconfig/CMake/Packaging/mantidpython.bat.in
@@ -34,6 +34,7 @@ if "%1"=="--classic" (
 
 :: Start ipython and pass through all arguments to it
 start "Mantid Python" /B /WAIT %_IPYTHON_CMD% %*
+if %ERRORLEVEL% NEQ 0 exit /B %ERRORLEVEL%
 goto TheEnd
 
 :StartPython
@@ -48,5 +49,7 @@ shift
 if not "%~1"=="" goto ArgumentsLoop
 
 start "Mantid Python" /B /WAIT %_PYTHON_EXE%%ArgsExceptFirst%
+if %ERRORLEVEL% NEQ 0 exit /B %ERRORLEVEL%
 
 :TheEnd
+exit /B 0


### PR DESCRIPTION
On Windows, if system tests fail while running the `systemtest.bat`, the failure should actually be reported after the conclusion of the script 

**To test:**

Ensure that the `systemtest.bat` reports failures of tests when run

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
