### PR TITLE
Fix GCC5 warnings.

### DIFF
--- a/Framework/DataObjects/test/MDFramesToSpecialCoordinateSystemTest.h
+++ b/Framework/DataObjects/test/MDFramesToSpecialCoordinateSystemTest.h
@@ -68,7 +68,8 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    boost::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
+    auto coordinateSystem = boost::make_optional(
+        false, Mantid::Kernel::SpecialCoordinateSystem::None);
     TSM_ASSERT_THROWS_NOTHING("Should throw nothing as coordinate system is "
                               "mixed only with one Q type.",
                               coordinateSystem = converter(ws.get()));
@@ -94,7 +95,8 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    boost::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
+    auto coordinateSystem = boost::make_optional(
+        false, Mantid::Kernel::SpecialCoordinateSystem::None);
     TS_ASSERT_THROWS_NOTHING(coordinateSystem = converter(ws.get()));
     TSM_ASSERT_EQUALS("Should be Qlab", *coordinateSystem,
                       Mantid::Kernel::SpecialCoordinateSystem::QLab);
@@ -117,7 +119,8 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    boost::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
+    auto coordinateSystem = boost::make_optional(
+        false, Mantid::Kernel::SpecialCoordinateSystem::None);
     TS_ASSERT_THROWS_NOTHING(coordinateSystem = converter(ws.get()));
     TSM_ASSERT_EQUALS("Should be QSample", *coordinateSystem,
                       Mantid::Kernel::SpecialCoordinateSystem::QSample);
@@ -140,7 +143,8 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    boost::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
+    auto coordinateSystem = boost::make_optional(
+        false, Mantid::Kernel::SpecialCoordinateSystem::None);
     TS_ASSERT_THROWS_NOTHING(coordinateSystem = converter(ws.get()));
     TSM_ASSERT_EQUALS("Should be HKL", *coordinateSystem,
                       Mantid::Kernel::SpecialCoordinateSystem::HKL);
@@ -163,7 +167,8 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    boost::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
+    auto coordinateSystem = boost::make_optional(
+        false, Mantid::Kernel::SpecialCoordinateSystem::None);
     TS_ASSERT_THROWS_NOTHING(coordinateSystem = converter(ws.get()));
     TSM_ASSERT_EQUALS("Should be None", *coordinateSystem,
                       Mantid::Kernel::SpecialCoordinateSystem::None);

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksCWSD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksCWSD.h
@@ -23,26 +23,26 @@ public:
   ~IntegratePeaksCWSD();
 
   /// Algorithm's name for identification
-  virtual const std::string name() const { return "IntegratePeaksCWSD"; }
+  const std::string name() const override { return "IntegratePeaksCWSD"; }
 
   /// Summary of algorithms purpose
