### PR TITLE
Improve exception information when range is misused in sequential fit UI

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -558,13 +558,12 @@ PlotPeakByLogValue::makeNames() const {
             try {
               start = boost::lexical_cast<double>(range[0]);
               end = boost::lexical_cast<double>(range[1]);
-            }
-            catch (boost::bad_lexical_cast &) {
+            } catch (boost::bad_lexical_cast &) {
               throw std::runtime_error(
-                std::string("Provided incorrect range values. Range is "
-                  "specfifed by start_value:stop_value, but "
-                  "provided ") +
-                range[0] + std::string(" and ") + range[1]);
+                  std::string("Provided incorrect range values. Range is "
+                              "specfifed by start_value:stop_value, but "
+                              "provided ") +
+                  range[0] + std::string(" and ") + range[1]);
             }
             if (start > end)
               std::swap(start, end);

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -541,13 +541,31 @@ PlotPeakByLogValue::makeNames() const {
           if (range.count() < 1) {
             wi = -2; // means use the whole range
           } else if (range.count() == 1) {
-            start = boost::lexical_cast<double>(range[0]);
+            try {
+              start = boost::lexical_cast<double>(range[0]);
+            } catch (boost::bad_lexical_cast &) {
+              throw std::runtime_error(
+                  std::string("Provided incorrect range values. Range is "
+                              "specfifed by start_value:stop_value, but "
+                              "provided ") +
+                  range[0]);
+            }
+
             end = start;
             wi = -1;
             spec = -1;
           } else if (range.count() > 1) {
-            start = boost::lexical_cast<double>(range[0]);
-            end = boost::lexical_cast<double>(range[1]);
+            try {
+              start = boost::lexical_cast<double>(range[0]);
+              end = boost::lexical_cast<double>(range[1]);
+            }
+            catch (boost::bad_lexical_cast &) {
+              throw std::runtime_error(
+                std::string("Provided incorrect range values. Range is "
+                  "specfifed by start_value:stop_value, but "
+                  "provided ") +
+                range[0] + std::string(" and ") + range[1]);
+            }
             if (start > end)
               std::swap(start, end);
             wi = -1;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/SequentialFitDialog.ui
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/SequentialFitDialog.ui
@@ -200,6 +200,9 @@
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QTableWidget" name="tWorkspaces">
+          <property name="toolTip">
+           <string/>
+          </property>
           <column>
            <property name="text">
             <string>Workspace/File</string>
@@ -214,15 +217,24 @@
            <property name="text">
             <string>Spectrum</string>
            </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets a spectrum to fit. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
           </column>
           <column>
            <property name="text">
             <string>WS Index</string>
            </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set a workspace-index to fit (alternative option to Spectrum)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
           </column>
           <column>
            <property name="text">
             <string>Range</string>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets a range of values on the numeric axis associated with the workspace index. The range is specfied by a start value and an end value and separated by a colon e.g. 2:5&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </column>
          </widget>


### PR DESCRIPTION
Added tooltip informationf or the range column in the sequential fit UI. It was not fully clear what to insert, and what the insertion format was (colon-separated range)

**To test:**
1. Load the file GEM38370_Focussed.nxs
2. Plot spectrum 2
3. Open the fit browser on top of the plot
4. Add a linear background fit function 
5. Select Sequential Fit --> the sequential fit browser should open
   - Confirm that there is tooltip for the `Range column`
6. Enable `Plot against log` and set the log vlaue to `Period log`
7. In the `Range column` insert 2:3
   - Confirm that the fitting works
8. Open the Sequential fit window.
9. In the `Range column` insert 2-
   - Confirm that a error message is shown in the logs indicating what the correct input format is

Fixes #16429
_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
