### PR TITLE
Fix for reading string DASlogs

### DIFF
--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -552,7 +552,7 @@ LoadNexusLogs::createTimeSeries(::NeXus::File &file,
     std::transform(time_double.begin(), time_double.end(), time_double.begin(),
                    std::bind2nd(std::multiplies<double>(), 60.0));
   }
-  
+
   // String logs use offsets to cut the 'value' string into strings
   // corresponding to each individual time value. Get the offset now
   // before we have to enter the 'value' element.
@@ -579,9 +579,10 @@ LoadNexusLogs::createTimeSeries(::NeXus::File &file,
   // Now the actual data
   ::NeXus::Info info = file.getInfo();
   // Check the size. The size should match the number of time values,
-  // except in the case of string values, which will be split using the 
+  // except in the case of string values, which will be split using the
   // offset information.
-  if (size_t(info.dims[0]) != time_double.size() && info.type != ::NeXus::CHAR) {
+  if (size_t(info.dims[0]) != time_double.size() &&
+      info.type != ::NeXus::CHAR) {
     file.closeData();
     throw ::NeXus::Exception("Invalid value entry for time series");
   }
@@ -623,15 +624,16 @@ LoadNexusLogs::createTimeSeries(::NeXus::File &file,
     DateAndTime::createVector(start_time, time_double, times);
 
     const size_t ntimes = times.size();
-    
+
     // This string splitting only makes sense of the number of string offsets
     // is equal to the number of time values.
     if (ntimes != str_offsets.size()) {
-       throw ::NeXus::Exception("Number of string offsets does not match number of time values");
+       throw ::NeXus::Exception(
+           "Number of string offsets does not match number of time values");
     }
     for (size_t i = 0; i < ntimes; ++i) {
       // Get the length of the string to extract from the offset values
-      size_t str_length = i == ntimes-1 ? values.size() : str_offsets[i+1];
+      size_t str_length = i == ntimes - 1 ? values.size() : str_offsets[i + 1];
       str_length -= str_offsets[i];
       std::string value_i =
           std::string(values.data() + str_offsets[i], str_length);

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -628,8 +628,8 @@ LoadNexusLogs::createTimeSeries(::NeXus::File &file,
     // This string splitting only makes sense of the number of string offsets
     // is equal to the number of time values.
     if (ntimes != str_offsets.size()) {
-       throw ::NeXus::Exception(
-           "Number of string offsets does not match number of time values");
+      throw ::NeXus::Exception(
+          "Number of string offsets does not match number of time values");
     }
     for (size_t i = 0; i < ntimes; ++i) {
       // Get the length of the string to extract from the offset values

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -605,8 +605,6 @@ LoadNexusLogs::createTimeSeries(::NeXus::File &file,
   } else if (info.type == ::NeXus::CHAR) {
     std::string values;
     try {
-      // The number of items is the number of time values
-      const int64_t nitems = time_double.size();
       const int64_t total_length = info.dims[0];
       boost::scoped_array<char> val_array(new char[total_length]);
       file.getData(val_array.get());

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -552,6 +552,19 @@ LoadNexusLogs::createTimeSeries(::NeXus::File &file,
     std::transform(time_double.begin(), time_double.end(), time_double.begin(),
                    std::bind2nd(std::multiplies<double>(), 60.0));
   }
+  
+  // String logs use offsets to cut the 'value' string into strings
+  // corresponding to each individual time value. Get the offset now
+  // before we have to enter the 'value' element.
+  std::vector<int> str_offsets;
+  try {
+    file.openData("offset");
+    file.getDataCoerce(str_offsets);
+    file.closeData();
+  } catch (::NeXus::Exception &) {
+    // No offsets found
+  }
+
   // Now the values: Could be a string, int or double
   file.openData("value");
   // Get the units of the property
@@ -565,8 +578,10 @@ LoadNexusLogs::createTimeSeries(::NeXus::File &file,
 
   // Now the actual data
   ::NeXus::Info info = file.getInfo();
-  // Check the size
-  if (size_t(info.dims[0]) != time_double.size()) {
+  // Check the size. The size should match the number of time values,
+  // except in the case of string values, which will be split using the 
+  // offset information.
+  if (size_t(info.dims[0]) != time_double.size() && info.type != ::NeXus::CHAR) {
     file.closeData();
     throw ::NeXus::Exception("Invalid value entry for time series");
   }
@@ -588,10 +603,10 @@ LoadNexusLogs::createTimeSeries(::NeXus::File &file,
     return tsp;
   } else if (info.type == ::NeXus::CHAR) {
     std::string values;
-    const int64_t item_length = info.dims[1];
     try {
-      const int64_t nitems = info.dims[0];
-      const int64_t total_length = nitems * item_length;
+      // The number of items is the number of time values
+      const int64_t nitems = time_double.size();
+      const int64_t total_length = info.dims[0];
       boost::scoped_array<char> val_array(new char[total_length]);
       file.getData(val_array.get());
       file.closeData();
@@ -606,10 +621,20 @@ LoadNexusLogs::createTimeSeries(::NeXus::File &file,
     auto tsp = new TimeSeriesProperty<std::string>(prop_name);
     std::vector<DateAndTime> times;
     DateAndTime::createVector(start_time, time_double, times);
+
     const size_t ntimes = times.size();
+    
+    // This string splitting only makes sense of the number of string offsets
+    // is equal to the number of time values.
+    if (ntimes != str_offsets.size()) {
+       throw ::NeXus::Exception("Number of string offsets does not match number of time values");
+    }
     for (size_t i = 0; i < ntimes; ++i) {
+      // Get the length of the string to extract from the offset values
+      size_t str_length = i == ntimes-1 ? values.size() : str_offsets[i+1];
+      str_length -= str_offsets[i];
       std::string value_i =
-          std::string(values.data() + i * item_length, item_length);
+          std::string(values.data() + str_offsets[i], str_length);
       tsp->addValue(times[i], value_i);
     }
     tsp->setUnits(value_units);


### PR DESCRIPTION
`LoadNexusLogs` allows for string logs, but the current loader doesn't load them correctly.

The content of a string DASlog looks like this:

```
  NX Data  : device_id (NX_UINT32)
  NX Data  : device_name[15] (NX_CHAR)
  NX Data  : length[3] (NX_UINT32)
  NX Data  : offset[3] (NX_UINT32)
  NX Data  : time[3] (NX_FLOAT64)
  NX Data  : value[47] (NX_CHAR)
```

where `value` is the concatenation of all the string values (one for each time value). `offset` is the start position of each value within the concatenated string.

To read the string values, one must first read the `value` entry, parse the `offset` entry, then loop through the offset entries to extract the sub-string corresponding to each time value.

**To test:**

Load a file that contains string logs and make sure they are read properly.

There is not GitHub 'issue' for this PR.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
