### PR TITLE
16810 spectrum detector indexing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,10 +129,11 @@ add_subdirectory ( Framework )
 
 include_directories ( Framework/Kernel/inc )
 include_directories ( Framework/HistogramData/inc )
+include_directories ( Framework/Indexing/inc )
 include_directories ( Framework/Geometry/inc )
 include_directories ( Framework/API/inc )
 
-set ( CORE_MANTIDLIBS Kernel HistogramData Geometry API )
+set ( CORE_MANTIDLIBS Kernel HistogramData Indexing Geometry API )
 
 # Add a target for all GUI tests
 add_custom_target ( GUITests )

--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -72,8 +72,13 @@ add_subdirectory (Kernel)
 include_directories (HistogramData/inc)
 add_subdirectory (HistogramData)
 
+include_directories (Indexing/inc)
+add_subdirectory (Indexing)
+
 # HistogramData has header-only dependency on Kernel, so Kernel comes after.
 set ( MANTIDLIBS ${MANTIDLIBS} HistogramData )
+# Indexing has header-only dependency on Kernel, so Kernel comes after.
+set ( MANTIDLIBS ${MANTIDLIBS} Indexing )
 set ( MANTIDLIBS ${MANTIDLIBS} Kernel )
 
 include_directories (Geometry/inc)
@@ -137,7 +142,7 @@ add_subdirectory (ISISLiveData)
 # Add a custom target to build all of the Framework
 ###########################################################################
 
