### PR TITLE
Skip OSIRISIqtAndIqtFitMulti test on OSX and Windows

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
@@ -1013,7 +1013,10 @@ class ISISIndirectInelasticIqtAndIqtFitMulti(ISISIndirectInelasticBase):
 class OSIRISIqtAndIqtFitMulti(ISISIndirectInelasticIqtAndIqtFitMulti):
 
     def skipTests(self):
-        return platform.system() == "Darwin"
+        operating_sys = platform.system()
+        # Skip Test on Windows and OSX
+        if operating_sys == "Darwin" or operating_sys == "Windows":
+            return True
 
     def __init__(self):
         ISISIndirectInelasticIqtAndIqtFitMulti.__init__(self)


### PR DESCRIPTION
In order to get the builds back on master and to ensure that the builds doesn't fail on the release branch this test is now skipped on both `Windows` and `OSX`

@mantidproject/gatekeepers this is targeted at `release-v3.7` but should probably be merged into master today as well to ensure the nightly builds are restored

**To test:**
- Ensure that the `ISISIndirectInelastic.OSIRISIqtAndIqtFitMulti` is skipped on windows

Fixes #16515

_Does not need to be in the release notes as it is a change to system tests._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
