### PR TITLE
Provide option to sort detector IDs for CropToComponent

### DIFF
--- a/Framework/Algorithms/src/CropToComponent.cpp
+++ b/Framework/Algorithms/src/CropToComponent.cpp
@@ -74,7 +74,7 @@ void CropToComponent::init() {
       "List of component names which are used to crop the workspace."
       "to.");
   declareProperty("OrderByDetId", false,
-                  "Whether to order the elements of"
+                  "Whether to order the elements of "
                   "the component by increasing detector ID.");
 }
 
@@ -95,7 +95,7 @@ void CropToComponent::exec() {
   std::vector<detid_t> detectorIDs(detectors.size());
   getDetectorIDs(detectors, detectorIDs);
 
-  bool orderByDetID = getProperty("OrderByDetId");
+  const bool orderByDetID = getProperty("OrderByDetId");
   if (orderByDetID) {
     std::sort(detectorIDs.begin(), detectorIDs.end());
   }

--- a/Framework/Algorithms/src/CropToComponent.cpp
+++ b/Framework/Algorithms/src/CropToComponent.cpp
@@ -73,6 +73,8 @@ void CropToComponent::init() {
           "ComponentNames"),
       "List of component names which are used to crop the workspace."
       "to.");
+  declareProperty("OrderByDetId", false, "Whether to order the elements of"
+                  "the component by increasing detector ID.");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -91,6 +93,11 @@ void CropToComponent::exec() {
   // Get the detector IDs from the Detectors
   std::vector<detid_t> detectorIDs(detectors.size());
   getDetectorIDs(detectors, detectorIDs);
+
+  bool orderByDetID = getProperty("OrderByDetId");
+  if (orderByDetID) {
+    std::sort(detectorIDs.begin(), detectorIDs.end());
+  }
 
   // Run ExtractSpectra in order to obtain the cropped workspace
   auto extract_alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(

--- a/Framework/Algorithms/src/CropToComponent.cpp
+++ b/Framework/Algorithms/src/CropToComponent.cpp
@@ -73,7 +73,8 @@ void CropToComponent::init() {
           "ComponentNames"),
       "List of component names which are used to crop the workspace."
       "to.");
-  declareProperty("OrderByDetId", false, "Whether to order the elements of"
+  declareProperty("OrderByDetId", false,
+                  "Whether to order the elements of"
                   "the component by increasing detector ID.");
 }
 

--- a/Framework/Algorithms/test/CropToComponentTest.h
+++ b/Framework/Algorithms/test/CropToComponentTest.h
@@ -170,7 +170,7 @@ public:
     // Test the first theree spectrum numbers.
     // The unordered workspace should show: 3, 131 259
     // The ordered workspace should show: 3, 4, 5
-    std::array<size_t, 3> indices{0, 1, 2};
+    std::array<size_t, 3> indices{{0, 1, 2}};
     std::array<size_t, 3> expectedUnordered{{3, 131, 259}};
     std::array<size_t, 3> expectedOrdered{{3, 4, 5}};
 

--- a/Framework/Algorithms/test/CropToComponentTest.h
+++ b/Framework/Algorithms/test/CropToComponentTest.h
@@ -139,7 +139,8 @@ public:
     loader.setPropertyValue("OutputWorkspace", "in");
     loader.execute();
     Mantid::API::MatrixWorkspace_sptr workspace =
-        Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>("in");
+        Mantid::API::AnalysisDataService::Instance()
+            .retrieveWS<Mantid::API::MatrixWorkspace>("in");
 
     std::vector<std::string> componentNames = {"main-detector-bank"};
 
@@ -155,7 +156,6 @@ public:
     TS_ASSERT(crop.isExecuted())
     Mantid::API::MatrixWorkspace_sptr unOrderedWorkspace =
         crop.getProperty("OutputWorkspace");
-
 
     crop.setProperty("InputWorkspace", workspace);
     crop.setProperty("OutputWorkspace", "ordered");
@@ -175,16 +175,16 @@ public:
     std::array<size_t, 3> expectedOrdered = {3, 4, 5};
 
     for (auto index : indices) {
-        const auto& specUnordered = unOrderedWorkspace->getSpectrum(index);
-        const auto& specOrdered = orderedWorkspace->getSpectrum(index);
-        TS_ASSERT_EQUALS(specUnordered.getSpectrumNo(), expectedUnordered[index]);
-        TS_ASSERT_EQUALS(specOrdered.getSpectrumNo(), expectedOrdered[index]);
+      const auto &specUnordered = unOrderedWorkspace->getSpectrum(index);
+      const auto &specOrdered = orderedWorkspace->getSpectrum(index);
+      TS_ASSERT_EQUALS(specUnordered.getSpectrumNo(), expectedUnordered[index]);
+      TS_ASSERT_EQUALS(specOrdered.getSpectrumNo(), expectedOrdered[index]);
     }
 
     // Clean up the ADS
     if (Mantid::API::AnalysisDataService::Instance().doesExist("in")) {
-        Mantid::API::AnalysisDataService::Instance().remove("in");
-      }
+      Mantid::API::AnalysisDataService::Instance().remove("in");
+    }
   }
 
 private:

--- a/Framework/Algorithms/test/CropToComponentTest.h
+++ b/Framework/Algorithms/test/CropToComponentTest.h
@@ -7,7 +7,10 @@
 #include "MantidAlgorithms/CropToComponent.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidDataHandling/LoadRaw3.h"
