### PR TITLE
Sort names for workspace selection

### DIFF
--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.h
@@ -338,7 +338,9 @@ public:
         } else
           ++it;
       }
-      return std::vector<std::string>(vals.begin(), vals.end());
+      auto values = std::vector<std::string>(vals.begin(), vals.end());
+      std::sort(values.begin(), values.end());
+      return values;
     } else {
       // For output workspaces, just return an empty set
       return std::vector<std::string>();

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFAddWorkspaceDialog.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFAddWorkspaceDialog.cpp
@@ -32,6 +32,7 @@ AddWorkspaceDialog::AddWorkspaceDialog(QWidget *parent):QDialog(parent),m_maxInd
       workspaceNames << QString::fromStdString( *name );
     }
   }
+  workspaceNames.sort();
   connect(m_uiForm.cbWorkspaceName,SIGNAL(currentIndexChanged(const QString&)),this,SLOT(workspaceNameChanged(const QString&)));
   m_uiForm.cbWorkspaceName->addItems( workspaceNames );
 

--- a/MantidQt/MantidWidgets/src/WorkspaceSelector.cpp
+++ b/MantidQt/MantidWidgets/src/WorkspaceSelector.cpp
@@ -265,12 +265,15 @@ void WorkspaceSelector::refresh() {
     items = ads.getObjectNames();
   }
 
+  QStringList namesToAdd;
   for (auto it = items.begin(); it != items.end(); ++it) {
     QString name = QString::fromStdString(*it);
     if (checkEligibility(name, ads.retrieve(*it))) {
-      addItem(name);
+      namesToAdd << name;
     }
   }
+  namesToAdd.sort();
+  this->addItems(namesToAdd);
 }
 
 /**


### PR DESCRIPTION
When presenting a drop-down list of workspaces to choose from in:
- generic algorithm dialog 
- multi-dataset fitting "add workspace" window,

ensure the list of workspaces is sorted. This makes it much easier to find the workspace(s) you want to select, especially when the ADS contains a lot of entries. (Point raised by beta testers)

Achieved this by sorting the list before populating the combo box. The alternative would be to use a `std::set` instead of a `std::unordered_set` as the return type for `DataService::getObjectNames()`, but this could have unintended effects elsewhere, especially this close to the release.

**To test:**
- Populate the ADS with a variety of workspaces with different names (see issue for example)
- Open an algorithm dialog for an algorithm that takes an _InputWorkspace_ and has a generic dialog (for example, `Rebin`). Look at the dropdown list for the workspace property and check the workspaces are sorted and easy to find.
- Open _Interfaces/General/Multi dataset fitting_ and click "Add workspace". In the dialog, check the dropdown list here too and make sure the workspaces are sorted and easy to find here.

Fixes #16462.

_Does not need to be in the release notes_ - too minor

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
