### PR TITLE
Clarify conditions under which SaveMD does not function as expected

### DIFF
--- a/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -83,30 +83,41 @@ void SaveMD::init() {
  */
 template <typename MDE, size_t nd>
 void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
-  std::string filename = getPropertyValue("Filename");
-  bool update = getProperty("UpdateFileBackEnd");
-  bool MakeFileBacked = getProperty("MakeFileBacked");
-
-  bool wsIsFileBacked = ws->isFileBacked();
-  if (update && MakeFileBacked)
+  bool updateFileBackend = getProperty("UpdateFileBackEnd");
+  bool makeFileBackend = getProperty("MakeFileBacked");
+  if (updateFileBackend && makeFileBackend)
     throw std::invalid_argument(
         "Please choose either UpdateFileBackEnd or MakeFileBacked, not both.");
 
-  if (MakeFileBacked && wsIsFileBacked)
-    throw std::invalid_argument(
-        "You picked MakeFileBacked but the workspace is already file-backed!");
-
+  bool wsIsFileBacked = ws->isFileBacked();
+  std::string filename = getPropertyValue("Filename");
   BoxController_sptr bc = ws->getBoxController();
+  if (wsIsFileBacked) {
+    if (!filename.empty() && filename != bc->getFilename()) {
+      throw std::runtime_error("Algorithm cannot currently save a file-backed "
+                               "workspace to a new file. Please make "
+                               "a copy outside of Mantid");
+    } else if (makeFileBackend) {
+      throw std::runtime_error(
+          "MakeFileBacked selected but workspace is already file backed.");
+    }
+  } else {
+    if (updateFileBackend) {
+      throw std::runtime_error(
+          "UpdateFileBackEnd selected but workspace is not file backed.");
+    }
+  }
 
-  if (!wsIsFileBacked) { // Erase the file if it exists
+  if (!wsIsFileBacked) {
     Poco::File oldFile(filename);
     if (oldFile.exists())
       oldFile.remove();
   }
 
   auto prog = new Progress(this, 0.0, 0.05, 1);
-  if (update) // workspace has its own file and ignores any changes to the
-              // algorithm parameters
+  if (updateFileBackend) // workspace has its own file and ignores any changes
+                         // to the
+                         // algorithm parameters
   {
     if (!ws->isFileBacked())
       throw std::runtime_error(" attempt to update non-file backed workspace");
@@ -123,7 +134,7 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
 
   // Save each NEW ExperimentInfo to a spot in the file
   MDBoxFlatTree::saveExperimentInfos(file.get(), ws);
-  if (!update || !data_exist) {
+  if (!updateFileBackend || !data_exist) {
     MDBoxFlatTree::saveWSGenericInfo(file.get(), ws);
   }
   file->closeGroup();
@@ -131,7 +142,7 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
 
   MDBoxFlatTree BoxFlatStruct;
   //-----------------------------------------------------------------------------------------------------
-  if (update) // the workspace is already file backed;
+  if (updateFileBackend) // the workspace is already file backed;
   {
     // remove all boxes from the DiskBuffer. DB will calculate boxes positions
     // on HDD.
@@ -147,7 +158,7 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     auto Saver = boost::shared_ptr<API::IBoxControllerIO>(
         new DataObjects::BoxControllerNeXusIO(bc.get()));
     Saver->setDataType(sizeof(coord_t), MDE::getTypeName());
-    if (MakeFileBacked) {
+    if (makeFileBackend) {
       // store saver with box controller
       bc->setFileBacked(Saver, filename);
       // get access to boxes array


### PR DESCRIPTION
Adds an error scenario when `SaveMD` is called on a file-backed workspace but the filename specified is different to the current file backend.

In theory this should work but at the moment the events are not saved properly and is a source of confusion to users so make it explicit that it does not work. The hint says just perform a copy outside of Mantid to achieve the say effect.

**To test:**

The following script demonstrates the new message:

``` python
nxspe = Load(Filename='CNCS_7860_coarse.nxspe')
md_ws = ConvertToMD(nxspe, QDimensions='Q3D', Q3DFrames='Q_sample', QConversionScales='HKL', OutputWorkspace='md_ws', Filename='file-backend.nxs', FileBackEnd=True)
SaveMD(md_ws, Filename='file-backend-different.nxs')
```

Refs #16387

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Ultimately the code should be able to support saving a file-backed
workspace to a different file. For now we just warn the user that
this is not supported.
Refs #16387
