### PR TITLE
Fix crash on startup on OSX when querying the proxy information

### DIFF
--- a/Framework/Kernel/src/NetworkProxyOSX.cpp
+++ b/Framework/Kernel/src/NetworkProxyOSX.cpp
@@ -14,20 +14,20 @@ namespace Kernel {
 
 /**
  * Helper function to convert CFStringRefs to std::string
- * @param stringRef : CRFStringRef variable
- * @return std::string
+ * @param str : CRFStringRef variable
+ * @return std::string containing the contents of the input string
  */
-std::string toString(CFStringRef stringRef) {
-  std::string buffer;
-  const int max_size = 1000;
-  buffer.resize(max_size);
-  CFStringGetCString(stringRef, &buffer[0], max_size, kCFStringEncodingUTF8);
-  // Strip out whitespace
-  std::stringstream trimmer;
-  trimmer << buffer;
-  buffer.clear();
-  trimmer >> buffer;
-  return buffer;
+std::string toString(CFStringRef str) {
+  if (!str)
+    return std::string();
+  CFIndex length = CFStringGetLength(str);
+  const UniChar *chars = CFStringGetCharactersPtr(str);
+  if (chars)
+    return std::string(reinterpret_cast<const char *>(chars), length);
+
+  std::vector<UniChar> buffer(length);
+  CFStringGetCharacters(str, CFRangeMake(0, length), buffer.data());
+  return std::string(reinterpret_cast<const char *>(buffer.data()), length);
 }
 
 /**


### PR DESCRIPTION
See #16369 for the full details with the crash report.

**To test:**

This will need to be tested at ISIS on an OSX machine. The instructions to try and reproduce the crash are in the issue.

Fixes #16369 

TODO: This should be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
