### PR TITLE
Fix copying ParaView plugins with Xcode generator.

### DIFF
--- a/buildconfig/CMake/MantidUtils.cmake
+++ b/buildconfig/CMake/MantidUtils.cmake
@@ -42,6 +42,9 @@ function( SET_TARGET_OUTPUT_DIRECTORY TARGET OUTPUT_DIR )
 
       # Lets get the location of the output for the given target
       # and copy it to where we want it to go
+      add_custom_command( TARGET ${TARGET} POST_BUILD
+                          COMMAND ${CMAKE_COMMAND} ARGS -E make_directory
+                          ${OUTPUT_DIR})
       add_custom_command (TARGET ${TARGET} POST_BUILD 
                           COMMAND ${CMAKE_COMMAND} ARGS -E echo 
                           "Copying \"$<TARGET_FILE:${TARGET}>\" to \"${OUTPUT_DIR}/\" "


### PR DESCRIPTION
Description of work.

The Xcode generator fails to copy the ParaView plugins libraries because the `MantidPlot.app/pvplugins/pvplugins` directory isn't created. After creating this directory by hand, the build finishes successfully. 

This updates our `SET_TARGET_OUTPUT_DIRECTORY` CMake function to create the target directory before copying files. This is already done with MSVC and fixes the above directory issue in Xcode.

**To test:**

<!-- Instructions for testing. -->

Compare with the equivalent line in the `if( MSVC )` block just above these changes.  

This is a small change with no issue number.

_Does not need to be in the release notes._ There should be no user-facing changes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