-set ( FRAMEWORK_LIBS Kernel HistogramData Geometry API DataObjects
+set ( FRAMEWORK_LIBS Kernel HistogramData Indexing Geometry API DataObjects
                      PythonKernelModule PythonGeometryModule PythonAPIModule
                      PythonDataObjectsModule
                      DataHandling Nexus Algorithms CurveFitting ICat

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -4,6 +4,8 @@ set ( SRC_FILES
 
 set ( INC_FILES
 	inc/MantidIndexing/DetectorID.h
+	inc/MantidIndexing/DetectorIDTranslator.h
+	inc/MantidIndexing/DetectorIndexSet.h
 	inc/MantidIndexing/DllConfig.h
 	inc/MantidIndexing/IndexSet.h
 	inc/MantidIndexing/IndexType.h
@@ -17,6 +19,8 @@ set ( INC_FILES
 
 set ( TEST_FILES
 	DetectorIDTest.h
+	DetectorIDTranslatorTest.h
+	DetectorIndexSetTest.h
 	IndexSetTest.h
 	IndexTypeTest.h
 	PartitionIndexTest.h

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -1,0 +1,53 @@
+set ( SRC_FILES
+  src/dummy.cpp
+)
+
+set ( INC_FILES
+	inc/MantidIndexing/DllConfig.h
+	inc/MantidIndexing/IndexSet.h
+	inc/MantidIndexing/SpectrumIndexSet.h
+	inc/MantidIndexing/SpectrumNumber.h
+	inc/MantidIndexing/SpectrumNumberTranslator.h
+)
+
+set ( TEST_FILES
+	IndexSetTest.h
+	SpectrumIndexSetTest.h
+	SpectrumNumberTest.h
+	SpectrumNumberTranslatorTest.h
+)
+
+if (COVERALLS)
+  foreach( loop_var ${SRC_FILES} ${INC_FILES})
+    set_property(GLOBAL APPEND PROPERTY COVERAGE_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/${loop_var}")
+  endforeach(loop_var)
+endif()
+
+if(UNITY_BUILD)
+  include(UnityBuild)
+  enable_unity_build(Indexing SRC_FILES SRC_UNITY_IGNORE_FILES 10)
+endif(UNITY_BUILD)
+
+# Add the target for this directory
+add_library ( Indexing ${SRC_FILES} ${INC_FILES} )
+# Set the name of the generated library
+set_target_properties ( Indexing PROPERTIES OUTPUT_NAME MantidIndexing
+  COMPILE_DEFINITIONS IN_MANTID_INDEXING )
+
+if (OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties ( Indexing PROPERTIES INSTALL_RPATH "@loader_path/../MacOS")
+endif ()
+
+# Add to the 'Framework' group in VS
+set_property ( TARGET Indexing PROPERTY FOLDER "MantidFramework" )
+
+target_link_libraries ( Indexing LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${MANTIDLIBS} )
+
+# Add the unit tests directory
+add_subdirectory ( test )
+
+###########################################################################
+# Installation settings
+###########################################################################
+
+install ( TARGETS Indexing ${SYSTEM_PACKAGE_TARGET} DESTINATION ${LIB_DIR} )

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -4,7 +4,9 @@ set ( SRC_FILES
 
 set ( INC_FILES
 	inc/MantidIndexing/DllConfig.h
+	inc/MantidIndexing/IPartitioning.h
 	inc/MantidIndexing/IndexSet.h
+	inc/MantidIndexing/RoundRobinPartitioning.h
 	inc/MantidIndexing/SpectrumIndexSet.h
 	inc/MantidIndexing/SpectrumNumber.h
 	inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -12,6 +14,7 @@ set ( INC_FILES
 
 set ( TEST_FILES
 	IndexSetTest.h
+	RoundRobinPartitioningTest.h
 	SpectrumIndexSetTest.h
 	SpectrumNumberTest.h
 	SpectrumNumberTranslatorTest.h

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -4,8 +4,8 @@ set ( SRC_FILES
 
 set ( INC_FILES
 	inc/MantidIndexing/DllConfig.h
-	inc/MantidIndexing/IPartitioning.h
 	inc/MantidIndexing/IndexSet.h
+	inc/MantidIndexing/Partitioning.h
 	inc/MantidIndexing/RoundRobinPartitioning.h
 	inc/MantidIndexing/SpectrumIndexSet.h
 	inc/MantidIndexing/SpectrumNumber.h

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -5,6 +5,7 @@ set ( SRC_FILES
 set ( INC_FILES
 	inc/MantidIndexing/DllConfig.h
 	inc/MantidIndexing/IndexSet.h
+	inc/MantidIndexing/IndexType.h
 	inc/MantidIndexing/PartitionIndex.h
 	inc/MantidIndexing/Partitioning.h
 	inc/MantidIndexing/RoundRobinPartitioning.h
@@ -15,8 +16,9 @@ set ( INC_FILES
 
 set ( TEST_FILES
 	IndexSetTest.h
-	PartitioningTest.h
+	IndexTypeTest.h
 	PartitionIndexTest.h
+	PartitioningTest.h
 	RoundRobinPartitioningTest.h
 	SpectrumIndexSetTest.h
 	SpectrumNumberTest.h

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -7,6 +7,7 @@ set ( INC_FILES
 	inc/MantidIndexing/DetectorIDTranslator.h
 	inc/MantidIndexing/DetectorIndexSet.h
 	inc/MantidIndexing/DllConfig.h
+	inc/MantidIndexing/GlobalWorkspaceIndex.h
 	inc/MantidIndexing/IndexSet.h
 	inc/MantidIndexing/IndexType.h
 	inc/MantidIndexing/PartitionIndex.h
@@ -21,6 +22,7 @@ set ( TEST_FILES
 	DetectorIDTest.h
 	DetectorIDTranslatorTest.h
 	DetectorIndexSetTest.h
+	GlobalWorkspaceIndexTest.h
 	IndexSetTest.h
 	IndexTypeTest.h
 	PartitionIndexTest.h

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -1,10 +1,11 @@
 set ( SRC_FILES
-  src/dummy.cpp
+	src/Partitioning.cpp
 )
 
 set ( INC_FILES
 	inc/MantidIndexing/DllConfig.h
 	inc/MantidIndexing/IndexSet.h
+	inc/MantidIndexing/PartitionIndex.h
 	inc/MantidIndexing/Partitioning.h
 	inc/MantidIndexing/RoundRobinPartitioning.h
 	inc/MantidIndexing/SpectrumIndexSet.h
@@ -14,6 +15,8 @@ set ( INC_FILES
 
 set ( TEST_FILES
 	IndexSetTest.h
+	PartitioningTest.h
+	PartitionIndexTest.h
 	RoundRobinPartitioningTest.h
 	SpectrumIndexSetTest.h
 	SpectrumNumberTest.h

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -3,6 +3,7 @@ set ( SRC_FILES
 )
 
 set ( INC_FILES
+	inc/MantidIndexing/DetectorID.h
 	inc/MantidIndexing/DllConfig.h
 	inc/MantidIndexing/IndexSet.h
 	inc/MantidIndexing/IndexType.h
@@ -15,6 +16,7 @@ set ( INC_FILES
 )
 
 set ( TEST_FILES
+	DetectorIDTest.h
 	IndexSetTest.h
 	IndexTypeTest.h
 	PartitionIndexTest.h

--- a/Framework/Indexing/inc/MantidIndexing/DetectorID.h
+++ b/Framework/Indexing/inc/MantidIndexing/DetectorID.h
@@ -1,0 +1,42 @@
+#ifndef MANTID_INDEXING_DETECTORID_H_
+#define MANTID_INDEXING_DETECTORID_H_
+
+#include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/IndexType.h"
+
+namespace Mantid {
+namespace Indexing {
+
+/** DetectorID : TODO: DESCRIPTION
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+struct MANTID_INDEXING_DLL DetectorID
+    : public detail::IndexType<DetectorID, int32_t> {
+  using detail::IndexType<DetectorID, int32_t>::IndexType;
+  using detail::IndexType<DetectorID, int32_t>::operator=;
+};
+
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_DETECTORID_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/DetectorIDTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/DetectorIDTranslator.h
@@ -45,14 +45,14 @@ public:
     partitioning.checkValid(m_partition);
 
     size_t currentIndex = 0;
-    for(const auto spectrumDefinition : spectrumDefinitions) {
+    for (const auto spectrumDefinition : spectrumDefinitions) {
       auto number = spectrumDefinition.first;
       auto partition = partitioning.indexOf(number);
       bool inThisPartition = (partition == m_partition);
-      for(const auto detectorID : spectrumDefinition.second) {
+      for (const auto detectorID : spectrumDefinition.second) {
         m_inThisPartition.emplace(detectorID, inThisPartition);
-      if (inThisPartition)
-        m_indices.emplace(detectorID, currentIndex++);
+        if (inThisPartition)
+          m_indices.emplace(detectorID, currentIndex++);
       }
     }
   }
@@ -64,8 +64,7 @@ public:
   // etc.
   // DetectorIndexSet makeIndexSet(DetectorID min, DetectorID max);
 
-  DetectorIndexSet
-  makeIndexSet(const std::vector<DetectorID> &detectorIDs) {
+  DetectorIndexSet makeIndexSet(const std::vector<DetectorID> &detectorIDs) {
     std::vector<size_t> indices;
     for (const auto &detectorID : detectorIDs) {
       const auto rank_iterator = m_inThisPartition.find(detectorID);
@@ -80,8 +79,7 @@ public:
 private:
   struct DetectorIDHash {
     std::size_t operator()(const DetectorID &detectorID) const {
-      return std::hash<std::int32_t>()(
-          static_cast<const int32_t>(detectorID));
+      return std::hash<std::int32_t>()(static_cast<const int32_t>(detectorID));
     }
   };
 

--- a/Framework/Indexing/inc/MantidIndexing/DetectorIDTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/DetectorIDTranslator.h
@@ -1,0 +1,96 @@
+#ifndef MANTID_INDEXING_DETECTORIDTRANSLATOR_H_
+#define MANTID_INDEXING_DETECTORIDTRANSLATOR_H_
+
+#include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/DetectorIndexSet.h"
+#include "MantidIndexing/DetectorID.h"
+#include "MantidIndexing/Partitioning.h"
+#include "MantidIndexing/SpectrumNumber.h"
+
+#include <unordered_map>
+
+namespace Mantid {
+namespace Indexing {
+
+/** DetectorIDTranslator : TODO: DESCRIPTION
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_INDEXING_DLL DetectorIDTranslator {
+public:
+  DetectorIDTranslator(
+      const std::vector<std::pair<SpectrumNumber, std::vector<DetectorID>>> &
+          spectrumDefinitions,
+      const Partitioning &partitioning, const PartitionIndex &partition)
+      : m_partition(partition) {
+    partitioning.checkValid(m_partition);
+
+    size_t currentIndex = 0;
+    for(const auto spectrumDefinition : spectrumDefinitions) {
+      auto number = spectrumDefinition.first;
+      auto partition = partitioning.indexOf(number);
+      bool inThisPartition = (partition == m_partition);
+      for(const auto detectorID : spectrumDefinition.second) {
+        m_inThisPartition.emplace(detectorID, inThisPartition);
+      if (inThisPartition)
+        m_indices.emplace(detectorID, currentIndex++);
+      }
+    }
+  }
+
+  // Full set
+  DetectorIndexSet makeIndexSet() { return DetectorIndexSet(m_indices.size()); }
+
+  // This one is more difficult with MPI, need to deal with partial overlaps,
+  // etc.
+  // DetectorIndexSet makeIndexSet(DetectorID min, DetectorID max);
+
+  DetectorIndexSet
+  makeIndexSet(const std::vector<DetectorID> &detectorIDs) {
+    std::vector<size_t> indices;
+    for (const auto &detectorID : detectorIDs) {
+      const auto rank_iterator = m_inThisPartition.find(detectorID);
+      if (rank_iterator == m_inThisPartition.end())
+        throw std::out_of_range("Invalid detector ID.");
+      if (rank_iterator->second)
+        indices.push_back(m_indices.at(detectorID));
+    }
+    return DetectorIndexSet(indices, m_indices.size());
+  }
+
+private:
+  struct DetectorIDHash {
+    std::size_t operator()(const DetectorID &detectorID) const {
+      return std::hash<std::int32_t>()(
+          static_cast<const int32_t>(detectorID));
+    }
+  };
+
+  const PartitionIndex m_partition;
+  std::unordered_map<DetectorID, bool, DetectorIDHash> m_inThisPartition;
+  std::unordered_map<DetectorID, size_t, DetectorIDHash> m_indices;
+};
+
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_DETECTORIDTRANSLATOR_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/DetectorIndexSet.h
+++ b/Framework/Indexing/inc/MantidIndexing/DetectorIndexSet.h
@@ -1,0 +1,45 @@
+#ifndef MANTID_INDEXING_DETECTORINDEXSET_H_
+#define MANTID_INDEXING_DETECTORINDEXSET_H_
+
+#include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/IndexSet.h"
+
+namespace Mantid {
+namespace Indexing {
+
+/** DetectorIndexSet : TODO: DESCRIPTION
+
+  @author Simon Heybrock
+  @date 2016
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_INDEXING_DLL DetectorIndexSet
+    : public detail::IndexSet<DetectorIndexSet> {
+public:
+  using detail::IndexSet<DetectorIndexSet>::IndexSet;
+};
+
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_DETECTORINDEXSET_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/DllConfig.h
+++ b/Framework/Indexing/inc/MantidIndexing/DllConfig.h
@@ -1,0 +1,37 @@
+#ifndef MANTID_INDEXING_DLLCONFIG_H_
+#define MANTID_INDEXING_DLLCONFIG_H_
+
+/*
+  This file contains the DLLExport/DLLImport linkage configuration for the
+  Indexing library
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+#include "MantidKernel/System.h"
+
+#ifdef IN_MANTID_INDEXING
+#define MANTID_INDEXING_DLL DLLExport
+#else
+#define MANTID_INDEXING_DLL DLLImport
+#endif // IN_MANTID_INDEXING
+
+#endif // MANTID_INDEXING_DLLCONFIG_H_

--- a/Framework/Indexing/inc/MantidIndexing/IPartitioning.h
+++ b/Framework/Indexing/inc/MantidIndexing/IPartitioning.h
@@ -1,15 +1,16 @@
-#ifndef MANTID_INDEXING_SPECTRUMNUMBER_H_
-#define MANTID_INDEXING_SPECTRUMNUMBER_H_
+#ifndef MANTID_INDEXING_IPARTITIONING_H_
+#define MANTID_INDEXING_IPARTITIONING_H_
 
 #include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/SpectrumNumber.h"
 
 namespace Mantid {
 namespace Indexing {
 
-/** SpectrumNumber : TODO: DESCRIPTION
+/** IPartitioning : TODO: DESCRIPTION
 
-  @author Simon Heybrock
-  @date 2016
+  The main intention of this class is defining partitioning of all spectrum
+  numbers into subsets for an MPI-based Mantid run.
 
   Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source
@@ -32,22 +33,16 @@ namespace Indexing {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_INDEXING_DLL SpectrumNumber {
+class MANTID_INDEXING_DLL IPartitioning {
 public:
-  explicit SpectrumNumber(int64_t number) noexcept : m_number(number) {}
-  explicit operator int64_t() const noexcept { return m_number; }
-  template <class T> bool operator==(const T &other) const noexcept {
-    return m_number == SpectrumNumber(other).m_number;
-  }
-  template <class T> bool operator!=(const T &other) const noexcept {
-    return m_number != SpectrumNumber(other).m_number;
-  }
+  virtual ~IPartitioning() = default;
 
-private:
-  int64_t m_number;
+  virtual int numberOfPartitions() const = 0;
+  virtual int partitionIndex() const = 0;
+  virtual int partitionIndexOf(const SpectrumNumber &spectrumNumber) const = 0;
 };
 
 } // namespace Indexing
 } // namespace Mantid
 
-#endif /* MANTID_INDEXING_SPECTRUMNUMBER_H_ */
+#endif /* MANTID_INDEXING_IPARTITIONING_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/IndexSet.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexSet.h
@@ -45,7 +45,7 @@ template <class T> class IndexSet {
 public:
   IndexSet(size_t fullRange);
   IndexSet(int64_t min, int64_t max, size_t fullRange);
-  IndexSet(const std::vector<size_t> indices, size_t fullRange);
+  IndexSet(const std::vector<size_t> &indices, size_t fullRange);
 
   /// Returns the size of the set.
   size_t size() const { return m_size; }
@@ -91,15 +91,12 @@ IndexSet<T>::IndexSet(int64_t min, int64_t max, size_t fullRange) {
 /// Constructor for a set containing all specified indices. Range is verified at
 /// construction time and duplicates are removed.
 template <class T>
-IndexSet<T>::IndexSet(const std::vector<size_t> indices, size_t fullRange)
+IndexSet<T>::IndexSet(const std::vector<size_t> &indices, size_t fullRange)
     : m_isRange(false) {
   // We use a set to create unique and ordered indices.
-  std::set<size_t> index_set;
-  for (const auto &index : indices) {
-    if (index >= fullRange)
-      throw std::out_of_range("IndexSet: specified index is out of range");
-    index_set.insert(index);
-  }
+  std::set<size_t> index_set(indices.cbegin(), indices.cend());
+  if (!index_set.empty() && *(index_set.rbegin()) >= fullRange)
+    throw std::out_of_range("IndexSet: specified index is out of range");
   m_indices = std::vector<size_t>(begin(index_set), end(index_set));
   m_size = m_indices.size();
 }

--- a/Framework/Indexing/inc/MantidIndexing/IndexSet.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexSet.h
@@ -70,7 +70,9 @@ private:
 };
 
 /// Constructor for a set covering the full range from 0 to fullRange-1.
-template <class T> IndexSet<T>::IndexSet(size_t fullRange) : m_size(fullRange) {}
+template <class T>
+IndexSet<T>::IndexSet(size_t fullRange)
+    : m_size(fullRange) {}
 
 /// Constructor for a set covering the range from min to max. Range is verified
 /// at construction time.

--- a/Framework/Indexing/inc/MantidIndexing/IndexSet.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexSet.h
@@ -1,0 +1,109 @@
+#ifndef MANTID_INDEXING_INDEXSET_H_
+#define MANTID_INDEXING_INDEXSET_H_
+
+#include "MantidIndexing/DllConfig.h"
+
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+namespace Mantid {
+namespace Indexing {
+namespace detail {
+
+/** IndexSet : TODO: DESCRIPTION
+  CRTP
+  We want DetectorIndexSet and SpectrumIndexSet, with the same functionality,
+  but the types should be incompatible. Thus, we use IndexSet<DetectorIndexSet>
+  and IndexSet<SpectrumIndexSet>.
+
+  @author Simon Heybrock
+  @date 2016
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+template <class T> class IndexSet {
+public:
+  IndexSet(size_t fullRange);
+  IndexSet(int64_t min, int64_t max, size_t fullRange);
+  IndexSet(const std::vector<size_t> indices, size_t fullRange);
+
+  /// Returns the size of the set.
+  size_t size() const { return m_size; }
+
+  /// Returns the element at given index (range 0...size()-1).
+  size_t operator[](size_t index) const {
+    // This is accessed frequently in loops and thus inlined.
+    if (m_isRange)
+      return m_min + index;
+    return m_indices[index];
+  }
+
+protected:
+  ~IndexSet() = default;
+
+private:
+  bool m_isRange = true;
+  // Default here to avoid uninitialized warning for m_isRange = false.
+  size_t m_min = 0;
+  size_t m_size;
+  std::vector<size_t> m_indices;
+};
+
+/// Constructor for a set covering the full range from 0 to fullRange-1.
+template <class T> IndexSet<T>::IndexSet(size_t fullRange) : m_size(fullRange) {}
+
+/// Constructor for a set covering the range from min to max. Range is verified
+/// at construction time.
+template <class T>
+IndexSet<T>::IndexSet(int64_t min, int64_t max, size_t fullRange) {
+  if (min < 0 || min > max)
+    throw std::logic_error("IndexSet: specified min or max values are invalid");
+  if (max >= static_cast<int64_t>(fullRange))
+    throw std::out_of_range("IndexSet: specified max value is out of range");
+
+  // Bounds checked, cast should be fine in all cases.
+  m_min = static_cast<size_t>(min);
+  m_size = static_cast<size_t>(max - min + 1);
+}
+
+/// Constructor for a set containing all specified indices. Range is verified at
+/// construction time and duplicates are removed.
+template <class T>
+IndexSet<T>::IndexSet(const std::vector<size_t> indices, size_t fullRange)
+    : m_isRange(false) {
+  // We use a set to create unique and ordered indices.
+  std::set<size_t> index_set;
+  for (const auto &index : indices) {
+    if (index >= fullRange)
+      throw std::out_of_range("IndexSet: specified index is out of range");
+    index_set.insert(index);
+  }
+  m_indices = std::vector<size_t>(begin(index_set), end(index_set));
+  m_size = m_indices.size();
+}
+
+} // namespace detail
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_INDEXSET_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/IndexType.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexType.h
@@ -1,0 +1,58 @@
+#ifndef MANTID_INDEXING_INDEXTYPE_H_
+#define MANTID_INDEXING_INDEXTYPE_H_
+
+#include "MantidIndexing/DllConfig.h"
+
+namespace Mantid {
+namespace Indexing {
+namespace detail {
+
+/** IndexType : TODO: DESCRIPTION
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+template <class Derived, class Int,
+          class = typename std::enable_if<std::is_integral<Int>::value>::type>
+class IndexType {
+public:
+  explicit IndexType(Int data) noexcept : m_data(data) {}
+  explicit operator Int() const noexcept { return m_data; }
+  template <class T> IndexType &operator=(const T &other) noexcept {
+    m_data = IndexType(other).m_data;
+    return *this;
+  }
+  template <class T> bool operator==(const T &other) const noexcept {
+    return m_data == IndexType(other).m_data;
+  }
+  template <class T> bool operator!=(const T &other) const noexcept {
+    return m_data != IndexType(other).m_data;
+  }
+
+private:
+  Int m_data;
+};
+
+} // namespace detail
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_INDEXTYPE_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/IndexType.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexType.h
@@ -46,6 +46,18 @@ public:
   template <class T> bool operator!=(const T &other) const noexcept {
     return m_data != IndexType(other).m_data;
   }
+  template <class T> bool operator>(const T &other) const noexcept {
+    return m_data > IndexType(other).m_data;
+  }
+  template <class T> bool operator>=(const T &other) const noexcept {
+    return m_data >= IndexType(other).m_data;
+  }
+  template <class T> bool operator<(const T &other) const noexcept {
+    return m_data < IndexType(other).m_data;
+  }
+  template <class T> bool operator<=(const T &other) const noexcept {
+    return m_data <= IndexType(other).m_data;
+  }
 
 private:
   Int m_data;

--- a/Framework/Indexing/inc/MantidIndexing/IndexType.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexType.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_INDEXING_INDEXTYPE_H_
 #define MANTID_INDEXING_INDEXTYPE_H_
 
-#include "MantidIndexing/DllConfig.h"
+#include <type_traits>
 
 namespace Mantid {
 namespace Indexing {

--- a/Framework/Indexing/inc/MantidIndexing/PartitionIndex.h
+++ b/Framework/Indexing/inc/MantidIndexing/PartitionIndex.h
@@ -2,11 +2,14 @@
 #define MANTID_INDEXING_PARTITIONINDEX_H_
 
 #include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/IndexType.h"
 
 namespace Mantid {
 namespace Indexing {
 
 /** PartitionIndex : TODO: DESCRIPTION
+
+  Partition index. This is an int since it is used as MPI rank.
 
   Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source
@@ -29,20 +32,10 @@ namespace Indexing {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_INDEXING_DLL PartitionIndex {
-public:
-  explicit PartitionIndex(int index) noexcept : m_index(index) {}
-  operator int() const noexcept { return m_index; }
-  template <class T> bool operator==(const T &other) const noexcept {
-    return m_index == PartitionIndex(other).m_index;
-  }
-  template <class T> bool operator!=(const T &other) const noexcept {
-    return m_index != PartitionIndex(other).m_index;
-  }
-
-private:
-  /// Partition index. This is an int since it is used as MPI rank.
-  int m_index;
+class MANTID_INDEXING_DLL PartitionIndex
+    : public detail::IndexType<PartitionIndex, int> {
+  using detail::IndexType<PartitionIndex, int>::IndexType;
+  using detail::IndexType<PartitionIndex, int>::operator=;
 };
 
 } // namespace Indexing

--- a/Framework/Indexing/inc/MantidIndexing/PartitionIndex.h
+++ b/Framework/Indexing/inc/MantidIndexing/PartitionIndex.h
@@ -1,18 +1,12 @@
-#ifndef MANTID_INDEXING_ROUNDROBINPARTITIONING_H_
-#define MANTID_INDEXING_ROUNDROBINPARTITIONING_H_
+#ifndef MANTID_INDEXING_PARTITIONINDEX_H_
+#define MANTID_INDEXING_PARTITIONINDEX_H_
 
 #include "MantidIndexing/DllConfig.h"
-#include "MantidIndexing/Partitioning.h"
-
-#include <stdexcept>
 
 namespace Mantid {
 namespace Indexing {
 
-/** RoundRobinPartitioning : TODO: DESCRIPTION
-
-  @author Simon Heybrock
-  @date 2016
+/** PartitionIndex : TODO: DESCRIPTION
 
   Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source
@@ -35,26 +29,23 @@ namespace Indexing {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_INDEXING_DLL RoundRobinPartitioning : public Partitioning {
+class MANTID_INDEXING_DLL PartitionIndex {
 public:
-  explicit RoundRobinPartitioning(int numberOfPartitions)
-      : m_partitions(numberOfPartitions) {
-    if (m_partitions < 1)
-      throw std::logic_error(
-          "RoundRobinPartitioning: There must be at least 1 partition");
+  explicit PartitionIndex(int index) noexcept : m_index(index) {}
+  operator int() const noexcept { return m_index; }
+  template <class T> bool operator==(const T &other) const noexcept {
+    return m_index == PartitionIndex(other).m_index;
   }
-
-  int numberOfPartitions() const override { return m_partitions; }
-  PartitionIndex indexOf(const SpectrumNumber &spectrumNumber) const override {
-    return PartitionIndex(
-        static_cast<int>(static_cast<int64_t>(spectrumNumber) % m_partitions));
+  template <class T> bool operator!=(const T &other) const noexcept {
+    return m_index != PartitionIndex(other).m_index;
   }
 
 private:
-  int m_partitions;
+  /// Partition index. This is an int since it is used as MPI rank.
+  int m_index;
 };
 
 } // namespace Indexing
 } // namespace Mantid
 
-#endif /* MANTID_INDEXING_ROUNDROBINPARTITIONING_H_ */
+#endif /* MANTID_INDEXING_PARTITIONINDEX_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/Partitioning.h
+++ b/Framework/Indexing/inc/MantidIndexing/Partitioning.h
@@ -1,5 +1,5 @@
-#ifndef MANTID_INDEXING_IPARTITIONING_H_
-#define MANTID_INDEXING_IPARTITIONING_H_
+#ifndef MANTID_INDEXING_PARTITIONING_H_
+#define MANTID_INDEXING_PARTITIONING_H_
 
 #include "MantidIndexing/DllConfig.h"
 #include "MantidIndexing/SpectrumNumber.h"
@@ -7,7 +7,7 @@
 namespace Mantid {
 namespace Indexing {
 
-/** IPartitioning : TODO: DESCRIPTION
+/** Partitioning : TODO: DESCRIPTION
 
   The main intention of this class is defining partitioning of all spectrum
   numbers into subsets for an MPI-based Mantid run.
@@ -33,9 +33,9 @@ namespace Indexing {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_INDEXING_DLL IPartitioning {
+class MANTID_INDEXING_DLL Partitioning {
 public:
-  virtual ~IPartitioning() = default;
+  virtual ~Partitioning() = default;
 
   virtual int numberOfPartitions() const = 0;
   virtual int partitionIndex() const = 0;
@@ -45,4 +45,4 @@ public:
 } // namespace Indexing
 } // namespace Mantid
 
-#endif /* MANTID_INDEXING_IPARTITIONING_H_ */
+#endif /* MANTID_INDEXING_PARTITIONING_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/Partitioning.h
+++ b/Framework/Indexing/inc/MantidIndexing/Partitioning.h
@@ -5,6 +5,8 @@
 #include "MantidIndexing/PartitionIndex.h"
 #include "MantidIndexing/SpectrumNumber.h"
 
+#include <vector>
+
 namespace Mantid {
 namespace Indexing {
 
@@ -36,14 +38,32 @@ namespace Indexing {
 */
 class MANTID_INDEXING_DLL Partitioning {
 public:
+  enum class MonitorStrategy { CloneOnEachPartition, DedicatedPartition };
+
+  Partitioning(const int numberOfPartitions, const PartitionIndex partition,
+               const MonitorStrategy monitorStrategy,
+               std::vector<SpectrumNumber> monitors);
+
   virtual ~Partitioning() = default;
 
-  virtual int numberOfPartitions() const = 0;
-  virtual PartitionIndex
-  indexOf(const SpectrumNumber &spectrumNumber) const = 0;
+  int numberOfPartitions() const;
+  PartitionIndex indexOf(const SpectrumNumber spectrumNumber) const;
 
-  bool isValid(const PartitionIndex &index) const;
-  void checkValid(const PartitionIndex &index) const;
+  bool isValid(const PartitionIndex index) const;
+  void checkValid(const PartitionIndex index) const;
+
+protected:
+  bool isMonitor(const SpectrumNumber spectrumNumber) const;
+  int numberOfNonMonitorPartitions() const;
+
+private:
+  virtual PartitionIndex
+  doIndexOf(const SpectrumNumber spectrumNumber) const = 0;
+
+  const int m_partitions;
+  const PartitionIndex m_partition;
+  const MonitorStrategy m_monitorStrategy;
+  const std::vector<SpectrumNumber> m_monitors;
 };
 
 } // namespace Indexing

--- a/Framework/Indexing/inc/MantidIndexing/Partitioning.h
+++ b/Framework/Indexing/inc/MantidIndexing/Partitioning.h
@@ -2,6 +2,7 @@
 #define MANTID_INDEXING_PARTITIONING_H_
 
 #include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/PartitionIndex.h"
 #include "MantidIndexing/SpectrumNumber.h"
 
 namespace Mantid {
@@ -38,8 +39,11 @@ public:
   virtual ~Partitioning() = default;
 
   virtual int numberOfPartitions() const = 0;
-  virtual int partitionIndex() const = 0;
-  virtual int partitionIndexOf(const SpectrumNumber &spectrumNumber) const = 0;
+  virtual PartitionIndex
+  indexOf(const SpectrumNumber &spectrumNumber) const = 0;
+
+  bool isValid(const PartitionIndex &index) const;
+  void checkValid(const PartitionIndex &index) const;
 };
 
 } // namespace Indexing

--- a/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
+++ b/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
@@ -38,20 +38,16 @@ namespace Indexing {
 class MANTID_INDEXING_DLL RoundRobinPartitioning : public Partitioning {
 public:
   explicit RoundRobinPartitioning(int numberOfPartitions)
-      : m_partitions(numberOfPartitions) {
-    if (m_partitions < 1)
-      throw std::logic_error(
-          "RoundRobinPartitioning: There must be at least 1 partition");
-  }
-
-  int numberOfPartitions() const override { return m_partitions; }
-  PartitionIndex indexOf(const SpectrumNumber &spectrumNumber) const override {
-    return PartitionIndex(
-        static_cast<int>(static_cast<int32_t>(spectrumNumber) % m_partitions));
-  }
+      : Partitioning(numberOfPartitions, PartitionIndex(0),
+                     Partitioning::MonitorStrategy::CloneOnEachPartition,
+                     std::vector<SpectrumNumber>{}) {}
 
 private:
-  int m_partitions;
+  PartitionIndex
+  doIndexOf(const SpectrumNumber spectrumNumber) const override {
+    return PartitionIndex(static_cast<int>(
+        static_cast<int32_t>(spectrumNumber) % numberOfNonMonitorPartitions()));
+  }
 };
 
 } // namespace Indexing

--- a/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
+++ b/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
@@ -47,7 +47,7 @@ public:
   int numberOfPartitions() const override { return m_partitions; }
   PartitionIndex indexOf(const SpectrumNumber &spectrumNumber) const override {
     return PartitionIndex(
-        static_cast<int>(static_cast<int64_t>(spectrumNumber) % m_partitions));
+        static_cast<int>(static_cast<int32_t>(spectrumNumber) % m_partitions));
   }
 
 private:

--- a/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
+++ b/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
@@ -1,0 +1,65 @@
+#ifndef MANTID_INDEXING_ROUNDROBINPARTITIONING_H_
+#define MANTID_INDEXING_ROUNDROBINPARTITIONING_H_
+
+#include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/IPartitioning.h"
+
+#include <stdexcept>
+
+namespace Mantid {
+namespace Indexing {
+
+/** RoundRobinPartitioning : TODO: DESCRIPTION
+
+  @author Simon Heybrock
+  @date 2016
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_INDEXING_DLL RoundRobinPartitioning : public IPartitioning {
+public:
+  RoundRobinPartitioning(int numberOfPartitions, int thisPartition)
+      : m_partitions(numberOfPartitions), m_partition(thisPartition) {
+    if (m_partitions < 1)
+      throw std::logic_error(
+          "RoundRobinPartitioning: There must be at least 1 partition");
+    if (m_partition < 0 || m_partition >= m_partitions)
+      throw std::out_of_range("RoundRobinPartitioning: Index of this partition "
+                              "is out of range 0...numberOfPartitions-1");
+  }
+
+  int numberOfPartitions() const override { return m_partitions; }
+  int partitionIndex() const override { return m_partition; }
+  int partitionIndexOf(const SpectrumNumber &spectrumNumber) const override {
+    return static_cast<int>(static_cast<int64_t>(spectrumNumber) %
+                            m_partitions);
+  }
+
+private:
+  int m_partitions;
+  int m_partition;
+};
+
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_ROUNDROBINPARTITIONING_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
+++ b/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
@@ -43,8 +43,7 @@ public:
                      std::vector<SpectrumNumber>{}) {}
 
 private:
-  PartitionIndex
-  doIndexOf(const SpectrumNumber spectrumNumber) const override {
+  PartitionIndex doIndexOf(const SpectrumNumber spectrumNumber) const override {
     return PartitionIndex(static_cast<int>(
         static_cast<int32_t>(spectrumNumber) % numberOfNonMonitorPartitions()));
   }

--- a/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
+++ b/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
@@ -37,10 +37,7 @@ namespace Indexing {
 */
 class MANTID_INDEXING_DLL RoundRobinPartitioning : public Partitioning {
 public:
-  explicit RoundRobinPartitioning(int numberOfPartitions)
-      : Partitioning(numberOfPartitions, PartitionIndex(0),
-                     Partitioning::MonitorStrategy::CloneOnEachPartition,
-                     std::vector<SpectrumNumber>{}) {}
+  using Partitioning::Partitioning;
 
 private:
   PartitionIndex doIndexOf(const SpectrumNumber spectrumNumber) const override {

--- a/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
+++ b/Framework/Indexing/inc/MantidIndexing/RoundRobinPartitioning.h
@@ -2,7 +2,7 @@
 #define MANTID_INDEXING_ROUNDROBINPARTITIONING_H_
 
 #include "MantidIndexing/DllConfig.h"
-#include "MantidIndexing/IPartitioning.h"
+#include "MantidIndexing/Partitioning.h"
 
 #include <stdexcept>
 
@@ -35,7 +35,7 @@ namespace Indexing {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_INDEXING_DLL RoundRobinPartitioning : public IPartitioning {
+class MANTID_INDEXING_DLL RoundRobinPartitioning : public Partitioning {
 public:
   RoundRobinPartitioning(int numberOfPartitions, int thisPartition)
       : m_partitions(numberOfPartitions), m_partition(thisPartition) {

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumIndexSet.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumIndexSet.h
@@ -1,0 +1,45 @@
+#ifndef MANTID_INDEXING_SPECTRUMINDEXSET_H_
+#define MANTID_INDEXING_SPECTRUMINDEXSET_H_
+
+#include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/IndexSet.h"
+
+namespace Mantid {
+namespace Indexing {
+
+/** SpectrumIndexSet : TODO: DESCRIPTION
+
+  @author Simon Heybrock
+  @date 2016
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_INDEXING_DLL SpectrumIndexSet
+    : public detail::IndexSet<SpectrumIndexSet> {
+public:
+  using detail::IndexSet<SpectrumIndexSet>::IndexSet;
+};
+
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_SPECTRUMINDEXSET_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumber.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumber.h
@@ -34,9 +34,9 @@ namespace Indexing {
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 struct MANTID_INDEXING_DLL SpectrumNumber
-    : public detail::IndexType<SpectrumNumber, int64_t> {
-  using detail::IndexType<SpectrumNumber, int64_t>::IndexType;
-  using detail::IndexType<SpectrumNumber, int64_t>::operator=;
+    : public detail::IndexType<SpectrumNumber, int32_t> {
+  using detail::IndexType<SpectrumNumber, int32_t>::IndexType;
+  using detail::IndexType<SpectrumNumber, int32_t>::operator=;
 };
 
 } // namespace Indexing

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumber.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumber.h
@@ -1,0 +1,55 @@
+#ifndef MANTID_INDEXING_SPECTRUMNUMBER_H_
+#define MANTID_INDEXING_SPECTRUMNUMBER_H_
+
+#include "MantidIndexing/DllConfig.h"
+
+namespace Mantid {
+namespace Indexing {
+
+/** SpectrumNumber : TODO: DESCRIPTION
+
+  @author Simon Heybrock
+  @date 2016
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_INDEXING_DLL SpectrumNumber {
+public:
+  explicit SpectrumNumber(int64_t number) noexcept : m_number(number) {}
+  template <class T> bool operator==(const T &other) const noexcept {
+    return m_number == SpectrumNumber(other).m_number;
+  }
+  template <class T> bool operator!=(const T &other) const noexcept {
+    return m_number != SpectrumNumber(other).m_number;
+  }
+  // This is explicit, it should help to avoid things like specNum2 = 42 +
+  // specNum1?
+  explicit operator int64_t() const noexcept { return m_number; }
+
+private:
+  int64_t m_number;
+};
+
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_SPECTRUMNUMBER_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumber.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumber.h
@@ -2,6 +2,7 @@
 #define MANTID_INDEXING_SPECTRUMNUMBER_H_
 
 #include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/IndexType.h"
 
 namespace Mantid {
 namespace Indexing {
@@ -32,19 +33,10 @@ namespace Indexing {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_INDEXING_DLL SpectrumNumber {
-public:
-  explicit SpectrumNumber(int64_t number) noexcept : m_number(number) {}
-  explicit operator int64_t() const noexcept { return m_number; }
-  template <class T> bool operator==(const T &other) const noexcept {
-    return m_number == SpectrumNumber(other).m_number;
-  }
-  template <class T> bool operator!=(const T &other) const noexcept {
-    return m_number != SpectrumNumber(other).m_number;
-  }
-
-private:
-  int64_t m_number;
+struct MANTID_INDEXING_DLL SpectrumNumber
+    : public detail::IndexType<SpectrumNumber, int64_t> {
+  using detail::IndexType<SpectrumNumber, int64_t>::IndexType;
+  using detail::IndexType<SpectrumNumber, int64_t>::operator=;
 };
 
 } // namespace Indexing

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -1,0 +1,84 @@
+#ifndef MANTID_INDEXING_SPECTRUMNUMBERTRANSLATOR_H_
+#define MANTID_INDEXING_SPECTRUMNUMBERTRANSLATOR_H_
+
+#include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/SpectrumIndexSet.h"
+#include "MantidIndexing/SpectrumNumber.h"
+
+#include <unordered_map>
+
+namespace Mantid {
+namespace Indexing {
+
+/** SpectrumNumberTranslator : TODO: DESCRIPTION
+
+  @author Simon Heybrock
+  @date 2016
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_INDEXING_DLL SpectrumNumberTranslator {
+public:
+  SpectrumNumberTranslator(const std::vector<SpectrumNumber> &spectrumNumbers,
+                           const std::vector<size_t> &indices) {
+    for (size_t i = 0; i < spectrumNumbers.size(); ++i) {
+      m_ranks[spectrumNumbers[i]] = m_rank;
+      m_indices[spectrumNumbers[i]] = indices[i];
+    }
+  }
+
+  // Full set
+  SpectrumIndexSet makeIndexSet() { return SpectrumIndexSet(m_indices.size()); }
+
+  // This one is more difficult with MPI, need to deal with partial overlaps, etc.
+  //SpectrumIndexSet makeIndexSet(SpectrumNumber min, SpectrumNumber max);
+
+  SpectrumIndexSet makeIndexSet(const std::vector<SpectrumNumber> &spectrumNumbers) {
+    std::vector<size_t> indices;
+    for(const auto &spectrumNumber : spectrumNumbers) {
+      const auto rank_iterator = m_ranks.find(spectrumNumber);
+      if (rank_iterator == m_ranks.end())
+        throw std::out_of_range("Invalid spectrum number.");
+      if (rank_iterator->second == m_rank)
+        indices.push_back(m_indices.at(spectrumNumber));
+    }
+    return SpectrumIndexSet(indices, m_indices.size());
+  }
+
+private:
+  struct SpectrumNumberHash {
+    std::size_t operator()(const SpectrumNumber &spectrumNumber) const {
+      return std::hash<std::int64_t>()(
+          static_cast<const int64_t>(spectrumNumber));
+    }
+  };
+
+  int m_rank{0};
+  std::unordered_map<SpectrumNumber, int, SpectrumNumberHash> m_ranks;
+  std::unordered_map<SpectrumNumber, size_t, SpectrumNumberHash> m_indices;
+};
+
+
+} // namespace Indexing
+} // namespace Mantid
+
+#endif /* MANTID_INDEXING_SPECTRUMNUMBERTRANSLATOR_H_ */

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -78,8 +78,8 @@ public:
 private:
   struct SpectrumNumberHash {
     std::size_t operator()(const SpectrumNumber &spectrumNumber) const {
-      return std::hash<std::int64_t>()(
-          static_cast<const int64_t>(spectrumNumber));
+      return std::hash<std::int32_t>()(
+          static_cast<const int32_t>(spectrumNumber));
     }
   };
 

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -53,6 +53,9 @@ public:
       if (partition == m_partition)
         m_indices.emplace(number, currentIndex++);
     }
+    if (spectrumNumbers.size() != m_partitions.size())
+      throw std::logic_error("SpectrumNumberTranslator: The vector of spectrum "
+                             "numbers contained duplicate entries.");
   }
 
   // Full set

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -2,6 +2,7 @@
 #define MANTID_INDEXING_SPECTRUMNUMBERTRANSLATOR_H_
 
 #include "MantidIndexing/DllConfig.h"
+#include "MantidIndexing/GlobalWorkspaceIndex.h"
 #include "MantidIndexing/Partitioning.h"
 #include "MantidIndexing/SpectrumIndexSet.h"
 #include "MantidIndexing/SpectrumNumber.h"
@@ -55,8 +56,11 @@ public:
       auto number = spectrumNumbers[i];
       auto partition = partitioning.indexOf(number);
       m_partitions.emplace(number, partition);
-      if (partition == m_partition)
-        m_indices.emplace(number, currentIndex++);
+      if (partition == m_partition) {
+        m_indices.emplace(number, currentIndex);
+        m_globalToLocal.emplace(GlobalWorkspaceIndex(i), currentIndex);
+        ++currentIndex;
+      }
     }
     if (spectrumNumbers.size() != m_partitions.size())
       throw std::logic_error("SpectrumNumberTranslator: The vector of spectrum "
@@ -79,6 +83,24 @@ public:
                             m_indices.size());
   }
 
+  SpectrumIndexSet makeIndexSet(GlobalWorkspaceIndex min,
+                                GlobalWorkspaceIndex max) {
+    if (min > max)
+      throw std::logic_error(
+          "SpectrumIndexTranslator: specified min is larger than max.");
+    if (max >= m_partitions.size())
+      throw std::out_of_range(
+          "SpectrumIndexTranslator: specified max value is out of range.");
+
+    const auto begin = m_globalToLocal.lower_bound(min);
+    const auto end = m_globalToLocal.upper_bound(max);
+    if (begin == m_globalToLocal.end() || end == m_globalToLocal.begin() ||
+        begin == end)
+      return SpectrumIndexSet(0);
+    return SpectrumIndexSet(begin->second, std::prev(end)->second,
+                            m_globalToLocal.size());
+  }
+
   SpectrumIndexSet
   makeIndexSet(const std::vector<SpectrumNumber> &spectrumNumbers) {
     std::vector<size_t> indices;
@@ -86,6 +108,20 @@ public:
       if (m_partitions.at(spectrumNumber) == m_partition)
         indices.push_back(m_indices.at(spectrumNumber));
     return SpectrumIndexSet(indices, m_indices.size());
+  }
+
+  SpectrumIndexSet
+  makeIndexSet(const std::vector<GlobalWorkspaceIndex> &globalIndices) {
+    std::vector<size_t> indices;
+    for (const auto &globalIndex : globalIndices) {
+      if (globalIndex >= m_partitions.size())
+        throw std::out_of_range(
+            "SpectrumIndexTranslator: specified index is out of range.");
+      const auto it = m_globalToLocal.find(globalIndex);
+      if (it != m_globalToLocal.end())
+        indices.push_back(std::distance(m_globalToLocal.begin(), it));
+    }
+    return SpectrumIndexSet(indices, m_globalToLocal.size());
   }
 
 private:
@@ -100,6 +136,7 @@ private:
   std::unordered_map<SpectrumNumber, PartitionIndex, SpectrumNumberHash>
       m_partitions;
   std::map<SpectrumNumber, size_t> m_indices;
+  std::map<GlobalWorkspaceIndex, size_t> m_globalToLocal;
 };
 
 } // namespace Indexing

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -67,11 +67,8 @@ public:
   SpectrumIndexSet makeIndexSet() { return SpectrumIndexSet(m_indices.size()); }
 
   SpectrumIndexSet makeIndexSet(SpectrumNumber min, SpectrumNumber max) {
-    const auto min_iterator = m_partitions.find(min);
-    const auto max_iterator = m_partitions.find(max);
-    if (min_iterator == m_partitions.end() ||
-        max_iterator == m_partitions.end())
-      throw std::out_of_range("Invalid spectrum number.");
+    checkAndGetPartitionIndex(min);
+    checkAndGetPartitionIndex(max);
 
     auto begin = m_indices.lower_bound(min);
     auto end = m_indices.upper_bound(max);
@@ -83,17 +80,21 @@ public:
   SpectrumIndexSet
   makeIndexSet(const std::vector<SpectrumNumber> &spectrumNumbers) {
     std::vector<size_t> indices;
-    for (const auto &spectrumNumber : spectrumNumbers) {
-      const auto rank_iterator = m_partitions.find(spectrumNumber);
-      if (rank_iterator == m_partitions.end())
-        throw std::out_of_range("Invalid spectrum number.");
-      if (rank_iterator->second == m_partition)
+    for (const auto &spectrumNumber : spectrumNumbers)
+      if (checkAndGetPartitionIndex(spectrumNumber) == m_partition)
         indices.push_back(m_indices.at(spectrumNumber));
-    }
     return SpectrumIndexSet(indices, m_indices.size());
   }
 
 private:
+  PartitionIndex
+  checkAndGetPartitionIndex(const SpectrumNumber &spectrumNumber) {
+    const auto rank_iterator = m_partitions.find(spectrumNumber);
+    if (rank_iterator == m_partitions.end())
+      throw std::out_of_range("Invalid spectrum number.");
+    return rank_iterator->second;
+  }
+
   struct SpectrumNumberHash {
     std::size_t operator()(const SpectrumNumber &spectrumNumber) const {
       return std::hash<std::int32_t>()(

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -40,15 +40,18 @@ namespace Indexing {
 class MANTID_INDEXING_DLL SpectrumNumberTranslator {
 public:
   SpectrumNumberTranslator(const std::vector<SpectrumNumber> &spectrumNumbers,
-                           const Partitioning &partitioning)
-      : m_partition(partitioning.partitionIndex()) {
+                           const Partitioning &partitioning,
+                           const PartitionIndex &partition)
+      : m_partition(partition) {
+    partitioning.checkValid(m_partition);
+
     size_t currentIndex = 0;
     for (size_t i = 0; i < spectrumNumbers.size(); ++i) {
       auto number = spectrumNumbers[i];
-      auto partition = partitioning.partitionIndexOf(number);
-      m_partitions[number] = partition;
+      auto partition = partitioning.indexOf(number);
+      m_partitions.emplace(number, partition);
       if (partition == m_partition)
-        m_indices[number] = currentIndex++;
+        m_indices.emplace(number, currentIndex++);
     }
   }
 
@@ -80,8 +83,9 @@ private:
     }
   };
 
-  int m_partition;
-  std::unordered_map<SpectrumNumber, int, SpectrumNumberHash> m_partitions;
+  const PartitionIndex m_partition;
+  std::unordered_map<SpectrumNumber, PartitionIndex, SpectrumNumberHash>
+      m_partitions;
   std::unordered_map<SpectrumNumber, size_t, SpectrumNumberHash> m_indices;
 };
 

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -67,8 +67,9 @@ public:
   SpectrumIndexSet makeIndexSet() { return SpectrumIndexSet(m_indices.size()); }
 
   SpectrumIndexSet makeIndexSet(SpectrumNumber min, SpectrumNumber max) {
-    checkAndGetPartitionIndex(min);
-    checkAndGetPartitionIndex(max);
+    // Range check
+    static_cast<void>(m_partitions.at(min));
+    static_cast<void>(m_partitions.at(max));
 
     const auto begin = m_indices.lower_bound(min);
     const auto end = m_indices.upper_bound(max);
@@ -82,20 +83,12 @@ public:
   makeIndexSet(const std::vector<SpectrumNumber> &spectrumNumbers) {
     std::vector<size_t> indices;
     for (const auto &spectrumNumber : spectrumNumbers)
-      if (checkAndGetPartitionIndex(spectrumNumber) == m_partition)
+      if (m_partitions.at(spectrumNumber) == m_partition)
         indices.push_back(m_indices.at(spectrumNumber));
     return SpectrumIndexSet(indices, m_indices.size());
   }
 
 private:
-  PartitionIndex
-  checkAndGetPartitionIndex(const SpectrumNumber &spectrumNumber) {
-    const auto rank_iterator = m_partitions.find(spectrumNumber);
-    if (rank_iterator == m_partitions.end())
-      throw std::out_of_range("Invalid spectrum number.");
-    return rank_iterator->second;
-  }
-
   struct SpectrumNumberHash {
     std::size_t operator()(const SpectrumNumber &spectrumNumber) const {
       return std::hash<std::int32_t>()(

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -2,7 +2,7 @@
 #define MANTID_INDEXING_SPECTRUMNUMBERTRANSLATOR_H_
 
 #include "MantidIndexing/DllConfig.h"
-#include "MantidIndexing/IPartitioning.h"
+#include "MantidIndexing/Partitioning.h"
 #include "MantidIndexing/SpectrumIndexSet.h"
 #include "MantidIndexing/SpectrumNumber.h"
 
@@ -40,7 +40,7 @@ namespace Indexing {
 class MANTID_INDEXING_DLL SpectrumNumberTranslator {
 public:
   SpectrumNumberTranslator(const std::vector<SpectrumNumber> &spectrumNumbers,
-                           const IPartitioning &partitioning)
+                           const Partitioning &partitioning)
       : m_partition(partitioning.partitionIndex()) {
     size_t currentIndex = 0;
     for (size_t i = 0; i < spectrumNumbers.size(); ++i) {

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -70,11 +70,12 @@ public:
     checkAndGetPartitionIndex(min);
     checkAndGetPartitionIndex(max);
 
-    auto begin = m_indices.lower_bound(min);
-    auto end = m_indices.upper_bound(max);
+    const auto begin = m_indices.lower_bound(min);
+    const auto end = m_indices.upper_bound(max);
     if (begin == m_indices.end() || end == m_indices.begin() || begin == end)
       return SpectrumIndexSet(0);
-    return SpectrumIndexSet(begin->second, (--end)->second, m_indices.size());
+    return SpectrumIndexSet(begin->second, std::prev(end)->second,
+                            m_indices.size());
   }
 
   SpectrumIndexSet

--- a/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
+++ b/Framework/Indexing/inc/MantidIndexing/SpectrumNumberTranslator.h
@@ -82,7 +82,7 @@ public:
         max_iterator == m_partitions.end())
       throw std::out_of_range("Invalid spectrum number.");
     // Empty set if range does not cover this partition.
-    if(min > m_max || max < m_min)
+    if (min > m_max || max < m_min)
       return SpectrumIndexSet(0);
     size_t minIndex;
     size_t maxIndex;

--- a/Framework/Indexing/src/Partitioning.cpp
+++ b/Framework/Indexing/src/Partitioning.cpp
@@ -1,18 +1,55 @@
 #include "MantidIndexing/Partitioning.h"
 
+#include <algorithm>
 #include <stdexcept>
 
 namespace Mantid {
 namespace Indexing {
 
-bool Partitioning::isValid(const PartitionIndex &index) const {
+Partitioning::Partitioning(const int numberOfPartitions,
+                           const PartitionIndex partition,
+                           const MonitorStrategy monitorStrategy,
+                           std::vector<SpectrumNumber> monitors)
+    : m_partitions(numberOfPartitions), m_partition(partition),
+      m_monitorStrategy(monitorStrategy), m_monitors(std::move(monitors)) {
+  if (numberOfNonMonitorPartitions() < 1)
+    throw std::logic_error("Partitioning: Number of non-monitor partitions "
+                           "must be larger than 0.");
+}
+
+int Partitioning::numberOfPartitions() const {
+  return m_partitions;
+}
+
+int Partitioning::numberOfNonMonitorPartitions() const {
+  if (m_monitorStrategy == MonitorStrategy::DedicatedPartition)
+    return m_partitions - 1;
+  return m_partitions;
+}
+
+PartitionIndex
+Partitioning::indexOf(const SpectrumNumber spectrumNumber) const {
+  if (isMonitor(spectrumNumber)) {
+    if (m_monitorStrategy == MonitorStrategy::DedicatedPartition)
+      return PartitionIndex(numberOfPartitions() - 1);
+    return m_partition;
+  }
+  return doIndexOf(spectrumNumber);
+}
+
+bool Partitioning::isValid(const PartitionIndex index) const {
   return index >= 0 && index < numberOfPartitions();
 }
 
-void Partitioning::checkValid(const PartitionIndex &index) const {
+void Partitioning::checkValid(const PartitionIndex index) const {
   if (!isValid(index))
     throw std::out_of_range(
         "PartitioningIndex is out of range 0...numberOfPartitions-1");
+}
+
+bool Partitioning::isMonitor(const SpectrumNumber spectrumNumber) const {
+  return std::find(m_monitors.begin(), m_monitors.end(), spectrumNumber) !=
+         m_monitors.end();
 }
 
 } // namespace Indexing

--- a/Framework/Indexing/src/Partitioning.cpp
+++ b/Framework/Indexing/src/Partitioning.cpp
@@ -17,9 +17,7 @@ Partitioning::Partitioning(const int numberOfPartitions,
                            "must be larger than 0.");
 }
 
-int Partitioning::numberOfPartitions() const {
-  return m_partitions;
-}
+int Partitioning::numberOfPartitions() const { return m_partitions; }
 
 int Partitioning::numberOfNonMonitorPartitions() const {
   if (m_monitorStrategy == MonitorStrategy::DedicatedPartition)

--- a/Framework/Indexing/src/Partitioning.cpp
+++ b/Framework/Indexing/src/Partitioning.cpp
@@ -1,0 +1,19 @@
+#include "MantidIndexing/Partitioning.h"
+
+#include <stdexcept>
+
+namespace Mantid {
+namespace Indexing {
+
+bool Partitioning::isValid(const PartitionIndex &index) const {
+  return index >= 0 && index < numberOfPartitions();
+}
+
+void Partitioning::checkValid(const PartitionIndex &index) const {
+  if (!isValid(index))
+    throw std::out_of_range(
+        "PartitioningIndex is out of range 0...numberOfPartitions-1");
+}
+
+} // namespace Indexing
+} // namespace Mantid

--- a/Framework/Indexing/src/dummy.cpp
+++ b/Framework/Indexing/src/dummy.cpp
@@ -1,0 +1,1 @@
+namespace {}

--- a/Framework/Indexing/test/CMakeLists.txt
+++ b/Framework/Indexing/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+if ( CXXTEST_FOUND )
+  include_directories ( SYSTEM ${CXXTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR} ${GTEST_INCLUDE_DIR} )
+
+  cxxtest_add_test ( IndexingTest ${TEST_FILES} ${GMOCK_TEST_FILES})
+  target_link_libraries( IndexingTest LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
+    Indexing
+    ${Boost_LIBRARIES}
+    ${GTEST_LIBRARIES} )
+
+  add_dependencies ( FrameworkTests IndexingTest )
+  # Add to the 'FrameworkTests' group in VS
+  set_property ( TARGET IndexingTest PROPERTY FOLDER "UnitTests" )
+endif ()

--- a/Framework/Indexing/test/DetectorIDTest.h
+++ b/Framework/Indexing/test/DetectorIDTest.h
@@ -1,0 +1,33 @@
+#ifndef MANTID_INDEXING_DETECTORIDTEST_H_
+#define MANTID_INDEXING_DETECTORIDTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/DetectorID.h"
+
+using namespace Mantid;
+using namespace Indexing;
+
+class DetectorIDTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static DetectorIDTest *createSuite() { return new DetectorIDTest(); }
+  static void destroySuite(DetectorIDTest *suite) { delete suite; }
+
+  void test_has_correct_mixins() {
+    DetectorID data(0);
+// AppleClang gives warning if the result is unused.
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+    TS_ASSERT_THROWS_NOTHING(
+        (dynamic_cast<detail::IndexType<DetectorID, int32_t> &>(data)));
+#if __clang__
+#pragma clang diagnostic pop
+#endif
+  }
+};
+
+#endif /* MANTID_INDEXING_DETECTORIDTEST_H_ */

--- a/Framework/Indexing/test/DetectorIDTranslatorTest.h
+++ b/Framework/Indexing/test/DetectorIDTranslatorTest.h
@@ -1,0 +1,105 @@
+#ifndef MANTID_INDEXING_DETECTORIDTRANSLATORTEST_H_
+#define MANTID_INDEXING_DETECTORIDTRANSLATORTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/DetectorIDTranslator.h"
+#include "MantidIndexing/RoundRobinPartitioning.h"
+
+using namespace Mantid::Indexing;
+
+class DetectorIDTranslatorTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static DetectorIDTranslatorTest *createSuite() { return new DetectorIDTranslatorTest(); }
+  static void destroySuite( DetectorIDTranslatorTest *suite ) { delete suite; }
+
+  DetectorIDTranslator makeTranslator(int ranks, int rank) {
+    std::vector<std::pair<SpectrumNumber, std::vector<DetectorID>>> spectra;
+    spectra.emplace_back(SpectrumNumber{2}, makeDetectorIDs({0}));
+    spectra.emplace_back(SpectrumNumber{1}, makeDetectorIDs({2}));
+    spectra.emplace_back(SpectrumNumber{4}, makeDetectorIDs({4,6}));
+    spectra.emplace_back(SpectrumNumber{5}, makeDetectorIDs({8}));
+    return {spectra, RoundRobinPartitioning(ranks),
+            PartitionIndex(rank)};
+  }
+
+  std::vector<DetectorID>
+  makeDetectorIDs(std::initializer_list<int64_t> init) {
+    return std::vector<DetectorID>(init.begin(), init.end());
+  }
+
+  template <class... T>
+  std::vector<DetectorID> makeDetectorIDs(T &&... args) {
+    return std::vector<DetectorID>(std::forward<T>(args)...);
+  }
+
+  void test_construct() {
+    auto detectorIDs = makeDetectorIDs({0});
+    std::vector<std::pair<SpectrumNumber, std::vector<DetectorID>>> spectra;
+    spectra.emplace_back(SpectrumNumber{1}, detectorIDs);
+    TS_ASSERT_THROWS_NOTHING(DetectorIDTranslator(
+        spectra, RoundRobinPartitioning(1), PartitionIndex(0)));
+  }
+
+  void test_makeIndexSet_full_1_rank() {
+    auto translator = makeTranslator(1, 0);
+    auto set = translator.makeIndexSet();
+    TS_ASSERT_EQUALS(set.size(), 5);
+    TS_ASSERT_EQUALS(set[0], 0);
+    TS_ASSERT_EQUALS(set[1], 1);
+    TS_ASSERT_EQUALS(set[2], 2);
+    TS_ASSERT_EQUALS(set[3], 3);
+  }
+
+  void test_makeIndexSet_full_3_ranks() {
+    auto translator = makeTranslator(3, 1);
+    auto set = translator.makeIndexSet();
+    // spectrumNumbers 1,2,4,5:
+    // 1 % 3 = 1, 4 % 3 = 1
+    // detector IDs are thus 2,4,6
+    TS_ASSERT_EQUALS(set.size(), 3);
+    TS_ASSERT_EQUALS(set[0], 0);
+    TS_ASSERT_EQUALS(set[1], 1);
+    TS_ASSERT_EQUALS(set[2], 2);
+  }
+
+  void test_makeIndexSet_partial_1_rank() {
+    auto translator = makeTranslator(1, 0);
+    auto set1 = translator.makeIndexSet(makeDetectorIDs({0, 2}));
+    TS_ASSERT_EQUALS(set1.size(), 2);
+    TS_ASSERT_EQUALS(set1[0], 0);
+    TS_ASSERT_EQUALS(set1[1], 1);
+    auto set2 = translator.makeIndexSet(makeDetectorIDs({4, 6, 8}));
+    TS_ASSERT_EQUALS(set2.size(), 3);
+    TS_ASSERT_EQUALS(set2[0], 2);
+    TS_ASSERT_EQUALS(set2[1], 3);
+    TS_ASSERT_EQUALS(set2[2], 4);
+  }
+
+  void test_makeIndexSet_partial_3_ranks_range_checks() {
+    auto translator = makeTranslator(3, 1);
+    TS_ASSERT_THROWS(translator.makeIndexSet(makeDetectorIDs({1})),
+                     std::out_of_range);
+    // Index is not on this rank but it is correct.
+    TS_ASSERT_THROWS_NOTHING(translator.makeIndexSet(makeDetectorIDs({0})));
+  }
+
+  void test_makeIndexSet_partial_3_ranks() {
+    auto translator = makeTranslator(3, 1);
+    // 2 is on this rank
+    auto set1 = translator.makeIndexSet(makeDetectorIDs({0, 2}));
+    TS_ASSERT_EQUALS(set1.size(), 1);
+    TS_ASSERT_EQUALS(set1[0], 0);
+    // 4 and 6 are on this rank
+    auto set2 = translator.makeIndexSet(makeDetectorIDs({4, 6, 8}));
+    TS_ASSERT_EQUALS(set2.size(), 2);
+    TS_ASSERT_EQUALS(set2[0], 1);
+    TS_ASSERT_EQUALS(set2[1], 2);
+  }
+
+};
+
+
+#endif /* MANTID_INDEXING_DETECTORIDTRANSLATORTEST_H_ */

--- a/Framework/Indexing/test/DetectorIDTranslatorTest.h
+++ b/Framework/Indexing/test/DetectorIDTranslatorTest.h
@@ -23,7 +23,11 @@ public:
     spectra.emplace_back(SpectrumNumber{1}, makeDetectorIDs({2}));
     spectra.emplace_back(SpectrumNumber{4}, makeDetectorIDs({4, 6}));
     spectra.emplace_back(SpectrumNumber{5}, makeDetectorIDs({8}));
-    return {spectra, RoundRobinPartitioning(ranks), PartitionIndex(rank)};
+    return {spectra, RoundRobinPartitioning(
+                         ranks, PartitionIndex(0),
+                         Partitioning::MonitorStrategy::CloneOnEachPartition,
+                         std::vector<SpectrumNumber>{}),
+            PartitionIndex(rank)};
   }
 
   std::vector<DetectorID> makeDetectorIDs(std::initializer_list<int64_t> init) {
@@ -39,7 +43,11 @@ public:
     std::vector<std::pair<SpectrumNumber, std::vector<DetectorID>>> spectra;
     spectra.emplace_back(SpectrumNumber{1}, detectorIDs);
     TS_ASSERT_THROWS_NOTHING(DetectorIDTranslator(
-        spectra, RoundRobinPartitioning(1), PartitionIndex(0)));
+        spectra, RoundRobinPartitioning(
+                     1, PartitionIndex(0),
+                     Partitioning::MonitorStrategy::CloneOnEachPartition,
+                     std::vector<SpectrumNumber>{}),
+        PartitionIndex(0)));
   }
 
   void test_makeIndexSet_full_1_rank() {

--- a/Framework/Indexing/test/DetectorIDTranslatorTest.h
+++ b/Framework/Indexing/test/DetectorIDTranslatorTest.h
@@ -12,26 +12,25 @@ class DetectorIDTranslatorTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static DetectorIDTranslatorTest *createSuite() { return new DetectorIDTranslatorTest(); }
-  static void destroySuite( DetectorIDTranslatorTest *suite ) { delete suite; }
+  static DetectorIDTranslatorTest *createSuite() {
+    return new DetectorIDTranslatorTest();
+  }
+  static void destroySuite(DetectorIDTranslatorTest *suite) { delete suite; }
 
   DetectorIDTranslator makeTranslator(int ranks, int rank) {
     std::vector<std::pair<SpectrumNumber, std::vector<DetectorID>>> spectra;
     spectra.emplace_back(SpectrumNumber{2}, makeDetectorIDs({0}));
     spectra.emplace_back(SpectrumNumber{1}, makeDetectorIDs({2}));
-    spectra.emplace_back(SpectrumNumber{4}, makeDetectorIDs({4,6}));
+    spectra.emplace_back(SpectrumNumber{4}, makeDetectorIDs({4, 6}));
     spectra.emplace_back(SpectrumNumber{5}, makeDetectorIDs({8}));
-    return {spectra, RoundRobinPartitioning(ranks),
-            PartitionIndex(rank)};
+    return {spectra, RoundRobinPartitioning(ranks), PartitionIndex(rank)};
   }
 
-  std::vector<DetectorID>
-  makeDetectorIDs(std::initializer_list<int64_t> init) {
+  std::vector<DetectorID> makeDetectorIDs(std::initializer_list<int64_t> init) {
     return std::vector<DetectorID>(init.begin(), init.end());
   }
 
-  template <class... T>
-  std::vector<DetectorID> makeDetectorIDs(T &&... args) {
+  template <class... T> std::vector<DetectorID> makeDetectorIDs(T &&... args) {
     return std::vector<DetectorID>(std::forward<T>(args)...);
   }
 
@@ -98,8 +97,6 @@ public:
     TS_ASSERT_EQUALS(set2[0], 1);
     TS_ASSERT_EQUALS(set2[1], 2);
   }
-
 };
-
 
 #endif /* MANTID_INDEXING_DETECTORIDTRANSLATORTEST_H_ */

--- a/Framework/Indexing/test/DetectorIndexSetTest.h
+++ b/Framework/Indexing/test/DetectorIndexSetTest.h
@@ -1,0 +1,35 @@
+#ifndef MANTID_INDEXING_DETECTORINDEXSETTEST_H_
+#define MANTID_INDEXING_DETECTORINDEXSETTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/DetectorIndexSet.h"
+
+using namespace Mantid;
+using namespace Indexing;
+
+class DetectorIndexSetTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static DetectorIndexSetTest *createSuite() {
+    return new DetectorIndexSetTest();
+  }
+  static void destroySuite(DetectorIndexSetTest *suite) { delete suite; }
+
+  void test_has_correct_mixins() {
+    DetectorIndexSet data(0);
+// AppleClang gives warning if the result is unused.
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+    TS_ASSERT_THROWS_NOTHING(
+        (dynamic_cast<detail::IndexSet<DetectorIndexSet> &>(data)));
+#if __clang__
+#pragma clang diagnostic pop
+#endif
+  }
+};
+
+#endif /* MANTID_INDEXING_DETECTORINDEXSETTEST_H_ */

--- a/Framework/Indexing/test/IndexSetTest.h
+++ b/Framework/Indexing/test/IndexSetTest.h
@@ -1,0 +1,90 @@
+#ifndef MANTID_INDEXING_INDEXSETTEST_H_
+#define MANTID_INDEXING_INDEXSETTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/IndexSet.h"
+
+using Mantid::Indexing::detail::IndexSet;
+
+class IndexSetTester : public IndexSet<IndexSetTester> {
+public:
+  using IndexSet<IndexSetTester>::IndexSet;
+};
+
+class IndexSetTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static IndexSetTest *createSuite() { return new IndexSetTest(); }
+  static void destroySuite(IndexSetTest *suite) { delete suite; }
+
+  void test_fullRangeConstructor() {
+    TS_ASSERT_THROWS_NOTHING(IndexSetTester set(3));
+    // Also empty set is supported
+    TS_ASSERT_THROWS_NOTHING(IndexSetTester set(0));
+  }
+
+  void test_rangeConstructor() {
+    // maximal possible range: 0...N-1
+    TS_ASSERT_THROWS_NOTHING(IndexSetTester set(0, 2, 3));
+    // smaller range works?
+    TS_ASSERT_THROWS_NOTHING(IndexSetTester set(1, 2, 3));
+    // min == max should work as well
+    TS_ASSERT_THROWS_NOTHING(IndexSetTester set(2, 2, 3));
+  }
+
+  void test_rangeConstructorErrorCases() {
+    // min negative
+    TS_ASSERT_THROWS(IndexSetTester set(-1, 2, 3), std::logic_error);
+    // min > max
+    TS_ASSERT_THROWS(IndexSetTester set(2, 1, 3), std::logic_error);
+    // max above count
+    TS_ASSERT_THROWS(IndexSetTester set(1, 3, 3), std::out_of_range);
+    // does it still fail if both are wrong?
+    TS_ASSERT_THROWS(IndexSetTester set(3, 3, 3), std::logic_error);
+  }
+
+  void test_indexListConstructor() {
+    TS_ASSERT_THROWS_NOTHING(IndexSetTester set({1, 2}, 3));
+    // Empty set is supported
+    TS_ASSERT_THROWS_NOTHING(IndexSetTester set({}, 3));
+  }
+
+  void test_indexListConstructorErrorCases() {
+    TS_ASSERT_THROWS(IndexSetTester set({3}, 3), std::out_of_range);
+  }
+
+  void test_size() {
+    size_t fullRange = 5;
+    IndexSetTester set1(fullRange);
+    TS_ASSERT_EQUALS(set1.size(), fullRange);
+    IndexSetTester set2(1, 2, fullRange);
+    TS_ASSERT_EQUALS(set2.size(), 2);
+  }
+
+  void test_fullRange() {
+    IndexSetTester set(3);
+    TS_ASSERT_EQUALS(set.size(), 3);
+    TS_ASSERT_EQUALS(set[0], 0);
+    TS_ASSERT_EQUALS(set[1], 1);
+    TS_ASSERT_EQUALS(set[2], 2);
+  }
+
+  void test_range() {
+    IndexSetTester set(1, 2, 3);
+    TS_ASSERT_EQUALS(set.size(), 2);
+    TS_ASSERT_EQUALS(set[0], 1);
+    TS_ASSERT_EQUALS(set[1], 2);
+  }
+
+  void test_indexList() {
+    // Note duplicate index
+    IndexSetTester set({2, 1, 2}, 3);
+    TS_ASSERT_EQUALS(set.size(), 2);
+    TS_ASSERT_EQUALS(set[0], 1);
+    TS_ASSERT_EQUALS(set[1], 2);
+  }
+};
+
+#endif /* MANTID_INDEXING_INDEXSETTEST_H_ */

--- a/Framework/Indexing/test/IndexTypeTest.h
+++ b/Framework/Indexing/test/IndexTypeTest.h
@@ -1,0 +1,65 @@
+#ifndef MANTID_INDEXING_INDEXTYPETEST_H_
+#define MANTID_INDEXING_INDEXTYPETEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/IndexType.h"
+
+using Mantid::Indexing::detail::IndexType;
+
+struct MyIndex : public IndexType<MyIndex, int64_t> {
+  using IndexType<MyIndex, int64_t>::IndexType;
+  using IndexType<MyIndex, int64_t>::operator=;
+};
+
+class IndexTypeTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static IndexTypeTest *createSuite() { return new IndexTypeTest(); }
+  static void destroySuite(IndexTypeTest *suite) { delete suite; }
+
+  void test_construct() {
+    MyIndex index(42);
+    TS_ASSERT_EQUALS(index, 42);
+  }
+
+  void test_copy() {
+    MyIndex index(42);
+    MyIndex copy(index);
+    TS_ASSERT_EQUALS(copy, 42);
+  }
+
+  void test_assignment() {
+    MyIndex index(42);
+    MyIndex assignee(0);
+    assignee = index;
+    TS_ASSERT_EQUALS(assignee, 42);
+    assignee = 0;
+    TS_ASSERT_EQUALS(assignee, 0);
+  }
+
+  void test_operator_equals() {
+    MyIndex data(42);
+    MyIndex same(42);
+    MyIndex different(100);
+    TS_ASSERT(data == data);
+    TS_ASSERT(data == same);
+    TS_ASSERT(!(data == different));
+    TS_ASSERT(data == 42);
+    TS_ASSERT(!(data == 100));
+  }
+
+  void test_operator_not_equals() {
+    MyIndex data(42);
+    MyIndex same(42);
+    MyIndex different(100);
+    TS_ASSERT(!(data != data));
+    TS_ASSERT(!(data != same));
+    TS_ASSERT(data != different);
+    TS_ASSERT(!(data != 42));
+    TS_ASSERT(data != 100);
+  }
+};
+
+#endif /* MANTID_INDEXING_INDEXTYPETEST_H_ */

--- a/Framework/Indexing/test/IndexTypeTest.h
+++ b/Framework/Indexing/test/IndexTypeTest.h
@@ -60,6 +60,30 @@ public:
     TS_ASSERT(!(data != 42));
     TS_ASSERT(data != 100);
   }
+
+  void test_operator_greater() {
+    MyIndex data(42);
+    TS_ASSERT(data > 41);
+    TS_ASSERT(!(data > 42));
+  }
+
+  void test_operator_greater_equal() {
+    MyIndex data(42);
+    TS_ASSERT(data >= 42);
+    TS_ASSERT(!(data >= 43));
+  }
+
+  void test_operator_less() {
+    MyIndex data(42);
+    TS_ASSERT(data < 43);
+    TS_ASSERT(!(data < 42));
+  }
+
+  void test_operator_less_equal() {
+    MyIndex data(42);
+    TS_ASSERT(data <= 42);
+    TS_ASSERT(!(data <= 41));
+  }
 };
 
 #endif /* MANTID_INDEXING_INDEXTYPETEST_H_ */

--- a/Framework/Indexing/test/PartitionIndexTest.h
+++ b/Framework/Indexing/test/PartitionIndexTest.h
@@ -5,7 +5,8 @@
 
 #include "MantidIndexing/PartitionIndex.h"
 
-using Mantid::Indexing::PartitionIndex;
+using namespace Mantid;
+using namespace Indexing;
 
 class PartitionIndexTest : public CxxTest::TestSuite {
 public:
@@ -14,31 +15,18 @@ public:
   static PartitionIndexTest *createSuite() { return new PartitionIndexTest(); }
   static void destroySuite(PartitionIndexTest *suite) { delete suite; }
 
-  void test_construct() {
-    PartitionIndex number(42);
-    TS_ASSERT_EQUALS(number, 42);
-  }
-
-  void test_operator_equals() {
-    PartitionIndex data(42);
-    PartitionIndex same(42);
-    PartitionIndex different(100);
-    TS_ASSERT(data == data);
-    TS_ASSERT(data == same);
-    TS_ASSERT(!(data == different));
-    TS_ASSERT(data == 42);
-    TS_ASSERT(!(data == 100));
-  }
-
-  void test_operator_not_equals() {
-    PartitionIndex data(42);
-    PartitionIndex same(42);
-    PartitionIndex different(100);
-    TS_ASSERT(!(data != data));
-    TS_ASSERT(!(data != same));
-    TS_ASSERT(data != different);
-    TS_ASSERT(!(data != 42));
-    TS_ASSERT(data != 100);
+  void test_has_correct_mixins() {
+    PartitionIndex data(0);
+// AppleClang gives warning if the result is unused.
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+    TS_ASSERT_THROWS_NOTHING(
+        (dynamic_cast<detail::IndexType<PartitionIndex, int> &>(data)));
+#if __clang__
+#pragma clang diagnostic pop
+#endif
   }
 };
 

--- a/Framework/Indexing/test/PartitionIndexTest.h
+++ b/Framework/Indexing/test/PartitionIndexTest.h
@@ -1,0 +1,45 @@
+#ifndef MANTID_INDEXING_PARTITIONINDEXTEST_H_
+#define MANTID_INDEXING_PARTITIONINDEXTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/PartitionIndex.h"
+
+using Mantid::Indexing::PartitionIndex;
+
+class PartitionIndexTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static PartitionIndexTest *createSuite() { return new PartitionIndexTest(); }
+  static void destroySuite(PartitionIndexTest *suite) { delete suite; }
+
+  void test_construct() {
+    PartitionIndex number(42);
+    TS_ASSERT_EQUALS(number, 42);
+  }
+
+  void test_operator_equals() {
+    PartitionIndex data(42);
+    PartitionIndex same(42);
+    PartitionIndex different(100);
+    TS_ASSERT(data == data);
+    TS_ASSERT(data == same);
+    TS_ASSERT(!(data == different));
+    TS_ASSERT(data == 42);
+    TS_ASSERT(!(data == 100));
+  }
+
+  void test_operator_not_equals() {
+    PartitionIndex data(42);
+    PartitionIndex same(42);
+    PartitionIndex different(100);
+    TS_ASSERT(!(data != data));
+    TS_ASSERT(!(data != same));
+    TS_ASSERT(data != different);
+    TS_ASSERT(!(data != 42));
+    TS_ASSERT(data != 100);
+  }
+};
+
+#endif /* MANTID_INDEXING_PARTITIONINDEXTEST_H_ */

--- a/Framework/Indexing/test/PartitioningTest.h
+++ b/Framework/Indexing/test/PartitioningTest.h
@@ -11,15 +11,20 @@ using namespace Indexing;
 class PartitioningHelper : public Partitioning {
 public:
   explicit PartitioningHelper(int numberOfPartitions)
-      : m_partitions(numberOfPartitions) {}
+      : Partitioning(numberOfPartitions, PartitionIndex(0),
+                     Partitioning::MonitorStrategy::CloneOnEachPartition,
+                     std::vector<SpectrumNumber>{}) {}
 
-  int numberOfPartitions() const override { return m_partitions; }
-  PartitionIndex indexOf(const SpectrumNumber &) const override {
-    return PartitionIndex(0);
+  PartitioningHelper(int numberOfPartitions, const PartitionIndex partition,
+                     const MonitorStrategy monitorStrategy,
+                     std::vector<SpectrumNumber> monitors)
+      : Partitioning(numberOfPartitions, partition, monitorStrategy, monitors) {
   }
 
 private:
-  int m_partitions;
+  PartitionIndex doIndexOf(const SpectrumNumber) const override {
+    return PartitionIndex(0);
+  }
 };
 
 class PartitioningTest : public CxxTest::TestSuite {
@@ -28,6 +33,24 @@ public:
   // This means the constructor isn't called when running other tests
   static PartitioningTest *createSuite() { return new PartitioningTest(); }
   static void destroySuite(PartitioningTest *suite) { delete suite; }
+
+  void test_constructor_failures() {
+    TS_ASSERT_THROWS(PartitioningHelper(-1), std::logic_error);
+    TS_ASSERT_THROWS(PartitioningHelper(0), std::logic_error);
+    TS_ASSERT_THROWS_NOTHING(
+        PartitioningHelper(1, PartitionIndex(13),
+                           Partitioning::MonitorStrategy::CloneOnEachPartition,
+                           std::vector<SpectrumNumber>{SpectrumNumber(3)}));
+    TS_ASSERT_THROWS(
+        PartitioningHelper(1, PartitionIndex(13),
+                           Partitioning::MonitorStrategy::DedicatedPartition,
+                           std::vector<SpectrumNumber>{SpectrumNumber(3)}),
+        std::logic_error);
+    TS_ASSERT_THROWS_NOTHING(
+        PartitioningHelper(2, PartitionIndex(13),
+                           Partitioning::MonitorStrategy::DedicatedPartition,
+                           std::vector<SpectrumNumber>{SpectrumNumber(3)}));
+  }
 
   void test_isValid() {
     PartitioningHelper p(42);
@@ -43,6 +66,33 @@ public:
     TS_ASSERT_THROWS_NOTHING(p.checkValid(PartitionIndex(0)));
     TS_ASSERT_THROWS_NOTHING(p.checkValid(PartitionIndex(41)));
     TS_ASSERT_THROWS(p.checkValid(PartitionIndex(42)), std::out_of_range);
+  }
+
+  void test_numberOfPartitions() {
+    TS_ASSERT_EQUALS(
+        PartitioningHelper(42, PartitionIndex(13),
+                           Partitioning::MonitorStrategy::CloneOnEachPartition,
+                           std::vector<SpectrumNumber>{}).numberOfPartitions(),
+        42);
+    TS_ASSERT_EQUALS(
+        PartitioningHelper(42, PartitionIndex(13),
+                           Partitioning::MonitorStrategy::DedicatedPartition,
+                           std::vector<SpectrumNumber>{}).numberOfPartitions(),
+        42);
+  }
+
+  void test_indexOf_cloned_monitors() {
+    PartitioningHelper p(42, PartitionIndex(13),
+                         Partitioning::MonitorStrategy::CloneOnEachPartition,
+                         std::vector<SpectrumNumber>{SpectrumNumber(3)});
+    TS_ASSERT_EQUALS(p.indexOf(SpectrumNumber(3)), PartitionIndex(13));
+  }
+
+  void test_indexOf_dedicated_monitors() {
+    PartitioningHelper p(42, PartitionIndex(13),
+                         Partitioning::MonitorStrategy::DedicatedPartition,
+                         std::vector<SpectrumNumber>{SpectrumNumber(3)});
+    TS_ASSERT_EQUALS(p.indexOf(SpectrumNumber(3)), PartitionIndex(41));
   }
 };
 

--- a/Framework/Indexing/test/PartitioningTest.h
+++ b/Framework/Indexing/test/PartitioningTest.h
@@ -1,0 +1,49 @@
+#ifndef MANTID_INDEXING_PARTITIONINGTEST_H_
+#define MANTID_INDEXING_PARTITIONINGTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/Partitioning.h"
+
+using namespace Mantid;
+using namespace Indexing;
+
+class PartitioningHelper : public Partitioning {
+public:
+  explicit PartitioningHelper(int numberOfPartitions)
+      : m_partitions(numberOfPartitions) {}
+
+  int numberOfPartitions() const override { return m_partitions; }
+  PartitionIndex indexOf(const SpectrumNumber &) const override {
+    return PartitionIndex(0);
+  }
+
+private:
+  int m_partitions;
+};
+
+class PartitioningTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static PartitioningTest *createSuite() { return new PartitioningTest(); }
+  static void destroySuite(PartitioningTest *suite) { delete suite; }
+
+  void test_isValid() {
+    PartitioningHelper p(42);
+    TS_ASSERT(!p.isValid(PartitionIndex(-1)));
+    TS_ASSERT(p.isValid(PartitionIndex(0)));
+    TS_ASSERT(p.isValid(PartitionIndex(41)));
+    TS_ASSERT(!p.isValid(PartitionIndex(42)));
+  }
+
+  void test_checkValid() {
+    PartitioningHelper p(42);
+    TS_ASSERT_THROWS(p.checkValid(PartitionIndex(-1)), std::out_of_range);
+    TS_ASSERT_THROWS_NOTHING(p.checkValid(PartitionIndex(0)));
+    TS_ASSERT_THROWS_NOTHING(p.checkValid(PartitionIndex(41)));
+    TS_ASSERT_THROWS(p.checkValid(PartitionIndex(42)), std::out_of_range);
+  }
+};
+
+#endif /* MANTID_INDEXING_PARTITIONINGTEST_H_ */

--- a/Framework/Indexing/test/RoundRobinPartitioningTest.h
+++ b/Framework/Indexing/test/RoundRobinPartitioningTest.h
@@ -5,8 +5,7 @@
 
 #include "MantidIndexing/RoundRobinPartitioning.h"
 
-using Mantid::Indexing::RoundRobinPartitioning;
-using Mantid::Indexing::SpectrumNumber;
+using namespace Mantid::Indexing;
 
 class RoundRobinPartitioningTest : public CxxTest::TestSuite {
 public:
@@ -17,13 +16,11 @@ public:
   }
   static void destroySuite(RoundRobinPartitioningTest *suite) { delete suite; }
 
-  void test_constructor_failures() {
-    TS_ASSERT_THROWS(RoundRobinPartitioning(-1), std::logic_error);
-    TS_ASSERT_THROWS(RoundRobinPartitioning(0), std::logic_error);
-  }
-
   void test_1_rank() {
-    RoundRobinPartitioning partitioning(1);
+    RoundRobinPartitioning partitioning(
+        1, PartitionIndex(0),
+        Partitioning::MonitorStrategy::CloneOnEachPartition,
+        std::vector<SpectrumNumber>{});
     TS_ASSERT_EQUALS(partitioning.numberOfPartitions(), 1);
     TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(0)), 0);
     TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(1)), 0);
@@ -31,7 +28,9 @@ public:
   }
 
   void test_3_ranks() {
-    RoundRobinPartitioning partitioning(3);
+    RoundRobinPartitioning partitioning(3, PartitionIndex(0),
+        Partitioning::MonitorStrategy::CloneOnEachPartition,
+        std::vector<SpectrumNumber>{});
     TS_ASSERT_EQUALS(partitioning.numberOfPartitions(), 3);
     TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(0)), 0);
     TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(1)), 1);

--- a/Framework/Indexing/test/RoundRobinPartitioningTest.h
+++ b/Framework/Indexing/test/RoundRobinPartitioningTest.h
@@ -18,29 +18,25 @@ public:
   static void destroySuite(RoundRobinPartitioningTest *suite) { delete suite; }
 
   void test_constructor_failures() {
-    TS_ASSERT_THROWS(RoundRobinPartitioning(-1, 0), std::logic_error);
-    TS_ASSERT_THROWS(RoundRobinPartitioning(0, 0), std::logic_error);
-    TS_ASSERT_THROWS(RoundRobinPartitioning(1, -1), std::logic_error);
-    TS_ASSERT_THROWS(RoundRobinPartitioning(1, 1), std::logic_error);
+    TS_ASSERT_THROWS(RoundRobinPartitioning(-1), std::logic_error);
+    TS_ASSERT_THROWS(RoundRobinPartitioning(0), std::logic_error);
   }
 
   void test_1_rank() {
-    RoundRobinPartitioning partitioning(1, 0);
+    RoundRobinPartitioning partitioning(1);
     TS_ASSERT_EQUALS(partitioning.numberOfPartitions(), 1);
-    TS_ASSERT_EQUALS(partitioning.partitionIndex(), 0);
-    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(0)), 0);
-    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(1)), 0);
-    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(2)), 0);
+    TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(0)), 0);
+    TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(1)), 0);
+    TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(2)), 0);
   }
 
   void test_3_ranks() {
-    RoundRobinPartitioning partitioning(3, 1);
+    RoundRobinPartitioning partitioning(3);
     TS_ASSERT_EQUALS(partitioning.numberOfPartitions(), 3);
-    TS_ASSERT_EQUALS(partitioning.partitionIndex(), 1);
-    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(0)), 0);
-    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(1)), 1);
-    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(2)), 2);
-    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(3)), 0);
+    TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(0)), 0);
+    TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(1)), 1);
+    TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(2)), 2);
+    TS_ASSERT_EQUALS(partitioning.indexOf(SpectrumNumber(3)), 0);
   }
 };
 

--- a/Framework/Indexing/test/RoundRobinPartitioningTest.h
+++ b/Framework/Indexing/test/RoundRobinPartitioningTest.h
@@ -1,0 +1,47 @@
+#ifndef MANTID_INDEXING_ROUNDROBINPARTITIONINGTEST_H_
+#define MANTID_INDEXING_ROUNDROBINPARTITIONINGTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/RoundRobinPartitioning.h"
+
+using Mantid::Indexing::RoundRobinPartitioning;
+using Mantid::Indexing::SpectrumNumber;
+
+class RoundRobinPartitioningTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static RoundRobinPartitioningTest *createSuite() {
+    return new RoundRobinPartitioningTest();
+  }
+  static void destroySuite(RoundRobinPartitioningTest *suite) { delete suite; }
+
+  void test_constructor_failures() {
+    TS_ASSERT_THROWS(RoundRobinPartitioning(-1, 0), std::logic_error);
+    TS_ASSERT_THROWS(RoundRobinPartitioning(0, 0), std::logic_error);
+    TS_ASSERT_THROWS(RoundRobinPartitioning(1, -1), std::logic_error);
+    TS_ASSERT_THROWS(RoundRobinPartitioning(1, 1), std::logic_error);
+  }
+
+  void test_1_rank() {
+    RoundRobinPartitioning partitioning(1, 0);
+    TS_ASSERT_EQUALS(partitioning.numberOfPartitions(), 1);
+    TS_ASSERT_EQUALS(partitioning.partitionIndex(), 0);
+    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(0)), 0);
+    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(1)), 0);
+    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(2)), 0);
+  }
+
+  void test_3_ranks() {
+    RoundRobinPartitioning partitioning(3, 1);
+    TS_ASSERT_EQUALS(partitioning.numberOfPartitions(), 3);
+    TS_ASSERT_EQUALS(partitioning.partitionIndex(), 1);
+    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(0)), 0);
+    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(1)), 1);
+    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(2)), 2);
+    TS_ASSERT_EQUALS(partitioning.partitionIndexOf(SpectrumNumber(3)), 0);
+  }
+};
+
+#endif /* MANTID_INDEXING_ROUNDROBINPARTITIONINGTEST_H_ */

