### PR TITLE
Indirect Reduction ISIS Calibration - add load log option

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
@@ -1,7 +1,8 @@
 #pylint: disable=no-init,too-many-instance-attributes
 from mantid.kernel import *
-from mantid.api import *
 from mantid.simpleapi import *
+from mantid.api import *
+
 
 import os.path
 
@@ -46,9 +47,9 @@ class IndirectCalibration(DataProcessorAlgorithm):
 
         self.declareProperty(name='ScaleFactor', defaultValue=1.0,
                              doc='Factor by which to scale the result.')
-                             
+
         self.declareProperty(name='LoadLogFiles', defaultValue=False,
-                             doc = 'Option to load log files.' ) 
+                             doc = 'Option to load log files.' )
 
         self.declareProperty(WorkspaceProperty('OutputWorkspace', '',
                                                direction=Direction.Output),

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
@@ -46,6 +46,9 @@ class IndirectCalibration(DataProcessorAlgorithm):
 
         self.declareProperty(name='ScaleFactor', defaultValue=1.0,
                              doc='Factor by which to scale the result.')
+                             
+        self.declareProperty(name='LoadLogFiles', defaultValue=False,
+                             doc = 'Option to load log files.' ) 
 
         self.declareProperty(WorkspaceProperty('OutputWorkspace', '',
                                                direction=Direction.Output),
@@ -99,7 +102,7 @@ class IndirectCalibration(DataProcessorAlgorithm):
                      OutputWorkspace=root,
                      SpectrumMin=int(self._spec_range[0]),
                      SpectrumMax=int(self._spec_range[1]),
-                     LoadLogFiles=False)
+                     LoadLogFiles=self.getProperty('LoadLogFiles').value)
 
                 runs.append(root)
                 self._run_numbers.append(get_run_number(root))

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
@@ -50,6 +50,9 @@ class IndirectResolution(DataProcessorAlgorithm):
                              doc='Rebinning parameters (min,width,max)')
         self.declareProperty(name='ScaleFactor', defaultValue=1.0,
                              doc='Factor to scale resolution curve by')
