### PR TITLE
Add Direct to EMode options for Paalman Pings algorithms

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/CylinderPaalmanPingsCorrection2.py
+++ b/Framework/PythonInterface/plugins/algorithms/CylinderPaalmanPingsCorrection2.py
@@ -105,8 +105,8 @@ class CylinderPaalmanPingsCorrection(PythonAlgorithm):
                              doc='Number of wavelengths for calculation')
 
         self.declareProperty(name='Emode', defaultValue='Elastic',
-                             validator=StringListValidator(['Elastic', 'Indirect']),
-                             doc='Emode: Elastic or Indirect')
+                             validator=StringListValidator(['Elastic', 'Indirect', 'Direct']),
+                             doc='Energy transfer mode')
         self.declareProperty(name='Efixed', defaultValue=1.0,
                              doc='Analyser energy')
 
@@ -358,9 +358,7 @@ class CylinderPaalmanPingsCorrection(PythonAlgorithm):
 
         if self._emode == 'Elastic':
             self._elastic = self._waves[int(len(self._waves) / 2)]
-        elif self._emode == 'Direct':
-            self._elastic = math.sqrt(81.787/self._efixed) # elastic wavelength
-        elif self._emode == 'Indirect':
+        else:
             self._elastic = math.sqrt(81.787/self._efixed) # elastic wavelength
 
         logger.information('Elastic lambda : %f' % (self._elastic))

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/FlatPlatePaalmanPingsCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/FlatPlatePaalmanPingsCorrection.py
@@ -87,8 +87,8 @@ class FlatPlatePaalmanPingsCorrection(PythonAlgorithm):
                              doc='Interpolate the correction workspaces to match the sample workspace')
 
         self.declareProperty(name='Emode', defaultValue='Elastic',
-                             validator=StringListValidator(['Elastic', 'Indirect']),
-                             doc='Emode: Elastic or Indirect')
+                             validator=StringListValidator(['Elastic', 'Indirect', 'Direct']),
+                             doc='Energy transfer mode')
         self.declareProperty(name='Efixed', defaultValue=1.0,
                              doc='Analyser energy')
 
@@ -281,7 +281,7 @@ class FlatPlatePaalmanPingsCorrection(PythonAlgorithm):
 
         if self._emode == 'Elastic':
             self._elastic = self._waves[int(number_waves / 2)]
-        elif self._emode == 'Indirect':
+        else:
             self._elastic = math.sqrt(81.787 / self._efixed)  # elastic wavelength
 
         logger.information('Elastic lambda %f' % self._elastic)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CylinderPaalmanPingsCorrection2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CylinderPaalmanPingsCorrection2Test.py
@@ -83,9 +83,9 @@ class CylinderPaalmanPingsCorrection2Test(unittest.TestCase):
             self._verify_workspace(workspace)
 
 
-    def test_sampleOnly(self):
+    def test_sampleOnly_Indirect(self):
         """
-        Test simple run with sample workspace only.
+        Test simple run with sample workspace only for indirect mode
         """
 
         CylinderPaalmanPingsCorrection(OutputWorkspace=self._corrections_ws_name,
@@ -97,7 +97,23 @@ class CylinderPaalmanPingsCorrection2Test(unittest.TestCase):
                                        Efixed=1.845)
 
         ass_ws_name = self._corrections_ws_name + '_ass'
-        self. _verify_workspace(ass_ws_name)
+        self._verify_workspace(ass_ws_name)
+
+    def test_sampleOnly_Direct(self):
+        """
+        Test simple run with sample workspace only for direct mode
+        """
+    
+        CylinderPaalmanPingsCorrection(OutputWorkspace=self._corrections_ws_name,
+                                       SampleWorkspace=self._sample_ws,
+                                       SampleChemicalFormula='H2-O',
+                                       SampleInnerRadius=0.05,
+                                       SampleOuterRadius=0.1,
+                                       Emode='Direct',
+                                       Efixed=1.845)
+    
+        ass_ws_name = self._corrections_ws_name + '_ass'
+        self._verify_workspace(ass_ws_name)
 
 
     def test_sampleAndCan(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FlatPlatePaalmanPingsCorrectionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FlatPlatePaalmanPingsCorrectionTest.py
@@ -82,9 +82,9 @@ class FlatPlatePaalmanPingsCorrectionTest(unittest.TestCase):
             self._verify_workspace(workspace)
 
 
-    def test_sampleOnly(self):
+    def test_sampleOnly_indirect(self):
         """
-        Test simple run with sample workspace only.
+        Test simple run with sample workspace only for indirect mode
         """
 
         FlatPlatePaalmanPingsCorrection(OutputWorkspace=self._corrections_ws_name,
@@ -96,6 +96,23 @@ class FlatPlatePaalmanPingsCorrectionTest(unittest.TestCase):
                                         Emode='Indirect',
                                         Efixed=1.845)
 
+        ass_ws_name = self._corrections_ws_name + '_ass'
+        self. _verify_workspace(ass_ws_name)
+
+    def test_sampleOnly_direct(self):
+        """
+        Test simple run with sample workspace only for direct mode
+        """
+    
+        FlatPlatePaalmanPingsCorrection(OutputWorkspace=self._corrections_ws_name,
+                                        SampleWorkspace=self._sample_ws,
+                                        SampleChemicalFormula='H2-O',
+                                        SampleThickness=0.1,
+                                        SampleAngle=45,
+                                        NumberWavelengths=10,
+                                        Emode='Direct',
+                                        Efixed=1.845)
+    
         ass_ws_name = self._corrections_ws_name + '_ass'
         self. _verify_workspace(ass_ws_name)
 

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -26,6 +26,9 @@ New
 Improved
 ########
 
+- :ref:`FlatPlatePaalmanPingsCorrection <algm-FlatPlatePaalmanPingsCorrection>` & :ref:`CylinderPaalmanPingsCorrection <algm-CylinderPaalmanPingsCorrection>`
+  now accept 'Direct' as a possible ``EMode`` parameter.
+
 - :ref:`FilterEvents <algm-FilterEvents>` now produces output
   workspaces with the same workspace numbers as specified by the
   ``SplittersWorkspace``.


### PR DESCRIPTION
As described in the linked issue the existing FlatPlate & Cylinder PaalmanPings algorithms supported Direct mode within the algorithmic code but they were prevented from running by the property validator.

**To test:**

Use the existing usage example as a guide to running the algorithm: http://docs.mantidproject.org/nightly/algorithms/FlatPlatePaalmanPingsCorrection-v1.html#usage and play with the `EMode` property. All three modes should function.

Fixes #15993 

[RELEASE NOTES](https://github.com/mantidproject/mantid/commit/b0f52f091add65ce2bf32c18d90a0404efbd1da8)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
