### PR TITLE
Fix segfaults from Google Mock and GCC 6.1

### DIFF
--- a/Testing/Tools/gmock-1.7.0/include/gmock/gmock-spec-builders.h
+++ b/Testing/Tools/gmock-1.7.0/include/gmock/gmock-spec-builders.h
@@ -1370,6 +1370,8 @@ class ActionResultHolder : public UntypedActionResultHolderBase {
 template <>
 class ActionResultHolder<void> : public UntypedActionResultHolderBase {
  public:
+  explicit ActionResultHolder() {}
+
   void GetValueAndDelete() const { delete this; }
 
   virtual void PrintAsActionResult(::std::ostream* /* os */) const {}
@@ -1381,7 +1383,7 @@ class ActionResultHolder<void> : public UntypedActionResultHolderBase {
       const typename Function<F>::ArgumentTuple& args,
       const string& call_description) {
     func_mocker->PerformDefaultAction(args, call_description);
-    return NULL;
+    return new ActionResultHolder();
   }
 
   // Performs the given action and returns NULL.
@@ -1390,7 +1392,7 @@ class ActionResultHolder<void> : public UntypedActionResultHolderBase {
       const Action<F>& action,
       const typename Function<F>::ArgumentTuple& args) {
     action.Perform(args);
-    return NULL;
+    return new ActionResultHolder();
   }
 };
 


### PR DESCRIPTION
Description of work.

[This patch](https://github.com/google/googletest/issues/705#issuecomment-235067917) for Google Mock 1.7 reduces the number of test failures on Fedora 24 from 47 to 2 :tada:

This has already been fixed upstream but not yet included in a release.

**To test:**

<!-- Instructions for testing. -->

Compare [build #6](http://builds.mantidproject.org/job/master_clean-fedora24/6/) and [build #7](http://builds.mantidproject.org/job/master_clean-fedora24/7/)

If the PR still builds pass, shipit.

This partially addresses #17146.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
