### PR TITLE
Fix issues in engg interface  - focus and calibrate

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -319,6 +319,12 @@ private:
   /// string to use for invalid run number error message
   const static std::string g_runNumberErrorStr;
 
+  // name of the workspace with the vanadium integration (of spectra)
+  static const std::string g_vanIntegrationWSName;
+
+  // name of the workspace with the vanadium (smoothed) curves
+  static const std::string g_vanCurvesWSName;
+
   /// whether to allow users to give the output calibration filename
   const static bool g_askUserCalibFilename;
 
@@ -333,9 +339,6 @@ private:
 
   /// bank name used or SpecNos for cropped calibration
   static std::string g_calibCropIdentifier;
-
-  // name of the workspace with the vanadium integration (of spectra)
-  static const std::string g_vanIntegrationWSName;
 
   QThread *m_workerThread;
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -27,7 +27,7 @@ MVP Model-View-Presenter pattern). In principle, in a strict MVP
 setup, signals from the model should always be handled through this
 presenter and never go directly to the view, and viceversa.
 
-Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD
+Copyright &copy; 2015-2016 ISIS Rutherford Appleton Laboratory, NScD
 Oak Ridge National Laboratory & European Spallation Source
 
 This file is part of Mantid.
@@ -73,7 +73,7 @@ public:
                   const std::string &dgFile);
 
   /// checks if its a valid run number returns string
-  std::string isValidRunNumber(std::vector<std::string> dir);
+  std::string isValidRunNumber(const std::vector<std::string> &dir);
 
   /// checks if its a valid run number inside vector and returns a vector;
   /// used for mutli-run focusing
@@ -306,6 +306,13 @@ private:
   std::string
   plotDifcZeroWorkspace(const std::string &customisedBankName) const;
 
+  /// keep track of the paths the user "browses to", to add them in
+  /// the file search path
+  void recordPathBrowsedTo(const std::string &filename);
+
+  /// paths the user has "browsed to", to add them to the search path
+  std::vector<std::string> m_browsedToPaths;
+
   /// string to use for ENGINX file names (as a prefix, etc.)
   const static std::string g_enginxStr;
 
@@ -324,7 +331,7 @@ private:
   /// saves the last valid run number
   static std::string g_lastValidRun;
 
-  /// bank name use or SpecNos for cropped calibration
+  /// bank name used or SpecNos for cropped calibration
   static std::string g_calibCropIdentifier;
 
   // name of the workspace with the vanadium integration (of spectra)

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -76,8 +76,9 @@ public:
   std::string isValidRunNumber(const std::vector<std::string> &dir);
 
   /// checks if its a valid run number inside vector and returns a vector;
-  /// used for mutli-run focusing
-  std::vector<std::string> isValidMultiRunNumber(std::vector<std::string> dir);
+  /// used for mutli-run focusing, and other multi-run file selections
+  std::vector<std::string>
+  isValidMultiRunNumber(const std::vector<std::string> &dir);
 
   /// pre-processing re-binning with Rebin, for a worker/thread
   void doRebinningTime(const std::string &runNo, double bin,
@@ -115,11 +116,10 @@ public:
   void runConvetUnitsAlg(std::string workspaceName);
 
   void runCloneWorkspaceAlg(std::string inputWorkspace,
-	  std::string outputWorkspace);
+                            std::string outputWorkspace);
 
   void setDataToClonedWS(std::string inputWorkspace,
-	  std::string outputWorkspace);
-
+                         std::string outputWorkspace);
 
 protected:
   void initialize();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtGUI.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtGUI.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>664</width>
-    <height>672</height>
+    <width>660</width>
+    <height>680</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -151,7 +151,7 @@
            </widget>
           </item>
           <item>
-           <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_vanadium_num" native="true">
+           <widget class="MantidQt::MantidWidgets::MWRunFiles" name="MWRunFiles_new_vanadium_num" native="true">
             <property name="text" stdset="0">
              <string>236516</string>
             </property>
@@ -175,7 +175,7 @@
            </widget>
           </item>
           <item>
-           <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_ceria_num" native="true">
+           <widget class="MantidQt::MantidWidgets::MWRunFiles" name="MWRunFiles_new_ceria_num" native="true">
             <property name="text" stdset="0">
              <string>241391</string>
             </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -155,6 +155,9 @@
             <property name="text" stdset="0">
              <string>236516</string>
             </property>
+            <property name="readOnly" stdset="0">
+              <bool>false</bool>
+            </property>
             <property name="label" stdset="0">
              <string>Vanadium #:</string>
             </property>
@@ -178,6 +181,9 @@
            <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_ceria_num" native="true">
             <property name="text" stdset="0">
              <string>241391</string>
+            </property>
+            <property name="readOnly" stdset="0">
+              <bool>false</bool>
             </property>
             <property name="label" stdset="0">
              <string>Calibration sample #:</string>
@@ -221,7 +227,7 @@
    <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_calib_cropped">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="title">
       <string>Cropped Calibration:</string>
@@ -286,7 +292,7 @@
       <item row="4" column="1">
        <widget class="QPushButton" name="pushButton_new_cropped_calib">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="text">
          <string>Calibrate</string>
@@ -300,6 +306,9 @@
        <layout class="QHBoxLayout" name="horizontalLayout_11">
         <item>
          <widget class="QLabel" name="label_cropped_spec_nos">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
           <property name="text">
            <string>Spectrum Numbers:</string>
           </property>
@@ -347,6 +356,9 @@
         </item>
         <item>
          <widget class="QLabel" name="label_calib_cropped_spec_ids">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
           <property name="text">
            <string>Bank Name:</string>
           </property>
@@ -354,6 +366,9 @@
         </item>
         <item>
          <widget class="QComboBox" name="comboBox_calib_cropped_bank_name">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
           <item>
            <property name="text">
             <string>Enable Spectrum-Nos</string>
@@ -378,7 +393,7 @@
         <item>
          <widget class="QLabel" name="label_vanadium_num_2">
           <property name="enabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="text">
            <string>Calibration sample #:</string>
@@ -400,11 +415,8 @@
         </item>
         <item>
          <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_cropped_run_num" native="true">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
           <property name="text" stdset="0">
-           <string/>
+           <string>256663</string>
           </property>
           <property name="readOnly" stdset="0">
            <bool>false</bool>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -155,9 +155,6 @@
             <property name="text" stdset="0">
              <string>236516</string>
             </property>
-            <property name="readOnly" stdset="0">
-              <bool>false</bool>
-            </property>
             <property name="label" stdset="0">
              <string>Vanadium #:</string>
             </property>
@@ -181,9 +178,6 @@
            <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_ceria_num" native="true">
             <property name="text" stdset="0">
              <string>241391</string>
-            </property>
-            <property name="readOnly" stdset="0">
-              <bool>false</bool>
             </property>
             <property name="label" stdset="0">
              <string>Calibration sample #:</string>
@@ -239,7 +233,70 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="3" column="0" colspan="2">
+      <item row="3" column="1">
+       <widget class="QPushButton" name="pushButton_new_cropped_calib">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Calibrate</string>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <spacer name="horizontalSpacer_19">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>473</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <item>
+         <widget class="QLabel" name="label_cropped_spec_nos">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Spectrum Numbers:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>38</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_spec_nos">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_14">
         <item>
          <spacer name="horizontalSpacer_22">
@@ -276,70 +333,7 @@
         </item>
        </layout>
       </item>
-      <item row="4" column="0">
-       <spacer name="horizontalSpacer_19">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>473</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="4" column="1">
-       <widget class="QPushButton" name="pushButton_new_cropped_calib">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="text">
-         <string>Calibrate</string>
-        </property>
-        <property name="autoDefault">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_11">
-        <item>
-         <widget class="QLabel" name="label_cropped_spec_nos">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Spectrum Numbers:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>38</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_cropped_spec_nos">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>1</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0" colspan="2">
+      <item row="0" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_10">
         <item>
          <spacer name="horizontalSpacer_15">
@@ -357,7 +351,7 @@
         <item>
          <widget class="QLabel" name="label_calib_cropped_spec_ids">
           <property name="enabled">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="text">
            <string>Bank Name:</string>
