### PR TITLE
Fix UBSAN warning 'constructor call on misaligned address'

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MDEvent.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEvent.h
@@ -12,9 +12,6 @@
 namespace Mantid {
 namespace DataObjects {
 
-// To ensure the structure is as small as possible
-#pragma pack(push, 2)
-
 /** Templated class holding data about a neutron detection event
  * in N-dimensions (for example, Qx, Qy, Qz, E).
  *
@@ -256,11 +253,7 @@ public:
     }
   }
 };
-// Return to normal packing
-#pragma pack(pop)
-
 } // namespace DataObjects
-
 } // namespace Mantid
 
 #endif /* MDEVENT_H_ */

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEvent.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEvent.h
@@ -253,6 +253,7 @@ public:
     }
   }
 };
+
 } // namespace DataObjects
 } // namespace Mantid
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
@@ -302,6 +302,7 @@ public:
     }
   }
 };
+
 } // namespace DataObjects
 } // namespace Mantid
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
@@ -13,9 +13,6 @@
 namespace Mantid {
 namespace DataObjects {
 
-// To ensure MDEvent is as small as possible
-#pragma pack(push, 2)
-
 /** Templated class holding data about a neutron detection event
  * in N-dimensions (for example, Qx, Qy, Qz, E).
  *
@@ -305,8 +302,6 @@ public:
     }
   }
 };
-// Return to normal packing
-#pragma pack(pop)
 } // namespace DataObjects
 } // namespace Mantid
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
@@ -13,6 +13,9 @@
 namespace Mantid {
 namespace DataObjects {
 
+// To ensure MDEvent is as small as possible
+#pragma pack(push, 2)
+
 /** Templated class holding data about a neutron detection event
  * in N-dimensions (for example, Qx, Qy, Qz, E).
  *
@@ -302,7 +305,8 @@ public:
     }
   }
 };
-
+// Return to normal packing
+#pragma pack(pop)
 } // namespace DataObjects
 } // namespace Mantid
 


### PR DESCRIPTION
Description of work.

The undefined behavior sanitizer gives several warnings about `MDEvent` and `MDLeanEvent` like the one below. (see the full build output [here](https://gist.github.com/quantumsteve/e40dce3a4ee5c57dd95b5ddadd8be00b) or [here](http://builds.mantidproject.org/view/All/job/undefined_behavior_sanitizer/3/console)).

```
233/1569 Test #587: DataObjectsTest_MDBoxTest ....................................***Failed    0.41 sec
Running 29 tests.........../Framework/DataObjects/inc/MantidDataObjects/MDEvent.h:33:38: runtime error: constructor call on misaligned address 0x000003a48546 for type 'struct MDLeanEvent', which requires 4 byte alignment
0x000003a48546: note: pointer points here
 14 00 00 00 59 40  00 00 00 40 00 00 40 40  9a 99 99 3f 9a 99 59 40  00 00 00 40 00 00 40 40  65 72
             ^ 
```

The warnings go away if I add also add `#pragma pack(push,2)` and `#pragma pack(pop)` to `MDLeanEvent`. I also tried using the [C++11 alignas specifier](http://en.cppreference.com/w/cpp/language/alignas), but got many compiler errors similar to 

```
In file included from /Users/svh/Documents/MantidProject/mantid/Framework/DataObjects/src/MDEventFactory.cpp:2:
In file included from /Users/svh/Documents/MantidProject/mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventFactory.h:6:
In file included from /Users/svh/Documents/MantidProject/mantid/Framework/DataObjects/inc/MantidDataObjects/MDBin.h:6:
/Users/svh/Documents/MantidProject/mantid/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h:35:38: error: requested alignment is less than minimum alignment of 4 for type 'Mantid::DataObjects::MDLeanEvent<1>'
template <size_t nd> class DLLExport alignas(2) MDLeanEvent {
                                     ^
/Users/svh/Documents/MantidProject/mantid/Framework/DataObjects/inc/MantidDataObjects/MDEvent.h:31:45: note: in instantiation of template class 'Mantid::DataObjects::MDLeanEvent<1>' requested here
class DLLExport alignas(2) MDEvent : public MDLeanEvent<nd> {
                                            ^
/Users/svh/Documents/MantidProject/mantid/Framework/DataObjects/src/MDEventFactory.cpp:36:26: note: in instantiation of template class 'Mantid::DataObjects::MDEvent<1>' requested here
template DLLExport class MDEvent<1>;
                         ^
```

**To test:**

<!-- Instructions for testing. -->
1. Do we want to remove the pack pragmas in `MDEvent` and let the compiler determine alignment? 
2. Is repeating these pragmas in `MDLeanEvent` the correct solution?
3. Will this have any negative effects on code using `MDLeanEvent` directly?

Instructions for running UBSAN are [here](http://www.mantidproject.org/Sanitizers)

This PR does not have an associated GitHub issue.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
