### PR TITLE
Add TOF limits to SCD Event Data Reduction Interface

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1111,7 +1111,7 @@ void LoadEventNexus::init() {
   declareProperty(
       make_unique<PropertyWithValue<bool>>("Precount", true, Direction::Input),
       "Pre-count the number of events in each pixel before allocating memory "
-      "(optional, default False). "
+      "(optional, default True). "
       "This can significantly reduce memory use and memory fragmentation; it "
       "may also speed up loading.");
 

--- a/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
@@ -156,8 +156,17 @@ bool MantidEVWorker::loadAndConvertToMD(
       IAlgorithm_sptr alg = AlgorithmManager::Instance().create("Load");
       alg->setProperty("Filename", file_name);
       alg->setProperty("OutputWorkspace", ev_ws_name);
-      alg->setProperty("Precount", true);
+      alg->setProperty("FilterByTofMin", 1000.0);
+      alg->setProperty("FilterByTofMax", 16666.0);
       alg->setProperty("LoadMonitors", true);
+
+      if (!alg->execute())
+        return false;
+
+      alg = AlgorithmManager::Instance().create("FilterBadPulses");
+      alg->setProperty("InputWorkspace", ev_ws_name);
+      alg->setProperty("OutputWorkspace", ev_ws_name);
+      alg->setProperty("LowerCutoff", 95.0);
 
       if (!alg->execute())
         return false;

--- a/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
@@ -166,7 +166,7 @@ bool MantidEVWorker::loadAndConvertToMD(
       alg = AlgorithmManager::Instance().create("FilterBadPulses");
       alg->setProperty("InputWorkspace", ev_ws_name);
       alg->setProperty("OutputWorkspace", ev_ws_name);
-      alg->setProperty("LowerCutoff", 95.0);
+      alg->setProperty("LowerCutoff", 25.0);
 
       if (!alg->execute())
         return false;


### PR DESCRIPTION
Description of work.
Added the TOF limits and FilterBadPulses used in reduction python scripts.  With DAS change, there are TOF=0 events in file that will be removed with these changes.

**To test:**

<!-- Instructions for testing. -->

Use SCD interface in Diffraction menu and ResetDefault Settings in File menu.
Make these changes
Filename TOPAZ_20379
Number of Peaks to Find 1500
Ellipsoidal Integration with Specify Size option
Fixes #17013

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
