### PR TITLE
Fix slice viewer crash for elliptical peaks

### DIFF
--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationEllipsoid.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationEllipsoid.h
@@ -61,6 +61,8 @@ public:
   /// Show the background radius
   void showBackgroundRadius(const bool show) override;
 
+  static const double zeroRadius;
+
 protected:
   std::shared_ptr<PeakPrimitives> getDrawingInformation(
       PeakRepresentationViewInformation viewInformation) override;

--- a/MantidQt/SliceViewer/src/PeakRepresentationEllipsoid.cpp
+++ b/MantidQt/SliceViewer/src/PeakRepresentationEllipsoid.cpp
@@ -1,18 +1,15 @@
+#include "MantidKernel/Logger.h"
 #include "MantidQtSliceViewer/EllipsoidPlaneSliceCalculator.h"
 #include "MantidQtSliceViewer/PeakBoundingBox.h"
 #include "MantidQtSliceViewer/PeakRepresentationEllipsoid.h"
-#include "MantidKernel/Logger.h"
-
 
 namespace {
-  Mantid::Kernel::Logger g_log("PeakRepresentation");
-
+Mantid::Kernel::Logger g_log("PeakRepresentation");
 }
 
 #include <QPainter>
 
-namespace
-{
+namespace {
 
 /**
  * Handles the roation, translation and scaling of an ellipse in Qt
@@ -26,34 +23,38 @@ namespace
  */
 QPainterPath getTransformedPainterPath(double angle, double transX,
                                        double transY, double scaleX,
-                                       double scaleY, QPainterPath &painterPath)
-{
-    // The ellipse which is passed in has its major axis along the x axis and
-    // the minor axis
-    // along the y axix. The origin is located at (0,0).
-    // In principal we need to:
-    // 1. Rotate the ellipse in radians
-    // 2. Scale the ellipse
-    // 3. Translate the ellipse
-    // QTransform needs to be specified in reverse order!!!
-    QTransform transform;
-    transform.translate(transX, transY);
-    transform.scale(scaleX, scaleY);
+                                       double scaleY,
+                                       QPainterPath &painterPath) {
+  // The ellipse which is passed in has its major axis along the x axis and
+  // the minor axis
+  // along the y axix. The origin is located at (0,0).
+  // In principal we need to:
+  // 1. Rotate the ellipse in radians
+  // 2. Scale the ellipse
+  // 3. Translate the ellipse
+  // QTransform needs to be specified in reverse order!!!
+  QTransform transform;
+  transform.translate(transX, transY);
+  transform.scale(scaleX, scaleY);
 
-    // Important Note for the rotation: The rotation in Qt is done clock-wise, since
-    // the y axis is pointing downwards. The workspace plot does not reflect this though
-    // Hence we should be applying a counter-clockwise rotation which is achieved by
-    // prefixing with a minus sign.
-    transform.rotateRadians(-angle);
+  // Important Note for the rotation: The rotation in Qt is done clock-wise,
+  // since
+  // the y axis is pointing downwards. The workspace plot does not reflect this
+  // though
+  // Hence we should be applying a counter-clockwise rotation which is achieved
+  // by
+  // prefixing with a minus sign.
+  transform.rotateRadians(-angle);
 
-    return transform.map(painterPath);
+  return transform.map(painterPath);
 }
 }
 
-namespace MantidQt
-{
-namespace SliceViewer
-{
+namespace MantidQt {
+namespace SliceViewer {
+
+const double PeakRepresentationEllipsoid::zeroRadius = 0.0;
+
 PeakRepresentationEllipsoid::PeakRepresentationEllipsoid(
     const Mantid::Kernel::V3D &origin, const std::vector<double> peakRadii,
     const std::vector<double> backgroundInnerRadii,
@@ -65,24 +66,22 @@ PeakRepresentationEllipsoid::PeakRepresentationEllipsoid(
       m_origin(origin), m_directions(directions), m_peakRadii(peakRadii),
       m_backgroundInnerRadii(backgroundInnerRadii),
       m_backgroundOuterRadii(backgroundOuterRadii), m_opacityMax(0.8),
-      m_opacityMin(0.0), m_cachedOpacityAtDistance(0.0),
-      m_angleEllipse(-1.0), m_showBackgroundRadii(false),
-      m_calculator(calculator)
-{
-    // Get projection lengths onto the xyz axes of the ellipsoid axes
-    auto projections = Mantid::SliceViewer::getProjectionLengths(
-        directions, backgroundOuterRadii);
+      m_opacityMin(0.0), m_cachedOpacityAtDistance(0.0), m_angleEllipse(-1.0),
+      m_showBackgroundRadii(false), m_calculator(calculator) {
+  // Get projection lengths onto the xyz axes of the ellipsoid axes
+  auto projections = Mantid::SliceViewer::getProjectionLengths(
+      directions, backgroundOuterRadii);
 
-    const auto opacityRange = m_opacityMin - m_opacityMax;
+  const auto opacityRange = m_opacityMin - m_opacityMax;
 
-    // Get the opacity gradient in all directions
-    int index = 0;
-    for (const auto &projection : projections) {
-        const auto gradient = opacityRange / projection;
-        m_originalCachedOpacityGradient[index] = gradient;
-        m_cachedOpacityGradient[index] = gradient;
-        ++index;
-    }
+  // Get the opacity gradient in all directions
+  int index = 0;
+  for (const auto &projection : projections) {
+    const auto gradient = opacityRange / projection;
+    m_originalCachedOpacityGradient[index] = gradient;
+    m_cachedOpacityGradient[index] = gradient;
+    ++index;
+  }
 }
 
 //----------------------------------------------------------------------------------------------
@@ -90,60 +89,57 @@ PeakRepresentationEllipsoid::PeakRepresentationEllipsoid(
 coordinates.
 @param z : position of the plane slice in the z dimension.
 */
-void PeakRepresentationEllipsoid::setSlicePoint(const double &z)
-{
+void PeakRepresentationEllipsoid::setSlicePoint(const double &z) {
 
-    // We check first the outer background. If there is no cut, then,
-    // there should be nothing to left to do. Otherewise we do the inner
-    // background and the peaks separately.
-    if (Mantid::SliceViewer::checkIfCutExists(
-            m_directions, m_backgroundOuterRadii, m_origin, z)) {
+  // We check first the outer background. If there is no cut, then,
+  // there should be nothing to left to do. Otherewise we do the inner
+  // background and the peaks separately.
+  if (Mantid::SliceViewer::checkIfCutExists(
+          m_directions, m_backgroundOuterRadii, m_origin, z)) {
 
-        // Handle the case of the outer background
-        auto ellipsoidInfoBackgroundOuter = m_calculator->getSlicePlaneInfo(
-            m_directions, m_backgroundOuterRadii, m_origin, z);
+    // Handle the case of the outer background
+    auto ellipsoidInfoBackgroundOuter = m_calculator->getSlicePlaneInfo(
+        m_directions, m_backgroundOuterRadii, m_origin, z);
 
-        // The angle should be the same for all
-        m_angleEllipse = ellipsoidInfoBackgroundOuter.angle;
-        m_radiiEllipseBackgroundOuter
-            = std::vector<double>{ellipsoidInfoBackgroundOuter.radiusMajorAxis,
-                                  ellipsoidInfoBackgroundOuter.radiusMinorAxis};
-        m_originEllipseBackgroundOuter = ellipsoidInfoBackgroundOuter.origin;
+    // The angle should be the same for all
+    m_angleEllipse = ellipsoidInfoBackgroundOuter.angle;
+    m_radiiEllipseBackgroundOuter =
+        std::vector<double>{ellipsoidInfoBackgroundOuter.radiusMajorAxis,
+                            ellipsoidInfoBackgroundOuter.radiusMinorAxis};
+    m_originEllipseBackgroundOuter = ellipsoidInfoBackgroundOuter.origin;
 
-        // Handle the peak radius
-        if (Mantid::SliceViewer::checkIfCutExists(m_directions, m_peakRadii,
-                                                  m_origin, z)) {
+    // Handle the peak radius
+    if (Mantid::SliceViewer::checkIfCutExists(m_directions, m_peakRadii,
+                                              m_origin, z)) {
 
-            auto ellipsoidInfoPeaks = m_calculator->getSlicePlaneInfo(
-                m_directions, m_peakRadii, m_origin, z);
-            m_radiiEllipse
-                = std::vector<double>{ellipsoidInfoPeaks.radiusMajorAxis,
-                                      ellipsoidInfoPeaks.radiusMinorAxis};
-            m_originEllipse = ellipsoidInfoPeaks.origin;
-        }
-
-        // Handle the inner background radius
-        if (Mantid::SliceViewer::checkIfCutExists(
-                m_directions, m_backgroundInnerRadii, m_origin, z)) {
-
-            auto ellipsoidInfoBackgroundInner = m_calculator->getSlicePlaneInfo(
-                m_directions, m_backgroundInnerRadii, m_origin, z);
-            m_radiiEllipseBackgroundInner = std::vector<double>{
-                ellipsoidInfoBackgroundInner.radiusMajorAxis,
-                ellipsoidInfoBackgroundInner.radiusMinorAxis};
-            m_originEllipseBackgroundInner
-                = ellipsoidInfoBackgroundInner.origin;
-        }
-
-        const auto distanceAbs = std::abs(z - m_origin.Z());
-        m_cachedOpacityAtDistance = m_cachedOpacityGradient[2] * distanceAbs
-                                    + m_opacityMax;
-    } else {
-        m_cachedOpacityAtDistance = m_opacityMin;
-        m_radiiEllipse.clear();
-        m_radiiEllipseBackgroundInner.clear();
-        m_radiiEllipseBackgroundOuter.clear();
+      auto ellipsoidInfoPeaks = m_calculator->getSlicePlaneInfo(
+          m_directions, m_peakRadii, m_origin, z);
+      m_radiiEllipse = std::vector<double>{ellipsoidInfoPeaks.radiusMajorAxis,
+                                           ellipsoidInfoPeaks.radiusMinorAxis};
+      m_originEllipse = ellipsoidInfoPeaks.origin;
     }
+
+    // Handle the inner background radius
+    if (Mantid::SliceViewer::checkIfCutExists(
+            m_directions, m_backgroundInnerRadii, m_origin, z)) {
+
+      auto ellipsoidInfoBackgroundInner = m_calculator->getSlicePlaneInfo(
+          m_directions, m_backgroundInnerRadii, m_origin, z);
+      m_radiiEllipseBackgroundInner =
+          std::vector<double>{ellipsoidInfoBackgroundInner.radiusMajorAxis,
+                              ellipsoidInfoBackgroundInner.radiusMinorAxis};
+      m_originEllipseBackgroundInner = ellipsoidInfoBackgroundInner.origin;
+    }
+
+    const auto distanceAbs = std::abs(z - m_origin.Z());
+    m_cachedOpacityAtDistance =
+        m_cachedOpacityGradient[2] * distanceAbs + m_opacityMax;
+  } else {
+    m_cachedOpacityAtDistance = m_opacityMin;
+    m_radiiEllipse.clear();
+    m_radiiEllipseBackgroundInner.clear();
+    m_radiiEllipseBackgroundOuter.clear();
+  }
 }
 
 /**
@@ -152,120 +148,135 @@ void PeakRepresentationEllipsoid::setSlicePoint(const double &z)
  *@param peakTransform : transform to use.
  */
 void PeakRepresentationEllipsoid::movePosition(
-    Mantid::Geometry::PeakTransform_sptr peakTransform)
-{
-    m_origin = peakTransform->transform(m_originalOrigin);
+    Mantid::Geometry::PeakTransform_sptr peakTransform) {
+  m_origin = peakTransform->transform(m_originalOrigin);
 
-    m_directions[0] = peakTransform->transform(m_originalDirections[0]);
-    m_directions[1] = peakTransform->transform(m_originalDirections[1]);
-    m_directions[2] = peakTransform->transform(m_originalDirections[2]);
+  m_directions[0] = peakTransform->transform(m_originalDirections[0]);
+  m_directions[1] = peakTransform->transform(m_originalDirections[1]);
+  m_directions[2] = peakTransform->transform(m_originalDirections[2]);
 
-    m_cachedOpacityGradient
-        = peakTransform->transform(m_originalCachedOpacityGradient);
+  m_cachedOpacityGradient =
+      peakTransform->transform(m_originalCachedOpacityGradient);
 }
 
 /**
  * Setter for showing/hiding the background radius.
  * @param show: Flag indicating what to do.
 */
-void PeakRepresentationEllipsoid::showBackgroundRadius(const bool show)
-{
-    m_showBackgroundRadii = show;
+void PeakRepresentationEllipsoid::showBackgroundRadius(const bool show) {
+  m_showBackgroundRadii = show;
 }
 
 /**
  *@return bounding box for peak in natural coordinates.
  */
-PeakBoundingBox PeakRepresentationEllipsoid::getBoundingBox() const
-{
-    using namespace Mantid::SliceViewer;
-    return getPeakBoundingBoxForEllipsoid(m_directions, m_backgroundOuterRadii,
+PeakBoundingBox PeakRepresentationEllipsoid::getBoundingBox() const {
+  using namespace Mantid::SliceViewer;
+  return getPeakBoundingBoxForEllipsoid(m_directions, m_backgroundOuterRadii,
                                         m_origin);
 }
 
-double PeakRepresentationEllipsoid::getEffectiveRadius() const
-{
-    return m_showBackgroundRadii ? m_backgroundOuterRadii[0] : m_peakRadii[0];
+double PeakRepresentationEllipsoid::getEffectiveRadius() const {
+  return m_showBackgroundRadii ? m_backgroundOuterRadii[0] : m_peakRadii[0];
 }
 
-void PeakRepresentationEllipsoid::setOccupancyInView(const double)
-{
-    // DO NOTHING
+void PeakRepresentationEllipsoid::setOccupancyInView(const double) {
+  // DO NOTHING
 }
 
-void PeakRepresentationEllipsoid::setOccupancyIntoView(const double)
-{
-    // DO NOTHING
+void PeakRepresentationEllipsoid::setOccupancyIntoView(const double) {
+  // DO NOTHING
 }
 
-const Mantid::Kernel::V3D &PeakRepresentationEllipsoid::getOrigin() const
-{
-    return m_originEllipseBackgroundOuter;
+const Mantid::Kernel::V3D &PeakRepresentationEllipsoid::getOrigin() const {
+  return m_originEllipseBackgroundOuter;
 }
 
 std::shared_ptr<PeakPrimitives>
-PeakRepresentationEllipsoid::getDrawingInformation(
-    PeakRepresentationViewInformation)
-{
-    auto drawingInformation = std::make_shared<PeakPrimitivesEllipse>(
-        Mantid::Kernel::V3D() /*peakOrigin*/, 0.0 /*peakOpacityAtDistance*/,
-        0 /* peakLineWidth */, 0.0 /*peakInnerRadiusMajorAxis*/,
-        0.0 /*peakInnerRadiusMinorAxis*/,
-        0.0 /*backgroundOuterRadiusMajorAxis*/,
-        0.0 /*backgroundOuterRadiusMinorAxis*/,
-        0.0 /*backgroundInnerRadiusMajorAxis*/,
-        0.0 /*backgroundInnerRadiusMinorAxis*/, 0.0 /*angle*/);
+    PeakRepresentationEllipsoid::getDrawingInformation(
+        PeakRepresentationViewInformation) {
+  auto drawingInformation = std::make_shared<PeakPrimitivesEllipse>(
+      Mantid::Kernel::V3D() /*peakOrigin*/, 0.0 /*peakOpacityAtDistance*/,
+      0 /* peakLineWidth */, 0.0 /*peakInnerRadiusMajorAxis*/,
+      0.0 /*peakInnerRadiusMinorAxis*/, 0.0 /*backgroundOuterRadiusMajorAxis*/,
+      0.0 /*backgroundOuterRadiusMinorAxis*/,
+      0.0 /*backgroundInnerRadiusMajorAxis*/,
+      0.0 /*backgroundInnerRadiusMinorAxis*/, 0.0 /*angle*/);
 
-    // Add peak radius
+  // Add peak radius if it is available.
+  if (m_radiiEllipse.size() > 0) {
     drawingInformation->peakInnerRadiusMajorAxis = m_radiiEllipse[0];
     drawingInformation->peakInnerRadiusMinorAxis = m_radiiEllipse[1];
-    drawingInformation->angle = m_angleEllipse;
+  } else {
+    drawingInformation->peakInnerRadiusMajorAxis = zeroRadius;
+    drawingInformation->peakInnerRadiusMinorAxis = zeroRadius;
+  }
 
-    // If the outer radius is selected, then add the outer radius
-    if (this->m_showBackgroundRadii) {
-        drawingInformation->backgroundOuterRadiusMajorAxis
-            = m_radiiEllipseBackgroundOuter[0];
-        drawingInformation->backgroundOuterRadiusMinorAxis
-            = m_radiiEllipseBackgroundOuter[1];
+  drawingInformation->angle = m_angleEllipse;
 
-        drawingInformation->backgroundInnerRadiusMajorAxis
-            = m_radiiEllipseBackgroundInner[0];
-        drawingInformation->backgroundInnerRadiusMinorAxis
-            = m_radiiEllipseBackgroundInner[1];
+  // If the outer radius is selected, then add the outer radius
+  if (this->m_showBackgroundRadii) {
+    if (m_radiiEllipseBackgroundOuter.size() > 0) {
+      drawingInformation->backgroundOuterRadiusMajorAxis =
+        m_radiiEllipseBackgroundOuter[0];
+      drawingInformation->backgroundOuterRadiusMinorAxis =
+        m_radiiEllipseBackgroundOuter[1];
+    }
+    else {
+      drawingInformation->backgroundOuterRadiusMajorAxis = zeroRadius;
+      drawingInformation->backgroundOuterRadiusMinorAxis = zeroRadius;
     }
 
-    drawingInformation->peakLineWidth = 2;
-    drawingInformation->peakOpacityAtDistance = m_cachedOpacityAtDistance;
-    drawingInformation->peakOrigin = m_originEllipseBackgroundOuter;
 
-    return drawingInformation;
+    // Add inner backgroudn radius if it is available. It might be that only a
+    // cut through the outer
+    // background radius exists
+    if (m_radiiEllipseBackgroundInner.size() > 0) {
+      drawingInformation->backgroundInnerRadiusMajorAxis =
+          m_radiiEllipseBackgroundInner[0];
+      drawingInformation->backgroundInnerRadiusMinorAxis =
+          m_radiiEllipseBackgroundInner[1];
+    } else {
+      drawingInformation->backgroundInnerRadiusMajorAxis = zeroRadius;
+      drawingInformation->backgroundInnerRadiusMinorAxis = zeroRadius;
+    }
+  }
+
+  drawingInformation->peakLineWidth = 2;
+  drawingInformation->peakOpacityAtDistance = m_cachedOpacityAtDistance;
+  drawingInformation->peakOrigin = m_originEllipseBackgroundOuter;
+
+  return drawingInformation;
 }
 
 void PeakRepresentationEllipsoid::doDraw(
     QPainter &painter, PeakViewColor &foregroundColor,
     PeakViewColor &backgroundColor,
     std::shared_ptr<PeakPrimitives> drawingInformation,
-    PeakRepresentationViewInformation viewInformation)
-{
-    // Scale factor for going from viewX to windowX
-    const auto scaleY = viewInformation.windowHeight
-                        / viewInformation.viewHeight;
-    // Scale factor for going from viewY to windowY
-    const auto scaleX = viewInformation.windowWidth / viewInformation.viewWidth;
+    PeakRepresentationViewInformation viewInformation) {
+  // Scale factor for going from viewX to windowX
+  const auto scaleY = viewInformation.windowHeight / viewInformation.viewHeight;
+  // Scale factor for going from viewY to windowY
+  const auto scaleX = viewInformation.windowWidth / viewInformation.viewWidth;
 
-    auto drawingInformationEllipse
-        = std::static_pointer_cast<PeakPrimitivesEllipse>(drawingInformation);
+  auto drawingInformationEllipse =
+      std::static_pointer_cast<PeakPrimitivesEllipse>(drawingInformation);
 
-    // Setup the QPainter
-    painter.setRenderHint(QPainter::Antialiasing);
-    painter.setOpacity(drawingInformationEllipse->peakOpacityAtDistance);
+  // Setup the QPainter
+  painter.setRenderHint(QPainter::Antialiasing);
+  painter.setOpacity(drawingInformationEllipse->peakOpacityAtDistance);
 
-    // Add a pen with color, style and stroke, and a painter path
-    auto foregroundColorEllipsoid = foregroundColor.colorEllipsoid;
+  // Add a pen with color, style and stroke, and a painter path
+  auto foregroundColorEllipsoid = foregroundColor.colorEllipsoid;
 
-    const QPointF zeroPoint(0.0, 0.0);
+  const QPointF zeroPoint(0.0, 0.0);
+
+  // Only draw the ellipsoid if the axis are larger than 0
+  if (drawingInformationEllipse->peakInnerRadiusMajorAxis != zeroRadius &&
+      drawingInformationEllipse->peakInnerRadiusMinorAxis != zeroRadius) {
     // Add the ellipse at the origin (in order to rotate)
     QPainterPath peakRadiusInnerPath;
+
     peakRadiusInnerPath.addEllipse(
         zeroPoint, drawingInformationEllipse->peakInnerRadiusMajorAxis,
         drawingInformationEllipse->peakInnerRadiusMinorAxis);
@@ -281,37 +292,41 @@ void PeakRepresentationEllipsoid::doDraw(
     pen.setStyle(Qt::DashLine);
 
     painter.strokePath(transformedPeakRadiusInnerPath, pen);
+  }
 
-    if (m_showBackgroundRadii) {
-        // Outer demarcation of the fill
-        QPainterPath backgroundOuterPath;
-        backgroundOuterPath.setFillRule(Qt::WindingFill);
-        backgroundOuterPath.addEllipse(
-            zeroPoint,
-            drawingInformationEllipse->backgroundOuterRadiusMajorAxis,
-            drawingInformationEllipse->backgroundOuterRadiusMinorAxis);
-        auto transformedBackgroundOuterPath = getTransformedPainterPath(
-            drawingInformationEllipse->angle, viewInformation.xOriginWindow,
-            viewInformation.yOriginWindow, scaleX, scaleY, backgroundOuterPath);
+  if (m_showBackgroundRadii) {
+    if (drawingInformationEllipse->backgroundOuterRadiusMajorAxis != zeroRadius &&
+        drawingInformationEllipse->backgroundOuterRadiusMinorAxis != zeroRadius &&
+        drawingInformationEllipse->backgroundInnerRadiusMajorAxis != zeroRadius &&
+        drawingInformationEllipse->backgroundInnerRadiusMinorAxis != zeroRadius) {
+      // Outer demarcation of the fill
+      QPainterPath backgroundOuterPath;
+      backgroundOuterPath.setFillRule(Qt::WindingFill);
+      backgroundOuterPath.addEllipse(
+        zeroPoint, drawingInformationEllipse->backgroundOuterRadiusMajorAxis,
+        drawingInformationEllipse->backgroundOuterRadiusMinorAxis);
+      auto transformedBackgroundOuterPath = getTransformedPainterPath(
+        drawingInformationEllipse->angle, viewInformation.xOriginWindow,
+        viewInformation.yOriginWindow, scaleX, scaleY, backgroundOuterPath);
 
-        // Inner demarcation of the fill
-        QPainterPath backgroundInnerPath;
-        backgroundInnerPath.addEllipse(
-            zeroPoint,
-            drawingInformationEllipse->backgroundInnerRadiusMajorAxis,
-            drawingInformationEllipse->backgroundInnerRadiusMinorAxis);
-        auto transformedBackgroundInnerPath = getTransformedPainterPath(
-            drawingInformationEllipse->angle, viewInformation.xOriginWindow,
-            viewInformation.yOriginWindow, scaleX, scaleY, backgroundInnerPath);
+      // Inner demarcation of the fill
+      QPainterPath backgroundInnerPath;
+      backgroundInnerPath.addEllipse(
+        zeroPoint, drawingInformationEllipse->backgroundInnerRadiusMajorAxis,
+        drawingInformationEllipse->backgroundInnerRadiusMinorAxis);
+      auto transformedBackgroundInnerPath = getTransformedPainterPath(
+        drawingInformationEllipse->angle, viewInformation.xOriginWindow,
+        viewInformation.yOriginWindow, scaleX, scaleY, backgroundInnerPath);
 
-        // Subtract inner fill from outer fill
-        QPainterPath backgroundRadiusFill
-            = transformedBackgroundOuterPath.subtracted(
-                transformedBackgroundInnerPath);
+      // Subtract inner fill from outer fill
+      QPainterPath backgroundRadiusFill =
+        transformedBackgroundOuterPath.subtracted(
+          transformedBackgroundInnerPath);
 
-        painter.fillPath(backgroundRadiusFill, backgroundColor.colorEllipsoid);
+      painter.fillPath(backgroundRadiusFill, backgroundColor.colorEllipsoid);
     }
-    painter.end();
+  }
+  painter.end();
 }
 }
 }

--- a/MantidQt/SliceViewer/src/PeakView.cpp
+++ b/MantidQt/SliceViewer/src/PeakView.cpp
@@ -35,10 +35,9 @@ void PeakView::doPaintPeaks(QPaintEvent *)
     const auto viewWidth
         = m_plot->axisScaleDiv(QwtPlot::xBottom)->interval().width();
 
-    QPainter painter(this);
-
     for (size_t i = 0; i < m_viewablePeaks.size(); ++i) {
         if (m_viewablePeaks[i]) {
+            QPainter painter(this);
             // Get the peak
             auto &peak = m_peaks[i];
             const auto &origin = peak->getOrigin();


### PR DESCRIPTION
The slice viewer crashed when adding elliptical peak workspaces.

The reason for this was that peaks were marked as visible although they didn't intersect the cut plane. The reason for this is that the `FindPeaks` agorithm is provided with an effictive radius to find visible peaks. In reality this effective radius can be much larger than the actual radii of a peak which was marked visible. In this case the program expected to plot an ellipsoid although there was no interesection. Now we have a check for this in place.

**To test:**

Run the following script (you need to the SystemTest Data in your Mantid path)

``` python
Load(Filename='TOPAZ_3132_event.nxs', OutputWorkspace='TOPAZ_3132_event', LoadMonitors=True)
ConvertToMD(InputWorkspace='TOPAZ_3132_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', LorentzCorrection=True, OutputWorkspace='TOPAZ_3132_md', MinValues='-25,-25,-25', MaxValues='25,25,25', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=13, MinRecursionDepth=7)
FindPeaksMD(InputWorkspace='TOPAZ_3132_md', PeakDistanceThreshold=0.37680000000000002, MaxPeaks=250, DensityThresholdFactor=100, OutputWorkspace='TOPAZ_3132_peaks')
FindUBUsingFFT(PeaksWorkspace='TOPAZ_3132_peaks', MinD=3, MaxD=15, Tolerance=0.12)
CopySample(InputWorkspace='TOPAZ_3132_peaks', OutputWorkspace='TOPAZ_3132_event', CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
IndexPeaks(PeaksWorkspace='TOPAZ_3132_peaks', Tolerance=0.12)
IntegrateEllipsoids(InputWorkspace='TOPAZ_3132_event', PeaksWorkspace='TOPAZ_3132_peaks', RegionRadius=0.25, SpecifySize=True, PeakSize=0.14000000000000001, BackgroundInnerSize=0.151, BackgroundOuterSize=0.18099999999999999, OutputWorkspace='TOPAZ_3132_peaks')
# End of script
```
- Open the MD workspace in the slice viewer.
- Drag the peaks workspace into the slice viewer
  - Confirm that there is no crash
- Slect peaks from the peak workspace. 
  - Confirm that there is no crash
-  Zoom out and pan around
  - Confirm that you can see multiple peaks (you might have to play around a bit to see this)

Fixes #16508 
_Does not need to be in the release notes._
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
