### PR TITLE
Indirect Elwin - Use instrument resolution to initialise range bars

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -19,7 +19,8 @@ private:
   void run() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
-  void setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws, const QPair<double, double> &range);
+  void setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
+                            const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);
 
 private slots:

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -19,7 +19,7 @@ private:
   void run() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
-  void setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws);
+  void setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws, const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);
 
 private slots:

--- a/docs/source/release/v3.8.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.8.0/indirect_inelastic.rst
@@ -34,6 +34,7 @@ Improvements
 - Algorithm :ref:`BASISReduction311 <algm-BASISReduction311>` has been included in algorithm :ref:`BASISReduction <algm-BASISReduction>`.
 - Range bars colours in the *ISIS Calibration* interface have been updated to match the convention in the fit wizard.
 - Vesuvio sigma_theta value updated for single and double differencing in both forward and back scattering. The new value is 0.016 for all.
+- The Elwin interface now uses the resolution of the instrument to create the range bars when possible
 
 
 Bugfixes


### PR DESCRIPTION
The Elwin interface should now use the resolution from the instrument parameter if it is available to create the range bars in the plot preview.

**To test:**

The files  for testing this are available from `\\olympic\babylon5\Public\ElliotOram\DataAnalysis\Elwin\`
- Open Elwin (Interfaces > Indirect > Data Analysis > Elwin)
- Load `iris26176_graphite002_red`
  - Ensure the `Integration Range` `Start`/`End` is equal to `+/- 0.017500` (resolution of IRIS) 
  - Ensure the preview plot shows these values with the blue range bars
  - Check the `Background Subtraction` option
    - Ensure the Background Range is a `Start`/`End` of `-0.17500` and `-0.157500` (-10 \* res and -9 \* res for IRIS)
    - Check the preview plot shows these values with the green range bars
- Load `osi92762_graphite002_red` 
  - Ensure the `Integration Range` `Start`/`End` is equal to `+/- 0.024500` (resolution of OSIRIS) 
  - Ensure the preview plot shows these values with the blue range bars
  - Check the `Background Subtraction` option (should already be checked from previous test)
    - Ensure the Background Range is a `Start`/`End` of `-0.24500` and `-0.220500` (-10 \* res and -9 \* res for OSIRIS)
    - Check the preview plot shows these values with the green range bars

Fixes #16887

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/af92e224a753cfb3f4ac886d3c1f442f3dee3593/docs/source/release/v3.8.0/indirect_inelastic.rst)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
