### PR TITLE
Engg:: add more unit tests and move remaining function to presenter for fitting tab

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -78,6 +78,8 @@ public:
 
   void addPeakToList();
 
+  std::string readPeaksFile(std::string fileDir);
+
   void plotFitPeaksCurves();
 
   void runEvaluateFunctionAlg(const std::string &bk2BkExpFunction,

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -116,7 +116,8 @@ public:
 
   void setBankItems();
 
-  void setRunNoItems(const std::vector<std::string> &runNumVector, bool multiRun);
+  void setRunNoItems(const std::vector<std::string> &runNumVector,
+                     bool multiRun);
 
   void setDefaultBank(const std::vector<std::string> &splittedBaseName,
                       const std::string &selectedFile);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -4,9 +4,9 @@
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtCustomInterfaces/DllConfig.h"
-#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionCalibration.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingPresenter.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h"
+#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionCalibration.h"
 
 #include <string>
 #include <vector>
@@ -80,7 +80,11 @@ public:
 
   void addPeakToList();
 
+  void savePeakList();
+
   std::string readPeaksFile(std::string fileDir);
+
+  void fittingWriteFile(const std::string &fileDir);
 
   void plotFitPeaksCurves();
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -116,7 +116,7 @@ public:
 
   void setBankItems();
 
-  void setRunNoItems(std::vector<std::string> runNumVector, bool multiRun);
+  void setRunNoItems(const std::vector<std::string> &runNumVector, bool multiRun);
 
   void setDefaultBank(const std::vector<std::string> &splittedBaseName,
                       const std::string &selectedFile);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -76,6 +76,8 @@ public:
                      std::string tableName, size_t row, std::string &startX,
                      std::string &endX);
 
+  void browsePeaksToFit();
+
   void addPeakToList();
 
   std::string readPeaksFile(std::string fileDir);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -76,16 +76,6 @@ public:
                      std::string tableName, size_t row, std::string &startX,
                      std::string &endX);
 
-  void browsePeaksToFit();
-
-  void addPeakToList();
-
-  void savePeakList();
-
-  std::string readPeaksFile(std::string fileDir);
-
-  void fittingWriteFile(const std::string &fileDir);
-
   void plotFitPeaksCurves();
 
   void runEvaluateFunctionAlg(const std::string &bk2BkExpFunction,
@@ -154,6 +144,16 @@ private:
 
   void enableMultiRun(std::string firstRun, std::string lastRun,
                       std::vector<std::string> &fittingRunNoDirVec);
+
+  void browsePeaksToFit();
+
+  void addPeakToList();
+
+  void savePeakList();
+
+  std::string readPeaksFile(std::string fileDir);
+
+  void fittingWriteFile(const std::string &fileDir);
 
   // whether to use AlignDetectors to convert units
   static const bool g_useAlignDetectors;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -76,6 +76,8 @@ public:
                      std::string tableName, size_t row, std::string &startX,
                      std::string &endX);
 
+  void addPeakToList();
+
   void plotFitPeaksCurves();
 
   void runEvaluateFunctionAlg(const std::string &bk2BkExpFunction,

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -136,6 +136,10 @@ public:
 
   void setFittingMultiRunMode(bool mode) override;
 
+  double getPeakCentre() const override;
+
+  bool peakPickerEnabled() const override;
+
   std::string fittingRunNoFactory(std::string bank, std::string fileName,
                                   std::string &bankDir, std::string fileDir);
 
@@ -147,8 +151,6 @@ public:
   void setPeakPickerEnabled(bool enabled);
 
   void setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak);
-
-  double getPeakCentre() const;
 
   void fittingWriteFile(const std::string &fileDir);
 
@@ -170,11 +172,11 @@ private slots:
   void setBankIdComboBox(int idx) override;
   void browsePeaksToFit();
   void setPeakPick();
-  void addPeakToList();
   void savePeakList();
   void clearPeakList();
   void fitClicked();
   void FittingRunNo();
+  void addPeaks();
   void plotSeparateWindow();
   void setBankDir(int idx);
   void listViewFittingRun();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -146,6 +146,8 @@ public:
 
   std::string getOpenFile(std::string prevPath) override;
 
+  std::string getSaveFile(std::string prevPath) override;
+
   std::string fittingRunNoFactory(std::string bank, std::string fileName,
                                   std::string &bankDir, std::string fileDir);
 
@@ -155,8 +157,6 @@ public:
   void setPeakPickerEnabled(bool enabled);
 
   void setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak);
-
-  void fittingWriteFile(const std::string &fileDir);
 
   void setZoomTool(bool enabled);
 
