### PR TITLE
Indirect Data Analysis - Fix Elwin integration range bars

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -404,8 +404,14 @@ void Elwin::plotInput() {
 
   try {
     QPair<double, double> range = m_uiForm.ppPlot->getCurveRange("Sample");
+    // Set maximum range of Integration
     m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange")
         ->setRange(range.first, range.second);
+    // Set initial values
+    m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange")
+        ->setMinimum(range.first);
+    m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange")
+        ->setMaximum(range.second);
   } catch (std::invalid_argument &exc) {
     showMessageBox(exc.what());
   }


### PR DESCRIPTION
Range bars on the preview plot in Elwin now update correctly giving the full integration range upon initial loading of the interface.

**To test:**
- Open Elwin (Interfaces > Indirect > Data Analysis > Elwin)
- Load `irs26176_graphite002_red.nxs` (available from unit test data) 
- Ensure that the range bars (blue) on the preview plot automatically update to the maximum x range of the data

Fixes #16258 

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
