### PR TITLE
LR: Load primary fraction from DAS logs

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -327,6 +327,13 @@ class LRAutoReduction(PythonAlgorithm):
         angle_offset = self._read_property(meta_data_run, "angle_offset", 0.016)
         angle_offset_err = self._read_property(meta_data_run, "angle_offset_error", 0.001)
 
+        _primary_range = self.getProperty("PrimaryFractionRange").value        
+        _primary_min = int(_primary_range[0])
+        _primary_max = int(_primary_range[1])
+        # The DAS logs are all stored as floats, but we are expecting an integer
+        primary_min = math.trunc(float(self._read_property(meta_data_run, "primary_range_min", _primary_min)))
+        primary_max = math.trunc(float(self._read_property(meta_data_run, "primary_range_max", _primary_max)))
+
         _sf_file = self.getProperty("ScalingFactorFile").value
         sf_file = self._read_property(meta_data_run, "scaling_factor_file",
                                       _sf_file, is_string=True)
@@ -344,7 +351,8 @@ class LRAutoReduction(PythonAlgorithm):
             d.incident_medium_index_selected = 0
             d.angle_offset = angle_offset
             d.angle_offset_error = angle_offset_err
-
+            d.clocking_from = primary_min
+            d.clocking_to = primary_max
             d.q_min = q_min
             d.q_step = q_step
             d.fourth_column_dq0 = dQ_constant


### PR DESCRIPTION
The LR primary fraction range is now part of the DASlogs.
It should be used when automatically creating a template.

**To test:**
- Review the code.
- Make sure the tests pass.

The is no GitHub "issue" for this PR.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
