### PR TITLE
Moved `MultipleFileProperty::flattenFileNames()` to `VectorHelper::flattenVector()`

### DIFF
--- a/Framework/API/inc/MantidAPI/MultipleFileProperty.h
+++ b/Framework/API/inc/MantidAPI/MultipleFileProperty.h
@@ -145,11 +145,6 @@ public:
   using Kernel::PropertyWithValue<std::vector<std::vector<std::string>>>::
   operator=;
 
-  /// Return a "flattened" vector with the contents of the given vector of
-  /// vectors.
-  static std::vector<std::string>
-  flattenFileNames(const std::vector<std::vector<std::string>> &fileNames);
-
 private:
   std::string setValueAsSingleFile(const std::string &propValue);
   std::string setValueAsMultipleFiles(const std::string &propValue);

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -7,6 +7,7 @@
 #include "MantidKernel/MultiFileValidator.h"
 #include "MantidKernel/Property.h"
 #include "MantidKernel/System.h"
+#include "MantidKernel/VectorHelper.h"
 
 #include <Poco/Path.h>
 #include <boost/algorithm/string.hpp>
@@ -126,36 +127,6 @@ std::string MultipleFileProperty::getDefault() const {
 }
 
 /**
- * A convenience function for the cases where we dont use the MultiFileProperty
- *to
- * *add* workspaces - only to list them.  It "flattens" the given vector of
- *vectors
- * into a single vector which is much easier to traverse.  For example:
- *
- * ((1), (2), (30), (31), (32), (100), (102)) becomes (1, 2, 30, 31, 32, 100,
- *102)
- *
- * Used on a vector of vectors that *has* added filenames, the following
- *behaviour is observed:
- *
- * ((1), (2), (30, 31, 32), (100), (102)) becomes (1, 2, 30, 31, 32, 100, 102)
- *
- * @param fileNames :: a vector of vectors, containing all the file names.
- * @return a single vector containing all the file names.
- */
-std::vector<std::string> MultipleFileProperty::flattenFileNames(
-    const std::vector<std::vector<std::string>> &fileNames) {
-  std::vector<std::string> flattenedFileNames;
-
-  for (const auto &fileName : fileNames) {
-    flattenedFileNames.insert(flattenedFileNames.end(), fileName.begin(),
-                              fileName.end());
-  }
-
-  return flattenedFileNames;
-}
-
-/**
  * Called by setValue in the case where a user has disabled multiple file
  *loading.
  *
@@ -262,7 +233,7 @@ MultipleFileProperty::setValueAsMultipleFiles(const std::string &propValue) {
       // load a single (and possibly existing) file within a token, but which
       // has unexpected zero
       // padding, or some other anomaly.
-      if (flattenFileNames(f).empty())
+      if (VectorHelper::flattenVector(f).empty())
         f.push_back(std::vector<std::string>(1, *plusTokenString));
 
       if (plusTokenStrings.size() > 1) {
@@ -296,7 +267,7 @@ MultipleFileProperty::setValueAsMultipleFiles(const std::string &propValue) {
   // First, find the default extension.  Flatten all the unresolved filenames
   // first, to make this easier.
   std::vector<std::string> flattenedAllUnresolvedFileNames =
-      flattenFileNames(allUnresolvedFileNames);
+      VectorHelper::flattenVector(allUnresolvedFileNames);
   std::string defaultExt;
   auto unresolvedFileName = flattenedAllUnresolvedFileNames.begin();
   for (; unresolvedFileName != flattenedAllUnresolvedFileNames.end();

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -79,8 +79,9 @@ bool MANTID_KERNEL_DLL isConstantValue(const std::vector<double> &arra);
  * @param v :: the vector of vectors to be flattened.
  * @return a single vector containing all elements in v.
  */
