### PR TITLE
ADS GetObjectNames method - Add params to get sorted or hidden object names

### DIFF
--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.h
@@ -322,10 +322,11 @@ public:
     if (this->direction() == Kernel::Direction::Input ||
         this->direction() == Kernel::Direction::InOut) {
       // If an input workspace, get the list of workspaces currently in the ADS
-      auto vals = AnalysisDataService::Instance().getObjectNames();
+      auto vals = AnalysisDataService::Instance().getObjectNames(
+          Mantid::Kernel::DataServiceSort::Sorted);
       if (isOptional()) // Insert an empty option
       {
-        vals.insert("");
+        vals.push_back("");
       }
       // Copy-construct a temporary workspace property to test the validity of
       // each workspace
@@ -338,9 +339,7 @@ public:
         } else
           ++it;
       }
-      auto values = std::vector<std::string>(vals.begin(), vals.end());
-      std::sort(values.begin(), values.end());
-      return values;
+      return vals;
     } else {
       // For output workspaces, just return an empty set
       return std::vector<std::string>();

--- a/Framework/API/src/ADSValidator.cpp
+++ b/Framework/API/src/ADSValidator.cpp
@@ -62,14 +62,13 @@ ADSValidator::checkValidity(const std::vector<std::string> &value) const {
 */
 std::vector<std::string> ADSValidator::allowedValues() const {
   // Get the list of workspaces currently in the ADS
-  auto vals = AnalysisDataService::Instance().getObjectNames();
+  auto vals = AnalysisDataService::Instance().getObjectNames(
+      Mantid::Kernel::DataServiceSort::Sorted);
   if (isOptional()) // Insert an empty option
   {
-    vals.insert("");
+    vals.push_back("");
   }
-  auto values = std::vector<std::string>(vals.begin(), vals.end());
-  std::sort(values.begin(), values.end());
-  return values;
+  return vals;
 }
 
 } // namespace API

--- a/Framework/API/test/AnalysisDataServiceTest.h
+++ b/Framework/API/test/AnalysisDataServiceTest.h
@@ -311,11 +311,11 @@ public:
     TSM_ASSERT_EQUALS("Hidden entries should not be returned", names.size(), 2);
     TSM_ASSERT_EQUALS("Hidden entries should not be returned", objects.size(),
                       2);
-    TS_ASSERT_DIFFERS(names.find("One"), names.end());
-    TS_ASSERT_DIFFERS(names.find("Two"), names.end());
-    TS_ASSERT_EQUALS(names.find("__Three"), names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "One"), names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "Two"), names.end());
+    TS_ASSERT_EQUALS(std::find(names.cbegin(), names.cend(), "__Three"), names.end());
     TSM_ASSERT_EQUALS("Hidden entries should not be returned",
-                      names.find("__Three"), names.end());
+		std::find(names.cbegin(), names.cend(), "__Three"), names.end());
 
     ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
                                         "1");
@@ -323,7 +323,7 @@ public:
     objects = ads.getObjects();
     TS_ASSERT_EQUALS(names.size(), 3);
     TS_ASSERT_EQUALS(objects.size(), 3);
-    TS_ASSERT_DIFFERS(names.find("__Three"), names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "__Three"), names.end());
     ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
                                         "0");
   }

--- a/Framework/API/test/AnalysisDataServiceTest.h
+++ b/Framework/API/test/AnalysisDataServiceTest.h
@@ -311,11 +311,15 @@ public:
     TSM_ASSERT_EQUALS("Hidden entries should not be returned", names.size(), 2);
     TSM_ASSERT_EQUALS("Hidden entries should not be returned", objects.size(),
                       2);
-    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "One"), names.end());
-    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "Two"), names.end());
-    TS_ASSERT_EQUALS(std::find(names.cbegin(), names.cend(), "__Three"), names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "One"),
+                      names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "Two"),
+                      names.end());
+    TS_ASSERT_EQUALS(std::find(names.cbegin(), names.cend(), "__Three"),
+                     names.end());
     TSM_ASSERT_EQUALS("Hidden entries should not be returned",
-		std::find(names.cbegin(), names.cend(), "__Three"), names.end());
+                      std::find(names.cbegin(), names.cend(), "__Three"),
+                      names.end());
 
     ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
                                         "1");
