### PR TITLE
Include BASISReduction311 into BASISReduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -12,20 +12,19 @@ DEFAULT_VANADIUM_BINS = [-0.0034, 0.068, 0.0034]  # meV
 DEFAULT_CONFIG_DIR = config["instrumentDefinition.directory"]
 
 # BASIS allows two possible reflections, with associated default properties
+#pylint: disable=line-too-long
 REFLECTIONS_DICT = {"silicon111": {"name": "silicon111",
                                    "energy_bins": [-150, 0.4, 500],  # micro-eV
                                    "q_bins": [0.3, 0.2, 1.9],  # inverse Angstroms
                                    "mask_file": "BASIS_Mask_ThreeQuartersRemain_SouthTop_NorthTop_NorthBottom_MorePixelsEliminated_08122015.xml",
                                    "parameter_file": "BASIS_silicon_111_Parameters.xml",
-                                   "default_energy": 2.0826  # mili-eV
-                                   },
+                                   "default_energy": 2.0826},  # mili-eV
                     "silicon311": {"name": "silicon311",
                                    "energy_bins": [-740, 1.6, 740],
                                    "q_bins": [0.5, 0.2, 3.7],
                                    "mask_file": "BASIS_Mask_OneQuarterRemains_SouthBottom.xml",
                                    "parameter_file": "BASIS_silicon_311_Parameters.xml",
-                                   "default_energy": 7.6368
-                                   },
+                                   "default_energy": 7.6368}
                     }
 
 #pylint: disable=too-many-instance-attributes

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -24,8 +24,7 @@ REFLECTIONS_DICT = {"silicon111": {"name": "silicon111",
                                    "q_bins": [0.5, 0.2, 3.7],
                                    "mask_file": "BASIS_Mask_OneQuarterRemains_SouthBottom.xml",
                                    "parameter_file": "BASIS_silicon_311_Parameters.xml",
-                                   "default_energy": 7.6368}
-                    }
+                                   "default_energy": 7.6368}}
 
 #pylint: disable=too-many-instance-attributes
 class BASISReduction(PythonAlgorithm):

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -3,14 +3,30 @@ import mantid.simpleapi as api
 from mantid.api import *
 from mantid.kernel import *
 from mantid import config
+from os.path import join as pjoin
 
-MICROEV_TO_MILLIEV = 1000.0
-DEFAULT_BINS = [0., 0., 0.]
 DEFAULT_RANGE = [6.24, 6.30]
-DEFAULT_MASK_GROUP_DIR = "/SNS/BSS/shared/autoreduce"
-DEFAULT_MASK_FILE = "BASIS_Mask.xml"
+DEFAULT_MASK_GROUP_DIR = "/SNS/BSS/shared/autoreduce/new_masks_08_12_2015"
 DEFAULT_VANADIUM_ENERGY_RANGE = [-0.0034, 0.0034]  # meV
 DEFAULT_VANADIUM_BINS = [-0.0034, 0.068, 0.0034]  # meV
+DEFAULT_CONFIG_DIR = config["instrumentDefinition.directory"]
+
+# BASIS allows two possible reflections, with associated default properties
+reflections_dict = {"silicon111": {"name": "silicon111",
+                                   "energy_bins": [-150, 0.4, 500],  # micro-eV
+                                   "q_bins": [0.3, 0.2, 1.9],  # inverse Angstroms
+                                   "mask_file": "BASIS_Mask_ThreeQuartersRemain_SouthTop_NorthTop_NorthBottom_MorePixelsEliminated_08122015.xml",
+                                   "parameter_file": "BASIS_silicon_111_Parameters.xml",
+                                   "default_energy": 2.0826  # mili-eV
+                                   },
+                    "silicon311": {"name": "silicon311",
+                                   "energy_bins": [-740, 1.6, 740],
+                                   "q_bins": [0.5, 0.2, 3.7],
+                                   "mask_file": "BASIS_Mask_OneQuarterRemains_SouthBottom.xml",
+                                   "parameter_file": "BASIS_silicon_311_Parameters.xml",
+                                   "default_energy": 7.6368
+                                   },
+                    }
 
 #pylint: disable=too-many-instance-attributes
 class BASISReduction(PythonAlgorithm):
