### PR TITLE
Error passing rebin parameters in StartLiveData

### DIFF
--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -291,7 +291,7 @@ FrameworkManagerImpl::createAlgorithm(const std::string &algName,
   IAlgorithm *alg = AlgorithmManager::Instance()
                         .create(algName, version)
                         .get(); // createAlgorithm(algName);
-  alg->setPropertiesWithSimpleString(propertiesArray);
+  alg->setPropertiesWithString(propertiesArray);
 
   return alg;
 }

--- a/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
@@ -79,7 +79,7 @@ public:
     @param ignoreProperties :: A set of names of any properties NOT to set
     from the propertiesArray
   */
-  virtual void setPropertiesWithSimpleString(
+  virtual void setPropertiesWithString(
       const std::string &propertiesString,
       const std::unordered_set<std::string> &
           ignoreProperties = std::unordered_set<std::string>()) = 0;

--- a/Framework/Kernel/inc/MantidKernel/PropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManager.h
@@ -88,7 +88,7 @@ public:
                      IPropertyManager *targetPropertyManager,
                      const std::unordered_set<std::string> &ignoreProperties =
                          std::unordered_set<std::string>());
-  void setPropertiesWithSimpleString(
+  void setPropertiesWithString(
       const std::string &propertiesString,
       const std::unordered_set<std::string> &ignoreProperties =
           std::unordered_set<std::string>()) override;
@@ -127,6 +127,12 @@ protected:
 private:
   /// Transform the given string to a key for the property index
   const std::string createKey(const std::string &text) const;
+  void setPropertiesWithSimpleString(
+      const std::string &propertiesString,
+      const std::unordered_set<std::string> &ignoreProperties);
+  void setPropertiesWithJSONString(
+      const std::string &propertiesString,
+      const std::unordered_set<std::string> &ignoreProperties);
 
   /// typedef for the map holding the properties
   typedef std::map<std::string, std::unique_ptr<Property>> PropertyMap;

--- a/Framework/Kernel/inc/MantidKernel/PropertyManagerOwner.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManagerOwner.h
@@ -70,7 +70,7 @@ public:
                          std::unordered_set<std::string>()) override;
 
   // sets all the declared properties using a simple string format
-  void setPropertiesWithSimpleString(
+  void setPropertiesWithString(
       const std::string &propertiesString,
       const std::unordered_set<std::string> &ignoreProperties =
           std::unordered_set<std::string>()) override;

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -314,7 +314,6 @@ void PropertyManager::setPropertiesWithString(
   }
 }
 
-
 /** Sets all the declared properties from a string.
   @param propertiesString :: A JSON code string.
   @param ignoreProperties :: A set of names of any properties NOT to set

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -292,6 +292,44 @@ void PropertyManager::setProperties(
 }
 
 /** Sets all the declared properties from a string.
+  @param propertiesString :: Either a list of name = value pairs separated by a
+    semicolon or a JSON code string.
+  @param ignoreProperties :: A set of names of any properties NOT to set
+  from the propertiesArray
+*/
+void PropertyManager::setPropertiesWithString(
+    const std::string &propertiesString,
+    const std::unordered_set<std::string> &ignoreProperties) {
+  if (propertiesString.empty()) {
+    return;
+  }
+  auto firstSymbol = propertiesString.find_first_not_of(" \n\t");
+  if (firstSymbol == std::string::npos) {
+    return;
+  }
+  if (propertiesString[firstSymbol] == '{') {
+    setPropertiesWithJSONString(propertiesString, ignoreProperties);
+  } else {
+    setPropertiesWithSimpleString(propertiesString, ignoreProperties);
+  }
+}
+
+
+/** Sets all the declared properties from a string.
+  @param propertiesString :: A JSON code string.
+  @param ignoreProperties :: A set of names of any properties NOT to set
+  from the propertiesArray
+*/
+void PropertyManager::setPropertiesWithJSONString(
+    const std::string &propertiesString,
+    const std::unordered_set<std::string> &ignoreProperties) {
+  ::Json::Reader reader;
+  ::Json::Value propertyJson;
+  reader.parse(propertiesString, propertyJson);
+  setProperties(propertyJson, ignoreProperties);
+}
+
+/** Sets all the declared properties from a string.
   @param propertiesString :: A list of name = value pairs separated by a
     semicolon
   @param ignoreProperties :: A set of names of any properties NOT to set

--- a/Framework/Kernel/src/PropertyManagerOwner.cpp
+++ b/Framework/Kernel/src/PropertyManagerOwner.cpp
@@ -77,8 +77,7 @@ void PropertyManagerOwner::setProperties(
 void PropertyManagerOwner::setPropertiesWithString(
     const std::string &propertiesString,
     const std::unordered_set<std::string> &ignoreProperties) {
-  m_properties->setPropertiesWithString(propertiesString,
-                                              ignoreProperties);
+  m_properties->setPropertiesWithString(propertiesString, ignoreProperties);
 }
 
 /** Set the value of a property by string

--- a/Framework/Kernel/src/PropertyManagerOwner.cpp
+++ b/Framework/Kernel/src/PropertyManagerOwner.cpp
@@ -74,10 +74,10 @@ void PropertyManagerOwner::setProperties(
   @param ignoreProperties :: A set of names of any properties NOT to set
   from the propertiesArray
 */
