### PR TITLE
Muon sequential fit dialog: wait for file finding

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
@@ -21,7 +21,7 @@ class IAlgorithm;
 namespace MantidQt {
 namespace MantidWidgets {
 /**
- * A class to allow the asyncronous finding of files.
+ * A class to allow the asynchronous finding of files.
  */
 class FindFilesThread : public QThread {
   Q_OBJECT

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
@@ -240,6 +240,8 @@ signals:
   void liveButtonPressed(bool);
   /// Signal emitted after asynchronous checking of live stream availability
   void liveButtonSetEnabledSignal(bool);
+  /// Emitted when inspection of any found files is completed
+  void fileInspectionFinished();
 
 public slots:
   /// Set the file text and try and find it

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonSequentialFitDialog.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonSequentialFitDialog.h
@@ -16,9 +16,10 @@ namespace MantidWidgets
   using namespace Mantid::Kernel;
   using namespace Mantid::API;
 
-  /** MuonSequentialFitDialog : TODO: DESCRIPTION
-    
-    Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+  /** MuonSequentialFitDialog : Dialog for running sequential fits for Muon data
+
+    Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+    National Laboratory & European Spallation Source
 
     This file is part of Mantid.
 

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonSequentialFitDialog.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonSequentialFitDialog.h
@@ -128,6 +128,9 @@ namespace MantidWidgets
     /// Stop fitting process
     void stopFit();
 
+    /// Run fit after getting file input
+    void continueFit();
+
   };
 
 

--- a/MantidQt/MantidWidgets/src/MWRunFiles.cpp
+++ b/MantidQt/MantidWidgets/src/MWRunFiles.cpp
@@ -812,6 +812,8 @@ void MWRunFiles::inspectThreadResult() {
     setFileProblem("");
   }
 
+  emit fileInspectionFinished();
+
   // Only emit the signal if file(s) were found
   if (!m_foundFiles.isEmpty())
     emit filesFound();

--- a/MantidQt/MantidWidgets/src/MuonSequentialFitDialog.cpp
+++ b/MantidQt/MantidWidgets/src/MuonSequentialFitDialog.cpp
@@ -295,7 +295,9 @@ void MuonSequentialFitDialog::startFit() {
   // changed.
   connect(m_ui.runs, SIGNAL(fileInspectionFinished()), this,
           SLOT(continueFit()));
-  m_ui.runs->findFiles();
+  if (!m_ui.runs->isSearching()) {
+    m_ui.runs->findFiles();
+  }
 }
 
 /**

--- a/MantidQt/MantidWidgets/src/MuonSequentialFitDialog.cpp
+++ b/MantidQt/MantidWidgets/src/MuonSequentialFitDialog.cpp
@@ -30,14 +30,13 @@ MuonSequentialFitDialog::MuonSequentialFitDialog(
   setState(Stopped);
 
   // Set initial run to be run number of the workspace selected in fit browser
-  // when starting
-  // seq. fit dialog
-  auto fitWS = boost::dynamic_pointer_cast<const MatrixWorkspace>(
+  // when starting seq. fit dialog
+  const auto fitWS = boost::dynamic_pointer_cast<const MatrixWorkspace>(
       m_fitPropBrowser->getWorkspace());
   m_ui.runs->setText(QString::number(fitWS->getRunNumber()) + "-");
   // Set the file finder to the correct instrument (not Mantid's default
   // instrument)
-  auto instName = fitWS->getInstrument()->getName();
+  const auto instName = fitWS->getInstrument()->getName();
   m_ui.runs->setInstrumentOverride(QString(instName.c_str()));
 
   // TODO: find a better initial one, e.g. previously used
@@ -76,20 +75,20 @@ MuonSequentialFitDialog::MuonSequentialFitDialog(
 MuonSequentialFitDialog::~MuonSequentialFitDialog() {}
 
 /**
- * Checks if specified name is valid as a name for label.
+ * Checks if specified name is valid as a name for the label.
  * @param label :: The name to check
- * @return Empty string if valid, otherwise a string describing why is invalid
+ * @return Empty string if valid, otherwise an error string
  */
 std::string MuonSequentialFitDialog::isValidLabel(const std::string &label) {
   if (label.empty())
-    return "Can not be empty";
+    return "Cannot be empty";
   else
     return AnalysisDataService::Instance().isValid(label);
 }
 
 /**
  * Returns displayable title for the given workspace;
- * @param ws :: Workpspace to get title from
+ * @param ws :: Workspace to get title from
  * @return The title, or empty string if unable to get one
  */
 std::string MuonSequentialFitDialog::getRunTitle(Workspace_const_sptr ws) {
@@ -143,7 +142,7 @@ void MuonSequentialFitDialog::initDiagnosisTable() {
 /**
  * Add a new entry to the diagnosis table.
  * @param runTitle       :: Title of the run fitted
- * @param fitQuality     :: Number representing a goodness of the fit
+ * @param fitQuality     :: Number representing goodness of the fit
  * @param fittedFunction :: Function containing fitted parameters
  */
 void MuonSequentialFitDialog::addDiagnosisEntry(const std::string &runTitle,
@@ -199,7 +198,7 @@ void MuonSequentialFitDialog::updateLabelError(const QString &label) {
 }
 
 /**
- * Check if all the input field are valid.
+ * Check if all the input fields are valid.
  * @return True if everything valid, false otherwise
  */
 bool MuonSequentialFitDialog::isInputValid() {
@@ -237,7 +236,7 @@ void MuonSequentialFitDialog::setState(DialogState newState) {
 }
 
 /**
- * Update enabled state off all the input widgets depending on new dialog state.
+ * Update enabled state of all the input widgets depending on new dialog state.
  * @param newState :: New state of the dialog
  */
 void MuonSequentialFitDialog::updateInputEnabled(DialogState newState) {
@@ -261,7 +260,7 @@ void MuonSequentialFitDialog::updateControlEnabled(DialogState newState) {
 
 /**
  * Update cursor depending on the new state of the dialog.
- * Waiting cursor is displayed while preparing so that user does now that
+ * Waiting cursor is displayed while preparing so that user does know that
  * something is happening.
  * @param newState :: New state of the dialog
  */
@@ -284,17 +283,15 @@ void MuonSequentialFitDialog::updateCursor(DialogState newState) {
  */
 void MuonSequentialFitDialog::startFit() {
   if (m_state != Stopped)
-    throw std::runtime_error("Couln't start: already running");
+    throw std::runtime_error("Couldn't start: already running");
 
   setState(Preparing);
 
   // Explicitly run the file search. This might be needed when Start is clicked
-  // straigh after
-  // editing the run box. In that case, lost focus event might not be processed
-  // yet and search
-  // might not have been started yet. Otherwise, search is not done as the
-  // widget sees that it
-  // has not been changed. Taken from LoadDialog.cpp:124.
+  // straight after editing the run box. In that case, lost focus event might
+  // not be processed yet and search might not have been started yet.
+  // Otherwise, search is not done as the widget sees that it has not been
+  // changed. Taken from LoadDialog.cpp:124.
   m_ui.runs->findFiles();
 
   // Wait for file search to finish.
@@ -464,7 +461,7 @@ void MuonSequentialFitDialog::startFit() {
       fit->setProperty("InputWorkspace", ws);
       fit->setProperty("Output", wsBaseName);
 
-      // We should have one spectra only in the workspace, so use the first one.
+      // We should have one spectrum only in the workspace, so use the first one.
       fit->setProperty("WorkspaceIndex", 0);
 
       // Various properties from the fit prop. browser
@@ -481,7 +478,7 @@ void MuonSequentialFitDialog::startFit() {
       break;
     }
 
-    // Make sure created fit workspaces end-up in the group
+    // Make sure created fit workspaces end up in the group
     // TODO: this really should use loop
     ads.addToGroup(labelGroupName, wsBaseName + "_NormalisedCovarianceMatrix");
     ads.addToGroup(labelGroupName, wsBaseName + "_Parameters");

--- a/MantidQt/MantidWidgets/src/MuonSequentialFitDialog.cpp
+++ b/MantidQt/MantidWidgets/src/MuonSequentialFitDialog.cpp
@@ -279,7 +279,8 @@ void MuonSequentialFitDialog::updateCursor(DialogState newState) {
 }
 
 /**
- * Start fitting process.
+ * Start fitting process by running file search.
+ * Once search is complete, fit continues in continueFit().
  */
 void MuonSequentialFitDialog::startFit() {
   if (m_state != Stopped)
@@ -291,16 +292,19 @@ void MuonSequentialFitDialog::startFit() {
   // straight after editing the run box. In that case, lost focus event might
   // not be processed yet and search might not have been started yet.
   // Otherwise, search is not done as the widget sees that it has not been
-  // changed. Taken from LoadDialog.cpp:124.
+  // changed.
+  connect(m_ui.runs, SIGNAL(fileInspectionFinished()), this,
+          SLOT(continueFit()));
   m_ui.runs->findFiles();
+}
 
-  // Wait for file search to finish.
-  while (m_ui.runs->isSearching()) {
-    QApplication::processEvents();
-  }
-
-  // To process events from the finished thread
-  QApplication::processEvents();
+/**
+ * Carries out the fitting process once the file search has completed.
+ * Called when the run control reports that its search has finished.
+ */
+void MuonSequentialFitDialog::continueFit() {
+  disconnect(m_ui.runs, SIGNAL(fileInspectionFinished()), this,
+             SLOT(continueFit()));
 
   // Validate input fields
   if (!isInputValid()) {


### PR DESCRIPTION
Intended to fix a problem seen occasionally in the muon sequential fit dialog.

The bug is as seen in #9963: an error dialog is produced when you click "Start".
I think the reason is that, when you click "Start":
- First, the line edit loses focus, which starts the file search.
- Then the file search is started again. Since the text has not been modified since the last search, it jumps straight to investigating the results.
- Here it checks the member variables of a thread that is still running (as the first search is still going) and finds an error that hasn't yet been cleared.

Fixed this by only starting a search explicitly if there isn't one already running.
Also refactored the busy wait into two separate functions.

**To test:**
_`Data files available in the doc test folder: MUSR00015189-93.nxs`_
1. Interfaces > Muon > MuonAnalysis, load `MUSR00015189.nxs`.
2. Go to "Data Analysis" tab and set any fit function.
3. Fit > Sequential fit to open dialog.
4. Type "15189-15193" in the "Runs" field.
5. _Without clicking anywhere else_, press "Start".

Verify that no error is shown. If possible, try the same steps before the fix and see if you can replicate the bug (I can't, but I have seen it demonstrated).

Fixes #9963. 

_Release notes:_
I haven't updated these yet. Since I couldn't reproduce the original bug, I don't know for sure that this is a fix (though it is hopefully an improvement). If you are able to reproduce the bug before the fix and not after, then I will add something to the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
