### PR TITLE
Fix method calls from C++ to Python for plugins in Python 3

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -174,13 +174,12 @@ void AlgorithmAdapter<BaseAlgorithm>::cancel() {
 template <typename BaseAlgorithm>
 std::map<std::string, std::string>
 AlgorithmAdapter<BaseAlgorithm>::validateInputs() {
-  // variables that are needed further down
-  boost::python::dict resultDict;
   std::map<std::string, std::string> resultMap;
 
   // this is a modified version of CallMethod0::dispatchWithDefaultReturn
   Environment::GlobalInterpreterLock gil;
   if (Environment::typeHasAttribute(getSelf(), "validateInputs")) {
+    boost::python::dict resultDict;
     try {
       resultDict = boost::python::call_method<boost::python::dict>(
           getSelf(), "validateInputs");
@@ -190,24 +189,23 @@ AlgorithmAdapter<BaseAlgorithm>::validateInputs() {
     } catch (boost::python::error_already_set &) {
       Environment::throwRuntimeError();
     }
-  }
-
-  // convert to a map<string,string>
-  boost::python::list keys = resultDict.keys();
-  size_t numItems = boost::python::len(keys);
-  for (size_t i = 0; i < numItems; ++i) {
-    boost::python::object value = resultDict[keys[i]];
-    if (value) {
-      try {
-        std::string key = boost::python::extract<std::string>(keys[i]);
-        std::string value =
-            boost::python::extract<std::string>(resultDict[keys[i]]);
-        resultMap[key] = value;
-      } catch (boost::python::error_already_set &) {
-        this->getLogger().error()
-            << "In validateInputs(self): Invalid type for key/value pair "
-            << "detected in dict.\n"
-            << "All keys and values must be strings\n";
+    // convert to a map<string,string>
+    boost::python::list keys = resultDict.keys();
+    size_t numItems = boost::python::len(keys);
+    for (size_t i = 0; i < numItems; ++i) {
+      boost::python::object value = resultDict[keys[i]];
+      if (value) {
+        try {
+          std::string key = boost::python::extract<std::string>(keys[i]);
+          std::string value =
+              boost::python::extract<std::string>(resultDict[keys[i]]);
+          resultMap[key] = value;
+        } catch (boost::python::error_already_set &) {
+          this->getLogger().error()
+              << "In validateInputs(self): Invalid type for key/value pair "
+              << "detected in dict.\n"
+              << "All keys and values must be strings\n";
+        }
       }
     }
   }

--- a/Framework/PythonInterface/mantid/kernel/src/Environment/WrapperHelpers.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Environment/WrapperHelpers.cpp
@@ -24,7 +24,11 @@ namespace Environment {
  */
 bool typeHasAttribute(PyObject *obj, const char *attr) {
   PyObject *cls_dict = obj->ob_type->tp_dict;
+#if PY_VERSION_HEX >= 0x03000000
+  return PyDict_Contains(cls_dict, PyUnicode_FromString(attr)) > 0;
+#else
   return PyDict_Contains(cls_dict, PyBytes_FromString(attr)) > 0;
+#endif
 }
 
 /** Same as above but taking a wrapper reference instead

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -1139,7 +1139,8 @@ def _translate():
             # Create the algorithm object
             algm_object = algorithm_mgr.createUnmanaged(name, max(versions))
             algm_object.initialize()
-        except Exception:
+        except Exception as exc:
+            logger.warning("Error initializing {0} on registration: '{1}'".format(name, str(exc)))
             continue
 
         algorithm_wrapper = _create_algorithm_function(name, max(versions), algm_object)


### PR DESCRIPTION
Fixes existence checks of Python methods from C++ in Python 3 by using a unicode object rather than a raw bytes object.

**To test:**

For Python 2 the build servers will tell you if this doesn't work.

For Python 3 there should be no warnings such as:

```
Python-[Warning] Error initializing SANSFitShiftScale on registration: 'SANSFitShiftScale has no function named 'PyInit'
Check the function exists and that its first argument is self.'
```

on start up. There will still be other warnings on start up but they will be addressed in the future and require this to be fixed first.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
