### PR TITLE
Adds support for rpm release numbers

### DIFF
--- a/buildconfig/CMake/CPackLinuxSetup.cmake
+++ b/buildconfig/CMake/CPackLinuxSetup.cmake
@@ -39,13 +39,21 @@ if ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" OR "${UNIX_DIST}" MATCHES "Fedora
     set ( CPACK_RPM_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}" )
     set ( CPACK_RPM_PACKAGE_URL "http://www.mantidproject.org" )
 
-    # reset the release name to include the RHEL version if known
-    if ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" )
-      string ( REGEX REPLACE "^([0-9])\\.[0-9]+$" "\\1" TEMP ${UNIX_RELEASE} )
-      set ( CPACK_RPM_PACKAGE_RELEASE "1.el${TEMP}" )
-    elseif ( "${UNIX_DIST}" MATCHES "Fedora" )
-      set ( CPACK_RPM_PACKAGE_RELEASE "1.fc${UNIX_RELEASE}" )
-    endif ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" )
+    # determine the distribution number
+    if(NOT CPACK_RPM_DIST)
+      execute_process(COMMAND ${RPMBUILD_CMD} -E %{?dist}
+                      OUTPUT_VARIABLE CPACK_RPM_DIST
+                      ERROR_QUIET
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
+
+    # release number defaults to 1
+    if(NOT CPACK_RPM_PACKAGE_RELEASE_NUMBER)
+      set(CPACK_RPM_PACKAGE_RELEASE_NUMBER "1")
+    endif()
+
+    # reset the release name
+    set( CPACK_RPM_PACKAGE_RELEASE "${CPACK_RPM_PACKAGE_RELEASE_NUMBER}${CPACK_RPM_DIST}" )
 
     # If CPACK_SET_DESTDIR is ON then the Prefix doesn't get put in the spec file
     if( CPACK_SET_DESTDIR )


### PR DESCRIPTION
Rework the cpack variables so the release number can be set in cmake.

**To test:**

There is no need to build anything. Just run `cmake` twice.
1. `cmake -DENABLE_CPACK=True ../` and see that the package name is correct.
2. `cmake -DENABLE_CPACK=True ../ -DCPACK_RPM_PACKAGE_RELEASE_NUMBER=42` and see that the package name has changed

Fixes #16147.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Re #16147