+                             
+        self.declareProperty(name = "LoadLogFiles", defaultValue=True, 
+                             doc='Option to load log files')
 
         self.declareProperty(WorkspaceProperty('OutputWorkspace', '',
                                                direction=Direction.Output),
@@ -68,6 +71,7 @@ class IndirectResolution(DataProcessorAlgorithm):
         iet_alg.setProperty('SumFiles', True)
         iet_alg.setProperty('InputFiles', self._input_files)
         iet_alg.setProperty('SpectraRange', self._detector_range)
+        iet_alg.setProperty('LoadLogFiles', self._load_logs)
         iet_alg.execute()
 
         group_ws = iet_alg.getProperty('OutputWorkspace').value
@@ -115,7 +119,7 @@ class IndirectResolution(DataProcessorAlgorithm):
         self._background = self.getProperty('BackgroundRange').value
         self._rebin_string = self.getProperty('RebinParam').value
         self._scale_factor = self.getProperty('ScaleFactor').value
-
+        self._load_logs = self.getProperty('LoadLogFiles').value
 
     def _post_process(self):
         """

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
@@ -16,7 +16,7 @@ class IndirectResolution(DataProcessorAlgorithm):
     _background = None
     _rebin_string = None
     _scale_factor = None
-
+    _load_logs = None
 
     def category(self):
         return 'Workflow\\Inelastic;Inelastic\\Indirect'
@@ -50,8 +50,8 @@ class IndirectResolution(DataProcessorAlgorithm):
                              doc='Rebinning parameters (min,width,max)')
         self.declareProperty(name='ScaleFactor', defaultValue=1.0,
                              doc='Factor to scale resolution curve by')
-                             
-        self.declareProperty(name = "LoadLogFiles", defaultValue=True, 
+
+        self.declareProperty(name = "LoadLogFiles", defaultValue=True,
                              doc='Option to load log files')
 
         self.declareProperty(WorkspaceProperty('OutputWorkspace', '',

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IndirectCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IndirectCalibrationTest.py
@@ -26,7 +26,8 @@ class IndirectCalibrationTest(unittest.TestCase):
 
         self.assertEqual(cal_ws.getNumberHistograms(), 51)
         self.assertEqual(cal_ws.blocksize(), 1)
+        
         self.assertEqual(cal_ws.run().getProperty('current_period').value, 1)
-
+        
 if __name__ == "__main__":
 	unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IndirectCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IndirectCalibrationTest.py
@@ -26,7 +26,7 @@ class IndirectCalibrationTest(unittest.TestCase):
 
         self.assertEqual(cal_ws.getNumberHistograms(), 51)
         self.assertEqual(cal_ws.blocksize(), 1)
-        self.assertEqual(cal_ws.run().getProperty('SampleLogs'))
+        self.assertEqual(cal_ws.run().getProperty('current_period'), 1)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IndirectCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IndirectCalibrationTest.py
@@ -16,6 +16,17 @@ class IndirectCalibrationTest(unittest.TestCase):
         self.assertEqual(cal_ws.getNumberHistograms(), 51)
         self.assertEqual(cal_ws.blocksize(), 1)
 
+    
+    def test_logs(self):
+        cal_ws = IndirectCalibration(InputFiles='IRS38633.raw',
+                                            DetectorRange=[3,53],
+                                            PeakRange=[62000,65000],
+                                            BackgroundRange=[59000,61000],
+                                            LoadLogFiles=True)
+
+        self.assertEqual(cal_ws.getNumberHistograms(), 51)
+        self.assertEqual(cal_ws.blocksize(), 1)
+        self.assertEqual(cal_ws.run().getProperty('SampleLogs'))
 
 if __name__ == "__main__":
 	unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IndirectCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IndirectCalibrationTest.py
@@ -26,7 +26,7 @@ class IndirectCalibrationTest(unittest.TestCase):
 
         self.assertEqual(cal_ws.getNumberHistograms(), 51)
         self.assertEqual(cal_ws.blocksize(), 1)
-        self.assertEqual(cal_ws.run().getProperty('current_period'), 1)
+        self.assertEqual(cal_ws.run().getProperty('current_period').value, 1)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISCalibration.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISCalibration.ui
@@ -98,7 +98,7 @@
                <string>Load Log Files</string>
              </property>
              <property name="checked">
-               <bool>true</bool>
+               <bool>false</bool>
              </property>
            </widget>
          </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISCalibration.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISCalibration.ui
@@ -92,7 +92,17 @@
           </property>
          </widget>
         </item>
-        <item>
+         <item>
+           <widget class="QCheckBox" name="ckLoadLogFiles">
+             <property name="text">
+               <string>Load Log Files</string>
+             </property>
+             <property name="checked">
+               <bool>true</bool>
+             </property>
+           </widget>
+         </item>
+         <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -242,8 +242,6 @@ void ISISCalibration::run() {
   if (save)
     addSaveWorkspaceToQueue(m_outputCalibrationName);
 
-
-
   // Configure the resolution algorithm
   if (m_uiForm.ckCreateResolution->isChecked()) {
     m_outputResolutionName = outputWorkspaceNameStem;
@@ -283,7 +281,7 @@ void ISISCalibration::run() {
     resAlg->setProperty("RebinParam", rebinString.toStdString());
     resAlg->setProperty("DetectorRange", resDetectorRange.toStdString());
     resAlg->setProperty("BackgroundRange", background.toStdString());
-	resAlg->setProperty("LoadLogFiles", loadLog);
+    resAlg->setProperty("LoadLogFiles", loadLog);
 
     if (m_uiForm.ckResolutionScale->isChecked())
       resAlg->setProperty("ScaleFactor", m_uiForm.spScale->value());

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -502,7 +502,8 @@ void ISISCalibration::calPlotEnergy() {
   reductionAlg->setProperty("OutputWorkspace",
                             "__IndirectCalibration_reduction");
   reductionAlg->setProperty("SpectraRange", detRange.toStdString());
-  reductionAlg->setProperty("LoadLogFiles", m_uiForm.ckLoadLogFiles->isChecked());
+  reductionAlg->setProperty("LoadLogFiles",
+                            m_uiForm.ckLoadLogFiles->isChecked());
   reductionAlg->execute();
 
   if (!reductionAlg->isExecuted()) {

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -502,6 +502,7 @@ void ISISCalibration::calPlotEnergy() {
   reductionAlg->setProperty("OutputWorkspace",
                             "__IndirectCalibration_reduction");
   reductionAlg->setProperty("SpectraRange", detRange.toStdString());
+  reductionAlg->setProperty("LoadLogFiles", m_uiForm.ckLoadLogFiles->isChecked());
   reductionAlg->execute();
 
   if (!reductionAlg->isExecuted()) {

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -212,6 +212,7 @@ void ISISCalibration::run() {
     m_outputCalibrationName += "_multi";
   m_outputCalibrationName += "_calib";
 
+  bool loadLog = m_uiForm.ckLoadLogFiles->isChecked();
   // Configure the calibration algorithm
   IAlgorithm_sptr calibrationAlg =
       AlgorithmManager::Instance().create("IndirectCalibration");
@@ -223,6 +224,7 @@ void ISISCalibration::run() {
   calibrationAlg->setProperty("DetectorRange", instDetectorRange.toStdString());
   calibrationAlg->setProperty("PeakRange", peakRange.toStdString());
   calibrationAlg->setProperty("BackgroundRange", backgroundRange.toStdString());
+  calibrationAlg->setProperty("LoadLogFiles", loadLog);
 
   if (m_uiForm.ckScale->isChecked()) {
     double scale = m_uiForm.spScale->value();
@@ -239,6 +241,8 @@ void ISISCalibration::run() {
   // Add save algorithm to queue if ticked
   if (save)
     addSaveWorkspaceToQueue(m_outputCalibrationName);
+
+
 
   // Configure the resolution algorithm
   if (m_uiForm.ckCreateResolution->isChecked()) {
@@ -279,6 +283,7 @@ void ISISCalibration::run() {
     resAlg->setProperty("RebinParam", rebinString.toStdString());
     resAlg->setProperty("DetectorRange", resDetectorRange.toStdString());
     resAlg->setProperty("BackgroundRange", background.toStdString());
+	resAlg->setProperty("LoadLogFiles", loadLog);
 
     if (m_uiForm.ckResolutionScale->isChecked())
       resAlg->setProperty("ScaleFactor", m_uiForm.spScale->value());

--- a/docs/source/release/v3.8.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.8.0/indirect_inelastic.rst
@@ -13,6 +13,13 @@ Algorithms
 
 * Remove CylinderPaalmanPingsCorrection v1. This algorithm has been replaced by :ref:`CylinderPaalmanPingsCorrection <algm-CylinderPaalmanPingsCorrection>`
 
+Data Reduction
+##############
+
+ISIS Calibration
+~~~~~~~~~~~~~~~~
+- Add load log option to ISIS calibration interface
+
 Data Analysis
 #############
 


### PR DESCRIPTION
Added a load log option to indirect calibration interface.

**To test:**

Load a data file with logs in repository. Run with load log option checked and then unchecked and compare results in sample logs. Repeat without logs in repository. 

Fixes #15989

[Release Notes](https://github.com/mantidproject/mantid/blob/e6b65d7f553430e77b974cdd305a16d23cc808bf/docs/source/release/v3.8.0/indirect_inelastic.rst)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
