### PR TITLE
ResampleX bugfix

### DIFF
--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -346,9 +346,8 @@ void ResampleX::exec() {
         for (int wkspIndex = 0; wkspIndex < numSpectra; ++wkspIndex) {
           PARALLEL_START_INTERUPT_REGION
           BinEdges xValues(0);
-          double delta = this->determineBinning(xValues.mutableRawData(),
-                                                xmins[wkspIndex],
-                                                xmaxs[wkspIndex]);
+          double delta = this->determineBinning(
+              xValues.mutableRawData(), xmins[wkspIndex], xmaxs[wkspIndex]);
           g_log.debug() << "delta[wkspindex=" << wkspIndex << "] = " << delta
                         << " xmin=" << xmins[wkspIndex]
                         << " xmax=" << xmaxs[wkspIndex] << "\n";

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -15,6 +15,7 @@ namespace Algorithms {
 using namespace API;
 using namespace DataObjects;
 using namespace Kernel;
+using HistogramData::BinEdges;
 using std::map;
 using std::pair;
 using std::string;
@@ -331,7 +332,7 @@ void ResampleX::exec() {
 
       if (common_limits) {
         // get the delta from the first since they are all the same
-        HistogramData::BinEdges xValues(0);
+        BinEdges xValues(0);
         double delta = this->determineBinning(xValues.mutableRawData(),
                                               xmins[0], xmaxs[0]);
         g_log.debug() << "delta = " << delta << "\n";
@@ -344,13 +345,14 @@ void ResampleX::exec() {
         PARALLEL_FOR2(inputEventWS, outputWS)
         for (int wkspIndex = 0; wkspIndex < numSpectra; ++wkspIndex) {
           PARALLEL_START_INTERUPT_REGION
-          MantidVec xValues;
-          double delta = this->determineBinning(xValues, xmins[wkspIndex],
+          BinEdges xValues(0);
+          double delta = this->determineBinning(xValues.mutableRawData(),
+                                                xmins[wkspIndex],
                                                 xmaxs[wkspIndex]);
           g_log.debug() << "delta[wkspindex=" << wkspIndex << "] = " << delta
                         << " xmin=" << xmins[wkspIndex]
                         << " xmax=" << xmaxs[wkspIndex] << "\n";
-          outputEventWS->setBinEdges(wkspIndex, xValues);
+          outputEventWS->setHistogram(wkspIndex, xValues);
           prog.report(name()); // Report progress
           PARALLEL_END_INTERUPT_REGION
         }


### PR DESCRIPTION
NOMAD's autoreduction is failing and needs to be working again. The issue was tracked down to the particular way that `ResampleX` was being used.

**To test:**

The following script (using `DocTest` data) exposes the bug. Make sure that it works now.

``` python
LoadEventNexus(Filename='PG3_4871', OutputWorkspace='PG3_4871')
ConvertUnits(InputWorkspace='PG3_4871',OutputWorkspace='PG3_4871',
             Target='dSpacing', EMode='Elastic')
ResampleX(InputWorkspace='PG3_4871',OutputWorkspace='PG3_4871',
          NumberBins=6000)
```

_There is no associated issue_

_Does not need to be in the release notes_ because it was not a bug in a release version.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
