### PR TITLE
Move VSI Check to ApplicationWindow.

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -464,10 +464,6 @@ endif ()
 set_property ( TARGET API PROPERTY FOLDER "MantidFramework" )
 
 target_link_libraries ( API LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${JSONCPP_LIBRARIES} ${MANTIDLIBS} ${GSL_LIBRARIES} ${NEXUS_LIBRARIES} ${WINSOCK} )
-if(MAKE_VATES)
-  target_include_directories( API SYSTEM PRIVATE ${PARAVIEW_INCLUDE_DIRS} )
-  target_link_libraries ( API LINK_PRIVATE vtkPVClientServerCoreRendering )
-endif()
 
 # Add the unit tests directory
 add_subdirectory ( test )

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -19,10 +19,6 @@
 
 #include <cstdarg>
 
-#ifdef MAKE_VATES
-#include "vtkPVDisplayInformation.h"
-#endif
-
 #ifdef _WIN32
 #include <winsock2.h>
 #endif
@@ -83,11 +79,6 @@ FrameworkManagerImpl::FrameworkManagerImpl()
 #ifdef MPI_BUILD
   g_log.notice() << "This MPI process is rank: "
                  << boost::mpi::communicator().rank() << std::endl;
-#endif
-
-#ifdef MAKE_VATES
-  if (!vtkPVDisplayInformation::SupportsOpenGLLocally())
-    g_log.error() << "The OpenGL configuration does not support the VSI.\n";
 #endif
 
   g_log.debug() << "FrameworkManager created." << std::endl;

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -216,6 +216,10 @@
 
 #include "MantidQtAPI/ScriptRepositoryView.h"
 
+#ifdef MAKE_VATES
+#include "vtkPVDisplayInformation.h"
+#endif
+
 using namespace Qwt3D;
 using namespace MantidQt::API;
 using Mantid::Kernel::ConfigService;
@@ -369,6 +373,11 @@ void ApplicationWindow::init(bool factorySettings, const QStringList &args) {
     LibraryManager::Instance().OpenAllLibraries(config.getPVPluginsPath(),
                                                 false);
   }
+
+#ifdef MAKE_VATES
+  if (!vtkPVDisplayInformation::SupportsOpenGLLocally())
+    g_log.error("The OpenGL configuration does not support the VSI.");
+#endif
 
   // Create UI object
   mantidUI = new MantidUI(this);


### PR DESCRIPTION
Description of work.

This moves the VSI check from `FrameworkManager` to `ApplicationWindow`. The previous location caused a linking error when importing mantid into a python terminal.

**To test:**

<!-- Instructions for testing. -->

Verify that the error in the issue no longer occurs.

Fixes #16537.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
