### PR TITLE
Fix CompressEventsTest on machines with > 50 threads.

### DIFF
--- a/Framework/DataHandling/test/CompressEventsTest.h
+++ b/Framework/DataHandling/test/CompressEventsTest.h
@@ -74,12 +74,7 @@ public:
     }
 
     // Half the previous # of events
-    if (numPixels <= 1) {
-      TS_ASSERT_DELTA(output->getNumberEvents(), 100 * numPixels,
-                      PARALLEL_GET_MAX_THREADS * 2);
-    } else {
-      TS_ASSERT_EQUALS(output->getNumberEvents(), 100 * numPixels);
-    }
+    TS_ASSERT_EQUALS(output->getNumberEvents(), 100 * numPixels);
 
     // Event list is now of type WeightedEventNoTime
     TS_ASSERT_EQUALS(output->getEventType(), WEIGHTED_NOTIME);


### PR DESCRIPTION
Description of work.

`CompressEventsTest` currently fails on computers with > 50 threads. Because the first argument in `TS_ASSERT_DELTA` is unsigned, subtracting a number larger than 100 generates a very large positive number. Since CompressEvents currently [isn't run in parallel](https://github.com/mantidproject/mantid/blob/master/Framework/DataObjects/src/EventList.cpp#L1770), the simplest solution is to remove the if/else and just use the stricter check.

**To test:**

<!-- Instructions for testing. -->

This PR has no associated issue.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