@@ -175,12 +175,12 @@ private slots:
   void resetFittingMultiMode();
   void setBankIdComboBox(int idx) override;
   void setPeakPick();
-  void savePeakList();
   void clearPeakList();
   void fitClicked();
   void FittingRunNo();
-  void addPeaks();
-  void browsePeaks();
+  void addClicked();
+  void browseClicked();
+  void saveClicked();
   void plotSeparateWindow();
   void setBankDir(int idx);
   void listViewFittingRun();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -143,8 +143,6 @@ public:
   std::string fittingRunNoFactory(std::string bank, std::string fileName,
                                   std::string &bankDir, std::string fileDir);
 
-  std::string readPeaksFile(std::string fileDir);
-
   void dataCurvesFactory(std::vector<boost::shared_ptr<QwtData>> &data,
                          std::vector<QwtPlotCurve *> &dataVector, bool focused);
 
@@ -177,6 +175,7 @@ private slots:
   void fitClicked();
   void FittingRunNo();
   void addPeaks();
+
   void plotSeparateWindow();
   void setBankDir(int idx);
   void listViewFittingRun();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -148,9 +148,6 @@ public:
 
   std::string getSaveFile(std::string prevPath) override;
 
-  std::string fittingRunNoFactory(std::string bank, std::string fileName,
-                                  std::string &bankDir, std::string fileDir);
-
   void dataCurvesFactory(std::vector<boost::shared_ptr<QwtData>> &data,
                          std::vector<QwtPlotCurve *> &dataVector, bool focused);
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -142,11 +142,11 @@ public:
 
   std::string getPreviousDir() const override;
 
-  void setPreviousDir(std::string path) override;
+  void setPreviousDir(const std::string &path) override;
 
-  std::string getOpenFile(std::string prevPath) override;
+  std::string getOpenFile(const std::string &prevPath) override;
 
-  std::string getSaveFile(std::string prevPath) override;
+  std::string getSaveFile(const std::string &prevPath) override;
 
   void dataCurvesFactory(std::vector<boost::shared_ptr<QwtData>> &data,
                          std::vector<QwtPlotCurve *> &dataVector, bool focused);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -140,6 +140,12 @@ public:
 
   bool peakPickerEnabled() const override;
 
+  std::string getPreviousDir() const override;
+
+  void setPreviousDir(std::string path) override;
+
+  std::string getOpenFile(std::string prevPath) override;
+
   std::string fittingRunNoFactory(std::string bank, std::string fileName,
                                   std::string &bankDir, std::string fileDir);
 
@@ -168,14 +174,13 @@ private slots:
   void browseFitFocusedRun();
   void resetFittingMultiMode();
   void setBankIdComboBox(int idx) override;
-  void browsePeaksToFit();
   void setPeakPick();
   void savePeakList();
   void clearPeakList();
   void fitClicked();
   void FittingRunNo();
   void addPeaks();
-
+  void browsePeaks();
   void plotSeparateWindow();
   void setBankDir(int idx);
   void listViewFittingRun();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
@@ -46,6 +46,7 @@ public:
     FitPeaks,     ///< Preforms single peak fits
     addPeaks,     ///< Adds peak to the list
     browsePeaks,  ///< Browse peaks to the list
+    savePeaks,    ///< Save the peaks list
     ShutDown,     ///< closing the interface
     LogMsg,       ///< need to send a message to the Mantid log system
   };

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
@@ -45,6 +45,7 @@ public:
     FittingRunNo, ///< Creates widgets and handles multi/run numbers
     FitPeaks,     ///< Preforms single peak fits
     addPeaks,     ///< Adds peak to the list
+    browsePeaks,  ///< Browse peaks to the list
     ShutDown,     ///< closing the interface
     LogMsg,       ///< need to send a message to the Mantid log system
   };

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
@@ -44,6 +44,7 @@ public:
     Start,        ///< Start and setup interface
     FittingRunNo, ///< Creates widgets and handles multi/run numbers
     FitPeaks,     ///< Preforms single peak fits
+    addPeaks,     ///< Adds peak to the list
     ShutDown,     ///< closing the interface
     LogMsg,       ///< need to send a message to the Mantid log system
   };

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h
@@ -159,6 +159,39 @@ public:
   virtual bool peakPickerEnabled() const = 0;
 
   /**
+  * gets the previously used directory path by the user
+  *
+  * @return directory of previously used directory by user,
+  * may return empty if no previous history
+  */
+  virtual std::string getPreviousDir() const = 0;
+
+  /**
+  * sets the previously used directory path
+  *
+  * @param path is set according to the file selected by user
+  */
+  virtual void setPreviousDir(const std::string &path) = 0;
+
+  /**
+  * gets the path as string which required when browsing the file
+  *
+  * @param path set according to the previously file selected
+  *
+  * @return string of the browsed file path
+  */
+  virtual std::string getOpenFile(const std::string &prevPath) = 0;
+
+  /**
+  * gets the path as string which is required when saving the file
+  *
+  * @param path set according to the previously selected file
+  *
+  * @return string of the saved file
+  */
+  virtual std::string getSaveFile(const std::string &prevPath) = 0;
+
+  /**
    * @return idx of current selected row of list widget
    */
   virtual int getFittingListWidgetCurrentRow() const = 0;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h
