### PR TITLE
Fix Coverity issue #1355932

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmHistory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmHistory.h
@@ -153,15 +153,15 @@ private:
   /// The name of the Algorithm
   std::string m_name;
   /// The version of the algorithm
-  int m_version;
+  int m_version{-1};
   /// The execution date of the algorithm
   Mantid::Kernel::DateAndTime m_executionDate;
   /// The execution duration of the algorithm
-  double m_executionDuration;
+  double m_executionDuration{-1.0};
   /// The PropertyHistory's defined for the algorithm
   Mantid::Kernel::PropertyHistories m_properties;
   /// count keeps track of execution order of an algorithm
-  std::size_t m_execCount;
+  std::size_t m_execCount{0};
   /// set of child algorithm histories for this history record
   AlgorithmHistories m_childHistories;
 };


### PR DESCRIPTION
Description of work.

This fixes Coverity issue #1355932, which found three uninitialized member variables in `AlgorithmHistory`.

This sets `m_version=-1`, `m_executionDuration=-1.0` and `m_execCount = 0` which, if these values are not later set by a member function, should make it clear to others that something is wrong.

**To test:**

<!-- Instructions for testing. -->

Verify that these are sensible default values.

This is a small change with no issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
