### PR TITLE
Fix bug creating MultiDomainFunction from string

### DIFF
--- a/Framework/API/src/FunctionFactory.cpp
+++ b/Framework/API/src/FunctionFactory.cpp
@@ -216,7 +216,14 @@ CompositeFunction_sptr FunctionFactoryImpl::createComposite(
     cfun->addFunction(fun);
     size_t i = cfun->nFunctions() - 1;
     for (auto &pAttribute : pAttributes) {
-      cfun->setLocalAttributeValue(i, pAttribute.first, pAttribute.second);
+      // Apply parent attributes of the child function to this function. If this
+      // function doesn't have those attributes, they get passed up the chain to
+      // this function's parent.
+      if (cfun->hasLocalAttribute(pAttribute.first)) {
+        cfun->setLocalAttributeValue(i, pAttribute.first, pAttribute.second);
+      } else {
+        parentAttributes[pAttribute.first] = pAttribute.second;
+      }
     }
   }
 

--- a/Framework/API/test/FunctionFactoryTest.h
+++ b/Framework/API/test/FunctionFactoryTest.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/IConstraint.h"
+#include "MantidAPI/MultiDomainFunction.h"
 #include "MantidKernel/System.h"
 
 #include <sstream>
@@ -377,13 +378,23 @@ public:
   }
 
   void test_MultiDomainFunction_creation() {
-    std::string fnString = "composite=MultiDomainFunction;"
-                           "name=FunctionFactoryTest_FunctA;"
-                           "name=FunctionFactoryTest_FunctB";
-    IFunction_sptr fun =
-        FunctionFactory::Instance().createInitialized(fnString);
+    const std::string fnString = "composite=MultiDomainFunction;"
+                                 "name=FunctionFactoryTest_FunctA;"
+                                 "name=FunctionFactoryTest_FunctB";
+    IFunction_sptr fun;
+    TS_ASSERT_THROWS_NOTHING(
+        fun = FunctionFactory::Instance().createInitialized(fnString));
     TS_ASSERT(fun);
-    // TODO: add more asserts
+    const auto mdfunc = boost::dynamic_pointer_cast<MultiDomainFunction>(fun);
+    TS_ASSERT(mdfunc);
+    if (mdfunc) {
+      TS_ASSERT_EQUALS(mdfunc->nFunctions(), 2);
+      const auto funcA = mdfunc->getFunction(0);
+      const auto funcB = mdfunc->getFunction(1);
+      TS_ASSERT_EQUALS(funcA->name(), "FunctionFactoryTest_FunctA");
+      TS_ASSERT_EQUALS(funcB->name(), "FunctionFactoryTest_FunctB");
+    }
+  }
   }
 
   void test_getFunctionNames() {

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -76,6 +76,7 @@ Python Algorithms
 Bug Fixes
 ---------
 - Scripts generated from history including algorithms that added dynamic properties at run time (for example Fit, and Load) will not not include those dynamic properties in their script.  This means they will execute without warnings.
+- Cloning a ``MultiDomainFunction``, or serializing to a string and recreating it, now preserves the domains.
 
 
 |


### PR DESCRIPTION
Fixes a bug found when creating a `MultiDomainFunction` from its string representation in certain cases (specifically, when the individual functions were themselves composite functions).

The `$domains` parent attribute is passed up to the parent function, but this only worked when the MultiDomainFunction contained simple functions. If it contained composite functions that themselves contained other functions, the attribute was only passed up one level. Now it is passed up as many levels as needed until it reaches the (grand)parent MultiDomainFunction.

**To test:**
- New unit test has been added for this case.
- Run the script in the issue - should work with no exceptions thrown.

Fixes #16942.

[Release notes](https://github.com/mantidproject/mantid/blob/a9718d8aa6094522c061172bbd949a42adc0f2d2/docs/source/release/v3.8.0/framework.rst#bug-fixes) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
