### PR TITLE
Resolution shells in d-spacing

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/SortHKL.h
+++ b/Framework/Crystal/inc/MantidCrystal/SortHKL.h
@@ -71,7 +71,7 @@ public:
                   size_t totalReflectionCount)
       : m_measuredReflections(0), m_uniqueReflections(0), m_completeness(0.0),
         m_redundancy(0.0), m_rMerge(0.0), m_rPim(0.0), m_meanIOverSigma(0.0),
-        m_lambdaMin(0.0), m_lambdaMax(0.0), m_chiSquared(0.0), m_peaks() {
+        m_dspacingMin(0.0), m_dspacingMax(0.0), m_chiSquared(0.0), m_peaks() {
     m_peaks.reserve(totalReflectionCount);
     calculatePeaksStatistics(uniqueReflections);
   }
@@ -83,8 +83,8 @@ public:
   double m_rMerge;
   double m_rPim;
   double m_meanIOverSigma;
-  double m_lambdaMin;
-  double m_lambdaMax;
+  double m_dspacingMin;
+  double m_dspacingMax;
   double m_chiSquared;
 
   std::vector<DataObjects::Peak> m_peaks;
@@ -98,7 +98,7 @@ private:
   double getRMS(const std::vector<double> &data) const;
 
   std::pair<double, double>
-  getLambdaLimits(const std::vector<DataObjects::Peak> &peaks) const;
+  getDSpacingLimits(const std::vector<DataObjects::Peak> &peaks) const;
 };
 
 /** Save a PeaksWorkspace to a Gsas-style ASCII .hkl file.

--- a/Framework/Crystal/src/SortHKL.cpp
+++ b/Framework/Crystal/src/SortHKL.cpp
@@ -291,8 +291,8 @@ void SortHKL::insertStatisticsIntoTable(
   // append to the table workspace
   API::TableRow newrow = table->appendRow();
 
-  newrow << name << statistics.m_uniqueReflections << statistics.m_lambdaMin
-         << statistics.m_lambdaMax << statistics.m_redundancy
+  newrow << name << statistics.m_uniqueReflections << statistics.m_dspacingMin
+         << statistics.m_dspacingMax << statistics.m_redundancy
          << statistics.m_meanIOverSigma << 100.0 * statistics.m_rMerge
          << 100.0 * statistics.m_rPim << 100.0 * completeness;
 }
@@ -328,18 +328,18 @@ double PeaksStatistics::getRMS(const std::vector<double> &data) const {
 
 /// Returns the lowest and hights wavelength in the peak list.
 std::pair<double, double>
-PeaksStatistics::getLambdaLimits(const std::vector<Peak> &peaks) const {
+PeaksStatistics::getDSpacingLimits(const std::vector<Peak> &peaks) const {
   if (peaks.empty()) {
     return std::make_pair(0.0, 0.0);
   }
 
-  auto lambdaLimitIterators = std::minmax_element(
+  auto dspacingLimitIterators = std::minmax_element(
       peaks.begin(), peaks.end(), [](const Peak &lhs, const Peak &rhs) {
-        return lhs.getWavelength() < rhs.getWavelength();
+        return lhs.getDSpacing() < rhs.getDSpacing();
       });
 
-  return std::make_pair((*(lambdaLimitIterators.first)).getWavelength(),
-                        (*(lambdaLimitIterators.second)).getWavelength());
+  return std::make_pair((*(dspacingLimitIterators.first)).getDSpacing(),
+                        (*(dspacingLimitIterators.second)).getDSpacing());
 }
 
 /// Sorts the peaks in the workspace by H, K and L.
@@ -451,9 +451,9 @@ void PeaksStatistics::calculatePeaksStatistics(
     m_meanIOverSigma =
         iOverSigmaSum / static_cast<double>(m_measuredReflections);
 
-    std::pair<double, double> lambdaLimits = getLambdaLimits(m_peaks);
-    m_lambdaMin = lambdaLimits.first;
-    m_lambdaMax = lambdaLimits.second;
+    std::pair<double, double> dspacingLimits = getDSpacingLimits(m_peaks);
+    m_dspacingMin = dspacingLimits.first;
+    m_dspacingMax = dspacingLimits.second;
   }
 }
 

--- a/Framework/Crystal/src/StatisticsOfPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/StatisticsOfPeaksWorkspace.cpp
@@ -70,8 +70,8 @@ void StatisticsOfPeaksWorkspace::init() {
                                      "Overall"};
   declareProperty("SortBy", sortTypes[0],
                   boost::make_shared<StringListValidator>(sortTypes),
-                  "Sort the peaks by bank, run number(default) or only overall "
-                  "statistics.");
+                  "Sort the peaks by resolution shell in d-Spacing(default), "
+                  "bank, run number, or only overall statistics.");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -151,7 +151,8 @@ void StatisticsOfPeaksWorkspace::exec() {
       sequence = p.getBankName();
 
     if (sequence.compare(oldSequence) != 0 && tempWS->getNumberPeaks() > 0) {
-      if (tempWS->getNumberPeaks() > 1) doSortHKL(tempWS, oldSequence);
+      if (tempWS->getNumberPeaks() > 1)
+        doSortHKL(tempWS, oldSequence);
       tempWS = WorkspaceFactory::Instance().createPeaks();
       // Copy over ExperimentInfo from input workspace
       tempWS->copyExperimentInfoFrom(ws.get());

--- a/Framework/Crystal/src/StatisticsOfPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/StatisticsOfPeaksWorkspace.cpp
@@ -88,7 +88,7 @@ void StatisticsOfPeaksWorkspace::exec() {
   // We must sort the peaks
   std::vector<std::pair<std::string, bool>> criteria;
   if (sortType.compare(0, 2, "Re") == 0)
-    criteria.push_back(std::pair<std::string, bool>("wavelength", false));
+    criteria.push_back(std::pair<std::string, bool>("DSpacing", false));
   else if (sortType.compare(0, 2, "Ru") == 0)
     criteria.push_back(std::pair<std::string, bool>("RunNumber", true));
   criteria.push_back(std::pair<std::string, bool>("BankName", true));
@@ -105,21 +105,21 @@ void StatisticsOfPeaksWorkspace::exec() {
   // run number
   std::string oldSequence;
   if (sortType.compare(0, 2, "Re") == 0) {
-    double wavelength = peaks[0].getWavelength();
-    if (wavelength > 3.0)
-      oldSequence = "first";
-    else if (wavelength > 2.5)
-      oldSequence = "second";
-    else if (wavelength > 2.0)
-      oldSequence = "third";
-    else if (wavelength > 1.5)
-      oldSequence = "fourth";
-    else if (wavelength > 1.0)
-      oldSequence = "fifth";
-    else if (wavelength > 0.5)
-      oldSequence = "sixth";
+    double dspacing = peaks[0].getDSpacing();
+    if (dspacing > 3.0)
+      oldSequence = "Inf - 3.0";
+    else if (dspacing > 2.5)
+      oldSequence = "3.0 - 2.5";
+    else if (dspacing > 2.0)
+      oldSequence = "2.5 - 2.0";
+    else if (dspacing > 1.5)
+      oldSequence = "2.0 - 1.5";
+    else if (dspacing > 1.0)
+      oldSequence = "1.5 - 1.0";
+    else if (dspacing > 0.5)
+      oldSequence = "1.0 - 0.5";
     else
-      oldSequence = "seventh";
+      oldSequence = "0.5 - 0.0";
   } else if (sortType.compare(0, 2, "Ru") == 0)
     oldSequence = boost::lexical_cast<std::string>(peaks[0].getRunNumber());
   else
@@ -130,28 +130,28 @@ void StatisticsOfPeaksWorkspace::exec() {
     Peak &p = peaks[wi];
     std::string sequence;
     if (sortType.compare(0, 2, "Re") == 0) {
-      double wavelength = p.getWavelength();
-      if (wavelength > 3.0)
-        sequence = "first";
-      else if (wavelength > 2.5)
-        sequence = "second";
-      else if (wavelength > 2.0)
-        sequence = "third";
-      else if (wavelength > 1.5)
-        sequence = "fourth";
-      else if (wavelength > 1.0)
-        sequence = "fifth";
-      else if (wavelength > 0.5)
-        sequence = "sixth";
+      double dspacing = p.getDSpacing();
+      if (dspacing > 3.0)
+        sequence = "Inf - 3.0";
+      else if (dspacing > 2.5)
+        sequence = "3.0 - 2.5";
+      else if (dspacing > 2.0)
+        sequence = "2.5 - 2.0";
+      else if (dspacing > 1.5)
+        sequence = "2.0 - 1.5";
+      else if (dspacing > 1.0)
+        sequence = "1.5 - 1.0";
+      else if (dspacing > 0.5)
+        sequence = "1.0 - 0.5";
       else
-        sequence = "seventh";
+        sequence = "0.5 - 0.0";
     } else if (sortType.compare(0, 2, "Ru") == 0)
       sequence = boost::lexical_cast<std::string>(p.getRunNumber());
     else
       sequence = p.getBankName();
 
     if (sequence.compare(oldSequence) != 0 && tempWS->getNumberPeaks() > 0) {
-      doSortHKL(tempWS, oldSequence);
+      if (tempWS->getNumberPeaks() > 1) doSortHKL(tempWS, oldSequence);
       tempWS = WorkspaceFactory::Instance().createPeaks();
       // Copy over ExperimentInfo from input workspace
       tempWS->copyExperimentInfoFrom(ws.get());

--- a/Framework/Crystal/test/SortHKLTest.h
+++ b/Framework/Crystal/test/SortHKLTest.h
@@ -144,8 +144,6 @@ public:
     TS_ASSERT_EQUALS(statistics.m_rMerge, 0.0);
     TS_ASSERT_EQUALS(statistics.m_rPim, 0.0);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 0.0);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 0.0);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 0.0);
   }
 
   void test_PeaksStatisticsOneObservation() {
@@ -160,8 +158,6 @@ public:
     TS_ASSERT_EQUALS(statistics.m_rMerge, 0.0);
     TS_ASSERT_EQUALS(statistics.m_rPim, 0.0);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 56.0 / 4.5);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 1.0);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 1.0);
   }
 
   void test_PeaksStatisticsOneObservationTwoUnique() {
@@ -177,8 +173,6 @@ public:
     TS_ASSERT_EQUALS(statistics.m_rMerge, 0.0);
     TS_ASSERT_EQUALS(statistics.m_rPim, 0.0);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 56.0 / 4.5);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 1.0);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 1.0);
   }
 
   void test_PeaksStatisticsTwoObservationTwoUnique() {
@@ -195,8 +189,6 @@ public:
     TS_ASSERT_EQUALS(statistics.m_rMerge, 0.0);
     TS_ASSERT_EQUALS(statistics.m_rPim, 0.0);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 15.0);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 1.0);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 2.0);
   }
 
   void test_PeaksStatisticsTwoObservationOneUnique() {
@@ -213,8 +205,6 @@ public:
     // For 2 observations this is the same since sqrt(1 / (2 - 1)) = 1
     TS_ASSERT_EQUALS(statistics.m_rPim, 1.0 / 3.0);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 150.0);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 1.0);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 1.0);
   }
 
   void test_PeaksStatisticsThreeObservationOneUnique() {
@@ -232,8 +222,6 @@ public:
     // For rpim the factor is  sqrt(1 / (3 - 1)) = sqrt(0.5)
     TS_ASSERT_EQUALS(statistics.m_rPim, sqrt(0.5) / 4.5);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 150.0);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 1.0);
-    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 1.0);
   }
 
   void test_Init() {

--- a/Framework/Crystal/test/SortHKLTest.h
+++ b/Framework/Crystal/test/SortHKLTest.h
@@ -144,8 +144,8 @@ public:
     TS_ASSERT_EQUALS(statistics.m_rMerge, 0.0);
     TS_ASSERT_EQUALS(statistics.m_rPim, 0.0);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 0.0);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMin, 0.0);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMax, 0.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 0.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 0.0);
   }
 
   void test_PeaksStatisticsOneObservation() {
@@ -160,8 +160,8 @@ public:
     TS_ASSERT_EQUALS(statistics.m_rMerge, 0.0);
     TS_ASSERT_EQUALS(statistics.m_rPim, 0.0);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 56.0 / 4.5);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMin, 1.0);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMax, 1.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 1.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 1.0);
   }
 
   void test_PeaksStatisticsOneObservationTwoUnique() {
@@ -177,8 +177,8 @@ public:
     TS_ASSERT_EQUALS(statistics.m_rMerge, 0.0);
     TS_ASSERT_EQUALS(statistics.m_rPim, 0.0);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 56.0 / 4.5);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMin, 1.0);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMax, 1.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 1.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 1.0);
   }
 
   void test_PeaksStatisticsTwoObservationTwoUnique() {
@@ -195,8 +195,8 @@ public:
     TS_ASSERT_EQUALS(statistics.m_rMerge, 0.0);
     TS_ASSERT_EQUALS(statistics.m_rPim, 0.0);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 15.0);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMin, 1.0);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMax, 2.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 1.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 2.0);
   }
 
   void test_PeaksStatisticsTwoObservationOneUnique() {
@@ -213,8 +213,8 @@ public:
     // For 2 observations this is the same since sqrt(1 / (2 - 1)) = 1
     TS_ASSERT_EQUALS(statistics.m_rPim, 1.0 / 3.0);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 150.0);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMin, 1.0);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMax, 1.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 1.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 1.0);
   }
 
   void test_PeaksStatisticsThreeObservationOneUnique() {
@@ -232,8 +232,8 @@ public:
     // For rpim the factor is  sqrt(1 / (3 - 1)) = sqrt(0.5)
     TS_ASSERT_EQUALS(statistics.m_rPim, sqrt(0.5) / 4.5);
     TS_ASSERT_EQUALS(statistics.m_meanIOverSigma, 150.0);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMin, 1.0);
-    TS_ASSERT_EQUALS(statistics.m_lambdaMax, 1.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMin, 1.0);
+    TS_ASSERT_EQUALS(statistics.m_dspacingMax, 1.0);
   }
 
   void test_Init() {

--- a/Framework/Crystal/test/StatisticsOfPeaksWorkspaceTest.h
+++ b/Framework/Crystal/test/StatisticsOfPeaksWorkspaceTest.h
@@ -78,8 +78,8 @@ public:
     TS_ASSERT_EQUALS(tableOut->rowCount(), 1);
     TS_ASSERT_EQUALS(tableOut->String(0, 0), "Overall");
     TS_ASSERT_EQUALS(tableOut->Int(0, 1), 3);
-    TS_ASSERT_DELTA(tableOut->Double(0, 2), 1.5, .1);
-    TS_ASSERT_DELTA(tableOut->Double(0, 3), 3.5, .1);
+    TS_ASSERT_DELTA(tableOut->Double(0, 2), 3.6, .1);
+    TS_ASSERT_DELTA(tableOut->Double(0, 3), 14.3, .1);
     TS_ASSERT_DELTA(tableOut->Double(0, 4), 8., .1);
     TS_ASSERT_DELTA(tableOut->Double(0, 5), 1.4195, .1);
     TS_ASSERT_DELTA(tableOut->Double(0, 6), 0., .1);

--- a/docs/source/algorithms/StatisticsOfPeaksWorkspace-v1.rst
+++ b/docs/source/algorithms/StatisticsOfPeaksWorkspace-v1.rst
@@ -61,8 +61,8 @@ Output:
 
     HKL of first peak in table -10 5.0 42.0
     Multiplicity = 1.21
-    Resolution Min = 0.30
-    Resolution Max = 3.17
+    Resolution Min = 0.21
+    Resolution Max = 2.08
     No. of Unique Reflections = 337
     Mean ((I)/sd(I)) = 27.51
     Rmerge = 10.08

--- a/docs/source/release/v3.7.0/diffraction.rst
+++ b/docs/source/release/v3.7.0/diffraction.rst
@@ -16,6 +16,7 @@ Crystal Improvements
 - :ref:`SaveHKL <algm-SaveHKL>` has option to write the same output as anvred3.py including direction cosines.
 - :ref:`LoadHKL <algm-LoadHKL>` reads hkl output that includes direction cosines.
 - :ref:`SaveIsawPeaks <algm-SaveIsawPeaks>` has DetCal information sorted by detector numbers
+- :ref:`StatisticsOfPeaksWorkspace <algm-StatisticsOfPeaksWorkspace>` has resolution shells in units of d-Spacing.
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
Description of work.
Resolution shells were changed from wavelength to d-spacing.
**To test:**
Use the following script with doctest data and check that statistics_table has Resolution max and min in units of d-spacing.  Sort peaks by DSpacing column descending to check table.

<!-- Instructions for testing. -->

``` python
peaks = LoadIsawPeaks(Filename=r'Peaks5637.integrate')

FindUBUsingFFT(peaks, MinD=0.25, MaxD=10, Tolerance=0.2)
SelectCellWithForm(peaks, FormNumber=9, Apply=True, Tolerance=0.15)
OptimizeLatticeForCellType(peaks,
                           CellType='Hexagonal', Apply=True, Tolerance=0.2)

# Run the SortHKL algorithm
sorted, statistics_table = StatisticsOfPeaksWorkspace(peaks, PointGroup='-3m1 (Trigonal - Hexagonal)', 
                                                      LatticeCentering='Rhombohedrally centred, obverse')
```

Fixes #16102 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
