### PR TITLE
Indirect Data Analysis Elwin - Add initial values to range bars

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -370,13 +370,17 @@ namespace IDA
     m_uiForm.ppPlot->clear();
     m_uiForm.ppPlot->addSpectrum("Sample", ws, specNo);
 
-    try
-    {
+    try {
       QPair<double, double> range = m_uiForm.ppPlot->getCurveRange("Sample");
-      m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange")->setRange(range.first, range.second);
-    }
-    catch(std::invalid_argument & exc)
-    {
+      // Set maximum range of Integration
+      m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange")
+          ->setRange(range.first, range.second);
+      // Set initial values
+      m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange")
+          ->setMinimum(range.first);
+      m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange")
+          ->setMaximum(range.second);
+    } catch (std::invalid_argument &exc) {
       showMessageBox(exc.what());
     }
   }

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -89,7 +89,6 @@ Bugfixes
 - :ref:`SimulatedDensityOfStates <algm-SimulatedDensityOfStates>` should no longer manipulate the actual data values and only rebins the data to the desired bin width.
 - :ref:`VesuvioCorrections <algm-VesuvioCorrections>` no longer always fits using only the first spectrum in the input workspace.
 - Fix bug with :ref: `BayesQuasi <algm-BayesQuasi>` docs not displaying online
-- The mini plot range bars in *BayesQuasi* now automatically update on sample loading.
 - *BayesStretched* interface now gives the option of using the current working directory if no default save path is provided.
 - The mini plot range bars in all interfaces now automatically update when a file is loaded.
 - In the *BayesQuasi* interface ResNorm files are now automatically loaded from file locations when entered.


### PR DESCRIPTION
The Elwin interface should now automatically have range bars at the minimum and maximum of the input data

**To test:**
- Open `Elwin` (Interfaces > Indirect > Data Analysis > Elwin)
- Load in the input data `irs26176_graphite002_red.nxs` (available from unit test data)
- Ensure that the range bars are updated to the maximum and minimum range of the data and the values are updated in the parameter table to the left of the mini plot.
- Ensure that the range bars can be moved by dragging them in the ui or changing them in the parameter table.

Fixes #16258

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/01451e70afa7499963755e01a06a1882521a9839/docs/source/release/v3.7.0/indirect_inelastic.rst#bugfixes)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
