### PR TITLE
Fix Python Exception for Algorithms Propagation under Python 3

### DIFF
--- a/Framework/PythonInterface/inc/MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h
@@ -55,24 +55,16 @@ public:
   const std::string name() const override;
   /// Returns a version of the algorithm
   int version() const override;
-  /// A default version, chosen if there is no override
-  int defaultVersion() const;
   /// Returns the summary for the algorithm
   const std::string summary() const override;
-  /// Returns the summary for the algorithm
-  std::string defaultSummary() const;
   /// Returns a category of the algorithm.
   const std::string category() const override;
-  /// A default category, chosen if there is no override
-  std::string defaultCategory() const;
   /// Allow the isRunning method to be overridden
   bool isRunning() const override;
   /// Allow the cancel method to be overridden
   void cancel() override;
   /// A return of false will allow processing workspace groups as a whole
   bool checkGroups() override;
-  /// A default value for checkGroups, chosen if there is no override
-  bool checkGroupsDefault();
   /// Returns the validateInputs result of the algorithm.
   std::map<std::string, std::string> validateInputs() override;
   ///@}

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/CallMethod.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/CallMethod.h
@@ -32,248 +32,30 @@ namespace Mantid {
 namespace PythonInterface {
 namespace Environment {
 
-/// Defines start of CallMethod function
-/// @param obj A Python object to perform the call
-/// @param name A string containing the method name
-#define PRE_CALL(obj, name)                                                    \
-  GlobalInterpreterLock gil;                                                   \
-  if (Environment::typeHasAttribute(self, funcName)) {                         \
-    try {
+/// Defines an exception for an undefined attribute
+class UndefinedAttributeError : std::runtime_error {
+public:
+  UndefinedAttributeError() : std::runtime_error("") {}
+};
 
-/// Defines the end of CallMethod that returns a default value
-#define POST_CALL_DEFAULT()                                                    \
-  }                                                                            \
-  catch (boost::python::error_already_set &) {                                 \
-    throwRuntimeError();                                                       \
-  }                                                                            \
-  }                                                                            \
-  return defaultValue;
-
-/// Defines the end of CallMethod that throws an exception if the method doesn't
-/// exist
-#define POST_CALL_EXCEPT()                                                     \
-  }                                                                            \
-  catch (boost::python::error_already_set &) {                                 \
-    throwRuntimeError();                                                       \
-  }                                                                            \
-  }                                                                            \
-  else {                                                                       \
-    std::ostringstream os;                                                     \
-    os << self->ob_type->tp_name << " has no function named '" << funcName     \
-       << "'\n"                                                                \
-       << "Check the function exists and that its first argument is self.";    \
-    throw std::runtime_error(os.str());                                        \
-  }                                                                            \
-  return ResultType(); // required to avoid compiler warning
-
-/// Defines the end of CallMethod that throws an exception but doesn't return
-/// anything
-/// to be used for void return types
-#define POST_CALL_EXCEPT_VOID()                                                \
-  }                                                                            \
-  catch (boost::python::error_already_set &) {                                 \
-    throwRuntimeError();                                                       \
-  }                                                                            \
-  }                                                                            \
-  else {                                                                       \
-    std::ostringstream os;                                                     \
-    os << self->ob_type->tp_name << " has no function named '" << funcName     \
-       << "'\n"                                                                \
-       << "Check the function exists and that its first argument is self.";    \
-    throw std::runtime_error(os.str());                                        \
-  }
-
-/** @name No argument Python calls */
-//@{
 /**
- * Perform a call to a python function that takes no arguments and returns a
- * value
+ * Wrapper around boost::python::call_method to acquire GIL for duration
+ * of call.
+ * @param obj Pointer to Python object
+ * @param methodName Name of the method call
+ * @param args A list of arguments to forward to call_method
  */
