### PR TITLE
Fix connect call on AlgorithmDialog creation

### DIFF
--- a/MantidQt/API/src/AlgorithmDialog.cpp
+++ b/MantidQt/API/src/AlgorithmDialog.cpp
@@ -650,7 +650,7 @@ QLayout *AlgorithmDialog::createDefaultButtonLayout(
   m_okButton->setDefault(true);
 
   m_exitButton = new QPushButton(cancelText);
-  connect(m_exitButton, SIGNAL(clicked()), this, SLOT(close()));
+  connect(m_exitButton, SIGNAL(clicked()), this, SLOT(reject()));
 
   QHBoxLayout *buttonRowLayout = new QHBoxLayout;
   buttonRowLayout->addWidget(createHelpButton(helpText));


### PR DESCRIPTION
The `close` button on `AlgorithmDialog` is now wired to the `reject()` slot so that other parts of the code assuming the `rejected()` signal was fired behave as intended.

**To test:**

Use the steps in the issue #16319 to reproduce the problem. I suggest first trying it without merging the fix to convince yourself that you understand the problem. After merging the problem should be fixed. 

Fixes #16319

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

On closing a dialog the algorithm must be removed from the algorithm manager. The removal
is keyed from the rejected() signal but this only fires on reject() calls not close()
