### PR TITLE
Fittings peaks value can now be added when text-field is empty

### DIFF
--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -1579,17 +1579,16 @@ void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::addPeakToList() {
     auto strPeakCentre = stream.str();
 
     auto curExpPeaksList = m_uiTabFitting.lineEdit_fitting_peaks->text();
+    QString comma = ",";
 
     if (!curExpPeaksList.isEmpty()) {
-
+      // when further peak added to list
       std::string expPeakStr = curExpPeaksList.toStdString();
       std::string lastTwoChr = expPeakStr.substr(expPeakStr.size() - 2);
       auto lastChr = expPeakStr.back();
-      char comma = ',';
-      if (lastChr == comma || lastTwoChr == ", ") {
-        curExpPeaksList.append(QString::fromStdString(" " + strPeakCentre));
+      if (lastChr == ',' || lastTwoChr == ", ") {
+        curExpPeaksList.append(QString::fromStdString(strPeakCentre));
       } else {
-        QString comma = ", ";
         curExpPeaksList.append(comma + QString::fromStdString(strPeakCentre));
       }
       m_uiTabFitting.lineEdit_fitting_peaks->setText(curExpPeaksList);

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -1592,6 +1592,11 @@ void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::addPeakToList() {
         curExpPeaksList.append(comma + QString::fromStdString(strPeakCentre));
       }
       m_uiTabFitting.lineEdit_fitting_peaks->setText(curExpPeaksList);
+    } else {
+      // when new peak given when list is empty
+      curExpPeaksList.append(QString::fromStdString(strPeakCentre));
+      curExpPeaksList.append(comma);
+      m_uiTabFitting.lineEdit_fitting_peaks->setText(curExpPeaksList);
     }
   }
 }


### PR DESCRIPTION
**Description of work.**

On the fitting tab, when the `peaks` list/text-field is empty, user should now be able to add peaks to the list by clicking `Add Peaks` button. 

**To test:**
Go to: `Interfaces/Diffraction/Engineering Diffraction/Fitting`
Browse to: `ENGINX_241391_focused_texture_bank_1.nxs`
_can be found here:_ `\\olympic\Babylon5\Public\Shahroz\FittingTest`
Click `Fit`

Upon completion of process the plot should enable and click `Select Peak`
_(make sure that the `Peaks` text-field/list is empty if not then clear the text-field)_
Once desired peak selected click: `Add Peak`
- [x] Make sure that the selected peak/s has been added to the list by clicking `Fit` again

<!-- Instructions for testing. -->

Fixes #16152
_Does not need to be in the release notes._

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
