### PR TITLE
Fix error with "autoscale" option in MuonAnalysis

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1882,7 +1882,10 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   s << "  if y_auto:";
   s << "    layer.setAutoScale()";
   s << "  else:";
-  s << "    layer.setAxisScale(Layer.Left, y_min, y_max)";
+  s << "    try:";
+  s << "      layer.setAxisScale(Layer.Left, float(y_min), float(y_max))";
+  s << "    except ValueError:";
+  s << "      layer.setAutoScale()";
   s << "";
 
   // Plot the data!

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisOptionTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisOptionTab.cpp
@@ -103,11 +103,9 @@ void MuonAnalysisOptionTab::initLayout()
   connect(m_uiForm.connectPlotType, SIGNAL(currentIndexChanged(int)), this, SIGNAL(plotStyleChanged()));
   connect(m_uiForm.showErrorBars, SIGNAL(clicked()), this, SIGNAL(plotStyleChanged()));
   connect(m_uiForm.yAxisAutoscale, SIGNAL(clicked()), this, SIGNAL(plotStyleChanged()));
-  connect(m_uiForm.yAxisMinimumInput, SIGNAL(editingFinished()), this,
-          SIGNAL(plotStyleChanged()));
-  connect(m_uiForm.yAxisMaximumInput, SIGNAL(editingFinished()), this,
-          SIGNAL(plotStyleChanged()));
-
+  connect(m_uiForm.yAxisMinimumInput, SIGNAL(returnPressed ()), this, SIGNAL(plotStyleChanged()));
+  connect(m_uiForm.yAxisMaximumInput, SIGNAL(returnPressed ()), this, SIGNAL(plotStyleChanged()));
+  
   // Connect auto updates of plot data
   connect(m_uiForm.timeComboBox, SIGNAL(currentIndexChanged(int)), this, SIGNAL(settingsTabUpdatePlot()));
   connect(m_uiForm.timeAxisStartAtInput, SIGNAL(returnPressed ()), this, SIGNAL(settingsTabUpdatePlot()));

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisOptionTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisOptionTab.cpp
@@ -103,9 +103,11 @@ void MuonAnalysisOptionTab::initLayout()
   connect(m_uiForm.connectPlotType, SIGNAL(currentIndexChanged(int)), this, SIGNAL(plotStyleChanged()));
   connect(m_uiForm.showErrorBars, SIGNAL(clicked()), this, SIGNAL(plotStyleChanged()));
   connect(m_uiForm.yAxisAutoscale, SIGNAL(clicked()), this, SIGNAL(plotStyleChanged()));
-  connect(m_uiForm.yAxisMinimumInput, SIGNAL(returnPressed ()), this, SIGNAL(plotStyleChanged()));
-  connect(m_uiForm.yAxisMaximumInput, SIGNAL(returnPressed ()), this, SIGNAL(plotStyleChanged()));
-  
+  connect(m_uiForm.yAxisMinimumInput, SIGNAL(editingFinished()), this,
+          SIGNAL(plotStyleChanged()));
+  connect(m_uiForm.yAxisMaximumInput, SIGNAL(editingFinished()), this,
+          SIGNAL(plotStyleChanged()));
+
   // Connect auto updates of plot data
   connect(m_uiForm.timeComboBox, SIGNAL(currentIndexChanged(int)), this, SIGNAL(settingsTabUpdatePlot()));
   connect(m_uiForm.timeAxisStartAtInput, SIGNAL(returnPressed ()), this, SIGNAL(settingsTabUpdatePlot()));


### PR DESCRIPTION
Fixed a bug where turning off the "autoscale" option didn't work.

Y maximum and minimum values weren't being passed to the plotting code correctly.
Changed this so that they now are.

**To test:**
- Open Interfaces/Muon/MuonAnalysis
- Load any muon nexus file (for example MUSR00015189.nxs from test data)
- On "Settings" tab, try checking and unchecking the "Autoscale" checkbox
  - This should do what it says and no error should be shown in the log
- With "Autoscale" unchecked, edit the minimum and maximum y limits.
  - Verify the scale is updated on pressing Return.

Fixes #16157. 

_No release notes necessary_ because the bug was not in release 3.6 (introduced more recently).

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
