### PR TITLE
Histogram Rollout - StripPeaks

### DIFF
--- a/Framework/Algorithms/src/StripPeaks.cpp
+++ b/Framework/Algorithms/src/StripPeaks.cpp
@@ -252,7 +252,7 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
     }
 
     // Get central bin values using points
-    auto binCenters = outputWS->points(i);
+    auto binCenters = outputWS->points(peakslist->getRef<int>("spectrum", i));
     const int spectrumLength = static_cast<int>(Y.size());
     for (int j = 0; j < spectrumLength; ++j) {
       double x = binCenters[j];

--- a/Framework/Algorithms/src/StripPeaks.cpp
+++ b/Framework/Algorithms/src/StripPeaks.cpp
@@ -188,8 +188,6 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
     // but Y needs to be mutable
     auto &X = outputWS->x(peakslist->getRef<int>("spectrum", i));
     auto &Y = outputWS->mutableY(peakslist->getRef<int>("spectrum", i));
-    // Also create point data for later
-    auto &pointData = outputWS->points(i);
     // Get back the gaussian parameters
     const double height = peakslist->getRef<double>("Height", i);
     const double centre = peakslist->getRef<double>("PeakCentre", i);
@@ -253,10 +251,11 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
                           << " x + " << a2 << " x^2\n";
     }
 
+	// Get central bin values using points
+	auto binCenters = outputWS->points(i);
     const int spectrumLength = static_cast<int>(Y.size());
     for (int j = 0; j < spectrumLength; ++j) {
-      // If this is histogram data, we want to use the bin's central value
-      double x = pointData[j];
+      double x = binCenters[j];
       // Skip if not anywhere near this peak
       if (x < centre - 5.0 * width)
         continue;

--- a/Framework/Algorithms/src/StripPeaks.cpp
+++ b/Framework/Algorithms/src/StripPeaks.cpp
@@ -188,8 +188,8 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
     // but Y needs to be mutable
     auto &X = outputWS->x(peakslist->getRef<int>("spectrum", i));
     auto &Y = outputWS->mutableY(peakslist->getRef<int>("spectrum", i));
-	// Also create point data for later
-	auto &pointData = outputWS->points(i);
+    // Also create point data for later
+    auto &pointData = outputWS->points(i);
     // Get back the gaussian parameters
     const double height = peakslist->getRef<double>("Height", i);
     const double centre = peakslist->getRef<double>("PeakCentre", i);
@@ -253,7 +253,6 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
                           << " x + " << a2 << " x^2\n";
     }
 
