### PR TITLE
Fix error running EvaluateFunction from dialog

### DIFF
--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -177,18 +177,22 @@ void IFittingAlgorithm::addWorkspace(const std::string &workspacePropertyName,
       creator->declareDatasetProperties(suffix, addProperties);
     }
   } else {
-    boost::shared_ptr<MultiDomainCreator> multiCreator =
-        boost::dynamic_pointer_cast<MultiDomainCreator>(m_domainCreator);
-    if (!multiCreator) {
-      auto &reference = *m_domainCreator;
-      throw std::runtime_error(
-          std::string("MultiDomainCreator expected, found ") +
-          typeid(reference).name());
-    }
-    if (!multiCreator->hasCreator(index)) {
+    if (fun->getNumberDomains() > 1) {
+      boost::shared_ptr<MultiDomainCreator> multiCreator =
+          boost::dynamic_pointer_cast<MultiDomainCreator>(m_domainCreator);
+      if (!multiCreator) {
+        auto &reference = *m_domainCreator;
+        throw std::runtime_error(
+            std::string("MultiDomainCreator expected, found ") +
+            typeid(reference).name());
+      }
+      if (!multiCreator->hasCreator(index)) {
+        creator->declareDatasetProperties(suffix, addProperties);
+      }
+      multiCreator->setCreator(index, creator);
+    } else {
       creator->declareDatasetProperties(suffix, addProperties);
     }
-    multiCreator->setCreator(index, creator);
   }
 }
 

--- a/Framework/CurveFitting/test/Algorithms/EvaluateFunctionTest.h
+++ b/Framework/CurveFitting/test/Algorithms/EvaluateFunctionTest.h
@@ -143,6 +143,12 @@ public:
     delete iter;
   }
 
+  void test_set_workspace_twice() {
+    Tester1D tester;
+    tester.setHistograms();
+    tester.initialiseAndSetWorkspaceTwice();
+  }
+
 private:
   class Tester1D {
     // values defining the workspace
@@ -277,6 +283,20 @@ private:
         TS_ASSERT_DELTA(tmp, 0.0, 1e-14);
         ++j;
       }
+    }
+
+    void initialiseAndSetWorkspaceTwice() {
+      makeXValues();
+      makeWorkspace();
+      makeFunction();
+
+      EvaluateFunction alg;
+      TS_ASSERT_THROWS_NOTHING(alg.initialize())
+      TS_ASSERT(alg.isInitialized())
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty(
+          "Function", boost::dynamic_pointer_cast<IFunction>(function)));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", workspace));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", workspace));
     }
   };
 };

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -98,6 +98,7 @@ Bug Fixes
 ---------
 - Scripts generated from history including algorithms that added dynamic properties at run time (for example Fit, and Load) will not not include those dynamic properties in their script.  This means they will execute without warnings.
 - Cloning a ``MultiDomainFunction``, or serializing to a string and recreating it, now preserves the domains.
+- :ref:`EvaluateFunction <algm-EvaluateFunction>` now works from its dialog in the GUI as well as from a script
 
 
 |


### PR DESCRIPTION
Fix a bug seen when running `EvaluateFunction` from its dialog in the GUI.

Clicking "Run" in the dialog set the properties for a second time before running, and checking the type of the domain creator failed since the function had only one domain. Add code to deal correctly with the case when the function has only one domain, and add a test exposing the bug.

**To test:**
- Run the following (from the issue):

``` python
CreateSimulationWorkspace(Instrument='HIFI', BinParams='0,0.016,32', OutputWorkspace='HIFIblank', UnitX='Time')
AsymmetryCalc(InputWorkspace='HIFIblank', OutputWorkspace='HIFIasym0', ForwardSpectra='1-32', BackwardSpectra='33-64')
EvaluateFunction(Function="name=DynamicKuboToyabe,Asym=0.2,Delta=0.3,Field=0,Nu=0",InputWorkspace="HIFIasym0",OutputWorkspace="KT_N0_B0")
```
- Launch the `EvaluateFunction` dialog in the GUI. Set the same function as above, input workspace as "HIFIasym0" and output workspace as "KT_N0_B0_2". 
- Click "Run" and verify that no error is shown and the algorithm runs OK.
- Check the workspaces "KT_N0_B0" and "KT_N0_B0_2" for equality - they should match.
- Revert the fix and verify the new unit test for `EvaluateFunction` fails

Fixes #17092.

[Release notes](https://github.com/mantidproject/mantid/blob/31b4918ae34486e6da68aa1c27ccc56eb98cb891/docs/source/release/v3.8.0/framework.rst#bug-fixes) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
