### PR TITLE
Increase default timeout for script repository download to 30 seconds

### DIFF
--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -64,6 +64,9 @@ namespace {
 Kernel::Logger g_log("ScriptRepositoryImpl");
 }
 
+/// Default timeout
+int DEFAULT_TIMEOUT_SEC = 30;
+
 const char *timeformat = "%Y-%b-%d %H:%M:%S";
 
 const char *emptyURL =
@@ -1394,7 +1397,7 @@ void ScriptRepositoryImpl::doDownloadFile(const std::string &url_file,
     int timeout;
     if (!ConfigService::Instance().getValue("network.scriptrepo.timeout",
                                             timeout)) {
-      timeout = 5; // the default value if the key is not found
+      timeout = DEFAULT_TIMEOUT_SEC;
     }
     inetHelper.setTimeout(timeout);
 

--- a/docs/source/release/v3.7.0/framework.rst
+++ b/docs/source/release/v3.7.0/framework.rst
@@ -180,6 +180,7 @@ Script Repository
 -----------------
 
 - A bug has been fixed that caused uploads to fail with some incorrectly configured proxy servers.
+- The default timeout has been increased from 5s to 30s to avoid hitting the timeout when tying to download some larger files.
 
 |
 


### PR DESCRIPTION
The default was 5 seconds and was too short in some places where large files were being downloaded, e.g. muon files at ISIS. The value can still be overridden with the `network.scriptrepo.timeout` properties variable but this should be a rare case now.

**To test:**

Check that the script repository downloads still work, in particular try downloading some or all of the muon files. It should proceed without error.

Fixes #16370

[Release Notes](https://github.com/mantidproject/mantid/commit/f9d9a62d50b761483b21d619458b603194625f0d#diff-987b30b265367931cb00582385038193)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
