### PR TITLE
Fix bug showing up in debug mode tests for cansas 

### DIFF
--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -409,7 +409,7 @@ public:
 
   Mantid::MantidVec::value_type *operator()(Mantid::API::MatrixWorkspace_sptr,
                                             int index) {
-    auto isPointData = m_workspace->blocksize() == m_spectrumAxisValues.size();
+    auto isPointData = m_workspace->getNumberHistograms() == m_spectrumAxisValues.size();
     double value = 0;
     if (isPointData) {
       value = m_spectrumAxisValues[index];

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -409,7 +409,8 @@ public:
 
   Mantid::MantidVec::value_type *operator()(Mantid::API::MatrixWorkspace_sptr,
                                             int index) {
-    auto isPointData = m_workspace->getNumberHistograms() == m_spectrumAxisValues.size();
+    auto isPointData =
+        m_workspace->getNumberHistograms() == m_spectrumAxisValues.size();
     double value = 0;
     if (isPointData) {
       value = m_spectrumAxisValues[index];

--- a/Framework/DataHandling/test/LoadNXcanSASTest.h
+++ b/Framework/DataHandling/test/LoadNXcanSASTest.h
@@ -3,14 +3,14 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidDataHandling/LoadNXcanSAS.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/Axis.h"
-#include "MantidAPI/Run.h"
-#include "MantidDataHandling/NXcanSASDefinitions.h"
-#include "NXcanSASTestHelper.h"
-#include "MantidKernel/Unit.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Run.h"
+#include "MantidDataHandling/LoadNXcanSAS.h"
+#include "MantidDataHandling/NXcanSASDefinitions.h"
+#include "MantidKernel/Unit.h"
+#include "NXcanSASTestHelper.h"
 
 using Mantid::DataHandling::LoadNXcanSAS;
 using namespace NXcanSASTestHelper;
@@ -366,12 +366,22 @@ private:
 
     auto length = axis1In->length();
 
-    // The numeric axis of wsIn is histo, while axisIn is point data
-    for (size_t index = 0; index < length - 1; ++index) {
-      TSM_ASSERT_DELTA(
-          "Axis 1 should have the same value",
-          (axis1In->getValue(index + 1) + axis1In->getValue(index)) / 2.0,
-          axis1Out->getValue(index), eps);
+    // The numeric axis of wsIn is histo or point data, while axisIn is point
+    // data
+    auto is_axis1_point_data = length == wsIn->getNumberHistograms();
+    if (is_axis1_point_data) {
+      for (size_t index = 0; index < length; ++index) {
+        TSM_ASSERT_DELTA("Axis 1 should have the same value",
+                         axis1In->getValue(index), axis1Out->getValue(index),
+                         eps);
+      }
+    } else {
+      for (size_t index = 0; index < length; ++index) {
+        TSM_ASSERT_DELTA(
+            "Axis 1 should have the same value",
+            (axis1In->getValue(index + 1) + axis1In->getValue(index)) / 2.0,
+            axis1Out->getValue(index), eps);
+      }
     }
   }
 
@@ -419,18 +429,21 @@ private:
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(transName);
 
     // Ensure that both have the same Y data
-    auto readDataY =
-        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataY(index); };
+    auto readDataY = [](MatrixWorkspace_sptr ws, size_t index) {
+      return ws->dataY(index);
+    };
     do_assert_data(transIn, transOut, readDataY);
 
     // Ensure that both have the same E data
-    auto readDataE =
-        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataE(index); };
+    auto readDataE = [](MatrixWorkspace_sptr ws, size_t index) {
+      return ws->dataE(index);
+    };
     do_assert_data(transIn, transOut, readDataE);
 
     // Ensure that both have the same X data
-    auto readDataX =
-        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataX(index); };
+    auto readDataX = [](MatrixWorkspace_sptr ws, size_t index) {
+      return ws->dataX(index);
+    };
     do_assert_data(transIn, transOut, readDataX);
   }
 
@@ -449,18 +462,21 @@ private:
     TSM_ASSERT("Should be a point workspace", !wsOut->isHistogramData());
 
     // Ensure that both have the same Y data
-    auto readDataY =
-        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataY(index); };
+    auto readDataY = [](MatrixWorkspace_sptr ws, size_t index) {
+      return ws->dataY(index);
+    };
     do_assert_data(wsIn, wsOut, readDataY);
 
     // Ensure that both have the same E data
-    auto readDataE =
-        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataE(index); };
+    auto readDataE = [](MatrixWorkspace_sptr ws, size_t index) {
+      return ws->dataE(index);
+    };
     do_assert_data(wsIn, wsOut, readDataE);
 
     // Ensure that both have the same X data
-    auto readDataX =
-        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataX(index); };
+    auto readDataX = [](MatrixWorkspace_sptr ws, size_t index) {
+      return ws->dataX(index);
+    };
     do_assert_data(wsIn, wsOut, readDataX);
 
     // If applicable, ensure that both have the same Xdev data

--- a/Framework/DataHandling/test/LoadNXcanSASTest.h
+++ b/Framework/DataHandling/test/LoadNXcanSASTest.h
@@ -429,21 +429,18 @@ private:
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(transName);
 
     // Ensure that both have the same Y data
-    auto readDataY = [](MatrixWorkspace_sptr ws, size_t index) {
-      return ws->dataY(index);
-    };
+    auto readDataY =
+        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataY(index); };
     do_assert_data(transIn, transOut, readDataY);
 
     // Ensure that both have the same E data
-    auto readDataE = [](MatrixWorkspace_sptr ws, size_t index) {
-      return ws->dataE(index);
-    };
+    auto readDataE =
+        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataE(index); };
     do_assert_data(transIn, transOut, readDataE);
 
     // Ensure that both have the same X data
-    auto readDataX = [](MatrixWorkspace_sptr ws, size_t index) {
-      return ws->dataX(index);
-    };
+    auto readDataX =
+        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataX(index); };
     do_assert_data(transIn, transOut, readDataX);
   }
 
@@ -462,21 +459,18 @@ private:
     TSM_ASSERT("Should be a point workspace", !wsOut->isHistogramData());
 
     // Ensure that both have the same Y data
-    auto readDataY = [](MatrixWorkspace_sptr ws, size_t index) {
-      return ws->dataY(index);
-    };
+    auto readDataY =
+        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataY(index); };
     do_assert_data(wsIn, wsOut, readDataY);
 
     // Ensure that both have the same E data
-    auto readDataE = [](MatrixWorkspace_sptr ws, size_t index) {
-      return ws->dataE(index);
-    };
+    auto readDataE =
+        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataE(index); };
     do_assert_data(wsIn, wsOut, readDataE);
 
     // Ensure that both have the same X data
-    auto readDataX = [](MatrixWorkspace_sptr ws, size_t index) {
-      return ws->dataX(index);
-    };
+    auto readDataX =
+        [](MatrixWorkspace_sptr ws, size_t index) { return ws->dataX(index); };
     do_assert_data(wsIn, wsOut, readDataX);
 
     // If applicable, ensure that both have the same Xdev data


### PR DESCRIPTION
**Context**

Bug in unit tests showed only up in debug mode. Essentially the length of the spectrum axis should have been compared to the number of histograms and not the binning.

Fixes #16214

**To test:**

Make sure that the tests pass in debug mode on Windows.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
