### PR TITLE
Indirect Bayes ResNorm - set initial values for range bars

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -213,6 +213,7 @@ void ResNorm::handleVanadiumInputReady(const QString &filename) {
   auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("ResNormERange");
 
   // Use the values from the instrument parameter file if we can
+  // The the maximum and minimum value of the plot
   if (getResolutionRangeFromWs(filename, res)) {
     // ResNorm resolution should be +/- 10 * the IPF resolution
     res.first = res.first * 10;
@@ -227,6 +228,10 @@ void ResNorm::handleVanadiumInputReady(const QString &filename) {
 
   setPlotPropertyRange(eRangeSelector, m_properties["EMin"],
                        m_properties["EMax"], range);
+
+  // Set the current values of the range bars
+  eRangeSelector->setMinimum(range.first);
+  eRangeSelector->setMaximum(range.second);
 }
 
 /**

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -86,7 +86,7 @@ Bugfixes
 - :ref:`SimulatedDensityOfStates <algm-SimulatedDensityOfStates>` should no longer manipulate the actual data values and only rebins the data to the desired bin width.
 - :ref:`VesuvioCorrections <algm-VesuvioCorrections>` no longer always fits using only the first spectrum in the input workspace.
 - Fix bug with *BayesQuasi* docs not displaying online
-- The mini plot range bars in *BayesQuasi* now automatically update on sample loading.
+- The mini plot range bars in all interfaces now automatically update when a file is loaded.
 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
Range bars are now actually updated with the initial values rather than only setting the min/max possible values in the ResNorm interface.

**To test:**
- Open the ResNorm interface (Interfaces > Indirect > Bayes > ResNorm)
- Load in data (`irs26173_graphite002_red.nxs` from the unit test data directory)
- Ensure that the range bars are set to the edge of the plot and that EMin / EMax are quoted as the maximum plot range in the left hand side property table

Fixes #16245

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/16245_ResNorm_ERange_not_updating/docs/source/release/v3.7.0/indirect_inelastic.rst#bugfixes)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
