### PR TITLE
Fix compiler warnings on OS X Yosemite.

### DIFF
--- a/MantidQt/CustomInterfaces/test/DataProcessorMockObjects.h
+++ b/MantidQt/CustomInterfaces/test/DataProcessorMockObjects.h
@@ -85,8 +85,10 @@ public:
 
 private:
   // Calls we don't care about
-  const std::map<std::string, QVariant> &options() const { return m_options; };
-  std::vector<DataProcessorCommand_uptr> publishCommands() {
+  const std::map<std::string, QVariant> &options() const override {
+    return m_options;
+  };
+  std::vector<DataProcessorCommand_uptr> publishCommands() override {
     std::vector<DataProcessorCommand_uptr> commands;
     for (size_t i = 0; i < 26; i++)
       commands.push_back(
@@ -97,12 +99,13 @@ private:
     return std::set<std::string>();
   };
   // Calls we don't care about
-  void setOptions(const std::map<std::string, QVariant> &){};
-  void transfer(const std::vector<std::map<std::string, std::string>> &){};
+  void setOptions(const std::map<std::string, QVariant> &) override{};
+  void
+  transfer(const std::vector<std::map<std::string, std::string>> &) override{};
   void setInstrumentList(const std::vector<std::string> &,
-                         const std::string &){};
+                         const std::string &) override{};
   // void accept(WorkspaceReceiver *) {};
-  void acceptViews(DataProcessorView *, ProgressableView *){};
+  void acceptViews(DataProcessorView *, ProgressableView *) override{};
 
   std::map<std::string, QVariant> m_options;
 };


### PR DESCRIPTION
Description of work.

This fixes 6 `-Winconsistent-missing-override` compiler warnings on [OS X Yosemite](http://builds.mantidproject.org/job/master_clean-osx-yosemite/18/warnings12Result/) that were introduced last night.

**To test:**

<!-- Instructions for testing. -->

Review changes. 

This is a small change with no issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
