### PR TITLE
16129 fix qt support warnings group 9

### DIFF
--- a/MantidPlot/src/ScriptingLangDialog.cpp
+++ b/MantidPlot/src/ScriptingLangDialog.cpp
@@ -38,7 +38,7 @@
 ScriptingLangDialog::ScriptingLangDialog(ScriptingEnv *env, ApplicationWindow *parent, Qt::WFlags fl )
   : QDialog(parent, fl), Scripted(env)
 {
-	setCaption(tr("MantidPlot - Select scripting language"));
+        setWindowTitle(tr("MantidPlot - Select scripting language"));
 
   langList = new QListWidget(this);
 
@@ -65,7 +65,7 @@ void ScriptingLangDialog::updateLangList()
 {
   langList->clear();
   langList->insertItems(0, ScriptingLangManager::languages());
-  QListWidgetItem *current = langList->findItems(scriptingEnv()->name(), Qt::MatchExactly).first();
+  QListWidgetItem *current = langList->findItems(scriptingEnv()->objectName(), Qt::MatchExactly).first();
   if (current)
     langList->setCurrentItem(current);
 }

--- a/MantidPlot/src/ScriptingWindow.cpp
+++ b/MantidPlot/src/ScriptingWindow.cpp
@@ -195,18 +195,18 @@ void ScriptingWindow::populateFileMenu() {
 
   if (scriptsOpen) {
     m_fileMenu->addAction(m_openInCurTab);
-    m_fileMenu->insertSeparator();
+    m_fileMenu->addSeparator();
     m_fileMenu->addAction(m_save);
     m_fileMenu->addAction(m_saveAs);
     m_fileMenu->addAction(m_print);
   }
 
-  m_fileMenu->insertSeparator();
+  m_fileMenu->addSeparator();
   m_fileMenu->addMenu(m_recentScripts);
   m_recentScripts->setEnabled(m_manager->recentScripts().count() > 0);
 
   if (scriptsOpen) {
-    m_fileMenu->insertSeparator();
+    m_fileMenu->addSeparator();
     m_fileMenu->addAction(m_closeTab);
   }
 }
@@ -230,15 +230,15 @@ void ScriptingWindow::populateEditMenu() {
   m_editMenu->addAction(m_copy);
   m_editMenu->addAction(m_paste);
 
-  m_editMenu->insertSeparator();
+  m_editMenu->addSeparator();
   m_editMenu->addAction(m_comment);
   m_editMenu->addAction(m_uncomment);
 
-  m_editMenu->insertSeparator();
+  m_editMenu->addSeparator();
   m_editMenu->addAction(m_tabsToSpaces);
   m_editMenu->addAction(m_spacesToTabs);
 
-  m_editMenu->insertSeparator();
+  m_editMenu->addSeparator();
   m_editMenu->addAction(m_find);
 }
 
@@ -268,19 +268,19 @@ void ScriptingWindow::populateWindowMenu() {
   m_windowMenu->addAction(m_hide);
 
   if (scriptsOpen) {
-    m_windowMenu->insertSeparator();
+    m_windowMenu->addSeparator();
     m_windowMenu->addAction(m_zoomIn);
     m_windowMenu->addAction(m_zoomOut);
     m_windowMenu->addAction(m_resetZoom);
     m_windowMenu->addAction(m_selectFont);
 
-    m_windowMenu->insertSeparator();
+    m_windowMenu->addSeparator();
     m_windowMenu->addAction(m_toggleProgress);
     m_windowMenu->addAction(m_toggleFolding);
     m_windowMenu->addAction(m_toggleWrapping);
     m_windowMenu->addAction(m_toggleWhitespace);
 
-    m_windowMenu->insertSeparator();
+    m_windowMenu->addSeparator();
     m_windowMenu->addAction(m_openConfigTabs);
   }
 }
@@ -324,7 +324,7 @@ void ScriptingWindow::setMenuStates(int ntabs) {
 void ScriptingWindow::setEditActionsDisabled(bool off) {
   auto actions = m_editMenu->actions();
   foreach (QAction *action, actions) {
-    if (strcmp("Find", action->name()) != 0) {
+    if (strcmp("Find", action->objectName()) != 0) {
       action->setDisabled(off);
     }
   }
@@ -773,7 +773,7 @@ void ScriptingWindow::openUnique(QString filename) {
   auto openFiles = m_manager->fileNamesToQStringList();
   // The list of open files contains absolute paths so make sure we have one
   // here
-  filename = QFileInfo(filename).absFilePath();
+  filename = QFileInfo(filename).absoluteFilePath();
   auto position = openFiles.indexOf(filename);
   if (position < 0) {
     m_manager->newTab(openFiles.size(), filename);
@@ -829,7 +829,7 @@ QStringList ScriptingWindow::extractPyFiles(const QList<QUrl> &urlList) const {
     if (fName.size() > 0) {
       QFileInfo fi(fName);
 
-      if (fi.suffix().upper() == "PY") {
+      if (fi.suffix().toUpper() == "PY") {
         filenames.append(fName);
       }
     }

--- a/MantidPlot/src/SendToProgramDialog.cpp
+++ b/MantidPlot/src/SendToProgramDialog.cpp
@@ -56,7 +56,9 @@ SendToProgramDialog::SendToProgramDialog(QWidget* parent, QString programName, s
 
   //Set the name of the program you wish to edit and make it so that the user can't change it
   m_uiform.nameText->setText(programName);
-  m_uiform.nameText->setBackgroundColor(QColor(230,230,230));
+  QPalette palette;
+  palette.setColor(m_uiform.nameText->backgroundRole(), QColor(230,230,230));
+  m_uiform.nameText->setPalette(palette);
   m_uiform.nameText->setReadOnly(true);
 
   //Assign the collected data on the program to the form boxes

--- a/MantidPlot/src/SetColValuesDialog.cpp
+++ b/MantidPlot/src/SetColValuesDialog.cpp
@@ -52,28 +52,28 @@
 SetColValuesDialog::SetColValuesDialog(ScriptingEnv *env, Table *t,
                                        Qt::WFlags fl)
     : QDialog(t, fl), Scripted(env) {
-  setName("SetColValuesDialog");
+  setObjectName("SetColValuesDialog");
   setWindowTitle(tr("MantidPlot - Set column values"));
   setSizeGripEnabled(true);
 
   QHBoxLayout *hbox1 = new QHBoxLayout();
   hbox1->addWidget(new QLabel(tr("For row (i)")));
   start = new QSpinBox();
-  start->setMinValue(1);
+  start->setMinimum(1);
   hbox1->addWidget(start);
 
   hbox1->addWidget(new QLabel(tr("to")));
 
   end = new QSpinBox();
-  end->setMinValue(1);
+  end->setMinimum(1);
   hbox1->addWidget(end);
 
   if (sizeof(int) == 2) { // 16 bit signed integer
-    start->setMaxValue(0x7fff);
-    end->setMaxValue(0x7fff);
+    start->setMaximum(0x7fff);
+    end->setMaximum(0x7fff);
   } else { // 32 bit signed integer
-    start->setMaxValue(0x7fffffff);
-    end->setMaxValue(0x7fffffff);
+    start->setMaximum(0x7fffffff);
+    end->setMaximum(0x7fffffff);
   }
 
   QGridLayout *gl1 = new QGridLayout();
@@ -222,7 +222,7 @@ void SetColValuesDialog::setTable(Table *w) {
   QStringList colNames = w->colNames();
   int cols = w->numCols();
   for (int i = 0; i < cols; i++)
-    boxColumn->insertItem("col(\"" + colNames[i] + "\")", i);
+    boxColumn->insertItem(i, "col(\"" + colNames[i] + "\")");
 
   if (w->hasSelection()) {
     w->setSelectedCol(w->leftSelectedColumn());

--- a/MantidPlot/src/SmoothCurveDialog.cpp
+++ b/MantidPlot/src/SmoothCurveDialog.cpp
@@ -47,7 +47,7 @@ SmoothCurveDialog::SmoothCurveDialog(int method, QWidget* parent, Qt::WFlags fl 
 {
   smooth_method = method;
 
-  setName( "SmoothCurveDialog" );
+  setObjectName( "SmoothCurveDialog" );
   setWindowTitle(tr("MantidPlot - Smoothing Options"));
 
   QGroupBox *gb1 = new QGroupBox();
@@ -97,7 +97,7 @@ SmoothCurveDialog::SmoothCurveDialog(int method, QWidget* parent, Qt::WFlags fl 
       gl1->addWidget(boxColor, 2, 1);
       gl1->setRowStretch(3, 1);
   }
-  gl1->setColStretch(2, 1);
+  gl1->setColumnStretch(2, 1);
 
   btnSmooth = new QPushButton(tr( "&Smooth" ));
   btnSmooth->setDefault(true);
@@ -149,6 +149,6 @@ void SmoothCurveDialog::activateCurve(const QString& curveName)
 	if (!c || c->rtti() != QwtPlotItem::Rtti_PlotCurve)
 		return;
 
-	boxPointsLeft->setMaxValue(c->dataSize()/2);
+	boxPointsLeft->setMaximum(c->dataSize()/2);
 	}
 }

--- a/MantidPlot/src/SurfaceDialog.cpp
+++ b/MantidPlot/src/SurfaceDialog.cpp
@@ -48,7 +48,7 @@
 SurfaceDialog::SurfaceDialog( QWidget* parent, Qt::WFlags fl )
     : QDialog( parent, fl )
 {
-	setName( "SurfaceDialog" );
+	setObjectName( "SurfaceDialog" );
 	setWindowTitle(tr("MantidPlot - Define surface plot"));
     setSizeGripEnabled( true );
 
@@ -285,7 +285,7 @@ void SurfaceDialog::setFunction(Graph3D *g)
 	if (!f)
 		return;
 
-    boxFunction->setCurrentText(f->formula());
+    boxFunction->setItemText(boxFunction->currentIndex(), f->formula());
     boxFuncColumns->setValue(static_cast<int>(f->columns()));
     boxFuncRows->setValue(static_cast<int>(f->rows()));
 
@@ -317,7 +317,7 @@ void SurfaceDialog::acceptParametricSurface()
     int list_size = 15;
     QString x_formula = boxX->text();
 	try {
-		parser.SetExpr(x_formula.ascii());
+		parser.SetExpr(x_formula.toAscii().constData());
 		parser.Eval();
 	} catch(mu::ParserError &e){
 		QMessageBox::critical(app, tr("MantidPlot - X Formula Error"), QString::fromStdString(e.GetMsg()));
@@ -325,14 +325,14 @@ void SurfaceDialog::acceptParametricSurface()
 		return;
 	}
 
-    app->d_param_surface_func.remove(x_formula);
+    app->d_param_surface_func.removeAll(x_formula);
 	app->d_param_surface_func.push_front(x_formula);
 	while ((int)app->d_param_surface_func.size() > list_size)
 		app->d_param_surface_func.pop_back();
 
     QString y_formula = boxY->text();
 	try {
-		parser.SetExpr(y_formula.ascii());
+		parser.SetExpr(y_formula.toAscii().constData());
 		parser.Eval();
 	} catch(mu::ParserError &e){
 		QMessageBox::critical(app, tr("MantidPlot - Y Formula Error"), QString::fromStdString(e.GetMsg()));
@@ -340,14 +340,14 @@ void SurfaceDialog::acceptParametricSurface()
 		return;
 	}
 
-    app->d_param_surface_func.remove(y_formula);
+    app->d_param_surface_func.removeAll(y_formula);
 	app->d_param_surface_func.push_front(y_formula);
 	while ((int)app->d_param_surface_func.size() > list_size)
 		app->d_param_surface_func.pop_back();
 
     QString z_formula = boxZ->text();
 	try {
-		parser.SetExpr(z_formula.ascii());
+		parser.SetExpr(z_formula.toAscii().constData());
 		parser.Eval();
 	} catch(mu::ParserError &e){
 		QMessageBox::critical(app, tr("MantidPlot - Z Formula Error"), QString::fromStdString(e.GetMsg()));
@@ -355,18 +355,18 @@ void SurfaceDialog::acceptParametricSurface()
 		return;
 	}
 
-    app->d_param_surface_func.remove(z_formula);
+    app->d_param_surface_func.removeAll(z_formula);
 	app->d_param_surface_func.push_front(z_formula);
 	while ((int)app->d_param_surface_func.size() > list_size)
 		app->d_param_surface_func.pop_back();
 
-	QString ufrom = boxUFrom->text().lower();
-	QString uto = boxUTo->text().lower();
-	QString vfrom = boxVFrom->text().lower();
-	QString vto = boxVTo->text().lower();
+	QString ufrom = boxUFrom->text().toLower();
+	QString uto = boxUTo->text().toLower();
+	QString vfrom = boxVFrom->text().toLower();
+	QString vto = boxVTo->text().toLower();
 	double ul, ur, vl, vr;
 	try{
-		parser.SetExpr(ufrom.ascii());
+		parser.SetExpr(ufrom.toAscii().constData());
 		ul = parser.Eval();
 	}
 	catch(mu::ParserError &e){
@@ -376,7 +376,7 @@ void SurfaceDialog::acceptParametricSurface()
 	}
 
 	try{
-		parser.SetExpr(uto.ascii());
+		parser.SetExpr(uto.toAscii().constData());
 		ur = parser.Eval();
 	}
 	catch(mu::ParserError &e){
@@ -386,7 +386,7 @@ void SurfaceDialog::acceptParametricSurface()
 	}
 
 	try{
-		parser.SetExpr(vfrom.ascii());
+		parser.SetExpr(vfrom.toAscii().constData());
 		vl = parser.Eval();
 	}
 	catch(mu::ParserError &e){
@@ -396,7 +396,7 @@ void SurfaceDialog::acceptParametricSurface()
 	}
 
 	try{
-		parser.SetExpr(vto.ascii());
+		parser.SetExpr(vto.toAscii().constData());
 		vr = parser.Eval();
 	}
 	catch(mu::ParserError &e){
@@ -422,18 +422,18 @@ void SurfaceDialog::acceptFunction()
 {
 ApplicationWindow *app = static_cast<ApplicationWindow *>(this->parent());
 
-QString Xfrom=boxXFrom->text().lower();
-QString Xto=boxXTo->text().lower();
-QString Yfrom=boxYFrom->text().lower();
-QString Yto=boxYTo->text().lower();
-QString Zfrom=boxZFrom->text().lower();
-QString Zto=boxZTo->text().lower();
+QString Xfrom=boxXFrom->text().toLower();
+QString Xto=boxXTo->text().toLower();
+QString Yfrom=boxYFrom->text().toLower();
+QString Yto=boxYTo->text().toLower();
+QString Zfrom=boxZFrom->text().toLower();
+QString Zto=boxZTo->text().toLower();
 
 double fromX, toX, fromY,toY, fromZ,toZ;
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Xfrom.ascii());
+	parser.SetExpr(Xfrom.toAscii().constData());
 	fromX=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -445,7 +445,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Xto.ascii());
+	parser.SetExpr(Xto.toAscii().constData());
 	toX=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -458,7 +458,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Yfrom.ascii());
+	parser.SetExpr(Yfrom.toAscii().constData());
 	fromY=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -470,7 +470,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Yto.ascii());
+	parser.SetExpr(Yto.toAscii().constData());
 	toY=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -482,7 +482,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Zfrom.ascii());
+	parser.SetExpr(Zfrom.toAscii().constData());
 	fromZ=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -494,7 +494,7 @@ catch(mu::ParserError &e)
 try
 	{
 	MyParser parser;
-	parser.SetExpr(Zto.ascii());
+	parser.SetExpr(Zto.toAscii().constData());
 	toZ=parser.Eval();
 	}
 catch(mu::ParserError &e)
@@ -521,7 +521,7 @@ try
 	double y=fromY;
 	parser.DefineVar("x", &x);
 	parser.DefineVar("y", &y);
-	parser.SetExpr(formula.ascii());
+	parser.SetExpr(formula.toAscii().constData());
 
 	
 	parser.Eval();

--- a/MantidPlot/src/lib/src/SymbolBox.cpp
+++ b/MantidPlot/src/lib/src/SymbolBox.cpp
@@ -155,11 +155,11 @@ void SymbolBox::setStyle(const QwtSymbol::Style& style)
   {
     if (symbols[i] == style)
     {
-      setCurrentItem(int(i));
+      setCurrentIndex(int(i));
       return;
     }
   }
-  setCurrentItem(0);
+  setCurrentIndex(0);
 //  const QwtSymbol::Style*ite = std::find(symbols, symbols + sizeof(symbols), style);
 //  if (ite == symbols + sizeof(symbols))
 //    this->setCurrentIndex(0);

--- a/MantidQt/CustomInterfaces/src/DynamicPDF/SliceSelector.cpp
+++ b/MantidQt/CustomInterfaces/src/DynamicPDF/SliceSelector.cpp
@@ -295,7 +295,7 @@ void SliceSelector::initPickerLine(){
 bool SliceSelector::isWorkspaceValid(){
   /// check the pointer to the workspace is not empty
   if(!m_loadedWorkspace->m_ws){
-    auto title = QString::fromStdString(this->name());
+    auto title = this->objectName();
     auto error = QString::fromStdString("Workspace must be of type MatrixWorkspace");
     QMessageBox::warning(this, title, error);
     return false;
@@ -303,7 +303,7 @@ bool SliceSelector::isWorkspaceValid(){
   /// check the units of the "X-axis" is momentum transfer
   auto axis = m_loadedWorkspace->m_ws->getAxis(0);
   if (axis->unit()->unitID() != "MomentumTransfer") {
-    auto title = QString::fromStdString(this->name());
+    auto title = this->objectName();
     auto error = QString::fromStdString("X-axis units must be momentum transfer");
     QMessageBox::warning(this, title, error);
     return false;
@@ -311,7 +311,7 @@ bool SliceSelector::isWorkspaceValid(){
   /// check the units of the "vertical" dimension is energy transfer
   axis = m_loadedWorkspace->m_ws->getAxis(1);
   if (axis->unit()->unitID() != "DeltaE") {
-    auto title = QString::fromStdString(this->name());
+    auto title = this->objectName();
     auto error = QString::fromStdString("Y-axis units must be energy transfer (meV)");
     QMessageBox::warning(this, title, error);
     return false;

--- a/MantidQt/CustomInterfaces/src/StepScan.cpp
+++ b/MantidQt/CustomInterfaces/src/StepScan.cpp
@@ -169,7 +169,7 @@ void StepScan::startLiveListenerComplete(bool error)
 
 void StepScan::loadFile(bool async)
 {
-  const QString filename = m_uiForm.mWRunFiles->getUserInput().asString();
+  const QString filename = m_uiForm.mWRunFiles->getUserInput().toString();
   // This handles the fact that mwRunFiles emits the filesFound signal more than
   // we want (on some platforms). TODO: Consider dealing with this up in mwRunFiles.
   if ( filename != m_inputFilename && m_uiForm.mWRunFiles->isValid() )

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -311,7 +311,8 @@ void SliceViewer::initMenus() {
     bar = parentWindow->menuBar();
   else {
     // Widget is not in a QMainWindow. Make a menu bar
-    bar = new QMenuBar(this, "Main Menu Bar");
+    bar = new QMenuBar(this);
+    bar->setObjectName("Main Menu Bar");
     ui.verticalLayout->insertWidget(0, bar);
   }
 
@@ -951,7 +952,7 @@ void SliceViewer::setNormalization(Mantid::API::MDNormalization norm,
     if (norm == Mantid::API::NoNormalization) {
       comboNormalization->setCurrentIndex(0);
     } else if (norm == Mantid::API::VolumeNormalization) {
-      comboNormalization->setCurrentItem(1);
+      comboNormalization->setCurrentIndex(1);
     } else {
       comboNormalization->setCurrentIndex(2);
     }
@@ -1196,7 +1197,7 @@ void SliceViewer::updateDisplaySlot(int index, double value) {
   UNUSED_ARG(value)
   this->updateDisplay();
   // Trigger a rebin on each movement of the slice point
-  if (m_rebinMode && ui.btnAutoRebin->isOn())
+  if (m_rebinMode && ui.btnAutoRebin->isChecked())
     this->rebinParamsChanged();
 
   // Update the colors scale if required
@@ -1244,7 +1245,7 @@ void SliceViewer::copyImageToClipboard() {
   // Create the image
   QPixmap pix = this->getImage();
   // Set the clipboard
-  QApplication::clipboard()->setImage(pix, QClipboard::Clipboard);
+  QApplication::clipboard()->setImage(pix.toImage(), QClipboard::Clipboard);
 }
 
 /**

--- a/MantidQt/SliceViewer/src/SliceViewerWindow.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewerWindow.cpp
@@ -58,7 +58,7 @@ SliceViewerWindow::SliceViewerWindow(const QString &wsName,
   QString caption = QString("Slice Viewer (") + wsName + QString(")");
   if (!m_label.isEmpty())
     caption += QString(" ") + m_label;
-  this->setCaption(caption);
+  this->setWindowTitle(caption);
   this->resize(500, 500);
 
   // Create the m_slicer and add it to the MDI window

--- a/MantidQt/SpectrumViewer/src/SpectrumView.cpp
+++ b/MantidQt/SpectrumViewer/src/SpectrumView.cpp
@@ -27,7 +27,7 @@ namespace SpectrumView
  *  @param parent Top-level widget for object.
  */
 SpectrumView::SpectrumView(QWidget *parent) :
-  QMainWindow(parent, 0),
+  QMainWindow(parent),
   WorkspaceObserver(),
   m_ui(new Ui::SpectrumViewer()),
   m_sliderHandler(NULL),
@@ -249,7 +249,7 @@ void SpectrumView::respondToTabCloseReqest(int tab)
       }
     }
     m_svConnections->removeSpectrumDisplay(displayToRemove.get());
-    m_spectrumDisplay.remove(displayToRemove);
+    m_spectrumDisplay.removeAll(displayToRemove);
     m_ui->imageTabs->removeTab(tab);
     m_hGraph->clear();
     m_vGraph->clear();

--- a/Vates/ParaviewPlugins/ParaViewWidgets/QtWidgets/SimpleBinInputWidget.cpp
+++ b/Vates/ParaviewPlugins/ParaViewWidgets/QtWidgets/SimpleBinInputWidget.cpp
@@ -44,7 +44,7 @@ Getter for the current entry.
 */
 int SimpleBinInputWidget::getEntry(double, double) const
 {
-  return atoi(m_nBinsBox->text());
+  return atoi(m_nBinsBox->text().toAscii().constData());
 }
 
 /// Destructor

--- a/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
@@ -302,14 +302,14 @@ void SplatterPlotView::checkPeaksCoordinates()
   {
 
     int peakViewCoords = vtkSMPropertyHelper(this->origSrc->getProxy(),
-                                             MantidQt::API::MdConstants::MantidParaViewSpecialCoordinates).GetAsInt();
+                                             MantidQt::API::MdConstants::MantidParaViewSpecialCoordinates.toAscii().constData()).GetAsInt();
     // Make commensurate with vtkPeakMarkerFactory
     peakViewCoords--;
 
     foreach(pqPipelineSource *src, this->m_peaksSource)
     {
       vtkSMPropertyHelper(src->getProxy(),
-                          MantidQt::API::MdConstants::PeakDimensions).Set(peakViewCoords);
+                          MantidQt::API::MdConstants::PeakDimensions.toAscii().constData()).Set(peakViewCoords);
       src->getProxy()->UpdateVTKObjects();
     }
   }
@@ -403,7 +403,7 @@ void SplatterPlotView::readAndSendCoordinates()
   {
     // Get coordinate type
     int peakViewCoords = vtkSMPropertyHelper(this->origSrc->getProxy(),
-                                             MantidQt::API::MdConstants::MantidParaViewSpecialCoordinates).GetAsInt();
+                                             MantidQt::API::MdConstants::MantidParaViewSpecialCoordinates.toAscii().constData()).GetAsInt();
     // Make commensurate with vtkPeakMarkerFactory
     peakViewCoords--;
 
@@ -609,9 +609,11 @@ void SplatterPlotView::setPeakButton(bool state)
  */
 void SplatterPlotView::setPeakSourceFrame(pqPipelineSource* source)
 {
-  int peakViewCoords = vtkSMPropertyHelper(this->origSrc->getProxy(), MantidQt::API::MdConstants::MantidParaViewSpecialCoordinates).GetAsInt();
+  int peakViewCoords = vtkSMPropertyHelper(this->origSrc->getProxy(),
+                                           MantidQt::API::MdConstants::MantidParaViewSpecialCoordinates.toAscii().constData()).GetAsInt();
   peakViewCoords--;
-  vtkSMPropertyHelper(source->getProxy(), MantidQt::API::MdConstants::PeakDimensions).Set(peakViewCoords);
+  vtkSMPropertyHelper(source->getProxy(),
+                      MantidQt::API::MdConstants::PeakDimensions.toAscii().constData()).Set(peakViewCoords);
 }
 
 /**
@@ -619,9 +621,11 @@ void SplatterPlotView::setPeakSourceFrame(pqPipelineSource* source)
  */
 bool SplatterPlotView::checkIfPeaksWorkspaceIsAlreadyBeingTracked(pqPipelineSource* source) {
   bool isContained = false;
-  std::string sourceName(vtkSMPropertyHelper(source->getProxy(), MantidQt::API::MdConstants::WorkspaceName).GetAsString());
+  std::string sourceName(vtkSMPropertyHelper(source->getProxy(),
+                                             MantidQt::API::MdConstants::WorkspaceName.toAscii().constData()).GetAsString());
   for (QList<QPointer<pqPipelineSource>>::Iterator it = m_peaksSource.begin(); it != m_peaksSource.end(); ++it) {
-    std::string trackedName(vtkSMPropertyHelper((*it)->getProxy(), MantidQt::API::MdConstants::WorkspaceName).GetAsString());
+    std::string trackedName(vtkSMPropertyHelper((*it)->getProxy(),
+                                                MantidQt::API::MdConstants::WorkspaceName.toAscii().constData()).GetAsString());
     if ((*it == source) || (sourceName == trackedName)) {
       isContained = true;
       break;
@@ -652,10 +656,10 @@ void SplatterPlotView::updatePeaksFilter(pqPipelineSource* filter) {
     }
 
     vtkSMPropertyHelper(filter->getProxy(),
-                        MantidQt::API::MdConstants::PeaksWorkspace)
+                        MantidQt::API::MdConstants::PeaksWorkspace.toAscii().constData())
         .Set(0, workspaceNamesConcatentated.c_str());
     vtkSMPropertyHelper(filter->getProxy(),
-                        MantidQt::API::MdConstants::PeaksWorkspace)
+                        MantidQt::API::MdConstants::PeaksWorkspace.toAscii().constData())
         .Set(1, m_peaksWorkspaceNameDelimiter.c_str());
     emit this->triggerAccept();
     filter->updatePipeline();


### PR DESCRIPTION
This is group 9 of #16129.

This fixes the Qt3Support warnings for group 6.
## To test:

Thorough code review, as note all elements are easily testable.

The changes in this PR have touched many areas of MantidPlot.  Below is a list of items which should be checked. Areas that need thorough testing:
- Make sure that the scripting window works. Run a dummy script
- Make sure that you can open saved scripts
- Create a table, select a column and select Table->Set Column Values ==> do something with it
- Plot parametric surface -> check the options
- Load something into the SliceViewer and play with it
- Load something into the SpectrumViewer and play with it

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
