### PR TITLE
Indirect ConvolutionFitSequential -  remove property logging

### DIFF
--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -139,7 +139,7 @@ void ConvolutionFitSequential::exec() {
 
   // Check if a delta function is being used
   auto delta = false;
-  auto usingDelta = "false";
+  std::string usingDelta = "false";
   auto pos = function.find("Delta");
   if (pos != std::string::npos) {
     delta = true;
@@ -173,14 +173,14 @@ void ConvolutionFitSequential::exec() {
   outputWsName += std::to_string(specMax);
 
   // Convert input workspace to get Q axis
-  const auto tempFitWsName = "__convfit_fit_ws";
+  const std::string tempFitWsName = "__convfit_fit_ws";
   convertInputToElasticQ(inputWs, tempFitWsName);
 
   Progress plotPeakStringProg(this, 0.0, 0.05, specMax - specMin);
   // Construct plotpeak string
   std::string plotPeakInput;
   for (int i = specMin; i < specMax + 1; i++) {
-    std::string nextWs = tempFitWsName + ",i";
+    auto nextWs = tempFitWsName + ",i";
     nextWs += std::to_string(i);
     plotPeakInput += nextWs + ";";
     plotPeakStringProg.report("Constructing PlotPeak name");
@@ -212,7 +212,7 @@ void ConvolutionFitSequential::exec() {
 
   // Delete workspaces
   Progress deleteProgress(this, 0.90, 0.91, 2);
-  auto deleter = createChildAlgorithm("DeleteWorkspace", enableLogging=false);
+  auto deleter = createChildAlgorithm("DeleteWorkspace", -1.0, -1.0, false);
   deleter->setProperty("WorkSpace",
                        outputWsName + "_NormalisedCovarianceMatrices");
   deleter->executeAsChildAlg();
@@ -280,7 +280,7 @@ void ConvolutionFitSequential::exec() {
   AnalysisDataService::Instance().addOrReplace(resultWsName, resultWs);
 
   // Handle sample logs
-  auto logCopier = createChildAlgorithm("CopyLogs", enableLogging=false);
+  auto logCopier = createChildAlgorithm("CopyLogs", -1.0, -1.0, false);
   logCopier->setProperty("InputWorkspace", inputWs);
   logCopier->setProperty("OutputWorkspace", resultWs);
   logCopier->executeAsChildAlg();
@@ -300,7 +300,7 @@ void ConvolutionFitSequential::exec() {
 
   Progress logAdderProg(this, 0.96, 0.97, 6);
   // Add String Logs
-  auto logAdder = createChildAlgorithm("AddSampleLog", enableLogging=false);
+  auto logAdder = createChildAlgorithm("AddSampleLog" , -1.0, -1.0, false);
   for (auto &sampleLogString : sampleLogStrings) {
     logAdder->setProperty("Workspace", resultWs);
     logAdder->setProperty("LogName", sampleLogString.first);
@@ -332,7 +332,7 @@ void ConvolutionFitSequential::exec() {
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(outputWsName +
                                                                  "_Workspaces");
   const auto groupWsNames = groupWs->getNames();
-  auto renamer = createChildAlgorithm("RenameWorkspace", enableLogging=false);
+  auto renamer = createChildAlgorithm("RenameWorkspace", -1.0, -1.0, false);
   Progress renamerProg(this, 0.98, 1.0, specMax + 1);
   for (int i = specMin; i < specMax + 1; i++) {
     renamer->setProperty("InputWorkspace", groupWsNames.at(i - specMin));
@@ -491,7 +491,7 @@ void ConvolutionFitSequential::calculateEISF(
   const auto ampErrorNames = searchForFitParams("Amplitude_Err", columns);
 
   // For each lorentzian, calculate EISF
-  const size_t maxSize = ampNames.size();
+  size_t maxSize = ampNames.size();
   if (ampErrorNames.size() > maxSize) {
     maxSize = ampErrorNames.size();
   }

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -212,13 +212,12 @@ void ConvolutionFitSequential::exec() {
 
   // Delete workspaces
   Progress deleteProgress(this, 0.90, 0.91, 2);
-  auto deleter = createChildAlgorithm("DeleteWorkspace");
+  auto deleter = createChildAlgorithm("DeleteWorkspace", enableLogging=false);
   deleter->setProperty("WorkSpace",
                        outputWsName + "_NormalisedCovarianceMatrices");
   deleter->executeAsChildAlg();
   deleteProgress.report("Deleting PlotPeak Output");
 
-  deleter = createChildAlgorithm("DeleteWorkspace");
   deleter->setProperty("WorkSpace", outputWsName + "_Parameters");
   deleter->executeAsChildAlg();
   deleteProgress.report("Deleting PlotPeak Output");
@@ -282,7 +281,7 @@ void ConvolutionFitSequential::exec() {
   AnalysisDataService::Instance().addOrReplace(resultWsName, resultWs);
 
   // Handle sample logs
-  auto logCopier = createChildAlgorithm("CopyLogs");
+  auto logCopier = createChildAlgorithm("CopyLogs", enableLogging=false);
   logCopier->setProperty("InputWorkspace", inputWs);
   logCopier->setProperty("OutputWorkspace", resultWs);
   logCopier->executeAsChildAlg();
@@ -302,7 +301,7 @@ void ConvolutionFitSequential::exec() {
 
   Progress logAdderProg(this, 0.96, 0.97, 6);
   // Add String Logs
-  auto logAdder = createChildAlgorithm("AddSampleLog");
+  auto logAdder = createChildAlgorithm("AddSampleLog", enableLogging=false);
   for (auto &sampleLogString : sampleLogStrings) {
     logAdder->setProperty("Workspace", resultWs);
     logAdder->setProperty("LogName", sampleLogString.first);
@@ -323,7 +322,7 @@ void ConvolutionFitSequential::exec() {
   }
 
   // Copy Logs to GroupWorkspace
-  logCopier = createChildAlgorithm("CopyLogs", 0.97, 0.98, true);
+  logCopier = createChildAlgorithm("CopyLogs", 0.97, 0.98, false);
   logCopier->setProperty("InputWorkspace", resultWs);
   std::string groupName = outputWsName + "_Workspaces";
   logCopier->setProperty("OutputWorkspace", groupName);
@@ -334,7 +333,7 @@ void ConvolutionFitSequential::exec() {
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(outputWsName +
                                                                  "_Workspaces");
   auto groupWsNames = groupWs->getNames();
-  auto renamer = createChildAlgorithm("RenameWorkspace");
+  auto renamer = createChildAlgorithm("RenameWorkspace", enableLogging=false);
   Progress renamerProg(this, 0.98, 1.0, specMax + 1);
   for (int i = specMin; i < specMax + 1; i++) {
     renamer->setProperty("InputWorkspace", groupWsNames.at(i - specMin));

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -300,7 +300,7 @@ void ConvolutionFitSequential::exec() {
 
   Progress logAdderProg(this, 0.96, 0.97, 6);
   // Add String Logs
-  auto logAdder = createChildAlgorithm("AddSampleLog" , -1.0, -1.0, false);
+  auto logAdder = createChildAlgorithm("AddSampleLog", -1.0, -1.0, false);
   for (auto &sampleLogString : sampleLogStrings) {
     logAdder->setProperty("Workspace", resultWs);
     logAdder->setProperty("LogName", sampleLogString.first);


### PR DESCRIPTION
Removed property logging for `AddSampleLogs`,`CopyLogs`,`DeleteWorkspace` and `RenameWorkspace` 

**To test:**
- Run the [usage example](http://docs.mantidproject.org/v3.7.1/algorithms/ConvolutionFitSequential-v1.html) and ensure that the Result log does not contain entries for any of `AddSampleLogs`,`CopyLogs`,`DeleteWorkspace` and `RenameWorkspace` _(these were at the end of the algorithm execution)_

Fixes #17177 

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
