### PR TITLE
DataProcessorUI: make pre-processing optional

### DIFF
--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflGenericDataProcessorPresenterFactory.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflGenericDataProcessorPresenterFactory.cpp
@@ -81,19 +81,18 @@ ReflGenericDataProcessorPresenterFactory::create() {
 
   // Pre-processing instructions as a map:
   // Keys are the column names
-  // Values are the associated pre-processing algorithms
+  // Values are the pre-processing algorithms that will be applied to columns
   std::map<std::string, DataProcessorPreprocessingAlgorithm> preprocessMap = {
-      /*This pre-processor will be applied to column 'Run(s)'*/
-      {/*The name of the column*/ "Run(s)",
-       /*The pre-processor algorithm, 'Plus' by default*/ DataProcessorPreprocessingAlgorithm()},
-      /*This pre-processor will be applied to column 'Transmission Run(s)'*/
-      {/*The name of the column*/ "Transmission Run(s)",
-       /*The pre-processor algorithm: CreateTransmissionWorkspaceAuto*/
+      /* 'Plus' will be applied to column 'Run(s)'*/
+      {"Run(s)",
        DataProcessorPreprocessingAlgorithm(
-           "CreateTransmissionWorkspaceAuto",
-           /*Prefix for the output workspace*/
-           "TRANS_",
-           /*Blacklist of properties we don't want to show*/
+           "Plus", "TOF_", std::set<std::string>{"LHSWorkspace", "RHSWorkspace",
+                                                 "OutputWorkspace"})},
+      /* 'CreateTransmissionWorkspaceAuto' will be applied to column
+         'Transmission Run(s)'*/
+      {"Transmission Run(s)",
+       DataProcessorPreprocessingAlgorithm(
+           "CreateTransmissionWorkspaceAuto", "TRANS_",
            std::set<std::string>{"FirstTransmissionRun",
                                  "SecondTransmissionRun", "OutputWorkspace"})}};
 

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflGenericDataProcessorPresenterFactory.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflGenericDataProcessorPresenterFactory.cpp
@@ -26,7 +26,8 @@ ReflGenericDataProcessorPresenterFactory::create() {
                        "/><i>required</i><br />Runs may be given as run "
                        "numbers or workspace names. Multiple runs may be "
                        "added together by separating them with a '+'. <br "
-                       "/><br /><b>Example:</b> <samp>1234+1235+1236</samp>");
+                       "/><br /><b>Example:</b> <samp>1234+1235+1236</samp>",
+                       true);
   whitelist.addElement(
       "Angle", "ThetaIn",
       "<b>Angle used during the run.< / b><br / ><i>optional</i><br />Unit: "
@@ -94,10 +95,7 @@ ReflGenericDataProcessorPresenterFactory::create() {
            "TRANS_",
            /*Blacklist of properties we don't want to show*/
            std::set<std::string>{"FirstTransmissionRun",
-                                 "SecondTransmissionRun", "OutputWorkspace"},
-           /*I don't want to show the transmission runs in the output ws
-              name*/
-           false)}};
+                                 "SecondTransmissionRun", "OutputWorkspace"})}};
 
   // The post-processor algorithm's name, 'Stitch1DMany' by default
   DataProcessorPostprocessingAlgorithm postprocessor;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorGenerateNotebook.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorGenerateNotebook.h
@@ -44,8 +44,8 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
-std::vector<std::string>
-    DLLExport splitByCommas(const std::string &names_string);
+std::vector<std::string> DLLExport
+splitByCommas(const std::string &names_string);
 
 std::string DLLExport plot1DString(const std::vector<std::string> &ws_names);
 
@@ -67,19 +67,20 @@ plotsString(const std::vector<std::string> &output_ws,
             const std::string &stitched_wsStr,
             const DataProcessorProcessingAlgorithm &processor);
 
-std::string DLLExport getReducedWorkspaceName(
-    int rowNo, QDataProcessorTableModel_sptr model,
-    const DataProcessorWhiteList &whitelist, const std::string &prefix = "");
+std::string DLLExport
+getReducedWorkspaceName(int rowNo, QDataProcessorTableModel_sptr model,
+                        const DataProcessorWhiteList &whitelist,
+                        const std::string &prefix = "");
 
