### PR TITLE
Added override keyword to Performance Tests in Algorithms G

### DIFF
--- a/Framework/Algorithms/test/GeneralisedSecondDifferenceTest.h
+++ b/Framework/Algorithms/test/GeneralisedSecondDifferenceTest.h
@@ -78,13 +78,13 @@ public:
     delete suite;
   }
 
-  void setUp() {
+  void setUp() override {
     inputMatrix = WorkspaceCreationHelper::Create2DWorkspaceBinned(10000, 1000);
     inputEvent =
         WorkspaceCreationHelper::CreateEventWorkspace(10000, 1000, 5000);
   }
 
-  void tearDown() {
+  void tearDown() override {
     Mantid::API::AnalysisDataService::Instance().remove("output");
     Mantid::API::AnalysisDataService::Instance().remove("output2");
   }

--- a/Framework/Algorithms/test/GenerateEventsFilterTest.h
+++ b/Framework/Algorithms/test/GenerateEventsFilterTest.h
@@ -1144,9 +1144,9 @@ public:
     delete suite;
   }
 
-  void setUp() { inputEvent = createEventWorkspaceIntLog(); }
+  void setUp() override { inputEvent = createEventWorkspaceIntLog(); }
 
-  void tearDown() {
+  void tearDown() override {
     Mantid::API::AnalysisDataService::Instance().remove("output");
     Mantid::API::AnalysisDataService::Instance().remove("infoOutput");
   }

--- a/Framework/Algorithms/test/GeneratePeaksTest.h
+++ b/Framework/Algorithms/test/GeneratePeaksTest.h
@@ -537,7 +537,7 @@ public:
     delete suite;
   }
 
-  void setUp() {
+  void setUp() override {
     FrameworkManager::Instance();
     peakparmsws = createTestPeakParameters2();
     AnalysisDataService::Instance().addOrReplace("TestParameterTable2",
@@ -546,7 +546,7 @@ public:
     AnalysisDataService::Instance().addOrReplace("RawSampleBinWS", inputws);
   }
 
-  void tearDown() {
+  void tearDown() override {
     AnalysisDataService::Instance().remove("TestParameterTable2");
     AnalysisDataService::Instance().remove("RawSampleBinWS");
     AnalysisDataService::Instance().remove("Test02WS");

--- a/Framework/Algorithms/test/GetAllEiTest.h
+++ b/Framework/Algorithms/test/GetAllEiTest.h
@@ -593,9 +593,9 @@ public:
   }
   static void destroySuite(GetAllEiTestPerformance *suite) { delete suite; }
 
-  void setUp() { inputMatrix = createTestingWS(false); }
+  void setUp() override { inputMatrix = createTestingWS(false); }
 
-  void tearDown() {
+  void tearDown() override {
     Mantid::API::AnalysisDataService::Instance().remove("monitor_peaks");
   }
 

--- a/Framework/Algorithms/test/GetEiTest.h
+++ b/Framework/Algorithms/test/GetEiTest.h
@@ -297,7 +297,7 @@ public:
   }
   static void destroySuite(GetEiTestPerformance *suite) { delete suite; }
 
-  void setUp() {
+  void setUp() override {
     getEiTest = GetEiTest();
     inputWS1 = GetEiTestHelper::createTestWorkspaceWithMonitors();
     outputName1 = "eitest1";
@@ -310,7 +310,7 @@ public:
     // This algorithm needs a name attached to the workspace
   }
 
-  void tearDown() {
+  void tearDown() override {
     AnalysisDataService::Instance().remove(outputName1);
     AnalysisDataService::Instance().remove(outputName2);
   }

--- a/Framework/Algorithms/test/GetTimeSeriesLogInformationTest.h
+++ b/Framework/Algorithms/test/GetTimeSeriesLogInformationTest.h
@@ -130,9 +130,9 @@ public:
     delete suite;
   }
 
-  void setUp() { inputWS = createEventWorkspace(); }
+  void setUp() override { inputWS = createEventWorkspace(); }
 
-  void tearDown() {
+  void tearDown() override {
     Mantid::API::AnalysisDataService::Instance().remove("TimeStat");
   }
 


### PR DESCRIPTION
## Description of work.

Added `override` keyword in `setUp()` and `tearDown()` methods in performance tests from #17047 to remove [GNU warnings](http://builds.mantidproject.org/job/master_clean-fedora/372/warnings30Result/)

<!-- Instructions for testing. -->

Fixes #17189.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
-->

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
