### PR TITLE
Usability fixes in ALC interface

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
@@ -99,6 +99,10 @@ namespace CustomInterfaces
     // -- End of IALCDataLoadingView interface -----------------------------------------------------
 
   private:
+    /// Common function to set available items in a combo box
+    void setAvailableItems(QComboBox *comboBox,
+                           const std::vector<std::string> &items);
+
     /// UI form
     Ui::ALCDataLoadingView m_ui;
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -107,22 +107,9 @@
              </widget>
             </item>
             <item>
-             <spacer name="logSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
              <widget class="QLabel" name="functionLabel">
               <property name="text">
-               <string>Function</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Take log value at&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
@@ -138,7 +125,7 @@
                <bool>false</bool>
               </property>
               <property name="currentIndex">
-               <number>4</number>
+               <number>0</number>
               </property>
               <item>
                <property name="text">
@@ -166,6 +153,19 @@
                </property>
               </item>
              </widget>
+            </item>
+            <item>
+             <spacer name="logSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </item>

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -207,6 +207,7 @@ void ALCDataLoadingPresenter::load(const std::string &lastFile) {
 
 void ALCDataLoadingPresenter::updateAvailableInfo() {
   Workspace_sptr loadedWs;
+  double firstGoodData = 0, timeZero = 0;
 
   try //... to load the first run
   {
@@ -222,6 +223,8 @@ void ALCDataLoadingPresenter::updateAvailableInfo() {
     load->execute();
 
     loadedWs = load->getProperty("OutputWorkspace");
+    firstGoodData = load->getProperty("FirstGoodData");
+    timeZero = load->getProperty("TimeZero");
   } catch (...) {
     m_view->setAvailableLogs(std::vector<std::string>()); // Empty logs list
     m_view->setAvailablePeriods(
@@ -251,7 +254,7 @@ void ALCDataLoadingPresenter::updateAvailableInfo() {
   m_view->setAvailablePeriods(periods);
 
   // Set time limits
-  m_view->setTimeLimits(ws->readX(0).front(), ws->readX(0).back());
+  m_view->setTimeLimits(firstGoodData - timeZero, ws->readX(0).back());
   // Set allowed time range
   m_view->setTimeRange(ws->readX(0).front(), ws->readX(0).back());
 }

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -190,38 +190,55 @@ ALCDataLoadingView::~ALCDataLoadingView() {
     QMessageBox::critical(m_widget, "Loading error", QString::fromStdString(error));
   }
 
-  void ALCDataLoadingView::setAvailableLogs(const std::vector<std::string>& logs)
-  {
-    // Keep the current log value
-    QString previousLog = m_ui.log->currentText();
-
-    // Clear previous log list
-    m_ui.log->clear();
-
-    // If previousLog is in 'logs' list, add it at the beginning
-    if ( std::find(logs.begin(), logs.end(), previousLog.toStdString()) != logs.end())
-    {
-      m_ui.log->addItem(previousLog);
-    }
-
-    // Add new items
-    for (auto it = logs.begin(); it != logs.end(); ++it)
-    {
-      m_ui.log->addItem(QString::fromStdString(*it));
-    }
+  /**
+   * Set list of available log values
+   * @param logs :: [input] List of log values
+   */
+  void
+  ALCDataLoadingView::setAvailableLogs(const std::vector<std::string> &logs) {
+    setAvailableItems(m_ui.log, logs);
   }
 
-  void ALCDataLoadingView::setAvailablePeriods(const std::vector<std::string>& periods)
-  {
+  /**
+   * Set list of available periods in both boxes
+   * @param periods :: [input] List of periods
+   */
+  void ALCDataLoadingView::setAvailablePeriods(
+      const std::vector<std::string> &periods) {
+    setAvailableItems(m_ui.redPeriod, periods);
+    setAvailableItems(m_ui.greenPeriod, periods);
+  }
+
+  /**
+   * Sets available items in a combo box from given list.
+   * If the current value is in the new list, keep it.
+   * @param comboBox :: [input] Pointer to combo box to populate
+   * @param items :: [input] Vector of items to populate box with
+   */
+  void
+  ALCDataLoadingView::setAvailableItems(QComboBox *comboBox,
+                                        const std::vector<std::string> &items) {
+    if (!comboBox) {
+      throw std::invalid_argument(
+          "No combobox to set items in: this should never happen");
+    }
+
+    // Keep the current value
+    const auto previousValue = comboBox->currentText().toStdString();
+
     // Clear previous list
-    m_ui.redPeriod->clear();
-    m_ui.greenPeriod->clear();
+    comboBox->clear();
+
+    // If previous value is in the list, add it at the beginning
+    if (std::find(items.begin(), items.end(), previousValue) != items.end()) {
+      comboBox->addItem(QString::fromStdString(previousValue));
+    }
 
     // Add new items
-    for (auto it=periods.begin(); it!=periods.end(); ++it)
-    {
-      m_ui.redPeriod->addItem(QString::fromStdString(*it));
-      m_ui.greenPeriod->addItem(QString::fromStdString(*it));
+    for (const auto item : items) {
+      if (item != previousValue) { // has already been added
+        comboBox->addItem(QString::fromStdString(item));
+      }
     }
   }
 

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -207,6 +207,11 @@ ALCDataLoadingView::~ALCDataLoadingView() {
       const std::vector<std::string> &periods) {
     setAvailableItems(m_ui.redPeriod, periods);
     setAvailableItems(m_ui.greenPeriod, periods);
+
+    // If single period, disable "Subtract" checkbox and green period box
+    const bool multiPeriod = periods.size() > 1;
+    m_ui.subtractCheckbox->setEnabled(multiPeriod);
+    m_ui.greenPeriod->setEnabled(multiPeriod);
   }
 
   /**

--- a/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -184,7 +184,7 @@ public:
                                                 Contains("1"),
                                                 Contains("2")))).Times(1);
     // Test time limits
-    EXPECT_CALL(*m_view, setTimeLimits(Le(-0.54),Ge(31.44))).Times(1);
+    EXPECT_CALL(*m_view, setTimeLimits(Le(0.107), Ge(31.44))).Times(1);
     m_view->selectFirstRun();
   }
 

--- a/docs/source/release/v3.7.0/muon.rst
+++ b/docs/source/release/v3.7.0/muon.rst
@@ -13,6 +13,11 @@ Muon ALC
 
 - The default directory for the last run is now set to the same directory selected for the first run `#15524 <https://github.com/mantidproject/mantid/pull/15524>`_
 - Fixed an occasional crash seen when "Auto" was selected `#15673 <https://github.com/mantidproject/mantid/pull/15673>`_
+- Several usability fixes were made to the interface: `#16161 <https://github.com/mantidproject/mantid/pull/16161>`_
+
+  - The "Function" box was renamed "Take log value at" and moved next to the log to which it applies
+  - The integration start time is initialised to the first good data rather than the first time bin
+  - The choice of periods is no longer reset when a new first run is loaded
 
 Muon Analysis
 #############


### PR DESCRIPTION
Several usability fixes, requested by scientists, were made to the interface.

These fix some problems that made the interface inconvenient or confusing to use at times:
- The "Function" box was renamed "Take log value at", defaulted to Mean rather than Last, and moved next to the log to which it applies
- Integration start time is now initialised to the first good data, rather than the first time bin
- When a new first run is loaded, the period control is no longer reset (unless the selected periods don't exist in the new dataset)

**To test:**
_Data available in unit test folder_
- Open Interfaces/Muon/ALC
- In "First" box, select `MUSR00015189.nxs`
  - Note the integration start time ("From" in the bottom group box) is 0.106 us, not a negative number as it was previously. 
- In the "Periods" group box, set the selection to 2 - 1 (or anything other than default)
- Now load `MUSR00015190.nxs` in the "First" box
  - Verify the periods choice has not changed - nothing else should have either
- Load `EMU00006473.nxs` in the "First" box (this is single-period)
  - Now the periods box should change to "1" and the option to subtract will be disabled.

Fixes #16145 

[Release notes](https://github.com/mantidproject/mantid/blob/39ce0b9e4776720082476a9b06beb15e0a80536d/docs/source/release/v3.7.0/muon.rst#muon-alc) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
