### PR TITLE
Fix hexahedron bounding box calculation

### DIFF
--- a/Framework/Geometry/src/Objects/Object.cpp
+++ b/Framework/Geometry/src/Objects/Object.cpp
@@ -1647,20 +1647,19 @@ void Object::calcBoundingBoxByGeometry() {
     }
   } break;
   case GluGeometryHandler::GeometryType::HEXAHEDRON: {
-    // Vectors are in the same order as the following webpage:
-    // http://docs.mantidproject.org/nightly/concepts/HowToDefineGeometricShape.html#hexahedron
-    auto &lf = vectors[1];
-    auto &lb = vectors[0];
-    auto &rb = vectors[3];
-    auto &rf = vectors[2];
-    auto dz = vectors[4] - lf;
+    // These will be replaced by more realistic values in the loop below
+    minX = minY = minZ = std::numeric_limits<decltype(minZ)>::max();
+    maxX = maxY = maxZ = -std::numeric_limits<decltype(maxZ)>::max();
 
-    minX = std::min(lf.X(), lb.X());
-    maxX = std::max(rb.X(), rf.X());
-    minY = lb.Y();
-    maxY = rf.Y();
-    minZ = 0;
-    maxZ = dz.Z();
+    // Loop over all corner points to find minima and maxima on each axis
+    for (const auto &vector : vectors) {
+      minX = std::min(minX, vector.X());
+      maxX = std::max(maxX, vector.X());
+      minY = std::min(minY, vector.Y());
+      maxY = std::max(maxY, vector.Y());
+      minZ = std::min(minZ, vector.Z());
+      maxZ = std::max(maxZ, vector.Z());
+    }
   } break;
   case GluGeometryHandler::GeometryType::CYLINDER:
   case GluGeometryHandler::GeometryType::SEGMENTED_CYLINDER: {

--- a/Framework/Geometry/test/ObjectTest.h
+++ b/Framework/Geometry/test/ObjectTest.h
@@ -811,7 +811,7 @@ public:
     // See
     // http://docs.mantidproject.org/nightly/concepts/HowToDefineGeometricShape.html#hexahedron
     Hexahedron hex;
-    hex.lbb = V3D(0, 0, 0);
+    hex.lbb = V3D(0, 0, -2);
     hex.lfb = V3D(1, 0, 0);
     hex.rfb = V3D(1, 1, 0);
     hex.rbb = V3D(0, 1, 0);
@@ -829,7 +829,7 @@ public:
     TS_ASSERT_DELTA(bb.zMax(), 2, 0.0001);
     TS_ASSERT_DELTA(bb.xMin(), 0, 0.0001);
     TS_ASSERT_DELTA(bb.yMin(), 0, 0.0001);
-    TS_ASSERT_DELTA(bb.zMin(), 0, 0.0001);
+    TS_ASSERT_DELTA(bb.zMin(), -2, 0.0001);
   }
 
   void testdefineBoundingBox()


### PR DESCRIPTION
The bounding box is now calculated in a more general way.

**To test:** Try viewing an instrument with hexahedron shapes with negative Z coordinates in Mantid GUI. With this fix the Instrument view should show up normally.

Fixes #16735.
