### PR TITLE
Cuboid/Hexahedron bug fix

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryHandler.h
@@ -48,7 +48,8 @@ class Object;
 class MANTID_GEOMETRY_DLL GluGeometryHandler : public GeometryHandler {
   /// the type of the geometry eg CUBOID,CYLINDER,CONE,SPHERE
   enum GEOMETRY_TYPE {
-    CUBOID = 1,        ///< CUBOID
+    NOSHAPE = 0,
+	CUBOID,        ///< CUBOID
     HEXAHEDRON,        ///< HEXAHEDRON
     SPHERE,            ///< SPHERE
     CYLINDER,          ///< CYLINDER

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryHandler.h
@@ -48,7 +48,7 @@ class Object;
 class MANTID_GEOMETRY_DLL GluGeometryHandler : public GeometryHandler {
   /// the type of the geometry eg CUBOID,CYLINDER,CONE,SPHERE
   enum GEOMETRY_TYPE {
-    CUBOID,            ///< CUBOID
+    CUBOID = 1,        ///< CUBOID
     HEXAHEDRON,        ///< HEXAHEDRON
     SPHERE,            ///< SPHERE
     CYLINDER,          ///< CYLINDER

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryHandler.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryHandler.h
@@ -49,7 +49,7 @@ class MANTID_GEOMETRY_DLL GluGeometryHandler : public GeometryHandler {
   /// the type of the geometry eg CUBOID,CYLINDER,CONE,SPHERE
   enum GEOMETRY_TYPE {
     NOSHAPE = 0,
-	CUBOID,        ///< CUBOID
+    CUBOID,            ///< CUBOID
     HEXAHEDRON,        ///< HEXAHEDRON
     SPHERE,            ///< SPHERE
     CYLINDER,          ///< CYLINDER

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Cone.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Cone.h
@@ -2,6 +2,7 @@
 #define Cone_h
 
 #include "MantidGeometry/DllConfig.h"
+#include "MantidGeometry/Surfaces/Quadratic.h"
 #include "MantidKernel/V3D.h"
 
 namespace Mantid {

--- a/Framework/Geometry/src/Instrument/ObjCompAssembly.cpp
+++ b/Framework/Geometry/src/Instrument/ObjCompAssembly.cpp
@@ -1,14 +1,14 @@
 #include "MantidGeometry/Instrument/ObjCompAssembly.h"
 #include "MantidGeometry/Instrument/ObjComponent.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
-#include "MantidGeometry/Objects/ShapeFactory.h"
 #include "MantidGeometry/Objects/Object.h"
+#include "MantidGeometry/Objects/ShapeFactory.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Logger.h"
 #include <algorithm>
-#include <stdexcept>
-#include <ostream>
 #include <iostream>
+#include <ostream>
+#include <stdexcept>
 
 namespace {
 Mantid::Kernel::Logger g_log("ObjCompAssembly");
@@ -383,7 +383,7 @@ boost::shared_ptr<Object> ObjCompAssembly::createOutline() {
   obj->GetObjectGeom(otype, vectors, radius, height);
   if (otype == 1) {
     type = "box";
-  } else if (otype == 3) {
+  } else if (otype == 4) {
     type = "cylinder";
   } else {
     throw std::runtime_error(

--- a/Framework/Geometry/src/Objects/Object.cpp
+++ b/Framework/Geometry/src/Objects/Object.cpp
@@ -1511,8 +1511,8 @@ const BoundingBox &Object::getBoundingBox() const {
   // Set to a large box so that a) we don't keep trying to calculate a box
   // every time this is called and b) to serve as a visual indicator that
   // something went wrong.
-  const_cast<Object *>(this)->defineBoundingBox(100, 100, 100, -100, -100,
-                                                -100);
+  const_cast<Object *>(this)
+      ->defineBoundingBox(100, 100, 100, -100, -100, -100);
   return m_boundingBox;
 }
 

--- a/Framework/Geometry/src/Objects/Object.cpp
+++ b/Framework/Geometry/src/Objects/Object.cpp
@@ -1,23 +1,23 @@
 #include "MantidGeometry/Objects/Object.h"
-#include "MantidKernel/Strings.h"
-#include "MantidKernel/Exception.h"
-#include "MantidKernel/MultiThreaded.h"
 #include "MantidGeometry/Objects/Rules.h"
 #include "MantidGeometry/Objects/Track.h"
+#include "MantidKernel/Exception.h"
+#include "MantidKernel/MultiThreaded.h"
+#include "MantidKernel/Strings.h"
 
-#include "MantidGeometry/Surfaces/Surface.h"
-#include "MantidGeometry/Surfaces/LineIntersectVisit.h"
-#include "MantidGeometry/Surfaces/Cylinder.h"
 #include "MantidGeometry/Surfaces/Cone.h"
+#include "MantidGeometry/Surfaces/Cylinder.h"
+#include "MantidGeometry/Surfaces/LineIntersectVisit.h"
+#include "MantidGeometry/Surfaces/Surface.h"
 
-#include "MantidGeometry/Rendering/GeometryHandler.h"
 #include "MantidGeometry/Rendering/CacheGeometryHandler.h"
+#include "MantidGeometry/Rendering/GeometryHandler.h"
 #include "MantidGeometry/Rendering/vtkGeometryCacheReader.h"
 #include "MantidGeometry/Rendering/vtkGeometryCacheWriter.h"
-#include "MantidKernel/make_unique.h"
 #include "MantidKernel/Quat.h"
 #include "MantidKernel/RegexStrings.h"
 #include "MantidKernel/Tolerance.h"
+#include "MantidKernel/make_unique.h"
 
 #include <boost/make_shared.hpp>
 
@@ -1021,14 +1021,14 @@ double Object::triangleSolidAngle(const V3D &observer) const {
   this->GetObjectGeom(type, geometry_vectors, radius, height);
   int nTri = this->NumberOfTriangles();
   // Cylinders are by far the most frequently used
-  if (type == 3)
+  if (type == 4)
     return CylinderSolidAngle(observer, geometry_vectors[0],
                               geometry_vectors[1], radius, height);
   else if (type == 1)
     return CuboidSolidAngle(observer, geometry_vectors);
-  else if (type == 2)
+  else if (type == 3)
     return SphereSolidAngle(observer, geometry_vectors, radius);
-  else if (type == 4)
+  else if (type == 5)
     return ConeSolidAngle(observer, geometry_vectors[0], geometry_vectors[1],
                           radius, height);
   else if (nTri == 0) // Fall back to raytracing if there are no triangles
@@ -1103,7 +1103,7 @@ double Object::triangleSolidAngle(const V3D &observer,
       for (auto &vector : vectors)
         vector *= scaleFactor;
       return CuboidSolidAngle(observer, vectors);
-    } else if (type == 2) // this is wrong for scaled objects
+    } else if (type == 3) // this is wrong for scaled objects
       return SphereSolidAngle(observer, vectors, radius);
     //
     // No special case, do the ray trace.
@@ -1511,8 +1511,8 @@ const BoundingBox &Object::getBoundingBox() const {
   // Set to a large box so that a) we don't keep trying to calculate a box
   // every time this is called and b) to serve as a visual indicator that
   // something went wrong.
-  const_cast<Object *>(this)
-      ->defineBoundingBox(100, 100, 100, -100, -100, -100);
+  const_cast<Object *>(this)->defineBoundingBox(100, 100, 100, -100, -100,
+                                                -100);
   return m_boundingBox;
 }
 
@@ -1645,8 +1645,8 @@ void Object::calcBoundingBoxByGeometry() {
     }
   } break;
 
-  case 3: // CYLINDER
-  case 5: // SEGMENTED_CYLINDER
+  case 4: // CYLINDER
+  case 6: // SEGMENTED_CYLINDER
   {
     // Center-point of base and normalized axis based on IDF XML
     auto &base = vectors[0];
@@ -1670,7 +1670,7 @@ void Object::calcBoundingBoxByGeometry() {
     maxZ = std::max(base.Z(), top.Z()) + rz;
   } break;
 
-  case 4: // CONE
+  case 5: // CONE
   {
     auto &tip = vectors[0];            // Tip-point of cone
     auto &axis = vectors[1];           // Normalized axis

--- a/Framework/Geometry/src/Rendering/GluGeometryHandler.cpp
+++ b/Framework/Geometry/src/Rendering/GluGeometryHandler.cpp
@@ -80,6 +80,8 @@ void GluGeometryHandler::Render() {
       Renderer->RenderSegmentedCylinder(m_points[0], m_points[1], radius,
                                         height);
       break;
+    case NOSHAPE:
+      break;
     }
   } else if (ObjComp != nullptr) {
     Renderer->Render(ObjComp);

--- a/Framework/Geometry/src/Rendering/GluGeometryHandler.cpp
+++ b/Framework/Geometry/src/Rendering/GluGeometryHandler.cpp
@@ -96,8 +96,8 @@ void GluGeometryHandler::GetObjectGeom(int &mytype,
     switch (type) {
     case CUBOID:
       break;
-	case HEXAHEDRON:
-		break;
+    case HEXAHEDRON:
+      break;
     case SPHERE:
       myradius = radius;
       break;

--- a/Framework/Geometry/src/Rendering/GluGeometryHandler.cpp
+++ b/Framework/Geometry/src/Rendering/GluGeometryHandler.cpp
@@ -1,7 +1,7 @@
+#include "MantidGeometry/Rendering/GluGeometryHandler.h"
 #include "MantidGeometry/Instrument/ObjComponent.h"
 #include "MantidGeometry/Objects/Object.h"
 #include "MantidGeometry/Rendering/GeometryHandler.h"
-#include "MantidGeometry/Rendering/GluGeometryHandler.h"
 #include "MantidGeometry/Rendering/GluGeometryRenderer.h"
 
 #include <boost/make_shared.hpp>
@@ -95,9 +95,6 @@ void GluGeometryHandler::GetObjectGeom(int &mytype,
     vectors = m_points;
     switch (type) {
     case CUBOID:
-      mytype = 1;
-      break;
-    case HEXAHEDRON:
       break;
     case SPHERE:
       myradius = radius;

--- a/Framework/Geometry/src/Rendering/GluGeometryHandler.cpp
+++ b/Framework/Geometry/src/Rendering/GluGeometryHandler.cpp
@@ -13,17 +13,17 @@ using Kernel::V3D;
 GluGeometryHandler::GluGeometryHandler(IObjComponent *comp)
     : GeometryHandler(comp),
       Renderer(Kernel::make_unique<GluGeometryRenderer>()), radius(0.0),
-      height(0.0), type(CUBOID) {}
+      height(0.0), type(NOSHAPE) {}
 
 GluGeometryHandler::GluGeometryHandler(boost::shared_ptr<Object> obj)
     : GeometryHandler(std::move(obj)),
       Renderer(Kernel::make_unique<GluGeometryRenderer>()), radius(0.0),
-      height(0.0), type(CUBOID) {}
+      height(0.0), type(NOSHAPE) {}
 
 GluGeometryHandler::GluGeometryHandler(Object *obj)
     : GeometryHandler(obj),
       Renderer(Kernel::make_unique<GluGeometryRenderer>()), radius(0.0),
-      height(0.0), type(CUBOID) {}
+      height(0.0), type(NOSHAPE) {}
 
 GluGeometryHandler::GluGeometryHandler(const GluGeometryHandler &other)
     : GeometryHandler(other), m_points(other.m_points), radius(other.radius),
@@ -96,6 +96,8 @@ void GluGeometryHandler::GetObjectGeom(int &mytype,
     switch (type) {
     case CUBOID:
       break;
+	case HEXAHEDRON:
+		break;
     case SPHERE:
       myradius = radius;
       break;

--- a/Framework/Geometry/test/ObjCompAssemblyTest.h
+++ b/Framework/Geometry/test/ObjCompAssemblyTest.h
@@ -365,7 +365,7 @@ public:
     double radius, height;
     shape->GetObjectGeom(otype, vectors, radius, height);
 
-    TS_ASSERT_EQUALS(otype, 5);
+    TS_ASSERT_EQUALS(otype, 6);
     TS_ASSERT_EQUALS(radius, 0.1);
     TS_ASSERT_EQUALS(height, 0.6);
   }

--- a/Framework/Geometry/test/ObjectTest.h
+++ b/Framework/Geometry/test/ObjectTest.h
@@ -59,7 +59,7 @@ public:
     double radius(-1.0), height(-1.0);
     std::vector<V3D> pts;
     original->GetObjectGeom(objType, pts, radius, height);
-    TS_ASSERT_EQUALS(2, objType);
+    TS_ASSERT_EQUALS(3, objType);
     TS_ASSERT(boost::dynamic_pointer_cast<GluGeometryHandler>(
         original->getGeometryHandler()));
 
@@ -68,7 +68,7 @@ public:
     objType = -1;
     copy.GetObjectGeom(objType, pts, radius, height);
 
-    TS_ASSERT_EQUALS(2, objType);
+    TS_ASSERT_EQUALS(3, objType);
     TS_ASSERT(boost::dynamic_pointer_cast<GluGeometryHandler>(
         copy.getGeometryHandler()));
     TS_ASSERT_EQUALS(copy.getName(), original->getName());
@@ -84,7 +84,7 @@ public:
     double radius(-1.0), height(-1.0);
     std::vector<V3D> pts;
     original->GetObjectGeom(objType, pts, radius, height);
-    TS_ASSERT_EQUALS(2, objType);
+    TS_ASSERT_EQUALS(3, objType);
     TS_ASSERT(boost::dynamic_pointer_cast<GluGeometryHandler>(
         original->getGeometryHandler()));
 
@@ -94,7 +94,7 @@ public:
     objType = -1;
     lhs.GetObjectGeom(objType, pts, radius, height);
 
-    TS_ASSERT_EQUALS(2, objType);
+    TS_ASSERT_EQUALS(3, objType);
     TS_ASSERT(boost::dynamic_pointer_cast<GluGeometryHandler>(
         lhs.getGeometryHandler()));
   }

--- a/Framework/Geometry/test/ParObjCompAssemblyTest.h
+++ b/Framework/Geometry/test/ParObjCompAssemblyTest.h
@@ -140,7 +140,7 @@ public:
     double radius, height;
     shape->GetObjectGeom(otype, vectors, radius, height);
 
-    TS_ASSERT_EQUALS(otype, 5);
+    TS_ASSERT_EQUALS(otype, 6);
     TS_ASSERT_EQUALS(radius, 0.1);
     TS_ASSERT_EQUALS(height, 0.6);
 


### PR DESCRIPTION
The GluGeometry handler no longer returns the same type for cuboids and hexahedra when the geometry is queried. SolidAngles for Hexahedra and Cuboids are now handled separately. A hexahedron special case will be developed as a part of another issue as this functionality is not urgent. Another issue to address the weakly typed enums for the glugeometryhandler/object can be found here #16057 

Code Review

Fixes #15999.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
