### PR TITLE
SaveMD allows to save to other file for file-backed workspaces

### DIFF
--- a/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -21,6 +21,18 @@ using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 
+namespace {
+  template <typename MDE, size_t nd>
+  void prepareUpdate(MDBoxFlatTree& BoxFlatStruct, BoxController* bc, typename MDEventWorkspace<MDE, nd>::sptr ws,  std::string filename) {
+    // remove all boxes from the DiskBuffer. DB will calculate boxes positions
+    // on HDD.
+    bc->getFileIO()->flushCache();
+    // flatten the box structure; this will remember boxes file positions in the
+    // box structure
+    BoxFlatStruct.initFlatStructure(ws, filename);
+  }
+}
+
 namespace Mantid {
 namespace MDAlgorithms {
 
@@ -87,24 +99,22 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   bool makeFileBackend = getProperty("MakeFileBacked");
   if (updateFileBackend && makeFileBackend)
     throw std::invalid_argument(
-        "Please choose either UpdateFileBackEnd or MakeFileBacked, not both.");
+      "Please choose either UpdateFileBackEnd or MakeFileBacked, not both.");
 
   bool wsIsFileBacked = ws->isFileBacked();
   std::string filename = getPropertyValue("Filename");
   BoxController_sptr bc = ws->getBoxController();
+  auto copyFile = wsIsFileBacked && !filename.empty() && filename != bc->getFilename();
   if (wsIsFileBacked) {
-    if (!filename.empty() && filename != bc->getFilename()) {
-      throw std::runtime_error("Algorithm cannot currently save a file-backed "
-                               "workspace to a new file. Please make "
-                               "a copy outside of Mantid");
-    } else if (makeFileBackend) {
+    if (makeFileBackend) {
       throw std::runtime_error(
-          "MakeFileBacked selected but workspace is already file backed.");
+        "MakeFileBacked selected but workspace is already file backed.");
     }
-  } else {
+  }
+  else {
     if (updateFileBackend) {
       throw std::runtime_error(
-          "UpdateFileBackEnd selected but workspace is not file backed.");
+        "UpdateFileBackEnd selected but workspace is not file backed.");
     }
   }
 
@@ -130,7 +140,7 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   int nDims = static_cast<int>(nd);
   bool data_exist;
   auto file = file_holder_type(MDBoxFlatTree::createOrOpenMDWSgroup(
-      filename, nDims, MDE::getTypeName(), false, data_exist));
+    filename, nDims, MDE::getTypeName(), false, data_exist));
 
   // Save each NEW ExperimentInfo to a spot in the file
   MDBoxFlatTree::saveExperimentInfos(file.get(), ws);
