### PR TITLE
Update the modulefile template

### DIFF
--- a/installers/LinuxInstaller/modulefile.template
+++ b/installers/LinuxInstaller/modulefile.template
@@ -1,12 +1,17 @@
 #%Module 1.0
-
-module load /etc/modulefiles/compat-openmpi-x86_64
 module load sns_software
 
 set                     PREFIX          @INSTALL_ROOT@/@CPACK_PACKAGE_FILE_NAME@
+set                     MPI_PREFIX      /sw/fermi/openmpi-1.8.7_nodlopen
+# This is specific to fermi.sns.gov.  If you want to use this modulefile
+# on a different machine, you're probably better off doing a 'module load
+# openmpi' up above.
 
-prepend-path            PATH            $PREFIX/bin
-# Second one is to pick up boostmpi (not openmpi itself which comes from the compat package above)
-prepend-path            LD_LIBRARY_PATH $PREFIX/lib:/usr/lib64/openmpi/lib
-prepend-path            PYTHONPATH      $PREFIX/bin
+prepend-path            PATH            $PREFIX/bin:$MPI_PREFIX/bin
+
+# /usr/lib64/openmpi/lib is so we pick up boostmpi (not openmpi itself)
+prepend-path            LD_LIBRARY_PATH $PREFIX/lib:$MPI_PREFIX/lib:/usr/lib64/openmpi/lib
+prepend-path            PYTHONPATH      $PREFIX/bin:/usr/lib64/python2.6/site-packages/openmpi
+# For reasons that are unclear, mpi4py is installed in
+# .../site-packages/openmpi/mpi4py insted of .../site-packages/mpi4py
 


### PR DESCRIPTION
Updated the template to generate a proper modulefile for fermi.ornl.gov

**To test:**

To test properly, we need to be able to build and install a working mpi-enabled Mantid framework on Fermi, which is something we can't do at the moment.  Once we can do that, then the test is to:
1. log in to fermi.ornl.gov
2. `module load mantid-mpi/<whatever version you're testing>`
3. `python -c "from mantid.simpleapi import *"`

If the python import works, we're good.

Fixes #17134 

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Update the template used to generate the modulefile for the MPI builds so
that it works with the current configuration of fermi.ornl.gov.

Refs #17134
