### PR TITLE
 vesuvio intensity constraints fixed

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioTOFFitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioTOFFitTest.py
@@ -6,9 +6,16 @@ are configured to find the Vesuvio data
 """
 import unittest
 import platform
+import numpy as np
 from mantid.api import AlgorithmManager
 import vesuvio.testing as testing
 import vesuvio.commands as vesuvio
+
+def _get_peak_height_and_bin(y_data):
+    peak_height = np.amax(y_data)
+    peak_bin = np.argmax(y_data)
+    return peak_height, peak_bin
+
 
 class VesuvioTOFFitTest(unittest.TestCase):
 
@@ -59,8 +66,9 @@ class VesuvioTOFFitTest(unittest.TestCase):
 
         self.assertAlmostEqual(0.0155041, output_ws.readY(0)[0])
         self.assertAlmostEqual(-0.0070975, output_ws.readY(0)[-1])
-        self.assertAlmostEqual(0.8693019e-05, output_ws.readY(1)[0])
-        self.assertTrue(abs(0.746e-04 - output_ws.readY(1)[-1]) < 0.2e-06)
+        peak_height_val, peak_height_bin = _get_peak_height_and_bin(output_ws.readY(1))
+        self.assertTrue(abs(0.14780208913 - peak_height_val) < 0.002)
+        self.assertTrue(abs(158 - peak_height_bin) <= 1)
 
     def test_single_run_produces_correct_output_workspace_index0_kfixed_including_background(self):
         profiles = "function=GramCharlier,width=[2, 5, 7],hermite_coeffs=[1, 0, 0],k_free=0,sears_flag=1;"\
@@ -82,8 +90,9 @@ class VesuvioTOFFitTest(unittest.TestCase):
 
         self.assertAlmostEqual(0.0279822, output_ws.readY(0)[0])
         self.assertAlmostEqual(0.0063585, output_ws.readY(0)[-1])
-        self.assertTrue(abs(-0.012 - output_ws.readY(1)[0]) < 0.002)
-        self.assertTrue(abs(0.0056 - output_ws.readY(1)[-1]) < 0.0004)
+        peak_height_val, peak_height_bin = _get_peak_height_and_bin(output_ws.readY(1))
+        self.assertTrue(abs(0.129538171297 - peak_height_val) < 0.002)
+        self.assertTrue(abs(159 - peak_height_bin) <= 1)
     # -------------- Failure cases ------------------
 
     def test_empty_masses_raises_error(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioTOFFitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioTOFFitTest.py
@@ -91,7 +91,7 @@ class VesuvioTOFFitTest(unittest.TestCase):
         self.assertAlmostEqual(0.0279822, output_ws.readY(0)[0])
         self.assertAlmostEqual(0.0063585, output_ws.readY(0)[-1])
         peak_height_val, peak_height_bin = _get_peak_height_and_bin(output_ws.readY(1))
-        self.assertTrue(abs(0.129538171297 - peak_height_val) < 0.002)
+        self.assertTrue(abs(0.129538171297 - peak_height_val) < 0.003)
         self.assertTrue(abs(159 - peak_height_bin) <= 1)
     # -------------- Failure cases ------------------
 

--- a/Testing/SystemTests/tests/analysis/VesuvioCommandsTest.py
+++ b/Testing/SystemTests/tests/analysis/VesuvioCommandsTest.py
@@ -150,8 +150,8 @@ class SingleSpectrumBackground(stresstesting.MantidStressTest):
         index_one_last = 0.00720728978699
         calc_data_height = 0.138704
         if _is_old_boost_version():
-            index_one_first = 6.809169e-04
-            index_one_last = 7.206634e-03
+            index_one_first = 0.000628498710145
+            index_two_first = -0.00487957546659
 
         _equal_within_tolerance(self, index_one_first, fitted_ws.readY(0)[0])
         _equal_within_tolerance(self, index_one_last, fitted_ws.readY(0)[-1])

--- a/Testing/SystemTests/tests/analysis/VesuvioCommandsTest.py
+++ b/Testing/SystemTests/tests/analysis/VesuvioCommandsTest.py
@@ -146,7 +146,7 @@ class SingleSpectrumBackground(stresstesting.MantidStressTest):
         self.assertAlmostEqual(50.0, fitted_ws.readX(0)[0])
         self.assertAlmostEqual(562.0, fitted_ws.readX(0)[-1])
 
-        index_one_first = -0.0221362198069
+        index_one_first = -0.00656639296531
         index_one_last = 0.00720728978699
         calc_data_height = 0.138704
         if _is_old_boost_version():


### PR DESCRIPTION
VesuvioTOFFit now returns the parameters from the initial Fit rather than those of the secondary fit that is used to calculate Chi Squared.

**Further updates to this have been made to ensure that all Vesuvio tests pass. All tests have passed locally on Ubuntu 14.04 and Windows7**

**To test:**

**I'd recommend building this in Release mode. The Vesuvio Algorithm, can run very slowly in Debug**
- Run the `Vesuvio_intensity_constraints_test.py` script available from `\\olympic\babylon5\Public\ElliotOram\Vesuvio` in the mantidplot scripting window with the DataArchive searching enabled.
  - You will also need the `IP_2015_06_Chimney_header.txt` in a directory where mantid can find it (this is in the same babylon5 directory)
- Inspect the data in the `23115-23153_params_iteration_1`
  - Ensure that `f4.Intensity / f3.Intensity = ~4.3437...` for each spectrum (`3`,`47`,`91`)
- Plot the data and fit from `23115-23153_data_backwards_bank_x_iteration_x` and check the fit looks reasonable.

Fixes #16039 

_Does not need to be in the release notes. As this has only been discovered in the nightly builds_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
