### PR TITLE
Set the detectors column as text

### DIFF
--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -1166,6 +1166,7 @@ Table *MantidUI::createDetectorTable(
     t->setColPlotDesignation(col, Table::None);
   }
   t->setHeaderColType();
+  t->setTextFormat(2);
   t->setTextFormat(ncols - 1);
 
   // Cache some frequently used values


### PR DESCRIPTION
Simple one line fix to set the column correctly as a text column

**To test:**
1. Load some datasets, including one that has grouped detectors (LET00026305 from the ISIS archive does)
2. right click the workspace and select show detectors
3. the detector id column should be filled with values for both grouped and ungrouped workspaces.  Certainly not filled with 0 throughout.

Fixes #15900

_Does not need to be in the release notes._ as it is a bug we introduced and fixed within this release.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Otherwise a validation check converts values with , in to 0