--- a/Framework/Indexing/test/SpectrumIndexSetTest.h
+++ b/Framework/Indexing/test/SpectrumIndexSetTest.h
@@ -1,0 +1,35 @@
+#ifndef MANTID_INDEXING_SPECTRUMINDEXSETTEST_H_
+#define MANTID_INDEXING_SPECTRUMINDEXSETTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/SpectrumIndexSet.h"
+
+using namespace Mantid;
+using namespace Indexing;
+
+class SpectrumIndexSetTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static SpectrumIndexSetTest *createSuite() {
+    return new SpectrumIndexSetTest();
+  }
+  static void destroySuite(SpectrumIndexSetTest *suite) { delete suite; }
+
+  void test_has_correct_mixins() {
+    SpectrumIndexSet data(0);
+// AppleClang gives warning if the result is unused.
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+    TS_ASSERT_THROWS_NOTHING(
+        (dynamic_cast<detail::IndexSet<SpectrumIndexSet> &>(data)));
+#if __clang__
+#pragma clang diagnostic pop
+#endif
+  }
+};
+
+#endif /* MANTID_INDEXING_SPECTRUMINDEXSETTEST_H_ */

--- a/Framework/Indexing/test/SpectrumNumberTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTest.h
@@ -5,7 +5,8 @@
 
 #include "MantidIndexing/SpectrumNumber.h"
 
