### PR TITLE
Fix segfault when using MD workspaces

### DIFF
--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.h
@@ -331,15 +331,14 @@ public:
       // Copy-construct a temporary workspace property to test the validity of
       // each workspace
       WorkspaceProperty<TYPE> tester(*this);
-      for (auto it = vals.begin(); it != vals.end();) {
-        // Remove any workspace that's not valid for this algorithm
-        if (!tester.setValue(*it).empty()) {
-          // Erase invalidates iterator so assign iterator returned from erase
-          it = vals.erase(
-              it++); // Post-fix so that it erase the previous when returned
-        } else
-          ++it;
-      }
+
+      // Remove any workspace that's not valid for this algorithm
+      auto eraseIter = remove_if(vals.begin(), vals.end(),
+                                 [&tester](const std::string &wsName) {
+                                   return !tester.setValue(wsName).empty();
+                                 });
+      // Erase everything past returned iterator afterwards for readability
+      vals.erase(eraseIter, vals.end());
       return vals;
     } else {
       // For output workspaces, just return an empty set

--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.h
@@ -334,7 +334,8 @@ public:
       for (auto it = vals.begin(); it != vals.end();) {
         // Remove any workspace that's not valid for this algorithm
         if (!tester.setValue(*it).empty()) {
-          vals.erase(
+          // Erase invalidates iterator so assign iterator returned from erase
+          it = vals.erase(
               it++); // Post-fix so that it erase the previous when returned
         } else
           ++it;

--- a/Framework/API/test/WorkspacePropertyTest.h
+++ b/Framework/API/test/WorkspacePropertyTest.h
@@ -185,6 +185,20 @@ public:
     TS_ASSERT_EQUALS(vals.size(), 1)
   }
 
+  void testInvalidAllowedValues() {
+    std::vector<std::string> vals;
+    WorkspaceProperty<TableWorkspaceTester> testTblProperty(
+        "Table Mismatch test", "ws3", Direction::Input);
+    WorkspaceProperty<WorkspaceGroup> testGroupProperty(
+        "Group Mismatch test", "ws1", Direction::Input);
+
+    TS_ASSERT_THROWS_NOTHING(vals = testTblProperty.allowedValues());
+    TS_ASSERT_EQUALS(vals.size(), 0);
+
+    TS_ASSERT_THROWS_NOTHING(vals = testGroupProperty.allowedValues());
+    TS_ASSERT_EQUALS(vals.size(), 0);
+  }
+
   void testCreateHistory() {
     PropertyHistory history = wsp1->createHistory();
     TS_ASSERT_EQUALS(history.name(), "workspace1")


### PR DESCRIPTION
**Description of work.**
As part of the changes following #16967 the returned type was changed from an unordered map to a vector. 
In `WorkspaceProperty.h` the loop erases various elements which invalidates the vector iterator which is subsequently dereferenced in the for loop crashing the program.

I've checked all the changed files from the previous PR for any other similar cases however this seems to be the only place where an iterator is invalidated in a loop

All test cases documented in #17165 have been fixed however if there are any more test cases I am happy to try them locally.

**To test:**
Open a MD workspace for example `MAPS_MDEW.nxs`.
Attempt to open the dialog box for an algorithm which does not take MD workspaces such as `Plus`
If the dialog box opens without crashing the test was successful.

Fixes #17165 .

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
