### PR TITLE
Indirect Data Analysis I(Q, t) Fit - Remove Fit and Diff curves when guess is added

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -657,10 +657,13 @@ void IqtFit::propertyChanged(QtProperty *prop, double val) {
 }
 
 void IqtFit::plotGuessChanged(bool checked) {
-  if (!checked)
+  if (!checked) {
     m_uiForm.ppPlot->removeSpectrum("Guess");
-  else
+  } else {
+    m_uiForm.ppPlot->removeSpectrum("Fit");
+    m_uiForm.ppPlot->removeSpectrum("Diff");
     plotGuess(NULL);
+  }
 }
 
 void IqtFit::checkBoxUpdate(QtProperty *prop, bool checked) {


### PR DESCRIPTION
After running an algorithm in the I(Q, t)Fit interface the Fit and Diff are plotted in the mini plot along with the sample. These curves are now removed when Plot guess is checked (leaving only sample and Guess curves)

**To test:**
- Open `I(Q, t) Fit`(Interfaces > Indirect > Data Analysis > I(Q, t) Fit
- Load in `iris26176_graphite002_iqt.nxs` from the unit test data directory
- Change `EndX` to `0.20`
- Click `Run`
- Observe that after the algorithm completes `Sample`, `Fit` and `Diff` curves are in the mini plot
- Check the Plot Guess option
- Ensure that the `Fit` and `Diff` are removed and `Guess` is added (leaving only `Guess` and `Sample` curves)

Fixes #16421

_Does not need to be in the release notes. Too minor_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
