### PR TITLE
Work around out-of-bounds memory accesses in slice viewer

### DIFF
--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -385,7 +385,7 @@ signal_t MDHistoWorkspace::getSignalWithMaskAtCoord(
     const coord_t *coords,
     const Mantid::API::MDNormalization &normalization) const {
   size_t linearIndex = this->getLinearIndexAtCoord(coords);
-  if (this->getIsMaskedAt(linearIndex)) {
+  if (linearIndex == size_t(-1) || this->getIsMaskedAt(linearIndex)) {
     return MDMaskValue;
   }
   return getSignalAtCoord(coords, normalization);
@@ -596,7 +596,7 @@ IMDWorkspace::LinePlot MDHistoWorkspace::getLinePoints(
       const auto linearIndex =
           this->getLinearIndexAtCoord(middle.getBareArray());
 
-      if (bin_centres && !this->getIsMaskedAt(linearIndex)) {
+      if (bin_centres) {
         coord_t bin_centrePos =
             static_cast<coord_t>((linePos + lastLinePos) * 0.5);
         line.x.push_back(bin_centrePos);

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -385,7 +385,8 @@ signal_t MDHistoWorkspace::getSignalWithMaskAtCoord(
     const coord_t *coords,
     const Mantid::API::MDNormalization &normalization) const {
   size_t linearIndex = this->getLinearIndexAtCoord(coords);
-  if (linearIndex == size_t(-1) || this->getIsMaskedAt(linearIndex)) {
+  if (linearIndex == std::numeric_limits<size_t>::max() ||
+      this->getIsMaskedAt(linearIndex)) {
     return MDMaskValue;
   }
   return getSignalAtCoord(coords, normalization);
@@ -596,7 +597,9 @@ IMDWorkspace::LinePlot MDHistoWorkspace::getLinePoints(
       const auto linearIndex =
           this->getLinearIndexAtCoord(middle.getBareArray());
 
-      if (bin_centres) {
+      if (bin_centres &&
+          !(linearIndex == std::numeric_limits<size_t>::max() ||
+            this->getIsMaskedAt(linearIndex))) {
         coord_t bin_centrePos =
             static_cast<coord_t>((linePos + lastLinePos) * 0.5);
         line.x.push_back(bin_centrePos);


### PR DESCRIPTION
Description of work.

This eliminates two causes out-of-bounds memory accesses when using the Slice Viewer, which could cause an intermittent segfault. It also suggests there is another issue causing the invalid index, which according to  [this comment](https://github.com/mantidproject/mantid/compare/16583_slice_viewer_outofbounds?expand=1#diff-ca8c28b5531e8af51ccdd0f76fd4932cR622)   should not happen.

I created issue #17084 to address the underlying cause of the invalid indices.

**To test:**

<!-- Instructions for testing. -->

This is part of #16583.

_Does not need to be in the release notes._ We'll add a note once the indexing issue is resolved.

I suggest using [this patch](https://github.com/mantidproject/mantid/files/391981/MDHistoWorkspace_out_of_range.txt) to detect out-of-bounds access to the MDHistoWorkspace. First apply this on `master`, but Mantid and view a MDHistoWorkpace in the Slice Viewer to verify the issue. Repeat with this branch and verify no exceptions are thrown.

Alternatively, use the `SliceViewerMantidPlotTest_SliceViewerPythonInterfaceTest` test, which also causes out-of-bounds access.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
