### PR TITLE
Allow negative determinant for UB

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Crystal/OrientedLattice.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/OrientedLattice.h
@@ -56,7 +56,7 @@ public:
   // Access private variables
   const Kernel::DblMatrix &getU() const;
   const Kernel::DblMatrix &getUB() const;
-  void setU(const Kernel::DblMatrix &newU, const bool force = false);
+  void setU(const Kernel::DblMatrix &newU, const bool force = true);
   void setUB(const Kernel::DblMatrix &newUB);
   // get u and v vectors for Horace/Mslice
   Kernel::V3D getuVector() const;

--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -94,7 +94,8 @@ const DblMatrix &OrientedLattice::getUB() const { return UB; }
   @param force :: If true, do not check that U matrix is valid
   */
 void OrientedLattice::setU(const DblMatrix &newU, const bool force) {
-  if (force || newU.isRotation()) {
+  // determinant ==1 or (determinant == +/-1 and force)
+  if (newU.isRotation() || (force && newU.isOrthogonal())) {
     U = newU;
     UB = U * getB();
   } else

--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -104,7 +104,7 @@ void OrientedLattice::setU(const DblMatrix &newU, const bool force) {
 /** Sets the UB matrix and recalculates lattice parameters
   @param newUB :: the new UB matrix*/
 void OrientedLattice::setUB(const DblMatrix &newUB) {
-  //check if determinant is close to 0. The 1e-10 value is arbitrary
+  // check if determinant is close to 0. The 1e-10 value is arbitrary
   if (std::fabs(newUB.determinant()) > 1e-10) {
     UB = newUB;
     DblMatrix newGstar, B;

--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -104,7 +104,8 @@ void OrientedLattice::setU(const DblMatrix &newU, const bool force) {
 /** Sets the UB matrix and recalculates lattice parameters
   @param newUB :: the new UB matrix*/
 void OrientedLattice::setUB(const DblMatrix &newUB) {
-  if (UB.determinant() > 0) {
+  //check if determinant is close to 0. The 1e-10 value is arbitrary
+  if (std::fabs(newUB.determinant()) > 1e-10) {
     UB = newUB;
     DblMatrix newGstar, B;
     newGstar = newUB.Tprime() * newUB;
@@ -113,7 +114,7 @@ void OrientedLattice::setUB(const DblMatrix &newUB) {
     B.Invert();
     U = newUB * B;
   } else
-    throw std::invalid_argument("determinant of UB is not greater than 0");
+    throw std::invalid_argument("determinant of UB is too close to 0");
 }
 
 /** Calculate the hkl corresponding to a given Q-vector

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
@@ -16,8 +16,8 @@ namespace //<unnamed>
 using namespace Mantid::PythonInterface;
 
 /// Set the U vector via a numpy array
-void setU(OrientedLattice &self, const object &data) {
-  self.setU(Converters::PyObjectToMatrix(data)());
+void setU(OrientedLattice &self, const object &data, const bool force) {
+  self.setU(Converters::PyObjectToMatrix(data)(), force);
 }
 
 /// Set the U vector via a numpy array
@@ -58,7 +58,7 @@ void export_OrientedLattice() {
       .def("getuVector", (&OrientedLattice::getuVector), arg("self"))
       .def("getvVector", (&OrientedLattice::getvVector), arg("self"))
       .def("getU", &OrientedLattice::getU, arg("self"), return_readonly_numpy())
-      .def("setU", &setU, (arg("self"), arg("newU")))
+      .def("setU", &setU, (arg("self"), arg("newU"), arg("force") = true))
       .def("getUB", &OrientedLattice::getUB, arg("self"),
            return_readonly_numpy())
       .def("setUB", &setUB, (arg("self"), arg("newUB")))

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -22,7 +22,7 @@ Concepts
 
 - ``MatrixWorkspace`` : When masking bins or detectors with non-zero weights,
   undefined and infinite values and errors will be zeroed.
-
+- ``Lattice`` : Allow setting a UB matrix with negative determinant (improper rotation)  
 
 Algorithms
 ----------
@@ -89,6 +89,7 @@ Python
 - :py:obj:`mantid.kernel.MaterialBuilder` has been exposed to python
   and :py:obj:`mantid.kernel.Material` has been modified to expose the
   individual atoms.
+- :py:obj:`mantid.geometry.OrientedLattice` set U with determinant -1 exposed to python
 
 Python Algorithms
 #################


### PR DESCRIPTION
Allow UB to be symmetrized by inversion or any operation that wil give `det(UB)!=0`

**To test:**
Create a workspace. Use `SetUB` algorithm with UB="-1,0,0,0,-1,0,0,0,-1"

Fixes #17068

Release notes were updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
