### PR TITLE
Indirect Bayes Stretch - Set initial values for range bars

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/Quest.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/Quest.py
@@ -81,6 +81,10 @@ class Quest(PythonAlgorithm):
         saveOp = self.getProperty('Save').value
 
         workdir = config['defaultsave.directory']
+        if not os.path.isdir(workdir):
+            workdir = os.getcwd()
+            logger.information('Default Save directory is not set. Defaulting to current working Directory: ' + workdir)
+
         if inType == 'File':
             spath = os.path.join(workdir, sname+'.nxs')        # path name for sample nxs file
             LoadNexusProcessed(Filename=spath, OutputWorkspace=sname)

--- a/MantidQt/CustomInterfaces/src/Indirect/Stretch.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Stretch.cpp
@@ -83,6 +83,23 @@ bool Stretch::validate() {
 void Stretch::run() {
   using namespace Mantid::API;
 
+  auto saveDirectory = Mantid::Kernel::ConfigService::Instance().getString(
+      "defaultsave.directory");
+  if (saveDirectory.compare("") == 0) {
+    const char *textMessage =
+        "BayesStretch requires a default save directory and "
+        "one is not currently set."
+        " If run, the algorithm will default to saving files "
+        "to the current working directory."
+        " Would you still like to run the algorithm?";
+    int result = QMessageBox::question(NULL, tr("Save Directory"),
+                                       tr(textMessage), QMessageBox::Yes,
+                                       QMessageBox::No, QMessageBox::NoButton);
+    if (result == QMessageBox::No) {
+      return;
+    }
+  }
+
   QString save("False");
 
   QString elasticPeak("False");

--- a/MantidQt/CustomInterfaces/src/Indirect/Stretch.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Stretch.cpp
@@ -151,12 +151,16 @@ void Stretch::loadSettings(const QSettings &settings) {
  */
 void Stretch::handleSampleInputReady(const QString &filename) {
   m_uiForm.ppPlot->addSpectrum("Sample", filename, 0);
+  // update the maximum and minimum range bar positions
   QPair<double, double> range = m_uiForm.ppPlot->getCurveRange("Sample");
   auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("StretchERange");
   setRangeSelector(eRangeSelector, m_properties["EMin"], m_properties["EMax"],
                    range);
   setPlotPropertyRange(eRangeSelector, m_properties["EMin"],
                        m_properties["EMax"], range);
+  //update the current positions of the range bars
+  eRangeSelector->setMinimum(range.first);
+  eRangeSelector->setMaximum(range.second);
 }
 
 /**

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -87,6 +87,7 @@ Bugfixes
 - :ref:`VesuvioCorrections <algm-VesuvioCorrections>` no longer always fits using only the first spectrum in the input workspace.
 - Fix bug with *BayesQuasi* docs not displaying online
 - The mini plot range bars in *BayesQuasi* now automatically update on sample loading.
+- *BayesStretched* interface now gives the option of using the current working directory if no default save path is provided.
 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -85,7 +85,7 @@ Bugfixes
 - :ref:`ISISIndirectEnergyTransfer <algm-ISISIndirectEnergyTransfer>` only corrects for detailed balance when one is actually specified as input.
 - :ref:`SimulatedDensityOfStates <algm-SimulatedDensityOfStates>` should no longer manipulate the actual data values and only rebins the data to the desired bin width.
 - :ref:`VesuvioCorrections <algm-VesuvioCorrections>` no longer always fits using only the first spectrum in the input workspace.
-- Fix bug with *BayesQuasi* docs not displaying online
+- Fix bug with :ref: `BayesQuasi <algm-BayesQuasi>` docs not displaying online
 - The mini plot range bars in *BayesQuasi* now automatically update on sample loading.
 - *BayesStretched* interface now gives the option of using the current working directory if no default save path is provided.
 

--- a/scripts/Inelastic/IndirectBayes.py
+++ b/scripts/Inelastic/IndirectBayes.py
@@ -506,7 +506,10 @@ def QuestRun(samWS,resWS,nbs,erange,nbins,Fit,Loop,Plot,Save):
 
     fitOp = [o_el, o_bgd, o_w1, o_res]
 
-    workdir = getDefaultWorkingDirectory()
+    workdir = config['defaultsave.directory']
+    if not os.path.isdir(workdir):
+        workdir = os.getcwd()
+        logger.information('Default Save directory is not set. Defaulting to current working Directory: ' + workdir)
 
     array_len = 4096                           # length of array in Fortran
     CheckXrange(erange,'Energy')


### PR DESCRIPTION
The Range bars  in the Bayes Stretch interface should now update when data is loaded

**To test:**
- Open Stretch (Interfaces > Indirect > Bayes > Stretch)
- Load in data (`irs26176_graphite002_red.nxs` from unit test data)
- Ensure that the range bars are updated to be at the furtherest edges of the data and that the EMin/EMax values are quoted as such in the parameter table

Fixes #16248 .

[Release Notes](https://github.com/mantidproject/mantid/blob/16245_ResNorm_ERange_not_updating/docs/source/release/v3.7.0/indirect_inelastic.rst#bugfixes) need no further update as they have been changed for a similar issue 

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
