### PR TITLE
Indirect Data Reduction - Fix Plot Spectra Option

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -163,7 +163,7 @@ namespace CustomInterfaces
     {
       auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(sqwWsName.toStdString());
       int numHist = static_cast<int>(ws->getNumberHistograms());
-      plotSpectrum(sqwWsName, 0, numHist);
+      plotSpectrum(sqwWsName, 0, numHist-1);
     }
   }
 

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -94,6 +94,7 @@ Bugfixes
 - In the *I(Q, t) Fit* interface, checking the plot guess check box now correctly adds and removes the curve from the plot
 - In the *BayesQuasi* interface ResNorm files are now automatically loaded from file locations when entered.
 - :ref:`LoadVesuvio <algm-LoadVesuvio>` now correctly parses input in the form 10-20,30-40,50-60
+- Using the Spectra option in *S(Q,w)* interface now works correctly
 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
It is now possible to plot using the `Spectra` option in the S(Q,w) interface in indirect Data reduction

**To test:**
- Change Default facility/instrument to `ISIS/IRIS` (view > preferences... > Mantid)
- open `S(Q,w)` (Interfaces > Indirect > Data Reduction > `S(Q,w)`)
- Load input file: irs26176_graphite002_red.nxs (available from unit test data directory)
- Q binning: 0.6, 0.1, 1.8
- Energy binning: -0.5, 0.05, 0.5
- Plot output = spectra
- Click `Run`

Fixes #16327

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/069bb86c2c5d45d678e5230052993cccab7cb589/docs/source/release/v3.7.0/indirect_inelastic.rst#bugfixes)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the coding standards? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
