### PR TITLE
Serialise selected mantid matrix tab in project file.

### DIFF
--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -1222,6 +1222,13 @@ IProjectSerialisable *MantidMatrix::loadFromProject(const std::string &lines,
     const std::string geometry = tsv.lineAsString("tgeometry");
     app->restoreWindowGeometry(app, matrix, QString::fromStdString(geometry));
   }
+
+  if(tsv.selectLine("SelectedTab")) {
+    int index;
+    tsv >> index;
+    matrix->m_tabs->setCurrentIndex(index);
+  }
+
   return matrix;
 }
 
@@ -1231,6 +1238,7 @@ std::string MantidMatrix::saveToProject(ApplicationWindow *app) {
   tsv.writeRaw("<mantidmatrix>");
   tsv.writeLine("WorkspaceName") << m_strName;
   tsv.writeRaw(app->windowGeometryInfo(this));
+  tsv.writeLine("SelectedTab") << m_tabs->currentIndex();
   tsv.writeRaw("</mantidmatrix>");
 
   return tsv.outputLines();

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -1223,7 +1223,7 @@ IProjectSerialisable *MantidMatrix::loadFromProject(const std::string &lines,
     app->restoreWindowGeometry(app, matrix, QString::fromStdString(geometry));
   }
 
-  if(tsv.selectLine("SelectedTab")) {
+  if (tsv.selectLine("SelectedTab")) {
     int index;
     tsv >> index;
     matrix->m_tabs->setCurrentIndex(index);


### PR DESCRIPTION
This ticket is part of the work in #15602 .

**To test:**
- Create a sample workspace
- View the data
- Select a tab other than Y (choose X or Error)
- Save to project
- Close and reopen Mantid
- Open project
- Correct tab should still be selected.

Fixes #16965 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