@@ -19,14 +35,10 @@ class BASISReduction(PythonAlgorithm):
     _long_inst = None
     _extension = None
     _doIndiv = None
-    _etBins = None
-    _qBins = None
     _noMonNorm = None
-    _maskFile = None
     _groupDetOpt = None
     _overrideMask = None
     _dMask = None
-
     _run_list = None  # a list of runs, or a list of sets of runs
     _samWs = None
     _samMonWs = None
@@ -35,9 +47,15 @@ class BASISReduction(PythonAlgorithm):
 
     def __init__(self):
         PythonAlgorithm.__init__(self)
-
         self._normalizeToFirst = False
-        # variables related to division by Vanadium (normalization)
+
+        # properties related to the chosen reflection
+        self._reflection = None  # entry in the reflections dictionary
+        self._etBins = None
+        self._qBins = None
+        self._maskFile = None
+
+        # properties related to division by Vanadium (normalization)
         self._doNorm = None  # stores the selected item from normalization_types
         self._normalizationType = None
         self._normRange = None
@@ -55,7 +73,7 @@ class BASISReduction(PythonAlgorithm):
         return 1
 
     def summary(self):
-        return "Multiple-file BASIS reduction."
+        return "Multiple-file BASIS reduction for its two reflections."
 
     def PyInit(self):
         self._short_inst = "BSS"
@@ -66,24 +84,37 @@ class BASISReduction(PythonAlgorithm):
         self.declareProperty("DoIndividual", False, "Do each run individually")
         self.declareProperty("NoMonitorNorm", False,
                              "Stop monitor normalization")
-        arrVal = FloatArrayLengthValidator(2)
-
-        self.declareProperty(FloatArrayProperty("EnergyBins", DEFAULT_BINS,
-                                                direction=Direction.Input),
-                             "Energy transfer binning scheme (in ueV)")
-        self.declareProperty(FloatArrayProperty("MomentumTransferBins",
-                                                DEFAULT_BINS,
-                                                direction=Direction.Input),
-                             "Momentum transfer binning scheme")
-        self.declareProperty(FileProperty(name="MaskFile", defaultValue="",
-                                          action=FileAction.OptionalLoad, extensions=['.xml']),
-                             "Directory location for standard masking and grouping files.")
         grouping_type = ["None", "Low-Resolution", "By-Tube"]
         self.declareProperty("GroupDetectors", "None",
                              StringListValidator(grouping_type),
                              "Switch for grouping detectors")
-
         self.declareProperty("NormalizeToFirst", False, "Normalize spectra to intensity of spectrum with lowest Q?")
+
+        # Properties affected by the reflection selected
+        titleReflection = "Reflection Selector"
+        available_reflections = reflections_dict.keys()
+        available_reflections.sort()  # preserve order in which they are presented
+        default_reflection = reflections_dict["silicon111"]
+        self.declareProperty("ReflectionType", default_reflection["name"],
+                             StringListValidator(available_reflections),
+                             "Analyzer. Documentation lists typical associated property values.")
+        self.setPropertyGroup("ReflectionType", titleReflection)
+        self.declareProperty(FloatArrayProperty("EnergyBins",
+                                                default_reflection["energy_bins"],
+                                                direction=Direction.Input),
+                              "Energy transfer binning scheme (in ueV)")
+        self.setPropertyGroup("EnergyBins", titleReflection)
+        self.declareProperty(FloatArrayProperty("MomentumTransferBins",
+                                                default_reflection["q_bins"],
+                                                direction=Direction.Input),
+                             "Momentum transfer binning scheme")
+        self.setPropertyGroup("MomentumTransferBins", titleReflection)
+        self.declareProperty(FileProperty(name="MaskFile",
+                                          defaultValue=pjoin(DEFAULT_MASK_GROUP_DIR,
+                                                             default_reflection["mask_file"]),
+                                          action=FileAction.OptionalLoad, extensions=['.xml']),
+                             "See documentation for latest mask files.")
+        self.setPropertyGroup("MaskFile", titleReflection)
 
         # Properties setting the division by vanadium
         titleDivideByVanadium = "Normalization by Vanadium"
