### PR TITLE
Allow log levels to match the lowest of all filter channels

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -224,6 +224,9 @@ public:
   /// Set the default facility
   void setFacility(const std::string &facilityName);
 
+  /// registers additional logging filter channels
+  void registerLoggingFilterChannel(const std::string &filterChannelName,
+                                    Poco::Channel *pChannel);
   /// Sets the log level priority for the File log channel
   void setFileLogLevel(int logLevel);
   /// Sets the log level priority for the Console log channel
@@ -270,6 +273,7 @@ private:
   void loadConfig(const std::string &filename, const bool append = false);
   /// Read a file and place its contents into the given string
   bool readFile(const std::string &filename, std::string &contents) const;
+
   /// Provides a string of a default configuration
   std::string defaultConfig() const;
   /// Writes out a fresh user properties file
@@ -298,6 +302,8 @@ private:
   /// Returns a list of all keys under a given root key
   void getKeysRecursive(const std::string &root,
                         std::vector<std::string> &allKeys) const;
+  ///Finds the lowest registered logging filter level
+  int ConfigServiceImpl::FindLowestFilterLevel() const;
 
   // Forward declaration of inner class
   template <class T> class WrappedObject;
@@ -341,6 +347,9 @@ private:
   Kernel::ProxyInfo m_proxyInfo;
   /// whether the proxy has been populated yet
   bool m_isProxySet;
+
+  /// store a list of logging FilterChannels
+  std::vector<std::string> m_filterChannels;
 };
 
 /// Forward declaration of a specialisation of SingletonHolder for

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -303,7 +303,7 @@ private:
   void getKeysRecursive(const std::string &root,
                         std::vector<std::string> &allKeys) const;
   /// Finds the lowest registered logging filter level
-  int ConfigServiceImpl::FindLowestFilterLevel() const;
+  int FindLowestFilterLevel() const;
 
   // Forward declaration of inner class
   template <class T> class WrappedObject;

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -302,7 +302,7 @@ private:
   /// Returns a list of all keys under a given root key
   void getKeysRecursive(const std::string &root,
                         std::vector<std::string> &allKeys) const;
-  ///Finds the lowest registered logging filter level
+  /// Finds the lowest registered logging filter level
   int ConfigServiceImpl::FindLowestFilterLevel() const;
 
   // Forward declaration of inner class

