### PR TITLE
BASISReduction: set normalization to first slice as option

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -49,7 +49,7 @@ class BASISReduction(PythonAlgorithm):
         return 1
 
     def summary(self):
-        return "This algorithm is meant to temporarily deal with letting BASIS reduce lots of files via Mantid."
+        return "Multiple-file BASIS reduction."
 
     def PyInit(self):
         self._short_inst = "BSS"
@@ -76,6 +76,8 @@ class BASISReduction(PythonAlgorithm):
         self.declareProperty("GroupDetectors", "None",
                              StringListValidator(grouping_type),
                              "Switch for grouping detectors")
+
+        self.declareProperty("NormalizeToFirst", False, "Normalize spectra to intensity of spectrum with lowest Q?")
 
         # Properties setting the division by vanadium
         titleDivideByVanadium = "Normalization by Vanadium"
@@ -111,6 +113,7 @@ class BASISReduction(PythonAlgorithm):
         self._noMonNorm = self.getProperty("NoMonitorNorm").value
         self._maskFile = self.getProperty("MaskFile").value
         self._groupDetOpt = self.getProperty("GroupDetectors").value
+        self._normalizeToFirst = self.getProperty("NormalizeToFirst").value
 
         datasearch = config["datasearch.searcharchive"]
         if datasearch != "On":
@@ -191,7 +194,8 @@ class BASISReduction(PythonAlgorithm):
             # involving this S(Q,w)
             api.ClearMaskFlag(Workspace=self._samSqwWs)
             # Scale so that elastic line has Y-values ~ 1
-            self._ScaleY(self._samSqwWs)
+            if self._normalizeToFirst:
+                self._ScaleY(self._samSqwWs)
             # Output Dave and Nexus files
             extension = "_divided.dat" if self._doNorm else ".dat"
             dave_grp_filename = self._makeRunName(self._samWsRun,

--- a/docs/source/algorithms/BASISReduction-v1.rst
+++ b/docs/source/algorithms/BASISReduction-v1.rst
@@ -22,9 +22,11 @@ Examples:
 If **DoIndividual** is checked, then each run number is reduced separately
 from the rest. The semicolon symbol is ignored.
 
-**Y-axis rescaling**: Since the Y-scale has arbitrary units, a
+**Rescaling to first spectrum**: Since the Y-scale has arbitrary units, a
 rescaling convention is taken whereby the maximum of the
-first spectrum (lowest Q-value) is rescaled to 1.0.
+first spectrum (lowest Q-value) is rescaled to 1.0. This rescaling may not
+be employed when the intent is to compare to other runs, like can substraction
+of comparison between deuterated and hydrogenated samples.
 
 Vanadium Normalization
 ======================

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -62,7 +62,7 @@ Improvements
    I(Q,t) Fit tab, but it does now have a dialogue box interface from the algorithm list.
    This also allows for better testing, progress tracking and documentation of the algorithm.
 
-- :ref:`BASISReduction <algm-BASISReduction>` now accepts Vanadium runs for normalization.
+- :ref:`BASISReduction <algm-BASISReduction>` now accepts Vanadium runs for normalization, and one option to normalize by the maximum of the first spectrum.
 
 - :ref:`QECoverage <Interfaces>` planning tool has now been updated, There is now an Emin option included for direct tab,
     If Emin or Emax are left empty; appropriate values are set automatically, the negative values of Ei are treated as


### PR DESCRIPTION
An option  to normalize by the maximum of the first spectrum is introduced as a property.

**To test:**

Build target `SystemTestData` and make sure the `myBuilDir/ExternalData/Testing/Data/SystemTest/` directory is at the top in the list of user directories of MantidPlot. Then run the following script

```
# Reduce
BASISReduction(RunNumbers="13387",EnergyBins=[-120,0.4,120], MomentumTransferBins=[0.2,0.2,2.0])
RenameWorkspace(InputWorkspace="BSS_13387_sqw", OutputWorkspace="BSS_13387_NotNormalized_sqw")
# Reduced and normalize all spectra to the maximum of the first spectrum
BASISReduction(RunNumbers="13387",EnergyBins=[-120,0.4,120], MomentumTransferBins=[0.2,0.2,2.0], NormalizeToFirst=1)
RenameWorkspace(InputWorkspace="BSS_13387_sqw", OutputWorkspace="BSS_13387_Normalized_sqw")
#######################################################################################
# BSS_13387_Normalized_sqw is just BSS_13387_NotNormalized_sqw multiplied by 0.717661
#######################################################################################

```

Fixes #16108.

[Release notes](https://github.com/mantidproject/mantid/blob/16108_BASISreduction/docs/source/release/v3.7.0/indirect_inelastic.rst) have been updated

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
