### PR TITLE
Make LoadGSS more flexible

### DIFF
--- a/Framework/DataHandling/src/LoadGSS.cpp
+++ b/Framework/DataHandling/src/LoadGSS.cpp
@@ -15,10 +15,10 @@
 #include "MantidKernel/UnitFactory.h"
 
 #include <boost/regex.hpp>
-#include <Poco/File.h>
-
 #include <fstream>
+#include <Poco/File.h>
 #include <sstream>
+#include <string>
 
 using namespace Mantid::DataHandling;
 using namespace Mantid::API;
@@ -197,7 +197,7 @@ API::MatrixWorkspace_sptr LoadGSS::loadGSASFile(const std::string &filename,
         boost::smatch result;
         if (boost::regex_search(inputLine.str(), result, L1_REG_EXP) &&
             result.size() == 2) {
-          primaryflightpath = atof(std::string(result[1]).c_str());
+          primaryflightpath = std::stod(std::string(result[1]));
 
         } else {
           std::stringstream msg;
@@ -220,9 +220,9 @@ API::MatrixWorkspace_sptr LoadGSS::loadGSASFile(const std::string &filename,
         boost::smatch result;
         if (boost::regex_search(inputLine.str(), result, DET_POS_REG_EXP) &&
             result.size() == 4) {
-          totalpath = atof(std::string(result[1]).c_str());
-          tth = atof(std::string(result[2]).c_str());
-          difc = atof(std::string(result[3]).c_str());
+          totalpath = std::stod(std::string(result[1]));
+          tth = std::stod(std::string(result[2]));
+          difc = std::stod(std::string(result[3]));
         } else {
           std::stringstream msg;
           msg << "Failed to parse position from line \"" << inputLine.str()
@@ -468,7 +468,7 @@ double LoadGSS::convertToDouble(std::string inputstring) {
     }
   }
 
-  double rd = atof(temps.c_str());
+  double rd = std::stod(temps);
 
   return rd;
 }

--- a/Framework/DataHandling/src/LoadGSS.cpp
+++ b/Framework/DataHandling/src/LoadGSS.cpp
@@ -14,7 +14,7 @@
 #include "MantidGeometry/Instrument/Component.h"
 #include "MantidKernel/UnitFactory.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/regex.hpp>
 #include <Poco/File.h>
 
 #include <fstream>
@@ -28,6 +28,13 @@ namespace Mantid {
 namespace DataHandling {
 
 DECLARE_FILELOADER_ALGORITHM(LoadGSS)
+
+namespace { // anonymous namespace
+const boost::regex DET_POS_REG_EXP{"^#.+flight path\\s+([0-9.]+).+"
+                                   "tth\\s+([0-9.]+).+"
+                                   "DIFC\\s+([0-9.]+)"};
+const boost::regex L1_REG_EXP{"^#.+flight path\\s+([0-9.]+)\\s*m"};
+} // end of anonymous namespace
 
 //----------------------------------------------------------------------------------------------
 /** Return the confidence with with this algorithm can load the file
@@ -187,33 +194,51 @@ API::MatrixWorkspace_sptr LoadGSS::loadGSASFile(const std::string &filename,
         }
       } else if (key1 == "Primary") {
         // Primary flight path ...
-        std::string s1, s2;
-        inputLine >> s1 >> s2;
-        primaryflightpath = atof(s2.c_str()); // convertToDouble(s2);
-        g_log.information() << "L1 = " << primaryflightpath << '\n';
+        boost::smatch result;
+        if (boost::regex_search(inputLine.str(), result, L1_REG_EXP) &&
+            result.size() == 2) {
+          primaryflightpath = atof(std::string(result[1]).c_str());
+
+        } else {
+          std::stringstream msg;
+          msg << "Failed to parse primary flight path from line \""
+              << inputLine.str() << "\"";
+          g_log.warning(msg.str());
+        }
+
+        std::stringstream msg;
+        msg << "L1 = " << primaryflightpath;
+        g_log.information(msg.str());
       } else if (key1 == "Total") {
         // Total flight path .... .... including total flying path, difc and
         // 2theta of 1 bank
-        std::string s1, s2, s3, s4, s5, s6;
-        inputLine >> s1 >> s2 >> s3 >> s4 >> s5 >> s6;
-#if 0
-          double totalpath = convertToDouble(s2);
-          double tth = convertToDouble(s4);
-          double difc = convertToDouble(s6);
-#else
-        double totalpath = atof(s2.c_str());
-        double tth = atof(s4.c_str());
-        double difc = atof(s6.c_str());
-#endif
+
+        double totalpath(0.f);
+        double tth(0.f);
+        double difc(0.f);
+
+        boost::smatch result;
+        if (boost::regex_search(inputLine.str(), result, DET_POS_REG_EXP) &&
+            result.size() == 4) {
+          totalpath = atof(std::string(result[1]).c_str());
+          tth = atof(std::string(result[2]).c_str());
+          difc = atof(std::string(result[3]).c_str());
+        } else {
+          std::stringstream msg;
+          msg << "Failed to parse position from line \"" << inputLine.str()
+              << "\"";
+          g_log.warning(msg.str());
+        }
 
         totalflightpaths.push_back(totalpath);
         twothetas.push_back(tth);
         difcs.push_back(difc);
 
-        g_log.information() << "Bank " << difcs.size() - 1
-                            << ": Total flight path = " << totalpath
-                            << "  2Theta = " << tth << "  DIFC = " << difc
-                            << "\n";
+        std::stringstream msg;
+        msg << "Bank " << difcs.size() - 1
+            << ": Total flight path = " << totalpath << "  2Theta = " << tth
+            << "  DIFC = " << difc;
+        g_log.information(msg.str());
       } // if keys....
 
     } // ENDIF for Line with #

--- a/Framework/DataHandling/test/LoadGSSTest.h
+++ b/Framework/DataHandling/test/LoadGSSTest.h
@@ -7,10 +7,12 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidTestHelpers/ScopedFileHelper.h"
+#include "MantidGeometry/Instrument.h"
 
 using namespace Mantid;
 using Mantid::DataHandling::LoadGSS;
 using ScopedFileHelper::ScopedFile;
+using Mantid::Kernel::V3D;
 
 class LoadGSSTest : public CxxTest::TestSuite {
 public:
@@ -52,7 +54,16 @@ public:
         "   115206.06310  1234567.00000003        0.00000000\n"
         "   115209.92877 12345678.00000004        0.00000000\n"
         "   115213.79731123456789.00000005        0.00000000\n"
-        "   115217.66873234567890.00000006        0.00000000";
+        "   115217.66873234567890.00000006        0.00000000\n"
+        "\n"
+        "# Total flight path 42.060 m, tth 154.257 deg, DIFC 10398.8\n"
+        "# Data for spectrum :1\n"
+        "BANK 2 4399 4399 RALF   166409      124   166409 0.00074 FXYE\n"
+        "   115202.20029        1.00000000        0.00000000\n"
+        "   115206.06310        1.00000000        0.00000000\n"
+        "   115209.92877        2.00000000        0.00000000\n"
+        "   115213.79731        3.00000000        0.00000000\n"
+        "   115217.66873        5.00000000        0.00000000\n";
     ScopedFile file(gss, "gss_large_x.txt");
     API::IAlgorithm_sptr loader = createAlgorithm();
     loader->setPropertyValue("Filename", file.getFileName());
@@ -69,6 +80,21 @@ public:
     dx = x2 - x1;
     y = ws->readY(0)[3] * dx;
     TS_ASSERT_DELTA(y, 123456789.00000005, 1e-10);
+
+    const auto source = ws->getInstrument()->getSource();
+    const auto sample = ws->getInstrument()->getSample();
+    TS_ASSERT_DELTA(sample->getDistance(*source), 40., 1e-4);
+
+    const auto det0 = ws->getDetector(0);
+    TS_ASSERT_DELTA(det0->getDistance(*sample), 2.2222, 1e-4);
+    TS_ASSERT_DELTA(det0->getTwoTheta(V3D(0.0, 0.0, 0.0), V3D(0.0, 0.0, 1.0)) *
+                        180. / M_PI,
+                    58.308, 1e-4);
+    const auto det1 = ws->getDetector(1);
+    TS_ASSERT_DELTA(det1->getDistance(*sample), 2.060, 1e-4);
+    TS_ASSERT_DELTA(det1->getTwoTheta(V3D(0.0, 0.0, 0.0), V3D(0.0, 0.0, 1.0)) *
+                        180. / M_PI,
+                    154.257, 1e-4);
   }
 
   void test_load_gss_ExtendedHeader_gsa() {


### PR DESCRIPTION
IDL reduction of NOMAD data was generating different spacing in the detector position line of the GSAS files. This change broke `LoadGSS` parsing the detector position from the file.

**To test:**

Since there is a unit test added for this behavior, a code review should suffice.

_There is no associated issue_

_Does not need to be in the release notes_ because not many users will see the issue

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