@@ -144,19 +154,23 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   //-----------------------------------------------------------------------------------------------------
   if (updateFileBackend) // the workspace is already file backed;
   {
-    // remove all boxes from the DiskBuffer. DB will calculate boxes positions
-    // on HDD.
-    bc->getFileIO()->flushCache();
-    // flatten the box structure; this will remember boxes file positions in the
-    // box structure
-    BoxFlatStruct.initFlatStructure(ws, filename);
-  } else // not file backed;
+    prepareUpdate<MDE, nd>(BoxFlatStruct, bc.get(), ws, filename);
+  }
+  else if (copyFile) {
+    // Update the original file
+    if (ws->fileNeedsUpdating()) {
+      prepareUpdate<MDE, nd>(BoxFlatStruct, bc.get(), ws, filename);
+      BoxFlatStruct.saveBoxStructure(filename);
+    }
+    Poco::File(bc->getFilename()).copyTo(filename);
+  }
+  else // not file backed;
   {
     // the boxes file positions are unknown and we need to calculate it.
     BoxFlatStruct.initFlatStructure(ws, filename);
     // create saver class
     auto Saver = boost::shared_ptr<API::IBoxControllerIO>(
-        new DataObjects::BoxControllerNeXusIO(bc.get()));
+      new DataObjects::BoxControllerNeXusIO(bc.get()));
     Saver->setDataType(sizeof(coord_t), MDE::getTypeName());
     if (makeFileBackend) {
       // store saver with box controller
@@ -190,7 +204,8 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       Saver->flushCache();
       // drop NeXus on HDD (not sure if it really necessary but just in case )
       Saver->flushData();
-    } else // just save data, and finish with it
+    }
+    else // just save data, and finish with it
     {
       Saver->openFile(filename, "w");
       BoxFlatStruct.setBoxesFilePositions(false);
@@ -214,7 +229,9 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   prog->resetNumSteps(8, 0.92, 1.00);
 
   // Save box structure;
-  BoxFlatStruct.saveBoxStructure(filename);
+  if (!copyFile) {
+   BoxFlatStruct.saveBoxStructure(filename);
+  }
 
   delete prog;
 

--- a/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -22,15 +22,17 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 
 namespace {
-  template <typename MDE, size_t nd>
-  void prepareUpdate(MDBoxFlatTree& BoxFlatStruct, BoxController* bc, typename MDEventWorkspace<MDE, nd>::sptr ws,  std::string filename) {
-    // remove all boxes from the DiskBuffer. DB will calculate boxes positions
-    // on HDD.
-    bc->getFileIO()->flushCache();
-    // flatten the box structure; this will remember boxes file positions in the
-    // box structure
-    BoxFlatStruct.initFlatStructure(ws, filename);
-  }
+template <typename MDE, size_t nd>
+void prepareUpdate(MDBoxFlatTree &BoxFlatStruct, BoxController *bc,
+                   typename MDEventWorkspace<MDE, nd>::sptr ws,
+                   std::string filename) {
+  // remove all boxes from the DiskBuffer. DB will calculate boxes positions
+  // on HDD.
+  bc->getFileIO()->flushCache();
+  // flatten the box structure; this will remember boxes file positions in the
+  // box structure
+  BoxFlatStruct.initFlatStructure(ws, filename);
+}
 }
 
 namespace Mantid {
@@ -99,22 +101,22 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   bool makeFileBackend = getProperty("MakeFileBacked");
   if (updateFileBackend && makeFileBackend)
     throw std::invalid_argument(
-      "Please choose either UpdateFileBackEnd or MakeFileBacked, not both.");
+        "Please choose either UpdateFileBackEnd or MakeFileBacked, not both.");
 
   bool wsIsFileBacked = ws->isFileBacked();
   std::string filename = getPropertyValue("Filename");
   BoxController_sptr bc = ws->getBoxController();
-  auto copyFile = wsIsFileBacked && !filename.empty() && filename != bc->getFilename();
+  auto copyFile =
+      wsIsFileBacked && !filename.empty() && filename != bc->getFilename();
   if (wsIsFileBacked) {
     if (makeFileBackend) {
       throw std::runtime_error(
-        "MakeFileBacked selected but workspace is already file backed.");
+          "MakeFileBacked selected but workspace is already file backed.");
     }
-  }
-  else {
+  } else {
     if (updateFileBackend) {
       throw std::runtime_error(
-        "UpdateFileBackEnd selected but workspace is not file backed.");
+          "UpdateFileBackEnd selected but workspace is not file backed.");
     }
   }
 
@@ -140,7 +142,7 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   int nDims = static_cast<int>(nd);
   bool data_exist;
   auto file = file_holder_type(MDBoxFlatTree::createOrOpenMDWSgroup(
-    filename, nDims, MDE::getTypeName(), false, data_exist));
+      filename, nDims, MDE::getTypeName(), false, data_exist));
 
   // Save each NEW ExperimentInfo to a spot in the file
   MDBoxFlatTree::saveExperimentInfos(file.get(), ws);
