### PR TITLE
Enable SpaceGroup to check if unit cell is compatible with symmetry

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h
@@ -169,6 +169,9 @@ public:
 
   std::vector<Kernel::V3D> operator*(const Kernel::V3D &vector) const;
 
+  bool isInvariant(const Kernel::DblMatrix &tensor,
+                   double tolerance = 1e-8) const;
+
   bool operator==(const Group &other) const;
   bool operator!=(const Group &other) const;
 
@@ -212,8 +215,8 @@ create(const std::vector<SymmetryOperation> &symmetryOperations) {
 }
 }
 
-MANTID_GEOMETRY_DLL Group_const_sptr
-operator*(const Group_const_sptr &lhs, const Group_const_sptr &rhs);
+MANTID_GEOMETRY_DLL Group_const_sptr operator*(const Group_const_sptr &lhs,
+                                               const Group_const_sptr &rhs);
 MANTID_GEOMETRY_DLL std::vector<Kernel::V3D>
 operator*(const Group_const_sptr &lhs, const Kernel::V3D &rhs);
 MANTID_GEOMETRY_DLL bool operator==(const Group_const_sptr &lhs,

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h
@@ -215,8 +215,8 @@ create(const std::vector<SymmetryOperation> &symmetryOperations) {
 }
 }
 
-MANTID_GEOMETRY_DLL Group_const_sptr operator*(const Group_const_sptr &lhs,
-                                               const Group_const_sptr &rhs);
+MANTID_GEOMETRY_DLL Group_const_sptr
+operator*(const Group_const_sptr &lhs, const Group_const_sptr &rhs);
 MANTID_GEOMETRY_DLL std::vector<Kernel::V3D>
 operator*(const Group_const_sptr &lhs, const Kernel::V3D &rhs);
 MANTID_GEOMETRY_DLL bool operator==(const Group_const_sptr &lhs,

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -5,6 +5,7 @@
 #include "MantidGeometry/Crystal/Group.h"
 #include "MantidGeometry/Crystal/PointGroup.h"
 #include "MantidGeometry/Crystal/SymmetryOperation.h"
+#include "MantidGeometry/Crystal/UnitCell.h"
 #include "MantidKernel/V3D.h"
 
 #include <set>
@@ -87,6 +88,7 @@ public:
   }
 
   bool isAllowedReflection(const Kernel::V3D &hkl) const;
+  bool isAllowedUnitCell(const UnitCell &cell) const;
 
   PointGroup_sptr getPointGroup() const;
   Group_const_sptr getSiteSymmetryGroup(const Kernel::V3D &position) const;

--- a/Framework/Geometry/src/Crystal/Group.cpp
+++ b/Framework/Geometry/src/Crystal/Group.cpp
@@ -81,6 +81,54 @@ std::vector<Kernel::V3D> Group::operator*(const Kernel::V3D &vector) const {
   return result;
 }
 
