### PR TITLE
Add usage tracking for interfaces

### DIFF
--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -26,7 +26,7 @@ InstrumentWindow::InstrumentWindow(const QString &wsName, const QString &label,
   connect(m_instrumentWidget, SIGNAL(clearingHandle()), this,
           SLOT(closeSafely()));
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
-    "Interface", "InstrumentView", false);
+      "Interface", "InstrumentView", false);
 }
 
 InstrumentWindow::~InstrumentWindow() {}

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -2,6 +2,7 @@
 #include "InstrumentWindow.h"
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidAPI/Workspace.h"
+#include "MantidKernel/UsageService.h"
 #include "TSVSerialiser.h"
 
 #include <MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h>
@@ -24,6 +25,8 @@ InstrumentWindow::InstrumentWindow(const QString &wsName, const QString &label,
           SLOT(closeSafely()));
   connect(m_instrumentWidget, SIGNAL(clearingHandle()), this,
           SLOT(closeSafely()));
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+    "Interface", "InstrumentView", false);
 }
 
 InstrumentWindow::~InstrumentWindow() {}

--- a/MantidQt/API/src/UserSubWindow.cpp
+++ b/MantidQt/API/src/UserSubWindow.cpp
@@ -55,7 +55,7 @@ void UserSubWindow::initializeLayout() {
 
   m_bIsInitialized = true;
 
-  Mantid::Kernel::UsageService::Instance().registerFeatureUsage("Interface", name(), false);
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage("Interface", m_ifacename.toStdString(), false);
 }
 
 /**

--- a/MantidQt/API/src/UserSubWindow.cpp
+++ b/MantidQt/API/src/UserSubWindow.cpp
@@ -55,7 +55,8 @@ void UserSubWindow::initializeLayout() {
 
   m_bIsInitialized = true;
 
-  Mantid::Kernel::UsageService::Instance().registerFeatureUsage("Interface", m_ifacename.toStdString(), false);
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Interface", m_ifacename.toStdString(), false);
 }
 
 /**

--- a/MantidQt/API/src/UserSubWindow.cpp
+++ b/MantidQt/API/src/UserSubWindow.cpp
@@ -4,6 +4,7 @@
 #include "MantidQtAPI/AlgorithmInputHistory.h"
 #include "MantidQtAPI/FileDialogHandler.h"
 #include "MantidQtAPI/UserSubWindow.h"
+#include "MantidKernel/UsageService.h"
 
 #include <QIcon>
 #include <QMessageBox>
@@ -53,6 +54,8 @@ void UserSubWindow::initializeLayout() {
   setWindowIcon(QIcon(":/MantidPlot_Icon_32offset.png"));
 
   m_bIsInitialized = true;
+
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage("Interface", name(), false);
 }
 
 /**

--- a/MantidQt/SliceViewer/src/LineViewer.cpp
+++ b/MantidQt/SliceViewer/src/LineViewer.cpp
@@ -5,6 +5,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidKernel/VMD.h"
+#include "MantidKernel/UsageService.h"
 #include "MantidQtSliceViewer/LineViewer.h"
 #include <qwt_plot_curve.h>
 #include <qwt_plot.h>
@@ -140,6 +141,9 @@ LineViewer::LineViewer(QWidget *parent)
                    SLOT(refreshPlot()));
   QObject::connect(m_lineOptions, SIGNAL(changedYLogScaling()), this,
                    SLOT(onToggleLogYAxis()));
+
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+    "Feature", "SliceViewer->LineViewer", false);
 }
 
 LineViewer::~LineViewer() {}

--- a/MantidQt/SliceViewer/src/LineViewer.cpp
+++ b/MantidQt/SliceViewer/src/LineViewer.cpp
@@ -143,7 +143,7 @@ LineViewer::LineViewer(QWidget *parent)
                    SLOT(onToggleLogYAxis()));
 
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
-    "Feature", "SliceViewer->LineViewer", false);
+      "Feature", "SliceViewer->LineViewer", false);
 }
 
 LineViewer::~LineViewer() {}

--- a/MantidQt/SliceViewer/src/PeaksViewer.cpp
+++ b/MantidQt/SliceViewer/src/PeaksViewer.cpp
@@ -3,6 +3,7 @@
 #include "MantidQtSliceViewer/ProxyCompositePeaksPresenter.h"
 #include "MantidQtSliceViewer/PeaksTableColumnsDialog.h"
 #include "MantidAPI/IPeaksWorkspace.h"
+#include "MantidKernel/UsageService.h"
 #include <QBoxLayout>
 #include <QLayoutItem>
 
@@ -11,6 +12,8 @@ namespace SliceViewer {
 /// Constructor
 PeaksViewer::PeaksViewer(QWidget *parent) : QWidget(parent) {
   this->setMinimumWidth(500);
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+    "Feature", "SliceViewer->PeaksViewer", false);
 }
 
 void PeaksViewer::setPeaksWorkspaces(const SetPeaksWorkspaces &) {}

--- a/MantidQt/SliceViewer/src/PeaksViewer.cpp
+++ b/MantidQt/SliceViewer/src/PeaksViewer.cpp
@@ -13,7 +13,7 @@ namespace SliceViewer {
 PeaksViewer::PeaksViewer(QWidget *parent) : QWidget(parent) {
   this->setMinimumWidth(500);
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
-    "Feature", "SliceViewer->PeaksViewer", false);
+      "Feature", "SliceViewer->PeaksViewer", false);
 }
 
 void PeaksViewer::setPeaksWorkspaces(const SetPeaksWorkspaces &) {}

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -173,7 +173,7 @@ SliceViewer::SliceViewer(QWidget *parent)
   m_rescaler = new QwtPlotRescaler(m_plot->canvas());
 
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
-    "Interface", "SliceViewer", false);
+      "Interface", "SliceViewer", false);
 }
 
 void SliceViewer::updateAspectRatios() {

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -5,6 +5,7 @@
 #include <boost/make_shared.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
+#include "MantidKernel/UsageService.h"
 #include "MantidAPI/CoordTransform.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/IMDIterator.h"
@@ -170,6 +171,9 @@ SliceViewer::SliceViewer(QWidget *parent)
 
   // --------- Rescaler --------------------
   m_rescaler = new QwtPlotRescaler(m_plot->canvas());
+
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+    "Interface", "SliceViewer", false);
 }
 
 void SliceViewer::updateAspectRatios() {

--- a/MantidQt/SpectrumViewer/src/SpectrumView.cpp
+++ b/MantidQt/SpectrumViewer/src/SpectrumView.cpp
@@ -1,6 +1,7 @@
 #include "MantidQtSpectrumViewer/SpectrumView.h"
 
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/UsageService.h"
 #include "MantidQtSpectrumViewer/ColorMaps.h"
 #include "MantidQtSpectrumViewer/SVConnections.h"
 #include "MantidQtSpectrumViewer/SpectrumDisplay.h"
@@ -44,6 +45,8 @@ SpectrumView::SpectrumView(QWidget *parent)
   observeAfterReplace();
   observePreDelete();
   observeADSClear();
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Interface", "SpectrumView", false);
 }
 
 SpectrumView::~SpectrumView() {

--- a/scripts/DGSPlanner/DGSPlannerGUI.py
+++ b/scripts/DGSPlanner/DGSPlannerGUI.py
@@ -101,6 +101,10 @@ class DGSPlannerGUI(QtGui.QWidget):
         #control for cancel button
         self.iterations=0
         self.progress_canceled=False
+        
+        #register startup
+        mantid.UsageService.registerFeatureUsage("Interface","DGSPlanner",False)
+
 
     @QtCore.pyqtSlot(mantid.geometry.OrientedLattice)
     def updateUB(self,ol):

--- a/scripts/DGSPlanner/DGSPlannerGUI.py
+++ b/scripts/DGSPlanner/DGSPlannerGUI.py
@@ -101,7 +101,7 @@ class DGSPlannerGUI(QtGui.QWidget):
         #control for cancel button
         self.iterations=0
         self.progress_canceled=False
-        
+
         #register startup
         mantid.UsageService.registerFeatureUsage("Interface","DGSPlanner",False)
 

--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -244,6 +244,9 @@ class MainWindow(QtGui.QMainWindow):
         # self.setInstrumentInputs()
 
         ##defaults
+        
+        #register startup
+        mantid.UsageService.registerFeatureUsage("Interface","EventFilter",False)
 
         return
 

--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -244,7 +244,7 @@ class MainWindow(QtGui.QMainWindow):
         # self.setInstrumentInputs()
 
         ##defaults
-        
+
         #register startup
         mantid.UsageService.registerFeatureUsage("Interface","EventFilter",False)
 

--- a/scripts/HFIRPowderReduction/HfirPDReductionControl.py
+++ b/scripts/HFIRPowderReduction/HfirPDReductionControl.py
@@ -57,6 +57,9 @@ class PDRManager(object):
         self._vanadiumPeakPosList = []
 
         self._wavelength = None
+        
+        #register startup
+        mantid.UsageService.registerFeatureUsage("Interface","HfirPowderReduction",False)
 
         return
 

--- a/scripts/HFIRPowderReduction/HfirPDReductionControl.py
+++ b/scripts/HFIRPowderReduction/HfirPDReductionControl.py
@@ -57,7 +57,7 @@ class PDRManager(object):
         self._vanadiumPeakPosList = []
 
         self._wavelength = None
-        
+
         #register startup
         mantid.UsageService.registerFeatureUsage("Interface","HfirPowderReduction",False)
 

--- a/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
+++ b/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
@@ -418,7 +418,7 @@ class MainWindow(QtGui.QMainWindow):
             self.ui.radioButton_useServer.setChecked(True)
             self.ui.radioButton_useLocal.setChecked(False)
         # ENDIF
-        
+
         #register startup
         mantid.UsageService.registerFeatureUsage("Interface","HfirPowderReduction",False)
 

--- a/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
+++ b/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
@@ -418,6 +418,9 @@ class MainWindow(QtGui.QMainWindow):
             self.ui.radioButton_useServer.setChecked(True)
             self.ui.radioButton_useLocal.setChecked(False)
         # ENDIF
+        
+        #register startup
+        mantid.UsageService.registerFeatureUsage("Interface","HfirPowderReduction",False)
 
         return
 

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
@@ -219,6 +219,9 @@ class CWSCDReductionControl(object):
         # A dictionary to manage all loaded and processed MDEventWorkspaces
         # self._expDataDict = {}
 
+        #register startup
+        mantid.UsageService.registerFeatureUsage("Interface","4-Circle Reduction",False)
+        
         return
 
     def add_peak_info(self, exp_number, scan_number, pt_number):

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
@@ -221,7 +221,7 @@ class CWSCDReductionControl(object):
 
         #register startup
         mantid.UsageService.registerFeatureUsage("Interface","4-Circle Reduction",False)
-        
+
         return
 
     def add_peak_info(self, exp_number, scan_number, pt_number):

--- a/scripts/Interface/reduction_gui/reduction/scripter.py
+++ b/scripts/Interface/reduction_gui/reduction/scripter.py
@@ -7,7 +7,7 @@
 # Disable unused import warning
 # pylint: disable=W0611
 try:
-    from mantid.kernel import ConfigService, Logger, version_str
+    from mantid.kernel import ConfigService, Logger, version_str, UsageService
 
     HAS_MANTID = True
 except (ImportError, ImportWarning):
@@ -356,6 +356,10 @@ class BaseReductionScripter(object):
         self._output_directory = os.path.expanduser('~')
         if HAS_MANTID:
             config = ConfigService.Instance()
+            #register startup
+            if HAS_MANTID:
+                UsageService.registerFeatureUsage("Interface",
+                    "Reduction_gui:{0:.5}-{1:.10}".format(facility, name),False)
             try:
                 head, _tail = os.path.split(config.getUserFilename())
                 if os.path.isdir(head):

--- a/scripts/Interface/reduction_gui/reduction/scripter.py
+++ b/scripts/Interface/reduction_gui/reduction/scripter.py
@@ -596,7 +596,7 @@ class BaseReductionScripter(object):
         else:
             Logger("scripter").error("Mantid is unavailable to submit a reduction job")
 
-# Disable warning about the use of exec, which we knowingly use to 
+# Disable warning about the use of exec, which we knowingly use to
 # execute generated code.
 # pylint: disable=W0122
     def execute_script(self, script):

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -22,6 +22,7 @@ from isis_reflectometry import load_live_runs
 from isis_reflectometry.combineMulti import *
 import mantidqtpython
 from mantid.api import Workspace, WorkspaceGroup, CatalogManager, AlgorithmManager
+from mantid import UsageService
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
@@ -123,6 +124,8 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
         settings.endGroup()
 
         del settings
+        #register startup
+        UsageService.registerFeatureUsage("Interface", "ISIS Reflectomety", False)
 
     def __del__(self):
         """

--- a/scripts/PyChop/PyChopGUI.py
+++ b/scripts/PyChop/PyChopGUI.py
@@ -29,6 +29,9 @@ class MainWindow(QtGui.QMainWindow):
         self.inst=config['default.instrument']
         self.chop=''
         self.ei=0.0
+        
+        #register startup
+        mantid.UsageService.registerFeatureUsage("Interface","PyChop",False)
 
     def set_inst(self,name):
         self.inst=name

--- a/scripts/QECoverage.py
+++ b/scripts/QECoverage.py
@@ -197,7 +197,7 @@ class QECoverageGUI(QtGui.QWidget):
         self.grid.addWidget(self.helpbtn)
         # Matplotlib does seem to rescale x-axis properly after axes.clear()
         self.xlim = 0
-        
+
         #register startup
         mantid.UsageService.registerFeatureUsage("Interface","QECoverage",False)
 

--- a/scripts/QECoverage.py
+++ b/scripts/QECoverage.py
@@ -197,6 +197,9 @@ class QECoverageGUI(QtGui.QWidget):
         self.grid.addWidget(self.helpbtn)
         # Matplotlib does seem to rescale x-axis properly after axes.clear()
         self.xlim = 0
+        
+        #register startup
+        mantid.UsageService.registerFeatureUsage("Interface","QECoverage",False)
 
     def onHelp(self):
         from pymantidplot.proxies import showCustomInterfaceHelp

--- a/scripts/TofConverter/converterGUI.py
+++ b/scripts/TofConverter/converterGUI.py
@@ -60,11 +60,11 @@ class MainWindow(QtGui.QMainWindow):
         self.flightpath = -1.0
         self.Theta = -1.0
         self.output = 0.0
-        
+
         try:
-           import mantid
-           #register startup
-           mantid.UsageService.registerFeatureUsage("Interface","TofConverter",False)
+            import mantid
+            #register startup
+            mantid.UsageService.registerFeatureUsage("Interface","TofConverter",False)
         except ImportError:
             pass
 

--- a/scripts/TofConverter/converterGUI.py
+++ b/scripts/TofConverter/converterGUI.py
@@ -60,6 +60,13 @@ class MainWindow(QtGui.QMainWindow):
         self.flightpath = -1.0
         self.Theta = -1.0
         self.output = 0.0
+        
+        try:
+           import mantid
+           #register startup
+           mantid.UsageService.registerFeatureUsage("Interface","TofConverter",False)
+        except ImportError:
+            pass
 
     def helpClicked(self):
         # Temporary import while method is in the wrong place


### PR DESCRIPTION
Added startup feature usage reports for
- all interfaces under the interface menu
- sliceviewer, lineviewer and peaks veiwer
- InstrumentView

**To test:**
1. Start Mantidplot
2. run this line of Python to turn usage reporting on
   `
   UsageService.setEnabled(True)
   `
3. Start all of the things in the list above, they should start without errors relating to the UsageService.
4. Contact me to get the logon to the back end database for the feature usage api, (see the note below).
5. Check to see records appeared in the database
6. Let me know so I can delete your testing data records from the DB.

**Notes:**
By default the usage reporting will only send a report every minute or so, or when there are over 60 reports to send.
You can force it to send the current buffer with `UsageService.flush()`

Fixes #16575.

Usage tracking is an existing feature, Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
