### PR TITLE
Fix regression: displaying a table should not cause it to lose precision

### DIFF
--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -9,7 +9,7 @@
 #include <QApplication>
 #include <QMessageBox>
 #include <QHash>
-
+#include <limits>
 #include <qfontmetrics.h>
 
 using namespace MantidQt::API;
@@ -133,6 +133,10 @@ void MantidTable::fillTable() {
     // Print out the data in each row of this column
     for (int j = 0; j < static_cast<int>(m_ws->rowCount()); j++) {
       std::ostringstream ostr;
+      // Avoid losing precision for numeric data
+      if (c->type() == "double") {
+        ostr.precision(std::numeric_limits<double>::max_digits10);
+      }
       // This is the method on the Column object to convert to a string.
       c->print(static_cast<size_t>(j), ostr);
       QString qstr = QString::fromStdString(ostr.str());
@@ -195,6 +199,10 @@ void MantidTable::fillTableTransposed() {
     // Print out the data in each row of this column
     for (int j = 0; j < static_cast<int>(m_ws->rowCount()); ++j) {
       std::ostringstream ostr;
+      // Avoid losing precision for numeric data
+      if (c->type() == "double") {
+        ostr.precision(std::numeric_limits<double>::max_digits10);
+      }
       // This is the method on the Column object to convert to a string.
       c->print(static_cast<size_t>(j), ostr);
       QString qstr = QString::fromStdString(ostr.str());
@@ -286,6 +294,10 @@ void MantidTable::cellEdited(int row, int col) {
   // Set the table view to be the same text after editing.
   // That way, if the string was stupid, it will be reset to the old value.
   std::ostringstream s;
+  // Avoid losing precision for numeric data
+  if (c->type() == "double") {
+    s.precision(std::numeric_limits<double>::max_digits10);
+  }
   c->print(index, s);
 
   d_table->setText(row, col, QString::fromStdString(s.str()));


### PR DESCRIPTION
Displaying a TableWorkspace in the GUI as a MantidTable should not affect the data in the workspace. 

Fixed a bug where showing the table caused the data to lose precision. 

**To test:**
- Run the script below, reproduced from the issue.
- The data should be printed out the same on both occasions, before and after the table is displayed in MantidPlot. (Note that Python's `print` command uses 12 significant figures by default)

``` python
logTab=WorkspaceFactory.createTable()
logTab.addColumn("int","Run")
logTab.addColumn("double","B")

# Generate some data
for i in range(77767,77777):
    z=20732.6576324+(i-77767)*19.654535098765
    logTab.addRow((i,z))
AnalysisDataService.addOrReplace("logTab",logTab)

# Print out the data
t=mtd["logTab"]
for r in t:
    print r["B"]

# Display the table
tabl = importTableWorkspace("logTab", True)

# This should print exactly the same as before
t2 = mtd["logTab"]
for r in t2:
    print r["B"]
```

Fixes #16465.

_Does not need to be in the release notes_ because the bug was introduced since the last release.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
