### PR TITLE
 fabs for line grids which can be backward

### DIFF
--- a/MantidQt/API/src/QwtWorkspaceSpectrumData.cpp
+++ b/MantidQt/API/src/QwtWorkspaceSpectrumData.cpp
@@ -77,7 +77,7 @@ Return the y value of data point i
 double QwtWorkspaceSpectrumData::getY(size_t i) const {
   double tmp = i < m_Y.size() ? m_Y[i] : m_Y[m_Y.size() - 1];
   if (m_isDistribution) {
-    tmp /= (m_X[i + 1] - m_X[i]);
+    tmp /= fabs(m_X[i + 1] - m_X[i]);
   }
   return tmp;
 }
@@ -89,7 +89,7 @@ double QwtWorkspaceSpectrumData::getEX(size_t i) const {
 double QwtWorkspaceSpectrumData::getE(size_t i) const {
   double ei = (i < m_E.size()) ? m_E[i] : m_E[m_E.size() - 1];
   if (m_isDistribution) {
-    ei /= (m_X[i + 1] - m_X[i]);
+    ei /= fabs(m_X[i + 1] - m_X[i]);
   }
   return ei;
 }


### PR DESCRIPTION
Description of work.
This could be solved by changing the preferences to not normalize histogram to bin width, but then it would be used for all histograms.  Since line plots from MD workspaces can have grids which are backward, I took the absolute value of the bin.

**To test:**

<!-- Instructions for testing. -->

https://www.dropbox.com/s/9csyk8ymghjiksm/line.nxs?dl=0
LoadMD(Filename='line.nxs', OutputWorkspace='read_line')
ConvertMDHistoToMatrixWorkspace(InputWorkspace='read_line', OutputWorkspace='out_matrix')
Then Plot Spectrum of out_matrix and Plot MD of read_line
Fixes #16012 

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