@@ -323,7 +327,8 @@ public:
     objects = ads.getObjects();
     TS_ASSERT_EQUALS(names.size(), 3);
     TS_ASSERT_EQUALS(objects.size(), 3);
-    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "__Three"), names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "__Three"),
+                      names.end());
     ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
                                         "0");
   }

--- a/Framework/API/test/InstrumentDataServiceTest.h
+++ b/Framework/API/test/InstrumentDataServiceTest.h
@@ -99,9 +99,9 @@ public:
 
   void testGetObjectNames() {
     InstrumentDataService::Instance().add("inst2", inst2);
-    std::unordered_set<std::string> names;
-    names.insert("inst1");
-    names.insert("inst2");
+    std::vector<std::string> names;
+    names.push_back("inst1");
+    names.push_back("inst2");
     auto result = InstrumentDataService::Instance().getObjectNames();
     TS_ASSERT_EQUALS(result, names);
     // Check with an empty store

--- a/Framework/API/test/ScopedWorkspaceTest.h
+++ b/Framework/API/test/ScopedWorkspaceTest.h
@@ -76,8 +76,10 @@ public:
   }
 
   void test_removedWhenOutOfScope() {
-    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
-		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
+    TS_ASSERT_EQUALS(
+        m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+                             Mantid::Kernel::DataServiceHidden::Include).size(),
+        0);
 
     { // Simulated scope
       MockWorkspace_sptr ws = MockWorkspace_sptr(new MockWorkspace);
@@ -89,13 +91,17 @@ public:
     }
 
     // Should be removed when goes out of scope
-    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
-		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
+    TS_ASSERT_EQUALS(
+        m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+                             Mantid::Kernel::DataServiceHidden::Include).size(),
+        0);
   }
 
   void test_removedWhenException() {
-    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
-		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
+    TS_ASSERT_EQUALS(
+        m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+                             Mantid::Kernel::DataServiceHidden::Include).size(),
+        0);
 
     try {
       MockWorkspace_sptr ws = MockWorkspace_sptr(new MockWorkspace);
@@ -111,13 +117,17 @@ public:
     } catch (...) {
     }
 
-    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
-		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
+    TS_ASSERT_EQUALS(
+        m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+                             Mantid::Kernel::DataServiceHidden::Include).size(),
+        0);
   }
 
   void test_workspaceGroups() {
-    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
-		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
+    TS_ASSERT_EQUALS(
+        m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+                             Mantid::Kernel::DataServiceHidden::Include).size(),
+        0);
 
     { // Simulated scope
       MockWorkspace_sptr ws1 = MockWorkspace_sptr(new MockWorkspace);
@@ -131,13 +141,18 @@ public:
       ScopedWorkspace testGroup;
       m_ads.add(testGroup.name(), wsGroup);
 
-      TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
-		  Mantid::Kernel::DataServiceHidden::Include).size(), 3);
+      TS_ASSERT_EQUALS(
+          m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+                               Mantid::Kernel::DataServiceHidden::Include)
+              .size(),
+          3);
     }
 
     // Whole group should be removed
-    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
-		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
+    TS_ASSERT_EQUALS(
+        m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+                             Mantid::Kernel::DataServiceHidden::Include).size(),
+        0);
   }
 
   void test_alreadyExistsInTheADS() {
@@ -171,8 +186,10 @@ public:
 
     TS_ASSERT_EQUALS(ws2->name(), test.name());
     TS_ASSERT(ws1->name().empty());
-    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
-		Mantid::Kernel::DataServiceHidden::Include).size(), 1);
+    TS_ASSERT_EQUALS(
+        m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+                             Mantid::Kernel::DataServiceHidden::Include).size(),
+        1);
   }
 
 private:

