### PR TITLE
Indirect Bayes ResNorm -  Fix crash when using workspace as input

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -149,16 +149,9 @@ void ResNorm::handleAlgorithmComplete(bool error) {
   if (error)
     return;
 
-  QString outputBase = (m_uiForm.dsResolution->getCurrentDataName()).toLower();
-  const int indexCut = outputBase.lastIndexOf("_");
-  outputBase = outputBase.left(indexCut);
-  outputBase += "_ResNorm";
-
-  std::string outputBaseStr = outputBase.toStdString();
-
   WorkspaceGroup_sptr fitWorkspaces =
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-          outputBaseStr + "_Fit_Workspaces");
+          m_pythonExportWsName + "_Fit_Workspaces");
   QString fitWsName("");
   if (fitWorkspaces)
     fitWsName =
@@ -172,12 +165,6 @@ void ResNorm::handleAlgorithmComplete(bool error) {
     plotSpectrum(QString::fromStdString(m_pythonExportWsName) + "_Stretch");
   if (plotOptions == "Fit" || plotOptions == "All")
     plotSpectrum(fitWsName, 0, 1);
-
-  if (!AnalysisDataService::Instance().doesExist(
-          m_uiForm.dsResolution->getCurrentDataName().toStdString())) {
-    loadFile(m_uiForm.dsResolution->getFullFilePath(),
-             m_uiForm.dsResolution->getCurrentDataName());
-  }
 
   // Update preview plot
   previewSpecChanged(m_previewSpec);

--- a/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -111,13 +111,13 @@ bool ResNorm::validate() {
  * Run the ResNorm v2 algorithm.
  */
 void ResNorm::run() {
-  QString vanWsName(m_uiForm.dsVanadium->getCurrentDataName());
-  QString resWsName(m_uiForm.dsResolution->getCurrentDataName());
+  const auto vanWsName(m_uiForm.dsVanadium->getCurrentDataName());
+  const auto resWsName(m_uiForm.dsResolution->getCurrentDataName());
 
-  double eMin(m_dblManager->value(m_properties["EMin"]));
-  double eMax(m_dblManager->value(m_properties["EMax"]));
+  const auto eMin(m_dblManager->value(m_properties["EMin"]));
+  const auto eMax(m_dblManager->value(m_properties["EMax"]));
 
-  QString outputWsName = getWorkspaceBasename(resWsName) + "_ResNorm";
+  const auto outputWsName = getWorkspaceBasename(resWsName) + "_ResNorm";
 
   IAlgorithm_sptr resNorm = AlgorithmManager::Instance().create("ResNorm", 2);
   resNorm->initialize();
@@ -132,7 +132,7 @@ void ResNorm::run() {
   m_batchAlgoRunner->addAlgorithm(resNorm);
 
   // Handle saving
-  bool save(m_uiForm.ckSave->isChecked());
+  const auto save(m_uiForm.ckSave->isChecked());
   if (save)
     addSaveWorkspaceToQueue(outputWsName);
 

--- a/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -173,8 +173,11 @@ void ResNorm::handleAlgorithmComplete(bool error) {
   if (plotOptions == "Fit" || plotOptions == "All")
     plotSpectrum(fitWsName, 0, 1);
 
-  loadFile(m_uiForm.dsResolution->getFullFilePath(),
-           m_uiForm.dsResolution->getCurrentDataName());
+  if (!AnalysisDataService::Instance().doesExist(
+          m_uiForm.dsResolution->getCurrentDataName().toStdString())) {
+    loadFile(m_uiForm.dsResolution->getFullFilePath(),
+             m_uiForm.dsResolution->getCurrentDataName());
+  }
 
   // Update preview plot
   previewSpecChanged(m_previewSpec);

--- a/docs/source/release/v3.8.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.8.0/indirect_inelastic.rst
@@ -27,5 +27,6 @@ Bugfixes
 --------
 
 * The documentation for :ref:`TransformToIqt <algm-TransformToIqt>` now correctly states that the ParameterWorkspace is a TableWorkspace
+* The *ResNorm* interface should no longer crash when using workspaces (rather than files) as input.
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.8%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
ResNorm should no longer crash when using workspaces (rather than files) as input.

**To test:**
- Load the `irs26173_graphite002_red.nxs` and `irs261763_graphite002_res.nxs` workspaces 
- Open ResNorm (Interfaces > Indirect > Bayes > Resnorm)
- Select the workspace option for the Vanadium and Resolution inputs
  - These should default to `_red` workspace for vanadium and `_res` workspace for Resolution (this is correct)
- Click `Run` 
- Ensure the algorithm runs without error and the mini plot is updated with the red `Fit` curve

Fixes #16621 

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/66c54c53372dacc7e049b10340d8ed54549f82d5/docs/source/release/v3.8.0/indirect_inelastic.rst#bugfixes)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
