### PR TITLE
Fix warnings on OS X Yosemite

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/IReflMainWindowPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/IReflMainWindowPresenter.h
@@ -49,10 +49,14 @@ public:
   virtual std::string askUserString(const std::string &prompt,
                                     const std::string &title,
                                     const std::string &defaultValue) = 0;
-  virtual bool askUserYesNo(std::string prompt, std::string title) = 0;
-  virtual void giveUserWarning(std::string prompt, std::string title) = 0;
-  virtual void giveUserCritical(std::string prompt, std::string title) = 0;
-  virtual void giveUserInfo(std::string prompt, std::string title) = 0;
+  virtual bool askUserYesNo(const std::string &prompt,
+                            const std::string &title) = 0;
+  virtual void giveUserWarning(const std::string &prompt,
+                               const std::string &title) = 0;
+  virtual void giveUserCritical(const std::string &prompt,
+                                const std::string &title) = 0;
+  virtual void giveUserInfo(const std::string &prompt,
+                            const std::string &title) = 0;
   virtual std::string runPythonAlgorithm(const std::string &pythonCode) = 0;
 };
 }

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/IReflMainWindowView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/IReflMainWindowView.h
@@ -43,10 +43,14 @@ public:
   virtual std::string askUserString(const std::string &prompt,
                                     const std::string &title,
                                     const std::string &defaultValue) = 0;
-  virtual bool askUserYesNo(std::string prompt, std::string title) = 0;
-  virtual void giveUserWarning(std::string prompt, std::string title) = 0;
-  virtual void giveUserCritical(std::string prompt, std::string title) = 0;
-  virtual void giveUserInfo(std::string prompt, std::string title) = 0;
+  virtual bool askUserYesNo(const std::string &prompt,
+                            const std::string &title) = 0;
+  virtual void giveUserWarning(const std::string &prompt,
+                               const std::string &title) = 0;
+  virtual void giveUserCritical(const std::string &prompt,
+                                const std::string &title) = 0;
+  virtual void giveUserInfo(const std::string &prompt,
+                            const std::string &title) = 0;
   virtual std::string runPythonAlgorithm(const std::string &pythonCode) = 0;
 };
 }

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/QtReflMainWindowView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/QtReflMainWindowView.h
@@ -53,10 +53,14 @@ public:
   /// Dialog/Prompt methods
   std::string askUserString(const std::string &prompt, const std::string &title,
                             const std::string &defaultValue) override;
-  bool askUserYesNo(std::string prompt, std::string title) override;
-  void giveUserWarning(std::string prompt, std::string title) override;
-  void giveUserCritical(std::string prompt, std::string title) override;
-  void giveUserInfo(std::string prompt, std::string title) override;
+  bool askUserYesNo(const std::string &prompt,
+                    const std::string &title) override;
+  void giveUserWarning(const std::string &prompt,
+                       const std::string &title) override;
+  void giveUserCritical(const std::string &prompt,
+                        const std::string &title) override;
+  void giveUserInfo(const std::string &prompt,
+                    const std::string &title) override;
   std::string runPythonAlgorithm(const std::string &pythonCode) override;
 
 private:

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/QtReflSettingsTabView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/QtReflSettingsTabView.h
@@ -43,15 +43,15 @@ public:
   /// Destructor
   ~QtReflSettingsTabView() override;
   /// Returns the presenter managing this view
-  IReflSettingsTabPresenter *getPresenter() const;
+  IReflSettingsTabPresenter *getPresenter() const override;
   /// Returns global options for 'Plus' algorithm
-  std::string getPlusOptions() const;
+  std::string getPlusOptions() const override;
   /// Returns global options for 'CreateTransmissionWorkspaceAuto'
-  std::string getTransmissionOptions() const;
+  std::string getTransmissionOptions() const override;
   /// Returns global options for 'ReflectometryReductionOneAuto'
-  std::string getReductionOptions() const;
+  std::string getReductionOptions() const override;
   /// Returns global options for 'Stitch1DMany'
-  std::string getStitchOptions() const;
+  std::string getStitchOptions() const override;
 
   /// Creates hints for 'Plus'
   void

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflMainWindowPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflMainWindowPresenter.h
@@ -47,20 +47,24 @@ public:
   /// Destructor
   ~ReflMainWindowPresenter() override;
   /// Returns global options for 'Plus' algorithm
-  std::string getPlusOptions() const;
+  std::string getPlusOptions() const override;
   /// Returns global options for 'CreateTransmissionWorkspaceAuto'
