### PR TITLE
Remove Qt3 from muParserScript class in MantidPlot.

### DIFF
--- a/MantidPlot/src/Table.cpp
+++ b/MantidPlot/src/Table.cpp
@@ -498,7 +498,7 @@ bool Table::muParserCalculate(int col, int startRow, int endRow,
   connect(mup, SIGNAL(print(const QString &)), scriptingEnv(),
           SIGNAL(print(const QString &)));
 
-  double *r = mup->defineVariable("i");
+  double *r = mup->defineVariable("i", 1.0);
   mup->defineVariable("j", (double)col);
   mup->defineVariable("sr", startRow + 1.0);
   mup->defineVariable("er", endRow + 1.0);

--- a/MantidPlot/src/muParserScript.h
+++ b/MantidPlot/src/muParserScript.h
@@ -35,7 +35,7 @@
 #include "MantidGeometry/muParser_Silent.h"
 #include "math.h"
 #include <gsl/gsl_sf.h>
-#include <q3asciidict.h>
+#include <QMap>
 
 class ScriptingEnv;
 
@@ -46,6 +46,7 @@ class muParserScript: public Script
   public:
     muParserScript(ScriptingEnv *env, const QString &name,
                    QObject *context, bool checkMultilineCode = true);
+    ~muParserScript();
 
     bool compilesToCompleteStatement(const QString &) const override {
       return true;
@@ -79,9 +80,10 @@ class muParserScript: public Script
     static double *mu_addVariable(const char *name, void *){ return current->addVariable(name); }
     static double *mu_addVariableR(const char *name, void *) { return current->addVariableR(name); }
     static QString compileColArg(const QString& in);
+    static void clearVariables(QMap<QString, double*> &vars);
 
     mu::Parser parser, rparser;
-    Q3AsciiDict<double> variables, rvariables;
+    QMap<QString, double*> variables, rvariables;
     QStringList muCode;
     //! Flag telling is the parser should warn users on multiline code input
     bool d_warn_multiline_code;

--- a/MantidPlot/src/muParserScripting.h
+++ b/MantidPlot/src/muParserScripting.h
@@ -37,7 +37,6 @@
 #include "MantidGeometry/muParser_Silent.h"
 #include "math.h"
 #include <gsl/gsl_sf.h>
-#include <q3asciidict.h>
 
 //Mantid - follows changes to ScriptingEnv
 class QsciLexer;


### PR DESCRIPTION
Replaced Q3AsciiDict with QMap (no Qt3 in muParserScript). Fixed a bug in calculating of column values: `col(column_name)` function should work now.

**To test:**

Check that there are no Qt3 objects left in muParserScript.(h, cpp).

The bug was unrelated to this issue but it was easy to fix. To test:
1. Open a new table.
2. Go to `Set column values` dialog.
3. Try to set column values using `col(column_name)` function. Column `column_name` must already have some numeric values set.

Fixes #15316 .

_No release notes at this point_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
