### PR TITLE
17204 merge md normalization

### DIFF
--- a/Framework/MDAlgorithms/src/MergeMD.cpp
+++ b/Framework/MDAlgorithms/src/MergeMD.cpp
@@ -72,6 +72,8 @@ void MergeMD::createOutputWorkspace(std::vector<std::string> &inputs) {
   // dims anyway
   IMDEventWorkspace_const_sptr ws0 = m_workspaces[0];
   size_t numDims = ws0->getNumDims();
+  auto displNorm=ws0->displayNormalization();
+  auto displNormH=ws0->displayNormalizationHisto();
 
   // Extents to create.
   std::vector<coord_t> dimMin(numDims, +1e30f);
@@ -114,6 +116,8 @@ void MergeMD::createOutputWorkspace(std::vector<std::string> &inputs) {
 
   // Have the factory create it
   out = MDEventFactory::CreateMDWorkspace(numDims, ws0->getEventTypeName());
+  out->setDisplayNormalization(displNorm);
+  out->setDisplayNormalizationHisto(displNormH);
 
   // Give all the dimensions
   for (size_t d = 0; d < numDims; d++) {

--- a/Framework/MDAlgorithms/src/MergeMD.cpp
+++ b/Framework/MDAlgorithms/src/MergeMD.cpp
@@ -72,8 +72,8 @@ void MergeMD::createOutputWorkspace(std::vector<std::string> &inputs) {
   // dims anyway
   IMDEventWorkspace_const_sptr ws0 = m_workspaces[0];
   size_t numDims = ws0->getNumDims();
-  auto displNorm=ws0->displayNormalization();
-  auto displNormH=ws0->displayNormalizationHisto();
+  auto displNorm = ws0->displayNormalization();
+  auto displNormH = ws0->displayNormalizationHisto();
 
   // Extents to create.
   std::vector<coord_t> dimMin(numDims, +1e30f);

--- a/Framework/MDAlgorithms/test/MergeMDTest.h
+++ b/Framework/MDAlgorithms/test/MergeMDTest.h
@@ -128,23 +128,24 @@ public:
   }
 
   void test_displayNormalization() {
-      // Name of the output workspace.
-      std::string outWSName("MergeMDTest_OutputWS");
-      auto ws0 = AnalysisDataService::Instance().retrieveWS<IMDEventWorkspace>(
-          "ws0");
-      ws0->setDisplayNormalization(API::MDNormalization::NoNormalization);
-      ws0->setDisplayNormalizationHisto(API::MDNormalization::NumEventsNormalization);
-      auto ws = execute_merge(outWSName);
-      if (!ws)
-        return;
+    // Name of the output workspace.
+    std::string outWSName("MergeMDTest_OutputWS");
+    auto ws0 =
+        AnalysisDataService::Instance().retrieveWS<IMDEventWorkspace>("ws0");
+    ws0->setDisplayNormalization(API::MDNormalization::NoNormalization);
+    ws0->setDisplayNormalizationHisto(
+        API::MDNormalization::NumEventsNormalization);
+    auto ws = execute_merge(outWSName);
+    if (!ws)
+      return;
 
+    TS_ASSERT_EQUALS(API::MDNormalization::NoNormalization,
+                     ws->displayNormalization());
+    TS_ASSERT_EQUALS(API::MDNormalization::NumEventsNormalization,
+                     ws->displayNormalizationHisto());
 
-      TS_ASSERT_EQUALS(API::MDNormalization::NoNormalization, ws->displayNormalization());
-      TS_ASSERT_EQUALS(API::MDNormalization::NumEventsNormalization, ws->displayNormalizationHisto());
-
-
-      // Remove workspace from the data service.
-      AnalysisDataService::Instance().remove(outWSName);
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
   }
 };
 

--- a/Framework/MDAlgorithms/test/MergeMDTest.h
+++ b/Framework/MDAlgorithms/test/MergeMDTest.h
@@ -126,6 +126,26 @@ public:
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
   }
+
+  void test_displayNormalization() {
+      // Name of the output workspace.
+      std::string outWSName("MergeMDTest_OutputWS");
+      auto ws0 = AnalysisDataService::Instance().retrieveWS<IMDEventWorkspace>(
+          "ws0");
+      ws0->setDisplayNormalization(API::MDNormalization::NoNormalization);
+      ws0->setDisplayNormalizationHisto(API::MDNormalization::NumEventsNormalization);
+      auto ws = execute_merge(outWSName);
+      if (!ws)
+        return;
+
+
+      TS_ASSERT_EQUALS(API::MDNormalization::NoNormalization, ws->displayNormalization());
+      TS_ASSERT_EQUALS(API::MDNormalization::NumEventsNormalization, ws->displayNormalizationHisto());
+
+
+      // Remove workspace from the data service.
+      AnalysisDataService::Instance().remove(outWSName);
+  }
 };
 
 #endif /* MANTID_MDALGORITHMS_MERGEMDTEST_H_ */