-  std::string getTransmissionOptions() const;
+  std::string getTransmissionOptions() const override;
   /// Returns global options for 'ReflectometryReductionOneAuto'
-  std::string getReductionOptions() const;
+  std::string getReductionOptions() const override;
   /// Returns global options for 'Stitch1DMany'
-  std::string getStitchOptions() const;
+  std::string getStitchOptions() const override;
   /// Dialog/Prompt methods
   std::string askUserString(const std::string &prompt, const std::string &title,
                             const std::string &defaultValue) override;
-  bool askUserYesNo(std::string prompt, std::string title) override;
-  void giveUserWarning(std::string prompt, std::string title) override;
-  void giveUserCritical(std::string prompt, std::string title) override;
-  void giveUserInfo(std::string prompt, std::string title) override;
+  bool askUserYesNo(const std::string &prompt,
+                    const std::string &title) override;
+  void giveUserWarning(const std::string &prompt,
+                       const std::string &title) override;
+  void giveUserCritical(const std::string &prompt,
+                        const std::string &title) override;
+  void giveUserInfo(const std::string &prompt,
+                    const std::string &title) override;
   std::string runPythonAlgorithm(const std::string &pythonCode) override;
 
 private:

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsTabPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsTabPresenter.h
@@ -48,13 +48,13 @@ public:
   void acceptMainPresenter(IReflMainWindowPresenter *mainPresenter) override;
 
   /// Returns global options for 'Plus' algorithm
-  std::string getPlusOptions() const;
+  std::string getPlusOptions() const override;
   /// Returns global options for 'CreateTransmissionWorkspaceAuto'
-  std::string getTransmissionOptions() const;
+  std::string getTransmissionOptions() const override;
   /// Returns global options for 'ReflectometryReductionOneAuto'
-  std::string getReductionOptions() const;
+  std::string getReductionOptions() const override;
   /// Returns global options for 'Stitch1DMany'
-  std::string getStitchOptions() const;
+  std::string getStitchOptions() const override;
 
 private:
   void createPlusHints();

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainWindowView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainWindowView.cpp
@@ -64,10 +64,11 @@ Show an critical error dialog
 @param prompt : The prompt to appear on the dialog
 @param title : The text for the title bar of the dialog
 */
