### PR TITLE
Speed up inputEnergyMode and add getPropertyValue to AlgHistory

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmHistory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmHistory.h
@@ -108,6 +108,8 @@ public:
   const Mantid::Kernel::PropertyHistories &getProperties() const {
     return m_properties;
   }
+  /// get the string representation of a specified property
+  const std::string &getPropertyValue(const std::string &name) const;
   /// get the child histories of this history object
   const AlgorithmHistories &getChildHistories() const {
     return m_childHistories;

--- a/Framework/API/src/AlgorithmHistory.cpp
+++ b/Framework/API/src/AlgorithmHistory.cpp
@@ -181,7 +181,7 @@ AlgorithmHistory_sptr AlgorithmHistory::operator[](const size_t index) const {
 */
 const std::string &
 AlgorithmHistory::getPropertyValue(const std::string &name) const {
-  for (auto &hist : m_properties) {
+  for (const auto &hist : m_properties) {
     if (hist->name() == name) {
       return hist->value();
     }

--- a/Framework/API/src/AlgorithmHistory.cpp
+++ b/Framework/API/src/AlgorithmHistory.cpp
@@ -148,7 +148,6 @@ size_t AlgorithmHistory::childHistorySize() const {
   return m_childHistories.size();
 }
 
-
 /**
   * Retrieve a child algorithm history by index
   * @param index ::  An index within the child algorithm history set
@@ -174,20 +173,21 @@ AlgorithmHistory_sptr AlgorithmHistory::operator[](const size_t index) const {
   return getChildAlgorithmHistory(index);
 }
 
-
 /**
 * Gets the value of a specified algorithm property
 * @param name ::  The property to find
 * @returns The string value of the property
 * @throw Exception::NotFoundError if the named property is unknown
 */
-const std::string& AlgorithmHistory::getPropertyValue(const std::string& name) const {
+const std::string &
+AlgorithmHistory::getPropertyValue(const std::string &name) const {
   for (auto &hist : m_properties) {
     if (hist->name() == name) {
       return hist->value();
     }
   }
-  throw Kernel::Exception::NotFoundError("Could not find the specified property", name);
+  throw Kernel::Exception::NotFoundError(
+      "Could not find the specified property", name);
 }
 
 /**

--- a/Framework/API/src/AlgorithmHistory.cpp
+++ b/Framework/API/src/AlgorithmHistory.cpp
@@ -148,12 +148,13 @@ size_t AlgorithmHistory::childHistorySize() const {
   return m_childHistories.size();
 }
 
+
 /**
- * Retrieve a child algorithm history by index
- * @param index ::  An index within the child algorithm history set
- * @returns A pointer to an AlgorithmHistory object
- * @throws std::out_of_range error if the index is invalid
- */
+  * Retrieve a child algorithm history by index
+  * @param index ::  An index within the child algorithm history set
+  * @returns A pointer to an AlgorithmHistory object
+  * @throws std::out_of_range error if the index is invalid
+  */
 AlgorithmHistory_sptr
 AlgorithmHistory::getChildAlgorithmHistory(const size_t index) const {
   if (index >= this->getChildHistories().size()) {
@@ -171,6 +172,22 @@ AlgorithmHistory::getChildAlgorithmHistory(const size_t index) const {
  */
 AlgorithmHistory_sptr AlgorithmHistory::operator[](const size_t index) const {
   return getChildAlgorithmHistory(index);
+}
+
+
+/**
+* Gets the value of a specified algorithm property
+* @param name ::  The property to find
+* @returns The string value of the property
+* @throw Exception::NotFoundError if the named property is unknown
+*/
+const std::string& AlgorithmHistory::getPropertyValue(const std::string& name) const {
+  for (auto &hist : m_properties) {
+    if (hist->name() == name) {
+      return hist->value();
+    }
+  }
+  throw Kernel::Exception::NotFoundError("Could not find the specified property", name);
 }
 
 /**

--- a/Framework/API/test/AlgorithmHistoryTest.h
+++ b/Framework/API/test/AlgorithmHistoryTest.h
@@ -54,6 +54,13 @@ public:
     TS_ASSERT_LESS_THAN(first, second);
   }
 
+  void test_getPropertyValue() {
+    AlgorithmHistory alg = createTestHistory();
+    TS_ASSERT_EQUALS(alg.getPropertyValue("arg1_param"), "x");
+    TS_ASSERT_EQUALS(alg.getPropertyValue("arg2_param"), "23");
+    TS_ASSERT_THROWS_ANYTHING(alg.getPropertyValue("none_existant"));
+  }
+
   void test_Created_Algorithm_Matches_History() {
     Mantid::API::AlgorithmFactory::Instance().subscribe<testalg>();
     Algorithm *testInput = new testalg;

--- a/Framework/API/test/AlgorithmHistoryTest.h
+++ b/Framework/API/test/AlgorithmHistoryTest.h
@@ -56,7 +56,7 @@ public:
 
   void test_getPropertyValue() {
     AlgorithmHistory alg = createTestHistory();
-    TS_ASSERT_EQUALS(alg.getPropertyValue("arg1_param"), "x");
+    TS_ASSERT_EQUALS(alg.getPropertyValue("arg1_param"), "y");
     TS_ASSERT_EQUALS(alg.getPropertyValue("arg2_param"), "23");
     TS_ASSERT_THROWS_ANYTHING(alg.getPropertyValue("none_existant"));
   }

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -222,7 +222,7 @@ std::string MDNormDirectSC::inputEnergyMode() const {
     emode = lastAlgHist->getPropertyValue("dEAnalysisMode");
   } else if ((lastAlgHist->name() == "Load" ||
               lastAlgHist->name() == "LoadMD") &&
-              penultimateAlgHist->name() == "ConvertToMD") {
+             penultimateAlgHist->name() == "ConvertToMD") {
     // get dEAnalysisMode
     emode = penultimateAlgHist->getPropertyValue("dEAnalysisMode");
   } else {

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -214,23 +214,17 @@ void MDNormDirectSC::cacheInputs() {
 std::string MDNormDirectSC::inputEnergyMode() const {
   const auto &hist = m_inputWS->getHistory();
   const size_t nalgs = hist.size();
-  const auto &lastAlgorithm = hist.lastAlgorithm();
+  const auto &lastAlgHist = hist.getAlgorithmHistory(nalgs - 1);
+  const auto &penultimateAlgHist = hist.getAlgorithmHistory(nalgs - 2);
 
   std::string emode("");
-  if (lastAlgorithm->name() == "ConvertToMD") {
-    emode = lastAlgorithm->getPropertyValue("dEAnalysisMode");
-  } else if ((lastAlgorithm->name() == "Load" ||
-              hist.lastAlgorithm()->name() == "LoadMD") &&
-             hist.getAlgorithmHistory(nalgs - 2)->name() == "ConvertToMD") {
+  if (lastAlgHist->name() == "ConvertToMD") {
+    emode = lastAlgHist->getPropertyValue("dEAnalysisMode");
+  } else if ((lastAlgHist->name() == "Load" ||
+              lastAlgHist->name() == "LoadMD") &&
+              penultimateAlgHist->name() == "ConvertToMD") {
     // get dEAnalysisMode
-    PropertyHistories histvec =
-        hist.getAlgorithmHistory(nalgs - 2)->getProperties();
-    for (auto &hist : histvec) {
-      if (hist->name() == "dEAnalysisMode") {
-        emode = hist->value();
-        break;
-      }
-    }
+    emode = penultimateAlgHist->getPropertyValue("dEAnalysisMode");
   } else {
     throw std::invalid_argument("The last algorithm in the history of the "
                                 "input workspace is not ConvertToMD");

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
@@ -87,6 +87,11 @@ void export_AlgorithmHistory() {
       .def("getProperties", &getPropertiesAsList, arg("self"),
            "Returns properties for this algorithm history.")
 
+      .def("getPropertyValue", &AlgorithmHistory::getPropertyValue,
+           (arg("self"), arg("index")),
+           return_value_policy<copy_const_reference>(),
+           "Returns the string representation of a specified property.")
+
       .def("getChildAlgorithm", &AlgorithmHistory::getChildAlgorithm,
            (arg("self"), arg("index")),
            "Returns the algorithm at the given index in the history")


### PR DESCRIPTION
This was a section of code `inputEnergyMode` that was slowing down as more complex worksaces were fed to it, and seemed to take too long anyway.

This came out to be that due to the special nature of he Load Algorithm when you reconsitute it by calling history.lastAlgorithm, It verifies and selects a loader for each file in the Filename property, and in this case there were several.

The main change here is to use the algorithm history objects directly rather than calling lastAlgorithm.  This takes the time to run that function from 500ms+ down to 3ms (windows debug timing).

To make the coding of this neater I have also added a getPropertyValue(name) method to the AlgorithmHistory class that operates like that of the Algorithm itself.

**To test:**

<!-- Instructions for testing. -->
1. Code review
2. A unit test is covering the new getPropertyValue
3. Issue #16562 has a python snippet that runs MDNormDirectSC

Fixes #16591.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
