### PR TITLE
EnggGUI: Fixes and improvements for fitting tab

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -219,6 +219,22 @@
      </layout>
     </widget>
    </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer_6">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>38</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_fititng_preview">
      <property name="sizePolicy">
@@ -243,19 +259,6 @@
       <string>Preview</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_qlist_bank">
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="text">
-         <string>Run #:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0" colspan="2">
        <widget class="QwtPlot" name="dataPlot">
         <property name="sizePolicy">
@@ -277,68 +280,6 @@
          </size>
         </property>
        </widget>
-      </item>
-      <item row="1" column="2">
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QListWidget" name="listWidget_fitting_run_num">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>28</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="1">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>187</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="2">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>28</height>
-         </size>
-        </property>
-       </spacer>
       </item>
       <item row="3" column="0" colspan="3">
        <widget class="QGroupBox" name="groupBox_peak_tools">
@@ -406,24 +347,97 @@
         </layout>
        </widget>
       </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_qlist_bank">
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string>Run #:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>28</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="2">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QListWidget" name="listWidget_fitting_run_num">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="1">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>187</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_peak_button_3">
+        <item>
+         <widget class="QPushButton" name="pushButton_plot_separate_window">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Plot Separate Window</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_19">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>38</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
-   </item>
-   <item row="1" column="0">
-    <spacer name="verticalSpacer_6">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Maximum</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>38</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -417,7 +417,7 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>Plot Separate Window</string>
+           <string>Plot To Separate Window</string>
           </property>
          </widget>
         </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -202,22 +202,6 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <spacer name="verticalSpacer_6">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Maximum</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>38</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_fititng_preview">
      <property name="sizePolicy">
@@ -242,14 +226,20 @@
       <string>Preview</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="3">
+      <item row="0" column="2">
        <widget class="QLabel" name="label_qlist_bank">
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
         <property name="text">
-         <string>Run Number:</string>
+         <string>Run #:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="3">
+      <item row="1" column="0" colspan="2">
        <widget class="QwtPlot" name="dataPlot">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -259,8 +249,8 @@
         </property>
         <property name="minimumSize">
          <size>
-          <width>531</width>
-          <height>300</height>
+          <width>0</width>
+          <height>0</height>
          </size>
         </property>
         <property name="sizeIncrement">
@@ -271,7 +261,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="3">
+      <item row="1" column="2">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
          <widget class="QListWidget" name="listWidget_fitting_run_num">
@@ -281,12 +271,12 @@
           <property name="minimumSize">
            <size>
             <width>40</width>
-            <height>300</height>
+            <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>55</width>
+            <width>50</width>
             <height>16777215</height>
            </size>
           </property>
@@ -321,60 +311,6 @@
        </spacer>
       </item>
       <item row="2" column="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_peak_button">
-        <item>
-         <spacer name="horizontalSpacer_17">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>38</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_select_peak">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Select Peak</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_add_peak">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Add Peak</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_save_peak_list">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Save Peaks List</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_comboBox_fitting_bank_3">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="3">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -387,8 +323,100 @@
         </property>
        </spacer>
       </item>
+      <item row="3" column="0" colspan="3">
+       <widget class="QGroupBox" name="groupBox_peak_tools">
+        <property name="title">
+         <string>Peak Tools</string>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>289</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_peak_button">
+           <item>
+            <spacer name="horizontalSpacer_17">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>38</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButton_select_peak">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Select Peak</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButton_add_peak">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Add Peak</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButton_save_peak_list">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>Save Peaks</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_comboBox_fitting_bank_3">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
      </layout>
     </widget>
+   </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer_6">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>38</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -181,6 +181,23 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_clear_peak_list">
+          <property name="text">
+           <string>Clear</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_save_peak_list">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>Save</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item row="3" column="0">
@@ -374,16 +391,6 @@
              </property>
              <property name="text">
               <string>Add Peak</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="pushButton_save_peak_list">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="text">
-              <string>Save Peaks</string>
              </property>
             </widget>
            </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -278,6 +278,7 @@ private slots:
   void clearPeakList();
   void fitClicked();
   void FittingRunNo();
+  void plotSeparateWindow();
   void setBankDir(int idx);
   void listViewFittingRun();
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -161,7 +161,7 @@ public:
   std::string getFocusDir() override;
 
   void setDataVector(std::vector<boost::shared_ptr<QwtData>> &data,
-                     bool focused) override;
+                     bool focused, bool plotSinglePeaks) override;
 
   void addBankItems(std::vector<std::string> splittedBaseName,
                     QString selectedFile) override;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -277,6 +277,7 @@ private slots:
   void setPeakPick();
   void addPeakToList();
   void savePeakList();
