### PR TITLE
Add Project Serialisation Tests

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -863,6 +863,7 @@ set ( MANTIDPLOT_TEST_PY_FILES
     MantidPlotSliceViewerTest.py
     MantidPlot1DPlotTest.py
     MantidPlot2DPlotTest.py
+    MantidPlotProjectSerialiseTest.py
     MantidPlotProxiesTest.py
     MantidPlotPythonImportTest.py
     MantidPlotFoldersTest.py

--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -843,6 +843,19 @@ def openProject(file_name, file_version = 0):
 
 
 # -----------------------------------------------------------------------------
+def saveProjectAs(file_name, compress=False):
+    """Save a mantid project
+
+    This will serialise all associated workspaces and windows
+
+    Args:
+        file_name :: file path to save to
+        compress :: whether to compress the project after saving
+    """
+    threadsafe_call(_qti.app.saveProjectAs, file_name, compress)
+
+
+# -----------------------------------------------------------------------------
 def newProject():
     """Start a new mantid project
 
@@ -856,9 +869,7 @@ plotTimeBin = plotBin
 
 # import 'safe' methods (i.e. no proxy required) of ApplicationWindow into the global namespace
 # Only 1 at the moment!
-appImports = [
-    'saveProjectAs'
-]
+appImports = []
 for name in appImports:
     globals()[name] = getattr(_qti.app, name)
 

--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -829,6 +829,20 @@ def closeAllSliceViewers():
 
 
 # -----------------------------------------------------------------------------
+def openProject(file_name, file_version = 0):
+    """Open a mantid project file.
+
+    This will load all associated workspaces and plots.
+
+    Args:
+        file_name :: file path to a mantid project file
+        file_version :: file version to use when loading (default 0).
+    """
+    working_dir = os.path.dirname(os.path.abspath(file_name))
+    threadsafe_call(_qti.app.openProject, working_dir, file_name, file_version)
+
+
+# -----------------------------------------------------------------------------
 # Legacy function
 plotTimeBin = plotBin
 

--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -843,6 +843,14 @@ def openProject(file_name, file_version = 0):
 
 
 # -----------------------------------------------------------------------------
+def newProject():
+    """Start a new mantid project
+
+    This will clear all existing unsaved projects
+    """
+    threadsafe_call(_qti.app.newProject)
+
+# -----------------------------------------------------------------------------
 # Legacy function
 plotTimeBin = plotBin
 

--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -829,7 +829,7 @@ def closeAllSliceViewers():
 
 
 # -----------------------------------------------------------------------------
-def openProject(file_name, file_version = 0):
+def openProject(file_name, file_version=0):
     """Open a mantid project file.
 
     This will load all associated workspaces and plots.
@@ -867,8 +867,8 @@ def newProject():
 # Legacy function
 plotTimeBin = plotBin
 
-# import 'safe' methods (i.e. no proxy required) of ApplicationWindow into the global namespace
-# Only 1 at the moment!
+# import 'safe' methods (i.e. no proxy required) of ApplicationWindow into
+# the global namespace. None at the moment!
 appImports = []
 for name in appImports:
     globals()[name] = getattr(_qti.app, name)

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6245,33 +6245,26 @@ void ApplicationWindow::saveProjectAs(const QString &fileName, bool compress) {
   }
 
   if (!fn.isEmpty()) {
-    // Check if exists. If not, create directory first.
-    QFileInfo tempFile(fn);
-    if (!tempFile.exists()) {
-      // Make the directory
-      QString dir(fn);
-      if (fn.contains('.'))
-        dir = fn.left(fn.indexOf('.'));
-      QDir().mkdir(dir);
+    QFileInfo fileInfo(fn);
+    bool isFile = fileInfo.fileName().endsWith(".mantid") || fileInfo.fileName().endsWith(".mantid.gz");
 
-      // Get the file name
-      QString file("temp");
-      for (int i = 0; i < dir.size(); ++i) {
-        if (dir[i] == '/')
-          file = dir.right(dir.size() - i);
-        else if (dir[i] == '\\')
-          file = dir.right(i);
-      }
-      fn = dir + file;
+    if(!isFile) {
+        QDir directory(fn);
+        if (!directory.exists()) {
+          // Make the directory
+          directory.mkdir(fn);
+        }
+
+        workingDir = directory.absolutePath();
+        QString projectFileName = directory.dirName();
+        projectFileName.append(".mantid");
+        projectname = directory.absoluteFilePath(projectFileName);
+
+    } else {
+        workingDir = fileInfo.absoluteDir().absolutePath();
+        projectname = fileInfo.absoluteFilePath();
     }
 
-    QFileInfo fi(fn);
-    workingDir = fi.absolutePath();
-    QString baseName = fi.fileName();
-    if (!baseName.contains("."))
-      fn.append(".mantid");
-
-    projectname = fn;
     if (saveProject(compress)) {
       recentProjects.removeAll(projectname);
       recentProjects.push_front(projectname);

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -4592,7 +4592,7 @@ void ApplicationWindow::openRecentProject(QAction *action) {
  * @param workingDir :: the file directiory to use
  * @param filename :: the path of the project file to open
  * @param fileVersion :: the file version to use
- * @return updated application window handle
+ * @return updated application window handler
  */
 ApplicationWindow *ApplicationWindow::openProject(const QString &workingDir,
                                                   const QString &filename,
@@ -9663,10 +9663,13 @@ void ApplicationWindow::foldersMenuActivated(int id) {
   }
 }
 
-void ApplicationWindow::newProject() {
-  // Save anything we need to
-  saveSettings();
-  mantidUI->saveProject(saved);
+void ApplicationWindow::newProject(const bool doNotSave) {
+
+  if (doNotSave) {
+      // Save anything we need to
+      saveSettings();
+      mantidUI->saveProject(saved);
+  }
 
   // Clear out any old folders
   folders->blockSignals(true);

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -4583,6 +4583,24 @@ void ApplicationWindow::openRecentProject(QAction *action) {
   }
 }
 
+/**
+ * Open project with the given working directory.
+ *
+ * This function allows a project to be opened without
+ * using a GUI from the Python interface.
+ *
+ * @param workingDir :: the file directiory to use
+ * @param filename :: the path of the project file to open
+ * @param fileVersion :: the file version to use
+ * @return updated application window handle
+ */
+ApplicationWindow *ApplicationWindow::openProject(const QString &workingDir,
+                                                  const QString &filename,
+                                                  const int fileVersion) {
+    this->workingDir = workingDir;
+    return openProject(filename, fileVersion);
+}
+
 ApplicationWindow *ApplicationWindow::openProject(const QString &filename,
                                                   const int fileVersion) {
   newProject();

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6246,23 +6246,24 @@ void ApplicationWindow::saveProjectAs(const QString &fileName, bool compress) {
 
   if (!fn.isEmpty()) {
     QFileInfo fileInfo(fn);
-    bool isFile = fileInfo.fileName().endsWith(".mantid") || fileInfo.fileName().endsWith(".mantid.gz");
+    bool isFile = fileInfo.fileName().endsWith(".mantid") ||
+                  fileInfo.fileName().endsWith(".mantid.gz");
 
-    if(!isFile) {
-        QDir directory(fn);
-        if (!directory.exists()) {
-          // Make the directory
-          directory.mkdir(fn);
-        }
+    if (!isFile) {
+      QDir directory(fn);
+      if (!directory.exists()) {
+        // Make the directory
+        directory.mkdir(fn);
+      }
 
-        workingDir = directory.absolutePath();
-        QString projectFileName = directory.dirName();
-        projectFileName.append(".mantid");
-        projectname = directory.absoluteFilePath(projectFileName);
+      workingDir = directory.absolutePath();
+      QString projectFileName = directory.dirName();
+      projectFileName.append(".mantid");
+      projectname = directory.absoluteFilePath(projectFileName);
 
     } else {
-        workingDir = fileInfo.absoluteDir().absolutePath();
-        projectname = fileInfo.absoluteFilePath();
+      workingDir = fileInfo.absoluteDir().absolutePath();
+      projectname = fileInfo.absoluteFilePath();
     }
 
     if (saveProject(compress)) {

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -4597,8 +4597,8 @@ void ApplicationWindow::openRecentProject(QAction *action) {
 ApplicationWindow *ApplicationWindow::openProject(const QString &workingDir,
                                                   const QString &filename,
                                                   const int fileVersion) {
-    this->workingDir = workingDir;
-    return openProject(filename, fileVersion);
+  this->workingDir = workingDir;
+  return openProject(filename, fileVersion);
 }
 
 ApplicationWindow *ApplicationWindow::openProject(const QString &filename,
@@ -9666,9 +9666,9 @@ void ApplicationWindow::foldersMenuActivated(int id) {
 void ApplicationWindow::newProject(const bool doNotSave) {
 
   if (doNotSave) {
-      // Save anything we need to
-      saveSettings();
-      mantidUI->saveProject(saved);
+    // Save anything we need to
+    saveSettings();
+    mantidUI->saveProject(saved);
   }
 
   // Clear out any old folders

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -655,7 +655,7 @@ public slots:
   void clearSelection();
   void copyActiveLayer();
 
-  void newProject();
+  void newProject(const bool doNotSave = false);
 
   //! Creates a new empty multilayer plot
   MultiLayer *newGraph(const QString &caption = tr("Graph"));

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -222,7 +222,9 @@ public slots:
   ApplicationWindow *open(const QString &fn, bool factorySettings = false,
                           bool newProject = true);
 
-  ApplicationWindow *openProject(const QString &workingDir, const QString &filename, const int fileVersion);
+  ApplicationWindow *openProject(const QString &workingDir,
+                                 const QString &filename,
+                                 const int fileVersion);
   ApplicationWindow *openProject(const QString &fn, const int fileVersion);
   void openProjectFolder(std::string lines, const int fileVersion,
                          bool isTopLevel = false);

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -221,6 +221,8 @@ public slots:
   void open();
   ApplicationWindow *open(const QString &fn, bool factorySettings = false,
                           bool newProject = true);
+
+  ApplicationWindow *openProject(const QString &workingDir, const QString &filename, const int fileVersion);
   ApplicationWindow *openProject(const QString &fn, const int fileVersion);
   void openProjectFolder(std::string lines, const int fileVersion,
                          bool isTopLevel = false);

--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -1232,7 +1232,7 @@ public:
   void disableTools();
 
   void saveProjectAs(const QString& fileName = QString(), bool = false);
-  void openProject(const QString& fileName = QString(), const int fileVersion = 0);
+  ApplicationWindow *openProject(const QString &workingDir, const QString &filename, const int fileVersion);
 
   MdiSubWindow* clone(MdiSubWindow*);
 

--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -1232,6 +1232,8 @@ public:
   void disableTools();
 
   void saveProjectAs(const QString& fileName = QString(), bool = false);
+  void openProject(const QString& fileName = QString(), const int fileVersion = 0);
+
   MdiSubWindow* clone(MdiSubWindow*);
 
   Matrix* tableToMatrix(Table* t);

--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -1218,6 +1218,7 @@ public:
   sipRes = sipCpp->currentFolder();
 %End
 
+  void newProject(const bool doNotSave = false);
   Folder* appendProject(const QString& file_name, Folder* parentFolder = 0);
   Folder* projectFolder() /PyName=rootFolder/;
 

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -1,0 +1,66 @@
+"""
+Test of basic project saving and loading
+"""
+import mantidplottests
+from mantidplottests import *
+import numpy as np
+from PyQt4 import QtGui, QtCore
+
+
+class MantidPlotProjectSerialiseTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_saveProjectAs(self):
+        raise RuntimeError("FAIL")
+
+    def test_openProject(self):
+        raise RuntimeError("FAIL")
+
+
+def create_dummy_workspace(ws_name):
+    """ Create a dummy mantid workspace with some data """
+    X1 = np.linspace(0,10, 100)
+    Y1 = 1000*(np.sin(X1)**2) + X1*10
+    X1 = np.append(X1, 10.1)
+
+    X2 = np.linspace(2,12, 100)
+    Y2 = 500*(np.cos(X2/2.)**2) + 20
+    X2 = np.append(X2, 12.10)
+
+    X = np.append(X1, X2)
+    Y = np.append(Y1, Y2)
+    E = np.sqrt(Y)
+
+    CreateWorkspace(OutputWorkspace=ws_name, DataX=list(X),
+                    DataY=list(Y), DataE=list(E), NSpec=2,
+                    UnitX="TOF", YUnitLabel="Counts",
+                    WorkspaceTitle="Faked data Workspace")
+
+
+def read_project_file(folder_name):
+    """ Read lines from a .mantid project file """
+
+    if not os.path.isdir(folder_name):
+        raise IOError('Path is not a directory')
+
+    project_name = os.path.basename(folder_name) + '.mantid'
+    project_file = os.path.join(project_name)
+
+    if not os.path.isfile(project_file):
+        raise IOError('Project file could not be found')
+
+    with open(project_file, 'r') as file_handle:
+        lines = file_handle.readlines()
+
+    format_func = lambda s: s.strip().split('\t')
+    tokens = map(format_func, lines)
+    return tokens
+
+
+# Run the unit tests
+mantidplottests.runTests(MantidPlotProjectSerialiseTest)

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -185,7 +185,7 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         for window in windows():
             # slight hack as 'type' only returns
             # an MDIWindow instance
-            self.assertIn('Graph', str(window))
+            self.assertTrue('Graph' in str(window))
 
     def test_serialise_1D_plot_with_one_plot_and_multiple_spectra(self):
         workspace_name = "fake_workspace"
@@ -202,7 +202,7 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         layer = graph.layer(1)
 
         # Check graph and layer exist
-        self.assertIn('Graph', str(graph))
+        self.assertTrue('Graph' in str(graph))
         self.assertIsNotNone(layer)
 
         # Check plot curves exist
@@ -225,7 +225,7 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
 
         # Check window exists
         graph = windows()[0]
-        self.assertIn('Graph', str(graph))
+        self.assertTrue('Graph' in str(graph))
 
         # Check plot curves exist
         layer = graph.layer(1)
@@ -248,7 +248,7 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
 
         # Check window exists
         graph = windows()[0]
-        self.assertIn('Graph', str(graph))
+        self.assertTrue('Graph' in str(graph))
 
     def assert_project_files_saved(self, workspace_name):
         """Check files were written to project folder """

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -12,6 +12,11 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
 
     def setUp(self):
         self._project_name = "MantidPlotTestProject"
+
+        # set the default directory to something if it is not set already
+        if config['defaultsave.directory'] == '':
+            config['defaultsave.directory'] = os.path.expanduser("~")
+
         self._project_folder = os.path.join(config['defaultsave.directory'],
                                             self._project_name)
         file_name = "%s.mantid" % self._project_name

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -207,7 +207,7 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
 
         # Check graph and layer exist
         self.assertTrue('Graph' in str(graph))
-        self.assertIsNotNone(layer)
+        self.assertTrue(layer is not None)
 
         # Check plot curves exist
         curve1 = layer.curve(0)

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -77,9 +77,9 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         # modify axes labels
         graph = windows()[0]
         layer = graph.layer(1)
-        layer.setTitle("Hello World")
-        layer.setAxisTitle(0, "Y Axis Modified")
-        layer.setAxisTitle(2, "X Axis Modified")
+        threadsafe_call(layer.setTitle, "Hello World")
+        threadsafe_call(layer.setAxisTitle, 0, "Y Axis Modified")
+        threadsafe_call(layer.setAxisTitle, 2, "X Axis Modified")
 
         saveProjectAs(self._project_folder)
 
@@ -121,8 +121,8 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         # modify axes scales
         graph = windows()[0]
         layer = graph.layer(1)
-        layer.setAxisScale(0, 10, 10)
-        layer.logYlinX()
+        threadsafe_call(layer.setAxisScale, 0, 10, 10)
+        threadsafe_call(layer.logYlinX)
 
         saveProjectAs(self._project_folder)
 
@@ -132,10 +132,10 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         # Check axis scales are as expected
         scale1, scale2, scale3, scale4 = find_elements(contents, 'scale')
 
-        self.assertEqual(int(scale1[2]), 10)
+        self.assertAlmostEqual(float(scale1[2]), 110.6670313)
         self.assertEqual(int(scale1[3]), 1000)
 
-        self.assertEqual(int(scale2[2]), 10)
+        self.assertAlmostEqual(float(scale2[2]), 110.6670313)
         self.assertEqual(int(scale2[3]), 1000)
 
         self.assertEqual(int(scale3[2]), 0)

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -12,8 +12,7 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
 
     def setUp(self):
         self._project_name = "MantidPlotTestProject"
-        self._project_folder = os.path.join(os.path.expanduser("~"),
-                                            self._project_name)
+        self._project_folder = os.path.expanduser("~/%s" % self._project_name)
         file_name = "%s.mantid" % self._project_name
         self._project_file = os.path.join(self._project_folder, file_name)
 

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -33,8 +33,11 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(self._project_file))
 
         file_text = "MantidPlot 0.9.5 project file\n" \
-                    "<scripting-lang>\tPython\n<windows>\t0\n" \
-                    "<mantidworkspaces>\nWorkspaceNames\n</mantidworkspaces>"
+                    "<scripting-lang>\tPython\n" \
+                    "<windows>\t0\n" \
+                    "<mantidworkspaces>\n" \
+                    "WorkspaceNames\tfake_workspace\n" \
+                    "</mantidworkspaces>"
 
         exp_contents = tokenise_project_file(file_text.split('\n'))
         contents = read_project_file(self._project_folder)
@@ -149,7 +152,7 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         # Check that objects were reloaded
         self.assertEqual(rootFolder().name(), self._project_name)
         self.assertEqual(len(windows()), 0)
-        self.assertEqual(len(mtd.getObjectNames()), 0)
+        self.assertEqual(len(mtd.getObjectNames()), 1)
 
     def test_serialise_1D_plot_with_plotted_spectrum(self):
         workspace_name = "fake_workspace"

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -276,8 +276,7 @@ def clear_mantid():
 
     # Clear workspaces
     mtd.clear()
-    # Start a blank project to remove
-    # anything else
+    # Start a blank project to remove anything else
     newProject()
 
 
@@ -288,11 +287,11 @@ def find_elements(tokens, name):
 
 def create_dummy_workspace(ws_name):
     """ Create a dummy mantid workspace with some data """
-    X1 = np.linspace(0,10, 100)
+    X1 = np.linspace(0, 10, 100)
     Y1 = 1000*(np.sin(X1)**2) + X1*10
     X1 = np.append(X1, 10.1)
 
-    X2 = np.linspace(2,12, 100)
+    X2 = np.linspace(2, 12, 100)
     Y2 = 500*(np.cos(X2/2.)**2) + 20
     X2 = np.append(X2, 12.10)
 
@@ -317,7 +316,6 @@ def remove_folder(folder_name):
         raise IOError('Could not clean up folder after test')
 
 
-
 def read_project_file(folder_name):
     """ Read lines from a .mantid project file """
 
@@ -335,10 +333,10 @@ def read_project_file(folder_name):
 
     return tokenise_project_file(lines)
 
+
 def tokenise_project_file(lines):
-    format_func = lambda s: s.strip().split('\t')
-    tokens = map(format_func, lines)
-    return tokens
+    """ Convert lines from a project file to a list of lists """
+    return map(lambda s: s.strip().split('\t'), lines)
 
 
 # Run the unit tests

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -12,7 +12,8 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
 
     def setUp(self):
         self._project_name = "MantidPlotTestProject"
-        self._project_folder = os.path.expanduser("~/%s" % self._project_name)
+        self._project_folder = os.path.join(config['defaultsave.directory'],
+                                            self._project_name)
         file_name = "%s.mantid" % self._project_name
         self._project_file = os.path.join(self._project_folder, file_name)
 

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -12,12 +12,7 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
 
     def setUp(self):
         self._project_name = "MantidPlotTestProject"
-
-        # set the default directory to something if it is not set already
-        if config['defaultsave.directory'] == '':
-            config['defaultsave.directory'] = os.path.expanduser("~")
-
-        self._project_folder = os.path.join(config['defaultsave.directory'],
+        self._project_folder = os.path.join(os.path.expanduser("~"),
                                             self._project_name)
         file_name = "%s.mantid" % self._project_name
         self._project_file = os.path.join(self._project_folder, file_name)

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -77,6 +77,8 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         # modify axes labels
         graph = windows()[0]
         layer = graph.layer(1)
+        # call using threadsafe_call to ensure things are executed on the GUI
+        # thread, otherwise we get segfaults.
         threadsafe_call(layer.setTitle, "Hello World")
         threadsafe_call(layer.setAxisTitle, 0, "Y Axis Modified")
         threadsafe_call(layer.setAxisTitle, 2, "X Axis Modified")
@@ -121,6 +123,8 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
         # modify axes scales
         graph = windows()[0]
         layer = graph.layer(1)
+        # call using threadsafe_call to ensure things are executed on the GUI
+        # thread. Otherwise we get segfaults.
         threadsafe_call(layer.setAxisScale, 0, 10, 10)
         threadsafe_call(layer.logYlinX)
 

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -12,7 +12,8 @@ class MantidPlotProjectSerialiseTest(unittest.TestCase):
 
     def setUp(self):
         self._project_name = "MantidPlotTestProject"
-        self._project_folder = os.path.expanduser("~/%s" % self._project_name)
+        self._project_folder = os.path.join(os.path.expanduser("~"),
+                                            self._project_name)
         file_name = "%s.mantid" % self._project_name
         self._project_file = os.path.join(self._project_folder, file_name)
 

--- a/MantidPlot/test/MantidPlotProjectSerialiseTest.py
+++ b/MantidPlot/test/MantidPlotProjectSerialiseTest.py
@@ -270,7 +270,10 @@ def clear_mantid():
     """
     # Remove windows and plots
     for window in windows():
+        window.confirmClose(False)
         window.close()
+        QtCore.QCoreApplication.processEvents()
+
     # Clear workspaces
     mtd.clear()
     # Start a blank project to remove


### PR DESCRIPTION
Added some automated Python tests for saving and loading Mantid project files. These tests are far from perfect and comprehensive, but they are a start. We are limited by the current project save/loading code being tightly mixed with the application window class. Until that code is refactored we cannot do a huge amount more.

**To test:**
Build the project and run the new suite of tests using the following command. Be sure that they all pass.

```
ctest -R MantidPlotProject -V
```

Closes #16719.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
