### PR TITLE
Fix issue with SANS data stitching (release 3.7)

### DIFF
--- a/scripts/LargeScaleStructures/data_stitching.py
+++ b/scripts/LargeScaleStructures/data_stitching.py
@@ -1,13 +1,16 @@
 #pylint: disable=invalid-name
+"""
+    Data stitching for SANS and reflectometry
+"""
 import os
 from mantid.simpleapi import *
 from mantid.kernel import Logger
 
-IS_IN_MANTIDPLOT = True
 try:
     import mantidplot
     from PyQt4 import QtCore
-except:
+    IS_IN_MANTIDPLOT = True
+except(ImportError, ImportWarning):
     IS_IN_MANTIDPLOT = False
 
 class RangeSelector(object):
@@ -18,7 +21,9 @@ class RangeSelector(object):
     __instance = None
 
     class _Selector(object):
-
+        """
+            Selector class for selecting ranges in Mantidplot
+        """
         def __init__(self):
             self._call_back = None
             self._ws_output_base = None
@@ -51,9 +56,9 @@ class RangeSelector(object):
 
             g = mantidplot.plotSpectrum(ws, [0], True)
             g.setName(self._graph)
-            l=g.activeLayer()
+            l = g.activeLayer()
             try:
-                title = ws[0].replace("_"," ")
+                title = ws[0].replace("_", " ")
                 title.strip()
             except:
                 title = " "
@@ -64,7 +69,7 @@ class RangeSelector(object):
             if x_title is not None:
                 l.setXTitle(x_title)
             if xmin is not None and xmax is not None:
-                l.setScale(2,xmin,xmax)
+                l.setScale(2, xmin, xmax)
 
             if range_min is not None and range_max is not None:
                 mantidplot.selectMultiPeak(g, False, range_min, range_max)
@@ -75,7 +80,9 @@ class RangeSelector(object):
     def connect(cls, ws, call_back, xmin=None, xmax=None,
                 range_min=None, range_max=None, x_title=None,
                 log_scale=False, ws_output_base=None):
-
+        """
+            Connect method for the range selector
+        """
         if RangeSelector.__instance is not None:
             RangeSelector.__instance.disconnect()
         else:
@@ -138,12 +145,12 @@ class DataSet(object):
             xmax = x[len(x)-1]
 
             for i in range(len(y)):
-                if y[i]!=0.0:
+                if y[i] != 0.0:
                     xmin = x[i+self._skip_first]
                     break
 
-            for i in range(len(y)-1,-1,-1):
-                if y[i]!=0.0:
+            for i in range(len(y)-1, -1, -1):
+                if y[i] != 0.0:
                     xmax = x[i-self._skip_last]
                     break
 
@@ -203,13 +210,10 @@ class DataSet(object):
 
         # Put back dQ
         dq_scaled = mtd[self._ws_scaled].dataDx(0)
-        for i in range(len(dq)):
+        for i in range(len(dq_scaled)):
             dq_scaled[i] = dq[i]
 
         if xmin is not None and xmax is not None:
-            # Make sure we have point data
-            ConvertToPointData(InputWorkspace=self._ws_scaled,
-                               OutputWorkspace=self._ws_scaled)
             x = mtd[self._ws_scaled].readX(0)
             dx = dq_scaled
             y = mtd[self._ws_scaled].readY(0)
@@ -220,7 +224,7 @@ class DataSet(object):
             y_trim = []
             e_trim = []
             for i in range(len(y)):
-                if x[i]>=xmin and x[i]<=xmax:
+                if x[i] >= xmin and x[i] <= xmax:
                     x_trim.append(x[i])
                     dx_trim.append(dx[i])
                     y_trim.append(y[i])
@@ -249,7 +253,7 @@ class DataSet(object):
             # Get rid of points with an error greater than the intensity
             if self._restricted_range:
                 for i in range(len(y_scaled)):
-                    if y_scaled[i]<=e_scaled[i]:
+                    if y_scaled[i] <= e_scaled[i]:
                         y_scaled[i] = 0
                         e_scaled[i] = 0
 
@@ -270,9 +274,16 @@ class DataSet(object):
         elif mtd.doesExist(self._file_path):
             self._ws_name = self._file_path
         else:
-            raise RuntimeError, "Specified file doesn't exist: %s" % self._file_path
+            raise RuntimeError("Specified file doesn't exist: %s" % self._file_path)
 
         if mtd.doesExist(self._ws_name):
