### PR TITLE
Internal improvements to ShapeFactory

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Objects/ShapeFactory.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/ShapeFactory.h
@@ -83,9 +83,11 @@ File change history is stored at: <https://github.com/mantidproject/mantid>
 */
 class MANTID_GEOMETRY_DLL ShapeFactory {
 public:
-  boost::shared_ptr<Object> createShape(Poco::XML::Element *pElem);
-  boost::shared_ptr<Object> createShape(std::string shapeXML,
-                                        bool addTypeTag = true);
+  template <typename ObjectType = Object>
+  boost::shared_ptr<ObjectType> createShape(Poco::XML::Element *pElem);
+  template <typename ObjectType = Object>
+  boost::shared_ptr<ObjectType> createShape(std::string shapeXML,
+                                            bool addTypeTag = true);
 
 private:
   std::string parseSphere(Poco::XML::Element *pElem,

--- a/Framework/Geometry/src/Objects/ShapeFactory.cpp
+++ b/Framework/Geometry/src/Objects/ShapeFactory.cpp
@@ -54,8 +54,9 @@ Logger g_log("ShapeFactory");
  *  @return A shared pointer to a geometric shape (defaults to an 'empty' shape
  *if XML tags contain no geo. info.)
  */
-boost::shared_ptr<Object> ShapeFactory::createShape(std::string shapeXML,
-                                                    bool addTypeTag) {
+template <typename ObjectType>
+boost::shared_ptr<ObjectType> ShapeFactory::createShape(std::string shapeXML,
+                                                        bool addTypeTag) {
   // wrap in a type tag
   if (addTypeTag)
     shapeXML = "<type name=\"userShape\"> " + shapeXML + " </type>";
@@ -69,15 +70,13 @@ boost::shared_ptr<Object> ShapeFactory::createShape(std::string shapeXML,
     g_log.warning("Unable to parse XML string " + shapeXML +
                   " . Empty geometry Object is returned.");
 
-    return boost::make_shared<Object>();
+    return boost::make_shared<ObjectType>();
   }
   // Get pointer to root element
   Element *pRootElem = pDoc->documentElement();
 
   // convert into a Geometry object
-  boost::shared_ptr<Object> retVal = createShape(pRootElem);
-
-  return retVal;
+  return createShape<ObjectType>(pRootElem);
 }
 
 /** Creates a geometric object from a DOM-element-node pointing to a \<type>
@@ -93,7 +92,9 @@ boost::shared_ptr<Object> ShapeFactory::createShape(std::string shapeXML,
  *  @throw logic_error Thrown if argument is not a pointer to a 'type' XML
  *element
  */
-boost::shared_ptr<Object> ShapeFactory::createShape(Poco::XML::Element *pElem) {
+template <typename ObjectType>
+boost::shared_ptr<ObjectType>
+ShapeFactory::createShape(Poco::XML::Element *pElem) {
   // check if pElem is an element with tag name 'type'
 
   if ((pElem->tagName()).compare("type")) {
@@ -106,14 +107,10 @@ boost::shared_ptr<Object> ShapeFactory::createShape(Poco::XML::Element *pElem) {
   std::stringstream xmlstream;
   DOMWriter writer;
   writer.writeNode(xmlstream, pElem);
-
   std::string shapeXML = xmlstream.str();
-
-  boost::shared_ptr<Object> retVal = boost::make_shared<Object>(shapeXML);
-
-  bool defaultAlgebra =
-      false; // if no <algebra> element then use default algebra
-
+  auto retVal = boost::make_shared<ObjectType>(shapeXML);
+  // if no <algebra> element then use default algebra
+  bool defaultAlgebra(false);
   // get algebra string
   Poco::AutoPtr<NodeList> pNL_algebra = pElem->getElementsByTagName("algebra");
   std::string algebraFromUser;
@@ -129,25 +126,22 @@ boost::shared_ptr<Object> ShapeFactory::createShape(Poco::XML::Element *pElem) {
     return retVal;
   }
 
-  std::map<std::string, std::string>
-      idMatching; // match id given to a shape by the user to
-                  // id understandable by Mantid code
+  // match id given to a shape by the user to
+  // id understandable by Mantid code
+  std::map<std::string, std::string> idMatching;
 
   // loop over all the sub-elements of pElem
-
   Poco::AutoPtr<NodeList> pNL = pElem->childNodes(); // get all child nodes
   unsigned long pNL_length = pNL->length();
-  int numPrimitives =
-      0; // used for counting number of primitives in this 'type' XML element
-  std::map<int, boost::shared_ptr<Surface>>
-      primitives; // stores the primitives that will be
-                  // used to build final shape
-  int l_id = 1; // used to build up unique id's for each shape added. Must start
-                // from int > zero.
-
-  Element *lastElement = nullptr; // This is to store element for the fixed
-  // complete objects such as sphere,cone,cylinder
-  // and cuboid
+  int numPrimitives = 0;
+  // stores the primitives that will be
+  // used to build final shape
+  std::map<int, boost::shared_ptr<Surface>> primitives;
+  // used to build up unique id's for each shape added. Must start
+  // from int > zero.
+  int l_id = 1;
+  // Element of fixed complete object
+  Element *lastElement = nullptr;
   for (unsigned int i = 0; i < pNL_length; i++) {
     if ((pNL->item(i))->nodeType() == Node::ELEMENT_NODE) {
       Element *pE = static_cast<Element *>(pNL->item(i));
@@ -1371,6 +1365,15 @@ void ShapeFactory::createGeometryHandler(Poco::XML::Element *pElem,
     geomHandler->setCone(parsePosition(pElemTipPoint), normVec, radius, height);
   }
 }
+
+///@cond
+// Template instantations
+template MANTID_GEOMETRY_DLL boost::shared_ptr<Object>
+ShapeFactory::createShape(std::string shapeXML, bool addTypeTag);
+
+template MANTID_GEOMETRY_DLL boost::shared_ptr<Object>
+ShapeFactory::createShape(Poco::XML::Element *pElem);
+///@endcond
 
 } // namespace Geometry
 } // namespace Mantid

--- a/Framework/Geometry/src/Objects/ShapeFactory.cpp
+++ b/Framework/Geometry/src/Objects/ShapeFactory.cpp
@@ -79,36 +79,24 @@ boost::shared_ptr<ObjectType> ShapeFactory::createShape(std::string shapeXML,
   return createShape<ObjectType>(pRootElem);
 }
 
-/** Creates a geometric object from a DOM-element-node pointing to a \<type>
- *element
- *  containing shape information. If no shape information an empty Object is
- *returned
+/** Creates a geometric object from a DOM-element-node pointing to an element
+ * whose child nodes contain the shape information. If no shape information
+ * an empty Object is returned.
  *
- *  @param pElem :: XML element from instrument def. file which may specify a
- *geometric shape
- *  @return A shared pointer to a geometric shape (defaults to an 'empty' shape
- *if XML tags contain no geo. info.)
- *
- *  @throw logic_error Thrown if argument is not a pointer to a 'type' XML
- *element
+ * @param pElem A pointer to an Element node whose children fully define the
+ * object. The name of this element is unimportant.
+ * @return A shared pointer to a geometric shape
  */
 template <typename ObjectType>
 boost::shared_ptr<ObjectType>
 ShapeFactory::createShape(Poco::XML::Element *pElem) {
-  // check if pElem is an element with tag name 'type'
-
-  if ((pElem->tagName()).compare("type")) {
-    g_log.error("Argument to function createShape must be a pointer to an XML "
-                "element with tag name type.");
-    throw std::logic_error("Argument to function createShape must be a pointer "
-                           "to an XML element with tag name type.");
-  }
-
+  // Write the definition to a string to store in the final object
   std::stringstream xmlstream;
   DOMWriter writer;
   writer.writeNode(xmlstream, pElem);
   std::string shapeXML = xmlstream.str();
   auto retVal = boost::make_shared<ObjectType>(shapeXML);
+
   // if no <algebra> element then use default algebra
   bool defaultAlgebra(false);
   // get algebra string


### PR DESCRIPTION
These changes template the `create` method on ShapeFactory. This allows it to create objects of classes that will derive from `Object`. This is important for #16044.

The second change is to remove the restriction on the name of the top-level tag for the geometry definitions. A top-level tag is required so that we can be sure the child nodes completely define the geometry but the name is unimportant.

**To test:**

Perform a code review and the tests must all pass without being altered.

No associated issue.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
