### PR TITLE
Remove duplicate version definitions (Qti plot)

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -45,6 +45,7 @@ set ( QTIPLOT_SRCS src/ApplicationWindow.cpp
                    src/Folder.cpp
                    src/FunctionCurve.cpp
                    src/FunctionDialog.cpp
+                   src/globals.cpp
                    src/Graph3D.cpp
                    src/Graph.cpp
                    src/Grid.cpp

--- a/MantidPlot/src/Mantid/MantidAbout.cpp
+++ b/MantidPlot/src/Mantid/MantidAbout.cpp
@@ -1,15 +1,6 @@
 #include "MantidAbout.h"
 #include "MantidKernel/MantidVersion.h"
-
-extern const int maj_version;
-extern const int min_version;
-extern const int patch_version;
-const int maj_version = 0;
-const int min_version = 9;
-const int patch_version = 5;
-extern const char *extra_version;
-extern const char *copyright_string;
-extern const char *release_date;
+#include "globals.h"
 
 /**
  * Constructor

--- a/MantidPlot/src/globals.cpp
+++ b/MantidPlot/src/globals.cpp
@@ -1,0 +1,15 @@
+#include "globals.h"
+
+//  Don't forget to change the Doxyfile when changing these!
+//! Major version number
+const int maj_version = 0;
+//! Minor version number (0..9)
+const int min_version = 9;
+//! Patch version number (0..9)
+const int patch_version = 5;
+//! Extra version information string (like "alpha", "-1", etc...)
+const char *extra_version = "";
+//! Copyright string containing the author names
+const char *copyright_string = "Copyright (C) 2004-2008 Ion Vasilief";
+//! Release date as a string
+const char *release_date = "10 Apr 2008";

--- a/MantidPlot/src/globals.h
+++ b/MantidPlot/src/globals.h
@@ -1,3 +1,5 @@
+#ifndef GLOBALS_H
+#define GLOBALS_H
 /***************************************************************************
     File                 : globals.h
     Project              : QtiPlot
@@ -28,16 +30,17 @@
  *                                                                         *
  ***************************************************************************/
 
-//  Don't forget to change the Doxyfile when changing these!
-//! Major version number
-const int maj_version = 0;
-//! Minor version number (0..9)
-const int min_version = 9;
-//! Patch version number (0..9)
-const int patch_version = 5;
-//! Extra version information string (like "alpha", "-2", etc...)
-const char *extra_version = "";
-//! Copyright string containing the author names
-const char *copyright_string = "Copyright (C) 2004-2008 Ion Vasilief";
-//! Release date as a string
-const char *release_date = "10 Apr 2008";
+/// Major version number
+extern const int maj_version;
+/// Minor version number (0..9)
+extern const int min_version;
+/// Patch version number (0..9)
+extern const int patch_version;
+/// Extra version information
+extern const char *extra_version;
+/// Copyright notice string
+extern const char *copyright_string;
+/// Release date as a string
+extern const char *release_date;
+
+#endif /* GLOBALS_H */


### PR DESCRIPTION
This removes some duplicate Qti plot version information from the project. The version information is now in a single .cpp file rather that being redefined in MantidAbout.

**To test:**

Super easy one:
- Check it compiles
- Check the Qti version number has not changed between this and master.
- Save a project and check that the file version (first line of the .mantid file) is unchanged between this and master.

Fixes #16693.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

This version information is now in a single place.
