### PR TITLE
Work around internal compiler error on Fedora 24

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/IValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/IValidator.h
@@ -12,8 +12,6 @@
 #include <boost/any.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/type_traits/is_convertible.hpp>
-#include <boost/type_traits/is_pointer.hpp>
 #endif
 #include <vector>
 #include <string>
@@ -32,11 +30,12 @@ typedef boost::shared_ptr<IValidator> IValidator_sptr;
 namespace {
 /// Helper object to determine if a type is either a pointer/shared_ptr
 /// Generic implementation says it is not
-template <class T> struct IsPtrType : public boost::is_pointer<T> {};
+template <class T> struct IsPtrType : public std::is_pointer<T> {};
 /// Helper object to determine if a type is either a pointer/shared_ptr
 /// Specialized implementation for shared_ptr
 template <class T>
-struct IsPtrType<boost::shared_ptr<T>> : public boost::true_type {};
+struct IsPtrType<boost::shared_ptr<T>> : public std::true_type {};
+template <> struct IsPtrType<decltype(nullptr)> : public std::true_type {};
 }
 
 /** IValidator is the basic interface for all validators for properties
@@ -142,7 +141,7 @@ private:
    * error
    */
   template <typename T>
-  std::string runCheck(const T &value, const boost::false_type &) const {
+  std::string runCheck(const T &value, const std::false_type &) const {
     const T *valuePtr =
         &value; // Avoid a copy by storing the pointer in the any holder
     return check(boost::any(valuePtr));
@@ -154,9 +153,11 @@ private:
    * error
    */
   template <typename T>
-  std::string runCheck(const T &value, const boost::true_type &) const {
-    return runCheckWithDataItemPtr(value,
-                                   boost::is_convertible<T, DataItem_sptr>());
+  std::string runCheck(const T &value, const std::true_type &) const {
+    return runCheckWithDataItemPtr(
+        value, std::integral_constant < bool,
+        std::is_convertible<T, DataItem_sptr>::value &&
+            !std::is_same<T, decltype(nullptr)>::value > ());
   }
   /** Calls the validator for a pointer type that is NOT convertible to
    * DataItem_sptr
@@ -166,7 +167,7 @@ private:
    */
   template <typename T>
   std::string runCheckWithDataItemPtr(const T &value,
-                                      const boost::false_type &) const {
+                                      const std::false_type &) const {
     return check(boost::any(value));
   }
   /** Calls the validator for a pointer type that IS convertible to
@@ -177,7 +178,7 @@ private:
    */
   template <typename T>
   std::string runCheckWithDataItemPtr(const T &value,
-                                      const boost::true_type &) const {
+                                      const std::true_type &) const {
     return check(boost::any(boost::static_pointer_cast<DataItem>(value)));
   }
 };


### PR DESCRIPTION
Description of work.

This addresses an internal compiler error when building `EqualBinSizesValidatorTest::test_null`. The problem appears to be [obtaining the address of a `nullptr_t`](https://github.com/mantidproject/mantid/blob/27ca913c1f2e640916cdcdfd65b15f80669523d5/Framework/Kernel/inc/MantidKernel/IValidator.h#L146). The best solution I've found so far is to treat `nullptr_t` the same as we treat other 
pointer types. 

I also updated IValidator.h to use type_traits from the standard library instead of boost.

**To test:**

<!-- Instructions for testing. -->

Build `APITest` with GCC 6.1

This is part of #17146.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
