### PR TITLE
Make Kernel::V3D behave like a list in Python

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
@@ -4,6 +4,8 @@
 #include <boost/python/operators.hpp>
 #include <boost/python/return_value_policy.hpp>
 #include <boost/python/return_arg.hpp>
+#include <boost/python/list.hpp>
+#include <boost/python/errors.hpp>
 
 using namespace boost::python;
 using Mantid::Kernel::V3D;
@@ -22,6 +24,47 @@ long hashV3D(V3D &self) {
   boost::python::object tmpObj(self.toString());
 
   return PyObject_Hash(tmpObj.ptr());
+}
+
+double getV3DItem(V3D &self, int index) {
+  switch (index) {
+  case -3:
+  case 0:
+    return self.X();
+  case -2:
+  case 1:
+    return self.Y();
+  case -1:
+  case 2:
+    return self.Z();
+  }
+  PyErr_SetString(PyExc_IndexError, "index out of range");
+  throw boost::python::error_already_set();
+}
+
+void setV3DItem(V3D &self, int index, double value) {
+  switch (index) {
+  case -3:
+  case 0:
+    self.setX(value);
+    break;
+  case -2:
+  case 1:
+    self.setY(value);
+    break;
+  case -1:
+  case 2:
+    self.setZ(value);
+    break;
+  default:
+    PyErr_SetString(PyExc_IndexError, "index out of range");
+    throw boost::python::error_already_set();
+  }
+}
+
+int getV3DLength(V3D &self) {
+  UNUSED_ARG(self);
+  return 3;
 }
 }
 
