### PR TITLE
Fix -Wsuggest-override warnings on GCC 5+

### DIFF
--- a/Framework/Algorithms/test/ScaleXTest.h
+++ b/Framework/Algorithms/test/ScaleXTest.h
@@ -392,13 +392,13 @@ public:
 
   static void destroySuite(ScaleXTestPerformance *suite) { delete suite; }
 
-  void setUp() {
+  void setUp() override {
     inputMatrix = WorkspaceCreationHelper::Create2DWorkspaceBinned(10000, 1000);
     inputEvent =
         WorkspaceCreationHelper::CreateEventWorkspace(10000, 1000, 5000);
   }
 
-  void tearDown() {
+  void tearDown() override {
     Mantid::API::AnalysisDataService::Instance().remove("output");
     Mantid::API::AnalysisDataService::Instance().remove("output2");
   }

--- a/Framework/Algorithms/test/StripPeaksTest.h
+++ b/Framework/Algorithms/test/StripPeaksTest.h
@@ -108,7 +108,7 @@ private:
 
 class StripPeaksTestPerformance : public CxxTest::TestSuite {
 public:
-  void setUp() {
+  void setUp() override {
     FrameworkManager::Instance();
     MatrixWorkspace_sptr WS =
         WorkspaceCreationHelper::Create2DWorkspaceBinned(2, 200, 0.5, 0.02);
@@ -143,7 +143,7 @@ public:
 
   void test_strip_peaks() { TS_ASSERT_THROWS_NOTHING(stripAlg.execute()); }
 
-  void tearDown() {
+  void tearDown() override {
     AnalysisDataService::Instance().remove("Stripped");
     AnalysisDataService::Instance().remove("toStrip");
   }

--- a/MantidPlot/src/WindowFactory.h
+++ b/MantidPlot/src/WindowFactory.h
@@ -64,7 +64,7 @@ public:
    * form.
    */
   Base *loadFromProject(const std::string &lines, ApplicationWindow *app,
-                        const int fileVersion = -1) const {
+                        const int fileVersion = -1) const override {
     return C::loadFromProject(lines, app, fileVersion);
   }
 };


### PR DESCRIPTION
Description of work.

This fixes serveral `-Wsuggest-override` warnings that have crept into master

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
