### PR TITLE
Check the OpenGL configuration on startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,16 @@ set( DOCS_BUILDDIR ${CMAKE_BINARY_DIR}/docs )
 set ( CXXTEST_SINGLE_LOGFILE CACHE BOOL "Switch to have the tests for each package run together")
 set ( CXXTEST_ADD_PERFORMANCE OFF CACHE BOOL "Switch to add Performance tests to the list of tests run by ctest?")
 
+
+# VATES flag. Requires ParaView
+set ( MAKE_VATES OFF CACHE BOOL "Switch for compiling the Vates project")
+if (MAKE_VATES)
+  find_package(ParaView)
+  if(ParaView_FOUND)
+    add_definitions ( -DMAKE_VATES )
+  endif()
+endif()
+
 add_subdirectory ( Framework )
 
 include_directories ( Framework/Kernel/inc )
@@ -158,15 +168,8 @@ if ( UNIX )
   set ( UNITY_BUILD OFF CACHE BOOL "Switch for utilising unity builds. Faster builds for selected components.")
 endif ( UNIX )
 
-# VATES flag. Requires ParaView
-set ( MAKE_VATES OFF CACHE BOOL "Switch for compiling the Vates project")
-
 if ( MAKE_VATES )
-  find_package( ParaView )
   add_subdirectory ( Vates )
-  if(ParaView_FOUND)
-    add_definitions ( -DMAKE_VATES )
-  endif()
   if (NOT APPLE)
     LIST( APPEND CPACK_INSTALL_CMAKE_PROJECTS
           "${ParaView_DIR}" "ParaView Runtime Libs" "Runtime" "${INBUNDLE}/"

--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -465,7 +465,7 @@ set_property ( TARGET API PROPERTY FOLDER "MantidFramework" )
 
 target_link_libraries ( API LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${JSONCPP_LIBRARIES} ${MANTIDLIBS} ${GSL_LIBRARIES} ${NEXUS_LIBRARIES} ${WINSOCK} )
 if(MAKE_VATES)
-  target_include_directories( API PRIVATE ${PARAVIEW_INCLUDE_DIRS} )
+  target_include_directories( API SYSTEM PRIVATE ${PARAVIEW_INCLUDE_DIRS} )
   target_link_libraries ( API LINK_PRIVATE vtkPVClientServerCoreRendering )
 endif()
 

--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -464,6 +464,10 @@ endif ()
 set_property ( TARGET API PROPERTY FOLDER "MantidFramework" )
 
 target_link_libraries ( API LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${JSONCPP_LIBRARIES} ${MANTIDLIBS} ${GSL_LIBRARIES} ${NEXUS_LIBRARIES} ${WINSOCK} )
+if(MAKE_VATES)
+  target_include_directories( API PRIVATE ${PARAVIEW_INCLUDE_DIRS} )
+  target_link_libraries ( API LINK_PRIVATE vtkPVClientServerCoreRendering )
+endif()
 
 # Add the unit tests directory
 add_subdirectory ( test )

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -19,6 +19,10 @@
 
 #include <cstdarg>
 
+#ifdef MAKE_VATES
+#include "vtkPVDisplayInformation.h"
+#endif
+
 #ifdef _WIN32
 #include <winsock2.h>
 #endif
@@ -79,6 +83,11 @@ FrameworkManagerImpl::FrameworkManagerImpl()
 #ifdef MPI_BUILD
   g_log.notice() << "This MPI process is rank: "
                  << boost::mpi::communicator().rank() << std::endl;
+#endif
+
+#ifdef MAKE_VATES
+  if (!vtkPVDisplayInformation::SupportsOpenGLLocally())
+    g_log.error() << "The OpenGL configuration does not support the VSI.\n";
 #endif
 
   g_log.debug() << "FrameworkManager created." << std::endl;

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -799,7 +799,7 @@ target_link_libraries ( MantidPlot LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
 )
 
 if(MAKE_VATES)
-  target_include_directories( MantidPlot PRIVATE ${PARAVIEW_INCLUDE_DIRS} )
+  target_include_directories( MantidPlot SYSTEM PRIVATE ${PARAVIEW_INCLUDE_DIRS} )
   target_link_libraries ( MantidPlot LINK_PRIVATE vtkPVClientServerCoreRendering )
 endif()
 

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -798,6 +798,11 @@ target_link_libraries ( MantidPlot LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
             ${OPENGL_LIBRARIES}
 )
 
+if(MAKE_VATES)
+  target_include_directories( MantidPlot PRIVATE ${PARAVIEW_INCLUDE_DIRS} )
+  target_link_libraries ( MantidPlot LINK_PRIVATE vtkPVClientServerCoreRendering )
+endif()
+
 if (WITH_ASAN)
   target_link_libraries ( MantidPlot LINK_PRIVATE -lasan )
 endif ()

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -26,6 +26,10 @@
 
 #include <Poco/Path.h>
 
+#ifdef MAKE_VATES
+#include "vtkPVDisplayInformation.h"
+#endif
+
 #include <algorithm>
 #include <sstream>
 
@@ -602,6 +606,10 @@ void MantidDockWidget::addMDEventWorkspaceMenuItems(
   menu->addAction(m_showVatesGui); // Show the Vates simple interface
   if (!MantidQt::API::InterfaceManager::hasVatesLibraries()) {
     m_showVatesGui->setEnabled(false);
+#ifdef MAKE_VATES
+  } else if (!vtkPVDisplayInformation::SupportsOpenGLLocally()) {
+    m_showVatesGui->setEnabled(false);
+#endif
   } else {
     std::size_t nDim = WS->getNonIntegratedDimensions().size();
     m_showVatesGui->setEnabled(nDim >= 3 && nDim < 5);
@@ -619,6 +627,10 @@ void MantidDockWidget::addMDHistoWorkspaceMenuItems(
   menu->addAction(m_showVatesGui); // Show the Vates simple interface
   if (!MantidQt::API::InterfaceManager::hasVatesLibraries()) {
     m_showVatesGui->setEnabled(false);
+#ifdef MAKE_VATES
+  } else if (!vtkPVDisplayInformation::SupportsOpenGLLocally()) {
+    m_showVatesGui->setEnabled(false);
+#endif
   } else {
     std::size_t nDim = WS->getNonIntegratedDimensions().size();
     m_showVatesGui->setEnabled(nDim >= 3 && nDim < 5);


### PR DESCRIPTION
Description of work.

This checks the OpenGL configuration and, if insufficient to run the VSI, displays a warning at startup, and disables the VSI. This should both give a warning if there is an issue and reduce the likelihood MantidPlot will crash when using the VSI on the ORNL Remote Analysis Cluster.

**To test:**

<!-- Instructions for testing. -->

Check that one can still open a MDWorkspace in the VSI. If you can find a remote machine where the VSI was previously crashing, check if a warnings message appears and the "Show Vates Simple Interface" option is disabled.

There is no issue associated with this pull request.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
