### PR TITLE
Rename Can to Container

### DIFF
--- a/Framework/API/test/SampleTest.h
+++ b/Framework/API/test/SampleTest.h
@@ -4,7 +4,7 @@
 #include "MantidAPI/Sample.h"
 #include "MantidGeometry/Crystal/CrystalStructure.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
-#include "MantidGeometry/Instrument/Can.h"
+#include "MantidGeometry/Instrument/Container.h"
 #include "MantidGeometry/Instrument/SampleEnvironment.h"
 #include "MantidKernel/Exception.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
@@ -54,7 +54,7 @@ public:
     Sample sample;
     const std::string envName("TestKit");
     SampleEnvironment *kit =
-        new SampleEnvironment(envName, boost::make_shared<const Can>(""));
+        new SampleEnvironment(envName, boost::make_shared<const Container>(""));
     kit->add(boost::make_shared<const Object>());
 
     TS_ASSERT_THROWS_NOTHING(sample.setEnvironment(kit));

--- a/Framework/Algorithms/test/MonteCarloTesting.h
+++ b/Framework/Algorithms/test/MonteCarloTesting.h
@@ -65,7 +65,7 @@ createAnnulus(double innerRadius, double outerRadius, double height,
 
 inline Mantid::API::Sample createSamplePlusCan() {
   using Mantid::API::Sample;
-  using Mantid::Geometry::Can;
+  using Mantid::Geometry::Container;
   using Mantid::Geometry::SampleEnvironment;
   using Mantid::Geometry::ShapeFactory;
   using Mantid::Kernel::Material;

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -50,10 +50,11 @@ std::map<std::string, std::string> SetSample::validateInputs() {
       }
     }
 
-    if (!environArgs->existsProperty("Can")) {
-      errors["Environment"] = "Environment flags must contain a 'Can' entry.";
+    if (!environArgs->existsProperty("Container")) {
+      errors["Environment"] =
+          "Environment flags must contain a 'Container' entry.";
     } else {
-      std::string name = environArgs->getPropertyValue("Can");
+      std::string name = environArgs->getPropertyValue("Container");
       if (name.empty()) {
         errors["Environment"] = "Environment 'Can' flag is an empty string!";
       }
@@ -132,7 +133,7 @@ SetSample::setSampleEnvironment(API::MatrixWorkspace_sptr &workspace,
   using Kernel::ConfigService;
 
   const std::string envName = args.getPropertyValue("Name");
-  const std::string canName = args.getPropertyValue("Can");
+  const std::string canName = args.getPropertyValue("Container");
   // The specifications need to be qualified by the facility and instrument.
   // Check instrument for name and then lookup facility if facility
   // is unknown then set to default facility & instrument.
@@ -175,7 +176,7 @@ SetSample::setSampleEnvironment(API::MatrixWorkspace_sptr &workspace,
 void SetSample::setSampleShape(API::MatrixWorkspace_sptr &workspace,
                                const Kernel::PropertyManager_sptr &args,
                                const Geometry::SampleEnvironment *sampleEnv) {
-  using Geometry::Can;
+  using Geometry::Container;
   /* The sample geometry can be specified in two ways:
      - a known set of primitive shapes with values or CSG string
      - or a <samplegeometry> field sample environment can, with values possible
@@ -191,9 +192,9 @@ void SetSample::setSampleShape(API::MatrixWorkspace_sptr &workspace,
   // Any arguments in the args dict are assumed to be values that should
   // override the default set by the sampleEnv samplegeometry if it exists
   if (sampleEnv) {
-    if (sampleEnv->can()->hasSampleShape()) {
-      const auto &can = sampleEnv->can();
-      Can::ShapeArgs shapeArgs;
+    if (sampleEnv->container()->hasSampleShape()) {
+      const auto &can = sampleEnv->container();
+      Container::ShapeArgs shapeArgs;
       if (args) {
         const auto &props = args->getProperties();
         for (const auto &prop : props) {

--- a/Framework/DataHandling/test/SetSampleTest.h
+++ b/Framework/DataHandling/test/SetSampleTest.h
@@ -43,8 +43,8 @@ public:
                             "  <material id=\"van\" formula=\"V\"/>"
                             " </materials>"
                             " <components>"
-                            "  <cans>"
-                            "   <can id=\"10mm\" material=\"van\">"
+                            "  <containers>"
+                            "   <container id=\"10mm\" material=\"van\">"
                             "    <geometry>"
                             "     <sphere id=\"sp-1\">"
                             "      <radius val=\"0.1\"/>"
@@ -57,8 +57,8 @@ public:
                             "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
                             "     </sphere>"
                             "    </samplegeometry>"
-                            "   </can>"
-                            "  </cans>"
+                            "   </container>"
+                            "  </containers>"
                             " </components>"
                             "</environmentspec>";
     Poco::File envFile(Poco::Path(testDirec, m_envName + ".xml"));
@@ -154,7 +154,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(env = &(sample.getEnvironment()));
     TS_ASSERT_EQUALS(m_envName, env->name());
     TS_ASSERT_EQUALS(1, env->nelements());
-    TS_ASSERT_EQUALS("10mm", env->canID());
+    TS_ASSERT_EQUALS("10mm", env->containerID());
     const auto &sampleShape = sample.getShape();
     TS_ASSERT(sampleShape.hasValidShape());
   }
@@ -187,7 +187,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(env = &(sample.getEnvironment()));
     TS_ASSERT_EQUALS(m_envName, env->name());
     TS_ASSERT_EQUALS(1, env->nelements());
-    TS_ASSERT_EQUALS("10mm", env->canID());
+    TS_ASSERT_EQUALS("10mm", env->containerID());
     const auto &sampleShape = sample.getShape();
     TS_ASSERT(sampleShape.hasValidShape());
     // New shape
@@ -267,12 +267,12 @@ public:
 
     auto args = boost::make_shared<PropertyManager>();
     args->declareProperty(
-        Mantid::Kernel::make_unique<StringProperty>("Can", "8mm"), "");
+        Mantid::Kernel::make_unique<StringProperty>("Container", "8mm"), "");
     alg->setProperty("Environment", args);
     TS_ASSERT_THROWS(alg->execute(), std::runtime_error);
   }
 
-  void test_Environment_Args_Without_Can_Invalid() {
+  void test_Environment_Args_Without_Container_Invalid() {
     using Mantid::Kernel::PropertyManager;
     using StringProperty = Mantid::Kernel::PropertyWithValue<std::string>;
     auto inputWS = WorkspaceCreationHelper::Create2DWorkspaceBinned(1, 1);
@@ -302,7 +302,7 @@ public:
     TS_ASSERT_THROWS(alg->execute(), std::runtime_error);
     args->removeProperty("Name");
     args->declareProperty(
-        Mantid::Kernel::make_unique<StringProperty>("Can", ""), "");
+        Mantid::Kernel::make_unique<StringProperty>("Container", ""), "");
     alg->setProperty("Environment", args);
     TS_ASSERT_THROWS(alg->execute(), std::runtime_error);
   }
@@ -353,7 +353,7 @@ private:
     props->declareProperty(
         Mantid::Kernel::make_unique<StringProperty>("Name", m_envName), "");
     props->declareProperty(
-        Mantid::Kernel::make_unique<StringProperty>("Can", "10mm"), "");
+        Mantid::Kernel::make_unique<StringProperty>("Container", "10mm"), "");
     return props;
   }
 

--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -43,7 +43,7 @@ set ( SRC_FILES
 	src/Crystal/V3R.cpp
 	src/IObjComponent.cpp
 	src/Instrument.cpp
-	src/Instrument/Can.cpp
+	src/Instrument/Container.cpp
 	src/Instrument/CompAssembly.cpp
 	src/Instrument/Component.cpp
 	src/Instrument/ComponentHelper.cpp
@@ -197,7 +197,7 @@ set ( INC_FILES
 	inc/MantidGeometry/IDetector_fwd.h
 	inc/MantidGeometry/IObjComponent.h
 	inc/MantidGeometry/Instrument.h
-	inc/MantidGeometry/Instrument/Can.h
+	inc/MantidGeometry/Instrument/Container.h
 	inc/MantidGeometry/Instrument/CompAssembly.h
 	inc/MantidGeometry/Instrument/Component.h
 	inc/MantidGeometry/Instrument/ComponentHelper.h
@@ -305,7 +305,7 @@ set ( TEST_FILES
 	BraggScattererFactoryTest.h
 	BraggScattererInCrystalStructureTest.h
 	BraggScattererTest.h
-	CanTest.h
+	ContainerTest.h
 	CenteringGroupTest.h
 	CompAssemblyTest.h
 	ComponentHelperTest.h

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
@@ -1,5 +1,5 @@
-#ifndef MANTID_GEOMETRY_CAN_H_
-#define MANTID_GEOMETRY_CAN_H_
+#ifndef MANTID_GEOMETRY_CONTAINER_H_
+#define MANTID_GEOMETRY_CONTAINER_H_
 
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Objects/Object.h"
@@ -9,7 +9,7 @@ namespace Mantid {
 namespace Geometry {
 
 /**
-  Models a Can, which is used to hold a sample in the beam. It gets most
+  Models a Container is used to hold a sample in the beam. It gets most
   of its functionality from Geometry::Object but can also hold a
   definition of what the sample geometry itself would be. If the sample shape
   definition is set then we term this a constriained sample geometry.
@@ -35,12 +35,12 @@ namespace Geometry {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_GEOMETRY_DLL Can final : public Object {
+class MANTID_GEOMETRY_DLL Container final : public Object {
 public:
   typedef std::unordered_map<std::string, double> ShapeArgs;
 
-  Can() = default;
-  Can(std::string canXML);
+  Container() = default;
+  Container(std::string xml);
 
   bool hasSampleShape() const;
   Object_sptr createSampleShape(const ShapeArgs &args) const;
@@ -52,11 +52,11 @@ private:
 };
 
 /// Typdef for a shared pointer
-typedef boost::shared_ptr<Can> Can_sptr;
+typedef boost::shared_ptr<Container> Container_sptr;
 /// Typdef for a shared pointer to a const object
-typedef boost::shared_ptr<const Can> Can_const_sptr;
+typedef boost::shared_ptr<const Container> Container_const_sptr;
 
 } // namespace Geometry
 } // namespace Mantid
 
-#endif /* MANTID_GEOMETRY_CAN_H_ */
+#endif /* MANTID_GEOMETRY_CONTAINER_H_ */

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/SampleEnvironment.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/SampleEnvironment.h
@@ -5,7 +5,7 @@
 // Includes
 //------------------------------------------------------------------------------
 #include "MantidGeometry/DllConfig.h"
-#include "MantidGeometry/Instrument/Can.h"
+#include "MantidGeometry/Instrument/Container.h"
 
 namespace Mantid {
 namespace Geometry {
@@ -38,15 +38,15 @@ class Track;
 */
 class MANTID_GEOMETRY_DLL SampleEnvironment {
 public:
-  SampleEnvironment(std::string name, Can_const_sptr can);
+  SampleEnvironment(std::string name, Container_const_sptr container);
 
   /// @return The name of kit
   inline const std::string name() const { return m_name; }
   /// @return The name of can
-  inline const std::string canID() const { return can()->id(); }
+  inline const std::string containerID() const { return container()->id(); }
   /// @return A const ptr to the can instance
-  inline Can_const_sptr can() const {
-    return boost::static_pointer_cast<const Can>(m_components.front());
+  inline Container_const_sptr container() const {
+    return boost::static_pointer_cast<const Container>(m_components.front());
   }
   /// @return The number of elements the environment is composed of
   inline size_t nelements() const { return m_components.size(); }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/SampleEnvironmentSpec.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/SampleEnvironmentSpec.h
@@ -2,7 +2,7 @@
 #define MANTID_GEOMETRY_SAMPLEENVIRONMENTSPEC_H_
 
 #include "MantidGeometry/DllConfig.h"
-#include "MantidGeometry/Instrument/Can.h"
+#include "MantidGeometry/Instrument/Container.h"
 #include "MantidGeometry/Instrument/SampleEnvironment.h"
 
 #include <string>
@@ -42,7 +42,7 @@ namespace Geometry {
 class MANTID_GEOMETRY_DLL SampleEnvironmentSpec {
 public:
   // Convenience typedefs
-  using CanIndex = std::unordered_map<std::string, Can_const_sptr>;
+  using CanIndex = std::unordered_map<std::string, Container_const_sptr>;
   using ComponentList = std::vector<Object_const_sptr>;
 
   SampleEnvironmentSpec(std::string name);
@@ -53,11 +53,11 @@ public:
   inline size_t ncans() const { return m_cans.size(); }
   /// @return The number of non-can components
   inline size_t ncomponents() const { return m_components.size(); }
-  Can_const_sptr findCan(const std::string &id) const;
+  Container_const_sptr findCan(const std::string &id) const;
 
   SampleEnvironment_uptr buildEnvironment(const std::string &canID) const;
 
-  void addCan(const Can_const_sptr &can);
+  void addCan(const Container_const_sptr &can);
   void addComponent(const Object_const_sptr &component);
 
 private:

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/SampleEnvironmentSpecParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/SampleEnvironmentSpecParser.h
@@ -61,9 +61,9 @@ private:
   void parseMaterials(Poco::XML::Element *element);
   void parseAndAddComponents(SampleEnvironmentSpec *spec,
                              Poco::XML::Element *element) const;
-  void parseAndAddCans(SampleEnvironmentSpec *spec,
-                       Poco::XML::Element *element) const;
-  Can_const_sptr parseCan(Poco::XML::Element *element) const;
+  void parseAndAddContainers(SampleEnvironmentSpec *spec,
+                             Poco::XML::Element *element) const;
+  Container_const_sptr parseContainer(Poco::XML::Element *element) const;
   template <typename ObjectType>
   boost::shared_ptr<ObjectType>
   parseComponent(Poco::XML::Element *element) const;

--- a/Framework/Geometry/src/Instrument/Container.cpp
+++ b/Framework/Geometry/src/Instrument/Container.cpp
@@ -1,4 +1,4 @@
-#include "MantidGeometry/Instrument/Can.h"
+#include "MantidGeometry/Instrument/Container.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
 
 #include "Poco/DOM/AutoPtr.h"
@@ -26,7 +26,8 @@ constexpr const char *VAL_ATT = "val";
  * to be updated
  * @param args A hash of tag names to values
  */
-void updateTreeValues(Poco::XML::Element *root, const Can::ShapeArgs &args) {
+void updateTreeValues(Poco::XML::Element *root,
+                      const Container::ShapeArgs &args) {
   using namespace Poco::XML;
   NodeIterator nodeIter(root, NodeFilter::SHOW_ELEMENT);
   Node *node = nodeIter.nextNode();
@@ -48,12 +49,12 @@ void updateTreeValues(Poco::XML::Element *root, const Can::ShapeArgs &args) {
  * Construct a Can providing an XML definition shape
  * @param canXML Definition of the can shape in xml
  */
-Can::Can(std::string canXML) : Object(canXML) {}
+Container::Container(std::string xml) : Object(xml) {}
 
 /**
  * @return True if the can contains a defintion of the sample shape
  */
-bool Can::hasSampleShape() const { return !m_sampleShapeXML.empty(); }
+bool Container::hasSampleShape() const { return !m_sampleShapeXML.empty(); }
 
 /**
  * Return an object that represents the sample shape from the current
@@ -62,7 +63,8 @@ bool Can::hasSampleShape() const { return !m_sampleShapeXML.empty(); }
  * @param args A hash of tag values to use in place of the default
  * @return A pointer to a object modeling the sample shape
  */
-Object_sptr Can::createSampleShape(const Can::ShapeArgs &args) const {
+Object_sptr
+Container::createSampleShape(const Container::ShapeArgs &args) const {
   using namespace Poco::XML;
   if (!hasSampleShape()) {
     throw std::runtime_error("Can::createSampleShape() - No definition found "
@@ -92,7 +94,7 @@ Object_sptr Can::createSampleShape(const Can::ShapeArgs &args) const {
  * Set the definition of the sample shape for this can
  * @param sampleShapeXML
  */
-void Can::setSampleShape(const std::string &sampleShapeXML) {
+void Container::setSampleShape(const std::string &sampleShapeXML) {
   using namespace Poco::XML;
   std::istringstream instrm(sampleShapeXML);
   InputSource src(instrm);

--- a/Framework/Geometry/src/Instrument/SampleEnvironment.cpp
+++ b/Framework/Geometry/src/Instrument/SampleEnvironment.cpp
@@ -21,10 +21,11 @@ using Kernel::V3D;
  * Constructor specifying a name for the environment. It is empty by default and
  * required by various other users of it
  * @param name A human-readable name for the kit
- * @param can The object that represents the can
+ * @param container The object that represents the can
  */
-SampleEnvironment::SampleEnvironment(std::string name, Can_const_sptr can)
-    : m_name(std::move(name)), m_components(1, can) {}
+SampleEnvironment::SampleEnvironment(std::string name,
+                                     Container_const_sptr container)
+    : m_name(std::move(name)), m_components(1, container) {}
 
 /**
  * @return An axis-aligned BoundingBox object that encompasses the whole kit.

--- a/Framework/Geometry/src/Instrument/SampleEnvironmentSpec.cpp
+++ b/Framework/Geometry/src/Instrument/SampleEnvironmentSpec.cpp
@@ -17,7 +17,8 @@ SampleEnvironmentSpec::SampleEnvironmentSpec(std::string name)
  * @return A pointer to the retrieved Can instance
  * @throws std::invalid_argument
  */
-Can_const_sptr SampleEnvironmentSpec::findCan(const std::string &id) const {
+Container_const_sptr
+SampleEnvironmentSpec::findCan(const std::string &id) const {
   auto indexIter = m_cans.find(id);
   if (indexIter != m_cans.end())
     return indexIter->second;
@@ -46,7 +47,7 @@ SampleEnvironmentSpec::buildEnvironment(const std::string &canID) const {
  * @param can A pointer to a Can object
  * @throws std::invalid::argument if the id is empty
  */
-void SampleEnvironmentSpec::addCan(const Can_const_sptr &can) {
+void SampleEnvironmentSpec::addCan(const Container_const_sptr &can) {
   if (can->id().empty()) {
     throw std::invalid_argument("SampleEnvironmentSpec::addCan() - Can must "
                                 "have an id field. Empty string found.");

--- a/Framework/Geometry/src/Instrument/SampleEnvironmentSpecParser.cpp
+++ b/Framework/Geometry/src/Instrument/SampleEnvironmentSpecParser.cpp
@@ -23,8 +23,8 @@ namespace {
 std::string MATERIALS_TAG = "materials";
 std::string COMPONENTS_TAG = "components";
 std::string COMPONENT_TAG = "component";
-std::string CANS_TAG = "cans";
-std::string CAN_TAG = "can";
+std::string CONTAINERS_TAG = "containers";
+std::string CONTAINER_TAG = "container";
 std::string COMPONENTGEOMETRY_TAG = "geometry";
 std::string SAMPLEGEOMETRY_TAG = "samplegeometry";
 }
@@ -154,8 +154,8 @@ void SampleEnvironmentSpecParser::parseAndAddComponents(
   while (node) {
     Element *childElement = static_cast<Element *>(node);
     const auto &nodeName = childElement->nodeName();
-    if (nodeName == CANS_TAG) {
-      parseAndAddCans(spec, childElement);
+    if (nodeName == CONTAINERS_TAG) {
+      parseAndAddContainers(spec, childElement);
     } else if (nodeName == COMPONENT_TAG) {
       spec->addComponent(parseComponent<Object>(childElement));
     }
@@ -164,20 +164,20 @@ void SampleEnvironmentSpecParser::parseAndAddComponents(
 }
 
 /**
- * Take a \<cans\> tag, parse the definitions and add them to the spec.
+ * Take a \<containers\> tag, parse the definitions and add them to the spec.
  * It requires the materials to have been parsed.
  * @param spec A pointer to a SampleEnvironmentSpec to update
  * @param element A pointer to a cans element
  */
-void SampleEnvironmentSpecParser::parseAndAddCans(SampleEnvironmentSpec *spec,
-                                                  Element *element) const {
+void SampleEnvironmentSpecParser::parseAndAddContainers(
+    SampleEnvironmentSpec *spec, Element *element) const {
   NodeIterator nodeIter(element, NodeFilter::SHOW_ELEMENT);
   nodeIter.nextNode();
   Node *node = nodeIter.nextNode();
   while (node) {
     Element *childElement = static_cast<Element *>(node);
-    if (childElement->nodeName() == CAN_TAG) {
-      spec->addCan(parseCan(childElement));
+    if (childElement->nodeName() == CONTAINER_TAG) {
+      spec->addCan(parseContainer(childElement));
     }
     node = nodeIter.nextNode();
   }
@@ -185,12 +185,13 @@ void SampleEnvironmentSpecParser::parseAndAddCans(SampleEnvironmentSpec *spec,
 
 /**
  * Parse a single definition of a Can
- * @param element A pointer to an XML \<can\> element
+ * @param element A pointer to an XML \<container\> element
  * @return A new Can instance
  */
-Can_const_sptr SampleEnvironmentSpecParser::parseCan(Element *element) const {
-  using Mantid::Geometry::Can;
-  auto can = parseComponent<Can>(element);
+Container_const_sptr
+SampleEnvironmentSpecParser::parseContainer(Element *element) const {
+  using Mantid::Geometry::Container;
+  auto can = parseComponent<Container>(element);
   auto sampleGeometry = element->getChildElement(SAMPLEGEOMETRY_TAG);
   if (sampleGeometry) {
     DOMWriter writer;
@@ -204,7 +205,7 @@ Can_const_sptr SampleEnvironmentSpecParser::parseCan(Element *element) const {
 /**
  * Parse a single definition of a component. If the component is a can the
  * sample geometry, if available, is also parsed.
- * @param element A pointer to an XML \<can\> element
+ * @param element A pointer to an XML \<container\> element
  * @return A new Object instance of the given type
  */
 template <typename ObjectType>
@@ -238,7 +239,7 @@ Mantid::Geometry::SampleEnvironmentSpecParser::parseComponent(
 ///@cond
 template boost::shared_ptr<Object>
 Mantid::Geometry::SampleEnvironmentSpecParser::parseComponent(Element *) const;
-template boost::shared_ptr<Can>
+template boost::shared_ptr<Container>
 Mantid::Geometry::SampleEnvironmentSpecParser::parseComponent(Element *) const;
 ///@endcond
 

--- a/Framework/Geometry/src/Objects/ShapeFactory.cpp
+++ b/Framework/Geometry/src/Objects/ShapeFactory.cpp
@@ -2,7 +2,7 @@
 // Includes
 //----------------------------------------------------------------------
 
-#include "MantidGeometry/Instrument/Can.h"
+#include "MantidGeometry/Instrument/Container.h"
 #include "MantidGeometry/Objects/Object.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
 #include "MantidGeometry/Rendering/GluGeometryHandler.h"
@@ -1485,12 +1485,12 @@ void ShapeFactory::createGeometryHandler(Poco::XML::Element *pElem,
 // Template instantations
 template MANTID_GEOMETRY_DLL boost::shared_ptr<Object>
 ShapeFactory::createShape(std::string shapeXML, bool addTypeTag);
-template MANTID_GEOMETRY_DLL boost::shared_ptr<Can>
+template MANTID_GEOMETRY_DLL boost::shared_ptr<Container>
 ShapeFactory::createShape(std::string shapeXML, bool addTypeTag);
 
 template MANTID_GEOMETRY_DLL boost::shared_ptr<Object>
 ShapeFactory::createShape(Poco::XML::Element *pElem);
-template MANTID_GEOMETRY_DLL boost::shared_ptr<Can>
+template MANTID_GEOMETRY_DLL boost::shared_ptr<Container>
 ShapeFactory::createShape(Poco::XML::Element *pElem);
 ///@endcond
 

--- a/Framework/Geometry/test/ContainerTest.h
+++ b/Framework/Geometry/test/ContainerTest.h
@@ -3,28 +3,28 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidGeometry/Instrument/Can.h"
+#include "MantidGeometry/Instrument/Container.h"
 #include "MantidGeometry/Objects/Rules.h"
 #include "MantidGeometry/Surfaces/Sphere.h"
 
 #include <boost/make_shared.hpp>
 
-using Mantid::Geometry::Can;
+using Mantid::Geometry::Container;
 
-class CanTest : public CxxTest::TestSuite {
+class ContainerTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static CanTest *createSuite() { return new CanTest(); }
-  static void destroySuite(CanTest *suite) { delete suite; }
+  static ContainerTest *createSuite() { return new ContainerTest(); }
+  static void destroySuite(ContainerTest *suite) { delete suite; }
 
   // ---------------------------------------------------------------------------
   // Success tests
   // ---------------------------------------------------------------------------
   void test_Default_Constructor_Has_No_Sample_Shape() {
-    Can can;
+    Container can;
     TS_ASSERT_EQUALS(false, can.hasSampleShape());
-    TS_ASSERT_THROWS(can.createSampleShape(Can::ShapeArgs()),
+    TS_ASSERT_THROWS(can.createSampleShape(Container::ShapeArgs()),
                      std::runtime_error);
   }
 
@@ -35,7 +35,7 @@ public:
                       "<radius val=\"0.0030\" />"
                       "<height val=\"0.05\" />"
                       "</cylinder>";
-    Can can(xml);
+    Container can(xml);
     TS_ASSERT_EQUALS(false, can.hasSampleShape());
     TS_ASSERT_EQUALS(xml, can.getShapeXML());
   }
@@ -47,8 +47,8 @@ public:
                         "<radius val=\"1.0\" /> "
                         "</sphere></samplegeometry>");
     Object_sptr sampleShape;
-    TS_ASSERT_THROWS_NOTHING(sampleShape =
-                                 can->createSampleShape(Can::ShapeArgs()));
+    TS_ASSERT_THROWS_NOTHING(
+        sampleShape = can->createSampleShape(Container::ShapeArgs()));
     TS_ASSERT(sampleShape->hasValidShape());
     TS_ASSERT_DELTA(1.0, getSphereRadius(*sampleShape), 1e-10);
   }
@@ -60,7 +60,7 @@ public:
                         "<radius val=\"1.0\" /> "
                         "</sphere></samplegeometry>");
     Object_sptr sampleShape;
-    Can::ShapeArgs args = {{"radius", 0.5}};
+    Container::ShapeArgs args = {{"radius", 0.5}};
     TS_ASSERT_THROWS_NOTHING(sampleShape = can->createSampleShape(args));
     TS_ASSERT(sampleShape->hasValidShape());
     TS_ASSERT_DELTA(0.5, getSphereRadius(*sampleShape), 1e-10);
@@ -73,7 +73,7 @@ public:
                         "<radius val=\"1.0\" /> "
                         "</sphere></samplegeometry>");
     Object_sptr sampleShape;
-    Can::ShapeArgs args = {{"height", 0.5}};
+    Container::ShapeArgs args = {{"height", 0.5}};
     TS_ASSERT_THROWS_NOTHING(sampleShape = can->createSampleShape(args));
     TS_ASSERT(sampleShape->hasValidShape());
     TS_ASSERT_DELTA(1.0, getSphereRadius(*sampleShape), 1e-10);
@@ -91,8 +91,8 @@ public:
   }
 
 private:
-  Mantid::Geometry::Can_sptr createTestCan() {
-    return boost::make_shared<Can>(
+  Mantid::Geometry::Container_sptr createTestCan() {
+    return boost::make_shared<Container>(
         "<type name=\"usertype\"><cylinder>"
         "<centre-of-bottom-base x=\"0.0\" y=\"0.0\" z=\"0.0\" />"
         "<axis x=\"0.0\" y=\"1.0\" z=\"0\" />"

--- a/Framework/Geometry/test/SampleEnvironmentFactoryTest.h
+++ b/Framework/Geometry/test/SampleEnvironmentFactoryTest.h
@@ -3,7 +3,7 @@
 
 #include <cxxtest/TestSuite.h>
 #include "MantidGeometry/Instrument/SampleEnvironmentFactory.h"
-#include "MantidGeometry/Instrument/Can.h"
+#include "MantidGeometry/Instrument/Container.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
 
 #include "MantidTestHelpers/ComponentCreationHelper.h"

--- a/Framework/Geometry/test/SampleEnvironmentSpecFileFinderTest.h
+++ b/Framework/Geometry/test/SampleEnvironmentSpecFileFinderTest.h
@@ -39,8 +39,8 @@ public:
                             "  <material id=\"van\" formula=\"V\"/>"
                             " </materials>"
                             " <components>"
-                            "  <cans>"
-                            "   <can id=\"10mm\" material=\"van\">"
+                            "  <containers>"
+                            "   <container id=\"10mm\" material=\"van\">"
                             "    <geometry>"
                             "     <sphere id=\"sp-1\">"
                             "      <radius val=\"0.1\"/>"
@@ -53,8 +53,8 @@ public:
                             "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
                             "     </sphere>"
                             "    </samplegeometry>"
-                            "   </can>"
-                            "  </cans>"
+                            "   </container>"
+                            "  </containers>"
                             " </components>"
                             "</environmentspec>";
     Poco::File envFile(Poco::Path(testDirec, m_envName + ".xml"));

--- a/Framework/Geometry/test/SampleEnvironmentSpecParserTest.h
+++ b/Framework/Geometry/test/SampleEnvironmentSpecParserTest.h
@@ -4,7 +4,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidGeometry/Instrument/SampleEnvironmentSpecParser.h"
-#include "MantidGeometry/Instrument/Can.h"
+#include "MantidGeometry/Instrument/Container.h"
 
 #include "Poco/AutoPtr.h"
 #include "Poco/SAX/InputSource.h"
@@ -32,7 +32,7 @@ public:
   // Success tests
   //----------------------------------------------------------------------------
   void test_Single_Can_Single_Material_With_SampleGeometry() {
-    using Mantid::Geometry::Can_const_sptr;
+    using Mantid::Geometry::Container_const_sptr;
 
     const std::string name = "CRYO001";
     auto spec = parseSpec(name, "<environmentspec>"
@@ -40,8 +40,8 @@ public:
                                 "  <material id=\"van\" formula=\"V\"/>"
                                 " </materials>"
                                 " <components>"
-                                "  <cans>"
-                                "   <can id=\"10mm\" material=\"van\">"
+                                "  <containers>"
+                                "   <container id=\"10mm\" material=\"van\">"
                                 "    <geometry>"
                                 "     <sphere id=\"sp-1\">"
                                 "      <radius val=\"0.1\"/>"
@@ -54,15 +54,15 @@ public:
                                 "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
                                 "     </sphere>"
                                 "    </samplegeometry>"
-                                "   </can>"
-                                "  </cans>"
+                                "   </container>"
+                                "  </containers>"
                                 " </components>"
                                 "</environmentspec>");
 
     TS_ASSERT_EQUALS(name, spec->name());
     TS_ASSERT_EQUALS(1, spec->ncans());
     TS_ASSERT_EQUALS(0, spec->ncomponents());
-    Can_const_sptr can10mm;
+    Container_const_sptr can10mm;
     TS_ASSERT_THROWS_NOTHING(can10mm = spec->findCan("10mm"));
     TS_ASSERT(can10mm);
     TS_ASSERT_EQUALS("10mm", can10mm->id());
@@ -71,7 +71,7 @@ public:
   }
 
   void test_Single_Can_Single_Material_With_No_SampleGeometry() {
-    using Mantid::Geometry::Can_const_sptr;
+    using Mantid::Geometry::Container_const_sptr;
 
     const std::string name = "CRYO001";
     auto spec = parseSpec(name, "<environmentspec>"
@@ -79,23 +79,23 @@ public:
                                 "  <material id=\"van\" formula=\"V\"/>"
                                 " </materials>"
                                 " <components>"
-                                "  <cans>"
-                                "   <can id=\"10mm\" material=\"van\">"
+                                "  <containers>"
+                                "   <container id=\"10mm\" material=\"van\">"
                                 "    <geometry>"
                                 "     <sphere id=\"sp-1\">"
                                 "      <radius val=\"0.1\"/>"
                                 "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
                                 "     </sphere>"
                                 "    </geometry>"
-                                "   </can>"
-                                "  </cans>"
+                                "   </container>"
+                                "  </containers>"
                                 " </components>"
                                 "</environmentspec>");
 
     TS_ASSERT_EQUALS(name, spec->name());
     TS_ASSERT_EQUALS(1, spec->ncans());
     TS_ASSERT_EQUALS(0, spec->ncomponents());
-    Can_const_sptr can10mm;
+    Container_const_sptr can10mm;
     TS_ASSERT_THROWS_NOTHING(can10mm = spec->findCan("10mm"));
     TS_ASSERT(can10mm);
     TS_ASSERT_EQUALS("10mm", can10mm->id());
@@ -104,7 +104,7 @@ public:
   }
 
   void test_Single_Can_And_Single_Componenent_With_SampleGeometry() {
-    using Mantid::Geometry::Can_const_sptr;
+    using Mantid::Geometry::Container_const_sptr;
 
     const std::string name = "CRYO001";
     auto spec = parseSpec(name, "<environmentspec>"
@@ -113,8 +113,8 @@ public:
                                 "  <material id=\"alum\" formula=\"Al\"/>"
                                 " </materials>"
                                 " <components>"
-                                "  <cans>"
-                                "   <can id=\"10mm\" material=\"van\">"
+                                "  <containers>"
+                                "   <container id=\"10mm\" material=\"van\">"
                                 "    <geometry>"
                                 "     <sphere id=\"sp-1\">"
                                 "      <radius val=\"0.1\"/>"
@@ -127,8 +127,8 @@ public:
                                 "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
                                 "     </sphere>"
                                 "    </samplegeometry>"
-                                "   </can>"
-                                "  </cans>"
+                                "   </container>"
+                                "  </containers>"
                                 "  <component id=\"outer\" material=\"alum\">"
                                 "    <geometry>"
                                 "     <sphere id=\"sp-1\">"
@@ -142,7 +142,7 @@ public:
 
     TS_ASSERT_EQUALS(name, spec->name());
     TS_ASSERT_EQUALS(1, spec->ncans());
-    Can_const_sptr can10mm;
+    Container_const_sptr can10mm;
     TS_ASSERT_THROWS_NOTHING(can10mm = spec->findCan("10mm"));
     TS_ASSERT(can10mm);
     TS_ASSERT_EQUALS("10mm", can10mm->id());
@@ -153,7 +153,7 @@ public:
   }
 
   void test_Multiple_Cans_And_Muliple_Componenents_With_SampleGeometry() {
-    using Mantid::Geometry::Can_const_sptr;
+    using Mantid::Geometry::Container_const_sptr;
 
     const std::string name = "CRYO001";
     auto spec = parseSpec(name, "<environmentspec>"
@@ -162,8 +162,8 @@ public:
                                 "  <material id=\"alum\" formula=\"Al\"/>"
                                 " </materials>"
                                 " <components>"
-                                "  <cans>"
-                                "   <can id=\"8mm\" material=\"alum\">"
+                                "  <containers>"
+                                "   <container id=\"8mm\" material=\"alum\">"
                                 "    <geometry>"
                                 "     <sphere id=\"sp-1\">"
                                 "      <radius val=\"0.05\"/>"
@@ -176,8 +176,8 @@ public:
                                 "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
                                 "     </sphere>"
                                 "    </samplegeometry>"
-                                "   </can>"
-                                "   <can id=\"10mm\" material=\"van\">"
+                                "   </container>"
+                                "   <container id=\"10mm\" material=\"van\">"
                                 "    <geometry>"
                                 "     <sphere id=\"sp-1\">"
                                 "      <radius val=\"0.1\"/>"
@@ -190,8 +190,8 @@ public:
                                 "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
                                 "     </sphere>"
                                 "    </samplegeometry>"
-                                "   </can>"
-                                "  </cans>"
+                                "   </container>"
+                                "  </containers>"
                                 "  <component id=\"outer1\" material=\"alum\">"
                                 "    <geometry>"
                                 "     <sphere id=\"sp-1\">"
@@ -215,7 +215,7 @@ public:
     TS_ASSERT_EQUALS(2, spec->ncomponents());
     TS_ASSERT_EQUALS(2, spec->ncans());
     // 10mm
-    Can_const_sptr can10mm;
+    Container_const_sptr can10mm;
     TS_ASSERT_THROWS_NOTHING(can10mm = spec->findCan("10mm"));
     TS_ASSERT(can10mm);
     TS_ASSERT_EQUALS("10mm", can10mm->id());
@@ -223,7 +223,7 @@ public:
     TS_ASSERT_EQUALS("van", can10mm->material().name());
     TS_ASSERT(can10mm->hasSampleShape());
     // 8mm
-    Can_const_sptr can8mm;
+    Container_const_sptr can8mm;
     TS_ASSERT_THROWS_NOTHING(can8mm = spec->findCan("8mm"));
     TS_ASSERT(can8mm);
     TS_ASSERT_EQUALS("8mm", can8mm->id());
@@ -249,7 +249,7 @@ public:
   }
 
   void test_Missing_Geometry_Tag_Under_Can_Throws_Error() {
-    using Mantid::Geometry::Can_const_sptr;
+    using Mantid::Geometry::Container_const_sptr;
 
     const std::string name = "CRYO001";
     TS_ASSERT_THROWS(parseSpec(name,
@@ -258,8 +258,8 @@ public:
                                "  <material id=\"van\" formula=\"V\"/>"
                                " </materials>"
                                " <components>"
-                               "  <cans>"
-                               "   <can id=\"10mm\" material=\"van\">"
+                               "  <containers>"
+                               "   <container id=\"10mm\" material=\"van\">"
                                "     <sphere id=\"sp-1\">"
                                "      <radius val=\"0.1\"/>"
                                "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
@@ -270,15 +270,15 @@ public:
                                "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
                                "     </sphere>"
                                "    </samplegeometry>"
-                               "   </can>"
-                               "  </cans>"
+                               "   </container>"
+                               "  </containers>"
                                " </components>"
                                "</environmentspec>"),
                      std::runtime_error);
   }
 
   void test_Missing_Can_ID_Throws_Error() {
-    using Mantid::Geometry::Can_const_sptr;
+    using Mantid::Geometry::Container_const_sptr;
 
     const std::string name = "CRYO001";
     TS_ASSERT_THROWS(parseSpec(name,
@@ -287,8 +287,8 @@ public:
                                "  <material id=\"van\" formula=\"V\"/>"
                                " </materials>"
                                " <components>"
-                               "  <cans>"
-                               "   <can material=\"van\">"
+                               "  <containers>"
+                               "   <container material=\"van\">"
                                "     <sphere id=\"sp-1\">"
                                "      <radius val=\"0.1\"/>"
                                "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
@@ -299,15 +299,15 @@ public:
                                "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
                                "     </sphere>"
                                "    </samplegeometry>"
-                               "   </can>"
-                               "  </cans>"
+                               "   </container>"
+                               "  </containers>"
                                " </components>"
                                "</environmentspec>"),
                      std::runtime_error);
   }
 
   void test_Missing_Material_For_Can_Throws_Error() {
-    using Mantid::Geometry::Can_const_sptr;
+    using Mantid::Geometry::Container_const_sptr;
 
     const std::string name = "CRYO001";
     TS_ASSERT_THROWS(parseSpec(name,
@@ -316,8 +316,8 @@ public:
                                "  <material id=\"van\" formula=\"V\"/>"
                                " </materials>"
                                " <components>"
-                               "  <cans>"
-                               "   <can id=\"10mm\">"
+                               "  <containers>"
+                               "   <container id=\"10mm\">"
                                "     <sphere id=\"sp-1\">"
                                "      <radius val=\"0.1\"/>"
                                "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
@@ -328,8 +328,8 @@ public:
                                "      <centre x=\"0.0\"  y=\"0.0\" z=\"0.0\"/>"
                                "     </sphere>"
                                "    </samplegeometry>"
-                               "   </can>"
-                               "  </cans>"
+                               "   </container>"
+                               "  </containers>"
                                " </components>"
                                "</environmentspec>"),
                      std::runtime_error);

--- a/Framework/Geometry/test/SampleEnvironmentSpecTest.h
+++ b/Framework/Geometry/test/SampleEnvironmentSpecTest.h
@@ -29,9 +29,9 @@ public:
   }
 
   void test_Add_Can_Stores_Can_Linked_To_ID() {
-    using Mantid::Geometry::Can;
+    using Mantid::Geometry::Container;
     SampleEnvironmentSpec spec("CRYO-001");
-    auto testCan = boost::make_shared<Can>("");
+    auto testCan = boost::make_shared<Container>("");
     testCan->setID("8mm");
 
     TS_ASSERT_EQUALS(0, spec.ncans());
@@ -51,7 +51,7 @@ public:
   }
 
   void test_buildEnvironment_Creates_Expected_Environment() {
-    using Mantid::Geometry::Can;
+    using Mantid::Geometry::Container;
     using Mantid::Geometry::ShapeFactory;
     using Mantid::Kernel::V3D;
 
@@ -79,22 +79,22 @@ public:
   // Failure tests
   //----------------------------------------------------------------------------
   void test_Add_Can_With_Empty_ID_Throws_Invalid_Argument() {
-    using Mantid::Geometry::Can;
+    using Mantid::Geometry::Container;
     SampleEnvironmentSpec spec("CRYO-001");
-    auto testCan = boost::make_shared<const Can>("");
+    auto testCan = boost::make_shared<const Container>("");
 
     TS_ASSERT_THROWS(spec.addCan(testCan), std::invalid_argument);
   }
 
   void test_Find_Throws_If_ID_Not_Found() {
-    using Mantid::Geometry::Can;
+    using Mantid::Geometry::Container;
     SampleEnvironmentSpec spec("CRYO-001");
 
     TS_ASSERT_THROWS(spec.findCan("8mm"), std::invalid_argument);
   }
 
   void test_BuildEnvironment_Throws_If_ID_Not_Found() {
-    using Mantid::Geometry::Can;
+    using Mantid::Geometry::Container;
     SampleEnvironmentSpec spec("CRYO-001");
 
     TS_ASSERT_THROWS(spec.buildEnvironment("8mm"), std::invalid_argument);

--- a/Framework/Geometry/test/SampleEnvironmentTest.h
+++ b/Framework/Geometry/test/SampleEnvironmentTest.h
@@ -21,14 +21,14 @@ public:
   static void destroySuite(SampleEnvironmentTest *suite) { delete suite; }
 
   void test_Constructor_Sets_Name_And_Single_Element() {
-    using Mantid::Geometry::Can;
-    auto can = boost::make_shared<Can>("");
+    using Mantid::Geometry::Container;
+    auto can = boost::make_shared<Container>("");
     can->setID("8mm");
 
     SampleEnvironment kit("TestKit", can);
     TS_ASSERT_EQUALS(kit.name(), "TestKit");
-    TS_ASSERT_EQUALS(kit.canID(), "8mm");
-    TS_ASSERT_EQUALS(kit.can(), can);
+    TS_ASSERT_EQUALS(kit.containerID(), "8mm");
+    TS_ASSERT_EQUALS(kit.container(), can);
     TS_ASSERT_EQUALS(1, kit.nelements());
   }
 

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -10,6 +10,7 @@ DEFAULT_RANGE = [6.24, 6.30]
 DEFAULT_MASK_GROUP_DIR = "/SNS/BSS/shared/autoreduce"
 DEFAULT_MASK_FILE = "BASIS_Mask.xml"
 DEFAULT_VANADIUM_ENERGY_RANGE = [-0.0034, 0.0034]  # meV
+DEFAULT_VANADIUM_BINS = [-0.0034, 0.068, 0.0034]  # meV
 
 #pylint: disable=too-many-instance-attributes
 class BASISReduction(PythonAlgorithm):
@@ -26,12 +27,6 @@ class BASISReduction(PythonAlgorithm):
     _overrideMask = None
     _dMask = None
 
-    # class variables related to division by Vanadium (normalization)
-    _normRange = None
-    _norm_run_list = None
-    _normWs = None
-    _normMonWs = None
-
     _run_list = None  # a list of runs, or a list of sets of runs
     _samWs = None
     _samMonWs = None
@@ -40,8 +35,15 @@ class BASISReduction(PythonAlgorithm):
 
     def __init__(self):
         PythonAlgorithm.__init__(self)
-        self._doNorm = None  # stores the selected item from normalization_types
+
         self._normalizeToFirst = False
+        # variables related to division by Vanadium (normalization)
+        self._doNorm = None  # stores the selected item from normalization_types
+        self._normalizationType = None
+        self._normRange = None
+        self._norm_run_list = None
+        self._normWs = None
+        self._normMonWs = None
 
     def category(self):
         return "Inelastic\\Reduction"
@@ -147,8 +149,8 @@ class BASISReduction(PythonAlgorithm):
         if self._doNorm and bool(norm_runs):
             if ";" in norm_runs:
                 raise SyntaxError("Normalization does not support run groups")
-            self._doNorm = self.getProperty("NormalizationType").value
-            self.log().information("Divide by Vanadium with normalization" + self._doNorm)
+            self._normalizationType = self.getProperty("NormalizationType").value
+            self.log().information("Divide by Vanadium with normalization" + self._normalizationType)
 
             # The following steps are common to all types of Vanadium normalization
 
@@ -158,7 +160,7 @@ class BASISReduction(PythonAlgorithm):
             self._normWs = self._sum_and_calibrate(norm_set, extra_extension="_norm")
 
             # This rebin integrates counts onto a histogram of a single bin
-            if self._doNorm == "by detectorID":
+            if self._normalizationType == "by detectorID":
                 normRange = self.getProperty("NormWavelengthRange").value
                 self._normRange = [normRange[0], normRange[1]-normRange[0], normRange[1]]
                 api.Rebin(InputWorkspace=self._normWs, OutputWorkspace=self._normWs,
@@ -169,8 +171,10 @@ class BASISReduction(PythonAlgorithm):
                                            OutputWorkspace="BASIS_NORM_MASK")
 
             # additional reduction steps when normalizing by Q slice
-            if self._doNorm == "by Q slice":
-                self._normWs = self._group_and_SofQW(self._normWs, self._etBins, isSample=False)
+            if self._normalizationType == "by Q slice":
+                self._normWs = self._group_and_SofQW(self._normWs,
+                                                     DEFAULT_VANADIUM_BINS,
+                                                     isSample=False)
 
         ##########################
         ##  Process the sample  ##
@@ -185,16 +189,13 @@ class BASISReduction(PythonAlgorithm):
                 api.MaskDetectors(Workspace=self._samWs,
                                   MaskedWorkspace='BASIS_NORM_MASK')
             # Divide by Vanadium
-            if self._doNorm == "by detector ID":
+            if self._normalizationType == "by detector ID":
                 api.Divide(LHSWorkspace=self._samWs, RHSWorkspace=self._normWs,
                            OutputWorkspace=self._samWs)
             # additional reduction steps
             self._samSqwWs = self._group_and_SofQW(self._samWs, self._etBins, isSample=True)
             # Divide by Vanadium
-            if self._doNorm == "by Q slice":
-                api.Integration(InputWorkspace=self._normWs, OutputWorkspace=self._normWs,
-                                RangeLower=DEFAULT_VANADIUM_ENERGY_RANGE[0],
-                                RangeUpper=DEFAULT_VANADIUM_ENERGY_RANGE[1])
+            if self._normalizationType == "by Q slice":
                 api.Divide(LHSWorkspace=self._samSqwWs, RHSWorkspace=self._normWs,
                            OutputWorkspace=self._samSqwWs)
             # Clear mask from reduced file. Needed for binary operations
@@ -331,6 +332,8 @@ class BASISReduction(PythonAlgorithm):
     def _group_and_SofQW(self, wsName, etRebins, isSample=True):
         """ Transforms from wavelength and detector ID to S(Q,E)
         @param wsName: workspace as a function of wavelength and detector id
+        @param etRebins: final energy domain and bin width
+        @param isSample: discriminates between sample and vanadium
         @return: S(Q,E)
         """
         api.ConvertUnits(InputWorkspace=wsName,

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -163,7 +163,7 @@ namespace CustomInterfaces
     {
       auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(sqwWsName.toStdString());
       int numHist = static_cast<int>(ws->getNumberHistograms());
-      plotSpectrum(sqwWsName, 0, numHist);
+      plotSpectrum(sqwWsName, 0, numHist-1);
     }
   }
 

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -94,6 +94,7 @@ Bugfixes
 - In the *I(Q, t) Fit* interface, checking the plot guess check box now correctly adds and removes the curve from the plot
 - In the *BayesQuasi* interface ResNorm files are now automatically loaded from file locations when entered.
 - :ref:`LoadVesuvio <algm-LoadVesuvio>` now correctly parses input in the form 10-20,30-40,50-60
+- Using the Spectra option in *S(Q,w)* interface now works correctly
 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
The term **can** has been replaced with **container** within the sample environment definitions (#16110). Can was felt to be to specific and container was agreed to sound more generic.

This is not in active use yet so I would like to put this in 3.7 so that the definition starts out correct for users. 

**To test:**

All tests should pass.

Fixes #16346. 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Refs #16346
