### PR TITLE
ALC: improve autoreduction performance

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/ALCLatestFileFinder.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCLatestFileFinder.cpp
@@ -9,27 +9,23 @@ namespace CustomInterfaces {
 
 /**
  * Gets the most recently modified valid Nexus file in the same directory as the
- * first run
+ * first run. Assumes files go in run number order.
  * @returns Path to most recently modified file
  */
 std::string ALCLatestFileFinder::getMostRecentFile() const {
   if (m_firstRunFileName.empty()) {
     return "";
   } else {
+    // List all valid Nexus files in the directory
     Poco::Path path(m_firstRunFileName);
-    Poco::File latestFile(path);
-    Poco::Timestamp lastModified(0); // start at Epoch
+    std::vector<std::string> fileNames;
     try {
       // Directory iterator - check if we were passed a file or a directory
-      Poco::DirectoryIterator iter(latestFile.isDirectory() ? path
-                                                            : path.parent());
+      Poco::DirectoryIterator iter(path.isDirectory() ? path : path.parent());
       Poco::DirectoryIterator end; // the end iterator
       while (iter != end) {
         if (isValid(iter->path())) {
-          if (iter->getLastModified() > lastModified) {
-            latestFile = *iter;
-            lastModified = iter->getLastModified();
-          }
+          fileNames.push_back(iter->path());
         }
         ++iter;
       }
@@ -38,7 +34,11 @@ std::string ALCLatestFileFinder::getMostRecentFile() const {
       // Return the file we were given.
       return path.toString();
     }
-    return latestFile.path();
+
+    // Sort by run number
+    std::sort(fileNames.begin(), fileNames.end());
+
+    return fileNames.back();
   }
 }
 

--- a/MantidQt/CustomInterfaces/test/ALCLatestFileFinderTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCLatestFileFinderTest.h
@@ -154,4 +154,42 @@ private:
   }
 };
 
+/// Performance tests
+class ALCLatestFileFinderTestPerformance : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ALCLatestFileFinderTestPerformance *createSuite() {
+    return new ALCLatestFileFinderTestPerformance();
+  }
+  static void destroySuite(ALCLatestFileFinderTestPerformance *suite) {
+    delete suite;
+  }
+
+  ALCLatestFileFinderTestPerformance() {
+    for (size_t i = 10; i < 59; i++) {
+      std::ostringstream time, run;
+      time << "2116-03-16T18:00:" << i;
+      run << "900" << i;
+      m_files.emplace_back(time.str(), "MUSR", run.str());
+    }
+  }
+
+  // Set up files here - will be deleted when the class is destroyed
+  void setUp() override {}
+
+  void tearDown() override {
+    TS_ASSERT_EQUALS(m_mostRecent, m_files.back().getFileName());
+  }
+
+  void test_latestFileFinder_performance() {
+    ALCLatestFileFinder finder(m_files[0].getFileName());
+    m_mostRecent = finder.getMostRecentFile();
+  }
+
+private:
+  std::vector<TestFile> m_files;
+  std::string m_mostRecent;
+};
+
 #endif /* MANTID_CUSTOMINTERFACES_ALCLATESTFILEFINDERTEST_H_ */

