### PR TITLE
MatrixWorkspace::maskBins  Replace NaN with 0.

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1061,8 +1061,11 @@ void MatrixWorkspace::maskBin(const size_t &workspaceIndex,
   // this is the actual result of the masking that most algorithms and plotting
   // implementations will see, the bin mask flags defined above are used by only
   // some algorithms
-  this->dataY(workspaceIndex)[binIndex] *= (1 - weight);
-  this->dataE(workspaceIndex)[binIndex] *= (1 - weight);
+  // NaN values are set to 0, other values are scaled by (1 - weight)
+  double &y = this->dataY(workspaceIndex)[binIndex];
+  isnan(y) ? y = 0 : y *= (1 - weight);
+  double &e = this->dataE(workspaceIndex)[binIndex];
+  isnan(e) ? e = 0 : e *= (1 - weight);
 }
 
 /** Writes the masking weight to m_masks (doesn't alter y-values). Contains a

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1061,11 +1061,16 @@ void MatrixWorkspace::maskBin(const size_t &workspaceIndex,
   // this is the actual result of the masking that most algorithms and plotting
   // implementations will see, the bin mask flags defined above are used by only
   // some algorithms
-  // NaN values are set to 0, other values are scaled by (1 - weight)
-  double &y = this->dataY(workspaceIndex)[binIndex];
-  isnan(y) ? y = 0 : y *= (1 - weight);
-  double &e = this->dataE(workspaceIndex)[binIndex];
-  isnan(e) ? e = 0 : e *= (1 - weight);
+  // If the weight is 0, nothing more needs to be done after flagMasked above
+  // (i.e. NaN and Inf will also stay intact)
+  // If the weight is not 0, NaN and Inf values are set to 0,
+  // whereas other values are scaled by (1 - weight)
+  if (weight != 0.) {
+    double &y = this->dataY(workspaceIndex)[binIndex];
+    (isnan(y) || isinf(y)) ? y = 0. : y *= (1 - weight);
+    double &e = this->dataE(workspaceIndex)[binIndex];
+    (isnan(e) || isinf(e)) ? e = 0. : e *= (1 - weight);
+  }
 }
 
 /** Writes the masking weight to m_masks (doesn't alter y-values). Contains a

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1066,9 +1066,9 @@ void MatrixWorkspace::maskBin(const size_t &workspaceIndex,
   // If the weight is not 0, NaN and Inf values are set to 0,
   // whereas other values are scaled by (1 - weight)
   if (weight != 0.) {
-    double &y = this->dataY(workspaceIndex)[binIndex];
+    double &y = this->mutableY(workspaceIndex)[binIndex];
     (isnan(y) || isinf(y)) ? y = 0. : y *= (1 - weight);
-    double &e = this->dataE(workspaceIndex)[binIndex];
+    double &e = this->mutableE(workspaceIndex)[binIndex];
     (isnan(e) || isinf(e)) ? e = 0. : e *= (1 - weight);
   }
 }

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -23,6 +23,7 @@
 #include <boost/make_shared.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <functional>
 #include <numeric>
 
@@ -342,6 +343,33 @@ public:
     TS_ASSERT_EQUALS(ws2->maskedBins(0).rbegin()->first, 1);
     TS_ASSERT_EQUALS(ws2->maskedBins(0).rbegin()->second, 0.5);
     TS_ASSERT_EQUALS(ws2->dataY(0)[1], 0.5);
+  }
+
+  void testMaskingNaNInf() {
+    const size_t s = 4;
+    const double y[s] = {NAN, INFINITY, -INFINITY, 2.};
+    WorkspaceTester ws;
+    ws.initialize(1, s + 1, s);
+
+    // initialize and mask first with 0 weights
+    // masking with 0 weight should be equiavalent to flagMasked
+    // i.e. values should not change, even Inf and NaN
+    for (size_t i = 0; i < s; ++i) {
+      ws.mutableY(0)[i] = y[i];
+      ws.maskBin(0, i, 0);
+    }
+
+    TS_ASSERT(isnan(ws.y(0)[0]));
+    TS_ASSERT(isinf(ws.y(0)[1]));
+    TS_ASSERT(isinf(ws.y(0)[2]));
+    TS_ASSERT_EQUALS(ws.y(0)[3], 2.);
+
+    // now mask w/o specifying weight (e.g. 1 by default)
+    // in this case everything should be 0, even NaN and Inf
+    for (size_t i = 0; i < s; ++i) {
+      ws.maskBin(0, i);
+      TS_ASSERT_EQUALS(ws.y(0)[i], 0.);
+    }
   }
 
   void testSize() {

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -18,9 +18,6 @@ A new module for dealing with histogram data has been added, it is now being use
 Concepts
 --------
 
-Improved
-########
-
 - ``MatrixWorkspace`` : When masking bins or detectors with non-zero weights,
   undefined and infinite values and errors will be zeroed.
 

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -21,7 +21,7 @@ Concepts
 Improved
 ########
 
-- :ref:`MatrixWorkspace` : When masking bins or detectors with non-zero weights,
+- ``MatrixWorkspace`` : When masking bins or detectors with non-zero weights,
   undefined and infinite values and errors will be zeroed.
 
 

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -15,6 +15,15 @@ A new module for dealing with histogram data has been added, it is now being use
   However, to ensure data consistency and to reduce the risk of bugs, histograms now enforce length limitations. For example, there must be one bin edge more than data (Y and E) values.
   If you experience trouble, in particular exceptions about size mismatch, please refer to the section `Dealing with problems <http://docs.mantidproject.org/nightly/concepts/HistogramData.html#dealing-with-problems>`_.
 
+Concepts
+--------
+
+Improved
+########
+
+- :red:`MatrixWorkspace` : When masking bins or detectors with non-zero weights,
+  undefined and infinite values and errors will be zeroed.
+
 
 Algorithms
 ----------

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -21,7 +21,7 @@ Concepts
 Improved
 ########
 
-- :red:`MatrixWorkspace` : When masking bins or detectors with non-zero weights,
+- :ref:`MatrixWorkspace` : When masking bins or detectors with non-zero weights,
   undefined and infinite values and errors will be zeroed.
 
 


### PR DESCRIPTION
This PR replaces NaN/Inf values/errors with 0 during the masking with non-0 weight.

**To test:**

<!-- Instructions for testing. -->
- Load/create a workspace with some NaN values.
- Mask the bins containing NaN with MaskBins or MaskDetectors.

Fixes #16948.

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/16948_MatrixWorkspace_maskBins_replaceNaNwithZero/docs/source/release/v3.8.0/framework.rst#id17) 

<!-- 
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
