### PR TITLE
Fix small buffer overrun in FitTest

### DIFF
--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -949,9 +949,9 @@ public:
     TS_ASSERT(alg2.isInitialized());
 
     // create mock data to test against
-    std::string wsName = "ExpDecayMockData";
-    int histogramNumber = 1;
-    int timechannels = 20;
+    const std::string wsName = "ExpDecayMockData";
+    const int histogramNumber = 1;
+    const int timechannels = 20;
     Workspace_sptr ws = WorkspaceFactory::Instance().create(
         "Workspace2D", histogramNumber, timechannels, timechannels);
     Workspace2D_sptr ws2D = boost::dynamic_pointer_cast<Workspace2D>(ws);
@@ -967,17 +967,13 @@ public:
          0.0656186436847, 0.04701781275748, 0.03368973499543, 0.02413974996916,
          0.01729688668232, 0.01239376088333, 0};
 
-    e.assign(19, 1.0);
-
-    // put this workspace in the data service
-    TS_ASSERT_THROWS_NOTHING(
-        AnalysisDataService::Instance().addOrReplace(wsName, ws2D));
+    e.assign(timechannels, 1.0);
 
     // alg2.setFunction(fn);
     alg2.setPropertyValue("Function", "name=ExpDecay,Height=1,Lifetime=1");
 
     // Set which spectrum to fit against and initial starting values
-    alg2.setPropertyValue("InputWorkspace", wsName);
+    alg2.setProperty("InputWorkspace", ws);
     alg2.setPropertyValue("WorkspaceIndex", "0");
     alg2.setPropertyValue("StartX", "0");
     alg2.setPropertyValue("EndX", "20");


### PR DESCRIPTION
The E vector was being assigned with size 19 instead of 20 (`timechannels`). This makes the test fail on windows in debug mode and occasionally in release builds.

**To test:**
- Check code changes
- Test should pass.

No issue number for this small fix.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
