### PR TITLE
Fix compiling isnan/isinf with GCC 5

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1073,9 +1073,9 @@ void MatrixWorkspace::maskBin(const size_t &workspaceIndex,
   // whereas other values are scaled by (1 - weight)
   if (weight != 0.) {
     double &y = this->mutableY(workspaceIndex)[binIndex];
-    (isnan(y) || isinf(y)) ? y = 0. : y *= (1 - weight);
+    (std::isnan(y) || std::isinf(y)) ? y = 0. : y *= (1 - weight);
     double &e = this->mutableE(workspaceIndex)[binIndex];
-    (isnan(e) || isinf(e)) ? e = 0. : e *= (1 - weight);
+    (std::isnan(e) || std::isinf(e)) ? e = 0. : e *= (1 - weight);
   }
 }
 


### PR DESCRIPTION
Mantid fails to compile with gcc 5, _i.e._ Ubuntu 16.04, this fixes that.

**To test:**
- build mantid with gcc 5

**_Does not need to be in the release notes.**_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