-using Mantid::Indexing::SpectrumNumber;
+using namespace Mantid;
+using namespace Indexing;
 
 class SpectrumNumberTest : public CxxTest::TestSuite {
 public:
@@ -14,31 +15,18 @@ public:
   static SpectrumNumberTest *createSuite() { return new SpectrumNumberTest(); }
   static void destroySuite(SpectrumNumberTest *suite) { delete suite; }
 
-  void test_construct() {
-    SpectrumNumber number(42);
-    TS_ASSERT_EQUALS(number, 42);
-  }
-
-  void test_operator_equals() {
-    SpectrumNumber data(42);
-    SpectrumNumber same(42);
-    SpectrumNumber different(100);
-    TS_ASSERT(data == data);
-    TS_ASSERT(data == same);
-    TS_ASSERT(!(data == different));
-    TS_ASSERT(data == 42);
-    TS_ASSERT(!(data == 100));
-  }
-
-  void test_operator_not_equals() {
-    SpectrumNumber data(42);
-    SpectrumNumber same(42);
-    SpectrumNumber different(100);
-    TS_ASSERT(!(data != data));
-    TS_ASSERT(!(data != same));
-    TS_ASSERT(data != different);
-    TS_ASSERT(!(data != 42));
-    TS_ASSERT(data != 100);
+  void test_has_correct_mixins() {
+    SpectrumNumber data(0);
+// AppleClang gives warning if the result is unused.
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+    TS_ASSERT_THROWS_NOTHING(
+        (dynamic_cast<detail::IndexType<SpectrumNumber, int64_t> &>(data)));
+#if __clang__
+#pragma clang diagnostic pop
+#endif
   }
 };
 

--- a/Framework/Indexing/test/SpectrumNumberTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTest.h
@@ -23,7 +23,7 @@ public:
 #pragma clang diagnostic ignored "-Wunused-value"
 #endif
     TS_ASSERT_THROWS_NOTHING(
-        (dynamic_cast<detail::IndexType<SpectrumNumber, int64_t> &>(data)));
+        (dynamic_cast<detail::IndexType<SpectrumNumber, int32_t> &>(data)));
 #if __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/Indexing/test/SpectrumNumberTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTest.h