+  void clearPeakList();
   void fitClicked();
   void FittingRunNo();
   void setBankDir(int idx);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -457,10 +457,11 @@ public:
   * generates and sets the curves on the fitting tab
   * @param data of the workspace to be passed as QwtData
   * @param focused to check whether focused workspace
+  * @param whether to plot single peak fitting ws
   *
   */
   virtual void setDataVector(std::vector<boost::shared_ptr<QwtData>> &data,
-                             bool focused) = 0;
+                             bool focused, bool plotSinglePeaks) = 0;
   //@}
 
   /**

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -457,7 +457,7 @@ public:
   * generates and sets the curves on the fitting tab
   * @param data of the workspace to be passed as QwtData
   * @param focused to check whether focused workspace
-  * @param whether to plot single peak fitting ws
+  * @param plotSinglePeaks whether to plot single peak fitting ws
   *
   */
   virtual void setDataVector(std::vector<boost::shared_ptr<QwtData>> &data,

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -885,7 +885,7 @@ void EnggDiffractionPresenter::runFittingAlgs(
       runCloneWorkspaceAlg(FocusedWSName, single_peak_out_WS);
 
       setDataToClonedWS(current_peak_out_WS, single_peak_out_WS);
-
+	  ADS.remove(current_peak_out_WS);
     } else {
       current_peak_cloned_WS =
           "__engggui_fitting_cloned_peaks" + std::to_string(i);

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -561,7 +561,7 @@ void MantidQt::CustomInterfaces::EnggDiffractionPresenter::
       }
     }
     // set the directory here to the first in the vector if its not empty
