### PR TITLE
Indirect Bayes Quasi -  Automatically Load ResNorm file

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Quasi.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Quasi.ui
@@ -225,7 +225,7 @@
            </sizepolicy>
           </property>
           <property name="autoLoad" stdset="0">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="workspaceSuffixes" stdset="0">
            <stringlist>

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -87,6 +87,7 @@ Bugfixes
 - :ref:`VesuvioCorrections <algm-VesuvioCorrections>` no longer always fits using only the first spectrum in the input workspace.
 - Fix bug with *BayesQuasi* docs not displaying online
 - The mini plot range bars in all interfaces now automatically update when a file is loaded.
+- In the *BayesQuasi* interface ResNorm files are now automatically loaded from file locations when entered.
 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
Bayes Quasi Interface should now automatically load the ResNorm file (if one have been provided). When the file location has been entered into the interface

**To test:**
- Open `Bayes Quasi` (Interfaces > Indirect > Bayes > Quasi)
- Check the `use ResNorm` checkbox
- Load: (all available from the unit test data directory) 
  - Sample = `irs26176_graphite002_red.nxs`
  - Resolution = `irs26173_graphite002_res.nxs`
  - ResNorm = `irs26173_graphite002_ResNorm.nxs`

Fixes #16247

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/318832e102455ab31e65703e04f9081688e44951/docs/source/release/v3.7.0/indirect_inelastic.rst#bugfixes)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
