### PR TITLE
Remove simple api import * in BayesStretch

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
@@ -4,7 +4,7 @@ from IndirectImport import *
 from mantid.api import (PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty,
                         WorkspaceGroupProperty, Progress)
 from mantid.kernel import StringListValidator, Direction
-from mantid.simpleapi import *
+import mantid.simpleapi as s_api
 from mantid import config, logger
 import os
 import numpy as np
@@ -214,21 +214,21 @@ class BayesStretch(PythonAlgorithm):
 
         group = fname + '_Sigma,' + fname + '_Beta'
         fit_ws = fname + '_Fit'
-        GroupWorkspaces(InputWorkspaces=group,
+        s_api.GroupWorkspaces(InputWorkspaces=group,
                         OutputWorkspace=fit_ws)
         contour_ws = fname + '_Contour'
-        GroupWorkspaces(InputWorkspaces=groupZ,
+        s_api.GroupWorkspaces(InputWorkspaces=groupZ,
                         OutputWorkspace=contour_ws)
 
         #Add some sample logs to the output workspaces
         log_prog = Progress(self, start=0.8, end =1.0, nreports=6)
         log_prog.report('Copying Logs to Fit workspace')
-        CopyLogs(InputWorkspace=self._sam_name,
+        s_api.CopyLogs(InputWorkspace=self._sam_name,
                  OutputWorkspace=fit_ws)
         log_prog.report('Adding Sample logs to Fit workspace')
         self._add_sample_logs(fit_ws, self._erange, self._nbins[0])
         log_prog.report('Copying logs to Contour workspace')
-        CopyLogs(InputWorkspace=self._sam_name,
+        s_api.CopyLogs(InputWorkspace=self._sam_name,
                  OutputWorkspace=contour_ws)
         log_prog.report('Adding sample logs to Contour workspace')
         self._add_sample_logs(contour_ws, self._erange, self._nbins[0])
@@ -286,15 +286,15 @@ class BayesStretch(PythonAlgorithm):
         if is_zp_ws:
             unit_x = 'MomentumTransfer'
 
-        CreateWorkspace(OutputWorkspace=name,
-                        DataX=xye[0], DataY=xye[1], DataE=xye[2],
-                        Nspec=num_spec, UnitX=unit_x,
-                        VerticalAxisUnit='MomentumTransfer',
-                        VerticalAxisValues=vert_axis)
+        ws = s_api.CreateWorkspace(OutputWorkspace=name,
+                                   DataX=xye[0], DataY=xye[1], DataE=xye[2],
+                                   Nspec=num_spec, UnitX=unit_x,
+                                   VerticalAxisUnit='MomentumTransfer',
+                                   VerticalAxisValues=vert_axis)
 
-        unitx = mtd[name].getAxis(0).setUnit("Label")
+        unitx = ws.getAxis(0).setUnit("Label")
         if is_zp_ws:
-            unity = mtd[name].getAxis(1).setUnit("Label")
+            unity = ws.getAxis(1).setUnit("Label")
             unitx.setLabel('beta' , '')
             unity.setLabel('sigma' , '')
         else:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
@@ -215,10 +215,10 @@ class BayesStretch(PythonAlgorithm):
         group = fname + '_Sigma,' + fname + '_Beta'
         fit_ws = fname + '_Fit'
         s_api.GroupWorkspaces(InputWorkspaces=group,
-                        OutputWorkspace=fit_ws)
+                              OutputWorkspace=fit_ws)
         contour_ws = fname + '_Contour'
         s_api.GroupWorkspaces(InputWorkspaces=groupZ,
-                        OutputWorkspace=contour_ws)
+                              OutputWorkspace=contour_ws)
 
         #Add some sample logs to the output workspaces
         log_prog = Progress(self, start=0.8, end =1.0, nreports=6)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
@@ -223,13 +223,19 @@ class BayesStretch(PythonAlgorithm):
         #Add some sample logs to the output workspaces
         log_prog = Progress(self, start=0.8, end =1.0, nreports=6)
         log_prog.report('Copying Logs to Fit workspace')
-        s_api.CopyLogs(InputWorkspace=self._sam_name,
-                 OutputWorkspace=fit_ws)
+        copy_log_alg = self.createChildAlgorithm('CopyLogs', enableLogging=False)
+        copy_log_alg.setProperty('InputWorkspace', self._sam_name)
+        copy_log_alg.setProperty('OutputWorkspace',fit_ws)
+        copy_log_alg.execute()
+
         log_prog.report('Adding Sample logs to Fit workspace')
         self._add_sample_logs(fit_ws, self._erange, self._nbins[0])
+
         log_prog.report('Copying logs to Contour workspace')
-        s_api.CopyLogs(InputWorkspace=self._sam_name,
-                 OutputWorkspace=contour_ws)
+        copy_log_alg.setProperty('InputWorkspace',self._sam_name)
+        copy_log_alg.setProperty('OutputWorkspace',contour_ws)
+        copy_log_alg.execute()
+
         log_prog.report('Adding sample logs to Contour workspace')
         self._add_sample_logs(contour_ws, self._erange, self._nbins[0])
         log_prog.report('Finialising log copying')


### PR DESCRIPTION
Remove the use of `from mantid.simpleapi import *` in BayesStretch as well as remove logging on CopyLogs by use of `self.createChildAlgorithm`

**To test:**
- Code Review
- Ensure unit tests pass

_No issue number for PR_
_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
