### PR TITLE
Fixed error in computation of population factor.

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -141,6 +141,9 @@ class ComputeIncoherentDOS(PythonAlgorithm):
         DWF = np.exp(-2*(qqgrid**2*msd))
         idm = np.where(engrid < 0)
         idp = np.where(engrid >= 0)
+        # The expression for the population (Bose) factor and phonon energy dependence below actually refer to the phonon
+        # energy (always defined to be positive) rather than the neutron energy transfer. So we need the absolute value here
+        engrid = np.abs(engrid)
         expm = np.exp(-engrid[idm]*mev2k/Temperature)
         expp = np.exp(-engrid[idp]*mev2k/Temperature)
         Bose = DWF*0

--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -107,8 +107,10 @@ class ComputeIncoherentDOS(PythonAlgorithm):
         mev2k = (constants.elementary_charge / 1000) / constants.k
 
         # Converts energy to meV for bose factor later
+        input_en_in_meV = 1
         if u0 == 'DeltaE_inWavenumber' or u1 == 'DeltaE_inWavenumber':
             en = en / mev2cm
+            input_en_in_meV = 0
 
         # Checks energy bins are ok.
         if EnergyBinning.count(',') != 2:
@@ -119,7 +121,7 @@ class ComputeIncoherentDOS(PythonAlgorithm):
             ei = max(en)
         try:
             # Do this in a function to make sure no other variables can be evaluated other than Emin, Emax and Ei.
-            if cm:
+            if not input_en_in_meV:
                 dosebin = evaluateEbin(min(en*mev2cm), max(en*mev2cm), ei*mev2cm, EnergyBinning)
             else:
                 dosebin = evaluateEbin(min(en), max(en), ei, EnergyBinning)
@@ -168,7 +170,6 @@ class ComputeIncoherentDOS(PythonAlgorithm):
 
         # Convert to wavenumbers if requested (y-axis is in mbarns/sr/fu/meV -> mb/sr/fu/cm^-1)
         if cm:
-            en = en*mev2cm
             y = y/mev2cm
             e = e/mev2cm
             yunit = 'DeltaE_inWavenumber'
@@ -186,7 +187,12 @@ class ComputeIncoherentDOS(PythonAlgorithm):
 
         # Make a 1D (energy dependent) cut
         dos1d = Rebin2D(dos2d, [dq[0], dq[1]-dq[0], dq[1]], dosebin, True, True)
-        dos1d.setYUnit(yunit)
+        if cm and input_en_in_meV:
+            dos1d.getAxis(0).setUnit('DeltaE_inWavenumber')
+            dos1d = ScaleX(dos1d, mev2cm)
+        elif not cm and not input_en_in_meV:
+            dos1d.getAxis(0).setUnit('DeltaE')
+            dos1d = ScaleX(dos1d, 1/mev2cm)
 
         if absunits:
             print "Converting to states/energy"

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ComputeIncoherentDOSTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ComputeIncoherentDOSTest.py
@@ -1,35 +1,70 @@
 import unittest
-from mantid.simpleapi import ComputeIncoherentDOS, CreateSampleWorkspace, LoadInstrument, ScaleX, SetSampleMaterial, SofQW, Transpose
+from mantid.simpleapi import ComputeIncoherentDOS, CreateSampleWorkspace, LoadInstrument, ScaleX, Scale, SetSampleMaterial, SofQW, Transpose
 import numpy as np
+from scipy import constants
 
 class ComputeIncoherentDOSTest(unittest.TestCase):
+
+    def createPhononWS(self, T, en, e_units):
+        fn = 'name=Gaussian, PeakCentre='+str(en)+', Height=1, Sigma=0.5;'
+        fn +='name=Gaussian, PeakCentre=-'+str(en)+', Height='+str(np.exp(-en*11.6/T))+', Sigma=0.5;'
+        ws = CreateSampleWorkspace(binWidth = 0.1, XMin = -25, XMax = 25, XUnit = e_units, Function = 'User Defined', UserDefinedFunction=fn)
+        LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap = True)
+        with self.assertRaises(RuntimeError):
+            ws_DOS = ComputeIncoherentDOS(ws)
+        ws = SofQW(ws, [0, 0.05, 8], 'Direct', 25)
+        qq = np.arange(0, 8, 0.05)+0.025
+        for i in range(ws.getNumberHistograms()):
+            ws.setY(i, ws.readY(i)*qq[i]**2)
+            ws.setE(i, ws.readE(i)*qq[i]**2)
+        return ws
+
+    def convertToWavenumber(self, ws):
+        mev2cm = (constants.elementary_charge / 1000) / (constants.h * constants.c * 100)
+        u0 = ws.getAxis(0).getUnit().unitID()
+        u1 = ws.getAxis(1).getUnit().unitID()
+        if u0 == 'DeltaE' or u1 == 'DeltaE':
+            if u0 == 'MomentumTransfer':
+                ws = Transpose(ws)
+            ws.getAxis(0).setUnit('DeltaE_inWavenumber')
+            ws = ScaleX(ws, mev2cm)
+            ws = Scale(ws, 1/mev2cm)
+            if u0 == 'MomentumTransfer':
+                ws = Transpose(ws)
+        return ws
 
     def test_computeincoherentdos(self):
         ws = CreateSampleWorkspace()
         # Will fail unless the input workspace has Q and DeltaE axes.
         with self.assertRaises(RuntimeError):
             ws_DOS = ComputeIncoherentDOS(ws)
-        ws = CreateSampleWorkspace(binWidth = 0.1, XMin = 0, XMax = 50, XUnit = 'DeltaE')
-        ws = ScaleX(ws, -25, "Add")
+        ws = CreateSampleWorkspace(XUnit = 'DeltaE')
         with self.assertRaises(RuntimeError):
             ws_DOS = ComputeIncoherentDOS(ws)
