### PR TITLE
Add usage tracking to the DynamicPDF interface

### DIFF
--- a/MantidQt/CustomInterfaces/src/DynamicPDF/DPDFBackgroundRemover.cpp
+++ b/MantidQt/CustomInterfaces/src/DynamicPDF/DPDFBackgroundRemover.cpp
@@ -32,8 +32,8 @@ DECLARE_SUBWINDOW(BackgroundRemover)
 BackgroundRemover::BackgroundRemover(QWidget *parent)
     : UserSubWindow{parent}, m_sliceSelector(), m_inputDataControl(),
       m_displayControl(), m_fitControl{nullptr}, m_fourierTransform{nullptr} {
-    Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
-        "Interface", "DynamicPDF->BackgroundRemover", false);
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Interface", "DynamicPDF->BackgroundRemover", false);
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/DynamicPDF/DPDFBackgroundRemover.cpp
+++ b/MantidQt/CustomInterfaces/src/DynamicPDF/DPDFBackgroundRemover.cpp
@@ -10,6 +10,7 @@
 // Mantid headers from other projects
 #include "MantidKernel/make_unique.h"
 #include "MantidQtAPI/HelpWindow.h"
+#include "MantidKernel/UsageService.h"
 // 3rd party library headers
 // System includes
 
@@ -31,7 +32,8 @@ DECLARE_SUBWINDOW(BackgroundRemover)
 BackgroundRemover::BackgroundRemover(QWidget *parent)
     : UserSubWindow{parent}, m_sliceSelector(), m_inputDataControl(),
       m_displayControl(), m_fitControl{nullptr}, m_fourierTransform{nullptr} {
-  // nothing in the body
+    Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+        "Interface", "DynamicPDF->BackgroundRemover", false);
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/DynamicPDF/SliceSelector.cpp
+++ b/MantidQt/CustomInterfaces/src/DynamicPDF/SliceSelector.cpp
@@ -8,7 +8,8 @@
 #include "MantidQtAPI/HelpWindow.h"
 #include "MantidQtCustomInterfaces/DynamicPDF/SliceSelector.h"
 #include <qwt_plot_spectrogram.h>
-// system includes
+// Mantid headers from other projects
+#include "MantidKernel/UsageService.h"
 
 namespace {
 Mantid::Kernel::Logger g_log("DynamicPDF");
@@ -64,6 +65,8 @@ SliceSelector::SliceSelector(QWidget *parent)
     : QMainWindow(parent), m_pickerLine{nullptr}, m_loadedWorkspace(),
       m_selectedWorkspaceIndex{0} {
   this->observePreDelete(true); // Subscribe to notifications
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+    "Feature", "DynamicPDF->SliceSelector", false);
   this->initLayout();
 }
 

--- a/MantidQt/CustomInterfaces/src/DynamicPDF/SliceSelector.cpp
+++ b/MantidQt/CustomInterfaces/src/DynamicPDF/SliceSelector.cpp
@@ -66,7 +66,7 @@ SliceSelector::SliceSelector(QWidget *parent)
       m_selectedWorkspaceIndex{0} {
   this->observePreDelete(true); // Subscribe to notifications
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
-    "Feature", "DynamicPDF->SliceSelector", false);
+      "Feature", "DynamicPDF->SliceSelector", false);
   this->initLayout();
 }
 


### PR DESCRIPTION
Description of work.

**To test:**
1. Start Mantidplot
2. run this line of Python in the _script interpreter_ to turn usage reporting on
   `
   UsageService.setEnabled(True)
   `
3. Start the _Background Remover_ interface (Interfaces --> DynamicPDF --> Background Remover)
4. Click in the `Load` button to start the Slice Selector widget.

Fixes #16750.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
