### PR TITLE
Align and focus empty

### DIFF
--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -56,6 +56,12 @@ Rebin::rebinParamsFromInput(const std::vector<double> &inParams,
     rbParams[0] = xmin;
     rbParams[1] = inParams[0];
     rbParams[2] = xmax;
+    if ((rbParams[1] < 0.) && (xmin < 0.) && (xmax > 0.)) {
+      std::stringstream msg;
+      msg << "Cannot create logorithmic binning that changes sign (xmin="
+          << xmin << ", xmax=" << xmax << ")";
+      throw std::runtime_error(msg.str());
+    }
   }
   return rbParams;
 }

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -123,7 +123,7 @@ string determineXMinMax(MatrixWorkspace_sptr inputWS, vector<double> &xmins,
   double xmax_wksp = inputWS->getXMax();
   EventWorkspace_const_sptr inputEventWS =
       boost::dynamic_pointer_cast<const EventWorkspace>(inputWS);
-  if (inputEventWS != nullptr) {
+  if (inputEventWS != nullptr && inputEventWS->getNumberEvents() > 0) {
     xmin_wksp = inputEventWS->getTofMin();
     xmax_wksp = inputEventWS->getTofMax();
   }
@@ -208,6 +208,12 @@ double ResampleX::determineBinning(MantidVec &xValues, const double xmin,
       throw std::invalid_argument("Cannot calculate log of xmin=0");
     if (xmax == 0)
       throw std::invalid_argument("Cannot calculate log of xmax=0");
+    if (xmin < 0. && xmax > 0.) {
+      std::stringstream msg;
+      msg << "Cannot calculate logorithmic binning that changes sign (xmin="
+          << xmin << ", xmax=" << xmax << ")";
+      throw std::invalid_argument(msg.str());
+    }
 
     const int MAX_ITER(100); // things went wrong if we get this far
 
@@ -256,7 +262,8 @@ double ResampleX::determineBinning(MantidVec &xValues, const double xmin,
   if (numBoundaries != expNumBoundaries) {
     g_log.warning()
         << "Did not generate the requested number of bins: generated "
-        << numBoundaries << " requested " << expNumBoundaries << "\n";
+        << numBoundaries << " requested " << expNumBoundaries
+        << "(xmin=" << xmin << ", xmax=" << xmax << ")\n";
   }
 
   // return the delta value so the caller can do debug printing

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -372,44 +372,42 @@ void AlignAndFocusPowder::exec() {
   m_progress->report();
 
   if (xmin > 0. || xmax > 0.) {
-    bool doCorrection(true);
-    if (m_outputEW) { // extra check for event workspaces
-      doCorrection = (m_outputEW->getNumberEvents() > 0);
-    }
+    double tempmin;
+    double tempmax;
+    m_outputW->getXMinMax(tempmin, tempmax);
 
-    if (doCorrection) {
-      double tempmin;
-      double tempmax;
-      m_outputW->getXMinMax(tempmin, tempmax);
-
-      g_log.information() << "running CropWorkspace(TOFmin=" << xmin
-                          << ", TOFmax=" << xmax << ")\n";
-      API::IAlgorithm_sptr cropAlg = createChildAlgorithm("CropWorkspace");
-      cropAlg->setProperty("InputWorkspace", m_outputW);
-      cropAlg->setProperty("OutputWorkspace", m_outputW);
-      if ((xmin > 0.) && (xmin > tempmin))
-        cropAlg->setProperty("Xmin", xmin);
-      if ((xmax > 0.) && (xmax < tempmax))
-        cropAlg->setProperty("Xmax", xmax);
-      cropAlg->executeAsChildAlg();
-      m_outputW = cropAlg->getProperty("OutputWorkspace");
-      m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
-    }
+    g_log.information() << "running CropWorkspace(TOFmin=" << xmin
+                        << ", TOFmax=" << xmax << ")\n";
+    API::IAlgorithm_sptr cropAlg = createChildAlgorithm("CropWorkspace");
+    cropAlg->setProperty("InputWorkspace", m_outputW);
+    cropAlg->setProperty("OutputWorkspace", m_outputW);
+    if ((xmin > 0.) && (xmin > tempmin))
+      cropAlg->setProperty("Xmin", xmin);
+    if ((xmax > 0.) && (xmax < tempmax))
+      cropAlg->setProperty("Xmax", xmax);
+    cropAlg->executeAsChildAlg();
+    m_outputW = cropAlg->getProperty("OutputWorkspace");
+    m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
   }
   m_progress->report();
 
   // filter the input events if appropriate
   double removePromptPulseWidth = getProperty("RemovePromptPulseWidth");
   if (removePromptPulseWidth > 0.) {
-    g_log.information() << "running RemovePromptPulse(Width="
-                        << removePromptPulseWidth << ")\n";
-    API::IAlgorithm_sptr filterPAlg = createChildAlgorithm("RemovePromptPulse");
-    filterPAlg->setProperty("InputWorkspace", m_outputW);
-    filterPAlg->setProperty("OutputWorkspace", m_outputW);
-    filterPAlg->setProperty("Width", removePromptPulseWidth);
-    filterPAlg->executeAsChildAlg();
-    m_outputW = filterPAlg->getProperty("OutputWorkspace");
     m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
+    if (m_outputEW->getNumberEvents() > 0) {
+      g_log.information() << "running RemovePromptPulse(Width="
+                          << removePromptPulseWidth << ")\n";
+      API::IAlgorithm_sptr filterPAlg = createChildAlgorithm("RemovePromptPulse");
+      filterPAlg->setProperty("InputWorkspace", m_outputW);
+      filterPAlg->setProperty("OutputWorkspace", m_outputW);
+      filterPAlg->setProperty("Width", removePromptPulseWidth);
+      filterPAlg->executeAsChildAlg();
+      m_outputW = filterPAlg->getProperty("OutputWorkspace");
+      m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
+    } else {
+      g_log.information("skipping RemovePromptPulse on empty EventWorkspace");
+    }
   }
   m_progress->report();
 
@@ -503,7 +501,7 @@ void AlignAndFocusPowder::exec() {
     m_outputW = removeAlg->getProperty("OutputWorkspace");
     if (ews)
       g_log.information() << "Number of events = " << ews->getNumberEvents()
-                          << ". ";
+                          << ".\n";
   } else if (DIFCref > 0.) {
     g_log.information() << "running RemoveLowResTof(RefDIFC=" << DIFCref
                         << ",K=3.22)\n";

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -398,7 +398,8 @@ void AlignAndFocusPowder::exec() {
     if (m_outputEW->getNumberEvents() > 0) {
       g_log.information() << "running RemovePromptPulse(Width="
                           << removePromptPulseWidth << ")\n";
-      API::IAlgorithm_sptr filterPAlg = createChildAlgorithm("RemovePromptPulse");
+      API::IAlgorithm_sptr filterPAlg =
+          createChildAlgorithm("RemovePromptPulse");
       filterPAlg->setProperty("InputWorkspace", m_outputW);
       filterPAlg->setProperty("OutputWorkspace", m_outputW);
       filterPAlg->setProperty("Width", removePromptPulseWidth);


### PR DESCRIPTION
This is a couple of fixes that were exposed when trying to process empty `EventWorkspace`s.
1. `Rebin` with just a negative width (for logarithmic binning) will go in an infinite loop trying to calculate the x-values for a workspace with negative xmin, and positive xmax. This now throws a meaningful error. `NOM_65454` is an example of a workspace that has this "feature" just after loading.
2. Same thing for `ResampleX`.
3. `AlignAndFocusPowder` was not running `CropWorkspace` (for TOF) if the input workspace was an empty event list. This left the workspace in an undesirable state for later binning.

**To test:**

Code review

_There is no associated issue_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
