### PR TITLE
Serialise composite function's local attributes in string

### DIFF
--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -68,12 +68,21 @@ std::string CompositeFunction::asString() const {
     ostr << ';';
   }
   for (size_t i = 0; i < nFunctions(); i++) {
+    const auto localAttr = this->getLocalAttributeNames();
     IFunction_sptr fun = getFunction(i);
     bool isComp =
         boost::dynamic_pointer_cast<CompositeFunction>(fun) != nullptr;
     if (isComp)
       ostr << '(';
     ostr << fun->asString();
+    for (const auto &localAttName : localAttr) {
+      const std::string localAttValue =
+          this->getLocalAttribute(i, localAttName).value();
+      if (!localAttValue.empty()) {
+        // local attribute names are prefixed by dollar sign
+        ostr << ',' << '$' << localAttName << '=' << localAttValue;
+      }
+    }
     if (isComp)
       ostr << ')';
     if (i < nFunctions() - 1) {

--- a/Framework/API/test/MultiDomainFunctionTest.h
+++ b/Framework/API/test/MultiDomainFunctionTest.h
@@ -434,6 +434,22 @@ public:
     }
   }
 
+  void test_clone_preserves_domains() {
+    const auto copy = multi.clone();
+    TS_ASSERT_EQUALS(copy->getNumberDomains(), multi.getNumberDomains());
+  }
+
+  void test_string_representation() {
+    const std::string expected =
+        "composite=MultiDomainFunction,NumDeriv=true;"
+        "name=MultiDomainFunctionTest_Function,A=0,B=1,$domains=i;"
+        "name=MultiDomainFunctionTest_Function,A=0,B=2,$domains=i;"
+        "name=MultiDomainFunctionTest_Function,A=0,B=3,$domains=i;ties=(f1.A="
+        "f0.A,f2.A=f0.A)";
+    TS_ASSERT_EQUALS(multi.asString(), expected);
+    TS_ASSERT_EQUALS(multi.asString(), multi.clone()->asString());
+  }
+
 private:
   MultiDomainFunction multi;
   JointDomain domain;


### PR DESCRIPTION
When converting a `CompositeFunction` to a string, make sure that any local attributes are included
in the string.

This is useful for a `MultiDomainFunction`, where the domains are stored as a local attribute.
Now cloning a `MultiDomainFunction`, or going to and from its string representation, should not lose the domains.

**To test:**
- Code review
- Unit tests have been added to check that cloning preserves the number of domains.
  Check that the tests fail before this change and pass after it.
- Try the following:

``` python
string = "composite=MultiDomainFunction;name=FlatBackground,A0=0,$domains=i; \
name=FlatBackground,A0=1,$domains=(0,1);name=FlatBackground,A0=2,$domains=(0,2)"

func = FunctionFactory.createInitialized(string)
print func
```

The function string printed out should look like the input, in particular it should have the domains in it.

Fixes #16835.

_Release notes:_ I think this does not need to be in the release notes as it is an 'internal' change?

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
