### PR TITLE
Update OS X packaging script to include tbb.

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -71,7 +71,10 @@ library_filenames = ["libboost_regex-mt.dylib",
                      "libsz.dylib",
                      "libjpeg.dylib",
                      "libssl.dylib",
-                     "libcrypto.dylib"]
+                     "libcrypto.dylib",
+                     "libtbb.dylib",
+                     "libtbbmalloc.dylib",
+                     "libtbbmalloc_proxy.dylib"]
 
 poco_version = "@POCO_VERSION@".split(".").map(&:to_i)
 if(poco_version[0] > 1 || (poco_version[0] == 1 && poco_version[1] >= 6))


### PR DESCRIPTION
Description of work.

This updates the OS X packaging script so the we can build ParaView with `VTK_SMP_IMPLEMENTATION_TYPE=TBB`

**To test:**

<!-- Instructions for testing. -->
- Double-check changes to the [OS X build instructions](https://github.com/mantidproject/mantid/wiki/Building-Mantid-on-OS-X-10.10-&-10.11-using-clang-and-Xcode) and [ParaView cachefile](https://github.com/mantidproject/paraview-build/blob/f311405f8c558195bfb13a12e65ef9b10deccfb4/osx.cmake).
- Verify that all tbb-related shared libraries are now included in the app bundle. 

There is no GitHub issue associated with this pull request.

_Does not need to be in the release notes._

**After this is merged into master**
- reinstall opencascade with tbb support
- rebuild ParaView with tbb support.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