-template <typename ResultType> struct DLLExport CallMethod0 {
-  /**
-   * Dispatch a call to the method on the given object. If the method does not
-   * exist
-   * then return the defaultValue
-   * @param self :: The object containing the method definition
-   * @param funcName :: The method name
-   * @param defaultValue :: A default value if the method does not exist
-   * @return The value of the function or the default value if it does not exist
-   */
-  static ResultType dispatchWithDefaultReturn(PyObject *self,
-                                              const char *funcName,
-                                              const ResultType &defaultValue) {
-    PRE_CALL(self, funcName);
-    return boost::python::call_method<ResultType>(self, funcName);
-    POST_CALL_DEFAULT();
+template <typename ReturnType, typename... Args>
+ReturnType callMethod(PyObject *obj, const char *methodName,
+                      const Args &... args) {
+  GlobalInterpreterLock gil;
+  if (Environment::typeHasAttribute(obj, methodName)) {
+    return boost::python::call_method<ReturnType, Args...>(obj, methodName,
+                                                           args...);
+  } else {
+    throw UndefinedAttributeError();
   }
-
-  /**
-   * Dispatch a call to the method on the given object. If the method does not
-   * exist
-   * then raise a std::runtime_error exception
-   * @param self :: The object containing the method definition
-   * @param funcName :: The method name
-   * @return The value of the function or the default value if it does not exist
-   */
-  static ResultType dispatchWithException(PyObject *self,
-                                          const char *funcName) {
-    PRE_CALL(self, funcName);
-    return boost::python::call_method<ResultType>(self, funcName);
-    POST_CALL_EXCEPT();
-  }
-};
-
-/// Specialization for void return type
-template <> struct DLLExport CallMethod0<void> {
-  /**
-   * Dispatch a call to the method on the given object. If the method does not
-   * exist
-   * then raise a runtime_error
-   * @param self :: The object containing the method definition
-   * @param funcName :: The method name
-   * @return The value of the function or the default value if it does not exist
-   */
-  static void dispatchWithException(PyObject *self, const char *funcName) {
-    PRE_CALL(self, funcName);
-    boost::python::call_method<void>(self, funcName);
-    POST_CALL_EXCEPT_VOID();
-  }
-};
-//@}
-
-/** @name Single argument Python calls */
-//@{
-/**
- * Perform a call to a python function that takes no arguments and returns a
- * value
- */
-template <typename ResultType, typename Arg1> struct DLLExport CallMethod1 {
-  /**
-   * Dispatch a call to the method on the given object. If the method does not
-   * exist
-   * then return the defaultValue
-   * @param self :: The object containing the method definition
-   * @param funcName :: The method name
-   * @param defaultValue :: A default value if the method does not exist
-   * @param arg1 :: The value of the first argument
-   * @return The value of the function or the default value if it does not exist
-   */
-  static ResultType dispatchWithDefaultReturn(PyObject *self,
-                                              const char *funcName,
-                                              const ResultType &defaultValue,
-                                              const Arg1 &arg1) {
-    PRE_CALL(self, funcName);
-    return boost::python::call_method<ResultType, Arg1>(self, funcName, arg1);
-    POST_CALL_DEFAULT();
-  }
-
-  /**
-   * Dispatch a call to the method on the given object. If the method does not
-   * exist
-   * then raise a std::runtime_error exception
-   * @param self :: The object containing the method definition
-   * @param funcName :: The method name
-   * @param arg1 :: The value of the first argument
-   * @return The value of the function or the default value if it does not exist
-   */
-  static ResultType dispatchWithException(PyObject *self, const char *funcName,
-                                          const Arg1 &arg1) {
-    PRE_CALL(self, funcName);
-    return boost::python::call_method<ResultType, Arg1>(self, funcName, arg1);
-    POST_CALL_EXCEPT();
-  }
-};
-
-/// Specialization for void return type
-template <typename Arg1> struct DLLExport CallMethod1<void, Arg1> {
-  /**
-   * Dispatch a call to the method on the given object. If the method does not
-   * exist
-   * then raise a runtime_error
-   * @param self :: The object containing the method definition
-   * @param funcName :: The method name
-   * @param arg1 :: The value of the first argument
-   * @return The value of the function or the default value if it does not exist
-   */
-  static void dispatchWithException(PyObject *self, const char *funcName,
-                                    const Arg1 &arg1) {
-    PRE_CALL(self, funcName);
-    boost::python::call_method<void, Arg1>(self, funcName, arg1);
-    POST_CALL_EXCEPT_VOID();
-  }
-};
-//@}
-
-/** @name Two argument Python calls */
-//@{
-template <typename ResultType, typename Arg1, typename Arg2>
-struct DLLExport CallMethod2 {
-  /**
-   * Dispatch a call to the method on the given object. If the method does not
-   * exist
-   * then return the defaultValue
-   * @param self :: The object containing the method definition
-   * @param funcName :: The method name
-   * @param defaultValue :: A default value if the method does not exist
-   * @param arg1 :: The value of the first argument
-   * @param arg2 :: The value of the second argument
-   * @return The value of the function or the default value if it does not exist
-   */
-  static ResultType dispatchWithDefaultReturn(PyObject *self,
-                                              const char *funcName,
-                                              const ResultType &defaultValue,
-                                              const Arg1 &arg1,
-                                              const Arg2 &arg2) {
-    PRE_CALL(self, funcName);
-    return boost::python::call_method<ResultType, Arg1, Arg2>(self, funcName,
-                                                              arg1, arg2);
-    POST_CALL_DEFAULT();
-  }
-
-  /**
-   * Dispatch a call to the method on the given object. If the method does not
-   * exist
-   * then raise a std::runtime_error exception
-   * @param self :: The object containing the method definition
-   * @param funcName :: The method name
-   * @param arg1 :: The value of the first argument
-   * @param arg2 :: The value of the second argument
-   * @return The value of the function or the default value if it does not exist
-   */
-  static ResultType dispatchWithException(PyObject *self, const char *funcName,
-                                          const Arg1 &arg1, const Arg2 &arg2) {
-    PRE_CALL(self, funcName);
-    return boost::python::call_method<ResultType, Arg1, Arg2>(self, funcName,
-                                                              arg1, arg2);
-    POST_CALL_EXCEPT();
-  }
-};
-
-/// Specialization for void return type
-template <typename Arg1, typename Arg2>
-struct DLLExport CallMethod2<void, Arg1, Arg2> {
-  /**
-   * Dispatch a call to the method on the given object. If the method does not
-   * exist
-   * then raise a runtime_error
-   * @param self :: The object containing the method definition
-   * @param funcName :: The method name
-   * @param arg1 :: The value of the first argument
-   * @param arg2 :: The value of the second argument
-   * @return The value of the function or the default value if it does not exist
-   */
-  static void dispatchWithException(PyObject *self, const char *funcName,
-                                    const Arg1 &arg1, const Arg2 &arg2) {
-    PRE_CALL(self, funcName);
-    boost::python::call_method<void, Arg1, Arg2>(self, funcName, arg1, arg2);
-    POST_CALL_EXCEPT_VOID();
-  }
-};
-//@}
-
-// Tidy up
-#undef PRE_CALL
-#undef POST_CALL_DEFAULT
+}
 }
 }
 }

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/ErrorHandling.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/ErrorHandling.h
@@ -22,17 +22,25 @@
     File change history is stored at: <https://github.com/mantidproject/mantid>
 */
 #include "MantidKernel/System.h"