-  virtual const std::string summary() const {
+  const std::string summary() const override {
     return "Integrate single-crystal peaks in reciprocal space, for "
            "MDEventWorkspaces from reactor-source single crystal "
            "diffractometer.";
   }
 
   /// Algorithm's version for identification
-  virtual int version() const { return 1; }
+  int version() const override { return 1; }
 
   /// Algorithm's category for identification
-  virtual const std::string category() const { return "MDAlgorithms\\Peaks"; }
+  const std::string category() const override { return "MDAlgorithms\\Peaks"; }
 
 private:
   /// Initialise the properties
-  void init();
+  void init() override;
   /// Run the algorithm
-  void exec();
+  void exec() override;
 
   /// Process and check input properties
   void processInputs();

--- a/MantidPlot/src/PythonScripting.cpp
+++ b/MantidPlot/src/PythonScripting.cpp
@@ -216,11 +216,11 @@ void PythonScripting::shutdown() {
 
 void PythonScripting::setupPythonPath() {
   using Mantid::Kernel::ConfigService;
-  // The python sys.path is updated as follows:
-  //   - the current working directory is inserted as position 0 to mimic the
-  //     behaviour of the vanilla python interpreter
-  //   - the directory of MantidPlot is added after this to find our bundled
-  //   - modules
+// The python sys.path is updated as follows:
+//   - the current working directory is inserted as position 0 to mimic the
+//     behaviour of the vanilla python interpreter
+//   - the directory of MantidPlot is added after this to find our bundled
+//   - modules
 #if PY_MAJOR_VERSION >= 3
   PyObject *syspath = PySys_GetObject("path");
 #else

--- a/MantidPlot/src/PythonScripting.cpp
+++ b/MantidPlot/src/PythonScripting.cpp
@@ -221,7 +221,12 @@ void PythonScripting::setupPythonPath() {
   //     behaviour of the vanilla python interpreter
   //   - the directory of MantidPlot is added after this to find our bundled
   //   - modules
+#if PY_MAJOR_VERSION >= 3
   PyObject *syspath = PySys_GetObject("path");
+#else
+  std::string path("path");
+  PyObject *syspath = PySys_GetObject(&path[0]);
+#endif
   PyList_Insert(syspath, 0, FROM_CSTRING(""));
   // This should contain only / separators
   const auto appPath = ConfigService::Instance().getPropertiesDir();

--- a/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -68,8 +68,6 @@ public:
   void selectFirstRun() { emit firstRunSelected(); }
 };
 
-GCC_DIAG_ON_SUGGEST_OVERRIDE
-
 MATCHER_P3(QwtDataX, i, value, delta, "") {
   return fabs(arg.x(i) - value) < delta;
 }
@@ -79,6 +77,8 @@ MATCHER_P3(QwtDataY, i, value, delta, "") {
 MATCHER_P3(VectorValue, i, value, delta, "") {
   return fabs(arg.at(i) - value) < delta;
 }
+
+GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 class ALCDataLoadingPresenterTest : public CxxTest::TestSuite {
   MockALCDataLoadingView *m_view;

--- a/MantidQt/CustomInterfaces/test/CMakeLists.txt
+++ b/MantidQt/CustomInterfaces/test/CMakeLists.txt
@@ -21,7 +21,6 @@ if ( CXXTEST_FOUND )
             Kernel
             ${Boost_LIBRARIES}
             ${POCO_LIBRARIES}
-            ${QWT_LIBRARIES}
             ${QT_LIBRARIES}
             ${GMOCK_LIBRARIES}
             ${GTEST_LIBRARIES} )

--- a/MantidQt/CustomInterfaces/test/CMakeLists.txt
+++ b/MantidQt/CustomInterfaces/test/CMakeLists.txt
@@ -21,6 +21,7 @@ if ( CXXTEST_FOUND )
             Kernel
             ${Boost_LIBRARIES}
             ${POCO_LIBRARIES}
+            ${QWT_LIBRARIES}
             ${QT_LIBRARIES}
             ${GMOCK_LIBRARIES}
             ${GTEST_LIBRARIES} )

--- a/Vates/VatesAPI/test/MockObjects.h
+++ b/Vates/VatesAPI/test/MockObjects.h
@@ -37,6 +37,11 @@ using Mantid::coord_t;
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
 
+#if defined(GCC_VERSION) && GCC_VERSION >= 50000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
 //=====================================================================================
 // Test Helper Types. These are shared by several tests in VatesAPI
 //=====================================================================================
@@ -452,6 +457,10 @@ std::string getStringFieldDataValue(vtkDataSet *ds, std::string fieldName) {
 
 #if __clang__
 #pragma clang diagnostic pop
+#endif
+
+#if defined(GCC_VERSION) && GCC_VERSION >= 50000
+#pragma gcc diagnostic pop
 #endif
 
 #endif


### PR DESCRIPTION
Description of work.

This fixes several warnings that appear when building Mantid with GCC 5 or later. The remaining warnings will be fixed in the next version of NeXus and we may be better off upgrading NeXus.

[This workaround](http://stackoverflow.com/questions/21755206/how-to-get-around-gcc-void-b-4-may-be-used-uninitialized-in-this-funct) appears to suppress the warnings from `boost::optional`.

**To test:**

<!-- Instructions for testing. -->

The [fedora 23 build](http://builds.mantidproject.org/job/master_clean-fedora/346/warnings29Result/) has the full list of compiler warnings.

There is no GitHub issue associated with this PR.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
