### PR TITLE
In ReplicatedMD, replace auto with const auto.

### DIFF
--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -298,13 +298,14 @@ void ReplicateMD::exec() {
     // Check that the indices stored in axes are compatible with the
     // dimensionality of the data workspace
     const auto numberOfDimensionsOfDataWorkspace = static_cast<int>(nDimsData);
-    for (auto &axis : axes) {
+    for (const auto &axis : axes) {
       if (axis >= numberOfDimensionsOfDataWorkspace) {
         std::string message =
             "ReplicateMD: Cannot transpose the data workspace. Attempting to "
             "swap dimension index " +
-            std::to_string(std::distance(axes.data(), &axis)) + " with index " +
-            std::to_string(axis) +
+            std::to_string(
+                std::distance(static_cast<const int *>(&axes[0]), &axis)) +
+            " with index " + std::to_string(axis) +
             ", but the dimensionality of the data workspace is " +
             std::to_string(nDimsData);
         throw std::runtime_error(message);


### PR DESCRIPTION
Description of work.

This makes the argument of a for loop in `ReplicateMD::exec()` `const auto &`. I had to add `static_cast<const int *>(...)` for template argument deduction.

**To test:**

<!-- Instructions for testing. -->

This addresses a comment in PR #16700.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
