### PR TITLE
Fix or suppress remaining -Wsuggest-override warnings

### DIFF
--- a/Framework/API/test/FunctionParameterDecoratorTest.h
+++ b/Framework/API/test/FunctionParameterDecoratorTest.h
@@ -3,17 +3,16 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidAPI/FunctionParameterDecorator.h"
 #include "MantidAPI/CompositeFunction.h"
-#include "MantidAPI/ParamFunction.h"
 #include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/FunctionParameterDecorator.h"
+#include "MantidAPI/ParamFunction.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/Exception.h"
-
+#include "MantidKernel/WarningSuppressions.h"
 #include <boost/make_shared.hpp>
-
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -432,7 +431,9 @@ private:
   class MockTestableFunctionParameterDecorator
       : public TestableFunctionParameterDecorator {
   public:
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_METHOD1(beforeDecoratedFunctionSet, void(const IFunction_sptr &));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/API/test/ILatticeFunctionTest.h
+++ b/Framework/API/test/ILatticeFunctionTest.h
@@ -13,8 +13,6 @@ using Mantid::Kernel::V3D;
 
 using namespace Mantid::API;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
-
 using ::testing::_;
 using ::testing::Mock;
 using ::testing::Return;
@@ -75,13 +73,10 @@ public:
 
 private:
   std::vector<V3D> getTestHKLs() { return {{1, 1, 0}}; }
-
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   // Mock function to check whether the correct methods are called
   class MockLatticeFunction : public ILatticeFunction {
   public:
-    MockLatticeFunction() : ILatticeFunction() {}
-    ~MockLatticeFunction() override {}
-
     MOCK_CONST_METHOD0(name, std::string());
     MOCK_CONST_METHOD2(functionLattice,
                        void(const LatticeDomain &, FunctionValues &));

--- a/Framework/API/test/ILiveListenerTest.h
+++ b/Framework/API/test/ILiveListenerTest.h
@@ -1,10 +1,11 @@
 #ifndef ILIVELISTENER_TEST_H_
 #define ILIVELISTENER_TEST_H_
 
+#include "MantidAPI/ILiveListener.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "MantidAPI/ILiveListener.h"
 
 using namespace Mantid::API;
 
@@ -14,6 +15,7 @@ public:
     // Set this flag to true for testing
     m_dataReset = true;
   }
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_CONST_METHOD0(name, std::string());
   MOCK_CONST_METHOD0(supportsHistory, bool());
   MOCK_CONST_METHOD0(buffersEvents, bool());
@@ -23,6 +25,7 @@ public:
   MOCK_METHOD0(isConnected, bool());
   MOCK_METHOD0(runStatus, RunStatus());
   MOCK_CONST_METHOD0(runNumber, int());
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class ILiveListenerTest : public CxxTest::TestSuite {

--- a/Framework/API/test/ImplicitFunctionFactoryTest.h
+++ b/Framework/API/test/ImplicitFunctionFactoryTest.h
@@ -107,6 +107,7 @@ private:
     MOCK_METHOD1(setSuccessorParser,
                  void(Mantid::API::ImplicitFunctionParameterParser *successor));
   };
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 
   class MockImplicitFunctionBuilderA
       : public Mantid::API::ImplicitFunctionBuilder {
@@ -186,7 +187,5 @@ public:
         std::runtime_error);
   }
 };
-
-GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif

--- a/Framework/API/test/ImplicitFunctionParameterParserFactoryTest.h
+++ b/Framework/API/test/ImplicitFunctionParameterParserFactoryTest.h
@@ -4,9 +4,10 @@
 #include <cxxtest/TestSuite.h>
 #include <vector>
 
+#include "MantidAPI/ImplicitFunctionParameterParser.h"
 #include "MantidAPI/ImplicitFunctionParameterParserFactory.h"
 #include "MantidKernel/ConfigService.h"
