### PR TITLE
Division by vanadium gives results different than older mantid version

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -10,6 +10,7 @@ DEFAULT_RANGE = [6.24, 6.30]
 DEFAULT_MASK_GROUP_DIR = "/SNS/BSS/shared/autoreduce"
 DEFAULT_MASK_FILE = "BASIS_Mask.xml"
 DEFAULT_VANADIUM_ENERGY_RANGE = [-0.0034, 0.0034]  # meV
+DEFAULT_VANADIUM_BINS = [-0.0034, 0.068, 0.0034]  # meV
 
 #pylint: disable=too-many-instance-attributes
 class BASISReduction(PythonAlgorithm):
@@ -26,12 +27,6 @@ class BASISReduction(PythonAlgorithm):
     _overrideMask = None
     _dMask = None
 
-    # class variables related to division by Vanadium (normalization)
-    _normRange = None
-    _norm_run_list = None
-    _normWs = None
-    _normMonWs = None
-
     _run_list = None  # a list of runs, or a list of sets of runs
     _samWs = None
     _samMonWs = None
@@ -40,8 +35,15 @@ class BASISReduction(PythonAlgorithm):
 
     def __init__(self):
         PythonAlgorithm.__init__(self)
-        self._doNorm = None  # stores the selected item from normalization_types
+
         self._normalizeToFirst = False
+        # variables related to division by Vanadium (normalization)
+        self._doNorm = None  # stores the selected item from normalization_types
+        self._normalizationType = None
+        self._normRange = None
+        self._norm_run_list = None
+        self._normWs = None
+        self._normMonWs = None
 
     def category(self):
         return "Inelastic\\Reduction"
@@ -147,8 +149,8 @@ class BASISReduction(PythonAlgorithm):
         if self._doNorm and bool(norm_runs):
             if ";" in norm_runs:
                 raise SyntaxError("Normalization does not support run groups")
-            self._doNorm = self.getProperty("NormalizationType").value
-            self.log().information("Divide by Vanadium with normalization" + self._doNorm)
+            self._normalizationType = self.getProperty("NormalizationType").value
+            self.log().information("Divide by Vanadium with normalization" + self._normalizationType)
 
             # The following steps are common to all types of Vanadium normalization
 
@@ -158,7 +160,7 @@ class BASISReduction(PythonAlgorithm):
             self._normWs = self._sum_and_calibrate(norm_set, extra_extension="_norm")
 
             # This rebin integrates counts onto a histogram of a single bin
-            if self._doNorm == "by detectorID":
+            if self._normalizationType == "by detectorID":
                 normRange = self.getProperty("NormWavelengthRange").value
                 self._normRange = [normRange[0], normRange[1]-normRange[0], normRange[1]]
                 api.Rebin(InputWorkspace=self._normWs, OutputWorkspace=self._normWs,
@@ -169,8 +171,10 @@ class BASISReduction(PythonAlgorithm):
                                            OutputWorkspace="BASIS_NORM_MASK")
 
             # additional reduction steps when normalizing by Q slice
-            if self._doNorm == "by Q slice":
-                self._normWs = self._group_and_SofQW(self._normWs, self._etBins, isSample=False)
+            if self._normalizationType == "by Q slice":
+                self._normWs = self._group_and_SofQW(self._normWs,
+                                                     DEFAULT_VANADIUM_BINS,
+                                                     isSample=False)
 
         ##########################
         ##  Process the sample  ##
@@ -185,16 +189,13 @@ class BASISReduction(PythonAlgorithm):
                 api.MaskDetectors(Workspace=self._samWs,
                                   MaskedWorkspace='BASIS_NORM_MASK')
             # Divide by Vanadium
-            if self._doNorm == "by detector ID":
+            if self._normalizationType == "by detector ID":
                 api.Divide(LHSWorkspace=self._samWs, RHSWorkspace=self._normWs,
                            OutputWorkspace=self._samWs)
             # additional reduction steps
             self._samSqwWs = self._group_and_SofQW(self._samWs, self._etBins, isSample=True)
             # Divide by Vanadium
-            if self._doNorm == "by Q slice":
-                api.Integration(InputWorkspace=self._normWs, OutputWorkspace=self._normWs,
-                                RangeLower=DEFAULT_VANADIUM_ENERGY_RANGE[0],
-                                RangeUpper=DEFAULT_VANADIUM_ENERGY_RANGE[1])
+            if self._normalizationType == "by Q slice":
                 api.Divide(LHSWorkspace=self._samSqwWs, RHSWorkspace=self._normWs,
                            OutputWorkspace=self._samSqwWs)
             # Clear mask from reduced file. Needed for binary operations
@@ -331,6 +332,8 @@ class BASISReduction(PythonAlgorithm):
     def _group_and_SofQW(self, wsName, etRebins, isSample=True):
         """ Transforms from wavelength and detector ID to S(Q,E)
         @param wsName: workspace as a function of wavelength and detector id
+        @param etRebins: final energy domain and bin width
+        @param isSample: discriminates between sample and vanadium
         @return: S(Q,E)
         """
         api.ConvertUnits(InputWorkspace=wsName,


### PR DESCRIPTION
The vanadium processing was assuming the same energy domain than the sample. Instead, the energy domain should be restricted to the width of the elastic line

Run this script in Mantidplot:

```
maskFile="/SNS/lustre/BSS/shared/autoreduce/new_masks_08_12_2015/"+\
         "BASIS_Mask_ThreeQuartersRemain_SouthTop_NorthTop_NorthBottom_MorePixelsEliminated_08122015.xml"

# First reduce data 56588 dividing by Vanadium 53768 
BASISReduction(RunNumbers="56588",
               EnergyBins="-120,0.4,120",
               MomentumTransferBins="0.2,0.2,2.0",
               MaskFile=maskFile,
               NormalizeToFirst=False,
               DivideByVanadium=True,
               NormalizationType="by Q slice",
               NormRunNumbers="53768",
               NormWavelengthRange="6.24,6.23")
# After reduction, workspace BSS_56588_divided_sqw should be produced

Second, reduce data 56588 with no Vanadium
BASISReduction(RunNumbers="56588",
               EnergyBins="-120,0.4,120",
               MomentumTransferBins="0.2,0.2,2.0",
               MaskFile=maskFile,
               NormalizeToFirst=False,
               DivideByVanadium=False)
# After reduction, workspace BSS_56588_sqw should be produced

# Third, reduce the Vanadium
BASISReduction(RunNumbers="53768",
               EnergyBins="-3.4,6.8,3.4",
               MomentumTransferBins="0.2,0.2,2.0",
               MaskFile=maskFile,               
               NormalizeToFirst=False,
               DivideByVanadium=False)
# After reduction, workspace BSS_53768_sqw should be produced

# Divide reduced data BSS_56588_sqw by the reduced Vanadium BSS_53768_sqw
Divide(LHSWorkspace="BSS_56588_sqw",
    RHSWorkspace="BSS_53768_sqw",
    OutputWorkspace="BSS_56588_sqw_thenDivided")
```

<b>Compare BSS_56588_sqw_thenDivided and BSS_56588_divided_sqw. They should be nearly identical</b>

Fixes #16338.
## Does not need to be in the release notes.*
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
