### PR TITLE
Replace MatrixWorkspace isDistribution flag by Y-storage mode in Histogram

### DIFF
--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -105,7 +105,7 @@ public:
     HistogramData::Histogram histogram(std::forward<T>(data)...);
     // Check for the special case EventList, it only accepts histograms without
     // Y and E data.
-    checkHistogram(histogram);
+    checkAndSanitizeHistogram(histogram);
     mutableHistogramRef() = std::move(histogram);
   }
 
@@ -251,7 +251,7 @@ public:
   }
 
 protected:
-  virtual void checkHistogram(const HistogramData::Histogram &) const {}
+  virtual void checkAndSanitizeHistogram(HistogramData::Histogram &) {}
   virtual void checkWorksWithPoints() const {}
   virtual void checkIsYAndEWritable() const {}
 

--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -114,7 +114,7 @@ public:
   }
   void setYMode(HistogramData::Histogram::YMode ymode) {
     checkIsYAndEWritable();
-    return mutableHistogramRef().setYMode(ymode);
+    mutableHistogramRef().setYMode(ymode);
   }
   void convertToCounts() {
     checkIsYAndEWritable();

--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -113,12 +113,15 @@ public:
     return histogramRef().yMode();
   }
   void setYMode(HistogramData::Histogram::YMode ymode) {
+    checkIsYAndEWritable();
     return mutableHistogramRef().setYMode(ymode);
   }
   void convertToCounts() {
+    checkIsYAndEWritable();
     mutableHistogramRef().convertToCounts();
   }
   void convertToFrequencies() {
+    checkIsYAndEWritable();
     mutableHistogramRef().convertToFrequencies();
   }
 

--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -109,6 +109,19 @@ public:
     mutableHistogramRef() = std::move(histogram);
   }
 
