### PR TITLE
Load correct detector IDs in LoadMuonNexus

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus2.h
@@ -95,6 +95,8 @@ private:
   void loadLogs(API::MatrixWorkspace_sptr ws, Mantid::NeXus::NXEntry &entry,
                 int period);
   void loadRunDetails(DataObjects::Workspace2D_sptr localWorkspace);
+  std::map<int, std::set<int>>
+  loadDetectorMapping(const Mantid::NeXus::NXInt &spectrumIndex);
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/LoadMuonNexus.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus.cpp
@@ -62,7 +62,8 @@ void LoadMuonNexus::init() {
 
   declareProperty(make_unique<ArrayProperty<specnum_t>>("SpectrumList"),
                   "Array, or comma separated list, of indexes of spectra to\n"
-                  "load");
+                  "load. If a range and a list of spectra are both supplied,\n"
+                  "all the specified spectra will be loaded.");
   declareProperty("AutoGroup", false,
                   "Determines whether the spectra are automatically grouped\n"
                   "together based on the groupings in the NeXus file, only\n"

--- a/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -676,7 +676,8 @@ void LoadMuonNexus1::loadData(size_t hist, specnum_t &i, specnum_t specNo,
 
   localWorkspace->setX(hist, timeChannelsVec);
   localWorkspace->getSpectrum(hist).setSpectrumNo(specNo);
-
+  // Muon v1 files: always a one-to-one mapping between spectra and detectors
+  localWorkspace->getSpectrum(hist).setDetectorID(static_cast<detid_t>(specNo));
   // Clean up
   delete[] timeChannels;
 }

--- a/Framework/DataHandling/src/LoadMuonNexus2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus2.cpp
@@ -131,6 +131,9 @@ void LoadMuonNexus2::doExec() {
   spectrum_index.load();
   m_numberOfSpectra = spectrum_index.dim0();
 
+  // Load detector mapping
+  const auto &detMapping = loadDetectorMapping(spectrum_index);
+
   // Call private method to validate the optional parameters, if set
   checkOptionalProperties();
 
@@ -250,6 +253,7 @@ void LoadMuonNexus2::doExec() {
       int i = index_spectrum[spec]; // if spec not found i is 0
       loadData(counts, timeBins, counter, period, i, localWorkspace);
       localWorkspace->getSpectrum(counter).setSpectrumNo(spectrum_index[i]);
+      localWorkspace->getSpectrum(counter).setDetectorIDs(detMapping.at(i));
       counter++;
       progress.report();
     }
@@ -260,6 +264,7 @@ void LoadMuonNexus2::doExec() {
         int k = index_spectrum[spec]; // if spec not found k is 0
         loadData(counts, timeBins, counter, period, k, localWorkspace);
         localWorkspace->getSpectrum(counter).setSpectrumNo(spectrum_index[k]);
+        localWorkspace->getSpectrum(counter).setDetectorIDs(detMapping.at(k));
         counter++;
         progress.report();
       }
@@ -445,6 +450,76 @@ int LoadMuonNexus2::confidence(Kernel::NexusDescriptor &descriptor) const {
   } catch (...) {
   }
   return 0;
+}
+
+/**
+ * Loads the mapping between index -> set of detector IDs
+ *
+ * If "detector_index", "detector_count" and "detector_list" are all present,
+ * use these to get the mapping, otherwise spectrum number = detector ID
+ * (one-to-one)
+ *
+ * The spectrum spectrum_index[i] maps to detector_count[i] detectors, whose
+ * detector IDs are in detector_list starting at the index detector_index[i]
+ *
+ * @returns :: map of index -> detector IDs
+ * @throws std::runtime_error if fails to read data from file
+ */
+std::map<int, std::set<int>>
+LoadMuonNexus2::loadDetectorMapping(const Mantid::NeXus::NXInt &spectrumIndex) {
+  std::map<int, std::set<int>> mapping;
+  const int nSpectra = spectrumIndex.dim0();
+
+  // Find and open the data group
+  NXRoot root(getPropertyValue("Filename"));
+  NXEntry entry = root.openEntry(m_entry_name);
+  const std::string detectorName = [&entry]() {
+    // Only the first NXdata found
+    for (auto &group : entry.groups()) {
+      std::string className = group.nxclass;
+      if (className == "NXdata") {
+        return group.nxname;
+      }
+    }
+    throw std::runtime_error("No NXdata found in file");
+  }();
+  NXData dataGroup = entry.openNXData(detectorName);
+
+  // Usually for muon data, detector id = spectrum number
+  // If not, the optional groups "detector_index", "detector_list" and
+  // "detector_count" will be present to map one to the other
+  const bool hasDetectorMapping = dataGroup.containsDataSet("detector_index") &&
+                                  dataGroup.containsDataSet("detector_list") &&
+                                  dataGroup.containsDataSet("detector_count");
+  if (hasDetectorMapping) {
+    // Read detector IDs
+    try {
+      const auto detIndex = dataGroup.openNXInt("detector_index");
+      const auto detCount = dataGroup.openNXInt("detector_count");
+      const auto detList = dataGroup.openNXInt("detector_list");
+      const int nSpectra = detIndex.dim0();
+      for (int i = 0; i < nSpectra; ++i) {
+        const int start = detIndex[i];
+        const int nDetectors = detCount[i];
+        std::set<int> detIDs;
+        for (int jDet = 0; jDet < nDetectors; ++jDet) {
+          detIDs.insert(detList[start + jDet]);
+        }
+        mapping[i] = detIDs;
+      }
+    } catch (const ::NeXus::Exception &err) {
+      // Throw a more user-friendly message
+      std::ostringstream message;
+      message << "Failed to read detector mapping: " << err.what();
+      throw std::runtime_error(message.str());
+    }
+  } else {
+    for (int i = 0; i < nSpectra; ++i) {
+      mapping[i] = std::set<int>{spectrumIndex[i]};
+    }
+  }
+
+  return mapping;
 }
 
 } // namespace DataHandling

