### PR TITLE
Re #16588 update of IN16B loader to accommodate changes in the nexus file format

### DIFF
--- a/Framework/DataHandling/src/LoadILLIndirect.cpp
+++ b/Framework/DataHandling/src/LoadILLIndirect.cpp
@@ -62,8 +62,10 @@ int LoadILLIndirect::confidence(Kernel::NexusDescriptor &descriptor) const {
   if (descriptor.pathExists("/entry0/wavelength")               // ILL
       && descriptor.pathExists("/entry0/experiment_identifier") // ILL
       && descriptor.pathExists("/entry0/mode")                  // ILL
-      && (descriptor.pathExists("/entry0/dataSD/dataSD") ||     // IN16B
-          descriptor.pathExists("/entry0/dataSD/SingleD_data")) // IN16B New format
+      &&
+      (descriptor.pathExists("/entry0/dataSD/dataSD") // IN16B
+       ||
+       descriptor.pathExists("/entry0/dataSD/SingleD_data")) // IN16B New format
       ) {
     return 80;
   } else {

--- a/Framework/DataHandling/src/LoadILLIndirect.cpp
+++ b/Framework/DataHandling/src/LoadILLIndirect.cpp
@@ -62,10 +62,8 @@ int LoadILLIndirect::confidence(Kernel::NexusDescriptor &descriptor) const {
   if (descriptor.pathExists("/entry0/wavelength")               // ILL
       && descriptor.pathExists("/entry0/experiment_identifier") // ILL
       && descriptor.pathExists("/entry0/mode")                  // ILL
-      && descriptor.pathExists("/entry0/dataSD/dataSD")         // IN16B
-      &&
-      descriptor.pathExists(
-          "/entry0/instrument/Doppler/doppler_frequency") // IN16B
+      && (descriptor.pathExists("/entry0/dataSD/dataSD") ||     // IN16B
+          descriptor.pathExists("/entry0/dataSD/SingleD_data")) // IN16B New format
       ) {
     return 80;
   } else {

--- a/Framework/DataHandling/src/LoadILLIndirect.cpp
+++ b/Framework/DataHandling/src/LoadILLIndirect.cpp
@@ -63,10 +63,12 @@ int LoadILLIndirect::confidence(Kernel::NexusDescriptor &descriptor) const {
       && descriptor.pathExists("/entry0/experiment_identifier") // ILL
       && descriptor.pathExists("/entry0/mode")                  // ILL
       &&
-      (descriptor.pathExists("/entry0/dataSD/dataSD") // IN16B
+      ((descriptor.pathExists("/entry0/instrument/Doppler/mirror_sense") &&
+        descriptor.pathExists("/entry0/dataSD/SingleD_data")) // IN16B new
        ||
-       descriptor.pathExists("/entry0/dataSD/SingleD_data")) // IN16B New format
-      ) {
+       (descriptor.pathExists("/entry0/instrument/Doppler/doppler_frequency") &&
+        descriptor.pathExists("/entry0/dataSD/dataSD")) // IN16B old
+       )) {
     return 80;
   } else {
     return 0;

--- a/Framework/DataHandling/test/LoadILLIndirectTest.h
+++ b/Framework/DataHandling/test/LoadILLIndirectTest.h
@@ -19,32 +19,57 @@ public:
   }
   static void destroySuite(LoadILLIndirectTest *suite) { delete suite; }
 
-  LoadILLIndirectTest() : m_dataFile("ILLIN16B_034745.nxs") {}
+  LoadILLIndirectTest() : m_dataFile2013("ILLIN16B_034745.nxs"), m_dataFile2015("ILLIN16B_127500.nxs") {}
 
-  void testInit() {
+  void test_Init() {
     LoadILLIndirect loader;
     TS_ASSERT_THROWS_NOTHING(loader.initialize())
     TS_ASSERT(loader.isInitialized())
   }
 
-  void testName() {
+  void test_Name() {
     LoadILLIndirect loader;
     TS_ASSERT_EQUALS(loader.name(), "LoadILLIndirect");
   }
 
-  void testVersion() {
+  void test_Version() {
     LoadILLIndirect loader;
     TS_ASSERT_EQUALS(loader.version(), 1);
   }
 
-  void testExec() {
+  void test_Load_2013_Format() {
+      doExecTest(m_dataFile2013);
+  }
+
+  void test_Load_2015_Format() {
+      doExecTest(m_dataFile2015);
+  }
+
+  void test_Confidence_2013_Format() {
+      doConfidenceTest(m_dataFile2013);
+  }
+
+  void test_Confidence_2015_Format() {
+      doConfidenceTest(m_dataFile2015);
+  }
+
+  void doConfidenceTest(const std::string & file) {
+     LoadILLIndirect alg;
+     TS_ASSERT_THROWS_NOTHING(alg.initialize());
+
+     alg.setPropertyValue("Filename", file);
+     Mantid::Kernel::NexusDescriptor descr(alg.getPropertyValue("Filename"));
+     TS_ASSERT_EQUALS(alg.confidence(descr), 80);
+  }
+
+  void doExecTest(const std::string & file) {
     // Name of the output workspace.
     std::string outWSName("LoadILLIndirectTest_OutputWS");
 
     LoadILLIndirect loader;
     TS_ASSERT_THROWS_NOTHING(loader.initialize())
     TS_ASSERT(loader.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(loader.setPropertyValue("Filename", m_dataFile));
+    TS_ASSERT_THROWS_NOTHING(loader.setPropertyValue("Filename", file));
     TS_ASSERT_THROWS_NOTHING(
         loader.setPropertyValue("OutputWorkspace", outWSName));
     TS_ASSERT_THROWS_NOTHING(loader.execute(););
@@ -70,7 +95,8 @@ public:
   }
 
 private:
-  std::string m_dataFile;
+  std::string m_dataFile2013;
+  std::string m_dataFile2015;
 };
 
 #endif /* MANTID_DATAHANDLING_LOADILLINDIRECTTEST_H_ */

--- a/Framework/DataHandling/test/LoadILLIndirectTest.h
+++ b/Framework/DataHandling/test/LoadILLIndirectTest.h
@@ -3,9 +3,9 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidDataHandling/LoadILLIndirect.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidDataHandling/LoadILLIndirect.h"
 
 using namespace Mantid::API;
 using Mantid::DataHandling::LoadILLIndirect;
@@ -19,7 +19,9 @@ public:
   }
   static void destroySuite(LoadILLIndirectTest *suite) { delete suite; }
 
-  LoadILLIndirectTest() : m_dataFile2013("ILLIN16B_034745.nxs"), m_dataFile2015("ILLIN16B_127500.nxs") {}
+  LoadILLIndirectTest()
+      : m_dataFile2013("ILLIN16B_034745.nxs"),
+        m_dataFile2015("ILLIN16B_127500.nxs") {}
 
   void test_Init() {
     LoadILLIndirect loader;
@@ -37,32 +39,24 @@ public:
     TS_ASSERT_EQUALS(loader.version(), 1);
   }
 
-  void test_Load_2013_Format() {
-      doExecTest(m_dataFile2013);
+  void test_Load_2013_Format() { doExecTest(m_dataFile2013); }
+
+  void test_Load_2015_Format() { doExecTest(m_dataFile2015); }
+
+  void test_Confidence_2013_Format() { doConfidenceTest(m_dataFile2013); }
+
+  void test_Confidence_2015_Format() { doConfidenceTest(m_dataFile2015); }
+
+  void doConfidenceTest(const std::string &file) {
+    LoadILLIndirect alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+
+    alg.setPropertyValue("Filename", file);
+    Mantid::Kernel::NexusDescriptor descr(alg.getPropertyValue("Filename"));
+    TS_ASSERT_EQUALS(alg.confidence(descr), 80);
   }
 
-  void test_Load_2015_Format() {
-      doExecTest(m_dataFile2015);
-  }
-
-  void test_Confidence_2013_Format() {
-      doConfidenceTest(m_dataFile2013);
-  }
-
-  void test_Confidence_2015_Format() {
-      doConfidenceTest(m_dataFile2015);
-  }
-
-  void doConfidenceTest(const std::string & file) {
-     LoadILLIndirect alg;
-     TS_ASSERT_THROWS_NOTHING(alg.initialize());
-
-     alg.setPropertyValue("Filename", file);
-     Mantid::Kernel::NexusDescriptor descr(alg.getPropertyValue("Filename"));
-     TS_ASSERT_EQUALS(alg.confidence(descr), 80);
-  }
-
-  void doExecTest(const std::string & file) {
+  void doExecTest(const std::string &file) {
     // Name of the output workspace.
     std::string outWSName("LoadILLIndirectTest_OutputWS");
 

--- a/Testing/Data/UnitTest/ILLIN16B_127500.nxs.md5
+++ b/Testing/Data/UnitTest/ILLIN16B_127500.nxs.md5
@@ -1,0 +1,1 @@
+7d2f46c7055d6cf24e5e856ffeab570a


### PR DESCRIPTION
Added the new entry name for single detector data for IN16B indirect reduction.
Check for doppler frequency or mirror sense in the confidence depending on the file format.
Added new test data file with a new IN16B format data.
Added confidence test.
Run load test both on old and new format data.

**To test:**

Load old and new nexus files from IN16B.

<!-- Instructions for testing. -->

Fixes #16588

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
-->

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
