### PR TITLE
 Add warning for 2D reduction with merge

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -453,7 +453,7 @@ private:
   /// Reset the to M3
   void resetToM3IfNecessary();
   /// Check the validty of inputs
-  bool areSettingsValid();
+  bool areSettingsValid(States type);
   /// Check setting for wavelengths and Q values
   void checkWaveLengthAndQValues(bool &isValid, QString &message,
                                  QLineEdit *min, QLineEdit *max,

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -2383,7 +2383,7 @@ void SANSRunWindow::handleReduceButtonClick(const QString &typeStr) {
   const States type = typeStr == "1D" ? OneD : TwoD;
 
   // Make sure that all settings are valid
-  if (!areSettingsValid()) {
+  if (!areSettingsValid(type)) {
     return;
   }
 
@@ -4412,10 +4412,18 @@ void SANSRunWindow::resetToM3IfNecessary() {
  * Check tha the Settings are valid. We need to do this for inputs which cannot
  * be checked with simple validators
  */
-bool SANSRunWindow::areSettingsValid() {
+bool SANSRunWindow::areSettingsValid(States type) {
   bool isValid = true;
   QString message;
   // ------------ GUI INPUT CHECKS ------------
+
+  // We currently do not allow a 2D reduction with a merged flag
+  auto isMergedReduction = m_uiForm.detbank_sel->currentIndex() == 3;
+  if (type == States::TwoD && isMergedReduction) {
+    isValid = false;
+    message += "A merged Detector Bank selection is currently not supported for 2D "
+           "reductions.\n";
+  }
 
   // R_MAX -- can be only >0 or -1
   auto r_max = m_uiForm.rad_max->text().simplified().toDouble();

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -4421,8 +4421,9 @@ bool SANSRunWindow::areSettingsValid(States type) {
   auto isMergedReduction = m_uiForm.detbank_sel->currentIndex() == 3;
   if (type == States::TwoD && isMergedReduction) {
     isValid = false;
-    message += "A merged Detector Bank selection is currently not supported for 2D "
-           "reductions.\n";
+    message +=
+        "A merged Detector Bank selection is currently not supported for 2D "
+        "reductions.\n";
   }
 
   // R_MAX -- can be only >0 or -1


### PR DESCRIPTION
Fixes #16709.

A warning should be displayed when the user intends to perform a 2D reduction while having the merge mechanism selected.

**To test:**

The test files can be found here: \olympic\Babylon5\Scratch\Anton\Testing\16712_add_2d_reduction_with_merge_warning
1. Open the ISIS SANS GUI
2. Set the isntrument to SANS2DTUBES
3. Load the user file: USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger
4. Load the sample scatter file: SANS2D00034484.nxs
5. On the Reduction Settings Tab under Detector->Detector bank select "merged"
6. On the Run Numbers Tab press "Reduce 2D"
   - Confirm that a warning pops up regarding the the incompatibility of a 2D reduction with the merged flag

_Does not need to be in the release notes. Small change_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
