### PR TITLE
Fix compiling MatrixWorkspaceTest with GCC 5

### DIFF
--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -359,9 +359,9 @@ public:
       ws.maskBin(0, i, 0);
     }
 
-    TS_ASSERT(isnan(ws.y(0)[0]));
-    TS_ASSERT(isinf(ws.y(0)[1]));
-    TS_ASSERT(isinf(ws.y(0)[2]));
+    TS_ASSERT(std::isnan(ws.y(0)[0]));
+    TS_ASSERT(std::isinf(ws.y(0)[1]));
+    TS_ASSERT(std::isinf(ws.y(0)[2]));
     TS_ASSERT_EQUALS(ws.y(0)[3], 2.);
 
     // now mask w/o specifying weight (e.g. 1 by default)


### PR DESCRIPTION
Same as #17032 but for the unit test.

Unittest fails to compile with gcc 5, _i.e._ Ubuntu 16.04, this fixes that.

**To test:**
- build APITest with gcc 5
## Does not need to be in the release notes.
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
