### PR TITLE
StructuredDetector IDFs now parsed correctly for multiple vertex definitions

### DIFF
--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -615,8 +615,9 @@ void InstrumentDefinitionParser::setLocation(Geometry::IComponent *comp,
 
     if (rElem) {
       double rotAngle =
-          angleConvertConst * atof((rElem->getAttribute("val"))
-                                       .c_str()); // assumed to be in degrees
+          angleConvertConst *
+          atof(
+              (rElem->getAttribute("val")).c_str()); // assumed to be in degrees
 
       double axis_x = 0.0;
       double axis_y = 0.0;
@@ -1401,6 +1402,7 @@ void InstrumentDefinitionParser::createStructuredDetector(
   const std::string shapeType = pType->getAttribute("type");
   boost::shared_ptr<Geometry::Object> shape = mapTypeNameToShape[shapeType];
 
+  std::string typeName = pType->getAttribute("name");
   // These parameters are in the TYPE defining StructuredDetector
   if (pType->hasAttribute("xpixels"))
     xpixels = atoi((pType->getAttribute("xpixels")).c_str());
@@ -1434,7 +1436,8 @@ void InstrumentDefinitionParser::createStructuredDetector(
     Element *check = static_cast<Element *>(pNode);
     if (pNode->nodeName().compare("type") == 0 && check->hasAttribute("is")) {
       std::string is = check->getAttribute("is").c_str();
-      if (StructuredDetector::compareName(is)) {
+      if (StructuredDetector::compareName(is) &&
+          typeName.compare(check->getAttribute("name")) == 0) {
         pElem = check;
         break;
       }
@@ -1449,7 +1452,6 @@ void InstrumentDefinitionParser::createStructuredDetector(
 
   // Ensure vertices are present within the IDF
   Poco::AutoPtr<NodeList> pNL = pElem->getElementsByTagName("vertex");
-
   if (pNL->length() == 0)
     throw Kernel::Exception::InstrumentDefinitionError(
         "StructuredDetector must contain vertices.", filename);
@@ -2302,7 +2304,8 @@ void InstrumentDefinitionParser::setComponentLinks(
         // user, and throw an exception.
         if (!detector) {
           g_log.error() << "Error whilst loading parameters. No detector "
-                           "found with id '" << detid << "'" << std::endl;
+                           "found with id '"
+                        << detid << "'" << std::endl;
           g_log.error() << "Please check that your detectors' ids are correct."
                         << std::endl;
           throw Kernel::Exception::InstrumentDefinitionError(

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -615,9 +615,8 @@ void InstrumentDefinitionParser::setLocation(Geometry::IComponent *comp,
 
     if (rElem) {
       double rotAngle =
-          angleConvertConst *
-          atof(
-              (rElem->getAttribute("val")).c_str()); // assumed to be in degrees
+          angleConvertConst * atof((rElem->getAttribute("val"))
+                                       .c_str()); // assumed to be in degrees
 
       double axis_x = 0.0;
       double axis_y = 0.0;
@@ -2304,8 +2303,7 @@ void InstrumentDefinitionParser::setComponentLinks(
         // user, and throw an exception.
         if (!detector) {
           g_log.error() << "Error whilst loading parameters. No detector "
-                           "found with id '"
-                        << detid << "'" << std::endl;
+                           "found with id '" << detid << "'" << std::endl;
           g_log.error() << "Please check that your detectors' ids are correct."
                         << std::endl;
           throw Kernel::Exception::InstrumentDefinitionError(


### PR DESCRIPTION
The IDF parser now correctly matches vertex definitions to the corresponding StructuredDetector tag.

**To test:**

Use attached IDF file [LOKI_Definition.txt](https://github.com/mantidproject/mantid/files/268112/LOKI_Definition.txt) (change extension to .xml), three increasingly smaller fan-like detector panels should be visible in the instrument view. Before there was an exception in the Results Log due to incorrect vertex calculations:
- In mantidplot call _LoadEmptyInstrument_ and load the IDF provided.
- right click on the workspace created and select **Show Instrument**
- three panels should be visible.
  Fixes #16256 .

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
