### PR TITLE
Add missing dependency to ubuntu dev package.

### DIFF
--- a/buildconfig/dev-packages/deb/mantid-developer/README
+++ b/buildconfig/dev-packages/deb/mantid-developer/README
@@ -2,5 +2,5 @@ This directory contains the structure required to build the simple mantid-develo
 
 To build the package:
    * Switch to the directory containing this file
-   * Run "dpkg --build mantid-developer-1.2.5"
-   * A file called mantid-developer-1.2.5.deb will appear in the current directory.
+   * Run "dpkg --build mantid-developer/mantid-developer-1.2.7"
+   * A file called mantid-developer-1.2.7.deb will appear in the mantid-developer directory.

--- a/buildconfig/dev-packages/deb/mantid-developer/mantid-developer-1.2.7/DEBIAN/control
+++ b/buildconfig/dev-packages/deb/mantid-developer/mantid-developer-1.2.7/DEBIAN/control
@@ -1,0 +1,13 @@
+Package: mantid-developer
+Version: 1.2.7
+Section: main
+Priority: optional
+Architecture: all
+Depends: g++, git, clang, cmake-qt-gui(>=2.8.12), qt4-qmake, qt4-dev-tools, libqtwebkit-dev, libqt4-dbg, libpoco-dev(>=1.4.2), libboost-all-dev, libboost-dbg, libnexus0-dev, libgoogle-perftools-dev, libqwt5-qt4-dev, libqwtplot3d-qt4-dev, python-qt4-dev, libgsl0-dev, liboce-visualization-dev, libmuparser-dev, python-numpy, libssl-dev, libqscintilla2-dev, texlive,texlive-latex-extra, dvipng, libhdf4-dev, doxygen, python-sphinx, python-scipy, ipython-qtconsole (>=1.2.0), libhdf5-dev, libhdf4-dev, libpococrypto11-dbg, libpocodata11-dbg, libpocofoundation11-dbg, libpocomysql11-dbg, libpoconet11-dbg, libpoconetssl11-dbg, libpocoodbc11-dbg, libpocosqlite11-dbg, libpocoutil11-dbg, libpocoxml11-dbg, libpocozip11-dbg, python-qt4-dbg, qt4-default, ninja-build, libjsoncpp-dev(>=0.7.0), python-dateutil, python-sphinx-bootstrap-theme, graphviz, python-matplotlib
+Installed-Size: 0
+Maintainer: Mantid Project <mantid-help@mantidproject.org>
+Description: Installs all packages required for a Mantid developer
+ A metapackage which requires all the dependencies and tools that are 
+ required for Mantid development. It works for Ubuntu version 14.04, 14.10
+ Some packages (poco) must be newer than those in the Ubuntu repository. Please 
+ follow instructions at http://www.mantidproject.org/Mantid_Prerequisites#Repositories

--- a/buildconfig/dev-packages/deb/mantid-developer/mantid-developer-1.2.7/DEBIAN/control
+++ b/buildconfig/dev-packages/deb/mantid-developer/mantid-developer-1.2.7/DEBIAN/control
@@ -8,6 +8,6 @@ Installed-Size: 0
 Maintainer: Mantid Project <mantid-help@mantidproject.org>
 Description: Installs all packages required for a Mantid developer
  A metapackage which requires all the dependencies and tools that are 
- required for Mantid development. It works for Ubuntu version 14.04, 14.10
+ required for Mantid development. It works for Ubuntu versions 14.04 and 16.04
  Some packages (poco) must be newer than those in the Ubuntu repository. Please 
  follow instructions at http://www.mantidproject.org/Mantid_Prerequisites#Repositories


### PR DESCRIPTION
Description of work.

This add the package `libqtwebkit-dev` to the ubuntu mantid-developers package since in 16.04 it is no longer included with `libqt4-dev`. Without this package installed, I get the error below.

```
CMake Error at /usr/share/cmake-3.5/Modules/FindPackageHandleStandardArgs.cmake:148 (message):
  Could NOT find Qt4 (missing: QT_QTWEBKIT_INCLUDE_DIR QT_QTWEBKIT_LIBRARY)
  (found version "4.8.7")
Call Stack (most recent call first):
  /usr/share/cmake-3.5/Modules/FindPackageHandleStandardArgs.cmake:388 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.5/Modules/FindQt4.cmake:1333 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  MantidQt/MantidWidgets/CMakeLists.txt:273 (find_package)
```

**To test:**

<!-- Instructions for testing. -->

There is no issue associated with this pull request.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
