### PR TITLE
Invalidate common-bins-flag in EventWorkspace.

### DIFF
--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -635,10 +635,7 @@ void EventWorkspace::deleteEmptyLists() {
 /// @param index :: the workspace index to return
 /// @returns A reference to the vector of binned X values
 MantidVec &EventWorkspace::dataX(const std::size_t index) {
-  if (index >= this->m_noVectors)
-    throw std::range_error(
-        "EventWorkspace::dataX, histogram number out of range");
-  return this->data[index]->dataX();
+  return getSpectrum(index)->dataX();
 }
 
 /// Return the data X error vector at a given workspace index
@@ -647,10 +644,7 @@ MantidVec &EventWorkspace::dataX(const std::size_t index) {
 /// @param index :: the workspace index to return
 /// @returns A reference to the vector of binned error values
 MantidVec &EventWorkspace::dataDx(const std::size_t index) {
-  if (index >= this->m_noVectors)
-    throw std::range_error(
-        "EventWorkspace::dataDx, histogram number out of range");
-  return this->data[index]->dataDx();
+  return getSpectrum(index)->dataDx();
 }
 
 /// Return the data Y vector at a given workspace index
@@ -658,9 +652,6 @@ MantidVec &EventWorkspace::dataDx(const std::size_t index) {
 /// @param index :: the workspace index to return
 /// @returns A reference to the vector of binned Y values
 MantidVec &EventWorkspace::dataY(const std::size_t index) {
-  if (index >= this->m_noVectors)
-    throw std::range_error(
-        "EventWorkspace::dataY, histogram number out of range");
   throw NotImplementedError("EventWorkspace::dataY cannot return a non-const "
                             "array: you can't modify the histogrammed data in "
                             "an EventWorkspace!");
@@ -671,9 +662,6 @@ MantidVec &EventWorkspace::dataY(const std::size_t index) {
 /// @param index :: the workspace index to return
 /// @returns A reference to the vector of binned error values
 MantidVec &EventWorkspace::dataE(const std::size_t index) {
-  if (index >= this->m_noVectors)
-    throw std::range_error(
-        "EventWorkspace::dataE, histogram number out of range");
   throw NotImplementedError("EventWorkspace::dataE cannot return a non-const "
                             "array: you can't modify the histogrammed data in "
                             "an EventWorkspace!");
@@ -687,51 +675,34 @@ MantidVec &EventWorkspace::dataE(const std::size_t index) {
 /** @return the const data X vector at a given workspace index
  * @param index :: workspace index   */
 const MantidVec &EventWorkspace::dataX(const std::size_t index) const {
-  if (index >= this->m_noVectors)
-    throw std::range_error(
-        "EventWorkspace::dataX, histogram number out of range");
-  return this->data[index]->constDataX();
+  return getSpectrum(index)->readX();
 }
 
 /** @return the const data X error vector at a given workspace index
  * @param index :: workspace index   */
 const MantidVec &EventWorkspace::dataDx(const std::size_t index) const {
-  if (index >= this->m_noVectors)
-    throw std::range_error(
-        "EventWorkspace::dataDx, histogram number out of range");
-  return this->data[index]->readDx();
+  return getSpectrum(index)->readDx();
 }
 
 //---------------------------------------------------------------------------
 /** @return the const data Y vector at a given workspace index
  * @param index :: workspace index   */
 const MantidVec &EventWorkspace::dataY(const std::size_t index) const {
-  if (index >= this->m_noVectors)
-    throw std::range_error(
-        "EventWorkspace::dataY, histogram number out of range");
-  const MantidVec &out = this->data[index]->constDataY();
-  return out;
+  return getSpectrum(index)->readY();
 }
 
 //---------------------------------------------------------------------------
 /** @return the const data E (error) vector at a given workspace index
  * @param index :: workspace index   */
 const MantidVec &EventWorkspace::dataE(const std::size_t index) const {
-  if (index >= this->m_noVectors)
-    throw std::range_error(
-        "EventWorkspace::dataE, histogram number out of range");
-  const MantidVec &out = this->data[index]->constDataE();
-  return out;
+  return getSpectrum(index)->readE();
 }
 
 //---------------------------------------------------------------------------
 /** @return a pointer to the X data vector at a given workspace index
  * @param index :: workspace index   */
 Kernel::cow_ptr<MantidVec> EventWorkspace::refX(const std::size_t index) const {
-  if (index >= this->m_noVectors)
-    throw std::range_error(
-        "EventWorkspace::refX, histogram number out of range");
-  return this->data[index]->ptrX();
+  return getSpectrum(index)->ptrX();
 }
 
 //---------------------------------------------------------------------------

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -649,8 +649,6 @@ MantidVec &EventWorkspace::dataDx(const std::size_t index) {
 
 /// Return the data Y vector at a given workspace index
 /// Note: these non-const access methods will throw NotImplementedError
-/// @param index :: the workspace index to return
-/// @returns A reference to the vector of binned Y values
 MantidVec &EventWorkspace::dataY(const std::size_t) {
   throw NotImplementedError("EventWorkspace::dataY cannot return a non-const "
                             "array: you can't modify the histogrammed data in "
@@ -659,8 +657,6 @@ MantidVec &EventWorkspace::dataY(const std::size_t) {
 
 /// Return the data E vector at a given workspace index
 /// Note: these non-const access methods will throw NotImplementedError
-/// @param index :: the workspace index to return
-/// @returns A reference to the vector of binned error values
 MantidVec &EventWorkspace::dataE(const std::size_t) {
   throw NotImplementedError("EventWorkspace::dataE cannot return a non-const "
                             "array: you can't modify the histogrammed data in "

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -651,7 +651,7 @@ MantidVec &EventWorkspace::dataDx(const std::size_t index) {
 /// Note: these non-const access methods will throw NotImplementedError
 /// @param index :: the workspace index to return
 /// @returns A reference to the vector of binned Y values
-MantidVec &EventWorkspace::dataY(const std::size_t index) {
+MantidVec &EventWorkspace::dataY(const std::size_t) {
   throw NotImplementedError("EventWorkspace::dataY cannot return a non-const "
                             "array: you can't modify the histogrammed data in "
                             "an EventWorkspace!");
@@ -661,7 +661,7 @@ MantidVec &EventWorkspace::dataY(const std::size_t index) {
 /// Note: these non-const access methods will throw NotImplementedError
 /// @param index :: the workspace index to return
 /// @returns A reference to the vector of binned error values
-MantidVec &EventWorkspace::dataE(const std::size_t index) {
+MantidVec &EventWorkspace::dataE(const std::size_t) {
   throw NotImplementedError("EventWorkspace::dataE cannot return a non-const "
                             "array: you can't modify the histogrammed data in "
                             "an EventWorkspace!");

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -886,6 +886,25 @@ public:
     TS_ASSERT(wsCastNonConst != NULL);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
+
+  void test_writeAccessInvalidatesCommonBinsFlagIsSet() {
+    int numEvents = 2;
+    int numHistograms = 2;
+    EventWorkspace_sptr ws =
+        WorkspaceCreationHelper::CreateRandomEventWorkspace(numEvents,
+                                                            numHistograms);
+    // Calling isCommonBins() sets the flag m_isCommonBinsFlagSet
+    TS_ASSERT(ws->isCommonBins());
+    // Calling dataX should unset the flag m_isCommonBinsFlagSet
+    ws->dataX(0)[0] += 0.0;
+    // m_isCommonBinsFlagSet is false, so this will re-validate and notice that
+    // dataX is still identical.
+    TS_ASSERT(ws->isCommonBins());
+    ws->dataX(0)[0] += 0.1;
+    // m_isCommonBinsFlagSet is false, so this will re-validate and notice that
+    // dataX(0) is now different from dataX(1).
+    TS_ASSERT(!ws->isCommonBins());
+  }
 };
 
 #endif /* EVENTWORKSPACETEST_H_ */

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -348,8 +348,8 @@ public:
     // Out of range
     TS_ASSERT_THROWS(ew->dataX(-123), std::range_error);
     TS_ASSERT_THROWS(ew->dataX(5123), std::range_error);
-    TS_ASSERT_THROWS(ew->dataE(5123), std::range_error);
-    TS_ASSERT_THROWS(ew->dataY(5123), std::range_error);
+    TS_ASSERT_THROWS(ew->dataE(5123), NotImplementedError);
+    TS_ASSERT_THROWS(ew->dataY(5123), NotImplementedError);
 
     // Can't try the const access; copy constructors are not allowed.
   }


### PR DESCRIPTION
Fixed #16133 by using `getSpectrum` in `dataX` etc., which then invalidates the common bins flag.

**To test:**
- Check if the commons bins flag is now invalided. Try the Python example from the issue.
- Make sure the added regression test fails if the bug is reintroduced.

Unless we encounter previously hidden issues after the fix, this does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
