### PR TITLE
Indirect Bayes SystemTest - Add s_api module for use of FileFinder

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -572,7 +572,7 @@ class BayesQuasi(PythonAlgorithm):
             logger.information('Width file is ' + widthFile)
             # read ascii based width file
             try:
-                wfPath = FileFinder.getFullPath(widthFile)
+                wfPath = s_api.FileFinder.getFullPath(widthFile)
                 handle = open(wfPath, 'r')
                 asc = []
                 for line in handle:


### PR DESCRIPTION
Added the s_api module were FileFinder was being used. We should attempt to test and merge this soon as it is stopping the creation of the nightly builds for Windows.

**To test:**

Ensure `ISISIndirectBayesTest.QLWidth` passes on windows

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
