### PR TITLE
ReplicateMD input dimensions checks

### DIFF
--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -193,6 +193,7 @@ std::map<std::string, std::string> ReplicateMD::validateInputs() {
   }
 
   size_t nonMatchingCount = 0;
+  bool haveMatchingIntegratedDims = false;
   for (size_t i = 0; i < shapeWS->getNumDims(); ++i) {
     const auto shapeDim = shapeWS->getDimension(i);
 
@@ -200,16 +201,29 @@ std::map<std::string, std::string> ReplicateMD::validateInputs() {
     const auto dataDim = findMatchingDimension(*dataWS, *shapeDim);
     if (dataDim) {
       if (dataDim->getIsIntegrated()) {
-        // We count this as a non-matching dimension
-        ++nonMatchingCount;
+        if (!shapeDim->getIsIntegrated()) {
+          // We count this as a non-matching dimension
+          ++nonMatchingCount;
+        } else {
+          haveMatchingIntegratedDims = true;
+        }
       } else {
         // Check bin sizes match between the two dimensions
         if (shapeDim->getNBins() != dataDim->getNBins()) {
           std::stringstream stream;
           stream << "Dimension with id " << shapeDim->getDimensionId()
-                 << "in ShapeWorkspace has a different number of bins as the "
+                 << " in ShapeWorkspace has a different number of bins as the "
                     "same id dimension in the DataWorkspace";
           errorMap.emplace("DataWorkspace", stream.str());
+        } else if (haveMatchingIntegratedDims) {
+          errorMap.emplace(
+              "ShapeWorkspace",
+              "Extra integrated dimensions must be only "
+              "the last dimensions, e.g.:\n\nThis is allowed:\n  "
+              "Shape: {10, 5, 1, 1}\n  Data:  { 1, 5, 1, 1}\n\nBut "
+              "this is not:\n  Shape: {10, 1, 5, 1}\n  Data:  { 1, 1, "
+              "5, 1}\n\nUse TransposeMD to re-arrange dimensions.");
+          break;
         }
       }
     } else {

--- a/docs/source/algorithms/ReplicateMD-v1.rst
+++ b/docs/source/algorithms/ReplicateMD-v1.rst
@@ -14,6 +14,10 @@ This algorithm creates a higher dimensional dataset by replicating along an addi
 
 The *ShapeWorkspace* input defines the shape of the *OutputWorkspace*, but not the contents. The *DataWorkspace* provides the data contents in the lower dimensionality cut, which will be replicated over. This algorithm operates on :ref:`MDHistoWorkspace <MDHistoWorkspace>` inputs and provides a :ref:`MDHistoWorkspace <MDHistoWorkspace>` as an output.
 
+The *ShapeWorkspace* and *DataWorkspace* can have any number of extra integrated trailing dimensions. For example the *ShapeWorkspace* can have shape ``[10, 5, 1, 1]``
+(where each number in the list is a number of bins in the corresponding dimension) and the *DataWorkspace* can have either ``[10, 1, 1, 1]`` or ``[1, 5, 1, 1]``.
+But the following arrangement will cause a run-time error: shape ``[10, 1, 5, 1]``, data ``[1, 1, 5, 1]``. In such case the dimensions can be re-arranged using
+:ref:`algm-TransposeMD` algorithm.
 
 Usage
 -----


### PR DESCRIPTION
Modified the validation method for the input dimensions to allow any number of "trailing" integrated dimensions. Added an error message if a particular condition isn't met.

**To test:**
1. Run the following script. It should fail on the last executable statement. Check that the warning log message makes sense.
2. Uncomment the last 3 statements and run them only. They should run without error and created `replicated` workspace must be filled in correctly.

```
#Some problems with MD algorithms / workflow

#Create an MD workspace, file backed because my system might not have enough memory:

import os
import numpy as np
from os import path
this_dir = path.dirname(__file__)

#Create projections workspace for later cutting
from mantid.api import Projection
# Create an identity projection
proj_id = Projection([1,1,0], [-1,1,0], [0,0,1])
proj_id.setType(0, 'r') 
proj_id.setType(1, 'r')
proj_id.setType(2, 'r') 
ws_id = proj_id.createWorkspace()

#Make MD mega file (like gen_sqw / accumulate_sqw)
psi_arr=np.arange(0.0,92.0,2)
run_arr=range(15052,15098)

input_runs = list()
psi = list()
gs = list()
gl = list()
#note that gl, gs etc are not mandtory inputs. If we do not specify them then they are set to zero.

input_runs = list()
psi = list()
gs = list()
gl = list()
for i in range(2):
    source_file = ('%s/map'+str(run_arr[i])+'_ei400.nxspe') % this_dir
    input_runs.append(source_file)
    psi.append(float(psi_arr[i]))
    gl.append(0.0)
    gs.append(0.0)

print(psi)
print(input_runs)

md_ws = CreateMD(input_runs, Emode='Direct', Alatt=[2.87,2.87,2.87], Angdeg=[ 90, 90, 90], u=[1, 0, 0,], v=[0,1,0], Psi=psi, Gl=gl, Gs=gs, EFix=400.0,Filename='test.nxs',FileBackEnd=True)
#Up to this point everything works as we would expect it to.

########################################

##Problem with ReplicateMD logic:

#2D slice (the shape workspace)
out_md_2d = CutMD(md_ws, Projection=ws_id, PBins=([-3,0.05,3],[-1.1,-0.9],[-0.1,0.1],[0,4,360]), NoPix=True)

#1D cut (the data workspace)
out_md_1d_nopix= CutMD(md_ws, Projection=ws_id, PBins=([2,3],[-1.1,-0.9],[-0.1,0.1],[0,4,360]), NoPix=True)

#Attempt to replicate data to shape:
replicated = ReplicateMD(out_md_2d, out_md_1d_nopix)

# Uncomment and run these lines:
#TransposeMD(out_md_2d, [0, 3, 1, 2], OutputWorkspace='t2d')
#TransposeMD(out_md_1d_nopix, [0, 3, 1, 2], OutputWorkspace='t1d')
#replicated = ReplicateMD('t2d', 't1d')
```

Fixes #16389.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