-        LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap = True)
-        ws = SofQW(ws, [0, 0.05, 8], 'Direct', 25)
+        # Creates a workspace with two optic phonon modes at +E and -E with Q^2 dependence and population correct for T=300K
+        ws = self.createPhononWS(300, 5, 'DeltaE')
         # This should work!
         ws_DOS = ComputeIncoherentDOS(ws)
         self.assertEquals(ws_DOS.getAxis(0).getUnit().unitID(), 'DeltaE')
         self.assertEquals(ws_DOS.getNumberHistograms(), 1)
+        # Checks that it works if the workspace has |Q| along x instead of y, and converts energy to wavenumber
         ws = Transpose(ws)
-        ws_DOS = ComputeIncoherentDOS(ws, EnergyBinning = '0, 5, 200', Wavenumbers = True)
+        ws_DOS = ComputeIncoherentDOS(ws, Temperature = 300, EnergyBinning = '-20, 0.2, 20', Wavenumbers = True)
         self.assertEquals(ws_DOS.getAxis(0).getUnit().unitID(), 'DeltaE_inWavenumber')
-        self.assertEquals(ws_DOS.blocksize(), 40)
-        # Check that conversion to states/meV is done
+        self.assertEquals(ws_DOS.blocksize(), 200)
+        # Checks that the Bose factor correction is ok.
+        dos_eplus = np.max(ws_DOS.readY(0)[range(100,200)])
+        dos_eminus = np.max(ws_DOS.readY(0)[range(0,100)])
+        self.assertAlmostEqual(dos_eplus, dos_eminus, places=1)
+        # Check that unit conversion from cm^-1 to meV works and also that conversion to states/meV is done
+        ws = self.convertToWavenumber(ws)
         SetSampleMaterial(ws, 'Al')
-        ws_DOSn = ComputeIncoherentDOS(ws, EnergyBinning = '0, 5, 200', Wavenumbers = True, StatesPerEnergy = True)
+        ws_DOSn = ComputeIncoherentDOS(ws, EnergyBinning = '-160, 1.6, 160', StatesPerEnergy = True)
         self.assertTrue('states' in ws_DOSn.YUnitLabel())
+        self.assertEquals(ws_DOSn.getAxis(0).getUnit().unitID(), 'DeltaE')
         material = ws.sample().getMaterial()
-        factor = material.relativeMolecularMass() / (material.totalScatterXSection() * 1000)
-        self.assertAlmostEqual(np.max(ws_DOSn.readY(0)), np.max(ws_DOS.readY(0))*factor, places=4)
+        factor = material.relativeMolecularMass() / (material.totalScatterXSection() * 1000) * 4 * np.pi
+        self.assertAlmostEqual(np.max(ws_DOSn.readY(0)), np.max(ws_DOS.readY(0))*factor, places=2)
 
 if __name__=="__main__":
     unittest.main()


### PR DESCRIPTION
There was an omission in the code for handling the neutron energy gain (upscattering) side in the thermal population (Bose) factor correction - the expressions for the corrections requires abs(E) rather than E.

**To test:**

With a fake dataset:

```
# Creates a fake dataset with an optic phonon mode at temperature T and energy en
T = 300
en = 5
fn = 'name=Gaussian, PeakCentre='+str(en)+', Height=1, Sigma=0.5;'
fn +='name=Gaussian, PeakCentre=-'+str(en)+', Height='+str(np.exp(-en*11.6/T))+', Sigma=0.5;'
ws = CreateSampleWorkspace(binWidth = 0.1, XMin = -25, XMax = 25, XUnit = 'DeltaE', Function = 'User Defined', UserDefinedFunction=fn)
LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap = True)
ws = SofQW3(ws, [0, 0.05, 8], 'Direct', 25)
ws = Transpose(ws)
# We also need to get the Q dependence correct or the DOS calculation will be wrong.
qq = ws.getAxis(0).extractValues()
qq = (qq[1:len(qq)]+qq[0:len(qq)-1])/2
y = ws.extractY()
e = ws.extractE()
qqgrid = np.tile(np.array(qq), (np.shape(y)[0], 1))
y = y * qqgrid**2
e = e * qqgrid**2
for i in range(len(y)):
    ws.setY(i, y[i,:])
    ws.setE(i, e[i,:])
ws_DOS= ComputeIncoherentDOS(ws,Temperature=T,EnergyBinning='-20,0.1,20')
```

with a real dataset:

```
from Direct import DirectEnergyConversion
rd = DirectEnergyConversion.DirectEnergyConversion('MARI')
ws = rd.convert_to_energy(21334, 21458, 50, [-45,0.05,45], 'mari_res2013.map',
    monovan_run=21496, sample_mass=9, sample_rmm=249.48, monovan_mapfile='mari_res2013.map')
ws_sqw = SofQW3(ws, [0,0.1,10], 'Direct', 50)
ws_dos = ComputeIncoherentDOS(ws_sqw, Temperature=300, EnergyBinning='-45,0.5,45')
```

With the old algorithm the DOS in the up- and down- scattering sides (negative and positive energy transfer respectively) do not match up, but they should. This PR fixes this. E.g.

![dos_popfactor_check](https://cloud.githubusercontent.com/assets/14106963/15183325/70cb52b2-1788-11e6-8e2f-efab1142d11a.png)

The black curve is without the bugfix, the red curve is with the bugfix. For the generated (fake) dataset, the peak at -en should be the same height as the peak at +en.

Fixes #15843 . 

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
