### PR TITLE
Fix performance regressions caused by regex matches 

### DIFF
--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -1563,7 +1563,7 @@ void InstrumentDefinitionParser::appendLeaf(Geometry::ICompAssembly *parent,
   if (pType->hasAttribute("is"))
     category = pType->getAttribute("is");
 
-  static boost::regex exp("Detector|detector|Monitor|monitor");
+  static const boost::regex exp("Detector|detector|Monitor|monitor");
 
   // do stuff a bit differently depending on which category the type belong to
   if (RectangularDetector::compareName(category)) {

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -30,7 +30,6 @@
 #include <Poco/SAX/AttributesImpl.h>
 
 #include <boost/make_shared.hpp>
-#include <boost/regex.hpp>
 #include <unordered_set>
 
 using namespace Mantid;
@@ -1563,14 +1562,15 @@ void InstrumentDefinitionParser::appendLeaf(Geometry::ICompAssembly *parent,
   if (pType->hasAttribute("is"))
     category = pType->getAttribute("is");
 
-  boost::regex exp("(Detector)|(detector)|(Monitor)|(monitor)");
-
   // do stuff a bit differently depending on which category the type belong to
   if (RectangularDetector::compareName(category)) {
     createRectangularDetector(parent, pLocElem, pCompElem, filename, pType);
   } else if (StructuredDetector::compareName(category)) {
     createStructuredDetector(parent, pLocElem, pCompElem, filename, pType);
-  } else if (boost::regex_match(category, exp)) {
+  } else if (category.compare("Detector") == 0 ||
+             category.compare("detector") == 0 ||
+             category.compare("Monitor") == 0 ||
+             category.compare("monitor") == 0) {
     createDetectorOrMonitor(parent, pLocElem, pCompElem, filename, idList,
                             category);
   } else {

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -30,6 +30,7 @@
 #include <Poco/SAX/AttributesImpl.h>
 
 #include <boost/make_shared.hpp>
+#include <boost/regex.hpp>
 #include <unordered_set>
 
 using namespace Mantid;
@@ -1562,15 +1563,14 @@ void InstrumentDefinitionParser::appendLeaf(Geometry::ICompAssembly *parent,
   if (pType->hasAttribute("is"))
     category = pType->getAttribute("is");
 
+  static boost::regex exp("Detector|detector|Monitor|monitor");
+
   // do stuff a bit differently depending on which category the type belong to
   if (RectangularDetector::compareName(category)) {
     createRectangularDetector(parent, pLocElem, pCompElem, filename, pType);
   } else if (StructuredDetector::compareName(category)) {
     createStructuredDetector(parent, pLocElem, pCompElem, filename, pType);
-  } else if (category.compare("Detector") == 0 ||
-             category.compare("detector") == 0 ||
-             category.compare("Monitor") == 0 ||
-             category.compare("monitor") == 0) {
+  } else if (boost::regex_match(category, exp)) {
     createDetectorOrMonitor(parent, pLocElem, pCompElem, filename, idList,
                             category);
   } else {

--- a/Framework/Geometry/src/Instrument/RectangularDetector.cpp
+++ b/Framework/Geometry/src/Instrument/RectangularDetector.cpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <ostream>
 #include <stdexcept>
-#include <boost/regex.hpp>
 #include "MantidGeometry/Instrument/RectangularDetectorPixel.h"
 
 namespace {
@@ -76,11 +75,10 @@ RectangularDetector::RectangularDetector(const std::string &n,
 }
 
 bool RectangularDetector::compareName(const std::string &proposedMatch) {
-  boost::regex exp(
-      "(RectangularDetector)|(rectangularDetector)|(rectangulardetector)|"
-      "(rectangular_detector)");
-
-  return boost::regex_match(proposedMatch, exp);
+  return (proposedMatch.compare("RectangularDetector") == 0 ||
+          proposedMatch.compare("rectangularDetector") == 0 ||
+          proposedMatch.compare("rectangulardetector") == 0 ||
+          proposedMatch.compare("rectangular_detector") == 0);
 }
 
 void RectangularDetector::init() {

--- a/Framework/Geometry/src/Instrument/RectangularDetector.cpp
+++ b/Framework/Geometry/src/Instrument/RectangularDetector.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <ostream>
 #include <stdexcept>
+#include <boost/regex.hpp>
 #include "MantidGeometry/Instrument/RectangularDetectorPixel.h"
 
 namespace {
@@ -75,10 +76,10 @@ RectangularDetector::RectangularDetector(const std::string &n,
 }
 
 bool RectangularDetector::compareName(const std::string &proposedMatch) {
-  return (proposedMatch.compare("RectangularDetector") == 0 ||
-          proposedMatch.compare("rectangularDetector") == 0 ||
-          proposedMatch.compare("rectangulardetector") == 0 ||
-          proposedMatch.compare("rectangular_detector") == 0);
+  static boost::regex exp("RectangularDetector|rectangularDetector|"
+                          "rectangulardetector|rectangular_detector");
+
+  return boost::regex_match(proposedMatch, exp);
 }
 
 void RectangularDetector::init() {

--- a/Framework/Geometry/src/Instrument/RectangularDetector.cpp
+++ b/Framework/Geometry/src/Instrument/RectangularDetector.cpp
@@ -76,8 +76,8 @@ RectangularDetector::RectangularDetector(const std::string &n,
 }
 
 bool RectangularDetector::compareName(const std::string &proposedMatch) {
-  static boost::regex exp("RectangularDetector|rectangularDetector|"
-                          "rectangulardetector|rectangular_detector");
+  static const boost::regex exp("RectangularDetector|rectangularDetector|"
+                                "rectangulardetector|rectangular_detector");
 
   return boost::regex_match(proposedMatch, exp);
 }

--- a/Framework/Geometry/src/Instrument/StructuredDetector.cpp
+++ b/Framework/Geometry/src/Instrument/StructuredDetector.cpp
@@ -7,7 +7,6 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Matrix.h"
 #include <algorithm>
-#include <boost/regex.hpp>
 #include <ostream>
 #include <stdexcept>
 
@@ -52,11 +51,10 @@ StructuredDetector::StructuredDetector(const StructuredDetector *base,
 }
 
 bool StructuredDetector::compareName(const std::string &proposedMatch) {
-  boost::regex exp(
-      "(StructuredDetector)|(structuredDetector)|(structureddetector)|"
-      "(structured_detector)");
-
-  return boost::regex_match(proposedMatch, exp);
+  return (proposedMatch.compare("StructuredDetector") == 0 ||
+          proposedMatch.compare("structuredDetector") == 0 ||
+          proposedMatch.compare("structureddetector") == 0 ||
+          proposedMatch.compare("structured_detector") == 0);
 }
 
 void StructuredDetector::init() {

--- a/Framework/Geometry/src/Instrument/StructuredDetector.cpp
+++ b/Framework/Geometry/src/Instrument/StructuredDetector.cpp
@@ -52,8 +52,8 @@ StructuredDetector::StructuredDetector(const StructuredDetector *base,
 }
 
 bool StructuredDetector::compareName(const std::string &proposedMatch) {
-  static boost::regex exp("StructuredDetector|structuredDetector|"
-                          "structureddetector|structured_detector");
+  static const boost::regex exp("StructuredDetector|structuredDetector|"
+                                "structureddetector|structured_detector");
 
   return boost::regex_match(proposedMatch, exp);
 }

--- a/Framework/Geometry/src/Instrument/StructuredDetector.cpp
+++ b/Framework/Geometry/src/Instrument/StructuredDetector.cpp
@@ -7,6 +7,7 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Matrix.h"
 #include <algorithm>
+#include <boost/regex.hpp>
 #include <ostream>
 #include <stdexcept>
 
@@ -51,10 +52,10 @@ StructuredDetector::StructuredDetector(const StructuredDetector *base,
 }
 
 bool StructuredDetector::compareName(const std::string &proposedMatch) {
-  return (proposedMatch.compare("StructuredDetector") == 0 ||
-          proposedMatch.compare("structuredDetector") == 0 ||
-          proposedMatch.compare("structureddetector") == 0 ||
-          proposedMatch.compare("structured_detector") == 0);
+  static boost::regex exp("StructuredDetector|structuredDetector|"
+                          "structureddetector|structured_detector");
+
+  return boost::regex_match(proposedMatch, exp);
 }
 
 void StructuredDetector::init() {


### PR DESCRIPTION
This addresses #15856 by optimizing the regex matches introduced in #15744.

Originally, regex matches introduced a significant slowdown. 

Reverting to string comparisons was explored as an option, but ultimately it turned out that the regex code could easily be optimized to nearly the same performance levels. 

Just making the regex expression definition `static` had a profound effect. Should be considered for other usages as well, where the expression is constant.

**To test:**

Run `DataHandlingTest LoadEventNexusTestPerformance` and `DataHandlingTest LoadEventPreNexusTestPerformance` and observe differences before and after this PR. 

It would be best to compare performance against dc9168c, to avoid other changes influencing test results.

Fixes #15856.

_Does not need to be in the release notes. (Addresses regression that was never released)_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
