### PR TITLE
Fix freeze in sequential fit dialog with bad run string

### DIFF
--- a/MantidQt/MantidWidgets/src/MWRunFiles.cpp
+++ b/MantidQt/MantidWidgets/src/MWRunFiles.cpp
@@ -794,6 +794,7 @@ void MWRunFiles::inspectThreadResult() {
 
   if (!error.empty()) {
     setFileProblem(QString::fromStdString(error));
+    emit fileInspectionFinished();
     return;
   }
 


### PR DESCRIPTION
Fix a freeze observed in the muon sequential fit dialog when the run number string was badly formed.

One-line fix: make sure the fileInspectionFinished signal is emitted even if there was an error.

**To test:**
- Open Interfaces/Muon/Muon Analysis and ensure the test data directories are in Mantid's directory path
- Load any muon file, for example `MUSR00015189.nxs` from the test data
- Go to "Data Analysis" tab and fit something to the data
- Click Fit/Sequential fit. In the dialog that opens, enter a bad run number string e.g. "15191-15189" and click Run
  - Should get an error and no freeze
- With a good run number string like "15189-15191", it should work as normal.

Fixes #16435.

_Does not need to be in the release notes._ (Problem was not in last release).

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
