### PR TITLE
Fix LoadRKH for data with second header and 2D data

### DIFF
--- a/Framework/DataHandling/src/LoadRKH.cpp
+++ b/Framework/DataHandling/src/LoadRKH.cpp
@@ -20,6 +20,26 @@
 #include <MantidKernel/StringTokenizer.h>
 
 #include <istream>
+#include <numeric>
+#include <boost/regex.hpp>
+
+
+namespace {
+  // Check if we are dealing with a unit line
+  bool isUnit(const Mantid::Kernel::StringTokenizer& codes) {
+    // The unit line needs to have the format of
+    //  1. Either 0 or 6 [06]
+    //  2. Then several characters [\w]
+    //  3. Open bracket
+    //  4. Several characters
+    //  5. Close bracket  
+    std::string input = std::accumulate(codes.begin(), codes.end(), std::string(""));
+    std::string reg("^[06][\\w]+\\([\\w\\^-]+\\)$");
+    boost::regex baseRegex(reg);
+    return boost::regex_match(input, baseRegex);
+  }
+}
+
 
 namespace Mantid {
 namespace DataHandling {
@@ -192,15 +212,20 @@ void LoadRKH::exec() {
   // Set the output workspace
   setProperty("OutputWorkspace", result);
 }
+
 /** Determines if the file is 1D or 2D based on the first after the workspace's
 *  title
 *  @param testLine :: the first line in the file after the title
 *  @return true if the file must contain 1D data
 */
 bool LoadRKH::is2D(const std::string &testLine) {
-  // check the line part of a valid for 2D data else assume the file is 1D
-  return readUnit(testLine) != "C++ no unit found";
+  // split the line into words
+  const Mantid::Kernel::StringTokenizer codes(
+      testLine, " ", Mantid::Kernel::StringTokenizer::TOK_TRIM |
+                         Mantid::Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
+  return isUnit(codes);
 }
+
 /** Read a data file that contains only one spectrum into a workspace
 *  @return the new workspace
 */
@@ -466,6 +491,11 @@ const std::string LoadRKH::readUnit(const std::string &line) {
   const Mantid::Kernel::StringTokenizer codes(
       line, " ", Mantid::Kernel::StringTokenizer::TOK_TRIM |
                      Mantid::Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
+
+  if (!isUnit(codes)) {
+    return "C++ no unit found";
+  }
+
   if (codes.count() < 1) {
     return "C++ no unit found";
   }
@@ -493,7 +523,7 @@ const std::string LoadRKH::readUnit(const std::string &line) {
     if (unit.find('(') != 0 || unit.find(')') != unit.size()) {
       std::string qCode = std::to_string(SaveRKH::Q_CODE);
       if (symbol == qCode && theQuantity == "q" &&
-          unit == "(1/Angstrom)") { // 6 q (1/Angstrom) is the synatx for
+          (unit == "(1/Angstrom)" || unit == "(Angstrom^-1)")) { // 6 q (1/Angstrom) is the synatx for
                                     // MomentumTransfer
         return "MomentumTransfer";
       }

--- a/Framework/DataHandling/src/LoadRKH.cpp
+++ b/Framework/DataHandling/src/LoadRKH.cpp
@@ -23,23 +23,22 @@
 #include <numeric>
 #include <boost/regex.hpp>
 
-
 namespace {
-  // Check if we are dealing with a unit line
-  bool isUnit(const Mantid::Kernel::StringTokenizer& codes) {
-    // The unit line needs to have the format of
-    //  1. Either 0 or 6 [06]
-    //  2. Then several characters [\w]
-    //  3. Open bracket
-    //  4. Several characters
-    //  5. Close bracket  
-    std::string input = std::accumulate(codes.begin(), codes.end(), std::string(""));
-    std::string reg("^[06][\\w]+\\([/ \\w\\^-]+\\)$");
-    boost::regex baseRegex(reg);
-    return boost::regex_match(input, baseRegex);
-  }
+// Check if we are dealing with a unit line
+bool isUnit(const Mantid::Kernel::StringTokenizer &codes) {
+  // The unit line needs to have the format of
+  //  1. Either 0 or 6 [06]
+  //  2. Then several characters [\w]
+  //  3. Open bracket
+  //  4. Several characters
+  //  5. Close bracket
+  std::string input =
+      std::accumulate(codes.begin(), codes.end(), std::string(""));
+  std::string reg("^[06][\\w]+\\([/ \\w\\^-]+\\)$");
+  boost::regex baseRegex(reg);
+  return boost::regex_match(input, baseRegex);
 }
-
+}
 
 namespace Mantid {
 namespace DataHandling {
@@ -523,8 +522,9 @@ const std::string LoadRKH::readUnit(const std::string &line) {
     if (unit.find('(') != 0 || unit.find(')') != unit.size()) {
       std::string qCode = std::to_string(SaveRKH::Q_CODE);
       if (symbol == qCode && theQuantity == "q" &&
-          (unit == "(1/Angstrom)" || unit == "(Angstrom^-1)")) { // 6 q (1/Angstrom) is the synatx for
-                                    // MomentumTransfer
+          (unit == "(1/Angstrom)" ||
+           unit == "(Angstrom^-1)")) { // 6 q (1/Angstrom) is the synatx for
+                                       // MomentumTransfer
         return "MomentumTransfer";
       }
 

--- a/Framework/DataHandling/src/LoadRKH.cpp
+++ b/Framework/DataHandling/src/LoadRKH.cpp
@@ -34,7 +34,7 @@ namespace {
     //  4. Several characters
     //  5. Close bracket  
     std::string input = std::accumulate(codes.begin(), codes.end(), std::string(""));
-    std::string reg("^[06][\\w]+\\([\\w\\^-]+\\)$");
+    std::string reg("^[06][\\w]+\\([/ \\w\\^-]+\\)$");
     boost::regex baseRegex(reg);
     return boost::regex_match(input, baseRegex);
   }

--- a/Framework/DataHandling/test/LoadRKHTest.h
+++ b/Framework/DataHandling/test/LoadRKHTest.h
@@ -22,7 +22,8 @@ public:
   // A sample file is in the repository
   LoadRKHTest()
       : dataFile(""), tempFile("LoadRKH_test_file_2D"),
-        tempFile2("LoadRKH_test_file_1D_with_DX"), tempFile3("LoadRKL_with_second_header"){
+        tempFile2("LoadRKH_test_file_1D_with_DX"),
+        tempFile3("LoadRKL_with_second_header") {
     dataFile = "DIRECT.041";
   }
 
@@ -187,7 +188,7 @@ public:
 
     TS_ASSERT(data->isHistogramData())
 
-    //remove(tempFile.c_str());
+    // remove(tempFile.c_str());
   }
 
   void test1DWithDx() {
@@ -251,56 +252,56 @@ public:
   }
 
   void test_LoadRKH_with_second_header() {
-      // Arrange
-      ConfigService::Instance().setString("default.facility", "ISIS");
-      writeTestFileWithSecondHeader();
-      std::string outputSpace = "rkh_with_second_header";
+    // Arrange
+    ConfigService::Instance().setString("default.facility", "ISIS");
+    writeTestFileWithSecondHeader();
+    std::string outputSpace = "rkh_with_second_header";
 
-      // Act
-      Mantid::DataHandling::LoadRKH rkhAlg;
-      rkhAlg.initialize();
-      rkhAlg.setPropertyValue("Filename", tempFile3);
-      rkhAlg.setPropertyValue("OutputWorkspace", outputSpace);
+    // Act
+    Mantid::DataHandling::LoadRKH rkhAlg;
+    rkhAlg.initialize();
+    rkhAlg.setPropertyValue("Filename", tempFile3);
+    rkhAlg.setPropertyValue("OutputWorkspace", outputSpace);
 
-      // Assert
-      std::string result;
-      TS_ASSERT_THROWS_NOTHING(result = rkhAlg.getPropertyValue("Filename"))
-        TS_ASSERT_THROWS_NOTHING(result =
-          rkhAlg.getPropertyValue("OutputWorkspace"))
-        TS_ASSERT(result == outputSpace);
-      TS_ASSERT_THROWS_NOTHING(rkhAlg.execute());
-      TS_ASSERT(rkhAlg.isExecuted());
+    // Assert
+    std::string result;
+    TS_ASSERT_THROWS_NOTHING(result = rkhAlg.getPropertyValue("Filename"))
+    TS_ASSERT_THROWS_NOTHING(result =
+                                 rkhAlg.getPropertyValue("OutputWorkspace"))
+    TS_ASSERT(result == outputSpace);
+    TS_ASSERT_THROWS_NOTHING(rkhAlg.execute());
+    TS_ASSERT(rkhAlg.isExecuted());
 
-      using namespace Mantid::API;
-      using namespace Mantid::DataObjects;
-      // Now need to test the resultant workspace, first retrieve it
-      Workspace_sptr rkhspace;
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    // Now need to test the resultant workspace, first retrieve it
+    Workspace_sptr rkhspace;
 
-      TS_ASSERT_THROWS_NOTHING(
+    TS_ASSERT_THROWS_NOTHING(
         rkhspace = AnalysisDataService::Instance().retrieve(outputSpace));
-      Workspace2D_sptr data = boost::dynamic_pointer_cast<Workspace2D>(rkhspace);
+    Workspace2D_sptr data = boost::dynamic_pointer_cast<Workspace2D>(rkhspace);
 
-      TS_ASSERT_EQUALS(data->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(data->getNumberHistograms(), 1);
 
-      TS_ASSERT_EQUALS(static_cast<int>(data->dataX(0).size()), 4);
-      TS_ASSERT_EQUALS(static_cast<int>(data->dataY(0).size()), 4);
-      TS_ASSERT_EQUALS(static_cast<int>(data->dataE(0).size()), 4);
+    TS_ASSERT_EQUALS(static_cast<int>(data->dataX(0).size()), 4);
+    TS_ASSERT_EQUALS(static_cast<int>(data->dataY(0).size()), 4);
+    TS_ASSERT_EQUALS(static_cast<int>(data->dataE(0).size()), 4);
 
-      double tolerance(1e-06);
+    double tolerance(1e-06);
 
-      TS_ASSERT_DELTA(data->dataX(0)[0], 0.00520, tolerance);
-      TS_ASSERT_DELTA(data->dataX(0)[1], 0.00562, tolerance);
-      TS_ASSERT_DELTA(data->dataX(0)[2], 0.00607, tolerance);
+    TS_ASSERT_DELTA(data->dataX(0)[0], 0.00520, tolerance);
+    TS_ASSERT_DELTA(data->dataX(0)[1], 0.00562, tolerance);
+    TS_ASSERT_DELTA(data->dataX(0)[2], 0.00607, tolerance);
 
-      TS_ASSERT_DELTA(data->dataY(0)[0], 1.055855e+00, tolerance);
-      TS_ASSERT_DELTA(data->dataY(0)[1], 9.784999e-01, tolerance);
-      TS_ASSERT_DELTA(data->dataY(0)[2], 1.239836e+00, tolerance);
+    TS_ASSERT_DELTA(data->dataY(0)[0], 1.055855e+00, tolerance);
+    TS_ASSERT_DELTA(data->dataY(0)[1], 9.784999e-01, tolerance);
+    TS_ASSERT_DELTA(data->dataY(0)[2], 1.239836e+00, tolerance);
 
-      TS_ASSERT_DELTA(data->dataE(0)[0], 2.570181e-01, tolerance);
-      TS_ASSERT_DELTA(data->dataE(0)[1], 1.365013e-01, tolerance);
-      TS_ASSERT_DELTA(data->dataE(0)[2], 9.582824e-02, tolerance);
+    TS_ASSERT_DELTA(data->dataE(0)[0], 2.570181e-01, tolerance);
+    TS_ASSERT_DELTA(data->dataE(0)[1], 1.365013e-01, tolerance);
+    TS_ASSERT_DELTA(data->dataE(0)[2], 9.582824e-02, tolerance);
 
-      remove(tempFile3.c_str());
+    remove(tempFile3.c_str());
   }
 
 private:
@@ -352,7 +353,8 @@ private:
 
   void writeTestFileWithSecondHeader() {
     std::ofstream file(tempFile3.c_str());
-    file << " SANS2D Fri 08-JUL-2016 11:10 Workspace: M3_42_3rd-MT_rear_cloned_temp\n";
+    file << " SANS2D Fri 08-JUL-2016 11:10 Workspace: "
+            "M3_42_3rd-MT_rear_cloned_temp\n";
     file << " M3-42_third_SANS\n";
     file << "   4    0    0    0    1   4    0\n";
     file << "          0         0         0         0\n";

--- a/Framework/DataHandling/test/LoadRKHTest.h
+++ b/Framework/DataHandling/test/LoadRKHTest.h
@@ -22,7 +22,7 @@ public:
   // A sample file is in the repository
   LoadRKHTest()
       : dataFile(""), tempFile("LoadRKH_test_file_2D"),
-        tempFile2("LoadRKH_test_file_1D_with_DX") {
+        tempFile2("LoadRKH_test_file_1D_with_DX"), tempFile3("LoadRKL_with_second_header"){
     dataFile = "DIRECT.041";
   }
 
@@ -187,7 +187,7 @@ public:
 
     TS_ASSERT(data->isHistogramData())
 
-    remove(tempFile.c_str());
+    //remove(tempFile.c_str());
   }
 
   void test1DWithDx() {
@@ -250,8 +250,61 @@ public:
     remove(tempFile2.c_str());
   }
 
+  void test_LoadRKH_with_second_header() {
+      // Arrange
+      ConfigService::Instance().setString("default.facility", "ISIS");
+      writeTestFileWithSecondHeader();
+      std::string outputSpace = "rkh_with_second_header";
+
+      // Act
+      Mantid::DataHandling::LoadRKH rkhAlg;
+      rkhAlg.initialize();
+      rkhAlg.setPropertyValue("Filename", tempFile3);
+      rkhAlg.setPropertyValue("OutputWorkspace", outputSpace);
+
+      // Assert
+      std::string result;
+      TS_ASSERT_THROWS_NOTHING(result = rkhAlg.getPropertyValue("Filename"))
+        TS_ASSERT_THROWS_NOTHING(result =
+          rkhAlg.getPropertyValue("OutputWorkspace"))
+        TS_ASSERT(result == outputSpace);
+      TS_ASSERT_THROWS_NOTHING(rkhAlg.execute());
+      TS_ASSERT(rkhAlg.isExecuted());
+
+      using namespace Mantid::API;
+      using namespace Mantid::DataObjects;
+      // Now need to test the resultant workspace, first retrieve it
+      Workspace_sptr rkhspace;
+
+      TS_ASSERT_THROWS_NOTHING(
+        rkhspace = AnalysisDataService::Instance().retrieve(outputSpace));
+      Workspace2D_sptr data = boost::dynamic_pointer_cast<Workspace2D>(rkhspace);
+
+      TS_ASSERT_EQUALS(data->getNumberHistograms(), 1);
+
+      TS_ASSERT_EQUALS(static_cast<int>(data->dataX(0).size()), 4);
+      TS_ASSERT_EQUALS(static_cast<int>(data->dataY(0).size()), 4);
+      TS_ASSERT_EQUALS(static_cast<int>(data->dataE(0).size()), 4);
+
+      double tolerance(1e-06);
+
+      TS_ASSERT_DELTA(data->dataX(0)[0], 0.00520, tolerance);
+      TS_ASSERT_DELTA(data->dataX(0)[1], 0.00562, tolerance);
+      TS_ASSERT_DELTA(data->dataX(0)[2], 0.00607, tolerance);
+
+      TS_ASSERT_DELTA(data->dataY(0)[0], 1.055855e+00, tolerance);
+      TS_ASSERT_DELTA(data->dataY(0)[1], 9.784999e-01, tolerance);
+      TS_ASSERT_DELTA(data->dataY(0)[2], 1.239836e+00, tolerance);
+
+      TS_ASSERT_DELTA(data->dataE(0)[0], 2.570181e-01, tolerance);
+      TS_ASSERT_DELTA(data->dataE(0)[1], 1.365013e-01, tolerance);
+      TS_ASSERT_DELTA(data->dataE(0)[2], 9.582824e-02, tolerance);
+
+      remove(tempFile3.c_str());
+  }
+
 private:
-  std::string dataFile, tempFile, tempFile2;
+  std::string dataFile, tempFile, tempFile2, tempFile3;
 
   /** Create a tiny 2x2 workspace in a tempory file that should
   *  be deleted
@@ -294,6 +347,20 @@ private:
     file << "     7.50000    1.000000e+00    1.000000e+00    2.737089e+00\n";
     file << "     8.50000    1.000000e+00    1.000000e+00    2.914214e+00\n";
     file << "     9.50000    1.000000e+00    1.000000e+00    3.081139e+00\n";
+    file.close();
+  }
+
+  void writeTestFileWithSecondHeader() {
+    std::ofstream file(tempFile3.c_str());
+    file << " SANS2D Fri 08-JUL-2016 11:10 Workspace: M3_42_3rd-MT_rear_cloned_temp\n";
+    file << " M3-42_third_SANS\n";
+    file << "   4    0    0    0    1   4    0\n";
+    file << "          0         0         0         0\n";
+    file << " 3 (F12.5,2E16.6)\n";
+    file << "     0.00520    1.055855e+00    2.570181e-01\n";
+    file << "     0.00562    9.784999e-01    1.365013e-01\n";
+    file << "     0.00607    1.239836e+00    9.582824e-02\n";
+    file << "     0.00655    1.260936e+00    7.041577e-02\n";
     file.close();
   }
 };

--- a/docs/source/release/v3.8.0/sans.rst
+++ b/docs/source/release/v3.8.0/sans.rst
@@ -11,6 +11,6 @@ Bug Fixes
 - Fix for beam center finder
 - Fix loading of multiperiod event files
 - Fix period selection when loading multiperiod files.
-
+- Fix the loading of RKH files
 
 `Full list of changes on github <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.8%22+is%3Amerged+label%3A%22Component%3A+SANS%22>`__


### PR DESCRIPTION
Fixes #16879 

This fixes a bug which is caused by the way `LoadRKH` switches between 1D and 2D loading. Up until now the switch looked if there is an entry in the second header line. This is bad. There is no reason to not have a multiple entries in there. 

Yet the second line (and potentially some subsequent lines) is the only way to figure out if the data is 1D or 2D. The 2D line will typically look something like
6 q (Angstrom^-1)

We implement a check to try and pattern-match the second line of an RKH file to the the above format. This is far from perfect, but currently the only option we have and considerably more robust than the status quo.

**To test:**

Please find sample files here: \olympic\Babylon5\Scratch\Anton\Testing\Fix_RKH
Make sure that the path is in your Mantid search directories.

**Test  RKH file which was crashing Mantid**
- Run 

``` python
ws = LoadRKH("M3_42_3rd-MT_rear.txt")
```
- Confirm that the file loads.
- Confirm that it is 1D by using Show Data

**Test with 2D RKH file**
- Run 

``` python
ws = LoadRKH("34481rear_2D_1.75_16.5.txt")
```
- Confirm that the file loads.
- Confirm that it is 2D by using Show Data

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