@@ -103,7 +134,7 @@ class BASISReduction(PythonAlgorithm):
         self.declareProperty("NormRunNumbers", "", "Normalization run numbers")
         self.setPropertySettings("NormRunNumbers", ifDivideByVanadium)
         self.setPropertyGroup("NormRunNumbers", titleDivideByVanadium)
-
+        arrVal = FloatArrayLengthValidator(2)
         self.declareProperty(FloatArrayProperty("NormWavelengthRange", DEFAULT_RANGE,
                                                 arrVal, direction=Direction.Input),
                              "Wavelength range for normalization")
@@ -113,9 +144,12 @@ class BASISReduction(PythonAlgorithm):
     def PyExec(self):
         config['default.facility'] = "SNS"
         config['default.instrument'] = self._long_inst
+        self._reflection = reflections_dict[self.getProperty("ReflectionType").value]
         self._doIndiv = self.getProperty("DoIndividual").value
-        self._etBins = self.getProperty("EnergyBins").value / MICROEV_TO_MILLIEV
+        self._etBins = 1.E-03 * self.getProperty("EnergyBins").value  # micro-eV to mili-eV
         self._qBins = self.getProperty("MomentumTransferBins").value
+        self._qBins[0] -= self._qBins[1]/2.0  # self._qBins[0] is leftmost bin boundary
+        self._qBins[2] += self._qBins[1]/2.0  # self._qBins[2] is rightmost bin boundary
         self._noMonNorm = self.getProperty("NoMonitorNorm").value
         self._maskFile = self.getProperty("MaskFile").value
         self._groupDetOpt = self.getProperty("GroupDetectors").value
@@ -126,11 +160,11 @@ class BASISReduction(PythonAlgorithm):
         if datasearch != "On":
             config["datasearch.searcharchive"] = "On"
 
-        # Handle masking file override if necessary
+        # Apply default mask if not supplied by user
         self._overrideMask = bool(self._maskFile)
         if not self._overrideMask:
             config.appendDataSearchDir(DEFAULT_MASK_GROUP_DIR)
-            self._maskFile = DEFAULT_MASK_FILE
+            self._maskFile = self._reflection["mask_file"]
 
         api.LoadMask(Instrument='BASIS', OutputWorkspace='BASIS_MASK',
                      InputFile=self._maskFile)
@@ -263,10 +297,16 @@ class BASISReduction(PythonAlgorithm):
             ws_name = self._makeRunName(run)
             if extra_ext is not None:
                 ws_name += extra_ext
-            mon_ws_name = ws_name  + "_monitors"
+            mon_ws_name = ws_name + "_monitors"
             run_file = self._makeRunFile(run)
 
-            api.Load(Filename=run_file, OutputWorkspace=ws_name)
+            # Faster loading for the 311 reflection
+            if self._reflection["name"] == "silicon311":
+                kwargs = {"BankName": "bank2"}  # 311 analyzers only in bank2
+            else:
+                kwargs = {}
+            api.LoadEventNexus(Filename=run_file, OutputWorkspace=ws_name, **kwargs)
+
             if not self._noMonNorm:
                 api.LoadNexusMonitors(Filename=run_file,
                                       OutputWorkspace=mon_ws_name)
