### PR TITLE
Add explanation of RRO and RROA relationship in RRO docs

### DIFF
--- a/docs/source/algorithms/ReflectometryReductionOne-v1.rst
+++ b/docs/source/algorithms/ReflectometryReductionOne-v1.rst
@@ -21,6 +21,15 @@ If :literal:`MonitorBackgroundWavelengthMin` and
 :literal:`MonitorBackgroundWavelengthMax` are both set to :literal:`0`, then
 background normalization will not be performed on the monitors.
 
+The properties of this algorithm should be manually selected by the user. If you wish
+to use the default values (found in the Instrument Defintion File) for the properties
+of this algorithm, you may want to consider using :ref:`algm-ReflectometryReductionOneAuto`.
+
+:ref:`algm-ReflectometryReductionOneAuto` also performs extra processing steps such as
+Background subtraction and :ref:`algm-PolarizationCorrection`. If you want to know how 
+these processing steps are used, please refer to the :ref:`algm-ReflectometryReductionOneAuto`
+documentation.
+
 Analysis Modes
 ##############
 


### PR DESCRIPTION
Currently there has been some confusion between scientists. They have been looking at the ReflectometryReductionOnedocumentation to see the workflow algorithm whilst using ReflectometryReductionOneAuto in their scripts. It seems that, as ReflectometryReductionOneAuto performs extra corrections that ReflectometryReductionOne does not, there has been some confusion in how the two algorithms are related.

It has been proposed that an explanation of the relationship between these algorithms should be in the ReflectometryReductionOne documentation as that is where most of the scientists are going to for this information.

**To test:**
- Build documentation locally
- Ensure that the relationship between the two algorithms is explained adequately. 

Fixes #16746 

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