@@ -1,0 +1,45 @@
+#ifndef MANTID_INDEXING_SPECTRUMNUMBERTEST_H_
+#define MANTID_INDEXING_SPECTRUMNUMBERTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/SpectrumNumber.h"
+
+using Mantid::Indexing::SpectrumNumber;
+
+class SpectrumNumberTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static SpectrumNumberTest *createSuite() { return new SpectrumNumberTest(); }
+  static void destroySuite(SpectrumNumberTest *suite) { delete suite; }
+
+  void test_construct() {
+    SpectrumNumber number(42);
+    TS_ASSERT_EQUALS(number, 42);
+  }
+
+  void test_operator_equals() {
+    SpectrumNumber data(42);
+    SpectrumNumber same(42);
+    SpectrumNumber different(100);
+    TS_ASSERT(data == data);
+    TS_ASSERT(data == same);
+    TS_ASSERT(!(data == different));
+    TS_ASSERT(data == 42);
+    TS_ASSERT(!(data == 100));
+  }
+
+  void test_operator_not_equals() {
+    SpectrumNumber data(42);
+    SpectrumNumber same(42);
+    SpectrumNumber different(100);
+    TS_ASSERT(!(data != data));
+    TS_ASSERT(!(data != same));
+    TS_ASSERT(data != different);
+    TS_ASSERT(!(data != 42));
+    TS_ASSERT(data != 100);
+  }
+};
+
+#endif /* MANTID_INDEXING_SPECTRUMNUMBERTEST_H_ */