+            # If we have hisogram data, convert it first.
+            # Make sure not to modify the original workspace.
+            if mtd[self._ws_name].isHistogramData():
+                point_data_ws = '%s_' % self._ws_name
+                ConvertToPointData(InputWorkspace=self._ws_name,
+                                   OutputWorkspace=point_data_ws)
+                self._ws_name = point_data_ws
             self._ws_scaled = self._ws_name+"_scaled"
             if update_range:
                 self._restricted_range = restricted_range
@@ -283,11 +294,11 @@ class DataSet(object):
                     x = mtd[self._ws_name].readX(0)
 
                     for i in range(len(y)):
-                        if y[i]!=0.0:
+                        if y[i] != 0.0:
                             self._xmin = x[i]
                             break
-                    for i in range(len(y)-1,-1,-1):
-                        if y[i]!=0.0:
+                    for i in range(len(y)-1, -1, -1):
+                        if y[i] != 0.0:
                             self._xmax = x[i]
                             break
 
@@ -302,17 +313,17 @@ class DataSet(object):
         x = mtd[self._ws_name].readX(0)
         y = mtd[self._ws_name].readY(0)
         e = mtd[self._ws_name].readE(0)
-        sum = 0.0
+        sum_cts = 0.0
         sum_err = 0.0
         for i in range(len(y)):
             upper_bound = x[i]
-            if len(x)==len(y)+1:
+            if len(x) == len(y)+1:
                 upper_bound = x[i+1]
-            if x[i]>=xmin and upper_bound<=xmax:
-                sum += y[i]/(e[i]*e[i])
+            if x[i] >= xmin and upper_bound <= xmax:
+                sum_cts += y[i]/(e[i]*e[i])
                 sum_err += 1.0/(e[i]*e[i])
 
-        return sum_err/sum
+        return sum_err/sum_cts
 
     def integrate(self, xmin=None, xmax=None):
         """
@@ -331,20 +342,20 @@ class DataSet(object):
         y = mtd[self._ws_name].readY(0)
         e = mtd[self._ws_name].readE(0)
 
-        is_histo = len(x)==len(y)+1
-        if not is_histo and len(x)!=len(y):
-            raise RuntimeError, "Corrupted I(q) %s" % self._ws_name
+        is_histo = len(x) == len(y)+1
+        if not is_histo and len(x) != len(y):
+            raise RuntimeError("Corrupted I(q) %s" % self._ws_name)
 
         sum = 0.0
         for i in range(len(y)-1):
             # Skip points compatible with zero within error
-            if self._restricted_range and y[i]<=e[i]:
+            if self._restricted_range and y[i] <= e[i]:
                 continue
-            if x[i]>=xmin and x[i+1]<=xmax:
+            if x[i] >= xmin and x[i+1] <= xmax:
                 sum += (y[i]+y[i+1])*(x[i+1]-x[i])/2.0
-            elif x[i]<xmin and x[i+1]>xmin:
+            elif x[i] < xmin and x[i+1] > xmin:
                 sum += (y[i+1]+(y[i]-y[i+1])/(x[i]-x[i+1])*(x[i]-xmin)/2.0) * (x[i+1]-xmin)
-            elif x[i]<xmax and x[i+1]>xmax:
+            elif x[i] < xmax and x[i+1] > xmax:
                 sum += (y[i]+(y[i+1]-y[i])/(x[i+1]-x[i])*(xmax-x[i])/2.0) * (xmax-x[i])
 
         return sum
@@ -370,8 +381,8 @@ class Stitcher(object):
             Returns a particular data set
             @param id: position of the data set in the list
         """
-        if id<0 or id>len(self._data_sets)-1:
-            raise "Stitcher has not data set number %s" % str(id)
+        if id < 0 or id > len(self._data_sets)-1:
+            raise RuntimeError("Stitcher has not data set number %s" % str(id))
         return self._data_sets[id]
 
     def size(self):
@@ -403,7 +414,7 @@ class Stitcher(object):
         d_min, d_max = data_to_scale.get_range()
 
         # Check that we have an overlap
-        if ref_max<d_min or ref_min>d_max:
+        if ref_max < d_min or ref_min > d_max:
             Logger("data_stitching").error("No overlap between %s and %s" % (str(data_ref), str(data_to_scale)))
             return
 
@@ -415,7 +426,7 @@ class Stitcher(object):
         sum_ref = data_ref.integrate(xmin, xmax)
         sum_d = data_to_scale.integrate(xmin, xmax)
 
-        if sum_ref!=0 and sum_d!=0:
+        if sum_ref != 0 and sum_d != 0:
             ref_scale = data_ref.get_scale()
             data_to_scale.set_scale(ref_scale*sum_ref/sum_d)
 
@@ -423,12 +434,12 @@ class Stitcher(object):
         """
             Compute scaling factors relative to reference data set
         """
-        if len(self._data_sets)<2:
+        if len(self._data_sets) < 2:
             return
 
