### PR TITLE
Parallelize runpylint script

### DIFF
--- a/buildconfig/CMake/PylintSetup.cmake
+++ b/buildconfig/CMake/PylintSetup.cmake
@@ -41,8 +41,10 @@ if ( PYLINT_FOUND )
         scripts/test
         Testing/SystemTests/tests/analysis/reference
   )
-  set ( PYLINT_OUTPUT_DIR ${CMAKE_BINARY_DIR}/bin/Testing )
-  set ( PYLINT_NTHREADS 8 )
+
+  set ( PYLINT_OUTPUT_DIR "" CACHE STRING "Directory used to write the output from each pyint check." )
+  # Choose the number of threads used
+  set ( PYLINT_NTHREADS 8 CACHE STRING "Number of processes used for running pylint" )
 
   add_custom_target ( pylintcheck
                       COMMAND ${PYTHON_EXECUTABLE} ${PYLINT_RUNNER_SCRIPT} --format=${PYLINT_OUTPUT_FORMAT}

--- a/buildconfig/CMake/PylintSetup.cmake
+++ b/buildconfig/CMake/PylintSetup.cmake
@@ -12,19 +12,14 @@ if ( PYLINT_FOUND )
   message ( STATUS "pylint version: ${PYLINT_VERSION}" )
 
   # Output format options
-  if ( NOT  PYLINT_OUTPUT_FORMAT )
-    # Use msvs for MSVC generator, colorized for everything else. The buildservers can
-    # set it to parseable for Jenkins
-    if ( MSVC )
-      set ( DEFAULT_FORMAT "msvs" )
-    else ()
-      set ( DEFAULT_FORMAT "colorized" )
-    endif ()
-    set ( PYLINT_OUTPUT_FORMAT ${DEFAULT_FORMAT} CACHE STRING "Desired pylint output format" )
-
-    # There are a limited set of allowed options
-    set_property( CACHE PYLINT_OUTPUT_FORMAT PROPERTY STRINGS "text" "html" "msvs" "parseable" "colorized" )
-  endif()
+  # Use msvs for MSVC generator, colorized for everything else. The buildservers can
+  # set it to parseable for Jenkins
+  if ( MSVC )
+    set ( DEFAULT_FORMAT "{path}({line}): [{msg_id}{obj}] {msg}" )
+  else ()
+    set ( DEFAULT_FORMAT "{C}:{line:3d},{column:2d}: {msg} ({symbol})" )
+  endif ()
+  set ( PYLINT_MSG_TEMPLATE ${DEFAULT_FORMAT} CACHE STRING "Desired pylint output format" )
 
   # add a pylint-check target to run pylint on the required files and directories
   # relative to the root source directory
@@ -47,7 +42,7 @@ if ( PYLINT_FOUND )
   set ( PYLINT_NTHREADS 8 CACHE STRING "Number of processes used for running pylint" )
 
   add_custom_target ( pylintcheck
-                      COMMAND ${PYTHON_EXECUTABLE} ${PYLINT_RUNNER_SCRIPT} --format=${PYLINT_OUTPUT_FORMAT}
+                      COMMAND ${PYTHON_EXECUTABLE} ${PYLINT_RUNNER_SCRIPT} --format="${PYLINT_MSG_TEMPLATE}"
                               --output=${PYLINT_OUTPUT_DIR}
                               --rcfile=${PYLINT_CFG_FILE}
                               --mantidpath=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}

--- a/buildconfig/CMake/PylintSetup.cmake
+++ b/buildconfig/CMake/PylintSetup.cmake
@@ -41,12 +41,17 @@ if ( PYLINT_FOUND )
         scripts/test
         Testing/SystemTests/tests/analysis/reference
   )
+  set ( PYLINT_OUTPUT_DIR ${CMAKE_BINARY_DIR}/bin/Testing )
+  set ( PYLINT_NTHREADS 8 )
+
   add_custom_target ( pylintcheck
                       COMMAND ${PYTHON_EXECUTABLE} ${PYLINT_RUNNER_SCRIPT} --format=${PYLINT_OUTPUT_FORMAT}
+                              --output=${PYLINT_OUTPUT_DIR}
                               --rcfile=${PYLINT_CFG_FILE}
                               --mantidpath=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}
                               --basedir=${BASE_DIR} --nofail
                               --exclude="${PYLINT_EXCLUDES}"
