### PR TITLE
Fix build errors with CMake 3.6 on OS X.

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -532,7 +532,7 @@ set_property ( TARGET DataHandling PROPERTY FOLDER "MantidFramework" )
 target_include_directories ( DataHandling PUBLIC inc ../Nexus/inc)
 target_include_directories ( DataHandling SYSTEM PRIVATE ${HDF5_INCLUDE_DIRS})
 
-target_link_libraries ( DataHandling LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${MANTIDLIBS} Nexus ${NEXUS_LIBRARIES} ${HDF5_LIBRARIES} ${JSONCPP_LIBRARIES} )
+target_link_libraries ( DataHandling LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${MANTIDLIBS} Nexus ${NEXUS_LIBRARIES} ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES} ${JSONCPP_LIBRARIES} )
 
 # Add the unit tests directory
 add_subdirectory ( test )

--- a/Framework/DataHandling/test/CMakeLists.txt
+++ b/Framework/DataHandling/test/CMakeLists.txt
@@ -26,7 +26,8 @@ if ( CXXTEST_FOUND )
             ${NEXUS_LIBRARIES}
             ${Boost_LIBRARIES}
             ${POCO_LIBRARIES}
-            ${HDF5_LIBRARIES} )
+            ${HDF5_LIBRARIES}
+            ${HDF5_HL_LIBRARIES} )
   add_dependencies ( DataHandlingTest Algorithms MDAlgorithms )
   add_dependencies ( FrameworkTests DataHandlingTest )
   # Test data

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -121,6 +121,10 @@ if (NOT OPENSSL_ROOT_DIR)
   set ( OPENSSL_ROOT_DIR /usr/local/opt/openssl )
 endif(NOT OPENSSL_ROOT_DIR)
 
+if (NOT HDF5_ROOT)
+  set ( HDF5_ROOT /usr/local/opt/hdf5 )
+endif()
+
 # Python packages
 
 install ( PROGRAMS ${SITEPACKAGES}/sip.so DESTINATION ${BIN_DIR} )


### PR DESCRIPTION
Description of work.

This works around an issue with FindHDF5 and fixes a linker error that occurred after upgrading to  CMake 3.6 on OS X. I have not tried CMake 3.6 on other platforms.

**To test:**

<!-- Instructions for testing. -->

I'm currently building this branch on `ornl-yosemite`
http://builds.mantidproject.org/job/master_clean-osx-yosemite/85/

This is a partial fix for #16829.

_Does not need to be in the release notes._ We may want to add something once the issues are fully addressed.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
