### PR TITLE
Vesuvio - LoadVesuvio spectrumlist parsing

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -162,7 +162,10 @@ class LoadVesuvio(LoadEmptyVesuvio):
 
         # Validate SpectrumList
         grp_spectra_list = self.getProperty(SPECTRA_PROP).value
-        if ";" in grp_spectra_list:
+        if "," in grp_spectra_list:
+            # Split on ',' if in form of 2-3,6-7
+            grp_spectra_list = grp_spectra_list.split(",")
+        elif ";" in grp_spectra_list:
             # Split on ';' if in form of 2-3;6-7
             grp_spectra_list = grp_spectra_list.split(";")
         else:
@@ -176,9 +179,6 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 spectra_list = spectra_grp.split("-")
                 # Validate format
                 issues = self._validate_range_formatting(spectra_list[0], spectra_list[1], SPECTRA_PROP, issues)
-            elif "," in spectra_grp:
-                # Split comma separated lists
-                spectra_list = spectra_grp.split(",")
             else:
                 # Single spectra (put into list for use in loop)
                 spectra_list = [spectra_grp]

--- a/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -352,7 +352,7 @@ class VesuvioTests(unittest.TestCase):
     def _do_size_check(self,name, expected_nhist):
         loaded_data = mtd[name]
         self.assertEquals(expected_nhist, loaded_data.getNumberHistograms())
-'''
+
     #================== Failure cases ================================
 
     def test_run_range_bad_order_raises_error(self):
@@ -407,7 +407,7 @@ class VesuvioTests(unittest.TestCase):
         self.assertTrue("__loadraw_evs" not in mtd)
         self.assertTrue("__loadraw_evs_monitors" not in mtd)
 
-'''
+
 #====================================================================================
 
 class LoadVesuvioTest(stresstesting.MantidStressTest):

--- a/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -20,7 +20,34 @@ class VesuvioTests(unittest.TestCase):
         if monitor_name in mtd:
             mtd.remove(monitor_name)
 
+
+    #==================== Test spectrum list validation ============================
+
+    def test_spectrum_list_single_range(self):
+        diff_mode = "DoubleDifference"
+        self._run_load("14188", "10-20", diff_mode)
+
+        # check workspace created
+        self.assertTrue(mtd.doesExist(self.ws_name))
+
+    def test_spectrum_list_comma_separated_list(self):
+        diff_mode = "DoubleDifference"
+        self._run_load("14188", "10,20,30,40", diff_mode)
+
+        # check workspace created
+        self.assertTrue(mtd.doesExist(self.ws_name))
+
+    def test_spectrum_list_comma_separated_ranges(self):
+        diff_mode = "DoubleDifference"
+        self._run_load("14188", "10-20;30-40", diff_mode, do_size_check=False)
+
+        # check workspace created
+        self.assertTrue(mtd.doesExist(self.ws_name))
+
+
     #================== Success cases ================================
+
+
     def test_load_with_back_scattering_spectra_produces_correct_workspace_using_double_difference(self):
         diff_mode = "DoubleDifference"
         self._run_load("14188", "3-134", diff_mode)
@@ -287,7 +314,7 @@ class VesuvioTests(unittest.TestCase):
                 self.assertAlmostEqual(sigma_gauss, 52.3, places=tol_places)
                 self.assertAlmostEqual(hwhm_lorentz, 141.2, places=tol_places)
 
-    def _run_load(self, runs, spectra, diff_opt, ip_file="", sum_runs=False, load_mon=False):
+    def _run_load(self, runs, spectra, diff_opt, ip_file="", sum_runs=False, load_mon=False, do_size_check=True):
         ms.LoadVesuvio(Filename=runs,OutputWorkspace=self.ws_name,
                        SpectrumList=spectra,Mode=diff_opt,InstrumentParFile=ip_file,
                        SumSpectra=sum_runs, LoadMonitors=load_mon)
@@ -309,8 +336,9 @@ class VesuvioTests(unittest.TestCase):
                 return len(elements)
             else:
                 return 1
+        if do_size_check:
+            self._do_size_check(self.ws_name, expected_size())
 
-        self._do_size_check(self.ws_name, expected_size())
         loaded_data = mtd[self.ws_name]
         if "Difference" in diff_opt:
             self.assertTrue(not loaded_data.isHistogramData())
@@ -324,7 +352,7 @@ class VesuvioTests(unittest.TestCase):
     def _do_size_check(self,name, expected_nhist):
         loaded_data = mtd[name]
         self.assertEquals(expected_nhist, loaded_data.getNumberHistograms())
-
+'''
     #================== Failure cases ================================
 
     def test_run_range_bad_order_raises_error(self):
@@ -379,7 +407,7 @@ class VesuvioTests(unittest.TestCase):
         self.assertTrue("__loadraw_evs" not in mtd)
         self.assertTrue("__loadraw_evs_monitors" not in mtd)
 
-
+'''
 #====================================================================================
 
 class LoadVesuvioTest(stresstesting.MantidStressTest):

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -93,6 +93,7 @@ Bugfixes
 - *BayesStretched* interface now gives the option of using the current working directory if no default save path is provided.
 - The mini plot range bars in all interfaces now automatically update when a file is loaded.
 - In the *BayesQuasi* interface ResNorm files are now automatically loaded from file locations when entered.
+- :ref:`LoadVesuvio <algm-LoadVesuvio>` now correctly parses input in the form 10-20,30-40,50-60
 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
The Spectrum List in LoadVesuvio should now be able to handle strings in the form `10-20,30-40` or `10-20;30-40` as well as more simple cases. Tests have also been added to support these changes

**To test:**
- Ensure that you have enabled searching the data archive and try the following script checking that all the spectra numbers are correct 

```
evs_ws_comma_ranges = LoadVesuvio(Filename='20000', SpectrumList='10-20,30-40')       # expected 22 spectra
evs_ws_semi_colon_ranges = LoadVesuvio(Filename='20000', SpectrumList='10-20;30-40')  # expected 22 spectra
evs_ws_comma = LoadVesuvio(Filename='20000', SpectrumList='10,20,30,40')              # expected 4  spectra
evs_ws_range = LoadVesuvio(Filename='20000', SpectrumList='10-20')                    # expected 11 spectra
```

Fixes #16097 

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/8134bbf9f8e2324a3375e1fc8df19852d90e2f1a/docs/source/release/v3.7.0/indirect_inelastic.rst#bugfixes)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
