### PR TITLE
IndirectCommon.py - Remove functions and tests

### DIFF
--- a/scripts/Inelastic/IndirectCommon.py
+++ b/scripts/Inelastic/IndirectCommon.py
@@ -528,68 +528,6 @@ def transposeFitParametersTable(params_table, output_table=None):
     RenameWorkspace(table_ws.name(), OutputWorkspace=output_table)
 
 
-def search_for_fit_params(suffix, table_ws):
-    """
-    Find all fit parameters in a table workspace with the given suffix.
-
-    @param suffix - the name of the parameter to find.
-    @param table_ws - the name of the table workspace to search.
-    """
-    return [name for name in mtd[table_ws].getColumnNames() if name.endswith(suffix)]
-
-
-def convertParametersToWorkspace(params_table, x_column, param_names, output_name):
-    """
-    Convert a parameter table output by PlotPeakByLogValue to a MatrixWorkspace.
-
-    This will make a spectrum for each parameter name using the x_column vairable as the
-    x values for the spectrum.
-
-    @param params_table - the table workspace to convert to a MatrixWorkspace.
-    @param x_column - the column in the table to use for the x values.
-    @param parameter_names - list of parameter names to add to the workspace
-    @param output_name - name to call the output workspace.
-    """
-    # Search for any parameters in the table with the given parameter names,
-    # ignoring their function index and output them to a workspace
-    workspace_names = []
-    for param_name in param_names:
-        column_names = search_for_fit_params(param_name, params_table)
-        column_error_names = search_for_fit_params(param_name + '_Err', params_table)
-        param_workspaces = []
-        for name, error_name in zip(column_names, column_error_names):
-            ConvertTableToMatrixWorkspace(params_table, x_column, name, error_name,
-                                          OutputWorkspace=name)
-            param_workspaces.append(name)
-        workspace_names.append(param_workspaces)
-
-    # Transpose list of workspaces, ignoring unequal length of lists
-    # this handles the case where a parameter occurs only once in the whole workspace
-    workspace_names = map(list, itertools.izip_longest(*workspace_names))
-    workspace_names = [filter(None, sublist) for sublist in workspace_names]
-
-    # Join all the parameters for each peak into a single workspace per peak
-    temp_workspaces = []
-    for peak_params in workspace_names:
-        temp_peak_ws = peak_params[0]
-        for param_ws in peak_params[1:]:
-            ConjoinWorkspaces(temp_peak_ws, param_ws, False)
-        temp_workspaces.append(temp_peak_ws)
-
-    # Join all peaks into a single workspace
-    temp_workspace = temp_workspaces[0]
-    for temp_ws in temp_workspaces[1:]:  # TODO: fairly certain something is wrong here
-        ConjoinWorkspaces(temp_workspace, temp_peak_ws, False)
-
-    RenameWorkspace(temp_workspace, OutputWorkspace=output_name)
-
-    # Replace axis on workspaces with text axis
-    axis = TextAxis.create(mtd[output_name].getNumberHistograms())
-    workspace_names = [name for sublist in workspace_names for name in sublist]
-    for i, name in enumerate(workspace_names):
-        axis.setLabel(i, name)
-    mtd[output_name].replaceAxis(1, axis)
-
 def IndentifyDataBoundaries(sample_ws):
     """
     Indentifies and returns the first and last no zero data point in a workspace

--- a/scripts/Inelastic/IndirectCommon.py
+++ b/scripts/Inelastic/IndirectCommon.py
@@ -1,6 +1,5 @@
 #pylint: disable=invalid-name
 from mantid.simpleapi import *
-from mantid.api import TextAxis
 from mantid import config, logger
 
 from IndirectImport import import_mantidplot
@@ -10,7 +9,6 @@ import math
 import datetime
 import re
 import numpy as np
-import itertools
 
 
 def StartTime(prog):

--- a/scripts/test/IndirectCommonTests.py
+++ b/scripts/test/IndirectCommonTests.py
@@ -262,34 +262,6 @@ class IndirectCommonTests(unittest.TestCase):
         self.assert_table_workspace_dimensions(params_table, expected_row_count=26, expected_column_count=3)
         self.assert_table_workspace_dimensions(output_name, expected_row_count=5, expected_column_count=11)
 
-    def test_search_for_fit_params(self):
-        ws = self.make_dummy_QENS_workspace()
-
-        #make a parameter table to search in
-        function = "name=LinearBackground, A0=0, A1=0;"
-        function += "name=Gaussian, Sigma=0.1, PeakCentre=0, Height=10;"
-        table_ws = PlotPeakByLogValue(Input=ws+",v", Function=function)
-
-        params = indirect_common.search_for_fit_params("Sigma", table_ws.name())
-
-        self.assertEqual(len(params), 1)
-        self.assertEqual(params[0], "f1.Sigma")
-
-    def test_convertParametersToWorkspace(self):
-        ws = self.make_dummy_QENS_workspace()
-
-        #make a parameter table to search in
-        function = "name=LinearBackground, A0=0, A1=0;"
-        function += "name=Gaussian, Sigma=0.1, PeakCentre=0, Height=10;"
-        table_ws = PlotPeakByLogValue(Input=ws + ",v0:10", Function=function)
-
-        param_names = ['A0', 'Sigma', 'PeakCentre']
-        indirect_common.convertParametersToWorkspace(table_ws.name(), 'axis-1', param_names, "params_workspace")
-        params_workspace = mtd["params_workspace"]
-
-        self.assert_matrix_workspace_dimensions(params_workspace.name(),
-                                                expected_num_histograms=3, expected_blocksize=5)
-
     #-----------------------------------------------------------
     # Custom assertion functions
     #-----------------------------------------------------------


### PR DESCRIPTION
removed `search_for_fit_params` and `convertParametersToWorkspace` from IndirectCommon.py and IndirectCommonTest.py as they have been replaced in functionality by `ProcessIndirectFitParameters`

**To test:**
- Ensure the functions have been removed from IndirectCommon.py and IndirectCommonTest.py
- Ensure builds pass 

Fixes #16820

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