-boost::tuple<std::string, std::string> DLLExport
-reduceRowString(const int rowNo, const std::string &instrument,
-                QDataProcessorTableModel_sptr model,
-                const DataProcessorWhiteList &whitelist,
-                const std::map<std::string, DataProcessorPreprocessingAlgorithm>
-                    &preprocessMap,
-                const DataProcessorProcessingAlgorithm &processor,
-                const std::map<std::string, std::string> &preprocessOoptionsMap,
-                const std::string &processingOptions);
+boost::tuple<std::string, std::string> DLLExport reduceRowString(
+    const int rowNo, const std::string &instrument,
+    QDataProcessorTableModel_sptr model,
+    const DataProcessorWhiteList &whitelist,
+    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
+        preprocessMap,
+    const DataProcessorProcessingAlgorithm &processor,
+    const std::map<std::string, std::string> &preprocessOoptionsMap,
+    const std::string &processingOptions);
 
 boost::tuple<std::string, std::string>
 loadWorkspaceString(const std::string &runStr, const std::string &instrument,
@@ -91,13 +92,12 @@ plusString(const std::string &input_name, const std::string &output_name,
            const DataProcessorPreprocessingAlgorithm &preprocessor,
            const std::string &options);
 
-boost::tuple<std::string, std::string>
-    DLLExport loadRunString(const std::string &run,
-                            const std::string &instrument,
-                            const std::string &prefix);
+boost::tuple<std::string, std::string> DLLExport
+loadRunString(const std::string &run, const std::string &instrument,
+              const std::string &prefix);
 
-std::string DLLExport completeOutputProperties(const std::string &algName,
-                                               size_t currentProperties);
+std::string DLLExport
+completeOutputProperties(const std::string &algName, size_t currentProperties);
 
 class DLLExport DataProcessorGenerateNotebook {
 
@@ -105,8 +105,8 @@ public:
   DataProcessorGenerateNotebook(
       std::string name, QDataProcessorTableModel_sptr model,
       const std::string instrument, const DataProcessorWhiteList &whitelist,
-      const std::map<std::string, DataProcessorPreprocessingAlgorithm>
-          &preprocessMap,
+      const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
+          preprocessMap,
       const DataProcessorProcessingAlgorithm &processor,
       const DataProcessorPostprocessingAlgorithm &postprocessor,
       const std::map<std::string, std::string> preprocessingInstructionsMap,

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorGenerateNotebook.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorGenerateNotebook.h
@@ -44,8 +44,8 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
-std::vector<std::string> DLLExport
-splitByCommas(const std::string &names_string);
+std::vector<std::string>
+    DLLExport splitByCommas(const std::string &names_string);
 
 std::string DLLExport plot1DString(const std::vector<std::string> &ws_names);
 
@@ -58,8 +58,8 @@ std::string DLLExport titleString(const std::string &wsName);
 boost::tuple<std::string, std::string> DLLExport postprocessGroupString(
     const std::set<int> &rows, QDataProcessorTableModel_sptr model,
     const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
-        preprocessMap,
+    const std::map<std::string, DataProcessorPreprocessingAlgorithm>
+        &preprocessMap,
     const DataProcessorProcessingAlgorithm &processor,
     const DataProcessorPostprocessingAlgorithm &postprocessor,
     const std::string &postprocessingOptions);
@@ -69,22 +69,19 @@ plotsString(const std::vector<std::string> &output_ws,
             const std::string &stitched_wsStr,
             const DataProcessorProcessingAlgorithm &processor);
 
-std::string DLLExport getWorkspaceName(
+std::string DLLExport getReducedWorkspaceName(
     int rowNo, QDataProcessorTableModel_sptr model,
-    const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
-        preprocessMap,
-    const DataProcessorProcessingAlgorithm &processor, bool prefix);
+    const DataProcessorWhiteList &whitelist, const std::string &prefix = "");
 
-boost::tuple<std::string, std::string> DLLExport reduceRowString(
-    const int rowNo, const std::string &instrument,
-    QDataProcessorTableModel_sptr model,
-    const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
-        preprocessMap,
-    const DataProcessorProcessingAlgorithm &processor,
-    const std::map<std::string, std::string> &preprocessOoptionsMap,
-    const std::string &processingOptions);
+boost::tuple<std::string, std::string> DLLExport
+reduceRowString(const int rowNo, const std::string &instrument,
+                QDataProcessorTableModel_sptr model,
+                const DataProcessorWhiteList &whitelist,
+                const std::map<std::string, DataProcessorPreprocessingAlgorithm>
+                    &preprocessMap,
+                const DataProcessorProcessingAlgorithm &processor,
+                const std::map<std::string, std::string> &preprocessOoptionsMap,
+                const std::string &processingOptions);
 
 boost::tuple<std::string, std::string>
 loadWorkspaceString(const std::string &runStr, const std::string &instrument,
@@ -96,12 +93,13 @@ plusString(const std::string &input_name, const std::string &output_name,
            const DataProcessorPreprocessingAlgorithm &preprocessor,
            const std::string &options);
 
-boost::tuple<std::string, std::string> DLLExport
-loadRunString(const std::string &run, const std::string &instrument,
-              const std::string &prefix);
+boost::tuple<std::string, std::string>
+    DLLExport loadRunString(const std::string &run,
+                            const std::string &instrument,
+                            const std::string &prefix);
 
-std::string DLLExport
-completeOutputProperties(const std::string &algName, size_t currentProperties);
+std::string DLLExport completeOutputProperties(const std::string &algName,
+                                               size_t currentProperties);
 
 class DLLExport DataProcessorGenerateNotebook {
 
@@ -109,8 +107,8 @@ public:
   DataProcessorGenerateNotebook(
       std::string name, QDataProcessorTableModel_sptr model,
       const std::string instrument, const DataProcessorWhiteList &whitelist,
-      const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
-          preprocessMap,
+      const std::map<std::string, DataProcessorPreprocessingAlgorithm>
+          &preprocessMap,
       const DataProcessorProcessingAlgorithm &processor,
       const DataProcessorPostprocessingAlgorithm &postprocessor,
       const std::map<std::string, std::string> preprocessingInstructionsMap,

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorGenerateNotebook.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorGenerateNotebook.h
@@ -58,8 +58,6 @@ std::string DLLExport titleString(const std::string &wsName);
 boost::tuple<std::string, std::string> DLLExport postprocessGroupString(
     const std::set<int> &rows, QDataProcessorTableModel_sptr model,
     const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm>
-        &preprocessMap,
     const DataProcessorProcessingAlgorithm &processor,
     const DataProcessorPostprocessingAlgorithm &postprocessor,
     const std::string &postprocessingOptions);

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorPreprocessingAlgorithm.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorPreprocessingAlgorithm.h
@@ -39,8 +39,7 @@ public:
   // Constructor
   DataProcessorPreprocessingAlgorithm(
       const std::string &name, const std::string &prefix = "",
-      const std::set<std::string> &blacklist = std::set<std::string>(),
-      bool show = true);
+      const std::set<std::string> &blacklist = std::set<std::string>());
   // Default constructor
   DataProcessorPreprocessingAlgorithm();
   // Destructor
@@ -58,7 +57,7 @@ public:
   bool show() const;
 
 private:
-  // The prefix of the output workspace
+  // A prefix to the name of the pre-processed output ws
   std::string m_prefix;
   // The name of the LHS input property
   std::string m_lhs;
@@ -66,8 +65,6 @@ private:
   std::string m_rhs;
   // The name of the output proerty
   std::string m_outProperty;
-  // Indicates wheter or not the information will appear in the output ws name
-  bool m_show;
 };
 }
 }

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorPreprocessingAlgorithm.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorPreprocessingAlgorithm.h
@@ -1,8 +1,8 @@
 #ifndef MANTIDQTMANTIDWIDGETS_DATAPROCESSORPREPROCESSINGALGORITHM_H
 #define MANTIDQTMANTIDWIDGETS_DATAPROCESSORPREPROCESSINGALGORITHM_H
 
-#include "MantidQtMantidWidgets/WidgetDllOption.h"
 #include "MantidQtMantidWidgets/DataProcessorUI/DataProcessorProcessingAlgorithmBase.h"
+#include "MantidQtMantidWidgets/WidgetDllOption.h"
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -53,8 +53,6 @@ public:
   std::string outputProperty() const;
   // The prefix to add to the output property
   std::string prefix() const;
-  // If we want to show the info associated with this pre-processor
-  bool show() const;
 
 private:
   // A prefix to the name of the pre-processed output ws

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorProcessingAlgorithmBase.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorProcessingAlgorithmBase.h
@@ -39,6 +39,9 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS DataProcessorProcessingAlgorithmBase {
 public:
+  // Default constructor
+  DataProcessorProcessingAlgorithmBase();
+
   // Constructor
   DataProcessorProcessingAlgorithmBase(
       const std::string &name,

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorWhiteList.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorWhiteList.h
@@ -40,11 +40,14 @@ public:
   virtual ~DataProcessorWhiteList(){};
 
   void addElement(const std::string &colName, const std::string &algProperty,
-                  const std::string &description = "");
+                  const std::string &description, bool showPrefix = false,
+                  const std::string &prefix = "");
   int colIndexFromColName(const std::string &colName) const;
   std::string colNameFromColIndex(int index) const;
   std::string algPropFromColIndex(int index) const;
   std::string description(int index) const;
+  std::string prefix(int index) const;
+  bool showPrefix(int index) const;
   size_t size() const;
 
 private:
@@ -52,6 +55,8 @@ private:
   std::map<std::string, int> m_colNameToColIndex;
   std::vector<std::string> m_colIndexToColName;
   std::vector<std::string> m_colIndexToAlgProp;
+  std::vector<bool> m_showPrefix;
+  std::vector<std::string> m_prefix;
   std::vector<std::string> m_description;
 };
 }

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorWhiteList.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorWhiteList.h
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -49,9 +50,9 @@ public:
 private:
   int m_lastIndex;
   std::map<std::string, int> m_colNameToColIndex;
-  std::map<int, std::string> m_colIndexToColName;
-  std::map<int, std::string> m_colIndexToAlgProp;
-  std::map<int, std::string> m_description;
+  std::vector<std::string> m_colIndexToColName;
+  std::vector<std::string> m_colIndexToAlgProp;
+  std::vector<std::string> m_description;
 };
 }
 }

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorWhiteList.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorWhiteList.h
@@ -40,14 +40,14 @@ public:
   virtual ~DataProcessorWhiteList(){};
 
   void addElement(const std::string &colName, const std::string &algProperty,
-                  const std::string &description, bool showPrefix = false,
+                  const std::string &description, bool showValue = false,
                   const std::string &prefix = "");
   int colIndexFromColName(const std::string &colName) const;
   std::string colNameFromColIndex(int index) const;
   std::string algPropFromColIndex(int index) const;
   std::string description(int index) const;
   std::string prefix(int index) const;
-  bool showPrefix(int index) const;
+  bool showValue(int index) const;
   size_t size() const;
 
 private:
@@ -55,7 +55,7 @@ private:
   std::map<std::string, int> m_colNameToColIndex;
   std::vector<std::string> m_colIndexToColName;
   std::vector<std::string> m_colIndexToAlgProp;
-  std::vector<bool> m_showPrefix;
+  std::vector<bool> m_showValue;
   std::vector<std::string> m_prefix;
   std::vector<std::string> m_description;
 };

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -51,8 +51,8 @@ class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS GenericDataProcessorPresenter
 public:
   GenericDataProcessorPresenter(
       const DataProcessorWhiteList &whitelist,
-      const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
-          preprocessMap,
+      const std::map<std::string, DataProcessorPreprocessingAlgorithm>
+          &preprocessMap,
       const DataProcessorProcessingAlgorithm &processor,
       const DataProcessorPostprocessingAlgorithm &postprocessor);
   ~GenericDataProcessorPresenter() override;
@@ -68,8 +68,14 @@ public:
                    ProgressableView *progressView) override;
   void setModel(std::string name) override;
 
-  // Only for testing purposes
+  // The following methods are public only for testing purposes
+  // Get the whitelist
   DataProcessorWhiteList getWhiteList() const { return m_whitelist; };
+  // Get the name of the reduced workspace for a given row
+  std::string getReducedWorkspaceName(int row, const std::string &prefix = "");
+  // Get the name of a post-processed workspace
+  std::string getPostprocessedWorkspaceName(const std::set<int> &rows,
+                                            const std::string &prefix = "");
 
 protected:
   // the workspace the model is currently representing
@@ -111,8 +117,6 @@ protected:
   prepareRunWorkspace(const std::string &run,
                       const DataProcessorPreprocessingAlgorithm &alg,
                       const std::map<std::string, std::string> &optionsMap);
-  // Get the workspace name for a given row
-  std::string getWorkspaceName(int row, bool prefix = true);
   // load a run into the ADS, or re-use one in the ADS if possible
   Mantid::API::Workspace_sptr loadRun(const std::string &run,
                                       const std::string &instrument,

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -55,6 +55,10 @@ public:
           &preprocessMap,
       const DataProcessorProcessingAlgorithm &processor,
       const DataProcessorPostprocessingAlgorithm &postprocessor);
