### PR TITLE
Update live data urls for ADARA beamlines

### DIFF
--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -5,6 +5,8 @@ Framework Changes
 .. contents:: Table of Contents
    :local:
 
+- ``Facilities.xml`` was updated for changes to the SNS live data servers.
+
 HistogramData
 -------------
 
@@ -36,9 +38,9 @@ Improved
 
 - :ref:`SavePlot1D <algm-SavePlot1D>` has options for writing out
   plotly html files.
-  
+
 - :ref:`ConvertTableToMatrixWorkspace <algm-ConvertTableToMatrixWorkspace>` The input dialog
-  had a bug where the table columns were in a reversed order in the dialogue's combo boxes. 
+  had a bug where the table columns were in a reversed order in the dialogue's combo boxes.
   This is now fixed and the order is correct.
 
 Deprecated

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -359,13 +359,15 @@
       <technique>technique</technique>
    </instrument>
 
-   <instrument name="TOF-USANS" beamline="1A">
+   <instrument name="USANS" shortname="USANS" beamline="1A">
       <technique>Small Angle Scattering</technique>
+      <livedata address="bl1a-daq1.sns.gov:31415" />
    </instrument>
 
    <instrument name="NOMAD" shortname="NOM" beamline="1B">
    	<technique>Neutron Diffraction</technique>
    	<technique>Neutron Amorphous</technique>
+        <livedata address="bl1b-daq1.sns.gov:31415" />
    </instrument>
 
    <instrument name="BASIS" shortname="BSS" beamline="2">
@@ -397,11 +399,6 @@
       <technique>Small Angle Scattering</technique>
    </instrument>
 
-   <instrument name="USANS" shortname="USANS" beamline="1A">
-      <technique>Small Angle Scattering</technique>
-      <livedata address="usans-daq1.sns.gov:31415" />
-   </instrument>
-
    <instrument name="VULCAN" beamline="7">
 	<technique>Neutron Diffraction</technique>
    </instrument>
@@ -409,11 +406,12 @@
    <instrument name="CORELLI" beamline="9">
 	<technique>Neutron Diffraction</technique>
 	<technique>Diffuse Scattering</technique>
-	<livedata address="corelli-daq1.sns.gov:31415" />
+	<livedata address="bl9-daq1.sns.gov:31415" />
    </instrument>
 
    <instrument name="POWGEN" shortname="PG3" beamline="11A">
 	<technique>Neutron Diffraction</technique>
+        <livedata address="bl11a-daq1.sns.gov:31415" />
    </instrument>
 
    <instrument name="MANDI" beamline="11B">
@@ -439,7 +437,7 @@
     <technique>Neutron Spectroscopy</technique>
     <technique>TOF Indirect Geometry Spectroscopy</technique>
     <technique>Neutron Diffraction</technique>
-    <livedata address="vision-daq1.sns.gov:31415" />
+    <livedata address="bl16b-daq1.sns.gov:31415" />
   </instrument>
 
    <instrument name="SEQUOIA" shortname="SEQ" beamline="17">


### PR DESCRIPTION
URLs for live data on CORELLI, NOMAD, POWGEN, and VISION had a URL change during the summer shutdown.

**To test:**

Try to connect to live data with an SNS instrument that has the url change.

_There is no associated issue_

_Does not need to be in the release notes._

This is also a PR for `release-v3.7` in #16906.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
