### PR TITLE
Remove locking mechanism from ISpectrum.

### DIFF
--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -115,11 +115,6 @@ public:
 
   void setSpectrumNo(specnum_t num);
 
-  // ---------------------------------------------------------
-  virtual void lockData() const;
-  virtual void unlockData() const;
-
-  //-------------------------------------------------------
   virtual bool hasDx() const;
   virtual void resetHasDx();
 

--- a/Framework/API/src/ISpectrum.cpp
+++ b/Framework/API/src/ISpectrum.cpp
@@ -207,17 +207,6 @@ specnum_t ISpectrum::getSpectrumNo() const { return m_specNo; }
  * @param num :: the spectrum number of this spectrum */
 void ISpectrum::setSpectrumNo(specnum_t num) { m_specNo = num; }
 
-// ---------------------------------------------------------
-/** Lock access to the data so that it does not get deleted while reading.
- * Does nothing unless overridden.
- */
-void ISpectrum::lockData() const {}
-
-/** Unlock access to the data so that it can again get deleted.
- * Does nothing unless overridden.
- */
-void ISpectrum::unlockData() const {}
-
 //---------------------------------------------------------
 /**
  * Gets the value of the use flag.

--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -643,7 +643,6 @@ void SmoothNeighbours::execWorkspace2D() {
       double weightSquared = weight * weight;
 
       const auto &inSpec = inWS->getSpectrum(inWI);
-      inSpec.lockData();
       const MantidVec &inY = inSpec.readY();
       const MantidVec &inE = inSpec.readE();
       const MantidVec &inX = inSpec.readX();
@@ -663,8 +662,6 @@ void SmoothNeighbours::execWorkspace2D() {
       if (inWS->isHistogramData()) {
         outX[YLength] = inX[YLength];
       }
-
-      inSpec.unlockData();
     } //(each neighbour)
 
     // Now un-square the error, since we summed it in quadrature

--- a/Framework/Crystal/src/AnvredCorrection.cpp
+++ b/Framework/Crystal/src/AnvredCorrection.cpp
@@ -189,7 +189,6 @@ void AnvredCorrection::exec() {
 
     // Copy over bin boundaries
     const auto &inSpec = m_inputWS->getSpectrum(i);
-    inSpec.lockData(); // for MRU-related thread safety
 
     const MantidVec &Xin = inSpec.readX();
     correctionFactors->dataX(i) = Xin;
@@ -246,8 +245,6 @@ void AnvredCorrection::exec() {
         E[j] = Ein[j] * value;
       }
     }
-
-    inSpec.unlockData();
 
     prog.report();
 

--- a/Framework/Crystal/src/NormaliseVanadium.cpp
+++ b/Framework/Crystal/src/NormaliseVanadium.cpp
@@ -79,8 +79,6 @@ void NormaliseVanadium::exec() {
 
     // Copy over bin boundaries
     const auto &inSpec = m_inputWS->getSpectrum(i);
-    inSpec.lockData(); // for MRU-related thread safety
-
     const MantidVec &Xin = inSpec.readX();
     correctionFactors->dataX(i) = Xin;
     const MantidVec &Yin = inSpec.readY();
@@ -137,8 +135,6 @@ void NormaliseVanadium::exec() {
       Y[j] = Yin[j] / normvalue;
       E[j] = Ein[j] / normvalue;
     }
-
-    inSpec.unlockData();
 
     prog.report();
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -156,9 +156,6 @@ public:
   void clear(const bool removeDetIDs = true) override;
   void clearUnused();
 
-  void lockData() const override;
-  void unlockData() const override;
-
   void setMRU(EventWorkspaceMRU *newMRU);
 
   EventWorkspaceMRU *getMRU();

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -379,9 +379,6 @@ private:
   /// Mutex that is locked while sorting an event list
   mutable std::mutex m_sortMutex;
 
-  /// Lock out deletion of items in the MRU
-  mutable bool m_lockedMRU;
-
   template <class T>
   static typename std::vector<T>::const_iterator
   findFirstEvent(const std::vector<T> &events, const double seek_tof);

--- a/Framework/DataObjects/inc/MantidDataObjects/EventWorkspaceMRU.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventWorkspaceMRU.h
@@ -24,8 +24,6 @@ public:
   /**
    * Constructor.
    * @param the_index :: unique index into the workspace of this data
-   * @param locked :: reference to a bool that will be set to true if
-   *        the marker should NOT be deleted
    */
   MantidVecWithMarker(const size_t the_index) : m_index(the_index) {}
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventWorkspaceMRU.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventWorkspaceMRU.h
@@ -27,8 +27,7 @@ public:
    * @param locked :: reference to a bool that will be set to true if
    *        the marker should NOT be deleted
    */