--- a/Framework/API/test/ScopedWorkspaceTest.h
+++ b/Framework/API/test/ScopedWorkspaceTest.h
@@ -76,7 +76,8 @@ public:
   }
 
   void test_removedWhenOutOfScope() {
-    TS_ASSERT_EQUALS(m_ads.getObjectNamesInclHidden().size(), 0);
+    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
 
     { // Simulated scope
       MockWorkspace_sptr ws = MockWorkspace_sptr(new MockWorkspace);
@@ -88,11 +89,13 @@ public:
     }
 
     // Should be removed when goes out of scope
-    TS_ASSERT_EQUALS(m_ads.getObjectNamesInclHidden().size(), 0);
+    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
   }
 
   void test_removedWhenException() {
-    TS_ASSERT_EQUALS(m_ads.getObjectNamesInclHidden().size(), 0);
+    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
 
     try {
       MockWorkspace_sptr ws = MockWorkspace_sptr(new MockWorkspace);
@@ -108,11 +111,13 @@ public:
     } catch (...) {
     }
 
-    TS_ASSERT_EQUALS(m_ads.getObjectNamesInclHidden().size(), 0);
+    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
   }
 
   void test_workspaceGroups() {
-    TS_ASSERT_EQUALS(m_ads.getObjectNamesInclHidden().size(), 0);
+    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
 
     { // Simulated scope
       MockWorkspace_sptr ws1 = MockWorkspace_sptr(new MockWorkspace);
@@ -126,11 +131,13 @@ public:
       ScopedWorkspace testGroup;
       m_ads.add(testGroup.name(), wsGroup);
 
-      TS_ASSERT_EQUALS(m_ads.getObjectNamesInclHidden().size(), 3);
+      TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+		  Mantid::Kernel::DataServiceHidden::Include).size(), 3);
     }
 
     // Whole group should be removed
-    TS_ASSERT_EQUALS(m_ads.getObjectNamesInclHidden().size(), 0);
+    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+		Mantid::Kernel::DataServiceHidden::Include).size(), 0);
   }
 
   void test_alreadyExistsInTheADS() {
@@ -164,7 +171,8 @@ public:
 
     TS_ASSERT_EQUALS(ws2->name(), test.name());
     TS_ASSERT(ws1->name().empty());
-    TS_ASSERT_EQUALS(m_ads.getObjectNamesInclHidden().size(), 1);
+    TS_ASSERT_EQUALS(m_ads.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+		Mantid::Kernel::DataServiceHidden::Include).size(), 1);
   }
 
 private:

--- a/Framework/Kernel/test/DataServiceTest.h
+++ b/Framework/Kernel/test/DataServiceTest.h
@@ -246,9 +246,6 @@ public:
             two); // Same pointer again - should appear twice in getObjects()
     svc.add("__Three", three);
 
-    typedef Mantid::Kernel::DataServiceSort sortedEnum;
-    typedef Mantid::Kernel::DataServiceHidden hiddenEnum;
-
     auto names = svc.getObjectNames();
     auto objects = svc.getObjects();
     TSM_ASSERT_EQUALS("Hidden entries should not be returned", names.size(), 3);

--- a/Framework/Kernel/test/DataServiceTest.h
+++ b/Framework/Kernel/test/DataServiceTest.h
@@ -246,31 +246,74 @@ public:
             two); // Same pointer again - should appear twice in getObjects()
     svc.add("__Three", three);
 
+    typedef Mantid::Kernel::DataServiceSort sortedEnum;
+    typedef Mantid::Kernel::DataServiceHidden hiddenEnum;
+
     auto names = svc.getObjectNames();
     auto objects = svc.getObjects();
     TSM_ASSERT_EQUALS("Hidden entries should not be returned", names.size(), 3);
     TSM_ASSERT_EQUALS("Hidden entries should not be returned", objects.size(),
                       3);
