### PR TITLE
Fix UBSAN warning in Histogram

### DIFF
--- a/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
@@ -446,7 +446,7 @@ template <> inline bool Histogram::selfAssignmentX(const HistogramX &data) {
 
 template <>
 inline bool Histogram::selfAssignmentX(const std::vector<double> &data) {
-  return &data == &(m_x->rawData());
+  return static_cast<bool>(m_x) && &data == &(m_x->rawData());
 }
 
 template <> inline bool Histogram::selfAssignmentDx(const HistogramDx &data) {
@@ -455,7 +455,7 @@ template <> inline bool Histogram::selfAssignmentDx(const HistogramDx &data) {
 
 template <>
 inline bool Histogram::selfAssignmentDx(const std::vector<double> &data) {
-  return &data == &(m_dx->rawData());
+  return static_cast<bool>(m_dx) && &data == &(m_dx->rawData());
 }
 
 template <> inline bool Histogram::selfAssignmentY(const HistogramY &data) {
@@ -464,7 +464,7 @@ template <> inline bool Histogram::selfAssignmentY(const HistogramY &data) {
 
 template <>
 inline bool Histogram::selfAssignmentY(const std::vector<double> &data) {
-  return &data == &(m_y->rawData());
+  return static_cast<bool>(m_y) && &data == &(m_y->rawData());
 }
 
 template <> inline bool Histogram::selfAssignmentE(const HistogramE &data) {
@@ -473,7 +473,7 @@ template <> inline bool Histogram::selfAssignmentE(const HistogramE &data) {
 
 template <>
 inline bool Histogram::selfAssignmentE(const std::vector<double> &data) {
-  return &data == &(m_e->rawData());
+  return static_cast<bool>(m_e) && &data == &(m_e->rawData());
 }
 
 MANTID_HISTOGRAMDATA_DLL Histogram::XMode getHistogramXMode(size_t xLength,


### PR DESCRIPTION
UBSAN warnings found by @quantumsteve:

```
02:19:40 Running 3 tests/home/builder/jenkins-linode/workspace/undefined_behavior_sanitizer/Framework/HistogramData/inc/MantidHistogramData/Histogram.h:476:34: runtime error: member call on null pointer of type 'const struct FixedLengthVector
```

```
02:18:07 /home/builder/jenkins-linode/workspace/undefined_behavior_sanitizer/Framework/HistogramData/inc/MantidHistogramData/Histogram.h:458:35: runtime error: member call on null pointer of type 'const struct FixedLengthVector'
```

The reason seems to be a nullptr-dereference for certain assignment types.

**To test:**

Code review. Run UBSAN if possible, otherwise wait until the master job does.

No issue, no release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Thanks @quantumsteve.
