### PR TITLE
Multi-dataset fitting: fix bug where global parameters lose their ties

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/FunctionBrowser.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/FunctionBrowser.h
@@ -239,8 +239,8 @@ protected:
   bool isTie(QtProperty* prop) const;
   /// Get a tie for a paramater
   std::string getTie(QtProperty* prop) const;
-  /// Remove all tie properties
-  void removeAllTieProperties();
+  /// Remove all local tie properties
+  void removeAllLocalTieProperties();
 
   /// Add a constraint property
   QList<AProperty> addConstraintProperties(QtProperty* prop, QString constraint);

--- a/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
@@ -1766,9 +1766,12 @@ void FunctionBrowser::removeTie()
   }
 }
 
-/// Remove all tie properties
-void FunctionBrowser::removeAllTieProperties()
-{
+/**
+ * Remove all tie properties from local parameters
+ * (Called when changing datasets)
+ * Ties on global parameters are left as they are.
+ */
+void FunctionBrowser::removeAllLocalTieProperties() {
   QList<QtProperty*> tieProperties;
   for (auto p : m_properties)
   {
@@ -1777,9 +1780,11 @@ void FunctionBrowser::removeAllTieProperties()
       tieProperties << p.prop;
     }
   }
-  for (auto prop : tieProperties)
-  {
-    removeProperty(prop);
+  for (auto prop : tieProperties) {
+    if (prop->hasOption(globalOptionName) &&
+        !prop->checkOption(globalOptionName)) {
+      removeProperty(prop);
+    }
   }
 }
 
@@ -2087,7 +2092,7 @@ void FunctionBrowser::setCurrentDataset(int i)
   {
     throw std::runtime_error("Dataset index is outside the range");
   }
-  removeAllTieProperties();
+  removeAllLocalTieProperties();
   auto localParameters = getLocalParameters();
   foreach(QString par, localParameters)
   {

--- a/docs/source/release/v3.7.0/ui.rst
+++ b/docs/source/release/v3.7.0/ui.rst
@@ -163,6 +163,8 @@ Bugs Resolved
 
 - Multi-dataset fit interface: a bug was fixed in the "edit local parameter" dialog where entering a value and selecting "fix" (for example) would truncate the final digit of the entered value.
 
+- Multi-dataset fit interface: a bug was fixed where global parameters would lose their ties when a fit was run or the dataset was changed.
+
 Full list of
 `GUI <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+GUI%22>`_
 and


### PR DESCRIPTION
Fixed a bug in multi-dataset interface where global parameters lost their ties/fixes when a fit was run or the displayed dataset was changed.

When the current dataset is changed, all tie properties were removed, but only those for local parameters were replaced. By definition, global parameters are shared across all datasets so their ties shouldn't have be removed in the first place.

**To test:**
- Generate some data

``` python
import numpy as np

def func(x, a, b):
    return 0.2 + a*x + b

for i in range(1, 4):
    xData = []
    yData = []
    eData = []
    for x in np.arange(0.1, 10, 0.1):
        xData.append(x)
        yData.append(func(x, i, i/2.0))
        eData.append(0.1)

    outname = 'ws' + str(i)    
    CreateWorkspace(DataX=xData, DataY=yData, DataE=eData, NSpec=1, OutputWorkspace=outname)
```
- Open _Interfaces/General/Multi dataset fitting_
- Add the workspaces you just generated
- Set up a function of _FlatBackground + LinearBackground_.
  - Set _A0_ for the flat background to 0.2 and check the box to set it global
  - Right-click and fix it as well
- Use the "<" and ">" buttons to change which dataset is displayed. 
  - The tie on _f0.A0_ should not disappear
- Run the fit
  - The tie on _f0.A0_ should not disappear

Fixes #16503.

[Release notes](https://github.com/mantidproject/mantid/blob/7e502eea91d0c3501635bce08cb999dc8d5626ee/docs/source/release/v3.7.0/ui.rst#bugs-resolved) have been updated - if this is retargeted at 3.8 then this will need to be removed from the 3.7 release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