+#include <stdexcept>
 
 /**
  * This file defines error handling code that transforms
  * a Python error state to C++ exceptions.
  */
-
 namespace Mantid {
 namespace PythonInterface {
 namespace Environment {
-/// Convert Python error state to C++ exception
-DLLExport void throwRuntimeError(const bool withTrace = true);
+/// Exception type that captures the current Python error state
+/// as a C++ exception
+class DLLExport PythonException : public std::exception {
+public:
+  PythonException(bool withTrace = true) noexcept;
+  const char *what() const noexcept override { return m_msg.c_str(); }
+
+private:
+  std::string m_msg;
+};
 }
 }
 }

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/ErrorHandling.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/ErrorHandling.h
@@ -23,6 +23,7 @@
 */
 #include "MantidKernel/System.h"
 #include <stdexcept>
+#include <string>
 
 /**
  * This file defines error handling code that transforms

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/ErrorHandling.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/ErrorHandling.h
@@ -36,7 +36,7 @@ namespace Environment {
 /// as a C++ exception
 class DLLExport PythonException : public std::exception {
 public:
-  PythonException(bool withTrace = true) noexcept;
+  PythonException(bool withTrace = true);
   const char *what() const noexcept override { return m_msg.c_str(); }
 
 private:

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/WrapperHelpers.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/WrapperHelpers.h
@@ -43,15 +43,6 @@ bool DLLExport typeHasAttribute(PyObject *obj, const char *attr);
 bool DLLExport
 typeHasAttribute(const boost::python::detail::wrapper_base &wrapper,
                  const char *attr);
-
-/**
- * Defines an exception for an undefined attribute
- */
-class UndefinedAttributeError : std::runtime_error {
-public:
-  /// Construct the exception
-  UndefinedAttributeError() : std::runtime_error("") {}
-};
 }
 }
 }

