### PR TITLE
Change grouping from unordered_set to set

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/FilterEvents.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FilterEvents.h
@@ -123,7 +123,7 @@ private:
   /// Flag to use matrix splitters or table splitters
   bool m_useTableSplitters;
 
-  std::unordered_set<int> m_workGroupIndexes;
+  std::set<int> m_workGroupIndexes;
   Kernel::TimeSplitterType m_splitters;
   std::map<int, DataObjects::EventWorkspace_sptr> m_outputWS;
   std::vector<std::string> m_wsNames;

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -15,6 +15,9 @@ New
 Improved
 ########
 
+- :ref:`FilterEvents <algm-FilterEvents>` now produces output
+  workspaces with the same workspace numbers as specified by the
+  ``SplittersWorkspace``.
 
 Deprecated
 ##########


### PR DESCRIPTION
See the original issue for a description.

**To test:**

See that event filtering still works. Ideally, filter events before and after this change and see that plotting the workspace group (as color fill plot) preserves the order.

Fixes #16689.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
