### PR TITLE
Fix checkbox interaction when first in algorithm dialog

### DIFF
--- a/MantidQt/API/src/PropertyWidget.cpp
+++ b/MantidQt/API/src/PropertyWidget.cpp
@@ -192,7 +192,7 @@ PropertyWidget::PropertyWidget(Mantid::Kernel::Property *prop, QWidget *parent,
   if (!prop)
     throw std::runtime_error(
         "NULL Property passed to the PropertyWidget constructor.");
-    setObjectName(QString::fromStdString(prop->name()));
+  setObjectName(QString::fromStdString(prop->name()));
 
   if (!m_gridLayout) {
     // Create a LOCAL grid layout
@@ -205,8 +205,10 @@ PropertyWidget::PropertyWidget(Mantid::Kernel::Property *prop, QWidget *parent,
   } else {
     // Use the parent of the provided QGridLayout when adding widgets
     m_parent = parent;
-    // HACK - In this mode a property widget is not a true self-contained widget: it has no children
-    //        of its own. By default, when added to a parent widget, it will be drawn invisble
+    // HACK - In this mode a property widget is not a true self-contained
+    // widget: it has no children
+    //        of its own. By default, when added to a parent widget, it will be
+    //        drawn invisble
     //        at the top left of the parent widget and obscure mouse clicks etc.
     //        The hack fix is to lower it down the visible stack.
     this->lower();

--- a/MantidQt/API/src/PropertyWidget.cpp
+++ b/MantidQt/API/src/PropertyWidget.cpp
@@ -204,6 +204,11 @@ PropertyWidget::PropertyWidget(Mantid::Kernel::Property *prop, QWidget *parent,
   } else {
     // Use the parent of the provided QGridLayout when adding widgets
     m_parent = parent;
+    // HACK - In this mode a property widget is not a true self-contained widget: it has no children
+    //        of its own. By default, when added to a parent widget, it will be drawn invisble
+    //        at the top left of the parent widget and obscure mouse clicks etc.
+    //        The hack fix is to lower it down the visible stack.
+    this->lower();
   }
 
   QWidget *infoWidget = new QWidget();

--- a/MantidQt/API/src/PropertyWidget.cpp
+++ b/MantidQt/API/src/PropertyWidget.cpp
@@ -192,6 +192,7 @@ PropertyWidget::PropertyWidget(Mantid::Kernel::Property *prop, QWidget *parent,
   if (!prop)
     throw std::runtime_error(
         "NULL Property passed to the PropertyWidget constructor.");
+    setObjectName(QString::fromStdString(prop->name()));
 
   if (!m_gridLayout) {
     // Create a LOCAL grid layout


### PR DESCRIPTION
Updates the base `PropertyWidget` class to force itself to be the lowest thing in the widget stack when it is passed an external layout to fill.

This avoids the widget itself sitting on top of other controls.

**To test:**

Before applying the fix you can try using the `DownloadInstrument` algorithm via the dialog. The checkbox can only be ticked if you click on a lower portion of it. Afterwards it should respond as expected.

Fixes #16571

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
