### PR TITLE
Remove string comparison from method in PredictPeaks

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
@@ -58,7 +58,7 @@ private:
 
   void setStructureFactorCalculatorFromSample(const API::Sample &sample);
 
-  void calculateQAndAddToOutput(Kernel::V3D &hkl,
+  void calculateQAndAddToOutput(const Kernel::V3D &hkl,
                                 const Kernel::DblMatrix &orientedUB,
                                 const Kernel::DblMatrix &goniometerMatrix);
 
@@ -72,8 +72,9 @@ private:
   Geometry::Instrument_const_sptr m_inst;
   /// Output peaks workspace
   Mantid::DataObjects::PeaksWorkspace_sptr m_pw;
-  std::string convention;
   Geometry::StructureFactorCalculator_sptr m_sfCalculator;
+
+  double m_qConventionFactor;
 };
 
 } // namespace Mantid

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -22,13 +22,26 @@ using namespace Mantid::DataObjects;
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
 
+namespace {
+/// Small helper function that return -1 if convention
+/// is "Crystallography" and 1 otherwise.
+double get_factor_for_q_convention(const std::string &convention) {
+  if (convention == "Crystallography") {
+    return -1.0;
+  }
+
+  return 1.0;
+}
+}
+
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
 PredictPeaks::PredictPeaks()
-    : m_runNumber(-1), m_inst(), m_pw(), m_sfCalculator() {
+    : m_runNumber(-1), m_inst(), m_pw(), m_sfCalculator(),
+      m_qConventionFactor(get_factor_for_q_convention(
+          ConfigService::Instance().getString("Q.convention"))) {
   m_refConds = getAllReflectionConditions();
-  convention = ConfigService::Instance().getString("Q.convention");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -341,16 +354,19 @@ void PredictPeaks::fillPossibleHKLsUsingPeaksWorkspace(
 
   bool roundHKL = getProperty("RoundHKL");
 
-  // HKL's are flipped by -1 because of the internal Q convention
-  // is not the same as the PeaksWorkspace convention
-  double qSign = 1.0;
-  if (peaksWorkspace->getConvention() == "Crystallography")
-    qSign = -1.0;
+  /* Q is at the end multiplied with the factor determined in the
+   * constructor (-1 for crystallography, 1 otherwise). So to avoid
+   * "flippling HKLs" when it's not required, the HKLs of the input
+   * workspace are also multiplied by the factor that is appropriate
+   * for the convention stored in the workspace.
+   */
+  double peaks_q_convention_factor =
+      get_factor_for_q_convention(peaksWorkspace->getConvention());
 
   for (int i = 0; i < static_cast<int>(peaksWorkspace->getNumberPeaks()); ++i) {
     IPeak &p = peaksWorkspace->getPeak(i);
     // Get HKL from that peak
-    V3D hkl = p.getHKL() * qSign;
+    V3D hkl = p.getHKL() * peaks_q_convention_factor;
 
     if (roundHKL)
       hkl.round();
@@ -398,16 +414,13 @@ void PredictPeaks::setStructureFactorCalculatorFromSample(
  * @param orientedUB
  * @param goniometerMatrix
  */
-void PredictPeaks::calculateQAndAddToOutput(V3D &hkl,
+void PredictPeaks::calculateQAndAddToOutput(const V3D &hkl,
                                             const DblMatrix &orientedUB,
                                             const DblMatrix &goniometerMatrix) {
   // The q-vector direction of the peak is = goniometer * ub * hkl_vector
   // This is in inelastic convention: momentum transfer of the LATTICE!
   // Also, q does have a 2pi factor = it is equal to 2pi/wavelength.
-  if (convention == "Crystallography") {
-    hkl = hkl * (-1.0);
-  }
-  V3D q = orientedUB * hkl * (2.0 * M_PI);
+  V3D q = orientedUB * hkl * (2.0 * M_PI * m_qConventionFactor);
 
   // Create the peak using the Q in the lab framewith all its info:
   Peak p(m_inst, q, boost::optional<double>());


### PR DESCRIPTION
Fixes #16758.

The `Q.convention` string is now used once to determine a multiplication factor (1 or -1) for going from `HKL` to `Q`. The check for the case of the PeaksWorkspace with a stored convention is still the same, but the logic has been moved into a small free function so that it can be reused for determining the factor in the algorithm's constructor.

The unit tests should still pass.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
