### PR TITLE
ALC: check for bad custom grouping before loading files

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingPresenter.h
@@ -84,6 +84,9 @@ namespace CustomInterfaces
     /// Start/stop watching directory
     void changeWatchState(bool watching);
 
+    /// Check custom grouping is sensible
+    bool checkCustomGrouping();
+
     /// View which the object works with
     IALCDataLoadingView* const m_view;
 
@@ -98,6 +101,9 @@ namespace CustomInterfaces
 
     /// ID of timer, if one is running
     int m_timerID;
+
+    /// Number of detectors for current first run
+    size_t m_numDetectors;
   };
 
 

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -2,6 +2,8 @@
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/Strings.h"
+#include "MantidGeometry/Instrument.h"
 
 #include "MantidQtCustomInterfaces/Muon/ALCHelper.h"
 #include "MantidQtCustomInterfaces/Muon/MuonAnalysisHelper.h"
@@ -129,6 +131,16 @@ void ALCDataLoadingPresenter::load(const std::string &lastFile) {
   // Use Path.toString() to ensure both are in same (native) format
   Poco::Path firstRun(m_view->firstRun());
   Poco::Path lastRun(lastFile);
+
+  // Before loading, check custom grouping (if used) is sensible
+  const bool groupingOK = checkCustomGrouping();
+  if (!groupingOK) {
+    m_view->displayError(
+        "Custom grouping not valid (bad format or detector numbers)");
+    m_view->enableAll();
+    return;
+  }
+
   try {
     IAlgorithm_sptr alg =
         AlgorithmManager::Instance().create("PlotAsymmetryByLogValue");
@@ -260,6 +272,9 @@ void ALCDataLoadingPresenter::updateAvailableInfo() {
       m_view->setTimeLimits(firstGoodData - timeZero, ws->readX(0).back());
     }
   }
+
+  // Update number of detectors for this new first run
+  m_numDetectors = ws->getInstrument()->getNumberDetectors();
 }
 
 MatrixWorkspace_sptr ALCDataLoadingPresenter::exportWorkspace() {
@@ -285,6 +300,28 @@ void ALCDataLoadingPresenter::setData(MatrixWorkspace_const_sptr data) {
   } else {
     std::invalid_argument("Cannot load an empty workspace");
   }
+}
+
+/**
+ * If custom grouping is supplied, check all detector numbers are valid
+ * @returns :: True if grouping OK, false if bad
+ */
+bool ALCDataLoadingPresenter::checkCustomGrouping() {
+  bool groupingOK = true;
+  if (m_view->detectorGroupingType() == "Custom") {
+    auto detectors =
+        Mantid::Kernel::Strings::parseRange(m_view->getForwardGrouping());
+    const auto backward =
+        Mantid::Kernel::Strings::parseRange(m_view->getBackwardGrouping());
+    detectors.insert(detectors.end(), backward.begin(), backward.end());
+    for (const int det : detectors) {
+      if (det < 0 || det > static_cast<int>(m_numDetectors)) {
+        groupingOK = false;
+        break;
+      }
+    }
+  }
+  return groupingOK;
 }
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -215,6 +215,16 @@ public:
     m_view->selectFirstRun();
   }
 
+  void test_badCustomGrouping() {
+    ON_CALL(*m_view, detectorGroupingType()).WillByDefault(Return("Custom"));
+    ON_CALL(*m_view, getForwardGrouping()).WillByDefault(Return("1-48"));
+    // Too many detectors (MUSR has only 64)
+    ON_CALL(*m_view, getBackwardGrouping()).WillByDefault(Return("49-96"));
+    EXPECT_CALL(*m_view, displayError(StrNe(""))).Times(1);
+    m_view->selectFirstRun();
+    m_view->requestLoading();
+  }
+
   void test_updateAvailableLogs_invalidFirstRun()
   {
     ON_CALL(*m_view, firstRun()).WillByDefault(Return(""));
@@ -291,8 +301,8 @@ public:
     // Set grouping, the same as the default
     ON_CALL(*m_view, getForwardGrouping()).WillByDefault(Return("33-64"));
     ON_CALL(*m_view, getBackwardGrouping()).WillByDefault(Return("1-32"));
-    EXPECT_CALL(*m_view, getForwardGrouping()).Times(1);
-    EXPECT_CALL(*m_view, getBackwardGrouping()).Times(1);
+    EXPECT_CALL(*m_view, getForwardGrouping()).Times(2);
+    EXPECT_CALL(*m_view, getBackwardGrouping()).Times(2);
     EXPECT_CALL(*m_view, enableAll()).Times(1);
     EXPECT_CALL(*m_view, setDataCurve(AllOf(Property(&QwtData::size, 3),
                                             QwtDataX(0, 1350, 1E-8),
@@ -305,7 +315,7 @@ public:
                                             VectorValue(0,1.285E-3,1E-6),
                                             VectorValue(1,1.284E-3,1E-6),
                                             VectorValue(2,1.280E-3,1E-6))));
-
+    m_view->selectFirstRun();
     m_view->requestLoading();
   }
 


### PR DESCRIPTION
Added a check for bad custom grouping before loading files.

Previously, if a bad custom grouping (e.g. with detector numbers not present in the instrument) was supplied, no error was given until _after_ all the files had been loaded - which can take some time if there are a lot of files. 

Added a check before data is loaded and give a more understandable error message if the supplied grouping is bad. Added a unit test for this case.

The issue mentions validating integration times and validating inputs to `MuonGroupDetectors` - I will leave this to the next release and open an issue for it (#16437).

**To test:**
_Data available at \olympic\babylon5\Scratch\TomPerkins\Data\ALC_
- Open Interfaces/Muon/ALC
- Set first run to `HIFI00051636.nxs` and last run to `HIFI00051638.nxs`
- Set the grouping radio button to "Custom" and enter "1-48" in "Forward" and "49-96" in "Backward". (HIFI has only 64 detectors).
- Click "Load" and check you get an error explaining what went wrong.
  - The error should appear _before_ the data is loaded
- If you use "Auto" grouping or a sensible custom grouping with valid detector numbers, data should be loaded without error.

Fixes #16393.

_Does not need to be in the release notes_ - this only changes _when_ the error appears, there was still an error shown before. 

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