-	
     const int spectrumLength = static_cast<int>(Y.size());
     for (int j = 0; j < spectrumLength; ++j) {
       // If this is histogram data, we want to use the bin's central value

--- a/Framework/Algorithms/src/StripPeaks.cpp
+++ b/Framework/Algorithms/src/StripPeaks.cpp
@@ -175,9 +175,7 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
   // progress 0.2 to 0.3 in this loop
   double prg = 0.2;
   for (size_t k = 0; k < hists; ++k) {
-    outputWS->dataX(k) = input->readX(k);
-    outputWS->dataY(k) = input->readY(k);
-    outputWS->dataE(k) = input->readE(k);
+    outputWS->setHistogram(k, input->histogram(k));
     prg += (0.1 / static_cast<double>(hists));
     progress(prg);
   }
@@ -187,9 +185,10 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
   prg = 0.3;
   // Loop over the list of peaks
   for (size_t i = 0; i < peakslist->rowCount(); ++i) {
-    // Get references to the data
-    const MantidVec &X = outputWS->readX(peakslist->getRef<int>("spectrum", i));
-    MantidVec &Y = outputWS->dataY(peakslist->getRef<int>("spectrum", i));
+    // Get references to the data - X can be const
+    // but Y needs to be mutable
+    auto &X = outputWS->x(peakslist->getRef<int>("spectrum", i));
+    auto &Y = outputWS->mutableY(peakslist->getRef<int>("spectrum", i));
     // Get back the gaussian parameters
     const double height = peakslist->getRef<double>("Height", i);
     const double centre = peakslist->getRef<double>("PeakCentre", i);

--- a/Framework/Algorithms/src/StripPeaks.cpp
+++ b/Framework/Algorithms/src/StripPeaks.cpp
@@ -251,8 +251,8 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
                           << " x + " << a2 << " x^2\n";
     }
 
-	// Get central bin values using points
-	auto binCenters = outputWS->points(i);
+    // Get central bin values using points
+    auto binCenters = outputWS->points(i);
     const int spectrumLength = static_cast<int>(Y.size());
     for (int j = 0; j < spectrumLength; ++j) {
       double x = binCenters[j];

--- a/Framework/Algorithms/src/StripPeaks.cpp
+++ b/Framework/Algorithms/src/StripPeaks.cpp
@@ -180,7 +180,6 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
     progress(prg);
   }
 
-  const bool isHistogramData = outputWS->isHistogramData();
   // progress from 0.3 to 1.0 here
   prg = 0.3;
   // Loop over the list of peaks
@@ -189,6 +188,8 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
     // but Y needs to be mutable
     auto &X = outputWS->x(peakslist->getRef<int>("spectrum", i));
     auto &Y = outputWS->mutableY(peakslist->getRef<int>("spectrum", i));
+	// Also create point data for later
+	auto &pointData = outputWS->points(i);
     // Get back the gaussian parameters
     const double height = peakslist->getRef<double>("Height", i);
     const double centre = peakslist->getRef<double>("PeakCentre", i);
@@ -252,11 +253,11 @@ StripPeaks::removePeaks(API::MatrixWorkspace_const_sptr input,
                           << " x + " << a2 << " x^2\n";
     }
 
-    // Loop over the spectrum elements
+	
     const int spectrumLength = static_cast<int>(Y.size());
     for (int j = 0; j < spectrumLength; ++j) {
       // If this is histogram data, we want to use the bin's central value
-      double x = (isHistogramData ? 0.5 * (X[j] + X[j + 1]) : X[j]);
+      double x = pointData[j];
       // Skip if not anywhere near this peak
       if (x < centre - 5.0 * width)
         continue;

--- a/Framework/Algorithms/test/StripPeaksTest.h
+++ b/Framework/Algorithms/test/StripPeaksTest.h
@@ -115,7 +115,7 @@ public:
     WS->getAxis(0)->unit() =
         Mantid::Kernel::UnitFactory::Instance().create("dSpacing");
 
-    auto &X = WS->x(1);
+    auto &X = WS->points(1);
     auto &Y1 = WS->mutableY(1);
     auto &E1 = WS->mutableE(1);
     auto &Y0 = WS->mutableY(0);
@@ -124,7 +124,7 @@ public:
       Y0[i] = 5000;
 
       // Spectrum 1
-      const double x = (X[i] + X[i + 1]) / 2;
+	  const double x = X[i];
       double funcVal = 2500 * exp(-0.5 * pow((x - 3.14) / 0.022, 2));
       funcVal += 1000 * exp(-0.5 * pow((x - 1.22) / 0.02, 2));
       Y1[i] = 5000 + funcVal;

--- a/Framework/Algorithms/test/StripPeaksTest.h
+++ b/Framework/Algorithms/test/StripPeaksTest.h
@@ -25,10 +25,10 @@ public:
     WS->getAxis(0)->unit() =
         Mantid::Kernel::UnitFactory::Instance().create("dSpacing");
 
-    const Mantid::MantidVec &X = WS->readX(1);
-    Mantid::MantidVec &Y1 = WS->dataY(1);
-    Mantid::MantidVec &E1 = WS->dataE(1);
-    Mantid::MantidVec &Y0 = WS->dataY(0);
+    auto &X = WS->x(1);
+    auto &Y1 = WS->mutableY(1);
+    auto &E1 = WS->mutableE(1);
+    auto &Y0 = WS->mutableY(0);
     for (size_t i = 0; i < Y1.size(); ++i) {
       // Spectrum 0
       Y0[i] = 5000;
@@ -83,11 +83,11 @@ public:
     TS_ASSERT_EQUALS(nbins, input->blocksize());
 
     for (size_t i = 0; i < nhist; ++i) {
-      const auto &inX = input->readX(i);
-      const auto &inE = input->readE(i);
-      const auto &outX = output->readX(i);
-      const auto &outY = output->readY(i);
-      const auto &outE = output->readE(i);
+      const auto &inX = input->x(i);
+      const auto &inE = input->e(i);
+      const auto &outX = output->x(i);
+      const auto &outY = output->y(i);
+      const auto &outE = output->e(i);
       for (size_t j = 0; j < nbins; ++j) {
         TS_ASSERT_EQUALS(outX[j], inX[j]);
         TS_ASSERT_DELTA(outY[j], 5000.0, 0.5);
@@ -115,10 +115,10 @@ public:
     WS->getAxis(0)->unit() =
         Mantid::Kernel::UnitFactory::Instance().create("dSpacing");
 
-    const Mantid::MantidVec &X = WS->readX(1);
-    Mantid::MantidVec &Y1 = WS->dataY(1);
-    Mantid::MantidVec &E1 = WS->dataE(1);
-    Mantid::MantidVec &Y0 = WS->dataY(0);
+    auto &X = WS->x(1);
+    auto &Y1 = WS->mutableY(1);
+    auto &E1 = WS->mutableE(1);
+    auto &Y0 = WS->mutableY(0);
     for (size_t i = 0; i < Y1.size(); ++i) {
       // Spectrum 0
       Y0[i] = 5000;
@@ -133,26 +133,23 @@ public:
 
     AnalysisDataService::Instance().add("toStrip", WS);
 
-	//Setup algorithm and prep for run
-	stripAlg.initialize();
-	stripAlg.setPropertyValue("InputWorkspace", "toStrip");
-	stripAlg.setPropertyValue("OutputWorkspace", "Stripped");
-	stripAlg.setProperty("HighBackground", false);
-	stripAlg.setProperty("FWHM", 7);
+    // Setup algorithm and prep for run
+    stripAlg.initialize();
+    stripAlg.setPropertyValue("InputWorkspace", "toStrip");
+    stripAlg.setPropertyValue("OutputWorkspace", "Stripped");
+    stripAlg.setProperty("HighBackground", false);
+    stripAlg.setProperty("FWHM", 7);
   }
 
-  void test_strip_peaks()
-  {
-	  TS_ASSERT_THROWS_NOTHING(stripAlg.execute());
-  }
+  void test_strip_peaks() { TS_ASSERT_THROWS_NOTHING(stripAlg.execute()); }
 
   void tearDown() {
-	  AnalysisDataService::Instance().remove("Stripped");
-	  AnalysisDataService::Instance().remove("toStrip");
+    AnalysisDataService::Instance().remove("Stripped");
+    AnalysisDataService::Instance().remove("toStrip");
   }
 
 private:
-	StripPeaks stripAlg;
+  StripPeaks stripAlg;
 };
 
 #endif /*STRIPPEAKSTEST_H_*/

--- a/Framework/Algorithms/test/StripPeaksTest.h
+++ b/Framework/Algorithms/test/StripPeaksTest.h
@@ -106,4 +106,53 @@ private:
   StripPeaks strip;
 };
 
+class StripPeaksTestPerformance : public CxxTest::TestSuite {
+public:
+  void setUp() {
+    FrameworkManager::Instance();
+    MatrixWorkspace_sptr WS =
+        WorkspaceCreationHelper::Create2DWorkspaceBinned(2, 200, 0.5, 0.02);
+    WS->getAxis(0)->unit() =
+        Mantid::Kernel::UnitFactory::Instance().create("dSpacing");
+
+    const Mantid::MantidVec &X = WS->readX(1);
+    Mantid::MantidVec &Y1 = WS->dataY(1);
+    Mantid::MantidVec &E1 = WS->dataE(1);
+    Mantid::MantidVec &Y0 = WS->dataY(0);
+    for (size_t i = 0; i < Y1.size(); ++i) {
+      // Spectrum 0
+      Y0[i] = 5000;
+
+      // Spectrum 1
+      const double x = (X[i] + X[i + 1]) / 2;
+      double funcVal = 2500 * exp(-0.5 * pow((x - 3.14) / 0.022, 2));
+      funcVal += 1000 * exp(-0.5 * pow((x - 1.22) / 0.02, 2));
+      Y1[i] = 5000 + funcVal;
+      E1[i] = sqrt(Y1[i]);
+    }
+
+    AnalysisDataService::Instance().add("toStrip", WS);
+
+	//Setup algorithm and prep for run
+	stripAlg.initialize();
+	stripAlg.setPropertyValue("InputWorkspace", "toStrip");
+	stripAlg.setPropertyValue("OutputWorkspace", "Stripped");
+	stripAlg.setProperty("HighBackground", false);
+	stripAlg.setProperty("FWHM", 7);
+  }
+
+  void test_strip_peaks()
+  {
+	  TS_ASSERT_THROWS_NOTHING(stripAlg.execute());
+  }
+
+  void tearDown() {
+	  AnalysisDataService::Instance().remove("Stripped");
+	  AnalysisDataService::Instance().remove("toStrip");
+  }
+
+private:
+	StripPeaks stripAlg;
+};
+
 #endif /*STRIPPEAKSTEST_H_*/

--- a/Framework/Algorithms/test/StripPeaksTest.h
+++ b/Framework/Algorithms/test/StripPeaksTest.h
@@ -124,7 +124,7 @@ public:
       Y0[i] = 5000;
 
       // Spectrum 1
-	  const double x = X[i];
+      const double x = X[i];
       double funcVal = 2500 * exp(-0.5 * pow((x - 3.14) / 0.022, 2));
       funcVal += 1000 * exp(-0.5 * pow((x - 1.22) / 0.02, 2));
       Y1[i] = 5000 + funcVal;

--- a/Framework/Algorithms/test/StripPeaksTest.h
+++ b/Framework/Algorithms/test/StripPeaksTest.h
@@ -115,7 +115,7 @@ public:
     WS->getAxis(0)->unit() =
         Mantid::Kernel::UnitFactory::Instance().create("dSpacing");
 
-    auto &X = WS->points(1);
+    auto X = WS->points(1);
     auto &Y1 = WS->mutableY(1);
     auto &E1 = WS->mutableE(1);
     auto &Y0 = WS->mutableY(0);


### PR DESCRIPTION
Description of work.
StripPeaks has been converted to use the new histrogram interface and a performance test has additionally been added.

The performance test locally before changes took 1.7s-1.8s. With the changes the performance test completes in 1.75-1.85s 

**To test:**
The unit tests should all pass and the time taken before and after should not degrade significantly. Strip peaks output should not have changed. 

Fixes #16877 
Does not need to be added to the relase notes

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