--- a/MantidQt/CustomInterfaces/test/ALCLatestFileFinderTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCLatestFileFinderTest.h
@@ -94,13 +94,13 @@ public:
   void test_getMostRecentFile() {
     auto files = generateTestFiles();
     ALCLatestFileFinder finder(files[0].getFileName());
-    TS_ASSERT_EQUALS(finder.getMostRecentFile(), files[1].getFileName());
+    TS_ASSERT_EQUALS(finder.getMostRecentFile(), files[2].getFileName());
     { // file added
       auto newFile = TestFile("2116-03-15T15:00:00", "MUSR", "90003");
       TS_ASSERT_EQUALS(finder.getMostRecentFile(), newFile.getFileName());
     }
     // file removed (newFile went out of scope)
-    TS_ASSERT_EQUALS(finder.getMostRecentFile(), files[1].getFileName());
+    TS_ASSERT_EQUALS(finder.getMostRecentFile(), files[2].getFileName());
   }
 
   /**
@@ -110,7 +110,7 @@ public:
     auto files = generateTestFiles();
     auto nonNexus = TestFile("2116-03-15T16:00:00", "MUSR", "90004", "run");
     ALCLatestFileFinder finder(files[0].getFileName());
-    TS_ASSERT_EQUALS(finder.getMostRecentFile(), files[1].getFileName());
+    TS_ASSERT_EQUALS(finder.getMostRecentFile(), files[2].getFileName());
   }
 
   /**
@@ -122,7 +122,7 @@ public:
     ALCLatestFileFinder finder(files[0].getFileName());
     std::string foundFile;
     TS_ASSERT_THROWS_NOTHING(foundFile = finder.getMostRecentFile());
-    TS_ASSERT_EQUALS(foundFile, files[1].getFileName());
+    TS_ASSERT_EQUALS(foundFile, files[2].getFileName());
   }
 
   /**
@@ -134,21 +134,22 @@ public:
     ALCLatestFileFinder finder(files[0].getFileName());
     std::string foundFile;
     TS_ASSERT_THROWS_NOTHING(foundFile = finder.getMostRecentFile());
-    TS_ASSERT_EQUALS(foundFile, files[1].getFileName());
+    TS_ASSERT_EQUALS(foundFile, files[2].getFileName());
   }
 
 private:
   /**
    * Generate three scoped test files
-   * The second file is the most recent
+   * The creation dates go in run number order, as is the case with real files
+   * (confirmed with scientists that this is always the case)
    * @returns :: vector containing three files
    */
   std::vector<TestFile> generateTestFiles() {
     std::vector<TestFile> files;
     // 100 years so it won't clash with other files in temp directory
     files.emplace_back("2116-03-15T12:00:00", "MUSR", "90000");
-    files.emplace_back("2116-03-15T14:00:00", "MUSR", "90001");
-    files.emplace_back("2116-03-15T13:00:00", "MUSR", "90002");
+    files.emplace_back("2116-03-15T13:00:00", "MUSR", "90001");
+    files.emplace_back("2116-03-15T14:00:00", "MUSR", "90002");
     return files;
   }
 };

--- a/docs/source/release/v3.7.0/muon.rst
+++ b/docs/source/release/v3.7.0/muon.rst
@@ -18,6 +18,7 @@ Muon ALC
   - The "Function" box was renamed "Take log value at" and moved next to the log to which it applies
   - The integration start time is initialised to the first good data rather than the first time bin, and is not reset when a new first run is loaded
   - The choice of periods is no longer reset when a new first run is loaded
+- Performance has been improved slightly for the "Auto" latest file finding functionality.
 
 Muon Analysis
 #############


### PR DESCRIPTION
When using the "Auto" latest file finding in the ALC interface, reduce the time it spends sitting around before loading data.

Instead of querying each file for its latest modification time (which may not be accurate in any case if files have been copied in batches), it is safe to assume the files go in run number order and the file with the highest run number is the most recent one. This should increase the speed of finding the latest file before file loading starts.

The file finding has existing unit tests and a new performance test has been added to these.

**To test:**

The problem is particularly noticeable when using large sets of data stored on a remote PC.
For example, test with data in `\\hifi\data`, which has 62,504 items: (may require Windows unless you can mount this share)
- Open Interfaces/Muon/ALC
- Set "first" run file to a file that's a few back from the end
- Tick the "Auto" checkbox next to the last run box
- Hit "Run" and see how long it takes before file loading starts.

I tested this using `HIFI00106584.nxs` as the first run (latest run at that time was `HIFI00106443.nxs`). The interface took 25 seconds before loading files on installed beta test build, and this PR build took more like 10 seconds.

Fixes #16373.

[Release notes](https://github.com/mantidproject/mantid/blob/36a22a3a961979a44024e6688ac2094a8ed2697f/docs/source/release/v3.7.0/muon.rst#muon-alc) have been updated.
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