-  MantidVecWithMarker(const size_t the_index, bool &locked)
-      : m_index(the_index), m_locked(locked) {}
+  MantidVecWithMarker(const size_t the_index) : m_index(the_index) {}
 
   /// Destructor
   ~MantidVecWithMarker() {
@@ -55,10 +54,6 @@ public:
 
   /// Set the unique index value.
   void setIndex(const size_t the_index) { m_index = the_index; }
-
-  /// Locked: can't be deleted. This will point to the EventList's m_lockedMRU
-  /// bool.
-  bool &m_locked;
 };
 
 //============================================================================
@@ -120,12 +115,6 @@ protected:
 
   /// The most-recently-used list of dataE histograms
   mutable mru_lists m_bufferedDataE;
-
-  /// These markers will be deleted when they are NOT locked
-  mutable std::vector<MantidVecWithMarker *> m_markersToDelete;
-
-  /// Mutex around accessing m_markersToDelete
-  std::mutex m_toDeleteMutex;
 
   /// Mutex when adding entries in the MRU list
   mutable std::mutex m_changeMruListsMutexE;

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -118,29 +118,25 @@ bool compareEventPulseTimeTOF(const TofEvent &e1, const TofEvent &e2) {
 // -------------------------------------------------------------------
 
 /// Constructor (empty)
-EventList::EventList()
-    : eventType(TOF), order(UNSORTED), mru(nullptr), m_lockedMRU(false) {}
+EventList::EventList() : eventType(TOF), order(UNSORTED), mru(nullptr) {}
 
 /** Constructor with a MRU list
  * @param mru :: pointer to the MRU of the parent EventWorkspace
  * @param specNo :: the spectrum number for the event list
  */
 EventList::EventList(EventWorkspaceMRU *mru, specnum_t specNo)
-    : IEventList(specNo), eventType(TOF), order(UNSORTED), mru(mru),
-      m_lockedMRU(false) {}
+    : IEventList(specNo), eventType(TOF), order(UNSORTED), mru(mru) {}
 
 /** Constructor copying from an existing event list
  * @param rhs :: EventList object to copy*/
-EventList::EventList(const EventList &rhs)
-    : IEventList(rhs), mru(rhs.mru), m_lockedMRU(false) {
+EventList::EventList(const EventList &rhs) : IEventList(rhs), mru(rhs.mru) {
   // Call the copy operator to do the job,
   this->operator=(rhs);
 }
 
 /** Constructor, taking a vector of events.
  * @param events :: Vector of TofEvent's */
-EventList::EventList(const std::vector<TofEvent> &events)
-    : mru(nullptr), m_lockedMRU(false) {
+EventList::EventList(const std::vector<TofEvent> &events) : mru(nullptr) {
   this->events.assign(events.begin(), events.end());
   this->eventType = TOF;
   this->order = UNSORTED;
@@ -148,8 +144,7 @@ EventList::EventList(const std::vector<TofEvent> &events)
 
 /** Constructor, taking a vector of events.
  * @param events :: Vector of WeightedEvent's */
-EventList::EventList(const std::vector<WeightedEvent> &events)
-    : mru(nullptr), m_lockedMRU(false) {
+EventList::EventList(const std::vector<WeightedEvent> &events) : mru(nullptr) {
   this->weightedEvents.assign(events.begin(), events.end());
   this->eventType = WEIGHTED;
   this->order = UNSORTED;
@@ -158,7 +153,7 @@ EventList::EventList(const std::vector<WeightedEvent> &events)
 /** Constructor, taking a vector of events.
  * @param events :: Vector of WeightedEventNoTime's */
 EventList::EventList(const std::vector<WeightedEventNoTime> &events)
-    : mru(nullptr), m_lockedMRU(false) {
+    : mru(nullptr) {
   this->weightedEventsNoTime.assign(events.begin(), events.end());
   this->eventType = WEIGHTED_NOTIME;
   this->order = UNSORTED;
@@ -1524,10 +1519,10 @@ const MantidVec &EventList::constDataY() const {
 
   if (yData == nullptr) {
     // Create the MRU object
-    yData = new MantidVecWithMarker(this->m_specNo, this->m_lockedMRU);
+    yData = new MantidVecWithMarker(this->m_specNo);
 
     // prepare to update the uncertainties
-    auto eData = new MantidVecWithMarker(this->m_specNo, this->m_lockedMRU);
+    auto eData = new MantidVecWithMarker(this->m_specNo);
     mru->ensureEnoughBuffersE(thread);
 
     // see if E should be calculated;
@@ -1566,7 +1561,7 @@ const MantidVec &EventList::constDataE() const {
 
   if (eData == nullptr) {
     // Create the MRU object
-    eData = new MantidVecWithMarker(this->m_specNo, this->m_lockedMRU);
+    eData = new MantidVecWithMarker(this->m_specNo);
 
     // Now use that to get E -- Y values are generated from another function
     MantidVec Y_ignored;

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -198,9 +198,6 @@ void EventList::createFromHistogram(const ISpectrum *inSpec, bool GenerateZeros,
   double inf = std::numeric_limits<double>::infinity();
   double ninf = -inf;
 
-  // For thread safety
-  inSpec->lockData();
-
   // Get the input histogram
   const MantidVec &X = inSpec->readX();
   const MantidVec &Y = inSpec->readY();
@@ -271,8 +268,6 @@ void EventList::createFromHistogram(const ISpectrum *inSpec, bool GenerateZeros,
   // Manually set that this is sorted by TOF, since it is. This will make it
   // "threadSafe" in other algos.
   this->setSortOrder(TOF_SORT);
-
-  inSpec->unlockData();
 }
 
 // --------------------------------------------------------------------------
@@ -915,17 +910,6 @@ EventWorkspaceMRU *EventList::getMRU() { return mru; }
  * @param num :: number of events that will be in this EventList
  */
 void EventList::reserve(size_t num) { this->events.reserve(num); }
-
-// ---------------------------------------------------------
-/** Lock access to the data so that it does not get deleted while reading.
- * Call this BEFORE readY() and readE().
- */
-void EventList::lockData() const { m_lockedMRU = true; }
-
-/** Unlock access to the data so that it can again get deleted.
- * Call this once you are done with using the Y or E data.
- */
-void EventList::unlockData() const { m_lockedMRU = false; }
 
 // ==============================================================================================
 // --- Sorting functions -----------------------------------------------------

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -54,6 +54,8 @@ EventWorkspace::~EventWorkspace() {
 
 //-----------------------------------------------------------------------------
 /** Returns true if the EventWorkspace is safe for multithreaded operations.
+ * WARNING: This is only true for OpenMP threading. EventWorkspace is NOT thread
+ * safe with Poco threads or other threading mechanisms.
  */
 bool EventWorkspace::threadSafe() const {
   // Since there is a mutex lock around sorting, EventWorkspaces are always

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -658,32 +658,18 @@ public:
     // OK, we grab data0 from the MRU.
     const auto &inSpec = ew2->getSpectrum(0);
     const auto &inSpec300 = ew2->getSpectrum(300);
-    inSpec.lockData();
-    inSpec300.lockData();
 
     const MantidVec &data0 = inSpec.readY();
     const MantidVec &e300 = inSpec300.readE();
     TS_ASSERT_EQUALS(data0.size(), NUMBINS - 1);
-    MantidVec data0_copy(data0);
-    MantidVec e300_copy(e300);
 
     // Fill up the MRU to make data0 drop off
     for (size_t i = 0; i < 200; i++)
       MantidVec otherData = ew2->readY(i);
 
-    // data0 should not have changed!
-    for (size_t i = 0; i < data0.size(); i++) {
-      TS_ASSERT_EQUALS(data0[i], data0_copy[i]);
-    }
-
-    for (size_t i = 0; i < e300.size(); i++) {
-      TS_ASSERT_EQUALS(e300[i], e300_copy[i]);
-    }
-
-    inSpec.unlockData();
-    inSpec300.unlockData();
-
-    MantidVec otherData = ew2->readY(255);
+    // data0 and e300 are now invalid references!
+    TS_ASSERT_DIFFERS(&data0, &inSpec.readY());
+    TS_ASSERT_DIFFERS(&e300, &inSpec.readE());
 
     // MRU is full
     TS_ASSERT_EQUALS(ew2->MRUSize(), 50);

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
@@ -507,9 +507,6 @@ void ConvertToDiffractionMDWorkspace::exec() {
     totalEvents = m_inEventWS->getNumberEvents();
   prog = boost::make_shared<Progress>(this, 0, 1.0, totalEvents);
 
-  // Is the addition of events thread-safe?
-  bool MultiThreadedAdding = m_inWS->threadSafe();
-
   // Create the thread pool that will run all of these.
   ThreadScheduler *ts = new ThreadSchedulerFIFO();
   ThreadPool tp(ts, 0);
@@ -523,53 +520,57 @@ void ConvertToDiffractionMDWorkspace::exec() {
     g_log.information() << cputim << ": initial setup. There are "
                         << lastNumBoxes << " MDBoxes.\n";
 
-  for (size_t wi = 0; wi < m_inWS->getNumberHistograms(); wi++) {
-    // Get an idea of how many events we'll be adding
-    size_t eventsAdding = m_inWS->blocksize();
-    if (m_inEventWS && !OneEventPerBin)
-      eventsAdding = m_inEventWS->getSpectrum(wi).getNumberEvents();
+  for (size_t wi = 0; wi < m_inWS->getNumberHistograms();) {
+    // 1. Determine next chunk of spectra to process
+    size_t start = wi;
+    for (; wi < m_inWS->getNumberHistograms(); ++wi) {
+      // Get an idea of how many events we'll be adding
+      size_t eventsAdding = m_inWS->blocksize();
+      if (m_inEventWS && !OneEventPerBin)
+        eventsAdding = m_inEventWS->getSpectrum(wi).getNumberEvents();
 
-    if (MultiThreadedAdding) {
-      // Equivalent to calling "this->convertSpectrum(wi)"
-      boost::function<void()> func =
-          boost::bind(&ConvertToDiffractionMDWorkspace::convertSpectrum, &*this,
-                      static_cast<int>(wi));
-      // Give this task to the scheduler
-      double cost = static_cast<double>(eventsAdding);
-      ts->push(new FunctionTask(func, cost));
-    } else {
-      // Not thread-safe. Just add right now
-      this->convertSpectrum(static_cast<int>(wi));
+      // Keep a running total of how many events we've added
+      eventsAdded += eventsAdding;
+      approxEventsInOutput += eventsAdding;
+
+      if (bc->shouldSplitBoxes(approxEventsInOutput, eventsAdded, lastNumBoxes))
+        break;
     }
 
-    // Keep a running total of how many events we've added
-    eventsAdded += eventsAdding;
-    approxEventsInOutput += eventsAdding;
-
-    if (bc->shouldSplitBoxes(approxEventsInOutput, eventsAdded, lastNumBoxes)) {
-      if (DODEBUG)
-        g_log.information() << cputim << ": Added tasks worth " << eventsAdded
-                            << " events. WorkspaceIndex " << wi << '\n';
-      // Do all the adding tasks
-      tp.joinAll();
-      if (DODEBUG)
-        g_log.information() << cputim
-                            << ": Performing the addition of these events.\n";
-
-      // Now do all the splitting tasks
-      ws->splitAllIfNeeded(ts);
-      if (ts->size() > 0)
-        prog->doReport("Splitting Boxes");
-      tp.joinAll();
-
-      // Count the new # of boxes.
-      lastNumBoxes = ws->getBoxController()->getTotalNumMDBoxes();
-      if (DODEBUG)
-        g_log.information() << cputim
-                            << ": Performing the splitting. There are now "
-                            << lastNumBoxes << " boxes.\n";
-      eventsAdded = 0;
+    // 2. Process next chunk of spectra (threaded)
+    PARALLEL_FOR1(m_inWS)
+    for (size_t i = start; i < wi; ++i) {
+      PARALLEL_START_INTERUPT_REGION
+      this->convertSpectrum(static_cast<int>(i));
+      PARALLEL_END_INTERUPT_REGION
     }
+    PARALLEL_CHECK_INTERUPT_REGION
+
+    // 3. Split boxes
+    if (DODEBUG)
+      g_log.information() << cputim << ": Added tasks worth " << eventsAdded
+                          << " events. WorkspaceIndex " << wi << std::endl;
+    // Do all the adding tasks
+    if (DODEBUG)
+      g_log.information() << cputim
+                          << ": Performing the addition of these events.\n";
+
+    // Now do all the splitting tasks
+    ws->splitAllIfNeeded(ts);
+    if (ts->size() > 0)
+      prog->doReport("Splitting Boxes");
+    // Note: For some reason removing this joinAll() increases the runtime
+    // significantly. Does it somehow affect threads in "ts" created by
+    // splitAllIfNeeded()?
+    tp.joinAll();
+
+    // Count the new # of boxes.
+    lastNumBoxes = ws->getBoxController()->getTotalNumMDBoxes();
+    if (DODEBUG)
+      g_log.information() << cputim
+                          << ": Performing the splitting. There are now "
+                          << lastNumBoxes << " boxes.\n";
+    eventsAdded = 0;
   }
 
   if (this->failedDetectorLookupCount > 0) {
@@ -582,23 +583,6 @@ void ConvertToDiffractionMDWorkspace::exec() {
                       << this->failedDetectorLookupCount
                       << " spectra. They have been skipped.\n";
   }
-
-  if (DODEBUG)
-    g_log.information() << cputim << ": We've added tasks worth " << eventsAdded
-                        << " events.\n";
-
-  tp.joinAll();
-  if (DODEBUG)
-    g_log.information() << cputim
-                        << ": Performing the FINAL addition of these events.\n";
-
-  // Do a final splitting of everything
-  ws->splitAllIfNeeded(ts);
-  tp.joinAll();
-  if (DODEBUG)
-    g_log.information()
-        << cputim << ": Performing the FINAL splitting of boxes. There are now "
-        << ws->getBoxController()->getTotalNumMDBoxes() << " boxes\n";
 
   // Recount totals at the end.
   cputim.reset();

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
@@ -522,7 +522,7 @@ void ConvertToDiffractionMDWorkspace::exec() {
 
   for (size_t wi = 0; wi < m_inWS->getNumberHistograms();) {
     // 1. Determine next chunk of spectra to process
-    size_t start = wi;
+    int start = static_cast<int>(wi);
     for (; wi < m_inWS->getNumberHistograms(); ++wi) {
       // Get an idea of how many events we'll be adding
       size_t eventsAdding = m_inWS->blocksize();
@@ -539,7 +539,7 @@ void ConvertToDiffractionMDWorkspace::exec() {
 
     // 2. Process next chunk of spectra (threaded)
     PARALLEL_FOR1(m_inWS)
-    for (size_t i = start; i < wi; ++i) {
+    for (int i = start; i < static_cast<int>(wi); ++i) {
       PARALLEL_START_INTERUPT_REGION
       this->convertSpectrum(static_cast<int>(i));
       PARALLEL_END_INTERUPT_REGION

--- a/Framework/MDAlgorithms/test/ConvertToDiffractionMDWorkspaceTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToDiffractionMDWorkspaceTest.h
@@ -219,8 +219,6 @@ public:
   void test_MINITOPAZ_fromWorkspace2D() {
     do_test_MINITOPAZ(TOF, 100, 400, 1, false, true);
   }
-
-  void test_MINITOPAZ_long() { do_test_MINITOPAZ(TOF, 10000, 10000); }
 };
 
 #endif /* MANTID_MDEVENTS_MAKEDIFFRACTIONMDEVENTWORKSPACETEST_H_ */

--- a/Framework/MDAlgorithms/test/ConvertToDiffractionMDWorkspaceTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToDiffractionMDWorkspaceTest.h
@@ -125,13 +125,12 @@ public:
     }
   }
 
-  void do_test_MINITOPAZ(EventType type, size_t numTimesToAdd = 1,
-                         bool OneEventPerBin = false,
+  void do_test_MINITOPAZ(EventType type, int numEventsPer, int numPixels,
+                         size_t numTimesToAdd = 1, bool OneEventPerBin = false,
                          bool MakeWorkspace2D = false) {
 
-    int numEventsPer = 100;
     EventWorkspace_sptr in_ws = Mantid::DataObjects::MDEventsTestHelper::
-        createDiffractionEventWorkspace(numEventsPer);
+        createDiffractionEventWorkspace(numEventsPer, numPixels);
     if (type == WEIGHTED)
       in_ws *= 2.0;
     if (type == WEIGHTED_NOTIME) {
@@ -201,23 +200,27 @@ public:
     AnalysisDataService::Instance().remove("test_md3");
   }
 
-  void test_MINITOPAZ() { do_test_MINITOPAZ(TOF); }
+  void test_MINITOPAZ() { do_test_MINITOPAZ(TOF, 100, 400); }
 
-  void test_MINITOPAZ_Weighted() { do_test_MINITOPAZ(WEIGHTED); }
+  void test_MINITOPAZ_Weighted() { do_test_MINITOPAZ(WEIGHTED, 100, 400); }
 
-  void test_MINITOPAZ_addToExistingWorkspace() { do_test_MINITOPAZ(TOF, 2); }
+  void test_MINITOPAZ_addToExistingWorkspace() {
+    do_test_MINITOPAZ(TOF, 100, 400, 2);
+  }
 
   void test_MINITOPAZ_OneEventPerBin_fromEventWorkspace() {
-    do_test_MINITOPAZ(TOF, 1, true, false);
+    do_test_MINITOPAZ(TOF, 100, 400, 1, true, false);
   }
 
   void test_MINITOPAZ_OneEventPerBin_fromWorkspace2D() {
-    do_test_MINITOPAZ(TOF, 1, true, true);
+    do_test_MINITOPAZ(TOF, 100, 400, 1, true, true);
   }
 
   void test_MINITOPAZ_fromWorkspace2D() {
-    do_test_MINITOPAZ(TOF, 1, false, true);
+    do_test_MINITOPAZ(TOF, 100, 400, 1, false, true);
   }
+
+  void test_MINITOPAZ_long() { do_test_MINITOPAZ(TOF, 10000, 10000); }
 };
 
 #endif /* MANTID_MDEVENTS_MAKEDIFFRACTIONMDEVENTWORKSPACETEST_H_ */


### PR DESCRIPTION
See #16378 for a description.

**To test:**

Code review, try to understand the MRU and locking mechanism thoroughly. In particular, try to verify that my understanding and reasoning is correct:
- Each thread has its own MRU.
- Therefore, locking is only needed if there is a risk that a particular thread kicks its own buffered data from the MRU, i.e., in code like this:
  
  ``` cpp
  auto &y0 = eventWS->readY(0);
  for(size_t i=0; i<eventWS->numberOfHistograms(); ++i) {
    auto &y = eventWS->readY(i);
    // y0 becomes an invalid reference after 50 iterations,
    // if we need it we would need to lock
  }
  ```
- Code like this does not seem to be present anywhere in the cases where `ISpectrum::lockData()` is used currently, so we can drop it completely.

Please also see below for my two comments regarding Poco threading.

Fixes #16378.

_Internal change, does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