--- a/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
@@ -27,7 +27,11 @@ public:
     // Local index          0 1 0 1
     auto numbers = {2, 1, 4, 5};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
-    return {spectrumNumbers, RoundRobinPartitioning(ranks),
+    return {spectrumNumbers,
+            RoundRobinPartitioning(
+                ranks, PartitionIndex(0),
+                Partitioning::MonitorStrategy::CloneOnEachPartition,
+                std::vector<SpectrumNumber>{}),
             PartitionIndex(rank)};
   }
 
@@ -50,23 +54,38 @@ public:
     auto numbers = {1, 2, 3, 4};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     TS_ASSERT_THROWS_NOTHING(SpectrumNumberTranslator(
-        spectrumNumbers, RoundRobinPartitioning(1), PartitionIndex(0)));
+        spectrumNumbers,
+        RoundRobinPartitioning(
+            1, PartitionIndex(0),
+            Partitioning::MonitorStrategy::CloneOnEachPartition,
+            std::vector<SpectrumNumber>{}),
+        PartitionIndex(0)));
   }
 
   void test_construct_fail() {
     auto numbers = {1, 2, 3, 3};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
-    TS_ASSERT_THROWS(SpectrumNumberTranslator(spectrumNumbers,
-                                              RoundRobinPartitioning(1),
-                                              PartitionIndex(0)),
-                     std::logic_error);
+    TS_ASSERT_THROWS(
+        SpectrumNumberTranslator(
+            spectrumNumbers,
+            RoundRobinPartitioning(
+                1, PartitionIndex(0),
+                Partitioning::MonitorStrategy::CloneOnEachPartition,
+                std::vector<SpectrumNumber>{}),
+            PartitionIndex(0)),
+        std::logic_error);
   }
 
   void test_spectrum_numbers_are_sorted() {
     auto numbers = {1, 0, 4, -1};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     SpectrumNumberTranslator translator(
-        spectrumNumbers, RoundRobinPartitioning(1), PartitionIndex(0));
+        spectrumNumbers,
+        RoundRobinPartitioning(
+            1, PartitionIndex(0),
+            Partitioning::MonitorStrategy::CloneOnEachPartition,
+            std::vector<SpectrumNumber>{}),
+        PartitionIndex(0));
 
     TS_ASSERT_EQUALS(translator.makeIndexSet(makeSpectrumNumbers({-1}))[0], 0);
     TS_ASSERT_EQUALS(translator.makeIndexSet(makeSpectrumNumbers({0}))[0], 1);