-#include "MantidAPI/ImplicitFunctionParameterParser.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include <boost/shared_ptr.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -16,11 +17,11 @@ private:
   class MockImplicitFunctionParameter
       : public Mantid::API::ImplicitFunctionParameter {
   public:
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_CONST_METHOD0(isValid, bool());
     MOCK_CONST_METHOD0(toXMLString, std::string());
-    ~MockImplicitFunctionParameter() override {}
-
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   protected:
     ImplicitFunctionParameter *clone() const override {
       return new MockImplicitFunctionParameter;

--- a/Framework/API/test/ModeratorModelTest.h
+++ b/Framework/API/test/ModeratorModelTest.h
@@ -2,6 +2,7 @@
 #define MANTID_API_MODERATORMODELTEST_H_
 
 #include "MantidAPI/ModeratorModel.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -12,11 +13,13 @@ public:
   boost::shared_ptr<ModeratorModel> clone() const override {
     return boost::shared_ptr<MockModerator>();
   }
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_CONST_METHOD0(emissionTimeMean, double());
   MOCK_CONST_METHOD0(emissionTimeVariance, double());
   MOCK_CONST_METHOD1(sampleTimeDistribution, double(const double));
   MOCK_METHOD2(setParameterValue,
                void(const std::string &, const std::string &));
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class ModeratorModelTest : public CxxTest::TestSuite {

--- a/Framework/API/test/WorkspaceGroupTest.h
+++ b/Framework/API/test/WorkspaceGroupTest.h
@@ -1,11 +1,12 @@
 #ifndef MANTID_API_WORKSPACEGROUPTEST_H_
 #define MANTID_API_WORKSPACEGROUPTEST_H_
 
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidKernel/Exception.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Timer.h"
-#include "MantidKernel/Exception.h"
-#include "MantidAPI/WorkspaceGroup.h"
-#include "MantidAPI/AnalysisDataService.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidTestHelpers/FakeObjects.h"
 #include "PropertyManagerHelper.h"
 
@@ -54,12 +55,13 @@ private:
 
   // Helper type, representing some concrete workspace type.
   class MockWorkspace : public Mantid::API::Workspace {
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(id, const std::string());
     MOCK_CONST_METHOD0(name, const std::string());
     MOCK_CONST_METHOD0(threadSafe, bool());
     MOCK_CONST_METHOD0(toString, const std::string());
     MOCK_CONST_METHOD0(getMemorySize, size_t());
-
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   private:
     MockWorkspace *doClone() const override {
       throw std::runtime_error("Cloning of MockWorkspace is not implemented.");

--- a/Framework/Algorithms/test/MCAbsorptionStrategyTest.h
+++ b/Framework/Algorithms/test/MCAbsorptionStrategyTest.h
@@ -3,8 +3,9 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidAlgorithms/SampleCorrections/MCAbsorptionStrategy.h"
 #include "MantidAlgorithms/SampleCorrections/IBeamProfile.h"
+#include "MantidAlgorithms/SampleCorrections/MCAbsorptionStrategy.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MonteCarloTesting.h"
 
 using Mantid::Algorithms::MCAbsorptionStrategy;
@@ -64,8 +65,10 @@ private:
   class MockBeamProfile final : public Mantid::Algorithms::IBeamProfile {
   public:
     using Mantid::Algorithms::IBeamProfile::Ray;
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(generatePoint,
                        Ray(Mantid::Kernel::PseudoRandomNumberGenerator &));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   MCAbsorptionStrategy createTestObject() {

--- a/Framework/Algorithms/test/MaxEnt/MaxentCalculatorTest.h
+++ b/Framework/Algorithms/test/MaxEnt/MaxentCalculatorTest.h
@@ -7,12 +7,13 @@
 #include "MantidAlgorithms/MaxEnt/MaxentCalculator.h"
 #include "MantidAlgorithms/MaxEnt/MaxentEntropy.h"
 #include "MantidAlgorithms/MaxEnt/MaxentTransform.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::Algorithms;
 using namespace testing;
 
 class MockEntropy : public MaxentEntropy {
-
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
 public:
   MOCK_METHOD2(derivative,
                std::vector<double>(const std::vector<double> &, double));
@@ -28,7 +29,7 @@ public:
   MOCK_METHOD1(imageToData, std::vector<double>(const std::vector<double> &));
   MOCK_METHOD1(dataToImage, std::vector<double>(const std::vector<double> &));
 };
-
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 using MockEntropy_sptr = std::shared_ptr<MockEntropy>;
 
 class MaxentCalculatorTest : public CxxTest::TestSuite {

--- a/Framework/Algorithms/test/MonteCarloTesting.h
+++ b/Framework/Algorithms/test/MonteCarloTesting.h
@@ -7,6 +7,7 @@
 #include "MantidGeometry/Objects/ShapeFactory.h"
 #include "MantidKernel/Material.h"
 #include "MantidKernel/PseudoRandomNumberGenerator.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
 
 #include <gmock/gmock.h>
@@ -22,6 +23,7 @@ namespace MonteCarloTesting {
 // -----------------------------------------------------------------------------
 class MockRNG final : public Mantid::Kernel::PseudoRandomNumberGenerator {
 public:
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(nextValue, double());
   MOCK_METHOD2(nextValue, double(double, double));
   MOCK_METHOD2(nextInt, int(int, int));
@@ -30,6 +32,7 @@ public:
   MOCK_METHOD0(restore, void());
   MOCK_METHOD1(setSeed, void(size_t));
   MOCK_METHOD2(setRange, void(const double, const double));
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 // -----------------------------------------------------------------------------

--- a/Framework/Algorithms/test/PlusMinusTest.in.h
+++ b/Framework/Algorithms/test/PlusMinusTest.in.h
@@ -1146,7 +1146,7 @@ public:
     DO_PLUS = @PLUSMINUSTEST_DO_PLUS@;
   }
   
-  void setUp()
+  void setUp() override
   {
   	ws2D_1 = WorkspaceCreationHelper::Create2DWorkspace(10000 /*histograms*/, 1000/*bins*/);
    	ws2D_2 = WorkspaceCreationHelper::Create2DWorkspace(10000 /*histograms*/, 1000/*bins*/);

--- a/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -98,7 +98,6 @@ public:
   MOCK_METHOD3(init, void(const size_t &, const size_t &, const size_t &));
   MOCK_CONST_METHOD0(getSpecialCoordinateSystem,
                      Mantid::Kernel::SpecialCoordinateSystem());
-  ~MockIEventWorkspace() override {}
 
 private:
   MockIEventWorkspace *doClone() const override {

--- a/Framework/Crystal/test/PeakBackgroundTest.h
+++ b/Framework/Crystal/test/PeakBackgroundTest.h
@@ -66,6 +66,7 @@ public:
   MOCK_CONST_METHOD1(isWithinBounds, bool(size_t));
 };
 }
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 class PeakBackgroundTest : public CxxTest::TestSuite {
 public:
@@ -160,7 +161,5 @@ public:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockIterator));
   }
 };
-
-GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /* MANTID_CRYSTAL_PEAKBACKGROUNDTEST_H_ */

--- a/Framework/DataObjects/test/MDBoxIteratorTest.h
+++ b/Framework/DataObjects/test/MDBoxIteratorTest.h
@@ -1,19 +1,20 @@
 #ifndef MANTID_DATAOBJECTS_MDBOXITERATORTEST_H_
 #define MANTID_DATAOBJECTS_MDBOXITERATORTEST_H_
 
+#include "MantidDataObjects/MDBox.h"
+#include "MantidDataObjects/MDBoxIterator.h"
+#include "MantidDataObjects/MDEventFactory.h"
+#include "MantidDataObjects/MDGridBox.h"
 #include "MantidGeometry/MDGeometry/MDBoxImplicitFunction.h"
 #include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
 #include "MantidGeometry/MDGeometry/MDPlane.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Timer.h"
-#include "MantidDataObjects/MDBoxIterator.h"
-#include "MantidDataObjects/MDEventFactory.h"
-#include "MantidDataObjects/MDGridBox.h"
-#include "MantidDataObjects/MDBox.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
+#include <boost/math/special_functions/fpclassify.hpp>
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 using namespace Mantid::DataObjects;
 using namespace Mantid::API;
@@ -492,7 +493,9 @@ public:
             pBC(MDBox<MDLeanEvent<2>, 2>::getBoxController())
 
       {}
+      GCC_DIAG_OFF_SUGGEST_OVERRIDE
       MOCK_CONST_METHOD0(getIsMasked, bool());
+      GCC_DIAG_ON_SUGGEST_OVERRIDE
       ~MockMDBox() override { delete pBC; }
     };
 
@@ -568,8 +571,10 @@ public:
     /// Mock Skipping Policy Type to inject.
     class MockSkippingPolicy : public SkippingPolicy {
     public:
+      GCC_DIAG_OFF_SUGGEST_OVERRIDE
       MOCK_CONST_METHOD0(keepGoing, bool());
       MOCK_METHOD0(Die, void());
+      GCC_DIAG_ON_SUGGEST_OVERRIDE
       ~MockSkippingPolicy() override { Die(); }
     };
 

--- a/Framework/DataObjects/test/MDGridBoxTest.h
+++ b/Framework/DataObjects/test/MDGridBoxTest.h
@@ -1,10 +1,16 @@
 #ifndef MDGRIDBOXTEST_H
 #define MDGRIDBOXTEST_H
 
+#include "MDBoxTest.h"
+#include "MantidAPI/BoxController.h"
+#include "MantidDataObjects/CoordTransformDistance.h"
+#include "MantidDataObjects/MDBox.h"
+#include "MantidDataObjects/MDGridBox.h"
+#include "MantidDataObjects/MDLeanEvent.h"
 #include "MantidGeometry/MDGeometry/MDBoxImplicitFunction.h"
 #include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
-#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/CPUTimer.h"
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Memory.h"
 #include "MantidKernel/MultiThreaded.h"
 #include "MantidKernel/ProgressText.h"
@@ -12,14 +18,9 @@
 #include "MantidKernel/ThreadScheduler.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/Utils.h"
-#include "MantidAPI/BoxController.h"
-#include "MantidDataObjects/CoordTransformDistance.h"
-#include "MantidDataObjects/MDBox.h"
-#include "MantidDataObjects/MDLeanEvent.h"
-#include "MantidDataObjects/MDGridBox.h"
-#include <nexus/NeXusFile.hpp>
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
-#include "MDBoxTest.h"
+#include <Poco/File.h>
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
@@ -27,11 +28,11 @@
 #include <boost/random/variate_generator.hpp>
 #include <cmath>
 #include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
 #include <map>
 #include <memory>
-#include <Poco/File.h>
+#include <nexus/NeXusFile.hpp>
 #include <vector>
-#include <gmock/gmock.h>
 
 using namespace Mantid;
 using namespace Mantid::Kernel;
@@ -50,10 +51,12 @@ private:
     MockMDBox()
         : MDBox<MDLeanEvent<1>, 1>(new API::BoxController(1)),
           pBC(MDBox<MDLeanEvent<1>, 1>::getBoxController()) {}
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(getIsMasked, bool());
     MOCK_METHOD0(mask, void());
     MOCK_METHOD0(unmask, void());
     ~MockMDBox() override { delete pBC; }
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // the sp to a box controller used as general reference to all tested

--- a/Framework/DataObjects/test/MockObjects.h
+++ b/Framework/DataObjects/test/MockObjects.h
@@ -10,6 +10,8 @@
 namespace Mantid {
 namespace DataObjects {
 
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
+
 class MockPeakShapeFactory : public PeakShapeFactory {
 public:
   MOCK_CONST_METHOD1(create,
@@ -19,8 +21,6 @@ public:
       void(boost::shared_ptr<const PeakShapeFactory> successorFactory));
   ~MockPeakShapeFactory() override {}
 };
-
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockPeakShape : public Mantid::Geometry::PeakShape {
 public:

--- a/Framework/Geometry/test/BasicHKLFiltersTest.h
+++ b/Framework/Geometry/test/BasicHKLFiltersTest.h
@@ -9,6 +9,8 @@
 #include "MantidGeometry/Crystal/SpaceGroupFactory.h"
 #include "MantidGeometry/Crystal/StructureFactorCalculator.h"
 
+#include "MantidKernel/WarningSuppressions.h"
+
 #include <strstream>
 
 using namespace Mantid::Geometry;
@@ -134,7 +136,7 @@ public:
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(mock.get()))
   }
-
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
 private:
   class MockStructureFactorCalculator : public StructureFactorCalculator {
   public:
@@ -142,5 +144,5 @@ private:
     MOCK_CONST_METHOD1(getFSquared, double(const V3D &));
   };
 };
-
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTID_GEOMETRY_BASICHKLFILTERSTEST_H_ */

--- a/Framework/Geometry/test/BraggScattererFactoryTest.h
+++ b/Framework/Geometry/test/BraggScattererFactoryTest.h
@@ -5,7 +5,7 @@
 #include <gmock/gmock.h>
 
 #include "MantidGeometry/Crystal/BraggScattererFactory.h"
-
+#include "MantidKernel/WarningSuppressions.h"
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
 
@@ -56,9 +56,10 @@ private:
     ~MockScatterer() override {}
 
     std::string name() const override { return "MockScatterer"; }
-
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(clone, BraggScatterer_sptr());
     MOCK_CONST_METHOD1(calculateStructureFactor, StructureFactor(const V3D &));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/BraggScattererInCrystalStructureTest.h
+++ b/Framework/Geometry/test/BraggScattererInCrystalStructureTest.h
@@ -6,6 +6,7 @@
 
 #include "MantidGeometry/Crystal/BraggScattererInCrystalStructure.h"
 #include "MantidGeometry/Crystal/SpaceGroupFactory.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
@@ -111,11 +112,12 @@ private:
   public:
     MockBraggScatterer() : BraggScattererInCrystalStructure() {}
     ~MockBraggScatterer() override {}
-
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(name, std::string());
     MOCK_CONST_METHOD0(clone, BraggScatterer_sptr());
     MOCK_CONST_METHOD1(calculateStructureFactor, StructureFactor(const V3D &));
     MOCK_METHOD1(afterScattererPropertySet, void(const std::string &));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/BraggScattererTest.h
+++ b/Framework/Geometry/test/BraggScattererTest.h
@@ -5,6 +5,7 @@
 #include <gmock/gmock.h>
 
 #include "MantidGeometry/Crystal/BraggScatterer.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
@@ -42,13 +43,12 @@ private:
 
   class MockBraggScatterer : public BraggScatterer {
   public:
-    MockBraggScatterer() : BraggScatterer() {}
-    ~MockBraggScatterer() override {}
-
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(name, std::string());
     MOCK_CONST_METHOD0(clone, BraggScatterer_sptr());
     MOCK_CONST_METHOD1(calculateStructureFactor, StructureFactor(const V3D &));
     MOCK_METHOD1(afterScattererPropertySet, void(const std::string &));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/CompositeImplicitFunctionTest.h
+++ b/Framework/Geometry/test/CompositeImplicitFunctionTest.h
@@ -8,7 +8,7 @@
 #include <typeinfo>
 
 #include "MantidGeometry/MDGeometry/CompositeImplicitFunction.h"
-#include "MantidKernel/WarningSuppresssions.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::Geometry;
 

--- a/Framework/Geometry/test/CompositeImplicitFunctionTest.h
+++ b/Framework/Geometry/test/CompositeImplicitFunctionTest.h
@@ -8,6 +8,7 @@
 #include <typeinfo>
 
 #include "MantidGeometry/MDGeometry/CompositeImplicitFunction.h"
+#include "MantidKernel/WarningSuppresssions.h"
 
 using namespace Mantid::Geometry;
 
@@ -17,9 +18,11 @@ private:
   // composite.
   class MockImplicitFunction : public Mantid::Geometry::MDImplicitFunction {
   public:
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(toXMLString, std::string());
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_METHOD1(isPointContained, bool(const Mantid::coord_t *coords));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
     bool isPointContained(const std::vector<Mantid::coord_t> &) override {
       return true;
     }

--- a/Framework/Geometry/test/HKLFilterTest.h
+++ b/Framework/Geometry/test/HKLFilterTest.h
@@ -183,7 +183,7 @@ public:
     TS_ASSERT_EQUALS(orFilterCasted->getLHS(), lhs);
     TS_ASSERT_EQUALS(orFilterCasted->getRHS(), rhs);
   }
-
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
 private:
   class MockHKLFilter : public HKLFilter {
   public:
@@ -211,4 +211,5 @@ private:
     MOCK_CONST_METHOD1(isAllowed, bool(const V3D &));
   };
 };
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTID_GEOMETRY_HKLFILTERTEST_H_ */

--- a/Framework/Geometry/test/HKLFilterTest.h
+++ b/Framework/Geometry/test/HKLFilterTest.h
@@ -7,6 +7,7 @@
 
 #include "MantidGeometry/Crystal/HKLFilter.h"
 #include "MantidKernel/V3D.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include <boost/make_shared.hpp>
 

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -1,15 +1,16 @@
 #ifndef MANTID_GEOMETRY_INSTRUMENTDEFINITIONPARSERTEST_H_
 #define MANTID_GEOMETRY_INSTRUMENTDEFINITIONPARSERTEST_H_
 
-#include <cxxtest/TestSuite.h>
 #include "MantidGeometry/Instrument/InstrumentDefinitionParser.h"
+#include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include "MantidKernel/ChecksumHelper.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Strings.h"
-#include "MantidGeometry/Instrument/RectangularDetector.h"
-#include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidTestHelpers/ScopedFileHelper.h"
+#include <cxxtest/TestSuite.h>
 
 #include <gmock/gmock.h>
 #include <boost/algorithm/string/replace.hpp>
@@ -21,7 +22,7 @@ using namespace testing;
 using ScopedFileHelper::ScopedFile;
 
 class InstrumentDefinitionParserTest : public CxxTest::TestSuite {
-
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
 private:
   /// Mock Type to act as IDF files.
   class MockIDFObject : public Mantid::Geometry::IDFObject {
@@ -39,7 +40,7 @@ private:
     MOCK_CONST_METHOD0(exists, bool());
     MOCK_CONST_METHOD0(getParentDirectory, const Poco::Path());
   };
-
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
   /**
   Helper type to pass around related IDF environment information in a
   collection.

--- a/Framework/Geometry/test/MDGeometryXMLBuilderTest.h
+++ b/Framework/Geometry/test/MDGeometryXMLBuilderTest.h
@@ -10,6 +10,7 @@
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 
 #include "MantidKernel/UnitLabel.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include <boost/functional/hash.hpp>
 #include <boost/algorithm/string.hpp>
@@ -31,6 +32,7 @@ private:
   /// dependency.
   class MockIMDDimension : public Mantid::Geometry::IMDDimension {
   public:
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_CONST_METHOD0(getUnits, const Mantid::Kernel::UnitLabel());
     MOCK_CONST_METHOD0(getDimensionId, std::string());
@@ -43,6 +45,7 @@ private:
     MOCK_METHOD3(setRange, void(size_t nBins, coord_t min, coord_t max));
     MOCK_CONST_METHOD0(getMDUnits, const Kernel::MDUnit &());
     MOCK_CONST_METHOD0(getMDFrame, const Geometry::MDFrame &());
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   static std::string createDimensionXMLString(unsigned int nbins, int min,

--- a/Framework/Geometry/test/PeakTransformSelectorTest.h
+++ b/Framework/Geometry/test/PeakTransformSelectorTest.h
@@ -1,10 +1,11 @@
 #ifndef MANTIDAPI_PEAKTRANSFORMSELECTOR_TEST_H_
 #define MANTIDAPI_PEAKTRANSFORMSELECTOR_TEST_H_
 
-#include <cxxtest/TestSuite.h>
 #include "MantidGeometry/Crystal/PeakTransform.h"
 #include "MantidGeometry/Crystal/PeakTransformSelector.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MockObjects.h"
+#include <cxxtest/TestSuite.h>
 
 using namespace Mantid::Geometry;
 using namespace Mantid;
@@ -22,10 +23,12 @@ private:
     enum { value = I };
 
   public:
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(createDefaultTransform, PeakTransform_sptr());
     MOCK_CONST_METHOD2(createTransform,
                        PeakTransform_sptr(const std::string &,
                                           const std::string &));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   typedef MockPeakTransformFactoryType<0> MockPeakTransformFactory;

--- a/Framework/Geometry/test/SpaceGroupFactoryTest.h
+++ b/Framework/Geometry/test/SpaceGroupFactoryTest.h
@@ -10,7 +10,7 @@ using ::testing::Return;
 #include "MantidGeometry/Crystal/CyclicGroup.h"
 #include "MantidGeometry/Crystal/PointGroupFactory.h"
 #include "MantidGeometry/Crystal/SpaceGroupFactory.h"
-#include "MantidKernel/WarningSuppresssions.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::Geometry;
 using Mantid::Kernel::V3D;

--- a/Framework/Geometry/test/SpaceGroupFactoryTest.h
+++ b/Framework/Geometry/test/SpaceGroupFactoryTest.h
@@ -7,9 +7,10 @@
 
 using ::testing::Return;
 
-#include "MantidGeometry/Crystal/SpaceGroupFactory.h"
-#include "MantidGeometry/Crystal/PointGroupFactory.h"
 #include "MantidGeometry/Crystal/CyclicGroup.h"
+#include "MantidGeometry/Crystal/PointGroupFactory.h"
+#include "MantidGeometry/Crystal/SpaceGroupFactory.h"
+#include "MantidKernel/WarningSuppresssions.h"
 
 using namespace Mantid::Geometry;
 using Mantid::Kernel::V3D;
@@ -397,9 +398,9 @@ private:
     MockSpaceGroupGenerator(size_t number, const std::string &hmSymbol,
                             const std::string &generatorInformation)
         : AbstractSpaceGroupGenerator(number, hmSymbol, generatorInformation) {}
-    ~MockSpaceGroupGenerator() override {}
-
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD0(generateGroup, Group_const_sptr());
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   /* Testing TransformationSpaceGroupGenerator is a bit hard in the sense that

--- a/Framework/Geometry/test/StructureFactorCalculatorTest.h
+++ b/Framework/Geometry/test/StructureFactorCalculatorTest.h
@@ -5,8 +5,9 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "MantidGeometry/Crystal/StructureFactorCalculator.h"
 #include "MantidGeometry/Crystal/SpaceGroupFactory.h"
+#include "MantidGeometry/Crystal/StructureFactorCalculator.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
@@ -98,9 +99,11 @@ private:
    */
   class MockStructureFactorCalculator : public StructureFactorCalculator {
   public:
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(getF, StructureFactor(const V3D &hkl));
     MOCK_METHOD1(crystalStructureSetHook,
                  void(const CrystalStructure &crystalStructure));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 };
 

--- a/Framework/Geometry/test/SymmetryElementFactoryTest.h
+++ b/Framework/Geometry/test/SymmetryElementFactoryTest.h
@@ -5,8 +5,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "MantidGeometry/Crystal/SymmetryElementFactory.h"
 #include "MantidGeometry/Crystal/SpaceGroupFactory.h"
+#include "MantidGeometry/Crystal/SymmetryElementFactory.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
@@ -395,11 +396,12 @@ private:
   class TestableSymmetryElementWithAxisGenerator
       : public SymmetryElementWithAxisGenerator {
     friend class SymmetryElementFactoryTest;
-
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(generateElement,
                        SymmetryElement_sptr(const SymmetryOperation &));
     MOCK_CONST_METHOD1(canProcess, bool(const SymmetryOperation &));
     MOCK_CONST_METHOD1(determineSymbol, std::string(const SymmetryOperation &));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   class TestableSymmetryElementRotationGenerator

--- a/Framework/Geometry/test/SymmetryElementTest.h
+++ b/Framework/Geometry/test/SymmetryElementTest.h
@@ -5,9 +5,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "MantidGeometry/Crystal/SymmetryElement.h"
-#include "MantidGeometry/Crystal/SpaceGroupFactory.h"
 #include "MantidGeometry/Crystal/PointGroupFactory.h"
+#include "MantidGeometry/Crystal/SpaceGroupFactory.h"
+#include "MantidGeometry/Crystal/SymmetryElement.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
@@ -158,7 +159,7 @@ public:
 private:
   class MockSymmetryElement : public SymmetryElement {
     friend class SymmetryElementTest;
-
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
   public:
     MockSymmetryElement(const std::string &hmSymbol)
         : SymmetryElement(hmSymbol) {}
@@ -174,6 +175,7 @@ private:
         : SymmetryElementWithAxis(symbol, axis, translation) {}
     MOCK_CONST_METHOD0(clone, SymmetryElement_sptr());
   };
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 #endif /* MANTID_GEOMETRY_SYMMETRYELEMENTTEST_H_ */

--- a/Framework/Kernel/test/MDUnitFactoryTest.h
+++ b/Framework/Kernel/test/MDUnitFactoryTest.h
@@ -1,11 +1,12 @@
 #ifndef MANTID_KERNEL_MDUNITFACTORYTEST_H_
 #define MANTID_KERNEL_MDUNITFACTORYTEST_H_
 
+#include "MantidKernel/MDUnit.h"
+#include "MantidKernel/MDUnitFactory.h"
+#include "MantidKernel/UnitLabelTypes.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
-#include "MantidKernel/MDUnitFactory.h"
-#include "MantidKernel/MDUnit.h"
-#include "MantidKernel/UnitLabelTypes.h"
 
 using namespace Mantid::Kernel;
 using namespace testing;
@@ -13,13 +14,13 @@ using namespace testing;
 /**
  * Helper Mock MDUnit
  */
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
 class MockMDUnit : public MDUnit {
 public:
   MOCK_CONST_METHOD0(getUnitLabel, UnitLabel());
   MOCK_CONST_METHOD1(canConvertTo, bool(const MDUnit &other));
   MOCK_CONST_METHOD0(isQUnit, bool());
   MOCK_CONST_METHOD0(clone, MDUnit *());
-  ~MockMDUnit() override {}
 };
 
 /**
@@ -29,9 +30,8 @@ class MockMDUnitFactory : public MDUnitFactory {
 public:
   MOCK_CONST_METHOD1(createRaw, MDUnit *(const std::string &));
   MOCK_CONST_METHOD1(canInterpret, bool(const std::string &));
-  ~MockMDUnitFactory() override {}
 };
-
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 class MDUnitFactoryTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically

--- a/Framework/Kernel/test/NDRandomNumberGeneratorTest.h
+++ b/Framework/Kernel/test/NDRandomNumberGeneratorTest.h
@@ -1,8 +1,9 @@
 #ifndef NDRandomNumberGeneratorTEST_H_
 #define NDRandomNumberGeneratorTEST_H_
 
-#include <cxxtest/TestSuite.h>
 #include "MantidKernel/NDRandomNumberGenerator.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include <cxxtest/TestSuite.h>
 
 #include <boost/scoped_ptr.hpp>
 #include <gmock/gmock.h>
@@ -14,12 +15,12 @@ private:
   class Mock3DRandomNumberGenerator
       : public Mantid::Kernel::NDRandomNumberGenerator {
   public:
-    Mock3DRandomNumberGenerator()
-        : Mantid::Kernel::NDRandomNumberGenerator(3) {}
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_METHOD0(generateNextPoint, void());
     MOCK_METHOD0(restart, void());
     MOCK_METHOD0(save, void());
     MOCK_METHOD0(restore, void());
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 
 public:

--- a/Framework/Kernel/test/NDRandomNumberGeneratorTest.h
+++ b/Framework/Kernel/test/NDRandomNumberGeneratorTest.h
@@ -15,6 +15,8 @@ private:
   class Mock3DRandomNumberGenerator
       : public Mantid::Kernel::NDRandomNumberGenerator {
   public:
+    Mock3DRandomNumberGenerator()
+        : Mantid::Kernel::NDRandomNumberGenerator(3) {}
     GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_METHOD0(generateNextPoint, void());
     MOCK_METHOD0(restart, void());

--- a/Framework/Kernel/test/TypedValidatorTest.h
+++ b/Framework/Kernel/test/TypedValidatorTest.h
@@ -13,7 +13,7 @@ namespace {
     Mantid::Kernel::IValidator_sptr clone() const override {                   \
       return boost::make_shared<ClassName>();                                  \
     }                                                                          \
-    std::string checkValidity(const HeldType &) const { return ""; }           \
+    std::string checkValidity(const HeldType &) const override { return ""; }  \
   };
 
 /// Dummy object to hold in a shared_ptr for test

--- a/Framework/Kernel/test/TypedValidatorTest.h
+++ b/Framework/Kernel/test/TypedValidatorTest.h
@@ -1,15 +1,16 @@
 #ifndef MANTID_KERNEL_TYPEDVALIDATORTEST_H_
 #define MANTID_KERNEL_TYPEDVALIDATORTEST_H_
 
-#include "MantidKernel/TypedValidator.h"
 #include "MantidKernel/DataItem.h"
+#include "MantidKernel/TypedValidator.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include <cxxtest/TestSuite.h>
 
 namespace {
 #define DECLARE_TEST_VALIDATOR(ClassName, HeldType)                            \
   class ClassName : public Mantid::Kernel::TypedValidator<HeldType> {          \
   public:                                                                      \
-    Mantid::Kernel::IValidator_sptr clone() const {                            \
+    Mantid::Kernel::IValidator_sptr clone() const override {                   \
       return boost::make_shared<ClassName>();                                  \
     }                                                                          \
     std::string checkValidity(const HeldType &) const { return ""; }           \

--- a/Framework/Kernel/test/UserCatalogInfoTest.h
+++ b/Framework/Kernel/test/UserCatalogInfoTest.h
@@ -1,9 +1,10 @@
 #ifndef MANTID_KERNEL_USERCATALOGINFOTEST_H_
 #define MANTID_KERNEL_USERCATALOGINFOTEST_H_
 
-#include <cxxtest/TestSuite.h>
 #include "MantidKernel/ICatalogInfo.h"
 #include "MantidKernel/UserCatalogInfo.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
 using namespace testing;
@@ -18,7 +19,7 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
   return out;
 }
 }
-
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
 using namespace Mantid::Kernel;
 class MockCatalogConfigService : public CatalogConfigService {
 public:
@@ -35,9 +36,8 @@ public:
   MOCK_CONST_METHOD0(macPrefix, const std::string());
   MOCK_CONST_METHOD0(linuxPrefix, const std::string());
   MOCK_CONST_METHOD0(clone, ICatalogInfo *());
-  ~MockICatalogInfo() override {}
 };
-
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 // Adaptee
 struct UserType {
   std::string getString(const std::string &) const { return "my_value"; }

--- a/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Framework/MDAlgorithms/test/BinMDTest.h
@@ -1,17 +1,18 @@
 #ifndef MANTID_MDEVENTS_BINTOMDHISTOWORKSPACETEST_H_
 #define MANTID_MDEVENTS_BINTOMDHISTOWORKSPACETEST_H_
 
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
-#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/ImplicitFunctionBuilder.h"
 #include "MantidAPI/ImplicitFunctionFactory.h"
-#include "MantidAPI/ImplicitFunctionParser.h"
 #include "MantidAPI/ImplicitFunctionParameterParserFactory.h"
+#include "MantidAPI/ImplicitFunctionParser.h"
+#include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
 #include "MantidGeometry/MDGeometry/QSample.h"
-#include "MantidGeometry/Instrument.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidMDAlgorithms/BinMD.h"
 #include "MantidMDAlgorithms/CreateMDWorkspace.h"
 #include "MantidMDAlgorithms/FakeMDEventData.h"
@@ -33,7 +34,7 @@ using namespace Mantid::MDAlgorithms;
 using Mantid::coord_t;
 
 class BinMDTest : public CxxTest::TestSuite {
-
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
 private:
   // Helper class. Mock Implicit function.
   class MockImplicitFunction : public Mantid::Geometry::MDImplicitFunction {
@@ -43,9 +44,8 @@ private:
     bool isPointContained(const Mantid::coord_t *) override { return false; }
     std::string getName() const override { return "MockImplicitFunction"; }
     MOCK_CONST_METHOD0(toXMLString, std::string());
-    ~MockImplicitFunction() override { ; }
   };
-
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
   // Helper class. Builds mock implicit functions.
   class MockImplicitFunctionBuilder
       : public Mantid::API::ImplicitFunctionBuilder {

--- a/Framework/MDAlgorithms/test/BinaryOperationMDTest.h
+++ b/Framework/MDAlgorithms/test/BinaryOperationMDTest.h
@@ -4,7 +4,7 @@
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
-#include "MantidKernel/WarningSuppresssions.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidMDAlgorithms/BinaryOperationMD.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"

--- a/Framework/MDAlgorithms/test/BinaryOperationMDTest.h
+++ b/Framework/MDAlgorithms/test/BinaryOperationMDTest.h
@@ -2,9 +2,10 @@
 #define MANTID_MDALGORITHMS_BINARYOPERATIONMDTEST_H_
 
 #include "MantidAPI/IMDEventWorkspace.h"
-#include "MantidDataObjects/WorkspaceSingleValue.h"
-#include "MantidMDAlgorithms/BinaryOperationMD.h"
 #include "MantidDataObjects/MDHistoWorkspace.h"
+#include "MantidDataObjects/WorkspaceSingleValue.h"
+#include "MantidKernel/WarningSuppresssions.h"
+#include "MantidMDAlgorithms/BinaryOperationMD.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
@@ -17,6 +18,8 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using namespace Mantid::MDAlgorithms;
 using namespace testing;
+
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockBinaryOperationMD : public BinaryOperationMD {
 public:
@@ -32,7 +35,7 @@ public:
            Mantid::DataObjects::WorkspaceSingleValue_const_sptr scalar));
   void exec() override { BinaryOperationMD::exec(); }
 };
-
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 class BinaryOperationMDTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically

--- a/Framework/MDAlgorithms/test/BooleanBinaryOperationMDTest.h
+++ b/Framework/MDAlgorithms/test/BooleanBinaryOperationMDTest.h
@@ -1,15 +1,15 @@
 #ifndef MANTID_MDALGORITHMS_BOOLEANBINARYOPERATIONMDTEST_H_
 #define MANTID_MDALGORITHMS_BOOLEANBINARYOPERATIONMDTEST_H_
 
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidMDAlgorithms/BooleanBinaryOperationMD.h"
-
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using namespace Mantid::MDAlgorithms;
 using namespace testing;
-
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
 class MockBooleanBinaryOperationMD : public BooleanBinaryOperationMD {
 public:
   MOCK_METHOD0(initExtraProperties, void());
@@ -17,7 +17,7 @@ public:
                void(Mantid::DataObjects::MDHistoWorkspace_sptr,
                     Mantid::DataObjects::MDHistoWorkspace_const_sptr));
 };
-
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 class BooleanBinaryOperationMDTest : public CxxTest::TestSuite {
 public:
   void test_basics() {

--- a/Framework/MDAlgorithms/test/UnaryOperationMDTest.h
+++ b/Framework/MDAlgorithms/test/UnaryOperationMDTest.h
@@ -4,8 +4,9 @@
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
-#include "MantidMDAlgorithms/UnaryOperationMD.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidMDAlgorithms/BinaryOperationMD.h"
+#include "MantidMDAlgorithms/UnaryOperationMD.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
@@ -22,9 +23,11 @@ using namespace testing;
 
 class MockUnaryOperationMD : public UnaryOperationMD {
 public:
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(execEvent, void(Mantid::API::IMDEventWorkspace_sptr));
   MOCK_METHOD0(checkInputs, void());
   MOCK_METHOD1(execHisto, void(Mantid::DataObjects::MDHistoWorkspace_sptr));
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
   void exec() override { UnaryOperationMD::exec(); }
 };
 

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h
@@ -36,7 +36,6 @@ using namespace Geometry;
 
 typedef std::pair<double, double> DoublePair;
 
-
 class MockDetector : public PoldiAbstractDetector {
 protected:
   std::vector<int> m_availableElements;

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h
@@ -36,7 +36,6 @@ using namespace Geometry;
 
 typedef std::pair<double, double> DoublePair;
 
-GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockDetector : public PoldiAbstractDetector {
 protected:
@@ -55,13 +54,14 @@ public:
   void loadConfiguration(Instrument_const_sptr poldiInstrument) override {
     UNUSED_ARG(poldiInstrument);
   }
-
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(efficiency, double());
   MOCK_METHOD1(twoTheta, double(int elementIndex));
   MOCK_METHOD1(distanceFromSample, double(int elementIndex));
   MOCK_METHOD0(elementCount, size_t());
   MOCK_METHOD0(centralElement, size_t());
   MOCK_METHOD2(qLimits, DoublePair(double lambdaMin, double lambdaMax));
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 
   const std::vector<int> &availableElements() override {
     return m_availableElements;
@@ -106,20 +106,20 @@ public:
   void loadConfiguration(Instrument_const_sptr poldiInstrument) override {
     UNUSED_ARG(poldiInstrument)
   }
-
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(rotationSpeed, double());
   MOCK_METHOD0(cycleTime, double());
   MOCK_METHOD0(zeroOffset, double());
   MOCK_METHOD0(distanceFromSample, double());
 
   MOCK_METHOD1(setRotationSpeed, void(double rotationSpeed));
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 
   const std::vector<double> &slitPositions() override {
     return m_slitPositions;
   }
   const std::vector<double> &slitTimes() override { return m_slitTimes; }
 };
-
 class PoldiFakeSourceComponent : public ObjComponent {
 public:
   PoldiFakeSourceComponent() : ObjComponent("FakePoldiSource", 0) {}
@@ -390,8 +390,6 @@ public:
     EXPECT_CALL(*chopper, zeroOffset()).WillRepeatedly(Return(0.15));
   }
 };
-
-GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 class PoldiPeakCollectionHelpers {
   /* This class contains some static helper function to create

--- a/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
@@ -45,7 +45,7 @@ public:
 
   MOCK_METHOD4(setMatrixWorkspace,
                void(MatrixWorkspace_const_sptr, size_t, double, double));
-
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 protected:
   void init() override { setDecoratedFunction("Gaussian"); }
 };
@@ -189,7 +189,5 @@ private:
 
   PoldiInstrumentAdapter_sptr m_instrument;
 };
-
-GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /* MANTID_SINQ_POLDISPECTRUMPAWLEYFUNCTIONTEST_H_ */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeGmockObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeGmockObjects.h
@@ -12,10 +12,11 @@
 #define FAKEGMOCKOBJECTS_H_
 
 #include "MantidGeometry/Instrument/INearestNeighboursFactory.h"
+#include "MantidKernel/WarningSuppressions.h"i
 #include "gmock/gmock.h"
 
 using namespace Mantid;
-
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
 // Helper and typedef for mocking NearestNeighbourFactory usage
 class MockNearestNeighboursFactory
     : public Mantid::Geometry::INearestNeighboursFactory {
@@ -41,5 +42,5 @@ public:
   MOCK_METHOD0(die, void());
   ~MockNearestNeighbours() override { die(); }
 };
-
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 #endif /* FAKEOBJECTS_H_ */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeGmockObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeGmockObjects.h
@@ -12,7 +12,7 @@
 #define FAKEGMOCKOBJECTS_H_
 
 #include "MantidGeometry/Instrument/INearestNeighboursFactory.h"
-#include "MantidKernel/WarningSuppressions.h"i
+#include "MantidKernel/WarningSuppressions.h"
 #include "gmock/gmock.h"
 
 using namespace Mantid;

--- a/MantidQt/API/test/SignalRangeTest.h
+++ b/MantidQt/API/test/SignalRangeTest.h
@@ -80,7 +80,7 @@ private:
     MOCK_CONST_METHOD0(getLinearIndex, size_t());
     MOCK_CONST_METHOD1(isWithinBounds, bool(size_t));
   };
-
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
   class NormalizableMockIterator : public MockMDIterator {
   public:
     Mantid::signal_t getNormalizedSignal() const override {
@@ -202,6 +202,5 @@ public:
     TS_ASSERT_DELTA(5.0, range.maxValue(), 1e-10);
   }
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /* MANTIDQT_API_SIGNALRANGETEST */

--- a/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
@@ -69,7 +69,6 @@ public:
 
   MOCK_METHOD2(fit, void(IFunction_const_sptr, const std::vector<Section> &));
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 MATCHER_P(FunctionName, name, "") { return arg->name() == name; }
 
@@ -86,6 +85,7 @@ MATCHER_P3(QwtDataY, i, value, delta, "") {
 MATCHER_P3(VectorValue, i, value, delta, "") {
   return fabs(arg.at(i) - value) < delta;
 }
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 class ALCBaselineModellingPresenterTest : public CxxTest::TestSuite {
   MockALCBaselineModellingView *m_view;

--- a/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
@@ -69,6 +69,7 @@ public:
 
   MOCK_METHOD2(fit, void(IFunction_const_sptr, const std::vector<Section> &));
 };
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 MATCHER_P(FunctionName, name, "") { return arg->name() == name; }
 
@@ -364,7 +365,5 @@ public:
     m_view->help();
   }
 };
-
-GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /* MANTIDQT_CUSTOMINTERFACES_ALCBASELINEMODELLINGTEST_H_ */

--- a/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -68,6 +68,8 @@ public:
   void selectFirstRun() { emit firstRunSelected(); }
 };
 
+GCC_DIAG_ON_SUGGEST_OVERRIDE
+
 MATCHER_P3(QwtDataX, i, value, delta, "") {
   return fabs(arg.x(i) - value) < delta;
 }
@@ -367,7 +369,5 @@ public:
     m_view->help();
   }
 };
-
-GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif /* MANTID_CUSTOMINTERFACES_ALCDATALOADINGTEST_H_ */

--- a/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
@@ -8,7 +8,7 @@
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
-#include "MantidKernel/WarningsSuppressions.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include "MantidQtCustomInterfaces/Muon/IALCPeakFittingView.h"
 #include "MantidQtCustomInterfaces/Muon/IALCPeakFittingModel.h"

--- a/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
@@ -6,8 +6,9 @@
 
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
-#include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidKernel/WarningsSuppressions.h"
 
 #include "MantidQtCustomInterfaces/Muon/IALCPeakFittingView.h"
 #include "MantidQtCustomInterfaces/Muon/IALCPeakFittingModel.h"
@@ -27,6 +28,8 @@ operator<<(std::basic_ostream<CharType, CharTrait> &out,
   return out;
 }
 }
+
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockALCPeakFittingView : public IALCPeakFittingView {
 public:
@@ -353,5 +356,5 @@ public:
     m_model->setError("Test error");
   }
 };
-
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 #endif /* MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGTEST_H_ */

--- a/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
+++ b/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
@@ -16,8 +16,6 @@ GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockView : public ReflMainView {
 public:
-  MockView(){};
-  ~MockView() override {}
 
   // Gmock requires parameters and return values of mocked methods to be
   // copyable

--- a/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
+++ b/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
@@ -16,7 +16,6 @@ GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockView : public ReflMainView {
 public:
-
   // Gmock requires parameters and return values of mocked methods to be
   // copyable
   // We can't mock setTableCommands(std::vector<DataProcessorCommand_uptr>)

--- a/MantidQt/CustomInterfaces/test/ReflMeasureTransferStrategyTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflMeasureTransferStrategyTest.h
@@ -1,6 +1,7 @@
 #ifndef MANTID_CUSTOMINTERFACES_REFLMEASURETRANSFERSTRATEGYTEST_H_
 #define MANTID_CUSTOMINTERFACES_REFLMEASURETRANSFERSTRATEGYTEST_H_
 
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidKernel/make_unique.h"
 #include "MantidQtCustomInterfaces/Reflectometry/ReflMeasureTransferStrategy.h"
 #include "MantidQtCustomInterfaces/Reflectometry/ReflMeasurementItemSource.h"
@@ -17,10 +18,11 @@ using namespace MantidQt::CustomInterfaces;
 class MockReflMeasurementItemSource
     : public MantidQt::CustomInterfaces::ReflMeasurementItemSource {
 public:
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_CONST_METHOD2(obtain, MantidQt::CustomInterfaces::MeasurementItem(
                                  const std::string &, const std::string &));
   MOCK_CONST_METHOD0(clone, MockReflMeasurementItemSource *());
-  ~MockReflMeasurementItemSource() override {}
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class ReflMeasureTransferStrategyTest : public CxxTest::TestSuite {

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/ProgressableViewMockObject.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/ProgressableViewMockObject.h
@@ -1,6 +1,7 @@
 #ifndef MANTID_MANTIDWIDGETS_PROGRESSABLEVIEWMOCKOBJECT_H
 #define MANTID_MANTIDWIDGETS_PROGRESSABLEVIEWMOCKOBJECT_H
 
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtMantidWidgets/ProgressableView.h"
 #include <gmock/gmock.h>
 
@@ -8,10 +9,11 @@ using namespace MantidQt::MantidWidgets;
 
 class MockProgressableView : public ProgressableView {
 public:
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(setProgress, void(int));
   MOCK_METHOD2(setProgressRange, void(int, int));
   MOCK_METHOD0(clearProgress, void());
-  ~MockProgressableView() override {}
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 #endif /* MANTID_MANTIDWIDGETS_PROGRESSABLEVIEWMOCKOBJECT_H */

--- a/Vates/VatesAPI/test/ConcretePeaksPresenterVsiTest.h
+++ b/Vates/VatesAPI/test/ConcretePeaksPresenterVsiTest.h
@@ -1,18 +1,19 @@
 #ifndef CONCRETE_PEAKS_PRESENTER_VSI_TEST_H_
 #define CONCRETE_PEAKS_PRESENTER_VSI_TEST_H_
 
-#include "MantidVatesAPI/ConcretePeaksPresenterVsi.h"
 #include "MantidAPI/IPeaksWorkspace.h"
-#include "MantidVatesAPI/ViewFrustum.h"
+#include "MantidDataObjects/NoShape.h"
+#include "MantidDataObjects/PeakShapeEllipsoid.h"
+#include "MantidDataObjects/PeakShapeSpherical.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Crystal/PeakShape.h"
-#include "MantidDataObjects/PeakShapeSpherical.h"
-#include "MantidDataObjects/PeakShapeEllipsoid.h"
-#include "MantidDataObjects/NoShape.h"
 #include "MantidKernel/V3D.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidVatesAPI/ConcretePeaksPresenterVsi.h"
+#include "MantidVatesAPI/ViewFrustum.h"
 #include "MockObjects.h"
-#include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -22,7 +23,7 @@
 
 using namespace ::testing;
 using namespace Mantid::VATES;
-
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
 class MockPeakConcrete : public Mantid::DataObjects::Peak {
 public:
   MOCK_CONST_METHOD0(getHKL, Mantid::Kernel::V3D(void));
@@ -37,7 +38,7 @@ public:
   MOCK_METHOD1(getPeak, Mantid::DataObjects::Peak &(int peakNum));
   MOCK_CONST_METHOD1(getPeak, const Mantid::DataObjects::Peak &(int peakNum));
 };
-
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 class ConcretePeaksPresenterVsiTest : public CxxTest::TestSuite {
 public:
   void testSetupPresenterCorrectly() {

--- a/Vates/VatesAPI/test/MDEWInMemoryLoadingPresenterTest.h
+++ b/Vates/VatesAPI/test/MDEWInMemoryLoadingPresenterTest.h
@@ -9,11 +9,12 @@
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidVatesAPI/FilteringUpdateProgressAction.h"
 #include "MantidVatesAPI/MDEWInMemoryLoadingPresenter.h"
-#include "MantidKernel/make_unique.h"
-#include <vtkUnstructuredGrid.h>
 #include <vtkSmartPointer.h>
+#include <vtkUnstructuredGrid.h>
 
 using namespace Mantid::VATES;
 using namespace Mantid::API;
@@ -25,10 +26,12 @@ private:
   // Helper type. Mocks a Workspace Provider.
   class MockWorkspaceProvider : public Mantid::VATES::WorkspaceProvider {
   public:
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(canProvideWorkspace, bool(std::string));
     MOCK_CONST_METHOD1(fetchWorkspace,
                        Mantid::API::Workspace_sptr(std::string));
     MOCK_CONST_METHOD1(disposeWorkspace, void(std::string));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // Helper method. Generates and returns a valid IMDEventWorkspace

--- a/Vates/VatesAPI/test/MDHWInMemoryLoadingPresenterTest.h
+++ b/Vates/VatesAPI/test/MDHWInMemoryLoadingPresenterTest.h
@@ -8,12 +8,13 @@
 #include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include "MantidVatesAPI/FilteringUpdateProgressAction.h"
 #include "MantidVatesAPI/MDHWInMemoryLoadingPresenter.h"
-#include "MantidKernel/make_unique.h"
-#include <vtkUnstructuredGrid.h>
 #include <vtkSmartPointer.h>
+#include <vtkUnstructuredGrid.h>
 
 using namespace Mantid::VATES;
 using namespace Mantid::API;
@@ -26,10 +27,12 @@ private:
   // Helper type. Mocks a Workspace Provider.
   class MockWorkspaceProvider : public Mantid::VATES::WorkspaceProvider {
   public:
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(canProvideWorkspace, bool(std::string));
     MOCK_CONST_METHOD1(fetchWorkspace,
                        Mantid::API::Workspace_sptr(std::string));
     MOCK_CONST_METHOD1(disposeWorkspace, void(std::string));
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // Helper method. Generates and returns a valid IMDHistoWorkspace

--- a/Vates/VatesAPI/test/VatesKnowledgeSerializerTest.h
+++ b/Vates/VatesAPI/test/VatesKnowledgeSerializerTest.h
@@ -1,17 +1,18 @@
 #ifndef REBINNING_XML_GENERATOR_TEST_H
 #define REBINNING_XML_GENERATOR_TEST_H
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-#include <cxxtest/TestSuite.h>
-#include <MantidGeometry/MDGeometry/IMDDimension.h>
-#include "MantidVatesAPI/VatesKnowledgeSerializer.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
 #include "MantidKernel/System.h"
-#include "MantidAPI/AnalysisDataService.h"
-#include <boost/shared_ptr.hpp>
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidVatesAPI/VatesKnowledgeSerializer.h"
 #include "MockObjects.h"
+#include <MantidGeometry/MDGeometry/IMDDimension.h>
+#include <boost/shared_ptr.hpp>
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 using namespace Mantid::VATES;
 
@@ -20,12 +21,13 @@ private:
   // Helper class
   class MockImplicitFunction : public Mantid::Geometry::MDImplicitFunction {
   public:
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_METHOD1(isPointContained, bool(const Mantid::coord_t *pPoint));
     MOCK_METHOD1(isPointContained, bool(const std::vector<Mantid::coord_t> &));
     MOCK_METHOD1(isPointContained, bool(const Mantid::Kernel::VMD &));
     MOCK_CONST_METHOD0(getName, std::string());
     MOCK_CONST_METHOD0(toXMLString, std::string());
-    ~MockImplicitFunction() override {}
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
   };
 
   // Test methods

--- a/Vates/VatesAPI/test/vtkDataSetFactoryTest.h
+++ b/Vates/VatesAPI/test/vtkDataSetFactoryTest.h
@@ -2,19 +2,20 @@
 #ifndef VTKDATASETFACTORYTEST_H_
 #define VTKDATASETFACTORYTEST_H_
 
+#include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/IMDWorkspace.h"
-#include "MantidVatesAPI/vtkDataSetFactory.h"
+#include "MantidAPI/Workspace.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidKernel/make_unique.h"
+#include "MantidTestHelpers/MDEventsTestHelper.h"
 #include "MantidVatesAPI/ProgressAction.h"
+#include "MantidVatesAPI/vtkDataSetFactory.h"
+#include "MantidVatesAPI/vtkStructuredGrid_Silent.h"
+#include "vtkDataSet.h"
+#include "vtkFloatArray.h"
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "vtkDataSet.h"
-#include "vtkFloatArray.h"
-#include "MantidAPI/Workspace.h"
-#include "MantidAPI/IMDHistoWorkspace.h"
-#include "MantidKernel/make_unique.h"
-#include "MantidTestHelpers/MDEventsTestHelper.h"
-#include "MantidVatesAPI/vtkStructuredGrid_Silent.h"
 
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
@@ -26,11 +27,13 @@ private:
   /// Mocked helper type
   class MockvtkDataSetFactory : public Mantid::VATES::vtkDataSetFactory {
   public:
+    GCC_DIAG_OFF_SUGGEST_OVERRIDE
     MOCK_CONST_METHOD1(
         create, vtkSmartPointer<vtkDataSet>(Mantid::VATES::ProgressAction &));
     MOCK_METHOD1(initialize, void(boost::shared_ptr<Mantid::API::Workspace>));
     MOCK_CONST_METHOD0(validate, void());
     MOCK_CONST_METHOD0(getFactoryTypeName, std::string());
+    GCC_DIAG_ON_SUGGEST_OVERRIDE
     void setSuccessorConcrete(std::unique_ptr<vtkDataSetFactory> pSuccessor) {
       vtkDataSetFactory::setSuccessor(pSuccessor);
     }

--- a/Vates/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
+++ b/Vates/VatesAPI/test/vtkDataSetToPeaksFilteredDataSetTest.h
@@ -1,22 +1,23 @@
 #ifndef MANTID_VATESAPI_VTKDATASETTOPEAKSFILTEREDDATASETTEST_H_
 #define MANTID_VATESAPI_VTKDATASETTOPEAKSFILTEREDDATASETTEST_H_
 
+#include "MantidAPI/IPeaksWorkspace.h"
+#include "MantidDataObjects/NoShape.h"
+#include "MantidDataObjects/PeakShapeEllipsoid.h"
+#include "MantidDataObjects/PeakShapeSpherical.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidGeometry/Crystal/PeakShape.h"
+#include "MantidKernel/V3D.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include "MantidVatesAPI/FieldDataToMetadata.h"
 #include "MantidVatesAPI/MetadataJsonManager.h"
 #include "MantidVatesAPI/MetadataToFieldData.h"
-#include "MantidVatesAPI/VatesConfigurations.h"
 #include "MantidVatesAPI/NoThresholdRange.h"
+#include "MantidVatesAPI/UserDefinedThresholdRange.h"
+#include "MantidVatesAPI/VatesConfigurations.h"
 #include "MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h"
 #include "MantidVatesAPI/vtkSplatterPlotFactory.h"
-#include "MantidVatesAPI/UserDefinedThresholdRange.h"
-#include "MantidAPI/IPeaksWorkspace.h"
-#include "MantidDataObjects/PeaksWorkspace.h"
-#include "MantidGeometry/Crystal/PeakShape.h"
-#include "MantidDataObjects/PeakShapeSpherical.h"
-#include "MantidDataObjects/PeakShapeEllipsoid.h"
-#include "MantidDataObjects/NoShape.h"
-#include "MantidKernel/V3D.h"
 
 #include "MockObjects.h"
 #include <gmock/gmock.h>
@@ -37,7 +38,7 @@
 using namespace Mantid::DataObjects;
 using namespace Mantid::VATES;
 using namespace ::testing;
-
+GCC_DIAG_OFF_SUGGEST_OVERRIDE
 class MockPeakFilter : public Mantid::DataObjects::Peak {
 public:
   MOCK_CONST_METHOD0(getHKL, Mantid::Kernel::V3D(void));
@@ -51,7 +52,7 @@ public:
   MOCK_METHOD1(getPeak, Mantid::DataObjects::Peak &(int peakNum));
   MOCK_CONST_METHOD1(getPeak, const Mantid::DataObjects::Peak &(int peakNum));
 };
-
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 struct PeaksFilterDataContainer {
   double radius;
   double radiusFactor;

--- a/Vates/VatesAPI/test/vtkPeakMarkerFactoryTest.h
+++ b/Vates/VatesAPI/test/vtkPeakMarkerFactoryTest.h
@@ -52,6 +52,7 @@ public:
   MOCK_METHOD1(getPeak, Mantid::DataObjects::Peak &(int peakNum));
   MOCK_CONST_METHOD1(getPeak, const Mantid::DataObjects::Peak &(int peakNum));
 };
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 //=====================================================================================
 // Functional Tests
@@ -313,6 +314,5 @@ public:
     }
   }
 };
-GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 #endif


### PR DESCRIPTION
Description of work.

This should fix or suppress most of the remaining `-Wsuggest-override` warnings when building with GCC 5+. The few that remain should be addressed in #16690.

I was also able to shrink the number of lines where these warnings are suppressed compared to #16668.

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
