### PR TITLE
Remove unnecessary const_cast.

### DIFF
--- a/Framework/DataHandling/src/LoadHelper.cpp
+++ b/Framework/DataHandling/src/LoadHelper.cpp
@@ -311,9 +311,8 @@ void LoadHelper::recurseAndAddNexusFieldsToWsRun(NXhandle nxfileID,
             int units_len = NX_MAXNAMELEN;
             int units_type = NX_CHAR;
 
-            units_status = NXgetattr(nxfileID, const_cast<char *>("units"),
-                                     static_cast<void *>(units_sbuf),
-                                     &units_len, &units_type);
+            units_status = NXgetattr(nxfileID, "units", units_sbuf, &units_len,
+                                     &units_type);
             if (units_status != NX_ERROR) {
               g_log.debug() << indent_str << "[ " << property_name
                             << " has unit " << units_sbuf << " ]" << std::endl;

--- a/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
+++ b/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
@@ -233,7 +233,7 @@ int SaveToSNSHistogramNexus::WriteOutDataOrErrors(
     NXname attrName = "errors";
     std::string attrBuffer = errors_field_name;
     if (NXputattr(outId, attrName,
-                  static_cast<void *>(const_cast<char *>(attrBuffer.c_str())),
+                  static_cast<const void *>(attrBuffer.c_str()),
                   static_cast<int>(attrBuffer.size()), NX_CHAR) != NX_OK)
       return NX_ERROR;
   }

--- a/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
+++ b/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
@@ -232,8 +232,7 @@ int SaveToSNSHistogramNexus::WriteOutDataOrErrors(
     // field.
     NXname attrName = "errors";
     std::string attrBuffer = errors_field_name;
-    if (NXputattr(outId, attrName,
-                  static_cast<const void *>(attrBuffer.c_str()),
+    if (NXputattr(outId, attrName, attrBuffer.c_str(),
                   static_cast<int>(attrBuffer.size()), NX_CHAR) != NX_OK)
       return NX_ERROR;
   }

--- a/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
@@ -286,8 +286,7 @@ NexusFileIO::writeNxValue(const std::string &name, const std::string &value,
   if (NXopendata(fileID, name.c_str()) == NX_ERROR)
     return false;
   for (unsigned int it = 0; it < attributes.size(); ++it) {
-    NXputattr(fileID, attributes[it].c_str(),
-              reinterpret_cast<void *>(const_cast<char *>(avalues[it].c_str())),
+    NXputattr(fileID, attributes[it].c_str(), avalues[it].c_str(),
               static_cast<int>(avalues[it].size() + 1), NX_CHAR);
   }
   NXputdata(fileID,

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.cxx
@@ -206,8 +206,7 @@ void vtkMDEWNexusReader::setTimeRange(vtkInformationVector *outputVector) {
 /*
 Getter for the workspace type name.
 */
-char *vtkMDEWNexusReader::GetWorkspaceTypeName() {
+const char *vtkMDEWNexusReader::GetWorkspaceTypeName() {
   // Forward request on to MVP presenter
-  typeName = m_presenter->getWorkspaceTypeName();
-  return const_cast<char *>(typeName.c_str());
+  return m_presenter->getWorkspaceTypeName().c_str();
 }

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.h
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.h
@@ -28,7 +28,7 @@ public:
   void updateAlgorithmProgress(double progress, const std::string &message);
 
   /// Getter for the workspace type
-  char *GetWorkspaceTypeName();
+  const char *GetWorkspaceTypeName();
   /// Getter for the input geometry
   const char *GetInputGeometryXML();
 

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
@@ -217,8 +217,7 @@ void vtkMDHWNexusReader::setTimeRange(vtkInformationVector *outputVector) {
 /*
 Getter for the workspace type name.
 */
-char *vtkMDHWNexusReader::GetWorkspaceTypeName() {
+const char *vtkMDHWNexusReader::GetWorkspaceTypeName() {
   // Forward request on to MVP presenter
-  typeName = m_presenter->getWorkspaceTypeName();
-  return const_cast<char *>(typeName.c_str());
+  return m_presenter->getWorkspaceTypeName().c_str();
 }

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.h
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.h
@@ -29,7 +29,7 @@ public:
   void updateAlgorithmProgress(double progress, const std::string &message);
 
   /// Getter for the workspace type
-  char *GetWorkspaceTypeName();
+  const char *GetWorkspaceTypeName();
   /// Getter for the input geometry
   const char *GetInputGeometryXML();
   /// Setter for the normalization

--- a/Vates/ParaviewPlugins/ParaViewReaders/NexusPeaksReader/vtkNexusPeaksReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/NexusPeaksReader/vtkNexusPeaksReader.cxx
@@ -240,8 +240,7 @@ void vtkNexusPeaksReader::updateAlgorithmProgress(double progress, const std::st
 /*
 Getter for the workspace type name.
 */
-char* vtkNexusPeaksReader::GetWorkspaceTypeName()
-{
+const char *vtkNexusPeaksReader::GetWorkspaceTypeName() {
   //Preload the Workspace and then cache it to avoid reloading later.
-  return const_cast<char*>(m_wsTypeName.c_str());
+  return m_wsTypeName.c_str();
 }

--- a/Vates/ParaviewPlugins/ParaViewReaders/NexusPeaksReader/vtkNexusPeaksReader.h
+++ b/Vates/ParaviewPlugins/ParaViewReaders/NexusPeaksReader/vtkNexusPeaksReader.h
@@ -21,7 +21,7 @@ public:
   /// Called by presenter to force progress information updating.
   void updateAlgorithmProgress(double progress, const std::string& message);
   /// Getter for the workspace type
-  char* GetWorkspaceTypeName();
+  const char *GetWorkspaceTypeName();
 
 protected:
   vtkNexusPeaksReader();

--- a/Vates/ParaviewPlugins/ParaViewReaders/PeaksReader/vtkPeaksReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/PeaksReader/vtkPeaksReader.cxx
@@ -208,8 +208,7 @@ void vtkPeaksReader::updateAlgorithmProgress(double progress, const std::string&
 /*
 Getter for the workspace type name.
 */
-char* vtkPeaksReader::GetWorkspaceTypeName()
-{
+const char *vtkPeaksReader::GetWorkspaceTypeName() {
   //Preload the Workspace and then cache it to avoid reloading later.
-  return const_cast<char*>(m_wsTypeName.c_str());
+  return m_wsTypeName.c_str();
 }

--- a/Vates/ParaviewPlugins/ParaViewReaders/PeaksReader/vtkPeaksReader.h
+++ b/Vates/ParaviewPlugins/ParaViewReaders/PeaksReader/vtkPeaksReader.h
@@ -21,7 +21,7 @@ public:
   /// Called by presenter to force progress information updating.
   void updateAlgorithmProgress(double progress, const std::string& message);
   /// Getter for the workspace type
-  char* GetWorkspaceTypeName();
+  const char *GetWorkspaceTypeName();
 
 protected:
   vtkPeaksReader();

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
@@ -322,16 +322,16 @@ void vtkMDEWSource::updateAlgorithmProgress(double progress, const std::string& 
 /*
 Getter for the workspace type name.
 */
-char *vtkMDEWSource::GetWorkspaceTypeName() {
+const char *vtkMDEWSource::GetWorkspaceTypeName() {
   if (m_presenter == nullptr) {
-    return const_cast<char *>("");
+    return "";
   }
   try {
     // Forward request on to MVP presenter
     typeName = m_presenter->getWorkspaceTypeName();
-    return const_cast<char *>(typeName.c_str());
+    return typeName.c_str();
   } catch (std::runtime_error &) {
-    return const_cast<char *>("");
+    return "";
   }
 }
 

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.h
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.h
@@ -70,7 +70,7 @@ public:
   /// Getter for the workspace name
   const char* GetWorkspaceName();
   /// Getter for the workspace type
-  char* GetWorkspaceTypeName();
+  const char *GetWorkspaceTypeName();
   /// Getter for the minimum value of the workspace data.
   double GetMinValue();
   /// Getter for the maximum value of the workspace data.

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
@@ -299,19 +299,18 @@ void vtkMDHWSource::updateAlgorithmProgress(double progress, const std::string& 
 /*
 Getter for the workspace type name.
 */
-char* vtkMDHWSource::GetWorkspaceTypeName()
-{
+const char *vtkMDHWSource::GetWorkspaceTypeName() {
   if (m_presenter == nullptr) {
-    return const_cast<char *>("");
+    return "";
   }
   try {
     //Forward request on to MVP presenter
     typeName = m_presenter->getWorkspaceTypeName();
-    return const_cast<char*>(typeName.c_str());
+    return typeName.c_str();
   }
   catch(std::runtime_error&)
   {
-    return const_cast<char*>("");
+    return "";
   }
 }
 

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.h
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.h
@@ -67,7 +67,7 @@ public:
   /// Getter for the workspace name
   const char* GetWorkspaceName();
   /// Getter for the workspace type
-  char* GetWorkspaceTypeName();
+  const char *GetWorkspaceTypeName();
   /// Getter for the minimum value of the workspace data
   double GetMinValue();
   /// Getter for the maximum value of the workspace data

--- a/Vates/ParaviewPlugins/ParaViewSources/PeaksSource/vtkPeaksSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/PeaksSource/vtkPeaksSource.cxx
@@ -120,9 +120,8 @@ void vtkPeaksSource::updateAlgorithmProgress(double progress, const std::string&
 /*
 Getter for the workspace type name.
 */
-char* vtkPeaksSource::GetWorkspaceTypeName()
-{
-  return const_cast<char*>(m_wsTypeName.c_str());
+const char *vtkPeaksSource::GetWorkspaceTypeName() {
+  return m_wsTypeName.c_str();
 }
 
 const char* vtkPeaksSource::GetWorkspaceName()

--- a/Vates/ParaviewPlugins/ParaViewSources/PeaksSource/vtkPeaksSource.h
+++ b/Vates/ParaviewPlugins/ParaViewSources/PeaksSource/vtkPeaksSource.h
@@ -52,7 +52,7 @@ public:
   /// Getter for the workspace name
   const char* GetWorkspaceName();
   /// Getter for the workspace type
-  char* GetWorkspaceTypeName();
+  const char *GetWorkspaceTypeName();
   /// Getter for the instrument associated with the workspace
   const char* GetInstrument();
 


### PR DESCRIPTION
Description of work.

This removes many `const_cast`s in NexusFileIO that are no longer necessary (did NeXus change its API since this was written?).  Similarly, for the ParaViewReaders `GetWorkspaceTypeName()` can return a `const char *`.

**To test:**

<!-- Instructions for testing. -->

Review changes and verify that the builds pass.

This is a small change with no issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