+
 #include <numeric>
+#include <array>
 
 class CropToComponentTest : public CxxTest::TestSuite {
 public:
@@ -126,6 +129,62 @@ public:
     crop.setProperty("ComponentNames", componentNames);
     TSM_ASSERT_THROWS("Invalid detector names will throw.", crop.execute(),
                       std::runtime_error)
+  }
+
+  void test_that_det_ids_can_be_ordered() {
+    // Arrange
+    Mantid::DataHandling::LoadRaw3 loader;
+    loader.initialize();
+    loader.setPropertyValue("Filename", "LOQ48097.raw");
+    loader.setPropertyValue("OutputWorkspace", "in");
+    loader.execute();
+    Mantid::API::MatrixWorkspace_sptr workspace =
+        Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>("in");
+
+    std::vector<std::string> componentNames = {"main-detector-bank"};
+
+    // Act
+    Mantid::Algorithms::CropToComponent crop;
+    crop.setChild(true);
+    crop.initialize();
+    crop.setProperty("InputWorkspace", workspace);
+    crop.setProperty("OutputWorkspace", "unordered");
+    crop.setProperty("ComponentNames", componentNames);
+    crop.setProperty("OrderByDetId", false);
+    crop.execute();
+    TS_ASSERT(crop.isExecuted())
+    Mantid::API::MatrixWorkspace_sptr unOrderedWorkspace =
+        crop.getProperty("OutputWorkspace");
+
+
+    crop.setProperty("InputWorkspace", workspace);
+    crop.setProperty("OutputWorkspace", "ordered");
+    crop.setProperty("ComponentNames", componentNames);
+    crop.setProperty("OrderByDetId", true);
+    crop.execute();
+    TS_ASSERT(crop.isExecuted())
+    Mantid::API::MatrixWorkspace_sptr orderedWorkspace =
+        crop.getProperty("OutputWorkspace");
+
+    // Assert
+    // Test the first theree spectrum numbers.
+    // The unordered workspace should show: 3, 131 259
+    // The ordered workspace should show: 3, 4, 5
+    std::array<size_t, 3> indices = {0, 1, 2};
+    std::array<size_t, 3> expectedUnordered = {3, 131, 259};
+    std::array<size_t, 3> expectedOrdered = {3, 4, 5};
+
+    for (auto index : indices) {
+        const auto& specUnordered = unOrderedWorkspace->getSpectrum(index);
+        const auto& specOrdered = orderedWorkspace->getSpectrum(index);
+        TS_ASSERT_EQUALS(specUnordered.getSpectrumNo(), expectedUnordered[index]);
+        TS_ASSERT_EQUALS(specOrdered.getSpectrumNo(), expectedOrdered[index]);
+    }
+
+    // Clean up the ADS
+    if (Mantid::API::AnalysisDataService::Instance().doesExist("in")) {
+        Mantid::API::AnalysisDataService::Instance().remove("in");
+      }
   }
 
 private:

--- a/Framework/Algorithms/test/CropToComponentTest.h
+++ b/Framework/Algorithms/test/CropToComponentTest.h
@@ -170,9 +170,9 @@ public:
     // Test the first theree spectrum numbers.
     // The unordered workspace should show: 3, 131 259
     // The ordered workspace should show: 3, 4, 5
-    std::array<size_t, 3> indices = {0, 1, 2};
-    std::array<size_t, 3> expectedUnordered = {3, 131, 259};
-    std::array<size_t, 3> expectedOrdered = {3, 4, 5};
+    std::array<size_t, 3> indices{0, 1, 2};
+    std::array<size_t, 3> expectedUnordered{3, 131, 259};
+    std::array<size_t, 3> expectedOrdered{3, 4, 5};
 
     for (auto index : indices) {
       const auto &specUnordered = unOrderedWorkspace->getSpectrum(index);

--- a/Framework/Algorithms/test/CropToComponentTest.h
+++ b/Framework/Algorithms/test/CropToComponentTest.h
@@ -171,8 +171,8 @@ public:
     // The unordered workspace should show: 3, 131 259
     // The ordered workspace should show: 3, 4, 5
     std::array<size_t, 3> indices{0, 1, 2};
-    std::array<size_t, 3> expectedUnordered{3, 131, 259};
-    std::array<size_t, 3> expectedOrdered{3, 4, 5};
+    std::array<size_t, 3> expectedUnordered{{3, 131, 259}};
+    std::array<size_t, 3> expectedOrdered{{3, 4, 5}};
 
     for (auto index : indices) {
       const auto &specUnordered = unOrderedWorkspace->getSpectrum(index);

--- a/docs/source/release/v3.8.0/sans.rst
+++ b/docs/source/release/v3.8.0/sans.rst
@@ -10,7 +10,7 @@ Features
 
 - :ref:`CropToComponent <algm-CropToComponent>` allows for cropping a workspace to a list of component names.
 - Detect missing Bench_Rot for LARMOR and provide meaningful error message
-
+- Add sort option to :ref:`CropToComponent <algm-CropToComponent>`
 
 Bug Fixes
 ---------


### PR DESCRIPTION
This addition to `CropToComponent` allows for sorting the detector IDs which are extracted for a particular component.

**To test:**
- Code Review should be sufficient
- The unit test should cover this new option

Fixes #17180

*\* Release Notes**

See [here]()

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
