### PR TITLE
Sns powder reduction bugfix

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -70,7 +70,6 @@ def is_event_workspace(workspace):
     else:
         return workspace.id() == EVENT_WORKSPACE_ID
 
-
 def allEventWorkspaces(*args):
     """
     Purpose:
@@ -746,7 +745,6 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                 if is_event_workspace(sumRun):
                     api.CompressEvents(InputWorkspace=sumRun, OutputWorkspace=sumRun,
                                        Tolerance=self.COMPRESS_TOL_TOF) # 10ns
-                    assert temp_ws is not None
                 # after adding all events, delete the current workspace.
                 api.DeleteWorkspace(out_ws_name)
             # ENDIF

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -3,11 +3,13 @@ from __future__ import (absolute_import, division, print_function)
 
 import os
 
-import mantid
-import mantid.api
 import mantid.simpleapi as api
-from mantid.api import *
-from mantid.kernel import *
+from mantid.api import mtd, AlgorithmFactory, AnalysisDataService, DataProcessorAlgorithm, \
+    FileAction, FileProperty, ITableWorkspaceProperty, MultipleFileProperty, PropertyMode, \
+    WorkspaceProperty
+from mantid.kernel import ConfigService, Direction, FloatArrayProperty, \
+    FloatBoundedValidator, IntArrayBoundedValidator, IntArrayProperty, \
+    Property, PropertyManagerDataService, StringArrayProperty, StringListValidator
 # Use xrange in Python 2
 from six.moves import range #pylint: disable=redefined-builtin
 
@@ -296,7 +298,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         focuspos = self._focusPos
         if self._lowResTOFoffset >= 0:
             # Dealing with the parameters for editing instrument parameters
-            if ("PrimaryFlightPath" in focuspos):
+            if "PrimaryFlightPath" in focuspos:
                 l1 = focuspos["PrimaryFlightPath"]
                 if l1 > 0:
                     specids = focuspos['SpectrumIDs'][:]
@@ -677,7 +679,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                 # comparess events
                 if is_event_workspace(sample_ws_name):
                     api.CompressEvents(InputWorkspace=sample_ws_name, OutputWorkspace=sample_ws_name,
-                                                 Tolerance=self.COMPRESS_TOL_TOF)  # 10ns
+                                       Tolerance=self.COMPRESS_TOL_TOF)  # 10ns
         # END-FOR
 
         # Normalize by current with new name
@@ -752,7 +754,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
 
         if self._normalisebycurrent is True:
             api.NormaliseByCurrent(InputWorkspace=sumRun,
-                                             OutputWorkspace=sumRun)
+                                   OutputWorkspace=sumRun)
             get_workspace(sumRun).getRun()['gsas_monitor'] = 1
 
         return sumRun
@@ -924,7 +926,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             try:
                 if normalisebycurrent is True:
                     api.NormaliseByCurrent(InputWorkspace=output_wksp_list[split_index],
-                                                     OutputWorkspace=output_wksp_list[split_index])
+                                           OutputWorkspace=output_wksp_list[split_index])
                     get_workspace(output_wksp_list[split_index]).getRun()['gsas_monitor'] = 1
             except RuntimeError as e:
                 self.log().warning(str(e))

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -138,11 +138,6 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         self.declareProperty(MultipleFileProperty(name="Filename",
                                                   extensions=EXTENSIONS_NXS),
                              "Event file")
-        self.declareProperty(FileProperty(name="LogFilename",
-                                          defaultValue="", action=FileAction.OptionalLoad,
-                                          extensions=EXTENSIONS_NXS),
-                             "Optional file to copy logs from")
-
         self.declareProperty("PreserveEvents", True,
                              "Argument to supply to algorithms that can change from events to histograms.")
         self.declareProperty("Sum", False,
@@ -582,15 +577,6 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                                                 str(self._filterBadPulses), out_ws_name)
                 self.log().information(message)
         # END-IF (filter bad pulse)
-
-        # this if block is only for sample runs and only for testing new adara files
-        if filename in self.getProperty("Filename").value:
-            donorLogfilename = self.getProperty("LogFilename").value
-            if donorLogfilename is not None and len(donorLogfilename) > 0:
-                api.Load(Filename=donorLogfilename, MetaDataOnly=True, OutputWorkspace='temp_log_donor')
-                api.CopyLogs(InputWorkspace='temp_log_donor', OutputWorkspace=out_ws_name,
-                             MergeStrategy='MergeKeepExisting')
-                api.DeleteWorkspace('temp_log_donor')
 
         return out_ws_name
 

--- a/docs/source/release/v3.8.0/diffraction.rst
+++ b/docs/source/release/v3.8.0/diffraction.rst
@@ -49,11 +49,11 @@ Powder Diffraction
 - :ref:`SNSPowderReduction <algm-SNSPowderReduction>` has changed
   parameters. ``Instrument``, ``RunNumber``, and ``Extension`` have
   been replaced with a single ``Filename`` parameter. This has been
-  paired with changes to the Powder Diffraction interface as well. An
-  additional parameter, ``LogFilename``, has been added to aid in
-  testing files being produced by the "new DAS" at SNS. This parameter
-  has not been added to the Powder Diffraction interface and will be
-  removed without notice.
+  paired with changes to the Powder Diffraction interface as
+  well. There were also a variety of bugfixes related to the output
+  workspaces. While it did not affect the saved data files, the output
+  workspaces were not always correctly normalized or in the requested
+  units.
 
 - :ref:`PDFFourierTransformSNSPowderReduction
   <algm-PDFFourierTransformSNSPowderReduction>` has been modified to


### PR DESCRIPTION
Output workspaces from `SNSPowderReduction` were not normalized or converted to the correct units. This was not noticed until recently because ORNL did not use mantid v3.6.

**To test:**

Run the following script before and after merging this branch. Plot the data that is produced as the files generated are unchanged.

``` python
SNSPowderReduction(FinalDataUnits="dSpacing",
                   ScaleData=100,
                   OutputDirectory="/tmp",
                   Filename='PG3_29600:29601',
                   SaveAs="gsas topas fullprof",
                   FilterBadPulses=10,
                   PushDataPositive="AddMinimum",
                   Binning=-0.0004,
                   CalibrationFile="/SNS/PG3/shared/CALIBRATION/2016_2_11A_CAL/PG3_PAC_d29581_2016_07_28.h5",
                   RemovePromptPulseWidth=50,
                   CharacterizationRunsFile="/SNS/PG3/shared/CALIBRATION/2016_2_11A_CAL/PG3_char_2016_08_01-HR-PAC-6mm.txt",
                   BackgroundSmoothParams="5,2")
```

_There is no associated issue_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