+                              --parallel=${PYLINT_NTHREADS}
                               ${PYLINT_INCLUDES}
                       COMMENT "Running pylint on selected python files"
                     )

--- a/buildconfig/Jenkins/pylint-buildscript
+++ b/buildconfig/Jenkins/pylint-buildscript
@@ -54,6 +54,9 @@ cd $BUILD_DIR
 # Clean some artifacts
 ###############################################################################
 rm -rf $BUILD_DIR/bin
+# legacy file
+rm -fr $BUILD_DIR/pylint.log
+
 
 ###############################################################################
 ## Build configuration

--- a/buildconfig/Jenkins/pylint-buildscript
+++ b/buildconfig/Jenkins/pylint-buildscript
@@ -76,7 +76,8 @@ fi
 # Need this because some strange control sequences when using default TERM=xterm
 export TERM="linux"
 PYLINT_OUTPUT_DIR=$BUILD_DIR/pylint
-$SCL_ON_RHEL6 "cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=OFF -DMAKE_VATES=OFF -DPYLINT_OUTPUT_FORMAT=parseable -DPYLINT_NTHREADS=$BUILD_THREADS -DPYLINT_OUTPUT_DIR=${PYLINT_OUTPUT_DIR} .."
+PYLINT_FORMAT="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"
+$SCL_ON_RHEL6 "cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=OFF -DMAKE_VATES=OFF -DPYLINT_MSG_TEMPLATE=\"${PYLINT_FORMAT}\" -DPYLINT_NTHREADS=$BUILD_THREADS -DPYLINT_OUTPUT_DIR=${PYLINT_OUTPUT_DIR} .."
 
 ###############################################################################
 # Build step (we only need the framework)

--- a/buildconfig/Jenkins/pylint-buildscript
+++ b/buildconfig/Jenkins/pylint-buildscript
@@ -75,7 +75,8 @@ fi
 
 # Need this because some strange control sequences when using default TERM=xterm
 export TERM="linux"
-$SCL_ON_RHEL6 "cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=OFF -DMAKE_VATES=OFF -DPYLINT_OUTPUT_FORMAT=parseable .."
+PYLINT_OUTPUT_DIR=$BUILD_DIR/pylint
+$SCL_ON_RHEL6 "cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=OFF -DMAKE_VATES=OFF -DPYLINT_OUTPUT_FORMAT=parseable -DPYLINT_NTHREADS=$BUILD_THREADS -DPYLINT_OUTPUT_DIR=${PYLINT_OUTPUT_DIR} .."
 
 ###############################################################################
 # Build step (we only need the framework)
@@ -83,6 +84,6 @@ $SCL_ON_RHEL6 "cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENA
 $SCL_ON_RHEL6 "cmake --build . --target Framework -- -j$BUILD_THREADS"
 
 ###############################################################################
-# Run plint check 
+# Run plint check
 ###############################################################################
-$SCL_ON_RHEL6 "cmake --build . --target pylintcheck" > pylint.log
+$SCL_ON_RHEL6 "cmake --build . --target pylintcheck"

--- a/tools/Pylint/run_pylint.py
+++ b/tools/Pylint/run_pylint.py
@@ -114,7 +114,7 @@ def main(argv):
 
     options, args = parse_arguments(argv[1:])
     setup_environment(options.mantidpath)
-
+    create_dir_if_required(options.outputdir)
     status = run_checks(args, options)
 
     if status or options.nofail:
@@ -215,6 +215,18 @@ def setup_mantidpath(mantidpath):
     # for subprocesses
     os.environ["PYTHONPATH"] = mantidpath + os.pathsep + cur_pypath
     sys.path.insert(0, mantidpath) # for current process
+
+#------------------------------------------------------------------------------
+
+def create_dir_if_required(path):
+    """
+    Create the given directory if it doesn't exist
+
+    Arguments:
+      path (str): Absolute path to a directory
+    """
+    if not os.path.exists(path):
+        os.makedirs(path)
 
 #------------------------------------------------------------------------------
 

--- a/tools/Pylint/run_pylint.py
+++ b/tools/Pylint/run_pylint.py
@@ -14,7 +14,7 @@ import sys
 import time
 
 # Default output format
