### PR TITLE
Fix warnings from -Wpessimizing-move

### DIFF
--- a/Framework/Geometry/test/SampleEnvironmentFactoryTest.h
+++ b/Framework/Geometry/test/SampleEnvironmentFactoryTest.h
@@ -40,7 +40,7 @@ public:
         Mantid::Kernel::make_unique<TestSampleEnvSpecFinder>());
     SampleEnvironment_uptr env;
     TS_ASSERT_THROWS_NOTHING(
-        env = std::move(factory.create("facility", "inst", "CRYO001", "10mm")));
+        env = factory.create("facility", "inst", "CRYO001", "10mm"));
     TS_ASSERT_EQUALS("CRYO001", env->name());
     TS_ASSERT_EQUALS("10mm", env->containerID());
     TS_ASSERT_EQUALS(1, env->nelements());
@@ -101,7 +101,7 @@ private:
       auto spec = Mantid::Kernel::make_unique<SampleEnvironmentSpec>("CRYO001");
       spec->addContainer(small);
       spec->addContainer(large);
-      return std::move(spec);
+      return spec;
     }
   };
 };

--- a/Framework/Geometry/test/SampleEnvironmentSpecFileFinderTest.h
+++ b/Framework/Geometry/test/SampleEnvironmentSpecFileFinderTest.h
@@ -85,7 +85,7 @@ public:
 
     SampleEnvironmentSpec_uptr spec;
     TS_ASSERT_THROWS_NOTHING(
-        spec = std::move(finder.find(m_facilityName, m_instName, m_envName)));
+        spec = finder.find(m_facilityName, m_instName, m_envName));
 
     // Does it look right
     TS_ASSERT_EQUALS(m_envName, spec->name());

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -28,7 +28,7 @@ createTestSeries(const std::string &name) {
   source->addValue("2007-11-30T16:17:20", 3);
   source->addValue("2007-11-30T16:17:30", 4);
   source->addValue("2007-11-30T16:17:40", 5);
-  return std::move(source);
+  return source;
 }
 
 /// Create test filter


### PR DESCRIPTION
Description of work.

This fixes some warnings when building with XCode 7.3.1

```
In file included from Framework/Kernel/test/PropertyManagerTest.cpp:17:
/Users/svh/Documents/MantidProject/mantid/Framework/Kernel/test/PropertyManagerTest.h:31:10: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
  return std::move(source);
         ^
/Users/svh/Documents/MantidProject/mantid/Framework/Kernel/test/PropertyManagerTest.h:31:10: note: remove std::move call here
  return std::move(source);
         ^~~~~~~~~~      ~
1 warning generated.
[608/2448] Building CXX object Framework/Geometry/test/CMakeFiles/GeometryTest.dir/SampleEnvironmentSpecFileFinderTest.cpp.o
In file included from Framework/Geometry/test/SampleEnvironmentSpecFileFinderTest.cpp:17:
/Users/svh/Documents/MantidProject/mantid/Framework/Geometry/test/SampleEnvironmentSpecFileFinderTest.h:88:16: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
        spec = std::move(finder.find(m_facilityName, m_instName, m_envName)));
               ^
1 warning generated.
[621/2448] Building CXX object Framework/Geometry/test/CMakeFiles/GeometryTest.dir/SampleEnvironmentFactoryTest.cpp.o
In file included from Framework/Geometry/test/SampleEnvironmentFactoryTest.cpp:17:
/Users/svh/Documents/MantidProject/mantid/Framework/Geometry/test/SampleEnvironmentFactoryTest.h:43:15: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
        env = std::move(factory.create("facility", "inst", "CRYO001", "10mm")));
              ^
/Users/svh/Documents/MantidProject/mantid/Framework/Geometry/test/SampleEnvironmentFactoryTest.h:104:14: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
      return std::move(spec);
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/Geometry/test/SampleEnvironmentFactoryTest.h:104:14: note: remove std::move call here
      return std::move(spec);
             ^~~~~~~~~~    ~
2 warnings generated.
```

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this PR.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