--- a/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspace.cpp
@@ -23,11 +23,15 @@ void export_IMDEventWorkspace() {
       .def("getBoxController", (BoxController_sptr (IMDEventWorkspace::*)()) &
                                    IMDEventWorkspace::getBoxController,
            arg("self"), "Returns the BoxController used in this workspace")
-      .def("setDisplayNormalization", &IMDEventWorkspace::setDisplayNormalization,
-           (arg("self"),arg("normalization")),"Sets the visual normalization of"
+      .def("setDisplayNormalization",
+           &IMDEventWorkspace::setDisplayNormalization,
+           (arg("self"), arg("normalization")),
+           "Sets the visual normalization of"
            " the workspace.")
-      .def("setDisplayNormalizationHisto", &IMDEventWorkspace::setDisplayNormalizationHisto,
-           (arg("self"),arg("normalization")),"For MDEventWorkspaces sets"
+      .def("setDisplayNormalizationHisto",
+           &IMDEventWorkspace::setDisplayNormalizationHisto,
+           (arg("self"), arg("normalization")),
+           "For MDEventWorkspaces sets"
            " the visual normalization of dervied "
            "MDHistoWorkspaces.");
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspace.cpp
@@ -22,7 +22,14 @@ void export_IMDEventWorkspace() {
 
       .def("getBoxController", (BoxController_sptr (IMDEventWorkspace::*)()) &
                                    IMDEventWorkspace::getBoxController,
-           arg("self"), "Returns the BoxController used in this workspace");
+           arg("self"), "Returns the BoxController used in this workspace")
+      .def("setDisplayNormalization", &IMDEventWorkspace::setDisplayNormalization,
+           (arg("self"),arg("normalization")),"Sets the visual normalization of"
+           " the workspace.")
+      .def("setDisplayNormalizationHisto", &IMDEventWorkspace::setDisplayNormalizationHisto,
+           (arg("self"),arg("normalization")),"For MDEventWorkspaces sets"
+           " the visual normalization of dervied "
+           "MDHistoWorkspaces.");
 
   RegisterWorkspacePtrToPython<IMDEventWorkspace>();
 }

--- a/Framework/PythonInterface/test/python/mantid/api/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/api/CMakeLists.txt
@@ -27,6 +27,7 @@ set ( TEST_PY_FILES
   ITableWorkspaceTest.py
   JacobianTest.py
   MatrixWorkspaceTest.py
+  MDEventWorkspaceTest.py
   MDGeometryTest.py
   MDHistoWorkspaceTest.py
   MultipleExperimentInfos.py

--- a/Framework/PythonInterface/test/python/mantid/api/MDEventWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MDEventWorkspaceTest.py
@@ -1,0 +1,32 @@
+from __future__ import (absolute_import, print_function)
+
+import unittest
+from testhelpers import run_algorithm
+from mantid import mtd
+import mantid
+
+class MDEventWorkspaceTest(unittest.TestCase):
+    """
+    Test the interface to MDEventWorkspaces
+    """
+
+    def setUp(self):
+        run_algorithm('CreateMDWorkspace', Dimensions='3',Extents='0,10,0,10,0,10',Names='x,y,z',Units='m,m,m',SplitInto='5',
+                      MaxRecursionDepth='20',OutputWorkspace='mdw')
+        run_algorithm('FakeMDEventData', InputWorkspace="mdw",  UniformParams="1e4")
+        
+
+    def tearDown(self):
+        mtd.remove('mdw')
+
+    def test_interface(self):
+        mdw= mtd['mdw']
+        self.assertEqual(mdw.displayNormalization(),mantid.api.MDNormalization.VolumeNormalization)
+        mdw.setDisplayNormalization(mantid.api.MDNormalization.NoNormalization)
+        self.assertEqual(mdw.displayNormalization(),mantid.api.MDNormalization.NoNormalization)
+        mdw.setDisplayNormalizationHisto(mantid.api.MDNormalization.NumEventsNormalization)
+        self.assertEqual(mdw.displayNormalizationHisto(),mantid.api.MDNormalization.NumEventsNormalization)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -75,6 +75,8 @@ Deprecated
 MD Algorithms (VATES CLI)
 #########################
 
+- :ref:`MergeMD <algm-MergeMD>` now preserves the display normalization from the first workspace in the list
+
 Performance
 -----------
 
@@ -101,6 +103,7 @@ Python
   and :py:obj:`mantid.kernel.Material` has been modified to expose the
   individual atoms.
 - :py:obj:`mantid.geometry.OrientedLattice` set U with determinant -1 exposed to python
+- The setDisplayNormalization and setDisplayNormalizationHisto methods for MDEventWorkspaces are now exposed to Python
 
 Python Algorithms
 #################


### PR DESCRIPTION
The output of `MergeMD` now has the same `displayNormalization` and `displayNormalizationHisto` as the first workspace in the list.
The seters for display normalizations are now exposed to python 

**To test:**
Create some MD event files from nxspe files (workspaces 2D). When viewed in `SliceViewer` and bined, they should each have #EventsNormalization. The output of MergeMD should now have the same display normalization. It used to switch back to Volume normalization.

Alternatively, create a could of MDEvent workspaces and set in python the display normalization. Check if the merged workspace has the same display normalization

Fixes #17204.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