-    TS_ASSERT_DIFFERS(names.find("One"), names.end());
-    TS_ASSERT_DIFFERS(names.find("Two"), names.end());
-    TS_ASSERT_DIFFERS(names.find("TwoAgain"), names.end());
-    TS_ASSERT_EQUALS(names.find("__Three"), names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "One"),
+                      names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "Two"),
+                      names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "TwoAgain"),
+                      names.end());
+    TS_ASSERT_EQUALS(std::find(names.cbegin(), names.cend(), "__Three"),
+                     names.end());
     TSM_ASSERT_EQUALS("Hidden entries should not be returned",
-                      names.find("__Three"), names.end());
+                      std::find(names.cbegin(), names.cend(), "__Three"),
+                      names.end());
     TS_ASSERT_EQUALS(objects.at(0), one);
     TS_ASSERT_EQUALS(objects.at(1), two);
     TS_ASSERT_EQUALS(objects.at(2), two);
 
-    auto allNamesSize = svc.getObjectNamesInclHidden().size();
+    auto allNamesSize = svc.getObjectNames().size();
     ConfigService::Instance().setString("MantidOptions.InvisibleWorkspaces",
                                         "1");
-    TS_ASSERT_EQUALS(allNamesSize, svc.getObjectNamesInclHidden().size())
+    TS_ASSERT_EQUALS(allNamesSize, 3)
     names = svc.getObjectNames();
     objects = svc.getObjects();
     TS_ASSERT_EQUALS(names.size(), 4);
     TS_ASSERT_EQUALS(objects.size(), 4);
-    TS_ASSERT_DIFFERS(names.find("__Three"), names.end());
+    TS_ASSERT_DIFFERS(std::find(names.cbegin(), names.cend(), "__Three"),
+                      names.end());
     TS_ASSERT_EQUALS(objects.at(3), three);
+  }
+
+  void test_sortedAndHiddenGetNames() {
+    auto one = boost::make_shared<int>(1);
+    auto two = boost::make_shared<int>(2);
+    auto three = boost::make_shared<int>(3);
+    auto four = boost::make_shared<int>(4);
+    // This time add them in a random order
+    svc.add("One", one);
+    svc.add("__Three", three);
+    svc.add("Four", four);
+    svc.add("Two", two);
+
+    typedef Mantid::Kernel::DataServiceSort sortedEnum;
+    typedef Mantid::Kernel::DataServiceHidden hiddenEnum;
+
+    // First assert that sort does not impact size
+    TS_ASSERT_EQUALS(svc.getObjectNames(sortedEnum::Sorted).size(),
+                     svc.getObjectNames(sortedEnum::Unsorted).size());
+
+    // Get unsorted and sort the manually
+    auto sortReference = svc.getObjectNames();
+    std::sort(sortReference.begin(), sortReference.end());
+
+    TS_ASSERT_EQUALS(svc.getObjectNames(sortedEnum::Sorted), sortReference);
+
+    // Next assert that Hidden flags behave
+    TS_ASSERT_EQUALS(
+        svc.getObjectNames(sortedEnum::Unsorted, hiddenEnum::Exclude).size(),
+        3);
+
+    TS_ASSERT_EQUALS(
+        svc.getObjectNames(sortedEnum::Unsorted, hiddenEnum::Include).size(),
+        4);
   }
 
   void test_threadSafety() {

--- a/Framework/Kernel/test/PropertyManagerDataServiceTest.h
+++ b/Framework/Kernel/test/PropertyManagerDataServiceTest.h
@@ -93,17 +93,14 @@ public:
   }
   void testGetObjectNames() {
     PropertyManagerDataService::Instance().add("inst2", inst2);
-    std::unordered_set<std::string> names;
-    names.insert("inst1");
-    names.insert("inst2");
-    std::unordered_set<std::string> result;
-    result = PropertyManagerDataService::Instance().getObjectNames();
-    TS_ASSERT_EQUALS(result, names);
+	std::vector<std::string> expectedNames = { "inst1", "inst2" };
+    auto result = PropertyManagerDataService::Instance().getObjectNames();
+    TS_ASSERT_EQUALS(result, expectedNames);
     // Check with an empty store
     PropertyManagerDataService::Instance().clear();
-    names.clear();
+	expectedNames.clear();
     result = PropertyManagerDataService::Instance().getObjectNames();
-    TS_ASSERT_EQUALS(result, names);
+    TS_ASSERT_EQUALS(result, expectedNames);
   }
 
 private:

