### PR TITLE
Fix clang-tidy warnings in DTRSMinimizer.

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/RalNlls/TrustRegion.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/RalNlls/TrustRegion.h
@@ -19,19 +19,19 @@ void mult_Jt(const DoubleFortranMatrix &J, const DoubleFortranVector &x,
 double evaluate_model(const DoubleFortranVector &f,
                       const DoubleFortranMatrix &J,
                       const DoubleFortranMatrix &hf,
-                      const DoubleFortranVector &d, const nlls_options options,
+                      const DoubleFortranVector &d, const nlls_options &options,
                       evaluate_model_work &w);
 double calculate_rho(double normf, double normfnew, double md,
                      const nlls_options &options);
 void update_trust_region_radius(double &rho, const nlls_options &options,
                                 nlls_inform &inform, NLLS_workspace &w);
-void rank_one_update(DoubleFortranMatrix &hf, NLLS_workspace w);
+void rank_one_update(DoubleFortranMatrix &hf, NLLS_workspace &w);
 void test_convergence(double normF, double normJF, double normF0,
                       double normJF0, const nlls_options &options,
                       nlls_inform &inform);
 void apply_scaling(const DoubleFortranMatrix &J, DoubleFortranMatrix &A,
                    DoubleFortranVector &v, apply_scaling_work &w,
-                   const nlls_options options, nlls_inform inform);
+                   const nlls_options &options, nlls_inform &inform);
 void all_eig_symm(const DoubleFortranMatrix &A, DoubleFortranVector &ew,
                   DoubleFortranMatrix &ev);
 // void apply_second_order_info(int n, int m, const DoubleFortranVector& X,

--- a/Framework/CurveFitting/src/FuncMinimizers/DTRSMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/DTRSMinimizer.cpp
@@ -343,14 +343,12 @@ void roots_quadratic(double a0, double a1, double a2, double tol, int &nroots,
     auto pprime = two * a2 * root1 + a1;
     if (pprime != zero) {
       root1 = root1 - p / pprime;
-      p = (a2 * root1 + a1) * root1 + a0;
     }
     if (nroots == 2) {
       p = (a2 * root2 + a1) * root2 + a0;
       pprime = two * a2 * root2 + a1;
       if (pprime != zero) {
         root2 = root2 - p / pprime;
-        p = (a2 * root2 + a1) * root2 + a0;
       }
     }
   }
@@ -592,14 +590,11 @@ void dtrs_solve_main(int n, double radius, double f,
         if (h(i) == lambda_min) {
           i_hard = i;
           break;
-        };
+        }
       }
       x(i_hard) = one / radius;
       inform.x_norm = radius;
       inform.obj = f + lambda_min * radius * radius;
-      lambda = -lambda_min;
-    } else {
-      lambda = zero;
     }
     inform.status = ErrorCode::ral_nlls_ok;
     return;
@@ -730,11 +725,6 @@ void dtrs_solve_main(int n, double radius, double f,
 
     if (fabs(inform.x_norm - radius) <=
         std::max(control.stop_normal * radius, control.stop_absolute_normal)) {
-      if (inform.x_norm > radius) {
-        lambda_l = std::max(lambda_l, lambda);
-      } else {
-        lambda_u = std::min(lambda_u, lambda);
-      }
       inform.status = ErrorCode::ral_nlls_ok;
       break;
     }

--- a/Framework/CurveFitting/src/RalNlls/TrustRegion.cpp
+++ b/Framework/CurveFitting/src/RalNlls/TrustRegion.cpp
@@ -110,7 +110,7 @@ double dot_product(const DoubleFortranVector &x, const DoubleFortranVector &y) {
 double evaluate_model(const DoubleFortranVector &f,
                       const DoubleFortranMatrix &J,
                       const DoubleFortranMatrix &hf,
-                      const DoubleFortranVector &d, const nlls_options options,
+                      const DoubleFortranVector &d, const nlls_options &options,
                       evaluate_model_work &w) {
 
   // Jd = J*d
@@ -163,7 +163,7 @@ double calculate_rho(double normf, double normfnew, double md,
 /// Update the Hessian matrix without actually evaluating it (quasi-Newton?)
 /// @param hf :: The matrix to update.
 /// @param w :: The work struct.
-void rank_one_update(DoubleFortranMatrix &hf, NLLS_workspace w) {
+void rank_one_update(DoubleFortranMatrix &hf, NLLS_workspace &w) {
 
   auto yts = dot_product(w.d, w.y);
   if (fabs(yts) < 10 * epsmch) {
@@ -292,7 +292,7 @@ void test_convergence(double normF, double normJF, double normF0,
 /// @param inform :: The information.
 void apply_scaling(const DoubleFortranMatrix &J, DoubleFortranMatrix &A,
                    DoubleFortranVector &v, apply_scaling_work &w,
-                   const nlls_options options, nlls_inform inform) {
+                   const nlls_options &options, nlls_inform &inform) {
   auto m = J.len1();
   auto n = J.len2();
   if (w.diag.len() != n) {


### PR DESCRIPTION
Fixed the reported clang-tidy and coverity warnings in the new minimizer code.

**To test:**

Code review.

Fixes #16728 .

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