--- a/Framework/Kernel/inc/MantidKernel/FilterChannel.h
+++ b/Framework/Kernel/inc/MantidKernel/FilterChannel.h
@@ -45,7 +45,7 @@ namespace Poco {
 /// channels simultaneously.
 class MANTID_KERNEL_DLL FilterChannel : public Channel {
 public:
-  /// Creates the SplitterChannel.
+  /// Creates the FilterChannel.
   FilterChannel();
 
   /// destructor

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -2023,7 +2023,7 @@ int ConfigServiceImpl::FindLowestFilterLevel() const {
   // Find the lowest level of all of the filter channels
   for (const auto filterChannelName : m_filterChannels) {
     try {
-      auto* channel = Poco::LoggingRegistry::defaultRegistry().channelForName(
+      auto *channel = Poco::LoggingRegistry::defaultRegistry().channelForName(
           filterChannelName);
       auto *filterChannel = dynamic_cast<Poco::FilterChannel *>(channel);
       if (filterChannel) {

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -2022,9 +2022,8 @@ int ConfigServiceImpl::FindLowestFilterLevel() const {
   int lowestPriority = Logger::Priority::PRIO_FATAL;
   // Find the lowest level of all of the filter channels
   for (const auto filterChannelName : m_filterChannels) {
-    Poco::Channel *channel = nullptr;
     try {
-      channel = Poco::LoggingRegistry::defaultRegistry().channelForName(
+      auto* channel = Poco::LoggingRegistry::defaultRegistry().channelForName(
           filterChannelName);
       auto *filterChannel = dynamic_cast<Poco::FilterChannel *>(channel);
       if (filterChannel) {

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -237,8 +237,7 @@ ConfigServiceImpl::ConfigServiceImpl()
                       << " revision " << MantidVersion::revision() << std::endl;
   g_log.information() << "running on " << getComputerName() << " starting "
                       << DateAndTime::getCurrentTime().toFormattedString(
-                             "%Y-%m-%dT%H:%MZ")
-                      << "\n";
+                             "%Y-%m-%dT%H:%MZ") << "\n";
   g_log.information() << "Properties file(s) loaded: " << propertiesFilesList
                       << std::endl;
 #ifndef MPI_BUILD // There is no logging to file by default in MPI build
@@ -645,22 +644,18 @@ void ConfigServiceImpl::createUserPropertiesFile() const {
         std::fstream::out);
 
     filestr << "# This file can be used to override any properties for this "
-               "installation."
-            << std::endl;
+               "installation." << std::endl;
     filestr << "# Any properties found in this file will override any that are "
-               "found in the Mantid.Properties file"
-            << std::endl;
+               "found in the Mantid.Properties file" << std::endl;
     filestr << "# As this file will not be replaced with futher installations "
-               "of Mantid it is a safe place to put "
-            << std::endl;
+               "of Mantid it is a safe place to put " << std::endl;
     filestr << "# properties that suit your particular installation."
             << std::endl;
     filestr << "#" << std::endl;
     filestr << "# See here for a list of possible options:" << std::endl;
     filestr << "# "
                "http://www.mantidproject.org/"
-               "Properties_File#Mantid.User.Properties"
-            << std::endl;
+               "Properties_File#Mantid.User.Properties" << std::endl;
     filestr << std::endl;
     filestr << "##" << std::endl;
     filestr << "## GENERAL" << std::endl;
@@ -693,21 +688,18 @@ void ConfigServiceImpl::createUserPropertiesFile() const {
     filestr << std::endl;
     filestr << "## Sets the Q.convention" << std::endl;
     filestr << "## Set to Crystallography for kf-ki instead of default "
-               "Inelastic which is ki-kf"
-            << std::endl;
+               "Inelastic which is ki-kf" << std::endl;
     filestr << "#Q.convention=Crystallography" << std::endl;
     filestr << "##" << std::endl;
     filestr << "## DIRECTORIES" << std::endl;
     filestr << "##" << std::endl;
     filestr << std::endl;
     filestr << "## Sets a list of directories (separated by semi colons) to "
-               "search for data"
-            << std::endl;
+               "search for data" << std::endl;
     filestr << "#datasearch.directories=../data;../isis/data" << std::endl;
     filestr << std::endl;
     filestr << "## Set a list (separated by semi colons) of directories to "
-               "look for additional Python scripts"
-            << std::endl;
+               "look for additional Python scripts" << std::endl;
     filestr << "#pythonscripts.directories=../scripts;../docs/MyScripts"
             << std::endl;
     filestr << std::endl;
@@ -748,8 +740,7 @@ void ConfigServiceImpl::createUserPropertiesFile() const {
     filestr << "#MantidOptions.ReusePlotInstances=Off" << std::endl;
     filestr << std::endl;
     filestr << "## Uncomment to disable use of OpenGL to render unwrapped "
-               "instrument views"
-            << std::endl;
+               "instrument views" << std::endl;
     filestr << "#MantidOptions.InstrumentView.UseOpenGL=Off" << std::endl;
 
     filestr.close();

--- a/Framework/Kernel/src/FilterChannel.cpp
+++ b/Framework/Kernel/src/FilterChannel.cpp
@@ -37,7 +37,7 @@ void FilterChannel::setProperty(const std::string &name,
 void FilterChannel::log(const Message &msg) {
   std::lock_guard<std::mutex> lock(_mutex);
 
-  if (msg.getPriority() <= _priority) {
+  if ((_channel) && (msg.getPriority() <= _priority)) {
     _channel->log(msg);
   }
 }

--- a/Framework/Kernel/src/Logger.cpp
+++ b/Framework/Kernel/src/Logger.cpp
@@ -25,8 +25,9 @@ Poco::NullOutputStream NULL_STREAM;
 }
 
 static const std::string PriorityNames_data[] = {
-    "PRIO_FATAL",  "PRIO_CRITICAL",    "PRIO_ERROR", "PRIO_WARNING",
-    "PRIO_NOTICE", "PRIO_INFORMATION", "PRIO_DEBUG", "PRIO_TRACE"};
+    "NOT_USED",         "PRIO_FATAL",   "PRIO_CRITICAL",
+    "PRIO_ERROR",       "PRIO_WARNING", "PRIO_NOTICE",
+    "PRIO_INFORMATION", "PRIO_DEBUG",   "PRIO_TRACE"};
 const std::string *Logger::PriorityNames = PriorityNames_data;
 
 /** Constructor

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -715,9 +715,8 @@ protected:
   std::string m_key;
   std::string m_preValue;
   std::string m_curValue;
-  void handleConfigChange(
-      const Poco::AutoPtr<Mantid::Kernel::ConfigServiceImpl::ValueChanged>
-          &pNf) {
+  void handleConfigChange(const Poco::AutoPtr<
+      Mantid::Kernel::ConfigServiceImpl::ValueChanged> &pNf) {
     m_valueChangedSent = true;
     m_key = pNf->key();
     m_preValue = pNf->preValue();

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -184,16 +184,17 @@ public:
 
     configService.setFilterChannelLogLevel(m_FilterChannelName,
                                            Logger::Priority::PRIO_TRACE);
-    TSM_ASSERT("The log level be PRIO_TRACE",
+    TSM_ASSERT("The log level should be PRIO_TRACE",
                log1.getLevel() == Logger::Priority::PRIO_TRACE);
-    TSM_ASSERT("The log filter priority be PRIO_TRACE",
+    TSM_ASSERT("The log filter priority should be PRIO_TRACE",
                testFilterChannel->getPriority() ==
                    Logger::Priority::PRIO_TRACE);
 
     configService.setFilterChannelLogLevel(m_FilterChannelName, prevLogLevel);
-    TSM_ASSERT("The log level be " + prevLogLevel,
+    TSM_ASSERT("The log level should be " + std::to_string(prevLogLevel),
                log1.getLevel() == prevLogLevel);
-    TSM_ASSERT("The log filter priority be " + prevLogLevel,
+    TSM_ASSERT("The log filter priority should be " +
+                   std::to_string(prevLogLevel),
                testFilterChannel->getPriority() ==
                    static_cast<unsigned int>(prevLogLevel));
   }

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -6,6 +6,7 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/TestChannel.h"
+#include "MantidKernel/FilterChannel.h"
 #include "MantidKernel/InstrumentInfo.h"
 #include "MantidKernel/FacilityInfo.h"
 
@@ -16,6 +17,8 @@
 #include <fstream>
 
 #include <Poco/NObserver.h>
+#include <Poco/SplitterChannel.h>
+#include <Poco/Logger.h>
 #include <Poco/Environment.h>
 #include <Poco/File.h>
 
@@ -56,8 +59,7 @@ public:
 
         );
 
-    // checking the level - this should be set to debug in the config file
-    // therefore this should only return false for debug
+    // checking the level - this is set above
     TS_ASSERT(log1.is(Poco::Message::PRIO_DEBUG) == false);       // debug
     TS_ASSERT(log1.is(Poco::Message::PRIO_INFORMATION) == false); // information
     TS_ASSERT(log1.is(Poco::Message::PRIO_NOTICE));               // notice
@@ -129,6 +131,71 @@ public:
         "setFilterChannelLogLevel did not throw",
         ConfigService::Instance().setFilterChannelLogLevel("consoleChannel", 4),
         std::invalid_argument);
+  }
+
+  void testLogLevelChangesWithFilteringLevels() {
+    Logger log1("testLogLevelChangesWithFilteringLevels");
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setConsoleLogLevel(4));
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setFileLogLevel(4));
+    TSM_ASSERT("The log level should be 4 after both filters are set to 4",
+               log1.is(4));
+
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setFileLogLevel(3));
+    TSM_ASSERT("The log level remain at 4 if any filter is at 4", log1.is(4));
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setConsoleLogLevel(3));
+    TSM_ASSERT("The log level should be 3 after both filters are set to 3",
+               log1.is(3));
+
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setFileLogLevel(5));
+    TSM_ASSERT("The log level should be at 5 if any filter is at 5",
+               log1.is(5));
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setConsoleLogLevel(5));
+    TSM_ASSERT("The log level remain at 5 after both filters are set to 5",
+               log1.is(5));
+
+    // return back to previous values
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setConsoleLogLevel(4));
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setFileLogLevel(4));
+  }
+
+  void testRegisteringaNewFilter() {
+    Logger log1("testRegisteringaNewFilter");
+    Poco::FilterChannel *testFilterChannel = new Poco::FilterChannel();
+    std::string m_FilterChannelName = "testRegisteringaNewFilter";
+
+    // Setup logging
+    auto &rootLogger = Poco::Logger::root();
+    auto *rootChannel = Poco::Logger::root().getChannel();
+    // The root channel might be a SplitterChannel
+    if (auto *splitChannel =
+            dynamic_cast<Poco::SplitterChannel *>(rootChannel)) {
+      splitChannel->addChannel(testFilterChannel);
+    } else {
+      Poco::Logger::setChannel(rootLogger.name(), testFilterChannel);
+    }
+
+    auto &configService = ConfigService::Instance();
+    configService.registerLoggingFilterChannel(m_FilterChannelName,
+                                               testFilterChannel);
+
+    int prevLogLevel = log1.getLevel();
+    TSM_ASSERT("The log level start above PRIO_TRACE",
+               log1.getLevel() < Logger::Priority::PRIO_TRACE);
+
+    configService.setFilterChannelLogLevel(m_FilterChannelName,
+                                           Logger::Priority::PRIO_TRACE);
+    TSM_ASSERT("The log level be PRIO_TRACE",
+               log1.getLevel() == Logger::Priority::PRIO_TRACE);
+    TSM_ASSERT("The log filter priority be PRIO_TRACE",
+               testFilterChannel->getPriority() ==
+                   Logger::Priority::PRIO_TRACE);
+
+    configService.setFilterChannelLogLevel(m_FilterChannelName, prevLogLevel);
+    TSM_ASSERT("The log level be " + prevLogLevel,
+               log1.getLevel() == prevLogLevel);
+    TSM_ASSERT("The log filter priority be " + prevLogLevel,
+               testFilterChannel->getPriority() ==
+                   static_cast<unsigned int>(prevLogLevel));
   }
 
   void testDefaultFacility() {
@@ -648,8 +715,9 @@ protected:
   std::string m_key;
   std::string m_preValue;
   std::string m_curValue;
-  void handleConfigChange(const Poco::AutoPtr<
-      Mantid::Kernel::ConfigServiceImpl::ValueChanged> &pNf) {
+  void handleConfigChange(
+      const Poco::AutoPtr<Mantid::Kernel::ConfigServiceImpl::ValueChanged>
+          &pNf) {
     m_valueChangedSent = true;
     m_key = pNf->key();
     m_preValue = pNf->preValue();

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MessageDisplay.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MessageDisplay.h
@@ -65,7 +65,7 @@ namespace MantidQt
       void setSource(const QString & source);
       /// Get the current source are emitted
       inline const QString & source() const { return m_logChannel->source(); }
-
+      
     signals:
       /// Indicate that a message of error or higher has been received.
       void errorReceived(const QString & text);
@@ -133,6 +133,9 @@ namespace MantidQt
       QSignalMapper *m_logLevelMapping;
       /// Log level actions
       QAction  *m_error,*m_warning,*m_notice, *m_information, *m_debug;
+
+      // the name of the fliter channel
+      const std::string m_FilterChannelName = "MessageDisplayPriority";
     };
 
   }

--- a/MantidQt/MantidWidgets/src/MessageDisplay.cpp
+++ b/MantidQt/MantidWidgets/src/MessageDisplay.cpp
@@ -3,6 +3,7 @@
 //-------------------------------------------
 #include "MantidQtMantidWidgets/MessageDisplay.h"
 
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Logger.h"
 
 #include <QAction>
@@ -19,379 +20,368 @@
 #include <Poco/Message.h>
 #include <Poco/SplitterChannel.h>
 
+namespace MantidQt {
+namespace MantidWidgets {
+using API::Message;
 
-namespace MantidQt
-{
-  namespace MantidWidgets
-  {
-    using API::Message;
+//-------------------------------------------
+// Public member functions
+//-------------------------------------------
+/**
+ * Constructs a widget that does not allow control over the global log level
+ * @param parent An optional parent widget
+ */
+MessageDisplay::MessageDisplay(QWidget *parent)
+    : QWidget(parent), m_logLevelControl(DisableLogLevelControl),
+      m_logChannel(new API::QtSignalChannel),
+      m_filterChannel(new Poco::FilterChannel),
+      m_textDisplay(new QPlainTextEdit(this)), m_formats(),
+      m_loglevels(new QActionGroup(this)),
+      m_logLevelMapping(new QSignalMapper(this)),
+      m_error(new QAction(tr("&Error"), this)),
+      m_warning(new QAction(tr("&Warning"), this)),
+      m_notice(new QAction(tr("&Notice"), this)),
+      m_information(new QAction(tr("&Information"), this)),
+      m_debug(new QAction(tr("&Debug"), this)) {
+  initActions();
+  initFormats();
+  setupTextArea();
+}
 
-    //-------------------------------------------
-    // Public member functions
-    //-------------------------------------------
-    /**
-     * Constructs a widget that does not allow control over the global log level
-     * @param parent An optional parent widget
-     */
-    MessageDisplay::MessageDisplay(QWidget *parent)
-    : QWidget(parent), m_logLevelControl(DisableLogLevelControl), m_logChannel(new API::QtSignalChannel),m_filterChannel(new Poco::FilterChannel),
-      m_textDisplay(new QPlainTextEdit(this)), m_formats(), m_loglevels(new QActionGroup(this)), m_logLevelMapping(new QSignalMapper(this)),
-      m_error(new QAction(tr("&Error"), this)), m_warning(new QAction(tr("&Warning"), this)),
-      m_notice(new QAction(tr("&Notice"), this)), m_information(new QAction(tr("&Information"), this)),
-      m_debug(new QAction(tr("&Debug"), this))
-    {
-      initActions();
-      initFormats();
-      setupTextArea();
-    }
+/**
+ * @param logLevelControl Controls whether this display shows the right-click
+ * option to change
+ * the global log level
+ * @param parent An optional parent widget
+ */
+MessageDisplay::MessageDisplay(LogLevelControl logLevelControl, QWidget *parent)
+    : QWidget(parent), m_logLevelControl(logLevelControl),
+      m_logChannel(new API::QtSignalChannel),
+      m_filterChannel(new Poco::FilterChannel),
+      m_textDisplay(new QPlainTextEdit(this)),
+      m_loglevels(new QActionGroup(this)),
+      m_logLevelMapping(new QSignalMapper(this)),
+      m_error(new QAction(tr("&Error"), this)),
+      m_warning(new QAction(tr("&Warning"), this)),
+      m_notice(new QAction(tr("&Notice"), this)),
+      m_information(new QAction(tr("&Information"), this)),
+      m_debug(new QAction(tr("&Debug"), this)) {
+  initActions();
+  initFormats();
+  setupTextArea();
+}
 
-    /**
-     * @param logLevelControl Controls whether this display shows the right-click option to change
-     * the global log level
-     * @param parent An optional parent widget
-     */
-    MessageDisplay::MessageDisplay(LogLevelControl logLevelControl, QWidget *parent)
-    : QWidget(parent), m_logLevelControl(logLevelControl), m_logChannel(new API::QtSignalChannel),m_filterChannel(new Poco::FilterChannel),
-      m_textDisplay(new QPlainTextEdit(this)), m_loglevels(new QActionGroup(this)), m_logLevelMapping(new QSignalMapper(this)),
-      m_error(new QAction(tr("&Error"), this)), m_warning(new QAction(tr("&Warning"), this)),
-      m_notice(new QAction(tr("&Notice"), this)), m_information(new QAction(tr("&Information"), this)),
-      m_debug(new QAction(tr("&Debug"), this))
-    {
-      initActions();
-      initFormats();
-      setupTextArea();
-    }
+/**
+ */
+MessageDisplay::~MessageDisplay() {
+  QSettings settings;
+  settings.setValue("MessageDisplayPriority",
+                    static_cast<int>(m_filterChannel->getPriority()));
+  // The Channel class is ref counted and will
+  // delete itself when required
+  m_filterChannel->release();
+  m_logChannel->release();
+  delete m_textDisplay;
+}
 
-    /**
-     */
-    MessageDisplay::~MessageDisplay()
-    {
-      QSettings settings;
-      settings.setValue("MessageDisplayPriority",
-                        static_cast<int>(m_filterChannel->getPriority()));
-      // The Channel class is ref counted and will
-      // delete itself when required
-      m_filterChannel->release();
-      m_logChannel->release();
-      delete m_textDisplay;
-    }
-
-    /**
-     * Attaches the Mantid logging framework
-     * (Note the ConfigService must have already been started)
-     */
-    void MessageDisplay::attachLoggingChannel()
-    {
-      // Setup logging
-      auto & rootLogger = Poco::Logger::root();
-      auto * rootChannel = Poco::Logger::root().getChannel();
-      // The root channel might be a SplitterChannel
-      if(auto *splitChannel = dynamic_cast<Poco::SplitterChannel*>(rootChannel))
-      {
-        splitChannel->addChannel(m_filterChannel);
-      }
-      else
-      {
-        Poco::Logger::setChannel(rootLogger.name(), m_filterChannel);
-      }
-      m_filterChannel->addChannel(m_logChannel);
-      
-      QSettings settings;
-      int priority =
-          settings
-              .value("MessageDisplayPriority", Message::Priority::PRIO_NOTICE)
-              .toInt();
-      m_filterChannel->setPriority(priority);
-
-      connect(m_logChannel, SIGNAL(messageReceived(const Message&)),
-          this, SLOT(append(const Message &)));
-    }
-
-    /**
-     * @param source A string specifying the required source for messages
-     * that will be emitted
-     */
-    void MessageDisplay::setSource(const QString & source)
-    {
-      m_logChannel->setSource(source);
-    }
-
-    //----------------------------------------------------------------------------------------
-    // Public slots
-    //----------------------------------------------------------------------------------------
-    /**
-     * @param text The text string to append at PRIO_FATAL level
-     */
-    void MessageDisplay::appendFatal(const QString & text)
-    {
-      this->append(Message(text, Message::Priority::PRIO_FATAL));
-    }
-
-    /**
-     * @param text The text string to append at PRIO_ERROR level
-     */
-    void MessageDisplay::appendError(const QString & text)
-    {
-      this->append(Message(text, Message::Priority::PRIO_ERROR));
-    }
-
-    /**
-     * @param text The text string to append at PRIO_WARNING level
-     */
-    void MessageDisplay::appendWarning(const QString & text)
-    {
-      this->append(Message(text, Message::Priority::PRIO_WARNING));
-    }
-
-    /**
-     * @param text The text string to append at PRIO_NOTICE level
-     */
-    void MessageDisplay::appendNotice(const QString & text)
-    {
-      this->append(Message(text, Message::Priority::PRIO_NOTICE));
-    }
-
-    /**
-     * @param text The text string to append at PRIO_INFORMATION level
-     */
-    void MessageDisplay::appendInformation(const QString & text)
-    {
-      this->append(Message(text, Message::Priority::PRIO_INFORMATION));
-    }
-
-    /**
-     * @param text The text string to append at PRIO_DEBUG level
-     */
-    void MessageDisplay::appendDebug(const QString & text)
-    {
-      this->append(Message(text, Message::Priority::PRIO_DEBUG));
-    }
-
-    /**
-     * @param msg A message that is echoed to the display after the
-     * current text
-     */
-    void MessageDisplay::append(const Message & msg)
-    {
-      QTextCursor cursor = moveCursorToEnd();
-      cursor.insertText(msg.text(), format(msg.priority()));
-      moveCursorToEnd();
-
-      if(msg.priority() <= Message::Priority::PRIO_ERROR ) emit errorReceived(msg.text());
-      if(msg.priority() <= Message::Priority::PRIO_WARNING ) emit warningReceived(msg.text());
-    }
-
-    /**
-     * @param msg Replace the current contents with this message
-     */
-    void MessageDisplay::replace(const Message & msg)
-    {
-      clear();
-      append(msg.text());
-    }
-
-    /**
-     * Clear all of the text
-     */
-    void MessageDisplay::clear()
-    {
-      m_textDisplay->clear();
-    }
-
-    /**
-     * @returns The cursor at the end of the text
-     */
-    QTextCursor MessageDisplay::moveCursorToEnd()
-    {
-      QTextCursor cursor( m_textDisplay->textCursor());
-      cursor.movePosition(QTextCursor::End);
-      m_textDisplay->setTextCursor(cursor);
-      return cursor;
-    }
-
-    /**
-     * @return True if scroll bar is at bottom, false otherwise
-     */
-    bool MessageDisplay::isScrollbarAtBottom() const
-    {
-      return m_textDisplay->verticalScrollBar()->value() == m_textDisplay->verticalScrollBar()->maximum();
-    }
-
-    /**
-     * Moves the cursor to the top of the document
-     */
-    void MessageDisplay::scrollToTop()
-    {
-      // Code taken from QtCreator source
-      m_textDisplay->verticalScrollBar()->setValue(m_textDisplay->verticalScrollBar()->minimum());
-      // QPlainTextEdit destroys the first calls value in case of multiline
-      // text, so make sure that the scroll bar actually gets the value set.
-      // Is a noop if the first call succeeded.
-      m_textDisplay->verticalScrollBar()->setValue(m_textDisplay->verticalScrollBar()->minimum());
-    }
-
-    /**
-     * Moves the cursor to the bottom of the document
-     */
-    void MessageDisplay::scrollToBottom()
-    {
-      // Code taken from QtCreator source
-      m_textDisplay->verticalScrollBar()->setValue(m_textDisplay->verticalScrollBar()->maximum());
-      // QPlainTextEdit destroys the first calls value in case of multiline
-      // text, so make sure that the scroll bar actually gets the value set.
-      // Is a noop if the first call succeeded.
-      m_textDisplay->verticalScrollBar()->setValue(m_textDisplay->verticalScrollBar()->maximum());
-    }
-
-    //----------------------------------------------------------------------------------------
-    // Protected members
-    //----------------------------------------------------------------------------------------
-
-    //-----------------------------------------------------------------------------
-    // Private slot member functions
-    //-----------------------------------------------------------------------------
-
-    void MessageDisplay::showContextMenu(const QPoint & mousePos)
-    {
-      QMenu * menu = m_textDisplay->createStandardContextMenu();
-      if(!m_textDisplay->document()->isEmpty()) menu->addAction("Clear",m_textDisplay, SLOT(clear()));
-
-      if(m_logLevelControl == MessageDisplay::EnableLogLevelControl)
-      {
-        menu->addSeparator();
-        QMenu *logLevelMenu = menu->addMenu("&Log Level");
-        logLevelMenu->addAction(m_error);
-        logLevelMenu->addAction(m_warning);
-        logLevelMenu->addAction(m_notice);
-        logLevelMenu->addAction(m_information);
-        logLevelMenu->addAction(m_debug);
-
-        //check the right level
-        int level = m_filterChannel->getPriority(); 
-        //get the root logger logging level
-        int rootLevel = Poco::Logger::root().getLevel();
-        if (rootLevel < level) {
-          level = rootLevel;
-        }
-
-        if (level == Poco::Message::PRIO_ERROR)
-          m_error->setChecked(true);
-        if (level == Poco::Message::PRIO_WARNING)
-          m_warning->setChecked(true);
-        if (level == Poco::Message::PRIO_NOTICE)
-          m_notice->setChecked(true);
-        if (level == Poco::Message::PRIO_INFORMATION)
-          m_information->setChecked(true);
-        if (level >= Poco::Message::PRIO_DEBUG)
-          m_debug->setChecked(true);
-      }
-
-      menu->exec(this->mapToGlobal(mousePos));
-      delete menu;
-    }
-
-    /*
-     * @param priority An integer that must match the Poco::Message priority
-     * enumeration
-     */
-    void MessageDisplay::setGlobalLogLevel(int priority)
-    {
-      //set Local filter level
-      m_filterChannel->setPriority(priority);
-      //if this is higher than the global level then that will have to be lowered to work
-      int rootLevel = Poco::Logger::root().getLevel();
-      if (rootLevel < priority)
-      {
-         Mantid::Kernel::Logger::setLevelForAll(priority);
-      }
-    }
-
-    //-----------------------------------------------------------------------------
-    // Private non-slot member functions
-    //-----------------------------------------------------------------------------
-    /*
-     */
-    void MessageDisplay::initActions()
-    {
-      m_error->setCheckable(true);
-      m_warning->setCheckable(true);
-      m_notice->setCheckable(true);
-      m_information->setCheckable(true);
-      m_debug->setCheckable(true);
-
-      m_loglevels->addAction(m_error);
-      m_loglevels->addAction(m_warning);
-      m_loglevels->addAction(m_notice);
-      m_loglevels->addAction(m_information);
-      m_loglevels->addAction(m_debug);
-
-      m_logLevelMapping->setMapping(m_error, Poco::Message::PRIO_ERROR);
-      m_logLevelMapping->setMapping(m_warning, Poco::Message::PRIO_WARNING);
-      m_logLevelMapping->setMapping(m_notice, Poco::Message::PRIO_NOTICE);
-      m_logLevelMapping->setMapping(m_information, Poco::Message::PRIO_INFORMATION);
-      m_logLevelMapping->setMapping(m_debug, Poco::Message::PRIO_DEBUG);
-
-      connect(m_error, SIGNAL(activated()), m_logLevelMapping, SLOT (map()));
-      connect(m_warning, SIGNAL(activated()), m_logLevelMapping, SLOT (map()));
-      connect(m_notice, SIGNAL(activated()), m_logLevelMapping, SLOT (map()));
-      connect(m_information, SIGNAL(activated()), m_logLevelMapping, SLOT (map()));
-      connect(m_debug, SIGNAL(activated()), m_logLevelMapping, SLOT (map()));
-
-      connect(m_logLevelMapping, SIGNAL(mapped(int)), this, SLOT(setGlobalLogLevel(int)));
-    }
-
-    /**
-     * Sets up the internal map of text formatters for each log level
-     */
-    void MessageDisplay::initFormats()
-    {
-      m_formats.clear();
-      QTextCharFormat format;
-
-      format.setForeground(Qt::red);
-      m_formats[Message::Priority::PRIO_ERROR] = format;
-
-      format.setForeground(QColor::fromRgb(255, 100, 0));
-      m_formats[Message::Priority::PRIO_WARNING] = format;
-
-      format.setForeground(Qt::gray);
-      m_formats[Message::Priority::PRIO_INFORMATION] = format;
-
-      format.setForeground(Qt::darkBlue);
-      m_formats[Message::Priority::PRIO_NOTICE] = format;
-    }
-
-    /**
-     * Set the properties of the text display, i.e read-only
-     * and make it occupy the whole widget
-     */
-    void MessageDisplay::setupTextArea()
-    {
-      m_textDisplay->setReadOnly(true);
-      m_textDisplay->ensureCursorVisible();
-      m_textDisplay->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-      m_textDisplay->setMouseTracking(true);
-      m_textDisplay->setUndoRedoEnabled(false);
-
-      this->setLayout(new QHBoxLayout(this));
-      QLayout *layout = this->layout();
-      layout->setContentsMargins(0,0,0,0);
-      layout->addWidget(m_textDisplay);
-
-      this->setFocusProxy(m_textDisplay);
-      m_textDisplay->setContextMenuPolicy(Qt::CustomContextMenu);
-      connect(m_textDisplay, SIGNAL(customContextMenuRequested(const QPoint&)),
-          this, SLOT(showContextMenu(const QPoint&)));
-    }
-
-    /**
-     * @param priority An enumeration for the log level
-     * @return format for given log level
-     */
-    QTextCharFormat MessageDisplay::format(const API::Message::Priority priority) const
-    {
-      return m_formats.value(priority,QTextCharFormat());
-    }
-
+/**
+ * Attaches the Mantid logging framework
+ * (Note the ConfigService must have already been started)
+ */
+void MessageDisplay::attachLoggingChannel() {
+  // Setup logging
+  auto &rootLogger = Poco::Logger::root();
+  auto *rootChannel = Poco::Logger::root().getChannel();
+  // The root channel might be a SplitterChannel
+  if (auto *splitChannel = dynamic_cast<Poco::SplitterChannel *>(rootChannel)) {
+    splitChannel->addChannel(m_filterChannel);
+  } else {
+    Poco::Logger::setChannel(rootLogger.name(), m_filterChannel);
   }
+  m_filterChannel->addChannel(m_logChannel);
+
+  QSettings settings;
+  int priority = settings.value(QString::fromStdString(m_FilterChannelName),
+                                Message::Priority::PRIO_NOTICE)
+                     .toInt();
+
+  auto &configService = Mantid::Kernel::ConfigService::Instance();
+  configService.registerLoggingFilterChannel(m_FilterChannelName,
+                                             m_filterChannel);
+  configService.setFilterChannelLogLevel(m_FilterChannelName, priority);
+
+  connect(m_logChannel, SIGNAL(messageReceived(const Message &)), this,
+          SLOT(append(const Message &)));
+}
+
+/**
+ * @param source A string specifying the required source for messages
+ * that will be emitted
+ */
+void MessageDisplay::setSource(const QString &source) {
+  m_logChannel->setSource(source);
+}
+
+//----------------------------------------------------------------------------------------
+// Public slots
+//----------------------------------------------------------------------------------------
+/**
+ * @param text The text string to append at PRIO_FATAL level
+ */
+void MessageDisplay::appendFatal(const QString &text) {
+  this->append(Message(text, Message::Priority::PRIO_FATAL));
+}
+
+/**
+ * @param text The text string to append at PRIO_ERROR level
+ */
+void MessageDisplay::appendError(const QString &text) {
+  this->append(Message(text, Message::Priority::PRIO_ERROR));
+}
+
+/**
+ * @param text The text string to append at PRIO_WARNING level
+ */
+void MessageDisplay::appendWarning(const QString &text) {
+  this->append(Message(text, Message::Priority::PRIO_WARNING));
+}
+
+/**
+ * @param text The text string to append at PRIO_NOTICE level
+ */
+void MessageDisplay::appendNotice(const QString &text) {
+  this->append(Message(text, Message::Priority::PRIO_NOTICE));
+}
+
+/**
+ * @param text The text string to append at PRIO_INFORMATION level
+ */
+void MessageDisplay::appendInformation(const QString &text) {
+  this->append(Message(text, Message::Priority::PRIO_INFORMATION));
+}
+
+/**
+ * @param text The text string to append at PRIO_DEBUG level
+ */
+void MessageDisplay::appendDebug(const QString &text) {
+  this->append(Message(text, Message::Priority::PRIO_DEBUG));
+}
+
+/**
+ * @param msg A message that is echoed to the display after the
+ * current text
+ */
+void MessageDisplay::append(const Message &msg) {
+  QTextCursor cursor = moveCursorToEnd();
+  cursor.insertText(msg.text(), format(msg.priority()));
+  moveCursorToEnd();
+
+  if (msg.priority() <= Message::Priority::PRIO_ERROR)
+    emit errorReceived(msg.text());
+  if (msg.priority() <= Message::Priority::PRIO_WARNING)
+    emit warningReceived(msg.text());
+}
+
+/**
+ * @param msg Replace the current contents with this message
+ */
+void MessageDisplay::replace(const Message &msg) {
+  clear();
+  append(msg.text());
+}
+
+/**
+ * Clear all of the text
+ */
+void MessageDisplay::clear() { m_textDisplay->clear(); }
+
+/**
+ * @returns The cursor at the end of the text
+ */
+QTextCursor MessageDisplay::moveCursorToEnd() {
+  QTextCursor cursor(m_textDisplay->textCursor());
+  cursor.movePosition(QTextCursor::End);
+  m_textDisplay->setTextCursor(cursor);
+  return cursor;
+}
+
+/**
+ * @return True if scroll bar is at bottom, false otherwise
+ */
+bool MessageDisplay::isScrollbarAtBottom() const {
+  return m_textDisplay->verticalScrollBar()->value() ==
+         m_textDisplay->verticalScrollBar()->maximum();
+}
+
+/**
+ * Moves the cursor to the top of the document
+ */
+void MessageDisplay::scrollToTop() {
+  // Code taken from QtCreator source
+  m_textDisplay->verticalScrollBar()->setValue(
+      m_textDisplay->verticalScrollBar()->minimum());
+  // QPlainTextEdit destroys the first calls value in case of multiline
+  // text, so make sure that the scroll bar actually gets the value set.
+  // Is a noop if the first call succeeded.
+  m_textDisplay->verticalScrollBar()->setValue(
+      m_textDisplay->verticalScrollBar()->minimum());
+}
+
+/**
+ * Moves the cursor to the bottom of the document
+ */
+void MessageDisplay::scrollToBottom() {
+  // Code taken from QtCreator source
+  m_textDisplay->verticalScrollBar()->setValue(
+      m_textDisplay->verticalScrollBar()->maximum());
+  // QPlainTextEdit destroys the first calls value in case of multiline
+  // text, so make sure that the scroll bar actually gets the value set.
+  // Is a noop if the first call succeeded.
+  m_textDisplay->verticalScrollBar()->setValue(
+      m_textDisplay->verticalScrollBar()->maximum());
+}
+
+//----------------------------------------------------------------------------------------
+// Protected members
+//----------------------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+// Private slot member functions
+//-----------------------------------------------------------------------------
+
+void MessageDisplay::showContextMenu(const QPoint &mousePos) {
+  QMenu *menu = m_textDisplay->createStandardContextMenu();
+  if (!m_textDisplay->document()->isEmpty())
+    menu->addAction("Clear", m_textDisplay, SLOT(clear()));
+
+  if (m_logLevelControl == MessageDisplay::EnableLogLevelControl) {
+    menu->addSeparator();
+    QMenu *logLevelMenu = menu->addMenu("&Log Level");
+    logLevelMenu->addAction(m_error);
+    logLevelMenu->addAction(m_warning);
+    logLevelMenu->addAction(m_notice);
+    logLevelMenu->addAction(m_information);
+    logLevelMenu->addAction(m_debug);
+
+    // check the right level
+    int level = m_filterChannel->getPriority();
+    // get the root logger logging level
+    int rootLevel = Poco::Logger::root().getLevel();
+    if (rootLevel < level) {
+      level = rootLevel;
+    }
+
+    if (level == Poco::Message::PRIO_ERROR)
+      m_error->setChecked(true);
+    if (level == Poco::Message::PRIO_WARNING)
+      m_warning->setChecked(true);
+    if (level == Poco::Message::PRIO_NOTICE)
+      m_notice->setChecked(true);
+    if (level == Poco::Message::PRIO_INFORMATION)
+      m_information->setChecked(true);
+    if (level >= Poco::Message::PRIO_DEBUG)
+      m_debug->setChecked(true);
+  }
+
+  menu->exec(this->mapToGlobal(mousePos));
+  delete menu;
+}
+
+/*
+ * @param priority An integer that must match the Poco::Message priority
+ * enumeration
+ */
+void MessageDisplay::setGlobalLogLevel(int priority) {
+  // set Local filter level
+
+  Mantid::Kernel::ConfigService::Instance().setFilterChannelLogLevel(
+      m_FilterChannelName, priority);
+  m_filterChannel->setPriority(priority);
+}
+
+//-----------------------------------------------------------------------------
+// Private non-slot member functions
+//-----------------------------------------------------------------------------
+/*
+ */
+void MessageDisplay::initActions() {
+  m_error->setCheckable(true);
+  m_warning->setCheckable(true);
+  m_notice->setCheckable(true);
+  m_information->setCheckable(true);
+  m_debug->setCheckable(true);
+
+  m_loglevels->addAction(m_error);
+  m_loglevels->addAction(m_warning);
+  m_loglevels->addAction(m_notice);
+  m_loglevels->addAction(m_information);
+  m_loglevels->addAction(m_debug);
+
+  m_logLevelMapping->setMapping(m_error, Poco::Message::PRIO_ERROR);
+  m_logLevelMapping->setMapping(m_warning, Poco::Message::PRIO_WARNING);
+  m_logLevelMapping->setMapping(m_notice, Poco::Message::PRIO_NOTICE);
+  m_logLevelMapping->setMapping(m_information, Poco::Message::PRIO_INFORMATION);
+  m_logLevelMapping->setMapping(m_debug, Poco::Message::PRIO_DEBUG);
+
+  connect(m_error, SIGNAL(activated()), m_logLevelMapping, SLOT(map()));
+  connect(m_warning, SIGNAL(activated()), m_logLevelMapping, SLOT(map()));
+  connect(m_notice, SIGNAL(activated()), m_logLevelMapping, SLOT(map()));
+  connect(m_information, SIGNAL(activated()), m_logLevelMapping, SLOT(map()));
+  connect(m_debug, SIGNAL(activated()), m_logLevelMapping, SLOT(map()));
+
+  connect(m_logLevelMapping, SIGNAL(mapped(int)), this,
+          SLOT(setGlobalLogLevel(int)));
+}
+
+/**
+ * Sets up the internal map of text formatters for each log level
+ */
+void MessageDisplay::initFormats() {
+  m_formats.clear();
+  QTextCharFormat format;
+
+  format.setForeground(Qt::red);
+  m_formats[Message::Priority::PRIO_ERROR] = format;
+
+  format.setForeground(QColor::fromRgb(255, 100, 0));
+  m_formats[Message::Priority::PRIO_WARNING] = format;
+
+  format.setForeground(Qt::gray);
+  m_formats[Message::Priority::PRIO_INFORMATION] = format;
+
+  format.setForeground(Qt::darkBlue);
+  m_formats[Message::Priority::PRIO_NOTICE] = format;
+}
+
+/**
+ * Set the properties of the text display, i.e read-only
+ * and make it occupy the whole widget
+ */
+void MessageDisplay::setupTextArea() {
+  m_textDisplay->setReadOnly(true);
+  m_textDisplay->ensureCursorVisible();
+  m_textDisplay->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+  m_textDisplay->setMouseTracking(true);
+  m_textDisplay->setUndoRedoEnabled(false);
+
+  this->setLayout(new QHBoxLayout(this));
+  QLayout *layout = this->layout();
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->addWidget(m_textDisplay);
+
+  this->setFocusProxy(m_textDisplay);
+  m_textDisplay->setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(m_textDisplay, SIGNAL(customContextMenuRequested(const QPoint &)),
+          this, SLOT(showContextMenu(const QPoint &)));
+}
+
+/**
+ * @param priority An enumeration for the log level
+ * @return format for given log level
+ */
+QTextCharFormat
+MessageDisplay::format(const API::Message::Priority priority) const {
+  return m_formats.value(priority, QTextCharFormat());
+}
+}
 }


### PR DESCRIPTION
The log level of all the loggers is now set to follow the lowest log level of all of the FilterChannels (File, Console and message display in mantidplot).  It used to track them going down to debug, but never back up again, now it does.

**To test:**
This is tested pretty well in the unit tests in ConfigServiceTest.  However you should also start up Mantidplot, change the log level of the log window and check the correct level filter is applied when running algorithms.

Fixes #14524 
##### RELEASE NOTES

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

This should allow the logger.is functionality to work correctly.
