### PR TITLE
Indirect Data Analysis - Ungroup Elwin output option

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -30,6 +30,7 @@ private slots:
   void minChanged(double val);
   void maxChanged(double val);
   void updateRS(QtProperty *prop, double val);
+  void unGroupInput(bool error);
 
 private:
   void addSaveAlgorithm(QString workspaceName, QString filename = "");

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.ui
@@ -45,6 +45,16 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="ckGroupInput">
+         <property name="text">
+           <string>Group Input</string>
+         </property>
+         <property name="checked">
+           <bool>true</bool>
+         </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/docs/source/release/v3.8.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.8.0/indirect_inelastic.rst
@@ -16,6 +16,11 @@ Algorithms
 Data Analysis
 #############
 
+Elwin
+~~~~~
+
+- Additional option to ungroup Elwin output
+
 Jump Fit
 ~~~~~~~~
 


### PR DESCRIPTION
Add an option in the Elwin interface to ungroup the input files. Files should be group by default

**To test:**
- Open the Elwin interface (Interfaces > Indirect > Data Analysis > Elwin)
- Load in the input File `irs26176_graphite002_red.nxs` (available from unit test data directory)
- Ensure the `Group Input` option is checked
- Click `Run`
  - Ensure a workspace named `IDA_Elwin_Input` is created and contains the input file.
- Uncheck the `Group Input` option 
  - Ensure no group workspace is created (or it is removed if it was already there) and that the input file in in the ADS 

_This algorithm also produces an addition 3 workspaces when run ending in `elf`,`eq` and `eq2`_

Fixes #16007

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/45b55f9704acd6d70ba9877263dd144c0b447932/docs/source/release/v3.8.0/indirect_inelastic.rst#elwin)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
