### PR TITLE
Fix Coverity issues #1355157 and #1355158. 

### DIFF
--- a/Vates/ParaviewPlugins/CMakeLists.txt
+++ b/Vates/ParaviewPlugins/CMakeLists.txt
@@ -6,7 +6,7 @@ set_mantid_subprojects( Vates/VatesAPI )
 if("${CMAKE_CFG_INTDIR}" STREQUAL ".")
   # This is NOT a multi-configuration builder
   find_library(NonOrthogonalSourcePlugin_LOCATION name NonOrthogonalSource HINTS ${ParaView_DIR}/lib)
-  file (COPY ${NonOrthogonalSourcePlugin_LOCATION} DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${PVPLUGINS_DIR}/${PVPLUGINS_SUBDIR})
+  #file (COPY ${NonOrthogonalSourcePlugin_LOCATION} DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${PVPLUGINS_DIR}/${PVPLUGINS_SUBDIR})
 elseif(MSVC)
   # find_library won't find dlls only import libraries so just hardcode them
   # Release

--- a/Vates/ParaviewPlugins/CMakeLists.txt
+++ b/Vates/ParaviewPlugins/CMakeLists.txt
@@ -6,7 +6,7 @@ set_mantid_subprojects( Vates/VatesAPI )
 if("${CMAKE_CFG_INTDIR}" STREQUAL ".")
   # This is NOT a multi-configuration builder
   find_library(NonOrthogonalSourcePlugin_LOCATION name NonOrthogonalSource HINTS ${ParaView_DIR}/lib)
-  #file (COPY ${NonOrthogonalSourcePlugin_LOCATION} DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${PVPLUGINS_DIR}/${PVPLUGINS_SUBDIR})
+  file (COPY ${NonOrthogonalSourcePlugin_LOCATION} DESTINATION ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${PVPLUGINS_DIR}/${PVPLUGINS_SUBDIR})
 elseif(MSVC)
   # find_library won't find dlls only import libraries so just hardcode them
   # Release

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.cxx
@@ -30,14 +30,13 @@ using Mantid::Geometry::IMDDimension_sptr;
 using Mantid::Geometry::IMDDimension_sptr;
 
 vtkMDEWNexusReader::vtkMDEWNexusReader()
