### PR TITLE
Fix bug with MantidPlot test runner

### DIFF
--- a/MantidPlot/test/mantidplottests.py
+++ b/MantidPlot/test/mantidplottests.py
@@ -58,10 +58,10 @@ def runTests(classname):
     QtCore.QCoreApplication.processEvents()
     QtCore.QCoreApplication.processEvents()
 
-    # Set Mantid exit code
+    # Close Mantid and set exit code
     if not res.wasSuccessful():
-        _qti.app.setExitCode(1)
+        sys.exit(1)
     else:
-        _qti.app.setExitCode(0)
+        sys.exit(0)
 
     return res


### PR DESCRIPTION
When the python tests for MantidPlot will currently always pass because the incorrect error code is being returned from within the bowls of ApplicationWindow. Technically it is doing the correct thing because the the _test runner_ finishes successfully, just not the actual tests.

Easiest solution here is to use the plain old python `sys.exit` to definitely close the program at this point. Everything we need to do including test clean ups should be done by this point so it shouldn't matter.

**To test:**
Easiest way to test is to pick a test case under `MantidPlot/test` and add a `self.fail()` to it. Run the unit test using ctest and using the verbose option. The verbose output should report that the test failed, but ctest will still say the test passed.

Test again with the changes applied and ctest should correctly report a failure.

Fixes #16721.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