+/**
+ * Returns true if the tensor is invariant under the group operations
+ *
+ * This method returns true if the supplied tensor is not changed by the
+ * group's symmetry operations. This is done by applying eq. 10 from [1],
+ *
+ *   G_i = W_i' * G * W_i
+ *
+ * where G is the tensor and W_i is the matrix of the i-th symmetry operation.
+ * If G_i == G holds for all i, the tensor is invariant with respect to the
+ * groups symmetry operations. To allow for floating point errors, a tolerance
+ * can be specified.
+ *
+ * One application of this method is to check whether a unit cell is compatible
+ * with the symmetry operations of a space group:
+ *
+ *   UnitCell cell(5, 5, 10);
+ *   SpaceGroup_const_sptr sg = SpaceGroupFactory::Instance()
+ *                                        .createSpaceGroup("F m -3 m");
+ *
+ *   // returns false:
+ *   sg->isTensorInvariant(cell.getG());
+ *
+ * This is expected, because the cell with a different length for c is not
+ * compatible with the restrictions imposed by cubic symmetry.
+ *
+ * [1] G. Rigault, Metric tensor and symmetry operations in crystallography,
+ *     http://www.iucr.org/education/pamphlets/10
+ *
+ * @param tensor :: Tensor to check.
+ * @param tolerance :: Tolerance for comparison of tensor equality.
+ * @return :: True if tensor is invariant.
+ */
+bool Group::isInvariant(const Kernel::DblMatrix &tensor,
+                        double tolerance) const {
+  auto transformTensor = [](const Kernel::DblMatrix &opMatrix,
+                            const Kernel::DblMatrix &tensor) {
+    return opMatrix.Tprime() * tensor * opMatrix;
+  };
+
+  return std::all_of(m_allOperations.cbegin(), m_allOperations.cend(),
+                     [&](const SymmetryOperation &op) {
+                       return transformTensor(
+                                  convertMatrix<double>(op.matrix()), tensor)
+                           .equals(tensor, tolerance);
+                     });
+}
+
 /// Returns true if both groups contain the same set of symmetry operations.
 bool Group::operator==(const Group &other) const {
   return m_operationSet == other.m_operationSet;

--- a/Framework/Geometry/src/Crystal/Group.cpp
+++ b/Framework/Geometry/src/Crystal/Group.cpp
@@ -116,10 +116,10 @@ std::vector<Kernel::V3D> Group::operator*(const Kernel::V3D &vector) const {
  */
 bool Group::isInvariant(const Kernel::DblMatrix &tensor,
                         double tolerance) const {
-  auto transformTensor = [](const Kernel::DblMatrix &opMatrix,
-                            const Kernel::DblMatrix &tensor) {
-    return opMatrix.Tprime() * tensor * opMatrix;
-  };
+  auto transformTensor =
+      [](const Kernel::DblMatrix &opMatrix, const Kernel::DblMatrix &tensor) {
+        return opMatrix.Tprime() * tensor * opMatrix;
+      };
 
   return std::all_of(m_allOperations.cbegin(), m_allOperations.cend(),
                      [&](const SymmetryOperation &op) {

--- a/Framework/Geometry/src/Crystal/SpaceGroup.cpp
+++ b/Framework/Geometry/src/Crystal/SpaceGroup.cpp
@@ -64,6 +64,12 @@ bool SpaceGroup::isAllowedReflection(const Kernel::V3D &hkl) const {
   return true;
 }
 
+/// Convenience function for checking compatibility of a cell metric with the
+/// space group, see Group::isInvariant.
+bool SpaceGroup::isAllowedUnitCell(const UnitCell &cell) const {
+  return isInvariant(cell.getG());
+}
+
 /**
  * Returns the point group of the space group
  *

--- a/Framework/Geometry/test/GroupTest.h
+++ b/Framework/Geometry/test/GroupTest.h
@@ -6,6 +6,7 @@
 #include "MantidKernel/V3D.h"
 #include "MantidGeometry/Crystal/Group.h"
 #include "MantidGeometry/Crystal/SymmetryOperationFactory.h"
+#include "MantidGeometry/Crystal/UnitCell.h"
 #include <boost/make_shared.hpp>
 
 using namespace Mantid::Geometry;
@@ -315,6 +316,21 @@ public:
 
     Group noIdentity("-x,-y,-z; x,y,-z; -x,-y,z");
     TS_ASSERT(!noIdentity.isGroup());
+  }
+
+  void test_isInvariant_triclinic_monoclinic() {
+    UnitCell triclinic(3, 4, 5, 91, 92, 93);
+    UnitCell monoclinic(3, 5, 6, 90, 100, 90);
+
+    // Both cells are compatible with triclinic symmetry
+    Group p1bar("x,y,z; -x,-y,-z");
+    TS_ASSERT(p1bar.isInvariant(triclinic.getG()));
+    TS_ASSERT(p1bar.isInvariant(monoclinic.getG()));
+
+    // But not with monoclinic
+    Group p2overm("x,y,z; -x,-y,-z; -x,y,-z; x,-y,z");
+    TS_ASSERT(p2overm.isInvariant(monoclinic.getG()));
+    TS_ASSERT(!p2overm.isInvariant(triclinic.getG()));
   }
 
   void testSmartPointerOperators() {

--- a/Framework/Geometry/test/SpaceGroupTest.h
+++ b/Framework/Geometry/test/SpaceGroupTest.h
@@ -83,11 +83,7 @@ public:
   }
 
   void testGetEquivalentsR3m9e() {
-    Group_const_sptr group = GroupFactory::create<ProductOfCyclicGroups>(
-        "-y,x-y,z; y,x,-z; -x,-y,-z");
-    Group_const_sptr centering = GroupFactory::create<CenteringGroup>("R");
-
-    SpaceGroup spaceGroup(166, "R-3m", *(group * centering));
+    SpaceGroup spaceGroup = getSpaceGroupR3m();
 
     std::vector<V3D> byOperator = spaceGroup * V3D(0.5, 0.0, 0.0);
     for (size_t i = 0; i < byOperator.size(); ++i) {
@@ -112,11 +108,7 @@ public:
      *
      * This test uses space group 166, R-3m, like above.
      */
-    Group_const_sptr group = GroupFactory::create<ProductOfCyclicGroups>(
-        "-y,x-y,z; y,x,-z; -x,-y,-z");
-    Group_const_sptr centering = GroupFactory::create<CenteringGroup>("R");
-
-    SpaceGroup spaceGroup(166, "R-3m", *(group * centering));
+    SpaceGroup spaceGroup = getSpaceGroupR3m();
 
     // Reflections hkl: -h + k + l = 3n
     V3D goodHKL(1, 4, 3); // -1 + 4 + 3 = 6 = 3 * 2
@@ -153,6 +145,16 @@ public:
     V3D badHH0(4, -4, 0);
     TS_ASSERT(spaceGroup.isAllowedReflection(goodHH0));
     TS_ASSERT(!spaceGroup.isAllowedReflection(badHH0));
+  }
+
+  void test_isAllowedUnitCell_R3m() {
+    UnitCell cell(6, 6, 10, 90, 90, 120);
+    UnitCell invalid(6, 7, 10, 90, 90, 120);
+
+    SpaceGroup sg = getSpaceGroupR3m();
+
+    TS_ASSERT(sg.isAllowedUnitCell(cell));
+    TS_ASSERT(!sg.isAllowedUnitCell(invalid));
   }
 
   void testSiteSymmetryGroupR3c() {
@@ -214,6 +216,16 @@ public:
   }
 
 private:
+  SpaceGroup getSpaceGroupR3m() {
+    Group_const_sptr group = GroupFactory::create<ProductOfCyclicGroups>(
+        "-y,x-y,z; y,x,-z; -x,-y,-z");
+    Group_const_sptr centering = GroupFactory::create<CenteringGroup>("R");
+
+    SpaceGroup sg(166, "R-3m", *(group * centering));
+
+    return sg;
+  }
+
   void checkSiteSymmetryGroupPositions(const V3D &position,
                                        const Group_const_sptr &siteSymmGroup,
                                        const std::string &wPosName,

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -1,5 +1,6 @@
 
 #include "MantidGeometry/Crystal/Group.h"
+#include "MantidPythonInterface/kernel/Converters/PyObjectToMatrix.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/enum.hpp>
@@ -11,6 +12,7 @@
 
 using namespace Mantid::Geometry;
 using Mantid::Geometry::SymmetryOperation;
+using Mantid::PythonInterface::Converters::PyObjectToMatrix;
 
 using namespace boost::python;
 
@@ -46,6 +48,15 @@ Group_sptr constructGroupFromPythonList(const boost::python::list &symOpList) {
 
   return boost::const_pointer_cast<Group>(
       GroupFactory::create<Group>(operations));
+}
+
+bool isInvariantDefault(Group &self, const boost::python::object &tensor) {
+  return self.isInvariant(PyObjectToMatrix(tensor)());
+}
+
+bool isInvariantTolerance(Group &self, const boost::python::object &tensor,
+                          double tolerance) {
+  return self.isInvariant(PyObjectToMatrix(tensor)(), tolerance);
 }
 }
 
@@ -89,6 +100,14 @@ void export_Group() {
       .def("containsOperation", &Group::containsOperation,
            (arg("self"), arg("operation")),
            "Checks whether a SymmetryOperation is included in Group.")
+
+      .def("isInvariant", &isInvariantDefault, (arg("self"), arg("tensor")),
+           "Returns true if the tensor is not changed by the group's symmetry "
+           "operations with a tolerance of 1e-8.")
+      .def("isInvariant", &isInvariantTolerance,
+           (arg("self"), arg("tensor"), arg("tolerance")),
+           "Returns true if the tensor is not changed by the group's symmetry "
+           "operations with the given tolerance.")
       .def("isGroup", &Group::isGroup, arg("self"),
            "Checks whether the contained symmetry "
            "operations fulfill the group axioms.")

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -63,6 +63,9 @@ void export_SpaceGroup() {
            (arg("self"), arg("hkl")),
            "Returns True if the supplied reflection is allowed with respect to "
            "space group symmetry operations.")
+      .def("isAllowedUnitCell", &SpaceGroup::isAllowedUnitCell,
+           (arg("self"), arg("cell")), "Returns true if the metric of the cell "
+                                       "is compatible with the space group.")
       .def("getPointGroup", &SpaceGroup::getPointGroup, arg("self"),
            "Returns the point group of the space group.")
       .def("getSiteSymmetryGroup", &getSiteSymmetryGroup,

--- a/Framework/PythonInterface/test/python/mantid/geometry/GroupTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/GroupTest.py
@@ -1,6 +1,7 @@
-#pylint: disable=no-init,invalid-name,too-many-public-methods
+# pylint: disable=no-init,invalid-name,too-many-public-methods
 import unittest
-from mantid.geometry import Group, SpaceGroupFactory
+from mantid.geometry import Group, SpaceGroupFactory, PointGroupFactory, UnitCell
+
 
 class GroupTest(unittest.TestCase):
     def test_creationFromString(self):
@@ -27,6 +28,19 @@ class GroupTest(unittest.TestCase):
 
         # But the constructed group is not actually a group
         self.assertFalse(group.isGroup())
+
+    def test_isInvariant_tolerance(self):
+        pg3barHex = PointGroupFactory.createPointGroup('-3')
+        pg3barRh = PointGroupFactory.createPointGroup('-3 r')
+
+        cellHex = UnitCell(3, 3, 6, 90, 90, 120)
+        cellRh = UnitCell(3, 3, 3, 75, 75, 75)
+
+        self.assertTrue(pg3barHex.isInvariant(cellHex.getG()))
+        self.assertFalse(pg3barHex.isInvariant(cellRh.getG()))
+
+        self.assertTrue(pg3barRh.isInvariant(cellRh.getG()))
+        self.assertFalse(pg3barRh.isInvariant(cellHex.getG()))
 
 
 if __name__ == '__main__':

--- a/Framework/PythonInterface/test/python/mantid/geometry/SpaceGroupTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/SpaceGroupTest.py
@@ -1,6 +1,6 @@
-#pylint: disable=no-init,invalid-name,too-many-public-methods
+# pylint: disable=no-init,invalid-name,too-many-public-methods
 import unittest
-from mantid.geometry import SpaceGroupFactory
+from mantid.geometry import SpaceGroupFactory, UnitCell
 
 
 class SpaceGroupTest(unittest.TestCase):
@@ -19,6 +19,32 @@ class SpaceGroupTest(unittest.TestCase):
         self.assertEqual(len(symOpStrings), 2)
         self.assertTrue("x,y,z" in symOpStrings)
         self.assertTrue("-x,-y,-z" in symOpStrings)
+
+    def test_isAllowedUnitCell_cubic(self):
+        cubic = UnitCell(6, 6, 6)
+        tetragonal = UnitCell(6, 6, 6.01)
+        sg = SpaceGroupFactory.createSpaceGroup('P m -3')
+
+        self.assertTrue(sg.isAllowedUnitCell(cubic))
+        self.assertFalse(sg.isAllowedUnitCell(tetragonal))
+
+    def test_isAllowedUnitCell_trigonal(self):
+        rhombohedral = UnitCell(5, 5, 5, 80, 80, 80)
+        hexagonal = UnitCell(5, 5, 4, 90, 90, 120)
+
+        sgRh = SpaceGroupFactory.createSpaceGroup('R -3 c :r')
+        sgHex = SpaceGroupFactory.createSpaceGroup('R -3 c')
+
+        sgP6m = SpaceGroupFactory.createSpaceGroup('P 6/m')
+
+        self.assertTrue(sgRh.isAllowedUnitCell(rhombohedral))
+        self.assertFalse(sgRh.isAllowedUnitCell(hexagonal))
+
+        self.assertTrue(sgHex.isAllowedUnitCell(hexagonal))
+        self.assertFalse(sgHex.isAllowedUnitCell(rhombohedral))
+
+        self.assertTrue(sgP6m.isAllowedUnitCell(hexagonal))
+        self.assertFalse(sgP6m.isAllowedUnitCell(rhombohedral))
 
     def test_equivalentPositions_Triclinic(self):
         wyckoffs = [([0.3, 0.4, 0.45], 2),

--- a/Testing/SystemTests/tests/analysis/SpaceGroupUnitCellTest.py
+++ b/Testing/SystemTests/tests/analysis/SpaceGroupUnitCellTest.py
@@ -1,0 +1,72 @@
+# pylint: disable=no-init,invalid-name
+import stresstesting
+from mantid.geometry import *
+
+
+class SpaceGroupUnitCellTest(stresstesting.MantidStressTest):
+    '''
+    This test checks that SpaceGroup.isAllowedUnitCell produces the expected result for each registered space group.
+    '''
+
+    def runTest(self):
+        cells = self.getUnitCells()
+        metric_compatibility = self.getMetricCompatibility(cells)
+
+        # For monoclinic space groups with unique c-axis the metric and compatible metrics are different
+        monoclinic_c_cells = cells.copy()
+        monoclinic_c_cells[PointGroup.LatticeSystem.Monoclinic] = UnitCell(5.0, 6.0, 7.0, 90.0, 90.0, 102.0)
+
+        monoclinic_c_compatiblity = metric_compatibility.copy()
+        monoclinic_c_compatiblity[PointGroup.LatticeSystem.Monoclinic] = \
+            metric_compatibility[PointGroup.LatticeSystem.Monoclinic] + [PointGroup.LatticeSystem.Hexagonal]
+
+        for sg_name in SpaceGroupFactory.getAllSpaceGroupSymbols():
+            sg = SpaceGroupFactory.createSpaceGroup(sg_name)
+            lattice_system = sg.getPointGroup().getLatticeSystem()
+
+            # Currently the c-unique monoclinic space groups are determined from the symbol
+            if lattice_system != PointGroup.LatticeSystem.Monoclinic or sg_name[2:5] != '1 1':
+                self._check_spacegroup(sg, cells, metric_compatibility[lattice_system])
+            else:
+                # These are the monoclinic space groups with unique c axis, which need a special treatment
+                self._check_spacegroup(sg, monoclinic_c_cells, monoclinic_c_compatiblity[lattice_system])
+
+    def _check_spacegroup(self, sg, cells, compatible_metrics):
+        for system, cell in cells.iteritems():
+            is_allowed = sg.isAllowedUnitCell(cell)
+            should_be_allowed = system in compatible_metrics
+
+            self.assertEqual(is_allowed, should_be_allowed,
+                             'Problem in space group {0}: UnitCell with {1} metric is {2}, should be {3}.'.format(
+                                 sg.getHMSymbol(), str(system), str(is_allowed), str(should_be_allowed)))
+
+    def getUnitCells(self):
+        # Create a unit cell for each of the lattice systems in a dictionary
+        return {
+            PointGroup.LatticeSystem.Triclinic: UnitCell(5.0, 6.0, 7.0, 100.0, 102.0, 103.0),
+            PointGroup.LatticeSystem.Monoclinic: UnitCell(5.0, 6.0, 7.0, 90.0, 102.0, 90.0),
+            PointGroup.LatticeSystem.Orthorhombic: UnitCell(5.0, 6.0, 7.0, 90.0, 90.0, 90.0),
+            PointGroup.LatticeSystem.Rhombohedral: UnitCell(5.0, 5.0, 5.0, 80.0, 80.0, 80.0),
+            PointGroup.LatticeSystem.Hexagonal: UnitCell(5.0, 5.0, 7.0, 90.0, 90.0, 120.0),
+            PointGroup.LatticeSystem.Tetragonal: UnitCell(5.0, 5.0, 7.0, 90.0, 90.0, 90.0),
+            PointGroup.LatticeSystem.Cubic: UnitCell(5.0, 5.0, 5.0, 90.0, 90.0, 90.0)
+        }
+
+    def getMetricCompatibility(self, cells):
+        # This map specifies which metrics are compatible. A cell with cubic metric is for example compatible
+        # with triclinic symmetry, but the opposite is not true.
+        return {
+            PointGroup.LatticeSystem.Triclinic: cells.keys(),
+            PointGroup.LatticeSystem.Monoclinic: [PointGroup.LatticeSystem.Monoclinic,
+                                                  PointGroup.LatticeSystem.Orthorhombic,
+                                                  PointGroup.LatticeSystem.Tetragonal,
+                                                  PointGroup.LatticeSystem.Cubic],
+            PointGroup.LatticeSystem.Orthorhombic: [PointGroup.LatticeSystem.Orthorhombic,
+                                                    PointGroup.LatticeSystem.Tetragonal,
+                                                    PointGroup.LatticeSystem.Cubic],
+            PointGroup.LatticeSystem.Rhombohedral: [PointGroup.LatticeSystem.Rhombohedral,
+                                                    PointGroup.LatticeSystem.Cubic],
+            PointGroup.LatticeSystem.Hexagonal: [PointGroup.LatticeSystem.Hexagonal],
+            PointGroup.LatticeSystem.Tetragonal: [PointGroup.LatticeSystem.Tetragonal, PointGroup.LatticeSystem.Cubic],
+            PointGroup.LatticeSystem.Cubic: [PointGroup.LatticeSystem.Cubic]
+        }

--- a/docs/source/concepts/PointAndSpaceGroups.rst
+++ b/docs/source/concepts/PointAndSpaceGroups.rst
@@ -174,6 +174,29 @@ This example code produces the output below upon execution:
     Number of independent reflections: 3
     Reflections: [[1,1,1], [1,0,0], [3,1,1]]
 
+Symmetry imposes restrictions on the metric of the unit cell. Cubic symmetry for example implies that all cell edges have the same length and all angles are 90 degrees. The ``Group``-class (and thus, by inheritance also ``PointGroup``) provides a method that checks is a metric tensor is compatible with the symmetry operations of the group:
+
+.. testcode:: ExPointGroupIsInvariant
+
+    from mantid.geometry import PointGroupFactory, UnitCell
+
+    cell = UnitCell(3, 3, 5)
+
+    pgCubic = PointGroupFactory.createPointGroup("m-3m")
+    print "Is the cell compatible with cubic symmetry?", pgCubic.isInvariant(cell.getG())
+
+    pgTetragonal = PointGroupFactory.createPointGroup("4/mmm")
+    print "Is the cell compatible with tetragonal symmetry?", pgTetragonal.isInvariant(cell.getG())
+
+Executing the code above will produce the following output that reveals that the cell is only compatible with tetragonal, but not with cubic symmetry:
+
+.. testoutput:: ExPointGroupIsInvariant
+
+    Is the cell compatible with cubic symmetry? False
+    Is the cell compatible with tetragonal symmetry? True
+
+The ``SpaceGroup`` class described below provides a convenience method that takes a unit cell object directly.
+
 This is all that's covered by the Python interface regarding point groups in Mantid at the time of this writing. The use in C++ is very similar and described in detail in the API documentation.
     
 Using space groups in Mantid
@@ -350,7 +373,31 @@ Because space group :math:`Fddd` contains diamond glide planes, only :math:`00l`
     [0,0,8] is allowed: True
 
 :ref:`Below <SpaceGroupCheck>` is a more elaborate example which shows one possibility to find a likely candidate space group for a list of reflections. Please note that these reflection conditions only covers the ones listed for the "general position" in ITA. When atoms are located on special positions, there may be additional conditions that need to be fulfilled. A notable example is the :math:`222`-reflection in Silicon. It is forbidden because the silicon atom is located on the :math:`8a` position, which introduces additional reflection conditions.
-    
+
+As mentioned above, ``SpaceGroup`` provides a function that verifies whether the metric of a unit cell is compatible with the space group's symmetry:
+
+.. testcode:: ExSpaceGroupIsAllowedUnitCell
+
+    from mantid.geometry import SpaceGroupFactory, UnitCell
+
+    # An arbitrary cell with hexagonal metric
+    cell = UnitCell(4.402, 4.402, 10.0, 90, 90, 120)
+
+    sgR3mRh = SpaceGroupFactory.createSpaceGroup("R -3 m :r")
+    print "Is the cell allowed in R-3m (rhombohedral setting)?", sgR3mRh.isAllowedUnitCell(cell)
+
+    sgR3mHex = SpaceGroupFactory.createSpaceGroup("R -3 m")
+    print "Is the cell allowed in R-3m (hexagonal setting)?", sgR3mHex.isAllowedUnitCell(cell)
+
+The code above shows that the defined cell is only compatible with space group :math:`R\bar{3}m` in hexagonal setting:
+
+.. testoutput:: ExSpaceGroupIsAllowedUnitCell
+
+    Is the cell allowed in R-3m (rhombohedral setting)? False
+    Is the cell allowed in R-3m (hexagonal setting)? True
+
+The method uses a tolerance of :math:`10^{-8}` for comparison of the metric tensor and its transform. For more fine-grained control of the tolerance it is possible to use the ``isInvariant``-method and supply the metric tensor along with the desired tolerance as a second parameter.
+
 Very similar constructions are available in C++ as well, as shown in the API documentation.
     
 Other ways of using groups in Mantid

--- a/docs/source/release/v3.7.0/diffraction.rst
+++ b/docs/source/release/v3.7.0/diffraction.rst
@@ -8,7 +8,7 @@ Diffraction Changes
 Documentation
 -------------
 
-- The documentation for all calibration approaches, including Powder diffrction, single crystal and engineering calibrations has been pulled together, and expanded :ref:`here<Calibration>`.
+- The documentation for all calibration approaches, including Powder diffraction, single crystal and engineering calibrations has been pulled together, and expanded :ref:`here<Calibration>`.
 
 Crystal Improvements
 --------------------

--- a/docs/source/release/v3.7.0/diffraction.rst
+++ b/docs/source/release/v3.7.0/diffraction.rst
@@ -24,6 +24,7 @@ Crystal Improvements
 - :ref:`LoadHKL <algm-LoadHKL>` reads hkl output that includes direction cosines.
 - :ref:`SaveIsawPeaks <algm-SaveIsawPeaks>` has DetCal information sorted by detector numbers
 - :ref:`StatisticsOfPeaksWorkspace <algm-StatisticsOfPeaksWorkspace>` has resolution shells in units of d-Spacing.
+- SpaceGroup now has a method to check whether a specified unit cell is compatible with the symmetry operations of the group.
 
 
 Engineering Diffraction


### PR DESCRIPTION
This fixes #16206.

The feature is implemented as described in the ticket. The base functionality is in `Group`, which now has a function that checks whether a tensor changes under any of the symmetry operations contained in the group.

SpaceGroup contains a convenience method that takes a unit cell and returns true if the cell metric is compatible with the group's symmetry. There is a system test that checks that this works for all space groups.

Both levels of functionality are exposed to Python.

**To test:**
Code review. Read the updated documentation and try the new usage examples and some variations.

Release notes have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
