### PR TITLE
Fix bug in SampleTransmission Calculator

### DIFF
--- a/MantidQt/CustomInterfaces/src/SampleTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/SampleTransmission.cpp
@@ -214,7 +214,16 @@ void SampleTransmission::algorithmComplete(bool error)
 
   m_uiForm.twResults->resizeColumnToContents(0);
 
-  // Plot transmission curve on preview plot
-  m_uiForm.ppTransmission->addSpectrum("Transmission", "CalculatedSampleTransmission", 0);
-  m_uiForm.ppTransmission->resizeX();
+  try {
+    // Plot transmission curve on preview plot
+    m_uiForm.ppTransmission->addSpectrum("Transmission",
+                                         "CalculatedSampleTransmission", 0);
+    m_uiForm.ppTransmission->resizeX();
+  } catch (std::runtime_error &e) {
+    // PreviewPlot may throw an exception if our workspace has less than two X
+    // values
+    showInformationBox(
+        QString::fromStdString("Unable to plot CalculatedSampleTransmission: " +
+                               std::string(e.what())));
+  }
 }


### PR DESCRIPTION
Fixes an unhandled exception thrown when the output workspace has less than two X values (`PreviewPlot` is not able to handle that case).

**To test:**
- Open Interfaces->General->Sample Transmission Calculator
- Set Low=0.1,Width=0.1,High=0.2
- Set ChemicalFormula=V
- Hit Calculate.
- An error message should be shown indicating the problem.

Fixes #16428

Does not need to be in the release notes, issue found during beta testing period.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