--- a/Framework/Kernel/test/PropertyManagerDataServiceTest.h
+++ b/Framework/Kernel/test/PropertyManagerDataServiceTest.h
@@ -93,12 +93,12 @@ public:
   }
   void testGetObjectNames() {
     PropertyManagerDataService::Instance().add("inst2", inst2);
-	std::vector<std::string> expectedNames = { "inst1", "inst2" };
+    std::vector<std::string> expectedNames = {"inst1", "inst2"};
     auto result = PropertyManagerDataService::Instance().getObjectNames();
     TS_ASSERT_EQUALS(result, expectedNames);
     // Check with an empty store
     PropertyManagerDataService::Instance().clear();
-	expectedNames.clear();
+    expectedNames.clear();
     result = PropertyManagerDataService::Instance().getObjectNames();
     TS_ASSERT_EQUALS(result, expectedNames);
   }

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFAddWorkspaceDialog.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFAddWorkspaceDialog.cpp
@@ -19,7 +19,8 @@ AddWorkspaceDialog::AddWorkspaceDialog(QWidget *parent)
   m_uiForm.setupUi(this);
   // populate the combo box with names of eligible workspaces
   QStringList workspaceNames;
-  auto wsNames = Mantid::API::AnalysisDataService::Instance().getObjectNames();
+  auto wsNames = Mantid::API::AnalysisDataService::Instance().getObjectNames(
+      Mantid::Kernel::DataServiceSort::Sorted);
   for (auto name = wsNames.begin(); name != wsNames.end(); ++name) {
     auto mws = Mantid::API::AnalysisDataService::Instance()
                    .retrieveWS<Mantid::API::MatrixWorkspace>(*name);

--- a/MantidQt/MantidWidgets/src/WorkspaceSelector.cpp
+++ b/MantidQt/MantidWidgets/src/WorkspaceSelector.cpp
@@ -258,9 +258,10 @@ void WorkspaceSelector::refresh() {
   if (m_optional)
     addItem("");
   auto &ads = Mantid::API::AnalysisDataService::Instance();
-  std::unordered_set<std::string> items;
+  std::vector<std::string> items;
   if (showHiddenWorkspaces()) {
-    items = ads.getObjectNamesInclHidden();
+	  items = ads.getObjectNames(Mantid::Kernel::DataServiceSort::Sorted,
+		  Mantid::Kernel::DataServiceHidden::Include);
   } else {
     items = ads.getObjectNames();
   }
@@ -272,7 +273,6 @@ void WorkspaceSelector::refresh() {
       namesToAdd << name;
     }
   }
-  namesToAdd.sort();
   this->addItems(namesToAdd);
 }
 

--- a/MantidQt/MantidWidgets/src/WorkspaceSelector.cpp
+++ b/MantidQt/MantidWidgets/src/WorkspaceSelector.cpp
@@ -260,8 +260,8 @@ void WorkspaceSelector::refresh() {
   auto &ads = Mantid::API::AnalysisDataService::Instance();
   std::vector<std::string> items;
   if (showHiddenWorkspaces()) {
-	  items = ads.getObjectNames(Mantid::Kernel::DataServiceSort::Sorted,
-		  Mantid::Kernel::DataServiceHidden::Include);
+    items = ads.getObjectNames(Mantid::Kernel::DataServiceSort::Sorted,
+                               Mantid::Kernel::DataServiceHidden::Include);
   } else {
     items = ads.getObjectNames();
   }


### PR DESCRIPTION
Description of work.
Previously the ADS `getObjectNames` method returned an unordered set of names. Many of the callers of this method subsequently sorted these names. 

The method has been rewritten to allow users to specify if they want the names sorted whilst the `getObjectNamesInclHidden()` has been merged in as an additional hidden parameter. 
The default parameters still return a unsorted list with hidden items included if set in the configuration as per the original behaviour.

All callers of this method have been checked and any which subsequently sorted the values have been refactored.

**To test:**

All units tests should pass. 
WorkspaceSelector and the Add workspace dialogue in multi dataset fitting should return sorted lists still.

Fixes #16500 .

Doesn't need to be added to release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