-    : m_loadInMemory(false), m_depth(1), m_time(0),
-      m_normalization(NoNormalization) {
-  this->FileName = NULL;
+    : FileName{nullptr}, m_loadInMemory{false}, m_depth{1}, m_time{0},
+      m_normalization{NoNormalization} {
   this->SetNumberOfInputPorts(0);
   this->SetNumberOfOutputPorts(1);
 }
 
-vtkMDEWNexusReader::~vtkMDEWNexusReader() { this->SetFileName(0); }
+vtkMDEWNexusReader::~vtkMDEWNexusReader() { this->SetFileName(nullptr); }
 
 void vtkMDEWNexusReader::SetDepth(int depth) {
   size_t temp = depth;
@@ -69,14 +68,14 @@ void vtkMDEWNexusReader::SetInMemory(bool inMemory) {
   themeselves.
   @return geometry xml const * char reference.
 */
-const char *vtkMDEWNexusReader::GetInputGeometryXML() {
+std::string vtkMDEWNexusReader::GetInputGeometryXML() {
   if (m_presenter == nullptr) {
-    return "";
+    return std::string();
   }
   try {
-    return m_presenter->getGeometryXML().c_str();
+    return m_presenter->getGeometryXML();
   } catch (std::runtime_error &) {
-    return "";
+    return std::string();
   }
 }
 
@@ -206,7 +205,7 @@ void vtkMDEWNexusReader::setTimeRange(vtkInformationVector *outputVector) {
 /*
 Getter for the workspace type name.
 */
-const char *vtkMDEWNexusReader::GetWorkspaceTypeName() {
+std::string vtkMDEWNexusReader::GetWorkspaceTypeName() {
   // Forward request on to MVP presenter
-  return m_presenter->getWorkspaceTypeName().c_str();
+  return m_presenter->getWorkspaceTypeName();
 }

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.h
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.h
@@ -11,6 +11,8 @@ class vtkImplicitFunction;
 class VTK_EXPORT vtkMDEWNexusReader : public vtkUnstructuredGridAlgorithm {
 public:
   static vtkMDEWNexusReader *New();
+  vtkMDEWNexusReader(const vtkMDEWNexusReader &) = delete;
+  void operator=(const vtkMDEWNexusReader &) = delete;
   vtkTypeMacro(vtkMDEWNexusReader, vtkUnstructuredGridAlgorithm) void PrintSelf(
       ostream &os, vtkIndent indent) override;
   vtkSetStringMacro(FileName)
@@ -28,9 +30,9 @@ public:
   void updateAlgorithmProgress(double progress, const std::string &message);
 
   /// Getter for the workspace type
-  const char *GetWorkspaceTypeName();
+  std::string GetWorkspaceTypeName();
   /// Getter for the input geometry
-  const char *GetInputGeometryXML();
+  std::string GetInputGeometryXML();
 
   void SetNormalization(int option);
 
@@ -41,16 +43,13 @@ protected:
                          vtkInformationVector *) override;
   int RequestData(vtkInformation *, vtkInformationVector **,
                   vtkInformationVector *) override;
-  int Canreadfile(const char *fname);
   /// Handle time variation.
   unsigned long GetMTime() override;
 
 private:
   void setTimeRange(vtkInformationVector *outputVector);
 
-  vtkMDEWNexusReader(const vtkMDEWNexusReader &);
 
-  void operator=(const vtkMDEWNexusReader &);
 
   /// File name from which to read.
   char *FileName;
@@ -70,9 +69,6 @@ private:
 
   /// Time.
   double m_time;
-
-  // Cached workspace type name.
-  std::string typeName;
 
   Mantid::VATES::VisualNormalization m_normalization;
 };

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
@@ -27,14 +27,13 @@ vtkStandardNewMacro(vtkMDHWNexusReader)
 using Mantid::Geometry::IMDDimension_sptr;
 
 vtkMDHWNexusReader::vtkMDHWNexusReader()
-    : m_loadInMemory(false), m_depth(1), m_time(0),
+    : FileName{nullptr}, m_loadInMemory(false), m_depth(1), m_time(0),
       m_normalizationOption(AutoSelect) {
-  this->FileName = NULL;
   this->SetNumberOfInputPorts(0);
   this->SetNumberOfOutputPorts(1);
 }
 
-vtkMDHWNexusReader::~vtkMDHWNexusReader() { this->SetFileName(0); }
+vtkMDHWNexusReader::~vtkMDHWNexusReader() { this->SetFileName(nullptr); }
 
 void vtkMDHWNexusReader::SetDepth(int depth) {
   size_t temp = depth;
@@ -66,14 +65,14 @@ void vtkMDHWNexusReader::SetInMemory(bool inMemory) {
  * themeselves.
  * @return geometry xml const * char reference.
  */
-const char *vtkMDHWNexusReader::GetInputGeometryXML() {
+std::string vtkMDHWNexusReader::GetInputGeometryXML() {
   if (m_presenter == nullptr) {
-    return "";
+    return std::string();
   }
   try {
     return m_presenter->getGeometryXML().c_str();
   } catch (std::runtime_error &) {
-    return "";
+    return std::string();
   }
 }
 
@@ -217,7 +216,7 @@ void vtkMDHWNexusReader::setTimeRange(vtkInformationVector *outputVector) {
 /*
 Getter for the workspace type name.
 */
-const char *vtkMDHWNexusReader::GetWorkspaceTypeName() {
+std::string vtkMDHWNexusReader::GetWorkspaceTypeName() {
   // Forward request on to MVP presenter
-  return m_presenter->getWorkspaceTypeName().c_str();
+  return m_presenter->getWorkspaceTypeName();
 }

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.h
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.h
@@ -12,6 +12,8 @@ class vtkImplicitFunction;
 class VTK_EXPORT vtkMDHWNexusReader : public vtkStructuredGridAlgorithm {
 public:
   static vtkMDHWNexusReader *New();
+  vtkMDHWNexusReader(const vtkMDHWNexusReader &) = delete;
+  void operator=(const vtkMDHWNexusReader &) = delete;
   vtkTypeMacro(vtkMDHWNexusReader, vtkStructuredGridAlgorithm) void PrintSelf(
       ostream &os, vtkIndent indent) override;
   vtkSetStringMacro(FileName)
@@ -29,9 +31,9 @@ public:
   void updateAlgorithmProgress(double progress, const std::string &message);
 
   /// Getter for the workspace type
-  const char *GetWorkspaceTypeName();
+  std::string GetWorkspaceTypeName();
   /// Getter for the input geometry
-  const char *GetInputGeometryXML();
+  std::string GetInputGeometryXML();
   /// Setter for the normalization
   void SetNormalization(int option);
 
@@ -42,16 +44,11 @@ protected:
                          vtkInformationVector *) override;
   int RequestData(vtkInformation *, vtkInformationVector **,
                   vtkInformationVector *) override;
-  int Canreadfile(const char *fname);
   /// Handle time variation.
   unsigned long GetMTime() override;
 
 private:
   void setTimeRange(vtkInformationVector *outputVector);
-
-  vtkMDHWNexusReader(const vtkMDHWNexusReader &);
-
-  void operator=(const vtkMDHWNexusReader &);
 
   /// File name from which to read.
   char *FileName;
@@ -71,9 +68,6 @@ private:
 
   /// Time.
   double m_time;
-
-  // Cached workspace type name.
-  std::string typeName;
 
   /// Normalization Option
   Mantid::VATES::VisualNormalization m_normalizationOption;

--- a/Vates/ParaviewPlugins/ParaViewReaders/NexusPeaksReader/vtkNexusPeaksReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/NexusPeaksReader/vtkNexusPeaksReader.cxx
@@ -34,20 +34,14 @@ using Mantid::Geometry::IMDDimension_sptr;
 using Mantid::API::Workspace_sptr;
 using Mantid::API::AnalysisDataService;
 
-vtkNexusPeaksReader::vtkNexusPeaksReader() :
-  m_isSetup(false), m_wsTypeName(""),
-  m_uintPeakMarkerSize(0.3), m_dimensions(1)
-{
-  this->FileName = NULL;
+vtkNexusPeaksReader::vtkNexusPeaksReader()
+    : FileName{nullptr}, m_isSetup{false}, m_uintPeakMarkerSize{0.3},
+      m_dimensions{1} {
   this->SetNumberOfInputPorts(0);
   this->SetNumberOfOutputPorts(1);
 }
 
-vtkNexusPeaksReader::~vtkNexusPeaksReader()
-{
-  this->SetFileName(0);
-}
-
+vtkNexusPeaksReader::~vtkNexusPeaksReader() { this->SetFileName(nullptr); }
 
 void vtkNexusPeaksReader::SetDimensions(int dimensions)
 {
@@ -184,8 +178,7 @@ int vtkNexusPeaksReader::CanReadFile(const char* fname)
     return 0; 
   }
 
-  ::NeXus::File * file = NULL;
-  file = new ::NeXus::File(fileString);
+  auto file = Mantid::Kernel::make_unique<::NeXus::File>(fileString);
   try
   {
     try
@@ -240,7 +233,7 @@ void vtkNexusPeaksReader::updateAlgorithmProgress(double progress, const std::st
 /*
 Getter for the workspace type name.
 */
-const char *vtkNexusPeaksReader::GetWorkspaceTypeName() {
+const std::string &vtkNexusPeaksReader::GetWorkspaceTypeName() {
   //Preload the Workspace and then cache it to avoid reloading later.
-  return m_wsTypeName.c_str();
+  return m_wsTypeName;
 }

--- a/Vates/ParaviewPlugins/ParaViewReaders/NexusPeaksReader/vtkNexusPeaksReader.h
+++ b/Vates/ParaviewPlugins/ParaViewReaders/NexusPeaksReader/vtkNexusPeaksReader.h
@@ -9,6 +9,8 @@ class VTK_EXPORT vtkNexusPeaksReader : public vtkPolyDataAlgorithm
 {
 public:
   static vtkNexusPeaksReader *New();
+  vtkNexusPeaksReader(const vtkNexusPeaksReader &) = delete;
+  void operator=(const vtkNexusPeaksReader &) = delete;
   vtkTypeMacro(vtkNexusPeaksReader,
                vtkPolyDataAlgorithm) void PrintSelf(ostream &os,
                                                     vtkIndent indent) override;
@@ -21,7 +23,7 @@ public:
   /// Called by presenter to force progress information updating.
   void updateAlgorithmProgress(double progress, const std::string& message);
   /// Getter for the workspace type
-  const char *GetWorkspaceTypeName();
+  const std::string &GetWorkspaceTypeName();
 
 protected:
   vtkNexusPeaksReader();
@@ -34,11 +36,6 @@ protected:
   unsigned long GetMTime() override;
 
 private:
-  
-  vtkNexusPeaksReader(const vtkNexusPeaksReader&);
-  
-  void operator = (const vtkNexusPeaksReader&);
-
   /// File name from which to read.
   char *FileName;
 

--- a/Vates/ParaviewPlugins/ParaViewReaders/PeaksReader/vtkPeaksReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/PeaksReader/vtkPeaksReader.cxx
@@ -33,20 +33,14 @@ using Mantid::Geometry::IMDDimension_sptr;
 using Mantid::API::Workspace_sptr;
 using Mantid::API::AnalysisDataService;
 
-vtkPeaksReader::vtkPeaksReader() :
-  m_isSetup(false), m_wsTypeName(""),
-  m_uintPeakMarkerSize(0.3), m_dimensions(1)
-{
-  this->FileName = NULL;
+vtkPeaksReader::vtkPeaksReader()
+    : FileName{NULL}, m_isSetup{false}, m_uintPeakMarkerSize{0.3},
+      m_dimensions{1} {
   this->SetNumberOfInputPorts(0);
   this->SetNumberOfOutputPorts(1);
 }
 
-vtkPeaksReader::~vtkPeaksReader()
-{
-  this->SetFileName(0);
-}
-
+vtkPeaksReader::~vtkPeaksReader() { this->SetFileName(nullptr); }
 
 void vtkPeaksReader::SetDimensions(int dimensions)
 {
@@ -208,7 +202,7 @@ void vtkPeaksReader::updateAlgorithmProgress(double progress, const std::string&
 /*
 Getter for the workspace type name.
 */
-const char *vtkPeaksReader::GetWorkspaceTypeName() {
+const std::string &vtkPeaksReader::GetWorkspaceTypeName() {
   //Preload the Workspace and then cache it to avoid reloading later.
-  return m_wsTypeName.c_str();
+  return m_wsTypeName;
 }

--- a/Vates/ParaviewPlugins/ParaViewReaders/PeaksReader/vtkPeaksReader.h
+++ b/Vates/ParaviewPlugins/ParaViewReaders/PeaksReader/vtkPeaksReader.h
@@ -9,6 +9,9 @@ class VTK_EXPORT vtkPeaksReader : public vtkPolyDataAlgorithm
 {
 public:
   static vtkPeaksReader *New();
+  vtkPeaksReader(const vtkPeaksReader &) = delete;
+
+  void operator=(const vtkPeaksReader &) = delete;
   vtkTypeMacro(vtkPeaksReader,
                vtkPolyDataAlgorithm) void PrintSelf(ostream &os,
                                                     vtkIndent indent) override;
@@ -21,7 +24,7 @@ public:
   /// Called by presenter to force progress information updating.
   void updateAlgorithmProgress(double progress, const std::string& message);
   /// Getter for the workspace type
-  const char *GetWorkspaceTypeName();
+  const std::string &GetWorkspaceTypeName();
 
 protected:
   vtkPeaksReader();
@@ -34,11 +37,6 @@ protected:
   unsigned long GetMTime() override;
 
 private:
-  
-  vtkPeaksReader(const vtkPeaksReader&);
-  
-  void operator = (const vtkPeaksReader&);
-
   /// File name from which to read.
   char *FileName;
 

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
@@ -33,7 +33,7 @@ vtkStandardNewMacro(vtkMDEWSource)
 
     /// Constructor
     vtkMDEWSource::vtkMDEWSource()
-    : m_wsName(""), m_depth(1000), m_time(0), m_normalization(AutoSelect) {
+    : m_depth(1000), m_time(0), m_normalization(AutoSelect) {
   this->SetNumberOfInputPorts(0);
   this->SetNumberOfOutputPorts(1);
 }
@@ -73,14 +73,14 @@ void vtkMDEWSource::SetWsName(std::string name)
   themeselves.
   @return geometry xml const * char reference.
 */
-const char *vtkMDEWSource::GetInputGeometryXML() {
+std::string vtkMDEWSource::GetInputGeometryXML() {
   if (m_presenter == nullptr) {
-    return "";
+    return std::string();
   }
   try {
-    return m_presenter->getGeometryXML().c_str();
+    return m_presenter->getGeometryXML();
   } catch (std::runtime_error &) {
-    return "";
+    return std::string();
   }
 }
 
@@ -136,14 +136,14 @@ double vtkMDEWSource::GetMaxValue() {
  * Gets the (first) instrument which is associated with the workspace.
  * @return The name of the instrument.
  */
-const char *vtkMDEWSource::GetInstrument() {
+std::string vtkMDEWSource::GetInstrument() {
   if (nullptr == m_presenter) {
-    return "";
+    return std::string();
   }
   try {
-    return m_presenter->getInstrument().c_str();
+    return m_presenter->getInstrument();
   } catch (std::runtime_error &) {
-    return "";
+    return std::string();
   }
 }
 
@@ -322,21 +322,16 @@ void vtkMDEWSource::updateAlgorithmProgress(double progress, const std::string& 
 /*
 Getter for the workspace type name.
 */
-const char *vtkMDEWSource::GetWorkspaceTypeName() {
+std::string vtkMDEWSource::GetWorkspaceTypeName() {
   if (m_presenter == nullptr) {
-    return "";
+    return std::string();
   }
   try {
     // Forward request on to MVP presenter
-    typeName = m_presenter->getWorkspaceTypeName();
-    return typeName.c_str();
+    return m_presenter->getWorkspaceTypeName();
   } catch (std::runtime_error &) {
-    return "";
+    return std::string();
   }
 }
 
-const char* vtkMDEWSource::GetWorkspaceName()
-{
-  return m_wsName.c_str();
-}
-
+const std::string &vtkMDEWSource::GetWorkspaceName() { return m_wsName; }

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.h
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.h
@@ -64,19 +64,19 @@ public:
   /// Update the algorithm progress.
   void updateAlgorithmProgress(double, const std::string& message);
   /// Getter for the input geometry xml
-  const char* GetInputGeometryXML();
+  std::string GetInputGeometryXML();
   /// Getter for the special coodinate value
   int GetSpecialCoordinates();
   /// Getter for the workspace name
-  const char* GetWorkspaceName();
+  const std::string &GetWorkspaceName();
   /// Getter for the workspace type
-  const char *GetWorkspaceTypeName();
+  std::string GetWorkspaceTypeName();
   /// Getter for the minimum value of the workspace data.
   double GetMinValue();
   /// Getter for the maximum value of the workspace data.
   double GetMaxValue();
   /// Getter for the instrument associated with the workspace data.
-  const char* GetInstrument();
+  std::string GetInstrument();
 
 protected:
   vtkMDEWSource();
@@ -99,9 +99,6 @@ private:
 
   /// MVP presenter.
   std::unique_ptr<Mantid::VATES::MDLoadingPresenter> m_presenter;
-
-  /// Cached typename.
-  std::string typeName;
 
   /// Normalization option
   Mantid::VATES::VisualNormalization m_normalization;

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
@@ -28,7 +28,7 @@ vtkStandardNewMacro(vtkMDHWSource)
 
     /// Constructor
     vtkMDHWSource::vtkMDHWSource()
-    : m_wsName(""), m_time(0), m_normalizationOption(AutoSelect) {
+    : m_time(0), m_normalizationOption(AutoSelect) {
   this->SetNumberOfInputPorts(0);
   this->SetNumberOfOutputPorts(1);
 }
@@ -40,8 +40,7 @@ vtkMDHWSource::~vtkMDHWSource() {}
   Setter for the workspace name.
   @param name : workspace name to extract from ADS.
 */
-void vtkMDHWSource::SetWsName(std::string name)
-{
+void vtkMDHWSource::SetWsName(const std::string &name) {
   if(m_wsName != name && name != "")
   {
     m_wsName = name;
@@ -53,14 +52,14 @@ void vtkMDHWSource::SetWsName(std::string name)
   Gets the geometry xml from the workspace. Allows object panels to configure themeselves.
   @return geometry xml const * char reference.
 */
-const char *vtkMDHWSource::GetInputGeometryXML() {
+std::string vtkMDHWSource::GetInputGeometryXML() {
   if (m_presenter == nullptr) {
-    return "";
+    return std::string();
   }
   try {
-    return m_presenter->getGeometryXML().c_str();
+    return m_presenter->getGeometryXML();
   } catch (std::runtime_error &) {
-    return "";
+    return std::string();
   }
 }
 
@@ -116,14 +115,14 @@ double vtkMDHWSource::GetMaxValue() {
  * Gets the (first) instrument which is associated with the workspace.
  * @return The name of the instrument.
  */
-const char *vtkMDHWSource::GetInstrument() {
+std::string vtkMDHWSource::GetInstrument() {
   if (nullptr == m_presenter) {
-    return "";
+    return std::string();
   }
   try {
-    return m_presenter->getInstrument().c_str();
+    return m_presenter->getInstrument();
   } catch (std::runtime_error &) {
-    return "";
+    return std::string();
   }
 }
 
@@ -299,24 +298,18 @@ void vtkMDHWSource::updateAlgorithmProgress(double progress, const std::string& 
 /*
 Getter for the workspace type name.
 */
-const char *vtkMDHWSource::GetWorkspaceTypeName() {
+std::string vtkMDHWSource::GetWorkspaceTypeName() {
   if (m_presenter == nullptr) {
-    return "";
+    return std::string();
   }
   try {
     //Forward request on to MVP presenter
-    typeName = m_presenter->getWorkspaceTypeName();
-    return typeName.c_str();
+    return m_presenter->getWorkspaceTypeName();
   }
   catch(std::runtime_error&)
   {
-    return "";
+    return std::string();
   }
 }
 
-const char* vtkMDHWSource::GetWorkspaceName()
-{
-  return m_wsName.c_str();
-}
-
-
+const std::string &vtkMDHWSource::GetWorkspaceName() { return m_wsName; }

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.h
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.h
@@ -46,11 +46,13 @@ namespace Mantid
 class VTK_EXPORT vtkMDHWSource : public vtkStructuredGridAlgorithm
 {
 public:
+  vtkMDHWSource(const vtkMDHWSource &) = delete;
+  void operator=(const vtkMDHWSource &) = delete;
   static vtkMDHWSource *New();
   vtkTypeMacro(vtkMDHWSource, vtkStructuredGridAlgorithm) void PrintSelf(
       ostream &os, vtkIndent indent) override;
 
-  void SetWsName(std::string wsName);
+  void SetWsName(const std::string &wsName);
 
   //------- MDLoadingView methods ----------------
   virtual double getTime() const;
@@ -59,21 +61,21 @@ public:
   //----------------------------------------------
 
   /// Update the algorithm progress.
-  void updateAlgorithmProgress(double, const std::string&);
+  void updateAlgorithmProgress(double progress, const std::string &message);
   /// Getter for the input geometry xml
-  const char* GetInputGeometryXML();
+  std::string GetInputGeometryXML();
   /// Getter for the special coodinate value
   int GetSpecialCoordinates();
   /// Getter for the workspace name
-  const char* GetWorkspaceName();
+  const std::string &GetWorkspaceName();
   /// Getter for the workspace type
-  const char *GetWorkspaceTypeName();
+  std::string GetWorkspaceTypeName();
   /// Getter for the minimum value of the workspace data
   double GetMinValue();
   /// Getter for the maximum value of the workspace data
   double GetMaxValue();
   /// Getter for the maximum value of the workspace data
-  const char* GetInstrument();
+  std::string GetInstrument();
   /// Setter for the normalization
   void SetNormalization(int option);
 
@@ -96,15 +98,10 @@ private:
   /// MVP presenter.
   std::unique_ptr<Mantid::VATES::MDLoadingPresenter> m_presenter;
 
-  /// Cached typename.
-  std::string typeName;
-
   /// Normalization Option
   Mantid::VATES::VisualNormalization m_normalizationOption;
 
 
-  vtkMDHWSource(const vtkMDHWSource&);
-  void operator = (const vtkMDHWSource&);
   void setTimeRange(vtkInformationVector* outputVector);
 };
 #endif

--- a/Vates/ParaviewPlugins/ParaViewSources/PeaksSource/vtkPeaksSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/PeaksSource/vtkPeaksSource.cxx
@@ -26,10 +26,9 @@ using Mantid::API::Workspace_sptr;
 using Mantid::API::AnalysisDataService;
 
 /// Constructor
-vtkPeaksSource::vtkPeaksSource() :  m_wsName(""), 
-  m_wsTypeName(""), m_uintPeakMarkerSize(0.3),
-  m_dimToShow(vtkPeakMarkerFactory::Peak_in_Q_lab)
-{
+vtkPeaksSource::vtkPeaksSource()
+    : m_uintPeakMarkerSize{0.3},
+      m_dimToShow{vtkPeakMarkerFactory::Peak_in_Q_lab} {
   this->SetNumberOfInputPorts(0);
   this->SetNumberOfOutputPorts(1);
 }
@@ -120,20 +119,14 @@ void vtkPeaksSource::updateAlgorithmProgress(double progress, const std::string&
 /*
 Getter for the workspace type name.
 */
-const char *vtkPeaksSource::GetWorkspaceTypeName() {
-  return m_wsTypeName.c_str();
+const std::string &vtkPeaksSource::GetWorkspaceTypeName() {
+  return m_wsTypeName;
 }
 
-const char* vtkPeaksSource::GetWorkspaceName()
-{
-  return m_wsName.c_str();
-}
+const std::string &vtkPeaksSource::GetWorkspaceName() { return m_wsName; }
 
 /**
  * Gets the (first) instrument which is associated with the workspace.
  * @return The name of the instrument.
  */
-const char* vtkPeaksSource::GetInstrument()
-{
-  return m_instrument.c_str();
-}
+const std::string &vtkPeaksSource::GetInstrument() { return m_instrument; }

--- a/Vates/ParaviewPlugins/ParaViewSources/PeaksSource/vtkPeaksSource.h
+++ b/Vates/ParaviewPlugins/ParaViewSources/PeaksSource/vtkPeaksSource.h
@@ -39,6 +39,8 @@ class VTK_EXPORT vtkPeaksSource : public vtkPolyDataAlgorithm
 {
 public:
   static vtkPeaksSource *New();
+  vtkPeaksSource(const vtkPeaksSource &) = delete;
+  void operator=(const vtkPeaksSource &) = delete;
   vtkTypeMacro(vtkPeaksSource,
                vtkPolyDataAlgorithm) void PrintSelf(ostream &os,
                                                     vtkIndent indent) override;
@@ -50,11 +52,11 @@ public:
   /// Update the algorithm progress.
   void updateAlgorithmProgress(double progress, const std::string& message);
   /// Getter for the workspace name
-  const char* GetWorkspaceName();
+  const std::string &GetWorkspaceName();
   /// Getter for the workspace type
-  const char *GetWorkspaceTypeName();
+  const std::string &GetWorkspaceTypeName();
   /// Getter for the instrument associated with the workspace
-  const char* GetInstrument();
+  const std::string &GetInstrument();
 
 protected:
   vtkPeaksSource();
@@ -82,8 +84,5 @@ private:
 
   /// Instrument name.
   std::string m_instrument;
-
-  vtkPeaksSource(const vtkPeaksSource&);
-  void operator = (const vtkPeaksSource&);
 };
 #endif


### PR DESCRIPTION
Description of work.

This fixes Coverity issues #1355157 and #1355158, which found that some of our ParaView plugins were returning a `const char *` and destroying the string that it points to. The easiest fix is to return a `std::string`. I made the same change for the other plugins as well as a little code cleanup.

I'm not sure why changing the return type from `char *` to `const char *` triggered these warning, but I fear both functions were only working because of undefined behavior.

**To test:**

<!-- Instructions for testing. -->

Changes should be clear from code review.

There is no issue associated with this pull request.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