--- a/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
@@ -23,7 +23,7 @@ public:
   SpectrumNumberTranslator makeTranslator(int ranks, int rank) {
     auto numbers = {2, 1, 4, 5};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
-    return {spectrumNumbers, RoundRobinPartitioning(ranks, rank)};
+    return {spectrumNumbers, RoundRobinPartitioning(ranks), PartitionIndex(rank)};
   }
 
   std::vector<SpectrumNumber>
@@ -42,7 +42,7 @@ public:
     auto numbers = {1, 2, 3, 4};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
     TS_ASSERT_THROWS_NOTHING(SpectrumNumberTranslator(
-        spectrumNumbers, RoundRobinPartitioning(1, 0)));
+        spectrumNumbers, RoundRobinPartitioning(1), PartitionIndex(0)));
   }
 
   void test_makeIndexSet_full_1_rank() {

--- a/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
@@ -3,6 +3,7 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidIndexing/RoundRobinPartitioning.h"
 #include "MantidIndexing/SpectrumNumberTranslator.h"
 
 using namespace Mantid;
@@ -19,15 +20,10 @@ public:
     delete suite;
   }
 
-  SpectrumNumberTranslator makeTranslator() {
-    // 2 -> 0
-    // 1 -> 1
-    // 4 -> 2
-    // 5 -> 3
+  SpectrumNumberTranslator makeTranslator(int ranks, int rank) {
     auto numbers = {2, 1, 4, 5};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
-    std::vector<size_t> indices{0, 1, 2, 3};
-    return {spectrumNumbers, indices};
+    return {spectrumNumbers, RoundRobinPartitioning(ranks, rank)};
   }
 
   std::vector<SpectrumNumber>
@@ -45,13 +41,12 @@ public:
   void test_construct() {
     auto numbers = {1, 2, 3, 4};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
-    std::vector<size_t> indices{0, 1, 2, 3};
-    TS_ASSERT_THROWS_NOTHING(
-        SpectrumNumberTranslator(spectrumNumbers, indices));
+    TS_ASSERT_THROWS_NOTHING(SpectrumNumberTranslator(
+        spectrumNumbers, RoundRobinPartitioning(1, 0)));
   }
 
-  void test_makeIndexSet_full() {
-    auto translator = makeTranslator();
+  void test_makeIndexSet_full_1_rank() {
+    auto translator = makeTranslator(1, 0);
     auto set = translator.makeIndexSet();
     TS_ASSERT_EQUALS(set.size(), 4);
     TS_ASSERT_EQUALS(set[0], 0);
@@ -60,8 +55,18 @@ public:
     TS_ASSERT_EQUALS(set[3], 3);
   }
 
-  void test_makeIndexSet_partial() {
-    auto translator = makeTranslator();
+  void test_makeIndexSet_full_3_ranks() {
+    auto translator = makeTranslator(3, 1);
+    auto set = translator.makeIndexSet();
+    // spectrumNumbers 1,2,4,5:
+    // 1 % 3 = 1, 4 % 3 = 1
+    TS_ASSERT_EQUALS(set.size(), 2);
+    TS_ASSERT_EQUALS(set[0], 0);
+    TS_ASSERT_EQUALS(set[1], 1);
+  }
+
+  void test_makeIndexSet_partial_1_rank() {
+    auto translator = makeTranslator(1, 0);
     auto set1 = translator.makeIndexSet(makeSpectrumNumbers({1, 2}));
     TS_ASSERT_EQUALS(set1.size(), 2);
     TS_ASSERT_EQUALS(set1[0], 0);
@@ -70,6 +75,26 @@ public:
     TS_ASSERT_EQUALS(set2.size(), 2);
     TS_ASSERT_EQUALS(set2[0], 2);
     TS_ASSERT_EQUALS(set2[1], 3);
+  }
+
+  void test_makeIndexSet_partial_3_ranks_range_checks() {
+    auto translator = makeTranslator(3, 1);
+    TS_ASSERT_THROWS(translator.makeIndexSet(makeSpectrumNumbers({0})),
+                     std::out_of_range);
+    // Index is not on this rank but it is correct.
+    TS_ASSERT_THROWS_NOTHING(translator.makeIndexSet(makeSpectrumNumbers({2})));
+  }
+
+  void test_makeIndexSet_partial_3_ranks() {
+    auto translator = makeTranslator(3, 1);
+    // 1 is on this rank
+    auto set1 = translator.makeIndexSet(makeSpectrumNumbers({1, 2}));
+    TS_ASSERT_EQUALS(set1.size(), 1);
+    TS_ASSERT_EQUALS(set1[0], 0);
+    // 4 is on this rank
+    auto set2 = translator.makeIndexSet(makeSpectrumNumbers({4, 5}));
+    TS_ASSERT_EQUALS(set2.size(), 1);
+    TS_ASSERT_EQUALS(set2[0], 1);
   }
 };
 

--- a/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
@@ -44,6 +44,15 @@ public:
         spectrumNumbers, RoundRobinPartitioning(1), PartitionIndex(0)));
   }
 
