### PR TITLE
use back() member function to get the last element of a container.

### DIFF
--- a/Framework/API/inc/MantidAPI/BoxController.h
+++ b/Framework/API/inc/MantidAPI/BoxController.h
@@ -336,7 +336,7 @@ public:
    * */
   double getAverageDepth() const {
     double total = 0;
-    double maxNumberOfFinestBoxes = m_maxNumMDBoxes[m_maxNumMDBoxes.size() - 1];
+    double maxNumberOfFinestBoxes = m_maxNumMDBoxes.back();
     for (size_t depth = 0; depth < m_numMDBoxes.size(); depth++) {
       // Add up the number of MDBoxes at that depth, weighed by their volume in
       // units of the volume of the finest possible box.

--- a/Framework/API/src/Expression.cpp
+++ b/Framework/API/src/Expression.cpp
@@ -123,8 +123,7 @@ void Expression::parse(const std::string &str) {
   m_expr = str;
   trim(m_expr);
 
-  if (m_expr.size() > 1 && m_expr[0] == '(' &&
-      m_expr[m_expr.size() - 1] == ')') {
+  if (m_expr.size() > 1 && m_expr.front() == '(' && m_expr.back() == ')') {
     if (m_expr.find('(', 1) == std::string::npos) {
       m_expr.erase(0, 1);
       m_expr.erase(m_expr.size() - 1, 1);

--- a/Framework/API/src/FunctionFactory.cpp
+++ b/Framework/API/src/FunctionFactory.cpp
@@ -292,10 +292,10 @@ void FunctionFactoryImpl::addTie(IFunction_sptr fun,
   if (expr.size() > 1) { // if size > 2 it is interpreted as setting a tie (last
                          // expr.term) to multiple parameters, e.g
     // f1.alpha = f2.alpha = f3.alpha = f0.beta^2/2
-    const std::string value = expr[expr.size() - 1].str();
-    for (size_t i = expr.size() - 1; i != 0;) {
-      --i;
-      fun->tie(expr[i].name(), value);
+                         const std::string value = expr[expr.size() - 1].str();
+                         for (size_t i = expr.size() - 1; i != 0;) {
+                           --i;
+                           fun->tie(expr[i].name(), value);
     }
   }
 }

--- a/Framework/API/src/FunctionFactory.cpp
+++ b/Framework/API/src/FunctionFactory.cpp
@@ -290,12 +290,12 @@ void FunctionFactoryImpl::addTies(IFunction_sptr fun,
 void FunctionFactoryImpl::addTie(IFunction_sptr fun,
                                  const Expression &expr) const {
   if (expr.size() > 1) { // if size > 2 it is interpreted as setting a tie (last
-                         // expr.term) to multiple parameters, e.g
+    // expr.term) to multiple parameters, e.g
     // f1.alpha = f2.alpha = f3.alpha = f0.beta^2/2
-                         const std::string value = expr[expr.size() - 1].str();
-                         for (size_t i = expr.size() - 1; i != 0;) {
-                           --i;
-                           fun->tie(expr[i].name(), value);
+    const std::string value = expr[expr.size() - 1].str();
+    for (size_t i = expr.size() - 1; i != 0;) {
+      --i;
+      fun->tie(expr[i].name(), value);
     }
   }
 }

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -572,7 +572,7 @@ protected:
     }
     if (m_value.size() > 2) {
       // check if the value is in barckets (...)
-      if (m_value[0] == '(' && m_value[m_value.size() - 1] == ')') {
+      if (m_value.front() == '(' && m_value.back() == ')') {
         m_value.erase(0, 1);
         m_value.erase(m_value.size() - 1);
       }

--- a/Framework/Algorithms/src/DiffractionFocussing.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing.cpp
@@ -219,14 +219,12 @@ void DiffractionFocussing::calculateRebinParams(
   int64_t length = workspace->getNumberHistograms();
   for (int64_t i = 0; i < length; i++) {
     const MantidVec &xVec = workspace->readX(i);
-    const double &localMin = xVec[0];
-    const double &localMax = xVec[xVec.size() - 1];
+    const double &localMin = xVec.front();
+    const double &localMax = xVec.back();
     if (localMin != std::numeric_limits<double>::infinity() &&
         localMax != std::numeric_limits<double>::infinity()) {
-      if (localMin < min)
-        min = localMin;
-      if (localMax > max)
-        max = localMax;
+      min = std::min(min, localMin);
+      max = std::max(max, localMax);
     }
   }
 

--- a/Framework/Algorithms/src/FFT.cpp
+++ b/Framework/Algorithms/src/FFT.cpp
@@ -361,7 +361,7 @@ bool FFT::areBinWidthsUneven(const MantidVec &xValues) const {
   const double dx = [&] {
     if (acceptXRoundingErrors) {
       // use average bin width
-      return (xValues[xValues.size() - 1] - xValues[0]) /
+      return (xValues.back() - xValues.front()) /
              static_cast<double>(xValues.size() - 1);
     } else {
       // use first bin width

--- a/Framework/Algorithms/src/FindPeakBackground.cpp
+++ b/Framework/Algorithms/src/FindPeakBackground.cpp
@@ -187,12 +187,12 @@ void FindPeakBackground::exec() {
     vector<cont_peak> peaks;
     if (mask[0] == 1) {
       peaks.push_back(cont_peak());
-      peaks[peaks.size() - 1].start = l0;
+      peaks.back().start = l0;
     }
     for (size_t l = 1; l < n - l0; ++l) {
       if (mask[l] != mask[l - 1] && mask[l] == 1) {
         peaks.push_back(cont_peak());
-        peaks[peaks.size() - 1].start = l + l0;
+        peaks.back().start = l + l0;
       } else if (!peaks.empty()) {
         size_t ipeak = peaks.size() - 1;
         if (mask[l] != mask[l - 1] && mask[l] == 0) {
@@ -208,8 +208,8 @@ void FindPeakBackground::exec() {
     if (!peaks.empty()) {
       g_log.debug() << "Peaks' size = " << peaks.size()
                     << " -> esitmate background. \n";
-      if (peaks[peaks.size() - 1].stop == 0)
-        peaks[peaks.size() - 1].stop = n - 1;
+      if (peaks.back().stop == 0)
+        peaks.back().stop = n - 1;
       std::sort(peaks.begin(), peaks.end(), by_len());
 
       // save endpoints

--- a/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
+++ b/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
@@ -310,7 +310,7 @@ void GetTimeSeriesLogInformation::exportErrorLog(MatrixWorkspace_sptr ws,
                                                  vector<DateAndTime> abstimevec,
                                                  double dts) {
   std::string outputdir = getProperty("OutputDirectory");
-  if (!outputdir.empty() && outputdir[outputdir.size() - 1] != '/')
+  if (!outputdir.empty() && outputdir.back() != '/')
     outputdir += "/";
 
   std::string ofilename = outputdir + "errordeltatime.txt";

--- a/Framework/Algorithms/src/InterpolatingRebin.cpp
+++ b/Framework/Algorithms/src/InterpolatingRebin.cpp
@@ -287,11 +287,12 @@ void InterpolatingRebin::cubicInterpolation(
       throw std::invalid_argument(
           std::string("At least one x-value to interpolate to is outside the "
                       "range of the original data.\n") +
-          "original data range: " + boost::lexical_cast<std::string>(xOld[0]) +
-          " to " + boost::lexical_cast<std::string>(xOld[xOld.size() - 1]) +
-          "\n" + "range to try to interpolate to " +
-          boost::lexical_cast<std::string>(xNew[0]) + " to " +
-          boost::lexical_cast<std::string>(xNew[xNew.size() - 1]));
+          "original data range: " +
+          boost::lexical_cast<std::string>(xOld.front()) + " to " +
+          boost::lexical_cast<std::string>(xOld.back()) + "\n" +
+          "range to try to interpolate to " +
+          boost::lexical_cast<std::string>(xNew.front()) + " to " +
+          boost::lexical_cast<std::string>(xNew.back()));
     }
   }
 

--- a/Framework/Algorithms/src/MaxEnt.cpp
+++ b/Framework/Algorithms/src/MaxEnt.cpp
@@ -172,7 +172,7 @@ std::map<std::string, std::string> MaxEnt::validateInputs() {
     // Average spacing
     const MantidVec &X = inWS->readX(0);
     const double dx =
-        (X[X.size() - 1] - X[0]) / static_cast<double>(X.size() - 1);
+        (X.back() - X.front()) / static_cast<double>(X.size() - 1);
     for (size_t i = 1; i < X.size() - 1; i++) {
       // 1% accuracy exceeded, but data still usable
       if (std::abs(X[i] - X[0] - static_cast<double>(i) * dx) / dx >

--- a/Framework/Algorithms/src/RadiusSum.cpp
+++ b/Framework/Algorithms/src/RadiusSum.cpp
@@ -329,8 +329,8 @@ RadiusSum::getBoundariesOfNumericImage(API::MatrixWorkspace_sptr inWS) {
 
   double min_x, max_x;
 
-  const double &first_x(refX[0]);
-  const double &last_x(refX[refX.size() - 1]);
+  const double &first_x = refX.front();
+  const double &last_x = refX.back();
   if (first_x < last_x) {
     min_x = first_x;
     max_x = last_x;
@@ -651,7 +651,7 @@ void RadiusSum::setUpOutputWorkspace(std::vector<double> &values) {
 
   for (int i = 0; i < (static_cast<int>(refX.size())) - 1; i++)
     refX[i] = min_radius + i * bin_size;
-  refX[refX.size() - 1] = max_radius;
+  refX.back() = max_radius;
 
   // configure the axis:
   // for numeric images, the axis are the same as the input workspace, and are

--- a/Framework/Algorithms/src/RingProfile.cpp
+++ b/Framework/Algorithms/src/RingProfile.cpp
@@ -338,8 +338,8 @@ void RingProfile::checkInputsForNumericWorkspace(
   const MantidVec &refX = inputWS->readX(inputWS->getNumberHistograms() / 2);
   // get the limits of the axis 0 (X)
   double min_v_x, max_v_x;
-  min_v_x = std::min(refX[0], refX[refX.size() - 1]);
-  max_v_x = std::max(refX[0], refX[refX.size() - 1]);
+  min_v_x = std::min(refX[0], refX.back());
+  max_v_x = std::max(refX[0], refX.back());
   g_log.notice() << "Limits X = " << min_v_x << " " << max_v_x << std::endl;
   // check centre is inside the X domain
   if (centre_x < min_v_x || centre_x > max_v_x) {

--- a/Framework/Algorithms/src/VesuvioL1ThetaResolution.cpp
+++ b/Framework/Algorithms/src/VesuvioL1ThetaResolution.cpp
@@ -441,10 +441,8 @@ VesuvioL1ThetaResolution::processDistribution(MatrixWorkspace_sptr ws,
   double xMax(DBL_MIN);
   for (size_t i = 0; i < numHist; i++) {
     const std::vector<double> &x = ws->readX(i);
-    if (x[0] < xMin)
-      xMin = x[0];
-    if (x[x.size() - 1] > xMax)
-      xMax = x[x.size() - 1];
+    xMin = std::min(xMin, x.front());
+    xMax = std::max(xMax, x.back());
   }
 
   std::stringstream binParams;

--- a/Framework/Algorithms/test/ReflectometryReductionOneTest.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneTest.h
@@ -229,11 +229,10 @@ public:
     // compare y data instead of workspaces.
     auto scaledYData = scaledWS->readY(0);
     auto nonScaledYData = nonScaledWS->readY(0);
-    TS_ASSERT_EQUALS(scaledYData[0], 2 * nonScaledYData[0]);
+    TS_ASSERT_EQUALS(scaledYData.front(), 2 * nonScaledYData.front());
     TS_ASSERT_EQUALS(scaledYData[scaledYData.size() / 2],
                      2 * nonScaledYData[nonScaledYData.size() / 2]);
-    TS_ASSERT_EQUALS(scaledYData[scaledYData.size() - 1],
-                     2 * nonScaledYData[nonScaledYData.size() - 1]);
+    TS_ASSERT_EQUALS(scaledYData.back(), 2 * nonScaledYData.back());
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove("Test");
     AnalysisDataService::Instance().remove("scaledTest");
@@ -265,7 +264,7 @@ public:
     TSM_ASSERT_DELTA("DQQ should be the same as abs(x[1]/x[0] - 1)",
                      binWidthFromLogarithmicEquation, 0.1, 1e-06);
     TSM_ASSERT_DELTA("Qmax should be the same as last Params entry (5.0)",
-                     xData[xData.size() - 1], 15.0, 1e-06);
+                     xData.back(), 15.0, 1e-06);
   }
   void test_post_processing_rebin_step_with_logarithmic_rebinning() {
     auto alg = construct_standard_algorithm();
@@ -287,7 +286,7 @@ public:
     TSM_ASSERT_DELTA("DQQ should be the same as abs(x[1]/x[0] - 1)",
                      binWidthFromLogarithmicEquation, 0.2, 1e-06);
     TSM_ASSERT_EQUALS("QMax should be the same as last Param entry",
-                      xData[xData.size() - 1], 5.0);
+                      xData.back(), 5.0);
   }
   void test_post_processing_rebin_step_with_linear_rebinning() {
     auto alg = construct_standard_algorithm();
@@ -307,7 +306,7 @@ public:
     TSM_ASSERT_DELTA("DQQ should the same as 0.2", xData[1] - xData[0], 0.2,
                      1e-06);
     TSM_ASSERT_DELTA("QMax should be the same as the last Param entry (5.233)",
-                     xData[xData.size() - 1], 5.233, 1e-06);
+                     xData.back(), 5.233, 1e-06);
   }
   void test_Qrange() {
     // set up the axis for the instrument

--- a/Framework/Algorithms/test/Stitch1DTest.h
+++ b/Framework/Algorithms/test/Stitch1DTest.h
@@ -334,9 +334,8 @@ public:
       }
     }
 
-    double start_overlap_determined = stitched_x[overlap_indexes[0]];
-    double end_overlap_determined =
-        stitched_x[overlap_indexes[overlap_indexes.size() - 1]];
+    double start_overlap_determined = stitched_x[overlap_indexes.front()];
+    double end_overlap_determined = stitched_x[overlap_indexes.back()];
     TS_ASSERT_DELTA(start_overlap_determined, -0.4, 0.000000001);
     TS_ASSERT_DELTA(end_overlap_determined, 0.2, 0.000000001);
   }
@@ -363,9 +362,8 @@ public:
       }
     }
 
-    double start_overlap_determined = stitched_x[overlap_indexes[0]];
-    double end_overlap_determined =
-        stitched_x[overlap_indexes[overlap_indexes.size() - 1]];
+    double start_overlap_determined = stitched_x[overlap_indexes.front()];
+    double end_overlap_determined = stitched_x[overlap_indexes.back()];
     TS_ASSERT_DELTA(start_overlap_determined, -0.4, 0.000000001);
     TS_ASSERT_DELTA(end_overlap_determined, 0.2, 0.000000001);
   }
@@ -392,9 +390,8 @@ public:
       }
     }
 
-    double start_overlap_determined = stitched_x[overlap_indexes[0]];
-    double end_overlap_determined =
-        stitched_x[overlap_indexes[overlap_indexes.size() - 1]];
+    double start_overlap_determined = stitched_x[overlap_indexes.front()];
+    double end_overlap_determined = stitched_x[overlap_indexes.back()];
     TS_ASSERT_DELTA(start_overlap_determined, -0.4, 0.000000001);
     TS_ASSERT_DELTA(end_overlap_determined, 0.2, 0.000000001);
   }
@@ -569,7 +566,7 @@ public:
     TSM_ASSERT("All error values are non-zero", !alg.hasNonzeroErrors(ws));
 
     // Run it again with some zeros
-    e[e.size() - 1] = 1;
+    e.back() = 1;
     ws = createWorkspace(x, y, e, 1);
     TSM_ASSERT("NOT all error values are non-zero", alg.hasNonzeroErrors(ws));
   }
@@ -597,7 +594,7 @@ public:
     TSM_ASSERT("All error values are non-zero", !alg.hasNonzeroErrors(ws));
 
     // Run it again with some zeros
-    e[e.size() - 1] = 1;
+    e.back() = 1;
     ws = createWorkspace(x, y, e, nspectrum);
     TSM_ASSERT("NOT all error values are non-zero", alg.hasNonzeroErrors(ws));
   }

--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -190,7 +190,7 @@ void OptimizeLatticeForCellType::exec() {
     AnalysisDataService::Instance().remove("_peaks");
     if (perRun) {
       std::string outputdir = getProperty("OutputDirectory");
-      if (outputdir[outputdir.size() - 1] != '/')
+      if (outputdir.back() != '/')
         outputdir += "/";
       // Save Peaks
       Mantid::API::IAlgorithm_sptr savePks_alg =

--- a/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
+++ b/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
@@ -448,7 +448,7 @@ void ProcessBackground::addRegion() {
     m_outputWS->dataE(0)[i] = ve[i];
   }
   if (vx.size() > vy.size())
-    m_outputWS->dataX(0)[vx.size() - 1] = vx.back();
+    m_outputWS->dataX(0).back() = vx.back();
 
   // Write out dummy output workspaces
   setupDummyOutputWSes();

--- a/Framework/DataHandling/src/DownloadInstrument.cpp
+++ b/Framework/DataHandling/src/DownloadInstrument.cpp
@@ -119,7 +119,7 @@ DownloadInstrument::StringToStringMap DownloadInstrument::processRepository() {
   // get the instrument directories
   auto instrumentDirs =
       Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
-  Poco::Path installPath(instrumentDirs[instrumentDirs.size() - 1]);
+  Poco::Path installPath(instrumentDirs.back());
   installPath.makeDirectory();
   Poco::Path localPath(instrumentDirs[0]);
   localPath.makeDirectory();

--- a/Framework/DataHandling/src/LoadMask.cpp
+++ b/Framework/DataHandling/src/LoadMask.cpp
@@ -288,8 +288,8 @@ void LoadMask::bankToDetectors(std::vector<std::string> singlebanks,
 
     // a) get information
     size_t numdets = idetectors.size();
-    detid_t detid_first = idetectors[0]->getID();
-    detid_t detid_last = idetectors[idetectors.size() - 1]->getID();
+    detid_t detid_first = idetectors.front()->getID();
+    detid_t detid_last = idetectors.back()->getID();
 
     // b) set detectors
     if (detid_first + int32_t(numdets) == detid_last + 1 && false) {

--- a/Framework/DataHandling/src/LoadSNSspec.cpp
+++ b/Framework/DataHandling/src/LoadSNSspec.cpp
@@ -164,8 +164,7 @@ void LoadSNSspec::exec() {
           spectra[working_with_spectrum_nbr].dataE().push_back(input[j]);
           nBins = j / 3;
         }
-        spectra[working_with_spectrum_nbr].dataX().push_back(
-            input[input.size() - 1]);
+        spectra[working_with_spectrum_nbr].dataX().push_back(input.back());
       }
       working_with_spectrum_nbr++;
       input.clear();
@@ -186,8 +185,7 @@ void LoadSNSspec::exec() {
         spectra[working_with_spectrum_nbr].dataE().push_back(input[j]);
         nBins = j / 3;
       }
-      spectra[working_with_spectrum_nbr].dataX().push_back(
-          input[input.size() - 1]);
+      spectra[working_with_spectrum_nbr].dataX().push_back(input.back());
     }
   } catch (...) {
   }

--- a/Framework/DataHandling/src/ProcessDasNexusLog.cpp
+++ b/Framework/DataHandling/src/ProcessDasNexusLog.cpp
@@ -194,7 +194,7 @@ void ProcessDasNexusLog::exportErrorLog(
     std::vector<Kernel::DateAndTime> pulsetimes,
     std::vector<double> orderedtofs, double dts) {
   std::string outputdir = getProperty("OutputDirectory");
-  if (outputdir[outputdir.size() - 1] != '/')
+  if (outputdir.back() != '/')
     outputdir += "/";
 
   std::string ofilename = outputdir + "errordeltatime.txt";
@@ -274,8 +274,8 @@ void ProcessDasNexusLog::calDistributions(
   std::vector<size_t> y2;
 
   size_t numperiods = 100;
-  int64_t spanns = timevec[timevec.size() - 1].totalNanoseconds() -
-                   timevec[0].totalNanoseconds();
+  int64_t spanns =
+      timevec.back().totalNanoseconds() - timevec.front().totalNanoseconds();
   double timestepsec =
       static_cast<double>(spanns) * 1.0E-9 / static_cast<double>(numperiods);
 
@@ -354,8 +354,8 @@ void ProcessDasNexusLog::checkLog(API::MatrixWorkspace_sptr ws,
 
   // 3. Output
   Kernel::DateAndTime t0(ws->run().getProperty("run_start")->value());
-  Kernel::time_duration dts = times[0] - t0;
-  Kernel::time_duration dtf = times[times.size() - 1] - t0;
+  Kernel::time_duration dts = times.front() - t0;
+  Kernel::time_duration dtf = times.back() - t0;
   size_t f = times.size() - 1;
 
   g_log.information() << "Number of Equal Time Stamps    = " << countsame

--- a/Framework/Kernel/src/BinFinder.cpp
+++ b/Framework/Kernel/src/BinFinder.cpp
@@ -98,7 +98,7 @@ BinFinder::BinFinder(const std::vector<double> &binParams) {
  */
 int BinFinder::lastBinIndex() {
   if (!endBinIndex.empty())
-    return endBinIndex[endBinIndex.size() - 1];
+    return endBinIndex.back();
   else
     return -1;
 }

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1658,7 +1658,7 @@ ConfigServiceImpl::getInstrumentDirectories() const {
  * @returns a last entry of getInstrumentDirectories
  */
 const std::string ConfigServiceImpl::getInstrumentDirectory() const {
-  return m_InstrumentDirs[m_InstrumentDirs.size() - 1];
+  return m_InstrumentDirs.back();
 }
 /**
  * Return the search directory for vtp files

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -349,7 +349,7 @@ public:
     }
     // Check that the last directory matches that returned by
     // getInstrumentDirectory
-    TS_ASSERT_EQUALS(directories[directories.size() - 1],
+    TS_ASSERT_EQUALS(directories.back(),
                      ConfigService::Instance().getInstrumentDirectory());
 
     // check all of the directory entries actually exist

--- a/Framework/MDAlgorithms/src/ConvToMDHistoWS.cpp
+++ b/Framework/MDAlgorithms/src/ConvToMDHistoWS.cpp
@@ -104,8 +104,7 @@ size_t ConvToMDHistoWS::conversionChunk(size_t startSpectra) {
         XtargetUnits[j - 1] = 0.5 * (xm + xm1);
         xm1 = xm;
       }
-      XtargetUnits[XtargetUnits.size() - 1] =
-          xm1; // just in case, should not be used
+      XtargetUnits.back() = xm1; // just in case, should not be used
     } else
       for (size_t j = 0; j < XtargetUnits.size(); j++)
         XtargetUnits[j] = localUnitConv.convertUnits(X[j]);

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -348,7 +348,7 @@ void ConvertToMD::copyMetaData(API::IMDEventWorkspace_sptr &mdEventWS) const {
       }
     }
     // sort bin boundaries in case if unit transformation have swapped them.
-    if (binBoundaries[0] > binBoundaries[binBoundaries.size() - 1]) {
+    if (binBoundaries[0] > binBoundaries.back()) {
       g_log.information() << "Bin boundaries are not arranged monotonously. "
                              "Sorting performed\n";
       std::sort(binBoundaries.begin(), binBoundaries.end());

--- a/Framework/RemoteAlgorithms/src/SimpleJSON.cpp
+++ b/Framework/RemoteAlgorithms/src/SimpleJSON.cpp
@@ -674,8 +674,8 @@ string readUntilCloseChar(istream &istr) {
   }
 
   // Strip any whitespace off the end of the value string
-  while (isspace(value[value.size() - 1])) {
-    value.resize(value.size() - 1);
+  while (isspace(value.back())) {
+    value.pop_back();
   }
 
   return value;

--- a/Framework/RemoteJobManagers/src/SimpleJSON.cpp
+++ b/Framework/RemoteJobManagers/src/SimpleJSON.cpp
@@ -674,8 +674,8 @@ string readUntilCloseChar(istream &istr) {
   }
 
   // Strip any whitespace off the end of the value string
-  while (isspace(value[value.size() - 1])) {
-    value.resize(value.size() - 1);
+  while (isspace(value.back())) {
+    value.pop_back();
   }
 
   return value;

--- a/Framework/SINQ/test/LoadFlexiNexusTest.h
+++ b/Framework/SINQ/test/LoadFlexiNexusTest.h
@@ -105,8 +105,8 @@ public:
 
     // test X
     TS_ASSERT_EQUALS(X.size(), 360);
-    TS_ASSERT_DELTA(X[0], 32471.4, .1);
-    TS_ASSERT_DELTA(X[X.size() - 1], 194590.43, .1);
+    TS_ASSERT_DELTA(X.front(), 32471.4, .1);
+    TS_ASSERT_DELTA(X.back(), 194590.43, .1);
 
     // test some meta data
     std::string title = data->getTitle();

--- a/Framework/SINQ/test/MDHistoToWorkspace2DTest.h
+++ b/Framework/SINQ/test/MDHistoToWorkspace2DTest.h
@@ -55,8 +55,8 @@ public:
 
     // test X
     TS_ASSERT_EQUALS(X.size(), 200);
-    TS_ASSERT_DELTA(X[0], -100, .1);
-    TS_ASSERT_DELTA(X[X.size() - 1], 99, .1);
+    TS_ASSERT_DELTA(X.front(), -100, .1);
+    TS_ASSERT_DELTA(X.back(), 99, .1);
 
     std::string tst = data->getTitle();
     size_t found = tst.find("Hugo");

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -191,14 +191,14 @@ ScriptRepositoryImpl::ScriptRepositoryImpl(const std::string &local_rep,
     throw ScriptRepoException(emptyURL, "Constructor Failed: remote_url.empty");
   }
 
-  if (remote_url[remote_url.size() - 1] != '/')
+  if (remote_url.back() != '/')
     remote_url.append("/");
 
   // if no folder is given, the repository is invalid.
   if (local_repository.empty())
     return;
 
-  if (local_repository[local_repository.size() - 1] != '/')
+  if (local_repository.back() != '/')
     local_repository.append("/");
 
   g_log.debug() << "ScriptRepository creation pointing to " << local_repository
@@ -262,7 +262,7 @@ ScriptRepositoryImpl::ScriptRepositoryImpl(const std::string &local_rep,
   // this is necessary because in windows, the absolute path is given
   // with \ slash.
   boost::replace_all(local_repository, "\\", "/");
-  if (local_repository[local_repository.size() - 1] != '/')
+  if (local_repository.back() != '/')
     local_repository.append("/");
 
   repo.clear();
@@ -354,7 +354,7 @@ void ScriptRepositoryImpl::install(const std::string &path) {
   // this is necessary because in windows, the absolute path is given
   // with \ slash.
   boost::replace_all(local_repository, "\\", "/");
-  if (local_repository[local_repository.size() - 1] != '/')
+  if (local_repository.back() != '/')
     local_repository.append("/");
 
   valid = true;
@@ -837,7 +837,7 @@ void ScriptRepositoryImpl::upload(const std::string &file_path,
     size_t pos = relative_path.rfind('/');
     if (pos != std::string::npos)
       folder += std::string(relative_path.begin(), relative_path.begin() + pos);
-    if (folder[folder.size() - 1] != '/')
+    if (folder.back() != '/')
       folder += "/";
     g_log.information() << "Uploading to folder: " << folder << std::endl;
     form.add("path", folder);

--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
@@ -602,7 +602,7 @@ std::string IntervalList::toStdString(int numOfIntervals) const {
     }
 
     output += ", ..., ";
-    output += m_list[m_list.size() - 1].toStdString();
+    output += m_list.back().toStdString();
   }
   return output;
 }

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -474,7 +474,7 @@ int OPJFile::ParseFormatOld() {
         size = 1000;
 
       fprintf(debug, "VALUES :\n");
-      SPREADSHEET[SPREADSHEET.size() - 1].maxRows = 1;
+      SPREADSHEET.back().maxRows = 1;
 
       double value = 0;
       for (i = 0; i < size; i++) { // read data
@@ -489,10 +489,9 @@ int OPJFile::ParseFormatOld() {
           stmp[1] = char(i / 26 % 26 + 0x41);
           stmp[2] = char(i % 26 + 0x41);
         }
-        SPREADSHEET[SPREADSHEET.size() - 1].column.push_back(stmp);
+        SPREADSHEET.back().column.push_back(stmp);
         CHECKED_FREAD(debug, &value, 8, 1, f);
-        SPREADSHEET[SPREADSHEET.size() - 1].column[i].odata.push_back(
-            originData(value));
+        SPREADSHEET.back().column[i].odata.push_back(originData(value));
 
         fprintf(debug, "%g ", value);
       }

--- a/MantidQt/API/src/QwtWorkspaceSpectrumData.cpp
+++ b/MantidQt/API/src/QwtWorkspaceSpectrumData.cpp
@@ -75,7 +75,7 @@ Return the y value of data point i
 @return y Y value of data point i
 */
 double QwtWorkspaceSpectrumData::getY(size_t i) const {
-  double tmp = i < m_Y.size() ? m_Y[i] : m_Y[m_Y.size() - 1];
+  double tmp = i < m_Y.size() ? m_Y[i] : m_Y.back();
   if (m_isDistribution) {
     tmp /= (m_X[i + 1] - m_X[i]);
   }
@@ -87,7 +87,7 @@ double QwtWorkspaceSpectrumData::getEX(size_t i) const {
 }
 
 double QwtWorkspaceSpectrumData::getE(size_t i) const {
-  double ei = (i < m_E.size()) ? m_E[i] : m_E[m_E.size() - 1];
+  double ei = (i < m_E.size()) ? m_E[i] : m_E.back();
   if (m_isDistribution) {
     ei /= (m_X[i + 1] - m_X[i]);
   }

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -1488,7 +1488,7 @@ void EnggDiffractionViewQtGUI::addBankItems(
             splitFittingDirectory(strVecFile);
 
         // get the last split in vector which will be bank
-        std::string bankID = (vecFileSplit[vecFileSplit.size() - 1]);
+        std::string bankID = (vecFileSplit.back());
 
         bool digit = isDigit(bankID);
 
@@ -1585,7 +1585,7 @@ void EnggDiffractionViewQtGUI::setDefaultBank(
 
   if (!splittedBaseName.empty()) {
 
-    std::string bankID = (splittedBaseName[splittedBaseName.size() - 1]);
+    std::string bankID = (splittedBaseName.back());
     auto combo_data =
         m_uiTabFitting.comboBox_bank->findText(QString::fromStdString(bankID));
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -2331,7 +2331,7 @@ void MuonAnalysis::setAppendingRun(int inc) {
   // Increment is positive (next button)
   if (inc < 0) {
     // Add the file to the beginning of mwRunFiles text box.
-    QString lastName = m_previousFilenames[m_previousFilenames.size() - 1];
+    QString lastName = m_previousFilenames.back();
     separateMuonFile(filePath, lastName, run, runSize);
     getFullCode(runSize, run);
     m_uiForm.mwRunFiles->setUserInput(newRun + '-' + run);


### PR DESCRIPTION
Description of work.

This uses [`std::vector::back()`](http://www.cplusplus.com/reference/vector/vector/back/) and [`std::string::back()`](http://www.cplusplus.com/reference/string/string/back/) to return a reference to the last element of a container instead of calculating `size() -1` and using `operator[]`.

The primary benefit is clearer code without compromising performance.

**To test:**

<!-- Instructions for testing. -->

Review changes and check builds.

This is a small change with no associated issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
