### PR TITLE
Fix column ordering in ConvertTableToMatrixWorkspaceDialogue

### DIFF
--- a/MantidQt/CustomDialogs/src/ConvertTableToMatrixWorkspaceDialog.cpp
+++ b/MantidQt/CustomDialogs/src/ConvertTableToMatrixWorkspaceDialog.cpp
@@ -63,9 +63,9 @@ void ConvertTableToMatrixWorkspaceDialog::fillColumnNames(
   for (std::vector<std::string>::const_iterator column = columns.begin();
        column != columns.end(); ++column) {
     QString qName = QString::fromStdString(*column);
-    m_form.cbColumnX->insertItem(-1, qName);
-    m_form.cbColumnY->insertItem(-1, qName);
-    m_form.cbColumnE->insertItem(-1, qName);
+    m_form.cbColumnX->addItem(qName); 
+    m_form.cbColumnY->addItem(qName);
+    m_form.cbColumnE->addItem(qName);
     Mantid::API::Column_sptr col = tws->getColumn(*column);
     if (col->getPlotType() == 1 && defaultXColumn.isEmpty()) // type X
     {

--- a/MantidQt/CustomDialogs/src/ConvertTableToMatrixWorkspaceDialog.cpp
+++ b/MantidQt/CustomDialogs/src/ConvertTableToMatrixWorkspaceDialog.cpp
@@ -63,7 +63,7 @@ void ConvertTableToMatrixWorkspaceDialog::fillColumnNames(
   for (std::vector<std::string>::const_iterator column = columns.begin();
        column != columns.end(); ++column) {
     QString qName = QString::fromStdString(*column);
-    m_form.cbColumnX->addItem(qName); 
+    m_form.cbColumnX->addItem(qName);
     m_form.cbColumnY->addItem(qName);
     m_form.cbColumnE->addItem(qName);
     Mantid::API::Column_sptr col = tws->getColumn(*column);

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -32,6 +32,10 @@ Improved
 
 - :ref:`SavePlot1D <algm-SavePlot1D>` has options for writing out
   plotly html files.
+  
+- :ref:`ConvertTableToMatrixWorkspaceTest <algm-ConvertTableToMatrixWorkspaceTest>`
+  had a bug where the table columns were in a reversed order. 
+  This is now fixed and the order is correct.
 
 Deprecated
 ##########

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -33,8 +33,8 @@ Improved
 - :ref:`SavePlot1D <algm-SavePlot1D>` has options for writing out
   plotly html files.
   
-- :ref:`ConvertTableToMatrixWorkspaceTest <algm-ConvertTableToMatrixWorkspaceTest>`
-  had a bug where the table columns were in a reversed order. 
+- :ref:`ConvertTableToMatrixWorkspaceDialog <algm-ConvertTableToMatrixWorkspaceDialog>`
+  had a bug where the table columns were in a reversed order in the dialogue's combo boxes. 
   This is now fixed and the order is correct.
 
 Deprecated


### PR DESCRIPTION
## Description of work.

The original source file [here](https://github.com/mantidproject/mantid/blob/00a929f7e57c4dc8a854de93ce8c046594352062/MantidQt/CustomDialogs/src/ConvertTableToMatrixWorkspaceDialog.cpp#L66-L68) was using QComboBox.insertItem(-1, value) which, by implementation, when passed a negative parameter appends to the front of the list. I have fixed the issue by using the QComboBox.addItem(value) method which automatically appends to the end of the list, as can be seen [here](https://github.com/mantidproject/mantid/commit/2b2b5ce2230c755189a294f3b74bb51862dd3b83).
## To test:

<!-- Instructions for testing. -->

Fixes #16445. Please refer to issue for testing instructions.
## Release Notes

See [here](https://github.com/mantidproject/mantid/commit/ac2167b80f6fcf58d512ed8f777d8dfe5be7c8ef).

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Inserting into the QComboBox now uses QComboBox.addItem(value)
