### PR TITLE
Return error in add test data script

### DIFF
--- a/tools/Development/git/git-add-test-data
+++ b/tools/Development/git/git-add-test-data
@@ -30,6 +30,9 @@ add_test_data() {
 
   # Compute hash
   hash=$(hash_code $content_file)
+  if [ "$hash" = "" ]; then
+    exit 1
+  fi
   debug_msg "${INDENT}${HASH_ALG} hash: $hash"
 
   # Create content link if required
@@ -68,6 +71,9 @@ hash_code() {
 md5sum() {
   md5cmd="cmake -E md5sum"
   cmake_output=$($md5cmd $1)
+  if [ "$cmake_output" = "" ]; then
+    fatal "CMake was unable to create the MD5 Sum"
+  fi
   # CMake output is of form: HASH   filename
   md5=$(echo $cmake_output | awk '{print $1}')
   echo $md5
@@ -181,6 +187,9 @@ datafiles=$*
 all_hashed_files=""
 for datafile in $datafiles; do
   hashed_content=$(add_test_data ${GIT_PREFIX}$datafile)
+  if [ "$hashed_content" = "" ]; then
+    fatal "Unable to add test data '${GIT_PREFIX}$datafile'"
+  fi
   all_hashed_files="$all_hashed_files $hashed_content"
 done
 

--- a/tools/Development/git/git-add-test-data
+++ b/tools/Development/git/git-add-test-data
@@ -31,7 +31,7 @@ add_test_data() {
   # Compute hash
   hash=$(hash_code $content_file)
   if [ "$hash" = "" ]; then
-    exit 1
+    return 1
   fi
   debug_msg "${INDENT}${HASH_ALG} hash: $hash"
 
@@ -68,11 +68,13 @@ hash_code() {
 # Computes the MD5 checksum of the given file.
 # MD5 code is printed to stdout
 #   @param $1 - Path to the file whose hash is computed
+#   @return 1 failure to create md5sum, 0 on success.
 md5sum() {
   md5cmd="cmake -E md5sum"
   cmake_output=$($md5cmd $1)
   if [ "$cmake_output" = "" ]; then
-    fatal "CMake was unable to create the MD5 Sum"
+    echo "CMake was unable to create the MD5 Sum" 1>&2
+    return 1
   fi
   # CMake output is of form: HASH   filename
   md5=$(echo $cmake_output | awk '{print $1}')


### PR DESCRIPTION
Minor change to git-add-test-data script that ensures an error message is returned if the MD5 Sum could not be created. The most common cause of this is that CMake could not be located.

**To test:**
- Remove CMake from system path and attempt to run `git add-test-data` from git bash
  - Ensure the error message `CMake was unable to create the MD5 Sum` is produced

**This PR has no issue number**

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