--- a/Framework/PythonInterface/mantid/api/src/Algorithms/RunPythonScript.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Algorithms/RunPythonScript.cpp
@@ -146,7 +146,7 @@ RunPythonScript::doExecuteScript(const std::string &script) const {
   try {
     boost::python::exec(script.c_str(), globals, locals);
   } catch (boost::python::error_already_set &) {
-    Environment::throwRuntimeError();
+    throw Environment::PythonException();
   }
   return locals;
 }

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunction1DAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunction1DAdapter.cpp
@@ -14,7 +14,7 @@
 //-----------------------------------------------------------------------------
 namespace Mantid {
 namespace PythonInterface {
-using Environment::CallMethod1;
+using Environment::callMethod;
 using namespace boost::python;
 
 /**
@@ -81,8 +81,7 @@ void IFunction1DAdapter::function1D(double *out, const double *xValues,
  */
 boost::python::object
 IFunction1DAdapter::function1D(const boost::python::object &xvals) const {
-  return CallMethod1<object, object>::dispatchWithException(
-      getSelf(), "function1D", xvals);
+  return callMethod<object, const object &>(getSelf(), "function1D", xvals);
 }
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunction1DAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunction1DAdapter.cpp
@@ -54,7 +54,7 @@ void IFunction1DAdapter::function1D(double *out, const double *xValues,
   Py_DECREF(xvals);
   if (PyErr_Occurred()) {
     Py_XDECREF(result);
-    Environment::throwRuntimeError(true);
+    throw Environment::PythonException();
   }
 
   PyArrayObject *nparray = reinterpret_cast<PyArrayObject *>(result);
@@ -113,7 +113,7 @@ void IFunction1DAdapter::functionDeriv1D(API::Jacobian *out,
     // boost::python::objects when using boost::python::call_method
     PyEval_CallMethod(getSelf(), "functionDeriv1D", "(OO)", xvals, jacobian);
     if (PyErr_Occurred())
-      Environment::throwRuntimeError(true);
+      throw Environment::PythonException();
   } else {
     IFunction1D::functionDeriv1D(out, xValues, nData);
   }

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunction1DAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunction1DAdapter.cpp
@@ -81,7 +81,7 @@ void IFunction1DAdapter::function1D(double *out, const double *xValues,
  */
 boost::python::object
 IFunction1DAdapter::function1D(const boost::python::object &xvals) const {
-  return callMethod<object, const object &>(getSelf(), "function1D", xvals);
+  return callMethod<object, object>(getSelf(), "function1D", xvals);
 }
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -6,9 +6,8 @@
 namespace Mantid {
 namespace PythonInterface {
 using API::IFunction;
-using PythonInterface::Environment::CallMethod0;
-using PythonInterface::Environment::CallMethod1;
-using PythonInterface::Environment::CallMethod2;
+using PythonInterface::Environment::callMethod;
+using PythonInterface::Environment::UndefinedAttributeError;
 using namespace boost::python;
 
 namespace {
@@ -67,15 +66,16 @@ std::string IFunctionAdapter::name() const { return m_name; }
  * Specify a category for the function
  */
 const std::string IFunctionAdapter::category() const {
-  return CallMethod0<std::string>::dispatchWithDefaultReturn(
-      getSelf(), "category", IFunction::category());
+  try {
+    return callMethod<std::string>(getSelf(), "category");
+  } catch (UndefinedAttributeError &) {
+    return IFunction::category();
+  }
 }
 
 /**
  */
-void IFunctionAdapter::init() {
-  CallMethod0<void>::dispatchWithException(getSelf(), "init");
-}
+void IFunctionAdapter::init() { callMethod<void>(getSelf(), "init"); }
 
 /**
  * Declare an attribute on the given function from a python object
@@ -87,8 +87,8 @@ void IFunctionAdapter::declareAttribute(const std::string &name,
   auto attr = createAttributeFromPythonValue(defaultValue);
   IFunction::declareAttribute(name, attr);
   if (PyObject_HasAttrString(getSelf(), "setAttributeValue")) {
-    CallMethod2<void, std::string, object>::dispatchWithException(
-        getSelf(), "setAttributeValue", name, defaultValue);
+    callMethod<void, std::string, object>(getSelf(), "setAttributeValue", name,
+                                          defaultValue);
   }
 }
 
@@ -135,8 +135,8 @@ void IFunctionAdapter::setAttribute(const std::string &attName,
                                     const Attribute &attr) {
   if (PyObject_HasAttrString(getSelf(), "setAttributeValue")) {
     object value = object(handle<>(getAttributeValue(attr)));
-    CallMethod2<void, std::string, object>::dispatchWithException(
-        getSelf(), "setAttributeValue", attName, value);
+    callMethod<void, std::string, object>(getSelf(), "setAttributeValue",
+                                          attName, value);
   } else {
     IFunction::setAttribute(attName, attr);
   }
@@ -160,8 +160,11 @@ void IFunctionAdapter::storeAttributePythonValue(const std::string &name,
  * @param i The index of the parameter
  */
 double IFunctionAdapter::activeParameter(size_t i) const {
-  return CallMethod1<double, size_t>::dispatchWithDefaultReturn(
-      getSelf(), "activeParameter", this->getParameter(i), i);
+  try {
+    return callMethod<double, size_t>(getSelf(), "activeParameter", i);
+  } catch (UndefinedAttributeError &) {
+    return IFunction::activeParameter(i);
+  }
 }
 
 /**
@@ -173,9 +176,8 @@ double IFunctionAdapter::activeParameter(size_t i) const {
  */
 void IFunctionAdapter::setActiveParameter(size_t i, double value) {
   try {
-    CallMethod2<void, size_t, double>::dispatchWithException(
-        getSelf(), "setActiveParameter", i, value);
-  } catch (std::runtime_error &) {
+    callMethod<void, size_t, double>(getSelf(), "setActiveParameter", i, value);
+  } catch (UndefinedAttributeError &) {
     IFunction::setActiveParameter(i, value);
   }
 }

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -86,9 +86,10 @@ void IFunctionAdapter::declareAttribute(const std::string &name,
                                         const object &defaultValue) {
   auto attr = createAttributeFromPythonValue(defaultValue);
   IFunction::declareAttribute(name, attr);
-  if (PyObject_HasAttrString(getSelf(), "setAttributeValue")) {
+  try {
     callMethod<void, std::string, object>(getSelf(), "setAttributeValue", name,
                                           defaultValue);
+  } catch (UndefinedAttributeError &) {
   }
 }
 
@@ -133,11 +134,11 @@ IFunctionAdapter::getAttributeValue(const API::IFunction::Attribute &attr) {
  */
 void IFunctionAdapter::setAttribute(const std::string &attName,
                                     const Attribute &attr) {
-  if (PyObject_HasAttrString(getSelf(), "setAttributeValue")) {
+  try {
     object value = object(handle<>(getAttributeValue(attr)));
     callMethod<void, std::string, object>(getSelf(), "setAttributeValue",
                                           attName, value);
-  } else {
+  } catch (UndefinedAttributeError &) {
     IFunction::setAttribute(attName, attr);
   }
 }

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IPeakFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IPeakFunctionAdapter.cpp
@@ -13,9 +13,7 @@
 //-----------------------------------------------------------------------------
 namespace Mantid {
 namespace PythonInterface {
-using Environment::CallMethod0;
-using Environment::CallMethod1;
-using Environment::CallMethod2;
+using Environment::callMethod;
 using namespace boost::python;
 
 /**
@@ -28,13 +26,13 @@ IPeakFunctionAdapter::IPeakFunctionAdapter(PyObject *self)
 /**
  */
 double IPeakFunctionAdapter::centre() const {
-  return CallMethod0<double>::dispatchWithException(getSelf(), "centre");
+  return callMethod<double>(getSelf(), "centre");
 }
 
 /**
  */
 double IPeakFunctionAdapter::height() const {
-  return CallMethod0<double>::dispatchWithException(getSelf(), "height");
+  return callMethod<double>(getSelf(), "height");
 }
 
 /**
@@ -42,7 +40,7 @@ double IPeakFunctionAdapter::height() const {
  * @param c The centre of the peak
  */
 void IPeakFunctionAdapter::setCentre(const double c) {
-  CallMethod1<void, double>::dispatchWithException(getSelf(), "setCentre", c);
+  callMethod<void, double>(getSelf(), "setCentre", c);
 }
 
 /**
@@ -50,12 +48,12 @@ void IPeakFunctionAdapter::setCentre(const double c) {
  * @param h The new height of the peak
  */
 void IPeakFunctionAdapter::setHeight(const double h) {
-  CallMethod1<void, double>::dispatchWithException(getSelf(), "setHeight", h);
+  callMethod<void, double>(getSelf(), "setHeight", h);
 }
 
 /// Calls Python fwhm method
 double IPeakFunctionAdapter::fwhm() const {
-  return CallMethod0<double>::dispatchWithException(getSelf(), "fwhm");
+  return callMethod<double>(getSelf(), "fwhm");
 }
 
 /**
@@ -64,8 +62,7 @@ double IPeakFunctionAdapter::fwhm() const {
  * such that fwhm=w
  */
 void IPeakFunctionAdapter::setFwhm(const double w) {
-  return CallMethod1<void, double>::dispatchWithException(getSelf(), "setFwhm",
-                                                          w);
+  return callMethod<void, double>(getSelf(), "setFwhm", w);
 }
 
 /**
@@ -126,8 +123,7 @@ void IPeakFunctionAdapter::functionLocal(double *out, const double *xValues,
  */
 object
 IPeakFunctionAdapter::functionLocal(const boost::python::object &xvals) const {
-  return CallMethod1<object, object>::dispatchWithException(
-      getSelf(), "functionLocal", xvals);
+  return callMethod<object, object>(getSelf(), "functionLocal", xvals);
 }
 
 /**
@@ -170,8 +166,8 @@ void IPeakFunctionAdapter::functionDerivLocal(API::Jacobian *out,
  */
 void IPeakFunctionAdapter::functionDerivLocal(
     const boost::python::object &xvals, boost::python::object &jacobian) {
-  CallMethod2<void, object, object>::dispatchWithException(
-      getSelf(), "functionDerivLocal", xvals, jacobian);
+  callMethod<void, object, object>(getSelf(), "functionDerivLocal", xvals,
+                                   jacobian);
 }
 }
 }

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IPeakFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IPeakFunctionAdapter.cpp
@@ -94,7 +94,7 @@ void IPeakFunctionAdapter::functionLocal(double *out, const double *xValues,
   Py_DECREF(xvals);
   if (PyErr_Occurred()) {
     Py_DECREF(result);
-    Environment::throwRuntimeError(true);
+    throw Environment::PythonException();
   }
 
   PyArrayObject *nparray = reinterpret_cast<PyArrayObject *>(result);
@@ -154,7 +154,7 @@ void IPeakFunctionAdapter::functionDerivLocal(API::Jacobian *out,
   // boost::python::objects when using boost::python::call_method
   PyEval_CallMethod(getSelf(), "functionDerivLocal", "(OO)", xvals, jacobian);
   if (PyErr_Occurred())
-    Environment::throwRuntimeError(true);
+    throw Environment::PythonException();
 }
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -113,7 +113,7 @@ bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
     Environment::GlobalInterpreterLock gil;
     PyObject *result = PyObject_CallObject(m_isRunningObj, nullptr);
     if (PyErr_Occurred())
-      Environment::throwRuntimeError(true);
+      throw Environment::PythonException();
     if (PyBool_Check(result)) {
 #if PY_MAJOR_VERSION >= 3
       return static_cast<bool>(PyLong_AsLong(result));

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -14,7 +14,8 @@
 namespace Mantid {
 namespace PythonInterface {
 using namespace boost::python;
-using Environment::CallMethod0;
+using Environment::callMethod;
+using Environment::UndefinedAttributeError;
 
 /**
  * Construct the "wrapper" and stores the reference to the PyObject
@@ -24,13 +25,9 @@ template <typename BaseAlgorithm>
 AlgorithmAdapter<BaseAlgorithm>::AlgorithmAdapter(PyObject *self)
     : BaseAlgorithm(), m_self(self), m_isRunningObj(nullptr),
       m_wikiSummary("") {
-  // Cache the isRunning call to save the lookup each time it is called
-  // as it is most likely called in a loop
-
-  // If the derived class type has isRunning then use that.
-  // A standard PyObject_HasAttr will check the whole inheritance
-  // hierarchy and always return true because IAlgorithm::isRunning is present.
-  // We just want to look at the Python class
+  // Only cache the isRunning attribute if it is overridden by the
+  // inheriting type otherwise we end up with an infinite recursive call
+  // as isRunning always exists from the interface
   if (Environment::typeHasAttribute(self, "isRunning"))
     m_isRunningObj = PyObject_GetAttrString(self, "isRunning");
 }
@@ -49,17 +46,11 @@ const std::string AlgorithmAdapter<BaseAlgorithm>::name() const {
  */
 template <typename BaseAlgorithm>
 int AlgorithmAdapter<BaseAlgorithm>::version() const {
-  return CallMethod0<int>::dispatchWithDefaultReturn(getSelf(), "version",
-                                                     defaultVersion());
-}
-
-/**
- * Returns the default version of the algorithm. If not overridden
- * it returns 1
- */
-template <typename BaseAlgorithm>
-int AlgorithmAdapter<BaseAlgorithm>::defaultVersion() const {
-  return 1;
+  try {
+    return callMethod<int>(getSelf(), "version");
+  } catch (UndefinedAttributeError &) {
+    return 1;
+  }
 }
 
 /**
@@ -69,16 +60,11 @@ int AlgorithmAdapter<BaseAlgorithm>::defaultVersion() const {
  */
 template <typename BaseAlgorithm>
 bool AlgorithmAdapter<BaseAlgorithm>::checkGroups() {
-  return CallMethod0<bool>::dispatchWithDefaultReturn(getSelf(), "checkGroups",
-                                                      checkGroupsDefault());
-}
-
-/**
- * Returns the default checkGroup (calls base class)
- */
-template <typename BaseAlgorithm>
-bool AlgorithmAdapter<BaseAlgorithm>::checkGroupsDefault() {
-  return BaseAlgorithm::checkGroups();
+  try {
+    return callMethod<bool>(getSelf(), "checkGroups");
+  } catch (UndefinedAttributeError &) {
+    return BaseAlgorithm::checkGroups();
+  }
 }
 
 /**
@@ -87,30 +73,20 @@ bool AlgorithmAdapter<BaseAlgorithm>::checkGroupsDefault() {
  */
 template <typename BaseAlgorithm>
 const std::string AlgorithmAdapter<BaseAlgorithm>::category() const {
-  const std::string algDefaultCategory = defaultCategory();
-  const std::string algCategory =
-      CallMethod0<std::string>::dispatchWithDefaultReturn(getSelf(), "category",
-                                                          algDefaultCategory);
-  if (algCategory == algDefaultCategory) {
+  const static std::string defaultCategory = "PythonAlgorithms";
+  std::string category = defaultCategory;
+  try {
+    category = callMethod<std::string>(getSelf(), "category");
+  } catch (UndefinedAttributeError &) {
+  }
+  if (category == defaultCategory) {
     // output a warning
-    const std::string &name = getSelf()->ob_type->tp_name;
-    int version = CallMethod0<int>::dispatchWithDefaultReturn(
-        getSelf(), "version", defaultVersion());
     this->getLogger().warning()
-        << "Python Algorithm " << name << " v" << version
+        << "Python Algorithm " << this->name() << " v" << this->version()
         << " does not have a category defined. See "
            "http://www.mantidproject.org/Basic_PythonAlgorithm_Structure\n";
   }
-  return algCategory;
-}
-
-/**
- * A default category, chosen if there is no override
- * @returns A default category
- */
-template <typename BaseAlgorithm>
-std::string AlgorithmAdapter<BaseAlgorithm>::defaultCategory() const {
-  return "PythonAlgorithms";
+  return category;
 }
 
 /**
@@ -119,17 +95,11 @@ std::string AlgorithmAdapter<BaseAlgorithm>::defaultCategory() const {
  */
 template <typename BaseAlgorithm>
 const std::string AlgorithmAdapter<BaseAlgorithm>::summary() const {
-  return CallMethod0<std::string>::dispatchWithDefaultReturn(
-      getSelf(), "summary", defaultSummary());
-}
-
-/**
- * A default summary, chosen if there is no override
- * @returns A default summary
- */
-template <typename BaseAlgorithm>
-std::string AlgorithmAdapter<BaseAlgorithm>::defaultSummary() const {
-  return m_wikiSummary;
+  try {
+    return callMethod<std::string>(getSelf(), "summary");
+  } catch (UndefinedAttributeError &) {
+    return m_wikiSummary;
+  }
 }
 
 /**
@@ -152,7 +122,7 @@ bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
 #endif
     } else
       throw std::runtime_error(
-          "AlgorithmAdapter.isRunning - Expected bool return type.");
+          "Algorithm.isRunning - Expected bool return type.");
   }
 }
 
@@ -160,12 +130,11 @@ bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
  */
 template <typename BaseAlgorithm>
 void AlgorithmAdapter<BaseAlgorithm>::cancel() {
-  // No real need for eye on performance here. Use standard methods
-  if (Environment::typeHasAttribute(getSelf(), "cancel")) {
-    Environment::GlobalInterpreterLock gil;
-    CallMethod0<void>::dispatchWithException(getSelf(), "cancel");
-  } else
+  try {
+    return callMethod<void>(getSelf(), "cancel");
+  } catch (UndefinedAttributeError &) {
     SuperClass::cancel();
+  }
 }
 
 /**
@@ -174,22 +143,13 @@ void AlgorithmAdapter<BaseAlgorithm>::cancel() {
 template <typename BaseAlgorithm>
 std::map<std::string, std::string>
 AlgorithmAdapter<BaseAlgorithm>::validateInputs() {
+  using boost::python::dict;
   std::map<std::string, std::string> resultMap;
 
-  // this is a modified version of CallMethod0::dispatchWithDefaultReturn
-  Environment::GlobalInterpreterLock gil;
-  if (Environment::typeHasAttribute(getSelf(), "validateInputs")) {
-    boost::python::dict resultDict;
-    try {
-      resultDict = boost::python::call_method<boost::python::dict>(
-          getSelf(), "validateInputs");
-
-      if (!bool(resultDict))
-        return resultMap;
-    } catch (boost::python::error_already_set &) {
-      Environment::throwRuntimeError();
-    }
+  try {
+    dict resultDict = callMethod<dict>(getSelf(), "validateInputs");
     // convert to a map<string,string>
+    Environment::GlobalInterpreterLock gil;
     boost::python::list keys = resultDict.keys();
     size_t numItems = boost::python::len(keys);
     for (size_t i = 0; i < numItems; ++i) {
@@ -208,7 +168,10 @@ AlgorithmAdapter<BaseAlgorithm>::validateInputs() {
         }
       }
     }
+  } catch (UndefinedAttributeError &) {
+    return resultMap;
   }
+
   return resultMap;
 }
 
@@ -249,7 +212,8 @@ void AlgorithmAdapter<BaseAlgorithm>::declarePyAlgProperty(
 }
 
 /**
- * Declare a property using the type of the defaultValue, a documentation string
+ * Declare a property using the type of the defaultValue, a documentation
+ * string
  * and validator
  * @param self A reference to the calling Python object
  * @param name :: The name of the new property
@@ -318,7 +282,7 @@ void AlgorithmAdapter<BaseAlgorithm>::declarePyAlgProperty(
  * overridden in the subclass by a function named PyInit
  */
 template <typename BaseAlgorithm> void AlgorithmAdapter<BaseAlgorithm>::init() {
-  CallMethod0<void>::dispatchWithException(getSelf(), "PyInit");
+  callMethod<void>(getSelf(), "PyInit");
 }
 
 /**
@@ -326,7 +290,7 @@ template <typename BaseAlgorithm> void AlgorithmAdapter<BaseAlgorithm>::init() {
  * overridden in the subclass by a function named PyExec
  */
 template <typename BaseAlgorithm> void AlgorithmAdapter<BaseAlgorithm>::exec() {
-  CallMethod0<void>::dispatchWithException(getSelf(), "PyExec");
+  callMethod<void>(getSelf(), "PyExec");
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------

--- a/Framework/PythonInterface/mantid/kernel/src/Environment/ErrorHandling.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Environment/ErrorHandling.cpp
@@ -4,10 +4,15 @@
 #include "MantidPythonInterface/kernel/Environment/ErrorHandling.h"
 #include "MantidPythonInterface/kernel/Environment/GlobalInterpreterLock.h"
 
+#include <boost/python/extract.hpp>
+#include <boost/python/object.hpp>
 #include <frameobject.h> //Python
 
 #include <sstream>
 #include <stdexcept>
+
+using boost::python::extract;
+using boost::python::object;
 
 namespace Mantid {
 namespace PythonInterface {
@@ -24,36 +29,37 @@ void tracebackToMsg(std::stringstream &msg, PyTracebackObject *traceback,
     msg << "caused by";
 
   msg << " line " << traceback->tb_lineno << " in \'"
-      << PyBytes_AsString(traceback->tb_frame->f_code->co_filename) << "\'";
+      << extract<const char *>(traceback->tb_frame->f_code->co_filename)()
+      << "\'";
   tracebackToMsg(msg, traceback->tb_next, false);
 }
 }
 
 /**
- * Convert a python error state to a C++ exception
- * @param withTrace If true then a traceback will be included in the exception
- * message
- * @throws std::runtime_error
+ * Construct an exception object where the message is populated from the
+ * current Python exception state
+ * @param withTrace If true, include the full traceback in the message
  */
-void throwRuntimeError(const bool withTrace) {
+PythonException::PythonException(bool withTrace) noexcept : std::exception(),
+                                                            m_msg() {
   GlobalInterpreterLock gil;
   if (!PyErr_Occurred()) {
     throw std::runtime_error(
-        "ErrorHandling::throwRuntimeError - No Python error state set!");
+        "PythonException thrown but no Python error state set!");
   }
   PyObject *exception(nullptr), *value(nullptr), *traceback(nullptr);
   PyErr_Fetch(&exception, &value, &traceback);
   PyErr_NormalizeException(&exception, &value, &traceback);
   PyErr_Clear();
-  PyObject *str_repr = PyObject_Str(value);
-  std::stringstream msg;
-  if (value && str_repr) {
-    msg << PyBytes_AsString(str_repr);
+  PyObject *strRepr = PyObject_Str(value);
+  std::stringstream builder;
+  if (value && strRepr) {
+    builder << extract<const char *>(strRepr)();
   } else {
-    msg << "Unknown exception has occurred.";
+    builder << "Unknown exception has occurred.";
   }
   if (withTrace) {
-    tracebackToMsg(msg, reinterpret_cast<PyTracebackObject *>(traceback));
+    tracebackToMsg(builder, reinterpret_cast<PyTracebackObject *>(traceback));
   }
 
   // Ensure we decrement the reference count on the traceback and exception
@@ -64,8 +70,7 @@ void throwRuntimeError(const bool withTrace) {
   Py_XDECREF(traceback);
   Py_XDECREF(exception);
   Py_XDECREF(value);
-  // Raise this error as a C++ error
-  throw std::runtime_error(msg.str());
+  m_msg = builder.str();
 }
 }
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Environment/ErrorHandling.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Environment/ErrorHandling.cpp
@@ -40,8 +40,7 @@ void tracebackToMsg(std::stringstream &msg, PyTracebackObject *traceback,
  * current Python exception state
  * @param withTrace If true, include the full traceback in the message
  */
-PythonException::PythonException(bool withTrace) noexcept : std::exception(),
-                                                            m_msg() {
+PythonException::PythonException(bool withTrace) : std::exception(), m_msg() {
   GlobalInterpreterLock gil;
   if (!PyErr_Occurred()) {
     throw std::runtime_error(

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadLogPropertyTableTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadLogPropertyTableTest.py
@@ -79,9 +79,13 @@ class LoadLogPropertyTableTest(unittest.TestCase):
         outputWorskapceName = "LoadLogPropertyTableTest_Test4"
 
         #invalid log name
-        alg_test = run_algorithm("LoadLogPropertyTable", FirstFile = "emu00006473.nxs",
-                LastFile = "emu00006475.nxs", LogNames="WrongTemp", OutputWorkspace = outputWorskapceName)
-        self.assertFalse(alg_test.isExecuted())
+        ExecptionThrownOnBadLogName = False
+        try:
+            alg_test = run_algorithm("LoadLogPropertyTable", FirstFile = "emu00006473.nxs",
+                                     LastFile = "emu00006475.nxs", LogNames="WrongTemp", OutputWorkspace = outputWorskapceName)
+        except RuntimeError:
+            ExecptionThrownOnBadLogName = True
+        self.assertEqual(True, ExecptionThrownOnBadLogName)
 
         #invalid first file
         ExecptionThrownOnBadFileParameter = False


### PR DESCRIPTION
Fixes exception message propagation from Python algorithms in Python 3. The fixes were avoid using `PyBytes_AsString` when converting strings from Python to C++  [here](https://github.com/mantidproject/mantid/pull/17171/files#diff-97aa0ca20fef3541c75155f3f53915f0R32) & [here](https://github.com/mantidproject/mantid/pull/17171/files#diff-97aa0ca20fef3541c75155f3f53915f0R57). In Python 3 the Python strings are unicode objects not byte objects. 

I have also taken the opportunity to tidy up some of this code by introducing a single variadic `callMethod` wrapper that replaces the existing special cases.

**To test:**
- All Python 2 unit tests should still pass
- The `GetEiT0atSNSTest` unit test should now pass under Python 3

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Allows for more perfect wrapping of boost::python::call_method without
having to define additional wrappers for more arguments.
