### PR TITLE
Remove final keyword from class_maker.py

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ImggTomographicReconstruction.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ImggTomographicReconstruction.h
@@ -33,23 +33,23 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_ALGORITHMS_DLL ImggTomographicReconstruction final
+class MANTID_ALGORITHMS_DLL ImggTomographicReconstruction
     : public API::Algorithm {
 public:
-  const std::string name() const override final;
+  const std::string name() const override;
 
-  int version() const override final;
+  int version() const override;
 
-  const std::string category() const override final;
+  const std::string category() const override;
 
-  const std::string summary() const override final;
+  const std::string summary() const override;
 
 private:
-  void init() override final;
+  void init() override;
 
-  void exec() override final;
+  void exec() override;
 
-  bool processGroups() override final;
+  bool processGroups() override;
 
   std::map<std::string, std::string> validateInputs() override;
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CrystalFieldEnergies.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CrystalFieldEnergies.h
@@ -30,17 +30,16 @@ namespace CurveFitting {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_CURVEFITTING_DLL CrystalFieldEnergies final
-    : public API::Algorithm {
+class MANTID_CURVEFITTING_DLL CrystalFieldEnergies : public API::Algorithm {
 public:
-  const std::string name() const override final;
-  int version() const override final;
-  const std::string category() const override final;
-  const std::string summary() const override final;
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
 
 private:
-  void init() override final;
-  void exec() override final;
+  void init() override;
+  void exec() override;
 };
 
 } // namespace CurveFitting

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FunctionGenerator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FunctionGenerator.h
@@ -54,97 +54,93 @@ public:
   /// m_source and m_target.
   //@{
   /// Set i-th parameter
-  virtual void setParameter(size_t, const double &value,
-                            bool explicitlySet = true) override;
+  void setParameter(size_t, const double &value,
+                    bool explicitlySet = true) override;
   /// Set i-th parameter description
-  virtual void setParameterDescription(size_t,
-                                       const std::string &description) override;
+  void setParameterDescription(size_t, const std::string &description) override;
   /// Get i-th parameter
-  virtual double getParameter(size_t i) const override;
+  double getParameter(size_t i) const override;
   /// Set parameter by name.
-  virtual void setParameter(const std::string &name, const double &value,
-                            bool explicitlySet = true) override;
+  void setParameter(const std::string &name, const double &value,
+                    bool explicitlySet = true) override;
   /// Set description of parameter by name.
-  virtual void setParameterDescription(const std::string &name,
-                                       const std::string &description) override;
+  void setParameterDescription(const std::string &name,
+                               const std::string &description) override;
   /// Get parameter by name.
-  virtual double getParameter(const std::string &name) const override;
+  double getParameter(const std::string &name) const override;
   /// Total number of parameters
-  virtual size_t nParams() const override;
+  size_t nParams() const override;
   /// Returns the index of parameter name
-  virtual size_t parameterIndex(const std::string &name) const override;
+  size_t parameterIndex(const std::string &name) const override;
   /// Returns the name of parameter i
-  virtual std::string parameterName(size_t i) const override;
+  std::string parameterName(size_t i) const override;
   /// Returns the description of parameter i
-  virtual std::string parameterDescription(size_t i) const override;
+  std::string parameterDescription(size_t i) const override;
   /// Checks if a parameter has been set explicitly
-  virtual bool isExplicitlySet(size_t i) const override;
+  bool isExplicitlySet(size_t i) const override;
   /// Get the fitting error for a parameter
-  virtual double getError(size_t i) const override;
+  double getError(size_t i) const override;
   /// Set the fitting error for a parameter
-  virtual void setError(size_t i, double err) override;
+  void setError(size_t i, double err) override;
 
   /// Check if a declared parameter i is fixed
-  virtual bool isFixed(size_t i) const override;
+  bool isFixed(size_t i) const override;
   /// Removes a declared parameter i from the list of active
-  virtual void fix(size_t i) override;
+  void fix(size_t i) override;
   /// Restores a declared parameter i to the active status
-  virtual void unfix(size_t i) override;
+  void unfix(size_t i) override;
 
   /// Return parameter index from a parameter reference.
-  virtual size_t
-  getParameterIndex(const API::ParameterReference &ref) const override;
+  size_t getParameterIndex(const API::ParameterReference &ref) const override;
   /// Tie a parameter to other parameters (or a constant)
-  virtual API::ParameterTie *tie(const std::string &parName,
-                                 const std::string &expr,
-                                 bool isDefault = false) override;
+  API::ParameterTie *tie(const std::string &parName, const std::string &expr,
+                         bool isDefault = false) override;
   /// Apply the ties
-  virtual void applyTies() override;
+  void applyTies() override;
   /// Remove all ties
-  virtual void clearTies() override;
+  void clearTies() override;
   // Unhide base class function: removeTie(string).
   using IFunction::removeTie;
   /// Removes i-th parameter's tie
-  virtual bool removeTie(size_t i) override;
+  bool removeTie(size_t i) override;
   /// Get the tie of i-th parameter
-  virtual API::ParameterTie *getTie(size_t i) const override;
+  API::ParameterTie *getTie(size_t i) const override;
 
   /// Add a constraint to function
-  virtual void addConstraint(API::IConstraint *ic) override;
+  void addConstraint(API::IConstraint *ic) override;
   /// Get constraint of i-th parameter
-  virtual API::IConstraint *getConstraint(size_t i) const override;
+  API::IConstraint *getConstraint(size_t i) const override;
   /// Remove a constraint
-  virtual void removeConstraint(const std::string &parName) override;
+  void removeConstraint(const std::string &parName) override;
 
   /// Set up the function for a fit.
-  virtual void setUpForFit() override;
+  void setUpForFit() override;
 
   /// Build target function.
   virtual void buildTargetFunction() const = 0;
 
 protected:
   /// Declare a new parameter
-  virtual void declareParameter(const std::string &name, double initValue = 0,
-                                const std::string &description = "") override;
+  void declareParameter(const std::string &name, double initValue = 0,
+                        const std::string &description = "") override;
 
   /// Add a new tie. Derived classes must provide storage for ties
-  virtual void addTie(API::ParameterTie *tie) override;
+  void addTie(API::ParameterTie *tie) override;
   //@}
 
 public:
   /** @name Attributes */
   //@{
   /// Returns the number of attributes associated with the function
-  virtual size_t nAttributes() const override;
+  size_t nAttributes() const override;
   /// Returns a list of attribute names
-  virtual std::vector<std::string> getAttributeNames() const override;
+  std::vector<std::string> getAttributeNames() const override;
   /// Return a value of attribute attName
-  virtual Attribute getAttribute(const std::string &name) const override;
+  Attribute getAttribute(const std::string &name) const override;
   /// Set a value to attribute attName
-  virtual void setAttribute(const std::string &name,
-                            const Attribute &) override;
+  void setAttribute(const std::string &name, const Attribute &) override;
   /// Check if attribute attName exists
-  virtual bool hasAttribute(const std::string &name) const override;
+  bool hasAttribute(const std::string &name) const override;
   //@}
 
   /// Evaluate the function

--- a/Framework/DataHandling/inc/MantidDataHandling/ImggAggregateWavelengths.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ImggAggregateWavelengths.h
@@ -37,16 +37,16 @@ namespace DataHandling {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport ImggAggregateWavelengths final : public API::Algorithm {
+class DLLExport ImggAggregateWavelengths : public API::Algorithm {
 public:
-  const std::string name() const override final;
-  int version() const override final;
-  const std::string category() const override final;
-  const std::string summary() const override final;
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
 
 private:
-  void init() override final;
-  void exec() override final;
+  void init() override;
+  void exec() override;
 
   std::map<std::string, std::string> validateInputs() override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -193,7 +193,7 @@ public:
       const Kernel::SpecialCoordinateSystem coordSystem) override;
   /// make the workspace file backed if it has not been already file backed;
   virtual void setFileBacked(const std::string &fileName);
-  virtual void setFileBacked() override;
+  void setFileBacked() override;
   /// if workspace was file-backed, this should clear file-backed information
   /// and close back-up files.
   void clearFileBacked(bool LoadFileBackedData) override;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksCWSD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegratePeaksCWSD.h
@@ -20,7 +20,6 @@ namespace MDAlgorithms {
 class DLLExport IntegratePeaksCWSD : public API::Algorithm {
 public:
   IntegratePeaksCWSD();
-  ~IntegratePeaksCWSD();
 
   /// Algorithm's name for identification
   const std::string name() const override { return "IntegratePeaksCWSD"; }

--- a/Framework/MDAlgorithms/src/IntegratePeaksCWSD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksCWSD.cpp
@@ -28,11 +28,6 @@ IntegratePeaksCWSD::IntegratePeaksCWSD()
     : m_useSinglePeakCenterFmUser(false), m_doMergePeak(false) {}
 
 //----------------------------------------------------------------------------------------------
-/** Destructor
- */
-IntegratePeaksCWSD::~IntegratePeaksCWSD() {}
-
-//----------------------------------------------------------------------------------------------
 /** Initialize the algorithm's properties.
  */
 void IntegratePeaksCWSD::init() {

--- a/buildconfig/class_maker.py
+++ b/buildconfig/class_maker.py
@@ -28,17 +28,17 @@ def write_header(subproject, classname, filename, args):
 
     # Create an Algorithm header; will not use it if not an algo
     algorithm_header = """
-  const std::string name() const override final;
-  int version() const override final;
-  const std::string category() const override final;
-  const std::string summary() const override final;
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
 
 private:
-  void init() override final;
-  void exec() override final;
+  void init() override;
+  void exec() override;
 """
 
-    alg_class_declare = " final : public API::Algorithm"
+    alg_class_declare = " : public API::Algorithm"
     alg_include = '#include "MantidAPI/Algorithm.h"'
 
     if not args.alg:
@@ -50,8 +50,8 @@ private:
     s = """#ifndef %s
 #define %s
 
-#include "Mantid%s/DllConfig.h"
 %s
+#include "Mantid%s/DllConfig.h"
 namespace Mantid {
 namespace %s {
 


### PR DESCRIPTION
Description of work.

This removes the final keyword from algorithms generated by `class_maker.py`. As discussed in #tech-steering, this is looking like a premature optimization and best reserved only for when deriving from a class or overriding a member function will cause bad things to happen.

I tried to clean up the damage and fixed all other warnings from clang-tidy's `modernize-use-override` check. 

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this PR.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
