### PR TITLE
Multi-dataset fit "edit parameter values": fix parameter truncation bug

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterEditor.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterEditor.h
@@ -40,6 +40,8 @@ private slots:
   void removeTie();
   void setTieAll();
   void removeAllTies();
+  void updateValue(const QString &value);
+
 private:
   bool eventFilter(QObject *widget, QEvent *evn) override;
   void setEditorState();

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterEditor.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterEditor.cpp
@@ -99,6 +99,9 @@ namespace MDF
 
   m_editor->installEventFilter(this);
 
+  connect(m_editor, SIGNAL(textEdited(const QString &)), this,
+          SLOT(updateValue(const QString &)));
+
   setEditorState();
 }
 
@@ -239,6 +242,14 @@ QString LocalParameterEditor::setTieDialog(QString tie)
     return input.textValue();
   }
   return "";
+}
+
+/**
+ * SLOT: when user edits value, make sure m_value is updated
+ * @param value :: [input] Changed text in the edit box
+ */
+void LocalParameterEditor::updateValue(const QString &value) {
+  m_value = value;
 }
 
 } // MDF

--- a/docs/source/release/v3.7.0/ui.rst
+++ b/docs/source/release/v3.7.0/ui.rst
@@ -161,6 +161,7 @@ Bugs Resolved
 
 - The Fit property browser (Fit Function window) in MantidPlot now supports fitting data plotted from a TableWorkspace.
 
+- Multi-dataset fit interface: a bug was fixed in the "edit local parameter" dialog where entering a value and selecting "fix" (for example) would truncate the final digit of the entered value.
 
 Full list of
 `GUI <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+GUI%22>`_


### PR DESCRIPTION
Fix a bug in the "Edit parameter values" dialog in the multi-dataset fitting interface.

Previously, typing a value into the box and then clicking "fix" or another option, without first pressing return, would result in the final digit of the entered value being truncated. For example, "23456" would become "2345" and "20001.2345" would become "20001.234".

Ensure that, when user edits value, the internally stored value is kept up to date so that the correct value is used.

**To test:**
- Load a small number of workspaces
- Open _Interfaces/General/Multi dataset fitting_
- Use "Add workspace" to add your workspaces
- Add a fit function. Click in one of the parameter values to edit it, and use this button to open the "edit parameter values" window:

![editparamvalues](https://cloud.githubusercontent.com/assets/15363125/15672243/63f06574-2727-11e6-870a-2545ebc0dedd.PNG)
- In the dialog, type a number into one of the value boxes and then select "Fix" from the drop-down list to the right.
  - The value you entered should _not_ have its final digit chopped off
  - Try this with an integer (23456) and a decimal (20001.2345)
  - Try other options besides "fix"
  - Also try fixing with the Ctrl+F shortcut

Re #16464 - **does not** close this issue because there are other bugs contained in it.

[Release notes](https://github.com/mantidproject/mantid/blob/fc0cfdb350752ba5b0f4c6374a2385712f2c9d5c/docs/source/release/v3.7.0/ui.rst#bugs-resolved) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