-DEFAULT_PYLINT_FORMAT = 'text'
+DEFAULT_PYLINT_FORMAT = '{msg_id}:{line:3d},{column}: {obj}: {msg}'
 # Exe to call
 DEFAULT_PYLINT_EXE = 'pylint'
 # Default log level
@@ -141,8 +141,7 @@ def parse_arguments(argv):
                            "Default is to simply call 'pylint'")
     parser.add_option("-f", "--format", dest="format", metavar = "FORMAT",
                       help="If provided, use the given format type "\
-                           "[default=%s]. Options are: text, html, msvs, "\
-                           "parseable" % DEFAULT_PYLINT_FORMAT)
+                           "[default=%s]." % DEFAULT_PYLINT_FORMAT)
     parser.add_option("-m", "--mantidpath", dest="mantidpath", metavar="MANTIDPATH",
                       help="If provided, use this as the MANTIDPATH, overriding"
                            "anything that is currently set.")
@@ -225,7 +224,7 @@ def create_dir_if_required(path):
     Arguments:
       path (str): Absolute path to a directory
     """
-    if not os.path.exists(path):
+    if path and not os.path.exists(path):
         os.makedirs(path)
 
 #------------------------------------------------------------------------------
@@ -471,7 +470,7 @@ def build_pylint_cmd(srcpath, options):
       A list of args to pass to subprocess.Popen
     """
     cmd = [options.exe]
-    cmd.extend(["-f", options.format])
+    cmd.extend(["--msg-template=" + options.format])
     if options.rcfile is not None:
         cmd.extend(["--rcfile=" + options.rcfile])
     # and finally, source module

--- a/tools/Pylint/run_pylint.py
+++ b/tools/Pylint/run_pylint.py
@@ -2,17 +2,16 @@
     runpylint
     ~~~~~~~~~
 
-    Run pylint on selected Python files/directories. By default the output is sent to stdout
-    but there is an option to save to a file
+    Run pylint on selected Python files/directories.
 """
 from __future__ import print_function
 
-from contextlib import contextmanager
 import logging
 from optparse import OptionParser
 import os.path
 import subprocess as subp
 import sys
+import time
 
 # Default output format
 DEFAULT_PYLINT_FORMAT = 'text'
@@ -22,24 +21,11 @@ DEFAULT_PYLINT_EXE = 'pylint'
 DEFAULT_LOG_LEVEL = logging.WARNING
 # Default config file
 DEFAULT_RCFILE = os.path.join(os.path.dirname(__file__), "pylint.cfg")
+# Default number of processes
+DEFAULT_NPROCS = 8
 
-#------------------------------------------------------------------------------
-
-@contextmanager
-def temp_dir_change(directory):
-    """
-    Change directory temporarily for a given context
-
-    Args:
-      directory (str): A string denoting the new directory
-    """
-    start_dir = os.getcwd()
-    if directory == start_dir:
-        yield
-    else:
-        os.chdir(directory)
-        yield
-        os.chdir(start_dir)
+# Prefix to label all result files
+OUTPUT_PREFIX = "PYLINT-"
 
 #------------------------------------------------------------------------------
 
@@ -128,11 +114,8 @@ def main(argv):
 
     options, args = parse_arguments(argv[1:])
     setup_environment(options.mantidpath)
-    serializer = get_serializer(options.output)
 
-    status = run_checks(args, serializer, options)
-    if type(serializer) == file:
-        serializer.close()
+    status = run_checks(args, options)
 
     if status or options.nofail:
         return 0
@@ -168,15 +151,18 @@ def parse_arguments(argv):
     parser.add_option("-r", "--rcfile", dest="rcfile", metavar = "CFG_FILE",
                       help="If provided, use this configuration file "
                            "instead of the default one")
-    parser.add_option("-o", "--output", dest="output", metavar="FILE",
-                      help="If provided, store the output in the given file.")
+    parser.add_option("-o", "--output", dest="outputdir", metavar="OUTDIR",
+                      help="If provided, store the output given directory")
     parser.add_option("-x", "--exclude", dest="exclude", metavar="EXCLUDES",
                       help="If provided, a space-separated list of "
                            "files/directories to exclude. Relative paths are "
                            "taken as relative to --basedir")
+    parser.add_option("-j", "--parallel", dest="parallel", metavar="PARALLEL",
+                      help="")
 
     parser.set_defaults(format=DEFAULT_PYLINT_FORMAT, exe=DEFAULT_PYLINT_EXE, nofail=False,
-                        basedir=os.getcwd(), rcfile=DEFAULT_RCFILE, exclude="")
+                        basedir=os.getcwd(), rcfile=DEFAULT_RCFILE, exclude="",
+                        parallel=DEFAULT_NPROCS)
 
     options, args = parser.parse_args(argv)
     if len(args) < 1:
@@ -268,69 +254,119 @@ def get_serializer(filename):
 
 #------------------------------------------------------------------------------
 
-def run_checks(targets, serializer, options):
+def run_checks(relpaths, options):
     """
