### PR TITLE
StretchedExpFT: change name of fitting parameter Center

### DIFF
--- a/Framework/PythonInterface/plugins/functions/StretchedExpFT.py
+++ b/Framework/PythonInterface/plugins/functions/StretchedExpFT.py
@@ -52,22 +52,22 @@ class StretchedExpFT(IFunction1D):
         self.declareParameter('Height', 0.1, 'Intensity at the origin')
         self.declareParameter('Tau', 100.0, 'Relaxation time')
         self.declareParameter('Beta', 1.0, 'Stretching exponent')
-        self.declareParameter('Center', 0.0, 'Center of the peak')
+        self.declareParameter('Centre', 0.0, 'Centre of the peak')
         # Keep order in which parameters are declared. Should be a class
         # variable but we initialize it just below parameter declaration
         # to make sure we follow the order.
-        self._parmList = ['Height', 'Tau', 'Beta', 'Center']
+        self._parmList = ['Height', 'Tau', 'Beta', 'Centre']
 
     def validateParams(self):
         """Check parameters are positive"""
         height = self.getParameterValue('Height')
         tau = self.getParameterValue('Tau')
         beta = self.getParameterValue('Beta')
-        center = self.getParameterValue('Center')
+        Centre = self.getParameterValue('Centre')
         for name, value in {'Height': height, 'Tau': tau, 'Beta': beta}.items():
             if value <= 0:
                 return None
-        return {'Height': height, 'Tau': tau, 'Beta': beta, 'Center': center}
+        return {'Height': height, 'Tau': tau, 'Beta': beta, 'Centre': Centre}
 
     def function1D(self, xvals, **optparms):
         """ Fourier transform of the Symmetrized Stretched Exponential
@@ -112,7 +112,7 @@ class StretchedExpFT(IFunction1D):
         # Find corresponding energies
         energies = StretchedExpFT._planck_constant * fftfreq(2*nt, d=dt)  # standard ordering
         energies = np.concatenate([energies[nt:], energies[:nt]])  # increasing ordering
-        transform = p['Height'] * interp(xvals-p['Center'], energies, fourier)
+        transform = p['Height'] * interp(xvals-p['Centre'], energies, fourier)
         return transform
 
     def fillJacobian(self, xvals, jacobian, partials):
@@ -146,7 +146,7 @@ class StretchedExpFT(IFunction1D):
         # Add these quantities to original parameter values
         dp = {'Tau': 1.0,  # change by 1ps
               'Beta': 0.01,
-              'Center': 0.0001  # change by 0.1 micro-eV
+              'Centre': 0.0001  # change by 0.1 micro-eV
              }
         for name in dp.keys():
             pp = copy.copy(p)

--- a/Framework/PythonInterface/plugins/functions/StretchedExpFT.py
+++ b/Framework/PythonInterface/plugins/functions/StretchedExpFT.py
@@ -1,4 +1,5 @@
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, anomalous-backslash-in-string, attribute-defined-outside-init
+
 '''
 @author Jose Borreguero, NScD
 @date October 06, 2013
@@ -25,7 +26,6 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 '''
 
 from mantid.api import IFunction1D, FunctionFactory
-from mantid import logger
 from numpy import interp
 import numpy as np
 import copy
@@ -64,7 +64,7 @@ class StretchedExpFT(IFunction1D):
         tau = self.getParameterValue('Tau')
         beta = self.getParameterValue('Beta')
         Centre = self.getParameterValue('Centre')
-        for name, value in {'Height': height, 'Tau': tau, 'Beta': beta}.items():
+        for _, value in {'Height': height, 'Tau': tau, 'Beta': beta}.items():
             if value <= 0:
                 return None
         return {'Height': height, 'Tau': tau, 'Beta': beta, 'Centre': Centre}

--- a/Framework/PythonInterface/test/python/plugins/functions/StretchedExpFTTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/StretchedExpFTTest.py
@@ -77,7 +77,7 @@ class StretchedExpFTTest(unittest.TestCase):
         functor = lambda E: np.sqrt(np.pi)/E0 * np.exp(-(np.pi*E/E0)**2)
         self.createData(functor)  # Create workspace "data"
         # Initial guess reasonably far from target parameters
-        fString = "name=StretchedExpFT,Height=3.0,Tau=50,Beta=1.5,Center=0.0002;" +\
+        fString = "name=StretchedExpFT,Height=3.0,Tau=50,Beta=1.5,Centre=0.0002;" +\
                   "name=FlatBackground,A0=0.0"
         Fit(Function=fString, InputWorkspace="data", MaxIterations=100, Output="fit")
         self.asserFit(mtd["fit_Parameters"], height, beta, tau)
@@ -96,7 +96,7 @@ class StretchedExpFTTest(unittest.TestCase):
         functor = lambda E: (1.0/np.pi) * hwhm/(hwhm**2 + E**2)
         self.createData(functor)  # Create workspace "data"
         # Initial guess reasonably far from target parameters
-        fString = "name=StretchedExpFT,Height=3.0,Tau=50,Beta=1.5,Center=0.0002;" +\
+        fString = "name=StretchedExpFT,Height=3.0,Tau=50,Beta=1.5,Centre=0.0002;" +\
                   "name=FlatBackground,A0=0.0"
         Fit(Function=fString, InputWorkspace="data", MaxIterations=100, Output="fit")
         self.asserFit(mtd["fit_Parameters"], height, beta, tau)

--- a/docs/source/fitfunctions/StretchedExpFT.rst
+++ b/docs/source/fitfunctions/StretchedExpFT.rst
@@ -15,7 +15,7 @@ Description
 
 Provides the Fourier Transform of the Symmetrized Stretched Exponential Function
 
-.. math:: S(Q,E) = Height \int_{-\infty}^{\infty} dt/h \cdot e^{-i2\pi (E-Center)t/h} \cdot e^{-|\frac{t}{Tau}|^{Beta}} )
+.. math:: S(Q,E) = Height \int_{-\infty}^{\infty} dt/h \cdot e^{-i2\pi (E-Centre)t/h} \cdot e^{-|\frac{t}{Tau}|^{Beta}} )
 
 with :math:`h` Planck's constant. If the energy units of energy are micro-eV, then tau is expressed in pico-seconds. If E-units are micro-eV then
 tau is expressed in nano-seconds.
@@ -57,7 +57,7 @@ Obtaining an initial guess close to the optimal fit is critical. For this model,
    function_string  = "(composite=Convolution,FixResolution=true,NumDeriv=true;"
    function_string += "name=TabulatedFunction,Workspace=resolution,WorkspaceIndex=0,Scaling=1,Shift=0,XScaling=1;"
    function_string += "(name=DeltaFunction,Height=1,Centre=0;"
-   function_string += "name=StretchedExpFT,Height=1.0,Tau=100,Beta=0.98,Center=0));"
+   function_string += "name=StretchedExpFT,Height=1.0,Tau=100,Beta=0.98,Centre=0));"
    function_string += "name=LinearBackground,A0=0,A1=0"
 
    # Carry out the fit. Produces workspaces  fit_results_Parameters,


### PR DESCRIPTION
Name of Fit parameter "Center" has been changed to "Centre"

Nothing to test, but you may want to manually run StretchedExpFTTest.py.

Fixes #16512.
## _Does not need to be in the release notes._
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
