### PR TITLE
 Improve NXcanSAS support

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
@@ -74,6 +74,10 @@ template <typename LocationType>
 void writeStrAttribute(LocationType &location, const std::string &name,
                        const std::string &value);
 
+template <typename NumT, typename LocationType>
+void writeNumAttribute(LocationType &location, const std::string &name,
+                       const NumT &value);
+
 MANTID_DATAHANDLING_DLL void write(H5::Group &group, const std::string &name,
                                    const std::string &value);
 
@@ -97,6 +101,10 @@ MANTID_DATAHANDLING_DLL std::string readString(H5::DataSet &dataset);
 template <typename LocationType>
 std::string readAttributeAsString(LocationType &dataset,
                                   const std::string &attributeName);
+
+template <typename NumT, typename LocationType>
+NumT readNumAttributeCoerce(LocationType &location,
+                            const std::string &attributeName);
 
 template <typename NumT>
 std::vector<NumT> readArray1DCoerce(H5::Group &group, const std::string &name);

--- a/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
@@ -85,10 +85,10 @@ void writeNumAttribute(LocationType &location, const std::string &name,
 MANTID_DATAHANDLING_DLL void write(H5::Group &group, const std::string &name,
                                    const std::string &value);
 
-MANTID_DATAHANDLING_DLL void
-writeWithStrAttributes(H5::Group &group, const std::string &name,
-                       const std::string &value,
-                       const std::map<std::string, std::string> &attributes);
+template <typename T>
+void writeScalarDataSetWithStrAttributes(
+    H5::Group &group, const std::string &name, const T &value,
+    const std::map<std::string, std::string> &attributes);
 
 template <typename NumT>
 void writeArray1D(H5::Group &group, const std::string &name,

--- a/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
@@ -61,6 +61,17 @@ MANTID_DATAHANDLING_DLL H5::Group createGroupNXS(H5::H5File &file,
 MANTID_DATAHANDLING_DLL H5::Group createGroupNXS(H5::Group &group,
                                                  const std::string &name,
                                                  const std::string &nxtype);
+
+MANTID_DATAHANDLING_DLL H5::Group createGroupCanSAS(H5::Group &group,
+                                                    const std::string &name,
+                                                    const std::string &nxtype,
+                                                    const std::string &cstype);
+
+MANTID_DATAHANDLING_DLL H5::Group createGroupCanSAS(H5::H5File &file,
+                                                    const std::string &name,
+                                                    const std::string &nxtype,
+                                                    const std::string &cstype);
+
 /**
  * Sets up the chunking and compression rate.
  * @param length

--- a/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
@@ -78,6 +78,10 @@ template <typename NumT, typename LocationType>
 void writeNumAttribute(LocationType &location, const std::string &name,
                        const NumT &value);
 
+template <typename NumT, typename LocationType>
+void writeNumAttribute(LocationType &location, const std::string &name,
+                       const std::vector<NumT> &value);
+
 MANTID_DATAHANDLING_DLL void write(H5::Group &group, const std::string &name,
                                    const std::string &value);
 

--- a/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
@@ -110,6 +110,10 @@ template <typename NumT, typename LocationType>
 NumT readNumAttributeCoerce(LocationType &location,
                             const std::string &attributeName);
 
+template <typename NumT, typename LocationType>
+std::vector<NumT> readNumArrayAttributeCoerce(LocationType &location,
+                                              const std::string &attributeName);
+
 template <typename NumT>
 std::vector<NumT> readArray1DCoerce(H5::Group &group, const std::string &name);
 

--- a/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
@@ -24,7 +24,7 @@ const std::string sasCanSASclass = "canSAS_class";
 
 // SASentry
 const std::string sasEntryClassAttr = "SASentry";
-const std::string nxEntryClassAttr = " NXentry";
+const std::string nxEntryClassAttr = "NXentry";
 const std::string sasEntryGroupName = "sasentry";
 const std::string sasEntryVersionAttr = "version";
 const std::string sasEntryVersionAttrValue = "1.0";

--- a/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
@@ -11,7 +11,7 @@ namespace NXcanSAS {
 enum class WorkspaceDimensionality { oneD, twoD, other };
 
 // NXcanSAS Tag Definitions
-const std::string sasUnitAttr = "unit";
+const std::string sasUnitAttr = "units";
 const std::string sasUncertaintyAttr = "uncertainty";
 const std::string sasSignal = "signal";
 const std::string sasSeparator = ",";
@@ -20,9 +20,11 @@ const std::string sasNone = "none";
 const std::string sasIntensity = "1/cm";
 const std::string sasMomentumTransfer = "1/A";
 const std::string sasNxclass = "NX_class";
+const std::string sasCanSASclass = "canSAS_class";
 
 // SASentry
 const std::string sasEntryClassAttr = "SASentry";
+const std::string nxEntryClassAttr = " NXentry";
 const std::string sasEntryGroupName = "sasentry";
 const std::string sasEntryVersionAttr = "version";
 const std::string sasEntryVersionAttrValue = "1.0";
@@ -34,6 +36,7 @@ const std::string sasEntryRunInLogs = "run_number";
 
 // SASdata
 const std::string sasDataClassAttr = "SASdata";
+const std::string nxDataClassAttr = "NXdata";
 const std::string sasDataGroupName = "sasdata";
 const std::string sasDataIAxesAttr = "I_axes";
 const std::string sasDataIUncertaintyAttr = "I_uncertainty";
@@ -52,23 +55,32 @@ const std::string sasDataMask = "Mask";
 
 // SASinstrument
 const std::string sasInstrumentClassAttr = "SASinstrument";
+const std::string nxInstrumentClassAttr = "NXinstrument";
 const std::string sasInstrumentGroupName = "sasinstrument";
 const std::string sasInstrumentName = "name";
 
 const std::string sasInstrumentSourceClassAttr = "SASsource";
+const std::string nxInstrumentSourceClassAttr = "NXsource";
+
 const std::string sasInstrumentSourceGroupName = "sassource";
 const std::string sasInstrumentSourceRadiation = "radiation";
 
 const std::string sasInstrumentCollimationClassAttr = "SAScollimation";
+const std::string nxInstrumentCollimationClassAttr = "NXcollimator";
+
 const std::string sasInstrumentCollimationGroupName = "sascollimation";
 
 const std::string sasInstrumentDetectorClassAttr = "SASdetector";
+const std::string nxInstrumentDetectorClassAttr = "NXdetector";
+
 const std::string sasInstrumentDetectorGroupName = "sasdetector";
 const std::string sasInstrumentDetectorName = "name";
 const std::string sasInstrumentDetectorSdd = "SDD";
 const std::string sasInstrumentDetectorSddUnitAttrValue = "m";
 
 const std::string sasInstrumentSampleClassAttr = "SASsample";
+const std::string nxInstrumentSampleClassAttr = "NXsample";
+
 const std::string sasInstrumentSampleGroupAttr = "sassample";
 const std::string sasInstrumentSampleId = "ID";
 
@@ -76,6 +88,7 @@ const std::string sasInstrumentIDF = "idf";
 
 // SASprocess
 const std::string sasProcessClassAttr = "SASprocess";
+const std::string nxProcessClassAttr = "NXprocess";
 const std::string sasProcessGroupName = "sasprocess";
 const std::string sasProcessName = "name";
 const std::string sasProcessNameValue = "Mantid_generated_NXcanSAS";
@@ -86,6 +99,7 @@ const std::string sasProcessUserFileInLogs = "UserFile";
 
 // SAStransmission_spectrum
 const std::string sasTransmissionSpectrumClassAttr = "SAStransmission_spectrum";
+const std::string nxTransmissionSpectrumClassAttr = "NXdata";
 const std::string sasTransmissionSpectrumGroupName = "sastransmission_spectrum";
 const std::string sasTransmissionSpectrumTIndices = "T_indices";
 const std::string sasTransmissionSpectrumTUncertainty = "T_uncertainty";

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSAS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSAS.h
@@ -57,6 +57,8 @@ private:
   void exec() override;
 };
 
+std::string MANTID_DATAHANDLING_DLL makeCanSASRelaxedName(const std::string &input);
+
 } // namespace DataHandling
 } // namespace Mantid
 

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSAS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSAS.h
@@ -57,7 +57,8 @@ private:
   void exec() override;
 };
 
-std::string MANTID_DATAHANDLING_DLL makeCanSASRelaxedName(const std::string &input);
+std::string MANTID_DATAHANDLING_DLL
+makeCanSASRelaxedName(const std::string &input);
 
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -19,6 +19,7 @@ namespace {
 Mantid::Kernel::Logger g_log("H5Util");
 
 const std::string NX_ATTR_CLASS("NX_class");
+const std::string CAN_SAS_ATTR_CLASS("canSAS_class");
 }
 
 // -------------------------------------------------------------------
@@ -104,6 +105,20 @@ Group createGroupNXS(Group &group, const std::string &name,
                      const std::string &nxtype) {
   auto outGroup = group.createGroup(name);
   writeStrAttribute(outGroup, NX_ATTR_CLASS, nxtype);
+  return outGroup;
+}
+
+Group createGroupCanSAS(H5File &file, const std::string &name,
+                     const std::string &nxtype, const std::string &cstype) {
+  auto outGroup = createGroupNXS(file, name, nxtype);
+  writeStrAttribute(outGroup, CAN_SAS_ATTR_CLASS, cstype);
+  return outGroup;
+}
+
+Group createGroupCanSAS(Group &group, const std::string &name,
+                     const std::string &nxtype, const std::string &cstype) {
+  auto outGroup = createGroupNXS(group, name, nxtype);
+  writeStrAttribute(outGroup, CAN_SAS_ATTR_CLASS, cstype);
   return outGroup;
 }
 

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -260,7 +260,7 @@ std::vector<NumT> readArray1DCoerce(H5::Group &group, const std::string &name) {
 namespace {
 template <typename InputNumT, typename OutputNumT>
 std::vector<OutputNumT> convertingRead(DataSet &dataset,
-                                          const DataType &dataType) {
+                                       const DataType &dataType) {
   DataSpace dataSpace = dataset.getSpace();
 
   std::vector<InputNumT> temp(dataSpace.getSelectNpoints());
@@ -280,7 +280,7 @@ std::vector<OutputNumT> convertingRead(DataSet &dataset,
 template <typename InputNumT, typename OutputNumT>
 std::vector<OutputNumT>
 convertingNumArrayAttributeRead(Attribute &attribute,
-                                   const DataType &dataType) {
+                                const DataType &dataType) {
   DataSpace dataSpace = attribute.getSpace();
 
   std::vector<InputNumT> temp(dataSpace.getSelectNpoints());
@@ -349,23 +349,19 @@ readNumArrayAttributeCoerce(LocationType &location,
     value.resize(dataSpace.getSelectNpoints());
     attribute.read(dataType, value.data());
   } else if (PredType::NATIVE_INT32 == dataType) {
-    value =
-        convertingNumArrayAttributeRead<int32_t, NumT>(attribute, dataType);
+    value = convertingNumArrayAttributeRead<int32_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_UINT32 == dataType) {
     value =
         convertingNumArrayAttributeRead<uint32_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_INT64 == dataType) {
-    value =
-        convertingNumArrayAttributeRead<int64_t, NumT>(attribute, dataType);
+    value = convertingNumArrayAttributeRead<int64_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_UINT64 == dataType) {
     value =
         convertingNumArrayAttributeRead<uint64_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_FLOAT == dataType) {
-    value =
-        convertingNumArrayAttributeRead<float, NumT>(attribute, dataType);
+    value = convertingNumArrayAttributeRead<float, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_DOUBLE == dataType) {
-    value =
-        convertingNumArrayAttributeRead<double, NumT>(attribute, dataType);
+    value = convertingNumArrayAttributeRead<double, NumT>(attribute, dataType);
   } else {
     // not a supported type
     throw DataTypeIException();

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -117,11 +117,24 @@ void writeNumAttribute(LocationType &location, const std::string &name,
   DataSpace attrSpace(H5S_SCALAR);
 
   auto attribute = location.createAttribute(name, attrType, attrSpace);
-
   // Wrap the data set in an array
   std::array<NumT, 1> valueArray = {value};
   attribute.write(attrType, valueArray.data());
+
 }
+
+template <typename NumT, typename LocationType>
+void writeNumAttribute(LocationType &location, const std::string &name,
+                    const std::vector<NumT> &value) {
+  static_assert(std::is_integral<NumT>::value || std::is_floating_point<NumT>::value,
+                "The writeNumAttribute function only accepts integral of floating point values.");
+  auto attrType = getType<NumT>();
+  DataSpace attrSpace = getDataSpace(value);
+
+  auto attribute = location.createAttribute(name, attrType, attrSpace);
+  attribute.write(attrType, value.data());
+}
+
 
 void write(Group &group, const std::string &name, const std::string &value) {
   writeScalarStrDataSet(group, name, value);
@@ -189,6 +202,7 @@ std::string readAttributeAsString(LocationType &location,
   attribute.read(attribute.getDataType(), value);
   return value;
 }
+
 
 template <typename NumT>
 std::vector<NumT> readArray1DCoerce(H5::Group &group, const std::string &name) {
@@ -347,6 +361,45 @@ writeNumAttribute(H5::Group &location, const std::string &name,
 template MANTID_DATAHANDLING_DLL void
 writeNumAttribute(H5::DataSet &location, const std::string &name,
                   const uint64_t &value);
+
+
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::Group &location, const std::string &name,
+                  const std::vector<float> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::DataSet &location, const std::string &name,
+                  const std::vector<float> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::Group &location, const std::string &name,
+                  const std::vector<double> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::DataSet &location, const std::string &name,
+                  const std::vector<double> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::Group &location, const std::string &name,
+                  const std::vector<int32_t> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::DataSet &location, const std::string &name,
+                  const std::vector<int32_t> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::Group &location, const std::string &name,
+                  const std::vector<uint32_t> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::DataSet &location, const std::string &name,
+                  const std::vector<uint32_t> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::Group &location, const std::string &name,
+                  const std::vector<int64_t> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::DataSet &location, const std::string &name,
+                  const std::vector<int64_t> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::Group &location, const std::string &name,
+                  const std::vector<uint64_t> &value);
+template MANTID_DATAHANDLING_DLL void
+writeNumAttribute(H5::DataSet &location, const std::string &name,
+                  const std::vector<uint64_t> &value);
+
 // -------------------------------------------------------------------
 // instantiations for readAttributeAsString
 // -------------------------------------------------------------------

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -63,11 +63,13 @@ template <typename NumT> DataSpace getDataSpace(const std::vector<NumT> &data) {
 
 namespace {
 
-template<typename NumT>
+template <typename NumT>
 H5::DataSet writeScalarDataSet(Group &group, const std::string &name,
-                                  const NumT &value) {
-  static_assert(std::is_integral<NumT>::value || std::is_floating_point<NumT>::value,
-                "The writeNumAttribute function only accepts integral of floating point values.");
+                               const NumT &value) {
+  static_assert(std::is_integral<NumT>::value ||
+                    std::is_floating_point<NumT>::value,
+                "The writeNumAttribute function only accepts integral of "
+                "floating point values.");
   auto dataType = getType<NumT>();
   DataSpace dataSpace = getDataSpace(1);
   H5::DataSet data = group.createDataSet(name, dataType, dataSpace);
@@ -75,9 +77,10 @@ H5::DataSet writeScalarDataSet(Group &group, const std::string &name,
   return data;
 }
 
-template<>
-H5::DataSet writeScalarDataSet<std::string>(Group &group, const std::string &name,
-                                  const std::string &value) {
+template <>
+H5::DataSet writeScalarDataSet<std::string>(Group &group,
+                                            const std::string &name,
+                                            const std::string &value) {
   StrType dataType(0, value.length() + 1);
   DataSpace dataSpace = getDataSpace(1);
   H5::DataSet data = group.createDataSet(name, dataType, dataSpace);
@@ -85,10 +88,7 @@ H5::DataSet writeScalarDataSet<std::string>(Group &group, const std::string &nam
   return data;
 }
 
-
-
 } // anonymous
-
 
 // -------------------------------------------------------------------
 // write methods
@@ -109,14 +109,14 @@ Group createGroupNXS(Group &group, const std::string &name,
 }
 
 Group createGroupCanSAS(H5File &file, const std::string &name,
-                     const std::string &nxtype, const std::string &cstype) {
+                        const std::string &nxtype, const std::string &cstype) {
   auto outGroup = createGroupNXS(file, name, nxtype);
   writeStrAttribute(outGroup, CAN_SAS_ATTR_CLASS, cstype);
   return outGroup;
 }
 
 Group createGroupCanSAS(Group &group, const std::string &name,
-                     const std::string &nxtype, const std::string &cstype) {
+                        const std::string &nxtype, const std::string &cstype) {
   auto outGroup = createGroupNXS(group, name, nxtype);
   writeStrAttribute(outGroup, CAN_SAS_ATTR_CLASS, cstype);
   return outGroup;
@@ -142,9 +142,11 @@ void writeStrAttribute(LocationType &location, const std::string &name,
 
 template <typename NumT, typename LocationType>
 void writeNumAttribute(LocationType &location, const std::string &name,
-                    const NumT &value) {
-  static_assert(std::is_integral<NumT>::value || std::is_floating_point<NumT>::value,
-                "The writeNumAttribute function only accepts integral of floating point values.");
+                       const NumT &value) {
+  static_assert(std::is_integral<NumT>::value ||
+                    std::is_floating_point<NumT>::value,
+                "The writeNumAttribute function only accepts integral of "
+                "floating point values.");
   auto attrType = getType<NumT>();
   DataSpace attrSpace(H5S_SCALAR);
 
@@ -152,14 +154,15 @@ void writeNumAttribute(LocationType &location, const std::string &name,
   // Wrap the data set in an array
   std::array<NumT, 1> valueArray = {value};
   attribute.write(attrType, valueArray.data());
-
 }
 
 template <typename NumT, typename LocationType>
 void writeNumAttribute(LocationType &location, const std::string &name,
-                    const std::vector<NumT> &value) {
-  static_assert(std::is_integral<NumT>::value || std::is_floating_point<NumT>::value,
-                "The writeNumAttribute function only accepts integral of floating point values.");
+                       const std::vector<NumT> &value) {
+  static_assert(std::is_integral<NumT>::value ||
+                    std::is_floating_point<NumT>::value,
+                "The writeNumAttribute function only accepts integral of "
+                "floating point values.");
   auto attrType = getType<NumT>();
   DataSpace attrSpace = getDataSpace(value);
 
@@ -167,12 +170,11 @@ void writeNumAttribute(LocationType &location, const std::string &name,
   attribute.write(attrType, value.data());
 }
 
-
 void write(Group &group, const std::string &name, const std::string &value) {
   writeScalarDataSet(group, name, value);
 }
 
-template<typename T>
+template <typename T>
 void writeScalarDataSetWithStrAttributes(
     H5::Group &group, const std::string &name, const T &value,
     const std::map<std::string, std::string> &attributes) {
@@ -181,7 +183,6 @@ void writeScalarDataSetWithStrAttributes(
     writeStrAttribute(data, attribute.first, attribute.second);
   }
 }
-
 
 template <typename NumT>
 void writeArray1D(Group &group, const std::string &name,
@@ -237,7 +238,6 @@ std::string readAttributeAsString(LocationType &location,
   return value;
 }
 
-
 template <typename NumT>
 std::vector<NumT> readArray1DCoerce(H5::Group &group, const std::string &name) {
   std::vector<NumT> result;
@@ -278,8 +278,9 @@ std::vector<OutputNumT> convertingingRead(DataSet &dataset,
 }
 
 template <typename InputNumT, typename OutputNumT>
-std::vector<OutputNumT> convertingingNumArrayAttributeRead(Attribute &attribute,
-                                          const DataType &dataType) {
+std::vector<OutputNumT>
+convertingingNumArrayAttributeRead(Attribute &attribute,
+                                   const DataType &dataType) {
   DataSpace dataSpace = attribute.getSpace();
 
   std::vector<InputNumT> temp(dataSpace.getSelectNpoints());
@@ -288,17 +289,15 @@ std::vector<OutputNumT> convertingingNumArrayAttributeRead(Attribute &attribute,
   std::vector<OutputNumT> result;
   result.resize(temp.size());
 
-  std::transform(temp.begin(), temp.end(), result.begin(),
-                 [](const InputNumT a) {
-                   return boost::numeric_cast<OutputNumT>(a);
-                 });
+  std::transform(
+      temp.begin(), temp.end(), result.begin(),
+      [](const InputNumT a) { return boost::numeric_cast<OutputNumT>(a); });
 
   return result;
 }
 
 template <typename InputNumT, typename OutputNumT>
-OutputNumT convertingingRead(Attribute &attribute,
-                                          const DataType &dataType) {
+OutputNumT convertingingRead(Attribute &attribute, const DataType &dataType) {
   InputNumT temp;
   attribute.read(dataType, &temp);
   OutputNumT result = boost::numeric_cast<OutputNumT>(temp);
@@ -307,59 +306,66 @@ OutputNumT convertingingRead(Attribute &attribute,
 
 } // anonymous
 
-template < typename NumT, typename LocationType>
+template <typename NumT, typename LocationType>
 NumT readNumAttributeCoerce(LocationType &location,
-                            const std::string &attributeName){
-    auto attribute = location.openAttribute(attributeName);
-    auto dataType = attribute.getDataType();
+                            const std::string &attributeName) {
+  auto attribute = location.openAttribute(attributeName);
+  auto dataType = attribute.getDataType();
 
-    NumT value;
+  NumT value;
 
-    if (getType<NumT>() == dataType) {
-        attribute.read(dataType, &value);
-    } else if (PredType::NATIVE_INT32 == dataType) {
-        value = convertingingRead<int32_t, NumT>(attribute, dataType);
-    } else if (PredType::NATIVE_UINT32 == dataType) {
-        value = convertingingRead<uint32_t, NumT>(attribute, dataType);
-    } else if (PredType::NATIVE_INT64 == dataType) {
-        value = convertingingRead<int64_t, NumT>(attribute, dataType);
-    } else if (PredType::NATIVE_UINT64 == dataType) {
-        value = convertingingRead<uint64_t, NumT>(attribute, dataType);
-    } else if (PredType::NATIVE_FLOAT == dataType) {
-        value = convertingingRead<float, NumT>(attribute, dataType);
-    } else if (PredType::NATIVE_DOUBLE == dataType) {
-        value = convertingingRead<double, NumT>(attribute, dataType);
-    }
+  if (getType<NumT>() == dataType) {
+    attribute.read(dataType, &value);
+  } else if (PredType::NATIVE_INT32 == dataType) {
+    value = convertingingRead<int32_t, NumT>(attribute, dataType);
+  } else if (PredType::NATIVE_UINT32 == dataType) {
+    value = convertingingRead<uint32_t, NumT>(attribute, dataType);
+  } else if (PredType::NATIVE_INT64 == dataType) {
+    value = convertingingRead<int64_t, NumT>(attribute, dataType);
+  } else if (PredType::NATIVE_UINT64 == dataType) {
+    value = convertingingRead<uint64_t, NumT>(attribute, dataType);
+  } else if (PredType::NATIVE_FLOAT == dataType) {
+    value = convertingingRead<float, NumT>(attribute, dataType);
+  } else if (PredType::NATIVE_DOUBLE == dataType) {
+    value = convertingingRead<double, NumT>(attribute, dataType);
+  }
 
-    return value;
+  return value;
 }
 
-template < typename NumT, typename LocationType>
-std::vector<NumT> readNumArrayAttributeCoerce(LocationType &location,
-                            const std::string &attributeName){
-    auto attribute = location.openAttribute(attributeName);
-    auto dataType = attribute.getDataType();
+template <typename NumT, typename LocationType>
+std::vector<NumT>
+readNumArrayAttributeCoerce(LocationType &location,
+                            const std::string &attributeName) {
+  auto attribute = location.openAttribute(attributeName);
+  auto dataType = attribute.getDataType();
 
-    std::vector<NumT> value;
+  std::vector<NumT> value;
 
-    if (getType<NumT>() == dataType) {
-        DataSpace dataSpace = attribute.getSpace();
-        value.resize(dataSpace.getSelectNpoints());
-        attribute.read(dataType, value.data());
-    } else if (PredType::NATIVE_INT32 == dataType) {
-        value = convertingingNumArrayAttributeRead<int32_t, NumT>(attribute, dataType);
-    } else if (PredType::NATIVE_UINT32 == dataType) {
-        value = convertingingNumArrayAttributeRead<uint32_t, NumT>(attribute, dataType);
-    } else if (PredType::NATIVE_INT64 == dataType) {
-        value = convertingingNumArrayAttributeRead<int64_t, NumT>(attribute, dataType);
-    } else if (PredType::NATIVE_UINT64 == dataType) {
-        value = convertingingNumArrayAttributeRead<uint64_t, NumT>(attribute, dataType);
-    } else if (PredType::NATIVE_FLOAT == dataType) {
-        value = convertingingNumArrayAttributeRead<float, NumT>(attribute, dataType);
-    } else if (PredType::NATIVE_DOUBLE == dataType) {
-        value = convertingingNumArrayAttributeRead<double, NumT>(attribute, dataType);
-    }
-    return value;
+  if (getType<NumT>() == dataType) {
+    DataSpace dataSpace = attribute.getSpace();
+    value.resize(dataSpace.getSelectNpoints());
+    attribute.read(dataType, value.data());
+  } else if (PredType::NATIVE_INT32 == dataType) {
+    value =
+        convertingingNumArrayAttributeRead<int32_t, NumT>(attribute, dataType);
+  } else if (PredType::NATIVE_UINT32 == dataType) {
+    value =
+        convertingingNumArrayAttributeRead<uint32_t, NumT>(attribute, dataType);
+  } else if (PredType::NATIVE_INT64 == dataType) {
+    value =
+        convertingingNumArrayAttributeRead<int64_t, NumT>(attribute, dataType);
+  } else if (PredType::NATIVE_UINT64 == dataType) {
+    value =
+        convertingingNumArrayAttributeRead<uint64_t, NumT>(attribute, dataType);
+  } else if (PredType::NATIVE_FLOAT == dataType) {
+    value =
+        convertingingNumArrayAttributeRead<float, NumT>(attribute, dataType);
+  } else if (PredType::NATIVE_DOUBLE == dataType) {
+    value =
+        convertingingNumArrayAttributeRead<double, NumT>(attribute, dataType);
+  }
+  return value;
 }
 
 template <typename NumT> std::vector<NumT> readArray1DCoerce(DataSet &dataset) {
@@ -406,43 +412,42 @@ writeStrAttribute(H5::DataSet &location, const std::string &name,
 // instantiations for writeNumAttribute
 // -------------------------------------------------------------------
 
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::Group &location, const std::string &name,
-                  const float &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::DataSet &location, const std::string &name,
-                  const float &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::Group &location, const std::string &name,
-                  const double &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::DataSet &location, const std::string &name,
-                  const double &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::Group &location, const std::string &name,
-                  const int32_t &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::DataSet &location, const std::string &name,
-                  const int32_t &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::Group &location, const std::string &name,
-                  const uint32_t &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::DataSet &location, const std::string &name,
-                  const uint32_t &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::Group &location, const std::string &name,
-                  const int64_t &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::DataSet &location, const std::string &name,
-                  const int64_t &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::Group &location, const std::string &name,
-                  const uint64_t &value);
-template MANTID_DATAHANDLING_DLL void
-writeNumAttribute(H5::DataSet &location, const std::string &name,
-                  const uint64_t &value);
-
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::Group &location,
+                                                        const std::string &name,
+                                                        const float &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::DataSet &location,
+                                                        const std::string &name,
+                                                        const float &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::Group &location,
+                                                        const std::string &name,
+                                                        const double &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::DataSet &location,
+                                                        const std::string &name,
+                                                        const double &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::Group &location,
+                                                        const std::string &name,
+                                                        const int32_t &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::DataSet &location,
+                                                        const std::string &name,
+                                                        const int32_t &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::Group &location,
+                                                        const std::string &name,
+                                                        const uint32_t &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::DataSet &location,
+                                                        const std::string &name,
+                                                        const uint32_t &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::Group &location,
+                                                        const std::string &name,
+                                                        const int64_t &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::DataSet &location,
+                                                        const std::string &name,
+                                                        const int64_t &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::Group &location,
+                                                        const std::string &name,
+                                                        const uint64_t &value);
+template MANTID_DATAHANDLING_DLL void writeNumAttribute(H5::DataSet &location,
+                                                        const std::string &name,
+                                                        const uint64_t &value);
 
 template MANTID_DATAHANDLING_DLL void
 writeNumAttribute(H5::Group &location, const std::string &name,
@@ -490,7 +495,6 @@ readAttributeAsString(H5::Group &location, const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::string
 readAttributeAsString(H5::DataSet &location, const std::string &attributeName);
 
-
 // -------------------------------------------------------------------
 // instantiations for readNumAttributeCoerce
 // -------------------------------------------------------------------
@@ -523,29 +527,41 @@ readNumAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
 // instantiations for readNumArrayAttributeCoerce
 // -------------------------------------------------------------------
 template MANTID_DATAHANDLING_DLL std::vector<float>
-readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::Group &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<float>
-readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::DataSet &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<double>
-readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::Group &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<double>
-readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::DataSet &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<int32_t>
-readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::Group &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<int32_t>
-readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::DataSet &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<uint32_t>
-readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::Group &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<uint32_t>
-readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::DataSet &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<int64_t>
-readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::Group &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<int64_t>
-readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::DataSet &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<uint64_t>
-readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::Group &location,
+                            const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL std::vector<uint64_t>
-readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+readNumArrayAttributeCoerce(H5::DataSet &location,
+                            const std::string &attributeName);
 
 // -------------------------------------------------------------------
 // instantiations for writeArray1D
@@ -568,7 +584,6 @@ writeArray1D(H5::Group &group, const std::string &name,
 template MANTID_DATAHANDLING_DLL void
 writeArray1D(H5::Group &group, const std::string &name,
              const std::vector<uint64_t> &values);
-
 
 // -------------------------------------------------------------------
 // Instantiations for writeScalarWithStrAttributes
@@ -594,7 +609,6 @@ template MANTID_DATAHANDLING_DLL void writeScalarDataSetWithStrAttributes(
 template MANTID_DATAHANDLING_DLL void writeScalarDataSetWithStrAttributes(
     H5::Group &group, const std::string &name, const uint64_t &value,
     const std::map<std::string, std::string> &attributes);
-
 
 // -------------------------------------------------------------------
 // instantiations for getDataSpace

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -145,7 +145,7 @@ void writeNumAttribute(LocationType &location, const std::string &name,
                        const NumT &value) {
   static_assert(std::is_integral<NumT>::value ||
                     std::is_floating_point<NumT>::value,
-                "The writeNumAttribute function only accepts integral of "
+                "The writeNumAttribute function only accepts integral or "
                 "floating point values.");
   auto attrType = getType<NumT>();
   DataSpace attrSpace(H5S_SCALAR);
@@ -259,7 +259,7 @@ std::vector<NumT> readArray1DCoerce(H5::Group &group, const std::string &name) {
 
 namespace {
 template <typename InputNumT, typename OutputNumT>
-std::vector<OutputNumT> convertingingRead(DataSet &dataset,
+std::vector<OutputNumT> convertingRead(DataSet &dataset,
                                           const DataType &dataType) {
   DataSpace dataSpace = dataset.getSpace();
 
@@ -279,7 +279,7 @@ std::vector<OutputNumT> convertingingRead(DataSet &dataset,
 
 template <typename InputNumT, typename OutputNumT>
 std::vector<OutputNumT>
-convertingingNumArrayAttributeRead(Attribute &attribute,
+convertingNumArrayAttributeRead(Attribute &attribute,
                                    const DataType &dataType) {
   DataSpace dataSpace = attribute.getSpace();
 
@@ -297,7 +297,7 @@ convertingingNumArrayAttributeRead(Attribute &attribute,
 }
 
 template <typename InputNumT, typename OutputNumT>
-OutputNumT convertingingRead(Attribute &attribute, const DataType &dataType) {
+OutputNumT convertingRead(Attribute &attribute, const DataType &dataType) {
   InputNumT temp;
   attribute.read(dataType, &temp);
   OutputNumT result = boost::numeric_cast<OutputNumT>(temp);
@@ -317,17 +317,17 @@ NumT readNumAttributeCoerce(LocationType &location,
   if (getType<NumT>() == dataType) {
     attribute.read(dataType, &value);
   } else if (PredType::NATIVE_INT32 == dataType) {
-    value = convertingingRead<int32_t, NumT>(attribute, dataType);
+    value = convertingRead<int32_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_UINT32 == dataType) {
-    value = convertingingRead<uint32_t, NumT>(attribute, dataType);
+    value = convertingRead<uint32_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_INT64 == dataType) {
-    value = convertingingRead<int64_t, NumT>(attribute, dataType);
+    value = convertingRead<int64_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_UINT64 == dataType) {
-    value = convertingingRead<uint64_t, NumT>(attribute, dataType);
+    value = convertingRead<uint64_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_FLOAT == dataType) {
-    value = convertingingRead<float, NumT>(attribute, dataType);
+    value = convertingRead<float, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_DOUBLE == dataType) {
-    value = convertingingRead<double, NumT>(attribute, dataType);
+    value = convertingRead<double, NumT>(attribute, dataType);
   } else {
     // not a supported type
     throw DataTypeIException();
@@ -350,22 +350,22 @@ readNumArrayAttributeCoerce(LocationType &location,
     attribute.read(dataType, value.data());
   } else if (PredType::NATIVE_INT32 == dataType) {
     value =
-        convertingingNumArrayAttributeRead<int32_t, NumT>(attribute, dataType);
+        convertingNumArrayAttributeRead<int32_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_UINT32 == dataType) {
     value =
-        convertingingNumArrayAttributeRead<uint32_t, NumT>(attribute, dataType);
+        convertingNumArrayAttributeRead<uint32_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_INT64 == dataType) {
     value =
-        convertingingNumArrayAttributeRead<int64_t, NumT>(attribute, dataType);
+        convertingNumArrayAttributeRead<int64_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_UINT64 == dataType) {
     value =
-        convertingingNumArrayAttributeRead<uint64_t, NumT>(attribute, dataType);
+        convertingNumArrayAttributeRead<uint64_t, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_FLOAT == dataType) {
     value =
-        convertingingNumArrayAttributeRead<float, NumT>(attribute, dataType);
+        convertingNumArrayAttributeRead<float, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_DOUBLE == dataType) {
     value =
-        convertingingNumArrayAttributeRead<double, NumT>(attribute, dataType);
+        convertingNumArrayAttributeRead<double, NumT>(attribute, dataType);
   } else {
     // not a supported type
     throw DataTypeIException();
@@ -385,17 +385,17 @@ template <typename NumT> std::vector<NumT> readArray1DCoerce(DataSet &dataset) {
   }
 
   if (PredType::NATIVE_INT32 == dataType) {
-    return convertingingRead<int32_t, NumT>(dataset, dataType);
+    return convertingRead<int32_t, NumT>(dataset, dataType);
   } else if (PredType::NATIVE_UINT32 == dataType) {
-    return convertingingRead<uint32_t, NumT>(dataset, dataType);
+    return convertingRead<uint32_t, NumT>(dataset, dataType);
   } else if (PredType::NATIVE_INT64 == dataType) {
-    return convertingingRead<int64_t, NumT>(dataset, dataType);
+    return convertingRead<int64_t, NumT>(dataset, dataType);
   } else if (PredType::NATIVE_UINT64 == dataType) {
-    return convertingingRead<uint64_t, NumT>(dataset, dataType);
+    return convertingRead<uint64_t, NumT>(dataset, dataType);
   } else if (PredType::NATIVE_FLOAT == dataType) {
-    return convertingingRead<float, NumT>(dataset, dataType);
+    return convertingRead<float, NumT>(dataset, dataType);
   } else if (PredType::NATIVE_DOUBLE == dataType) {
-    return convertingingRead<double, NumT>(dataset, dataType);
+    return convertingRead<double, NumT>(dataset, dataType);
   }
 
   // not a supported type

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -29,8 +29,6 @@ H5::DataSet writeScalarStrDataSet(Group &group, const std::string &name,
   return data;
 }
 
-
-
 } // anonymous
 
 // -------------------------------------------------------------------
@@ -244,6 +242,25 @@ std::vector<OutputNumT> convertingingRead(DataSet &dataset,
 }
 
 template <typename InputNumT, typename OutputNumT>
+std::vector<OutputNumT> convertingingNumArrayAttributeRead(Attribute &attribute,
+                                          const DataType &dataType) {
+  DataSpace dataSpace = attribute.getSpace();
+
+  std::vector<InputNumT> temp(dataSpace.getSelectNpoints());
+  attribute.read(dataType, temp.data());
+
+  std::vector<OutputNumT> result;
+  result.resize(temp.size());
+
+  std::transform(temp.begin(), temp.end(), result.begin(),
+                 [](const InputNumT a) {
+                   return boost::numeric_cast<OutputNumT>(a);
+                 });
+
+  return result;
+}
+
+template <typename InputNumT, typename OutputNumT>
 OutputNumT convertingingRead(Attribute &attribute,
                                           const DataType &dataType) {
   InputNumT temp;
@@ -252,7 +269,6 @@ OutputNumT convertingingRead(Attribute &attribute,
   return result;
 }
 
-
 } // anonymous
 
 template < typename NumT, typename LocationType>
@@ -260,6 +276,7 @@ NumT readNumAttributeCoerce(LocationType &location,
                             const std::string &attributeName){
     auto attribute = location.openAttribute(attributeName);
     auto dataType = attribute.getDataType();
+
     NumT value;
 
     if (getType<NumT>() == dataType) {
@@ -278,6 +295,34 @@ NumT readNumAttributeCoerce(LocationType &location,
         value = convertingingRead<double, NumT>(attribute, dataType);
     }
 
+    return value;
+}
+
+template < typename NumT, typename LocationType>
+std::vector<NumT> readNumArrayAttributeCoerce(LocationType &location,
+                            const std::string &attributeName){
+    auto attribute = location.openAttribute(attributeName);
+    auto dataType = attribute.getDataType();
+
+    std::vector<NumT> value;
+
+    if (getType<NumT>() == dataType) {
+        DataSpace dataSpace = attribute.getSpace();
+        value.resize(dataSpace.getSelectNpoints());
+        attribute.read(dataType, value.data());
+    } else if (PredType::NATIVE_INT32 == dataType) {
+        value = convertingingNumArrayAttributeRead<int32_t, NumT>(attribute, dataType);
+    } else if (PredType::NATIVE_UINT32 == dataType) {
+        value = convertingingNumArrayAttributeRead<uint32_t, NumT>(attribute, dataType);
+    } else if (PredType::NATIVE_INT64 == dataType) {
+        value = convertingingNumArrayAttributeRead<int64_t, NumT>(attribute, dataType);
+    } else if (PredType::NATIVE_UINT64 == dataType) {
+        value = convertingingNumArrayAttributeRead<uint64_t, NumT>(attribute, dataType);
+    } else if (PredType::NATIVE_FLOAT == dataType) {
+        value = convertingingNumArrayAttributeRead<float, NumT>(attribute, dataType);
+    } else if (PredType::NATIVE_DOUBLE == dataType) {
+        value = convertingingNumArrayAttributeRead<double, NumT>(attribute, dataType);
+    }
     return value;
 }
 
@@ -437,6 +482,34 @@ template MANTID_DATAHANDLING_DLL uint64_t
 readNumAttributeCoerce(H5::Group &location, const std::string &attributeName);
 template MANTID_DATAHANDLING_DLL uint64_t
 readNumAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+
+// -------------------------------------------------------------------
+// instantiations for readNumArrayAttributeCoerce
+// -------------------------------------------------------------------
+template MANTID_DATAHANDLING_DLL std::vector<float>
+readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<float>
+readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<double>
+readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<double>
+readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<int32_t>
+readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<int32_t>
+readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<uint32_t>
+readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<uint32_t>
+readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<int64_t>
+readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<int64_t>
+readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<uint64_t>
+readNumArrayAttributeCoerce(H5::Group &location, const std::string &attributeName);
+template MANTID_DATAHANDLING_DLL std::vector<uint64_t>
+readNumArrayAttributeCoerce(H5::DataSet &location, const std::string &attributeName);
 
 // -------------------------------------------------------------------
 // instantiations for writeArray1D

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -152,7 +152,7 @@ void writeNumAttribute(LocationType &location, const std::string &name,
 
   auto attribute = location.createAttribute(name, attrType, attrSpace);
   // Wrap the data set in an array
-  std::array<NumT, 1> valueArray = {value};
+  std::array<NumT, 1> valueArray = {{value}};
   attribute.write(attrType, valueArray.data());
 }
 
@@ -328,8 +328,10 @@ NumT readNumAttributeCoerce(LocationType &location,
     value = convertingingRead<float, NumT>(attribute, dataType);
   } else if (PredType::NATIVE_DOUBLE == dataType) {
     value = convertingingRead<double, NumT>(attribute, dataType);
+  } else {
+    // not a supported type
+    throw DataTypeIException();
   }
-
   return value;
 }
 
@@ -364,6 +366,9 @@ readNumArrayAttributeCoerce(LocationType &location,
   } else if (PredType::NATIVE_DOUBLE == dataType) {
     value =
         convertingingNumArrayAttributeRead<double, NumT>(attribute, dataType);
+  } else {
+    // not a supported type
+    throw DataTypeIException();
   }
   return value;
 }

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -215,7 +215,8 @@ void addDetectors(H5::Group &group, Mantid::API::MatrixWorkspace_sptr workspace,
 
       std::string sasDetectorName =
           sasInstrumentDetectorGroupName + detectorName;
-      sasDetectorName = Mantid::DataHandling::makeCanSASRelaxedName(sasDetectorName);
+      sasDetectorName =
+          Mantid::DataHandling::makeCanSASRelaxedName(sasDetectorName);
 
       auto instrument = workspace->getInstrument();
       auto component = instrument->getComponentByName(detectorName);

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -35,33 +35,32 @@ namespace {
 
 enum class StoreType { Qx, Qy, I, Idev, Other };
 
-bool isCanSASCompliant(bool isStrict, const std::string &input)
-{
-    auto baseRegex = isStrict ? std::regex("[a-z_][a-z0-9_]*")
-                              : std::regex("[A-Za-z_][\\w_]*");
-    return std::regex_match(input, baseRegex);
+bool isCanSASCompliant(bool isStrict, const std::string &input) {
+  auto baseRegex = isStrict ? std::regex("[a-z_][a-z0-9_]*")
+                            : std::regex("[A-Za-z_][\\w_]*");
+  return std::regex_match(input, baseRegex);
 }
 
-void removeSpecialCharacters(std::string &input)
-{
-    std::regex toReplace("[-\\.]");
-    std::string replaceWith("_");
-    input = std::regex_replace(input, toReplace, replaceWith);
+void removeSpecialCharacters(std::string &input) {
+  std::regex toReplace("[-\\.]");
+  std::string replaceWith("_");
+  input = std::regex_replace(input, toReplace, replaceWith);
 }
 
-std::string makeCompliantName(const std::string& input, bool isStrict, std::function<void(std::string&)> captializeStrategy) {
+std::string
+makeCompliantName(const std::string &input, bool isStrict,
+                  std::function<void(std::string &)> captializeStrategy) {
   auto output = input;
   // Check if input is compliant
   if (!isCanSASCompliant(isStrict, output)) {
-      removeSpecialCharacters(output);
-      captializeStrategy(output);
-      // Check if the changes have made it compliant
-      if (!isCanSASCompliant(isStrict, output)) {
-          std::string message
-              = "SaveNXcanSAS: The input " + input
-                + "is not compliant with the NXcanSAS format.";
-          throw std::runtime_error(message);
-      }
+    removeSpecialCharacters(output);
+    captializeStrategy(output);
+    // Check if the changes have made it compliant
+    if (!isCanSASCompliant(isStrict, output)) {
+      std::string message = "SaveNXcanSAS: The input " + input +
+                            "is not compliant with the NXcanSAS format.";
+      throw std::runtime_error(message);
+    }
   }
   return output;
 }
@@ -71,13 +70,11 @@ std::string makeCompliantName(const std::string& input, bool isStrict, std::func
  * "[A-Za-z_][\w_]*"
  * For now "-" is converted to "_", "." is converted to "_", else we throw
  */
-std::string makeCanSASRelaxedName(const std::string &input)
-{
+std::string makeCanSASRelaxedName(const std::string &input) {
   bool isStrict = false;
   auto emptyCapitalizationStrategy = [](std::string &) {};
   return makeCompliantName(input, isStrict, emptyCapitalizationStrategy);
 }
-
 
 template <typename NumT>
 void writeArray1DWithStrAttributes(
@@ -226,11 +223,11 @@ void addDetectors(H5::Group &group, Mantid::API::MatrixWorkspace_sptr workspace,
         continue;
       }
 
-      std::cout << "======================" <<std::endl;
+      std::cout << "======================" << std::endl;
       std::string sasDetectorName =
           sasInstrumentDetectorGroupName + detectorName;
       sasDetectorName = makeCanSASRelaxedName(sasDetectorName);
-      std::cout << "======================" <<std::endl;
+      std::cout << "======================" << std::endl;
       std::cout << sasDetectorName;
       auto instrument = workspace->getInstrument();
       auto component = instrument->getComponentByName(detectorName);

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -133,8 +133,8 @@ H5::Group addSasEntry(H5::H5File &file,
                       const std::string &suffix) {
   using namespace Mantid::DataHandling::NXcanSAS;
   const std::string sasEntryName = sasEntryGroupName + suffix;
-  auto sasEntry = Mantid::DataHandling::H5Util::createGroupNXS(
-      file, sasEntryName, sasEntryClassAttr);
+  auto sasEntry = Mantid::DataHandling::H5Util::createGroupCanSAS(
+      file, sasEntryName, nxEntryClassAttr, sasEntryClassAttr);
 
   // Add version
   Mantid::DataHandling::H5Util::writeStrAttribute(sasEntry, sasEntryVersionAttr,
@@ -188,8 +188,8 @@ void addDetectors(H5::Group &group, Mantid::API::MatrixWorkspace_sptr workspace,
         std::map<std::string, std::string> sddAttributes;
         sddAttributes.insert(
             std::make_pair(sasUnitAttr, sasInstrumentDetectorSddUnitAttrValue));
-        auto detector = Mantid::DataHandling::H5Util::createGroupNXS(
-            group, sasDetectorName, sasInstrumentDetectorClassAttr);
+        auto detector = Mantid::DataHandling::H5Util::createGroupCanSAS(
+            group, sasDetectorName, nxInstrumentDetectorClassAttr, sasInstrumentDetectorClassAttr);
         Mantid::DataHandling::H5Util::write(detector, sasInstrumentDetectorName,
                                             detectorName);
         Mantid::DataHandling::H5Util::writeScalarDataSetWithStrAttributes(
@@ -214,8 +214,8 @@ void addInstrument(H5::Group &group,
                    const std::vector<std::string> &detectorNames) {
   // Setup instrument
   const std::string sasInstrumentNameForGroup = sasInstrumentGroupName;
-  auto instrument = Mantid::DataHandling::H5Util::createGroupNXS(
-      group, sasInstrumentNameForGroup, sasInstrumentClassAttr);
+  auto instrument = Mantid::DataHandling::H5Util::createGroupCanSAS(
+      group, sasInstrumentNameForGroup, nxInstrumentClassAttr, sasInstrumentClassAttr);
   auto instrumentName = getInstrumentName(workspace);
   Mantid::DataHandling::H5Util::write(instrument, sasInstrumentName,
                                       instrumentName);
@@ -225,8 +225,8 @@ void addInstrument(H5::Group &group,
 
   // Setup source
   const std::string sasSourceName = sasInstrumentSourceGroupName;
-  auto source = Mantid::DataHandling::H5Util::createGroupNXS(
-      instrument, sasSourceName, sasInstrumentSourceClassAttr);
+  auto source = Mantid::DataHandling::H5Util::createGroupCanSAS(
+      instrument, sasSourceName, nxInstrumentSourceClassAttr, sasInstrumentSourceClassAttr);
   Mantid::DataHandling::H5Util::write(source, sasInstrumentSourceRadiation,
                                       radiationSource);
 
@@ -255,8 +255,8 @@ std::string getDate() {
 void addProcess(H5::Group &group, Mantid::API::MatrixWorkspace_sptr workspace) {
   // Setup process
   const std::string sasProcessNameForGroup = sasProcessGroupName;
-  auto process = Mantid::DataHandling::H5Util::createGroupNXS(
-      group, sasProcessNameForGroup, sasProcessClassAttr);
+  auto process = Mantid::DataHandling::H5Util::createGroupCanSAS(
+      group, sasProcessNameForGroup,  nxProcessClassAttr, sasProcessClassAttr);
 
   // Add name
   Mantid::DataHandling::H5Util::write(process, sasProcessName,
@@ -556,8 +556,8 @@ void addData2D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
 
 void addData(H5::Group &group, Mantid::API::MatrixWorkspace_sptr workspace) {
   const std::string sasDataName = sasDataGroupName;
-  auto data = Mantid::DataHandling::H5Util::createGroupNXS(group, sasDataName,
-                                                           sasDataClassAttr);
+  auto data = Mantid::DataHandling::H5Util::createGroupCanSAS(group, sasDataName,
+                                                           nxDataClassAttr, sasDataClassAttr);
 
   auto workspaceDimensionality = getWorkspaceDimensionality(workspace);
   switch (workspaceDimensionality) {
@@ -580,8 +580,9 @@ void addTransmission(H5::Group &group,
   // Setup process
   const std::string sasTransmissionName =
       sasTransmissionSpectrumGroupName + "_" + transmissionName;
-  auto transmission = Mantid::DataHandling::H5Util::createGroupNXS(
-      group, sasTransmissionName, sasTransmissionSpectrumClassAttr);
+  auto transmission = Mantid::DataHandling::H5Util::createGroupCanSAS(
+      group, sasTransmissionName, nxTransmissionSpectrumClassAttr,
+        sasTransmissionSpectrumClassAttr);
 
   // Add attributes for @signal, @T_axes, @T_indices, @T_uncertainty, @name,
   // @timestamp

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -189,12 +189,12 @@ void addDetectors(H5::Group &group, Mantid::API::MatrixWorkspace_sptr workspace,
         sddAttributes.insert(
             std::make_pair(sasUnitAttr, sasInstrumentDetectorSddUnitAttrValue));
         auto detector = Mantid::DataHandling::H5Util::createGroupCanSAS(
-            group, sasDetectorName, nxInstrumentDetectorClassAttr, sasInstrumentDetectorClassAttr);
+            group, sasDetectorName, nxInstrumentDetectorClassAttr,
+            sasInstrumentDetectorClassAttr);
         Mantid::DataHandling::H5Util::write(detector, sasInstrumentDetectorName,
                                             detectorName);
         Mantid::DataHandling::H5Util::writeScalarDataSetWithStrAttributes(
-            detector, sasInstrumentDetectorSdd, distance,
-            sddAttributes);
+            detector, sasInstrumentDetectorSdd, distance, sddAttributes);
       }
     }
   }
@@ -215,7 +215,8 @@ void addInstrument(H5::Group &group,
   // Setup instrument
   const std::string sasInstrumentNameForGroup = sasInstrumentGroupName;
   auto instrument = Mantid::DataHandling::H5Util::createGroupCanSAS(
-      group, sasInstrumentNameForGroup, nxInstrumentClassAttr, sasInstrumentClassAttr);
+      group, sasInstrumentNameForGroup, nxInstrumentClassAttr,
+      sasInstrumentClassAttr);
   auto instrumentName = getInstrumentName(workspace);
   Mantid::DataHandling::H5Util::write(instrument, sasInstrumentName,
                                       instrumentName);
@@ -226,7 +227,8 @@ void addInstrument(H5::Group &group,
   // Setup source
   const std::string sasSourceName = sasInstrumentSourceGroupName;
   auto source = Mantid::DataHandling::H5Util::createGroupCanSAS(
-      instrument, sasSourceName, nxInstrumentSourceClassAttr, sasInstrumentSourceClassAttr);
+      instrument, sasSourceName, nxInstrumentSourceClassAttr,
+      sasInstrumentSourceClassAttr);
   Mantid::DataHandling::H5Util::write(source, sasInstrumentSourceRadiation,
                                       radiationSource);
 
@@ -241,7 +243,7 @@ std::string getDate() {
   time_t rawtime;
   time(&rawtime);
   char temp[25];
-  strftime(temp, 25,"%Y-%m-%dT%H:%M:%S", localtime(&rawtime));
+  strftime(temp, 25, "%Y-%m-%dT%H:%M:%S", localtime(&rawtime));
   std::string sasDate(temp);
   return sasDate;
 }
@@ -256,7 +258,7 @@ void addProcess(H5::Group &group, Mantid::API::MatrixWorkspace_sptr workspace) {
   // Setup process
   const std::string sasProcessNameForGroup = sasProcessGroupName;
   auto process = Mantid::DataHandling::H5Util::createGroupCanSAS(
-      group, sasProcessNameForGroup,  nxProcessClassAttr, sasProcessClassAttr);
+      group, sasProcessNameForGroup, nxProcessClassAttr, sasProcessClassAttr);
 
   // Add name
   Mantid::DataHandling::H5Util::write(process, sasProcessName,
@@ -556,8 +558,8 @@ void addData2D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
 
 void addData(H5::Group &group, Mantid::API::MatrixWorkspace_sptr workspace) {
   const std::string sasDataName = sasDataGroupName;
-  auto data = Mantid::DataHandling::H5Util::createGroupCanSAS(group, sasDataName,
-                                                           nxDataClassAttr, sasDataClassAttr);
+  auto data = Mantid::DataHandling::H5Util::createGroupCanSAS(
+      group, sasDataName, nxDataClassAttr, sasDataClassAttr);
 
   auto workspaceDimensionality = getWorkspaceDimensionality(workspace);
   switch (workspaceDimensionality) {
@@ -582,7 +584,7 @@ void addTransmission(H5::Group &group,
       sasTransmissionSpectrumGroupName + "_" + transmissionName;
   auto transmission = Mantid::DataHandling::H5Util::createGroupCanSAS(
       group, sasTransmissionName, nxTransmissionSpectrumClassAttr,
-        sasTransmissionSpectrumClassAttr);
+      sasTransmissionSpectrumClassAttr);
 
   // Add attributes for @signal, @T_axes, @T_indices, @T_uncertainty, @name,
   // @timestamp

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -303,6 +303,14 @@ std::string getIntensityUnitLabel(std::string intensityUnitLabel) {
   }
 }
 
+std::string getIntensityUnit(Mantid::API::MatrixWorkspace_sptr workspace) {
+  auto iUnit = workspace->YUnit();
+  if (iUnit.empty()) {
+    iUnit = workspace->YUnitLabel();
+  }
+  return iUnit;
+}
+
 std::string getMomentumTransferLabel(std::string momentumTransferLabel) {
   if (momentumTransferLabel == "Angstrom^-1") {
     return sasMomentumTransfer;
@@ -355,7 +363,8 @@ void addData1D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
   // Add I with units + uncertainty definition
   const auto intensity = workspace->readY(0);
   std::map<std::string, std::string> iAttributes;
-  auto iUnit = workspace->YUnit();
+  auto iUnit = getIntensityUnit(workspace);
+  iUnit = getIntensityUnitLabel(iUnit);
   iAttributes.insert(std::make_pair(sasUnitAttr, iUnit));
   iAttributes.insert(std::make_pair(sasUncertaintyAttr, sasDataIdev));
 
@@ -535,7 +544,7 @@ void addData2D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
 
   // Get 2D I data and store it
   std::map<std::string, std::string> iAttributes;
-  auto iUnit = workspace->YUnit();
+  auto iUnit = getIntensityUnit(workspace);
   iUnit = getIntensityUnitLabel(iUnit);
   iAttributes.insert(std::make_pair(sasUnitAttr, iUnit));
   iAttributes.insert(std::make_pair(sasUncertaintyAttr, sasDataIdev));

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -192,8 +192,8 @@ void addDetectors(H5::Group &group, Mantid::API::MatrixWorkspace_sptr workspace,
             group, sasDetectorName, sasInstrumentDetectorClassAttr);
         Mantid::DataHandling::H5Util::write(detector, sasInstrumentDetectorName,
                                             detectorName);
-        Mantid::DataHandling::H5Util::writeWithStrAttributes(
-            detector, sasInstrumentDetectorSdd, std::to_string(distance),
+        Mantid::DataHandling::H5Util::writeScalarDataSetWithStrAttributes(
+            detector, sasInstrumentDetectorSdd, distance,
             sddAttributes);
       }
     }

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -322,8 +322,9 @@ void addData1D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
                                                   sasDataQ);
   Mantid::DataHandling::H5Util::writeStrAttribute(data, sasDataIUncertaintyAttr,
                                                   sasDataIdev);
-  Mantid::DataHandling::H5Util::writeStrAttribute(data, sasDataQIndicesAttr,
-                                                  "0");
+  Mantid::DataHandling::H5Util::writeNumAttribute(data, sasDataQIndicesAttr,
+                                                  std::vector<int>{0});
+
   if (workspace->hasDx(0)) {
     Mantid::DataHandling::H5Util::writeStrAttribute(
         data, sasDataQUncertaintyAttr, sasDataQdev);
@@ -508,8 +509,9 @@ void addData2D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
                                                   sasDataIAxesAttr2D);
   Mantid::DataHandling::H5Util::writeStrAttribute(data, sasDataIUncertaintyAttr,
                                                   sasDataIdev);
-  Mantid::DataHandling::H5Util::writeStrAttribute(data, sasDataQIndicesAttr,
-                                                  "0,1");
+  // Write the Q Indices as Int Array
+  Mantid::DataHandling::H5Util::writeNumAttribute(data, sasDataQIndicesAttr,
+                                                  std::vector<int>{0, 1});
 
   // Store the 2D Qx data + units
   std::map<std::string, std::string> qxAttributes;

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -241,7 +241,7 @@ std::string getDate() {
   time_t rawtime;
   time(&rawtime);
   char temp[25];
-  strftime(temp, 25, "%d-%b-%Y %H:%M:%S", localtime(&rawtime));
+  strftime(temp, 25,"%Y-%m-%dT%H:%M:%S", localtime(&rawtime));
   std::string sasDate(temp);
   return sasDate;
 }

--- a/Framework/DataHandling/test/H5UtilTest.h
+++ b/Framework/DataHandling/test/H5UtilTest.h
@@ -81,8 +81,8 @@ public:
     { // write tests
       H5File file(FILENAME, H5F_ACC_EXCL);
       auto group = H5Util::createGroupNXS(file, GRP_NAME, "NXentry");
-      H5Util::writeWithStrAttributes(group, DATA_NAME, DATA_VALUE,
-                                     stringAttributesScalar);
+      H5Util::writeScalarDataSetWithStrAttributes(group, DATA_NAME, DATA_VALUE,
+                                                   stringAttributesScalar);
       auto data = group.openDataSet(DATA_NAME);
       // Add the float and int attribute
       H5Util::writeNumAttribute(data, ATTR_NAME_3, ATTR_VALUE_3);

--- a/Framework/DataHandling/test/H5UtilTest.h
+++ b/Framework/DataHandling/test/H5UtilTest.h
@@ -245,8 +245,27 @@ private:
       TSM_ASSERT_EQUALS("Should retrieve the correct attribute value",
                         attribute.second, value);
     }
-  }
 
+    for (auto &attribute : floatVectorAttributes) {
+      std::vector<float> value = H5Util::readNumArrayAttributeCoerce<float>(data, attribute.first);
+      TSM_ASSERT_EQUALS("Should retrieve the correct attribute value",
+                        attribute.second, value);
+    }
+
+    for (auto &attribute : intVectorAttributes) {
+      std::vector<int> value = H5Util::readNumArrayAttributeCoerce<int>(data, attribute.first);
+      TSM_ASSERT_EQUALS("Should retrieve the correct attribute value",
+                        attribute.second, value);
+    }
+
+    // Test that coerced read works
+    std::vector<int> expectedCoerced = {12, 34, 455};
+    for (auto &attribute : floatVectorAttributes) {
+      std::vector<int> value = H5Util::readNumArrayAttributeCoerce<int>(data, attribute.first);
+      TSM_ASSERT_EQUALS("Should retrieve the correct attribute value",
+                        expectedCoerced, value);
+    }
+  }
 };
 
 #endif /* MANTID_DATAHANDLING_H5UTILTEST_H_ */

--- a/Framework/DataHandling/test/H5UtilTest.h
+++ b/Framework/DataHandling/test/H5UtilTest.h
@@ -67,6 +67,11 @@ public:
     const std::string ATTR_NAME_4("attributeName4");
     const int ATTR_VALUE_4(7);
 
+    const std::string ATTR_NAME_5("attributeName5");
+    const std::vector<float> ATTR_VALUE_5 = {12.5f, 34.6f, 455.5f};
+    const std::string ATTR_NAME_6("attributeName6");
+    const std::vector<int> ATTR_VALUE_6 = {12, 44, 78};
+
     std::map<std::string, std::string> stringAttributesScalar{
         {ATTR_NAME_1, ATTR_VALUE_1}, {ATTR_NAME_2, ATTR_VALUE_2}};
 
@@ -79,9 +84,14 @@ public:
       H5Util::writeWithStrAttributes(group, DATA_NAME, DATA_VALUE,
                                      stringAttributesScalar);
       auto data = group.openDataSet(DATA_NAME);
-      // Add the float and string attribute
+      // Add the float and int attribute
       H5Util::writeNumAttribute(data, ATTR_NAME_3, ATTR_VALUE_3);
       H5Util::writeNumAttribute(data, ATTR_NAME_4, ATTR_VALUE_4);
+
+      // Add the float and int vector attributes
+      H5Util::writeNumAttribute(data, ATTR_NAME_5, ATTR_VALUE_5);
+      H5Util::writeNumAttribute(data, ATTR_NAME_6, ATTR_VALUE_6);
+
       file.close();
     }
 
@@ -89,9 +99,14 @@ public:
     TS_ASSERT(Poco::File(FILENAME).exists());
     std::map<std::string, float> floatAttributesScalar{{ATTR_NAME_3, ATTR_VALUE_3}};
     std::map<std::string, int> intAttributesScalar{{ATTR_NAME_4, ATTR_VALUE_4}};
+    std::map<std::string, std::vector<float>> floatVectorAttributesScalar{
+        {ATTR_NAME_5, ATTR_VALUE_5}};
+    std::map<std::string, std::vector<int>> intVectorAttributesScalar{
+        {ATTR_NAME_6, ATTR_VALUE_6}};
     do_assert_simple_string_data_set(FILENAME, GRP_NAME, DATA_NAME, DATA_VALUE,
                                      stringAttributesScalar, floatAttributesScalar,
-                                     intAttributesScalar);
+                                     intAttributesScalar, floatVectorAttributesScalar,
+                                     intVectorAttributesScalar);
 
     // cleanup
     removeFile(FILENAME);
@@ -166,7 +181,11 @@ private:
       const std::map<std::string, float> &floatAttributes =
       std::map<std::string, float>(),
       const std::map<std::string, int> &intAttributes =
-      std::map<std::string, int>()) {
+      std::map<std::string, int>(),
+      const std::map<std::string, std::vector<float>> &floatVectorAttributes =
+      std::map<std::string, std::vector<float>>(),
+      const std::map<std::string, std::vector<int>> &intVectorAttributes =
+      std::map<std::string, std::vector<int>>()) {
     TS_ASSERT(Poco::File(filename).exists());
 
     // read tests
@@ -184,21 +203,29 @@ private:
     TS_ASSERT_EQUALS(dataCheck, dataValue);
 
     // Check the attributes
-    do_test_attributes_on_data_set(data, stringAttributes, floatAttributes, intAttributes);
+    do_test_attributes_on_data_set(data, stringAttributes, floatAttributes,
+                                   intAttributes, floatVectorAttributes,
+                                   intVectorAttributes);
     file.close();
   }
 
   void do_test_attributes_on_data_set(
       H5::DataSet &data, const std::map<std::string, std::string>& stringAttributes,
       const std::map<std::string, float>& floatAttributes,
-      const std::map<std::string, int>& intAttributes) {
+      const std::map<std::string, int>& intAttributes,
+      const std::map<std::string, std::vector<float>>& floatVectorAttributes,
+      const std::map<std::string, std::vector<int>>& intVectorAttributes) {
     auto numAttributes = data.getNumAttrs();
     auto expectedNumStringAttributes = static_cast<int>(stringAttributes.size());
     auto expectedNumFloatAttributes = static_cast<int>(floatAttributes.size());
     auto expectedNumIntAttributes = static_cast<int>(intAttributes.size());
+    auto expectedNumFloatVectorAttributes = static_cast<int>(floatVectorAttributes.size());
+    auto expectedNumIntVectorAttributes = static_cast<int>(intVectorAttributes.size());
     int totalNumAttributs = expectedNumStringAttributes +
                             expectedNumFloatAttributes +
-                            expectedNumIntAttributes;
+                            expectedNumIntAttributes +
+                            expectedNumFloatVectorAttributes +
+                            expectedNumIntVectorAttributes;
     TSM_ASSERT_EQUALS("There should be two attributes present.",
                       totalNumAttributs, numAttributes);
 

--- a/Framework/DataHandling/test/H5UtilTest.h
+++ b/Framework/DataHandling/test/H5UtilTest.h
@@ -82,7 +82,7 @@ public:
       H5File file(FILENAME, H5F_ACC_EXCL);
       auto group = H5Util::createGroupNXS(file, GRP_NAME, "NXentry");
       H5Util::writeScalarDataSetWithStrAttributes(group, DATA_NAME, DATA_VALUE,
-                                                   stringAttributesScalar);
+                                                  stringAttributesScalar);
       auto data = group.openDataSet(DATA_NAME);
       // Add the float and int attribute
       H5Util::writeNumAttribute(data, ATTR_NAME_3, ATTR_VALUE_3);
@@ -97,21 +97,21 @@ public:
 
     // Assert
     TS_ASSERT(Poco::File(FILENAME).exists());
-    std::map<std::string, float> floatAttributesScalar{{ATTR_NAME_3, ATTR_VALUE_3}};
+    std::map<std::string, float> floatAttributesScalar{
+        {ATTR_NAME_3, ATTR_VALUE_3}};
     std::map<std::string, int> intAttributesScalar{{ATTR_NAME_4, ATTR_VALUE_4}};
     std::map<std::string, std::vector<float>> floatVectorAttributesScalar{
         {ATTR_NAME_5, ATTR_VALUE_5}};
     std::map<std::string, std::vector<int>> intVectorAttributesScalar{
         {ATTR_NAME_6, ATTR_VALUE_6}};
-    do_assert_simple_string_data_set(FILENAME, GRP_NAME, DATA_NAME, DATA_VALUE,
-                                     stringAttributesScalar, floatAttributesScalar,
-                                     intAttributesScalar, floatVectorAttributesScalar,
-                                     intVectorAttributesScalar);
+    do_assert_simple_string_data_set(
+        FILENAME, GRP_NAME, DATA_NAME, DATA_VALUE, stringAttributesScalar,
+        floatAttributesScalar, intAttributesScalar, floatVectorAttributesScalar,
+        intVectorAttributesScalar);
 
     // cleanup
     removeFile(FILENAME);
   }
-
 
   void test_array1d() {
     const std::string FILENAME("H5UtilTest_array1d.h5");
@@ -179,13 +179,13 @@ private:
       const std::map<std::string, std::string> &stringAttributes =
           std::map<std::string, std::string>(),
       const std::map<std::string, float> &floatAttributes =
-      std::map<std::string, float>(),
+          std::map<std::string, float>(),
       const std::map<std::string, int> &intAttributes =
-      std::map<std::string, int>(),
+          std::map<std::string, int>(),
       const std::map<std::string, std::vector<float>> &floatVectorAttributes =
-      std::map<std::string, std::vector<float>>(),
+          std::map<std::string, std::vector<float>>(),
       const std::map<std::string, std::vector<int>> &intVectorAttributes =
-      std::map<std::string, std::vector<int>>()) {
+          std::map<std::string, std::vector<int>>()) {
     TS_ASSERT(Poco::File(filename).exists());
 
     // read tests
@@ -210,22 +210,25 @@ private:
   }
 
   void do_test_attributes_on_data_set(
-      H5::DataSet &data, const std::map<std::string, std::string>& stringAttributes,
-      const std::map<std::string, float>& floatAttributes,
-      const std::map<std::string, int>& intAttributes,
-      const std::map<std::string, std::vector<float>>& floatVectorAttributes,
-      const std::map<std::string, std::vector<int>>& intVectorAttributes) {
+      H5::DataSet &data,
+      const std::map<std::string, std::string> &stringAttributes,
+      const std::map<std::string, float> &floatAttributes,
+      const std::map<std::string, int> &intAttributes,
+      const std::map<std::string, std::vector<float>> &floatVectorAttributes,
+      const std::map<std::string, std::vector<int>> &intVectorAttributes) {
     auto numAttributes = data.getNumAttrs();
-    auto expectedNumStringAttributes = static_cast<int>(stringAttributes.size());
+    auto expectedNumStringAttributes =
+        static_cast<int>(stringAttributes.size());
     auto expectedNumFloatAttributes = static_cast<int>(floatAttributes.size());
     auto expectedNumIntAttributes = static_cast<int>(intAttributes.size());
-    auto expectedNumFloatVectorAttributes = static_cast<int>(floatVectorAttributes.size());
-    auto expectedNumIntVectorAttributes = static_cast<int>(intVectorAttributes.size());
-    int totalNumAttributs = expectedNumStringAttributes +
-                            expectedNumFloatAttributes +
-                            expectedNumIntAttributes +
-                            expectedNumFloatVectorAttributes +
-                            expectedNumIntVectorAttributes;
+    auto expectedNumFloatVectorAttributes =
+        static_cast<int>(floatVectorAttributes.size());
+    auto expectedNumIntVectorAttributes =
+        static_cast<int>(intVectorAttributes.size());
+    int totalNumAttributs =
+        expectedNumStringAttributes + expectedNumFloatAttributes +
+        expectedNumIntAttributes + expectedNumFloatVectorAttributes +
+        expectedNumIntVectorAttributes;
     TSM_ASSERT_EQUALS("There should be two attributes present.",
                       totalNumAttributs, numAttributes);
 
@@ -237,7 +240,8 @@ private:
 
     for (auto &attribute : floatAttributes) {
       auto value = H5Util::readNumAttributeCoerce<float>(data, attribute.first);
-      TSM_ASSERT_EQUALS("Should retrieve the correct attribute value", attribute.second, value);
+      TSM_ASSERT_EQUALS("Should retrieve the correct attribute value",
+                        attribute.second, value);
     }
 
     for (auto &attribute : intAttributes) {
@@ -247,13 +251,15 @@ private:
     }
 
     for (auto &attribute : floatVectorAttributes) {
-      std::vector<float> value = H5Util::readNumArrayAttributeCoerce<float>(data, attribute.first);
+      std::vector<float> value =
+          H5Util::readNumArrayAttributeCoerce<float>(data, attribute.first);
       TSM_ASSERT_EQUALS("Should retrieve the correct attribute value",
                         attribute.second, value);
     }
 
     for (auto &attribute : intVectorAttributes) {
-      std::vector<int> value = H5Util::readNumArrayAttributeCoerce<int>(data, attribute.first);
+      std::vector<int> value =
+          H5Util::readNumArrayAttributeCoerce<int>(data, attribute.first);
       TSM_ASSERT_EQUALS("Should retrieve the correct attribute value",
                         attribute.second, value);
     }
@@ -261,7 +267,8 @@ private:
     // Test that coerced read works
     std::vector<int> expectedCoerced = {12, 34, 455};
     for (auto &attribute : floatVectorAttributes) {
-      std::vector<int> value = H5Util::readNumArrayAttributeCoerce<int>(data, attribute.first);
+      std::vector<int> value =
+          H5Util::readNumArrayAttributeCoerce<int>(data, attribute.first);
       TSM_ASSERT_EQUALS("Should retrieve the correct attribute value",
                         expectedCoerced, value);
     }

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -325,9 +325,9 @@ private:
                           std::vector<std::string> detectors) {
     for (auto &detector : detectors) {
       std::string detectorName = sasInstrumentDetectorGroupName + detector;
-      auto detectorNameSanitized = Mantid::DataHandling::makeCanSASRelaxedName(detectorName);
-      auto detectorGroup =
-          instrument.openGroup(detectorNameSanitized);
+      auto detectorNameSanitized =
+          Mantid::DataHandling::makeCanSASRelaxedName(detectorName);
+      auto detectorGroup = instrument.openGroup(detectorNameSanitized);
 
       auto numAttributes = detectorGroup.getNumAttrs();
       TSM_ASSERT_EQUALS("Should have 2 attributes", 2, numAttributes);

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -20,6 +20,7 @@
 #include <sstream>
 
 namespace {
+const std::string sasclass = "canSAS_class";
 const std::string nxclass = "NX_class";
 const std::string suffix = "01";
 }
@@ -223,7 +224,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    removeFile(parameters.filename);
+    //removeFile(parameters.filename);
   }
 
 private:
@@ -259,13 +260,17 @@ private:
                           const std::string &title) {
     using namespace Mantid::DataHandling::NXcanSAS;
     auto numAttributes = entry.getNumAttrs();
-    TSM_ASSERT_EQUALS("Should have three attributes", 2, numAttributes);
+    TSM_ASSERT_EQUALS("Should have three attributes", 3, numAttributes);
 
-    // NX_class attribute
+    // canSAS_class and NX_class attribute
     auto classAttribute =
-        Mantid::DataHandling::H5Util::readAttributeAsString(entry, nxclass);
+        Mantid::DataHandling::H5Util::readAttributeAsString(entry, sasclass);
     TSM_ASSERT_EQUALS("Should be SASentry class", classAttribute,
                       sasEntryClassAttr);
+    classAttribute =
+        Mantid::DataHandling::H5Util::readAttributeAsString(entry, nxclass);
+    TSM_ASSERT_EQUALS("Should be NXentr class", classAttribute,
+                      nxEntryClassAttr);
 
     // Version attribute
     auto versionAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
@@ -296,13 +301,17 @@ private:
   void do_assert_source(H5::Group &source, const std::string &radiationSource) {
 
     auto numAttributes = source.getNumAttrs();
-    TSM_ASSERT_EQUALS("Should have 1 attribute", 1, numAttributes);
+    TSM_ASSERT_EQUALS("Should have 2 attribute", 2, numAttributes);
 
-    // NX_class attribute
+    // canSAS_class and NX_class attribute
     auto classAttribute =
-        Mantid::DataHandling::H5Util::readAttributeAsString(source, nxclass);
+        Mantid::DataHandling::H5Util::readAttributeAsString(source, sasclass);
     TSM_ASSERT_EQUALS("Should be SASsource class", classAttribute,
                       sasInstrumentSourceClassAttr);
+    classAttribute =
+        Mantid::DataHandling::H5Util::readAttributeAsString(source, nxclass);
+    TSM_ASSERT_EQUALS("Should be NXsource class", classAttribute,
+                      nxInstrumentSourceClassAttr);
 
     // Radiation data set
     auto radiationDataSet = source.openDataSet(sasInstrumentSourceRadiation);
@@ -319,13 +328,17 @@ private:
           instrument.openGroup(sasInstrumentDetectorGroupName + detector);
 
       auto numAttributes = detectorGroup.getNumAttrs();
-      TSM_ASSERT_EQUALS("Should have 1 attribute", 1, numAttributes);
+      TSM_ASSERT_EQUALS("Should have 2 attributes", 2, numAttributes);
 
-      // NX_class attribute
+      // canSAS_class and NX_class attribute
       auto classAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
-          detectorGroup, nxclass);
+          detectorGroup, sasclass);
       TSM_ASSERT_EQUALS("Should be SASdetector class", classAttribute,
                         sasInstrumentDetectorClassAttr);
+      classAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
+          detectorGroup, nxclass);
+      TSM_ASSERT_EQUALS("Should be NXdetector class", classAttribute,
+                        nxInstrumentDetectorClassAttr);
 
       // Detector name data set
       auto name = detectorGroup.openDataSet(sasInstrumentDetectorName);
@@ -346,9 +359,10 @@ private:
       if (objectType == H5G_GROUP) {
         auto subGroupName = instrument.getObjnameByIdx(index);
         auto subGroup = instrument.openGroup(subGroupName);
+        // canSAS_class and NX_class attribute
         auto classAttribute =
             Mantid::DataHandling::H5Util::readAttributeAsString(subGroup,
-                                                                nxclass);
+                                                                sasclass);
         TSM_ASSERT("Should not be a detector",
                    classAttribute != sasInstrumentDetectorClassAttr);
       }
@@ -362,13 +376,17 @@ private:
                             const std::vector<std::string> &detectors,
                             bool invalidDetectors) {
     auto numAttributes = instrument.getNumAttrs();
-    TSM_ASSERT_EQUALS("Should have 1 attribute", 1, numAttributes);
+    TSM_ASSERT_EQUALS("Should have 2 attribute", 2, numAttributes);
 
-    // NX_class attribute
+    // canSAS_class and NX_class attribute
     auto classAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
-        instrument, nxclass);
+        instrument, sasclass);
     TSM_ASSERT_EQUALS("Should be SASentry class", classAttribute,
                       sasInstrumentClassAttr);
+    classAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
+        instrument, nxclass);
+    TSM_ASSERT_EQUALS("Should be NXentry class", classAttribute,
+                      nxInstrumentClassAttr);
 
     // Name data set
     auto instrumentNameDataSet = instrument.openDataSet(sasInstrumentName);
@@ -397,13 +415,17 @@ private:
 
   void do_assert_process(H5::Group &process, const std::string &userFile) {
     auto numAttributes = process.getNumAttrs();
-    TSM_ASSERT_EQUALS("Should have 1 attribute", 1, numAttributes);
+    TSM_ASSERT_EQUALS("Should have 2 attribute", 2, numAttributes);
 
-    // NX_class attribute
+    // canSAS_class and NX_class attribute
     auto classAttribute =
-        Mantid::DataHandling::H5Util::readAttributeAsString(process, nxclass);
+        Mantid::DataHandling::H5Util::readAttributeAsString(process, sasclass);
     TSM_ASSERT_EQUALS("Should be SASprocess class", classAttribute,
                       sasProcessClassAttr);
+    classAttribute =
+        Mantid::DataHandling::H5Util::readAttributeAsString(process, nxclass);
+    TSM_ASSERT_EQUALS("Should be NXprocess class", classAttribute,
+                      nxProcessClassAttr);
 
     // Date data set
     auto dateDataSet = process.openDataSet(sasProcessDate);
@@ -487,18 +509,22 @@ private:
                       double xmin, double xmax, double xerror, bool hasDx) {
     auto numAttributes = data.getNumAttrs();
     if (hasDx) {
-      TSM_ASSERT_EQUALS("Should have 6 attribute", 6, numAttributes);
+      TSM_ASSERT_EQUALS("Should have 7 attribute", 7, numAttributes);
     } else {
       TSM_ASSERT_EQUALS(
-          "Should have 5 attribute, since Q_uncertainty is not present", 5,
+          "Should have 6 attribute, since Q_uncertainty is not present", 6,
           numAttributes);
     }
 
-    // NX_class attribute
+    // canSAS_class and NX_class attribute
     auto classAttribute =
-        Mantid::DataHandling::H5Util::readAttributeAsString(data, nxclass);
+        Mantid::DataHandling::H5Util::readAttributeAsString(data, sasclass);
     TSM_ASSERT_EQUALS("Should be SASdata class", classAttribute,
                       sasDataClassAttr);
+    classAttribute =
+        Mantid::DataHandling::H5Util::readAttributeAsString(data, nxclass);
+    TSM_ASSERT_EQUALS("Should be NXdata class", classAttribute,
+                      nxDataClassAttr);
 
     // I_axes attribute
     auto intensityAttribute =
@@ -567,14 +593,18 @@ private:
   void do_assert_2D_data(H5::Group &data) {
     auto numAttributes = data.getNumAttrs();
     TSM_ASSERT_EQUALS(
-        "Should have 5 attributes, since Q_uncertainty is not present", 5,
+        "Should have 6 attributes, since Q_uncertainty is not present", 6,
         numAttributes);
 
-    // NX_class attribute
+    // canSAS_class and NX_class attribute
     auto classAttribute =
-        Mantid::DataHandling::H5Util::readAttributeAsString(data, nxclass);
+        Mantid::DataHandling::H5Util::readAttributeAsString(data, sasclass);
     TSM_ASSERT_EQUALS("Should be SASdata class", classAttribute,
                       sasDataClassAttr);
+    classAttribute =
+        Mantid::DataHandling::H5Util::readAttributeAsString(data, nxclass);
+    TSM_ASSERT_EQUALS("Should be NXdata class", classAttribute,
+                      nxDataClassAttr);
 
     // I_axes attribute
     auto intensityAttribute =
@@ -612,11 +642,15 @@ private:
     auto transmission = entry.openGroup(sasTransmissionSpectrumGroupName + "_" +
                                         parameters.name);
 
-    // NX_class attribute
+    // canSAS_class and NX_class attribute
     auto classAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
-        transmission, nxclass);
+        transmission, sasclass);
     TSM_ASSERT_EQUALS("Should be SAStransmission_spectrum class",
                       classAttribute, sasTransmissionSpectrumClassAttr);
+    classAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
+        transmission, nxclass);
+    TSM_ASSERT_EQUALS("Should be NXdata class",
+                      classAttribute, nxTransmissionSpectrumClassAttr);
 
     // Name attribute
     auto nameAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -538,8 +538,9 @@ private:
     TSM_ASSERT_EQUALS("Should be just Idev", errorAttribute, sasDataIdev);
 
     // Q_indices attribute
-    auto qAttribute = Mantid::DataHandling::H5Util::readNumArrayAttributeCoerce<int>(
-        data, sasDataQIndicesAttr);
+    auto qAttribute =
+        Mantid::DataHandling::H5Util::readNumArrayAttributeCoerce<int>(
+            data, sasDataQIndicesAttr);
     TSM_ASSERT_EQUALS("Should be just 0", qAttribute, std::vector<int>{0});
 
     // Signal attribute
@@ -619,9 +620,10 @@ private:
     TSM_ASSERT_EQUALS("Should be just Idev", errorAttribute, sasDataIdev);
 
     // Q_indices attribute
-    auto qAttribute = Mantid::DataHandling::H5Util::readNumArrayAttributeCoerce<int>(
-        data, sasDataQIndicesAttr);
-    std::vector<int> expectedQIndices{0,1};
+    auto qAttribute =
+        Mantid::DataHandling::H5Util::readNumArrayAttributeCoerce<int>(
+            data, sasDataQIndicesAttr);
+    std::vector<int> expectedQIndices{0, 1};
     TSM_ASSERT_EQUALS("Should be just 0,1", qAttribute, expectedQIndices);
 
     // Signal attribute
@@ -649,8 +651,8 @@ private:
                       classAttribute, sasTransmissionSpectrumClassAttr);
     classAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
         transmission, nxclass);
