### PR TITLE
Slice viewer should display nonintegrated dimensions by default

### DIFF
--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -629,15 +629,15 @@ void SliceViewer::updateDimensionSliceWidgets() {
     if ((dimXset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false)) {
       m_dimX = d;
       dimXset = true;
-		}
+    }
     if ((dimYset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false) && (d != m_dimX)) {
       m_dimY = d;
       dimYset = true;
-		}
+    }
     if ((dimXset == true) && (dimYset == true)) {
       break;
-		}
-	}
+    }
+  }
 
   int maxLabelWidth = 10;
   int maxUnitsWidth = 10;

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -627,15 +627,15 @@ void SliceViewer::updateDimensionSliceWidgets() {
 // put non integrated dimensions first
   for (size_t d = 0; d < m_dimensions.size(); d++) {
     if ((dimXset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false)) {
-		  m_dimX = d;
-		  dimXset = true;
+      m_dimX = d;
+      dimXset = true;
 		}
-	  if ((dimYset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false) && (d != m_dimX)) {
-		  m_dimY = d;
-		  dimYset = true;
+    if ((dimYset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false) && (d != m_dimX)) {
+      m_dimY = d;
+      dimYset = true;
 		}
-	  if ((dimXset == true) && (dimYset == true)) {
-		  break;
+    if ((dimXset == true) && (dimYset == true)) {
+      break;
 		}
 	}
 

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -622,23 +622,22 @@ void SliceViewer::updateDimensionSliceWidgets() {
     widget->hide();
   }
 
-  bool m_dimXset = false;
-  bool m_dimYset = false;
-  if (m_firstWorkspaceOpen == false) { // put non integrated dimensions first
-	  for (size_t d = 0; d < m_dimensions.size(); d++) {
-		  if ((m_dimXset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false)) {
-			  m_dimX = d;
-			  m_dimXset = true;
-		  }
-		  if ((m_dimYset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false) && (d != m_dimX)) {
-			  m_dimY = d;
-			  m_dimYset = true;
-		  }
-		  if ((m_dimXset == true) && (m_dimYset == true)) {
-			  break;
-		  }
-	  }
-  }
+  bool dimXset = false;
+  bool dimYset = false;
+// put non integrated dimensions first
+  for (size_t d = 0; d < m_dimensions.size(); d++) {
+    if ((dimXset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false)) {
+		  m_dimX = d;
+		  dimXset = true;
+		}
+	  if ((dimYset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false) && (d != m_dimX)) {
+		  m_dimY = d;
+		  dimYset = true;
+		}
+	  if ((dimXset == true) && (dimYset == true)) {
+		  break;
+		}
+	}
 
   int maxLabelWidth = 10;
   int maxUnitsWidth = 10;

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -624,13 +624,15 @@ void SliceViewer::updateDimensionSliceWidgets() {
 
   bool dimXset = false;
   bool dimYset = false;
-// put non integrated dimensions first
+  // put non integrated dimensions first
   for (size_t d = 0; d < m_dimensions.size(); d++) {
-    if ((dimXset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false)) {
+    if ((dimXset == false) &&
+        (m_ws->getDimension(d)->getIsIntegrated() == false)) {
       m_dimX = d;
       dimXset = true;
     }
-    if ((dimYset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false) && (d != m_dimX)) {
+    if ((dimYset == false) &&
+        (m_ws->getDimension(d)->getIsIntegrated() == false) && (d != m_dimX)) {
       m_dimY = d;
       dimYset = true;
     }

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -622,6 +622,24 @@ void SliceViewer::updateDimensionSliceWidgets() {
     widget->hide();
   }
 
+  bool m_dimXset = false;
+  bool m_dimYset = false;
+  if (m_firstWorkspaceOpen == false) { // put non integrated dimensions first
+	  for (size_t d = 0; d < m_dimensions.size(); d++) {
+		  if ((m_dimXset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false)) {
+			  m_dimX = d;
+			  m_dimXset = true;
+		  }
+		  if ((m_dimYset == false) && (m_ws->getDimension(d)->getIsIntegrated() == false) && (d != m_dimX)) {
+			  m_dimY = d;
+			  m_dimYset = true;
+		  }
+		  if ((m_dimXset == true) && (m_dimYset == true)) {
+			  break;
+		  }
+	  }
+  }
+
   int maxLabelWidth = 10;
   int maxUnitsWidth = 10;
   // Set each dimension

--- a/docs/source/release/v3.8.0/ui.rst
+++ b/docs/source/release/v3.8.0/ui.rst
@@ -37,7 +37,7 @@ Bugs Resolved
 
 SliceViewer Improvements
 ------------------------
-
+* When opening the sliceviewer, it will default to showing the first two non-integrated dimensions
 |
 
 Full list of


### PR DESCRIPTION
When opening the sliceviewer, it will default to showing the first two non-integrated dimensions as X, Y. If none are available it will use the first two dimensions in the file.

**To test:**
Code review
Check when opening data files with the sliceviewer that the dimensions displayed by default are non-integrated (ie have more than one bin).
can use the below for generating workspaces with mixed integrated/non integrated dimensions

``` python
mdws = CreateMDWorkspace(Dimensions=3, Extents='-10,10,-10,10,-10,10', Names='A,B,C', Units='U,U,U')
mdws2 = SliceMD(mdws,AlignedDim0='A,-2,2,64',AlignedDim1='B,0,1,1', AlignedDim2='C,-2,2,3' )
mdws3 = SliceMD(mdws, AlignedDim0='A,0,1,1', AlignedDim1='B,-2,2,3', AlignedDim2='C,-2,2,3')
mdws4 = SliceMD(mdws, AlignedDim0='A,0,1,1', AlignedDim1='B,0,1,1', AlignedDim2='C,0,1,1')
```

Fixes #15266 

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
