### PR TITLE
Remove DLL macro from histogram data inline classes

### DIFF
--- a/Framework/HistogramData/inc/MantidHistogramData/LinearGenerator.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/LinearGenerator.h
@@ -29,7 +29,7 @@ namespace HistogramData {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_HISTOGRAMDATA_DLL LinearGenerator {
+class LinearGenerator {
 public:
   LinearGenerator(double start, double increment)
       : start(start), increment(increment) {}

--- a/Framework/HistogramData/inc/MantidHistogramData/LogarithmicGenerator.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/LogarithmicGenerator.h
@@ -29,7 +29,7 @@ namespace HistogramData {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_HISTOGRAMDATA_DLL LogarithmicGenerator {
+class LogarithmicGenerator {
 public:
   LogarithmicGenerator(double start, double increment)
       : current(start), increment(1.0 + increment) {}


### PR DESCRIPTION
Removed the DLL macros from the `HistogramData` inline classes `LinearGenerator` and `LogarithmicGenerator`. This was causing a build failure with visual studio update 3

This was tested locally and works (builds) with update 3

**To test:**
- Build all on visual studio with update 2 (done by build servers)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
