### PR TITLE
Multi Dataset Fitting interface beta bugs

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MultiDatasetFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MultiDatasetFit.h
@@ -137,6 +137,8 @@ private:
   QString m_outputWorkspaceName;
   /// Fit algorithm runner
   boost::shared_ptr<API::AlgorithmRunner> m_fitRunner;
+  /// Remembers setting for just current session
+  int m_fitAllSettings;
 };
 
 } // CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
@@ -124,10 +124,6 @@ void DataController::workspaceSelectionChanged()
 {
   auto selection = m_dataTable->selectionModel();
   bool enableRemoveButton = selection->hasSelection();
-  if ( enableRemoveButton )
-  {
-    enableRemoveButton = selection->selectedRows().size() > 0;
-  }
 
   emit hasSelection(enableRemoveButton);
 }

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFFunctionPlotData.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFFunctionPlotData.cpp
@@ -8,7 +8,10 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/Exception.h"
 
+#include <qwt_plot.h>
 #include <qwt_plot_curve.h>
+
+
 
 namespace MantidQt
 {
@@ -58,9 +61,20 @@ void MDFFunctionPlotData::setDomain(double startX, double endX, size_t nX)
 }
 
 /// Show the curves on a plot.
-void MDFFunctionPlotData::show(QwtPlot *plot)
-{
+void MDFFunctionPlotData::show(QwtPlot *plot) {
   m_functionCurve->attach(plot);
+
+  auto itemList = plot->itemList();
+
+  // set the guess plot on the bottom
+  double lowestZ = 0.0;
+  for (auto item : itemList) {
+    auto z = item->z();
+    if (lowestZ > z)
+      lowestZ = z;
+  }
+
+  m_functionCurve->setZ(lowestZ - 1.0);
 }
 
 /// Hide the curves from any plot.

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFPlotController.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFPlotController.cpp
@@ -457,7 +457,7 @@ void PlotController::showGuessFunction(bool ok)
   m_showGuessFunction = ok;
   if (ok)
   {
-    updateGuessPlot();
+	plotGuess();
   }
   else
   {

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFPlotController.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFPlotController.cpp
@@ -457,7 +457,7 @@ void PlotController::showGuessFunction(bool ok)
   m_showGuessFunction = ok;
   if (ok)
   {
-    plotGuess();
+    updateGuessPlot();
   }
   else
   {

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFPlotController.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFPlotController.cpp
@@ -273,22 +273,32 @@ void PlotController::exportCurrentPlot()
 }
 
 /// Export all plots
-void PlotController::exportAllPlots()
-{
+void PlotController::exportAllPlots() {
   int nPlots = owner()->getNumberOfSpectra();
-  if (nPlots <= 0) return;
-  QString pyInput = "from mantidplot import newTiledWindow\n";
-  pyInput += "newTiledWindow(sources=[";
-  for(int index = 0; index < nPlots; ++index)
-  {
-    if (index > 0)
-    {
-      pyInput += ",";
-    }
-    pyInput += QString("(%1)").arg(makePyPlotSource(index));
+  int exportPlot = QMessageBox::Yes;
+  if (nPlots > 20) {
+    exportPlot = QMessageBox::question(owner(), "Export All Plot?",
+                                       "Are you sure, you want to export " +
+                                           QString::number(nPlots) +
+                                           " plots? This may take a long time!",
+                                       QMessageBox::Yes, QMessageBox::No);
   }
-  pyInput += "])\n";
-  owner()->runPythonCode(pyInput);
+
+  if (exportPlot == QMessageBox::Yes) {
+
+    if (nPlots <= 0)
+      return;
+    QString pyInput = "from mantidplot import newTiledWindow\n";
+    pyInput += "newTiledWindow(sources=[";
+    for (int index = 0; index < nPlots; ++index) {
+      if (index > 0) {
+        pyInput += ",";
+      }
+      pyInput += QString("(%1)").arg(makePyPlotSource(index));
+    }
+    pyInput += "])\n";
+    owner()->runPythonCode(pyInput);
+  }
 }
 
 /// Disable all plot tools. It is a helper method 

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFPlotController.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFPlotController.cpp
@@ -85,7 +85,7 @@ void PlotController::tableUpdated()
   for(int row = 0; row < rowCount; ++row)
   {
     QString itemText = QString("%1 (%2)").arg(m_table->item(row,wsColumn)->text(),m_table->item(row,wsIndexColumn)->text());
-    m_plotSelector->insertItem(-1, itemText);
+    m_plotSelector->insertItem(row, itemText);
   }
   m_plotData.clear();
   m_currentIndex = -1;

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
@@ -36,7 +36,7 @@ DECLARE_SUBWINDOW(MultiDatasetFit)
 /// @param parent :: The parent widget
 MultiDatasetFit::MultiDatasetFit(QWidget *parent)
 :UserSubWindow(parent), m_plotController(NULL), m_dataController(NULL), m_functionBrowser(NULL),
- m_fitOptionsBrowser(NULL)
+ m_fitOptionsBrowser(NULL), m_fitAllSettings(QMessageBox::No)
 {
 }
 
@@ -181,8 +181,9 @@ void MultiDatasetFit::fitSequential()
 {
   try
   {
-	// disable button to avoid multiple fit click
-	m_uiForm.btnFit->setEnabled(false);
+
+    /// disable button to avoid multiple fit click
+    m_uiForm.btnFit->setEnabled(false);
 
     std::ostringstream input;
 
@@ -231,7 +232,8 @@ void MultiDatasetFit::fitSimultaneous()
 {
   try
   {
-	m_uiForm.btnFit->setEnabled(false);
+
+    m_uiForm.btnFit->setEnabled(false);
     auto fun = createFunction();
     auto fit = Mantid::API::AlgorithmManager::Instance().create("Fit");
     fit->initialize();
@@ -304,23 +306,29 @@ void MultiDatasetFit::fit() {
   int fitAll = QMessageBox::Yes;
 
   if (fittingType == MantidWidgets::FitOptionsBrowser::Simultaneous) {
-    if (n > 20) {
+    if (n > 20 && m_fitAllSettings == QMessageBox::No) {
       fitAll = QMessageBox::question(this, "Fit All?",
                                      "Are you sure you would like to fit " +
                                          QString::number(n) +
                                          " spectrum simultaneously?",
                                      QMessageBox::Yes, QMessageBox::No);
+
+      if (fitAll == QMessageBox::Yes)
+        m_fitAllSettings = QMessageBox::Yes;
     }
     if (fitAll == QMessageBox::Yes) {
       fitSimultaneous();
     }
 
   } else if (fittingType == MantidWidgets::FitOptionsBrowser::Sequential) {
-    if (n > 100) {
+    if (n > 100 && m_fitAllSettings == QMessageBox::No) {
       fitAll = QMessageBox::question(
           this, "Fit All?", "Are you sure you would like to fit " +
                                 QString::number(n) + " spectrum sequentially?",
           QMessageBox::Yes, QMessageBox::No);
+
+      if (fitAll == QMessageBox::Yes)
+        m_fitAllSettings = QMessageBox::Yes;
     }
     if (fitAll == QMessageBox::Yes) {
       fitSequential();

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
@@ -181,6 +181,9 @@ void MultiDatasetFit::fitSequential()
 {
   try
   {
+	// disable button to avoid multiple fit click
+	m_uiForm.btnFit->setEnabled(false);
+
     std::ostringstream input;
 
     int n = getNumberOfSpectra();
@@ -228,6 +231,7 @@ void MultiDatasetFit::fitSimultaneous()
 {
   try
   {
+	m_uiForm.btnFit->setEnabled(false);
     auto fun = createFunction();
     auto fit = Mantid::API::AlgorithmManager::Instance().create("Fit");
     fit->initialize();
@@ -418,6 +422,7 @@ void MultiDatasetFit::finishFit(bool error)
       showParameterPlot();
     }
   }
+  m_uiForm.btnFit->setEnabled(true);
 }
 
 /// Update the interface to have the same parameter values as in a function.

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
@@ -224,6 +224,7 @@ void MultiDatasetFit::fitSequential()
       mess += "...";
     }
     QMessageBox::critical( this, "MantidPlot - Error", QString("PlotPeakByLogValue failed:\n\n  %1").arg(mess) );
+    m_uiForm.btnFit->setEnabled(true);
   }
 }
 
@@ -291,6 +292,7 @@ void MultiDatasetFit::fitSimultaneous()
       mess += "...";
     }
     QMessageBox::critical( this, "MantidPlot - Error", QString("Fit failed:\n\n  %1").arg(mess) );
+    m_uiForm.btnFit->setEnabled(true);
   }
 }
 

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
@@ -293,27 +293,41 @@ void MultiDatasetFit::fitSimultaneous()
 }
 
 /// Run the fitting algorithm.
-void MultiDatasetFit::fit()
-{
-  if ( !m_functionBrowser->hasFunction() )
-  {
-    QMessageBox::warning( this, "MantidPlot - Warning","Function wasn't set." );
+void MultiDatasetFit::fit() {
+  if (!m_functionBrowser->hasFunction()) {
+    QMessageBox::warning(this, "MantidPlot - Warning", "Function wasn't set.");
     return;
   }
 
   auto fittingType = m_fitOptionsBrowser->getCurrentFittingType();
-  
-  if (fittingType == MantidWidgets::FitOptionsBrowser::Simultaneous)
-  {
-    fitSimultaneous();
-  }
-  else if (fittingType == MantidWidgets::FitOptionsBrowser::Sequential)
-  {
-    fitSequential();
-  }
-  else
-  {
-    throw std::logic_error("Unrecognised fitting type. Only Normal and Sequential are accepted.");
+  auto n = getNumberOfSpectra();
+  int fitAll = QMessageBox::Yes;
+
+  if (fittingType == MantidWidgets::FitOptionsBrowser::Simultaneous) {
+    if (n > 20) {
+      fitAll = QMessageBox::question(this, "Fit All?",
+                                     "Are you sure you would like to fit " +
+                                         QString::number(n) +
+                                         " spectrum simultaneously?",
+                                     QMessageBox::Yes, QMessageBox::No);
+    }
+    if (fitAll == QMessageBox::Yes) {
+      fitSimultaneous();
+    }
+
+  } else if (fittingType == MantidWidgets::FitOptionsBrowser::Sequential) {
+    if (n > 100) {
+      fitAll = QMessageBox::question(
+          this, "Fit All?", "Are you sure you would like to fit " +
+                                QString::number(n) + " spectrum sequentially?",
+          QMessageBox::Yes, QMessageBox::No);
+    }
+    if (fitAll == QMessageBox::Yes) {
+      fitSequential();
+    }
+  } else {
+    throw std::logic_error(
+        "Unrecognised fitting type. Only Normal and Sequential are accepted.");
   }
 }
 


### PR DESCRIPTION
**Description of work.**

This PR should fix few bugs found on the Multi-Dataset Fitting interface. 
It was recommended that I should not change the term `workspace index` to anything else for the moment as it is not spectrum number displayed within the table. _Fit parameters shrinking text_ seems to be a platform issue as it seems to work fine on Windows. With help of @Jon-Taylor also discovered that `Edit Parameter Values` dialog doesn't seem to pop-up on Mac. -> Separate issue should be created for this. 
- Fixes bug with `Remove` button 
- Combobox below is now sorted in ascending order
- Plot Guess curve always plotted under fitted curve
- `Fit` button disabled during Fitting process
- pop-up question when `Export All Plot` is clicked and more than 20 spectra in table
- pop-up question when fitting simultaneous  and more than more than 20 spectra in table
- pop-up question when fitting sequentially and more than more than 100 spectra in table
  - if desired to continue fitting the settings will be remembered for current session

**To Test:**
Load -> `MUSR00015189` or any preferred data 
Go To: `Interfaces/Multi-dataset fitting` interface
`Add Workspace` & click `All Spectra` & `OK` (128 spectra should be added)
Once table loaded, Check that workspace/s can deleted be removed more freely
Check `combobox` below table is now sorted in ascending order
Right/Left button function more appropriately
Add a Function e.g: (ExpDecay)
Click `Fit` when `Fitting` property set to `Simultaneous`
Valid pop message should be displayed
Check same with `Sequential`
Check that it also remembers setting for session if `Yes` clicked

Reduce the number of spectra and `Fit` a function
Check that Plot Guess is always plotted behind `Fitted` Curve

To plot Fitted curve for `Sequential` -> `Create Ouput` property needs to be set as `true`

<!-- Instructions for testing. -->

Fixes #16430.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
