### PR TITLE
Remove unused member function from MultiDomainFunction

### DIFF
--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -192,13 +192,6 @@ public:
   virtual std::vector<std::string> getLocalAttributeNames() const {
     return std::vector<std::string>();
   }
-  /// Return a value of attribute attName
-  virtual Attribute getLocalAttribute(size_t i,
-                                      const std::string &attName) const {
-    (void)i;
-    throw std::invalid_argument("Attribute " + attName +
-                                " not found in function " + this->name());
-  }
   /// Set a value to attribute attName
   virtual void setLocalAttribute(size_t i, const std::string &attName,
                                  const Attribute &) {

--- a/Framework/API/inc/MantidAPI/MultiDomainFunction.h
+++ b/Framework/API/inc/MantidAPI/MultiDomainFunction.h
@@ -85,9 +85,6 @@ public:
   std::vector<std::string> getLocalAttributeNames() const override {
     return std::vector<std::string>(1, "domains");
   }
-  /// Return a value of attribute attName
-  Attribute getLocalAttribute(size_t i,
-                              const std::string &attName) const override;
   /// Set a value to attribute attName
   void setLocalAttribute(size_t i, const std::string &attName,
                          const Attribute &) override;

--- a/Framework/API/src/MultiDomainFunction.cpp
+++ b/Framework/API/src/MultiDomainFunction.cpp
@@ -190,32 +190,6 @@ void MultiDomainFunction::iterationFinished() {
   }
 }
 
-/// Return a value of attribute attName
-IFunction::Attribute
-MultiDomainFunction::getLocalAttribute(size_t i,
-                                       const std::string &attName) const {
-  if (attName != "domains") {
-    throw std::invalid_argument("MultiDomainFunction does not have attribute " +
-                                attName);
-  }
-  if (i >= nFunctions()) {
-    throw std::out_of_range("Function index is out of range.");
-  }
-  auto it = m_domains.find(i);
-  if (it == m_domains.end()) {
-    return IFunction::Attribute("All");
-  } else if (it->second.size() == 1 && it->second.front() == i) {
-    return IFunction::Attribute("i");
-  } else if (!it->second.empty()) {
-    std::string out(boost::lexical_cast<std::string>(it->second.front()));
-    for (auto i = it->second.begin() + 1; i != it->second.end(); ++it) {
-      out += "," + boost::lexical_cast<std::string>(*i);
-    }
-    return IFunction::Attribute(out);
-  }
-  return IFunction::Attribute("");
-}
-
 /**
  * Set a value to a "local" attribute, ie an attribute related to a member
  *function.


### PR DESCRIPTION
Description of work.

This deletes the unused member function `MultiDomainFunction::getLocalAttribute`. I was investigating a potential iterator error and couldn't find any place where this member function is called or exposed to Python. Therefore I think it is better to remove it.

**To test:**

<!-- Instructions for testing. -->

There is no issue associated with this pull request.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
