### PR TITLE
Fix performance regression in EventList

### DIFF
--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1526,14 +1526,14 @@ const HistogramData::HistogramY &EventList::y() const {
     throw std::runtime_error(
         "'EventList::y()' called with no MRU set. This is not allowed.");
 
-  return histogram().y();
+  return *sharedY();
 }
 const HistogramData::HistogramE &EventList::e() const {
   if (!mru)
     throw std::runtime_error(
         "'EventList::e()' called with no MRU set. This is not allowed.");
 
-  return histogram().e();
+  return *sharedE();
 }
 Kernel::cow_ptr<HistogramData::HistogramY> EventList::sharedY() const {
   // This is the thread number from which this function was called.

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1600,9 +1600,9 @@ const MantidVec &EventList::dataY() const {
     throw std::runtime_error(
         "'EventList::dataY()' called with no MRU set. This is not allowed.");
 
-  // WARNING: The Y data of histogram() is stored in MRU, returning reference
-  // fine as long as it stays there.
-  return histogram().dataY();
+  // WARNING: The Y data of sharedY() is stored in MRU, returning reference fine
+  // as long as it stays there.
+  return sharedY()->rawData();
 }
 
 /** Look in the MRU to see if the E histogram has been generated before.
@@ -1615,9 +1615,9 @@ const MantidVec &EventList::dataE() const {
     throw std::runtime_error(
         "'EventList::dataE()' called with no MRU set. This is not allowed.");
 
-  // WARNING: The E data of histogram() is stored in MRU, returning reference
-  // fine as long as it stays there.
-  return histogram().dataE();
+  // WARNING: The E data of sharedE() is stored in MRU, returning reference fine
+  // as long as it stays there.
+  return sharedE()->rawData();
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
@LamarMoore notices a performance regression in `DiffractionFocussing2PerformanceTest` by the `Histogram::YMode` PR.

The performance results are here: http://builds.mantidproject.org/view/Tests/job/master_performancetests/Master_branch_performance_tests/AlgorithmsTest.DiffractionFocussing2TestPerformance.test_SNAP_event_six_groups_dontPreserveEvents.htm.

```
100 2016-07-26 09:18:57 f759dc8 diff        6.033   1.69441 
99  2016-07-26 08:57:42 8534a80 diff        5.946   1.69504 
98  2016-07-25 13:49:30 ead5760 diff        6.108   1.69646 
97  2016-07-25 09:31:56 6f6ed2d diff        5.925   1.70133 
96  2016-07-25 09:05:06 d4fe7ae diff        7.124   1.38968 
95  2016-07-23 23:53:18 e7901ed diff        7.986   1.28852 
94  2016-07-22 23:22:50 ac3c4dd diff        5.897   1.70326 
93  2016-07-22 23:01:50 7bdf0f3 diff        5.834   1.69924 
92  2016-07-22 22:34:50 a966d75 diff        5.754   1.67303 
91  2016-07-22 15:31:45 a6eecf7 diff        6.324   1.69839 
90  2016-07-22 09:30:12 717a200 diff        3.061   1.66984 
89  2016-07-22 09:06:35 4ffef1c diff        3.081   1.66816 
88  2016-07-21 23:29:47 d7f8863 diff        3.129   1.65929 
87  2016-07-21 23:09:12 d7f8863 diff        3.018   1.66478 
86  2016-07-21 13:07:13 77a2b60 diff        3.106   1.65729 
85  2016-07-21 10:52:46 43096d2 diff        3.313   1.61791 
84  2016-07-21 09:59:52 43096d2 diff        3.216   1.6038  
83  2016-07-21 09:34:59 1c23080 diff        3.231   1.66098 
82  2016-07-20 22:20:04 fa98011 diff        3.151   1.66597 
81  2016-07-20 16:16:29 4b996f4 diff        3.257   1.6633  
80  2016-07-15 09:33:23 589fa35 diff        3.051   1.6786
```

This turns out to be due to changes in `EventList` that increased the number of look-ups in the MRU, and also the `shared_ptr` handling. I had not contemplated this as critical during the implementation, but apparently it is.

Here we reduce the number of look-ups back to the previous amount for `Y` and `E` access.

For the typed accessors (`counts()`, `frequencies()`, ...) we are still going the route via `histogram()` with more look-ups.  This could also be fixed but is slightly more complicated. We can do so if we notice more performance issues. This issue can be entirely avoided in clients by working with `EventList::histogram()` and operating based on the returned `Histogram` instead of using the individual access.

**To test:**

<!-- Instructions for testing. -->
- Code review.
- Check DiffractionFocussing2PerformanceTest results and see if they are back to normal.
- No corresponding issue.
- No release notes since the PR that caused this was merged after the last release.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Caused by recent changes when introducing Histogram::YMode. Performance
regression was visible in
AlgorithmsTest.DiffractionFocussing2TestPerformance
test_SNAP_event_six_groups_dontPreserveEvents.

The overhead seems to be cause by map lookup in the MRU, which I had
previously considered insignificant.
