### PR TITLE
Avoid division by 0 in MD error propagation

### DIFF
--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -845,6 +845,9 @@ MDHistoWorkspace &MDHistoWorkspace::operator*=(const MDHistoWorkspace &b_ws) {
  *
  * Error propagation of \f$ f = a * b \f$  is given by:
  * \f$ df^2 = f^2 * (da^2 / a^2 + db^2 / b^2) \f$
+ * Rewritten as:
+ * \f$ df^2 = b^2 da^2 + a^2 * db^2 \f$
+ * to avoid problems when a or b are 0
  *
  * @param b_ws :: workspace on the RHS of the operation
  * */
@@ -858,7 +861,7 @@ void MDHistoWorkspace::multiply(const MDHistoWorkspace &b_ws) {
     signal_t db2 = b_ws.m_errorsSquared[i];
 
     signal_t f = a * b;
-    signal_t df2 = (f * f) * (da2 / (a * a) + db2 / (b * b));
+    signal_t df2 = da2 * b * b + db2 * a * a;
 
     m_signals[i] = f;
     m_errorsSquared[i] = df2;
@@ -870,6 +873,9 @@ void MDHistoWorkspace::multiply(const MDHistoWorkspace &b_ws) {
  *
  * Error propagation of \f$ f = a * b \f$  is given by:
  * \f$ df^2 = f^2 * (da^2 / a^2 + db^2 / b^2) \f$
+ *  Rewritten as:
+ * \f$ df^2 = b^2 da^2 + a^2 * db^2 \f$
+ * to avoid problems when a or b are 0
  *
  * @param signal :: signal to apply
  * @param error :: error (not squared) to apply
@@ -877,13 +883,13 @@ void MDHistoWorkspace::multiply(const MDHistoWorkspace &b_ws) {
 void MDHistoWorkspace::multiply(const signal_t signal, const signal_t error) {
   signal_t b = signal;
   signal_t db2 = error * error;
-  signal_t db2_relative = db2 / (b * b);
+
   for (size_t i = 0; i < m_length; ++i) {
     signal_t a = m_signals[i];
     signal_t da2 = m_errorsSquared[i];
 
     signal_t f = a * b;
-    signal_t df2 = (f * f) * (da2 / (a * a) + db2_relative);
+    signal_t df2 = da2 * b * b + db2 * a * a;
 
     m_signals[i] = f;
     m_errorsSquared[i] = df2;
@@ -908,6 +914,9 @@ MDHistoWorkspace &MDHistoWorkspace::operator/=(const MDHistoWorkspace &b_ws) {
  *
  * Error propagation of \f$ f = a / b \f$  is given by:
  * \f$ df^2 = f^2 * (da^2 / a^2 + db^2 / b^2) \f$
+ * Rewritten as:
+ * \f$ df^2 = da^2 / b^2 + db^2 *f^2 / b^2 \f$
+ * to avoid problems when a or b are 0
  *
  * @param b_ws :: workspace on the RHS of the operation
  **/
@@ -921,7 +930,7 @@ void MDHistoWorkspace::divide(const MDHistoWorkspace &b_ws) {
     signal_t db2 = b_ws.m_errorsSquared[i];
 
     signal_t f = a / b;
-    signal_t df2 = (f * f) * (da2 / (a * a) + db2 / (b * b));
+    signal_t df2 = da2 / (b * b) + db2 * f * f / (b * b);
 
     m_signals[i] = f;
     m_errorsSquared[i] = df2;
@@ -933,6 +942,9 @@ void MDHistoWorkspace::divide(const MDHistoWorkspace &b_ws) {
  *
  * Error propagation of \f$ f = a / b \f$  is given by:
  * \f$ df^2 = f^2 * (da^2 / a^2 + db^2 / b^2) \f$
+ * Rewritten as:
+ * \f$ df^2 = da^2 / b^2 + db^2 *f^2 / b^2 \f$
+ * to avoid problems when a or b are 0
  *
  * @param signal :: signal to apply
  * @param error :: error (not squared) to apply
@@ -946,7 +958,7 @@ void MDHistoWorkspace::divide(const signal_t signal, const signal_t error) {
     signal_t da2 = m_errorsSquared[i];
 
     signal_t f = a / b;
-    signal_t df2 = (f * f) * (da2 / (a * a) + db2_relative);
+    signal_t df2 = da2 / (b * b) + db2_relative * f * f;
 
     m_signals[i] = f;
     m_errorsSquared[i] = df2;

--- a/Framework/MDAlgorithms/src/DivideMD.cpp
+++ b/Framework/MDAlgorithms/src/DivideMD.cpp
@@ -59,7 +59,7 @@ void DivideMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   float scalar = float(m_rhs_scalar->dataY(0)[0]);
   float scalarError = float(m_rhs_scalar->dataE(0)[0]);
   float scalarErrorSquared = scalarError * scalarError;
-  float inverseScalarSquared = 1. / (scalar * scalar);
+  float inverseScalarSquared = 1.f / (scalar * scalar);
 
   // Get all the MDBoxes contained
   MDBoxBase<MDE, nd> *parentBox = ws->getBox();

--- a/Framework/MDAlgorithms/src/DivideMD.cpp
+++ b/Framework/MDAlgorithms/src/DivideMD.cpp
@@ -58,8 +58,8 @@ void DivideMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   // Get the scalar multiplying
   float scalar = float(m_rhs_scalar->dataY(0)[0]);
   float scalarError = float(m_rhs_scalar->dataE(0)[0]);
-  float scalarRelativeErrorSquared =
-      (scalarError * scalarError) / (scalar * scalar);
+  float scalarErrorSquared = scalarError * scalarError;
+  float scalarSquared = scalar * scalar;
 
   // Get all the MDBoxes contained
   MDBoxBase<MDE, nd> *parentBox = ws->getBox();
@@ -85,8 +85,8 @@ void DivideMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         float oldSignal = it->getSignal();
         float signal = oldSignal / scalar;
         float errorSquared =
-            signal * signal * (it->getErrorSquared() / (oldSignal * oldSignal) +
-                               scalarRelativeErrorSquared);
+            it->getErrorSquared() / scalarSquared +
+            scalarErrorSquared *oldSignal * oldSignal / (scalarSquared * scalarSquared);
         it->setSignal(signal);
         it->setErrorSquared(errorSquared);
         ic++;

--- a/Framework/MDAlgorithms/src/DivideMD.cpp
+++ b/Framework/MDAlgorithms/src/DivideMD.cpp
@@ -85,7 +85,7 @@ void DivideMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         float oldSignal = it->getSignal();
         float signal = oldSignal / scalar;
         float errorSquared = it->getErrorSquared() / scalarSquared +
-                             scalarErrorSquared *oldSignal * oldSignal /
+                             scalarErrorSquared * oldSignal * oldSignal /
                                  (scalarSquared * scalarSquared);
         it->setSignal(signal);
         it->setErrorSquared(errorSquared);

--- a/Framework/MDAlgorithms/src/DivideMD.cpp
+++ b/Framework/MDAlgorithms/src/DivideMD.cpp
@@ -59,7 +59,7 @@ void DivideMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   float scalar = float(m_rhs_scalar->dataY(0)[0]);
   float scalarError = float(m_rhs_scalar->dataE(0)[0]);
   float scalarErrorSquared = scalarError * scalarError;
-  float scalarSquared = scalar * scalar;
+  float inverseScalarSquared = 1./(scalar * scalar);
 
   // Get all the MDBoxes contained
   MDBoxBase<MDE, nd> *parentBox = ws->getBox();
@@ -84,9 +84,9 @@ void DivideMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         // Multiply weight by a scalar, propagating error
         float oldSignal = it->getSignal();
         float signal = oldSignal / scalar;
-        float errorSquared = it->getErrorSquared() / scalarSquared +
-                             scalarErrorSquared * oldSignal * oldSignal /
-                                 (scalarSquared * scalarSquared);
+        float errorSquared = it->getErrorSquared() * inverseScalarSquared +
+                             scalarErrorSquared * oldSignal * oldSignal *
+                                 inverseScalarSquared * inverseScalarSquared;
         it->setSignal(signal);
         it->setErrorSquared(errorSquared);
         ic++;

--- a/Framework/MDAlgorithms/src/DivideMD.cpp
+++ b/Framework/MDAlgorithms/src/DivideMD.cpp
@@ -86,7 +86,8 @@ void DivideMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         float signal = oldSignal / scalar;
         float errorSquared =
             it->getErrorSquared() / scalarSquared +
-            scalarErrorSquared *oldSignal * oldSignal / (scalarSquared * scalarSquared);
+            scalarErrorSquared *oldSignal * oldSignal /
+                (scalarSquared * scalarSquared);
         it->setSignal(signal);
         it->setErrorSquared(errorSquared);
         ic++;

--- a/Framework/MDAlgorithms/src/DivideMD.cpp
+++ b/Framework/MDAlgorithms/src/DivideMD.cpp
@@ -59,7 +59,7 @@ void DivideMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   float scalar = float(m_rhs_scalar->dataY(0)[0]);
   float scalarError = float(m_rhs_scalar->dataE(0)[0]);
   float scalarErrorSquared = scalarError * scalarError;
-  float inverseScalarSquared = 1./(scalar * scalar);
+  float inverseScalarSquared = 1. / (scalar * scalar);
 
   // Get all the MDBoxes contained
   MDBoxBase<MDE, nd> *parentBox = ws->getBox();

--- a/Framework/MDAlgorithms/src/DivideMD.cpp
+++ b/Framework/MDAlgorithms/src/DivideMD.cpp
@@ -84,10 +84,9 @@ void DivideMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         // Multiply weight by a scalar, propagating error
         float oldSignal = it->getSignal();
         float signal = oldSignal / scalar;
-        float errorSquared =
-            it->getErrorSquared() / scalarSquared +
-            scalarErrorSquared *oldSignal * oldSignal /
-                (scalarSquared * scalarSquared);
+        float errorSquared = it->getErrorSquared() / scalarSquared +
+                             scalarErrorSquared *oldSignal * oldSignal /
+                                 (scalarSquared * scalarSquared);
         it->setSignal(signal);
         it->setErrorSquared(errorSquared);
         ic++;

--- a/Framework/MDAlgorithms/src/MultiplyMD.cpp
+++ b/Framework/MDAlgorithms/src/MultiplyMD.cpp
@@ -59,8 +59,8 @@ void MultiplyMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   // Get the scalar multiplying
   float scalar = float(m_rhs_scalar->dataY(0)[0]);
   float scalarError = float(m_rhs_scalar->dataE(0)[0]);
-  float scalarRelativeErrorSquared =
-      (scalarError * scalarError) / (scalar * scalar);
+  float scalarErrorSquared = scalarError * scalarError;
+  float scalarSquared = scalar * scalar;
 
   // Get all the MDBoxes contained
   MDBoxBase<MDE, nd> *parentBox = ws->getBox();
@@ -86,8 +86,7 @@ void MultiplyMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         float oldSignal = it->getSignal();
         float signal = oldSignal * scalar;
         float errorSquared =
-            signal * signal * (it->getErrorSquared() / (oldSignal * oldSignal) +
-                               scalarRelativeErrorSquared);
+            scalarSquared * it->getErrorSquared() + oldSignal * oldSignal * scalarErrorSquared;
         it->setSignal(signal);
         it->setErrorSquared(errorSquared);
       }

--- a/Framework/MDAlgorithms/src/MultiplyMD.cpp
+++ b/Framework/MDAlgorithms/src/MultiplyMD.cpp
@@ -85,8 +85,8 @@ void MultiplyMD::execEventScalar(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         // Multiply weight by a scalar, propagating error
         float oldSignal = it->getSignal();
         float signal = oldSignal * scalar;
-        float errorSquared =
-            scalarSquared * it->getErrorSquared() + oldSignal * oldSignal * scalarErrorSquared;
+        float errorSquared = scalarSquared * it->getErrorSquared() +
+                             oldSignal * oldSignal * scalarErrorSquared;
         it->setSignal(signal);
         it->setErrorSquared(errorSquared);
       }


### PR DESCRIPTION
Explicitly perform operations to avoid division by 0. 

**To test:**

Make sure all unit test, system tests, and doc tests that use multiplication and division of MD workspaces are OK.

The following script should yield `[0.]`. The same if you replace division by multiplication. (The current version returns NaN)

```
d=CreateMDHistoWorkspace(SignalInput='0', ErrorInput='0', Dimensionality=1, Extents='0,1', NumberOfBins='1', Names='d1', Units='x')
n=CreateMDHistoWorkspace(SignalInput='1', ErrorInput='0', Dimensionality=1, Extents='0,1', NumberOfBins='1', Names='d1', Units='x')
out=d/n
print out.getErrorSquaredArray()
```

Fixes #16077.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

_Does not need to be in the release notes._

**NOTE** 
The branch is based on release-v3.7, but it should be merged in both the release and master

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
