### PR TITLE
Support fitting data from table workspaces

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -8182,7 +8182,7 @@ void ApplicationWindow::selectMultiPeak(MultiLayer *plot,
     return;
   }
 
-  if (plot->activeGraph()->isPiePlot()) {
+  if (dynamic_cast<Graph *>(plot->activeGraph())->isPiePlot()) {
     QMessageBox::warning(
         this, tr("MantidPlot - Warning"), // Mantid
         tr("This functionality is not available for pie plots!"));

--- a/MantidQt/MantidWidgets/src/FitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/FitPropertyBrowser.cpp
@@ -1435,14 +1435,14 @@ void FitPropertyBrowser::setCurrentFunction(
  * Creates an instance of Fit algorithm, sets its properties and launches it.
  */
 void FitPropertyBrowser::doFit(int maxIterations) {
-  std::string wsName = workspaceName();
+  const std::string wsName = workspaceName();
 
   if (wsName.empty()) {
     QMessageBox::critical(this, "Mantid - Error", "Workspace name is not set");
     return;
   }
 
-  auto ws = getWorkspace();
+  const auto ws = getWorkspace();
   if (!ws) {
     return;
   }
@@ -1454,13 +1454,13 @@ void FitPropertyBrowser::doFit(int maxIterations) {
     }
     m_fitActionUndoFit->setEnabled(true);
 
-    std::string funStr = getFittingFunction()->asString();
+    const std::string funStr = getFittingFunction()->asString();
 
     Mantid::API::IAlgorithm_sptr alg =
         Mantid::API::AlgorithmManager::Instance().create("Fit");
     alg->initialize();
     alg->setPropertyValue("Function", funStr);
-    alg->setPropertyValue("InputWorkspace", wsName);
+    alg->setProperty("InputWorkspace", ws);
     alg->setProperty("WorkspaceIndex", workspaceIndex());
     alg->setProperty("StartX", startX());
     alg->setProperty("EndX", endX());
@@ -1478,7 +1478,7 @@ void FitPropertyBrowser::doFit(int maxIterations) {
     observeFinish(alg);
     alg->executeAsync();
 
-  } catch (std::exception &e) {
+  } catch (const std::exception &e) {
     QString msg = "Fit algorithm failed.\n\n" + QString(e.what()) + "\n";
     QMessageBox::critical(this, "Mantid - Error", msg);
   }

--- a/docs/source/release/v3.7.0/ui.rst
+++ b/docs/source/release/v3.7.0/ui.rst
@@ -125,6 +125,8 @@ Bugs Resolved
 
 -  Plots from tables auto-update when the TableWorkspace is replaced in the ADS. If extra rows are added then the new points are added to the graph.
 
+- The Fit property browser (Fit Function window) in MantidPlot now supports fitting data plotted from a TableWorkspace.
+
 SliceViewer Improvements
 ------------------------
 


### PR DESCRIPTION
**[Required for a course at ISIS on 14th May]**

Fix a bug where attempting to fit data plotted from a TableWorkspace failed.

The FitPropertyBrowser has a method called `getWorkspace()` which converts a TableWorkspace to a MatrixWorkspace to use internally. The result of this method was never used.
Changed this so that the MatrixWorkspace is passed to the `Fit` algorithm.

Checked that the correct name still appears in the workspace history when fitting a MatrixWorkspace as usual.
(If fitting a TableWorkspace, a 'temporary workspace' name will appear here instead.)

**To test:**
- Generate a table:

``` python
tab = CreateEmptyTableWorkspace()
tab.addColumn("int", "x", 1)  
tab.addColumn("double", "y", 2)         
tab.addRow([20, 40])
tab.addRow([30, 60])
tabl = importTableWorkspace('tab', True)
```
- Plot a graph from the table
- Use the Fit Function window to fit a straight line to the data
  - Verify the fit works and no error is shown in the log or in a dialog box.

Fixes #16069.

[Release notes](https://github.com/mantidproject/mantid/blob/1ed9ab724845be654b1ef3397696eb148c4161e7/docs/source/release/v3.7.0/ui.rst#bugs-resolved) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
