### PR TITLE
Use copy constructor when cloning TableColumn

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -145,12 +145,7 @@ public:
     return static_cast<long int>(m_data.size() * sizeof(Type));
   }
   /// Clone
-  TableColumn *clone() const override {
-    TableColumn *temp = new TableColumn();
-    temp->m_data = this->m_data;
-    temp->setName(this->m_name);
-    return temp;
-  }
+  TableColumn *clone() const override { return new TableColumn(*this); }
 
   /**
    * Cast an element to double if possible. If it's impossible

--- a/Framework/DataObjects/test/TableColumnTest.h
+++ b/Framework/DataObjects/test/TableColumnTest.h
@@ -197,7 +197,16 @@ public:
     TS_ASSERT_EQUALS(data2[8], "one");
     TS_ASSERT_EQUALS(data2[9], "zero");
   }
-
+  void test_clone_table_column() {
+    const size_t n = 2;
+    TableWorkspace ws(n);
+    ws.addColumn("int", "col1");
+    ws.addColumn("str", "col2");
+    auto clonedColInt = ws.getColumn("col1")->clone();
+    auto clonedColStr = ws.getColumn("col2")->clone();
+    TS_ASSERT_EQUALS(clonedColInt->type(), "int");
+    TS_ASSERT_EQUALS(clonedColStr->type(), "str");
+  }
   void test_sortValues_by_two_keys() {
     const size_t n = 10;
     TableWorkspace ws(n);


### PR DESCRIPTION
When using the default constructor to create a TableColumn the types were being decided by finding certain characters in their type names i.e `m.find(`f`)` would set a type to `float`. Since there was no direct conversion from `std::string` to `str` and we were using `m.find('d')` to convert to `double`. the d in std::string was causing any std::string(s) to be converted to double types in the table.

**To test:**
- Ensure that Unit/Doc/System tests pass
- Code Review

Fixes #16136.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
