### PR TITLE
Fix for Mantid crash when empty sequence is passed to PropertyManagerProperty

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
@@ -177,6 +177,12 @@ PropertyWithValueFactory::lookup(PyObject *const object) {
  */
 const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
   if (PyList_Check(object) || PyTuple_Check(object)) {
+    // If we are dealing with an empty list/tuple, then we cannot deduce the
+    // ArrayType. We need to throw at this point.
+    if (PySequence_Size(object) < 1) {
+      throw std::runtime_error("Cannot have a sequence type of length zero in a mapping type.");
+    }
+
     PyObject *item = PySequence_Fast_GET_ITEM(object, 0);
     // Boolean can be cast to int, so check first.
     if (PyBool_Check(item)) {

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
@@ -180,7 +180,8 @@ const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
     // If we are dealing with an empty list/tuple, then we cannot deduce the
     // ArrayType. We need to throw at this point.
     if (PySequence_Size(object) < 1) {
-      throw std::runtime_error("Cannot have a sequence type of length zero in a mapping type.");
+      throw std::runtime_error(
+          "Cannot have a sequence type of length zero in a mapping type.");
     }
 
     PyObject *item = PySequence_Fast_GET_ITEM(object, 0);

--- a/Framework/PythonInterface/test/python/mantid/kernel/PropertyManagerPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PropertyManagerPropertyTest.py
@@ -7,6 +7,13 @@ from mantid.kernel import PropertyManagerProperty, Direction, PropertyManager
 from mantid.api import Algorithm
 import numpy as np
 
+class FakeAlgorithm(Algorithm):
+    def PyInit(self):
+        self.declareProperty(PropertyManagerProperty("Args"))
+
+    def PyExec(self):
+        pass
+
 class PropertyManagerPropertyTest(unittest.TestCase):
 
     def test_default_constructor_raises_an_exception(self):
@@ -25,13 +32,6 @@ class PropertyManagerPropertyTest(unittest.TestCase):
         self._check_object_attributes(arr, name, direc)
 
     def test_set_property_on_algorithm_from_dictionary(self):
-        class FakeAlgorithm(Algorithm):
-            def PyInit(self):
-                self.declareProperty(PropertyManagerProperty("Args"))
-
-            def PyExec(self):
-                pass
-        #
         fake = FakeAlgorithm()
         fake.initialize()
         fake.setProperty("Args", {'A': 1, 
@@ -76,6 +76,16 @@ class PropertyManagerPropertyTest(unittest.TestCase):
         self.assertEqual("test", nested_l2_pmgr['I'].value)
         self.assertTrue('J' in nested_l2_pmgr)
         self.assertEqual(120.6, nested_l2_pmgr['J'].value)
+
+    def test_that_empty_sequence_in_property_manager_raises(self):
+        fake = FakeAlgorithm()
+        fake.initialize()
+        try:
+            fake.setProperty("Args", {'A': []})
+            has_raised = False
+        except RuntimeError:
+            has_raised = True
+        self.assertTrue(has_raised)
 
     def _check_object_attributes(self, prop, name, direction):
         self.assertEquals(prop.name, name)


### PR DESCRIPTION
Fixes #17113 

This fixes a bug of the PropertyManagerProperty which did not handle the case of the PropertyManager having an empty array. Now we handle the situation by throwing an exception. 

I don't think we can handle it in any better way. We need some type information, but the emptysequence in a PropertyManager cannot give this to us, hence the best thing that we can do is to let the user/developer know that empty sequence types are not supported in PropertyManagers.

**To test:**

Run the following script and confirm that Mantid does not crash. You should see an exception message instead:

``` python
class FakeAlgorithm(Algorithm):
    def PyInit(self):
        self.declareProperty(PropertyManagerProperty("Args"))

    def PyExec(self):
        pass
fake = FakeAlgorithm()
fake.initialize()
fake.setProperty("Args", {"test": []})
```

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
