### PR TITLE
Expose MultipleFileProperty constructor to python

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/api/MultipleFilePropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MultipleFilePropertyTest.py
@@ -12,7 +12,10 @@ class MultipleFilePropertyTest(unittest.TestCase):
         algorithm = create_algorithm('Load', Filename='LOQ48127.raw',OutputWorkspace='w',
                                   SpectrumMin=1,SpectrumMax=1,child=True)
         prop = algorithm.getProperty("Filename")
-        self.assertTrue(isinstance(prop.value, str))
+        filenames = prop.value
+        self.assertTrue(isinstance(filenames, list))
+        self.assertTrue(isinstance(filenames[0], str))
+        self.assertEquals(len(filenames), 1)
 
     def test_value_member_returns_python_list_for_multiple_files(self):
         algorithm = create_algorithm('Load', Filename='MUSR15189,15190,15191.nxs',OutputWorkspace='w',

--- a/scripts/Interface/reduction_gui/reduction/inelastic/dgs_reduction_script.py
+++ b/scripts/Interface/reduction_gui/reduction/inelastic/dgs_reduction_script.py
@@ -180,9 +180,4 @@ class DgsReductionScripter(BaseReductionScripter):
         alg = mantid.api.AlgorithmManager.createUnmanaged("Load")
         alg.initialize()
         alg.setPropertyValue('Filename',str(filename))
-        fnames=alg.getProperty('Filename').value
-        if not isinstance(fnames,list):
-            fnames=[fnames] #make a list with one element
-        return fnames
-
-
+        return alg.getProperty('Filename').value


### PR DESCRIPTION
As part of the continuing effort to make things easier to do in python, expose the constructor for `MultipleFileProperty`. This also simplifies client code by always returning a `list` of `str`.

**To test:**

This can be verified by a simple code review.

_There is no associated issue_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Also changed the return to always be a list of strings. This
required changing the unit tests.
