### PR TITLE
Fixed cow_ptr move constructor and assignment

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/cow_ptr.h
+++ b/Framework/Kernel/inc/MantidKernel/cow_ptr.h
@@ -72,10 +72,10 @@ public:
   constexpr cow_ptr(std::nullptr_t) : Data(nullptr) {}
   cow_ptr(const cow_ptr<DataType> &);
   // Move is hand-written, since std::mutex member prevents auto-generation.
-  cow_ptr(cow_ptr<DataType> &&other) : Data(std::move(other.Data)) {}
+  cow_ptr(cow_ptr<DataType> &&other) noexcept : Data(std::move(other.Data)) {}
   cow_ptr<DataType> &operator=(const cow_ptr<DataType> &);
   // Move is hand-written, since std::mutex member prevents auto-generation.
-  cow_ptr<DataType> &operator=(cow_ptr<DataType> &&rhs) {
+  cow_ptr<DataType> &operator=(cow_ptr<DataType> &&rhs) noexcept {
     Data = std::move(rhs.Data);
     return *this;
   }

--- a/Framework/Kernel/inc/MantidKernel/cow_ptr.h
+++ b/Framework/Kernel/inc/MantidKernel/cow_ptr.h
@@ -71,9 +71,14 @@ public:
   /// Constructs a cow_ptr with no managed object, i.e. empty cow_ptr.
   constexpr cow_ptr(std::nullptr_t) : Data(nullptr) {}
   cow_ptr(const cow_ptr<DataType> &);
-  cow_ptr(cow_ptr<DataType> &&) = default;
+  // Move is hand-written, since std::mutex member prevents auto-generation.
+  cow_ptr(cow_ptr<DataType> &&other) : Data(std::move(other.Data)) {}
   cow_ptr<DataType> &operator=(const cow_ptr<DataType> &);
-  cow_ptr<DataType> &operator=(cow_ptr<DataType> &&) = default;
+  // Move is hand-written, since std::mutex member prevents auto-generation.
+  cow_ptr<DataType> &operator=(cow_ptr<DataType> &&rhs) {
+    Data = std::move(rhs.Data);
+    return *this;
+  }
   cow_ptr<DataType> &operator=(const ptr_type &);
 
   /// Returns the stored pointer.

--- a/Framework/Kernel/test/CowPtrTest.h
+++ b/Framework/Kernel/test/CowPtrTest.h
@@ -63,6 +63,23 @@ public:
                       2)
   }
 
+  void test_move_constructor() {
+    auto resource = boost::make_shared<int>(42);
+    cow_ptr<int> source{resource};
+    cow_ptr<int> clone(std::move(source));
+    TS_ASSERT(!source);
+    TS_ASSERT_EQUALS(clone.get(), resource.get());
+  }
+
+  void test_move_assignment() {
+    auto resource = boost::make_shared<int>(42);
+    cow_ptr<int> source{resource};
+    cow_ptr<int> clone;
+    clone = std::move(source);
+    TS_ASSERT(!source);
+    TS_ASSERT_EQUALS(clone.get(), resource.get());
+  }
+
   void test_copy_assign_nullptr() {
     cow_ptr<MyType> cow1{nullptr};
     TS_ASSERT(!cow1);


### PR DESCRIPTION
Defaulted (compiler generated) move of `Kernel::cow_ptr` did not do what expected due to a non-movable class member. In this commit we therefore provide a custom implementation.

**To test:**

Code review & make sure the tests catch the regression if the bug is reintroduced.

Fixes #16476 .

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
