### PR TITLE
Support loading older muon data

### DIFF
--- a/Framework/DataHandling/src/LoadMuonNexus.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus.cpp
@@ -7,6 +7,7 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidAPI/FileProperty.h"
+#include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/Detector.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/TableRow.h"
@@ -159,10 +160,12 @@ void LoadMuonNexus::runLoadInstrument(
 
   // If loading instrument definition file fails,
   // we may get instrument by some other means yet to be decided upon
-  // at present we do nothing.
-  // if ( ! loadInst->isExecuted() )
-  //{
-  //}
+  // at present just create a dummy instrument with the correct name.
+  if (!loadInst->isExecuted()) {
+    auto inst = boost::make_shared<Geometry::Instrument>();
+    inst->setName(m_instrument_name);
+    localWorkspace->setInstrument(inst);
+  }
 }
 
 /**

--- a/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -379,7 +379,7 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
     } else {
 
       if (m_numberOfPeriods == 1) {
-        // Simpliest case - one dead time for one detector
+        // Simplest case - one dead time for one detector
 
         // Populate deadTimes
         for (auto &spectra : specToLoad) {
@@ -389,6 +389,19 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
         TableWorkspace_sptr table = createDeadTimeTable(specToLoad, deadTimes);
         setProperty("DeadTimeTable", table);
 
+      } else if (numDeadTimes == m_numberOfSpectra) {
+        // Multiple periods, but the same dead times for each
+
+        specToLoad.clear();
+        for (int i = 1; i < numDeadTimes + 1; i++) {
+          specToLoad.push_back(i);
+        }
+        for (const auto &spectrum : specToLoad) {
+          deadTimes.emplace_back(deadTimesData[spectrum - 1]);
+        }
+        // Load into table
+        TableWorkspace_sptr table = createDeadTimeTable(specToLoad, deadTimes);
+        setProperty("DeadTimeTable", table);
       } else {
         // More complex case - different dead times for different periods
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1217,8 +1217,14 @@ MuonAnalysis::load(const QStringList &files) const {
 
       // Check that is a valid Muon instrument
       if (m_uiForm.instrSelector->findText(QString::fromStdString(instrName)) ==
-          -1)
-        throw std::runtime_error("Instrument is not recognized: " + instrName);
+          -1) {
+        if (0 !=
+            instrName.compare(
+                "DEVA")) { // special case - no IDF but let it load anyway
+          throw std::runtime_error("Instrument is not recognized: " +
+                                   instrName);
+        }
+      }
 
       if (m_uiForm.deadTimeType->currentText() == "From Data File") {
         result->loadedDeadTimes = load->getProperty("DeadTimeTable");

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1202,7 +1202,9 @@ MuonAnalysis::load(const QStringList &files) const {
 
     if (f == files.constBegin()) {
       // These are only needed for the first file
-      load->setPropertyValue("DeadTimeTable", "__NotUsed");
+      if (m_uiForm.deadTimeType->currentText() == "From Data File") {
+        load->setPropertyValue("DeadTimeTable", "__NotUsed");
+      }
       load->setPropertyValue("DetectorGroupingTable", "__NotUsed");
     }
 
@@ -1218,7 +1220,9 @@ MuonAnalysis::load(const QStringList &files) const {
           -1)
         throw std::runtime_error("Instrument is not recognized: " + instrName);
 
-      result->loadedDeadTimes = load->getProperty("DeadTimeTable");
+      if (m_uiForm.deadTimeType->currentText() == "From Data File") {
+        result->loadedDeadTimes = load->getProperty("DeadTimeTable");
+      }
       result->loadedGrouping = load->getProperty("DetectorGroupingTable");
       result->mainFieldDirection =
           static_cast<std::string>(load->getProperty("MainFieldDirection"));

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
@@ -827,7 +827,11 @@ QString runNumberString(const std::string &workspaceName,
     // Remove "INST000" off the start
     // No muon instruments have numbers in their names
     size_t numPos = instRuns.find_first_of("123456789");
-    instRuns = instRuns.substr(numPos, instRuns.size());
+    if (numPos != std::string::npos) {
+      instRuns = instRuns.substr(numPos, instRuns.size());
+    } else { // run number was zero?
+      instRuns = "0";
+    }
     if (numTokens > 5) { // periods included
       periods = tokenizer[4];
     }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
@@ -373,7 +373,15 @@ std::string getRunLabel(const Workspace_sptr& ws)
   int runNumber = firstPrd->getRunNumber();
   std::string instrName = firstPrd->getInstrument()->getName();
 
-  int zeroPadding = ConfigService::Instance().getInstrument(instrName).zeroPadding(runNumber);
+  int zeroPadding;
+  try {
+    zeroPadding =
+        ConfigService::Instance().getInstrument(instrName).zeroPadding(
+            runNumber);
+  } catch (const Mantid::Kernel::Exception::NotFoundError &) {
+    // Old muon instrument without an IDF - default to 3 zeros
+    zeroPadding = 3;
+  }
 
   std::ostringstream label;
   label << instrName;

--- a/MantidQt/CustomInterfaces/test/MuonAnalysisHelperTest.h
+++ b/MantidQt/CustomInterfaces/test/MuonAnalysisHelperTest.h
@@ -297,6 +297,27 @@ public:
     doTestRunNumberString("15189-90, 15192", true);
   }
 
+  // This can happen when loading very old files in which the stored run number
+  // is zero
+  void test_runNumberString_zeroRunNumber() {
+    const std::string sep("; ");
+    std::ostringstream wsName;
+    wsName << "DEVA000" << sep;
+    wsName << "Pair" << sep;
+    wsName << "long" << sep;
+    wsName << "Asym" << sep;
+    wsName << "1+2" << sep;
+    wsName << "#1";
+
+    // create expected output
+    QString expected = "0: 1+2";
+    QString result;
+
+    // test
+    TS_ASSERT_THROWS_NOTHING(result = runNumberString(wsName.str(), "0"));
+    TS_ASSERT_EQUALS(expected, result);
+  }
+
   void test_isReloadGroupingNecessary_No() {
     const auto currentWs = createWs("MUSR", 15189);
     const auto loadedWs = createWs("MUSR", 15190);


### PR DESCRIPTION
Fix `LoadMuonNexus` to deal with certain older files, and enable MuonAnalysis to load old muon data

The file in the issue was an old muon file that has been converted to Nexus and wouldn't load in MuonAnalysis.

There were several related issues here:
- `LoadMuonNexus` (version 1) failed to load the dead times and detector groupings for muon files like the one in the issue. Fixed this to load them correctly.
- There is no IDF for the instrument this data was recorded on (DEVA). As a short-term fix to enable loading this data into the muon interface, added a special case to allow this. (In the long term this should be removed and an IDF added, if this instrument is to be supported).
- If the dead times option in the interface is set to "None", it shouldn't try to load dead times from the file.

**To test:**

The data file is at `\\olympic\babylon5\Scratch\TomPerkins\Data\old_muon\01360.NXS`.
- Try loading this file with `LoadMuonNexus`. Set workspace names for the _DeadTimeTable_ and _DetectorGroupingTable_ properties and check these are loaded ok (the dead times are all zero and there is only one group, but check they load without error).
- Open the MuonAnalysis interface and try loading the file into it. It should load ok and you should be able to fit the data.

Fixes #16396

_I haven't added this to the release notes_ because DEVA still is not a supported instrument. The ability to load this old data is useful for instrument scientists, but the workspace doesn't have an instrument and this might cause problems if other algorithms are run on it.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
