### PR TITLE
Fix deselecting a first subcategory in Pref->Mantid->Options unticks main category 

### DIFF
--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -1096,106 +1096,110 @@ void ConfigDialog::addDialog() {
 
 // Edit a program
 void ConfigDialog::editDialog() {
-  auto firstSelectedItem = treePrograms->selectedItems()[0];
-  auto selectedProgram =
-      m_sendToSettings.find(firstSelectedItem->text(0).toStdString());
-  // If the program name itself isn't initially selected, recurse up.
-  while (selectedProgram == m_sendToSettings.end()) {
-    firstSelectedItem = treePrograms->itemAbove(firstSelectedItem);
-    // It shouldn't happen that we get to the top without finding anything, but
-    // should this happen just return
-    if (firstSelectedItem == treePrograms->invisibleRootItem())
-      return;
-    selectedProgram =
-        m_sendToSettings.find(firstSelectedItem->text(0).toStdString());
-  }
+	auto firstSelectedItem = treePrograms->selectedItems()[0];
+	auto selectedProgram =
+		m_sendToSettings.find(firstSelectedItem->text(0).toStdString());
+	// If the program name itself isn't initially selected, recurse up.
+	while (selectedProgram == m_sendToSettings.end()) {
+		firstSelectedItem = treePrograms->itemAbove(firstSelectedItem);
+		// It shouldn't happen that we get to the top without finding anything, but
+		// should this happen just return
+		if (firstSelectedItem == treePrograms->invisibleRootItem())
+			return;
+		selectedProgram =
+			m_sendToSettings.find(firstSelectedItem->text(0).toStdString());
+	}
 
-  SendToProgramDialog *editProgram = new SendToProgramDialog(
-      this, firstSelectedItem->text(0), selectedProgram->second);
+	SendToProgramDialog *editProgram = new SendToProgramDialog(
+		this, firstSelectedItem->text(0), selectedProgram->second);
 
-  editProgram->setWindowTitle(tr("Edit a Program"));
-  editProgram->setModal(true);
-  if (editProgram->exec() == 1) {
-    // Get the settings of the program the user just edited
-    std::pair<std::string, std::map<std::string, std::string>> tempSettings =
-        editProgram->getSettings();
-    m_sendToSettings[tempSettings.first] = tempSettings.second;
-  }
+	editProgram->setWindowTitle(tr("Edit a Program"));
+	editProgram->setModal(true);
+	if (editProgram->exec() == 1) {
+		// Get the settings of the program the user just edited
+		std::pair<std::string, std::map<std::string, std::string>> tempSettings =
+			editProgram->getSettings();
+		m_sendToSettings[tempSettings.first] = tempSettings.second;
+	}
 
-  // clear the tree and repopulate it without the programs that have just been
-  // deleted
-  treePrograms->clear();
-  updateProgramTree();
-  enableButtons();
+	// clear the tree and repopulate it without the programs that have just been
+	// deleted
+	treePrograms->clear();
+	updateProgramTree();
+	enableButtons();
 }
 
 // Deleting send to options. Deletes them off the mantid.user.properties
 void ConfigDialog::deleteDialog() {
-  QList<QTreeWidgetItem *> selectedItems = treePrograms->selectedItems();
-  if (selectedItems.size() > 0) {
-    // Question box asking to continue to avoid accidental deletion of program
-    // options
-    int status = QMessageBox::question(
-        this, tr("Delete save options?"),
-        tr("Are you sure you want to delete \nthe (%1) selected save "
-           "option(s)?").arg(selectedItems.size()),
-        QMessageBox::Yes | QMessageBox::Default,
-        QMessageBox::No | QMessageBox::Escape, QMessageBox::NoButton);
+	QList<QTreeWidgetItem *> selectedItems = treePrograms->selectedItems();
+	if (selectedItems.size() > 0) {
+		// Question box asking to continue to avoid accidental deletion of program
+		// options
+		int status = QMessageBox::question(
+			this, tr("Delete save options?"),
+			tr("Are you sure you want to delete \nthe (%1) selected save "
+				"option(s)?").arg(selectedItems.size()),
+			QMessageBox::Yes | QMessageBox::Default,
+			QMessageBox::No | QMessageBox::Escape, QMessageBox::NoButton);
 
-    if (status == QMessageBox::Yes) {
-      // For each program selected, remove all details from the user.properties
-      // file;
-      for (int i = 0; i < selectedItems.size(); ++i) {
-        m_sendToSettings.erase(selectedItems[i]->text(0).toStdString());
-      }
-      // clear the tree and repopulate it without the programs that have just
-      // been deleted
-      treePrograms->clear();
-      updateProgramTree();
-    }
-  }
+		if (status == QMessageBox::Yes) {
+			// For each program selected, remove all details from the user.properties
+			// file;
+			for (int i = 0; i < selectedItems.size(); ++i) {
+				m_sendToSettings.erase(selectedItems[i]->text(0).toStdString());
+			}
+			// clear the tree and repopulate it without the programs that have just
+			// been deleted
+			treePrograms->clear();
+			updateProgramTree();
+		}
+	}
 }
 
 void ConfigDialog::populateProgramTree() {
-  std::vector<std::string> programNames =
-      Mantid::Kernel::ConfigService::Instance().getKeys(
-          "workspace.sendto.name");
+	std::vector<std::string> programNames =
+		Mantid::Kernel::ConfigService::Instance().getKeys(
+			"workspace.sendto.name");
 
-  for (size_t i = 0; i < programNames.size(); i++) {
-    // Create a map for the keys and details to go into
-    std::map<std::string, std::string> programKeysAndDetails;
+	for (size_t i = 0; i < programNames.size(); i++) {
+		// Create a map for the keys and details to go into
+		std::map<std::string, std::string> programKeysAndDetails;
 
-    // Get a list of the program detail keys (mandatory - target, saveusing)
-    // (optional - arguments, save parameters, workspace type)
-    std::vector<std::string> programKeys =
-        (Mantid::Kernel::ConfigService::Instance().getKeys("workspace.sendto." +
-                                                           programNames[i]));
+		// Get a list of the program detail keys (mandatory - target, saveusing)
+		// (optional - arguments, save parameters, workspace type)
+		std::vector<std::string> programKeys =
+			(Mantid::Kernel::ConfigService::Instance().getKeys("workspace.sendto." +
+				programNames[i]));
 
-    for (size_t j = 0; j < programKeys.size(); j++) {
-      // Assign a key to its value using the map
-      programKeysAndDetails[programKeys[j]] =
-          (Mantid::Kernel::ConfigService::Instance().getString(
-              ("workspace.sendto." + programNames[i] + "." + programKeys[j])));
-    }
+		for (size_t j = 0; j < programKeys.size(); j++) {
+			// Assign a key to its value using the map
+			programKeysAndDetails[programKeys[j]] =
+				(Mantid::Kernel::ConfigService::Instance().getString(
+				("workspace.sendto." + programNames[i] + "." + programKeys[j])));
+		}
 
-    m_sendToSettings.emplace(programNames[i], programKeysAndDetails);
-  }
-  updateProgramTree();
+		m_sendToSettings.emplace(programNames[i], programKeysAndDetails);
+	}
+	updateProgramTree();
 }
 
 void ConfigDialog::updateProgramTree() {
-  // Store into a map ready to go into config service when apply is clicked
-  std::map<std::string, std::map<std::string, std::string>>::const_iterator
-      itr = m_sendToSettings.begin();
-  for (; itr != m_sendToSettings.end(); ++itr) {
-    // creating the map of kvps needs to happen first as createing the item
-    // requires them.
-    std::map<std::string, std::string> programKeysAndDetails = itr->second;
+	// Store into a map ready to go into config service when apply is clicked
+	std::map<std::string, std::map<std::string, std::string>>::const_iterator
+		itr = m_sendToSettings.begin();
+	for (; itr != m_sendToSettings.end(); ++itr) {
+		// creating the map of kvps needs to happen first as createing the item
+		// requires them.
+		std::map<std::string, std::string> programKeysAndDetails = itr->second;
+
+		Qt::CheckState checkStatus = Qt::Unchecked;
+		if (programKeysAndDetails.find("visible")->second == "Yes") {
+			checkStatus = Qt::Checked;
+		}
 
     // Populate list
     QTreeWidgetItem *program = createCheckedTreeItem(
-        QString::fromStdString(itr->first),
-        (programKeysAndDetails.find("visible")->second == "Yes"));
+        QString::fromStdString(itr->first), checkStatus);
     treePrograms->addTopLevelItem(program);
     updateChildren(programKeysAndDetails, program);
   }
@@ -1308,30 +1312,45 @@ void ConfigDialog::buildTreeCategoryStructure(
   // We wont be using the last element (null) of the array so decrement 1
   splitCatIndex--;
 
+  //Finally create tick status
+  Qt::CheckState tickStatus = Qt::Unchecked;
+  if (!isHidden) {
+	  tickStatus = Qt::Checked;
+  }
+  
+
   if (splitCatIndex == 0) {
     // This is a top level category and standalone
-    QTreeWidgetItem *catWidget = createCheckedTreeItem(splitCats[0], !isHidden);
+    QTreeWidgetItem *catWidget = createCheckedTreeItem(splitCats[0], tickStatus);
     treeCategories->addTopLevelItem(catWidget);
     seenCategories->insert(catKey, catWidget);
   } else {
     // We need to determine if we have seen this category before
-    // and get any pointers to its parent(s)
+    // and get any pointers to its parent(s) and set their tick status
     int prevElement = splitCatIndex - 1;
     QTreeWidgetItem *parentWidgetPtr =
-        walkBackwardsThroughCategories(catNames, prevElement, seenCategories);
+        walkBackwardsThroughCategories(catNames, prevElement,
+			seenCategories, tickStatus);
 
     // At this point we now all parent categories have been created
     // So lets create the child
     QTreeWidgetItem *newChildCat =
-        createCheckedTreeItem(splitCats[splitCatIndex], !isHidden);
+        createCheckedTreeItem(splitCats[splitCatIndex], tickStatus);
     parentWidgetPtr->addChild(newChildCat);
     seenCategories->insert(catKey, newChildCat);
+  }
+
+  // We have built tree now fix any ticks or make partial ticks
+  int topLevelCats = treeCategories->topLevelItemCount();
+  for (int i = 0; i < topLevelCats; i++) {
+	  correctTreePatrialTicks(treeCategories->topLevelItem(i));
   }
 }
 
 QTreeWidgetItem *ConfigDialog::walkBackwardsThroughCategories(
     const QString *catNames, int elementToCheck,
-    QMap<QString, QTreeWidgetItem *> *seenCategories) {
+    QMap<QString, QTreeWidgetItem *> *seenCategories, 
+	Qt::CheckState childTickState) {
 
   // Split the categories whose name is delimited by '\\'
   QStringList splitCats = catNames->split('\\');
@@ -1349,16 +1368,18 @@ QTreeWidgetItem *ConfigDialog::walkBackwardsThroughCategories(
   // right category pointer
   if (!seenCategories->contains(catKey)) {
     // We have not see this parent category check any other parents first
+	// From the array of categories
     if (elementToCheck > 0) {
       int prevElement = elementToCheck - 1;
       parentWidgetPtr =
-          walkBackwardsThroughCategories(catNames, prevElement, seenCategories);
+          walkBackwardsThroughCategories(catNames, prevElement, 
+			  seenCategories, childTickState);
     }
     // Now deal with this category
     if (!parentWidgetPtr) {
       // We are the most top level category which is ticked or visible
       QTreeWidgetItem *catWidget =
-          createCheckedTreeItem(splitCats[elementToCheck], true);
+          createCheckedTreeItem(splitCats[elementToCheck], childTickState);
       treeCategories->addTopLevelItem(catWidget);
       seenCategories->insert(catKey, catWidget);
       // Assign pointer to return for caller
@@ -1366,7 +1387,7 @@ QTreeWidgetItem *ConfigDialog::walkBackwardsThroughCategories(
     } else {
       // We need to create a child which is ticked or visible
       QTreeWidgetItem *childWidget =
-          createCheckedTreeItem(splitCats[elementToCheck], true);
+          createCheckedTreeItem(splitCats[elementToCheck], childTickState);
       parentWidgetPtr->addChild(childWidget);
       seenCategories->insert(catKey, childWidget);
       // Make the child the parent for caller
@@ -1380,15 +1401,52 @@ QTreeWidgetItem *ConfigDialog::walkBackwardsThroughCategories(
   return parentWidgetPtr;
 }
 
+void ConfigDialog::correctTreePatrialTicks(QTreeWidgetItem *topLevelCat) {
+	// Check all children for a tick and untick we need to do this
+	// as some parents come with their own tick status which we might
+	// need to override 
+	bool hasUntickedChildren = false;
+	bool hasTickedChildren = false;
+	bool hasChildren = false;
+
+	int childCount = topLevelCat->childCount();
+	for (int i = 0; i < childCount; i++) {
+		hasChildren = true;
+		//Check for nested children and deal with them
+		correctTreePatrialTicks(topLevelCat->child(i));
+		
+		QTreeWidgetItem *child = topLevelCat->child(i);
+		//Now actually check this ptr's children for their tick status
+		if (child->checkState(0) == Qt::Checked) {
+			hasTickedChildren = true;
+		}
+		else if (child->checkState(0) == Qt::Unchecked) {
+			hasUntickedChildren = true;
+		}
+		else {
+			//Partial tick - we will count this as a normal tick
+			hasTickedChildren = true;
+		}
+	} //Checked all children now set parent
+
+	if (hasChildren && hasUntickedChildren && hasTickedChildren) {
+		topLevelCat->setCheckState(0, Qt::PartiallyChecked);
+	}
+	else if (hasChildren && hasTickedChildren) {
+		topLevelCat->setCheckState(0, Qt::Checked);
+	}
+	else if (hasChildren) {
+		//Everything is unticked at this point 
+		topLevelCat->setCheckState(0, Qt::Unchecked);
+	}
+
+}
+
 QTreeWidgetItem *ConfigDialog::createCheckedTreeItem(QString name,
-                                                     bool checkBoxState) {
+                                                     Qt::CheckState checkBoxState) {
   QTreeWidgetItem *item = new QTreeWidgetItem(QStringList(name));
   item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
-  if (checkBoxState) {
-    item->setCheckState(0, Qt::Checked);
-  } else {
-    item->setCheckState(0, Qt::Unchecked);
-  }
+    item->setCheckState(0, checkBoxState);
   return item;
 }
 

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -1399,7 +1399,7 @@ QTreeWidgetItem *ConfigDialog::walkBackwardsThroughCategories(
 
 void ConfigDialog::tickBoxClickedSlot(QTreeWidgetItem *widgetPtr, int column) {
   int numberOfChildren = widgetPtr->childCount();
-  Qt::CheckState newState = widgetPtr->checkState(0);
+  Qt::CheckState newState = widgetPtr->checkState(column);
 
   // Now we have new state lets update children to reflect this
   for (int i = 0; i < numberOfChildren; i++) {

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -715,8 +715,8 @@ void ConfigDialog::initMantidPage() {
 
   // Populate boxes
   auto faclist = cfgSvc.getFacilityNames();
-  for (auto it = faclist.begin(); it != faclist.end(); ++it) {
-    facility->addItem(QString::fromStdString(*it));
+  for (auto it : faclist) {
+    facility->addItem(QString::fromStdString(it));
   }
 
   // Set default property
@@ -1279,7 +1279,7 @@ void ConfigDialog::refreshTreeCategories() {
   widgetMap categories; // Keeps track of categories added to the tree
 
   // Loop over all categories loaded into Mantid
-  for (auto i = categoryMap.cbegin(); i != categoryMap.cend(); ++i) {
+  for (const auto i : categoryMap) {
 
     QString catNames = QString::fromStdString(i->first);
     // Start recursion down building tree from names

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -1281,9 +1281,9 @@ void ConfigDialog::refreshTreeCategories() {
   // Loop over all categories loaded into Mantid
   for (const auto i : categoryMap) {
 
-    QString catNames = QString::fromStdString(i->first);
+    QString catNames = QString::fromStdString(i.first);
     // Start recursion down building tree from names
-    buildTreeCategoryStructure(catNames, i->second, categories);
+    buildTreeCategoryStructure(catNames, i.second, categories);
   }
 }
 

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -1096,110 +1096,110 @@ void ConfigDialog::addDialog() {
 
 // Edit a program
 void ConfigDialog::editDialog() {
-	auto firstSelectedItem = treePrograms->selectedItems()[0];
-	auto selectedProgram =
-		m_sendToSettings.find(firstSelectedItem->text(0).toStdString());
-	// If the program name itself isn't initially selected, recurse up.
-	while (selectedProgram == m_sendToSettings.end()) {
-		firstSelectedItem = treePrograms->itemAbove(firstSelectedItem);
-		// It shouldn't happen that we get to the top without finding anything, but
-		// should this happen just return
-		if (firstSelectedItem == treePrograms->invisibleRootItem())
-			return;
-		selectedProgram =
-			m_sendToSettings.find(firstSelectedItem->text(0).toStdString());
-	}
+  auto firstSelectedItem = treePrograms->selectedItems()[0];
+  auto selectedProgram =
+      m_sendToSettings.find(firstSelectedItem->text(0).toStdString());
+  // If the program name itself isn't initially selected, recurse up.
+  while (selectedProgram == m_sendToSettings.end()) {
+    firstSelectedItem = treePrograms->itemAbove(firstSelectedItem);
+    // It shouldn't happen that we get to the top without finding anything, but
+    // should this happen just return
+    if (firstSelectedItem == treePrograms->invisibleRootItem())
+      return;
+    selectedProgram =
+        m_sendToSettings.find(firstSelectedItem->text(0).toStdString());
+  }
 
-	SendToProgramDialog *editProgram = new SendToProgramDialog(
-		this, firstSelectedItem->text(0), selectedProgram->second);
+  SendToProgramDialog *editProgram = new SendToProgramDialog(
+      this, firstSelectedItem->text(0), selectedProgram->second);
 
-	editProgram->setWindowTitle(tr("Edit a Program"));
-	editProgram->setModal(true);
-	if (editProgram->exec() == 1) {
-		// Get the settings of the program the user just edited
-		std::pair<std::string, std::map<std::string, std::string>> tempSettings =
-			editProgram->getSettings();
-		m_sendToSettings[tempSettings.first] = tempSettings.second;
-	}
+  editProgram->setWindowTitle(tr("Edit a Program"));
+  editProgram->setModal(true);
+  if (editProgram->exec() == 1) {
+    // Get the settings of the program the user just edited
+    std::pair<std::string, std::map<std::string, std::string>> tempSettings =
+        editProgram->getSettings();
+    m_sendToSettings[tempSettings.first] = tempSettings.second;
+  }
 
-	// clear the tree and repopulate it without the programs that have just been
-	// deleted
-	treePrograms->clear();
-	updateProgramTree();
-	enableButtons();
+  // clear the tree and repopulate it without the programs that have just been
+  // deleted
+  treePrograms->clear();
+  updateProgramTree();
+  enableButtons();
 }
 
 // Deleting send to options. Deletes them off the mantid.user.properties
 void ConfigDialog::deleteDialog() {
-	QList<QTreeWidgetItem *> selectedItems = treePrograms->selectedItems();
-	if (selectedItems.size() > 0) {
-		// Question box asking to continue to avoid accidental deletion of program
-		// options
-		int status = QMessageBox::question(
-			this, tr("Delete save options?"),
-			tr("Are you sure you want to delete \nthe (%1) selected save "
-				"option(s)?").arg(selectedItems.size()),
-			QMessageBox::Yes | QMessageBox::Default,
-			QMessageBox::No | QMessageBox::Escape, QMessageBox::NoButton);
+  QList<QTreeWidgetItem *> selectedItems = treePrograms->selectedItems();
+  if (selectedItems.size() > 0) {
+    // Question box asking to continue to avoid accidental deletion of program
+    // options
+    int status = QMessageBox::question(
+        this, tr("Delete save options?"),
+        tr("Are you sure you want to delete \nthe (%1) selected save "
+           "option(s)?").arg(selectedItems.size()),
+        QMessageBox::Yes | QMessageBox::Default,
+        QMessageBox::No | QMessageBox::Escape, QMessageBox::NoButton);
 
-		if (status == QMessageBox::Yes) {
-			// For each program selected, remove all details from the user.properties
-			// file;
-			for (int i = 0; i < selectedItems.size(); ++i) {
-				m_sendToSettings.erase(selectedItems[i]->text(0).toStdString());
-			}
-			// clear the tree and repopulate it without the programs that have just
-			// been deleted
-			treePrograms->clear();
-			updateProgramTree();
-		}
-	}
+    if (status == QMessageBox::Yes) {
+      // For each program selected, remove all details from the user.properties
+      // file;
+      for (int i = 0; i < selectedItems.size(); ++i) {
+        m_sendToSettings.erase(selectedItems[i]->text(0).toStdString());
+      }
+      // clear the tree and repopulate it without the programs that have just
+      // been deleted
+      treePrograms->clear();
+      updateProgramTree();
+    }
+  }
 }
 
 void ConfigDialog::populateProgramTree() {
-	std::vector<std::string> programNames =
-		Mantid::Kernel::ConfigService::Instance().getKeys(
-			"workspace.sendto.name");
+  std::vector<std::string> programNames =
+      Mantid::Kernel::ConfigService::Instance().getKeys(
+          "workspace.sendto.name");
 
-	for (size_t i = 0; i < programNames.size(); i++) {
-		// Create a map for the keys and details to go into
-		std::map<std::string, std::string> programKeysAndDetails;
+  for (size_t i = 0; i < programNames.size(); i++) {
+    // Create a map for the keys and details to go into
+    std::map<std::string, std::string> programKeysAndDetails;
 
-		// Get a list of the program detail keys (mandatory - target, saveusing)
-		// (optional - arguments, save parameters, workspace type)
-		std::vector<std::string> programKeys =
-			(Mantid::Kernel::ConfigService::Instance().getKeys("workspace.sendto." +
-				programNames[i]));
+    // Get a list of the program detail keys (mandatory - target, saveusing)
+    // (optional - arguments, save parameters, workspace type)
+    std::vector<std::string> programKeys =
+        (Mantid::Kernel::ConfigService::Instance().getKeys("workspace.sendto." +
+                                                           programNames[i]));
 
-		for (size_t j = 0; j < programKeys.size(); j++) {
-			// Assign a key to its value using the map
-			programKeysAndDetails[programKeys[j]] =
-				(Mantid::Kernel::ConfigService::Instance().getString(
-				("workspace.sendto." + programNames[i] + "." + programKeys[j])));
-		}
+    for (size_t j = 0; j < programKeys.size(); j++) {
+      // Assign a key to its value using the map
+      programKeysAndDetails[programKeys[j]] =
+          (Mantid::Kernel::ConfigService::Instance().getString(
+              ("workspace.sendto." + programNames[i] + "." + programKeys[j])));
+    }
 
-		m_sendToSettings.emplace(programNames[i], programKeysAndDetails);
-	}
-	updateProgramTree();
+    m_sendToSettings.emplace(programNames[i], programKeysAndDetails);
+  }
+  updateProgramTree();
 }
 
 void ConfigDialog::updateProgramTree() {
-	// Store into a map ready to go into config service when apply is clicked
-	std::map<std::string, std::map<std::string, std::string>>::const_iterator
-		itr = m_sendToSettings.begin();
-	for (; itr != m_sendToSettings.end(); ++itr) {
-		// creating the map of kvps needs to happen first as createing the item
-		// requires them.
-		std::map<std::string, std::string> programKeysAndDetails = itr->second;
+  // Store into a map ready to go into config service when apply is clicked
+  std::map<std::string, std::map<std::string, std::string>>::const_iterator
+      itr = m_sendToSettings.begin();
+  for (; itr != m_sendToSettings.end(); ++itr) {
+    // creating the map of kvps needs to happen first as createing the item
+    // requires them.
+    std::map<std::string, std::string> programKeysAndDetails = itr->second;
 
-		Qt::CheckState checkStatus = Qt::Unchecked;
-		if (programKeysAndDetails.find("visible")->second == "Yes") {
-			checkStatus = Qt::Checked;
-		}
+    Qt::CheckState checkStatus = Qt::Unchecked;
+    if (programKeysAndDetails.find("visible")->second == "Yes") {
+      checkStatus = Qt::Checked;
+    }
 
     // Populate list
-    QTreeWidgetItem *program = createCheckedTreeItem(
-        QString::fromStdString(itr->first), checkStatus);
+    QTreeWidgetItem *program =
+        createCheckedTreeItem(QString::fromStdString(itr->first), checkStatus);
     treePrograms->addTopLevelItem(program);
     updateChildren(programKeysAndDetails, program);
   }
@@ -1312,25 +1312,24 @@ void ConfigDialog::buildTreeCategoryStructure(
   // We wont be using the last element (null) of the array so decrement 1
   splitCatIndex--;
 
-  //Finally create tick status
+  // Finally create tick status
   Qt::CheckState tickStatus = Qt::Unchecked;
   if (!isHidden) {
-	  tickStatus = Qt::Checked;
+    tickStatus = Qt::Checked;
   }
-  
 
   if (splitCatIndex == 0) {
     // This is a top level category and standalone
-    QTreeWidgetItem *catWidget = createCheckedTreeItem(splitCats[0], tickStatus);
+    QTreeWidgetItem *catWidget =
+        createCheckedTreeItem(splitCats[0], tickStatus);
     treeCategories->addTopLevelItem(catWidget);
     seenCategories->insert(catKey, catWidget);
   } else {
     // We need to determine if we have seen this category before
     // and get any pointers to its parent(s) and set their tick status
     int prevElement = splitCatIndex - 1;
-    QTreeWidgetItem *parentWidgetPtr =
-        walkBackwardsThroughCategories(catNames, prevElement,
-			seenCategories, tickStatus);
+    QTreeWidgetItem *parentWidgetPtr = walkBackwardsThroughCategories(
+        catNames, prevElement, seenCategories, tickStatus);
 
     // At this point we now all parent categories have been created
     // So lets create the child
@@ -1343,14 +1342,14 @@ void ConfigDialog::buildTreeCategoryStructure(
   // We have built tree now fix any ticks or make partial ticks
   int topLevelCats = treeCategories->topLevelItemCount();
   for (int i = 0; i < topLevelCats; i++) {
-	  correctTreePatrialTicks(treeCategories->topLevelItem(i));
+    correctTreePatrialTicks(treeCategories->topLevelItem(i));
   }
 }
 
 QTreeWidgetItem *ConfigDialog::walkBackwardsThroughCategories(
     const QString *catNames, int elementToCheck,
-    QMap<QString, QTreeWidgetItem *> *seenCategories, 
-	Qt::CheckState childTickState) {
+    QMap<QString, QTreeWidgetItem *> *seenCategories,
+    Qt::CheckState childTickState) {
 
   // Split the categories whose name is delimited by '\\'
   QStringList splitCats = catNames->split('\\');
@@ -1368,12 +1367,11 @@ QTreeWidgetItem *ConfigDialog::walkBackwardsThroughCategories(
   // right category pointer
   if (!seenCategories->contains(catKey)) {
     // We have not see this parent category check any other parents first
-	// From the array of categories
+    // From the array of categories
     if (elementToCheck > 0) {
       int prevElement = elementToCheck - 1;
-      parentWidgetPtr =
-          walkBackwardsThroughCategories(catNames, prevElement, 
-			  seenCategories, childTickState);
+      parentWidgetPtr = walkBackwardsThroughCategories(
+          catNames, prevElement, seenCategories, childTickState);
     }
     // Now deal with this category
     if (!parentWidgetPtr) {
@@ -1402,51 +1400,47 @@ QTreeWidgetItem *ConfigDialog::walkBackwardsThroughCategories(
 }
 
 void ConfigDialog::correctTreePatrialTicks(QTreeWidgetItem *topLevelCat) {
-	// Check all children for a tick and untick we need to do this
-	// as some parents come with their own tick status which we might
-	// need to override 
-	bool hasUntickedChildren = false;
-	bool hasTickedChildren = false;
-	bool hasChildren = false;
+  // Check all children for a tick and untick we need to do this
+  // as some parents come with their own tick status which we might
+  // need to override
+  bool hasUntickedChildren = false;
+  bool hasTickedChildren = false;
+  bool hasChildren = false;
 
-	int childCount = topLevelCat->childCount();
-	for (int i = 0; i < childCount; i++) {
-		hasChildren = true;
-		//Check for nested children and deal with them
-		correctTreePatrialTicks(topLevelCat->child(i));
-		
-		QTreeWidgetItem *child = topLevelCat->child(i);
-		//Now actually check this ptr's children for their tick status
-		if (child->checkState(0) == Qt::Checked) {
-			hasTickedChildren = true;
-		}
-		else if (child->checkState(0) == Qt::Unchecked) {
-			hasUntickedChildren = true;
-		}
-		else {
-			//Partial tick - we will count this as a normal tick
-			hasTickedChildren = true;
-		}
-	} //Checked all children now set parent
+  int childCount = topLevelCat->childCount();
+  for (int i = 0; i < childCount; i++) {
+    hasChildren = true;
+    // Check for nested children and deal with them
+    correctTreePatrialTicks(topLevelCat->child(i));
 
-	if (hasChildren && hasUntickedChildren && hasTickedChildren) {
-		topLevelCat->setCheckState(0, Qt::PartiallyChecked);
-	}
-	else if (hasChildren && hasTickedChildren) {
-		topLevelCat->setCheckState(0, Qt::Checked);
-	}
-	else if (hasChildren) {
-		//Everything is unticked at this point 
-		topLevelCat->setCheckState(0, Qt::Unchecked);
-	}
+    QTreeWidgetItem *child = topLevelCat->child(i);
+    // Now actually check this ptr's children for their tick status
+    if (child->checkState(0) == Qt::Checked) {
+      hasTickedChildren = true;
+    } else if (child->checkState(0) == Qt::Unchecked) {
+      hasUntickedChildren = true;
+    } else {
+      // Partial tick - we will count this as a normal tick
+      hasTickedChildren = true;
+    }
+  } // Checked all children now set parent
 
+  if (hasChildren && hasUntickedChildren && hasTickedChildren) {
+    topLevelCat->setCheckState(0, Qt::PartiallyChecked);
+  } else if (hasChildren && hasTickedChildren) {
+    topLevelCat->setCheckState(0, Qt::Checked);
+  } else if (hasChildren) {
+    // Everything is unticked at this point
+    topLevelCat->setCheckState(0, Qt::Unchecked);
+  }
 }
 
-QTreeWidgetItem *ConfigDialog::createCheckedTreeItem(QString name,
-                                                     Qt::CheckState checkBoxState) {
+QTreeWidgetItem *
+ConfigDialog::createCheckedTreeItem(QString name,
+                                    Qt::CheckState checkBoxState) {
   QTreeWidgetItem *item = new QTreeWidgetItem(QStringList(name));
   item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
-    item->setCheckState(0, checkBoxState);
+  item->setCheckState(0, checkBoxState);
   return item;
 }
 

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -1280,103 +1280,104 @@ void ConfigDialog::refreshTreeCategories() {
 
   // Loop over all categories loaded into Mantid
   for (auto i = categoryMap.cbegin(); i != categoryMap.cend(); ++i) {
-	  
-	  QString catNames = QString::fromStdString(i->first);
-	  // Start recursion down building tree from names
-	  buildTreeCategoryStructure(&catNames, i->second, &categories);
+
+    QString catNames = QString::fromStdString(i->first);
+    // Start recursion down building tree from names
+    buildTreeCategoryStructure(&catNames, i->second, &categories);
   }
 }
 
-void ConfigDialog::buildTreeCategoryStructure(const QString *catNames, const bool isHidden,
-	QMap<QString, QTreeWidgetItem *> *seenCategories) {
-	/* Some categories come as standalone and some are discovered
-	// via their subcategory. E.g. Arithmetic vs Crystal\\Cell
-	// If standalone it has its own isHidden attribute otherwise
-	// we have to assume it to be visible (or ticked) as that information
-	// is not stored. */
+void ConfigDialog::buildTreeCategoryStructure(
+    const QString *catNames, const bool isHidden,
+    QMap<QString, QTreeWidgetItem *> *seenCategories) {
+  /* Some categories come as standalone and some are discovered
+  // via their subcategory. E.g. Arithmetic vs Crystal\\Cell
+  // If standalone it has its own isHidden attribute otherwise
+  // we have to assume it to be visible (or ticked) as that information
+  // is not stored. */
 
-	// Split the categories whose name is delimited by '\\'
-	QStringList splitCats = catNames->split('\\');
+  // Split the categories whose name is delimited by '\\'
+  QStringList splitCats = catNames->split('\\');
 
-	//Create a unique key for storing into the mapping
-	QString catKey(*catNames);
-	//We need to remove delimiter as top level categories do not come with it
-	catKey.remove('\\');
+  // Create a unique key for storing into the mapping
+  QString catKey(*catNames);
+  // We need to remove delimiter as top level categories do not come with it
+  catKey.remove('\\');
 
-	int splitCatIndex = splitCats.size();
-	// We wont be using the last element (null) of the array so decrement 1
-	splitCatIndex--;
+  int splitCatIndex = splitCats.size();
+  // We wont be using the last element (null) of the array so decrement 1
+  splitCatIndex--;
 
-	if (splitCatIndex == 0) {
-		//This is a top level category and standalone 
-		QTreeWidgetItem *catWidget = createCheckedTreeItem(splitCats[0], !isHidden);
-		treeCategories->addTopLevelItem(catWidget);
-		seenCategories->insert(catKey, catWidget);
-	}
-	else {
-		// We need to determine if we have seen this category before
-		// and get any pointers to its parent(s)
-		int prevElement = splitCatIndex - 1;
-		QTreeWidgetItem *parentWidgetPtr = walkBackwardsThroughCategories(
-			catNames, prevElement, seenCategories);
-		
-		// At this point we now all parent categories have been created
-		// So lets create the child
-		QTreeWidgetItem *newChildCat = createCheckedTreeItem(splitCats[splitCatIndex], !isHidden);
-		parentWidgetPtr->addChild(newChildCat);
-		seenCategories->insert(catKey, newChildCat);
-	}
+  if (splitCatIndex == 0) {
+    // This is a top level category and standalone
+    QTreeWidgetItem *catWidget = createCheckedTreeItem(splitCats[0], !isHidden);
+    treeCategories->addTopLevelItem(catWidget);
+    seenCategories->insert(catKey, catWidget);
+  } else {
+    // We need to determine if we have seen this category before
+    // and get any pointers to its parent(s)
+    int prevElement = splitCatIndex - 1;
+    QTreeWidgetItem *parentWidgetPtr =
+        walkBackwardsThroughCategories(catNames, prevElement, seenCategories);
 
+    // At this point we now all parent categories have been created
+    // So lets create the child
+    QTreeWidgetItem *newChildCat =
+        createCheckedTreeItem(splitCats[splitCatIndex], !isHidden);
+    parentWidgetPtr->addChild(newChildCat);
+    seenCategories->insert(catKey, newChildCat);
+  }
 }
 
-QTreeWidgetItem * ConfigDialog::walkBackwardsThroughCategories(const QString *catNames,
-	int elementToCheck, QMap<QString, QTreeWidgetItem*>* seenCategories) {
+QTreeWidgetItem *ConfigDialog::walkBackwardsThroughCategories(
+    const QString *catNames, int elementToCheck,
+    QMap<QString, QTreeWidgetItem *> *seenCategories) {
 
-	// Split the categories whose name is delimited by '\\'
-	QStringList splitCats = catNames->split('\\');
-	// Build a unique key only from the elements we should check
-	// Element to check is always 1 minus so check last element as well
-	QString catKey = "";
-	for (int i = 0; i <= elementToCheck; i++) {
-		catKey += splitCats[i];
-	}
+  // Split the categories whose name is delimited by '\\'
+  QStringList splitCats = catNames->split('\\');
+  // Build a unique key only from the elements we should check
+  // Element to check is always 1 minus so check last element as well
+  QString catKey = "";
+  for (int i = 0; i <= elementToCheck; i++) {
+    catKey += splitCats[i];
+  }
 
-	QTreeWidgetItem *parentWidgetPtr = nullptr;
+  QTreeWidgetItem *parentWidgetPtr = nullptr;
 
-	// Walk backwards through a string list discovering any missed categories
-	// If a parent category already exists we exit returning the most
-	// right category pointer
-	if (!seenCategories->contains(catKey)) {
-		//We have not see this parent category check any other parents first
-		if (elementToCheck > 0) {
-			int prevElement = elementToCheck - 1;
-			parentWidgetPtr = walkBackwardsThroughCategories(catNames, prevElement, 
-				seenCategories);
-		}
-		// Now deal with this category 
-		if (!parentWidgetPtr) {
-			// We are the most top level category which is ticked or visible
-			QTreeWidgetItem *catWidget = createCheckedTreeItem(splitCats[elementToCheck], true);
-			treeCategories->addTopLevelItem(catWidget);
-			seenCategories->insert(catKey, catWidget);
-			// Assign pointer to return for caller
-			parentWidgetPtr = catWidget;
-		}
-		else {
-			// We need to create a child which is ticked or visible 
-			QTreeWidgetItem *childWidget = createCheckedTreeItem(splitCats[elementToCheck], true);
-			parentWidgetPtr->addChild(childWidget);
-			seenCategories->insert(catKey, childWidget);
-			// Make the child the parent for caller
-			parentWidgetPtr = childWidget;
-		}
-	}
-	else {
-		// The category has already been created - lets return it
-		parentWidgetPtr = seenCategories->value(catKey);
-	}
+  // Walk backwards through a string list discovering any missed categories
+  // If a parent category already exists we exit returning the most
+  // right category pointer
+  if (!seenCategories->contains(catKey)) {
+    // We have not see this parent category check any other parents first
+    if (elementToCheck > 0) {
+      int prevElement = elementToCheck - 1;
+      parentWidgetPtr =
+          walkBackwardsThroughCategories(catNames, prevElement, seenCategories);
+    }
+    // Now deal with this category
+    if (!parentWidgetPtr) {
+      // We are the most top level category which is ticked or visible
+      QTreeWidgetItem *catWidget =
+          createCheckedTreeItem(splitCats[elementToCheck], true);
+      treeCategories->addTopLevelItem(catWidget);
+      seenCategories->insert(catKey, catWidget);
+      // Assign pointer to return for caller
+      parentWidgetPtr = catWidget;
+    } else {
+      // We need to create a child which is ticked or visible
+      QTreeWidgetItem *childWidget =
+          createCheckedTreeItem(splitCats[elementToCheck], true);
+      parentWidgetPtr->addChild(childWidget);
+      seenCategories->insert(catKey, childWidget);
+      // Make the child the parent for caller
+      parentWidgetPtr = childWidget;
+    }
+  } else {
+    // The category has already been created - lets return it
+    parentWidgetPtr = seenCategories->value(catKey);
+  }
 
-	return parentWidgetPtr;
+  return parentWidgetPtr;
 }
 
 QTreeWidgetItem *ConfigDialog::createCheckedTreeItem(QString name,

--- a/MantidPlot/src/ConfigDialog.h
+++ b/MantidPlot/src/ConfigDialog.h
@@ -154,16 +154,16 @@ private:
   void populateProgramTree();
   void updateProgramTree();
 
-  void buildTreeCategoryStructure(const QString *catNames, const bool isHidden,
+  void
+  buildTreeCategoryStructure(const QString *catNames, const bool isHidden,
                              QMap<QString, QTreeWidgetItem *> *seenCategories);
 
-  QTreeWidgetItem *walkBackwardsThroughCategories(const QString *catNames, 
-	  int elementToCheck,QMap<QString, QTreeWidgetItem *> *seenCategories,
-	  Qt::CheckState childTickState);
+  QTreeWidgetItem *walkBackwardsThroughCategories(
+      const QString *catNames, int elementToCheck,
+      QMap<QString, QTreeWidgetItem *> *seenCategories,
+      Qt::CheckState childTickState);
 
   void correctTreePatrialTicks(QTreeWidgetItem *topLevelCat);
-
-
 
   // MD Plotting
   void initMdPlottingPage();
@@ -172,7 +172,8 @@ private:
   void updateMdPlottingSettings();
   void setupMdPlottingConnections();
 
-  QTreeWidgetItem *createCheckedTreeItem(QString name, Qt::CheckState checkBoxState);
+  QTreeWidgetItem *createCheckedTreeItem(QString name,
+                                         Qt::CheckState checkBoxState);
   QStringList buildHiddenCategoryString(QTreeWidgetItem *parent = 0);
 
   std::map<std::string, std::map<std::string, std::string>> m_sendToSettings;

--- a/MantidPlot/src/ConfigDialog.h
+++ b/MantidPlot/src/ConfigDialog.h
@@ -157,15 +157,16 @@ private:
   void populateProgramTree();
   void updateProgramTree();
 
-  //Options Window - Selected Options
+  // Options Window - Selected Options
   void
   buildTreeCategoryStructure(const QString &catNames, const bool isHidden,
                              QMap<QString, QTreeWidgetItem *> &seenCategories);
-  QTreeWidgetItem* walkBackwardsThroughCategories(
+  QTreeWidgetItem *walkBackwardsThroughCategories(
       const QString &catNames, int elementToCheck,
       QMap<QString, QTreeWidgetItem *> &seenCategories,
       Qt::CheckState childTickState);
-  void updateChildTickStatuses(QTreeWidgetItem &widgetPtr, const Qt::CheckState newState);
+  void updateChildTickStatuses(QTreeWidgetItem &widgetPtr,
+                               const Qt::CheckState newState);
   void correctTreePatrialTicks(QTreeWidgetItem &topLevelCat);
 
   // MD Plotting

--- a/MantidPlot/src/ConfigDialog.h
+++ b/MantidPlot/src/ConfigDialog.h
@@ -125,6 +125,9 @@ private slots:
   void editDialog();
   void deleteDialog();
 
+  // Slot for tick boxes in options
+  void tickBoxClickedSlot(QTreeWidgetItem *widgetPtr, int column);
+
 private:
   void initPlotsPage();
   void initOptionsPage();
@@ -154,15 +157,15 @@ private:
   void populateProgramTree();
   void updateProgramTree();
 
+  //Options Window - Selected Options
   void
   buildTreeCategoryStructure(const QString *catNames, const bool isHidden,
                              QMap<QString, QTreeWidgetItem *> *seenCategories);
-
   QTreeWidgetItem *walkBackwardsThroughCategories(
       const QString *catNames, int elementToCheck,
       QMap<QString, QTreeWidgetItem *> *seenCategories,
       Qt::CheckState childTickState);
-
+  void updateChildTickStatuses(QTreeWidgetItem *widgetPtr, const Qt::CheckState newState);
   void correctTreePatrialTicks(QTreeWidgetItem *topLevelCat);
 
   // MD Plotting

--- a/MantidPlot/src/ConfigDialog.h
+++ b/MantidPlot/src/ConfigDialog.h
@@ -151,16 +151,19 @@ private:
   void initMantidOptionsTab();
   void initSendToProgramTab();
   void refreshTreeCategories();
-  void
-  buildTreeCategoryStructure(const QString *catNames, const bool isHidden,
-                             QMap<QString, QTreeWidgetItem *> *seenCategories);
-
-  QTreeWidgetItem *walkBackwardsThroughCategories(
-      const QString *catNames, int elementToCheck,
-      QMap<QString, QTreeWidgetItem *> *seenCategories);
-
   void populateProgramTree();
   void updateProgramTree();
+
+  void buildTreeCategoryStructure(const QString *catNames, const bool isHidden,
+                             QMap<QString, QTreeWidgetItem *> *seenCategories);
+
+  QTreeWidgetItem *walkBackwardsThroughCategories(const QString *catNames, 
+	  int elementToCheck,QMap<QString, QTreeWidgetItem *> *seenCategories,
+	  Qt::CheckState childTickState);
+
+  void correctTreePatrialTicks(QTreeWidgetItem *topLevelCat);
+
+
 
   // MD Plotting
   void initMdPlottingPage();
@@ -169,7 +172,7 @@ private:
   void updateMdPlottingSettings();
   void setupMdPlottingConnections();
 
-  QTreeWidgetItem *createCheckedTreeItem(QString name, bool checkBoxState);
+  QTreeWidgetItem *createCheckedTreeItem(QString name, Qt::CheckState checkBoxState);
   QStringList buildHiddenCategoryString(QTreeWidgetItem *parent = 0);
 
   std::map<std::string, std::map<std::string, std::string>> m_sendToSettings;

--- a/MantidPlot/src/ConfigDialog.h
+++ b/MantidPlot/src/ConfigDialog.h
@@ -152,11 +152,12 @@ private:
   void initSendToProgramTab();
   void refreshTreeCategories();
   void
-  buildTreeCategoryStructure(const QStringList *splitCats, const bool isHidden,
+  buildTreeCategoryStructure(const QString *catNames, const bool isHidden,
                              QMap<QString, QTreeWidgetItem *> *seenCategories);
 
-  QTreeWidgetItem * walkBackwardsThroughCategories(const QStringList *splitCats,
-	  int elementToCheck, QMap<QString, QTreeWidgetItem*>* seenCategories);
+  QTreeWidgetItem *walkBackwardsThroughCategories(
+      const QString *catNames, int elementToCheck,
+      QMap<QString, QTreeWidgetItem *> *seenCategories);
 
   void populateProgramTree();
   void updateProgramTree();

--- a/MantidPlot/src/ConfigDialog.h
+++ b/MantidPlot/src/ConfigDialog.h
@@ -151,6 +151,13 @@ private:
   void initMantidOptionsTab();
   void initSendToProgramTab();
   void refreshTreeCategories();
+  void
+  buildTreeCategoryStructure(const QStringList *splitCats, const bool isHidden,
+                             QMap<QString, QTreeWidgetItem *> *seenCategories);
+
+  QTreeWidgetItem * walkBackwardsThroughCategories(const QStringList *splitCats,
+	  int elementToCheck, QMap<QString, QTreeWidgetItem*>* seenCategories);
+
   void populateProgramTree();
   void updateProgramTree();
 

--- a/MantidPlot/src/ConfigDialog.h
+++ b/MantidPlot/src/ConfigDialog.h
@@ -159,14 +159,14 @@ private:
 
   //Options Window - Selected Options
   void
-  buildTreeCategoryStructure(const QString *catNames, const bool isHidden,
-                             QMap<QString, QTreeWidgetItem *> *seenCategories);
-  QTreeWidgetItem *walkBackwardsThroughCategories(
-      const QString *catNames, int elementToCheck,
-      QMap<QString, QTreeWidgetItem *> *seenCategories,
+  buildTreeCategoryStructure(const QString &catNames, const bool isHidden,
+                             QMap<QString, QTreeWidgetItem *> &seenCategories);
+  QTreeWidgetItem* walkBackwardsThroughCategories(
+      const QString &catNames, int elementToCheck,
+      QMap<QString, QTreeWidgetItem *> &seenCategories,
       Qt::CheckState childTickState);
-  void updateChildTickStatuses(QTreeWidgetItem *widgetPtr, const Qt::CheckState newState);
-  void correctTreePatrialTicks(QTreeWidgetItem *topLevelCat);
+  void updateChildTickStatuses(QTreeWidgetItem &widgetPtr, const Qt::CheckState newState);
+  void correctTreePatrialTicks(QTreeWidgetItem &topLevelCat);
 
   // MD Plotting
   void initMdPlottingPage();

--- a/docs/source/release/v3.8.0/ui.rst
+++ b/docs/source/release/v3.8.0/ui.rst
@@ -48,11 +48,13 @@ Documentation
 #############
 * Added Ragged Workspace as a concept page
 
+Options Window
+###############
+- Within Preferences->Mantid->Options ticking a category off/on will now untick/tick all subcategories. Also having some subcategories on and off will now show a partially ticked box for that category. 
+
 
 Bugs Resolved
 -------------
-
-- Within Preferences->Mantid->Options unticking the first element of some subcategories cause the whole category to become unticked when loading the options window again. These categories will now remain on if a subcategory exists. 
 
 
 SliceViewer Improvements

--- a/docs/source/release/v3.8.0/ui.rst
+++ b/docs/source/release/v3.8.0/ui.rst
@@ -52,6 +52,9 @@ Documentation
 Bugs Resolved
 -------------
 
+- Within Preferences->Mantid->Options unticking the first element of some subcategories cause the whole category to become unticked when loading the options window again. These categories will now remain on if a subcategory exists. 
+
+
 SliceViewer Improvements
 ------------------------
 * When opening the sliceviewer, it will default to showing the first two non-integrated dimensions


### PR DESCRIPTION
Description of work.
Certain categories under "View->Preferences->Mantid->Options" would take the value of their first subcategory depending on if they themselves were a category. 

When we get the list of categories and subcategories we now recurse backwards checking for any parent categories which were first seen from a subcategory and default them to a tick on as they do not have a visibility property associated.

**To test:**
Open "View->Preferences->Mantid->Options" all categories and subcategories should render correctly.
Categories such as "Algorithm" will preserve the tick option as it is standalone. The "Crystal" category is derived from its sub categories so will always appear ticked. 
Ensure the users selection is preserved across applying and re-opening the settings window.

Fixes #16871 .

Release notes have been updated

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