-void PropertyManagerOwner::setPropertiesWithSimpleString(
+void PropertyManagerOwner::setPropertiesWithString(
     const std::string &propertiesString,
     const std::unordered_set<std::string> &ignoreProperties) {
-  m_properties->setPropertiesWithSimpleString(propertiesString,
+  m_properties->setPropertiesWithString(propertiesString,
                                               ignoreProperties);
 }
 

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -526,6 +526,40 @@ public:
                mgr.validateProperties());
   }
 
+  void test_setPropertiesWithSimpleString() {
+    PropertyManagerHelper mgr;
+
+    mgr.declareProperty(
+        Mantid::Kernel::make_unique<PropertyWithValue<double>>("double", 12.0),
+        "docs");
+    mgr.declareProperty(
+        Mantid::Kernel::make_unique<PropertyWithValue<int>>("int", 23), "docs");
+
+    mgr.setPropertiesWithString("double= 13.0 ;int=22 ");
+    double d = mgr.getProperty("double");
+    int i = mgr.getProperty("int");
+    TS_ASSERT_EQUALS(d, 13.0);
+    TS_ASSERT_EQUALS(i, 22);
+
+    mgr.setPropertiesWithString("double= 23.4 ;int=11", {"int"});
+    d = mgr.getProperty("double");
+    i = mgr.getProperty("int");
+    TS_ASSERT_EQUALS(d, 23.4);
+    TS_ASSERT_EQUALS(i, 22);
+
+    mgr.setPropertiesWithString("{\"double\": 14.0, \"int\":33}");
+    d = mgr.getProperty("double");
+    i = mgr.getProperty("int");
+    TS_ASSERT_EQUALS(d, 14.0);
+    TS_ASSERT_EQUALS(i, 33);
+
+    mgr.setPropertiesWithString("{\"double\": 12.3 ,\"int\":11}", {"int"});
+    d = mgr.getProperty("double");
+    i = mgr.getProperty("int");
+    TS_ASSERT_EQUALS(d, 12.3);
+    TS_ASSERT_EQUALS(i, 33);
+  }
+
 private:
   PropertyManagerHelper *manager;
 };

--- a/Framework/LiveData/src/LiveDataAlgorithm.cpp
+++ b/Framework/LiveData/src/LiveDataAlgorithm.cpp
@@ -247,7 +247,7 @@ IAlgorithm_sptr LiveDataAlgorithm::makeAlgorithm(bool postProcessing) {
     ignoreProps.insert("OutputWorkspace");
 
     // ...and pass it the properties
-    alg->setPropertiesWithSimpleString(props, ignoreProps);
+    alg->setPropertiesWithString(props, ignoreProps);
 
     // Warn if someone put both values.
     if (!script.empty())


### PR DESCRIPTION
Allowed setting algorithm properties via a JSON encoded string.

**To test:**
1. Set Facility to TEST_LIVE
2. Start FaleISISHistoDAE
3. Start LIve Data dialog and select ISIS_Histogram as the instrument.
4. Set "Rebin" as the processing algorithm and set some rebin parameters, say "0,100,200000"
5. Run Live Data.

Live data collection should work normally.

Fixes #16243, #16309 .

_Does not need to be in the release notes._

Needs to be in Release 3.7

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
