### PR TITLE
Disable h5py usage on RHEL6

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SaveNexusPD.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveNexusPD.py
@@ -4,10 +4,12 @@ import mantid.simpleapi as api
 from mantid.kernel import StringListValidator
 import numpy as np
 
-try:
-    import h5py  # http://www.h5py.org/
-except ImportError:
-    pass
+import platform
+if platform.linux_distribution()[2] != 'Santiago':
+    try:
+        import h5py  # http://www.h5py.org/
+    except ImportError:
+        pass
 
 class SaveNexusPD(mantid.api.PythonAlgorithm):
     NX_CLASS = 'NX_class'

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveNexusPDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveNexusPDTest.py
@@ -4,14 +4,19 @@ from mantid.api import AnalysisDataService
 from mantid.simpleapi import CreateWorkspace, SaveNexusPD
 import numpy as np
 import os
+import platform
 from testhelpers import WorkspaceCreationHelper as WCH
 import unittest
 
-runTests = True
-try:
-    import h5py
-except ImportError:
+# RHEL6 has troubles with h5py
+if platform.linux_distribution()[2] == 'Santiago':
     runTests = False
+else:
+    runTests = True
+    try:
+        import h5py
+    except ImportError:
+        runTests = False
 
 class SaveNexusPDTest(unittest.TestCase):
     def saveFilePath(self, wkspname):

--- a/scripts/Inelastic/Direct/ReductionWrapper.py
+++ b/scripts/Inelastic/Direct/ReductionWrapper.py
@@ -9,12 +9,17 @@ from Direct.DirectEnergyConversion import DirectEnergyConversion
 import os
 import re
 import time
-try:
-    import h5py
-    h5py_installed = True
-except ImportError:
+
+# h5py seems to hang mantid imports on RHEL6
+import platform
+if platform.linux_distribution()[2] == 'Santiago':
     h5py_installed = False
-    pass
+else:
+    try:
+        import h5py
+        h5py_installed = True
+    except ImportError:
+        h5py_installed = False
 from abc import abstractmethod
 
 # R0921 abstract class not referenced -- wrong, client references it.


### PR DESCRIPTION
Disables any usage of `h5py` in Python on RHEL6. The process hangs on importing the module.

**To test:**

The system tests should work on RHEL6 after this change.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

The imports seem to hang the process when importing mantid in
the unit and system tests.