+  void test_construct_fail() {
+    auto numbers = {1, 2, 3, 3};
+    std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
+    TS_ASSERT_THROWS(SpectrumNumberTranslator(spectrumNumbers,
+                                              RoundRobinPartitioning(1),
+                                              PartitionIndex(0)),
+                     std::logic_error);
+  }
+
   void test_makeIndexSet_full_1_rank() {
     auto translator = makeTranslator(1, 0);
     auto set = translator.makeIndexSet();

--- a/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
@@ -23,7 +23,8 @@ public:
   SpectrumNumberTranslator makeTranslator(int ranks, int rank) {
     auto numbers = {2, 1, 4, 5};
     std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
-    return {spectrumNumbers, RoundRobinPartitioning(ranks), PartitionIndex(rank)};
+    return {spectrumNumbers, RoundRobinPartitioning(ranks),
+            PartitionIndex(rank)};
   }
 
   std::vector<SpectrumNumber>
@@ -34,8 +35,6 @@ public:
   template <class... T>
   std::vector<SpectrumNumber> makeSpectrumNumbers(T &&... args) {
     return std::vector<SpectrumNumber>(std::forward<T>(args)...);
-    // std::vector<int64_t> numbers(std::forward<T>(args)...);
-    // return std::vector<SpectrumNumber>(numbers.begin(), numbers.end());
   }
 
   void test_construct() {

--- a/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTranslatorTest.h
@@ -1,0 +1,76 @@
+#ifndef MANTID_INDEXING_SPECTRUMNUMBERTRANSLATORTEST_H_
+#define MANTID_INDEXING_SPECTRUMNUMBERTRANSLATORTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidIndexing/SpectrumNumberTranslator.h"
+
+using namespace Mantid;
+using namespace Indexing;
+
+class SpectrumNumberTranslatorTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static SpectrumNumberTranslatorTest *createSuite() {
+    return new SpectrumNumberTranslatorTest();
+  }
+  static void destroySuite(SpectrumNumberTranslatorTest *suite) {
+    delete suite;
+  }
+
+  SpectrumNumberTranslator makeTranslator() {
+    // 2 -> 0
+    // 1 -> 1
+    // 4 -> 2
+    // 5 -> 3
+    auto numbers = {2, 1, 4, 5};
+    std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
+    std::vector<size_t> indices{0, 1, 2, 3};
+    return {spectrumNumbers, indices};
+  }
+
+  std::vector<SpectrumNumber>
+  makeSpectrumNumbers(std::initializer_list<int64_t> init) {
+    return std::vector<SpectrumNumber>(init.begin(), init.end());
+  }
+
+  template <class... T>
+  std::vector<SpectrumNumber> makeSpectrumNumbers(T &&... args) {
+    return std::vector<SpectrumNumber>(std::forward<T>(args)...);
+    // std::vector<int64_t> numbers(std::forward<T>(args)...);
+    // return std::vector<SpectrumNumber>(numbers.begin(), numbers.end());
+  }
+
+  void test_construct() {
+    auto numbers = {1, 2, 3, 4};
+    std::vector<SpectrumNumber> spectrumNumbers(numbers.begin(), numbers.end());
+    std::vector<size_t> indices{0, 1, 2, 3};
+    TS_ASSERT_THROWS_NOTHING(
+        SpectrumNumberTranslator(spectrumNumbers, indices));
+  }
+
+  void test_makeIndexSet_full() {
+    auto translator = makeTranslator();
+    auto set = translator.makeIndexSet();
+    TS_ASSERT_EQUALS(set.size(), 4);
+    TS_ASSERT_EQUALS(set[0], 0);
+    TS_ASSERT_EQUALS(set[1], 1);
+    TS_ASSERT_EQUALS(set[2], 2);
+    TS_ASSERT_EQUALS(set[3], 3);
+  }
+
+  void test_makeIndexSet_partial() {
+    auto translator = makeTranslator();
+    auto set1 = translator.makeIndexSet(makeSpectrumNumbers({1, 2}));
+    TS_ASSERT_EQUALS(set1.size(), 2);
+    TS_ASSERT_EQUALS(set1[0], 0);
+    TS_ASSERT_EQUALS(set1[1], 1);
+    auto set2 = translator.makeIndexSet(makeSpectrumNumbers({4, 5}));
+    TS_ASSERT_EQUALS(set2.size(), 2);
+    TS_ASSERT_EQUALS(set2[0], 2);
+    TS_ASSERT_EQUALS(set2[1], 3);
+  }
+};
+
+#endif /* MANTID_INDEXING_SPECTRUMNUMBERTRANSLATORTEST_H_ */


### PR DESCRIPTION
Do not merge, for review and discussion only.

@OwenArnold These are the essential indexing bits. We would have basically the same also for `DetectorId`.
- `SpectrumNumberTranslator` would be associated to a workspace (probably via a `shared_ptr` or `cow_ptr` since it changes rarely).
- Algorithm properties yield spectrum numbers, translated via `SpectrumNumber::makeIndexSet(...)`.
- Algorithms use
  
  ``` cpp
  #pragma omp parallel for
  for (size_t i=0; i<indexSet.size(); ++i) {
    // use indexSet[i] to access workspace
  }
  ```