@@ -287,7 +327,8 @@ class BASISReduction(PythonAlgorithm):
         api.ModeratorTzeroLinear(InputWorkspace=sam_ws,\
                            OutputWorkspace=sam_ws)
         api.LoadParameterFile(Workspace=sam_ws,
-                              Filename=config.getInstrumentDirectory() + 'BASIS_silicon_111_Parameters.xml')
+                              Filename=pjoin(DEFAULT_CONFIG_DIR,
+                                             self._reflection["parameter_file"]))
         api.ConvertUnits(InputWorkspace=sam_ws,
                          OutputWorkspace=sam_ws,
                          Target='Wavelength', EMode='Indirect')
@@ -360,7 +401,7 @@ class BASISReduction(PythonAlgorithm):
         api.SofQW3(InputWorkspace=wsName,
                    OutputWorkspace=wsSqwName,
                    QAxisBinning=self._qBins, EMode='Indirect',
-                   EFixed='2.0826')
+                   EFixed=self._reflection["default_energy"])
         return wsSqwName
 
     def _ScaleY(self, wsName):

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -12,7 +12,7 @@ DEFAULT_VANADIUM_BINS = [-0.0034, 0.068, 0.0034]  # meV
 DEFAULT_CONFIG_DIR = config["instrumentDefinition.directory"]
 
 # BASIS allows two possible reflections, with associated default properties
