### PR TITLE
Re-enable h5py on RHEL6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ if ( ENABLE_CPACK )
       message ( STATUS " CPACK_PACKAGE_FILE_NAME = ${CPACK_PACKAGE_FILE_NAME}" )
 
       # rhel requirements
-      set ( CPACK_RPM_PACKAGE_REQUIRES "qt4 >= 4.2,nexus >= 4.3.1,nexus-python >= 4.3.1,gsl,glibc,qwtplot3d-qt4,muParser,numpy,h5py" )
+      set ( CPACK_RPM_PACKAGE_REQUIRES "qt4 >= 4.2,nexus >= 4.3.1,nexus-python >= 4.3.1,gsl,glibc,qwtplot3d-qt4,muParser,numpy,h5py >= 2.3.1" )
       # OCE
       set( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},OCE-draw,OCE-foundation,OCE-modeling,OCE-ocaf,OCE-visualization")
       set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},poco-crypto,poco-data,poco-mysql,poco-sqlite,poco-odbc,poco-util,poco-xml,poco-zip,poco-net,poco-netssl,poco-foundation,PyQt4,sip" )

--- a/Framework/PythonInterface/plugins/algorithms/SaveNexusPD.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveNexusPD.py
@@ -4,12 +4,10 @@ import mantid.simpleapi as api
 from mantid.kernel import StringListValidator
 import numpy as np
 
-import platform
-if platform.linux_distribution()[2] != 'Santiago':
-    try:
-        import h5py  # http://www.h5py.org/
-    except ImportError:
-        pass
+try:
+    import h5py  # http://www.h5py.org/
+except ImportError:
+    pass
 
 class SaveNexusPD(mantid.api.PythonAlgorithm):
     NX_CLASS = 'NX_class'

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveNexusPDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveNexusPDTest.py
@@ -4,19 +4,14 @@ from mantid.api import AnalysisDataService
 from mantid.simpleapi import CreateWorkspace, SaveNexusPD
 import numpy as np
 import os
-import platform
 from testhelpers import WorkspaceCreationHelper as WCH
 import unittest
 
-# RHEL6 has troubles with h5py
-if platform.linux_distribution()[2] == 'Santiago':
+runTests = True
+try:
+    import h5py
+except ImportError:
     runTests = False
-else:
-    runTests = True
-    try:
-        import h5py
-    except ImportError:
-        runTests = False
 
 class SaveNexusPDTest(unittest.TestCase):
     def saveFilePath(self, wkspname):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveNexusPDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveNexusPDTest.py
@@ -81,7 +81,7 @@ class SaveNexusPDTest(unittest.TestCase):
 
             nxmoderator = nxinstrument['moderator']
             if withInstrument:
-                self.assertLess(nxmoderator['distance'][0], 0.)
+                self.assertTrue(nxmoderator['distance'][0] < 0.)
 
             for name in nxinstrument.keys():
                 if name == 'moderator':

--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -1,5 +1,5 @@
 Name:           mantid-developer
-Version:        1.15
+Version:        1.16
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -25,7 +25,7 @@ Requires: git-all
 Requires: gsl-devel
 Requires: hdf-devel
 Requires: hdf5-devel
-Requires: h5py
+Requires: h5py >= 2.3.1
 Requires: jsoncpp-devel >= 0.7.0
 Requires: muParser-devel
 Requires: mxml-devel
@@ -97,6 +97,9 @@ required for Mantid development.
 %files
 
 %changelog
+* Wed May 18 2016 Martyn Gigg <martyn.gigg@stfc.ac.uk>
+- Require h5py >= 2.3.1
+
 * Tue May 03 2016 Pete Peterson <petersonpf@ornl.gov>
 - Require python-matplotlib-qt4 and h5py
 

--- a/scripts/Inelastic/Direct/ReductionWrapper.py
+++ b/scripts/Inelastic/Direct/ReductionWrapper.py
@@ -9,17 +9,12 @@ from Direct.DirectEnergyConversion import DirectEnergyConversion
 import os
 import re
 import time
-
-# h5py seems to hang mantid imports on RHEL6
-import platform
-if platform.linux_distribution()[2] == 'Santiago':
+try:
+    import h5py
+    h5py_installed = True
+except ImportError:
     h5py_installed = False
-else:
-    try:
-        import h5py
-        h5py_installed = True
-    except ImportError:
-        h5py_installed = False
+    pass
 from abc import abstractmethod
 
 # R0921 abstract class not referenced -- wrong, client references it.


### PR DESCRIPTION
This reverts the changes from #16208 and re-enables h5py on RHEL6. The minimum version now required by the rpm is 2.3.1 and the `mantid-developer.spec` file has been updated accordingly. 

**To test:**

All of the builds should pass.

Try using `SaveNexusPD` on `RHEL6`

No issue.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