-void QtReflMainWindowView::giveUserCritical(std::string prompt,
-                                            std::string title) {
-  QMessageBox::critical(this, QString(title.c_str()), QString(prompt.c_str()),
-                        QMessageBox::Ok, QMessageBox::Ok);
+void QtReflMainWindowView::giveUserCritical(const std::string &prompt,
+                                            const std::string &title) {
+  QMessageBox::critical(this, QString::fromStdString(title),
+                        QString::fromStdString(prompt), QMessageBox::Ok,
+                        QMessageBox::Ok);
 }
 
 /**
@@ -75,10 +76,11 @@ Show a warning dialog
 @param prompt : The prompt to appear on the dialog
 @param title : The text for the title bar of the dialog
 */
-void QtReflMainWindowView::giveUserWarning(std::string prompt,
-                                           std::string title) {
-  QMessageBox::warning(this, QString(title.c_str()), QString(prompt.c_str()),
-                       QMessageBox::Ok, QMessageBox::Ok);
+void QtReflMainWindowView::giveUserWarning(const std::string &prompt,
+                                           const std::string &title) {
+  QMessageBox::warning(this, QString::fromStdString(title),
+                       QString::fromStdString(prompt), QMessageBox::Ok,
+                       QMessageBox::Ok);
 }
 
 /**
@@ -86,9 +88,10 @@ Show an information dialog
 @param prompt : The prompt to appear on the dialog
 @param title : The text for the title bar of the dialog
 */
-void QtReflMainWindowView::giveUserInfo(std::string prompt, std::string title) {
-  QMessageBox::information(this, QString(title.c_str()),
-                           QString(prompt.c_str()), QMessageBox::Ok,
+void QtReflMainWindowView::giveUserInfo(const std::string &prompt,
+                                        const std::string &title) {
+  QMessageBox::information(this, QString::fromStdString(title),
+                           QString::fromStdString(prompt), QMessageBox::Ok,
                            QMessageBox::Ok);
 }
 
@@ -98,9 +101,10 @@ Ask the user a Yes/No question
 @param title : The text for the title bar of the dialog
 @returns a boolean true if Yes, false if No
 */
-bool QtReflMainWindowView::askUserYesNo(std::string prompt, std::string title) {
+bool QtReflMainWindowView::askUserYesNo(const std::string &prompt,
+                                        const std::string &title) {
   auto response = QMessageBox::question(
-      this, QString(title.c_str()), QString(prompt.c_str()),
+      this, QString::fromStdString(title), QString::fromStdString(prompt),
       QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
   if (response == QMessageBox::Yes) {
     return true;

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflMainWindowPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflMainWindowPresenter.cpp
@@ -73,8 +73,8 @@ Tells the view to show an critical error dialog
 @param prompt : The prompt to appear on the dialog
 @param title : The text for the title bar of the dialog
 */
-void ReflMainWindowPresenter::giveUserCritical(std::string prompt,
-                                               std::string title) {
+void ReflMainWindowPresenter::giveUserCritical(const std::string &prompt,
+                                               const std::string &title) {
 
   m_view->giveUserCritical(prompt, title);
 }
@@ -84,8 +84,8 @@ Tells the view to show a warning dialog
 @param prompt : The prompt to appear on the dialog
 @param title : The text for the title bar of the dialog
 */
-void ReflMainWindowPresenter::giveUserWarning(std::string prompt,
-                                              std::string title) {
+void ReflMainWindowPresenter::giveUserWarning(const std::string &prompt,
+                                              const std::string &title) {
 
   m_view->giveUserWarning(prompt, title);
 }
@@ -95,8 +95,8 @@ Tells the view to show an information dialog
 @param prompt : The prompt to appear on the dialog
 @param title : The text for the title bar of the dialog
 */
-void ReflMainWindowPresenter::giveUserInfo(std::string prompt,
-                                           std::string title) {
+void ReflMainWindowPresenter::giveUserInfo(const std::string &prompt,
+                                           const std::string &title) {
 
   m_view->giveUserInfo(prompt, title);
 }
@@ -107,8 +107,8 @@ Tells the view to ask the user a Yes/No question
 @param title : The text for the title bar of the dialog
 @returns a boolean true if Yes, false if No
 */
-bool ReflMainWindowPresenter::askUserYesNo(std::string prompt,
-                                           std::string title) {
+bool ReflMainWindowPresenter::askUserYesNo(const std::string &prompt,
+                                           const std::string &title) {
 
   return m_view->askUserYesNo(prompt, title);
 }

--- a/MantidQt/CustomInterfaces/test/ReflMockObjects.h
+++ b/MantidQt/CustomInterfaces/test/ReflMockObjects.h
@@ -94,10 +94,11 @@ public:
   MOCK_METHOD3(askUserString,
                std::string(const std::string &, const std::string &,
                            const std::string &));
-  MOCK_METHOD2(askUserYesNo, bool(std::string, std::string));
-  MOCK_METHOD2(giveUserWarning, void(std::string, std::string));
-  MOCK_METHOD2(giveUserCritical, void(std::string, std::string));
-  MOCK_METHOD2(giveUserInfo, void(std::string, std::string));
+  MOCK_METHOD2(askUserYesNo, bool(const std::string &, const std::string &));
+  MOCK_METHOD2(giveUserWarning, void(const std::string &, const std::string &));
+  MOCK_METHOD2(giveUserCritical,
+               void(const std::string &, const std::string &));
+  MOCK_METHOD2(giveUserInfo, void(const std::string &, const std::string &));
   MOCK_METHOD1(runPythonAlgorithm, std::string(const std::string &));
   ~MockMainWindowView() override{};
 };
@@ -135,10 +136,11 @@ public:
   MOCK_METHOD3(askUserString,
                std::string(const std::string &, const std::string &,
                            const std::string &));
-  MOCK_METHOD2(askUserYesNo, bool(std::string, std::string));
-  MOCK_METHOD2(giveUserWarning, void(std::string, std::string));
-  MOCK_METHOD2(giveUserCritical, void(std::string, std::string));
-  MOCK_METHOD2(giveUserInfo, void(std::string, std::string));
+  MOCK_METHOD2(askUserYesNo, bool(const std::string &, const std::string &));
+  MOCK_METHOD2(giveUserWarning, void(const std::string &, const std::string &));
+  MOCK_METHOD2(giveUserCritical,
+               void(const std::string &, const std::string &));
+  MOCK_METHOD2(giveUserInfo, void(const std::string &, const std::string &));
   MOCK_METHOD1(runPythonAlgorithm, std::string(const std::string &));
   ~MockMainWindowPresenter() override{};
 };


### PR DESCRIPTION
Description of work.

This fixes several `-Winconsistent-override` warnings found when building Mantid on OS X Yosemite. I also changed several function signatures to pass std::string by reference.

I'm currently moving ORNL's build servers to OS X Yosemite, making this build increasingly important.

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
