### PR TITLE
Fix workspace description for file-backed MD with no instrument

### DIFF
--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -88,14 +88,21 @@ const std::string ExperimentInfo::toString() const {
   std::ostringstream out;
 
   Geometry::Instrument_const_sptr inst = this->getInstrument();
-  out << "Instrument: " << inst->getName() << " ("
-      << inst->getValidFromDate().toFormattedString("%Y-%b-%d") << " to "
-      << inst->getValidToDate().toFormattedString("%Y-%b-%d") << ")";
-  out << "\n";
-  if (!inst->getFilename().empty()) {
-    out << "Instrument from: " << inst->getFilename();
-    out << "\n";
+  const auto instName = inst->getName();
+  out << "Instrument: ";
+  if (!instName.empty()) {
+    out << instName << " ("
+        << inst->getValidFromDate().toFormattedString("%Y-%b-%d") << " to "
+        << inst->getValidToDate().toFormattedString("%Y-%b-%d") << ")";
+    const auto instFilename = inst->getFilename();
+    if (!instFilename.empty()) {
+      out << "Instrument from: " << instFilename;
+      out << "\n";
+    }
+  } else {
+    out << "None";
   }
+  out << "\n";
 
   // parameter files loaded
   auto paramFileVector = this->instrumentParameters().getParameterFilenames();

--- a/Framework/API/src/FileBackedExperimentInfo.cpp
+++ b/Framework/API/src/FileBackedExperimentInfo.cpp
@@ -38,7 +38,12 @@ ExperimentInfo *FileBackedExperimentInfo::cloneExperimentInfo() const {
 
 /// @returns A human-readable description of the object
 const std::string FileBackedExperimentInfo::toString() const {
-  populateIfNotLoaded();
+  try {
+    populateIfNotLoaded();
+  } catch (std::exception &) {
+    // Catch any errors so that the string returned has as much information
+    // as possible
+  }
   return ExperimentInfo::toString();
 }
 

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -88,7 +88,7 @@ public:
                            "X axis: Time-of-flight / microsecond\n"
                            "Y axis: Counts\n"
                            "Distribution: False\n"
-                           "Instrument:  (1990-Jan-01 to 1990-Jan-01)\n"
+                           "Instrument: None\n"
                            "Run start: not available\n"
                            "Run end:  not available\n";
 


### PR DESCRIPTION
Fixes workspace details for workspace with an instrument that has no definition file, e.g. one loaded from LoadNXSPE, converted to a file-backed MD workspace and reloaded with `LoadMD`.

**To test:**

The following script can be used to demonstrate the problem:

``` python
nxspe = Load(Filename='CNCS_7860_coarse.nxspe')
md_ws = ConvertToMD(nxspe, QDimensions='Q3D', Q3DFrames='Q_sample', QConversionScales='HKL', OutputWorkspace='md_ws', Filename='file-backend.nxs', FileBackEnd=True)
md_ws2 = Load(Filename='file-backend.nxs', FileBackEnd=True)
```

Check the details in the "Workspaces" box. Before the fix you get an error like this:

![md-nxspe-info](https://cloud.githubusercontent.com/assets/733773/15611509/833b67c4-2422-11e6-8ed2-f812011be996.png)

After the fix the standard details should be displayed but the instrument field will say "None".

Refs #16387.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
