### PR TITLE
Upgrade Embedded IPython Wrappers for IPython 5  

### DIFF
--- a/Framework/PythonInterface/mantid/__init__.py
+++ b/Framework/PythonInterface/mantid/__init__.py
@@ -48,7 +48,8 @@ except ImportError:
 ###############################################################################
 import warnings as _warnings
 # Default we see everything
-_warnings.filterwarnings("default",category=DeprecationWarning)
+_warnings.filterwarnings("default",category=DeprecationWarning,
+                         module="mantid.*")
 # We can't do anything about numpy.oldnumeric being deprecated but
 # still used in other libraries, e.g scipy, so just ignore those
 _warnings.filterwarnings("ignore",category=DeprecationWarning,

--- a/MantidPlot/ipython_widget/mantid_ipython_widget.py
+++ b/MantidPlot/ipython_widget/mantid_ipython_widget.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division,
 import inspect
 import threading
 import types
+import warnings
 
 from PyQt4 import QtGui
 
@@ -14,8 +15,20 @@ from pygments.lexer import RegexLexer
 # Monkeypatch!
 RegexLexer.get_tokens_unprocessed_unpatched = RegexLexer.get_tokens_unprocessed
 
-from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
-from IPython.qt.inprocess import QtInProcessKernelManager
+# Ignore Jupyter/IPython deprecation warnings that we can't do anything about
+warnings.filterwarnings('ignore', category=DeprecationWarning, module='IPython.*')
+warnings.filterwarnings('ignore', category=DeprecationWarning, module='ipykernel.*')
+warnings.filterwarnings('ignore', category=DeprecationWarning, module='jupyter_client.*')
+warnings.filterwarnings('ignore', category=DeprecationWarning, module='qtconsole.*')
+del warnings
+
+try:
+    # Later versions of Qtconsole are part of Jupyter
+    from qtconsole.rich_jupyter_widget import RichJupyterWidget as RichIPythonWidget
+    from qtconsole.inprocess import QtInProcessKernelManager
+except ImportError:
+    from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
+    from IPython.qt.inprocess import QtInProcessKernelManager
 
 def our_run_code(self, code_obj, result=None):
     """ Method with which we replace the run_code method of IPython's InteractiveShell class.

--- a/MantidPlot/src/PythonScript.h
+++ b/MantidPlot/src/PythonScript.h
@@ -62,13 +62,15 @@ public:
   /// Create a PyObject that wraps this C++ instance
   PyObject *createSipInstanceFromMe();
 
-  // -------------------------- Print/error message handling ------------------
+  // -------------------------- I/O-like behaviour ------------------
   /// Connects the python stdout to a Qt signal
   inline void write(const QString &text) { emit print(text); }
   /// Simulate file-like object (required for IPython)
   inline void flush() {}
   /// Simulate file-like object (required for colorama)
-  inline bool closed() { return false; }
+  inline bool closed() const { return false; }
+  /// Simulate file-like object
+  inline bool isatty() const { return false; }
   /// Is the given code complete
   bool compilesToCompleteStatement(const QString &code) const override;
 

--- a/MantidPlot/src/PythonScripting.h
+++ b/MantidPlot/src/PythonScripting.h
@@ -54,7 +54,10 @@ public:
   /// Simulate file-like object (required for IPython)
   inline void flush() {}
   /// Simulate file-like object (required for colorama)
-  inline bool closed() { return false; }
+  inline bool closed() const { return false; }
+  /// Simulate file-like object
+  inline bool isatty() const { return false; }
+
   /// 'Fake' method needed for IPython import
   void set_parent(PyObject *) {}
 

--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -130,7 +130,7 @@ public:
 
   SIP_PYOBJECT text(SIP_PYOBJECT, int);
 %MethodCode
-  
+
   sipIsErr = 0;
   CHECK_TABLE_COL(a0);
   CHECK_TABLE_ROW(a1);
@@ -684,13 +684,13 @@ private:
 	Grid(const Grid&);
 };
 
-namespace MantidQt 
+namespace MantidQt
 {
-%TypeHeaderCode 
+%TypeHeaderCode
 #include "MantidQtAPI/DistributionOptions.h"
 %End
 
-	enum DistributionFlag {DistributionDefault, DistributionTrue, DistributionFalse};  
+	enum DistributionFlag {DistributionDefault, DistributionTrue, DistributionFalse};
 };
 
 class Graph : QWidget /PyName=Layer/
@@ -1128,9 +1128,9 @@ public:
 %End
   Matrix* newMatrix();
   Matrix* newMatrix(const QString&, int=32, int=32);
-  
+
   TiledWindow *newTiledWindow();
-  
+
   MultiLayer *plot(const QString&) /PyName=graph/;
 %MethodCode
   sipRes = sipCpp->currentFolder()->graph(*a0, false);
@@ -1291,7 +1291,9 @@ public:
   // Simulate file-like object (required for IPython)
   void flush();
   // Simulate file-like object (required for colorama)
-  bool closed();
+  bool closed() const;
+  // Simulate file-like object
+  bool isatty() const;
   void set_parent(SIP_PYOBJECT);
 private:
   PythonScripting(const PythonScripting&);
@@ -1307,6 +1309,8 @@ public:
   void flush();
   // Simulate file-like object (required for colorama)
   bool closed();
+  // Simulate file-like object
+  bool isatty() const;
   // Line number trace
   void lineNumberChanged(SIP_PYOBJECT,int);
 private:


### PR DESCRIPTION
Allows for old and new structure of IPython and its Qt console now that it has moved to Jupyter.

**To test:**
- Checkout the pull request and test that MantidPlot still starts with the stock version of IPython
- Use `pip` to install IPython 5:

`pip install --user --upgrade IPython`
- I got an error byte-compiling `pexpect` but the installation was successful otherwise.
- Check MantidPlot still starts

Fixes #16911

_Does not need to be in the release notes as it is an internal change._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
