### PR TITLE
Indirect Data Analysis I(Q, t) Fit - Workspace naming conventions

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IqtFitSequential.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IqtFitSequential.py
@@ -109,7 +109,7 @@ class IqtFitSequential(PythonAlgorithm):
         logger.information(self._function)
 
         setup_prog.report('Cropping workspace')
-        tmp_fit_name = "__furyfit_fit_ws"
+        tmp_fit_name = "__IqtFit_ws"
         crop_alg = self.createChildAlgorithm("CropWorkspace")
         crop_alg.setProperty("InputWorkspace", self._input_ws)
         crop_alg.setProperty("OutputWorkspace", tmp_fit_name)
@@ -122,7 +122,7 @@ class IqtFitSequential(PythonAlgorithm):
             self._spec_max = num_hist - 1
 
         # Name stem for generated workspace
-        output_workspace = '%sfury_%s%d_to_%d' % (getWSprefix(self._input_ws.getName()),
+        output_workspace = '%sIqtFit_%s%d_to_%d' % (getWSprefix(self._input_ws.getName()),
                                                   self._fit_type, self._spec_min,
                                                   self._spec_max)
 
@@ -159,6 +159,8 @@ class IqtFitSequential(PythonAlgorithm):
         delete_alg.setProperty("Workspace", output_workspace + '_NormalisedCovarianceMatrices')
         delete_alg.execute()
         delete_alg.setProperty("Workspace", output_workspace + '_Parameters')
+        delete_alg.execute()
+        delete_alg.setProperty("Workspace", tmp_fit_name)
         delete_alg.execute()
 
         conclusion_prog.report('Renaming workspaces')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IqtFitSequential.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IqtFitSequential.py
@@ -122,7 +122,7 @@ class IqtFitSequential(PythonAlgorithm):
             self._spec_max = num_hist - 1
 
         # Name stem for generated workspace
-        output_workspace = '%sIqtFit_%s%d_to_%d' % (getWSprefix(self._input_ws.getName()),
+        output_workspace = '%sIqtFit_%s_s%d_to_%d' % (getWSprefix(self._input_ws.getName()),
                                                   self._fit_type, self._spec_min,
                                                   self._spec_max)
 
@@ -190,7 +190,7 @@ class IqtFitSequential(PythonAlgorithm):
         # Process generated workspaces
         wsnames = mtd[self._fit_group_name].getNames()
         for i, workspace in enumerate(wsnames):
-            output_ws = output_workspace + '_%d_Workspace' % i
+            output_ws = output_workspace + '_Workspace_%d' % i
             rename_alg.setProperty("InputWorkspace", workspace)
             rename_alg.setProperty("OutputWorkspace", output_ws)
             rename_alg.execute()

--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -302,7 +302,7 @@ std::string IqtFit::constructBaseName(const std::string &inputName,
 
   QString baseName = QString::fromStdString(inputName);
   baseName = baseName.left(baseName.lastIndexOf("_"));
-  baseName += "_Iqt_";
+  baseName += "_IqtFit_";
   baseName += functionType;
   baseName += QString::number(specMin);
   baseName += "_to_";


### PR DESCRIPTION
The naming convention for the workspaces produced by the `I(Q, t) Fit` Interface should now be correct

**To test:**
- Open `I(Q, t) Fit` (Interfaces > Indirect > Data Analysis > `I(Q, t) Fit`)
- Load `iris26176_graphite002_iqt.nxs` as the input file (available from the unit test data directory)
- Change `EndX` to `0.2` in the Property table (or by dragging the range bar
- Click `Run`
- Ensure that:
  - There are 3 additional (input + 3 more) workspaces in the ADS (1 matrix, 1 table and 1 group)
    - They should have the naming convention `iris26176_graphite002_IqtFit_1E_s0_to_16_` followed by `Parameters` (table), `Result` (matrix), `Workspaces`(group)
  - Ensure the group has 17 entries and the workspace are named `irs26176_graphite002_IqtFit_1E_s0_to_16_Workspace_` followed by a number 0 -> 16

Fixes #16279 

_Does not need to be in the release notes. As Algorithm in question has only recently been added to the nightlys_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