-    Run pylint on the chosen targets
+    Run pylint on the chosen files/directories
 
     Args:
-      targets (list): A list of relative directory/file targets relative
+      relpaths (list): A list of relative directory/file targets relative
                       to options.basedir
-      serializer (file-like): An object with a write method that will receive
-                              the output
       options (object): Settings to use when running pylint
     Returns:
       bool: Success/failure
     """
-    overall_stats = Results()
     # convert to excludes absolute paths
-    def make_abs(path):
-        return os.path.join(options.basedir, path)
-    excludes = map(make_abs, options.exclude)
+    excludes = map(lambda path: os.path.join(options.basedir, path),
+                   options.exclude)
+    # Gather targets first
+    target_paths = gather_targets(options.basedir, relpaths, excludes)
+    logging.debug("Found {} targets".format(len(target_paths)))
+    max_jobs = int(options.parallel)
+    processes = []
+    results = Results()
+    logging.debug("Parallezing over {0} processes".format(options.parallel))
+    for index, target in enumerate(target_paths):
+        results_path = get_results_path(options.outputdir,
+                                        os.path.relpath(target, options.basedir))
+        if len(processes) == max_jobs:
+            logging.debug("Full processor load hit. Waiting for available slot.")
+            while True:
+                processes, child_results = get_proc_results(processes)
+                if child_results.totalchecks > 0:
+                    # Implies there is a slot available
+                    results.update(child_results)
+                    break
+                else:
+                    time.sleep(0.2)
+        #endif
+        logging.debug("Slot available. Running next check.")
+        serializer = open(results_path, 'w')
+        processes.append(start_pylint(target, serializer, options))
+    #endfor
+    # There will be a last set of processes in the list
+    _, child_results = get_proc_results(processes, wait=True)
+    results.update(child_results)
 
-    for target in targets:
-        # pylint will only check modules or packages so we need to do some additional work
-        # for plain directories
-        targetpath = os.path.join(options.basedir, target)
-        pkg_init = os.path.join(targetpath, "__init__.py")
-        if os.path.isfile(targetpath) or os.path.isfile(pkg_init):
-            overall_stats.add(targetpath, exec_pylint_on_importable(targetpath, serializer, options))
-        else:
-            overall_stats.update(exec_pylint_on_all(targetpath, serializer, options, excludes))
-    ##
-    print(overall_stats.summary())
-
-    return overall_stats.success
+    # Get a summary of the failures
+    print(results.summary())
+    return results.success
 
 #------------------------------------------------------------------------------
 
-def exec_pylint_on_all(dirpath, serializer, options, excludes=[]):
+def get_proc_results(processes, wait=False):
     """
-    Executes pylint on .py files and packages from the given starting directory
+    Return a list of processed results if any are available and pops
+    the finished ones of the list
 
     Args:
