### PR TITLE
Upgrade matplotlib on Windows

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -10,7 +10,7 @@ if( MSVC )
   include ( ExternalProject )
   set( EXTERNAL_ROOT ${PROJECT_SOURCE_DIR}/external )
   set( THIRD_PARTY_GIT_URL "https://github.com/mantidproject/thirdparty-msvc2015.git" )
-  set ( THIRD_PARTY_GIT_SHA1 c29672780a6ac233d6d7e401b8b18a1df73729fa )
+  set ( THIRD_PARTY_GIT_SHA1 988f1be53a5dbbac30afb5ed11320862d06627aa )
   set ( THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty )
   # Generates a script to do the clone/update in tmp
   set ( _project_name ThirdParty )

--- a/buildconfig/CMake/Packaging/launch_mantidplot.bat
+++ b/buildconfig/CMake/Packaging/launch_mantidplot.bat
@@ -27,6 +27,10 @@ set _EXTRA_PATH_DIRS=%_INSTALL_DIR%\bin;%_INSTALL_DIR%\PVPlugins;%_INSTALL_DIR%\
 set MANTIDPATH=%_BIN_DIR%
 set PATH=%_EXTRA_PATH_DIRS%;%PATH%
 set PV_PLUGIN_PATH=%_INSTALL_DIR%\PVPlugins\PVPlugins
+:: Matplotlib backend should default to Qt if not set (requires matplotlib >= 1.5)
+if "%MPLBACKEND%"=="" (
+  set MPLBACKEND=qt4agg
+)
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Start MantidPlot

--- a/buildconfig/CMake/Packaging/mantidpython.bat.in
+++ b/buildconfig/CMake/Packaging/mantidpython.bat.in
@@ -21,6 +21,11 @@ set PYTHONPATH=%MANTIDPATH%;%PYTHONPATH%
 set _PYTHON_EXE=%PYTHONHOME%\python.exe
 set _IPYTHON_CMD=%PYTHONHOME%\Scripts\ipython.cmd
 
+:: Matplotlib backend should default to Qt if not set (requires matplotlib >= 1.5)
+if "%MPLBACKEND%"=="" (
+  set MPLBACKEND=qt4agg
+)
+
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Start python
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
The default backend for matplotlib is tcl/tk but we don't ship this on Windows. This PR upgrades the bundled matplotlib on Windows to 1.5.1, which exposes the `MPLBACKEND` environment variable that is then set to `Qt` to force matplotlib to use Qt as the backend.

**To test:**
- Build the code for this branch and verify that matplotlib is now v1.5.1:

``` python
import matplotlib as mpl
print(mpl.__version__)
```
- Use the `mantidpython.bat` startup script to run a Vanilla Python interpreter and try and plot an mpl figure:

``` python
from matplotlib.pyplot import plot, show
import numpy as np

x = np.arange(0,1,0.1)
plot(x,x)
show()
```

Fixes #15249

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
