### PR TITLE
Added Python export for UnitCell::getBinv()

### DIFF
--- a/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
@@ -167,6 +167,7 @@ void export_UnitCell() {
       .def("getGstar", &UnitCell::getGstar, arg("self"),
            return_readonly_numpy())
       .def("getB", &UnitCell::getB, arg("self"), return_readonly_numpy())
+      .def("getBinv", &UnitCell::getBinv, arg("self"), return_readonly_numpy())
       .def("recalculateFromGstar", &recalculateFromGstar,
            (arg("self"), arg("NewGstar")));
 


### PR DESCRIPTION
This fixes #16236.

It doesn't need to be in the release notes, because it's in the documentation already.

**To test:**

Run the following script:

```
import numpy as np

u = UnitCell(2,3,5)
ijk=[0,0.5,0.25]
print np.dot(ijk, u.getBinv()) # Should print [0, 1.5, 1.25]
```

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