+  GenericDataProcessorPresenter(
+      const DataProcessorWhiteList &whitelist,
+      const DataProcessorProcessingAlgorithm &processor,
+      const DataProcessorPostprocessingAlgorithm &postprocessor);
   ~GenericDataProcessorPresenter() override;
   void notify(DataProcessorPresenter::Flag flag) override;
   const std::map<std::string, QVariant> &options() const override;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -51,8 +51,8 @@ class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS GenericDataProcessorPresenter
 public:
   GenericDataProcessorPresenter(
       const DataProcessorWhiteList &whitelist,
-      const std::map<std::string, DataProcessorPreprocessingAlgorithm>
-          &preprocessMap,
+      const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
+          preprocessMap,
       const DataProcessorProcessingAlgorithm &processor,
       const DataProcessorPostprocessingAlgorithm &postprocessor);
   GenericDataProcessorPresenter(

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorGenerateNotebook.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorGenerateNotebook.cpp
@@ -377,7 +377,7 @@ std::string getReducedWorkspaceName(int rowNo,
   for (int col = 0; col < ncols; col++) {
 
     // Do we want to use this column to generate the name of the output ws?
-    if (whitelist.showPrefix(col)) {
+    if (whitelist.showValue(col)) {
 
       // Get what's in the column
       const std::string valueStr =

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorGenerateNotebook.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorGenerateNotebook.cpp
@@ -2,8 +2,8 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/NotebookWriter.h"
 #include "MantidKernel/make_unique.h"
-#include "MantidQtMantidWidgets/DataProcessorUI/ParseKeyValueString.h"
 #include "MantidQtMantidWidgets/DataProcessorUI/DataProcessorVectorString.h"
+#include "MantidQtMantidWidgets/DataProcessorUI/ParseKeyValueString.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/foreach.hpp>
@@ -52,8 +52,8 @@ specified via the corresponding hinting line edit in the view
 DataProcessorGenerateNotebook::DataProcessorGenerateNotebook(
     std::string name, QDataProcessorTableModel_sptr model,
     const std::string instrument, const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
-        preprocessMap,
+    const std::map<std::string, DataProcessorPreprocessingAlgorithm>
+        &preprocessMap,
     const DataProcessorProcessingAlgorithm &processor,
     const DataProcessorPostprocessingAlgorithm &postprocessor,
     const std::map<std::string, std::string> preprocessingOptionsMap,
@@ -290,8 +290,8 @@ std::string tableString(QDataProcessorTableModel_sptr model,
 boost::tuple<std::string, std::string> postprocessGroupString(
     const std::set<int> &rows, QDataProcessorTableModel_sptr model,
     const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
-        preprocessMap,
+    const std::map<std::string, DataProcessorPreprocessingAlgorithm>
+        &preprocessMap,
     const DataProcessorProcessingAlgorithm &processor,
     const DataProcessorPostprocessingAlgorithm &postprocessor,
     const std::string &postprocessingOptions) {
@@ -313,8 +313,7 @@ boost::tuple<std::string, std::string> postprocessGroupString(
   for (auto rowIt = rows.begin(); rowIt != rows.end(); ++rowIt) {
 
     // The reduced ws name without prefix (for example 'TOF_13460_13462')
-    auto suffix = getWorkspaceName(*rowIt, model, whitelist, preprocessMap,
-                                   processor, false);
+    auto suffix = getReducedWorkspaceName(*rowIt, model, whitelist);
 
     // The reduced ws name: 'IvsQ_TOF_13460_13462'
     inputNames.emplace_back(processor.prefix(0) + suffix);
@@ -327,7 +326,8 @@ boost::tuple<std::string, std::string> postprocessGroupString(
   stitch_string << outputWSName;
   stitch_string << completeOutputProperties(
                        postprocessor.name(),
-                       postprocessor.numberOfOutputProperties()) << " = ";
+                       postprocessor.numberOfOutputProperties())
+                << " = ";
   stitch_string << postprocessor.name() << "(";
   stitch_string << postprocessor.inputProperty() << " = '";
   stitch_string << boost::algorithm::join(inputNames, ", ") << "'";
@@ -365,49 +365,41 @@ std::string plot1DString(const std::vector<std::string> &ws_names) {
  @param prefix : wheter to return the name with the prefix or not
  @return : the workspace name
 */
-std::string getWorkspaceName(
-    int rowNo, QDataProcessorTableModel_sptr model,
-    const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
-        preprocessMap,
-    const DataProcessorProcessingAlgorithm &processor, bool prefix) {
+std::string getReducedWorkspaceName(int rowNo,
+                                    QDataProcessorTableModel_sptr model,
+                                    const DataProcessorWhiteList &whitelist,
+                                    const std::string &prefix) {
 
-  // The name of the output workspaces, e.g. 'TOF_13462', 'TRANS_13463', etc
-  std::vector<std::string> workspaceNames;
+  std::vector<std::string> names;
 
   int ncols = static_cast<int>(whitelist.size());
 
-  // Run through columns, excluding 'Group' and 'Options'
-  for (int col = 0; col < ncols - 2; col++) {
+  for (int col = 0; col < ncols; col++) {
 
-    const std::string colName = whitelist.colNameFromColIndex(col);
+    // Do we want to use this column to generate the name of the output ws?
+    if (whitelist.showPrefix(col)) {
 
-    // We only included in the ws name pre-processed columns
-    if (preprocessMap.count(colName)) {
+      // Get what's in the column
+      const std::string valueStr =
+          model->data(model->index(rowNo, col)).toString().toStdString();
 
-      auto preprocessor = preprocessMap.at(colName);
+      // If it's not empty, use it
+      if (!valueStr.empty()) {
 
-      // Did we include this bit in the output ws name?
-      if (preprocessor.show()) {
-        // The runs
-        const std::string runStr =
-            model->data(model->index(rowNo, col)).toString().toStdString();
+        // But we may have things like '1+2' which we want to replace with '1_2'
+        std::vector<std::string> value;
+        boost::split(value, valueStr, boost::is_any_of("+"));
 
-        if (!runStr.empty()) {
-
-          std::vector<std::string> runs;
-          boost::split(runs, runStr, boost::is_any_of("+"));
-
-          workspaceNames.emplace_back(preprocessor.prefix() +
-                                      boost::algorithm::join(runs, "_"));
-        }
+        names.push_back(whitelist.prefix(col) +
+                        boost::algorithm::join(value, "_"));
       }
     }
-  }
-  if (prefix)
-    return processor.prefix(0) + boost::algorithm::join(workspaceNames, "_");
-  else
-    return boost::algorithm::join(workspaceNames, "_");
+  } // Columns
+
+  std::string wsname = prefix;
+  wsname += boost::algorithm::join(names, "_");
+
+  return wsname;
 }
 
 /**
@@ -430,8 +422,8 @@ boost::tuple<std::string, std::string> reduceRowString(
     const int rowNo, const std::string &instrument,
     QDataProcessorTableModel_sptr model,
     const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
-        preprocessMap,
+    const std::map<std::string, DataProcessorPreprocessingAlgorithm>
+        &preprocessMap,
     const DataProcessorProcessingAlgorithm &processor,
     const std::map<std::string, std::string> &preprocessingOptionsMap,
     const std::string &processingOptions) {
@@ -507,11 +499,7 @@ boost::tuple<std::string, std::string> reduceRowString(
     algProperties.push_back(kvp->first + " = " + kvp->second);
   }
 
-  /* Now construct the output workspace names */
-
-  // The output ws suffix, for example 'TOF_13460_13462'
-  const std::string outputName = getWorkspaceName(
-      rowNo, model, whitelist, preprocessMap, processor, false);
+  /* Now construct the names of the reduced workspaces*/
 
   // Vector containing the output ws names
   // For example
@@ -519,7 +507,8 @@ boost::tuple<std::string, std::string> reduceRowString(
   // 'IvsLam_TOF_13460_13462
   std::vector<std::string> output_properties;
   for (size_t prop = 0; prop < processor.numberOfOutputProperties(); prop++) {
-    output_properties.push_back(processor.prefix(prop) + outputName);
+    output_properties.push_back(getReducedWorkspaceName(
+        rowNo, model, whitelist, processor.prefix(prop)));
   }
 
   std::string outputPropertiesStr =
@@ -559,7 +548,7 @@ loadWorkspaceString(const std::string &runStr, const std::string &instrument,
                     const std::string &options) {
 
   std::vector<std::string> runs;
-  boost::split(runs, runStr, boost::is_any_of("+"));
+  boost::split(runs, runStr, boost::is_any_of("+,"));
 
   std::ostringstream load_strings;
 

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorGenerateNotebook.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorGenerateNotebook.cpp
@@ -278,7 +278,6 @@ std::string tableString(QDataProcessorTableModel_sptr model,
   @param rows : rows in the group
   @param model : table model containing details of runs and processing settings
   @param whitelist : the whitelist
-  @param preprocessMap : pre-processing instructions as a map
   @param processor : the reduction algorithm
   @param postprocessor : the algorithm responsible for post-processing
   groups
@@ -356,8 +355,6 @@ std::string plot1DString(const std::vector<std::string> &ws_names) {
  @param rowNo : the row
  @param model : tablemodel for the full table
  @param whitelist : the whitelist
- @param preprocessMap : the pre-processing instructions as a map
- @param processor : the processing (reduction) algorithm
  @param prefix : wheter to return the name with the prefix or not
  @return : the workspace name
 */

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorGenerateNotebook.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorGenerateNotebook.cpp
@@ -52,8 +52,8 @@ specified via the corresponding hinting line edit in the view
 DataProcessorGenerateNotebook::DataProcessorGenerateNotebook(
     std::string name, QDataProcessorTableModel_sptr model,
     const std::string instrument, const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm>
-        &preprocessMap,
+    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
+        preprocessMap,
     const DataProcessorProcessingAlgorithm &processor,
     const DataProcessorPostprocessingAlgorithm &postprocessor,
     const std::map<std::string, std::string> preprocessingOptionsMap,
@@ -323,8 +323,7 @@ boost::tuple<std::string, std::string> postprocessGroupString(
   stitch_string << outputWSName;
   stitch_string << completeOutputProperties(
                        postprocessor.name(),
-                       postprocessor.numberOfOutputProperties())
-                << " = ";
+                       postprocessor.numberOfOutputProperties()) << " = ";
   stitch_string << postprocessor.name() << "(";
   stitch_string << postprocessor.inputProperty() << " = '";
   stitch_string << boost::algorithm::join(inputNames, ", ") << "'";
@@ -419,8 +418,8 @@ boost::tuple<std::string, std::string> reduceRowString(
     const int rowNo, const std::string &instrument,
     QDataProcessorTableModel_sptr model,
     const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm>
-        &preprocessMap,
+    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
+        preprocessMap,
     const DataProcessorProcessingAlgorithm &processor,
     const std::map<std::string, std::string> &preprocessingOptionsMap,
     const std::string &processingOptions) {

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorGenerateNotebook.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorGenerateNotebook.cpp
@@ -122,9 +122,8 @@ std::string DataProcessorGenerateNotebook::generateNotebook(
     /** Post-process group **/
 
     boost::tuple<std::string, std::string> postprocess_string =
-        postprocessGroupString(groupRows, m_model, m_whitelist, m_preprocessMap,
-                               m_processor, m_postprocessor,
-                               m_postprocessingOptions);
+        postprocessGroupString(groupRows, m_model, m_whitelist, m_processor,
+                               m_postprocessor, m_postprocessingOptions);
     notebook->codeCell(boost::get<0>(postprocess_string));
 
     /** Draw plots **/
@@ -290,8 +289,6 @@ std::string tableString(QDataProcessorTableModel_sptr model,
 boost::tuple<std::string, std::string> postprocessGroupString(
     const std::set<int> &rows, QDataProcessorTableModel_sptr model,
     const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm>
-        &preprocessMap,
     const DataProcessorProcessingAlgorithm &processor,
     const DataProcessorPostprocessingAlgorithm &postprocessor,
     const std::string &postprocessingOptions) {

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorPreprocessingAlgorithm.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorPreprocessingAlgorithm.cpp
@@ -5,16 +5,14 @@ namespace MantidWidgets {
 
 /** Constructor
  * @param name : The name of the pre-processing algorithm
- * @param prefix : The prefix that will added to the output workspace name
+ * @param prefix : A prefix that will added to the output workspace name
  * @param blacklist : The list of properties we don't want to show
- * @param show : Whether or not to show the prefix of this pre-processing
  * algorithm in the processed workspace's name
  */
 DataProcessorPreprocessingAlgorithm::DataProcessorPreprocessingAlgorithm(
     const std::string &name, const std::string &prefix,
-    const std::set<std::string> &blacklist, bool show)
-    : DataProcessorProcessingAlgorithmBase(name, blacklist), m_prefix(prefix),
-      m_show(show) {
+    const std::set<std::string> &blacklist)
+    : DataProcessorProcessingAlgorithmBase(name, blacklist), m_prefix(prefix) {
 
   auto inputWsProperties = getInputWsProperties();
 
@@ -66,8 +64,5 @@ std::string DataProcessorPreprocessingAlgorithm::prefix() const {
   return m_prefix;
 }
 
-// Returns a boolean indicating whether or not we want to add the prefix
-// associated to this pre-processor to the output workspace name
-bool DataProcessorPreprocessingAlgorithm::show() const { return m_show; }
 }
 }

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorPreprocessingAlgorithm.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorPreprocessingAlgorithm.cpp
@@ -34,12 +34,10 @@ DataProcessorPreprocessingAlgorithm::DataProcessorPreprocessingAlgorithm(
   m_outProperty = outputWsProperties.at(0);
 }
 
-/** Default constructor: use 'Plus' as the default pre-processor algorithm
+/** Default constructor: do nothing
 */
 DataProcessorPreprocessingAlgorithm::DataProcessorPreprocessingAlgorithm()
-    : DataProcessorPreprocessingAlgorithm(
-          "Plus", "TOF_", std::set<std::string>{"LHSWorkspace", "RHSWorkspace",
-                                                "OutputWorkspace"}) {}
+    : m_prefix(), m_lhs(), m_rhs(), m_outProperty() {}
 
 // Destructor
 DataProcessorPreprocessingAlgorithm::~DataProcessorPreprocessingAlgorithm() {}
@@ -63,6 +61,5 @@ std::string DataProcessorPreprocessingAlgorithm::outputProperty() const {
 std::string DataProcessorPreprocessingAlgorithm::prefix() const {
   return m_prefix;
 }
-
 }
 }

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorProcessingAlgorithmBase.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorProcessingAlgorithmBase.cpp
@@ -12,6 +12,12 @@ DataProcessorProcessingAlgorithmBase::DataProcessorProcessingAlgorithmBase(
   countWsProperties();
 }
 
+/** Default constructor (nothing to do) */
+DataProcessorProcessingAlgorithmBase::DataProcessorProcessingAlgorithmBase()
+    : m_algName(), m_blacklist(), m_inputWsProperties(),
+      m_inputStrListProperties(), m_OutputWsProperties() {
+}
+
 /** Destructor */
 DataProcessorProcessingAlgorithmBase::~DataProcessorProcessingAlgorithmBase() {}
 

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorProcessingAlgorithmBase.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorProcessingAlgorithmBase.cpp
@@ -15,8 +15,7 @@ DataProcessorProcessingAlgorithmBase::DataProcessorProcessingAlgorithmBase(
 /** Default constructor (nothing to do) */
 DataProcessorProcessingAlgorithmBase::DataProcessorProcessingAlgorithmBase()
     : m_algName(), m_blacklist(), m_inputWsProperties(),
-      m_inputStrListProperties(), m_OutputWsProperties() {
-}
+      m_inputStrListProperties(), m_OutputWsProperties() {}
 
 /** Destructor */
 DataProcessorProcessingAlgorithmBase::~DataProcessorProcessingAlgorithmBase() {}

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorWhiteList.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorWhiteList.cpp
@@ -11,9 +11,10 @@ namespace MantidWidgets {
 void DataProcessorWhiteList::addElement(const std::string &colName,
                                         const std::string &algProperty,
                                         const std::string &description) {
-  m_colIndexToColName[m_lastIndex] = colName;
-  m_colIndexToAlgProp[m_lastIndex] = algProperty;
-  m_description[m_lastIndex] = description;
+
+  m_colIndexToColName.push_back(colName);
+  m_colIndexToAlgProp.push_back(algProperty);
+  m_description.push_back(description);
   m_colNameToColIndex[colName] = m_lastIndex++;
 }
 

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorWhiteList.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorWhiteList.cpp
@@ -4,16 +4,23 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 /** Adds an element to the whitelist
-    @param colName : the name of the column to be added
-    @param algProperty : the name of the property linked to this column
-    @param description : a description of this column
+* @param colName : the name of the column to be added
+* @param algProperty : the name of the property linked to this column
+* @param showPrefix : true if we want to use what's in this column to generate
+* the output ws name
+* @param prefix : the prefix to be added to the value of this column
+* @param description : a description of this column
 */
 void DataProcessorWhiteList::addElement(const std::string &colName,
                                         const std::string &algProperty,
-                                        const std::string &description) {
+                                        const std::string &description,
+                                        bool showPrefix,
+                                        const std::string &prefix) {
 
   m_colIndexToColName.push_back(colName);
   m_colIndexToAlgProp.push_back(algProperty);
+  m_showPrefix.push_back(showPrefix);
+  m_prefix.push_back(prefix);
   m_description.push_back(description);
   m_colNameToColIndex[colName] = m_lastIndex++;
 }
@@ -51,6 +58,22 @@ std::string DataProcessorWhiteList::description(int index) const {
 */
 size_t DataProcessorWhiteList::size() const {
   return m_colNameToColIndex.size();
+}
+
+/** Returns true if this column should be used to generate the name of the
+ * output ws
+ * @param index : The column index
+*/
+bool DataProcessorWhiteList::showPrefix(int index) const {
+  return m_showPrefix.at(index);
+}
+
+/** Returns the column prefix used to generate the name of the output ws (will
+* only be used if shosPrefix is true for this column
+* @param index : The column index
+*/
+std::string DataProcessorWhiteList::prefix(int index) const {
+  return m_prefix.at(index);
 }
 }
 }

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorWhiteList.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/DataProcessorWhiteList.cpp
@@ -6,7 +6,7 @@ namespace MantidWidgets {
 /** Adds an element to the whitelist
 * @param colName : the name of the column to be added
 * @param algProperty : the name of the property linked to this column
-* @param showPrefix : true if we want to use what's in this column to generate
+* @param showValue : true if we want to use what's in this column to generate
 * the output ws name
 * @param prefix : the prefix to be added to the value of this column
 * @param description : a description of this column
@@ -14,12 +14,12 @@ namespace MantidWidgets {
 void DataProcessorWhiteList::addElement(const std::string &colName,
                                         const std::string &algProperty,
                                         const std::string &description,
-                                        bool showPrefix,
+                                        bool showValue,
                                         const std::string &prefix) {
 
   m_colIndexToColName.push_back(colName);
   m_colIndexToAlgProp.push_back(algProperty);
-  m_showPrefix.push_back(showPrefix);
+  m_showValue.push_back(showValue);
   m_prefix.push_back(prefix);
   m_description.push_back(description);
   m_colNameToColIndex[colName] = m_lastIndex++;
@@ -60,16 +60,16 @@ size_t DataProcessorWhiteList::size() const {
   return m_colNameToColIndex.size();
 }
 
-/** Returns true if this column should be used to generate the name of the
- * output ws
+/** Returns true if the contents of this column should be used to generate the
+ * name of the output ws
  * @param index : The column index
 */
-bool DataProcessorWhiteList::showPrefix(int index) const {
-  return m_showPrefix.at(index);
+bool DataProcessorWhiteList::showValue(int index) const {
+  return m_showValue.at(index);
 }
 
 /** Returns the column prefix used to generate the name of the output ws (will
-* only be used if shosPrefix is true for this column
+* only be used if showValue is true for this column
 * @param index : The column index
 */
 std::string DataProcessorWhiteList::prefix(int index) const {

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -660,7 +660,7 @@ std::string GenericDataProcessorPresenter::getReducedWorkspaceName(
   for (int col = 0; col < m_columns; col++) {
 
     // Do we want to use this column to generate the name of the output ws?
-    if (m_whitelist.showPrefix(col)) {
+    if (m_whitelist.showValue(col)) {
 
       // Get what's in the column
       const std::string valueStr =

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -38,8 +38,8 @@
 #include "MantidQtMantidWidgets/DataProcessorUI/QDataProcessorTableModel.h"
 #include "MantidQtMantidWidgets/DataProcessorUI/QtDataProcessorOptionsDialog.h"
 #include "MantidQtMantidWidgets/DataProcessorUI/WorkspaceReceiver.h"
-#include "MantidQtMantidWidgets/ProgressableView.h"
 #include "MantidQtMantidWidgets/ProgressPresenter.h"
+#include "MantidQtMantidWidgets/ProgressableView.h"
 
 #include <boost/regex.hpp>
 #include <boost/tokenizer.hpp>
@@ -64,8 +64,8 @@ namespace MantidWidgets {
 */
 GenericDataProcessorPresenter::GenericDataProcessorPresenter(
     const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
-        preprocessMap,
+    const std::map<std::string, DataProcessorPreprocessingAlgorithm>
+        &preprocessMap,
     const DataProcessorProcessingAlgorithm &processor,
     const DataProcessorPostprocessingAlgorithm &postprocessor)
     : WorkspaceObserver(), m_view(nullptr), m_progressView(nullptr),
@@ -404,25 +404,24 @@ void GenericDataProcessorPresenter::postProcessRows(std::set<int> rows) {
 
   // The input workspace names
   std::vector<std::string> inputNames;
-  // Vector to construct the output ws name
-  std::vector<std::string> outputNames;
 
-  // Go through each row and prepare the properties
+  // The name to call the post-processed ws
+  const std::string outputWSName =
+      getPostprocessedWorkspaceName(rows, m_postprocessor.prefix());
+
+  // Go through each row and get the input ws names
   for (auto rowIt = rows.begin(); rowIt != rows.end(); ++rowIt) {
 
-    // The names of the processed workspaces (without prefix)
-    const std::string runStr = getWorkspaceName(*rowIt, false);
+    // The name of the reduced workspace for this row
+    const std::string inputWSName =
+        getReducedWorkspaceName(*rowIt, m_processor.prefix(0));
 
-    if (AnalysisDataService::Instance().doesExist(m_processor.prefix(0) +
-                                                  runStr)) {
+    if (AnalysisDataService::Instance().doesExist(inputWSName)) {
 
-      inputNames.emplace_back(m_processor.prefix(0) + runStr);
-      outputNames.emplace_back(runStr);
+      inputNames.emplace_back(inputWSName);
     }
   }
   const std::string inputWSNames = boost::algorithm::join(inputNames, ", ");
-  const std::string outputWSName =
-      m_postprocessor.prefix() + boost::algorithm::join(outputNames, "_");
 
   // If the previous result is in the ADS already, we'll need to remove it.
   // If it's a group, we'll get an error for trying to group into a used group
@@ -620,58 +619,75 @@ Workspace_sptr GenericDataProcessorPresenter::prepareRunWorkspace(
 }
 
 /**
-Returns the name of the workspace
+Returns the name of the reduced workspace for a given row
 @param row : The row
-@param prefix : Wheter or not to include the prefix
+@param prefix : A prefix to be appended to the generated ws name
 @throws std::runtime_error if the workspace could not be prepared
 @returns : The name of the workspace
 */
-std::string GenericDataProcessorPresenter::getWorkspaceName(int row,
-                                                            bool prefix) {
+std::string GenericDataProcessorPresenter::getReducedWorkspaceName(
+    int row, const std::string &prefix) {
 
   /* This method calculates, for a given row, the name of the output (processed)
-   * workspace. In Reflectometry for example, where we have two columns that
-   * need pre-processing, 'Run(s)' and 'Transmission Run(s)', the name of the
-   * output ws will contain the information (i.e. run numbers) displayed in
-   * those columns. To construct the ws name we also need the prefix associated
-   * with the processor algorithm (for instance 'IvsQ_' in Reflectometry)
-   */
+   * workspace. This is done using the white list, which contains information
+   * about the columns that should be included to create the ws name. In
+   * Reflectometry for example, we want to include values in the 'Run(s)' and
+   * 'Transmission Run(s)' columns. We may also use a prefix associated with
+   * the column when specified. Finally, to construct the ws name we may also
+   * use a 'global' prefix associated with the processing algorithm (for
+   * instance 'IvsQ_' in Reflectometry) this is given by the second argument to
+   * this method */
 
   // Temporary vector of strings to construct the name
   std::vector<std::string> names;
 
   for (int col = 0; col < m_columns; col++) {
 
-    const std::string colName = m_whitelist.colNameFromColIndex(col);
+    // Do we want to use this column to generate the name of the output ws?
+    if (m_whitelist.showPrefix(col)) {
 
-    if (m_preprocessMap.count(colName)) {
-      // OK, this column was pre-processed, that means that the output ws name
-      // may contain information associated with this pre-processor
+      // Get what's in the column
+      const std::string valueStr =
+          m_model->data(m_model->index(row, col)).toString().toStdString();
 
-      if (m_preprocessMap[colName].show()) {
-        // OK, we do want to show the pre-processed run numbers
+      // If it's not empty, use it
+      if (!valueStr.empty()) {
 
-        const std::string runStr =
-            m_model->data(m_model->index(row, col)).toString().toStdString();
+        // But we may have things like '1+2' which we want to replace with '1_2'
+        std::vector<std::string> value;
+        boost::split(value, valueStr, boost::is_any_of("+"));
 
-        if (!runStr.empty()) {
-          std::vector<std::string> runs;
-          boost::split(runs, runStr, boost::is_any_of("+"));
-
-          names.push_back(m_preprocessMap[colName].prefix() +
-                          boost::algorithm::join(runs, "_"));
-        }
+        names.push_back(m_whitelist.prefix(col) +
+                        boost::algorithm::join(value, "_"));
       }
     }
-  }
+  } // Columns
 
-  std::string wsname;
-
-  if (prefix)
-    wsname += m_processor.prefix(0);
+  std::string wsname = prefix;
   wsname += boost::algorithm::join(names, "_");
 
   return wsname;
+}
+
+/**
+Returns the name of the reduced workspace for a given row
+@param rows : The set of rows that belong to a group
+@param prefix : A prefix to be appended to the generated ws name
+@returns : The name of the workspace
+*/
+std::string GenericDataProcessorPresenter::getPostprocessedWorkspaceName(
+    const std::set<int> &rows, const std::string &prefix) {
+
+  /* This method calculates, for a given set of rows, the name of the output
+   * (post-processed) workspace */
+
+  std::vector<std::string> outputNames;
+
+  for (auto &row : rows) {
+    outputNames.push_back(getReducedWorkspaceName(row));
+  }
+
+  return prefix + boost::join(outputNames, "_");
 }
 
 /**
@@ -803,7 +819,7 @@ void GenericDataProcessorPresenter::reduceRow(int rowNo) {
   /* We need to give a name to the output workspaces */
   for (size_t i = 0; i < m_processor.numberOfOutputProperties(); i++) {
     alg->setProperty(m_processor.outputPropertyName(i),
-                     m_processor.prefix(i) + getWorkspaceName(rowNo, false));
+                     getReducedWorkspaceName(rowNo, m_processor.prefix(i)));
   }
 
   /* Now run the processing algorithm */
@@ -1176,8 +1192,9 @@ void GenericDataProcessorPresenter::expandSelection() {
   std::set<int> selection;
 
   for (int i = 0; i < m_model->rowCount(); ++i)
-    if (groupIds.find(m_model->data(m_model->index(i, m_columns - 2))
-                          .toInt()) != groupIds.end())
+    if (groupIds.find(
+            m_model->data(m_model->index(i, m_columns - 2)).toInt()) !=
+        groupIds.end())
       selection.insert(i);
 
   m_view->setSelection(selection);
@@ -1321,7 +1338,8 @@ void GenericDataProcessorPresenter::plotRow() {
 
   std::set<std::string> workspaces, notFound;
   for (auto row = selectedRows.begin(); row != selectedRows.end(); ++row) {
-    const std::string wsName = getWorkspaceName(*row);
+    const std::string wsName =
+        getReducedWorkspaceName(*row, m_processor.prefix(0));
     if (AnalysisDataService::Instance().doesExist(wsName))
       workspaces.insert(wsName);
     else
@@ -1353,7 +1371,7 @@ void GenericDataProcessorPresenter::plotGroup() {
         m_model->data(m_model->index(*row, m_columns - 2)).toInt());
 
   // Now, get the rows belonging to the specified groups
-  std::map<int, std::vector<int>> rowsByGroup;
+  std::map<int, std::set<int>> rowsByGroup;
   const int numRows = m_model->rowCount();
   for (int row = 0; row < numRows; ++row) {
     int group = m_model->data(m_model->index(row, m_columns - 2)).toInt();
@@ -1363,7 +1381,7 @@ void GenericDataProcessorPresenter::plotGroup() {
       continue;
 
     // Add this row to group 'group'
-    rowsByGroup[group].push_back(row);
+    rowsByGroup[group].insert(row);
   }
 
   // Now get the workspace names
@@ -1374,13 +1392,9 @@ void GenericDataProcessorPresenter::plotGroup() {
 
     auto rows = rowsMap->second;
 
-    std::vector<std::string> names;
-    for (auto &row : rows) {
-      names.emplace_back(getWorkspaceName(row, false));
-    }
-
     const std::string wsName =
-        m_postprocessor.prefix() + boost::algorithm::join(names, "_");
+        getPostprocessedWorkspaceName(rows, m_postprocessor.prefix());
+
     if (AnalysisDataService::Instance().doesExist(wsName))
       workspaces.insert(wsName);
     else

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -64,8 +64,8 @@ namespace MantidWidgets {
 */
 GenericDataProcessorPresenter::GenericDataProcessorPresenter(
     const DataProcessorWhiteList &whitelist,
-    const std::map<std::string, DataProcessorPreprocessingAlgorithm>
-        &preprocessMap,
+    const std::map<std::string, DataProcessorPreprocessingAlgorithm> &
+        preprocessMap,
     const DataProcessorProcessingAlgorithm &processor,
     const DataProcessorPostprocessingAlgorithm &postprocessor)
     : WorkspaceObserver(), m_view(nullptr), m_progressView(nullptr),
@@ -1208,9 +1208,8 @@ void GenericDataProcessorPresenter::expandSelection() {
   std::set<int> selection;
 
   for (int i = 0; i < m_model->rowCount(); ++i)
-    if (groupIds.find(
-            m_model->data(m_model->index(i, m_columns - 2)).toInt()) !=
-        groupIds.end())
+    if (groupIds.find(m_model->data(m_model->index(i, m_columns - 2))
+                          .toInt()) != groupIds.end())
       selection.insert(i);
 
   m_view->setSelection(selection);

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -97,6 +97,22 @@ GenericDataProcessorPresenter::GenericDataProcessorPresenter(
 }
 
 /**
+* Delegating constructor (no pre-processing needed)
+* @param whitelist : The set of properties we want to show as columns
+* @param processor : A DataProcessorProcessingAlgorithm
+* @param postprocessor : A DataProcessorPostprocessingAlgorithm
+* workspaces
+*/
+GenericDataProcessorPresenter::GenericDataProcessorPresenter(
+    const DataProcessorWhiteList &whitelist,
+    const DataProcessorProcessingAlgorithm &processor,
+    const DataProcessorPostprocessingAlgorithm &postprocessor)
+    : GenericDataProcessorPresenter(
+          whitelist,
+          std::map<std::string, DataProcessorPreprocessingAlgorithm>(),
+          processor, postprocessor) {}
+
+/**
 * Destructor
 */
 GenericDataProcessorPresenter::~GenericDataProcessorPresenter() {}

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorGenerateNotebookTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorGenerateNotebookTest.h
@@ -25,15 +25,16 @@ private:
 
     // Reflectometry white list
     DataProcessorWhiteList whitelist;
-    whitelist.addElement("Run(s)", "InputWorkspace");
-    whitelist.addElement("Angle", "ThetaIn");
-    whitelist.addElement("Transmission Run(s)", "FirstTransmissionRun");
-    whitelist.addElement("Q min", "MomentumTransferMinimum");
-    whitelist.addElement("Q max", "MomentumTransferMaximum");
-    whitelist.addElement("dQ/Q", "MomentumTransferStep");
-    whitelist.addElement("Scale", "ScaleFactor");
-    whitelist.addElement("Group", "Group");
-    whitelist.addElement("Options", "Options");
+    whitelist.addElement("Run(s)", "InputWorkspace", "", true, "TOF_");
+    whitelist.addElement("Angle", "ThetaIn", "");
+    whitelist.addElement("Transmission Run(s)", "FirstTransmissionRun", "",
+                         true, "TRANS_");
+    whitelist.addElement("Q min", "MomentumTransferMinimum", "");
+    whitelist.addElement("Q max", "MomentumTransferMaximum", "");
+    whitelist.addElement("dQ/Q", "MomentumTransferStep", "");
+    whitelist.addElement("Scale", "ScaleFactor", "");
+    whitelist.addElement("Group", "Group", "");
+    whitelist.addElement("Options", "Options", "");
     return whitelist;
   }
   std::map<std::string, DataProcessorPreprocessingAlgorithm>

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorGenerateNotebookTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorGenerateNotebookTest.h
@@ -183,17 +183,10 @@ public:
     std::vector<std::string> notebookLines;
     boost::split(notebookLines, generatedNotebook, boost::is_any_of("\n"));
     const std::string result[] = {
-        "{",
-        "   \"metadata\" : {",
-        "      \"name\" : \"Mantid Notebook\"",
-        "   },",
-        "   \"nbformat\" : 3,",
-        "   \"nbformat_minor\" : 0,",
-        "   \"worksheets\" : [",
-        "      {",
-        "         \"cells\" : [",
-        "            {",
-        "               \"cell_type\" : \"markdown\",",
+        "{", "   \"metadata\" : {", "      \"name\" : \"Mantid Notebook\"",
+        "   },", "   \"nbformat\" : 3,", "   \"nbformat_minor\" : 0,",
+        "   \"worksheets\" : [", "      {", "         \"cells\" : [",
+        "            {", "               \"cell_type\" : \"markdown\",",
     };
 
     // Check that the first 10 lines are output as expected

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorGenerateNotebookTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorGenerateNotebookTest.h
@@ -48,8 +48,8 @@ private:
          DataProcessorPreprocessingAlgorithm(
              "CreateTransmissionWorkspaceAuto", "TRANS_",
              std::set<std::string>{"FirstTransmissionRun",
-                                   "SecondTransmissionRun", "OutputWorkspace"},
-             false)}};
+                                   "SecondTransmissionRun",
+                                   "OutputWorkspace"})}};
   }
 
   DataProcessorProcessingAlgorithm createReflectometryProcessor() {
@@ -183,10 +183,17 @@ public:
     std::vector<std::string> notebookLines;
     boost::split(notebookLines, generatedNotebook, boost::is_any_of("\n"));
     const std::string result[] = {
-        "{", "   \"metadata\" : {", "      \"name\" : \"Mantid Notebook\"",
-        "   },", "   \"nbformat\" : 3,", "   \"nbformat_minor\" : 0,",
-        "   \"worksheets\" : [", "      {", "         \"cells\" : [",
-        "            {", "               \"cell_type\" : \"markdown\",",
+        "{",
+        "   \"metadata\" : {",
+        "      \"name\" : \"Mantid Notebook\"",
+        "   },",
+        "   \"nbformat\" : 3,",
+        "   \"nbformat_minor\" : 0,",
+        "   \"worksheets\" : [",
+        "      {",
+        "         \"cells\" : [",
+        "            {",
+        "               \"cell_type\" : \"markdown\",",
     };
 
     // Check that the first 10 lines are output as expected
@@ -291,10 +298,21 @@ public:
     std::string userOptions = "Params = '0.1, -0.04, 2.9', StartOverlaps = "
                               "'1.4, 0.1, 1.4', EndOverlaps = '1.6, 2.9, 1.6'";
 
+    DataProcessorWhiteList whitelist;
+    whitelist.addElement("Run(s)", "InputWorkspace", "", true);
+    whitelist.addElement("Angle", "ThetaIn", "");
+    whitelist.addElement("Transmission Run(s)", "FirstTransmissionRun", "");
+    whitelist.addElement("Q min", "MomentumTransferMinimum", "");
+    whitelist.addElement("Q max", "MomentumTransferMaximum", "");
+    whitelist.addElement("dQ/Q", "MomentumTransferStep", "");
+    whitelist.addElement("Scale", "ScaleFactor", "");
+    whitelist.addElement("Group", "Group", "");
+    whitelist.addElement("Options", "Options", "");
+
     boost::tuple<std::string, std::string> output = postprocessGroupString(
-        m_rows, m_model, createReflectometryWhiteList(),
-        createReflectometryPreprocessMap(), createReflectometryProcessor(),
-        DataProcessorPostprocessingAlgorithm(), userOptions);
+        m_rows, m_model, whitelist, createReflectometryPreprocessMap(),
+        createReflectometryProcessor(), DataProcessorPostprocessingAlgorithm(),
+        userOptions);
 
     const std::string result[] = {
         "#Post-process workspaces",

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorGenerateNotebookTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorGenerateNotebookTest.h
@@ -310,9 +310,8 @@ public:
     whitelist.addElement("Options", "Options", "");
 
     boost::tuple<std::string, std::string> output = postprocessGroupString(
-        m_rows, m_model, whitelist, createReflectometryPreprocessMap(),
-        createReflectometryProcessor(), DataProcessorPostprocessingAlgorithm(),
-        userOptions);
+        m_rows, m_model, whitelist, createReflectometryProcessor(),
+        DataProcessorPostprocessingAlgorithm(), userOptions);
 
     const std::string result[] = {
         "#Post-process workspaces",

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorPreprocessingAlgorithmTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorPreprocessingAlgorithmTest.h
@@ -65,8 +65,7 @@ public:
     TS_ASSERT_EQUALS(plus.rhsProperty(), "");
     TS_ASSERT_EQUALS(plus.outputProperty(), "");
     TS_ASSERT_EQUALS(plus.prefix(), "");
-    std::set<std::string> blacklist = {};
-    TS_ASSERT_EQUALS(plus.blacklist(), blacklist);
+    TS_ASSERT_EQUALS(plus.blacklist().size(), 0);
   }
 
   void test_WeightedMean() {

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorPreprocessingAlgorithmTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorPreprocessingAlgorithmTest.h
@@ -65,7 +65,6 @@ public:
     TS_ASSERT_EQUALS(plus.rhsProperty(), "RHSWorkspace");
     TS_ASSERT_EQUALS(plus.outputProperty(), "OutputWorkspace");
     TS_ASSERT_EQUALS(plus.prefix(), "TOF_");
-    TS_ASSERT_EQUALS(plus.show(), true);
     std::set<std::string> blacklist = {"LHSWorkspace", "RHSWorkspace",
                                        "OutputWorkspace"};
     TS_ASSERT_EQUALS(plus.blacklist(), blacklist);

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorPreprocessingAlgorithmTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorPreprocessingAlgorithmTest.h
@@ -58,15 +58,14 @@ public:
 
   void test_default() {
 
-    // Default: Plus
+    // Default: no algorithm
     auto plus = DataProcessorPreprocessingAlgorithm();
-    TS_ASSERT_EQUALS(plus.name(), "Plus");
-    TS_ASSERT_EQUALS(plus.lhsProperty(), "LHSWorkspace");
-    TS_ASSERT_EQUALS(plus.rhsProperty(), "RHSWorkspace");
-    TS_ASSERT_EQUALS(plus.outputProperty(), "OutputWorkspace");
-    TS_ASSERT_EQUALS(plus.prefix(), "TOF_");
-    std::set<std::string> blacklist = {"LHSWorkspace", "RHSWorkspace",
-                                       "OutputWorkspace"};
+    TS_ASSERT_EQUALS(plus.name(), "");
+    TS_ASSERT_EQUALS(plus.lhsProperty(), "");
+    TS_ASSERT_EQUALS(plus.rhsProperty(), "");
+    TS_ASSERT_EQUALS(plus.outputProperty(), "");
+    TS_ASSERT_EQUALS(plus.prefix(), "");
+    std::set<std::string> blacklist = {};
     TS_ASSERT_EQUALS(plus.blacklist(), blacklist);
   }
 

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorWhiteListTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorWhiteListTest.h
@@ -24,15 +24,14 @@ public:
   }
   static void destroySuite(DataProcessorWhiteListTest *suite) { delete suite; }
 
-  void test_whitelist() {
+  void test_column_index() {
     DataProcessorWhiteList whitelist;
     whitelist.addElement("Column1", "Property1", "Description1");
     whitelist.addElement("Column2", "Property2", "Description2");
     whitelist.addElement("Column3", "Property3", "Description3");
     whitelist.addElement("Column4", "Property4", "Description4");
     whitelist.addElement("Column5", "Property5", "Description5");
-    // Not much to test, just make sure that columns are inserted in the right
-    // order
+
     TS_ASSERT_EQUALS(whitelist.size(), 5);
     // Column indices
     TS_ASSERT_EQUALS(whitelist.colIndexFromColName("Column1"), 0);
@@ -44,6 +43,72 @@ public:
     // Descriptions
     TS_ASSERT_EQUALS(whitelist.description(2), "Description3");
     TS_ASSERT_EQUALS(whitelist.description(4), "Description5");
+  }
+
+  void test_column_name() {
+    DataProcessorWhiteList whitelist;
+    whitelist.addElement("Column1", "Property1", "Description1");
+    whitelist.addElement("Column2", "Property2", "Description2");
+    whitelist.addElement("Column3", "Property3", "Description3");
+    whitelist.addElement("Column4", "Property4", "Description4");
+    whitelist.addElement("Column5", "Property5", "Description5");
+
+    TS_ASSERT_EQUALS(whitelist.size(), 5);
+    // Column indices
+    TS_ASSERT_EQUALS(whitelist.colNameFromColIndex(0), "Column1");
+    TS_ASSERT_EQUALS(whitelist.colNameFromColIndex(3), "Column4");
+    TS_ASSERT_EQUALS(whitelist.colNameFromColIndex(4), "Column5");
+  }
+
+  void test_column_property() {
+    DataProcessorWhiteList whitelist;
+    whitelist.addElement("Column1", "Property1", "Description1");
+    whitelist.addElement("Column2", "Property2", "Description2");
+    whitelist.addElement("Column3", "Property3", "Description3");
+    whitelist.addElement("Column4", "Property4", "Description4");
+    whitelist.addElement("Column5", "Property5", "Description5");
+
+    TS_ASSERT_EQUALS(whitelist.size(), 5);
+    // Algorithm properties
+    TS_ASSERT_EQUALS(whitelist.algPropFromColIndex(1), "Property2");
+    TS_ASSERT_EQUALS(whitelist.algPropFromColIndex(3), "Property4");
+  }
+
+  void test_column_description() {
+    DataProcessorWhiteList whitelist;
+    whitelist.addElement("Column1", "Property1", "Description1");
+    whitelist.addElement("Column2", "Property2", "Description2");
+    whitelist.addElement("Column3", "Property3", "Description3");
+    whitelist.addElement("Column4", "Property4", "Description4");
+    whitelist.addElement("Column5", "Property5", "Description5");
+
+    TS_ASSERT_EQUALS(whitelist.size(), 5);
+    // Descriptions
+    TS_ASSERT_EQUALS(whitelist.description(0), "Description1");
+    TS_ASSERT_EQUALS(whitelist.description(2), "Description3");
+    TS_ASSERT_EQUALS(whitelist.description(4), "Description5");
+  }
+
+  void test_column_showPrefix() {
+    DataProcessorWhiteList whitelist;
+    whitelist.addElement("Column1", "Property1", "Description1");
+    whitelist.addElement("Column3", "Property3", "Description3", true);
+
+    TS_ASSERT_EQUALS(whitelist.size(), 2);
+    // Descriptions
+    TS_ASSERT_EQUALS(whitelist.showPrefix(0), false);
+    TS_ASSERT_EQUALS(whitelist.showPrefix(1), true);
+  }
+
+  void test_column_prefix() {
+    DataProcessorWhiteList whitelist;
+    whitelist.addElement("Column1", "Property1", "Description1");
+    whitelist.addElement("Column3", "Property3", "Description3", true, "blah");
+
+    TS_ASSERT_EQUALS(whitelist.size(), 2);
+    // Descriptions
+    TS_ASSERT_EQUALS(whitelist.prefix(0), "");
+    TS_ASSERT_EQUALS(whitelist.prefix(1), "blah");
   }
 };
 #endif /* MANTID_MANTIDWIDGETS_DATAPROCESSORWHITELISTTEST_H */

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorWhiteListTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorWhiteListTest.h
@@ -89,15 +89,15 @@ public:
     TS_ASSERT_EQUALS(whitelist.description(4), "Description5");
   }
 
-  void test_column_showPrefix() {
+  void test_column_showValue() {
     DataProcessorWhiteList whitelist;
     whitelist.addElement("Column1", "Property1", "Description1");
     whitelist.addElement("Column3", "Property3", "Description3", true);
 
     TS_ASSERT_EQUALS(whitelist.size(), 2);
     // Descriptions
-    TS_ASSERT_EQUALS(whitelist.showPrefix(0), false);
-    TS_ASSERT_EQUALS(whitelist.showPrefix(1), true);
+    TS_ASSERT_EQUALS(whitelist.showValue(0), false);
+    TS_ASSERT_EQUALS(whitelist.showValue(1), true);
   }
 
   void test_column_prefix() {

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -62,7 +62,10 @@ private:
   createReflectometryPreprocessMap() {
 
     return std::map<std::string, DataProcessorPreprocessingAlgorithm>{
-        {"Run(s)", DataProcessorPreprocessingAlgorithm()},
+        {"Run(s)", DataProcessorPreprocessingAlgorithm(
+                       "Plus", "TOF_",
+                       std::set<std::string>{"LHSWorkspace", "RHSWorkspace",
+                                             "OutputWorkspace"})},
         {"Transmission Run(s)",
          DataProcessorPreprocessingAlgorithm(
              "CreateTransmissionWorkspaceAuto", "TRANS_",

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -47,9 +47,10 @@ private:
   DataProcessorWhiteList createReflectometryWhiteList() {
 
     DataProcessorWhiteList whitelist;
-    whitelist.addElement("Run(s)", "InputWorkspace", "");
+    whitelist.addElement("Run(s)", "InputWorkspace", "", true, "TOF_");
     whitelist.addElement("Angle", "ThetaIn", "");
-    whitelist.addElement("Transmission Run(s)", "FirstTransmissionRun", "");
+    whitelist.addElement("Transmission Run(s)", "FirstTransmissionRun", "",
+                         true, "TRANS_");
     whitelist.addElement("Q min", "MomentumTransferMinimum", "");
     whitelist.addElement("Q max", "MomentumTransferMaximum", "");
     whitelist.addElement("dQ/Q", "MomentumTransferStep", "");
@@ -66,8 +67,8 @@ private:
          DataProcessorPreprocessingAlgorithm(
              "CreateTransmissionWorkspaceAuto", "TRANS_",
              std::set<std::string>{"FirstTransmissionRun",
-                                   "SecondTransmissionRun", "OutputWorkspace"},
-             false)}};
+                                   "SecondTransmissionRun",
+                                   "OutputWorkspace"})}};
   }
 
   DataProcessorProcessingAlgorithm createReflectometryProcessor() {
@@ -167,6 +168,45 @@ private:
     row << "24682"
         << "1.5"
         << ""
+        << "1.4"
+        << "2.9"
+        << "0.04"
+        << "1" << 1 << "";
+    return ws;
+  }
+
+  ITableWorkspace_sptr
+  createPrefilledWorkspaceWithTrans(const std::string &wsName,
+                                    const DataProcessorWhiteList &whitelist) {
+    auto ws = createWorkspace(wsName, whitelist);
+    TableRow row = ws->appendRow();
+    row << "12345"
+        << "0.5"
+        << "11115"
+        << "0.1"
+        << "1.6"
+        << "0.04"
+        << "1" << 0 << "";
+    row = ws->appendRow();
+    row << "12346"
+        << "1.5"
+        << "11116"
+        << "1.4"
+        << "2.9"
+        << "0.04"
+        << "1" << 0 << "";
+    row = ws->appendRow();
+    row << "24681"
+        << "0.5"
+        << "22221"
+        << "0.1"
+        << "1.6"
+        << "0.04"
+        << "1" << 1 << "";
+    row = ws->appendRow();
+    row << "24682"
+        << "1.5"
+        << "22222"
         << "1.4"
         << "2.9"
         << "0.04"
@@ -2005,6 +2045,79 @@ public:
         dynamic_cast<DataProcessorSeparatorCommand *>(commands[24].get()));
     TS_ASSERT(
         dynamic_cast<DataProcessorDeleteRowCommand *>(commands[25].get()));
+  }
+
+  void testWorkspaceNamesNoTrans() {
+    NiceMock<MockDataProcessorView> mockDataProcessorView;
+    NiceMock<MockProgressableView> mockProgress;
+    GenericDataProcessorPresenter presenter(
+        createReflectometryWhiteList(), createReflectometryPreprocessMap(),
+        createReflectometryProcessor(), createReflectometryPostprocessor());
+    presenter.acceptViews(&mockDataProcessorView, &mockProgress);
+
+    createPrefilledWorkspace("TestWorkspace", presenter.getWhiteList());
+    EXPECT_CALL(mockDataProcessorView, getWorkspaceToOpen())
+        .Times(1)
+        .WillRepeatedly(Return("TestWorkspace"));
+    presenter.notify(DataProcessorPresenter::OpenTableFlag);
+
+    // Tidy up
+    AnalysisDataService::Instance().remove("TestWorkspace");
+
+    // Test the names of the reduced workspaces
+    TS_ASSERT_EQUALS(presenter.getReducedWorkspaceName(0, "prefix_1_"),
+                     "prefix_1_TOF_12345");
+    TS_ASSERT_EQUALS(presenter.getReducedWorkspaceName(1, "prefix_2_"),
+                     "prefix_2_TOF_12346");
+    TS_ASSERT_EQUALS(presenter.getReducedWorkspaceName(2), "TOF_24681");
+    TS_ASSERT_EQUALS(presenter.getReducedWorkspaceName(3), "TOF_24682");
+    // Test the names of the post-processed ws
+    TS_ASSERT_EQUALS(presenter.getPostprocessedWorkspaceName(
+                         std::set<int>{0, 1}, "new_prefix_"),
+                     "new_prefix_TOF_12345_TOF_12346");
+    TS_ASSERT_EQUALS(
+        presenter.getPostprocessedWorkspaceName(std::set<int>{2, 3}),
+        "TOF_24681_TOF_24682");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockDataProcessorView));
+  }
+
+  void testWorkspaceNamesWithTrans() {
+    NiceMock<MockDataProcessorView> mockDataProcessorView;
+    NiceMock<MockProgressableView> mockProgress;
+    GenericDataProcessorPresenter presenter(
+        createReflectometryWhiteList(), createReflectometryPreprocessMap(),
+        createReflectometryProcessor(), createReflectometryPostprocessor());
+    presenter.acceptViews(&mockDataProcessorView, &mockProgress);
+
+    createPrefilledWorkspaceWithTrans("TestWorkspace",
+                                      presenter.getWhiteList());
+    EXPECT_CALL(mockDataProcessorView, getWorkspaceToOpen())
+        .Times(1)
+        .WillRepeatedly(Return("TestWorkspace"));
+    presenter.notify(DataProcessorPresenter::OpenTableFlag);
+
+    // Tidy up
+    AnalysisDataService::Instance().remove("TestWorkspace");
+
+    // Test the names of the reduced workspaces
+    TS_ASSERT_EQUALS(presenter.getReducedWorkspaceName(0, "prefix_1_"),
+                     "prefix_1_TOF_12345_TRANS_11115");
+    TS_ASSERT_EQUALS(presenter.getReducedWorkspaceName(1, "prefix_2_"),
+                     "prefix_2_TOF_12346_TRANS_11116");
+    TS_ASSERT_EQUALS(presenter.getReducedWorkspaceName(2),
+                     "TOF_24681_TRANS_22221");
+    TS_ASSERT_EQUALS(presenter.getReducedWorkspaceName(3),
+                     "TOF_24682_TRANS_22222");
+    // Test the names of the post-processed ws
+    TS_ASSERT_EQUALS(presenter.getPostprocessedWorkspaceName(
+                         std::set<int>{0, 1}, "new_prefix_"),
+                     "new_prefix_TOF_12345_TRANS_11115_TOF_12346_TRANS_11116");
+    TS_ASSERT_EQUALS(
+        presenter.getPostprocessedWorkspaceName(std::set<int>{2, 3}),
+        "TOF_24681_TRANS_22221_TOF_24682_TRANS_22222");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockDataProcessorView));
   }
 };
 

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -47,13 +47,13 @@ private:
   DataProcessorWhiteList createReflectometryWhiteList() {
 
     DataProcessorWhiteList whitelist;
-    whitelist.addElement("Run(s)", "InputWorkspace");
-    whitelist.addElement("Angle", "ThetaIn");
-    whitelist.addElement("Transmission Run(s)", "FirstTransmissionRun");
-    whitelist.addElement("Q min", "MomentumTransferMinimum");
-    whitelist.addElement("Q max", "MomentumTransferMaximum");
-    whitelist.addElement("dQ/Q", "MomentumTransferStep");
-    whitelist.addElement("Scale", "ScaleFactor");
+    whitelist.addElement("Run(s)", "InputWorkspace", "");
+    whitelist.addElement("Angle", "ThetaIn", "");
+    whitelist.addElement("Transmission Run(s)", "FirstTransmissionRun", "");
+    whitelist.addElement("Q min", "MomentumTransferMinimum", "");
+    whitelist.addElement("Q max", "MomentumTransferMaximum", "");
+    whitelist.addElement("dQ/Q", "MomentumTransferStep", "");
+    whitelist.addElement("Scale", "ScaleFactor", "");
     return whitelist;
   }
 


### PR DESCRIPTION
Changes to `DataProcessorUI` to make pre-processing step optional:
- Previously, `GenericDataProcessorPresenter` (the widget's presenter) needed four arguments to its constructor: 
  1. A whitelist, defining the number of columns, their names and how they relate to the main reduction algorithm's properties
  2. A map containing pre-processing instructions (keys were columns that need pre-processing and values algorithms performing the pre-processing step)
  3. The main reduction algorithm
  4. A post-processing algorithm
- This PR is to make the pre-processing step optional. To resolve this I've used a [delegating constructor](https://github.com/mantidproject/mantid/blob/16631_Make_preprocessing_optional/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp#L106-L113) that, when no pre-processing map is given, just uses an empty one.

**To test:**
- Changes should not have any effect on the Reflectometry interface. Please, perform functional testing to ensure results are the same as before. The following reduction table (note that the instrument is wrong, INTER should be used instead of OFFSPEC), which I've just copied from https://github.com/mantidproject/mantid/pull/15943:

![intertest](https://cloud.githubusercontent.com/assets/8956985/15220007/cd3df0f6-185d-11e6-8627-3b8922c588b3.png)

should give the following results:
![intertestresults](https://cloud.githubusercontent.com/assets/8956985/15221360/04d84ca0-1863-11e6-8561-3c22611be721.png)
- There is just a minor change in the Reflectometry interface with respect to the master branch: the names of the generated workspaces. I have refactored the code to make workspace names more similar to what we had before:
  1. Loaded workspaces are called `TOF_12345` and `TRANS_12346` (assuming a run number `12345` and a transmission run `12346`)
  2. Reduced workspaces are called: `IvsQ_12345`, `IvsLam_12345` (for run number `12345`), instead of the previous `IvsQ_TOF_12345` and `IvsLam_TOF_12346`.
  3. Stitched workspaces are called: `IvsQ_12345_12345` (for run numbers `12345` and `12346`), instead of the previous `IvsQ_TOF_12345_TOF_12346`
- Ensure that the options `Plot` and `Plot Group` work as before
- Ensure that the generated notebook is correct

Fixes #16631.

<!-- RELEASE NOTES
Changes not visible to users, I don't think this needs to be in release notes.
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