@@ -155,22 +157,20 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   if (updateFileBackend) // the workspace is already file backed;
   {
     prepareUpdate<MDE, nd>(BoxFlatStruct, bc.get(), ws, filename);
-  }
-  else if (copyFile) {
+  } else if (copyFile) {
     // Update the original file
     if (ws->fileNeedsUpdating()) {
       prepareUpdate<MDE, nd>(BoxFlatStruct, bc.get(), ws, filename);
       BoxFlatStruct.saveBoxStructure(filename);
     }
     Poco::File(bc->getFilename()).copyTo(filename);
-  }
-  else // not file backed;
+  } else // not file backed;
   {
     // the boxes file positions are unknown and we need to calculate it.
     BoxFlatStruct.initFlatStructure(ws, filename);
     // create saver class
     auto Saver = boost::shared_ptr<API::IBoxControllerIO>(
-      new DataObjects::BoxControllerNeXusIO(bc.get()));
+        new DataObjects::BoxControllerNeXusIO(bc.get()));
     Saver->setDataType(sizeof(coord_t), MDE::getTypeName());
     if (makeFileBackend) {
       // store saver with box controller
@@ -204,8 +204,7 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       Saver->flushCache();
       // drop NeXus on HDD (not sure if it really necessary but just in case )
       Saver->flushData();
-    }
-    else // just save data, and finish with it
+    } else // just save data, and finish with it
     {
       Saver->openFile(filename, "w");
       BoxFlatStruct.setBoxesFilePositions(false);
@@ -230,7 +229,7 @@ void SaveMD::doSaveEvents(typename MDEventWorkspace<MDE, nd>::sptr ws) {
 
   // Save box structure;
   if (!copyFile) {
-   BoxFlatStruct.saveBoxStructure(filename);
+    BoxFlatStruct.saveBoxStructure(filename);
   }
 
   delete prog;

--- a/Framework/MDAlgorithms/test/SaveMDTest.h
+++ b/Framework/MDAlgorithms/test/SaveMDTest.h
@@ -3,6 +3,7 @@
 
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidDataObjects/MDEventFactory.h"
 #include "MantidMDAlgorithms/BinMD.h"
 #include "MantidMDAlgorithms/SaveMD.h"
@@ -38,9 +39,14 @@ public:
     do_test_exec(23, "SaveMDTest_updating.nxs", true, true);
   }
 
+  void test_MakeFileBacked_then_save_under_other_file_name() {
+    do_test_exec(23, "SaveMDTest_other_file_name_test.nxs", true, false, true);
+  }
+
   void do_test_exec(size_t numPerBox, std::string filename,
                     bool MakeFileBacked = false,
-                    bool UpdateFileBackEnd = false) {
+                    bool UpdateFileBackEnd = false,
+                    bool OtherFileName = false) {
 
     // Make a 1D MDEventWorkspace
     MDEventWorkspace1Lean::sptr ws =
@@ -84,10 +90,13 @@ public:
     }
 
     // Continue the test
-    if (UpdateFileBackEnd)
+    if (UpdateFileBackEnd) {
       do_test_UpdateFileBackEnd(ws, filename);
+    }
+    else if (OtherFileName){
+      do_test_OtherFileName(ws, filename);
+    }
     else {
-
       ws->clearFileBacked(false);
       if (Poco::File(this_filename).exists())
         Poco::File(this_filename).remove();
@@ -135,6 +144,61 @@ public:
     std::string fullPath = alg.getPropertyValue("Filename");
     if (Poco::File(fullPath).exists())
       Poco::File(fullPath).remove();
+  }
+
+  void do_test_OtherFileName(MDEventWorkspace1Lean::sptr ws, std::string originalFileName) {
+    const std::string otherFileName = "SaveMD_other_file_name.nxs";
+
+    auto algSave = AlgorithmManager::Instance().createUnmanaged("SaveMD");
+    algSave->initialize();
+    algSave->setChild(true);
+    algSave->setProperty("InputWorkspace", ws);
+    algSave->setProperty("Filename", otherFileName);
+    algSave->execute();
+    TS_ASSERT(algSave->isExecuted());
+
+    // Now reload into another workspace 
+    {
+      auto load_alg = AlgorithmManager::Instance().createUnmanaged("LoadMD");
+      load_alg->initialize();
+      load_alg->setChild(true);
+      load_alg->setProperty("Filename", otherFileName);
+      load_alg->setProperty("FileBackEnd", true);
+      load_alg->setProperty("OutputWorkspace", "blank");
+      TS_ASSERT_THROWS_NOTHING(load_alg->execute());
+      Mantid::API::IMDWorkspace_sptr reference_out_ws =
+        load_alg->getProperty("OutputWorkspace");
+      // Make sure that the output workspaces exist
+      TS_ASSERT(ws);
+      TS_ASSERT(reference_out_ws);
+      auto ws_cast =
+        boost::dynamic_pointer_cast<Mantid::API::IMDHistoWorkspace_sptr>(
+          reference_out_ws);
+
+      // Compare the loaded and original workspace
+      auto compare_alg =
+        Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+          "CompareMDWorkspaces");
+      compare_alg->setChild(true);
+      compare_alg->initialize();
+      compare_alg->setProperty("Workspace1", ws);
+      compare_alg->setProperty("Workspace2", reference_out_ws);
+      compare_alg->setProperty("Tolerance", 0.00001);
+      compare_alg->setProperty("CheckEvents", true);
+      compare_alg->setProperty("IgnoreBoxID", true);
+      TS_ASSERT_THROWS_NOTHING(compare_alg->execute());
+      bool is_equal = compare_alg->getProperty("Equals");
+      TS_ASSERT(is_equal);
+    }
+
+    // Clean up file and other file
+    ws->clearFileBacked(false);
+    std::string fullPath = algSave->getProperty("Filename");
+    if (Poco::File(fullPath).exists())
+      Poco::File(fullPath).remove();
+
+    if (Poco::File(originalFileName).exists())
+      Poco::File(originalFileName).remove();
   }
 
   void test_saveExpInfo() {

--- a/Framework/MDAlgorithms/test/SaveMDTest.h
+++ b/Framework/MDAlgorithms/test/SaveMDTest.h
@@ -92,7 +92,7 @@ public:
     if (UpdateFileBackEnd) {
       do_test_UpdateFileBackEnd(ws, filename);
     } else if (OtherFileName) {
-      do_test_OtherFileName(ws, filename);
+      do_test_OtherFileName(ws, this_filename);
     } else {
       ws->clearFileBacked(false);
       if (Poco::File(this_filename).exists())

--- a/Framework/MDAlgorithms/test/SaveMDTest.h
+++ b/Framework/MDAlgorithms/test/SaveMDTest.h
@@ -44,8 +44,7 @@ public:
   }
 
   void do_test_exec(size_t numPerBox, std::string filename,
-                    bool MakeFileBacked = false,
-                    bool UpdateFileBackEnd = false,
+                    bool MakeFileBacked = false, bool UpdateFileBackEnd = false,
                     bool OtherFileName = false) {
 
     // Make a 1D MDEventWorkspace
@@ -92,11 +91,9 @@ public:
     // Continue the test
     if (UpdateFileBackEnd) {
       do_test_UpdateFileBackEnd(ws, filename);
-    }
-    else if (OtherFileName){
+    } else if (OtherFileName) {
       do_test_OtherFileName(ws, filename);
-    }
-    else {
+    } else {
       ws->clearFileBacked(false);
       if (Poco::File(this_filename).exists())
         Poco::File(this_filename).remove();
@@ -146,7 +143,8 @@ public:
       Poco::File(fullPath).remove();
   }
 
-  void do_test_OtherFileName(MDEventWorkspace1Lean::sptr ws, std::string originalFileName) {
+  void do_test_OtherFileName(MDEventWorkspace1Lean::sptr ws,
+                             std::string originalFileName) {
     const std::string otherFileName = "SaveMD_other_file_name.nxs";
 
     auto algSave = AlgorithmManager::Instance().createUnmanaged("SaveMD");
@@ -157,7 +155,7 @@ public:
     algSave->execute();
     TS_ASSERT(algSave->isExecuted());
 
-    // Now reload into another workspace 
+    // Now reload into another workspace
     {
       auto load_alg = AlgorithmManager::Instance().createUnmanaged("LoadMD");
       load_alg->initialize();
@@ -167,18 +165,18 @@ public:
       load_alg->setProperty("OutputWorkspace", "blank");
       TS_ASSERT_THROWS_NOTHING(load_alg->execute());
       Mantid::API::IMDWorkspace_sptr reference_out_ws =
-        load_alg->getProperty("OutputWorkspace");
+          load_alg->getProperty("OutputWorkspace");
       // Make sure that the output workspaces exist
       TS_ASSERT(ws);
       TS_ASSERT(reference_out_ws);
       auto ws_cast =
-        boost::dynamic_pointer_cast<Mantid::API::IMDHistoWorkspace_sptr>(
-          reference_out_ws);
+          boost::dynamic_pointer_cast<Mantid::API::IMDHistoWorkspace_sptr>(
+              reference_out_ws);
 
       // Compare the loaded and original workspace
       auto compare_alg =
-        Mantid::API::AlgorithmManager::Instance().createUnmanaged(
-          "CompareMDWorkspaces");
+          Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+              "CompareMDWorkspaces");
       compare_alg->setChild(true);
       compare_alg->initialize();
       compare_alg->setProperty("Workspace1", ws);


### PR DESCRIPTION
These changes should allow the user to save contents of a file-backed MD workspace to a file which is not part of the file-backend.

**To test:**
- Run the following script:

``` python
nxspe = Load(Filename='CNCS_7860_coarse.nxspe')
md_ws = ConvertToMD(nxspe, QDimensions='Q3D', Q3DFrames='Q_sample', QConversionScales='HKL', OutputWorkspace='md_ws', Filename='file-backend.nxs', FileBackEnd=True)
SaveMD(md_ws, Filename='file-backend-different.nxs')
```
- Confirm that a new file was created
- Load the new file and compare the two workspaces

No number for this change

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
