### PR TITLE
Engg: Fix engineering diffraction interface crashes on new install

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -239,6 +239,9 @@ private:
   /// save settings (before closing)
   void saveSettings() const override;
 
+  // when the interface is shown
+  void showEvent(QShowEvent *) override;
+
   // window (custom interface) close
   void closeEvent(QCloseEvent *ev) override;
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -116,11 +116,11 @@ void EnggDiffractionViewQtGUI::initLayout() {
   doSetupTabSettings();
 
   m_presenter->notify(IEnggDiffractionPresenter::Start);
-  // Never do this here: if the RB-number checks show a pop-up (splash
-  // message), it will be shown very early (before the interface
+  // We need to delay the RB-number check for the pop-up (splash message)
+  // as it will be shown very early (before the interface
   // window itself is shown) and that will cause a crash in Qt code on
   // some platforms (windows 10, and 7 sometimes).
-  // m_presenter->notify(IEnggDiffractionPresenter::RBNumberChange);
+  // so perform the check in the showEvent method to check on start up
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabCalib() {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -116,7 +116,11 @@ void EnggDiffractionViewQtGUI::initLayout() {
   doSetupTabSettings();
 
   m_presenter->notify(IEnggDiffractionPresenter::Start);
-  m_presenter->notify(IEnggDiffractionPresenter::RBNumberChange);
+  // Never do this here: if the RB-number checks show a pop-up (splash
+  // message), it will be shown very early (before the interface
+  // window itself is shown) and that will cause a crash in Qt code on
+  // some platforms (windows 10, and 7 sometimes).
+  // m_presenter->notify(IEnggDiffractionPresenter::RBNumberChange);
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabCalib() {
@@ -1049,6 +1053,11 @@ void EnggDiffractionViewQtGUI::setPrefix(std::string prefix) {
 
   // rebin tab
   m_uiTabPreproc.MWRunFiles_preproc_run_num->setInstrumentOverride(prefixInput);
+}
+
+void EnggDiffractionViewQtGUI::showEvent(QShowEvent *) {
+  // make sure that the RB number is checked on interface startup/show
+  m_presenter->notify(IEnggDiffractionPresenter::RBNumberChange);
 }
 
 void EnggDiffractionViewQtGUI::closeEvent(QCloseEvent *event) {


### PR DESCRIPTION
Description of work.
On initialisation of the interface a notification should check and display a pop up informing the user they should enter a RB number if they have never entered one before (not used the interface before). 
However when this check happens and the window is set to visible QT framework gets confused between the main interface and the pop up window and deferences a null pointer crashing Mantid. 
To avoid this we should set the notification to appear after the main interface has loaded.
**To test:**
On a copy of Mantid where no RB number has been set open Custom Interfaces -> Diffraction -> Engineering Diffraction. If the window opens and a notification appears asking the user to enter an RB number the bug has been fixed

Fixes #17088 .

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
