### PR TITLE
Muon Analysis plot options: add option to set number of fit curves to keep

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.ui
@@ -2411,22 +2411,6 @@ p, li { white-space: pre-wrap; }
             <layout class="QGridLayout" name="gridLayout_20">
              <item row="3" column="0">
               <layout class="QGridLayout" name="gridLayout_21">
-               <item row="0" column="2">
-                <spacer name="horizontalSpacer_23">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Fixed</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>200</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
                <item row="0" column="1">
                 <widget class="QComboBox" name="plotCreation">
                  <property name="sizePolicy">
@@ -2456,6 +2440,22 @@ p, li { white-space: pre-wrap; }
                   </property>
                  </item>
                 </widget>
+               </item>
+               <item row="0" column="2">
+                <spacer name="horizontalSpacer_23">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>200</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
                <item row="0" column="0">
                 <widget class="QLabel" name="label_7">
@@ -2518,11 +2518,39 @@ p, li { white-space: pre-wrap; }
                   </layout>
                  </widget>
                  <widget class="QWidget" name="page_2">
-                  <layout class="QHBoxLayout" name="horizontalLayout_15">
-                   <property name="margin">
-                    <number>0</number>
+                  <widget class="QWidget" name="">
+                   <property name="geometry">
+                    <rect>
+                     <x>0</x>
+                     <y>0</y>
+                     <width>131</width>
+                     <height>22</height>
+                    </rect>
                    </property>
-                  </layout>
+                   <layout class="QHBoxLayout" name="horizontalLayout_KeepNPlots">
+                    <item>
+                     <widget class="QLabel" name="lblKeepLast">
+                      <property name="text">
+                       <string>Keep last</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QSpinBox" name="spinBoxNPlotsToKeep">
+                      <property name="value">
+                       <number>1</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="lblPlots">
+                      <property name="text">
+                       <string>plot(s)</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
                  </widget>
                 </widget>
                </item>

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1844,7 +1844,8 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   s << "";
 
   // Remove data and difference from given plot (keep fit and guess)
-  s << "def remove_data(window):";
+  // num_to_keep: number of previous fits to keep
+  s << "def remove_data(window, num_to_keep):";
   s << "  if window is None:";
   s << "    raise ValueError('No plot to remove data from')";
   s << "  to_keep = ['Workspace-Calc', 'CompositeFunction']";
@@ -1889,7 +1890,7 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
 
   // Plot the data!
   s << "win = get_window('%WSNAME%', '%PREV%', %USEPREV%)";
-  s << "remove_data(win)";
+  s << "remove_data(win, %FITSTOKEEP%)";
   s << "g = plot_data('%WSNAME%', %ERRORS%, %CONNECT%, win)";
   s << "format_graph(g, '%WSNAME%', %LOGSCALE%, %YAUTO%, '%YMIN%', '%YMAX%')";
 
@@ -1915,6 +1916,11 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   pyS.replace("%YAUTO%", params["YAxisAuto"]);
   pyS.replace("%YMIN%", params["YAxisMin"]);
   pyS.replace("%YMAX%", params["YAxisMax"]);
+  if (policy == MuonAnalysisOptionTab::PreviousWindow) {
+    pyS.replace("%FITSTOKEEP%", m_uiForm.spinBoxNPlotsToKeep->text());
+  } else {
+    pyS.replace("%FITSTOKEEP%", "-1");
+  }
 
   runPythonCode(pyS);
 }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
@@ -14,6 +14,7 @@
 #include <QLineEdit>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QSpinBox>
 
 #include <boost/scope_exit.hpp>
 #include <stdexcept>
@@ -190,7 +191,7 @@ void WidgetAutoSaver::registerWidget(QWidget *widget, const QString &name,
 }
 
 /**
- * Return a signal (which can be used instead of SIGNAL()) which is emmited when
+ * Return a signal (which can be used instead of SIGNAL()) which is emitted when
  * given widget is
  * changed.
  * @param widget
@@ -204,8 +205,10 @@ const char *WidgetAutoSaver::changedSignal(QWidget *widget) {
     return SIGNAL(stateChanged(int));
   } else if (qobject_cast<QComboBox *>(widget)) {
     return SIGNAL(currentIndexChanged(int));
+  } else if (qobject_cast<QSpinBox *>(widget)) {
+    return SIGNAL(valueChanged(int));
   }
-  // ... add more as neccessary
+  // ... add more as necessary
   else {
     throw std::runtime_error("Unsupported widget type");
   }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisOptionTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisOptionTab.cpp
@@ -71,6 +71,7 @@ void MuonAnalysisOptionTab::initLayout() {
   m_autoSaver.registerWidget(m_uiForm.newPlotPolicy, "newPlotPolicy", 0);
   m_autoSaver.registerWidget(m_uiForm.hideToolbars, "toolbars", true);
   m_autoSaver.registerWidget(m_uiForm.hideGraphs, "hiddenGraphs", true);
+  m_autoSaver.registerWidget(m_uiForm.spinBoxNPlotsToKeep, "fitsToKeep", 1);
   m_autoSaver.endGroup();
 
   // Set validators for double fields

--- a/docs/source/release/v3.8.0/muon.rst
+++ b/docs/source/release/v3.8.0/muon.rst
@@ -11,6 +11,8 @@ Interfaces
 Muon Analysis
 #############
 
+- When reusing the same plot window, an option has been added on the Settings tab to control how many previous fits are kept. It can be adjusted to 0 (remove all previous fits; default pre-Mantid 3.7), 1 (keep just one previous fit plus this one; new default) or higher.
+
 Algorithms
 ----------
 


### PR DESCRIPTION
Provide a new option on the Settings tab of the MuonAnalysis interface.

When reusing the existing plot window to plot a new dataset, this option controls how many previous fit curves remain on the graph.

Setting the option to 0 is the behaviour pre-Mantid 3.7. The new default is 1 (from discussion with scientists). Plot guesses are always kept.

**To test:**
- Open Interfaces/Muon/Muon Analysis
- Go to the Settings tab. Under General/New Plot Policy select "Use previous window". 
  - Verify there is a new option next to this to select the number of curves to keep
    ![newplotpolicy](https://cloud.githubusercontent.com/assets/15363125/16113186/0606de00-33b3-11e6-8f1d-6a23d70073c0.PNG)
- Go back to the Home tab and load a dataset
- Go to the Data Analysis tab and fit something to the data
- Load another dataset. The new data should replace the old data. If you selected "0" for the fit curves option, the old fit should disappear, otherwise it should remain on the plot.
  ![keepoldfit](https://cloud.githubusercontent.com/assets/15363125/16113216/30637050-33b3-11e6-8375-9f606c28797f.PNG)
- Fit the same function to this dataset too
  ![fitthistoo](https://cloud.githubusercontent.com/assets/15363125/16113237/4d9bb33a-33b3-11e6-84a5-78f364d654bc.PNG)
- Load another dataset. Again all previous datasets should disappear from the graph, and the last n fits should be kept depending on the number you chose. Keep fitting and loading new datasets, and changing the number of fits to keep, until you are satisfied the option does what it's supposed to do.

![loadnextset](https://cloud.githubusercontent.com/assets/15363125/16113259/64813ce6-33b3-11e6-93b9-983b4709d13c.PNG)
- When the new plot policy is "Create new window", you shouldn't see any change in behaviour from before.

Fixes #16374.

[Release notes](https://github.com/mantidproject/mantid/blob/3ef4037f6afa0b014503371a7f3d28b77a2eee89/docs/source/release/v3.8.0/muon.rst#interfaces) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
