### PR TITLE
Fix some compiler warnings generated by GCC 5+.

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -165,7 +165,7 @@ public:
   class CancelException : public std::exception {
   public:
     /// Returns the message string.
-    const char *what() const throw() override { return outMessage.c_str(); }
+    const char *what() const noexcept override { return outMessage.c_str(); }
 
   private:
     /// The message returned by what()

--- a/Framework/API/inc/MantidAPI/ScriptRepository.h
+++ b/Framework/API/inc/MantidAPI/ScriptRepository.h
@@ -104,7 +104,7 @@ public:
                       const std::string &file = std::string(), int line = -1);
 
   /// Returns the message string.
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 
   /// Returns the error description with technical details on the origin and
   /// cause.

--- a/Framework/API/inc/MantidAPI/VectorParameter.h
+++ b/Framework/API/inc/MantidAPI/VectorParameter.h
@@ -249,8 +249,8 @@ ElemType &VectorParameter<Derived, ElemType>::at(size_t index) {
     static std::string parameterName() { return #classname; }                  \
     classname() : SuperType() {}                                               \
     classname(size_t index) : SuperType(index) {}                              \
-    std::string getName() const { return #classname; }                         \
-    classname *clone() const { return new classname(*this); }                  \
+    std::string getName() const override { return #classname; }                \
+    classname *clone() const override { return new classname(*this); }         \
   };
 }
 }

--- a/Framework/API/src/ScriptRepository.cpp
+++ b/Framework/API/src/ScriptRepository.cpp
@@ -48,7 +48,7 @@ ScriptRepoException::ScriptRepoException(const std::string &info,
   }
 }
 
