### PR TITLE
Remove slot associated with Help Page in QtReflMainView

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/QtReflMainView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/QtReflMainView.h
@@ -109,7 +109,6 @@ private:
 private slots:
   void on_actionSearch_triggered();
   void on_actionTransfer_triggered();
-  void on_actionHelp_triggered();
   void slitCalculatorTriggered();
   void icatSearchComplete();
   void instrumentChanged(int index);

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QDataProcessorWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QDataProcessorWidget.cpp
@@ -74,7 +74,7 @@ this method is intended to be called by the presenter
 */
 void QDataProcessorWidget::setModel(const std::string &name) {
   m_toOpen = name;
-  m_presenter->notify(DataProcessorPresenter::OpenTableFlag);
+  m_presenter->notify(DataProcessorPresenter::TableUpdatedFlag);
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QDataProcessorWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QDataProcessorWidget.cpp
@@ -74,7 +74,7 @@ this method is intended to be called by the presenter
 */
 void QDataProcessorWidget::setModel(const std::string &name) {
   m_toOpen = name;
-  m_presenter->notify(DataProcessorPresenter::TableUpdatedFlag);
+  m_presenter->notify(DataProcessorPresenter::OpenTableFlag);
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
@@ -219,16 +219,6 @@ void QtReflMainView::on_actionTransfer_triggered() {
 }
 
 /**
-This slot opens the documentation when the "help" button has been pressed
-*/
-void QtReflMainView::on_actionHelp_triggered() {
-  MantidQt::API::HelpWindow::showPage(
-      this,
-      QString(
-          "qthelp://org.mantidproject/doc/interfaces/ISIS_Reflectometry.html"));
-}
-
-/**
 This slot shows the slit calculator
 */
 void QtReflMainView::slitCalculatorTriggered() {


### PR DESCRIPTION
Now that the help page is accessible via the help button in QDataProcessorWidget, there is no longer any need to have a `on_actionHelp_triggered()` slot present in `QtReflMainView` so it should be removed.

**To test:**
- Open ISIS Reflectometry (Polref) interface (`Interfaces > Reflectometry > ISIS Reflectometry (Polref)`)
- See that no warning about `on_actionHelp_triggered()` appears.

Fixes #16561 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
