### PR TITLE
DynamicPDF: fix coverity warning in DPDFInputDataControl

### DIFF
--- a/MantidQt/CustomInterfaces/src/DynamicPDF/DPDFInputDataControl.cpp
+++ b/MantidQt/CustomInterfaces/src/DynamicPDF/DPDFInputDataControl.cpp
@@ -27,6 +27,7 @@ namespace DynamicPDF {
  */
 InputDataControl::InputDataControl() :
   m_workspace(),
+  m_selectedWorkspaceIndex{0},
   m_domain() {
   this->observePreDelete(true); // Subscribe to notifications
 }


### PR DESCRIPTION
A simple fix: initialize member attribute of class InputDataControl in the constructor

**To test:**
Nothing to test

Fixes #16112.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