@@ -367,7 +361,7 @@
         <item>
          <widget class="QComboBox" name="comboBox_calib_cropped_bank_name">
           <property name="enabled">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <item>
            <property name="text">
@@ -384,49 +378,6 @@
             <string>Bank South - 2</string>
            </property>
           </item>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QLabel" name="label_vanadium_num_2">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Calibration sample #:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_14">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>98</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_cropped_run_num" native="true">
-          <property name="text" stdset="0">
-           <string>256663</string>
-          </property>
-          <property name="readOnly" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="label" stdset="0">
-           <string>Run #:</string>
-          </property>
-          <property name="multipleFiles" stdset="0">
-           <bool>true</bool>
-          </property>
          </widget>
         </item>
        </layout>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -264,7 +264,7 @@
         <item>
          <widget class="QLabel" name="label_cropped_spec_nos">
           <property name="enabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="text">
            <string>Spectrum Numbers:</string>
@@ -351,7 +351,7 @@
         <item>
          <widget class="QLabel" name="label_calib_cropped_spec_ids">
           <property name="enabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="text">
            <string>Bank Name:</string>
@@ -361,11 +361,11 @@
         <item>
          <widget class="QComboBox" name="comboBox_calib_cropped_bank_name">
           <property name="enabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <item>
            <property name="text">
-            <string>Enable Spectrum-Nos</string>
+            <string>Use spectrum numbers</string>
            </property>
           </item>
           <item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -6,58 +6,24 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>595</width>
-    <height>640</height>
+    <width>600</width>
+    <height>650</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_5">
+   <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox_current_calib">
      <property name="title">
       <string>Current calibration:</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="3" column="0" colspan="4">
-       <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>406</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="3" column="4">
-       <widget class="QPushButton" name="pushButton_load_calib">
-        <property name="text">
-         <string>Load existing calibration</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_current_calib_filename">
-        <property name="text">
-         <string>Path:</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_vanadium_num">
         <property name="text">
          <string>Vanadium #:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_ceria_num">
-        <property name="text">
-         <string>Calibration sample #:</string>
         </property>
        </widget>
       </item>
@@ -74,6 +40,23 @@
         </property>
        </spacer>
       </item>
+      <item row="0" column="2">
+       <widget class="QLineEdit" name="lineEdit_current_vanadium_num">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_ceria_num">
+        <property name="text">
+         <string>Calibration sample #:</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <spacer name="horizontalSpacer_3">
         <property name="orientation">
@@ -87,7 +70,7 @@
         </property>
        </spacer>
       </item>
-      <item row="1" column="2" colspan="3">
+      <item row="1" column="2">
        <widget class="QLineEdit" name="lineEdit_current_ceria_num">
         <property name="text">
          <string/>
@@ -97,17 +80,34 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2" colspan="3">
-       <widget class="QLineEdit" name="lineEdit_current_vanadium_num">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_current_calib_filename">
         <property name="text">
-         <string/>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
+         <string>Path:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="4">
+      <item row="3" column="0" colspan="2">
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>406</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="2">
+       <widget class="QPushButton" name="pushButton_load_calib">
+        <property name="text">
+         <string>Load existing calibration</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
        <widget class="QLineEdit" name="lineEdit_current_calib_filename">
         <property name="readOnly">
          <bool>true</bool>
@@ -117,8 +117,8 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <spacer name="horizontalSpacer_6">
        <property name="orientation">
@@ -141,75 +141,87 @@
         <bool>false</bool>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_new_ceria_num">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
-         <widget class="QLabel" name="label_new_vanadium_num">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QLabel" name="label_new_vanadium_num">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_vanadium_num" native="true">
+            <property name="text" stdset="0">
+             <string>236516</string>
+            </property>
+            <property name="label" stdset="0">
+             <string>Vanadium #:</string>
+            </property>
+            <property name="multipleFiles" stdset="0">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
-        <item row="1" column="1" colspan="2">
-         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_ceria_num" native="true">
-          <property name="text" stdset="0">
-           <string>241391</string>
-          </property>
-          <property name="label" stdset="0">
-           <string>Calibration sample #:</string>
-          </property>
-          <property name="multipleFiles" stdset="0">
-           <bool>true</bool>
-          </property>
-         </widget>
+        <item row="1" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="label_new_ceria_num">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_ceria_num" native="true">
+            <property name="text" stdset="0">
+             <string>241391</string>
+            </property>
+            <property name="label" stdset="0">
+             <string>Calibration sample #:</string>
+            </property>
+            <property name="multipleFiles" stdset="0">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
-        <item row="0" column="1" colspan="2">
-         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_vanadium_num" native="true">
-          <property name="text" stdset="0">
-           <string>236516</string>
-          </property>
-          <property name="label" stdset="0">
-           <string>Vanadium #:</string>
-          </property>
-          <property name="multipleFiles" stdset="0">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QPushButton" name="pushButton_new_calib">
-          <property name="text">
-           <string>Calibrate</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0" colspan="2">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>128</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
+        <item row="2" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>128</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pushButton_new_calib">
+            <property name="text">
+             <string>Calibrate</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>
      </item>
     </layout>
    </item>
-   <item>
+   <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_calib_cropped">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="title">
       <string>Cropped Calibration:</string>
@@ -221,32 +233,6 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="4" column="1">
-       <widget class="QPushButton" name="pushButton_new_cropped_calib">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Calibrate</string>
-        </property>
-        <property name="autoDefault">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <spacer name="horizontalSpacer_19">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>473</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
       <item row="3" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_14">
         <item>
@@ -279,6 +265,66 @@
           </property>
           <property name="text">
            <string>cropped</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="4" column="0">
+       <spacer name="horizontalSpacer_19">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>473</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="4" column="1">
+       <widget class="QPushButton" name="pushButton_new_cropped_calib">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Calibrate</string>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <item>
+         <widget class="QLabel" name="label_cropped_spec_nos">
+          <property name="text">
+           <string>Spectrum Numbers:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>38</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_spec_nos">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
          </widget>
         </item>
@@ -327,44 +373,13 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="0" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_11">
-        <item>
-         <widget class="QLabel" name="label_cropped_spec_nos">
-          <property name="text">
-           <string>Spectrum Numbers:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>38</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_cropped_spec_nos">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>1</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
       <item row="0" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_9">
         <item>
          <widget class="QLabel" name="label_vanadium_num_2">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="text">
            <string>Calibration sample #:</string>
           </property>
@@ -385,6 +400,9 @@
         </item>
         <item>
          <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_cropped_run_num" native="true">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="text" stdset="0">
            <string/>
           </property>
@@ -404,20 +422,7 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <spacer name="horizontalSpacer_21">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>554</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
+   <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox_output_calib">
      <property name="title">
       <string>Output:</string>
@@ -445,20 +450,7 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <spacer name="horizontalSpacer_20">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>554</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
+   <item row="4" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
-    <height>650</height>
+    <width>660</width>
+    <height>680</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>664</width>
-    <height>683</height>
+    <width>660</width>
+    <height>680</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>660</width>
-    <height>682</height>
+    <height>680</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -411,9 +411,12 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_20">
         <item>
-         <widget class="QCheckBox" name="checkBox_FocusedWS">
+         <widget class="QCheckBox" name="checkBox_plot_focused_ws">
           <property name="text">
            <string>Plot Focused Workspace</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -505,9 +508,12 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_22">
         <item>
-         <widget class="QCheckBox" name="checkBox_SaveOutputFiles">
+         <widget class="QCheckBox" name="checkBox_save_output_files">
           <property name="text">
-           <string>Output Files</string>
+           <string>Save output Files</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>616</width>
-    <height>630</height>
+    <width>660</width>
+    <height>682</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -460,7 +460,7 @@
         <item>
          <widget class="QComboBox" name="comboBox_PlotData">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -560,7 +560,7 @@
            <bool>true</bool>
           </property>
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -574,7 +574,7 @@
           <property name="maximumSize">
            <size>
             <width>175</width>
-            <height>20</height>
+            <height>16777215</height>
            </size>
           </property>
           <property name="sizeIncrement">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -47,13 +47,6 @@
       <item row="1" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
