### PR TITLE
SaveNexus crashes with long file name

### DIFF
--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -10,7 +10,7 @@
 #include <io.h>
 // Define the MAX_NAME macro for Windows
 // Maximum base file name size on modern windows systems is 260 characters
-#define MAX_NAME 260
+#define NAME_MAX 260
 #endif /* _WIN32 */
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/TimeSeriesProperty.h"

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -22,6 +22,7 @@
 #include "MantidDataObjects/RebinnedOutput.h"
 
 #include <Poco/File.h>
+#include <Poco/Path.h>
 
 namespace Mantid {
 namespace NeXus {
@@ -99,6 +100,15 @@ void NexusFileIO::openNexusWrite(const std::string &fileName,
 
   /*Only create the file handle if needed.*/
   if (!m_filehandle) {
+    // The nexus or HDF5 libraries crash when the filename is greater than 255
+    // on OSX and Ubuntu.
+    Poco::Path path(fileName);
+    std::string baseName = path.getBaseName();
+    if(baseName.size() >= 256) {
+      std::string message = "Filename is too long. Unable to open file: ";
+      throw Exception::FileError(message, fileName);
+    }
+
     // open the file and copy the handle into the NeXus::File object
     NXstatus status = NXopen(fileName.c_str(), mode, &fileID);
     if (status == NX_ERROR) {

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -8,6 +8,9 @@
 
 #ifdef _WIN32
 #include <io.h>
+// Define the MAX_NAME macro for Windows
+// Maximum base file name size on modern windows systems is 260 characters
+#define MAX_NAME 260
 #endif /* _WIN32 */
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/TimeSeriesProperty.h"

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -104,7 +104,7 @@ void NexusFileIO::openNexusWrite(const std::string &fileName,
     // on OSX and Ubuntu.
     Poco::Path path(fileName);
     std::string baseName = path.getBaseName();
-    if(baseName.size() >= 256) {
+    if(baseName.size() > NAME_MAX) {
       std::string message = "Filename is too long. Unable to open file: ";
       throw Exception::FileError(message, fileName);
     }

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -104,7 +104,7 @@ void NexusFileIO::openNexusWrite(const std::string &fileName,
     // on OSX and Ubuntu.
     Poco::Path path(fileName);
     std::string baseName = path.getBaseName();
-    if(baseName.size() > NAME_MAX) {
+    if (baseName.size() > NAME_MAX) {
       std::string message = "Filename is too long. Unable to open file: ";
       throw Exception::FileError(message, fileName);
     }


### PR DESCRIPTION
#16146 reported a crash when file names are extremely long. A little digging shows that this is due to something going wrong in the NXopen call in SaveNexus. As we can't directly edit that code here's a fix that throws an exception in the event that the file name is too long and the file cannot be created.

**To test:**

Here's a script that should reproduce the error. The first file should be saved correctly, but Mantid should crash on saving the second file. Applying the fix should show that the first file still saves correctly but that the second file now gives and error in the output log. You might need to change the size of the filename depending on the limits of your file system (but it's probably 255).

``` python
wsname = "a"*255
CreateSampleWorkspace(OutputWorkspace=wsname)
SaveNexus(wsname, wsname)

wsname = "b"*256
CreateSampleWorkspace(OutputWorkspace=wsname)
SaveNexus(wsname, wsname)
```

Fixes #16146.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
