### PR TITLE
Fixed the issue for importing NavigationToolbar2QT

### DIFF
--- a/scripts/FilterEvents/MplFigureCanvas.py
+++ b/scripts/FilterEvents/MplFigureCanvas.py
@@ -3,7 +3,7 @@ from PyQt4 import QtGui
 
 import matplotlib
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
 
 class MplFigureCanvas(FigureCanvas):

--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -71,41 +71,6 @@ class MyPopErrorMsg(QWidget):
 
 class MainWindow(QtGui.QMainWindow):
     """ Class of Main Window (top)
-
-    Copy to ui.setupUI
-
-    # Version 3.0 + Import for ui_MainWindow.py
-        from MplFigureCanvas import Qt4MplCanvas
-
-        # Replace 'self.graphicsView = QtGui.QtGraphicsView' with the following
-        self.graphicsView = Qt4MplCanvas(self.centralwidget)
-        self.mainplot = self.graphicsView.getPlot()
-
-
-    # Version 2.0 + Import
-        import matplotlib
-        from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-        from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
-        from matplotlib.figure import Figure
-
-        self.figure = Figure((4.0, 3.0), dpi=100)
-        self.mainplot = self.figure.add_subplot(111)
-        self.graphicsView = FigureCanvas(self.figure)
-        self.graphicsView.setParent(self.centralwidget)
-        self.graphicsView.setGeometry(QtCore.QRect(20, 150, 741, 411))
-        self.graphicsView.setObjectName(_fromUtf8("graphicsView"))
-
-    # Version 1.0
-        Replacement is not a valid approach as the UI is setup at the end of self.ui.setupUI
-        self.dpi = 100
-        self.fig = Figure((5.0, 4.0), dpi=self.dpi)
-        self.figure = Figure((4.0, 3.0), dpi=100)
-        self.mainplot = self.figure.add_subplot(111)
-        self.ui.graphicsView = FigureCanvas(self.figure)
-        self.ui.graphicsView.setParent(self.centralwidget)
-        self.ui.graphicsView.setGeometry(QtCore.QRect(40, 230, 821, 411))
-        self.ui.graphicsView.setObjectName(_fromUtf8("graphicsView"))
-
     """
 
     _errMsgWindow = None

--- a/scripts/HFIRPowderReduction/MplFigureCanvas.py
+++ b/scripts/HFIRPowderReduction/MplFigureCanvas.py
@@ -5,7 +5,7 @@ import numpy as np
 from PyQt4 import QtGui
 
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
 import matplotlib.image
 

--- a/scripts/HFIR_4Circle_Reduction/mplgraphicsview.py
+++ b/scripts/HFIR_4Circle_Reduction/mplgraphicsview.py
@@ -5,7 +5,10 @@ import numpy as np
 from PyQt4 import QtGui
 
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar2
+try: 
+    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar2
+except ImportError:
+    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar2
 from matplotlib.figure import Figure
 import matplotlib.image
 


### PR DESCRIPTION
Description of work.

In some platforms, matplotlib does not support NavigationToolbar2QTAgg but NavigationToolbar2QT. Make HFIR_4circle_reduction GUI flexible on this issue.

**To test:**

A Ubuntu 15.10 user should test this.  HFIR 4-circle reduction GUI should be able to launch by this fix.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
