### PR TITLE
Ensure properties are removed properly to fix crash

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/FitOptionsBrowser.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/FitOptionsBrowser.h
@@ -97,6 +97,8 @@ private:
     QString (FitOptionsBrowser::*getter)(QtProperty*)const, 
     void (FitOptionsBrowser::*setter)(QtProperty*,const QString&));
 
+  void removeProperty(const QString &name);
+
   //  Setters and getters
   QString getMinimizer(QtProperty*) const;
   void setMinimizer(QtProperty*, const QString&);

--- a/MantidQt/MantidWidgets/src/FitOptionsBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/FitOptionsBrowser.cpp
@@ -285,6 +285,20 @@ void FitOptionsBrowser::addProperty(const QString& name, QtProperty* prop,
   m_setters[prop] = setter;
 }
 
+/**
+ * Remove a property previously added with addProperty
+ * (If property doesn't exist, does nothing).
+ * @param name :: [input] Name of property to remove
+ */
+void FitOptionsBrowser::removeProperty(const QString &name) {
+  if (m_propertyNameMap.contains(name)) {
+    const auto prop = m_propertyNameMap[name];
+    m_getters.remove(prop);
+    m_setters.remove(prop);
+    m_propertyNameMap.remove(name);
+  }
+}
+
 /*                *********************
  *                **  Private Slots  **
  *                *********************/
@@ -328,6 +342,7 @@ void FitOptionsBrowser::updateMinimizer()
     if ( prop != m_minimizer )
     {
       m_minimizerGroup->removeSubProperty(prop);
+      removeProperty(prop->propertyName());
     }
   }
 


### PR DESCRIPTION
Fix a crash seen in multi-dataset fitting interface.

**To test:**

It's probably easier to try replicating the bug first: 
- on installed beta testing build, try opening _Interfaces/General/Multi-dataset fitting_. 
- If this succeeds, switch the minimiser to something other than `Levenberg-Marquardt` and then back again.
- You should see a dialog as in the issue: "Property AbsError already added".
- Try the same steps with this PR build. The error should not appear.

Fixes #16407.

_Does not need to be in the release notes._ (The error was not in the last release).

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
