### PR TITLE
 Suppress -Wunused-function warnings with GCC 5

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
+++ b/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
@@ -89,4 +89,10 @@
 #endif
 // clang-format on
 
+#ifdef GCC_VERSION
+#define GCC_UNUSED_FUNCTION __attribute__((unused))
+#else
+#define GCC_UNUSED_FUNCTION
+#endif
+
 #endif /*MANTID_KERNEL_WARNINGSUPPRESSIONS_H_*/

--- a/Vates/VatesAPI/test/MockObjects.h
+++ b/Vates/VatesAPI/test/MockObjects.h
@@ -31,17 +31,6 @@ using Mantid::Geometry::MDHistoDimension;
 using Mantid::Geometry::MDHistoDimension_sptr;
 using Mantid::coord_t;
 
-// Allow unused functions.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#endif
-
-#if defined(GCC_VERSION) && GCC_VERSION >= 50000
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-#endif
-
 //=====================================================================================
 // Test Helper Types. These are shared by several tests in VatesAPI
 //=====================================================================================
@@ -195,7 +184,8 @@ Create a field data entry containing (as contents) the argument text.
 @param testData : Text to enter
 @return new vtkFieldData object containing text.
 */
-vtkFieldData *createFieldDataWithCharArray(std::string testData) {
+GCC_UNUSED_FUNCTION vtkFieldData *
+createFieldDataWithCharArray(std::string testData) {
   vtkFieldData *fieldData = vtkFieldData::New();
   vtkCharArray *charArray = vtkCharArray::New();
   charArray->SetName(Mantid::VATES::XMLDefinitions::metaDataId().c_str());
@@ -279,10 +269,11 @@ view.
 view.
 @return full xml as string.
 */
-std::string constructXML(const std::string &xDimensionIdMapping,
-                         const std::string &yDimensionIdMapping,
-                         const std::string &zDimensionIdMapping,
-                         const std::string &tDimensionIdMapping) {
+GCC_UNUSED_FUNCTION std::string
+constructXML(const std::string &xDimensionIdMapping,
+             const std::string &yDimensionIdMapping,
+             const std::string &zDimensionIdMapping,
+             const std::string &tDimensionIdMapping) {
   return std::string("<?xml version=\"1.0\" encoding=\"utf-8\"?>") +
          "<MDInstruction>" + "<MDWorkspaceName>Input</MDWorkspaceName>" +
          "<MDWorkspaceLocation>test_horace_reader.sqw</MDWorkspaceLocation>" +
@@ -376,7 +367,7 @@ view.
 view.
 @return full xml as string.
 */
-std::string
+GCC_UNUSED_FUNCTION std::string
 constructXMLForMDEvHelperData(const std::string &xDimensionIdMapping,
                               const std::string &yDimensionIdMapping,
                               const std::string &zDimensionIdMapping,
@@ -407,8 +398,8 @@ Mantid::API::Workspace_sptr createSimple3DWorkspace() {
   return outWs;
 }
 
-Mantid::API::Workspace_sptr get3DWorkspace(bool integratedTDimension,
-                                           bool sliceMD) {
+GCC_UNUSED_FUNCTION Mantid::API::Workspace_sptr
+get3DWorkspace(bool integratedTDimension, bool sliceMD) {
   using namespace Mantid::API;
   using namespace Mantid::DataObjects;
 
@@ -446,7 +437,8 @@ Mantid::API::Workspace_sptr get3DWorkspace(bool integratedTDimension,
  * @param fieldName : The requested field data entry
  * @return The value of the requested field data entry
  */
-std::string getStringFieldDataValue(vtkDataSet *ds, std::string fieldName) {
+GCC_UNUSED_FUNCTION std::string getStringFieldDataValue(vtkDataSet *ds,
+                                                        std::string fieldName) {
   vtkAbstractArray *value =
       ds->GetFieldData()->GetAbstractArray(fieldName.c_str());
   vtkStringArray *array = vtkStringArray::SafeDownCast(value);
@@ -454,13 +446,5 @@ std::string getStringFieldDataValue(vtkDataSet *ds, std::string fieldName) {
 }
 
 } // namespace
-
-#if __clang__
-#pragma clang diagnostic pop
-#endif
-
-#if defined(GCC_VERSION) && GCC_VERSION >= 50000
-#pragma GCC diagnostic pop
-#endif
 
 #endif

--- a/Vates/VatesAPI/test/MockObjects.h
+++ b/Vates/VatesAPI/test/MockObjects.h
@@ -379,7 +379,6 @@ std::string constructXMLForMDEvHelperData(
              xDimensionIdMapping, yDimensionIdMapping, zDimensionIdMapping,
              tDimensionIdMapping) +
          "</MDInstruction>";
-  `
 }
 
 Mantid::API::Workspace_sptr createSimple3DWorkspace() {

--- a/Vates/VatesAPI/test/MockObjects.h
+++ b/Vates/VatesAPI/test/MockObjects.h
@@ -379,6 +379,7 @@ std::string constructXMLForMDEvHelperData(
              xDimensionIdMapping, yDimensionIdMapping, zDimensionIdMapping,
              tDimensionIdMapping) +
          "</MDInstruction>";
+  `
 }
 
 Mantid::API::Workspace_sptr createSimple3DWorkspace() {

--- a/Vates/VatesAPI/test/MockObjects.h
+++ b/Vates/VatesAPI/test/MockObjects.h
@@ -184,8 +184,8 @@ Create a field data entry containing (as contents) the argument text.
 @param testData : Text to enter
 @return new vtkFieldData object containing text.
 */
-vtkFieldData *
-createFieldDataWithCharArray(std::string testData) GCC_UNUSED_FUNCTION {
+GCC_UNUSED_FUNCTION vtkFieldData *
+createFieldDataWithCharArray(std::string testData) {
   vtkFieldData *fieldData = vtkFieldData::New();
   vtkCharArray *charArray = vtkCharArray::New();
   charArray->SetName(Mantid::VATES::XMLDefinitions::metaDataId().c_str());
@@ -269,11 +269,11 @@ view.
 view.
 @return full xml as string.
 */
-std::string
+GCC_UNUSED_FUNCTION std::string
 constructXML(const std::string &xDimensionIdMapping,
              const std::string &yDimensionIdMapping,
              const std::string &zDimensionIdMapping,
-             const std::string &tDimensionIdMapping) GCC_UNUSED_FUNCTION {
+             const std::string &tDimensionIdMapping) {
   return std::string("<?xml version=\"1.0\" encoding=\"utf-8\"?>") +
          "<MDInstruction>" + "<MDWorkspaceName>Input</MDWorkspaceName>" +
          "<MDWorkspaceLocation>test_horace_reader.sqw</MDWorkspaceLocation>" +
@@ -367,11 +367,11 @@ view.
 view.
 @return full xml as string.
 */
-std::string constructXMLForMDEvHelperData(
-    const std::string &xDimensionIdMapping,
-    const std::string &yDimensionIdMapping,
-    const std::string &zDimensionIdMapping,
-    const std::string &tDimensionIdMapping) GCC_UNUSED_FUNCTION {
+GCC_UNUSED_FUNCTION std::string
+constructXMLForMDEvHelperData(const std::string &xDimensionIdMapping,
+                              const std::string &yDimensionIdMapping,
+                              const std::string &zDimensionIdMapping,
+                              const std::string &tDimensionIdMapping) {
   return std::string("<?xml version=\"1.0\" encoding=\"utf-8\"?>") +
          "<MDInstruction>" + "<MDWorkspaceName>Input</MDWorkspaceName>" +
          "<MDWorkspaceLocation>test_horace_reader.sqw</MDWorkspaceLocation>" +
@@ -379,7 +379,6 @@ std::string constructXMLForMDEvHelperData(
              xDimensionIdMapping, yDimensionIdMapping, zDimensionIdMapping,
              tDimensionIdMapping) +
          "</MDInstruction>";
-  `
 }
 
 Mantid::API::Workspace_sptr createSimple3DWorkspace() {
@@ -399,8 +398,8 @@ Mantid::API::Workspace_sptr createSimple3DWorkspace() {
   return outWs;
 }
 
-Mantid::API::Workspace_sptr get3DWorkspace(bool integratedTDimension,
-                                           bool sliceMD) GCC_UNUSED_FUNCTION {
+GCC_UNUSED_FUNCTION Mantid::API::Workspace_sptr
+get3DWorkspace(bool integratedTDimension, bool sliceMD) {
   using namespace Mantid::API;
   using namespace Mantid::DataObjects;
 
@@ -438,8 +437,8 @@ Mantid::API::Workspace_sptr get3DWorkspace(bool integratedTDimension,
  * @param fieldName : The requested field data entry
  * @return The value of the requested field data entry
  */
-std::string getStringFieldDataValue(vtkDataSet *ds,
-                                    std::string fieldName) GCC_UNUSED_FUNCTION {
+GCC_UNUSED_FUNCTION std::string getStringFieldDataValue(vtkDataSet *ds,
+                                                        std::string fieldName) {
   vtkAbstractArray *value =
       ds->GetFieldData()->GetAbstractArray(fieldName.c_str());
   vtkStringArray *array = vtkStringArray::SafeDownCast(value);

--- a/Vates/VatesAPI/test/MockObjects.h
+++ b/Vates/VatesAPI/test/MockObjects.h
@@ -184,8 +184,8 @@ Create a field data entry containing (as contents) the argument text.
 @param testData : Text to enter
 @return new vtkFieldData object containing text.
 */
-GCC_UNUSED_FUNCTION vtkFieldData *
-createFieldDataWithCharArray(std::string testData) {
+vtkFieldData *
+createFieldDataWithCharArray(std::string testData) GCC_UNUSED_FUNCTION {
   vtkFieldData *fieldData = vtkFieldData::New();
   vtkCharArray *charArray = vtkCharArray::New();
   charArray->SetName(Mantid::VATES::XMLDefinitions::metaDataId().c_str());
@@ -269,11 +269,11 @@ view.
 view.
 @return full xml as string.
 */
-GCC_UNUSED_FUNCTION std::string
+std::string
 constructXML(const std::string &xDimensionIdMapping,
              const std::string &yDimensionIdMapping,
              const std::string &zDimensionIdMapping,
-             const std::string &tDimensionIdMapping) {
+             const std::string &tDimensionIdMapping) GCC_UNUSED_FUNCTION {
   return std::string("<?xml version=\"1.0\" encoding=\"utf-8\"?>") +
          "<MDInstruction>" + "<MDWorkspaceName>Input</MDWorkspaceName>" +
          "<MDWorkspaceLocation>test_horace_reader.sqw</MDWorkspaceLocation>" +
@@ -367,11 +367,11 @@ view.
 view.
 @return full xml as string.
 */
-GCC_UNUSED_FUNCTION std::string
-constructXMLForMDEvHelperData(const std::string &xDimensionIdMapping,
-                              const std::string &yDimensionIdMapping,
-                              const std::string &zDimensionIdMapping,
-                              const std::string &tDimensionIdMapping) {
+std::string constructXMLForMDEvHelperData(
+    const std::string &xDimensionIdMapping,
+    const std::string &yDimensionIdMapping,
+    const std::string &zDimensionIdMapping,
+    const std::string &tDimensionIdMapping) GCC_UNUSED_FUNCTION {
   return std::string("<?xml version=\"1.0\" encoding=\"utf-8\"?>") +
          "<MDInstruction>" + "<MDWorkspaceName>Input</MDWorkspaceName>" +
          "<MDWorkspaceLocation>test_horace_reader.sqw</MDWorkspaceLocation>" +
@@ -379,6 +379,7 @@ constructXMLForMDEvHelperData(const std::string &xDimensionIdMapping,
              xDimensionIdMapping, yDimensionIdMapping, zDimensionIdMapping,
              tDimensionIdMapping) +
          "</MDInstruction>";
+  `
 }
 
 Mantid::API::Workspace_sptr createSimple3DWorkspace() {
@@ -398,8 +399,8 @@ Mantid::API::Workspace_sptr createSimple3DWorkspace() {
   return outWs;
 }
 
-GCC_UNUSED_FUNCTION Mantid::API::Workspace_sptr
-get3DWorkspace(bool integratedTDimension, bool sliceMD) {
+Mantid::API::Workspace_sptr get3DWorkspace(bool integratedTDimension,
+                                           bool sliceMD) GCC_UNUSED_FUNCTION {
   using namespace Mantid::API;
   using namespace Mantid::DataObjects;
 
@@ -437,8 +438,8 @@ get3DWorkspace(bool integratedTDimension, bool sliceMD) {
  * @param fieldName : The requested field data entry
  * @return The value of the requested field data entry
  */
-GCC_UNUSED_FUNCTION std::string getStringFieldDataValue(vtkDataSet *ds,
-                                                        std::string fieldName) {
+std::string getStringFieldDataValue(vtkDataSet *ds,
+                                    std::string fieldName) GCC_UNUSED_FUNCTION {
   vtkAbstractArray *value =
       ds->GetFieldData()->GetAbstractArray(fieldName.c_str());
   vtkStringArray *array = vtkStringArray::SafeDownCast(value);


### PR DESCRIPTION
Description of work.

This suppresses several `-Wunused-function` warnings that appear in `Vates/VatesAPI/test/MockObjects.h` with GCC 5+ and can be safely ignored. 

Unfortunately, [a compiler bug not fixed until GCC 6.0](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64079) prevents us from using pragmas to suppress these warnings. As a workaround, we instead add `__attribute__((unused))` to each function generating a warning.

**To test:**

<!-- Instructions for testing. -->

Build Mantid with GCC 5 and `MAKE_VATES=ON`. Verify there are no `-Wunused-function` warnings remaining.

Fixes #16840.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
