### PR TITLE
Store EMode on workspace during ConvertUnits operation

### DIFF
--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -583,7 +583,7 @@ int ExperimentInfo::getRunNumber() const {
  * the instrument if one is not found. If neither exist then the run is
  * considered Elastic.
  * @return The emode enum for the energy transfer mode of this run. Currently
- * only checks the instrument
+ * checks the sample log & instrument in this order
  */
 Kernel::DeltaEMode::Type ExperimentInfo::getEMode() const {
   static const char *emodeTag = "deltaE-mode";

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -14,6 +14,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
+#include "MantidKernel/DeltaEMode.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/UnitFactory.h"
 
@@ -239,6 +240,10 @@ API::MatrixWorkspace_sptr ConvertUnits::setupOutputWorkspace(
 
   // Set the final unit that our output workspace will have
   outputWS->getAxis(0)->unit() = m_outputUnit;
+  // Store the emode
+  const bool overwrite(true);
+  outputWS->mutableRun().addProperty("deltaE-mode", getPropertyValue("EMode"),
+                                     overwrite);
 
   return outputWS;
 }

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -223,6 +223,8 @@ public:
             "quickOut2"));
     TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(), "Energy");
     TS_ASSERT_DELTA(output->dataX(1)[1], 10.10, 0.01);
+    // Check EMode has been set
+    TS_ASSERT_EQUALS(Mantid::Kernel::DeltaEMode::Elastic, output->getEMode());
 
     AnalysisDataService::Instance().remove("quickOut2");
   }
@@ -384,6 +386,8 @@ public:
             outputSpace));
     TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(), "DeltaE");
     TS_ASSERT_EQUALS(output->blocksize(), 1669);
+    // Check EMode has been set
+    TS_ASSERT_EQUALS(Mantid::Kernel::DeltaEMode::Direct, output->getEMode());
 
     ConvertUnits conv2;
     conv2.initialize();
@@ -400,6 +404,8 @@ public:
     TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(),
                      "DeltaE_inWavenumber");
     TS_ASSERT_EQUALS(output->blocksize(), 2275);
+    // Check EMode has been set
+    TS_ASSERT_EQUALS(Mantid::Kernel::DeltaEMode::Indirect, output->getEMode());
 
     AnalysisDataService::Instance().remove(outputSpace);
   }
@@ -448,6 +454,8 @@ public:
     TS_ASSERT_DIFFERS(a_tof, WS->getEventList(wkspIndex).getEvents()[0].tof());
     // and a X changed
     TS_ASSERT_DIFFERS(a_x, WS->getEventList(wkspIndex).dataX()[1]);
+    // Check EMode has been set
+    TS_ASSERT_EQUALS(Mantid::Kernel::DeltaEMode::Direct, WS->getEMode());
   }
 
   void testExecEvent_TwoStepConversionWithDeltaE() {


### PR DESCRIPTION
Stores the EMode as a run log on the workspace.

**To test:**

A code review of the actual change + unit test should suffice for this.

Fixes #15922 

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