+  HistogramData::Histogram::YMode yMode() const {
+    return histogramRef().yMode();
+  }
+  void setYMode(HistogramData::Histogram::YMode ymode) {
+    return mutableHistogramRef().setYMode(ymode);
+  }
+  void convertToCounts() {
+    mutableHistogramRef().convertToCounts();
+  }
+  void convertToFrequencies() {
+    mutableHistogramRef().convertToFrequencies();
+  }
+
   HistogramData::BinEdges binEdges() const { return histogramRef().binEdges(); }
   HistogramData::BinEdgeStandardDeviations binEdgeStandardDeviations() const {
     return histogramRef().binEdgeStandardDeviations();

--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -113,7 +113,6 @@ public:
     return histogramRef().yMode();
   }
   void setYMode(HistogramData::Histogram::YMode ymode) {
-    checkIsYAndEWritable();
     mutableHistogramRef().setYMode(ymode);
   }
   void convertToCounts() {

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -187,6 +187,12 @@ public:
   void setHistogram(const size_t index, T &&... data) & {
     getSpectrum(index).setHistogram(std::forward<T>(data)...);
   }
+  void convertToCounts(const size_t index) {
+    getSpectrum(index).convertToCounts();
+  }
+  void convertToFrequencies(const size_t index) {
+    getSpectrum(index).convertToFrequencies();
+  }
   HistogramData::BinEdges binEdges(const size_t index) const {
     return getSpectrum(index).binEdges();
   }
@@ -451,7 +457,7 @@ public:
   void setYUnitLabel(const std::string &newLabel);
 
   /// Are the Y-values dimensioned?
-  const bool &isDistribution() const;
+  bool isDistribution() const;
   void setDistribution(bool newValue);
 
   /// Mask a given workspace index, setting the data and error values to zero
@@ -599,8 +605,6 @@ private:
   std::string m_YUnit;
   /// A text label for use when plotting spectra
   std::string m_YUnitLabel;
-  /// Flag indicating whether the Y-values are dimensioned. False by default
-  bool m_isDistribution;
 
   /// Flag indicating whether the m_isCommonBinsFlag has been set. False by
   /// default

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -41,9 +41,8 @@ const std::string MatrixWorkspace::yDimensionId = "yDimension";
 MatrixWorkspace::MatrixWorkspace(
     Mantid::Geometry::INearestNeighboursFactory *nnFactory)
     : IMDWorkspace(), ExperimentInfo(), m_axes(), m_isInitialized(false),
-      m_YUnit(), m_YUnitLabel(), m_isDistribution(false),
-      m_isCommonBinsFlagSet(false), m_isCommonBinsFlag(false), m_masks(),
-      m_indexCalculator(),
+      m_YUnit(), m_YUnitLabel(), m_isCommonBinsFlagSet(false),
+      m_isCommonBinsFlag(false), m_masks(), m_indexCalculator(),
       m_nearestNeighboursFactory(
           (nnFactory == nullptr) ? new NearestNeighboursFactory : nnFactory),
       m_nearestNeighbours() {}
@@ -57,7 +56,6 @@ MatrixWorkspace::MatrixWorkspace(const MatrixWorkspace &other)
   m_isInitialized = other.m_isInitialized;
   m_YUnit = other.m_YUnit;
   m_YUnitLabel = other.m_YUnitLabel;
-  m_isDistribution = other.m_isDistribution;
   m_isCommonBinsFlagSet = other.m_isCommonBinsFlagSet;
   m_isCommonBinsFlag = other.m_isCommonBinsFlag;
   m_masks = other.m_masks;
@@ -926,13 +924,21 @@ void MatrixWorkspace::setYUnitLabel(const std::string &newLabel) {
 * TODO: For example: ????
 * @return whether workspace is a distribution or not
 */
-const bool &MatrixWorkspace::isDistribution() const { return m_isDistribution; }
+bool MatrixWorkspace::isDistribution() const {
+  return getSpectrum(0).yMode() == HistogramData::Histogram::YMode::Frequencies;
+}
 
 /** Set the flag for whether the Y-values are dimensioned
 *  @return whether workspace is now a distribution
 */
 void MatrixWorkspace::setDistribution(bool newValue) {
-  m_isDistribution = newValue;
+  if(isDistribution() == newValue)
+    return;
+  HistogramData::Histogram::YMode ymode =
+      newValue ? HistogramData::Histogram::YMode::Frequencies
+               : HistogramData::Histogram::YMode::Counts;
+  for (size_t i = 0; i < getNumberHistograms(); ++i)
+    getSpectrum(i).setYMode(ymode);
 }
 
 /**

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -932,7 +932,7 @@ bool MatrixWorkspace::isDistribution() const {
 *  @return whether workspace is now a distribution
 */
 void MatrixWorkspace::setDistribution(bool newValue) {
-  if(isDistribution() == newValue)
+  if (isDistribution() == newValue)
     return;
   HistogramData::Histogram::YMode ymode =
       newValue ? HistogramData::Histogram::YMode::Frequencies

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -19,7 +19,8 @@ using namespace Mantid::API;
 class CompositeFunctionTest_MocSpectrum : public SpectrumTester {
 public:
   CompositeFunctionTest_MocSpectrum(size_t nx, size_t ny)
-      : SpectrumTester(HistogramData::getHistogramXMode(nx, ny)) {
+      : SpectrumTester(HistogramData::getHistogramXMode(nx, ny),
+                       HistogramData::Histogram::YMode::Counts) {
     dataX().resize(nx);
     dataY().resize(ny);
     dataE().resize(ny);

--- a/Framework/API/test/FunctionTest.h
+++ b/Framework/API/test/FunctionTest.h
@@ -20,7 +20,8 @@ using namespace Mantid::API;
 class MocSpectrum : public SpectrumTester {
 public:
   MocSpectrum(size_t nx, size_t ny)
-      : SpectrumTester(HistogramData::getHistogramXMode(nx, ny)) {
+      : SpectrumTester(HistogramData::getHistogramXMode(nx, ny),
+                       HistogramData::Histogram::YMode::Counts) {
     dataX().resize(nx);
     dataY().resize(ny);
     dataE().resize(ny);

--- a/Framework/API/test/ISpectrumTest.h
+++ b/Framework/API/test/ISpectrumTest.h
@@ -10,26 +10,27 @@
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
+using Mantid::HistogramData::Histogram;
 
 class ISpectrumTest : public CxxTest::TestSuite {
 public:
   void test_empty_constructor() {
-    SpectrumTester s(HistogramData::Histogram::XMode::Points);
+    SpectrumTester s(Histogram::XMode::Points, Histogram::YMode::Counts);
     TS_ASSERT_EQUALS(s.getDetectorIDs().size(), 0);
     TS_ASSERT_EQUALS(s.getSpectrumNo(), 0);
   }
 
   void test_constructor() {
-    SpectrumTester s(1234, HistogramData::Histogram::XMode::Points);
+    SpectrumTester s(1234, Histogram::XMode::Points, Histogram::YMode::Counts);
     TS_ASSERT_EQUALS(s.getDetectorIDs().size(), 0);
     TS_ASSERT_EQUALS(s.getSpectrumNo(), 1234);
   }
 
   void test_copyInfoFrom() {
-    SpectrumTester a(1234, HistogramData::Histogram::XMode::Points);
+    SpectrumTester a(1234, Histogram::XMode::Points, Histogram::YMode::Counts);
     a.addDetectorID(678);
     a.addDetectorID(789);
-    SpectrumTester b(456, HistogramData::Histogram::XMode::Points);
+    SpectrumTester b(456, Histogram::XMode::Points, Histogram::YMode::Counts);
 
     TS_ASSERT_EQUALS(b.getDetectorIDs().size(), 0);
     b.copyInfoFrom(a);
@@ -38,14 +39,14 @@ public:
   }
 
   void test_setSpectrumNo() {
-    SpectrumTester s(HistogramData::Histogram::XMode::Points);
+    SpectrumTester s(Histogram::XMode::Points, Histogram::YMode::Counts);
     TS_ASSERT_EQUALS(s.getSpectrumNo(), 0);
     s.setSpectrumNo(1234);
     TS_ASSERT_EQUALS(s.getSpectrumNo(), 1234);
   }
 
   void test_detectorID_handling() {
-    SpectrumTester s(HistogramData::Histogram::XMode::Points);
+    SpectrumTester s(Histogram::XMode::Points, Histogram::YMode::Counts);
     TS_ASSERT(s.getDetectorIDs().empty());
     s.addDetectorID(123);
     TS_ASSERT_EQUALS(s.getDetectorIDs().size(), 1);
@@ -87,19 +88,19 @@ public:
   }
 
   void test_use_dx_flag_being_set_when_accessing_dx_with_non_const() {
-    SpectrumTester s(HistogramData::Histogram::XMode::Points);
+    SpectrumTester s(Histogram::XMode::Points, Histogram::YMode::Counts);
     s.setPointStandardDeviations(0);
     TS_ASSERT(s.hasDx());
 
     // setDX vesion 2
-    SpectrumTester s4(HistogramData::Histogram::XMode::Points);
+    SpectrumTester s4(Histogram::XMode::Points, Histogram::YMode::Counts);
     auto Dx_vec_ptr_type =
         boost::make_shared<Mantid::HistogramData::HistogramDx>(0);
     s4.setSharedDx(Dx_vec_ptr_type);
     TS_ASSERT(s4.hasDx());
 
     // setDX version 3
-    SpectrumTester s5(HistogramData::Histogram::XMode::Points);
+    SpectrumTester s5(Histogram::XMode::Points, Histogram::YMode::Counts);
     cow_ptr<Mantid::HistogramData::HistogramDx> Dx_vec_ptr;
     s5.setSharedDx(Dx_vec_ptr);
     TS_ASSERT(s5.hasDx());
@@ -107,7 +108,7 @@ public:
 
   void test_use_dx_flag_is_copied_during_copy_construction() {
     // Copy spectrum which had the flag set
-    SpectrumTester s(HistogramData::Histogram::XMode::Points);
+    SpectrumTester s(Histogram::XMode::Points, Histogram::YMode::Counts);
     s.setPointStandardDeviations(0);
     TS_ASSERT(s.hasDx());
 
@@ -115,7 +116,7 @@ public:
     TS_ASSERT(s2.hasDx());
 
     // Copy spectrum which did not have the flag set
-    SpectrumTester s3(HistogramData::Histogram::XMode::Points);
+    SpectrumTester s3(Histogram::XMode::Points, Histogram::YMode::Counts);
     SpectrumTester s4(s);
     TS_ASSERT(!s3.hasDx());
   }

--- a/Framework/API/test/RawCountValidatorTest.h
+++ b/Framework/API/test/RawCountValidatorTest.h
@@ -19,12 +19,14 @@ public:
 
   void test_success() {
     auto ws = boost::make_shared<WorkspaceTester>();
+    ws->initialize(1, 1, 1);
     RawCountValidator validator;
     TS_ASSERT_EQUALS(validator.isValid(ws), "");
   }
 
   void test_fail() {
     auto ws = boost::make_shared<WorkspaceTester>();
+    ws->initialize(1, 1, 1);
     ws->setDistribution(true);
     RawCountValidator validator;
     TS_ASSERT_EQUALS(

--- a/Framework/API/test/WorkspaceOpOverloadsTest.h
+++ b/Framework/API/test/WorkspaceOpOverloadsTest.h
@@ -155,7 +155,7 @@ public:
     auto ws = boost::make_shared<WorkspaceTester>();
     ws->init(2, 2, 1);
     ws->dataX(0)[1] = 3.0;
-    ws->dataX(1)[1] = 0.5;
+    ws->dataX(1)[1] = 1.5;
     TS_ASSERT(!ws->isDistribution());
 
     TS_ASSERT_THROWS_NOTHING(WorkspaceHelpers::makeDistribution(ws));
@@ -163,7 +163,7 @@ public:
     TS_ASSERT_EQUALS(ws->readX(0)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readX(0)[1], 3.0)
     TS_ASSERT_EQUALS(ws->readX(1)[0], 1.0)
-    TS_ASSERT_EQUALS(ws->readX(1)[1], 0.5)
+    TS_ASSERT_EQUALS(ws->readX(1)[1], 1.5)
     TS_ASSERT_EQUALS(ws->readY(0)[0], 0.5)
     TS_ASSERT_EQUALS(ws->readY(1)[0], 2.0)
     TS_ASSERT_EQUALS(ws->readE(0)[0], 0.5)
@@ -175,7 +175,7 @@ public:
     TS_ASSERT_EQUALS(ws->readX(0)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readX(0)[1], 3.0)
     TS_ASSERT_EQUALS(ws->readX(1)[0], 1.0)
-    TS_ASSERT_EQUALS(ws->readX(1)[1], 0.5)
+    TS_ASSERT_EQUALS(ws->readX(1)[1], 1.5)
     TS_ASSERT_EQUALS(ws->readY(0)[0], 0.5)
     TS_ASSERT_EQUALS(ws->readY(1)[0], 2.0)
     TS_ASSERT_EQUALS(ws->readE(0)[0], 0.5)
@@ -187,7 +187,7 @@ public:
     TS_ASSERT_EQUALS(ws->readX(0)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readX(0)[1], 3.0)
     TS_ASSERT_EQUALS(ws->readX(1)[0], 1.0)
-    TS_ASSERT_EQUALS(ws->readX(1)[1], 0.5)
+    TS_ASSERT_EQUALS(ws->readX(1)[1], 1.5)
     TS_ASSERT_EQUALS(ws->readY(0)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readY(1)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readE(0)[0], 1.0)
@@ -199,7 +199,7 @@ public:
     TS_ASSERT_EQUALS(ws->readX(0)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readX(0)[1], 3.0)
     TS_ASSERT_EQUALS(ws->readX(1)[0], 1.0)
-    TS_ASSERT_EQUALS(ws->readX(1)[1], 0.5)
+    TS_ASSERT_EQUALS(ws->readX(1)[1], 1.5)
     TS_ASSERT_EQUALS(ws->readY(0)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readY(1)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readE(0)[0], 1.0)

--- a/Framework/DataHandling/src/LoadAscii.cpp
+++ b/Framework/DataHandling/src/LoadAscii.cpp
@@ -177,7 +177,9 @@ API::Workspace_sptr LoadAscii::readData(std::ifstream &file) const {
   // could be blank lines and comment lines
   int numBins(0), lineNo(0);
   std::vector<DataObjects::Histogram1D> spectra(
-      numSpectra, HistogramData::Histogram::XMode::Points);
+      numSpectra,
+      DataObjects::Histogram1D(HistogramData::Histogram::XMode::Points,
+                               HistogramData::Histogram::YMode::Counts));
   std::vector<double> dx;
   std::vector<double> values(numCols, 0.);
   do {

--- a/Framework/DataHandling/src/LoadAscii2.cpp
+++ b/Framework/DataHandling/src/LoadAscii2.cpp
@@ -81,7 +81,8 @@ API::Workspace_sptr LoadAscii2::readData(std::ifstream &file) {
 
   m_spectra.clear();
   m_curSpectra =
-      new DataObjects::Histogram1D(HistogramData::Histogram::XMode::Points);
+      new DataObjects::Histogram1D(HistogramData::Histogram::XMode::Points,
+                                   HistogramData::Histogram::YMode::Counts);
   std::string line;
 
   std::list<std::string> columns;
@@ -508,7 +509,8 @@ void LoadAscii2::newSpectra() {
     }
 
     m_curSpectra =
-        new DataObjects::Histogram1D(HistogramData::Histogram::XMode::Points);
+        new DataObjects::Histogram1D(HistogramData::Histogram::XMode::Points,
+                                     HistogramData::Histogram::YMode::Counts);
     m_curDx.clear();
     m_spectraStart = true;
   }

--- a/Framework/DataHandling/src/LoadSNSspec.cpp
+++ b/Framework/DataHandling/src/LoadSNSspec.cpp
@@ -128,7 +128,9 @@ void LoadSNSspec::exec() {
     }
   }
 
-  spectra.resize(spectra_nbr, HistogramData::Histogram::XMode::BinEdges);
+  spectra.resize(spectra_nbr, DataObjects::Histogram1D(
+                                  HistogramData::Histogram::XMode::BinEdges,
+                                  HistogramData::Histogram::YMode::Counts));
   file.clear(); // end of file has been reached so we need to clear file state
   file.seekg(0, std::ios::beg); // go back to beginning of file
 

--- a/Framework/DataHandling/src/LoadSpec.cpp
+++ b/Framework/DataHandling/src/LoadSpec.cpp
@@ -75,10 +75,9 @@ void LoadSpec::exec() {
     }
   }
 
-  spectra.resize(
-      spectra_nbr,
-      DataObjects::Histogram1D(HistogramData::Histogram::XMode::Points,
-                               HistogramData::Histogram::YMode::Counts));
+  spectra.resize(spectra_nbr, DataObjects::Histogram1D(
+                                  HistogramData::Histogram::XMode::Points,
+                                  HistogramData::Histogram::YMode::Counts));
   file.clear(); // end of file has been reached so we need to clear file state
   file.seekg(0, std::ios::beg); // go back to beginning of file
 

--- a/Framework/DataHandling/src/LoadSpec.cpp
+++ b/Framework/DataHandling/src/LoadSpec.cpp
@@ -75,7 +75,10 @@ void LoadSpec::exec() {
     }
   }
 
-  spectra.resize(spectra_nbr, HistogramData::Histogram::XMode::Points);
+  spectra.resize(
+      spectra_nbr,
+      DataObjects::Histogram1D(HistogramData::Histogram::XMode::Points,
+                               HistogramData::Histogram::YMode::Counts));
   file.clear(); // end of file has been reached so we need to clear file state
   file.seekg(0, std::ios::beg); // go back to beginning of file
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -344,7 +344,7 @@ public:
   Kernel::cow_ptr<HistogramData::HistogramE> sharedE() const override;
 
 protected:
-  void checkHistogram(const HistogramData::Histogram &histogram) const override;
+  void checkAndSanitizeHistogram(HistogramData::Histogram &histogram) override;
   void checkWorksWithPoints() const override;
   void checkIsYAndEWritable() const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventWorkspaceMRU.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventWorkspaceMRU.h
@@ -5,8 +5,8 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/cow_ptr.h"
 #include "MantidKernel/MRUList.h"
-#include "MantidHistogramData/Counts.h"
-#include "MantidHistogramData/CountStandardDeviations.h"
+#include "MantidHistogramData/HistogramY.h"
+#include "MantidHistogramData/HistogramE.h"
 #include <vector>
 #include <mutex>
 
@@ -71,13 +71,14 @@ public:
 */
 class DLLExport EventWorkspaceMRU {
 public:
-  using YWithMarker = TypeWithMarker<HistogramData::Counts>;
-  using EWithMarker = TypeWithMarker<HistogramData::CountStandardDeviations>;
+  using YType = Kernel::cow_ptr<HistogramData::HistogramY>;
+  using EType = Kernel::cow_ptr<HistogramData::HistogramE>;
+  using YWithMarker = TypeWithMarker<YType>;
+  using EWithMarker = TypeWithMarker<EType>;
   // Typedef for a Most-Recently-Used list of Data objects.
   using mru_listY = Kernel::MRUList<YWithMarker>;
   using mru_listE = Kernel::MRUList<EWithMarker>;
 
-  EventWorkspaceMRU();
   ~EventWorkspaceMRU();
 
   void ensureEnoughBuffersY(size_t thread_num) const;
@@ -85,12 +86,10 @@ public:
 
   void clear();
 
-  HistogramData::Counts findY(size_t thread_num, size_t index);
-  HistogramData::CountStandardDeviations findE(size_t thread_num, size_t index);
-  void insertY(size_t thread_num, HistogramData::Counts data,
-               const size_t index);
-  void insertE(size_t thread_num, HistogramData::CountStandardDeviations data,
-               const size_t index);
+  YType findY(size_t thread_num, size_t index);
+  EType findE(size_t thread_num, size_t index);
+  void insertY(size_t thread_num, YType data, const size_t index);
+  void insertE(size_t thread_num, EType data, const size_t index);
 
   void deleteIndex(size_t index);
 

--- a/Framework/DataObjects/inc/MantidDataObjects/Histogram1D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Histogram1D.h
@@ -37,8 +37,9 @@ private:
   HistogramData::Histogram m_histogram;
 
 public:
-  Histogram1D(HistogramData::Histogram::XMode mode)
-      : API::ISpectrum(), m_histogram(mode) {
+  Histogram1D(HistogramData::Histogram::XMode xmode,
+              HistogramData::Histogram::YMode ymode)
+      : API::ISpectrum(), m_histogram(xmode, ymode) {
     m_histogram.setCounts(0);
     m_histogram.setCountStandardDeviations(0);
   }

--- a/Framework/DataObjects/inc/MantidDataObjects/Histogram1D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Histogram1D.h
@@ -38,11 +38,7 @@ private:
 
 public:
   Histogram1D(HistogramData::Histogram::XMode xmode,
-              HistogramData::Histogram::YMode ymode)
-      : API::ISpectrum(), m_histogram(xmode, ymode) {
-    m_histogram.setCounts(0);
-    m_histogram.setCountStandardDeviations(0);
-  }
+              HistogramData::Histogram::YMode ymode);
 
   Histogram1D(const Histogram1D &) = default;
   Histogram1D(Histogram1D &&) = default;

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -81,7 +81,8 @@ private:
             const std::size_t &YLength) override;
 
   /// Instance of Histogram1D that holds the "spectrum" (AKA the single value);
-  Histogram1D data{HistogramData::Histogram::XMode::Points};
+  Histogram1D data{HistogramData::Histogram::XMode::Points,
+                   HistogramData::Histogram::YMode::Frequencies};
 };
 
 /// shared pointer to the WorkspaceSingleValue class

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -82,7 +82,7 @@ private:
 
   /// Instance of Histogram1D that holds the "spectrum" (AKA the single value);
   Histogram1D data{HistogramData::Histogram::XMode::Points,
-                   HistogramData::Histogram::YMode::Frequencies};
+                   HistogramData::Histogram::YMode::Counts};
 };
 
 /// shared pointer to the WorkspaceSingleValue class

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -120,22 +120,24 @@ bool compareEventPulseTimeTOF(const TofEvent &e1, const TofEvent &e2) {
 /// Constructor (empty)
 // EventWorkspace is always histogram data and so is thus EventList
 EventList::EventList()
-    : m_histogram(HistogramData::Histogram::XMode::BinEdges), eventType(TOF),
-      order(UNSORTED), mru(nullptr) {}
+    : m_histogram(HistogramData::Histogram::XMode::BinEdges,
+                  HistogramData::Histogram::YMode::Counts),
+      eventType(TOF), order(UNSORTED), mru(nullptr) {}
 
 /** Constructor with a MRU list
  * @param mru :: pointer to the MRU of the parent EventWorkspace
  * @param specNo :: the spectrum number for the event list
  */
 EventList::EventList(EventWorkspaceMRU *mru, specnum_t specNo)
-    : IEventList(specNo),
-      m_histogram(HistogramData::Histogram::XMode::BinEdges), eventType(TOF),
-      order(UNSORTED), mru(mru) {}
+    : IEventList(specNo), m_histogram(HistogramData::Histogram::XMode::BinEdges,
+                                      HistogramData::Histogram::YMode::Counts),
+      eventType(TOF), order(UNSORTED), mru(mru) {}
 
 /** Constructor copying from an existing event list
  * @param rhs :: EventList object to copy*/
 EventList::EventList(const EventList &rhs)
-    : IEventList(rhs), m_histogram(HistogramData::Histogram::XMode::BinEdges),
+    : IEventList(rhs), m_histogram(HistogramData::Histogram::XMode::BinEdges,
+                                   HistogramData::Histogram::YMode::Counts),
       mru(rhs.mru) {
   // Call the copy operator to do the job,
   this->operator=(rhs);
@@ -144,8 +146,9 @@ EventList::EventList(const EventList &rhs)
 /** Constructor, taking a vector of events.
  * @param events :: Vector of TofEvent's */
 EventList::EventList(const std::vector<TofEvent> &events)
-    : m_histogram(HistogramData::Histogram::XMode::BinEdges), eventType(TOF),
-      mru(nullptr) {
+    : m_histogram(HistogramData::Histogram::XMode::BinEdges,
+                  HistogramData::Histogram::YMode::Counts),
+      eventType(TOF), mru(nullptr) {
   this->events.assign(events.begin(), events.end());
   this->eventType = TOF;
   this->order = UNSORTED;
@@ -154,7 +157,9 @@ EventList::EventList(const std::vector<TofEvent> &events)
 /** Constructor, taking a vector of events.
  * @param events :: Vector of WeightedEvent's */
 EventList::EventList(const std::vector<WeightedEvent> &events)
-    : m_histogram(HistogramData::Histogram::XMode::BinEdges), mru(nullptr) {
+    : m_histogram(HistogramData::Histogram::XMode::BinEdges,
+                  HistogramData::Histogram::YMode::Counts),
+      mru(nullptr) {
   this->weightedEvents.assign(events.begin(), events.end());
   this->eventType = WEIGHTED;
   this->order = UNSORTED;
@@ -163,7 +168,9 @@ EventList::EventList(const std::vector<WeightedEvent> &events)
 /** Constructor, taking a vector of events.
  * @param events :: Vector of WeightedEventNoTime's */
 EventList::EventList(const std::vector<WeightedEventNoTime> &events)
-    : m_histogram(HistogramData::Histogram::XMode::BinEdges), mru(nullptr) {
+    : m_histogram(HistogramData::Histogram::XMode::BinEdges,
+                  HistogramData::Histogram::YMode::Counts),
+      mru(nullptr) {
   this->weightedEventsNoTime.assign(events.begin(), events.end());
   this->eventType = WEIGHTED_NOTIME;
   this->order = UNSORTED;

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1492,16 +1492,54 @@ MantidVec *EventList::makeDataE() const {
 
 HistogramData::Histogram EventList::histogram() const {
   HistogramData::Histogram ret(m_histogram);
-  ret.setCounts(counts());
-  ret.setCountStandardDeviations(countStandardDeviations());
+  ret.setSharedY(sharedY());
+  ret.setSharedE(sharedE());
   return ret;
 }
 
-HistogramData::Counts EventList::counts() const {
+HistogramData::Counts EventList::counts() const { return histogram().counts(); }
+
+HistogramData::CountVariances EventList::countVariances() const {
+  return histogram().countVariances();
+}
+
+HistogramData::CountStandardDeviations
+EventList::countStandardDeviations() const {
+  return histogram().countStandardDeviations();
+}
+
+HistogramData::Frequencies EventList::frequencies() const {
+  return histogram().frequencies();
+}
+
+HistogramData::FrequencyVariances EventList::frequencyVariances() const {
+  return histogram().frequencyVariances();
+}
+
+HistogramData::FrequencyStandardDeviations
+EventList::frequencyStandardDeviations() const {
+  return histogram().frequencyStandardDeviations();
+}
+
+const HistogramData::HistogramY &EventList::y() const {
+  if (!mru)
+    throw std::runtime_error(
+        "'EventList::y()' called with no MRU set. This is not allowed.");
+
+  return histogram().y();
+}
+const HistogramData::HistogramE &EventList::e() const {
+  if (!mru)
+    throw std::runtime_error(
+        "'EventList::e()' called with no MRU set. This is not allowed.");
+
+  return histogram().e();
+}
+Kernel::cow_ptr<HistogramData::HistogramY> EventList::sharedY() const {
   // This is the thread number from which this function was called.
   int thread = PARALLEL_THREAD_NUMBER;
 
-  HistogramData::Counts yData;
+  Kernel::cow_ptr<HistogramData::HistogramY> yData(nullptr);
 
   // Is the data in the mrulist?
   if (mru) {
@@ -1510,23 +1548,23 @@ HistogramData::Counts EventList::counts() const {
   }
 
   if (!yData) {
-    // Create the MRU object
-    yData = HistogramData::Counts(0);
-
-    // prepare to update the uncertainties
-    auto eData = HistogramData::CountStandardDeviations(0);
-
     // see if E should be calculated;
     bool skipErrors = (eventType == TOF);
 
     // Set the Y data in it
-    this->generateHistogram(readX(), yData.mutableRawData(),
-                            eData.mutableRawData(), skipErrors);
+    MantidVec Y;
+    MantidVec E;
+    this->generateHistogram(readX(), Y, E, skipErrors);
+
+    // Create the MRU object
+    yData = Kernel::make_cow<HistogramData::HistogramY>(std::move(Y));
 
     // Lets save it in the MRU
     if (mru) {
       mru->insertY(thread, yData, this->m_specNo);
       if (!skipErrors) {
+        // prepare to update the uncertainties
+        auto eData = Kernel::make_cow<HistogramData::HistogramE>(std::move(E));
         mru->ensureEnoughBuffersE(thread);
         mru->insertE(thread, eData, this->m_specNo);
       }
@@ -1534,17 +1572,11 @@ HistogramData::Counts EventList::counts() const {
   }
   return yData;
 }
-
-HistogramData::CountVariances EventList::countVariances() const {
-  return HistogramData::CountVariances(countStandardDeviations());
-}
-
-HistogramData::CountStandardDeviations
-EventList::countStandardDeviations() const {
+Kernel::cow_ptr<HistogramData::HistogramE> EventList::sharedE() const {
   // This is the thread number from which this function was called.
   int thread = PARALLEL_THREAD_NUMBER;
 
-  HistogramData::CountStandardDeviations eData;
+  Kernel::cow_ptr<HistogramData::HistogramE> eData(nullptr);
 
   // Is the data in the mrulist?
   if (mru) {
@@ -1553,48 +1585,17 @@ EventList::countStandardDeviations() const {
   }
 
   if (!eData) {
-    eData = HistogramData::CountStandardDeviations(0);
-
     // Now use that to get E -- Y values are generated from another function
     MantidVec Y_ignored;
-    this->generateHistogram(readX(), Y_ignored, eData.mutableRawData());
+    MantidVec E;
+    this->generateHistogram(readX(), Y_ignored, E);
+    eData = Kernel::make_cow<HistogramData::HistogramE>(std::move(E));
 
     // Lets save it in the MRU
     if (mru)
       mru->insertE(thread, eData, this->m_specNo);
   }
   return eData;
-}
-HistogramData::Frequencies EventList::frequencies() const {
-  return HistogramData::Frequencies(counts(), binEdges());
-}
-HistogramData::FrequencyVariances EventList::frequencyVariances() const {
-  return HistogramData::FrequencyVariances(countVariances(), binEdges());
-}
-HistogramData::FrequencyStandardDeviations
-EventList::frequencyStandardDeviations() const {
-  return HistogramData::FrequencyStandardDeviations(countStandardDeviations(),
-                                                    binEdges());
-}
-const HistogramData::HistogramY &EventList::y() const {
-  if (!mru)
-    throw std::runtime_error(
-        "'EventList::y()' called with no MRU set. This is not allowed.");
-
-  return counts().data();
-}
-const HistogramData::HistogramE &EventList::e() const {
-  if (!mru)
-    throw std::runtime_error(
-        "'EventList::e()' called with no MRU set. This is not allowed.");
-
-  return countStandardDeviations().data();
-}
-Kernel::cow_ptr<HistogramData::HistogramY> EventList::sharedY() const {
-  return counts().cowData();
-}
-Kernel::cow_ptr<HistogramData::HistogramE> EventList::sharedE() const {
-  return countStandardDeviations().cowData();
 }
 /** Look in the MRU to see if the Y histogram has been generated before.
  * If so, return that. If not, calculate, cache and return it.
@@ -1606,9 +1607,9 @@ const MantidVec &EventList::dataY() const {
     throw std::runtime_error(
         "'EventList::dataY()' called with no MRU set. This is not allowed.");
 
-  // WARNING: counts() is stored in MRU, returning reference fine as long as it
-  // stays there.
-  return counts().rawData();
+  // WARNING: The Y data of histogram() is stored in MRU, returning reference
+  // fine as long as it stays there.
+  return histogram().dataY();
 }
 
 /** Look in the MRU to see if the E histogram has been generated before.
@@ -1621,9 +1622,9 @@ const MantidVec &EventList::dataE() const {
     throw std::runtime_error(
         "'EventList::dataE()' called with no MRU set. This is not allowed.");
 
-  // WARNING: countStandardDeviations() is stored in MRU, returning reference
+  // WARNING: The E data of histogram() is stored in MRU, returning reference
   // fine as long as it stays there.
-  return countStandardDeviations().rawData();
+  return histogram().dataE();
 }
 
 // --------------------------------------------------------------------------
@@ -4574,14 +4575,19 @@ HistogramData::Histogram &EventList::mutableHistogramRef() {
   return m_histogram;
 }
 
-void EventList::checkHistogram(
-    const HistogramData::Histogram &histogram) const {
+void EventList::checkAndSanitizeHistogram(HistogramData::Histogram &histogram) {
   if (histogram.xMode() != HistogramData::Histogram::XMode::BinEdges)
     throw std::runtime_error("EventList: setting histogram with storage mode "
                              "other than BinEdges is not possible");
   if (histogram.sharedY() || histogram.sharedE())
     throw std::runtime_error("EventList: setting histogram data with non-null "
                              "Y or E data is not possible");
+  // Avoid flushing of YMode: we only change X but YMode depends on events.
+  if (histogram.yMode() == HistogramData::Histogram::YMode::Uninitialized)
+    histogram.setYMode(m_histogram.yMode());
+  if (histogram.yMode() != m_histogram.yMode())
+    throw std::runtime_error("EventList: setting histogram data with different "
+                             "YMode is not possible");
 }
 
 void EventList::checkWorksWithPoints() const {

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1548,13 +1548,9 @@ Kernel::cow_ptr<HistogramData::HistogramY> EventList::sharedY() const {
   }
 
   if (!yData) {
-    // see if E should be calculated;
-    bool skipErrors = (eventType == TOF);
-
-    // Set the Y data in it
     MantidVec Y;
     MantidVec E;
-    this->generateHistogram(readX(), Y, E, skipErrors);
+    this->generateHistogram(readX(), Y, E);
 
     // Create the MRU object
     yData = Kernel::make_cow<HistogramData::HistogramY>(std::move(Y));
@@ -1562,12 +1558,9 @@ Kernel::cow_ptr<HistogramData::HistogramY> EventList::sharedY() const {
     // Lets save it in the MRU
     if (mru) {
       mru->insertY(thread, yData, this->m_specNo);
-      if (!skipErrors) {
-        // prepare to update the uncertainties
-        auto eData = Kernel::make_cow<HistogramData::HistogramE>(std::move(E));
-        mru->ensureEnoughBuffersE(thread);
-        mru->insertE(thread, eData, this->m_specNo);
-      }
+      auto eData = Kernel::make_cow<HistogramData::HistogramE>(std::move(E));
+      mru->ensureEnoughBuffersE(thread);
+      mru->insertE(thread, eData, this->m_specNo);
     }
   }
   return yData;

--- a/Framework/DataObjects/src/Histogram1D.cpp
+++ b/Framework/DataObjects/src/Histogram1D.cpp
@@ -5,6 +5,21 @@
 namespace Mantid {
 namespace DataObjects {
 
+/// Construct empty
+Histogram1D::Histogram1D(HistogramData::Histogram::XMode xmode,
+                         HistogramData::Histogram::YMode ymode)
+    : API::ISpectrum(), m_histogram(xmode, ymode) {
+  if (ymode == HistogramData::Histogram::YMode::Counts) {
+    m_histogram.setCounts(0);
+    m_histogram.setCountStandardDeviations(0);
+  } else if(ymode == HistogramData::Histogram::YMode::Frequencies) {
+    m_histogram.setFrequencies(0);
+    m_histogram.setFrequencyStandardDeviations(0);
+  } else {
+    throw std::logic_error("Histogram1D: YMode must be Counts or Frequencies");
+  }
+}
+
 /// Construct from ISpectrum.
 Histogram1D::Histogram1D(const ISpectrum &other)
     : ISpectrum(other), m_histogram(other.histogram()) {}

--- a/Framework/DataObjects/src/Histogram1D.cpp
+++ b/Framework/DataObjects/src/Histogram1D.cpp
@@ -12,7 +12,7 @@ Histogram1D::Histogram1D(HistogramData::Histogram::XMode xmode,
   if (ymode == HistogramData::Histogram::YMode::Counts) {
     m_histogram.setCounts(0);
     m_histogram.setCountStandardDeviations(0);
-  } else if(ymode == HistogramData::Histogram::YMode::Frequencies) {
+  } else if (ymode == HistogramData::Histogram::YMode::Frequencies) {
     m_histogram.setFrequencies(0);
     m_histogram.setFrequencyStandardDeviations(0);
   } else {

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -74,7 +74,8 @@ void Workspace2D::init(const std::size_t &NVectors, const std::size_t &XLength,
   for (size_t i = 0; i < m_noVectors; i++) {
     // Create the spectrum upon init
     auto spec =
-        new Histogram1D(HistogramData::getHistogramXMode(XLength, YLength));
+        new Histogram1D(HistogramData::getHistogramXMode(XLength, YLength),
+                        HistogramData::Histogram::YMode::Counts);
     data[i] = spec;
     // Set the data and X
     spec->setX(x);

--- a/Framework/DataObjects/test/Histogram1DTest.h
+++ b/Framework/DataObjects/test/Histogram1DTest.h
@@ -16,8 +16,8 @@ using namespace Mantid::HistogramData;
 class Histogram1DTest : public CxxTest::TestSuite {
 private:
   int nel; // Number of elements in the array
-  Histogram1D h{Histogram::XMode::Points};
-  Histogram1D h2{Histogram::XMode::Points};
+  Histogram1D h{Histogram::XMode::Points, Histogram::YMode::Counts};
+  Histogram1D h2{Histogram::XMode::Points, Histogram::YMode::Counts};
   MantidVec x1, y1, e1; // vectors
   boost::shared_ptr<HistogramY> pa;
   boost::shared_ptr<HistogramE> pb;
@@ -109,7 +109,8 @@ public:
   }
 
   void test_copy_constructor() {
-    const Histogram1D source(Histogram::XMode::Points);
+    const Histogram1D source(Histogram::XMode::Points,
+                             Histogram::YMode::Counts);
     Histogram1D clone(source);
     TS_ASSERT_EQUALS(&clone.readX(), &source.readX());
     TS_ASSERT_EQUALS(&clone.readY(), &source.readY());
@@ -117,7 +118,7 @@ public:
   }
 
   void test_move_constructor() {
-    Histogram1D source(Histogram::XMode::Points);
+    Histogram1D source(Histogram::XMode::Points, Histogram::YMode::Counts);
     auto oldX = &source.readX();
     auto oldY = &source.readY();
     auto oldE = &source.readE();
@@ -129,7 +130,7 @@ public:
   }
 
   void test_constructor_from_ISpectrum() {
-    Histogram1D resource(Histogram::XMode::Points);
+    Histogram1D resource(Histogram::XMode::Points, Histogram::YMode::Counts);
     resource.dataX() = {0.1};
     resource.dataY() = {0.2};
     resource.dataE() = {0.3};
@@ -148,8 +149,9 @@ public:
   }
 
   void test_copy_assignment() {
-    const Histogram1D source(Histogram::XMode::Points);
-    Histogram1D clone(Histogram::XMode::Points);
+    const Histogram1D source(Histogram::XMode::Points,
+                             Histogram::YMode::Counts);
+    Histogram1D clone(Histogram::XMode::Points, Histogram::YMode::Counts);
     clone = source;
     TS_ASSERT_EQUALS(&clone.readX(), &source.readX());
     TS_ASSERT_EQUALS(&clone.readY(), &source.readY());
@@ -157,11 +159,11 @@ public:
   }
 
   void test_move_assignment() {
-    Histogram1D source(Histogram::XMode::Points);
+    Histogram1D source(Histogram::XMode::Points, Histogram::YMode::Counts);
     auto oldX = &source.readX();
     auto oldY = &source.readY();
     auto oldE = &source.readE();
-    Histogram1D clone(Histogram::XMode::Points);
+    Histogram1D clone(Histogram::XMode::Points, Histogram::YMode::Counts);
     clone = std::move(source);
     TS_ASSERT(!source.ptrX());
     TS_ASSERT_EQUALS(&clone.readX(), oldX);
@@ -170,12 +172,12 @@ public:
   }
 
   void test_assign_ISpectrum() {
-    Histogram1D resource(Histogram::XMode::Points);
+    Histogram1D resource(Histogram::XMode::Points, Histogram::YMode::Counts);
     resource.dataX() = {0.1};
     resource.dataY() = {0.2};
     resource.dataE() = {0.3};
     const Mantid::API::ISpectrum &source = resource;
-    Histogram1D clone(Histogram::XMode::Points);
+    Histogram1D clone(Histogram::XMode::Points, Histogram::YMode::Counts);
     clone = source;
     // X is shared...
     TS_ASSERT_EQUALS(&clone.readX(), &source.readX());

--- a/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
@@ -182,6 +182,11 @@ public:
     return m_dx->rawData();
   }
 
+  // TODO This is a temporary helper function for refactoring, must be removed!
+  void setYMode(YMode ymode) { m_yMode = ymode; }
+  void convertToCounts();
+  void convertToFrequencies();
+
 private:
   template <class TX> void initX(const TX &x);
   template <class TY> void initY(const TY &y);

--- a/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
@@ -247,7 +247,10 @@ template <class TE> void Histogram::initE(const TE &e) {
                              "histogram without data");
     setUncertainties(e);
   } else if (m_y) {
-    setCountVariances(m_y->rawData());
+    if (yMode() == YMode::Counts)
+      setCountVariances(m_y->rawData());
+    if (yMode() == YMode::Frequencies)
+      setFrequencyVariances(m_y->rawData());
   }
 }
 

--- a/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
@@ -394,11 +394,8 @@ template <typename... T> void Histogram::setFrequencies(T &&... data) & {
   checkAndSetYModeFrequencies();
   Frequencies frequencies(std::forward<T>(data)...);
   checkSize(frequencies);
-  // No sensible self assignment is possible, we do not store frequencies, so if
-  // anyone tries to set our current data as frequencies it must be an error.
   if (selfAssignmentY(data...))
-    throw std::logic_error("Histogram::setFrequencies: Attempt to self-assign "
-                           "counts as frequencies.");
+    return;
   m_y = Counts(frequencies, binEdges()).cowData();
 }
 
@@ -407,11 +404,8 @@ template <typename... T> void Histogram::setFrequencyVariances(T &&... data) & {
   checkAndSetYModeFrequencies();
   FrequencyVariances frequencies(std::forward<T>(data)...);
   checkSize(frequencies);
-  // No sensible self assignment is possible, we do not store frequencies, so if
-  // anyone tries to set our current data as frequencies it must be an error.
   if (selfAssignmentE(data...))
-    throw std::logic_error("Histogram::setFrequencyVariances: Attempt to "
-                           "self-assign counts as frequencies.");
+    return;
   m_e = CountStandardDeviations(frequencies, binEdges()).cowData();
 }
 
@@ -421,11 +415,8 @@ void Histogram::setFrequencyStandardDeviations(T &&... data) & {
   checkAndSetYModeFrequencies();
   FrequencyStandardDeviations frequencies(std::forward<T>(data)...);
   checkSize(frequencies);
-  // No sensible self assignment is possible, we do not store frequencies, so if
-  // anyone tries to set our current data as frequencies it must be an error.
   if (selfAssignmentE(data...))
-    throw std::logic_error("Histogram::setFrequencyVariances: Attempt to "
-                           "self-assign counts as frequencies.");
+    return;
   m_e = CountStandardDeviations(frequencies, binEdges()).cowData();
 }
 

--- a/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
@@ -76,9 +76,11 @@ private:
 
 public:
   enum class XMode { BinEdges, Points };
-  /// Construct with given storage mode for X data (BinEdges or Points).
-  explicit Histogram(XMode mode)
-      : m_x(Kernel::make_cow<HistogramX>(0)), m_xMode(mode) {}
+  enum class YMode { Uninitialized, Counts, Frequencies };
+  /// Construct with given storage mode for X data (BinEdges or Points) and Y
+  /// data (Counts or Frequencies).
+  explicit Histogram(XMode xmode, YMode ymode)
+      : m_x(Kernel::make_cow<HistogramX>(0)), m_xMode(xmode), m_yMode(ymode) {}
 
   template <class TX, class TY = Counts, class TE = CountVariances>
   explicit Histogram(const TX &x, const TY &y = Counts(),
@@ -93,6 +95,9 @@ public:
 
   /// Returns the storage mode of the X data (BinEdges or Points).
   XMode xMode() const noexcept { return m_xMode; }
+
+  /// Returns the storage mode of the Y data (Counts or Frequencies).
+  YMode yMode() const noexcept { return m_yMode; }
 
   BinEdges binEdges() const;
   BinEdgeVariances binEdgeVariances() const;
@@ -183,6 +188,8 @@ private:
   template <class TE> void initE(const TE &e);
   template <class TY> void setValues(const TY &y);
   template <class TE> void setUncertainties(const TE &e);
+  void checkAndSetYModeCounts();
+  void checkAndSetYModeFrequencies();
   template <class T> void checkSize(const T &data) const;
   template <class... T> bool selfAssignmentX(const T &...) { return false; }
   template <class... T> bool selfAssignmentDx(const T &...) { return false; }
@@ -192,6 +199,7 @@ private:
   void switchDxToPoints();
 
   XMode m_xMode;
+  YMode m_yMode{YMode::Uninitialized};
 };
 
 template <> MANTID_HISTOGRAMDATA_DLL void Histogram::initX(const Points &x);
@@ -344,6 +352,7 @@ void Histogram::setPointStandardDeviations(T &&... data) & {
  however, a size check ensures that the Histogram stays valid, i.e., that x and
  y lengths are consistent. */
 template <typename... T> void Histogram::setCounts(T &&... data) & {
+  checkAndSetYModeCounts();
   Counts counts(std::forward<T>(data)...);
   checkSize(counts);
   if (selfAssignmentY(data...))
@@ -353,6 +362,7 @@ template <typename... T> void Histogram::setCounts(T &&... data) & {
 
 /// Sets the Histogram's count variances.
 template <typename... T> void Histogram::setCountVariances(T &&... data) & {
+  checkAndSetYModeCounts();
   CountVariances counts(std::forward<T>(data)...);
   checkSize(counts);
   // No sensible self assignment is possible, we do not store variances, so if
@@ -367,6 +377,7 @@ template <typename... T> void Histogram::setCountVariances(T &&... data) & {
 /// Sets the Histogram's count standard deviations.
 template <typename... T>
 void Histogram::setCountStandardDeviations(T &&... data) & {
+  checkAndSetYModeCounts();
   CountStandardDeviations counts(std::forward<T>(data)...);
   checkSize(counts);
   if (selfAssignmentE(data...))
@@ -380,6 +391,7 @@ void Histogram::setCountStandardDeviations(T &&... data) & {
  allowed, however, a size check ensures that the Histogram stays valid, i.e.,
  that x and y lengths are consistent. */
 template <typename... T> void Histogram::setFrequencies(T &&... data) & {
+  checkAndSetYModeFrequencies();
   Frequencies frequencies(std::forward<T>(data)...);
   checkSize(frequencies);
   // No sensible self assignment is possible, we do not store frequencies, so if
@@ -392,6 +404,7 @@ template <typename... T> void Histogram::setFrequencies(T &&... data) & {
 
 /// Sets the Histogram's frequency variances.
 template <typename... T> void Histogram::setFrequencyVariances(T &&... data) & {
+  checkAndSetYModeFrequencies();
   FrequencyVariances frequencies(std::forward<T>(data)...);
   checkSize(frequencies);
   // No sensible self assignment is possible, we do not store frequencies, so if
@@ -405,6 +418,7 @@ template <typename... T> void Histogram::setFrequencyVariances(T &&... data) & {
 /// Sets the Histogram's frequency standard deviations.
 template <typename... T>
 void Histogram::setFrequencyStandardDeviations(T &&... data) & {
+  checkAndSetYModeFrequencies();
   FrequencyStandardDeviations frequencies(std::forward<T>(data)...);
   checkSize(frequencies);
   // No sensible self assignment is possible, we do not store frequencies, so if

--- a/Framework/HistogramData/src/Histogram.cpp
+++ b/Framework/HistogramData/src/Histogram.cpp
@@ -79,8 +79,9 @@ PointStandardDeviations Histogram::pointStandardDeviations() const {
 
 /** Returns the counts of the Histogram.
 
-  The returned Counts's internal pointer references the same data as the
-  Histogram, i.e., there is little overhead. */
+  If the histogram stores frequencies, the counts are computed based on them.
+  Otherwise the returned Counts's internal pointer references the same data as
+  the Histogram, i.e., there is little overhead. */
 Counts Histogram::counts() const {
   if (yMode() == YMode::Counts)
     return Counts(m_y);
@@ -98,9 +99,10 @@ CountVariances Histogram::countVariances() const {
 
 /** Returns the standard deviations of the counts of the Histogram.
 
-  The returned CountStandardDeviations's internal pointer references the same
-  data as the uncertainties stored in the Histogram, i.e., there is little
-  overhead. */
+  If the histogram stores frequencies, the CountStandardDeviations are computed
+  based on the standard deviations of the frequencies. Otherwise the returned
+  CountStandardDeviations's internal pointer references the same data as the
+  Histogram, i.e., there is little overhead. */
 CountStandardDeviations Histogram::countStandardDeviations() const {
   if (yMode() == YMode::Counts)
     return CountStandardDeviations(m_e);
@@ -112,8 +114,9 @@ CountStandardDeviations Histogram::countStandardDeviations() const {
 /** Returns the frequencies of the Histogram, i.e., the counts divided by the
   bin widths.
 
-  The frequencies are computed on the fly from other data stored in the
-  Histogram, i.e., this method comes with an overhead. */
+  If the histogram stores counts, the frequencies are computed based on them.
+  Otherwise the returned Frequencies's internal pointer references the same data
+  as the Histogram, i.e., there is little overhead. */
 Frequencies Histogram::frequencies() const {
   if (yMode() == YMode::Counts)
     return Frequencies(Counts(m_y), binEdges());
@@ -131,8 +134,10 @@ FrequencyVariances Histogram::frequencyVariances() const {
 
 /** Returns the standard deviations of the frequencies of the Histogram.
 
-  The standard deviations are computed on the fly from other data stored in the
-  Histogram, i.e., this method comes with an overhead. */
+  If the histogram stores counts, the FrequencyStandardDeviations are computed
+  based on the standard deviations of the counts. Otherwise the returned
+  FrequencyStandardDeviations's internal pointer references the same data as the
+  Histogram, i.e., there is little overhead. */
 FrequencyStandardDeviations Histogram::frequencyStandardDeviations() const {
   if (yMode() == YMode::Counts)
     return FrequencyStandardDeviations(CountStandardDeviations(m_e),
@@ -145,8 +150,6 @@ FrequencyStandardDeviations Histogram::frequencyStandardDeviations() const {
 
   Throws if the size does not match the current size. */
 void Histogram::setSharedX(const Kernel::cow_ptr<HistogramX> &x) & {
-  // TODO Check size only if we have y-data.
-  // TODO but if size changes, also need to invalidate m_dx!
   if (m_x->size() != x->size())
     throw std::logic_error("Histogram::setSharedX: size mismatch\n");
   m_x = x;
@@ -182,6 +185,7 @@ void Histogram::setSharedDx(const Kernel::cow_ptr<HistogramDx> &Dx) & {
   m_dx = Dx;
 }
 
+/// Converts the histogram storage mode into YMode::Counts
 void Histogram::convertToCounts() {
   if (yMode() == YMode::Counts)
     return;
@@ -196,6 +200,7 @@ void Histogram::convertToCounts() {
   m_yMode = YMode::Counts;
 }
 
+/// Converts the histogram storage mode into YMode::Frequencies
 void Histogram::convertToFrequencies() {
   if (yMode() == YMode::Frequencies)
     return;

--- a/Framework/HistogramData/src/Histogram.cpp
+++ b/Framework/HistogramData/src/Histogram.cpp
@@ -182,6 +182,34 @@ void Histogram::setSharedDx(const Kernel::cow_ptr<HistogramDx> &Dx) & {
   m_dx = Dx;
 }
 
+void Histogram::convertToCounts() {
+  if (yMode() == YMode::Counts)
+    return;
+  const auto &X = x();
+  auto &Y = mutableY();
+  auto &E = mutableE();
+  for (size_t i = 0; i < Y.size(); ++i) {
+    double width = X[i + 1] - X[i];
+    Y[i] *= width;
+    E[i] *= width;
+  }
+  m_yMode = YMode::Counts;
+}
+
+void Histogram::convertToFrequencies() {
+  if (yMode() == YMode::Frequencies)
+    return;
+  const auto &X = x();
+  auto &Y = mutableY();
+  auto &E = mutableE();
+  for (size_t i = 0; i < Y.size(); ++i) {
+    double width = X[i + 1] - X[i];
+    Y[i] /= width;
+    E[i] /= width;
+  }
+  m_yMode = YMode::Frequencies;
+}
+
 template <> void Histogram::initX(const Points &x) {
   m_xMode = XMode::Points;
   m_x = x.cowData();

--- a/Framework/HistogramData/src/Histogram.cpp
+++ b/Framework/HistogramData/src/Histogram.cpp
@@ -83,7 +83,7 @@ PointStandardDeviations Histogram::pointStandardDeviations() const {
   Otherwise the returned Counts's internal pointer references the same data as
   the Histogram, i.e., there is little overhead. */
 Counts Histogram::counts() const {
-  if (yMode() == YMode::Counts)
+  if (yMode() != YMode::Frequencies)
     return Counts(m_y);
   else
     return Counts(Frequencies(m_y), binEdges());
@@ -104,7 +104,7 @@ CountVariances Histogram::countVariances() const {
   CountStandardDeviations's internal pointer references the same data as the
   Histogram, i.e., there is little overhead. */
 CountStandardDeviations Histogram::countStandardDeviations() const {
-  if (yMode() == YMode::Counts)
+  if (yMode() != YMode::Frequencies)
     return CountStandardDeviations(m_e);
   else
     return CountStandardDeviations(FrequencyStandardDeviations(m_e),

--- a/Framework/HistogramData/test/HistogramTest.h
+++ b/Framework/HistogramData/test/HistogramTest.h
@@ -27,11 +27,13 @@ public:
   static void destroySuite(HistogramTest *suite) { delete suite; }
 
   void test_construction_Points() {
-    TS_ASSERT_THROWS_NOTHING(Histogram hist(Histogram::XMode::Points));
+    TS_ASSERT_THROWS_NOTHING(
+        Histogram hist(Histogram::XMode::Points, Histogram::YMode::Counts));
   }
 
   void test_construction_BinEdges() {
-    TS_ASSERT_THROWS_NOTHING(Histogram hist(Histogram::XMode::BinEdges));
+    TS_ASSERT_THROWS_NOTHING(
+        Histogram hist(Histogram::XMode::BinEdges, Histogram::YMode::Counts));
   }
 
   void test_construct_from_Points() {
@@ -112,7 +114,7 @@ public:
 
   void test_copy_assignment() {
     Histogram src(Points{0.1, 0.2, 0.4});
-    Histogram dest(Histogram::XMode::BinEdges);
+    Histogram dest(Histogram::XMode::BinEdges, Histogram::YMode::Counts);
     TS_ASSERT_EQUALS(dest.xMode(), Histogram::XMode::BinEdges);
     dest = src;
     TS_ASSERT(src.points());
@@ -127,7 +129,7 @@ public:
 
   void test_move_assignment() {
     Histogram src(Points{0.1, 0.2, 0.4});
-    Histogram dest(Histogram::XMode::BinEdges);
+    Histogram dest(Histogram::XMode::BinEdges, Histogram::YMode::Counts);
     TS_ASSERT_EQUALS(dest.xMode(), Histogram::XMode::BinEdges);
     dest = std::move(src);
     TS_ASSERT(!src.points());
@@ -136,9 +138,9 @@ public:
   }
 
   void test_xMode() {
-    Histogram hist1(Histogram::XMode::Points);
+    Histogram hist1(Histogram::XMode::Points, Histogram::YMode::Counts);
     TS_ASSERT_EQUALS(hist1.xMode(), Histogram::XMode::Points);
-    Histogram hist2(Histogram::XMode::BinEdges);
+    Histogram hist2(Histogram::XMode::BinEdges, Histogram::YMode::Counts);
     TS_ASSERT_EQUALS(hist2.xMode(), Histogram::XMode::BinEdges);
   }
 

--- a/Framework/HistogramData/test/HistogramTest.h
+++ b/Framework/HistogramData/test/HistogramTest.h
@@ -576,16 +576,18 @@ public:
     Histogram h(Points(0));
     h.setFrequencies(0);
     auto &y = h.y();
-    h.setCounts(y);
-    // y is always counts, setting it as frequencies must fail.
-    TS_ASSERT_THROWS(h.setFrequencies(y), std::logic_error);
+    auto old_address = &y;
+    h.setFrequencies(y);
+    TS_ASSERT_EQUALS(&h.y(), old_address);
   }
 
   void test_setFrequencies_legacy_self_assignment() {
     Histogram h(Points(0));
-    h.setCounts(0);
+    h.setFrequencies(0);
     auto &y = h.readY();
-    TS_ASSERT_THROWS(h.setFrequencies(y), std::logic_error);
+    auto old_address = &y;
+    h.setFrequencies(y);
+    TS_ASSERT_EQUALS(&h.readY(), old_address);
   }
 
   void test_setCountVariances() {

--- a/Framework/HistogramData/test/HistogramTest.h
+++ b/Framework/HistogramData/test/HistogramTest.h
@@ -26,14 +26,24 @@ public:
   static HistogramTest *createSuite() { return new HistogramTest(); }
   static void destroySuite(HistogramTest *suite) { delete suite; }
 
-  void test_construction_Points() {
+  void test_construction_Points_Counts() {
     TS_ASSERT_THROWS_NOTHING(
         Histogram hist(Histogram::XMode::Points, Histogram::YMode::Counts));
   }
 
-  void test_construction_BinEdges() {
+  void test_construction_BinEdges_Counts() {
     TS_ASSERT_THROWS_NOTHING(
         Histogram hist(Histogram::XMode::BinEdges, Histogram::YMode::Counts));
+  }
+
+  void test_construction_Points_Frequencies() {
+    TS_ASSERT_THROWS_NOTHING(Histogram hist(Histogram::XMode::Points,
+                                            Histogram::YMode::Frequencies));
+  }
+
+  void test_construction_BinEdges_Frequencies() {
+    TS_ASSERT_THROWS_NOTHING(Histogram hist(Histogram::XMode::BinEdges,
+                                            Histogram::YMode::Frequencies));
   }
 
   void test_construct_from_Points() {
@@ -840,6 +850,72 @@ public:
     Histogram hist{BinEdges(0)};
     hist.setCountStandardDeviations(data1);
     TS_ASSERT_THROWS(hist.setSharedE(data2), std::logic_error);
+  }
+
+  void test_yMode() {
+    Histogram hist1(Histogram::XMode::Points, Histogram::YMode::Counts);
+    TS_ASSERT_EQUALS(hist1.yMode(), Histogram::YMode::Counts);
+    Histogram hist2(Histogram::XMode::Points, Histogram::YMode::Frequencies);
+    TS_ASSERT_EQUALS(hist2.yMode(), Histogram::YMode::Frequencies);
+  }
+
+  void test_yMode_Uninitialized() {
+    Histogram hist(Points(1));
+    TS_ASSERT_EQUALS(hist.yMode(), Histogram::YMode::Uninitialized);
+  }
+
+  void test_yMode_initialized_by_setCounts() {
+    Histogram h(Points(2));
+    h.setCounts(2);
+    TS_ASSERT_EQUALS(h.yMode(), Histogram::YMode::Counts);
+  }
+
+  void test_yMode_initialized_by_setCountStandardDeviations() {
+    Histogram h(Points(2));
+    h.setCountStandardDeviations(2);
+    TS_ASSERT_EQUALS(h.yMode(), Histogram::YMode::Counts);
+  }
+
+  void test_yMode_initialized_by_setCountVariances() {
+    Histogram h(Points(2));
+    h.setCountVariances(2);
+    TS_ASSERT_EQUALS(h.yMode(), Histogram::YMode::Counts);
+  }
+
+  void test_yMode_initialized_by_setFrequencies() {
+    Histogram h(Points(2));
+    h.setFrequencies(2);
+    TS_ASSERT_EQUALS(h.yMode(), Histogram::YMode::Frequencies);
+  }
+
+  void test_yMode_initialized_by_setFrequencyStandardDeviations() {
+    Histogram h(Points(2));
+    h.setFrequencyStandardDeviations(2);
+    TS_ASSERT_EQUALS(h.yMode(), Histogram::YMode::Frequencies);
+  }
+
+  void test_yMode_initialized_by_setFrequencyVariances() {
+    Histogram h(Points(2));
+    h.setFrequencyVariances(2);
+    TS_ASSERT_EQUALS(h.yMode(), Histogram::YMode::Frequencies);
+  }
+
+  void test_yMode_cannot_be_changed_by_setters() {
+    Histogram countHist(Points(1), Counts(1));
+    TS_ASSERT_THROWS(countHist.setFrequencies(1), std::logic_error);
+    TS_ASSERT_THROWS(countHist.setFrequencyVariances(1), std::logic_error);
+    TS_ASSERT_THROWS(countHist.setFrequencyStandardDeviations(1),
+                     std::logic_error);
+    Histogram freqHist(Points(1), Frequencies(1));
+    TS_ASSERT_THROWS(freqHist.setCounts(1), std::logic_error);
+    TS_ASSERT_THROWS(freqHist.setCountVariances(1), std::logic_error);
+    TS_ASSERT_THROWS(freqHist.setCountStandardDeviations(1), std::logic_error);
+  }
+
+  void test_setSharedY_fails_for_YMode_Uninitialized() {
+    Histogram hist(Points(1));
+    Counts counts(1);
+    TS_ASSERT_THROWS(hist.setSharedY(counts.cowData()), std::logic_error);
   }
 };
 

--- a/Framework/HistogramData/test/HistogramTest.h
+++ b/Framework/HistogramData/test/HistogramTest.h
@@ -900,16 +900,18 @@ public:
     TS_ASSERT_EQUALS(h.yMode(), Histogram::YMode::Frequencies);
   }
 
-  void test_yMode_cannot_be_changed_by_setters() {
-    Histogram countHist(Points(1), Counts(1));
-    TS_ASSERT_THROWS(countHist.setFrequencies(1), std::logic_error);
-    TS_ASSERT_THROWS(countHist.setFrequencyVariances(1), std::logic_error);
-    TS_ASSERT_THROWS(countHist.setFrequencyStandardDeviations(1),
-                     std::logic_error);
-    Histogram freqHist(Points(1), Frequencies(1));
-    TS_ASSERT_THROWS(freqHist.setCounts(1), std::logic_error);
-    TS_ASSERT_THROWS(freqHist.setCountVariances(1), std::logic_error);
-    TS_ASSERT_THROWS(freqHist.setCountStandardDeviations(1), std::logic_error);
+  void test_yMode_cannot_be_changed_by_Count_setters() {
+    Histogram h(Points(1), Counts(1));
+    TS_ASSERT_THROWS(h.setFrequencies(1), std::logic_error);
+    TS_ASSERT_THROWS(h.setFrequencyVariances(1), std::logic_error);
+    TS_ASSERT_THROWS(h.setFrequencyStandardDeviations(1), std::logic_error);
+  }
+
+  void test_yMode_cannot_be_changed_by_Frequency_setters() {
+    Histogram h(Points(1), Frequencies(1));
+    TS_ASSERT_THROWS(h.setCounts(1), std::logic_error);
+    TS_ASSERT_THROWS(h.setCountVariances(1), std::logic_error);
+    TS_ASSERT_THROWS(h.setCountStandardDeviations(1), std::logic_error);
   }
 
   void test_setSharedY_fails_for_YMode_Uninitialized() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -232,10 +232,9 @@ void export_MatrixWorkspace() {
            "Get a pointer to a workspace axis")
       .def("isHistogramData", &MatrixWorkspace::isHistogramData, arg("self"),
            "Returns True if this is considered to be binned data.")
-      .def("isDistribution", (const bool &(MatrixWorkspace::*)() const) &
+      .def("isDistribution", (bool (MatrixWorkspace::*)() const) &
                                  MatrixWorkspace::isDistribution,
-           arg("self"), return_value_policy<copy_const_reference>(),
-           "Returns the status of the distribution flag")
+           arg("self"), "Returns the status of the distribution flag")
       .def("YUnit", &MatrixWorkspace::YUnit, arg("self"),
            "Returns the current Y unit for the data (Y axis) in the workspace")
       .def("YUnitLabel", &MatrixWorkspace::YUnitLabel, arg("self"),

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -40,13 +40,15 @@ using namespace Mantid;
 /** Helper class that implements ISpectrum */
 class SpectrumTester : public ISpectrum {
 public:
-  SpectrumTester(HistogramData::Histogram::XMode mode)
-      : ISpectrum(), m_histogram(mode) {
+  SpectrumTester(HistogramData::Histogram::XMode xmode,
+                 HistogramData::Histogram::YMode ymode)
+      : ISpectrum(), m_histogram(xmode, ymode) {
     m_histogram.setCounts(0);
     m_histogram.setCountStandardDeviations(0);
   }
-  SpectrumTester(const specnum_t specNo, HistogramData::Histogram::XMode mode)
-      : ISpectrum(specNo), m_histogram(mode) {
+  SpectrumTester(const specnum_t specNo, HistogramData::Histogram::XMode xmode,
+                 HistogramData::Histogram::YMode ymode)
+      : ISpectrum(specNo), m_histogram(xmode, ymode) {
     m_histogram.setCounts(0);
     m_histogram.setCountStandardDeviations(0);
   }
@@ -109,7 +111,8 @@ public:
   const std::string id() const override { return "WorkspaceTester"; }
   void init(const size_t &numspec, const size_t &j, const size_t &k) override {
     spec = numspec;
-    vec.resize(spec, HistogramData::getHistogramXMode(j, k));
+    vec.resize(spec, SpectrumTester(HistogramData::getHistogramXMode(j, k),
+                                    HistogramData::Histogram::YMode::Counts));
     for (size_t i = 0; i < spec; i++) {
       vec[i].dataX().resize(j, 1.0);
       vec[i].dataY().resize(k, 1.0);


### PR DESCRIPTION
See https://github.com/mantidproject/mantid/issues/16902 for a description.

This PR implements the storage mode for Y in histogram. `MatriWorkspace::isDistribution` is now based on the storage mode of the first spectrum (all spectra must have the same storage mode, and this is the case in current Mantid code).

In this PR no fundamental functionality has been changed. As a next step, https://github.com/mantidproject/mantid/issues/16913 will deal with cleaning up the storage mode mechanism.

**To test:**

Code review.

Fixes #16902 .

Internal change, no release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
