### PR TITLE
WorkspaceGroup 3D plots: single-spectrum data

### DIFF
--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
@@ -179,12 +179,16 @@ void MantidWSIndexWidget::init() {
  */
 void MantidWSIndexWidget::initWorkspaceBox() {
   m_wsBox = new QVBoxLayout;
-  m_wsMessage = new QLabel(
-      tr("Enter Workspace Indices: " + m_wsIndexIntervals.toQString()));
+  const QString wsIndices = m_wsIndexIntervals.toQString();
+  m_wsMessage = new QLabel(tr("Enter Workspace Indices: " + wsIndices));
   m_wsField = new QLineEditWithErrorMark();
 
   m_wsField->lineEdit()->setValidator(
       new IntervalListValidator(this, m_wsIndexIntervals));
+  if (wsIndices == "0") { // single spectrum
+    m_wsField->lineEdit()->setEnabled(false);
+    m_wsField->lineEdit()->setText("0");
+  }
   m_wsBox->add(m_wsMessage);
   m_wsBox->add(m_wsField);
   m_outer->addItem(m_wsBox);
@@ -198,13 +202,17 @@ void MantidWSIndexWidget::initWorkspaceBox() {
  */
 void MantidWSIndexWidget::initSpectraBox() {
   m_spectraBox = new QVBoxLayout;
-  m_spectraMessage =
-      new QLabel(tr("Enter Spectra Numbers: " + m_spectraNumIntervals.toQString()));
+  const QString spectraNumbers = m_spectraNumIntervals.toQString();
+  m_spectraMessage = new QLabel(tr("Enter Spectra Numbers: " + spectraNumbers));
   m_spectraField = new QLineEditWithErrorMark();
   m_orMessage = new QLabel(tr("<br>Or"));
 
   m_spectraField->lineEdit()->setValidator(
       new IntervalListValidator(this, m_spectraNumIntervals));
+  if (spectraNumbers == "1") { // single spectrum
+    m_spectraField->lineEdit()->setEnabled(false);
+    m_spectraField->lineEdit()->setText("1");
+  }
   m_spectraBox->add(m_spectraMessage);
   m_spectraBox->add(m_spectraField);
   m_spectraBox->add(m_orMessage);

--- a/docs/source/release/v3.7.0/ui.rst
+++ b/docs/source/release/v3.7.0/ui.rst
@@ -33,6 +33,10 @@ Line plots
 .. figure::  ../../images/R37PlotAllErrorsOption.png
    :align: center
 
+3D plots from group workspaces
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- For single-spectrum data, the choice of spectrum number to plot has been disabled because it has only one possible answer.
+
 Instrument View
 ###############
 


### PR DESCRIPTION
When plotting 3D or contour plots from a WorkspaceGroup (on right-click), disable the choice of spectrum number for single-spectrum data.

(as there is only one possible choice: "1").

This doesn't affect the regular "plot spectrum" dialog as that is only shown when the data is not single-spectrum. (Here we still need to show the dialog as it has other options too).

**To test:**

Run the following script to create the groups:

``` python
to_group1 = list()
to_group2 = list()

for i in range(3):
    name = 'ws' + str(i)
    to_group1.append(name)
    CreateWorkspace(DataX=range(200, 210, 1), DataY=[i+1]*20, NSpec=2, OutputWorkspace=name)
    AddSampleLog(Workspace=name, LogName="MyLog", LogText=str((i+1)*5), LogType='Number')
group1 = GroupWorkspaces(InputWorkspaces=','.join(to_group1))

for i in range(3,6):
    name = 'ws' + str(i)
    to_group2.append(name)
    CreateWorkspace(DataX=range(200, 210, 1), DataY=[i+1]*10, NSpec=1, OutputWorkspace=name)
    AddSampleLog(Workspace=name, LogName="MyLog", LogText=str((i+1)*5), LogType='Number')
group2 = GroupWorkspaces(InputWorkspaces=','.join(to_group2))
```
- Right-click on `group1` and select "Plot Surface from Group" or "Plot Contour from Group".
  - There should be the opportunity to plot spectrum 1 or 2 by typing in the box.
- Right-click on `group2` and choose the same option.
  - This time the spectrum number box should be greyed out, as the only possible choice is "1".

Fixes one part of #14964, but should _not_ close that issue because it has other points too.

[Release notes](https://github.com/mantidproject/mantid/blob/6f279f014adae2b6587ed171d2e525221c91487c/docs/source/release/v3.7.0/ui.rst#d-plots-from-group-workspaces) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
