### PR TITLE
Register VSI usage with UsageService

### DIFF
--- a/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -9,6 +9,7 @@
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/InstrumentInfo.h"
+#include "MantidKernel/UsageService.h"
 #include "MantidQtAPI/InterfaceManager.h"
 #include "MantidQtAPI/MdConstants.h"
 #include "MantidQtAPI/MdSettings.h"
@@ -305,7 +306,8 @@ void MdViewerWidget::connectLoadDataReaction(QAction *action) {
 }
 
 /**
- * This function creates the requested view on the main window.
+ * This function creates the requested view on the main window. It also
+ * registers a usage of the view with the UsageService.
  * @param container the UI widget to associate the view mode with
  * @param v the view mode to set on the main window
  * @return the requested view
@@ -314,27 +316,35 @@ ViewBase *
 MdViewerWidget::createAndSetMainViewWidget(QWidget *container,
                                            ModeControlWidget::Views v) {
   ViewBase *view;
+  std::string featureName("VSI:");
   switch (v) {
   case ModeControlWidget::STANDARD: {
     view = new StandardView(container, &m_rebinnedSourcesManager);
+    featureName += "StandardView";
   } break;
   case ModeControlWidget::THREESLICE: {
     view = new ThreeSliceView(container, &m_rebinnedSourcesManager);
+    featureName += "ThreeSliceView";
   } break;
   case ModeControlWidget::MULTISLICE: {
     view = new MultiSliceView(container, &m_rebinnedSourcesManager);
+    featureName += "MultiSliceView";
   } break;
   case ModeControlWidget::SPLATTERPLOT: {
     view = new SplatterPlotView(container, &m_rebinnedSourcesManager);
+    featureName += "SplatterPlotView";
   } break;
   default:
-    view = NULL;
+    view = nullptr;
     break;
   }
 
   // Set the colorscale lock
   view->setColorScaleLock(&m_colorScaleLock);
 
+  using Mantid::Kernel::UsageService;
+  UsageService::Instance().registerFeatureUsage("Interface", featureName,
+                                                false);
   return view;
 }
 


### PR DESCRIPTION
The VSI was missed when the interfaces were updated to start tracking their usage. These changes plug that hole.

Each view is registered separately to get a better picture of the actual usage. 

**To test:**
1. Load the `SEQ_MDEW.nxs` from the system test data into MantidPlot
2. Run this line of Python to turn usage reporting on  UsageService.setEnabled(True) 
3. Right click on the workspace and show the VSI
4. Switch between all of the views
5. Close down MantidPlot
6. Go to http://reports.mantidproject.org/api/feature?page=31 (31 may need to be updated if this is no longer the last page in the results. If "next": null is at the top then it is the last page) in your browser and search on the page for VSI. There should be records for all of the view types.
7. Let me know so I can delete your testing data records from the DB.

No issue number.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
