### PR TITLE
Avoid copying values into std::vector only to erase them

### DIFF
--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -166,6 +166,7 @@ public:
     for (size_t i = 0; i < vec.size(); ++i) {
       vec[i] = static_cast<T>(toDouble(i));
     }
+    return vec;
   }
 
 protected:

--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -157,10 +157,12 @@ public:
 
   /**
    * Fills a std vector with values from the column if the types are compatible.
-   * @param vec :: The vector to fill in.
+   * @param maxSize :: Set size than the full column.
    */
-  template <class T> void numeric_fill(std::vector<T> &vec) const {
-    vec.resize(size());
+  template <class T = double>
+  std::vector<T>
+  numeric_fill(size_t maxSize = std::numeric_limits<size_t>::max()) const {
+    std::vector<T> vec(std::min(size(), maxSize));
     for (size_t i = 0; i < vec.size(); ++i) {
       vec[i] = static_cast<T>(toDouble(i));
     }

--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -157,7 +157,7 @@ public:
 
   /**
    * Fills a std vector with values from the column if the types are compatible.
-   * @param maxSize :: Set size than the full column.
+   * @param maxSize :: Set size to less than the full column.
    */
   template <class T = double>
   std::vector<T>

--- a/Framework/Algorithms/src/ConvertTableToMatrixWorkspace.cpp
+++ b/Framework/Algorithms/src/ConvertTableToMatrixWorkspace.cpp
@@ -52,10 +52,9 @@ void ConvertTableToMatrixWorkspace::exec() {
   if (nrows == 0) {
     throw std::runtime_error("The input table is empty");
   }
-  std::vector<double> X(nrows);
-  std::vector<double> Y(nrows);
-  inputWorkspace->getColumn(columnX)->numeric_fill(X);
-  inputWorkspace->getColumn(columnY)->numeric_fill(Y);
+
+  auto X = inputWorkspace->getColumn(columnX)->numeric_fill<>();
+  auto Y = inputWorkspace->getColumn(columnY)->numeric_fill<>();
 
   MatrixWorkspace_sptr outputWorkspace =
       WorkspaceFactory::Instance().create("Workspace2D", 1, nrows, nrows);
@@ -64,9 +63,8 @@ void ConvertTableToMatrixWorkspace::exec() {
   outputWorkspace->mutableY(0).assign(Y.begin(), Y.end());
 
   if (!columnE.empty()) {
-    std::vector<double> E(nrows);
-    inputWorkspace->getColumn(columnE)->numeric_fill(E);
-    outputWorkspace->mutableE(0) = std::move(E);
+    outputWorkspace->mutableE(0) =
+        inputWorkspace->getColumn(columnE)->numeric_fill<>();
   }
 
   auto labelX = boost::dynamic_pointer_cast<Units::Label>(

--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -101,18 +101,14 @@ std::map<std::string, std::string> SaveDiffCal::validateInputs() {
 void SaveDiffCal::writeDoubleFieldFromTable(H5::Group &group,
                                             const std::string &name) {
   auto column = m_calibrationWS->getColumn(name);
-  std::vector<double> data;
-  column->numeric_fill(data);
-  data.erase(data.begin() + m_numValues, data.end());
+  auto data = column->numeric_fill<>(m_numValues);
   H5Util::writeArray1D(group, name, data);
 }
 
 void SaveDiffCal::writeIntFieldFromTable(H5::Group &group,
                                          const std::string &name) {
   auto column = m_calibrationWS->getColumn(name);
-  std::vector<int32_t> data;
-  column->numeric_fill(data);
-  data.erase(data.begin() + m_numValues, data.end());
+  auto data = column->numeric_fill<int32_t>(m_numValues);
   H5Util::writeArray1D(group, name, data);
 }
 
@@ -121,8 +117,6 @@ void SaveDiffCal::writeIntFieldFromSVWS(
     H5::Group &group, const std::string &name,
     DataObjects::SpecialWorkspace2D_const_sptr ws) {
   auto detidCol = m_calibrationWS->getColumn("detid");
-  std::vector<detid_t> detids;
-  detidCol->numeric_fill(detids);
   bool isMask = bool(boost::dynamic_pointer_cast<const MaskWorkspace>(ws));
 
   // output array defaults to all one (one group, use the pixel)
@@ -153,8 +147,7 @@ void SaveDiffCal::generateDetidToIndex() {
   m_detidToIndex.clear();
 
   auto detidCol = m_calibrationWS->getColumn("detid");
-  std::vector<detid_t> detids;
-  detidCol->numeric_fill(detids);
+  auto detids = detidCol->numeric_fill<detid_t>();
 
   const size_t numDets = detids.size();
   for (size_t i = 0; i < numDets; ++i) {

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -485,10 +485,8 @@ void ConvolutionFitSequential::calculateEISF(
   auto columns = tableWs->getColumnNames();
   std::string height = searchForFitParams("Height", columns).at(0);
   std::string heightErr = searchForFitParams("Height_Err", columns).at(0);
-  auto heightY = std::vector<double>();
-  tableWs->getColumn(height)->numeric_fill(heightY);
-  auto heightE = std::vector<double>();
-  tableWs->getColumn(heightErr)->numeric_fill(heightE);
+  auto heightY = tableWs->getColumn(height)->numeric_fill<>();
+  auto heightE = tableWs->getColumn(heightErr)->numeric_fill<>();
 
   // Get amplitude column names
   auto ampNames = searchForFitParams("Amplitude", columns);
@@ -502,11 +500,9 @@ void ConvolutionFitSequential::calculateEISF(
   for (size_t i = 0; i < maxSize; i++) {
     // Get amplitude from column in table workspace
     std::string ampName = ampNames.at(i);
-    auto ampY = std::vector<double>();
-    tableWs->getColumn(ampName)->numeric_fill(ampY);
+    auto ampY = tableWs->getColumn(ampName)->numeric_fill<>();
     std::string ampErrorName = ampErrorNames.at(i);
-    auto ampErr = std::vector<double>();
-    tableWs->getColumn(ampErrorName)->numeric_fill(ampErr);
+    auto ampErr = tableWs->getColumn(ampErrorName)->numeric_fill<>();
 
     // Calculate EISF and EISF error
     // total = heightY + ampY

--- a/Framework/WorkflowAlgorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Framework/WorkflowAlgorithms/test/ProcessIndirectFitParametersTest.h
@@ -174,13 +174,11 @@ public:
 
     // Test output values
     auto heightY = outWs->readY(0);
-    auto heightTest = std::vector<double>();
-    tableWs->getColumn("f1.f1.f0.Height")->numeric_fill(heightTest);
+    auto heightTest = tableWs->getColumn("f1.f1.f0.Height")->numeric_fill<>();
     TS_ASSERT_EQUALS(heightY, heightTest);
 
     auto ampY = outWs->readY(1);
-    auto ampTest = std::vector<double>();
-    tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill(ampTest);
+    auto ampTest = tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill<>();
     TS_ASSERT_EQUALS(ampY, ampTest);
 
     // Test axis units
@@ -223,23 +221,19 @@ public:
 
     // Test output values
     auto heightY = outWs->readY(0);
-    auto heightTest = std::vector<double>();
-    tableWs->getColumn("f1.f1.f0.Height")->numeric_fill(heightTest);
+    auto heightTest = tableWs->getColumn("f1.f1.f0.Height")->numeric_fill<>();
     TS_ASSERT_EQUALS(heightY, heightTest);
 
     auto ampY = outWs->readY(1);
-    auto ampTest = std::vector<double>();
-    tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill(ampTest);
+    auto ampTest = tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill<>();
     TS_ASSERT_EQUALS(ampY, ampTest);
 
     auto height1Y = outWs->readY(2);
-    auto height1Test = std::vector<double>();
-    tableWs->getColumn("f1.f1.f1.Height")->numeric_fill(height1Test);
+    auto height1Test = tableWs->getColumn("f1.f1.f1.Height")->numeric_fill<>();
     TS_ASSERT_EQUALS(height1Y, height1Test);
 
     auto height2Y = outWs->readY(3);
-    auto height2Test = std::vector<double>();
-    tableWs->getColumn("f1.f1.f2.Height")->numeric_fill(height2Test);
+    auto height2Test = tableWs->getColumn("f1.f1.f2.Height")->numeric_fill<>();
     TS_ASSERT_EQUALS(height2Y, height2Test);
 
     // Test axis units


### PR DESCRIPTION
Description of work.

This adds an optional parameter to `Column::fill_numeric` to specify a maximum number of elements. Without this, there are two locations where we are inserting values into a vector only to erase them shortly after. 

**To test:**

<!-- Instructions for testing. -->

Fixes #15884.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
