### PR TITLE
Add sanity check on std::vector::shrink_to_fit.

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -384,7 +384,7 @@ set ( TEST_FILES
 	RebinHistogramTest.h
 	RebinParamsValidatorTest.h
 	RegexStringsTest.h
-        ShrinkToFitTest.h
+	ShrinkToFitTest.h
 	SLSQPMinimizerTest.h
 	SobolSequenceTest.h
 	SpecialCoordinateSystemTest.h

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -384,6 +384,7 @@ set ( TEST_FILES
 	RebinHistogramTest.h
 	RebinParamsValidatorTest.h
 	RegexStringsTest.h
+        ShrinkToFitTest.h
 	SLSQPMinimizerTest.h
 	SobolSequenceTest.h
 	SpecialCoordinateSystemTest.h

--- a/Framework/Kernel/test/ShrinkToFitTest.h
+++ b/Framework/Kernel/test/ShrinkToFitTest.h
@@ -1,0 +1,51 @@
+#ifndef MANTID_SHRINKTOFITTEST_H_
+#define MANTID_SHRINKTOFITTEST_H_
+
+#include <cxxtest/TestSuite.h>
+#include <string>
+#include <vector>
+
+/**
+   \class ShrinkToFitTest
+   Verify that the non-binding request shrink_to_fit() does reduce the
+   container's capacity.
+*/
+
+class ShrinkToFitTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ShrinkToFitTest *createSuite() { return new ShrinkToFitTest(); }
+  static void destroySuite(ShrinkToFitTest *suite) { delete suite; }
+
+  void test_vector() {
+
+    // verify that std::vector::shrink_to_fit() reduces the vector's capacity.
+    std::size_t oldsize{1000};
+    std::size_t newsize{100};
+    std::vector<double> original(oldsize);
+    TS_ASSERT_EQUALS(original.size(), oldsize);
+    TS_ASSERT_LESS_THAN_EQUALS(oldsize, original.capacity());
+    original.resize(100);
+    TS_ASSERT_EQUALS(original.size(), newsize);
+    std::size_t capacityAfterResize = original.capacity();
+    original.shrink_to_fit();
+    TS_ASSERT_EQUALS(original.size(), newsize);
+    std::size_t capacityAfterShrinkToFit = original.capacity();
+    TS_ASSERT_LESS_THAN(capacityAfterShrinkToFit, capacityAfterResize);
+
+    // Use shrink-to-fit idiom and compare against shrink_to_fit()
+    original.resize(1000);
+    TS_ASSERT_EQUALS(original.size(), oldsize);
+    original.resize(100);
+    TS_ASSERT_EQUALS(original.size(), newsize);
+    {
+      std::vector<double> temp(original);
+      std::swap(original, temp);
+    }
+
+    TS_ASSERT_LESS_THAN_EQUALS(capacityAfterShrinkToFit, original.capacity());
+  }
+};
+
+#endif // MANTID_SHRINKTOFITTEST_H_

--- a/Framework/Kernel/test/StringTokenizerTest.h
+++ b/Framework/Kernel/test/StringTokenizerTest.h
@@ -1,5 +1,5 @@
-#ifndef MANTID_SUPPORTTEST_H_
-#define MANTID_SUPPORTTEST_H_
+#ifndef MANTID_STRINGTOKENIZERTEST_H_
+#define MANTID_STRINGTOKENIZERTEST_H_
 
 #include <cxxtest/TestSuite.h>
 #include <random>
@@ -233,4 +233,4 @@ public:
   }
 };
 
-#endif // MANTID_SUPPORTTEST_H_
+#endif // MANTID_STRINGTOKENZIERTEST_H_


### PR DESCRIPTION
Description of work.

C++11 adds `std::vector::shrink_to_fit()`, which is a non-binding request to reduce to the container's capacity to its size. Currently this is being done in Mantid using a copy and a swap (shrink-to-fit idiom).

Since the standard doesn't guarantee that every implementation reduces the capacity of `std::vector`, it is useful to have a test verifying that it does as we expect and reduces the capacity by at least as much as copy-and-swap.

http://clang.llvm.org/extra/clang-tidy/checks/modernize-shrink-to-fit.html
https://groups.google.com/a/isocpp.org/forum/#!topic/std-discussion/ts9WlqHtMsc

**To test:**

<!-- Instructions for testing. -->

This pull request has no associated issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
