### PR TITLE
Revert pylint output format change

### DIFF
--- a/buildconfig/CMake/PylintSetup.cmake
+++ b/buildconfig/CMake/PylintSetup.cmake
@@ -15,7 +15,7 @@ if ( PYLINT_FOUND )
   # Use msvs for MSVC generator, colorized for everything else. The buildservers can
   # set it to parseable for Jenkins
   if ( MSVC )
-    set ( DEFAULT_FORMAT "{path}({line}): [{msg_id}{obj}] {msg}" )
+    set ( DEFAULT_FORMAT "msvs" )
   else ()
     set ( DEFAULT_FORMAT "{C}:{line:3d},{column:2d}: {msg} ({symbol})" )
   endif ()

--- a/buildconfig/Jenkins/pylint-buildscript
+++ b/buildconfig/Jenkins/pylint-buildscript
@@ -79,7 +79,7 @@ fi
 # Need this because some strange control sequences when using default TERM=xterm
 export TERM="linux"
 PYLINT_OUTPUT_DIR=$BUILD_DIR/pylint
-PYLINT_FORMAT="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}"
+PYLINT_FORMAT="parseable"
 $SCL_ON_RHEL6 "cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=OFF -DMAKE_VATES=OFF -DPYLINT_MSG_TEMPLATE=\"${PYLINT_FORMAT}\" -DPYLINT_NTHREADS=$BUILD_THREADS -DPYLINT_OUTPUT_DIR=${PYLINT_OUTPUT_DIR} .."
 
 ###############################################################################

--- a/tools/Pylint/run_pylint.py
+++ b/tools/Pylint/run_pylint.py
@@ -14,7 +14,7 @@ import sys
 import time
 
 # Default output format
-DEFAULT_PYLINT_FORMAT = '{msg_id}:{line:3d},{column}: {obj}: {msg}'
+DEFAULT_PYLINT_FORMAT = 'parseable'
 # Exe to call
 DEFAULT_PYLINT_EXE = 'pylint'
 # Default log level
@@ -470,7 +470,7 @@ def build_pylint_cmd(srcpath, options):
       A list of args to pass to subprocess.Popen
     """
     cmd = [options.exe]
-    cmd.extend(["--msg-template=" + options.format])
+    cmd.extend(["--output-format=" + options.format])
     if options.rcfile is not None:
         cmd.extend(["--rcfile=" + options.rcfile])
     # and finally, source module


### PR DESCRIPTION
Fixes Jenkins parsing of pylint output.

**To test:**

Check that the _pylint_ build now parses warnings and does not give 0 violations.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
