### PR TITLE
LoadILLSANS: fix buffer overrun when loading metadata

### DIFF
--- a/Framework/DataHandling/src/LoadILLSANS.cpp
+++ b/Framework/DataHandling/src/LoadILLSANS.cpp
@@ -25,7 +25,7 @@ DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadILLSANS)
 /** Constructor
  */
 LoadILLSANS::LoadILLSANS()
-    : m_supportedInstruments{"D33"}, m_defaultBinning{2} {}
+    : m_supportedInstruments{"D33"}, m_defaultBinning{0, 0} {}
 
 //----------------------------------------------------------------------------------------------
 /// Algorithm's name for identification. @see Algorithm::name


### PR DESCRIPTION
Fixes a buffer overrun uncovered by the MSVC debug mode in LoadILLSANSTest, test case `test_exec_nonTOF`.

From the code in `LoadILLSANS::loadMetaData()` it seems that they intended to initialize the vector with two elements.

**To test:**
- check code changes
- tests should pass on all the CI builds, and also in windows debug mode

No issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
