### PR TITLE
Indirect Data Analysis I(Q,t) Fit - correctly update plot output

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.h
@@ -40,6 +40,7 @@ private slots:
   void propertyChanged(QtProperty *, double);
   void checkBoxUpdate(QtProperty *prop, bool checked);
   void plotGuessChanged(bool);
+  void updateCurrentPlotOption(QString newOption);
   void singleFit();
   void plotGuess(QtProperty *);
   void fitContextMenu(const QPoint &);

--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -135,6 +135,8 @@ void IqtFit::setup() {
           SLOT(specMaxChanged(int)));
   connect(m_uiForm.ckPlotGuess, SIGNAL(toggled(bool)), this,
           SLOT(plotGuessChanged(bool)));
+  connect(m_uiForm.cbPlotType, SIGNAL(currentIndexChanged(QString)), this,
+          SLOT(updateCurrentPlotOption(QString)));
 
   // Set a custom handler for the QTreePropertyBrowser's ContextMenu event
   m_ffTree->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -468,6 +470,8 @@ QString IqtFit::fitTypeString() const {
 }
 
 void IqtFit::typeSelection(int index) {
+  disconnect(m_uiForm.cbPlotType, SIGNAL(currentIndexChanged(QString)), this,
+             SLOT(updateCurrentPlotOption(QString)));
   m_ffTree->clear();
 
   m_ffTree->addProperty(m_properties["StartX"]);
@@ -523,10 +527,26 @@ void IqtFit::typeSelection(int index) {
 
     break;
   }
+  const auto optionIndex =
+      m_uiForm.cbPlotType->findText(QString::fromStdString(m_plotOption));
+  if (optionIndex != -1) {
+    m_uiForm.cbPlotType->setCurrentIndex(optionIndex);
+  } else {
+    m_uiForm.cbPlotType->setCurrentIndex(0);
+  }
 
   plotGuess(NULL);
   m_uiForm.ppPlot->removeSpectrum("Fit");
   m_uiForm.ppPlot->removeSpectrum("Diff");
+  connect(m_uiForm.cbPlotType, SIGNAL(currentIndexChanged(QString)), this,
+          SLOT(updateCurrentPlotOption(QString)));
+}
+
+/**
+ * Update the current plot option selected
+ */
+void IqtFit::updateCurrentPlotOption(QString newOption) {
+	m_plotOption = newOption.toStdString();
 }
 
 void IqtFit::updatePlot() {

--- a/docs/source/release/v3.7.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.7.0/indirect_inelastic.rst
@@ -95,6 +95,7 @@ Bugfixes
 - In the *BayesQuasi* interface ResNorm files are now automatically loaded from file locations when entered.
 - :ref:`LoadVesuvio <algm-LoadVesuvio>` now correctly parses input in the form 10-20,30-40,50-60
 - Using the Spectra option in *S(Q,w)* interface now works correctly
+- The Plot Output options in the *I(Q, t) Fit* interface now update properly when switching between Fit Types
 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
The I(Q, t) Fit interface should now properly update the plot output options when switching between Fit types

**To test:**
- Open `I(Q, t) Fit` (Interfaces > Indirect > Data Analysis > `I(Q, t) Fit`)
- Change the `Plot output` to `All` 
- Change the `Fit Type` to `2 Exponential` 
- Ensure the Plot Output is still `All`
- Change to Fit type to `1 stretched exponential`
- Change Plot Output to `Beta` 
- Change Fit type to `1 exponential`
- Ensure the Plot Output is now `None`
  - `Beta` does not exist as a plot output for `1 exponential` hence defaults to `None`

Fixes #16385

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/ea5ca60991704177e70fb993075eca6777caa2be/docs/source/release/v3.7.0/indirect_inelastic.rst#bugfixes)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
