### PR TITLE
Wrong link for help in DGSPlanner

### DIFF
--- a/scripts/DGSPlanner/DGSPlannerGUI.py
+++ b/scripts/DGSPlanner/DGSPlannerGUI.py
@@ -121,7 +121,7 @@ class DGSPlannerGUI(QtGui.QWidget):
     def help(self):
         try:
             import pymantidplot
-            pymantidplot.proxies.showCustomInterfaceHelp('DGSReduction')
+            pymantidplot.proxies.showCustomInterfaceHelp('DGSPlanner')
         except ImportError:
             self.assistantProcess.close()
             self.assistantProcess.waitForFinished()


### PR DESCRIPTION
The help button in the DGSPlanner tries to load the help for DGSReduction page 

**To test:**

<!-- Instructions for testing. -->

Rebuild help. Start DGSPlanner. Click on **?** button. The correct help should show up

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state-->

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
