### PR TITLE
Remove old use of pickle

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSMask.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSMask.py
@@ -126,17 +126,14 @@ class SANSMask(PythonAlgorithm):
         # Check whether the workspace has mask information
         if workspace.getRun().hasProperty("rectangular_masks"):
             mask_str = workspace.getRun().getProperty("rectangular_masks").value
-            try:
-                rectangular_masks = pickle.loads(mask_str)
-            except pickle.PickleError:
-                rectangular_masks = []
-                toks = mask_str.split(',')
-                for item in toks:
-                    if len(item) > 0:
-                        c = item.strip().split(' ')
-                        if len(c) == 4:
-                            rectangular_masks.append(
-                                [int(c[0]), int(c[2]), int(c[1]), int(c[3])])
+            rectangular_masks = []
+            toks = mask_str.split(',')
+            for item in toks:
+                if len(item) > 0:
+                    c = item.strip().split(' ')
+                    if len(c) == 4:
+                        rectangular_masks.append(
+                            [int(c[0]), int(c[2]), int(c[1]), int(c[3])])
             masked_pixels = []
             for rec in rectangular_masks:
                 try:


### PR DESCRIPTION
The very first version of the SANS reduction was all python and used to store mask information as a pickled string. This was later moved to a simple string. A recent "improvement" of the SANSMask.py code highlighted the fact that the code that loads the mask pickle was never used and can be removed.

**To test:**
- Inspect the code.
- Make sure the tests pass.
- As a sanity check, search for "rectangular_masks" in the python and C++ code and verify that it's always written as a string (not a pickle).

There is no GitHub issue for this PR. This is it...

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