-      dirpath (str): A string giving a directory to parse
-      serializer (file-like): An object with a write method that will receive
-                              the output
-      options (object): Settings to use when running pylint
-      excludes (list): A list of absolute paths to exclude from the checks
+      processes: A list of running processes
+      wait (bool): If true, wait until all processes have finished
+    Returns:
+      (Updated processes, results)
+    """
+    results = Results()
+    nprocs = len(processes)
+    running = []
+    for index, proc_info in enumerate(processes):
+        if wait:
+            proc_info[0].wait()
+        else:
+            proc_info[0].poll()
+        exitcode = proc_info[0].returncode
+        if exitcode is None:
+            running.append(proc_info)
+        else:
+            results.add(proc_info[1], (exitcode == 0))
+            proc_info[2].close()
+
+    if wait:
+        assert(len(running) == 0)
+        return None, results
+    else:
+        return running, results
+
+#------------------------------------------------------------------------------
+
+def gather_targets(basedir, relpaths, excludes=[]):
+    """
+    Walks the given directories and finds all importable entities.
+
+    Args:
+      basedir (str): A string giving a directory to which all relative
+                     paths are based
+      relpaths (list): A list of relative paths to search for importable
+                       entities
+      excludes (list): A list of absolute paths to exclude
     Returns:
       Results: Object detailing passes and failures
     """
-    def skip_item(abspath):
-        for excluded in excludes:
-            if abspath.startswith(excluded):
-                return True
-        return False
-    logging.debug("Discovering all importable python modules/packages"
-                  " from '%s'" , dirpath)
-    targets  = find_importable_targets(dirpath)
-    stats = Results()
-    for item in targets:
-        if skip_item(item):
-            logging.debug("Skipping item '%s' by request", item)
+    logging.debug("Discovering all importable python modules/packages")
+    targets = []
+    for relpath in relpaths:
+        # pylint will only check modules or packages
+        targetpath = os.path.join(basedir, relpath)
+        pkg_init = os.path.join(targetpath, "__init__.py")
+        if os.path.isfile(targetpath) or os.path.isfile(pkg_init):
+            targets.append(targetpath)
         else:
-            stats.add(item, exec_pylint_on_importable(item, serializer, options))
-    return stats
+            targets.extend(find_importable_targets(targetpath))
+    #endfor
+    def include_target(path):
+        for exclude_path in excludes:
+            if path.startswith(exclude_path):
+                return False
+        return True
+    return filter(include_target, targets)
 
 #------------------------------------------------------------------------------
 
@@ -362,18 +398,50 @@ def find_importable_targets(dirpath):
 
 #------------------------------------------------------------------------------
 
-def exec_pylint_on_importable(srcpath, serializer, options):
+def get_results_path(dirname, target):
     """
-    Runs the pylint executable on the given file/package path to produce output
-    in the chosen format
+    Return the path to a results file for the given target
+
+    Args:
+      dirname (str): An output directory to store the file
+      target (str): An absolute path to a target
+    Returns:
+      An absolute path to a results file
+    """
+    return os.path.join(dirname, OUTPUT_PREFIX + target.replace("/", "-") + ".log")
+
+#------------------------------------------------------------------------------
+
+def start_pylint(srcpath, serializer, options):
+    """
+    Runs pylint on the given file/package
 
     Args:
       srcpath (str): A string giving a path to a file or package to analyze
       serializer (file-like): An object with a write method that will receive
                               the output
       options (object): Settings to use when running pylint
+    Returns:
+      The (proc, srcpath, serializer)
     """
     logging.info("Running pylint on '%s'", srcpath)
+    proc = subp.Popen(build_pylint_cmd(srcpath, options), stdout=serializer,
+                      stderr=serializer,
+                      cwd=os.path.dirname(srcpath))
+    return proc, srcpath, serializer
+
+#------------------------------------------------------------------------------
+
+def build_pylint_cmd(srcpath, options):
+    """
+    Build a list defining the command to run pylint for the given target
+
+    Args:
+      srcpath (str): A string giving a path to a file or package to analyze
+      options (object): Settings to use when running pylint
+    Returns:
+      A list of args to pass to subprocess.Popen
+    """
     cmd = [options.exe]
     cmd.extend(["-f", options.format])
     if options.rcfile is not None:
@@ -382,15 +450,9 @@ def exec_pylint_on_importable(srcpath, serializer, options):
     # pylint runs by importing the modules so we strip the filepath
     # and change directory to the containing folder
     cmd.append(os.path.basename(srcpath))
-
-    logging.debug("Command '%s'" , " ".join(cmd))
-    with temp_dir_change(os.path.dirname(srcpath)):
-        status = subp.call(cmd, stdout=serializer)
-
-    return status == 0
+    return cmd
 
 #------------------------------------------------------------------------------
-
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))


### PR DESCRIPTION
The `run_pylint.py` script now has the option to run the checks in parallel. This is configured using the cmake variable `PYLINT_NTHREADS`, similarly to `cppcheck` 

**To test:**
- Run `cmake -DPYLINT_NTHREADS=X` and replace `X` with the required number
- Check the resource utilization and you should see X number of separate processes running.

On my machine the checks in serial took around 5 minutes. With `DPYLINT_NTHREADS=8` they completed in less than a minute.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