-template<typename T>
-std::vector<T> MANTID_KERNEL_DLL flattenVector(const std::vector<std::vector<T>> &v) {
+template <typename T>
+std::vector<T> MANTID_KERNEL_DLL
+flattenVector(const std::vector<std::vector<T>> &v) {
   std::vector<T> flattened;
 
   for (const auto &subVector : v) {

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -80,8 +80,7 @@ bool MANTID_KERNEL_DLL isConstantValue(const std::vector<double> &arra);
  * @return a single vector containing all elements in v.
  */
 template <typename T>
-MANTID_KERNEL_DLL std::vector<T>
-flattenVector(const std::vector<std::vector<T>> &v) {
+std::vector<T> flattenVector(const std::vector<std::vector<T>> &v) {
   std::vector<T> flattened;
 
   for (const auto &subVector : v) {

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -80,7 +80,7 @@ bool MANTID_KERNEL_DLL isConstantValue(const std::vector<double> &arra);
  * @return a single vector containing all elements in v.
  */
 template <typename T>
-std::vector<T> MANTID_KERNEL_DLL
+MANTID_KERNEL_DLL std::vector<T>
 flattenVector(const std::vector<std::vector<T>> &v) {
   std::vector<T> flattened;
 

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -70,6 +70,26 @@ convertToBinBoundary(const std::vector<double> &bin_centers,
 
 bool MANTID_KERNEL_DLL isConstantValue(const std::vector<double> &arra);
 
+/**
+ * A convenience function to "flatten" the given vector of vectors
+ * into a single vector.  For example:
+ *
+ * ((1), (2, 3), (4), (5, 6)) becomes (1, 2, 3, 4, 5, 6)
+ *
+ * @param v :: the vector of vectors to be flattened.
+ * @return a single vector containing all elements in v.
+ */
+template<typename T>
+std::vector<T> MANTID_KERNEL_DLL flattenVector(const std::vector<std::vector<T>> &v) {
+  std::vector<T> flattened;
+
+  for (const auto &subVector : v) {
+    flattened.insert(flattened.end(), subVector.begin(), subVector.end());
+  }
+
+  return flattened;
+}
+
 template <typename NumT>
 MANTID_KERNEL_DLL std::vector<NumT>
 splitStringIntoVector(std::string listString);

--- a/Framework/Kernel/test/VectorHelperTest.h
+++ b/Framework/Kernel/test/VectorHelperTest.h
@@ -142,9 +142,8 @@ public:
 
   void test_flattenContainer_SingleSubvectorWithMultipleValues() {
     std::vector<std::vector<int>> input;
-    auto values = {3, 1, -1, -3, -5};
-    input.emplace_back(values);
-    const std::vector<int> expected(values);
+    input.emplace_back(std::vector<int>{3, 1, -1, -3, -5});
+    const std::vector<int> expected{3, 1, -1, -3, -5};
     const auto result = VectorHelper::flattenVector(input);
     TS_ASSERT_EQUALS(result.size(), expected.size());
     for (size_t i = 0; i < result.size(); ++i) {

--- a/Framework/Kernel/test/VectorHelperTest.h
+++ b/Framework/Kernel/test/VectorHelperTest.h
@@ -134,6 +134,53 @@ public:
     TS_ASSERT_DELTA(bin_edges[2], 2.0, 1e-12);
   }
 
+  void test_flattenContainer_EmptyInputVector() {
+    const std::vector<std::vector<int>> emptyInput;
+    const auto result = VectorHelper::flattenVector<int>(emptyInput);
+    TS_ASSERT(result.empty());
+  }
+
+  void test_flattenContainer_SingleSubvectorWithMultipleValues() {
+    std::vector<std::vector<int>> input;
+    auto values = {3, 1, -1, -3, -5};
+    input.emplace_back(values);
+    const std::vector<int> expected(values);
+    const auto result = VectorHelper::flattenVector(input);
+    TS_ASSERT_EQUALS(result.size(), expected.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+      TS_ASSERT_EQUALS(result[i], expected[i]);
+    }
+  }
+
+  void test_flattenContainer_MultipleSubvectorsWithSingleValues() {
+    std::vector<std::vector<int>> input;
+    input.emplace_back(std::vector<int>{3});
+    input.emplace_back(std::vector<int>{1});
+    input.emplace_back(std::vector<int>{-1});
+    input.emplace_back(std::vector<int>{-3});
+    input.emplace_back(std::vector<int>{-5});
+    const std::vector<int> expected{3, 1, -1, -3, -5};
+    const auto result = VectorHelper::flattenVector(input);
+    TS_ASSERT_EQUALS(result.size(), expected.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+      TS_ASSERT_EQUALS(result[i], expected[i]);
+    }
+  }
+
+  void test_flattenContainer_VariableSizedSubvectors() {
+    std::vector<std::vector<int>> input;
+    input.emplace_back(std::vector<int>{3, 1});
+    input.emplace_back(std::vector<int>{});
+    input.emplace_back(std::vector<int>{-1});
+    input.emplace_back(std::vector<int>{-3, -5});
+    const std::vector<int> expected{3, 1, -1, -3, -5};
+    const auto result = VectorHelper::flattenVector(input);
+    TS_ASSERT_EQUALS(result.size(), expected.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+      TS_ASSERT_EQUALS(result[i], expected[i]);
+    }
+  }
+
   // TODO: More tests of other methods
 
   void test_splitStringIntoVector() {

--- a/Framework/MDAlgorithms/src/MergeMDFiles.cpp
+++ b/Framework/MDAlgorithms/src/MergeMDFiles.cpp
@@ -355,8 +355,7 @@ void MergeMDFiles::exec() {
     throw std::logic_error(
         "Filenames property must have MultipleFileProperty type.");
   }
-  m_Filenames =
-      VectorHelper::flattenVector(multiFileProp->operator()());
+  m_Filenames = VectorHelper::flattenVector(multiFileProp->operator()());
   if (m_Filenames.empty())
     throw std::invalid_argument("Must specify at least one filename.");
   std::string firstFile = m_Filenames[0];

--- a/Framework/MDAlgorithms/src/MergeMDFiles.cpp
+++ b/Framework/MDAlgorithms/src/MergeMDFiles.cpp
@@ -3,6 +3,7 @@
 #include "MantidKernel/CPUTimer.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/System.h"
+#include "MantidKernel/VectorHelper.h"
 #include "MantidDataObjects/MDBoxBase.h"
 #include "MantidDataObjects/MDEventFactory.h"
 #include "MantidDataObjects/BoxControllerNeXusIO.h"
@@ -355,7 +356,7 @@ void MergeMDFiles::exec() {
         "Filenames property must have MultipleFileProperty type.");
   }
   m_Filenames =
-      MultipleFileProperty::flattenFileNames(multiFileProp->operator()());
+      VectorHelper::flattenVector(multiFileProp->operator()());
   if (m_Filenames.empty())
     throw std::invalid_argument("Must specify at least one filename.");
   std::string firstFile = m_Filenames[0];

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -207,6 +207,7 @@
 #include "MantidKernel/LibraryManager.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/MantidVersion.h"
+#include "MantidKernel/VectorHelper.h"
 
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidAPI/AnalysisDataService.h"
@@ -13324,7 +13325,7 @@ void ApplicationWindow::updateRecentFilesList(QString fname) {
       Mantid::API::MultipleFileProperty mfp("tester");
       mfp.setValue(recentFiles[i].toStdString());
       const std::vector<std::string> files =
-          Mantid::API::MultipleFileProperty::flattenFileNames(mfp());
+          Mantid::Kernel::VectorHelper::flattenVector(mfp());
       if (files.size() == 1) {
         ostr << "&" << menuCount << " " << files[0];
       } else if (files.size() > 1) {

--- a/MantidQt/MantidWidgets/src/MWRunFiles.cpp
+++ b/MantidQt/MantidWidgets/src/MWRunFiles.cpp
@@ -2,6 +2,7 @@
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/FacilityInfo.h"
+#include "MantidKernel/VectorHelper.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FileFinder.h"
 #include "MantidAPI/FileProperty.h"
@@ -173,7 +174,7 @@ void FindFilesThread::getFilesFromAlgorithm() {
     std::vector<std::vector<std::string>> filenames =
         algorithm->getProperty(propName);
     std::vector<std::string> flattenedNames =
-        MultipleFileProperty::flattenFileNames(filenames);
+        VectorHelper::flattenVector(filenames);
 
     for (auto filename = flattenedNames.begin();
          filename != flattenedNames.end(); ++filename) {


### PR DESCRIPTION
Templatized `MultipleFileProperty::flattenFileNames()` to work on vectors of whatever type and moved the method to `VectorHelper` namespace under the name `flattenVector()`. The more generalized version will be needed in another branch I'm working on (issue 17009).

Changed the usages of the original method to use the new function.

Implements #17077.

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
