### PR TITLE
Fix for transpose issue in ReplicateMD

### DIFF
--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -293,7 +293,7 @@ void ReplicateMD::exec() {
    the linear index -> linear index calculation below will not work correctly.
    */
   MDHistoWorkspace_const_sptr transposedDataWS = dataWS;
-  if (dataWS->getNumDims() == shapeWS->getNumDims()) {
+  if (dataWS->getNumDims() <= shapeWS->getNumDims()) {
     auto axes = findAxes(*shapeWS, *dataWS);
     transposedDataWS = transposeMD(dataWS, axes);
     nDimsData = transposedDataWS->getNumDims();

--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -303,8 +303,8 @@ void ReplicateMD::exec() {
       if (axis >= numberOfDimensionsOfDataWorkspace) {
         std::string message =
             "ReplicateMD: Cannot transpose the data workspace. Attempting to "
-            "swap dimension index" +
-            std::to_string(axisDimCounter) + " with inxex " +
+            "swap dimension index " +
+            std::to_string(axisDimCounter) + " with index " +
             std::to_string(axis) +
             ", but the dimensionality of the data workspace is " +
             std::to_string(nDimsData);

--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -293,8 +293,25 @@ void ReplicateMD::exec() {
    the linear index -> linear index calculation below will not work correctly.
    */
   MDHistoWorkspace_const_sptr transposedDataWS = dataWS;
-  if (dataWS->getNumDims() <= shapeWS->getNumDims()) {
+  if (nDimsData <= nDimsShape) {
     auto axes = findAxes(*shapeWS, *dataWS);
+    // Check that the indices stored in axes are compatible with the
+    // dimensionality of the data workspace
+    const auto numberOfDimensionsOfDataWorkspace = static_cast<int>(nDimsData);
+    int axisDimCounter = 0;
+    for (const auto &axis : axes) {
+      if (axis >= numberOfDimensionsOfDataWorkspace) {
+        std::string message =
+            "ReplicateMD: Cannot transpose the data workspace. Attempting to "
+            "swap dimension index" +
+            std::to_string(axisDimCounter) + " with inxex " +
+            std::to_string(axis) +
+            ", but the dimensionality of the data workspace is " +
+            std::to_string(nDimsData);
+        throw std::runtime_error(message);
+      }
+      ++axisDimCounter;
+    }
     transposedDataWS = transposeMD(dataWS, axes);
     nDimsData = transposedDataWS->getNumDims();
   }

--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -298,7 +298,7 @@ void ReplicateMD::exec() {
     // Check that the indices stored in axes are compatible with the
     // dimensionality of the data workspace
     const auto numberOfDimensionsOfDataWorkspace = static_cast<int>(nDimsData);
-    for (const auto &axis : axes) {
+    for (auto &axis : axes) {
       if (axis >= numberOfDimensionsOfDataWorkspace) {
         std::string message =
             "ReplicateMD: Cannot transpose the data workspace. Attempting to "

--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -298,19 +298,17 @@ void ReplicateMD::exec() {
     // Check that the indices stored in axes are compatible with the
     // dimensionality of the data workspace
     const auto numberOfDimensionsOfDataWorkspace = static_cast<int>(nDimsData);
-    int axisDimCounter = 0;
     for (const auto &axis : axes) {
       if (axis >= numberOfDimensionsOfDataWorkspace) {
         std::string message =
             "ReplicateMD: Cannot transpose the data workspace. Attempting to "
             "swap dimension index " +
-            std::to_string(axisDimCounter) + " with index " +
+            std::to_string(std::distance(axes.data(), &axis)) + " with index " +
             std::to_string(axis) +
             ", but the dimensionality of the data workspace is " +
             std::to_string(nDimsData);
         throw std::runtime_error(message);
       }
-      ++axisDimCounter;
     }
     transposedDataWS = transposeMD(dataWS, axes);
     nDimsData = transposedDataWS->getNumDims();

--- a/docs/source/algorithms/ReplicateMD-v1.rst
+++ b/docs/source/algorithms/ReplicateMD-v1.rst
@@ -39,8 +39,8 @@ Output:
 
 .. testoutput:: ReplicateMDExample1D
 
-   Num dims: 2
-   Num points: 10000
+   Num dims: 3
+   Num points: 6000
 
 .. categories::
 

--- a/docs/source/algorithms/ReplicateMD-v1.rst
+++ b/docs/source/algorithms/ReplicateMD-v1.rst
@@ -27,8 +27,8 @@ Usage
 .. testcode:: ReplicateMDExample1D
 
    import numpy as np
-   data = CreateMDHistoWorkspace(1, SignalInput=np.arange(100), ErrorInput=np.arange(100), NumberOfEvents=np.arange(100), Extents=[-10, 10], NumberOfBins=[100], Names='E', Units='MeV')
-   shape = CreateMDHistoWorkspace(2, SignalInput=np.tile([1], 10000), ErrorInput=np.tile([1], 10000), NumberOfEvents=np.tile([1], 10000), Extents=[-1,1, -10, 10], NumberOfBins=[100,100], Names='Q,E', Units='A^-1, MeV')
+   data = CreateMDHistoWorkspace(2, SignalInput=np.arange(20*30), ErrorInput=np.arange(20*30), NumberOfEvents=np.arange(20*30), Extents=[-10, 10, -1,1], NumberOfBins=[20, 30], Names='E,Qx', Units='MeV,A^-1')
+   shape = CreateMDHistoWorkspace(3, SignalInput=np.tile([1], 20*30*10), ErrorInput=np.tile([1], 20*30*10), NumberOfEvents=np.tile([1], 20*30*10), Extents=[-1,1, -10, 10, -10,10], NumberOfBins=[30,20,10], Names='Qx,E,Qy', Units='A^-1, MeV, A^-1')
 
    replicated = ReplicateMD(ShapeWorkspace=shape, DataWorkspace=data)
 


### PR DESCRIPTION
This PR fixes a bug in the ReplicateMD algorithm. TransposeMD was only applied to the DataWorkspace if it had the same dimensionality as the ShapeWorkspace, i.e. DIM(data) == DIM(shape). In general the dimensionality of the ShapeWorkspace will be larger than the DataWorkspace (for ReplicateMD to make sense) in which case the automatic TransposeMD mechanism had not been applied. 

The automatic TransposeMD check was changed to DIM(data) <= DIM(shape).

Fixes  #16619 
**To test:**

Follow the instructions in #16619 and confirm that the unit tests do not break any longer.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
