### PR TITLE
Add two simple logging statements to filefinder

### DIFF
--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -125,6 +125,7 @@ std::string FileFinderImpl::getFullPath(const std::string &filename,
   const std::vector<std::string> &searchPaths =
       Kernel::ConfigService::Instance().getDataSearchDirs();
   for (const auto &searchPath : searchPaths) {
+    g_log.debug() << "Searching for " << fName << " in " << searchPath << "\n";
 // On windows globbing is note working properly with network drives
 // for example a network drive containing a $
 // For this reason, and since windows is case insensitive anyway
@@ -683,6 +684,7 @@ FileFinderImpl::getArchivePath(const std::vector<IArchiveSearch_sptr> &archs,
   std::string path;
   for (const auto &arch : archs) {
     try {
+      g_log.debug() << "Getting archive path for requested files\n";
       path = arch->getArchivePath(filenames, exts);
       if (!path.empty()) {
         return path;


### PR DESCRIPTION
Improve logging when searching for files

**To test:**
1. Turn the log down to debug
   1, In the load dialog (or any other that loads files), select some files that exists and some that don't.
2. look at the debug messages you should get messages like this:

``` text
Searching for filename000.raw in c:\path\that\is\being\searched
```

Fixes #16917 

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

re #16917
