### PR TITLE
Added more noexcept keywords to cow_ptr, following shared_ptr.

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/cow_ptr.h
+++ b/Framework/Kernel/inc/MantidKernel/cow_ptr.h
@@ -64,22 +64,22 @@ private:
   std::mutex copyMutex;
 
 public:
-  cow_ptr(ptr_type &&resourceSptr);
-  cow_ptr(const ptr_type &resourceSptr);
+  cow_ptr(ptr_type &&resourceSptr) noexcept;
+  cow_ptr(const ptr_type &resourceSptr) noexcept;
   explicit cow_ptr(DataType *resourcePtr);
   cow_ptr();
   /// Constructs a cow_ptr with no managed object, i.e. empty cow_ptr.
-  constexpr cow_ptr(std::nullptr_t) : Data(nullptr) {}
-  cow_ptr(const cow_ptr<DataType> &);
+  constexpr cow_ptr(std::nullptr_t) noexcept : Data(nullptr) {}
+  cow_ptr(const cow_ptr<DataType> &) noexcept;
   // Move is hand-written, since std::mutex member prevents auto-generation.
   cow_ptr(cow_ptr<DataType> &&other) noexcept : Data(std::move(other.Data)) {}
-  cow_ptr<DataType> &operator=(const cow_ptr<DataType> &);
+  cow_ptr<DataType> &operator=(const cow_ptr<DataType> &) noexcept;
   // Move is hand-written, since std::mutex member prevents auto-generation.
   cow_ptr<DataType> &operator=(cow_ptr<DataType> &&rhs) noexcept {
     Data = std::move(rhs.Data);
     return *this;
   }
-  cow_ptr<DataType> &operator=(const ptr_type &);
+  cow_ptr<DataType> &operator=(const ptr_type &) noexcept;
 
   /// Returns the stored pointer.
   const DataType *get() const noexcept { return Data.get(); }
@@ -101,7 +101,7 @@ public:
   const DataType *operator->() const {
     return Data.get();
   } ///<indirectrion dereference access
-  bool operator==(const cow_ptr<DataType> &A) {
+  bool operator==(const cow_ptr<DataType> &A) noexcept {
     return Data == A.Data;
   } ///< Based on ptr equality
   DataType &access();
@@ -128,8 +128,8 @@ cow_ptr<DataType>::cow_ptr()
 */
 // Note: Need custom implementation, since std::mutex is not copyable.
 template <typename DataType>
-cow_ptr<DataType>::cow_ptr(const cow_ptr<DataType> &A)
-    : Data(A.Data) {}
+cow_ptr<DataType>::cow_ptr(const cow_ptr<DataType> &A) noexcept : Data(A.Data) {
+}
 
 /**
   Assignment operator : double references the data object
@@ -139,7 +139,8 @@ cow_ptr<DataType>::cow_ptr(const cow_ptr<DataType> &A)
 */
 // Note: Need custom implementation, since std::mutex is not copyable.
 template <typename DataType>
-cow_ptr<DataType> &cow_ptr<DataType>::operator=(const cow_ptr<DataType> &A) {
+cow_ptr<DataType> &cow_ptr<DataType>::
+operator=(const cow_ptr<DataType> &A) noexcept {
   if (this != &A) {
     Data = A.Data;
   }
@@ -153,7 +154,7 @@ cow_ptr<DataType> &cow_ptr<DataType>::operator=(const cow_ptr<DataType> &A) {
   @return *this
 */
 template <typename DataType>
-cow_ptr<DataType> &cow_ptr<DataType>::operator=(const ptr_type &A) {
+cow_ptr<DataType> &cow_ptr<DataType>::operator=(const ptr_type &A) noexcept {
   if (this->Data != A) {
     Data = A;
   }
@@ -187,12 +188,12 @@ template <typename DataType> DataType &cow_ptr<DataType>::access() {
 }
 
 template <typename DataType>
-cow_ptr<DataType>::cow_ptr(ptr_type &&resourceSptr) {
+cow_ptr<DataType>::cow_ptr(ptr_type &&resourceSptr) noexcept {
   this->Data = std::move(resourceSptr);
 }
 
 template <typename DataType>
-cow_ptr<DataType>::cow_ptr(const ptr_type &resourceSptr) {
+cow_ptr<DataType>::cow_ptr(const ptr_type &resourceSptr) noexcept {
   this->Data = resourceSptr;
 }
 


### PR DESCRIPTION
Not all methods of `Kernel::cow_ptr` that can be `noexcept` were `noexcept`. This PR fixes this, potentially allowing for better optimization by the compiler and use of `noexcept` in higher level code that uses `cow_ptr`.

**To test:**

Code review only, this reference for `boost::shared_ptr` should be helpful: http://www.boost.org/doc/libs/1_57_0/libs/smart_ptr/shared_ptr.htm.

No release notes, internal change.
No corresponding issue.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
