### PR TITLE
MDNormDirectSC option to skip safety tests

### DIFF
--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -96,6 +96,13 @@ void MDNormDirectSC::init() {
       "An input workspace containing integrated vanadium (a measure of the "
       "solid angle).");
 
+  declareProperty(make_unique<PropertyWithValue<bool>>(
+                      "SkipSafetyCheck", false, Direction::Input),
+                  "If set to true, the algorithm does "
+                  "not check history if the workspace was modified since the"
+                  "ConvertToMD algorithm was run, and assume that the direct "
+                  "geometry inelastic mode is used.");
+
   declareProperty(make_unique<WorkspaceProperty<Workspace>>(
                       "OutputWorkspace", "", Direction::Output),
                   "A name for the output data MDHistoWorkspace.");
@@ -141,7 +148,8 @@ void MDNormDirectSC::exec() {
  */
 void MDNormDirectSC::cacheInputs() {
   m_inputWS = getProperty("InputWorkspace");
-  if (inputEnergyMode() != "Direct") {
+  bool skipCheck = getProperty("SkipSafetyCheck");
+  if (!skipCheck && (inputEnergyMode() != "Direct")) {
     throw std::invalid_argument("Invalid energy transfer mode. Algorithm only "
                                 "supports direct geometry spectrometers.");
   }
@@ -242,7 +250,8 @@ MDHistoWorkspace_sptr MDNormDirectSC::binInputWS() {
   for (auto prop : props) {
     const auto &propName = prop->name();
     if (propName != "SolidAngleWorkspace" &&
-        propName != "OutputNormalizationWorkspace") {
+        propName != "OutputNormalizationWorkspace" &&
+        propName != "SkipSafetyCheck") {
       binMD->setPropertyValue(propName, prop->value());
     }
   }

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -96,8 +96,8 @@ void MDNormDirectSC::init() {
       "An input workspace containing integrated vanadium (a measure of the "
       "solid angle).");
 
-  declareProperty(make_unique<PropertyWithValue<bool>>(
-                      "SkipSafetyCheck", false, Direction::Input),
+  declareProperty(make_unique<PropertyWithValue<bool>>("SkipSafetyCheck", false,
+                                                       Direction::Input),
                   "If set to true, the algorithm does "
                   "not check history if the workspace was modified since the"
                   "ConvertToMD algorithm was run, and assume that the direct "

--- a/docs/source/release/v3.8.0/direct_inelastic.rst
+++ b/docs/source/release/v3.8.0/direct_inelastic.rst
@@ -5,5 +5,10 @@ Direct Inelastic Changes
 .. contents:: Table of Contents
    :local:
 
+Improvements
+------------
+
+- :ref:`MDNormDirectSC <algm-MDNormDirectSC>` has an option to skip safety checks. This improves the speed when acting on workspace groups.
+
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.8%22+is%3Amerged+label%3A%22Component%3A+Direct+Inelastic%22>`_
 


### PR DESCRIPTION
Found out that for short runs, a significant amount of time is spent parsing history. This is especially bad if the input workspace was processed before as part of a group

**To test:**

<!-- Instructions for testing. -->

Test the timing with and without the safety checks.

```
from mantid.simpleapi import *
import time
import numpy as np

N=60
w_in=Load("CNCS_7860")
w=DgsReduction(SampleInputWorkspace=w_in, SofPhiEIsDistribution='0',)
w=w[0]
SetUB(Workspace=w, a='4.48', b='4.48', c='10.8', u='1,0,0',v='0,0,1')
SetGoniometer(w,Axis0="0,0,1,0,1")
md=ConvertToMD(InputWorkspace=w, QDimensions='Q3D', Q3DFrames='HKL', QConversionScales='HKL', MinValues='-5,-5,-5,-5', MaxValues='5,5,5,5')
for i in range(N):
    SaveMD(md,Filename='/tmp/md_'+str(i)+'.nxs')

x=np.arange(2,60)
y=np.zeros(58)
for j in range(58):
    newN=j+2
    mdg=Load(','.join(['/tmp/md_'+str(i)+'.nxs' for i in range(newN)]))
    start=time.time()
    histoData,histoNorm=MDNormDirectSC(mdg[0],
                                           AlignedDim0="[H,0,0],-3,3,111",
                                           AlignedDim1="[0,0,L],-3,3,325",
                                           AlignedDim2="[0,K,0],-0.2,0.2,1",
                                           AlignedDim3="DeltaE,-1.5,1.5,1",
                                           SkipSafetyCheck=True)
    y[j]=time.time()-start
    print "time for ",newN," group:", y[j]

tws=CreateWorkspace(x,y)

```

Here is what I get:
![mdnormnew](https://cloud.githubusercontent.com/assets/1128952/15876243/5510d3c8-2cda-11e6-8cd0-aef3d73ceb08.png)

Fixes #16562.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