-         <widget class="QLabel" name="label_banks_sel">
-          <property name="text">
-           <string>Banks:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <spacer name="horizontalSpacer_5">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -65,6 +58,13 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_banks_sel">
+          <property name="text">
+           <string>Banks:</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>
@@ -131,7 +131,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_run_num" native="true">
+         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="MWRunFiles_run_num" native="true">
           <property name="text" stdset="0">
            <string/>
           </property>
@@ -189,7 +189,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_cropped_run_num" native="true">
+         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="MWRunFiles_cropped_run_num" native="true">
           <property name="text" stdset="0">
            <string/>
           </property>
@@ -305,7 +305,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_texture_run_num" native="true">
+         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="MWRunFiles_texture_run_num" native="true">
           <property name="text" stdset="0">
            <string/>
           </property>
@@ -397,7 +397,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_focus_3">
+    <widget class="QGroupBox" name="groupBox_focus_output_options">
      <property name="minimumSize">
       <size>
        <width>596</width>
@@ -612,7 +612,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_13">
      <item>
-      <widget class="QPushButton" name="pushButton_stopFocus">
+      <widget class="QPushButton" name="pushButton_stop_focus">
        <property name="text">
         <string>Stop Focus</string>
        </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabPreproc.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabPreproc.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>615</width>
-    <height>562</height>
+    <width>660</width>
+    <height>680</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabSettings.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabSettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>616</width>
-    <height>560</height>
+    <width>660</width>
+    <height>680</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -254,9 +254,6 @@ private slots:
   // slots of plot spectrum check box status
   void plotFocusStatus();
 
-  // updates the cropped calib run number with new ceria
-  void updateCroppedCalibRun();
-
   // enables the text field when appropriate bank name is selected
   void enableSpecNos();
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -69,8 +69,7 @@ void EnggDiffractionPresenter::cleanup() {
   if (m_workerThread) {
     if (m_workerThread->isRunning()) {
       g_log.notice() << "A calibration process is currently running, shutting "
-                        "it down immediately..."
-                     << std::endl;
+                        "it down immediately..." << std::endl;
       m_workerThread->wait(10);
     }
     delete m_workerThread;
@@ -184,8 +183,7 @@ void EnggDiffractionPresenter::processCalcCalib() {
     return;
   }
   g_log.notice() << "EnggDiffraction GUI: starting new calibration. This may "
-                    "take a few seconds... "
-                 << std::endl;
+                    "take a few seconds... " << std::endl;
 
   const std::string outFilename = outputCalibFilename(vanNo, ceriaNo);
 
@@ -218,8 +216,7 @@ void EnggDiffractionPresenter::ProcessCropCalib() {
 
   g_log.notice()
       << "EnggDiffraction GUI: starting cropped calibration. This may "
-         "take a few seconds... "
-      << std::endl;
+         "take a few seconds... " << std::endl;
 
   const std::string outFilename = outputCalibFilename(vanNo, ceriaNo);
 
@@ -416,8 +413,7 @@ void EnggDiffractionPresenter::processRebinTime() {
   g_log.notice() << "EnggDiffraction GUI: starting new pre-processing "
                     "(re-binning) with a TOF bin into workspace '" +
                         outWSName + "'. This "
-                                    "may take some seconds... "
-                 << std::endl;
+                                    "may take some seconds... " << std::endl;
 
   m_view->enableCalibrateAndFocusActions(false);
   // GUI-blocking alternative:
@@ -443,8 +439,7 @@ void EnggDiffractionPresenter::processRebinMultiperiod() {
   g_log.notice() << "EnggDiffraction GUI: starting new pre-processing "
                     "(re-binning) by pulse times into workspace '" +
                         outWSName + "'. This "
-                                    "may take some seconds... "
-                 << std::endl;
+                                    "may take some seconds... " << std::endl;
 
   m_view->enableCalibrateAndFocusActions(false);
   // GUI-blocking alternative:
@@ -470,8 +465,7 @@ void EnggDiffractionPresenter::processFitPeaks() {
   g_log.notice() << "EnggDiffraction GUI: starting new "
                     "single peak fits into workspace '" +
                         outWSName + "'. This "
-                                    "may take some seconds... "
-                 << std::endl;
+                                    "may take some seconds... " << std::endl;
 
   // startAsyncFittingWorker
   // doFitting()
@@ -496,8 +490,7 @@ void EnggDiffractionPresenter::inputChecksBeforeFitting(
   if (ExpectedPeaks.empty()) {
     g_log.warning() << "Expected peaks were not passed, via fitting interface,"
                        "the default list of"
-                       "expected peaks will be utlised instead."
-                    << std::endl;
+                       "expected peaks will be utlised instead." << std::endl;
   }
   bool contains_non_digits =
       ExpectedPeaks.find_first_not_of("0123456789,. ") != std::string::npos;
@@ -531,8 +524,7 @@ void EnggDiffractionPresenter::doFitting(const std::string &focusedRunNo,
   // disable GUI to avoid any double threads
   m_view->enableCalibrateAndFocusActions(false);
   g_log.notice() << "EnggDiffraction GUI: starting new fitting. This may "
-                    "take a few seconds... "
-                 << std::endl;
+                    "take a few seconds... " << std::endl;
 
   MatrixWorkspace_sptr focusedWS;
   const std::string FocusedWSName = "engggui_fitting_focused_ws";
@@ -598,8 +590,7 @@ void EnggDiffractionPresenter::doFitting(const std::string &focusedRunNo,
 
   } catch (std::invalid_argument &ia) {
     g_log.error() << "Error, Fitting could not finish off correctly, " +
-                         std::string(ia.what())
-                  << std::endl;
+                         std::string(ia.what()) << std::endl;
     return;
   }
 }
@@ -735,8 +726,7 @@ void EnggDiffractionPresenter::runEvaluateFunctionAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm EvaluateFunction, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << std::endl;
+                         static_cast<std::string>(re.what()) << std::endl;
   }
 }
 
@@ -753,8 +743,7 @@ void EnggDiffractionPresenter::runCropWorkspaceAlg(std::string workspaceName) {
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm CropWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << std::endl;
+                         static_cast<std::string>(re.what()) << std::endl;
   }
 }
 
@@ -771,8 +760,7 @@ void EnggDiffractionPresenter::runAppendSpectraAlg(std::string workspace1Name,
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm AppendWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << std::endl;
+                         static_cast<std::string>(re.what()) << std::endl;
   }
 }
 
@@ -789,8 +777,7 @@ void EnggDiffractionPresenter::runRebinToWorkspaceAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm RebinToWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << std::endl;
+                         static_cast<std::string>(re.what()) << std::endl;
   }
 }
 
@@ -809,8 +796,7 @@ void EnggDiffractionPresenter::runConvetUnitsAlg(std::string workspaceName) {
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm ConvertUnits, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << std::endl;
+                         static_cast<std::string>(re.what()) << std::endl;
   }
 }
 
@@ -828,8 +814,7 @@ void EnggDiffractionPresenter::runCloneWorkspaceAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm CreateWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << std::endl;
+                         static_cast<std::string>(re.what()) << std::endl;
   }
 }
 
@@ -866,8 +851,7 @@ void EnggDiffractionPresenter::plotFitPeaksCurves() {
   } else {
     g_log.error() << "Fitting could not be plotted as there is no " +
                          singlePeaksWs + " or " + focusedPeaksWs +
-                         " workspace found."
-                  << std::endl;
+                         " workspace found." << std::endl;
   }
 }
 