-    if (!runnoDirVector.empty()) {
+    if (!runnoDirVector.empty() && !selectedfPath.isFile()) {
       QString firstDir = QString::fromStdString(runnoDirVector[0]);
       m_view->setFittingRunNo(firstDir);
 
@@ -1075,8 +1075,7 @@ void EnggDiffractionPresenter::plotFitPeaksCurves() {
       m_view->setDataVector(focusedData, true, m_fittingFinishedOK);
 
       if (m_fittingFinishedOK) {
-        g_log.debug() << "single peaks fitting being plotted now."
-                            << std::endl;
+        g_log.debug() << "single peaks fitting being plotted now." << std::endl;
         auto singlePeaksWS = ADS.retrieveWS<MatrixWorkspace>(singlePeaksWs);
         auto singlePeaksData = ALCHelper::curveDataFromWs(singlePeaksWS);
         m_view->setDataVector(singlePeaksData, false, true);

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1072,14 +1072,15 @@ void EnggDiffractionPresenter::plotFitPeaksCurves() {
     try {
       auto focusedPeaksWS = ADS.retrieveWS<MatrixWorkspace>(focusedPeaksWs);
       auto focusedData = ALCHelper::curveDataFromWs(focusedPeaksWS);
-      m_view->setDataVector(focusedData, true);
+      m_view->setDataVector(focusedData, true, m_fittingFinishedOK);
 
-      g_log.error() << " m_fittingFinishedOK? " << m_fittingFinishedOK
-                    << std::endl;
       if (m_fittingFinishedOK) {
+        g_log.debug() << "single peaks fitting being plotted now."
+                            << std::endl;
         auto singlePeaksWS = ADS.retrieveWS<MatrixWorkspace>(singlePeaksWs);
         auto singlePeaksData = ALCHelper::curveDataFromWs(singlePeaksWS);
-        m_view->setDataVector(singlePeaksData, false);
+        m_view->setDataVector(singlePeaksData, false, true);
+
       } else {
         g_log.notice() << "Focused workspace has been plotted to the "
                           "graph; further peaks can be adding using Peak Tools."

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -701,6 +701,8 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
   m_uiTabFitting.pushButton_fitting_browse_peaks->setEnabled(enable);
   m_uiTabFitting.lineEdit_fitting_peaks->setEnabled(enable);
   m_uiTabFitting.pushButton_fit->setEnabled(enable);
+  m_uiTabFitting.pushButton_clear_peak_list->setEnabled(enable);
+  m_uiTabFitting.pushButton_save_peak_list->setEnabled(enable);
   m_uiTabFitting.comboBox_bank->setEnabled(enable);
   m_uiTabFitting.groupBox_fititng_preview->setEnabled(enable);
 }
@@ -812,6 +814,9 @@ void EnggDiffractionViewQtGUI::setDataVector(
 
     if (m_fittedDataVector.size() > 0)
       m_fittedDataVector.clear();
+
+    // set it as false as there will be no valid workspace to plot
+    m_uiTabFitting.pushButton_plot_separate_window->setEnabled(false);
   }
 
   if (focused) {
@@ -854,6 +859,9 @@ void EnggDiffractionViewQtGUI::dataCurvesFactory(
       dataCurve->setStyle(QwtPlotCurve::Lines);
       auto randIndex = dis(gen);
       dataCurve->setPen(QPen(QPenList[randIndex], 2));
+
+      // only set enabled when single peak workspace plotted
+      m_uiTabFitting.pushButton_plot_separate_window->setEnabled(true);
     } else {
       dataCurve->setStyle(QwtPlotCurve::NoCurve);
       // focused workspace in bg set as darkGrey crosses insted of line

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -1365,14 +1365,21 @@ std::string EnggDiffractionViewQtGUI::getFittingRunNo() const {
 void EnggDiffractionViewQtGUI::plotSeparateWindow() {
   std::string pyCode =
 
-      "single_peak_ws = workspace(\"engggui_fitting_single_peaks\")\n"
+      "fitting_single_peaks_twin_ws = \"__engggui_fitting_single_peaks_twin\"\n"
+      "if (mtd.doesExist(fitting_single_peaks_twin_ws)):\n"
+      " DeleteWorkspace(fitting_single_peaks_twin_ws)\n"
+
+      "single_peak_ws = CloneWorkspace(InputWorkspace = "
+      "\"engggui_fitting_single_peaks\", OutputWorkspace = "
+      "fitting_single_peaks_twin_ws)\n"
       "tot_spec = single_peak_ws.getNumberHistograms()\n"
 
       "spec_list = []\n"
       "for i in range(0, tot_spec):\n"
       " spec_list.append(i)\n"
 
-      "plotSpectrum(single_peak_ws, spec_list)\n";
+      "fitting_plot = plotSpectrum(single_peak_ws, spec_list).activeLayer()\n"
+      "fitting_plot.setTitle(\"Engg GUI Single Peaks Fitting Workspace\")\n";
 
   std::string status =
       runPythonCode(QString::fromStdString(pyCode), false).toStdString();

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -259,6 +259,9 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
   connect(m_uiTabFitting.pushButton_clear_peak_list, SIGNAL(released()),
           SLOT(clearPeakList()));
 
+  connect(m_uiTabFitting.pushButton_plot_separate_window, SIGNAL(released()),
+	  SLOT(plotSeparateWindow()));
+
   m_uiTabFitting.dataPlot->setCanvasBackground(Qt::white);
   m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::xBottom, "d-Spacing (A)");
   m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::yLeft, "Counts (us)^-1");
@@ -1357,6 +1360,25 @@ void EnggDiffractionViewQtGUI::setFittingRunNo(QString path) {
 
 std::string EnggDiffractionViewQtGUI::getFittingRunNo() const {
   return m_uiTabFitting.lineEdit_pushButton_run_num->text().toStdString();
+}
+
+void EnggDiffractionViewQtGUI::plotSeparateWindow() {
+  std::string pyCode =
+
+      "single_peak_ws = workspace(\"engggui_fitting_single_peaks\")\n"
+      "tot_spec = single_peak_ws.getNumberHistograms()\n"
+
+      "spec_list = []\n"
+      "for i in range(0, tot_spec):\n"
+      " spec_list.append(i)\n"
+
+      "plotSpectrum(single_peak_ws, spec_list)\n";
+
+  std::string status =
+      runPythonCode(QString::fromStdString(pyCode), false).toStdString();
+  m_logMsgs.emplace_back("Plotted output focused data, with status string " +
+                         status);
+  m_presenter->notify(IEnggDiffractionPresenter::LogMsg);
 }
 
 std::string EnggDiffractionViewQtGUI::fittingPeaksData() const {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -260,7 +260,7 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
           SLOT(clearPeakList()));
 
   connect(m_uiTabFitting.pushButton_plot_separate_window, SIGNAL(released()),
-	  SLOT(plotSeparateWindow()));
+          SLOT(plotSeparateWindow()));
 
   m_uiTabFitting.dataPlot->setCanvasBackground(Qt::white);
   m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::xBottom, "d-Spacing (A)");
@@ -1643,8 +1643,7 @@ void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::savePeakList() {
 }
 
 void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::clearPeakList() {
-  QString emptyStr = "";
-  m_uiTabFitting.lineEdit_fitting_peaks->setText(emptyStr);
+  m_uiTabFitting.lineEdit_fitting_peaks->clear();
 }
 
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -797,7 +797,23 @@ std::string EnggDiffractionViewQtGUI::readPeaksFile(std::string fileDir) {
 }
 
 void EnggDiffractionViewQtGUI::setDataVector(
-    std::vector<boost::shared_ptr<QwtData>> &data, bool focused) {
+    std::vector<boost::shared_ptr<QwtData>> &data, bool focused,
+    bool plotSinglePeaks) {
+
+  if (!plotSinglePeaks) {
+    // clear vector and detach curves to avoid plot crash
+    // when only plotting focused workspace
+    for (auto curves : m_fittedDataVector) {
+      if (curves) {
+        curves->detach();
+        delete curves;
+      }
+    }
+
+    if (m_fittedDataVector.size() > 0)
+      m_fittedDataVector.clear();
+  }
+
   if (focused) {
     dataCurvesFactory(data, m_focusedDataVector, focused);
   } else {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -818,11 +818,11 @@ void EnggDiffractionViewQtGUI::dataCurvesFactory(
     dataVector.clear();
   resetView();
 
-  // dark colours could be removed so the colored peaks stand out more
+  // dark colours could be removed so that the coloured peaks stand out more
   const std::array<QColor, 16> QPenList{
       {Qt::white, Qt::red, Qt::darkRed, Qt::green, Qt::darkGreen, Qt::blue,
        Qt::darkBlue, Qt::cyan, Qt::darkCyan, Qt::magenta, Qt::darkMagenta,
-       Qt::yellow, Qt::darkYellow, Qt::gray, Qt::darkGray, Qt::lightGray}};
+       Qt::yellow, Qt::darkYellow, Qt::gray, Qt::lightGray, Qt::black}};
 
   std::mt19937 gen;
   std::uniform_int_distribution<std::size_t> dis(0, QPenList.size() - 1);
@@ -831,10 +831,15 @@ void EnggDiffractionViewQtGUI::dataCurvesFactory(
     auto *peak = data[i].get();
 
     QwtPlotCurve *dataCurve = new QwtPlotCurve();
-    dataCurve->setStyle(QwtPlotCurve::Lines);
     if (!focused) {
+      dataCurve->setStyle(QwtPlotCurve::Lines);
       auto randIndex = dis(gen);
-      dataCurve->setPen(QPen(QPenList[randIndex], 1));
+      dataCurve->setPen(QPen(QPenList[randIndex], 2));
+    } else {
+      dataCurve->setStyle(QwtPlotCurve::NoCurve);
+	  // focused workspace in bg set as darkGrey crosses insted of line
+      dataCurve->setSymbol(QwtSymbol(QwtSymbol::XCross, QBrush(),
+                                     QPen(Qt::darkGray, 1), QSize(3, 3)));
     }
     dataCurve->setRenderHint(QwtPlotItem::RenderAntialiased, true);
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -256,6 +256,9 @@ void EnggDiffractionViewQtGUI::doSetupTabFitting() {
   connect(m_uiTabFitting.pushButton_save_peak_list, SIGNAL(released()),
           SLOT(savePeakList()));
 
+  connect(m_uiTabFitting.pushButton_clear_peak_list, SIGNAL(released()),
+          SLOT(clearPeakList()));
+
   m_uiTabFitting.dataPlot->setCanvasBackground(Qt::white);
   m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::xBottom, "d-Spacing (A)");
   m_uiTabFitting.dataPlot->setAxisTitle(QwtPlot::yLeft, "Counts (us)^-1");
@@ -837,7 +840,7 @@ void EnggDiffractionViewQtGUI::dataCurvesFactory(
       dataCurve->setPen(QPen(QPenList[randIndex], 2));
     } else {
       dataCurve->setStyle(QwtPlotCurve::NoCurve);
-	  // focused workspace in bg set as darkGrey crosses insted of line
+      // focused workspace in bg set as darkGrey crosses insted of line
       dataCurve->setSymbol(QwtSymbol(QwtSymbol::XCross, QBrush(),
                                      QPen(Qt::darkGray, 1), QSize(3, 3)));
     }
@@ -1598,6 +1601,11 @@ void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::savePeakList() {
                 "Invalid file path or or could not be saved. Please try again");
     return;
   }
+}
+
+void MantidQt::CustomInterfaces::EnggDiffractionViewQtGUI::clearPeakList() {
+  QString emptyStr = "";
+  m_uiTabFitting.lineEdit_fitting_peaks->setText(emptyStr);
 }
 
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -198,9 +198,9 @@ public:
                     const std::string &type));
 
   // virtual void setDataVector
-  MOCK_METHOD2(setDataVector,
+  MOCK_METHOD3(setDataVector,
                void(std::vector<boost::shared_ptr<QwtData>> &data,
-                    bool focused));
+                    bool focused, bool plotSinglePeaks));
 
   // virtual void plotVanCurvesCalibOutput();
   MOCK_METHOD0(plotVanCurvesCalibOutput, void());

--- a/docs/source/interfaces/Engineering_Diffraction.rst
+++ b/docs/source/interfaces/Engineering_Diffraction.rst
@@ -330,9 +330,9 @@ Output
 
 Once the Fit button has been clicked, wait until the Fitting process has
 completed and upon completion you should be able to view on the Fitting
-tab plots the focused workspace in the background in black, whereas the
-expected peaks plotted in various colours over lapping the focused
-workspace peaks.
+tab; the focused workspace plotted in the background in grey crosses.
+Whereas the expected peaks plotted in various colours over lapping the
+focused workspace peaks.
 
 Within the :ref:`Preview-Engineering_Diffraction-ref` section user is
 able to zoom-in or zoom-out as well as select, add and save peaks.
@@ -353,7 +353,10 @@ Preview
 ^^^^^^^
 Once the fitting process has completed and you are able to view a
 focused workspace with listed expected peaks on the data plot, Select
-Peak button should should also be enabled.
+Peak button should should also be enabled. If the fitting fails with
+the given peaks then the focused workspace will still be plotted so
+that user can select peaks manually.
+
 By clicking Select Peak button the peak picker tool can be activated.
 To select a peak simply hold *Shift* key and left-click on the graph
 near the peak's center.
@@ -366,9 +369,14 @@ the plot.
 
 When user is satisfied with the center position of the peak, you may
 add the selected peak to :ref:`ExpectedPeaks-Engineering_Diffraction-ref`
-list by clicking Add Peak button. User may rerun Fit process with
-the new selected peaks or save the peaks list as *CSV* file by clicking
-Save Peak List button.
+list by clicking Add Peak button. User may rerun Fit process by
+clearing peaks list using Clear button and manually selecting peaking
+using Select Peak button or instead Save the peaks list in *CSV* file
+by clicking Save button.
+
+User may plot single peak fitting workspace in separate window by using
+Plot To Separate Window button, if the *engggui_fitting_single_peaks*
+is available.
 
 .. _setting-Engineering_Diffraction-ref:
 

--- a/docs/source/release/v3.7.0/diffraction.rst
+++ b/docs/source/release/v3.7.0/diffraction.rst
@@ -89,7 +89,12 @@ Graphical user interface:
   the consecutive run numbers to the list widget from the range provided by the
   user, bank combo-box will update upon selection of run number.
 
-
+- Further improvements to Fitting tab, if for some reason the fitting
+  fails, the focused workspace should still be plotted. This will
+  enable user to select valid peaks and run Fit accordingly. User also
+  now have an option to plot single peak fitting in separate workspace
+  by using *Plot To Separate Window* button. Peak list can now also be
+  cleared using the *Clear* button.
 
 Imaging
 -------


### PR DESCRIPTION
**Description of work.**

Various changes which were required on the `Fitting` tab after feedback from `Engin-X` scientists.
The plot of the focused workspace should now be plotting in crosses instead of lines, the focused workspace in the background should now be plotted in dark grey to improve to visibility of the single fit peaks. When fitting fails, the focused workspace should still be plotted in the background in `dSpacing` so that peaks on top can still be added. When file is selecting using browse button, the correct bank file should now be selected.
Improved layout of the tab; the peak tools to plot add new peaks have been differentiated in to separate group. `Save` and `Clear` button have been introduced next to the peak list.
A `Plot In Separate Window` button which will enable user to plot all peaks in `engggui_fitting_single_peaks` workspace

**To test:**

Go to: `Interfaces/Diffraction/Engineering Diffraction/Fitting`
`Browse` to the file and make sure the correct file selected is found within Focused Run# text-field

_Would be good idea testing invalid focused file e.g:_ (`ENGINX_228062_focused_bank_1`) _can be found under:_  `\\olympic\Babylon5\Public\Shahroz\FittingTest` 

Click `Clear` button to check whether the peaks list is cleared
Click `Save` button to check the peaks list is still being saved 
Input invalid peak and click `Fit`
Check that focused workspace is always displayed whether the fittings fails or not
Check that focused workspace is being plotted in `dSpacing` so that valid `dSpacing` peaks can be added to list
Check that `Plot In Separate Window` is disabled when fitting fails
This can be tested by: Selecting peak using clicking `Select Peak` and adding to list by clicking `Add Peak`
Click Fit and Check the peaks added have been fitted
Click `Plot In Separate Window` to check if `engggui_fitting_single_peaks` Workspace is plotted with appropriate title

<!-- Instructions for testing. -->

Fixes #16194

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