-    TSM_ASSERT_EQUALS("Should be NXdata class",
-                      classAttribute, nxTransmissionSpectrumClassAttr);
+    TSM_ASSERT_EQUALS("Should be NXdata class", classAttribute,
+                      nxTransmissionSpectrumClassAttr);
 
     // Name attribute
     auto nameAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -224,7 +224,7 @@ public:
     do_assert(parameters);
 
     // Clean up
-    //removeFile(parameters.filename);
+    removeFile(parameters.filename);
   }
 
 private:

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -324,8 +324,10 @@ private:
   void do_assert_detector(H5::Group &instrument,
                           std::vector<std::string> detectors) {
     for (auto &detector : detectors) {
+      std::string detectorName = sasInstrumentDetectorGroupName + detector;
+      auto detectorNameSanitized = Mantid::DataHandling::makeCanSASRelaxedName(detectorName);
       auto detectorGroup =
-          instrument.openGroup(sasInstrumentDetectorGroupName + detector);
+          instrument.openGroup(detectorNameSanitized);
 
       auto numAttributes = detectorGroup.getNumAttrs();
       TSM_ASSERT_EQUALS("Should have 2 attributes", 2, numAttributes);

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -512,9 +512,9 @@ private:
     TSM_ASSERT_EQUALS("Should be just Idev", errorAttribute, sasDataIdev);
 
     // Q_indices attribute
-    auto qAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
+    auto qAttribute = Mantid::DataHandling::H5Util::readNumArrayAttributeCoerce<int>(
         data, sasDataQIndicesAttr);
-    TSM_ASSERT_EQUALS("Should be just 0", qAttribute, "0");
+    TSM_ASSERT_EQUALS("Should be just 0", qAttribute, std::vector<int>{0});
 
     // Signal attribute
     auto signalAttribute =
@@ -589,9 +589,10 @@ private:
     TSM_ASSERT_EQUALS("Should be just Idev", errorAttribute, sasDataIdev);
 
     // Q_indices attribute
-    auto qAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
+    auto qAttribute = Mantid::DataHandling::H5Util::readNumArrayAttributeCoerce<int>(
         data, sasDataQIndicesAttr);
-    TSM_ASSERT_EQUALS("Should be just 0,1", qAttribute, "0,1");
+    std::vector<int> expectedQIndices{0,1};
+    TSM_ASSERT_EQUALS("Should be just 0,1", qAttribute, expectedQIndices);
 
     // Signal attribute
     auto signalAttribute =


### PR DESCRIPTION
~~This is currently with Stephen King and the CanSAS consortium.~~
The CanSAS committee has approved of the changes.

Fixes #16685

Several issues, reported by the CanSAS consortium, were fixed:
1. Introduce canSAS_class
2. Provide NX_class with equivalent class names. This attribute lives in parallel to the canSAS_class one. Essentially this makes the file format compatible with Nexus and CanSAS
3. Set dates to ISO-8601 format
4. Change the Q_indices attribute to be a int array
5. SDD which is part of the detectors is now a floating point instead of a string
6. change `unit` to `units` 
## For testing
- The changes will be presented to the CanSAS consortium again, hence we have scientific validation for this.
- Code review. 
  Does not have to be in release notes since it is a "small" enhancement
  ---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
