### PR TITLE
BASISReduction uses vanadium from previous run even when not requested

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -27,7 +27,6 @@ class BASISReduction(PythonAlgorithm):
     _dMask = None
 
     # class variables related to division by Vanadium (normalization)
-    _doNorm = None  # stores the selected item from normalization_types
     _normRange = None
     _norm_run_list = None
     _normWs = None
@@ -38,6 +37,11 @@ class BASISReduction(PythonAlgorithm):
     _samMonWs = None
     _samWsRun = None
     _samSqwWs = None
+
+    def __init__(self):
+        PythonAlgorithm.__init__(self)
+        self._doNorm = None  # stores the selected item from normalization_types
+        self._normalizeToFirst = False
 
     def category(self):
         return "Inelastic\\Reduction"
@@ -114,6 +118,8 @@ class BASISReduction(PythonAlgorithm):
         self._maskFile = self.getProperty("MaskFile").value
         self._groupDetOpt = self.getProperty("GroupDetectors").value
         self._normalizeToFirst = self.getProperty("NormalizeToFirst").value
+        self._normalizeToVanadium = self.getProperty("GroupDetectors").value
+        self._doNorm = self.getProperty("DivideByVanadium").value
 
         datasearch = config["datasearch.searcharchive"]
         if datasearch != "On":
@@ -136,8 +142,9 @@ class BASISReduction(PythonAlgorithm):
         ############################
         ##  Process the Vanadium  ##
         ############################
+
         norm_runs = self.getProperty("NormRunNumbers").value
-        if bool(norm_runs):
+        if self._doNorm and bool(norm_runs):
             if ";" in norm_runs:
                 raise SyntaxError("Normalization does not support run groups")
             self._doNorm = self.getProperty("NormalizationType").value


### PR DESCRIPTION
A condition to check if property DivideByVanadium is set is introduced

**To test:**
Set instrument to BASIS, then run this script in MantidPlot

```
# First reduce data 56588 dividing by Vanadium 53768 
BASISReduction(RunNumbers="56588",
    EnergyBins="-120,0.4,120",
    MomentumTransferBins="0.2,0.2,2.0",
    NormalizeToFirst=False,
    DivideByVanadium=True,
    NormalizationType="by Q slice",
    NormRunNumbers="53768",
    NormWavelengthRange="6.24,6.23")
# After reduction, workspace BSS_56588_divided_sqw should be produced

# Second, reduce data 56588 with no Vanadium
BASISReduction(RunNumbers="56588",
    EnergyBins="-120,0.4,120",
    MomentumTransferBins="0.2,0.2,2.0",
    NormalizeToFirst=False,
    DivideByVanadium=False)
# After reduction, workspace BSS_56588_sqw should be produced. Before the fix,
# workspace BSS_56588_divided_sqw would have been produced, again.

```

Fixes #1631.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