@@ -885,8 +869,7 @@ void EnggDiffractionPresenter::fittingFinished() {
 
   } else {
     g_log.notice() << "The single peak fitting finished - the output "
-                      "workspace is ready."
-                   << std::endl;
+                      "workspace is ready." << std::endl;
 
     if (m_workerThread) {
       delete m_workerThread;
@@ -895,8 +878,7 @@ void EnggDiffractionPresenter::fittingFinished() {
 
     g_log.notice()
         << "EnggDiffraction GUI: plotting peaks for single peak fits "
-           "has started... "
-        << std::endl;
+           "has started... " << std::endl;
     try {
       plotFitPeaksCurves();
 
@@ -909,8 +891,7 @@ void EnggDiffractionPresenter::fittingFinished() {
       throw;
     }
     g_log.notice() << "EnggDiffraction GUI: plotting of peaks for single peak "
-                      "fits has completed. "
-                   << std::endl;
+                      "fits has completed. " << std::endl;
   }
   // enable the GUI
   m_view->enableCalibrateAndFocusActions(true);
@@ -943,8 +924,7 @@ void EnggDiffractionPresenter::processStopFocus() {
   if (m_workerThread) {
     if (m_workerThread->isRunning()) {
       g_log.notice() << "A focus process is currently running, shutting "
-                        "it down as soon as possible..."
-                     << std::endl;
+                        "it down as soon as possible..." << std::endl;
 
       g_abortThread = true;
       g_log.warning() << "Focus Stop has been clicked, please wait until "
@@ -1263,6 +1243,9 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
   g_log.notice() << "Generating new calibration file: " << outFilename
                  << std::endl;
 
+  std::cerr << "In doNewCalibration, vanNo: " << vanNo
+            << ", ceriaNo: " << ceriaNo << " specNos: " << specNos << std::endl;
+
   EnggDiffCalibSettings cs = m_view->currentCalibSettings();
   Mantid::Kernel::ConfigServiceImpl &conf =
       Mantid::Kernel::ConfigService::Instance();
@@ -1282,13 +1265,11 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
   } catch (std::runtime_error &) {
     g_log.error() << "The calibration calculations failed. One of the "
                      "algorithms did not execute correctly. See log messages "
-                     "for details. "
-                  << std::endl;
+                     "for details. " << std::endl;
   } catch (std::invalid_argument &) {
     g_log.error()
         << "The calibration calculations failed. Some input properties "
-           "were not valid. See log messages for details. "
-        << std::endl;
+           "were not valid. See log messages for details. " << std::endl;
   }
   // restore normal data search paths
   conf.setDataSearchDirs(tmpDirs);
@@ -1707,8 +1688,7 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
     g_lastValidRun = runNo;
 
     g_log.notice() << "Generating new focusing workspace(s) and file(s) into "
-                      "this directory: "
-                   << dir << std::endl;
+                      "this directory: " << dir << std::endl;
 
     // TODO: this is almost 100% common with doNewCalibrate() - refactor
     EnggDiffCalibSettings cs = m_view->currentCalibSettings();
@@ -1751,8 +1731,7 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
           loadDetectorGroupingCSV(dgFile, bankIDs, specs);
         } catch (std::runtime_error &re) {
           g_log.error() << "Error loading detector grouping file: " + dgFile +
-                               ". Detailed error: " + re.what()
-                        << std::endl;
+                               ". Detailed error: " + re.what() << std::endl;
           bankIDs.clear();
           specs.clear();
         }
@@ -1768,8 +1747,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
           fpath.append(effectiveFilenames[idx]).toString();
       g_log.notice() << "Generating new focused file (bank " +
                             boost::lexical_cast<std::string>(bankIDs[idx]) +
-                            ") for run " + runNo + " into: "
-                     << effectiveFilenames[idx] << std::endl;
+                            ") for run " + runNo +
+                            " into: " << effectiveFilenames[idx] << std::endl;
       try {
         m_focusFinishedOK = false;
         doFocusing(cs, fullFilename, runNo, bankIDs[idx], specs[idx], dgFile);
@@ -1782,8 +1761,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
       } catch (std::invalid_argument &ia) {
         g_log.error() << "The focusing failed. Some input properties "
                          "were not valid. "
-                         "See log messages for details. Error: "
-                      << ia.what() << std::endl;
+                         "See log messages for details. Error: " << ia.what()
+                      << std::endl;
       }
     }
 
@@ -1879,8 +1858,7 @@ void EnggDiffractionPresenter::focusingFinished() {
     if (lastRun != lastValid) {
       g_log.warning()
           << "Focussing process has been stopped, last successful "
-             "run number: "
-          << g_lastValidRun
+             "run number: " << g_lastValidRun
           << " , total number of focus run that could not be processed: "
           << (lastRun - lastValid) << std::endl;
     }
@@ -1959,8 +1937,7 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
 
     if (multi_RunNo.size() == 1) {
       g_log.notice() << "Only single file has been listed, the Sum Of Files"
-                        "cannot not be processed"
-                     << std::endl;
+                        "cannot not be processed" << std::endl;
     } else {
       g_log.notice()
           << "Load alogirthm has successfully merged the files provided"
@@ -2130,8 +2107,7 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "This is possibly because some of the settings are not "
                        "consistent. Please check the log messages for "
                        "details. Details: " +
-                           std::string(ia.what())
-                    << std::endl;
+                           std::string(ia.what()) << std::endl;
       throw;
     } catch (std::runtime_error &re) {
       g_log.error() << "Failed to calculate Vanadium corrections. "
@@ -2140,15 +2116,14 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "There was no obvious error in the input properties "
                        "but the algorithm failed. Please check the log "
                        "messages for details." +
-                           std::string(re.what())
-                    << std::endl;
+                           std::string(re.what()) << std::endl;
       throw;
     }
   } else {
     g_log.notice() << "Found precalculated Vanadium correction features for "
-                      "Vanadium run "
-                   << vanNo << ". Re-using these files: " << preIntegFilename
-                   << ", and " << preCurvesFilename << std::endl;
+                      "Vanadium run " << vanNo
+                   << ". Re-using these files: " << preIntegFilename << ", and "
+                   << preCurvesFilename << std::endl;
     try {
       loadVanadiumPrecalcWorkspaces(preIntegFilename, preCurvesFilename,
                                     vanIntegWS, vanCurvesWS, vanNo, specNos);
@@ -2411,15 +2386,14 @@ void EnggDiffractionPresenter::doRebinningTime(const std::string &runNo,
   } catch (std::invalid_argument &ia) {
     g_log.error() << "Error when rebinning with a regular bin width in time. "
                      "There was an error in the inputs to the algorithm " +
-                         rebinName + ". Error description: " + ia.what() + "."
-                  << std::endl;
+                         rebinName + ". Error description: " + ia.what() +
+                         "." << std::endl;
     return;
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning with a regular bin width in time. "
                      "Coult not run the algorithm " +
                          rebinName + " successfully. Error description: " +
-                         re.what() + "."
-                  << std::endl;
+                         re.what() + "." << std::endl;
     return;
   }
 
@@ -2515,15 +2489,14 @@ void EnggDiffractionPresenter::doRebinningPulses(const std::string &runNo,
   } catch (std::invalid_argument &ia) {
     g_log.error() << "Error when rebinning by pulse times. "
                      "There was an error in the inputs to the algorithm " +
-                         rebinName + ". Error description: " + ia.what() + "."
-                  << std::endl;
+                         rebinName + ". Error description: " + ia.what() +
+                         "." << std::endl;
     return;
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning by pulse times. "
                      "Coult not run the algorithm " +
                          rebinName + " successfully. Error description: " +
-                         re.what() + "."
-                  << std::endl;
+                         re.what() + "." << std::endl;
     return;
   }
 
@@ -2577,8 +2550,7 @@ void EnggDiffractionPresenter::rebinningFinished() {
         << std::endl;
   } else {
     g_log.notice() << "Pre-processing (re-binning) finished - the output "
-                      "workspace is ready."
-                   << std::endl;
+                      "workspace is ready." << std::endl;
   }
   if (m_workerThread) {
     delete m_workerThread;

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1028,15 +1028,12 @@ EnggDiffractionPresenter::isValidMultiRunNumber(std::vector<std::string> dir) {
   std::vector<std::string> multi_run_number;
 
   // if empty string
-  size_t i = 0;
-  if (!dir.empty() && dir.at(i) != "") {
+  if (!dir.empty() && dir.at(0) != "") {
 
     auto p = run_vec.begin();
-    int i = 0;
     while (p != run_vec.end()) {
       run_number = *p;
       p++;
-      i++;
 
       try {
         if (Poco::File(run_number).exists()) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -949,30 +949,24 @@ bool EnggDiffractionPresenter::validateRBNumber(const std::string &rbn) const {
 * provided it will convert it to a run number. It also records the
 * paths the user has browsed to.
 *
-* @param path the input/directory given by the user via the "browse"
+* @param userPaths the input/directory given by the user via the "browse"
 * button
 *
 * @return run_number 6 character string of a run number
 */
 std::string EnggDiffractionPresenter::isValidRunNumber(
-    const std::vector<std::string> &path) {
+    const std::vector<std::string> &userPaths) {
 
   std::string run_number;
-  if (path.empty()) {
+  if (userPaths.empty() || userPaths.front().empty()) {
     return run_number;
   }
 
-  std::vector<std::string> run_vec = path;
-
-  auto p = run_vec.begin();
-  while (p != run_vec.end()) {
-    run_number = *p;
-    p++;
-
+  for (const auto &path : userPaths) {
+    run_number = "";
     try {
-      if (Poco::File(run_number).exists()) {
-        Poco::Path inputDir = run_number;
-        run_number = "";
+      if (Poco::File(path).exists()) {
+        Poco::Path inputDir = path;
 
         // get file name via poco::path
         std::string filename = inputDir.getFileName();
@@ -1002,7 +996,7 @@ std::string EnggDiffractionPresenter::isValidRunNumber(
     }
   }
 
-  g_log.debug() << "Run number inferred from browse path (" << path.front()
+  g_log.debug() << "Run number inferred from browse path (" << userPaths.front()
                 << ") is: " << run_number << std::endl;
 
   return run_number;
@@ -1011,29 +1005,22 @@ std::string EnggDiffractionPresenter::isValidRunNumber(
 /**
 * Checks if the provided run number is valid and if a directory is provided
 *
-* @param dir takes the input/directory of the user
+* @param paths takes the input/paths of the user
 *
 * @return vector of string multi_run_number, 6 character string of a run number
 */
-std::vector<std::string>
-EnggDiffractionPresenter::isValidMultiRunNumber(std::vector<std::string> dir) {
+std::vector<std::string> EnggDiffractionPresenter::isValidMultiRunNumber(
+    const std::vector<std::string> &paths) {
 
   std::vector<std::string> multi_run_number;
-  if (dir.empty())
+  if (paths.empty() || paths.front().empty())
     return multi_run_number;
 
-  std::vector<std::string> run_vec = dir;
-  std::string run_number;
-
-  auto p = run_vec.begin();
-  while (p != run_vec.end()) {
-    run_number = *p;
-    p++;
-
+  for (auto path : paths) {
+    std::string run_number;
     try {
-      if (Poco::File(run_number).exists()) {
-        Poco::Path inputDir = run_number;
-        run_number = "";
+      if (Poco::File(path).exists()) {
+        Poco::Path inputDir = path;
 
         // get file name name via poco::path
         std::string filename = inputDir.getFileName();
@@ -1061,8 +1048,10 @@ EnggDiffractionPresenter::isValidMultiRunNumber(std::vector<std::string> dir) {
     multi_run_number.push_back(run_number);
   }
 
-  g_log.debug() << "Run number inferred from a multi-run selection: "
-                << run_number << std::endl;
+  g_log.debug()
+      << "First and last run number inferred from a multi-run selection: "
+      << multi_run_number.front() << " ... " << multi_run_number.back()
+      << std::endl;
 
   return multi_run_number;
 }

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -35,8 +35,12 @@ const std::string EnggDiffractionPresenter::g_runNumberErrorStr =
 
 // discouraged at the moment
 const bool EnggDiffractionPresenter::g_askUserCalibFilename = false;
+
 const std::string EnggDiffractionPresenter::g_vanIntegrationWSName =
     "engggui_vanadium_integration_ws";
+const std::string EnggDiffractionPresenter::g_vanCurvesWSName =
+    "engggui_vanadium_curves_ws";
+
 int EnggDiffractionPresenter::g_croppedCounter = 0;
 int EnggDiffractionPresenter::g_plottingCounter = 0;
 bool EnggDiffractionPresenter::g_abortThread = false;
@@ -2244,7 +2248,7 @@ void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
       Mantid::API::AlgorithmManager::Instance().createUnmanaged("LoadNexus");
   algCurves->initialize();
   algCurves->setPropertyValue("Filename", preCurvesFilename);
-  std::string curvesWSName = "engggui_vanadium_curves_ws";
+  const std::string curvesWSName = g_vanCurvesWSName;
   algCurves->setPropertyValue("OutputWorkspace", curvesWSName);
   algCurves->execute();
   // algCurves->getProperty("OutputWorkspace");
@@ -2314,7 +2318,7 @@ void EnggDiffractionPresenter::calcVanadiumWorkspaces(
   alg->setProperty("VanadiumWorkspace", vanWS);
   std::string integName = g_vanIntegrationWSName;
   alg->setPropertyValue("OutIntegrationWorkspace", integName);
-  std::string curvesName = "engggui_van_curves_ws";
+  const std::string curvesName = g_vanCurvesWSName;
   alg->setPropertyValue("OutCurvesWorkspace", curvesName);
   alg->execute();
 
@@ -2615,8 +2619,7 @@ void EnggDiffractionPresenter::plotCalibWorkspace(std::vector<double> difc,
     if (g_plottingCounter == 1) {
       m_view->plotVanCurvesCalibOutput();
     } else {
-      m_view->plotReplacingWindow("engggui_vanadium_curves_ws", "[0, 1, 2]",
-                                  "2");
+      m_view->plotReplacingWindow(g_vanCurvesWSName, "[0, 1, 2]", "2");
     }
 
     // Get the Customised Bank Name text-ield string from qt

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -401,9 +401,11 @@ void EnggDiffractionViewQtGUI::readSettings() {
   m_uiTabFocus.checkBox_save_output_files->setChecked(
       qs.value("user-params-focus-save-output-files", true).toBool());
 
-  m_uiTabFocus.comboBox_PlotData->setCurrentIndex(0);
+  m_uiTabFocus.comboBox_PlotData->setCurrentIndex(
+      qs.value("user-params-focus-plot-type", 0).toInt());
 
-  m_uiTabFocus.comboBox_Multi_Runs->setCurrentIndex(0);
+  m_uiTabFocus.comboBox_Multi_Runs->setCurrentIndex(
+      qs.value("user-params-multiple-runs-focus-mode", 0).toInt());
 
   // pre-processing (re-binning)
   m_uiTabPreproc.MWRunFiles_preproc_run_num->setUserInput(
@@ -520,6 +522,12 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
 
   qs.setValue("user-params-focus-save-output-files",
               m_uiTabFocus.checkBox_plot_focused_ws->isChecked());
+
+  qs.setValue("user-params-focus-plot-type",
+              m_uiTabFocus.comboBox_PlotData->currentIndex());
+
+  qs.setValue("user-params-multiple-runs-focus-mode",
+              m_uiTabFocus.comboBox_Multi_Runs->currentIndex());
 
   // pre-processing (re-binning)
   qs.setValue("user-params-preproc-runno",

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -1233,7 +1233,7 @@ EnggDiffractionViewQtGUI::qListToVector(QStringList list,
                                         bool validator) const {
   std::vector<std::string> vec;
   if (validator) {
-    foreach (QString str, list) { vec.push_back(str.toStdString()); }
+    foreach (const QString &str, list) { vec.push_back(str.toStdString()); }
     return vec;
   } else {
     return vec;

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -141,8 +141,6 @@ void EnggDiffractionViewQtGUI::doSetupTabCalib() {
       QString::fromStdString(vanadiumRun));
   m_uiTabCalib.lineEdit_new_ceria_num->setUserInput(
       QString::fromStdString(ceriaRun));
-  m_uiTabCalib.lineEdit_cropped_run_num->setUserInput(
-      QString::fromStdString(ceriaRun));
 
   // push button signals/slots
   connect(m_uiTabCalib.pushButton_load_calib, SIGNAL(released()), this,
@@ -344,9 +342,6 @@ void EnggDiffractionViewQtGUI::readSettings() {
 
   m_uiTabCalib.groupBox_calib_cropped->setChecked(
       qs.value("user-params-calib-cropped-group-checkbox", false).toBool());
-
-  m_uiTabCalib.lineEdit_cropped_run_num->setText(
-      qs.value("user-params-new-ceria-num", "").toString());
 
   m_uiTabCalib.comboBox_calib_cropped_bank_name->setCurrentIndex(0);
 
@@ -1286,7 +1281,6 @@ void EnggDiffractionViewQtGUI::plotFocusStatus() {
 
 void EnggDiffractionViewQtGUI::updateCroppedCalibRun() {
   auto ceria = m_uiTabCalib.lineEdit_new_ceria_num->getText();
-  m_uiTabCalib.lineEdit_cropped_run_num->setText(ceria);
 }
 
 void EnggDiffractionViewQtGUI::calibspecNoChanged(int /*idx*/) {
@@ -1632,7 +1626,6 @@ void EnggDiffractionViewQtGUI::setPrefix(std::string prefix) {
   // focus tab
   m_uiTabFocus.lineEdit_run_num->setInstrumentOverride(prefixInput);
   m_uiTabFocus.lineEdit_texture_run_num->setInstrumentOverride(prefixInput);
-  m_uiTabFocus.lineEdit_cropped_run_num->setInstrumentOverride(prefixInput);
 
   // calibration tab
   m_uiTabCalib.lineEdit_new_ceria_num->setInstrumentOverride(prefixInput);
@@ -1640,7 +1633,6 @@ void EnggDiffractionViewQtGUI::setPrefix(std::string prefix) {
 
   // rebin tab
   m_uiTabPreproc.MWRunFiles_preproc_run_num->setInstrumentOverride(prefixInput);
-  m_uiTabCalib.lineEdit_cropped_run_num->setInstrumentOverride(prefixInput);
 }
 
 void EnggDiffractionViewQtGUI::closeEvent(QCloseEvent *event) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -394,10 +394,10 @@ void EnggDiffractionViewQtGUI::readSettings() {
   m_uiTabFocus.groupBox_texture->setChecked(
       qs.value("user-params-focus-texture-group-checkbox", false).toBool());
 
-  m_uiTabFocus.checkBox_plot_focus_ws->setChecked(
+  m_uiTabFocus.checkBox_plot_focused_ws->setChecked(
       qs.value("user-params-focus-plot-focused-ws", true).toBool());
 
-  m_uiTabFocus.checkBox_plotfocused_ws->setChecked(
+  m_uiTabFocus.checkBox_save_output_files->setChecked(
       qs.value("user-params-focus-save-output-files", true).toBool());
 
   m_uiTabFocus.comboBox_PlotData->setCurrentIndex(0);
@@ -515,10 +515,10 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
               m_uiTabFocus.groupBox_texture->isChecked());
 
   qs.setValue("user-params-focus-plot-focused-ws",
-              m_uiTabFocus.checkBox_plotfocused_ws->isChecked());
+              m_uiTabFocus.checkBox_plot_focused_ws->isChecked());
 
   qs.setValue("user-params-focus-save-output-files",
-              m_uiTabFocus.checkBox_plotfocused_ws->isChecked());
+              m_uiTabFocus.checkBox_plot_focused_ws->isChecked());
 
   // pre-processing (re-binning)
   qs.setValue("user-params-preproc-runno",
@@ -673,7 +673,7 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
   m_uiTabFocus.groupBox_texture->setEnabled(enable);
 
   m_uiTabFocus.pushButton_focus->setEnabled(enable);
-  m_uiTabFocus.checkBox_plot_focus_ws->setEnabled(enable);
+  m_uiTabFocus.checkBox_plot_focused_ws->setEnabled(enable);
   m_uiTabFocus.checkBox_save_output_files->setEnabled(enable);
   m_uiTabFocus.comboBox_Multi_Runs->setEnabled(enable);
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -193,7 +193,7 @@ void EnggDiffractionViewQtGUI::doSetupTabFocus() {
   connect(m_uiTabFocus.comboBox_Multi_Runs, SIGNAL(currentIndexChanged(int)),
           this, SLOT(multiRunModeChanged(int)));
 
-  connect(m_uiTabFocus.checkBox_FocusedWS, SIGNAL(clicked()), this,
+  connect(m_uiTabFocus.checkBox_plot_focused_ws, SIGNAL(clicked()), this,
           SLOT(plotFocusStatus()));
 }
 
@@ -251,8 +251,7 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
           SLOT(savePeakList()));
 
   m_uiTabFitting.dataPlot->setCanvasBackground(Qt::white);
-  m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::xBottom,
-                                        "d-Spacing (A)");
+  m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::xBottom, "d-Spacing (A)");
   m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::yLeft, "Counts (us)^-1");
   QFont font("MS Shell Dlg 2", 8);
   m_uiTabFitting.dataPlot->setAxisFont(QwtPlot::xBottom, font);
@@ -395,8 +394,11 @@ void EnggDiffractionViewQtGUI::readSettings() {
   m_uiTabFocus.groupBox_texture->setChecked(
       qs.value("user-params-focus-texture-group-checkbox", false).toBool());
 
-  m_uiTabFocus.checkBox_FocusedWS->setChecked(
-      qs.value("user-params-focus-plot-ws", true).toBool());
+  m_uiTabFocus.checkBox_plot_focus_ws->setChecked(
+      qs.value("user-params-focus-plot-focused-ws", true).toBool());
+
+  m_uiTabFocus.checkBox_plotfocused_ws->setChecked(
+      qs.value("user-params-focus-save-output-files", true).toBool());
 
   m_uiTabFocus.comboBox_PlotData->setCurrentIndex(0);
 
@@ -512,7 +514,11 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
   qs.setValue("user-params-focus-texture-group-checkbox",
               m_uiTabFocus.groupBox_texture->isChecked());
 
-  qs.setValue("value", m_uiTabFocus.checkBox_FocusedWS->isChecked());
+  qs.setValue("user-params-focus-plot-focused-ws",
+              m_uiTabFocus.checkBox_plotfocused_ws->isChecked());
+
+  qs.setValue("user-params-focus-save-output-files",
+              m_uiTabFocus.checkBox_plotfocused_ws->isChecked());
 
   // pre-processing (re-binning)
   qs.setValue("user-params-preproc-runno",
@@ -667,8 +673,8 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
   m_uiTabFocus.groupBox_texture->setEnabled(enable);
 
   m_uiTabFocus.pushButton_focus->setEnabled(enable);
-  m_uiTabFocus.checkBox_FocusedWS->setEnabled(enable);
-  m_uiTabFocus.checkBox_SaveOutputFiles->setEnabled(enable);
+  m_uiTabFocus.checkBox_plot_focus_ws->setEnabled(enable);
+  m_uiTabFocus.checkBox_save_output_files->setEnabled(enable);
   m_uiTabFocus.comboBox_Multi_Runs->setEnabled(enable);
 
   m_uiTabFocus.pushButton_focus->setEnabled(enable);
@@ -1261,7 +1267,7 @@ std::string EnggDiffractionViewQtGUI::focusingTextureGroupingFile() const {
 }
 
 bool EnggDiffractionViewQtGUI::focusedOutWorkspace() const {
-  return m_uiTabFocus.checkBox_FocusedWS->checkState();
+  return m_uiTabFocus.checkBox_plot_focused_ws->checkState();
 }
 
 bool EnggDiffractionViewQtGUI::plotCalibWorkspace() const {
@@ -1269,7 +1275,7 @@ bool EnggDiffractionViewQtGUI::plotCalibWorkspace() const {
 }
 
 bool EnggDiffractionViewQtGUI::saveFocusedOutputFiles() const {
-  return m_uiTabFocus.checkBox_SaveOutputFiles->checkState();
+  return m_uiTabFocus.checkBox_save_output_files->checkState();
 }
 
 void EnggDiffractionViewQtGUI::plotFocusStatus() {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -112,6 +112,10 @@ void EnggDiffractionViewQtGUI::initLayout() {
   m_currentInst = inst->currentText().toStdString();
 
   setPrefix(m_currentInst);
+  // An initial check on the RB number will enable the tabs after all
+  // the widgets and connections are set up
+  enableTabs(false);
+
   readSettings();
 
   // basic UI setup, connect signals, etc.
@@ -313,8 +317,6 @@ void EnggDiffractionViewQtGUI::doSetupTabSettings() {
 }
 
 void EnggDiffractionViewQtGUI::doSetupGeneralWidgets() {
-  enableTabs(false);
-
   // change instrument
   connect(m_ui.comboBox_instrument, SIGNAL(currentIndexChanged(int)), this,
           SLOT(instrumentChanged(int)));
@@ -456,6 +458,8 @@ void EnggDiffractionViewQtGUI::readSettings() {
   // 'focusing' block
   m_focusDir = qs.value("focus-dir").toString().toStdString();
 
+  m_ui.tabMain->setCurrentIndex(qs.value("selected-tab-index").toInt());
+
   restoreGeometry(qs.value("interface-win-geometry").toByteArray());
   qs.endGroup();
 }
@@ -563,6 +567,8 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
 
   // 'focusing' block
   qs.setValue("focus-dir", QString::fromStdString(m_focusDir));
+
+  qs.setValue("selected-tab-index", m_ui.tabMain->currentIndex());
 
   qs.setValue("interface-win-geometry", saveGeometry());
   qs.endGroup();

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -348,8 +348,6 @@ void EnggDiffractionViewQtGUI::readSettings() {
   m_uiTabCalib.lineEdit_cropped_run_num->setText(
       qs.value("user-params-new-ceria-num", "").toString());
 
-  m_uiTabCalib.lineEdit_cropped_run_num->setReadOnly(true);
-
   m_uiTabCalib.comboBox_calib_cropped_bank_name->setCurrentIndex(0);
 
   m_uiTabCalib.lineEdit_cropped_spec_nos->setText(

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -31,7 +31,9 @@ namespace CustomInterfaces {
 
 // Add this class to the list of specialised dialogs in this namespace
 DECLARE_SUBWINDOW(EnggDiffractionViewQtGUI)
+
 const double EnggDiffractionViewQtGUI::g_defaultRebinWidth = -0.0005;
+
 int EnggDiffractionViewQtGUI::m_currentType = 0;
 int EnggDiffractionViewQtGUI::m_currentRunMode = 0;
 int EnggDiffractionViewQtGUI::m_currentCropCalibBankName = 0;
@@ -132,15 +134,24 @@ void EnggDiffractionViewQtGUI::initLayout() {
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabCalib() {
-  // Last available runs. This (as well as the empty defaults just
-  // above) should probably be made persistent - and encapsulated into a
-  // CalibrationParameters or similar class/structure
+  // Some recent available runs as defaults. This (as well as the
+  // empty defaults just above) should probably be made persistent -
+  // and encapsulated into a CalibrationParameters or similar
+  // class/structure
   const std::string vanadiumRun = "236516";
   const std::string ceriaRun = "241391";
-  m_uiTabCalib.lineEdit_new_vanadium_num->setUserInput(
-      QString::fromStdString(vanadiumRun));
-  m_uiTabCalib.lineEdit_new_ceria_num->setUserInput(
-      QString::fromStdString(ceriaRun));
+  if (m_uiTabCalib.MWRunFiles_new_vanadium_num->getUserInput()
+          .toString()
+          .isEmpty()) {
+    m_uiTabCalib.MWRunFiles_new_vanadium_num->setUserInput(
+        QString::fromStdString(vanadiumRun));
+  }
+  if (m_uiTabCalib.MWRunFiles_new_ceria_num->getUserInput()
+          .toString()
+          .isEmpty()) {
+    m_uiTabCalib.MWRunFiles_new_ceria_num->setUserInput(
+        QString::fromStdString(ceriaRun));
+  }
 
   // push button signals/slots
   connect(m_uiTabCalib.pushButton_load_calib, SIGNAL(released()), this,
@@ -155,9 +166,6 @@ void EnggDiffractionViewQtGUI::doSetupTabCalib() {
   connect(m_uiTabCalib.comboBox_calib_cropped_bank_name,
           SIGNAL(currentIndexChanged(int)), this,
           SLOT(calibspecNoChanged(int)));
-
-  connect(m_uiTabCalib.lineEdit_new_ceria_num, SIGNAL(fileTextChanged(QString)),
-          this, SLOT(updateCroppedCalibRun()));
 
   connect(m_uiTabCalib.comboBox_calib_cropped_bank_name,
           SIGNAL(currentIndexChanged(int)), this, SLOT(enableSpecNos()));
@@ -182,7 +190,7 @@ void EnggDiffractionViewQtGUI::doSetupTabFocus() {
   connect(m_uiTabFocus.pushButton_reset, SIGNAL(released()), this,
           SLOT(focusResetClicked()));
 
-  connect(m_uiTabFocus.pushButton_stopFocus, SIGNAL(released()), this,
+  connect(m_uiTabFocus.pushButton_stop_focus, SIGNAL(released()), this,
           SLOT(focusStopClicked()));
 
   connect(m_uiTabFocus.comboBox_PlotData, SIGNAL(currentIndexChanged(int)),
@@ -335,9 +343,9 @@ void EnggDiffractionViewQtGUI::readSettings() {
   m_uiTabCalib.lineEdit_current_calib_filename->setText(calibFname);
   m_currentCalibFilename = calibFname.toStdString();
 
-  m_uiTabCalib.lineEdit_new_vanadium_num->setText(
+  m_uiTabCalib.MWRunFiles_new_vanadium_num->setUserInput(
       qs.value("user-params-new-vanadium-num", "").toString());
-  m_uiTabCalib.lineEdit_new_ceria_num->setText(
+  m_uiTabCalib.MWRunFiles_new_ceria_num->setUserInput(
       qs.value("user-params-new-ceria-num", "").toString());
 
   m_uiTabCalib.groupBox_calib_cropped->setChecked(
@@ -356,7 +364,7 @@ void EnggDiffractionViewQtGUI::readSettings() {
       qs.value("user-param-calib-plot-data", true).toBool());
 
   // user params - focusing
-  m_uiTabFocus.lineEdit_run_num->setUserInput(
+  m_uiTabFocus.MWRunFiles_run_num->setUserInput(
       qs.value("user-params-focus-runno", "").toString());
 
   qs.beginReadArray("user-params-focus-bank_i");
@@ -368,13 +376,13 @@ void EnggDiffractionViewQtGUI::readSettings() {
       qs.value("value", true).toBool());
   qs.endArray();
 
-  m_uiTabFocus.lineEdit_cropped_run_num->setUserInput(
+  m_uiTabFocus.MWRunFiles_cropped_run_num->setUserInput(
       qs.value("user-params-focus-cropped-runno", "").toString());
 
   m_uiTabFocus.lineEdit_cropped_spec_nos->setText(
       qs.value("user-params-focus-cropped-spectrum-nos", "").toString());
 
-  m_uiTabFocus.lineEdit_texture_run_num->setUserInput(
+  m_uiTabFocus.MWRunFiles_texture_run_num->setUserInput(
       qs.value("user-params-focus-texture-runno", "").toString());
 
   m_uiTabFocus.lineEdit_texture_grouping_file->setText(
@@ -464,9 +472,9 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
               m_uiTabCalib.lineEdit_current_calib_filename->text());
 
   qs.setValue("user-params-new-vanadium-num",
-              m_uiTabCalib.lineEdit_new_vanadium_num->getText());
+              m_uiTabCalib.MWRunFiles_new_vanadium_num->getText());
   qs.setValue("user-params-new-ceria-num",
-              m_uiTabCalib.lineEdit_new_ceria_num->getText());
+              m_uiTabCalib.MWRunFiles_new_ceria_num->getText());
 
   qs.setValue("user-params-calib-cropped-group-checkbox",
               m_uiTabCalib.groupBox_calib_cropped->isChecked());
@@ -482,7 +490,7 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
 
   // user params - focusing
   qs.setValue("user-params-focus-runno",
-              m_uiTabFocus.lineEdit_run_num->getText());
+              m_uiTabFocus.MWRunFiles_run_num->getText());
 
   qs.beginWriteArray("user-params-focus-bank_i");
   qs.setArrayIndex(0);
@@ -492,12 +500,12 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
   qs.endArray();
 
   qs.setValue("user-params-focus-cropped-runno",
-              m_uiTabFocus.lineEdit_cropped_run_num->getText());
+              m_uiTabFocus.MWRunFiles_cropped_run_num->getText());
   qs.setValue("user-params-focus-cropped-spectrum-nos",
               m_uiTabFocus.lineEdit_cropped_spec_nos->text());
 
   qs.setValue("user-params-focus-texture-runno",
-              m_uiTabFocus.lineEdit_texture_run_num->getText());
+              m_uiTabFocus.MWRunFiles_texture_run_num->getText());
   qs.setValue("user-params-focus-texture-detector-grouping-file",
               m_uiTabFocus.lineEdit_texture_grouping_file->text());
 
@@ -620,13 +628,13 @@ std::string EnggDiffractionViewQtGUI::currentCeriaNo() const {
 }
 
 std::vector<std::string> EnggDiffractionViewQtGUI::newVanadiumNo() const {
-  return qListToVector(m_uiTabCalib.lineEdit_new_vanadium_num->getFilenames(),
-                       m_uiTabCalib.lineEdit_new_vanadium_num->isValid());
+  return qListToVector(m_uiTabCalib.MWRunFiles_new_vanadium_num->getFilenames(),
+                       m_uiTabCalib.MWRunFiles_new_vanadium_num->isValid());
 }
 
 std::vector<std::string> EnggDiffractionViewQtGUI::newCeriaNo() const {
-  return qListToVector(m_uiTabCalib.lineEdit_new_ceria_num->getFilenames(),
-                       m_uiTabCalib.lineEdit_new_ceria_num->isValid());
+  return qListToVector(m_uiTabCalib.MWRunFiles_new_ceria_num->getFilenames(),
+                       m_uiTabCalib.MWRunFiles_new_ceria_num->isValid());
 }
 
 std::string EnggDiffractionViewQtGUI::currentCalibFile() const {
@@ -660,18 +668,15 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
   m_uiTabCalib.checkBox_PlotData_Calib->setEnabled(enable);
 
   // focus
-  m_uiTabFocus.lineEdit_run_num->setEnabled(enable);
+  m_uiTabFocus.MWRunFiles_run_num->setEnabled(enable);
+  m_uiTabFocus.pushButton_focus->setEnabled(enable);
 
   m_uiTabFocus.groupBox_cropped->setEnabled(enable);
   m_uiTabFocus.groupBox_texture->setEnabled(enable);
+  m_uiTabFocus.groupBox_focus_output_options->setEnabled(enable);
 
-  m_uiTabFocus.pushButton_focus->setEnabled(enable);
-  m_uiTabFocus.checkBox_plot_focused_ws->setEnabled(enable);
-  m_uiTabFocus.checkBox_save_output_files->setEnabled(enable);
-  m_uiTabFocus.comboBox_Multi_Runs->setEnabled(enable);
-
-  m_uiTabFocus.pushButton_focus->setEnabled(enable);
-  m_uiTabFocus.pushButton_stopFocus->setDisabled(enable);
+  m_uiTabFocus.pushButton_stop_focus->setDisabled(enable);
+  m_uiTabFocus.pushButton_reset->setEnabled(enable);
 
   // pre-processing
   m_uiTabPreproc.MWRunFiles_preproc_run_num->setEnabled(enable);
@@ -927,17 +932,17 @@ void EnggDiffractionViewQtGUI::plotDifcZeroCalibOutput(
 }
 
 void EnggDiffractionViewQtGUI::resetFocus() {
-  m_uiTabFocus.lineEdit_run_num->setText("");
+  m_uiTabFocus.MWRunFiles_run_num->setUserInput("");
   m_uiTabFocus.checkBox_focus_bank1->setChecked(true);
   m_uiTabFocus.checkBox_focus_bank2->setChecked(true);
 
-  m_uiTabFocus.lineEdit_cropped_run_num->setText("");
+  m_uiTabFocus.MWRunFiles_cropped_run_num->setUserInput("");
   m_uiTabFocus.lineEdit_cropped_spec_nos->setText("");
 
   m_uiTabFocus.groupBox_cropped->setChecked(false);
   m_uiTabFocus.groupBox_texture->setChecked(false);
 
-  m_uiTabFocus.lineEdit_texture_run_num->setText("");
+  m_uiTabFocus.MWRunFiles_run_num->setUserInput("");
   m_uiTabFocus.lineEdit_texture_grouping_file->setText("");
 }
 
@@ -1212,20 +1217,20 @@ void EnggDiffractionViewQtGUI::browsePeaksToFit() {
 }
 
 std::vector<std::string> EnggDiffractionViewQtGUI::focusingRunNo() const {
-  return qListToVector(m_uiTabFocus.lineEdit_run_num->getFilenames(),
-                       m_uiTabFocus.lineEdit_run_num->isValid());
+  return qListToVector(m_uiTabFocus.MWRunFiles_run_num->getFilenames(),
+                       m_uiTabFocus.MWRunFiles_run_num->isValid());
 }
 
 std::vector<std::string>
 EnggDiffractionViewQtGUI::focusingCroppedRunNo() const {
-  return qListToVector(m_uiTabFocus.lineEdit_cropped_run_num->getFilenames(),
-                       m_uiTabFocus.lineEdit_cropped_run_num->isValid());
+  return qListToVector(m_uiTabFocus.MWRunFiles_cropped_run_num->getFilenames(),
+                       m_uiTabFocus.MWRunFiles_cropped_run_num->isValid());
 }
 
 std::vector<std::string>
 EnggDiffractionViewQtGUI::focusingTextureRunNo() const {
-  return qListToVector(m_uiTabFocus.lineEdit_texture_run_num->getFilenames(),
-                       m_uiTabFocus.lineEdit_texture_run_num->isValid());
+  return qListToVector(m_uiTabFocus.MWRunFiles_texture_run_num->getFilenames(),
+                       m_uiTabFocus.MWRunFiles_texture_run_num->isValid());
 }
 
 std::vector<std::string>
@@ -1234,10 +1239,9 @@ EnggDiffractionViewQtGUI::qListToVector(QStringList list,
   std::vector<std::string> vec;
   if (validator) {
     foreach (const QString &str, list) { vec.push_back(str.toStdString()); }
-    return vec;
-  } else {
-    return vec;
   }
+
+  return vec;
 }
 
 std::string EnggDiffractionViewQtGUI::focusingDir() const {
@@ -1277,10 +1281,6 @@ void EnggDiffractionViewQtGUI::plotFocusStatus() {
   } else {
     m_uiTabFocus.comboBox_PlotData->setEnabled(false);
   }
-}
-
-void EnggDiffractionViewQtGUI::updateCroppedCalibRun() {
-  auto ceria = m_uiTabCalib.lineEdit_new_ceria_num->getText();
 }
 
 void EnggDiffractionViewQtGUI::calibspecNoChanged(int /*idx*/) {
@@ -1624,12 +1624,12 @@ void EnggDiffractionViewQtGUI::userSelectInstrument(const QString &prefix) {
 void EnggDiffractionViewQtGUI::setPrefix(std::string prefix) {
   QString prefixInput = QString::fromStdString(prefix);
   // focus tab
-  m_uiTabFocus.lineEdit_run_num->setInstrumentOverride(prefixInput);
-  m_uiTabFocus.lineEdit_texture_run_num->setInstrumentOverride(prefixInput);
+  m_uiTabFocus.MWRunFiles_run_num->setInstrumentOverride(prefixInput);
+  m_uiTabFocus.MWRunFiles_texture_run_num->setInstrumentOverride(prefixInput);
 
   // calibration tab
-  m_uiTabCalib.lineEdit_new_ceria_num->setInstrumentOverride(prefixInput);
-  m_uiTabCalib.lineEdit_new_vanadium_num->setInstrumentOverride(prefixInput);
+  m_uiTabCalib.MWRunFiles_new_ceria_num->setInstrumentOverride(prefixInput);
+  m_uiTabCalib.MWRunFiles_new_vanadium_num->setInstrumentOverride(prefixInput);
 
   // rebin tab
   m_uiTabPreproc.MWRunFiles_preproc_run_num->setInstrumentOverride(prefixInput);


### PR DESCRIPTION
Fixes all the issues described in #16087.

**To test:**
- Use the focus and calibrate tabs with the data from previous PRs, and the new example data for ENGIN-X. All the focus and calibration actions should work well and produce all the expected output plots and files. Pick some files from the "raw data dir", but also from other locations using the "browse" buttons.
- Check carefully every of the user interface issues identified in #16087.
- Check that the status and contents of all the widgets is remembered by the interface, especially when you use the "browse" option of the MWRunFiles widgets.
- Code should look good and all tests should pass.

Fixes #16087.

All these features were either working well in the past or have been introduced in this release and should have been working well. No release notes needed.
Small additions like remembering the selected tab do not deserve a release note.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
