### PR TITLE
Indirect Diffraction OSIRIS Diffspec - default value for spectra max 

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -487,10 +487,6 @@ void IndirectDiffractionReduction::instrumentSelected(
   double specMin = instrument->getNumberParameter("spectra-min")[0];
   double specMax = instrument->getNumberParameter("spectra-max")[0];
 
-  if (instrumentName == "OSIRIS" && reflectionName == "diffspec") {
-	  specMax = 15;
-  }
-
   m_uiForm.spSpecMin->setValue(static_cast<int>(specMin));
   m_uiForm.spSpecMax->setValue(static_cast<int>(specMax));
 

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -487,6 +487,10 @@ void IndirectDiffractionReduction::instrumentSelected(
   double specMin = instrument->getNumberParameter("spectra-min")[0];
   double specMax = instrument->getNumberParameter("spectra-max")[0];
 
+  if (instrumentName == "OSIRIS" && reflectionName == "diffspec") {
+	  specMax = 15;
+  }
+
   m_uiForm.spSpecMin->setValue(static_cast<int>(specMin));
   m_uiForm.spSpecMax->setValue(static_cast<int>(specMax));
 

--- a/instrument/OSIRIS_diffraction_diffspec_Parameters.xml
+++ b/instrument/OSIRIS_diffraction_diffspec_Parameters.xml
@@ -19,7 +19,7 @@
 </parameter>
 
 <parameter name="spectra-max">
-	<value val="962" />
+	<value val="15" />
 </parameter>
 
 <parameter name="Workflow.Diffraction.Correction" type="string">


### PR DESCRIPTION
Indirect Diffraction OSIRIS Diffspec interface should now have a default value of 15 for specMax

**To test:**
- Change default facility/instrument to `ISIS/OSIRIS` (View > Preferences > Mantid)
- Open Indirect Diffraction (Interfaces > Indirect > Diffraction)
- Change instrument to `OSIRIS` (if not already set)
- Change Reflection to `diffspec` 
- Observe that the default `Spectra Max` is `15`

Fixes #16333

_Does not need to be in the release notes. As it is a minor update to the default value in an interface_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
