### PR TITLE
Fix builds: rename isDistribution=>setDistribution in new files, as in PR #16061

### DIFF
--- a/Framework/DataHandling/src/LoadNXcanSAS.cpp
+++ b/Framework/DataHandling/src/LoadNXcanSAS.cpp
@@ -213,7 +213,7 @@ bool hasQDev(H5::Group &dataGroup) {
 void loadData1D(H5::Group &dataGroup,
                 Mantid::API::MatrixWorkspace_sptr workspace) {
   // General
-  workspace->isDistribution(true);
+  workspace->setDistribution(true);
 
   // Load the Q value
   Mantid::MantidVec qData =
@@ -326,7 +326,7 @@ void readQyInto2DWorkspace(H5::DataSet &dataSet,
 void loadData2D(H5::Group &dataGroup,
                 Mantid::API::MatrixWorkspace_sptr workspace) {
   // General
-  workspace->isDistribution(true);
+  workspace->setDistribution(true);
   //-----------------------------------------
   // Load the I value.
   auto iDataSet = dataGroup.openDataSet(sasDataI);


### PR DESCRIPTION
When merging #16061 I didn't notice that some new files added after the last build of that PR could be using the now renamed `isDistribution()` setter. And of course that happens, luckily only in `LoadNXcanSAS.cpp`. master doesn't compile at the moment, see for example: http://builds.mantidproject.org/job/pull_requests-pylint/6467/console
This should fix master to compile correctly again.

**To test:**

This simply uses the new name of `isDistribution(bool)` => `setDistribution(bool)`
See that the builds go well. If there are still issues the Pylint build will fail.

No issue number for this quick fix.
_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
