### PR TITLE
Fix Coverity issue #1355248

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ThreadSchedulerMutexes.h
+++ b/Framework/Kernel/inc/MantidKernel/ThreadSchedulerMutexes.h
@@ -64,8 +64,7 @@ public:
 
           if (!map.empty()) {
             // Look for the largest cost item in it.
-            auto it2 = mutexedMap.second.end();
-            it2--;
+            auto it2 = map.rbegin();
             // Great, we found something.
             temp = it2->second;
             // Take it out of the map (popped)

--- a/Framework/Kernel/inc/MantidKernel/ThreadSchedulerMutexes.h
+++ b/Framework/Kernel/inc/MantidKernel/ThreadSchedulerMutexes.h
@@ -64,7 +64,8 @@ public:
 
           if (!map.empty()) {
             // Look for the largest cost item in it.
-            auto it2 = map.rbegin();
+            auto it2 = map.end();
+            --it2;
             // Great, we found something.
             temp = it2->second;
             // Take it out of the map (popped)


### PR DESCRIPTION
Description of work.

This (hopefully) appeases Coverity by constructing `it2` from map instead of `mutexedMap.second`. While this might be a bit easier to read, the result should be identical.

**To test:**

<!-- Instructions for testing. -->

Verify that `it2` points to the same key-value pair.

This is a small change with no issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
