### PR TITLE
Update weights used during CorelliCrossCorrelate

### DIFF
--- a/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
@@ -131,10 +131,9 @@ void CorelliCrossCorrelate::exec() {
 
   // Calculate the duty cycle and the event weights from the duty cycle.
   double dutyCycle = totalOpen / sequence.back();
-  float weightTransparent = static_cast<float>(1.0 / dutyCycle);
-  float weightAbsorbing = static_cast<float>(-1.0 / (1.0 - dutyCycle));
+  float weightAbsorbing = static_cast<float>(-dutyCycle / (1.0 - dutyCycle));
   g_log.information() << "dutyCycle = " << dutyCycle
-                      << " weightTransparent = " << weightTransparent
+                      << " weightTransparent = 1.0"
                       << " weightAbsorbing = " << weightAbsorbing << "\n";
 
   // Read in the TDC timings for the correlation chopper and apply the timing
@@ -184,7 +183,6 @@ void CorelliCrossCorrelate::exec() {
 
   // Do the cross correlation.
   int64_t numHistograms = static_cast<int64_t>(inputWS->getNumberHistograms());
-  g_log.notice("Start cross-correlation\n");
   API::Progress prog = API::Progress(this, 0.0, 1.0, numHistograms);
   PARALLEL_FOR1(outputWS)
   for (int64_t i = 0; i < numHistograms; ++i) {
@@ -245,9 +243,6 @@ void CorelliCrossCorrelate::exec() {
       if ((location - sequence.begin()) % 2 == 0) {
         it->m_weight *= weightAbsorbing;
         it->m_errorSquared *= weightAbsorbing * weightAbsorbing;
-      } else {
-        it->m_weight *= weightTransparent;
-        it->m_errorSquared *= weightTransparent * weightTransparent;
       }
     }
 

--- a/Framework/Algorithms/test/CorelliCrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CorelliCrossCorrelateTest.h
@@ -96,11 +96,11 @@ public:
 
     std::vector<WeightedEvent> &events = evlist.getWeightedEvents();
 
-    TS_ASSERT_DELTA(events[0].weight(), -1.99392, 0.00001)
-    TS_ASSERT_DELTA(events[1].weight(), -1.99392, 0.00001)
-    TS_ASSERT_DELTA(events[2].weight(), 2.00612, 0.00001)
-    TS_ASSERT_DELTA(events[3].weight(), -1.99392, 0.00001)
-    TS_ASSERT_DELTA(events[4].weight(), 2.00612, 0.00001)
+    TS_ASSERT_DELTA(events[0].weight(), -0.993919, 0.00001)
+    TS_ASSERT_DELTA(events[1].weight(), -0.993919, 0.00001)
+    TS_ASSERT_DELTA(events[2].weight(), 1.0, 0.00001)
+    TS_ASSERT_DELTA(events[3].weight(), -0.993919, 0.00001)
+    TS_ASSERT_DELTA(events[4].weight(), 1.0, 0.00001)
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);

--- a/docs/source/algorithms/CorelliCrossCorrelate-v1.rst
+++ b/docs/source/algorithms/CorelliCrossCorrelate-v1.rst
@@ -12,6 +12,8 @@ Description
 
 The algorithm calculates the elastic signal for the Corelli diffractometer. This is done by calculating the cross-correlation with the correlation chopper. The correlation chopper modulates the incident neutron beam with a pseudo-random sequence. The calculated signal is applied the each event in the form of a weight.
 
+The weights that the events are scaled by are :math:`1` for transparent and :math:`\frac{-c}{1-c}` for absorbing, where :math:`c` is the duty cycle (:math:`c\approx0.498475`).
+
 The algorithm requires the timing offset of the TDC signal from the correlation chopper to run. The timing offset is dependent on the frequency of the chopper and should not change if the frequency has not changed.
 
 Usage
@@ -29,10 +31,10 @@ Usage
     ws = Load('CORELLI_2100')
 
     # You will need to load the instrument if the one in the NeXus file doesn't contain the chopper sequence.
-    LoadInstrument(ws, MonitorList='-1,-2,-3', InstrumentName='CORELLI', RewriteSpectraMap=True)
+    LoadInstrument(ws, InstrumentName='CORELLI', RewriteSpectraMap=False)
 
     # Run the cross-correlation. This is using a TDC timing offset of 56000ns.
-    wsOut = CorelliCrossCorrelate(ws,56000)
+    wsOut = CorelliCrossCorrelate(ws, 56000)
 
     print 'The detector 172305 has ' + str(ws.getSpectrum(172305).getNumberEvents()) + ' events.'
     print 'The event weights before cross-correlation are ' + str(ws.getSpectrum(172305).getWeights())
@@ -44,7 +46,7 @@ Output:
 
     The detector 172305 has 3 events.
     The event weights before cross-correlation are [ 1.  1.  1.]
-    The event weights after  cross-correlation are [-1.99391854  2.00611877  2.00611877]
+    The event weights after  cross-correlation are [-0.99391854  1.          1.        ]
 
 .. categories::
 

--- a/docs/source/release/v3.8.0/diffraction.rst
+++ b/docs/source/release/v3.8.0/diffraction.rst
@@ -60,6 +60,10 @@ Powder Diffraction
    S-Empty option, simply provide the S-Empty run number within the
    ``.pref`` file.
 
+- :ref:`CorelliCrossCorrelate <algm-CorelliCrossCorrelate>`: The
+  weights applied to events have changed by a factor of the duty cycle
+  (:math:`c\approx0.498`) as requested by the instrument scientists.
+
 Full list of `diffraction <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.8%22+is%3Amerged+label%3A%22Component%3A+Diffraction%22>`_
 and
 `imaging <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.8%22+is%3Amerged+label%3A%22Component%3A+Imaging%22>`_ changes on GitHub.


### PR DESCRIPTION
This is done at the request of the Corelli instrument scientists to be better inline with what the users expect the algorithm to do. This simply changes the scale of the weight by a factor of the duty cycle (c≈0.498).

**To test:**
- Load in a file from Corelli and apply the CorelliCrossCorrelation, compared the scale before and after this change, they should differ by a factor of ≈0.498.

Release notes have been updated!!!

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
