### PR TITLE
Fix floating windows being hidden on OSX

### DIFF
--- a/MantidPlot/src/FloatingWindow.cpp
+++ b/MantidPlot/src/FloatingWindow.cpp
@@ -39,6 +39,14 @@ FloatingWindow::FloatingWindow(ApplicationWindow *appWindow, Qt::WindowFlags f)
   // Instead, the ApplicationWindow->removeFloatingWindow() call takes care of
   // calling deleteLater().
   setAttribute(Qt::WA_DeleteOnClose, false);
+
+#ifdef Q_OS_MAC
+  // Work around to ensure that floating windows remain on top of the main
+  // application window, but below other applications on Mac
+  Qt::WindowFlags flags = windowFlags();
+  Qt::WindowFlags new_flags = flags | Qt::Tool;
+  setWindowFlags(new_flags);
+#endif
 }
 
 FloatingWindow::~FloatingWindow() {

--- a/docs/source/release/v3.8.0/ui.rst
+++ b/docs/source/release/v3.8.0/ui.rst
@@ -51,6 +51,7 @@ Documentation
 
 Bugs Resolved
 -------------
+ - Floating windows now always stay on top of the main window in OSX
 
 SliceViewer Improvements
 ------------------------


### PR DESCRIPTION
**Needs to be tested by a Mac user**

This fix prevents floating windows for disappearing behind the main Mantid application window.

**To test:**
- Go to Mantid > Preferences > General > Floating Windows and set everything to floating
- Create lots of different types of windows
- Check that they remain in front of the main window at all times.
- Check that they remain below any other open applications when Mantid is not focused.

Fixes #16790 .

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
