### PR TITLE
Crystal field peaks fit fails

### DIFF
--- a/Framework/CurveFitting/src/GeneralDomainCreator.cpp
+++ b/Framework/CurveFitting/src/GeneralDomainCreator.cpp
@@ -59,18 +59,19 @@ GeneralDomainCreator::GeneralDomainCreator(
 void GeneralDomainCreator::declareDatasetProperties(const std::string &suffix,
                                                     bool addProp) {
   UNUSED_ARG(suffix);
-  UNUSED_ARG(addProp);
-  for (auto &propName : m_domainColumnNames) {
-    declareProperty(new Kernel::PropertyWithValue<std::string>(propName, ""),
-                    "A name of a domain column.");
-  }
-  for (auto &propName : m_dataColumnNames) {
-    declareProperty(new Kernel::PropertyWithValue<std::string>(propName, ""),
-                    "A name of a fitting data column.");
-  }
-  for (auto &propName : m_weightsColumnNames) {
-    declareProperty(new Kernel::PropertyWithValue<std::string>(propName, ""),
-                    "A name of a fitting weights column.");
+  if (addProp) {
+    for (auto &propName : m_domainColumnNames) {
+      declareProperty(new Kernel::PropertyWithValue<std::string>(propName, ""),
+                      "A name of a domain column.");
+    }
+    for (auto &propName : m_dataColumnNames) {
+      declareProperty(new Kernel::PropertyWithValue<std::string>(propName, ""),
+                      "A name of a fitting data column.");
+    }
+    for (auto &propName : m_weightsColumnNames) {
+      declareProperty(new Kernel::PropertyWithValue<std::string>(propName, ""),
+                      "A name of a fitting weights column.");
+    }
   }
 }
 

--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -261,7 +261,7 @@ void IFittingAlgorithm::addWorkspaces() {
   if (!m_domainCreator) {
     IDomainCreator *creator =
         createDomainCreator(m_function.get(), "", this, m_domainType);
-    creator->declareDatasetProperties("", false);
+    creator->declareDatasetProperties("", true);
     m_domainCreator.reset(creator);
     m_workspacePropertyNames.clear();
   }

--- a/Framework/CurveFitting/test/Functions/CrystalFieldPeaksTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldPeaksTest.h
@@ -173,6 +173,10 @@ public:
     eval.removeProperty("InputWorkspace");
     eval.setProperty("OutputWorkspace", "out");
     eval.execute();
+    TS_ASSERT(eval.isExecuted());
+    if (!eval.isExecuted()) {
+      return;
+    }
 
     ITableWorkspace_sptr output =
         AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("out");

--- a/Framework/CurveFitting/test/GeneralDomainCreatorTest.h
+++ b/Framework/CurveFitting/test/GeneralDomainCreatorTest.h
@@ -98,7 +98,7 @@ public:
     TS_ASSERT(manager.existsProperty("WeightsColumn_1"));
     TS_ASSERT(manager.existsProperty("WeightsColumn_2"));
     TS_ASSERT(!manager.existsProperty("WeightsColumn_3"));
-    TS_ASSERT_THROWS_NOTHING(creator.declareDatasetProperties("",false));
+    TS_ASSERT_THROWS_NOTHING(creator.declareDatasetProperties("", false));
   }
 
   void test_domain_values() {

--- a/Framework/CurveFitting/test/GeneralDomainCreatorTest.h
+++ b/Framework/CurveFitting/test/GeneralDomainCreatorTest.h
@@ -98,6 +98,7 @@ public:
     TS_ASSERT(manager.existsProperty("WeightsColumn_1"));
     TS_ASSERT(manager.existsProperty("WeightsColumn_2"));
     TS_ASSERT(!manager.existsProperty("WeightsColumn_3"));
+    TS_ASSERT_THROWS_NOTHING(creator.declareDatasetProperties("",false));
   }
 
   void test_domain_values() {


### PR DESCRIPTION
It was failing due to a bug in GeneralDomainCreator which is used in CrystalFieldPeaks function at the moment. The bug is fixed.

**To test:**

Run the script from the issue description.

Fixes #16495.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
