### PR TITLE
Extend getLogAsSingleValue for other numeric types

### DIFF
--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -356,8 +356,8 @@ double LogManager::getPropertyAsSingleValue(
         return std::stod(stringLog->value());
       } catch (const std::invalid_argument &) {
         throw std::invalid_argument(
-            "Run::getPropertyAsSingleValue - Property\"" + name +
-            "\"cannot be converted to a numeric value.");
+            "Run::getPropertyAsSingleValue - Property \"" + name +
+            "\" cannot be converted to a numeric value.");
       }
     } else {
       throw std::invalid_argument(

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -335,6 +335,16 @@ double LogManager::getPropertyAsSingleValue(
     if (convertSingleValue(log, singleValue) ||
         convertTimeSeriesToDouble(log, singleValue, statistic)) {
       return singleValue;
+    } else if (const auto stringLog =
+                   dynamic_cast<const PropertyWithValue<std::string> *>(log)) {
+      // Try to lexically cast string to a double
+      try {
+        return std::stod(stringLog->value());
+      } catch (const std::invalid_argument &) {
+        throw std::invalid_argument(
+            "Run::getPropertyAsSingleValue - Property\"" + name +
+            "\"cannot be converted to a numeric value.");
+      }
     } else {
       throw std::invalid_argument(
           "Run::getPropertyAsSingleValue - Property \"" + name +

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -20,6 +20,29 @@ using namespace Kernel;
 namespace {
 /// static logger
 Logger g_log("LogManager");
+
+// Templated method to convert property to double
+template <typename T>
+bool convertSingleValue(const Property *property, double &value) {
+  if (auto log = dynamic_cast<const PropertyWithValue<T> *>(property)) {
+    value = static_cast<double>(*log);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+// Converts numeric property to double
+bool convertSingleValue(const Property *property, double &value) {
+  // The first one to succeed short-circuits and the value is returned.
+  // If all fail, returns false.
+  return convertSingleValue<double>(property, value) ||
+         convertSingleValue<int32_t>(property, value) ||
+         convertSingleValue<int64_t>(property, value) ||
+         convertSingleValue<float>(property, value) ||
+         convertSingleValue<uint32_t>(property, value) ||
+         convertSingleValue<uint64_t>(property, value);
+}
 }
 
 /// Name of the log entry containing the proton charge when retrieved using
@@ -268,16 +291,15 @@ double LogManager::getPropertyAsSingleValue(
   const auto key = std::make_pair(name, statistic);
   if (!m_singleValueCache.getCache(key, singleValue)) {
     const Property *log = getProperty(name);
-    if (auto singleDouble =
-            dynamic_cast<const PropertyWithValue<double> *>(log)) {
-      singleValue = (*singleDouble)();
+    if (convertSingleValue(log, singleValue)) {
+      return singleValue;
     } else if (auto seriesDouble =
                    dynamic_cast<const TimeSeriesProperty<double> *>(log)) {
-      singleValue = Mantid::Kernel::filterByStatistic(seriesDouble, statistic);
+      return Mantid::Kernel::filterByStatistic(seriesDouble, statistic);
     } else {
       throw std::invalid_argument(
           "Run::getPropertyAsSingleValue - Property \"" + name +
-          "\" is not a single double or time series double.");
+          "\" is not a single numeric value or numeric time series.");
     }
     // Put it in the cache
     m_singleValueCache.setCache(key, singleValue);

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -49,16 +49,30 @@ template <typename T>
 bool convertTimeSeriesToDouble(const Property *property, double &value,
                                const Math::StatisticType &function) {
   if (const auto *log = dynamic_cast<const TimeSeriesProperty<T> *>(property)) {
-    if (function == Math::Mean) {
+    switch (function) {
+    case Math::TimeAveragedMean:
       value = static_cast<double>(log->timeAverageValue());
-    } else if (function == Math::FirstValue) {
+      break;
+    case Math::FirstValue:
       value = static_cast<double>(log->firstValue());
-    } else if (function == Math::Minimum) {
-      value = static_cast<double>(log->minValue());
-    } else if (function == Math::Maximum) {
-      value = static_cast<double>(log->maxValue());
-    } else { // default
+      break;
+    case Math::LastValue:
       value = static_cast<double>(log->lastValue());
+      break;
+    case Math::Maximum:
+      value = static_cast<double>(log->maxValue());
+      break;
+    case Math::Minimum:
+      value = static_cast<double>(log->minValue());
+      break;
+    case Math::Mean:
+      value = log->getStatistics().mean;
+      break;
+    case Math::Median:
+      value = log->getStatistics().median;
+      break;
+    default: // should not happen
+      throw std::invalid_argument("Statistic type not recognised/supported");
     }
     return true;
   } else {

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -261,7 +261,7 @@ public:
     runInfo.addProperty<std::string>(name, value);
     double result = std::nan("1");
     TS_ASSERT_THROWS_NOTHING(result = runInfo.getPropertyAsSingleValue(name));
-    TS_ASSERT_EQUALS(value, std::to_string(result));
+    TS_ASSERT_DELTA(1.0, result, 1e-12);
   }
 
   void test_GetPropertyAsSingleValue_TimeSeries_DoubleType() {

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -255,7 +255,7 @@ public:
     doTest_GetPropertyAsSingleValue_SingleType<uint64_t>(1UL);
   }
 
-  void doTest_GetPropertyAsSingleValue_SingleValue_StringType() {
+  void test_GetPropertyAsSingleValue_SingleValue_StringType() {
     LogManager runInfo;
     const std::string name = "string_prop", value = "1";
     runInfo.addProperty<std::string>(name, value);
@@ -487,9 +487,10 @@ private:
     LogManager runInfo;
     const std::string name = "T_series";
     addTestTimeSeries<T>(runInfo, name);
-    const double expectedValue(13.0);
-    TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name), expectedValue,
-                    1e-12);
+    const double expectedValue(24.0);
+    TS_ASSERT_DELTA(
+        runInfo.getPropertyAsSingleValue(name, Mantid::Kernel::Math::LastValue),
+        expectedValue, 1e-12);
   }
 };
 

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -487,9 +487,9 @@ private:
     LogManager runInfo;
     const std::string name = "T_series";
     addTestTimeSeries<T>(runInfo, name);
-    const double expectedValue(24.0);
+    const double expectedValue(13.0);
     TS_ASSERT_DELTA(
-        runInfo.getPropertyAsSingleValue(name, Mantid::Kernel::Math::LastValue),
+        runInfo.getPropertyAsSingleValue(name, Mantid::Kernel::Math::Mean),
         expectedValue, 1e-12);
   }
 };

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -288,11 +288,21 @@ public:
     doTest_GetPropertyAsSingleValue_TimeSeriesType<uint64_t>();
   }
 
-  void
-  test_GetPropertyAsSingleValue_Throws_If_Type_Is_Not_Numeric_Or_TimeSeries_Numeric() {
+  void test_GetPropertyAsSingleValue_Throws_If_String_Is_Invalid() {
     LogManager runInfo;
     const std::string name = "string_prop";
-    runInfo.addProperty<std::string>(name, "hello"); // Adds a string property
+    runInfo.addProperty<std::string>(name, "hello"); // not a number
+
+    TS_ASSERT_THROWS(runInfo.getPropertyAsSingleValue(name),
+                     std::invalid_argument);
+  }
+
+  void
+  test_GetPropertyAsSingleValue_Throws_If_Type_Is_Not_Numeric_Or_TimeSeries_Numeric_Or_Valid_String() {
+    LogManager runInfo;
+    const std::string name = "bool_prop";
+    const bool value(false);
+    runInfo.addProperty<bool>(name, value); // Adds a bool property
 
     TS_ASSERT_THROWS(runInfo.getPropertyAsSingleValue(name),
                      std::invalid_argument);

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -264,6 +264,30 @@ public:
     TS_ASSERT_EQUALS(value, std::to_string(result));
   }
 
+  void test_GetPropertyAsSingleValue_TimeSeries_DoubleType() {
+    doTest_GetPropertyAsSingleValue_TimeSeriesType<double>();
+  }
+
+  void test_GetPropertyAsSingleValue_TimeSeries_FloatType() {
+    doTest_GetPropertyAsSingleValue_TimeSeriesType<float>();
+  }
+
+  void test_GetPropertyAsSingleValue_TimeSeries_Int32Type() {
+    doTest_GetPropertyAsSingleValue_TimeSeriesType<int32_t>();
+  }
+
+  void test_GetPropertyAsSingleValue_TimeSeries_Int64Type() {
+    doTest_GetPropertyAsSingleValue_TimeSeriesType<int64_t>();
+  }
+
+  void test_GetPropertyAsSingleValue_TimeSeries_Uint32Type() {
+    doTest_GetPropertyAsSingleValue_TimeSeriesType<uint32_t>();
+  }
+
+  void test_GetPropertyAsSingleValue_TimeSeries_Uint64Type() {
+    doTest_GetPropertyAsSingleValue_TimeSeriesType<uint64_t>();
+  }
+
   void
   test_GetPropertyAsSingleValue_Throws_If_Type_Is_Not_Numeric_Or_TimeSeries_Numeric() {
     LogManager runInfo;
@@ -457,6 +481,15 @@ private:
     double result = std::nan("1");
     TS_ASSERT_THROWS_NOTHING(result = runInfo.getPropertyAsSingleValue(name));
     TS_ASSERT_EQUALS(value, static_cast<T>(result));
+  }
+
+  template <typename T> void doTest_GetPropertyAsSingleValue_TimeSeriesType() {
+    LogManager runInfo;
+    const std::string name = "T_series";
+    addTestTimeSeries<T>(runInfo, name);
+    const double expectedValue(13.0);
+    TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name), expectedValue,
+                    1e-12);
   }
 };
 

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -255,6 +255,15 @@ public:
     doTest_GetPropertyAsSingleValue_SingleType<uint64_t>(1UL);
   }
 
+  void doTest_GetPropertyAsSingleValue_SingleValue_StringType() {
+    LogManager runInfo;
+    const std::string name = "string_prop", value = "1";
+    runInfo.addProperty<std::string>(name, value);
+    double result = std::nan("1");
+    TS_ASSERT_THROWS_NOTHING(result = runInfo.getPropertyAsSingleValue(name));
+    TS_ASSERT_EQUALS(value, std::to_string(result));
+  }
+
   void
   test_GetPropertyAsSingleValue_Throws_If_Type_Is_Not_Numeric_Or_TimeSeries_Numeric() {
     LogManager runInfo;

--- a/Framework/API/test/RunTest.h
+++ b/Framework/API/test/RunTest.h
@@ -190,13 +190,21 @@ public:
   }
 
   void
-  test_GetPropertyAsSingleValue_Throws_If_Type_Is_Not_Double_Or_TimeSeries_Double() {
+  test_GetPropertyAsSingleValue_Throws_If_Type_Is_Not_Numeric_Or_TimeSeries_Numeric() {
+    Run runInfo;
+    const std::string name = "string_prop";
+    runInfo.addProperty<std::string>(name, "string"); // Adds a string property
+
+    TS_ASSERT_THROWS(runInfo.getPropertyAsSingleValue(name),
+                     std::invalid_argument);
+  }
+
+  void test_GetPropertyAsSingleValue_Does_Not_Throw_If_Type_Is_Int() {
     Run runInfo;
     const std::string name = "int_prop";
     runInfo.addProperty(name, 1); // Adds an int property
 
-    TS_ASSERT_THROWS(runInfo.getPropertyAsSingleValue(name),
-                     std::invalid_argument);
+    TS_ASSERT_THROWS_NOTHING(runInfo.getPropertyAsSingleValue(name));
   }
 
   void


### PR DESCRIPTION
Extend `LogManager::getLogAsSingleValue` to work with logs of integer (or time series integer) types as well as doubles and time series doubles.

`LogManager::getLogAsSingleValue` previously only worked for log values stored as doubles or time series doubles and threw an exception if used on an integer log. It is less surprising to the caller if the function works on any numeric, or time series numeric, log and does what is suggested by the name.

**To test:**
Unit tests have been written to cover all new cases. Since this function is not exposed to Python it is difficult to test manually - code review and check the new tests cover the behaviour.

Fixes #17087. (This feature is also required for #17079.)

_Does not need to be in the release notes_ (internal change not visible to users)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
