### PR TITLE
ALC integration time fix

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -467,10 +467,10 @@
                   <number>3</number>
                  </property>
                  <property name="minimum">
-                  <double>-6.000000000000000</double>
+                  <double>-10.000000000000000</double>
                  </property>
                  <property name="maximum">
-                  <double>33.000000000000000</double>
+                  <double>50.000000000000000</double>
                  </property>
                 </widget>
                </item>
@@ -487,10 +487,10 @@
                   <number>3</number>
                  </property>
                  <property name="minimum">
-                  <double>-6.000000000000000</double>
+                  <double>-10.000000000000000</double>
                  </property>
                  <property name="maximum">
-                  <double>33.000000000000000</double>
+                  <double>50.000000000000000</double>
                  </property>
                 </widget>
                </item>

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -253,10 +253,13 @@ void ALCDataLoadingPresenter::updateAvailableInfo() {
   }
   m_view->setAvailablePeriods(periods);
 
-  // Set time limits
-  m_view->setTimeLimits(firstGoodData - timeZero, ws->readX(0).back());
-  // Set allowed time range
-  m_view->setTimeRange(ws->readX(0).front(), ws->readX(0).back());
+  // Set time limits if this is the first data loaded (will both be zero)
+  if (auto timeLimits = m_view->timeRange()) {
+    if (std::abs(timeLimits->first) < 0.0001 &&
+        std::abs(timeLimits->second) < 0.0001) {
+      m_view->setTimeLimits(firstGoodData - timeZero, ws->readX(0).back());
+    }
+  }
 }
 
 MatrixWorkspace_sptr ALCDataLoadingPresenter::exportWorkspace() {

--- a/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -184,9 +184,9 @@ public:
                                                 Contains("1"),
                                                 Contains("2")))).Times(1);
     // Test time limits
-    boost::optional<std::pair<double, double>> timeRange;
-    timeRange.emplace(0.0, 0.0);
-    ON_CALL(*m_view, timeRange()).WillByDefault(Return(timeRange));
+    auto timeRange = std::make_pair<double, double>(0.0, 0.0);
+    ON_CALL(*m_view, timeRange())
+        .WillByDefault(Return(boost::make_optional(timeRange)));
     EXPECT_CALL(*m_view, setTimeLimits(Le(0.107), Ge(31.44))).Times(1);
     m_view->selectFirstRun();
   }
@@ -206,9 +206,10 @@ public:
                                    Contains("1"), Contains("2"))))
         .Times(1);
     // Test time limits
-    boost::optional<std::pair<double, double>> timeRange;
-    timeRange.emplace(0.1, 10.0); // this is not the first run loaded
-    ON_CALL(*m_view, timeRange()).WillByDefault(Return(timeRange));
+    auto timeRange =
+        std::make_pair<double, double>(0.1, 10.0); // not the first run loaded
+    ON_CALL(*m_view, timeRange())
+        .WillByDefault(Return(boost::make_optional(timeRange)));
     EXPECT_CALL(*m_view, setTimeLimits(_, _))
         .Times(0); // shouldn't reset time limits
     m_view->selectFirstRun();

--- a/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -184,7 +184,33 @@ public:
                                                 Contains("1"),
                                                 Contains("2")))).Times(1);
     // Test time limits
+    boost::optional<std::pair<double, double>> timeRange;
+    timeRange.emplace(0.0, 0.0);
+    ON_CALL(*m_view, timeRange()).WillByDefault(Return(timeRange));
     EXPECT_CALL(*m_view, setTimeLimits(Le(0.107), Ge(31.44))).Times(1);
+    m_view->selectFirstRun();
+  }
+
+  void test_updateAvailableInfo_NotFirstRun() {
+    EXPECT_CALL(*m_view, firstRun()).WillRepeatedly(Return("MUSR00015189.nxs"));
+    // Test logs
+    EXPECT_CALL(*m_view,
+                setAvailableLogs(
+                    AllOf(Property(&std::vector<std::string>::size, 39),
+                          Contains("run_number"), Contains("sample_magn_field"),
+                          Contains("Field_Danfysik"))))
+        .Times(1);
+    // Test periods
+    EXPECT_CALL(*m_view, setAvailablePeriods(
+                             AllOf(Property(&std::vector<std::string>::size, 2),
+                                   Contains("1"), Contains("2"))))
+        .Times(1);
+    // Test time limits
+    boost::optional<std::pair<double, double>> timeRange;
+    timeRange.emplace(0.1, 10.0); // this is not the first run loaded
+    ON_CALL(*m_view, timeRange()).WillByDefault(Return(timeRange));
+    EXPECT_CALL(*m_view, setTimeLimits(_, _))
+        .Times(0); // shouldn't reset time limits
     m_view->selectFirstRun();
   }
 

--- a/docs/source/release/v3.7.0/muon.rst
+++ b/docs/source/release/v3.7.0/muon.rst
@@ -16,7 +16,7 @@ Muon ALC
 - Several usability fixes were made to the interface: `#16161 <https://github.com/mantidproject/mantid/pull/16161>`_
 
   - The "Function" box was renamed "Take log value at" and moved next to the log to which it applies
-  - The integration start time is initialised to the first good data rather than the first time bin
+  - The integration start time is initialised to the first good data rather than the first time bin, and is not reset when a new first run is loaded
   - The choice of periods is no longer reset when a new first run is loaded
 
 Muon Analysis


### PR DESCRIPTION
As requested from beta testing: ALC interface should not reset integration time limits on loading a new first run.

Also doesn't coerce the text entered into the boxes to be in the valid range.
Will add a warning if the entered time is outside the range of the data in #16393, as that issue is going to add a `validateInputs()` to `PlotAsymmetryByLogValue` and that's the most sensible place to put this check.

**To test:**
_Data available at \olympic\babylon5\Scratch\TomPerkins\Data\ALC_
- Open Interfaces/Muon/ALC
- In top group box, set first run to `HIFI00051636.nxs` and last run to `HIFI00051638.nxs`
  - Note the integration "from" and "max" in the bottom group box have been set to non-zero values (it's the first good data and last bin)
- Type something else into the "from" and "max" integration time boxes in the bottom groupbox
  - Check it doesn't have to be in the range from first good data to last bin
- Now set the first run to `HIFI00051637.nxs`
  - Check the integration time limits have _not_ been reset

Fixes #16372.

[Release notes](https://github.com/mantidproject/mantid/blob/2277754222869525a535c7c6643536394e08a528/docs/source/release/v3.7.0/muon.rst#muon-alc) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
