### PR TITLE
PredictPeaks working with Crystallography Convention

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
@@ -58,7 +58,7 @@ private:
 
   void setStructureFactorCalculatorFromSample(const API::Sample &sample);
 
-  void calculateQAndAddToOutput(const Kernel::V3D &hkl,
+  void calculateQAndAddToOutput(Kernel::V3D &hkl,
                                 const Kernel::DblMatrix &orientedUB,
                                 const Kernel::DblMatrix &goniometerMatrix);
 
@@ -72,7 +72,7 @@ private:
   Geometry::Instrument_const_sptr m_inst;
   /// Output peaks workspace
   Mantid::DataObjects::PeaksWorkspace_sptr m_pw;
-
+  std::string convention;
   Geometry::StructureFactorCalculator_sptr m_sfCalculator;
 };
 

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -398,8 +398,7 @@ void PredictPeaks::calculateQAndAddToOutput(V3D &hkl,
   // The q-vector direction of the peak is = goniometer * ub * hkl_vector
   // This is in inelastic convention: momentum transfer of the LATTICE!
   // Also, q does have a 2pi factor = it is equal to 2pi/wavelength.
-  if (convention == "Crystallography")
-  {
+  if (convention == "Crystallography") {
     hkl = hkl * (-1.0);
   }
   V3D q = orientedUB * hkl * (2.0 * M_PI);

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -344,7 +344,7 @@ void PredictPeaks::fillPossibleHKLsUsingPeaksWorkspace(
   // HKL's are flipped by -1 because of the internal Q convention
   // is not the same as the PeaksWorkspace convention
   double qSign = 1.0;
-  if (peaksWorkspace->getConvention() ==  "Crystallography")
+  if (peaksWorkspace->getConvention() == "Crystallography")
     qSign = -1.0;
 
   for (int i = 0; i < static_cast<int>(peaksWorkspace->getNumberPeaks()); ++i) {

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -28,6 +28,7 @@ using namespace Mantid::Kernel;
 PredictPeaks::PredictPeaks()
     : m_runNumber(-1), m_inst(), m_pw(), m_sfCalculator() {
   m_refConds = getAllReflectionConditions();
+  convention = ConfigService::Instance().getString("Q.convention");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -391,12 +392,16 @@ void PredictPeaks::setStructureFactorCalculatorFromSample(
  * @param orientedUB
  * @param goniometerMatrix
  */
-void PredictPeaks::calculateQAndAddToOutput(const V3D &hkl,
+void PredictPeaks::calculateQAndAddToOutput(V3D &hkl,
                                             const DblMatrix &orientedUB,
                                             const DblMatrix &goniometerMatrix) {
   // The q-vector direction of the peak is = goniometer * ub * hkl_vector
   // This is in inelastic convention: momentum transfer of the LATTICE!
   // Also, q does have a 2pi factor = it is equal to 2pi/wavelength.
+  if (convention == "Crystallography")
+  {
+    hkl = hkl * (-1.0);
+  }
   V3D q = orientedUB * hkl * (2.0 * M_PI);
 
   // Create the peak using the Q in the lab framewith all its info:

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -341,10 +341,17 @@ void PredictPeaks::fillPossibleHKLsUsingPeaksWorkspace(
 
   bool roundHKL = getProperty("RoundHKL");
 
+  // HKL's are flipped by -1 because of the internal Q convention
+  // is not the same as the PeaksWorkspace convention
+  double qSign = 1.0;
+  if (peaksWorkspace->getConvention() !=   convention)
+    qSign = -1.0;
+
+
   for (int i = 0; i < static_cast<int>(peaksWorkspace->getNumberPeaks()); ++i) {
     IPeak &p = peaksWorkspace->getPeak(i);
     // Get HKL from that peak
-    V3D hkl = p.getHKL();
+    V3D hkl = p.getHKL() * qSign;
 
     if (roundHKL)
       hkl.round();

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -344,9 +344,8 @@ void PredictPeaks::fillPossibleHKLsUsingPeaksWorkspace(
   // HKL's are flipped by -1 because of the internal Q convention
   // is not the same as the PeaksWorkspace convention
   double qSign = 1.0;
-  if (peaksWorkspace->getConvention() !=   convention)
+  if (peaksWorkspace->getConvention() ==  "Crystallography")
     qSign = -1.0;
-
 
   for (int i = 0; i < static_cast<int>(peaksWorkspace->getNumberPeaks()); ++i) {
     IPeak &p = peaksWorkspace->getPeak(i);

--- a/Framework/Crystal/test/PredictPeaksTest.h
+++ b/Framework/Crystal/test/PredictPeaksTest.h
@@ -175,7 +175,8 @@ public:
   void test_manual_U_and_gonio() { do_test_manual(22.5, 22.5); }
 
   void test_crystallography() {
-    Kernel::ConfigService::Instance().setString("Q.convention", "Crystallography");
+    Kernel::ConfigService::Instance().setString("Q.convention", 
+                                                "Crystallography");
     do_test_exec("Primitive", 10, std::vector<V3D>());
   }
 };

--- a/Framework/Crystal/test/PredictPeaksTest.h
+++ b/Framework/Crystal/test/PredictPeaksTest.h
@@ -11,6 +11,7 @@
 #include <cxxtest/TestSuite.h>
 #include "MantidKernel/V3D.h"
 #include "MantidGeometry/IDTypes.h"
+#include "MantidKernel/ConfigService.h"
 
 using namespace Mantid;
 using namespace Mantid::Crystal;
@@ -172,6 +173,11 @@ public:
   void test_manual_goniometer_alone() { do_test_manual(0, 45.0); }
 
   void test_manual_U_and_gonio() { do_test_manual(22.5, 22.5); }
+
+  void test_crystallography() {
+    Kernel::ConfigService::Instance().setString("Q.convention", "Crystallography");
+    do_test_exec("Primitive", 10, std::vector<V3D>());
+  }
 };
 
 #endif /* MANTID_CRYSTAL_PREDICTPEAKSTEST_H_ */

--- a/Framework/Crystal/test/PredictPeaksTest.h
+++ b/Framework/Crystal/test/PredictPeaksTest.h
@@ -175,7 +175,7 @@ public:
   void test_manual_U_and_gonio() { do_test_manual(22.5, 22.5); }
 
   void test_crystallography() {
-    Kernel::ConfigService::Instance().setString("Q.convention", 
+    Kernel::ConfigService::Instance().setString("Q.convention",
                                                 "Crystallography");
     do_test_exec("Primitive", 10, std::vector<V3D>());
   }


### PR DESCRIPTION
Description of work.
PredictPeaks was modified so that it works correctly when using Crystallography Convention.  It fails with a negative wavelength without this change.

**To test:**
In Preferences use Mantid tab to check Crystallography convention checkbox.

``` Python
Load(Filename='TOPAZ_3132_event.nxs', OutputWorkspace='TOPAZ_3132_event', LoadMonitors=True)
ConvertToMD(InputWorkspace='TOPAZ_3132_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', LorentzCorrection=True, OutputWorkspace='TOPAZ_3132_md', MinValues='-25,-25,-25', MaxValues='25,25,25', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=13, MinRecursionDepth=7)
FindPeaksMD(InputWorkspace='TOPAZ_3132_md', PeakDistanceThreshold=0.3768, MaxPeaks=50, DensityThresholdFactor=100, OutputWorkspace='TOPAZ_3132_peaks')
FindUBUsingFFT(PeaksWorkspace='TOPAZ_3132_peaks', MinD=3, MaxD=15, Tolerance=0.12)
IndexPeaks(PeaksWorkspace='TOPAZ_3132_peaks', Tolerance=0.12)
PredictPeaks(InputWorkspace='TOPAZ_3132_peaks', WavelengthMin=0.4, WavelengthMax=3.5, MinDSpacing=0.4, MaxDSpacing=8.5, OutputWorkspace='TOPAZ_3131_peaks')
```

Fixes #16722

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
