### PR TITLE
Indirect - Elwin interface multiple files

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -33,7 +33,8 @@ private slots:
   void unGroupInput(bool error);
 
 private:
-  void addSaveAlgorithm(const std::string &workspaceName, std::string filename = "");
+  void addSaveAlgorithm(const std::string &workspaceName,
+                        std::string filename = "");
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -33,7 +33,7 @@ private slots:
   void unGroupInput(bool error);
 
 private:
-  void addSaveAlgorithm(QString workspaceName, QString filename = "");
+  void addSaveAlgorithm(const std::string &workspaceName, std::string &filename = "");
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -33,7 +33,7 @@ private slots:
   void unGroupInput(bool error);
 
 private:
-  void addSaveAlgorithm(const std::string &workspaceName, std::string &filename = "");
+  void addSaveAlgorithm(const std::string &workspaceName, std::string filename = "");
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -125,7 +125,7 @@ void Elwin::run() {
   QString eltWorkspace = workspaceBaseName + "elt";
 
   // Load input files
-  std::vector<std::string> inputWorkspaceNames;
+  std::string inputWorkspacesString;
 
   for (auto it = inputFilenames.begin(); it != inputFilenames.end(); ++it) {
     QFileInfo inputFileInfo(*it);
@@ -137,17 +137,18 @@ void Elwin::run() {
     loadAlg->setProperty("OutputWorkspace", workspaceName);
 
     m_batchAlgoRunner->addAlgorithm(loadAlg);
-    inputWorkspaceNames.push_back(workspaceName);
+    inputWorkspacesString += workspaceName + ",";
   }
 
   // Group input workspaces
   IAlgorithm_sptr groupWsAlg =
       AlgorithmManager::Instance().create("GroupWorkspaces");
   groupWsAlg->initialize();
-  groupWsAlg->setProperty("InputWorkspaces", inputWorkspaceNames);
+  API::BatchAlgorithmRunner::AlgorithmRuntimeProps runTimeProps;
+  runTimeProps["InputWorkspaces"] = inputWorkspacesString;
   groupWsAlg->setProperty("OutputWorkspace", inputGroupWsName);
 
-  m_batchAlgoRunner->addAlgorithm(groupWsAlg);
+  m_batchAlgoRunner->addAlgorithm(groupWsAlg, runTimeProps);
 
   // Configure ElasticWindowMultiple algorithm
   IAlgorithm_sptr elwinMultAlg =

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -184,8 +184,7 @@ void Elwin::run() {
   elwinMultAlg->setProperty("Plot", m_uiForm.ckPlot->isChecked());
 
   elwinMultAlg->setProperty("OutputInQ", qWorkspace);
-  elwinMultAlg->setProperty("OutputInQSquared",
-                            qSquaredWorkspace);
+  elwinMultAlg->setProperty("OutputInQSquared", qSquaredWorkspace);
   elwinMultAlg->setProperty("OutputELF", elfWorkspace);
 
   elwinMultAlg->setProperty("SampleEnvironmentLogName",
@@ -259,7 +258,8 @@ void Elwin::unGroupInput(bool error) {
  * @param workspaceName Name of the workspace to save
  * @param filename Name of the file to save it as
  */
-void Elwin::addSaveAlgorithm(const std::string &workspaceName, std::string filename) {
+void Elwin::addSaveAlgorithm(const std::string &workspaceName,
+                             std::string filename) {
   // Set a default filename if none provided
   if (filename.length() == 0)
     filename = workspaceName + ".nxs";

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -234,7 +234,7 @@ void Elwin::unGroupInput(bool error) {
  * @param workspaceName Name of the workspace to save
  * @param filename Name of the file to save it as
  */
-void Elwin::addSaveAlgorithm(const std::string &workspaceName, std::string &filename) {
+void Elwin::addSaveAlgorithm(const std::string &workspaceName, std::string filename) {
   // Set a default filename if none provided
   if (filename.length() == 0)
     filename = workspaceName + ".nxs";

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -115,14 +115,15 @@ void Elwin::run() {
   std::string inputGroupWsName = "IDA_Elwin_Input";
 
   QFileInfo firstFileInfo(inputFilenames[0]);
-  QString filename = firstFileInfo.baseName();
-  QString workspaceBaseName =
+  const auto filename = firstFileInfo.baseName();
+
+  auto workspaceBaseName =
       filename.left(filename.lastIndexOf("_")) + "_elwin_";
 
-  QString qWorkspace = workspaceBaseName + "eq";
-  QString qSquaredWorkspace = workspaceBaseName + "eq2";
-  QString elfWorkspace = workspaceBaseName + "elf";
-  QString eltWorkspace = workspaceBaseName + "elt";
+  const auto qWorkspace = (workspaceBaseName + "eq").toStdString();
+  const auto qSquaredWorkspace = (workspaceBaseName + "eq2").toStdString();
+  const auto elfWorkspace = (workspaceBaseName + "elf").toStdString();
+  const auto eltWorkspace = (workspaceBaseName + "elt").toStdString();
 
   // Load input files
   std::string inputWorkspacesString;
@@ -157,10 +158,10 @@ void Elwin::run() {
 
   elwinMultAlg->setProperty("Plot", m_uiForm.ckPlot->isChecked());
 
-  elwinMultAlg->setProperty("OutputInQ", qWorkspace.toStdString());
+  elwinMultAlg->setProperty("OutputInQ", qWorkspace);
   elwinMultAlg->setProperty("OutputInQSquared",
-                            qSquaredWorkspace.toStdString());
-  elwinMultAlg->setProperty("OutputELF", elfWorkspace.toStdString());
+                            qSquaredWorkspace);
+  elwinMultAlg->setProperty("OutputELF", elfWorkspace);
 
   elwinMultAlg->setProperty("SampleEnvironmentLogName",
                             m_uiForm.leLogName->text().toStdString());
@@ -184,7 +185,7 @@ void Elwin::run() {
   }
 
   if (m_blnManager->value(m_properties["Normalise"])) {
-    elwinMultAlg->setProperty("OutputELT", eltWorkspace.toStdString());
+    elwinMultAlg->setProperty("OutputELT", eltWorkspace);
   }
 
   BatchAlgorithmRunner::AlgorithmRuntimeProps elwinInputProps;
@@ -207,7 +208,7 @@ void Elwin::run() {
   m_batchAlgoRunner->executeBatchAsync();
 
   // Set the result workspace for Python script export
-  m_pythonExportWsName = qSquaredWorkspace.toStdString();
+  m_pythonExportWsName = qSquaredWorkspace;
 }
 
 /**
@@ -233,18 +234,18 @@ void Elwin::unGroupInput(bool error) {
  * @param workspaceName Name of the workspace to save
  * @param filename Name of the file to save it as
  */
-void Elwin::addSaveAlgorithm(QString workspaceName, QString filename) {
+void Elwin::addSaveAlgorithm(const std::string &workspaceName, std::string &filename) {
   // Set a default filename if none provided
-  if (filename.isEmpty())
+  if (filename.length() == 0)
     filename = workspaceName + ".nxs";
 
   // Configure the algorithm
   IAlgorithm_sptr loadAlg = AlgorithmManager::Instance().create("SaveNexus");
   loadAlg->initialize();
-  loadAlg->setProperty("Filename", filename.toStdString());
+  loadAlg->setProperty("Filename", filename);
 
   BatchAlgorithmRunner::AlgorithmRuntimeProps saveAlgProps;
-  saveAlgProps["InputWorkspace"] = workspaceName.toStdString();
+  saveAlgProps["InputWorkspace"] = workspaceName;
 
   // Add it to the batch runner
   m_batchAlgoRunner->addAlgorithm(loadAlg, saveAlgProps);

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -117,8 +117,33 @@ void Elwin::run() {
   QFileInfo firstFileInfo(inputFilenames[0]);
   const auto filename = firstFileInfo.baseName();
 
-  auto workspaceBaseName =
-      filename.left(filename.lastIndexOf("_")) + "_elwin_";
+  auto workspaceBaseName = filename.left(filename.lastIndexOf("_"));
+
+  if (inputFilenames.size() > 1) {
+    QFileInfo fileInfo(inputFilenames[inputFilenames.length() - 1]);
+    auto runNumber = fileInfo.baseName().toStdString();
+    runNumber = runNumber.substr(0, runNumber.find_first_of("_"));
+    size_t runNumberStart = 0;
+    const auto strLength = runNumber.length();
+    for (size_t i = 0; i < strLength; i++) {
+      if (std::isdigit(runNumber[i])) {
+        runNumberStart = i;
+        break;
+      }
+    }
+    // reassemble workspace base name with additional run number
+    runNumber = runNumber.substr(runNumberStart, strLength);
+    auto baseName = firstFileInfo.baseName();
+    const auto prefix = baseName.left(baseName.indexOf("_"));
+    auto testPre = prefix.toStdString();
+    const auto suffix =
+        baseName.right(baseName.length() - baseName.indexOf("_"));
+    auto testsuf = suffix.toStdString();
+    workspaceBaseName =
+        prefix + QString::fromStdString("-" + runNumber) + suffix;
+  }
+
+  workspaceBaseName += "_elwin_";
 
   const auto qWorkspace = (workspaceBaseName + "eq").toStdString();
   const auto qSquaredWorkspace = (workspaceBaseName + "eq2").toStdString();

--- a/docs/source/release/v3.8.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.8.0/indirect_inelastic.rst
@@ -20,6 +20,8 @@ Elwin
 ~~~~~
 
 - Additional option to ungroup Elwin output
+- When using multiple input files, the naming convention for the outputworkspace contains the `first-final` run number.
+  An example of this would be `osi92764-92767_graphite002_red_elwin_elf` for OSIRIS run between 92764-92767
 
 Jump Fit
 ~~~~~~~~
@@ -32,6 +34,7 @@ Improvements
 - Algorithm :ref:`BASISReduction311 <algm-BASISReduction311>` has been included in algorithm :ref:`BASISReduction <algm-BASISReduction>`.
 - Range bars colours in the *ISIS Calibration* interface have been updated to match the convention in the fit wizard.
 
+
 Bugfixes
 --------
 
@@ -41,5 +44,6 @@ Bugfixes
 * Fix memory leak in :ref:`LoadSassena <algm-LoadSassena>`
 * The *ResNorm* interface should no longer crash when using workspaces (rather than files) as input.
 * Fix bug showing incorrect doublet peaks in :ref:`ISISIndirectDiffractionReduction <algm-ISISIndirectDiffractionReduction>`
+
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.8%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
The Elwin interface is now able to use multiple files as input once again.
Additionally, the file name convention for multiple files has been updated to show the first and last run number from the input data in the outputworkspace name

**To test:**
- Open the Elwin interface (Interfaces > Indirect > Data Analysis > Elwin(tab))
- Select all the OSIRIS files (`osi`) files from `\\olympic\Babylon5\Public\ElliotOram\DataAnalysis\Elwin`
- Click `Run`
- Ensure that the interface runs without error and the files produced in the ADS (ignore the input files in the `IDA_Elwin_Input` group) start with `osi92762-92767_graphite002_red_elwin_` and end in `elf`/`eq`/`eq2`
- Perform the same test but with a single file 
- Ensure the interface concludes without error and the workspace names start with `osi92762_graphite002_red_elwin_`

Fixes #16851

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/ebefcdea939fe0ced58bf8107acc52b34c150cf9/docs/source/release/v3.8.0/indirect_inelastic.rst)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