-        for i in range(self._reference-1,-1,-1):
+        for i in range(self._reference-1, -1, -1):
             Stitcher.normalize(self._data_sets[i+1], self._data_sets[i])
-        for i in range(self._reference,len(self._data_sets)-1):
+        for i in range(self._reference, len(self._data_sets)-1):
             Stitcher.normalize(self._data_sets[i], self._data_sets[i+1])
 
     def set_reference(self, id):
@@ -436,8 +447,8 @@ class Stitcher(object):
             Select which data set is the reference to normalize to
             @param id: index of the reference in the internal file list.
         """
-        if id>=len(self._data_sets):
-            raise RuntimeError, "Stitcher: invalid reference ID"
+        if id >= len(self._data_sets):
+            raise RuntimeError("Stitcher: invalid reference ID")
         self._reference = id
 
     def save_combined(self, file_path=None, as_canSAS=True, workspace=None):
@@ -455,35 +466,35 @@ class Stitcher(object):
                           WriteXError=True, WriteSpectrumID=False)
 
     def trim_zeros(self, x, y, e, dx):
-        zipped = zip(x,y,e,dx)
+        zipped = zip(x, y, e, dx)
         trimmed = []
 
         data_started = False
         # First the zeros at the beginning
         for i in range(len(zipped)):
-            if data_started or zipped[i][1]!=0:
+            if data_started or zipped[i][1] != 0:
                 data_started = True
                 trimmed.append(zipped[i])
 
         # Then the trailing zeros
         zipped = []
         data_started = False
-        for i in range(len(trimmed)-1,-1,-1):
-            if data_started or trimmed[i][1]!=0:
+        for i in range(len(trimmed)-1, -1, -1):
+            if data_started or trimmed[i][1] != 0:
                 data_started = True
                 zipped.append(trimmed[i])
 
-        if len(zipped)>0:
-            x,y,e,dx = zip(*zipped)
+        if len(zipped) > 0:
+            x, y, e, dx = zip(*zipped)
         else:
-            return [],[],[],[]
+            return [], [], [], []
         return list(x), list(y), list(e), list(dx)
 
     def get_scaled_data(self, workspace=None):
         """
             Return the data points for the scaled data set
         """
-        if len(self._data_sets)==0:
+        if len(self._data_sets) == 0:
             return
 
         ws_combined = "combined_Iq"
@@ -505,7 +516,7 @@ class Stitcher(object):
                 _y = mtd[ws].dataY(0)
                 _e = mtd[ws].dataE(0)
                 _dx = mtd[ws].dataDx(0)
-                if len(_x)==len(_y)+1:
+                if len(_x) == len(_y)+1:
                     xtmp = [(_x[i]+_x[i+1])/2.0 for i in range(len(_y))]
                     dxtmp = [(_dx[i]+_dx[i+1])/2.0 for i in range(len(_y))]
                     _x = xtmp
@@ -517,13 +528,13 @@ class Stitcher(object):
                 e.extend(_e)
                 dx.extend(_dx)
 
-        zipped = zip(x,y,e,dx)
-        def cmp(p1,p2):
-            if p2[0]==p1[0]:
+        zipped = zip(x, y, e, dx)
+        def cmp(p1, p2):
+            if p2[0] == p1[0]:
                 return 0
-            return -1 if p2[0]>p1[0] else 1
+            return -1 if p2[0] > p1[0] else 1
         combined = sorted(zipped, cmp)
-        x,y,e,dx = zip(*combined)
+        x, y, e, dx = zip(*combined)
 
         CreateWorkspace(DataX=x, DataY=y, DataE=e,\
                        OutputWorkspace=ws_combined,\
@@ -556,29 +567,29 @@ def stitch(data_list=[], q_min=None, q_max=None, output_workspace=None,
        (q_max is not None and q_min is None):
         error_msg = "Both q_min and q_max parameters should be provided, not just one"
         Logger("data_stitching").error(error_msg)
-        raise RuntimeError, error_msg
+        raise RuntimeError(error_msg)
 
-    if not type(data_list)==list:
+    if not type(data_list) == list:
         error_msg = "The data_list parameter should be a list"
         Logger("data_stitching").error(error_msg)
-        raise RuntimeError, error_msg
+        raise RuntimeError(error_msg)
 
     n_data_sets = len(data_list)
-    if n_data_sets<2:
+    if n_data_sets < 2:
         error_msg = "The data_list parameter should contain at least two data sets"
         Logger("data_stitching").error(error_msg)
-        raise RuntimeError, error_msg
+        raise RuntimeError(error_msg)
 
     # Check whether we just need to scale the data sets using the provided
     # scaling factors
     has_scale_factors = False
-    if type(scale)==list:
-        if len(scale)==n_data_sets:
+    if type(scale) == list:
+        if len(scale) == n_data_sets:
             has_scale_factors = True
         else:
             error_msg = "If the scale parameter is provided as a list, it should have the same length as data_list"
             Logger("data_stitching").error(error_msg)
-            raise RuntimeError, error_msg
+            raise RuntimeError(error_msg)
 
     is_q_range_limited = False
     if q_min is not None and q_max is not None:
@@ -588,19 +599,19 @@ def stitch(data_list=[], q_min=None, q_max=None, output_workspace=None,
         if type(q_max) in [int, float]:
             q_max = [q_max]
 
-        if not type(q_min)==list or not type(q_max)==list:
+        if not type(q_min) == list or not type(q_max) == list:
             error_msg = "The q_min and q_max parameters must be lists"
             Logger("data_stitching").error(error_msg)
-            raise RuntimeError, error_msg
+            raise RuntimeError(error_msg)
 
-        if not len(q_min)==n_data_sets-1:
+        if not len(q_min) == n_data_sets-1:
             error_msg = "The length of q_min must be 1 shorter than the length of data_list: q_min=%s" % str(q_min)
             Logger("data_stitching").error(error_msg)
-            raise RuntimeError, error_msg
-        if not len(q_max)==n_data_sets-1:
+            raise RuntimeError(error_msg)
+        if not len(q_max) == n_data_sets-1:
             error_msg = "The length of q_max must be 1 shorter than the length of data_list: q_max=%s" % str(q_max)
             Logger("data_stitching").error(error_msg)
-            raise RuntimeError, error_msg
+            raise RuntimeError(error_msg)
 
         # Sanity check
         for i in range(n_data_sets-1):
@@ -610,7 +621,7 @@ def stitch(data_list=[], q_min=None, q_max=None, output_workspace=None,
             except:
                 error_msg = "The Q range parameters are invalid: q_min=%s   q_max=%s" % (str(q_min), str(q_max))
                 Logger("data_stitching").error(error_msg)
-                raise RuntimeError, error_msg
+                raise RuntimeError(error_msg)
     else:
         q_min = (n_data_sets-1)*[None]
         q_max = (n_data_sets-1)*[None]
@@ -624,12 +635,12 @@ def stitch(data_list=[], q_min=None, q_max=None, output_workspace=None,
         # Set the Q range to be used to stitch
         xmin, xmax = d.get_range()
         if is_q_range_limited:
-            if i==0:
+            if i == 0:
                 xmax = q_max[i]
-            elif i<n_data_sets-1:
+            elif i < n_data_sets-1:
                 xmin = q_min[i-1]
                 xmax = q_max[i]
-            elif i==n_data_sets-1:
+            elif i == n_data_sets-1:
                 xmin = q_min[i-1]
 
         d.set_range(xmin, xmax)
@@ -637,7 +648,7 @@ def stitch(data_list=[], q_min=None, q_max=None, output_workspace=None,
         # Set the scale of the reference data as needed
         if has_scale_factors:
             d.set_scale(float(scale[i]))
-        elif i==0 and type(scale) in [int, float]:
+        elif i == 0 and type(scale) in [int, float]:
             d.set_scale(scale)
 
         s.append(d)
@@ -651,9 +662,9 @@ def stitch(data_list=[], q_min=None, q_max=None, output_workspace=None,
     for i in range(n_data_sets):
         d = s.get_data_set(i)
         xmin, xmax = d.get_range()
-        if i>0:
+        if i > 0:
             xmin = q_min[i-1]
-        if i<n_data_sets-1:
+        if i < n_data_sets-1:
             xmax = q_max[i]
 
         d.apply_scale(xmin, xmax)


### PR DESCRIPTION
**This is a duplicate of PR #16360 for release 3.7**

The ORNL SANS reduction UI allows you to stitch data set. Those data sets can either be from a file, or a workspace. Everything works when stitching from file. There is a problem stitching data from a workspace.

The I(q) workspace produced by the reduction is a histogram, while the saved data files are point data.
Currently, the stitching code loads the histogram data, scales it, then transforms it to point data at the end. This order is wrong. It should first transform to point data as needed, then stitch.

**To test:**
- Perform a EQSANS reduction, then stitch it to itself by selecting the workspace for the first data set and the data that was written to file for the second. Click the auto-stitch button. The two curves should remain on top of each other (they didn't before).

Here's an example reduction: `/SNS/EQSANS/IPTS-15454/shared/67315_Iq.xml`
(Make sure to change the output directory on the first tab...)

There is no GitHub issue for this PR.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
