### PR TITLE
Fix Geometry in class_maker.py

### DIFF
--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -442,7 +442,7 @@ endif(UNITY_BUILD)
 
 # ===================== Open Cascade ===================
 if (ENABLE_OPENCASCADE)
-  set (SRC_FILES ${SRC_FILES} ${OPENCASCADE_SRC} )
+  LIST (APPEND SRC_FILES ${OPENCASCADE_SRC} )
 endif ()
 
 # A few defines needed for OpenCascade on the Mac


### PR DESCRIPTION
Fixes #16104 

**Description**

Add a new class via the `class_maker.py` utility script did not work properly for `Geometry` because teh `SRC_FILES` was updated at with open cascade cpp files. The class maker uses a string search to find all the src files. That broke the current configuration.

Using the `LIST(APPEND myVar newVar)` approach fixes this. 

**To test:**
1.  Run `python python class_maker.py Geometry MyNewClass`
2. Build  + Run Mantid
   - Confirm that there are no build errors and that linking works

No release notes. 

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
