### PR TITLE
Indirect Data Analysis I(Q,t) - Elow/EHigh validation

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
@@ -205,10 +205,10 @@ bool Iqt::validate() {
   uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsInput);
   uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
 
-  const auto eMin = m_dblManager->value(m_properties["ELow"]);
-  const auto eMax = m_dblManager->value(m_properties["EHigh"]);
-  if (eMin >= eMax)
-    uiv.addErrorMessage("EMin must be strictly less than EMax.\n");
+  const auto eLow = m_dblManager->value(m_properties["ELow"]);
+  const auto eHigh = m_dblManager->value(m_properties["EHigh"]);
+  if (eLow >= eHigh)
+    uiv.addErrorMessage("ELow must be strictly less than EHigh.\n");
 
   QString message = uiv.generateErrorMessage();
   showMessageBox(message);
@@ -257,9 +257,6 @@ void Iqt::updatePropertyValues(QtProperty *prop, double val) {
 void Iqt::calculateBinning() {
   using namespace Mantid::API;
 
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updatePropertyValues(QtProperty *, double)));
-
   QString wsName = m_uiForm.dsInput->getCurrentDataName();
   QString resName = m_uiForm.dsResolution->getCurrentDataName();
   if (wsName.isEmpty() || resName.isEmpty())
@@ -268,7 +265,10 @@ void Iqt::calculateBinning() {
   double energyMin = m_dblManager->value(m_properties["ELow"]);
   double energyMax = m_dblManager->value(m_properties["EHigh"]);
   double numBins = m_dblManager->value(m_properties["SampleBinning"]);
+
   if (numBins == 0)
+    return;
+  if (energyMin == 0 && energyMax == 0)
     return;
 
   IAlgorithm_sptr furyAlg =
@@ -296,6 +296,9 @@ void Iqt::calculateBinning() {
   double energyWidth = propsTable->getColumn("EnergyWidth")->cell<float>(0);
   int sampleBins = propsTable->getColumn("SampleOutputBins")->cell<int>(0);
   int resolutionBins = propsTable->getColumn("ResolutionBins")->cell<int>(0);
+
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+	  SLOT(updatePropertyValues(QtProperty *, double)));
 
   // Update data in property editor
   m_dblManager->setValue(m_properties["EWidth"], energyWidth);

--- a/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
@@ -205,6 +205,11 @@ bool Iqt::validate() {
   uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsInput);
   uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
 
+  const auto eMin = m_dblManager->value(m_properties["ELow"]);
+  const auto eMax = m_dblManager->value(m_properties["EHigh"]);
+  if (eMin >= eMax)
+    uiv.addErrorMessage("EMin must be strictly less than EMax.\n");
+
   QString message = uiv.generateErrorMessage();
   showMessageBox(message);
 

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -78,6 +78,9 @@ Improvements
 
 - Updated the :ref:`SimulatedDensityOfStates <algm-SimulatedDensityOfStates>` workflow diagram to show an overview of the algorithm.
 
+- the *Iqt* interface now validates that EMin is strictly less than EMax
+
+
 Bugfixes
 --------
 

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -78,7 +78,7 @@ Improvements
 
 - Updated the :ref:`SimulatedDensityOfStates <algm-SimulatedDensityOfStates>` workflow diagram to show an overview of the algorithm.
 
-- the *Iqt* interface now validates that EMin is strictly less than EMax
+- the *Iqt* interface now validates that EMin is strictly less than EMax and that they are both not equal to 0
 
 
 Bugfixes


### PR DESCRIPTION
The `I(Q,t)` interface should now ensure that no algorithms are run if the ELow/EHigh range is equal to 0. 

**To test:**
- Open `I(Q,t)` (Interfaces > Indirect > Data Analysis > `I(Q,t)`)
- Load in the `irs26176_graphite002_red.nxs` as the sample
- Load in the `irs26173_graphite002_res.nxs` as the resolution
  - Both of these file are in the unit test data directory
- Change the ELow/EHigh values to both be zero (changing one should change both)
- Click `Run`
- Ensure the interface does not validate and you get a message box explaining to problem
- Change the values to be non 0.
- Check the Range bars mirror the change (e.g change EHigh to 0.2 should change ELow to -0.2)
- Click `Run` 
- Ensure the algorithm runs correctly without error

Fixes #16259

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/6d9356a41e27fa972a2fe1f782f66a521618199a/docs/source/release/v3.7.0/indirect_inelastic.rst#improvements)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
