### PR TITLE
Fix ComputeIncoherentDOS doc test on RHEL6

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -103,7 +103,8 @@ class ComputeIncoherentDOS(PythonAlgorithm):
         # Gets meV to cm^-1 conversion
         mev2cm = (constants.elementary_charge / 1000) / (constants.h * constants.c * 100)
         # Gets meV to Kelvin conversion
-        mev2k = (constants.elementary_charge / 1000) / constants.Boltzmann
+        # Note: constants.Boltzmann alias for constants.k not used here because it is not available on RHEL6
+        mev2k = (constants.elementary_charge / 1000) / constants.k
 
         # Converts energy to meV for bose factor later
         if u0 == 'DeltaE_inWavenumber' or u1 == 'DeltaE_inWavenumber':


### PR DESCRIPTION
Replace `constants.Boltzmann` with `constants.k` for rhel6 (scipy 0.7.2, where the list of constants is much shorter than in more recent scipy versions: http://docs.scipy.org/doc/scipy-0.7.x/scipy-ref.pdf).
docs-test was failing on RHEL6 after #15953 was merged in. 

Setting as "High Priority" because this makes the nightly docs-test fail. Otherwise this is a very minor change.

Check the code change.

No issue number for this quick fix.

No release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
