### PR TITLE
Fix crash on clicking Column Options for a table

### DIFF
--- a/MantidPlot/src/Table.cpp
+++ b/MantidPlot/src/Table.cpp
@@ -74,7 +74,7 @@ Table::Table(ScriptingEnv *env, int r, int c, const QString &label,
 
 void Table::init(int rows, int cols) {
   selectedCol = -1;
-  d_saved_cells = 0;
+  d_saved_cells = nullptr;
   d_show_comments = false;
   d_numeric_precision = 13;
 
@@ -1598,7 +1598,7 @@ void Table::setText(int row, int col, const QString &text) {
 
 void Table::saveToMemory()
 {
-  // clear d_saved_cells
+  // clear d_saved_cells, if any
   freeMemory();
   d_saved_cells = new double *[d_table->columnCount()];
   for (int i = 0; i < d_table->columnCount(); ++i)
@@ -1709,12 +1709,17 @@ void Table::saveToMemory()
   }
 }
 
+/**
+ * Clears d_saved_cells. Does nothing if there are no saved cells.
+ */
 void Table::freeMemory() {
-  for (int i = 0; i < d_table->columnCount(); i++)
-    delete[] d_saved_cells[i];
+  if (d_saved_cells) {
+    for (int i = 0; i < d_table->columnCount(); i++)
+      delete[] d_saved_cells[i];
 
-  delete[] d_saved_cells;
-  d_saved_cells = 0;
+    delete[] d_saved_cells;
+    d_saved_cells = nullptr;
+  }
 }
 
 void Table::setTextFormat(int col) {


### PR DESCRIPTION
Check for null pointer before attempting to delete it.

[A call to freeMemory()](https://github.com/mantidproject/mantid/blob/c8db225f7cea3f33eff0b464133d6b2633111e43/MantidPlot/src/Table.cpp#L1601-L1602) was recently added when a Table is saved
to memory. Add a check in this function to avoid attempting to
free memory that has already been freed.

**To test:**
- Run the example script below (from issue). 

``` python
w = CreateEmptyTableWorkspace()
w.addColumn('str', 'Code')
w.addColumn('str', 'Value')
w.addRow(['',''])
w.addRow(['',''])
tab = importTableWorkspace('w', True)
```
- Right-click on the column header "Code" and select "Column Options..."
- Verify there is no crash. The "Column options" dialog should be displayed.

Fixes #16082.

**No release notes necessary** as the bug is not in release 3.6 (was introduced since then).

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