@@ -1,9 +1,9 @@
 #ifndef MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGVIEW_H_
 #define MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_IENGGDIFFFITTINGVIEW_H_
 
-#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionUserMsg.h"
-#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionSettings.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPythonRunner.h"
+#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionSettings.h"
+#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionUserMsg.h"
 
 #include <string>
 #include <vector>
@@ -142,6 +142,21 @@ public:
    * @param enable or disable the fitting list widget
    */
   virtual void enableFittingListWidget(bool enable) const = 0;
+
+  /**
+  * Gets the peak picker's center (d-spacing value)
+  *
+  * @return the peak picker's center value
+  */
+  virtual double getPeakCentre() const = 0;
+
+  /**
+  * Checks whether peak picker widget is enabled or no
+  *
+  * @return true or false according to the state of the
+  *  peak picker widget
+  */
+  virtual bool peakPickerEnabled() const = 0;
 
   /**
    * @return idx of current selected row of list widget

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h
@@ -176,7 +176,7 @@ public:
   /**
   * gets the path as string which required when browsing the file
   *
-  * @param path set according to the previously file selected
+  * @param prevPath path set according to the previously file selected
   *
   * @return string of the browsed file path
   */
@@ -185,7 +185,7 @@ public:
   /**
   * gets the path as string which is required when saving the file
   *
-  * @param path set according to the previously selected file
+  * @param prevPath path set according to the previously selected file
   *
   * @return string of the saved file
   */

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -82,6 +82,10 @@ void EnggDiffFittingPresenter::notify(
     addPeakToList();
     break;
 
+  case IEnggDiffFittingPresenter::browsePeaks:
+    browsePeaksToFit();
+	break;
+
   case IEnggDiffFittingPresenter::ShutDown:
     processShutDown();
     break;
@@ -712,6 +716,32 @@ std::string EnggDiffFittingPresenter::functionStrFactory(
       boost::lexical_cast<std::string>(S);
 
   return functionStr;
+}
+
+void EnggDiffFittingPresenter::browsePeaksToFit() {
+  try {
+    QString prevPath = QString::fromStdString(m_view->focusingDir());
+    if (prevPath.isEmpty()) {
+      prevPath = QString::fromStdString(m_view->getPreviousDir());
+    }
+
+    std::string pathStd = m_view->getOpenFile(prevPath.toStdString());
+
+    if (pathStd.empty()) {
+      return;
+    }
+
+    m_view->setPreviousDir(pathStd);
+
+    std::string peaksData = readPeaksFile(pathStd);
+
+    m_view->setPeakList(peaksData);
+  } catch (...) {
+    m_view->userWarning(
+        "Unable to import the peaks from a file: ",
+        "File corrupted or could not be opened. Please try again");
+    return;
+  }
 }
 
 void EnggDiffFittingPresenter::addPeakToList() {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -1128,7 +1128,7 @@ void EnggDiffFittingPresenter::setBankItems() {
 }
 
 void EnggDiffFittingPresenter::setRunNoItems(
-    std::vector<std::string> runNumVector, bool multiRun) {
+    const std::vector<std::string> &runNumVector, bool multiRun) {
   try {
     if (!runNumVector.empty()) {
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -7,6 +7,7 @@
 #include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresWorker.h"
 #include "MantidQtCustomInterfaces/Muon/ALCHelper.h"
 
+#include <fstream>
 #include <boost/lexical_cast.hpp>
 
 #include <Poco/DirectoryIterator.h>
@@ -744,6 +745,28 @@ void EnggDiffFittingPresenter::addPeakToList() {
       m_view->setPeakList(curExpPeaksList.toStdString());
     }
   }
+}
+
+std::string EnggDiffFittingPresenter::readPeaksFile(std::string fileDir) {
+  std::string fileData = "";
+  std::string line;
+  std::string comma = ", ";
+
+  std::ifstream peakFile(fileDir);
+
+  if (peakFile.is_open()) {
+    while (std::getline(peakFile, line)) {
+      fileData += line;
+      if (!peakFile.eof())
+        fileData += comma;
+    }
+    peakFile.close();
+  }
+
+  else
+    fileData = "";
+
+  return fileData;
 }
 
 void EnggDiffFittingPresenter::runEvaluateFunctionAlg(

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -84,12 +84,11 @@ void EnggDiffFittingPresenter::notify(
 
   case IEnggDiffFittingPresenter::browsePeaks:
     browsePeaksToFit();
-	break;
+    break;
 
   case IEnggDiffFittingPresenter::savePeaks:
-	savePeakList();
-	break;
-
+    savePeakList();
+    break;
 
   case IEnggDiffFittingPresenter::ShutDown:
     processShutDown();
@@ -782,27 +781,26 @@ void EnggDiffFittingPresenter::addPeakToList() {
   }
 }
 
-void EnggDiffFittingPresenter::savePeakList()
-{
-	try {
-		QString prevPath = QString::fromStdString(m_view->focusingDir());
-		if (prevPath.isEmpty()) {
-			prevPath = QString::fromStdString(m_view->getPreviousDir());
-		}
+void EnggDiffFittingPresenter::savePeakList() {
+  try {
+    QString prevPath = QString::fromStdString(m_view->focusingDir());
+    if (prevPath.isEmpty()) {
+      prevPath = QString::fromStdString(m_view->getPreviousDir());
+    }
 
-		std::string path = m_view->getSaveFile(prevPath.toStdString());
+    std::string path = m_view->getSaveFile(prevPath.toStdString());
 
-		if (path.empty()) {
-			return;
-		}
+    if (path.empty()) {
+      return;
+    }
 
-		fittingWriteFile(path);
-	}
-	catch (...) {
-		m_view->userWarning("Unable to save the peaks file: ",
-			"Invalid file path or or could not be saved. Please try again");
-		return;
-	}
+    fittingWriteFile(path);
+  } catch (...) {
+    m_view->userWarning(
+        "Unable to save the peaks file: ",
+        "Invalid file path or or could not be saved. Please try again");
+    return;
+  }
 }
 
 std::string EnggDiffFittingPresenter::readPeaksFile(std::string fileDir) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -77,6 +77,10 @@ void EnggDiffFittingPresenter::notify(
     processFitPeaks();
     break;
 
+  case IEnggDiffFittingPresenter::addPeaks:
+    addPeakToList();
+    break;
+
   case IEnggDiffFittingPresenter::ShutDown:
     processShutDown();
     break;
@@ -707,6 +711,39 @@ std::string EnggDiffFittingPresenter::functionStrFactory(
       boost::lexical_cast<std::string>(S);
 
   return functionStr;
+}
+
+void EnggDiffFittingPresenter::addPeakToList() {
+
+  if (m_view->peakPickerEnabled()) {
+    auto peakCentre = m_view->getPeakCentre();
+
+    std::stringstream stream;
+    stream << std::fixed << std::setprecision(4) << peakCentre;
+    auto strPeakCentre = stream.str();
+
+    QString curExpPeaksList =
+        QString::fromStdString(m_view->fittingPeaksData());
+    QString comma = ",";
+
+    if (!curExpPeaksList.isEmpty()) {
+      // when further peak added to list
+      std::string expPeakStr = curExpPeaksList.toStdString();
+      std::string lastTwoChr = expPeakStr.substr(expPeakStr.size() - 2);
+      auto lastChr = expPeakStr.back();
+      if (lastChr == ',' || lastTwoChr == ", ") {
+        curExpPeaksList.append(QString::fromStdString(strPeakCentre));
+      } else {
+        curExpPeaksList.append(comma + QString::fromStdString(strPeakCentre));
+      }
+      m_view->setPeakList(curExpPeaksList.toStdString());
+    } else {
+      // when new peak given when list is empty
+      curExpPeaksList.append(QString::fromStdString(strPeakCentre));
+      curExpPeaksList.append(comma);
+      m_view->setPeakList(curExpPeaksList.toStdString());
+    }
+  }
 }
 
 void EnggDiffFittingPresenter::runEvaluateFunctionAlg(

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -259,18 +259,6 @@ void EnggDiffFittingViewQtWidget::resetFittingMultiMode() {
   m_fittingMutliRunMode = false;
 }
 
-std::string EnggDiffFittingViewQtWidget::fittingRunNoFactory(
-    std::string bank, std::string fileName, std::string &bankDir,
-    std::string fileDir) {
-
-  std::string genDir = fileName.substr(0, fileName.size() - 1);
-  Poco::Path bankFile(genDir + bank + ".nxs");
-  if (bankFile.isFile()) {
-    bankDir = fileDir + genDir + bank + ".nxs";
-  }
-  return bankDir;
-}
-
 void EnggDiffFittingViewQtWidget::setDataVector(
     std::vector<boost::shared_ptr<QwtData>> &data, bool focused,
     bool plotSinglePeaks) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -394,12 +394,12 @@ std::string EnggDiffFittingViewQtWidget::getPreviousDir() const {
   return prevPath.toStdString();
 }
 
-void EnggDiffFittingViewQtWidget::setPreviousDir(std::string path) {
+void EnggDiffFittingViewQtWidget::setPreviousDir(const std::string &path) {
   QString qPath = QString::fromStdString(path);
   MantidQt::API::AlgorithmInputHistory::Instance().setPreviousDirectory(qPath);
 }
 
-std::string EnggDiffFittingViewQtWidget::getOpenFile(std::string prevPath) {
+std::string EnggDiffFittingViewQtWidget::getOpenFile(const std::string &prevPath) {
 
   QString path(QFileDialog::getOpenFileName(
       this, tr("Open Peaks To Fit"), QString::fromStdString(prevPath),
@@ -408,7 +408,7 @@ std::string EnggDiffFittingViewQtWidget::getOpenFile(std::string prevPath) {
   return path.toStdString();
 }
 
-std::string EnggDiffFittingViewQtWidget::getSaveFile(std::string prevPath) {
+std::string EnggDiffFittingViewQtWidget::getSaveFile(const std::string &prevPath) {
 
 	QString path(QFileDialog::getSaveFileName(
 		this, tr("Save Expected Peaks List"), QString::fromStdString(prevPath),

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -225,9 +225,8 @@ void EnggDiffFittingViewQtWidget::browseClicked() {
 }
 
 void EnggDiffFittingViewQtWidget::saveClicked() {
-	m_presenter->notify(IEnggDiffFittingPresenter::savePeaks);
+  m_presenter->notify(IEnggDiffFittingPresenter::savePeaks);
 }
-
 
 void EnggDiffFittingViewQtWidget::setBankDir(int idx) {
 
@@ -399,7 +398,8 @@ void EnggDiffFittingViewQtWidget::setPreviousDir(const std::string &path) {
   MantidQt::API::AlgorithmInputHistory::Instance().setPreviousDirectory(qPath);
 }
 
-std::string EnggDiffFittingViewQtWidget::getOpenFile(const std::string &prevPath) {
+std::string
+EnggDiffFittingViewQtWidget::getOpenFile(const std::string &prevPath) {
 
   QString path(QFileDialog::getOpenFileName(
       this, tr("Open Peaks To Fit"), QString::fromStdString(prevPath),
@@ -408,13 +408,14 @@ std::string EnggDiffFittingViewQtWidget::getOpenFile(const std::string &prevPath
   return path.toStdString();
 }
 
-std::string EnggDiffFittingViewQtWidget::getSaveFile(const std::string &prevPath) {
+std::string
+EnggDiffFittingViewQtWidget::getSaveFile(const std::string &prevPath) {
 
-	QString path(QFileDialog::getSaveFileName(
-		this, tr("Save Expected Peaks List"), QString::fromStdString(prevPath),
-		QString::fromStdString(g_peaksListExt)));
+  QString path(QFileDialog::getSaveFileName(
+      this, tr("Save Expected Peaks List"), QString::fromStdString(prevPath),
+      QString::fromStdString(g_peaksListExt)));
 
-	return path.toStdString();
+  return path.toStdString();
 }
 
 void EnggDiffFittingViewQtWidget::browseFitFocusedRun() {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -106,7 +106,7 @@ void EnggDiffFittingViewQtWidget::doSetup() {
   // add peak by clicking the button
   connect(m_ui.pushButton_select_peak, SIGNAL(released()), SLOT(setPeakPick()));
 
-  connect(m_ui.pushButton_add_peak, SIGNAL(released()), SLOT(addPeakToList()));
+  connect(m_ui.pushButton_add_peak, SIGNAL(released()), SLOT(addPeaks()));
 
   connect(m_ui.pushButton_save_peak_list, SIGNAL(released()),
           SLOT(savePeakList()));
@@ -215,6 +215,10 @@ void EnggDiffFittingViewQtWidget::fitClicked() {
 
 void EnggDiffFittingViewQtWidget::FittingRunNo() {
   m_presenter->notify(IEnggDiffFittingPresenter::FittingRunNo);
+}
+
+void EnggDiffFittingViewQtWidget::addPeaks() {
+	m_presenter->notify(IEnggDiffFittingPresenter::addPeaks);
 }
 
 void EnggDiffFittingViewQtWidget::setBankDir(int idx) {
@@ -388,6 +392,10 @@ double EnggDiffFittingViewQtWidget::getPeakCentre() const {
   auto peak = m_peakPicker->peak();
   auto centre = peak->centre();
   return centre;
+}
+
+bool EnggDiffFittingViewQtWidget::peakPickerEnabled() const {
+	return m_peakPicker->isEnabled();
 }
 
 void EnggDiffFittingViewQtWidget::fittingWriteFile(const std::string &fileDir) {
@@ -595,38 +603,6 @@ void EnggDiffFittingViewQtWidget::setPeakPick() {
   // set the peak to BackToBackExponential function
   setPeakPicker(bk2bkFunc);
   setPeakPickerEnabled(true);
-}
-
-void EnggDiffFittingViewQtWidget::addPeakToList() {
-
-  if (m_peakPicker->isEnabled()) {
-    auto peakCentre = getPeakCentre();
-
-    std::stringstream stream;
-    stream << std::fixed << std::setprecision(4) << peakCentre;
-    auto strPeakCentre = stream.str();
-
-    auto curExpPeaksList = m_ui.lineEdit_fitting_peaks->text();
-    QString comma = ",";
-
-    if (!curExpPeaksList.isEmpty()) {
-      // when further peak added to list
-      std::string expPeakStr = curExpPeaksList.toStdString();
-      std::string lastTwoChr = expPeakStr.substr(expPeakStr.size() - 2);
-      auto lastChr = expPeakStr.back();
-      if (lastChr == ',' || lastTwoChr == ", ") {
-        curExpPeaksList.append(QString::fromStdString(strPeakCentre));
-      } else {
-        curExpPeaksList.append(comma + QString::fromStdString(strPeakCentre));
-      }
-      m_ui.lineEdit_fitting_peaks->setText(curExpPeaksList);
-    } else {
-      // when new peak given when list is empty
-      curExpPeaksList.append(QString::fromStdString(strPeakCentre));
-      curExpPeaksList.append(comma);
-      m_ui.lineEdit_fitting_peaks->setText(curExpPeaksList);
-    }
-  }
 }
 
 void EnggDiffFittingViewQtWidget::savePeakList() {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -263,28 +263,6 @@ std::string EnggDiffFittingViewQtWidget::fittingRunNoFactory(
   return bankDir;
 }
 
-std::string EnggDiffFittingViewQtWidget::readPeaksFile(std::string fileDir) {
-  std::string fileData = "";
-  std::string line;
-  std::string comma = ", ";
-
-  std::ifstream peakFile(fileDir);
-
-  if (peakFile.is_open()) {
-    while (std::getline(peakFile, line)) {
-      fileData += line;
-      if (!peakFile.eof())
-        fileData += comma;
-    }
-    peakFile.close();
-  }
-
-  else
-    fileData = "";
-
-  return fileData;
-}
-
 void EnggDiffFittingViewQtWidget::setDataVector(
     std::vector<boost::shared_ptr<QwtData>> &data, bool focused,
     bool plotSinglePeaks) {

--- a/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
@@ -363,9 +363,6 @@ public:
     testing::NiceMock<MockEnggDiffFittingView> mockView;
     EnggDiffFittingPresenterNoThread pres(&mockView);
 
-    // should not get to the point where the status is updated
-    EXPECT_CALL(mockView, showStatus(testing::_)).Times(0);
-
     EXPECT_CALL(mockView, focusingDir()).Times(1);
 
     EXPECT_CALL(mockView, getPreviousDir()).Times(1);
@@ -373,6 +370,31 @@ public:
     EXPECT_CALL(mockView, getOpenFile(testing::_)).Times(1);
 
     EXPECT_CALL(mockView, getSaveFile(testing::_)).Times(0);
+
+    // No errors/0 warnings.
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffFittingPresenter::browsePeaks);
+  }
+
+  void test_browse_peaks_list_with_warning() {
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    EnggDiffFittingPresenterNoThread pres(&mockView);
+
+    std::string dummyDir = "I/am/a/dummy/directory";
+
+    EXPECT_CALL(mockView, focusingDir()).Times(1);
+
+    EXPECT_CALL(mockView, getPreviousDir()).Times(1);
+
+    EXPECT_CALL(mockView, getOpenFile(testing::_))
+        .Times(1)
+        .WillOnce(Return(dummyDir));
+
+    EXPECT_CALL(mockView, setPreviousDir(dummyDir)).Times(1);
+
+    EXPECT_CALL(mockView, setPeakList(testing::_)).Times(1);
 
     // No errors/0 warnings.
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
@@ -489,6 +511,57 @@ public:
 
     pres.notify(IEnggDiffFittingPresenter::addPeaks);
   }
+
+  void test_add_customised_valid_peaks_to_list_without_comma() {
+
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    EnggDiffFittingPresenterNoThread pres(&mockView);
+
+    EXPECT_CALL(mockView, peakPickerEnabled()).Times(1).WillOnce(Return(true));
+
+    EXPECT_CALL(mockView, getPeakCentre()).Times(1).WillOnce(Return(3.0234));
+
+    EXPECT_CALL(mockView, fittingPeaksData())
+        .Times(1)
+        .WillOnce(Return("2.0684,1.2676"));
+
+    EXPECT_CALL(mockView, setPeakList("2.0684,1.2676,3.0234")).Times(1);
+
+    // should not be updating the status
+    EXPECT_CALL(mockView, showStatus(testing::_)).Times(0);
+
+    // No errors/0 warnings.
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffFittingPresenter::addPeaks);
+  }
+
+  void test_add_invalid_peaks_to_list() {
+
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    EnggDiffFittingPresenterNoThread pres(&mockView);
+
+    EXPECT_CALL(mockView, peakPickerEnabled()).Times(1).WillOnce(Return(true));
+
+    EXPECT_CALL(mockView, getPeakCentre()).Times(1).WillOnce(Return(0.0133));
+
+    EXPECT_CALL(mockView, fittingPeaksData()).Times(1).WillOnce(Return(""));
+
+    // string should be "0.133," instead
+    EXPECT_CALL(mockView, setPeakList("0.0133")).Times(0);
+
+    EXPECT_CALL(mockView, setPeakList(",0.0133")).Times(0);
+
+    EXPECT_CALL(mockView, setPeakList("0.0133,")).Times(1);
+
+    // No errors/0 warnings. File entered is not found
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffFittingPresenter::addPeaks);
+  }
+
   void test_shutDown() {
     testing::NiceMock<MockEnggDiffFittingView> mockView;
     MantidQt::CustomInterfaces::EnggDiffFittingPresenter pres(&mockView,

--- a/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
@@ -398,6 +398,29 @@ public:
     pres.notify(IEnggDiffFittingPresenter::savePeaks);
   }
 
+  void test_save_peaks_list_with_warning() {
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    EnggDiffFittingPresenterNoThread pres(&mockView);
+
+    std::string dummyDir = "/dummy/directory/";
+
+    EXPECT_CALL(mockView, focusingDir()).Times(1);
+
+    EXPECT_CALL(mockView, getPreviousDir()).Times(1);
+
+    EXPECT_CALL(mockView, getSaveFile(testing::_))
+        .Times(1)
+        .WillOnce(Return(dummyDir));
+
+    EXPECT_CALL(mockView, fittingPeaksData()).Times(0);
+
+    // No errors/1 warnings. Dummy file entered is not found
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
+
+    pres.notify(IEnggDiffFittingPresenter::savePeaks);
+  }
+
   void test_add_peaks_to_empty_list() {
 
     testing::NiceMock<MockEnggDiffFittingView> mockView;
@@ -422,6 +445,50 @@ public:
     pres.notify(IEnggDiffFittingPresenter::addPeaks);
   }
 
+  void test_add_peaks_with_disabled_peak_picker() {
+
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    EnggDiffFittingPresenterNoThread pres(&mockView);
+
+    EXPECT_CALL(mockView, peakPickerEnabled()).Times(1).WillOnce(Return(false));
+
+    EXPECT_CALL(mockView, getPeakCentre()).Times(0);
+
+    EXPECT_CALL(mockView, fittingPeaksData()).Times(0);
+
+    EXPECT_CALL(mockView, setPeakList(testing::_)).Times(0);
+
+    // should not be updating the status
+    EXPECT_CALL(mockView, showStatus(testing::_)).Times(0);
+
+    // No errors/0 warnings.
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffFittingPresenter::addPeaks);
+  }
+
+  void test_add_valid_peaks_to_list_with_comma() {
+
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    EnggDiffFittingPresenterNoThread pres(&mockView);
+
+    EXPECT_CALL(mockView, peakPickerEnabled()).Times(1).WillOnce(Return(true));
+
+    EXPECT_CALL(mockView, getPeakCentre()).Times(1).WillOnce(Return(2.0684));
+
+    EXPECT_CALL(mockView, fittingPeaksData())
+        .Times(1)
+        .WillOnce(Return("1.7906,2.0684,1.2676,"));
+
+    EXPECT_CALL(mockView, setPeakList("1.7906,2.0684,1.2676,2.0684")).Times(1);
+
+    // No errors/0 warnings.
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffFittingPresenter::addPeaks);
+  }
   void test_shutDown() {
     testing::NiceMock<MockEnggDiffFittingView> mockView;
     MantidQt::CustomInterfaces::EnggDiffFittingPresenter pres(&mockView,

--- a/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
@@ -359,6 +359,69 @@ public:
     pres.notify(IEnggDiffFittingPresenter::FittingRunNo);
   }
 
+  void test_browse_peaks_list() {
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    EnggDiffFittingPresenterNoThread pres(&mockView);
+
+    // should not get to the point where the status is updated
+    EXPECT_CALL(mockView, showStatus(testing::_)).Times(0);
+
+    EXPECT_CALL(mockView, focusingDir()).Times(1);
+
+    EXPECT_CALL(mockView, getPreviousDir()).Times(1);
+
+    EXPECT_CALL(mockView, getOpenFile(testing::_)).Times(1);
+
+    EXPECT_CALL(mockView, getSaveFile(testing::_)).Times(0);
+
+    // No errors/0 warnings.
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffFittingPresenter::browsePeaks);
+  }
+
+  void test_save_peaks_list() {
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    EnggDiffFittingPresenterNoThread pres(&mockView);
+
+    EXPECT_CALL(mockView, focusingDir()).Times(1);
+
+    EXPECT_CALL(mockView, getPreviousDir()).Times(1);
+
+    EXPECT_CALL(mockView, getSaveFile(testing::_)).Times(1);
+
+    // No errors/No warnings.
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffFittingPresenter::savePeaks);
+  }
+
+  void test_add_peaks_to_empty_list() {
+
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    EnggDiffFittingPresenterNoThread pres(&mockView);
+
+    EXPECT_CALL(mockView, peakPickerEnabled()).Times(1).WillOnce(Return(true));
+
+    EXPECT_CALL(mockView, getPeakCentre()).Times(1);
+
+    EXPECT_CALL(mockView, fittingPeaksData()).Times(1).WillOnce(Return(""));
+    ;
+
+    EXPECT_CALL(mockView, setPeakList(testing::_)).Times(1);
+
+    // should not be updating the status
+    EXPECT_CALL(mockView, showStatus(testing::_)).Times(0);
+
+    // No errors/0 warnings.
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffFittingPresenter::addPeaks);
+  }
+
   void test_shutDown() {
     testing::NiceMock<MockEnggDiffFittingView> mockView;
     MantidQt::CustomInterfaces::EnggDiffFittingPresenter pres(&mockView,

--- a/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
@@ -550,9 +550,7 @@ public:
 
     // string should be "0.133," instead
     EXPECT_CALL(mockView, setPeakList("0.0133")).Times(0);
-
     EXPECT_CALL(mockView, setPeakList(",0.0133")).Times(0);
-
     EXPECT_CALL(mockView, setPeakList("0.0133,")).Times(1);
 
     // No errors/0 warnings. File entered is not found

--- a/MantidQt/CustomInterfaces/test/EnggDiffFittingViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffFittingViewMock.h
@@ -79,6 +79,24 @@ public:
   // enables or disables the fitting list widget
   MOCK_CONST_METHOD1(enableFittingListWidget, void(bool enable));
 
+  // gets the previously used directory path by the user
+  MOCK_CONST_METHOD0(getPreviousDir, std::string());
+
+  // sets the previously used directory path
+  MOCK_METHOD1(setPreviousDir, void(const std::string &path));
+
+  // gets the path as string which required when browsing the file
+  MOCK_METHOD1(getOpenFile, std::string(const std::string &prevPath));
+
+  // gets the path as string which is required when saving the file
+  MOCK_METHOD1(getSaveFile, std::string(const std::string &prevPath));
+
+  // Gets the peak picker's center (d-spacing value)
+  MOCK_CONST_METHOD0(getPeakCentre, double());
+
+  // Checks whether peak picker widget is enabled or no
+  MOCK_CONST_METHOD0(peakPickerEnabled, bool());
+
   // return idx of current selected row of list widget
   MOCK_CONST_METHOD0(getFittingListWidgetCurrentRow, int());
 


### PR DESCRIPTION
Description of work.

Remaining bit of code mentioned in #16637 have been moved to presenter, (`setDataVector` wasn't required to be moved to presenter in the end).
There are now many test cases included which will test the user interaction around the Fitting tab such as `adding peaks` to the list , `browsing` & `saving` _csv_ files and `importing peaks` from the _csv_ file to the interface.

**To test:**
Code review
All builds pass successfully
Presenter test have been updated
Fitting tab still functions as expected
Any further test cases which could be included..?

<!-- Instructions for testing. -->

Fixes #16637 
_Does not need to be in the release notes._

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