-reflections_dict = {"silicon111": {"name": "silicon111",
+REFLECTIONS_DICT = {"silicon111": {"name": "silicon111",
                                    "energy_bins": [-150, 0.4, 500],  # micro-eV
                                    "q_bins": [0.3, 0.2, 1.9],  # inverse Angstroms
                                    "mask_file": "BASIS_Mask_ThreeQuartersRemain_SouthTop_NorthTop_NorthBottom_MorePixelsEliminated_08122015.xml",
@@ -92,9 +92,9 @@ class BASISReduction(PythonAlgorithm):
 
         # Properties affected by the reflection selected
         titleReflection = "Reflection Selector"
-        available_reflections = reflections_dict.keys()
+        available_reflections = REFLECTIONS_DICT.keys()
         available_reflections.sort()  # preserve order in which they are presented
-        default_reflection = reflections_dict["silicon111"]
+        default_reflection = REFLECTIONS_DICT["silicon111"]
         self.declareProperty("ReflectionType", default_reflection["name"],
                              StringListValidator(available_reflections),
                              "Analyzer. Documentation lists typical associated property values.")
@@ -102,7 +102,7 @@ class BASISReduction(PythonAlgorithm):
         self.declareProperty(FloatArrayProperty("EnergyBins",
                                                 default_reflection["energy_bins"],
                                                 direction=Direction.Input),
-                              "Energy transfer binning scheme (in ueV)")
+                             "Energy transfer binning scheme (in ueV)")
         self.setPropertyGroup("EnergyBins", titleReflection)
         self.declareProperty(FloatArrayProperty("MomentumTransferBins",
                                                 default_reflection["q_bins"],
@@ -144,7 +144,7 @@ class BASISReduction(PythonAlgorithm):
     def PyExec(self):
         config['default.facility'] = "SNS"
         config['default.instrument'] = self._long_inst
-        self._reflection = reflections_dict[self.getProperty("ReflectionType").value]
+        self._reflection = REFLECTIONS_DICT[self.getProperty("ReflectionType").value]
         self._doIndiv = self.getProperty("DoIndividual").value
         self._etBins = 1.E-03 * self.getProperty("EnergyBins").value  # micro-eV to mili-eV
         self._qBins = self.getProperty("MomentumTransferBins").value

--- a/docs/source/algorithms/BASISReduction-v1.rst
+++ b/docs/source/algorithms/BASISReduction-v1.rst
@@ -6,9 +6,14 @@
 
 .. properties::
 
+For each property, the algorithm will remember the last value used. If user deletes
+this value and leaves blank the property field, the default value will be used. Default
+values are typical of the silicon111 reflection.
+
 Description
 -----------
 
+**Run numbers**:
 The syntax for the run numbers designation allows runs to be segregated
 into sets. The semicolon symbol ";" is used to separate the runs into sets.
 Runs within each set are jointly reduced.
@@ -19,14 +24,47 @@ Examples:
 
 - 2144-2147,2149;2156  is set 2144-2147,2149 and set 2156. The sets are reduced separately from each other.
 
-If **DoIndividual** is checked, then each run number is reduced separately
+If *DoIndividual* is checked, then each run number is reduced separately
 from the rest. The semicolon symbol is ignored.
+
+**Momentum transfer binning scheme**: Three values are required, the
+center of the bin with the minimum momentum, the bin width, and the
+center of the bin with the maximum momentum.
 
 **Rescaling to first spectrum**: Since the Y-scale has arbitrary units, a
 rescaling convention is taken whereby the maximum of the
 first spectrum (lowest Q-value) is rescaled to 1.0. This rescaling may not
 be employed when the intent is to compare to other runs, like can substraction
 of comparison between deuterated and hydrogenated samples.
+
+Reflection Selector
+===================
+
+Currently two types of reflection are possible, associated with the two analyzers of BASIS.
+There are typical values for the properties of each reflection:
+
++------------+----------------+------------------------+
+| Reflection |  Energy bins   | Momentum transfer bins |
+|            |   (micro-eV)   |   (inverse Angstroms)  |
++============+================+========================+
+| silicon111 | -150, 0.4, 500 |      0.3, 0.2, 1.9     |
++------------+----------------+------------------------+
+| silicon311 | -740, 1.6, 740 |      0.5, 0.2, 3.7     |
++------------+----------------+------------------------+
+
+Also the following mask files are associated to each reflection:
+
++-----------+------------------------------------------------------------------------------------------------+
+|Reflection | Mask file                                                                                      |
++===========+================================================================================================+
+|silicon111 | BASIS_Mask_ThreeQuartersRemain_SouthTop_NorthTop_NorthBottom_MorePixelsEliminated_08122015.xml |
++-----------+------------------------------------------------------------------------------------------------+
+|silicon311 | BASIS_Mask_OneQuarterRemains_SouthBottom.xml                                                   |
++-----------+------------------------------------------------------------------------------------------------+
+
+These mask files can be found in the SNS filesystem
+(**/SNS/BSS/shared/autoreduce/new_masks_08_12_2015/**)
+
 
 Vanadium Normalization
 ======================

--- a/docs/source/release/v3.8.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.8.0/indirect_inelastic.rst
@@ -29,6 +29,7 @@ Improvements
 
 - :ref:`LoadVesuvio <algm-LoadVesuvio>` now uses the whole TOF range for loaded monitor data (0-20000)
 - Physical positions were included to the 311 reflection of BASIS instrument for improved instrument view.
+- Algorithm :ref:`BASISReduction311 <algm-BASISReduction311>` has been included in algorithm :ref:`BASISReduction311 <algm-BASISReduction311>`.
 - Range bars colours in the *ISIS Calibration* interface have been updated to match the convention in the fit wizard.
 
 Bugfixes

--- a/docs/source/release/v3.8.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.8.0/indirect_inelastic.rst
@@ -29,7 +29,7 @@ Improvements
 
 - :ref:`LoadVesuvio <algm-LoadVesuvio>` now uses the whole TOF range for loaded monitor data (0-20000)
 - Physical positions were included to the 311 reflection of BASIS instrument for improved instrument view.
-- Algorithm :ref:`BASISReduction311 <algm-BASISReduction311>` has been included in algorithm :ref:`BASISReduction311 <algm-BASISReduction311>`.
+- Algorithm :ref:`BASISReduction311 <algm-BASISReduction311>` has been included in algorithm :ref:`BASISReduction <algm-BASISReduction>`.
 - Range bars colours in the *ISIS Calibration* interface have been updated to match the convention in the fit wizard.
 
 Bugfixes


### PR DESCRIPTION
A pull down menu allows user to select reflection

To test:
download reference reduced data [test.zip](https://github.com/mantidproject/mantid/files/326730/test.zip) and run the below script. The script will reduce one particular run for each reflection, and compare output to the corresponding reference reduced data.The comparison is carried out by calculating and printing their Chi-square.

Fixes #16474.

[Release notes](https://github.com/mantidproject/mantid/blob/12015b81b90d945f457b393e69f5977fc73c05f2/docs/source/release/v3.8.0/indirect_inelastic.rst) have been updated

```
from mantid.simpleapi import BASISReduction, LoadDaveGrp, mtd
from os.path import join as pjoin

# CRITICAL: replace this directory with the directory where you unzipped the test.zip file
saveDir = "/projects/development/BASIS_reduction/i16474/test"
# Rest of the script should be left unchanged

# mask directory
maskDir = "/SNS/BSS/shared/autoreduce/new_masks_08_12_2015"

# Defaults for each reflection
reflections_dict = {"silicon111": {"name": "silicon111",
                                   "energy_bins": [-150, 0.4, 150],  # micro-eV
                                   "q_bins": [0.3, 0.2, 1.9],  # inverse Angstroms
                                   "mask_file": "BASIS_Mask_ThreeQuartersRemain_SouthTop_NorthTop_NorthBottom_MorePixelsEliminated_08122015.xml",
                                  },
                    "silicon311": {"name": "silicon311",
                                   "energy_bins": [-740, 1.6, 740],
                                   "q_bins": [0.5, 0.2, 3.7],
                                   "mask_file": "BASIS_Mask_OneQuarterRemains_SouthBottom.xml",
                                  },
                   }

# Reference data to compare output of algorithm BASISReduction
reference_dict  = {"silicon111": {"run": "33207",
                                   "file": pjoin(saveDir,"BASIS_33207.dat"),
                                   "outputWorkspace": "reference_33207"
                                 },
                   "silicon311": {"run": "56748",  # IPTS-15173, run 56748
                                  "file": pjoin(saveDir,"BASIS_56748.dat"),
                                  "outputWorkspace": "reference_56748"
                                 },
                  }

# Test each reflection with a fit between the output of the reduction
# and the reference data
for reflection in ("silicon111", "silicon311"):
    reference = reference_dict[reflection]
    # Load the reference data
    print reference["file"] 
    LoadDaveGrp(Filename=reference["file"],
                IsMicroEV=True,
                XAxisUnits="DeltaE",
                OutputWorkspace=reference["outputWorkspace"])

    # Reduce the events file
    property_default = reflections_dict[reflection]
    BASISReduction(RunNumbers=reference["run"],
        ReflectionType=reflection,
        EnergyBins=property_default["energy_bins"],
        MomentumTransferBins=property_default["q_bins"],
        MaskFile=pjoin(maskDir,property_default["mask_file"]))    
    # Workspace containing the output S(Q,E)
    proposed = mtd["BSS_{0}_sqw".format(reference["run"])]

    # Compare proposed to reference with a fit between the workspaces for each Q-value
    print "## Reflection ", reflection
    avChi2 = 0.0  # Chi2 averaged over all spectra (over all Q-values)
    print("#spectrum  Chi2")
    for wi in range(proposed.getNumberHistograms()):
        fStr = "name=TabulatedFunction,Workspace={0},WorkspaceIndex={1},ties=(XScaling=1)".format(proposed.name(),wi)
        Fit(fStr,
            InputWorkspace=reference["outputWorkspace"],
            WorkspaceIndex=wi,
            Output="fit")
        chi2 = mtd["fit_Parameters"].row(3)['Value']
        avChi2 += chi2
        print("{0:2d} {1:4.2f}".format(wi,chi2))

    print("Average Chi2 = {0:4.2f}".format(avChi2/proposed.getNumberHistograms()))

    # Only for instrument visualization: Some pixels have incorrect events.
    # We set those pixels to zero in the events file
    event_file = "BSS_{0}".format(reference["run"])
    ReplaceSpecialValues(InputWorkspace=event_file,
                         NANValue=0,
                         InfinityValue=0,
                         OutputWorkspace=event_file)
```

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
