### PR TITLE
Fix clang-tidy warnings in the performance category.

### DIFF
--- a/Framework/API/src/ADSValidator.cpp
+++ b/Framework/API/src/ADSValidator.cpp
@@ -46,7 +46,7 @@ ADSValidator::checkValidity(const std::vector<std::string> &value) const {
   }
   auto &ads = AnalysisDataService::Instance();
   std::ostringstream os;
-  for (std::string wsName : value) {
+  for (const auto &wsName : value) {
     if (!ads.doesExist(wsName)) {
       os << "The workspace \"" << wsName
          << "\" is not in the workspace list.\n";

--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -97,7 +97,7 @@ double MCInteractionVolume::calculateAbsorption(
       scatterPos = segItr->entryPoint + direc * length;
     }
     const auto &segObj = *(segItr->object);
-    const auto segMat = segObj.material();
+    const auto &segMat = segObj.material();
     atten *= attenuation(segMat.numberDensity(),
                          segMat.totalScatterXSection(lambdaBefore) +
                              segMat.absorbXSection(lambdaBefore),
@@ -116,7 +116,7 @@ double MCInteractionVolume::calculateAbsorption(
   for (const auto &segment : path2) {
     double length = segment.distInsideObject;
     const auto &segObj = *(segment.object);
-    const auto segMat = segObj.material();
+    const auto &segMat = segObj.material();
     atten *= attenuation(segMat.numberDensity(),
                          segMat.totalScatterXSection(lambdaAfter) +
                              segMat.absorbXSection(lambdaAfter),

--- a/Framework/DataHandling/src/LoadSpice2D.cpp
+++ b/Framework/DataHandling/src/LoadSpice2D.cpp
@@ -308,7 +308,7 @@ std::vector<int> LoadSpice2D::getData(const std::string &dataXpath = "//Data") {
                 << detectors.size() << '\n';
 
   // iterate every detector in the xml file
-  for (const auto detector : detectors) {
+  for (const auto &detector : detectors) {
     std::string detectorXpath = dataXpath + "/" + detector;
     // type : INT32[192,256]
     std::map<std::string, std::string> attributes =

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1994,7 +1994,7 @@ void ConfigServiceImpl::setFilterChannelLogLevel(
 int ConfigServiceImpl::FindLowestFilterLevel() const {
   int lowestPriority = Logger::Priority::PRIO_FATAL;
   // Find the lowest level of all of the filter channels
-  for (const auto filterChannelName : m_filterChannels) {
+  for (const auto &filterChannelName : m_filterChannels) {
     try {
       auto *channel = Poco::LoggingRegistry::defaultRegistry().channelForName(
           filterChannelName);


### PR DESCRIPTION
Description of work.

This fixes several clang-tidy "performance" warnings that recently appeared in master. Each change eliminates an unnecessary copy. It's an easy check to ensure we aren't doing unnecessary work.  

http://builds.mantidproject.org/view/Static%20Analysis/job/clang_tidy/241/warnings13Result/category.1110131910/
http://builds.mantidproject.org/view/Static%20Analysis/job/clang_tidy/241/warnings13Result/category.-1705388828/

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this PR.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