--- a/Framework/DataHandling/test/LoadMuonNexus1Test.h
+++ b/Framework/DataHandling/test/LoadMuonNexus1Test.h
@@ -339,6 +339,7 @@ public:
   void testPartialSpectraLoading() {
     LoadMuonNexus1 alg1;
     LoadMuonNexus1 alg2;
+    inputFile = "emu00006473.nxs";
 
     const std::string deadTimeWSName = "LoadMuonNexus1Test_DeadTimes";
     const std::string groupingWSName = "LoadMuonNexus1Test_Grouping";
@@ -434,6 +435,41 @@ public:
     testVec.push_back(31);
     TS_ASSERT_EQUALS(groupingTable->cell<std::vector<int>>(1, 0), testVec);
     AnalysisDataService::Instance().remove(groupingWSName);
+  }
+
+  void testPartialSpectraLoading_spectrumNumbers_detectorIDs() {
+    LoadMuonNexus1 alg;
+
+    // It will only load some spectra
+    try {
+      alg.initialize();
+      alg.setChild(true);
+      alg.setPropertyValue("Filename", "emu00006473.nxs");
+      alg.setPropertyValue("OutputWorkspace", "__NotUsed");
+      alg.setPropertyValue("SpectrumList", "29,31");
+      alg.setPropertyValue("SpectrumMin", "5");
+      alg.setPropertyValue("SpectrumMax", "10");
+      alg.execute();
+    } catch (const std::exception &ex) {
+      TS_FAIL(std::string("Loading failed: ") + ex.what());
+    }
+
+    Workspace_sptr outWS = alg.getProperty("OutputWorkspace");
+    const auto loadedWS = boost::dynamic_pointer_cast<Workspace2D>(outWS);
+    TS_ASSERT(loadedWS);
+
+    // Check the right spectra have been loaded
+    const std::vector<Mantid::specnum_t> expectedSpectra{5, 6,  7,  8,
+                                                         9, 10, 29, 31};
+    TS_ASSERT_EQUALS(loadedWS->getNumberHistograms(), expectedSpectra.size());
+    for (size_t i = 0; i < loadedWS->getNumberHistograms(); ++i) {
+      const auto spec = loadedWS->getSpectrum(i);
+      TS_ASSERT_EQUALS(spec.getSpectrumNo(), expectedSpectra[i]);
+      // detector ID = spectrum number for muon Nexus v1
+      const auto detIDs = spec.getDetectorIDs();
+      TS_ASSERT_EQUALS(detIDs.size(), 1);
+      TS_ASSERT_EQUALS(*detIDs.begin(), static_cast<int>(spec.getSpectrumNo()));
+    }
   }
 
   void test_loadingDeadTimes_singlePeriod() {

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -1245,9 +1245,14 @@ Table *MantidUI::createDetectorTable(
       // Need to get R, theta through these methods to be correct for grouped
       // detectors
       R = det->getDistance(*sample);
-      theta = showSignedTwoTheta ? ws->detectorSignedTwoTheta(*det)
-                                 : ws->detectorTwoTheta(*det);
-      theta *= 180.0 / M_PI; // To degrees
+      try {
+        theta = showSignedTwoTheta ? ws->detectorSignedTwoTheta(*det)
+                                   : ws->detectorTwoTheta(*det);
+        theta *= 180.0 / M_PI; // To degrees
+      } catch (const Mantid::Kernel::Exception::InstrumentDefinitionError &ex) {
+        // Log the error and leave theta as it is
+        g_log.error(ex.what());
+      }
       QString isMonitor = det->isMonitor() ? "yes" : "no";
 
       colValues << QVariant(specNo) << QVariant(detIds);

--- a/docs/source/algorithms/LoadMuonNexus-v1.rst
+++ b/docs/source/algorithms/LoadMuonNexus-v1.rst
@@ -24,8 +24,12 @@ load all the specified spectra.
 
 -  TODO get XML descriptions of Muon instruments. This data is not in
    existing Muon Nexus files.
--  TODO load the spectra detector mapping. This may be very simple for
-   Muon instruments.
+
+Spectra-detector mapping
+########################
+
+For all v1 muon Nexus files, there is a one-to-one mapping between spectrum
+number and detector ID.
 
 Time series data
 ################

--- a/docs/source/algorithms/LoadMuonNexus-v2.rst
+++ b/docs/source/algorithms/LoadMuonNexus-v2.rst
@@ -23,8 +23,6 @@ loaded.
 
 -  TODO get XML descriptions of Muon instruments. This data is not in
    existing Muon Nexus files.
--  TODO load the spectra detector mapping. This may be very simple for
-   Muon instruments.
 
 Version Identification
 ######################
@@ -74,6 +72,7 @@ Here are more details of data loaded from the Nexus file:
 |                                  |                                            | as loaded by LoadInstrumentFromNexus   |
 +----------------------------------+--------------------------------------------+----------------------------------------+
 | Spectrum of each workspace index | [DET]``/spectrum_index``                   | Spectra-Detector mapping of workspace  |
+|                                  |                                            | (see below)                            |
 +----------------------------------+--------------------------------------------+----------------------------------------+
 | Title (optional)                 | ``title``                                  | ``title`` in workspace                 |
 +----------------------------------+--------------------------------------------+----------------------------------------+
@@ -94,7 +93,7 @@ Here are more details of data loaded from the Nexus file:
 
 Run Object
 ''''''''''
-LoadMuonNexus does not run LoadNexuslogs to load run logs. Information is loaded as follows:
+LoadMuonNexus does not run LoadNexusLogs to load run logs. Information is loaded as follows:
 
 +---------------------------+----------------------------------+
 | Nexus                     | Workspace run object             |
@@ -116,6 +115,20 @@ LoadMuonNexus does not run LoadNexuslogs to load run logs. Information is loaded
 
 
 (data) indicates that the number is got from the histogram data in an appropiate manner.
+
+Spectra-detector mapping
+''''''''''''''''''''''''
+Unlike muon v1 NeXus files, v2 files have the possibility that one spectrum maps to multiple detectors.
+This mapping is handled as follows:
+
+The spectrum numbers are in ``run/detector_fb/spectrum_index``.
+
+The spectrum ``spectrum_index[j]`` maps to ``detector_count[j]`` detectors.
+Their detector IDs are contained in ``detector_list``, starting at the index ``detector_index[j]``.
+
+If the above optional entries ``detector_count``, ``detector_list`` and ``detector_index`` are not present
+in the file, it is assumed that the mapping is one-to-one (spectrum number = detector ID). This is the case
+for most ISIS data at the moment.
 
 
 Child Algorithms used

--- a/docs/source/release/v3.8.0/muon.rst
+++ b/docs/source/release/v3.8.0/muon.rst
@@ -35,6 +35,8 @@ Algorithms
 
 - :ref:`LoadMuonNexus <algm-LoadMuonNexus>`: Fixed loading of certain v1 NeXus files converted from other formats that did not contain number of good frames.
 
+- :ref:`LoadMuonNexus <algm-LoadMuonNexus>`: Now loads the correct detector IDs, whether the whole file is loaded or just a selection of spectra. Correctly handles muon v2 Nexus files, in which one spectrum can map to multiple detectors.
+
 Fit Functions
 -------------
 


### PR DESCRIPTION
Set detector ID(s) correctly for each spectrum loaded with `LoadMuonNexus`.

Previously, the detectors were numbered 1, 2, 3... regardless of which spectra were loaded from the file. This was OK if the whole file was loaded (for muon instruments, there is usually one spectrum per detector) but not if the _SpectrumList_ property was used to load a selection of spectra.

Changes made:
- For v1 files, detector ID = spectrum number for each spectrum
- For v2 files, this is not necessarily the case (though it often is). If there is a more complicated mapping, handle this as specified in the v2 definition (Note 3 in [this document](http://www.isis.stfc.ac.uk/groups/muons/downloads/nexus-definition-v27924.pdf)).

**To test:**

_Version 1 file:_
(file in the unit test data)
- `Load(Filename='MUSR00022725.nxs', OutputWorkspace='MUSR00022725', SpectrumList='1-5,8-11')`
- Right-click on workspace and "Show detectors"
- Verify that spectrum numbers are 1-5, 8-11 and the detector IDs are the same.

_Version 2 file:_
(also in the unit test data)
- `Load(Filename='argus0026287.nxs', OutputWorkspace='argus0026287', SpectrumList='1-5,8-11')`
- Right-click on workspace and "Show detectors"
- Verify that spectrum numbers are 1-5, 8-11 and the detector IDs are the same.

(There will be some errors in the log on "Show detectors" with the ARGUS file - these are because the source is not set in the instrument and so are not related to the current PR)

Fixes #16628.

Algorithm documentation has been updated for [LoadMuonNexus-v1](https://github.com/mantidproject/mantid/blob/ddd57cc3ae8c942b971d69bf18e234395336993a/docs/source/algorithms/LoadMuonNexus-v1.rst#spectra-detector-mapping) and [LoadMuonNexus-v2](https://github.com/mantidproject/mantid/blob/ddd57cc3ae8c942b971d69bf18e234395336993a/docs/source/algorithms/LoadMuonNexus-v2.rst#spectra-detector-mapping). (Both are in active use).

[Release notes](https://github.com/mantidproject/mantid/blob/ddd57cc3ae8c942b971d69bf18e234395336993a/docs/source/release/v3.8.0/muon.rst#algorithms) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
