### PR TITLE
Add slit tolerance as a property

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRDirectBeamSort.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRDirectBeamSort.py
@@ -105,6 +105,7 @@ class LRDirectBeamSort(PythonAlgorithm):
                              "Ordered list of run numbers")
         self.declareProperty(StringArrayProperty("OrderedNameList", [], direction=Direction.Output),
                              "Ordered list of workspace names corresponding to the run list")
+        self.declareProperty("SlitTolerance", 0.02, doc="Tolerance for matching slit positions")
 
     def PyExec(self):
         compute = self.getProperty("ComputeScalingFactors").value
@@ -229,12 +230,14 @@ class LRDirectBeamSort(PythonAlgorithm):
 
             # Compute the scaling factors
             logger.notice("Computing scaling factors for %s" % str(direct_beam_runs))
+            slit_tolerance = self.getProperty("SlitTolerance").value
             LRScalingFactors(DirectBeamRuns=direct_beam_runs,
                              TOFRange=tof_range, TOFSteps=tof_steps,
                              SignalPeakPixelRange=peak_ranges,
                              SignalBackgroundPixelRange=bck_ranges,
                              LowResolutionPixelRange=x_ranges,
                              IncidentMedium=incident_medium,
+                             SlitTolerance=slit_tolerance,
                              ScalingFactorFile=scaling_file)
         logger.notice(summary)
 

--- a/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
@@ -194,8 +194,10 @@ class LRReflectivityOutput(PythonAlgorithm):
         start_time = mtd[scaled_ws_list[0] + '_scaled'].getRun().getProperty("start_time").value
         experiment = mtd[scaled_ws_list[0] + '_scaled'].getRun().getProperty("experiment_identifier").value
         run_number = mtd[scaled_ws_list[0] + '_scaled'].getRun().getProperty("run_number").value
+        run_title = mtd[scaled_ws_list[0] + '_scaled'].getTitle()
 
         content = '# Experiment %s Run %s\n' % (experiment, run_number)
+        content += '# Run title: %s\n' % run_title
         content += '# Run start time: %s\n' % start_time
         content += '# Reduction time: %s\n' % time.ctime()
         content += '# Mantid version: %s\n' % mantid.__version__


### PR DESCRIPTION
The slit tolerance in the reduction has to match the data acquisition.
Most underlying algorithms take the tolerance as a parameter, but not the top-level algorithms used in the auto-reduction.

**To test:**
- Make sure the system tests pass.
- Try out a reduction by hand (RefRed).
- Look in the output reflectivity file that the run title is there.

There is no "issue" for this PR.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