@@ -68,6 +111,15 @@ void export_V3D() {
       .def("__sub__", &V3D::operator-, (arg("left"), arg("right")))
       .def("__isub__", &V3D::operator-=, return_self<>(),
            (arg("self"), arg("other")))
+      .def("__len__", &getV3DLength, (arg("self")),
+           "Returns the length of the vector for list-like interface. Always "
+           "returns 3.")
+      .def("__getitem__", &getV3DItem, (arg("self"), arg("index")),
+           "Access the V3D-object like a list for getting elements.")
+      .def("__setitem__", &setV3DItem,
+           (arg("self"), arg("index"), arg("value")),
+           "Access the V3D-object like a list for setting elements.")
+
       .def(self * self)
       .def(self *= self)
       .def(self / self)

--- a/Framework/PythonInterface/test/python/mantid/kernel/V3DTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/V3DTest.py
@@ -1,9 +1,10 @@
 import unittest
 import math
+import numpy as np
 from mantid.kernel import V3D
 
-class V3DTest(unittest.TestCase):
 
+class V3DTest(unittest.TestCase):
     def test_default_construction_is_at_origin(self):
         p = V3D()
         self.assertEquals(p.X(), 0.0)
@@ -11,16 +12,16 @@ class V3DTest(unittest.TestCase):
         self.assertEquals(p.Z(), 0.0)
 
     def test_construction_with_xyz(self):
-        p = V3D(1.5,2.4,6.5)
+        p = V3D(1.5, 2.4, 6.5)
         self.assertEquals(p.X(), 1.5)
         self.assertEquals(p.Y(), 2.4)
         self.assertEquals(p.Z(), 6.5)
 
     def test_distance(self):
-        a = V3D(0.0,0.0,0.0)
-        b = V3D(2.0,2.0,2.0)
+        a = V3D(0.0, 0.0, 0.0)
+        b = V3D(2.0, 2.0, 2.0)
         d = a.distance(b)
-        self.assertAlmostEquals(d, 2.0*math.sqrt(3.0))
+        self.assertAlmostEquals(d, 2.0 * math.sqrt(3.0))
 
     def test_angle(self):
         a = V3D(2.0, 0.0, 0.0)
@@ -47,53 +48,53 @@ class V3DTest(unittest.TestCase):
         self.assertAlmostEquals(a.zenith(b), 3.0 * math.pi / 4.0)
 
     def test_scalarprod(self):
-        a = V3D(1.0,2.0,1.0)
-        b = V3D(1.0,-2.0,-1.0)
+        a = V3D(1.0, 2.0, 1.0)
+        b = V3D(1.0, -2.0, -1.0)
         sp = a.scalar_prod(b)
-        self.assertAlmostEquals(sp,-4.0)
+        self.assertAlmostEquals(sp, -4.0)
 
     def test_crossprod(self):
-        a = V3D(1.0,0.0,0.0)
-        b = V3D(0.0,1.0,0.0)
+        a = V3D(1.0, 0.0, 0.0)
+        b = V3D(0.0, 1.0, 0.0)
         c = a.cross_prod(b)
-        self.assertAlmostEquals(c.X(),0.0)
-        self.assertAlmostEquals(c.Y(),0.0)
-        self.assertAlmostEquals(c.Z(),1.0)
+        self.assertAlmostEquals(c.X(), 0.0)
+        self.assertAlmostEquals(c.Y(), 0.0)
+        self.assertAlmostEquals(c.Z(), 1.0)
 
     def test_norm(self):
-        p = V3D(1.0,-5.0,8.0);
+        p = V3D(1.0, -5.0, 8.0);
         self.assertAlmostEquals(p.norm(), math.sqrt(90.0))
 
     def test_norm2(self):
-        p = V3D(1.0,-5.0,8.0);
+        p = V3D(1.0, -5.0, 8.0);
         self.assertAlmostEquals(p.norm2(), 90.0)
 
     def test_equality_operators_use_value_comparison(self):
-        p1 = V3D(1.0,-5.0,8.0)
-        p2 = V3D(1.0,-5.0,8.0)
+        p1 = V3D(1.0, -5.0, 8.0)
+        p2 = V3D(1.0, -5.0, 8.0)
         self.assertTrue(p1 == p2)
 
     def test_inequality_operators_use_value_comparison(self):
-        p1 = V3D(1.0,-5.0,8.0)
-        p2 = V3D(1.0,-5.0,8.0) # different objects, same value
+        p1 = V3D(1.0, -5.0, 8.0)
+        p2 = V3D(1.0, -5.0, 8.0)  # different objects, same value
         self.assertFalse(p1 != p2)
-        p3 = V3D(1.0,-5.0,10.0)
+        p3 = V3D(1.0, -5.0, 10.0)
         self.assertTrue(p1 != p3)
 
     def test_directionAngles_rads(self):
         v = V3D(1, 1, 1)
         inDegrees = False
         angles = v.directionAngles(inDegrees)
-        self.assertAlmostEquals(math.acos(1.0/math.sqrt(3.0)), angles.X())
-        self.assertAlmostEquals(math.acos(1.0/math.sqrt(3.0)), angles.Y())
-        self.assertAlmostEquals(math.acos(1.0/math.sqrt(3.0)), angles.Z())
+        self.assertAlmostEquals(math.acos(1.0 / math.sqrt(3.0)), angles.X())
+        self.assertAlmostEquals(math.acos(1.0 / math.sqrt(3.0)), angles.Y())
+        self.assertAlmostEquals(math.acos(1.0 / math.sqrt(3.0)), angles.Z())
 
     def test_directionAngles(self):
         v = V3D(1, 1, 1)
         angles = v.directionAngles()
-        self.assertAlmostEquals(math.acos(1.0/math.sqrt(3.0)) * 180 / math.pi, angles.X())
-        self.assertAlmostEquals(math.acos(1.0/math.sqrt(3.0)) * 180 / math.pi, angles.Y())
-        self.assertAlmostEquals(math.acos(1.0/math.sqrt(3.0)) * 180 / math.pi, angles.Z())
+        self.assertAlmostEquals(math.acos(1.0 / math.sqrt(3.0)) * 180 / math.pi, angles.X())
+        self.assertAlmostEquals(math.acos(1.0 / math.sqrt(3.0)) * 180 / math.pi, angles.Y())
+        self.assertAlmostEquals(math.acos(1.0 / math.sqrt(3.0)) * 180 / math.pi, angles.Z())
 
     def test_hash(self):
         v1 = V3D(1, 1, 1)
@@ -103,6 +104,58 @@ class V3DTest(unittest.TestCase):
         a = set([v1, v2, v3])
 
         self.assertEquals(len(a), 2)
+
+    def test_get_item(self):
+        v = V3D(2, 1, 3)
+
+        self.assertRaises(IndexError, v.__getitem__, 3)
+        self.assertRaises(IndexError, v.__getitem__, -4)
+
+        self.assertEquals(v[0], 2.0)
+        self.assertEquals(v[1], 1.0)
+        self.assertEquals(v[2], 3.0)
+
+        self.assertEquals(v[-3], 2.0)
+        self.assertEquals(v[-2], 1.0)
+        self.assertEquals(v[-1], 3.0)
+
+    def test_set_item(self):
+        v = V3D(2, 1, 3)
+
+        self.assertRaises(IndexError, v.__setitem__, 3, 0.0)
+        self.assertRaises(IndexError, v.__setitem__, -4, 0.0)
+
+        v[0] = 1.0
+        v[1] = 2.0
+        v[2] = 4.0
+
+        self.assertEquals(v[0], 1.0)
+        self.assertEquals(v[1], 2.0)
+        self.assertEquals(v[2], 4.0)
+
+        v[-3] = 3.0
+        v[-2] = 5.0
+        v[-1] = 6.0
+
+        self.assertEquals(v[0], 3.0)
+        self.assertEquals(v[1], 5.0)
+        self.assertEquals(v[2], 6.0)
+
+    def test_iterator(self):
+        times_two = [2 * x for x in V3D(3, 4, 5)]
+
+        self.assertEquals(times_two[0], 6.0)
+        self.assertEquals(times_two[1], 8.0)
+        self.assertEquals(times_two[2], 10.0)
+
+    def test_len(self):
+        self.assertEquals(len(V3D(2, 2, 2)), 3)
+
+    def test_numpy_conversion(self):
+        v = V3D(1, 2, 3)
+        v_as_numpy = np.array(v)
+
+        self.assertTrue(np.all(v_as_numpy == np.array([1, 2, 3])))
 
 
 if __name__ == '__main__':

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -155,6 +155,8 @@ Python
 
 - The plot() function of mantidplot.pyplot now supports empty marker (marker=None).
 
+- V3D is now iterable in Python, which makes it possible to easily construct numpy arrays like this ``np.array(V3D(1,2, 3))``.
+
 Python Algorithms
 #################
 


### PR DESCRIPTION
This fixes #16160.

As described in the [forum](http://forum.mantidproject.org/t/real-space-crystallography/118/3), it's complicated to use `Kernel::V3D` in connection with other Python objects or libraries (numpy).

This adds `__getitem__`, `__setitem__` and `__len__` to `V3D` in Python so that it behaves like a list. Iterators are generated automatically, so that it's possible to do these things now:

```
v = V3D(1, 2, 3)
new_list = [2 * x for x in v]

for x in v:
   print x

import numpy as np
as_np = np.array(v)
```

Not sure if this needs to be in the release notes.

**To test:**

Code review. If you like you could play around with the new functionality a bit. There are a few new unit tests that cover this behaviour. 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
