### PR TITLE
Indirect Data Analysis I(Q, t) Fit - Plot Guess functioning correctly

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.h
@@ -39,6 +39,7 @@ private slots:
   void backgroundSelected(double val);
   void propertyChanged(QtProperty *, double);
   void checkBoxUpdate(QtProperty *prop, bool checked);
+  void plotGuessChanged(bool);
   void singleFit();
   void plotGuess(QtProperty *);
   void fitContextMenu(const QPoint &);

--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -571,7 +571,7 @@ void IqtFit::updatePlot() {
         outputGroup->getItem(specNo));
     if (ws) {
       if (m_uiForm.ckPlotGuess->isChecked()) {
-        m_uiForm.ppPlot->removeSpectrum("Guess");
+        m_uiForm.ckPlotGuess->setChecked(false);
       }
       m_uiForm.ppPlot->addSpectrum("Fit", ws, 1, Qt::red);
       m_uiForm.ppPlot->addSpectrum("Diff", ws, 2, Qt::blue);

--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -133,6 +133,8 @@ void IqtFit::setup() {
           SLOT(specMinChanged(int)));
   connect(m_uiForm.spSpectraMax, SIGNAL(valueChanged(int)), this,
           SLOT(specMaxChanged(int)));
+  connect(m_uiForm.ckPlotGuess, SIGNAL(toggled(bool)), this,
+          SLOT(plotGuessChanged(bool)));
 
   // Set a custom handler for the QTreePropertyBrowser's ContextMenu event
   m_ffTree->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -652,6 +654,13 @@ void IqtFit::propertyChanged(QtProperty *prop, double val) {
     m_dblManager->setValue(m_properties["Exponential2.Intensity"], val);
     m_dblManager->setValue(m_properties["StretchedExp.Intensity"], val);
   }
+}
+
+void IqtFit::plotGuessChanged(bool checked) {
+  if (!checked)
+    m_uiForm.ppPlot->removeSpectrum("Guess");
+  else
+    plotGuess(NULL);
 }
 
 void IqtFit::checkBoxUpdate(QtProperty *prop, bool checked) {

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -87,6 +87,7 @@ Bugfixes
 - :ref:`VesuvioCorrections <algm-VesuvioCorrections>` no longer always fits using only the first spectrum in the input workspace.
 - Fix bug with *BayesQuasi* docs not displaying online
 - The mini plot range bars in all interfaces now automatically update when a file is loaded.
+- In the *I(Q, t) Fit* interface, checking the plot guess check box now correctly adds and removes the curve from the plot
 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
The plot guess button should now in the `I(Q, t) Fit` interface. 

**To test:**
- Open `I(Q, t)` Fit (Interfaces > Indirect > Data Analysis > I(Q, t) Fit)
- Load in the Input File `iris26176_graphite002_iqt.nxs` (available from the unit test data directory)
- The Plot guess check box should be checked and the guess should be visible in the miniplot.
- Uncheck the Plot Guess check box
- Ensure that the Plot Guess curve is removed.
- Check the Plot Guess check box
- Click `Run`
- Ensure the algorithm runs and the mini plot now contains the Fit and Diff Curve (But NOT the guess)
- Ensure the plot Guess check box is now unchecked 
- Check the Plot Guess check box
- Ensure the Guess, Fit, Diff and Sample curves are present in the mini plot

Fixes #16261

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/23035b10f6001558100907b9dbddf422295b77db/docs/source/release/v3.7.0/indirect_inelastic.rst#bugfixes)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