-const char *ScriptRepoException::what() const throw() {
+const char *ScriptRepoException::what() const noexcept {
   return _user_info.c_str();
 }
 

--- a/Framework/API/test/FunctionDomainGeneralTest.h
+++ b/Framework/API/test/FunctionDomainGeneralTest.h
@@ -16,45 +16,45 @@ public:
   /// Constructor
   TestColumn(size_t n) : m_data(n) {}
   /// Number of individual elements in the column.
-  virtual size_t size() const { return m_data.size(); }
+  size_t size() const override { return m_data.size(); }
   /// Returns typeid for the data in the column
-  virtual const std::type_info &get_type_info() const { return typeid(T); }
+  const std::type_info &get_type_info() const override { return typeid(T); }
   /// Returns typeid for the pointer type to the data element in the column
-  virtual const std::type_info &get_pointer_type_info() const {
+  const std::type_info &get_pointer_type_info() const override {
     return typeid(T *);
   }
   /// Prints out the value to a stream
-  virtual void print(size_t, std::ostream &) const {
+  void print(size_t, std::ostream &) const override {
     throw std::logic_error("Not implemented");
   }
   /// Specialized type check
-  virtual bool isBool() const { return false; }
+  bool isBool() const override { return false; }
   /// Must return overall memory size taken by the column.
-  virtual long int sizeOfData() const {
+  long int sizeOfData() const override {
     throw std::logic_error("Not implemented");
   }
   /// Virtual constructor. Fully clone any column.
-  virtual Column *clone() const { throw std::logic_error("Not implemented"); }
+  Column *clone() const override { throw std::logic_error("Not implemented"); }
   /// Cast an element to double if possible
-  virtual double toDouble(size_t) const {
+  double toDouble(size_t) const override {
     throw std::logic_error("Not implemented");
   }
   /// Assign an element from double if possible
-  virtual void fromDouble(size_t, double) {
+  void fromDouble(size_t, double) override {
     throw std::logic_error("Not implemented");
   }
 
 protected:
   /// Sets the new column size.
-  virtual void resize(size_t) { throw std::logic_error("Not implemented"); }
+  void resize(size_t) override { throw std::logic_error("Not implemented"); }
   /// Inserts an item.
-  virtual void insert(size_t) { throw std::logic_error("Not implemented"); }
+  void insert(size_t) override { throw std::logic_error("Not implemented"); }
   /// Removes an item.
-  virtual void remove(size_t) { throw std::logic_error("Not implemented"); }
+  void remove(size_t) override { throw std::logic_error("Not implemented"); }
   /// Pointer to a data element
-  virtual void *void_pointer(size_t index) { return &m_data[index]; }
+  void *void_pointer(size_t index) override { return &m_data[index]; }
   /// Pointer to a data element
-  virtual const void *void_pointer(size_t index) const {
+  const void *void_pointer(size_t index) const override {
     return &m_data[index];
   }
   /// Data storage

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CrystalFieldEnergies.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CrystalFieldEnergies.h
@@ -33,14 +33,14 @@ namespace CurveFitting {
 class MANTID_CURVEFITTING_DLL CrystalFieldEnergies final
     : public API::Algorithm {
 public:
-  const std::string name() const final;
-  int version() const final;
-  const std::string category() const final;
-  const std::string summary() const final;
+  const std::string name() const override final;
+  int version() const override final;
+  const std::string category() const override final;
+  const std::string summary() const override final;
 
 private:
-  void init() final;
-  void exec() final;
+  void init() override final;
+  void exec() override final;
 };
 
 } // namespace CurveFitting

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -823,7 +823,7 @@ TMDE(void MDEventWorkspace)::getBoundariesInDimension(
   for (size_t i = 1; i <= num_boundaries; i++) {
     size_t current_id = std::numeric_limits<size_t>::max();
     // Position along the line
-    coord_t this_x = i * box_size;
+    coord_t this_x = static_cast<coord_t>(i) * box_size;
     auto linePos = static_cast<coord_t>(this_x / fabs(dir_current_dim));
     // Full position
     auto pos = start + (dir * linePos);

--- a/Framework/Geometry/test/SampleEnvironmentFactoryTest.h
+++ b/Framework/Geometry/test/SampleEnvironmentFactoryTest.h
@@ -25,7 +25,7 @@ public:
     delete suite;
   }
 
-  void tearDown() {
+  void tearDown() override {
     // Clear monostate cache
     SampleEnvironmentFactory().clearCache();
   }

--- a/Framework/ICat/inc/MantidICat/ICat3/ICat3Catalog.h
+++ b/Framework/ICat/inc/MantidICat/ICat3/ICat3Catalog.h
@@ -41,47 +41,47 @@ public:
   /// constructor
   ICat3Catalog();
   /// destructor
-  virtual ~ICat3Catalog();
+  ~ICat3Catalog() override;
   /// login to isis catalog
-  virtual API::CatalogSession_sptr login(const std::string &username,
-                                         const std::string &password,
-                                         const std::string &endpoint,
-                                         const std::string &facility);
+  API::CatalogSession_sptr login(const std::string &username,
+                                 const std::string &password,
+                                 const std::string &endpoint,
+                                 const std::string &facility) override;
   /// logout from isis catalog
-  virtual void logout();
+  void logout() override;
   /// search isis data
-  virtual void search(const CatalogSearchParam &inputs,
-                      Mantid::API::ITableWorkspace_sptr &ws_sptr,
-                      const int &offset, const int &limit);
+  void search(const CatalogSearchParam &inputs,
+              Mantid::API::ITableWorkspace_sptr &ws_sptr, const int &offset,
+              const int &limit) override;
   /// Obtain the number of results returned by the search method.
-  virtual int64_t getNumberOfSearchResults(const CatalogSearchParam &inputs);
+  int64_t getNumberOfSearchResults(const CatalogSearchParam &inputs) override;
   /// logged in user's investigations search
-  virtual void myData(Mantid::API::ITableWorkspace_sptr &mydataws_sptr);
+  void myData(Mantid::API::ITableWorkspace_sptr &mydataws_sptr) override;
   /// get datasets
-  virtual void getDataSets(const std::string &investigationId,
-                           Mantid::API::ITableWorkspace_sptr &datasetsws_sptr);
+  void getDataSets(const std::string &investigationId,
+                   Mantid::API::ITableWorkspace_sptr &datasetsws_sptr) override;
   /// get datafiles
-  virtual void
+  void
   getDataFiles(const std::string &investigationId,
-               Mantid::API::ITableWorkspace_sptr &datafilesws_sptr);
+               Mantid::API::ITableWorkspace_sptr &datafilesws_sptr) override;
   /// get instruments list
-  virtual void listInstruments(std::vector<std::string> &instruments);
+  void listInstruments(std::vector<std::string> &instruments) override;
   /// get investigationtypes list
-  virtual void listInvestigationTypes(std::vector<std::string> &invstTypes);
+  void listInvestigationTypes(std::vector<std::string> &invstTypes) override;
   /// get file location strings
-  virtual const std::string getFileLocation(const long long &fileID);
+  const std::string getFileLocation(const long long &fileID) override;
   /// get urls
-  virtual const std::string getDownloadURL(const long long &fileID);
+  const std::string getDownloadURL(const long long &fileID) override;
   /// get URL of where to PUT (publish) files.
-  virtual const std::string
+  const std::string
   getUploadURL(const std::string &investigationID,
                const std::string &createFileName,
-               const std::string &dataFileDescription);
+               const std::string &dataFileDescription) override;
   /// keep alive
-  virtual void keepAlive();
+  void keepAlive() override;
   /// Obtains the investigations that the user can publish to and saves related
   /// information to a workspace.
-  virtual API::ITableWorkspace_sptr getPublishInvestigations();
+  API::ITableWorkspace_sptr getPublishInvestigations() override;
 
 private:
   /// The helper class that accesses ICAT functionality.

--- a/Framework/ICat/inc/MantidICat/ICat3/ICat3ErrorHandling.h
+++ b/Framework/ICat/inc/MantidICat/ICat3/ICat3ErrorHandling.h
@@ -64,7 +64,7 @@ public:
   /// constructor
   SessionException(const std::string &error);
   /// return the error message
-  const char *what() const throw();
+  const char *what() const noexcept override;
 };
 }
 }

--- a/Framework/ICat/src/ICat3/ICat3ErrorHandling.cpp
+++ b/Framework/ICat/src/ICat3/ICat3ErrorHandling.cpp
@@ -30,6 +30,6 @@ void CErrorHandling::throwErrorMessages(ICat3::ICATPortBindingProxy &icat) {
 SessionException::SessionException(const std::string &error)
     : std::runtime_error(error), m_error(error) {}
 
-const char *SessionException::what() const throw() { return m_error.c_str(); }
+const char *SessionException::what() const noexcept { return m_error.c_str(); }
 }
 }

--- a/Framework/Kernel/inc/MantidKernel/Exception.h
+++ b/Framework/Kernel/inc/MantidKernel/Exception.h
@@ -122,7 +122,7 @@ public:
   FileError(const FileError &A);
   /// Assignment operator
   FileError &operator=(const FileError &A);
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 
 /// Records the filename, the description of failure and the line on which it
@@ -147,14 +147,14 @@ public:
   ParseError(const ParseError &A);
   /// Assignment operator
   ParseError &operator=(const ParseError &A);
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 
 /// Marks code as not implemented yet.
 class MANTID_KERNEL_DLL NotImplementedError final : public std::logic_error {
 public:
   NotImplementedError(const std::string &);
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 
 /// Exception for when an item is not found in a collection.
@@ -173,7 +173,7 @@ public:
   NotFoundError(const NotFoundError &A);
   /// Assignment operator
   NotFoundError &operator=(const NotFoundError &A);
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 
 /// Exception for when an item is already in a collection.
@@ -190,7 +190,7 @@ public:
   /// Assignment operator
   ExistsError &operator=(const ExistsError &A);
 
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 
 /**
@@ -228,7 +228,7 @@ public:
   /// Assignment operator
   AbsObjMethod &operator=(const AbsObjMethod &A);
 
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 
 /// Exception for errors associated with the instrument definition.
@@ -247,7 +247,7 @@ public:
   /// Assignment operator
   InstrumentDefinitionError &operator=(const InstrumentDefinitionError &A);
 
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 
 /**
@@ -267,7 +267,7 @@ public:
   /// Assignment operator
   OpenGLError &operator=(const OpenGLError &A);
 
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 /**
 \class MisMatch
@@ -288,7 +288,7 @@ public:
   MisMatch<T> &operator=(const MisMatch<T> &rhs);
 
   /// Overloaded reporting method
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 
 /**
@@ -310,7 +310,7 @@ public:
   IndexError &operator=(const IndexError &A);
 
   /// Overloaded reporting method
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 
 /** Exception thrown when an attempt is made to dereference a null pointer
@@ -326,7 +326,7 @@ private:
 public:
   NullPointerException(const std::string &place, const std::string &objectName);
   /// Overloaded reporting method
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
 };
 
 /** Exception thrown when error occurs accessing an internet resource
@@ -343,7 +343,7 @@ private:
 public:
   InternetError(const std::string &message, const int &errorCode = 0);
   /// Overloaded reporting method
-  const char *what() const throw() override;
+  const char *what() const noexcept override;
   const int &errorCode() const;
 };
 

--- a/Framework/Kernel/src/Exception.cpp
+++ b/Framework/Kernel/src/Exception.cpp
@@ -23,7 +23,7 @@ FileError::FileError(const FileError &A)
 /** Writes out the range and limits
         @returns a char array of foramtted error information
 */
-const char *FileError::what() const throw() { return outMessage.c_str(); }
+const char *FileError::what() const noexcept { return outMessage.c_str(); }
 
 //-------------------------
 // ParseError
@@ -39,7 +39,7 @@ ParseError::ParseError(const std::string &desc, const std::string &fileName,
 ParseError::ParseError(const ParseError &A)
     : FileError(A), m_lineNumber(A.m_lineNumber) {}
 
-const char *ParseError::what() const throw() { return m_outMessage.c_str(); }
+const char *ParseError::what() const noexcept { return m_outMessage.c_str(); }
 
 //-------------------------
 // NotImplementedError
@@ -53,7 +53,7 @@ NotImplementedError::NotImplementedError(const std::string &Desc)
 /** Writes out the range and limits
         @returns a char array of foramtted error information
 */
-const char *NotImplementedError::what() const throw() {
+const char *NotImplementedError::what() const noexcept {
   return std::logic_error::what();
 }
 
@@ -113,7 +113,7 @@ NotFoundError::NotFoundError(const NotFoundError &A)
 /** Writes out the range and limits
         @returns a char array of foramtted error information
 */
-const char *NotFoundError::what() const throw() { return outMessage.c_str(); }
+const char *NotFoundError::what() const noexcept { return outMessage.c_str(); }
 
 //-------------------------
 // ExistsError
@@ -135,7 +135,7 @@ ExistsError::ExistsError(const ExistsError &A)
 /** Writes out the range and limits
         @returns a char array of foramtted error information
 */
-const char *ExistsError::what() const throw() { return outMessage.c_str(); }
+const char *ExistsError::what() const noexcept { return outMessage.c_str(); }
 
 //-------------------------
 // AbsObjMethod
@@ -155,7 +155,7 @@ AbsObjMethod::AbsObjMethod(const AbsObjMethod &A)
 /** Writes out the range and limits
         @returns a char array of foramtted error information
 */
-const char *AbsObjMethod::what() const throw() { return outMessage.c_str(); }
+const char *AbsObjMethod::what() const noexcept { return outMessage.c_str(); }
 
 //-------------------------
 // InstrumentDefinitionError
@@ -188,7 +188,7 @@ InstrumentDefinitionError::InstrumentDefinitionError(
 /** Writes out the range and limits
         @returns a char array of foramtted error information
 */
-const char *InstrumentDefinitionError::what() const throw() {
+const char *InstrumentDefinitionError::what() const noexcept {
   return outMessage.c_str();
 }
 
@@ -219,7 +219,7 @@ OpenGLError::OpenGLError(const OpenGLError &A)
 /** Writes out the range and limits
         @returns a char array of foramtted error information
 */
-const char *OpenGLError::what() const throw() { return outMessage.c_str(); }
+const char *OpenGLError::what() const noexcept { return outMessage.c_str(); }
 
 //-------------------------
 // MisMatch
@@ -258,7 +258,7 @@ template <typename T> MisMatch<T> &MisMatch<T>::operator=(const MisMatch<T> &) {
 }
 
 template <typename T>
-const char *MisMatch<T>::what() const throw()
+const char *MisMatch<T>::what() const noexcept
 /**
   Writes out the two mismatched items
   @return String description of error
@@ -300,7 +300,7 @@ IndexError::IndexError(const IndexError &A)
   Writes out the range and limits
   @return the error string
 */
-const char *IndexError::what() const throw() { return m_message.c_str(); }
+const char *IndexError::what() const noexcept { return m_message.c_str(); }
 
 //-------------------------
 // NullPointerException class
@@ -316,7 +316,7 @@ NullPointerException::NullPointerException(const std::string &place,
       outMessage("Attempt to dereference zero pointer (" + objectName +
                  ") in function " + place) {}
 
-const char *NullPointerException::what() const throw() {
+const char *NullPointerException::what() const noexcept {
   return outMessage.c_str();
 }
 
@@ -345,7 +345,7 @@ InternetError::InternetError(const std::string &message, const int &errorCode)
   Writes out the range and limits
   @return the error string
 */
-const char *InternetError::what() const throw() { return outMessage.c_str(); }
+const char *InternetError::what() const noexcept { return outMessage.c_str(); }
 
 /**
   Writes out the range and limits

--- a/Framework/Kernel/test/BinaryStreamReaderTest.h
+++ b/Framework/Kernel/test/BinaryStreamReaderTest.h
@@ -25,7 +25,7 @@ public:
     createTestStream();
   }
 
-  void setUp() { resetStreamToStart(); }
+  void setUp() override { resetStreamToStart(); }
 
   //----------------------------------------------------------------------------
   // Successes cases

--- a/Framework/MDAlgorithms/src/CompareMDWorkspaces.cpp
+++ b/Framework/MDAlgorithms/src/CompareMDWorkspaces.cpp
@@ -20,7 +20,6 @@ class CompareFailsException : public std::runtime_error {
 public:
   explicit CompareFailsException(const std::string &msg)
       : std::runtime_error(msg) {}
-  ~CompareFailsException() throw() override {}
   std::string getMessage() const { return this->what(); }
 };
 

--- a/Framework/ScriptRepository/test/ScriptRepositoryTestImpl.h
+++ b/Framework/ScriptRepository/test/ScriptRepositoryTestImpl.h
@@ -104,8 +104,6 @@ public:
     tofconv_tofconverter_content = TOFCONV_CONVERTER;
     fail = false;
   }
-  ~ScriptRepositoryImplLocal() throw() override{};
-
   std::string repository_json_content;
   std::string tofconv_readme_content;
   std::string tofconv_tofconverter_content;

--- a/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
+++ b/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
@@ -150,14 +150,14 @@ signals:
     void clicked();
 
 protected:
-    void mousePressEvent(QMouseEvent *e);
-    void mouseMoveEvent(QMouseEvent *e);
-    void mouseReleaseEvent(QMouseEvent *e);
-    void keyPressEvent(QKeyEvent *e);
-    void keyReleaseEvent(QKeyEvent *e);
-    void paintEvent(QPaintEvent *e);
-    void focusInEvent(QFocusEvent *e);
-    void focusOutEvent(QFocusEvent *e);
+  void mousePressEvent(QMouseEvent *e) override;
+  void mouseMoveEvent(QMouseEvent *e) override;
+  void mouseReleaseEvent(QMouseEvent *e) override;
+  void keyPressEvent(QKeyEvent *e) override;
+  void keyReleaseEvent(QKeyEvent *e) override;
+  void paintEvent(QPaintEvent *e) override;
+  void focusInEvent(QFocusEvent *e) override;
+  void focusOutEvent(QFocusEvent *e) override;
 };
 
 /*
@@ -185,10 +185,10 @@ public slots:
     void setColor(const QColor &color, const QString &text = QString());
 
 protected:
-    void mousePressEvent(QMouseEvent *e);
-    void mouseReleaseEvent(QMouseEvent *e);
-    void mouseMoveEvent(QMouseEvent *e);
-    void paintEvent(QPaintEvent *e);
+  void mousePressEvent(QMouseEvent *e) override;
+  void mouseReleaseEvent(QMouseEvent *e) override;
+  void mouseMoveEvent(QMouseEvent *e) override;
+  void paintEvent(QPaintEvent *e) override;
 
 private:
     QColor c;
@@ -229,12 +229,12 @@ protected slots:
     void updateSelected();
 
 protected:
-    void keyPressEvent(QKeyEvent *e);
-    void showEvent(QShowEvent *e);
-    void hideEvent(QHideEvent *e);
-    void mouseReleaseEvent(QMouseEvent *e);
+  void keyPressEvent(QKeyEvent *e) override;
+  void showEvent(QShowEvent *e) override;
+  void hideEvent(QHideEvent *e) override;
+  void mouseReleaseEvent(QMouseEvent *e) override;
 
-    void regenerateGrid();
+  void regenerateGrid();
 
 private:
     QMap<int, QMap<int, QWidget *> > widgetAt;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/DataProcessorCommandBase.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/DataProcessorCommandBase.h
@@ -40,12 +40,6 @@ public:
       throw std::invalid_argument("Invalid abstract presenter");
     }
   };
-  virtual ~DataProcessorCommandBase(){};
-
-  virtual void execute() = 0;
-  virtual std::string name() = 0;
-  virtual std::string icon() = 0;
-
 protected:
   DataProcessorPresenter *const m_presenter;
 };

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ProgressPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ProgressPresenter.h
@@ -22,7 +22,7 @@ public:
                                          static_cast<int>(end));
   }
 
-  void doReport(const std::string &) {
+  void doReport(const std::string &) override {
     m_progressableView->setProgress(static_cast<int>(m_i));
   }
   void clear() { m_progressableView->clearProgress(); }

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/HintingLineEditFactory.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/HintingLineEditFactory.h
@@ -42,9 +42,8 @@ namespace MantidQt
     {
     public:
       HintingLineEditFactory(HintStrategy* hintStrategy) : m_strategy(hintStrategy) {};
-      virtual ~HintingLineEditFactory() {};
-      virtual QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const
-      {
+      QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option,
+                            const QModelIndex &index) const override {
         Q_UNUSED(option);
         Q_UNUSED(index);
 

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/OpenGLError.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/OpenGLError.h
@@ -15,8 +15,7 @@ namespace MantidQt
 		{
 		public:
 			explicit OpenGLError(const std::string& msg) :m_msg(msg) {}
-                        ~OpenGLError() throw() override {}
-                        const char *what() const throw() override {
+                        const char *what() const noexcept override {
                           return m_msg.c_str();
                         }
                         static bool check(const std::string& funName);

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ScriptEditor.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ScriptEditor.h
@@ -91,9 +91,10 @@ public:
   {
   public:
     /// Return a message
-    const char *what() const throw() override {
-      return "File saving was cancelled";
-    }
+    const char *what() const noexcept override { return m_msg.c_str(); }
+
+  private:
+    std::string m_msg{"File Saving was cancelled"};
   };
 
 

--- a/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
@@ -462,8 +462,7 @@ public:
   }
 protected:
   /// Create string property
-  FunctionBrowser::AProperty apply(const std::string& str)const
-  {
+  FunctionBrowser::AProperty apply(const std::string &str) const override {
     QtProperty* prop = NULL;
     if (m_attName == "FileName")
     {
@@ -488,29 +487,26 @@ protected:
     return m_browser->addProperty(m_parent,prop);
   }
   /// Create double property
-  FunctionBrowser::AProperty apply(const double& d)const
-  {
+  FunctionBrowser::AProperty apply(const double &d) const override {
     QtProperty* prop = m_browser->m_attributeDoubleManager->addProperty(m_attName);
     m_browser->m_attributeDoubleManager->setValue(prop, d);
     return m_browser->addProperty(m_parent,prop);
   }
   /// Create int property
-  FunctionBrowser::AProperty apply(const int& i)const
-  {
+  FunctionBrowser::AProperty apply(const int &i) const override {
     QtProperty* prop = m_browser->m_attributeIntManager->addProperty(m_attName);
     m_browser->m_attributeIntManager->setValue(prop, i);
     return m_browser->addProperty(m_parent,prop);
   }
   /// Create bool property
-  FunctionBrowser::AProperty apply(const bool& b)const
-  {
+  FunctionBrowser::AProperty apply(const bool &b) const override {
     QtProperty* prop = m_browser->m_attributeBoolManager->addProperty(m_attName);
     m_browser->m_attributeBoolManager->setValue(prop, b);
     return m_browser->addProperty(m_parent,prop);
   }
   /// Create vector property
-  FunctionBrowser::AProperty apply(const std::vector<double>& v)const
-  {
+  FunctionBrowser::AProperty
+  apply(const std::vector<double> &v) const override {
     QtProperty* prop = m_browser->m_attributeVectorManager->addProperty(m_attName);
     FunctionBrowser::AProperty aprop = m_browser->addProperty(m_parent,prop);
 
@@ -551,8 +547,7 @@ public:
   }
 protected:
   /// Set string attribute
-  void apply(std::string& str)const
-  {
+  void apply(std::string &str) const override {
     QString attName = m_prop->propertyName();
     if ( attName == "FileName" )
     {
@@ -572,37 +567,33 @@ protected:
     }
   }
   /// Set double attribute
-  void apply(double& d)const
-  {
+  void apply(double &d) const override {
     d = m_browser->m_attributeDoubleManager->value(m_prop);
   }
   /// Set int attribute
-  void apply(int& i)const
-  {
+  void apply(int &i) const override {
     i = m_browser->m_attributeIntManager->value(m_prop);
   }
   /// Set bool attribute
-  void apply(bool& b)const
-  {
+  void apply(bool &b) const override {
     b = m_browser->m_attributeBoolManager->value(m_prop);
   }
   /// Set vector attribute
-  void apply(std::vector<double>& v)const
-  {
-      //throw std::runtime_error("Vector setter not implemented.");
-      QList<QtProperty*> members = m_prop->subProperties();
-      if ( members.empty() ) throw std::runtime_error("FunctionBrowser: empty vector attribute group.");
-      int n = members.size() - 1;
-      if ( n == 0 )
-      {
-          v.clear();
-          return;
-      }
-      v.resize( n );
-      for(int i = 0; i < n; ++i)
-      {
-          v[i] = m_browser->m_attributeVectorDoubleManager->value( members[i+1] );
-      }
+  void apply(std::vector<double> &v) const override {
+    // throw std::runtime_error("Vector setter not implemented.");
+    QList<QtProperty *> members = m_prop->subProperties();
+    if (members.empty())
+      throw std::runtime_error(
+          "FunctionBrowser: empty vector attribute group.");
+    int n = members.size() - 1;
+    if (n == 0) {
+      v.clear();
+      return;
+    }
+    v.resize(n);
+    for (int i = 0; i < n; ++i) {
+      v[i] = m_browser->m_attributeVectorDoubleManager->value(members[i + 1]);
+    }
   }
 private:
   FunctionBrowser* m_browser;

--- a/MantidQt/RefDetectorViewer/inc/MantidQtRefDetectorViewer/RefImagePlotItem.h
+++ b/MantidQt/RefDetectorViewer/inc/MantidQtRefDetectorViewer/RefImagePlotItem.h
@@ -42,10 +42,9 @@ public:
   ~RefImagePlotItem();
 
   /// Draw the image (this is called by QWT and must not be called directly.)
-  virtual void draw(      QPainter    * painter,
-                    const QwtScaleMap & xMap,
-                    const QwtScaleMap & yMap,
-                    const QRect       & canvasRect) const;
+  virtual void draw(QPainter *painter, const QwtScaleMap &xMap,
+                    const QwtScaleMap &yMap,
+                    const QRect &canvasRect) const override;
 
 private:
   const RefLimitsHandler * const m_limitsHandler;

--- a/MantidQt/SpectrumViewer/inc/MantidQtSpectrumViewer/RangeHandler.h
+++ b/MantidQt/SpectrumViewer/inc/MantidQtSpectrumViewer/RangeHandler.h
@@ -48,10 +48,10 @@ class EXPORT_OPT_MANTIDQT_SPECTRUMVIEWER RangeHandler : public IRangeHandler
     RangeHandler( Ui_SpectrumViewer* svUI );
 
     /// Configure min, max and step controls for the specified data source
-    void configureRangeControls( SpectrumDataSource_sptr dataSource );
+    void configureRangeControls(SpectrumDataSource_sptr dataSource) override;
 
     /// Get the range of data to display in the image, from GUI controls
-    void getRange( double &min, double &max, double &step );
+    void getRange(double &min, double &max, double &step) override;
 
     /// Set the values displayed in the GUI controls
     void setRange( double min, double max, double step );

--- a/MantidQt/SpectrumViewer/inc/MantidQtSpectrumViewer/SliderHandler.h
+++ b/MantidQt/SpectrumViewer/inc/MantidQtSpectrumViewer/SliderHandler.h
@@ -51,28 +51,27 @@ class EXPORT_OPT_MANTIDQT_SPECTRUMVIEWER SliderHandler : public ISliderHandler
     SliderHandler( Ui_SpectrumViewer* svUI );
 
     /// Configure the image scrollbars for the specified data and drawing area
-    void configureSliders( QRect drawArea,
-                           SpectrumDataSource_sptr dataSource );
+    void configureSliders(QRect drawArea,
+                          SpectrumDataSource_sptr dataSource) override;
 
     /// Configure the image scrollbars for the specified drawing area
     void reConfigureSliders( QRect drawArea,
                              SpectrumDataSource_sptr dataSource );
 
     /// Configure the horizontal scrollbar to cover the specified range
-    void configureHSlider( int nDataSteps,
-                           int nPixels );
+    void configureHSlider(int nDataSteps, int nPixels) override;
 
     /// Return true if the image horizontal scrollbar is enabled.
-    bool hSliderOn();
+    bool hSliderOn() override;
 
     /// Return true if the image vertical scrollbar is enabled.
-    bool vSliderOn();
+    bool vSliderOn() override;
 
     /// Get the range of columns to display in the image.
-    void getHSliderInterval( int &xMin, int &xMax );
+    void getHSliderInterval(int &xMin, int &xMax) override;
 
     /// Get the range of rows to display in the image.
-    void getVSliderInterval( int &yMin, int &yMax );
+    void getVSliderInterval(int &yMin, int &yMax) override;
 
   private:
     /// Configure the specified scrollbar to cover the specified range

--- a/QtPropertyBrowser/src/CompositeEditorFactory.h
+++ b/QtPropertyBrowser/src/CompositeEditorFactory.h
@@ -31,20 +31,18 @@ public:
   }
 
 protected:
-  void connectPropertyManager(ManagerType *manager)
-  {
+  void connectPropertyManager(ManagerType *manager) override {
     (void) manager; // Unused
     // Do nothing
   }
 
-  void disconnectPropertyManager(ManagerType *manager)
-  {
+  void disconnectPropertyManager(ManagerType *manager) override {
     (void) manager; // Unused
     // Do nothing
   }
 
-  QWidget *createEditorForManager(ManagerType *manager, QtProperty *property, QWidget *parent)
-  {
+  QWidget *createEditorForManager(ManagerType *manager, QtProperty *property,
+                                  QWidget *parent) override {
     if ( !m_secondaryFactory )
     {
       throw std::logic_error("Secondary editor factory isn't set.");

--- a/Vates/VatesAPI/src/SaveMDWorkspaceToVTKImpl.cpp
+++ b/Vates/VatesAPI/src/SaveMDWorkspaceToVTKImpl.cpp
@@ -28,7 +28,7 @@ namespace {
 // This progress object gets called by PV (and is used by the plugins),
 // it does not have much use here.
 class NullProgressAction : public Mantid::VATES::ProgressAction {
-  virtual void eventRaised(double) {}
+  void eventRaised(double) override {}
 };
 
 bool has_suffix(const std::string &stringToCheck, const std::string &suffix) {

--- a/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -47,7 +47,7 @@ class QMenuWithToolTip: public QMenu {
 public:
   explicit QMenuWithToolTip(QWidget *parent) : QMenu(parent) {}
 
-  bool event(QEvent* e) {
+  bool event(QEvent *e) override {
     if (QEvent::ToolTip == e->type()) {
       // grab the action specific tooltip
       QHelpEvent *he = dynamic_cast<QHelpEvent*>(e);


### PR DESCRIPTION
Description of work.

This fixes many of the compiler warnings generated by our [Fedora 23 build server](http://builds.mantidproject.org/job/master_clean-fedora/). Most of the changes just add the missing `override` keyword.  

The next version of NeXus will address the warning `ISO C++ forbids converting a string constant to ‘char*’ [-Wpedantic]` (see https://github.com/nexusformat/code/pull/430)

I [added a patch](https://github.com/mantidproject/paraview-build/blob/master/patches/vtk_override.patch) to address the ParaView-related warnings from -Wsuggest-override.

In C++11, the std::exception signature now contains `const char* what() const noexcept`. Since `std::string::c_str()` is `noexcept`, I changed many places where we previously had `throw()` with `noexcept`.

**To test:**

<!-- Instructions for testing. -->

There is no issue associated with this pull request.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
