### PR TITLE
Fix linking issues in the OS X package.

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -825,7 +825,7 @@ endif ()
 add_dependencies( MantidPlot mantidqtpython CompilePyUI )
 
 if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidPlot PROPERTIES INSTALL_RPATH "@executable_path/")
+  set_target_properties(MantidPlot PROPERTIES INSTALL_RPATH "@executable_path;@executable_path/../Libraries")
 endif ()
 
 ###########################################################################

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -324,7 +324,7 @@ search_patterns.each do |pattern|
       if( "@MAKE_VATES@" == "ON" )
         if dependency.include? "@loader_path"
           if dependency.include? "libvtk"
-            p "ParaView libraries found Contents/Libraries. Is the vatesfiles list is complete?
+            p "ParaView libraries found Contents/Libraries. Is the vatesfiles list is complete?"
             exit 1
           end
         end

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -322,9 +322,11 @@ search_patterns.each do |pattern|
         #exit 1
       end
       if( "@MAKE_VATES@" == "ON" )
-        if dependency.include? "@loader_path" && dependency.include? "libvtk"
-          p "ParaView libraries found Contents/Libraries. Is the vatesfiles list is complete?
-          exit 1
+        if dependency.include? "@loader_path"
+          if dependency.include? "libvtk"
+            p "ParaView libraries found Contents/Libraries. Is the vatesfiles list is complete?
+            exit 1
+          end
         end
         if dependency.include? "#{ParaView_dir}"
           p "issue with library: #{library} linking against: #{dependency}"

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -185,7 +185,7 @@ if Dir.exist?("Contents/PlugIns")
   end
 else
   p "Contents/PlugIns not created by macdeployqt."
-  #exit 1
+  exit 1
 end
 
 # We only need one copy of openssl

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -49,7 +49,7 @@ library_filenames = ["libboost_regex-mt.dylib",
                      "libTKernel.dylib",
                      "libTKBO.dylib",
                      "libTKernel.dylib",
-                     "libTKBO.dylib",
+                     "libTKShHealing.dylib",
                      "libTKPrim.dylib",
                      "libTKMesh.dylib",
                      "libTKBRep.dylib",
@@ -321,6 +321,12 @@ search_patterns.each do |pattern|
         p "issue with library: #{library} linked against: #{dependency}"
         exit 1
       end
+      if dependency.include? "@loader_path/libTK"
+        p "issue with library: #{library} linked against: #{dependency}"
+        p "Is an OpenCascade library missing?"
+        exit 1
+      end
+
       if( "@MAKE_VATES@" == "ON" )
         if dependency.include? "@loader_path"
           if dependency.include? "libvtk"

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -66,12 +66,16 @@ library_filenames = ["libboost_regex-mt.dylib",
                      "libhdf5.dylib",
                      "libhdf5_hl.dylib",
                      "libhdf5_cpp.dylib",
+                     "libhdf5_hl_cpp.dylib",
                      "libmfhdf.dylib",
                      "libdf.dylib",
                      "libsz.dylib",
                      "libjpeg.dylib",
                      "libssl.dylib",
-                     "libcrypto.dylib"]
+                     "libcrypto.dylib",
+                     "libtbb.dylib",
+                     "libtbbmalloc.dylib",
+                     "libtbbmalloc_proxy.dylib"]
 
 poco_version = "@POCO_VERSION@".split(".").map(&:to_i)
 if(poco_version[0] > 1 || (poco_version[0] == 1 && poco_version[1] >= 6))
@@ -110,7 +114,7 @@ if( "@MAKE_VATES@" == "ON" )
   end
 
   `mkdir Contents/Libraries`
-  vatesfiles = ["Contents/MacOS/VatesSimpleGui","Contents/MacOS/libMantidParaViewQtWidgets.dylib","Contents/MacOS/libMantidVatesAPI.dylib","pvplugins/libMantidVatesSimpleGuiViewWidgets.dylib"]+Dir["pvplugins/pvplugins/*.dylib"] 
+  vatesfiles = ["Contents/MacOS/MantidPlot","Contents/MacOS/libMantidQtAPI.dylib","Contents/MacOS/VatesSimpleGui","Contents/MacOS/libMantidParaViewQtWidgets.dylib","Contents/MacOS/libMantidVatesAPI.dylib","pvplugins/libMantidVatesSimpleGuiViewWidgets.dylib"]+Dir["pvplugins/pvplugins/*.dylib"] 
   vatesfiles.each do |file|
     add_ParaView_Libraries(file)
   end
@@ -181,9 +185,14 @@ if Dir.exist?("Contents/PlugIns")
   end
 else
   p "Contents/PlugIns not created by macdeployqt."
-  exit 1
+  #exit 1
 end
 
+# We only need one copy of openssl
+`install_name_tool -change @loader_path/../../../libssl.1.0.0.dylib @loader_path/../../../../MacOS/libssl.dylib Contents/Frameworks/QtNetwork.framework/Versions/4/QtNetwork`
+`install_name_tool -change @loader_path/../../../libcrypto.1.0.0.dylib @loader_path/../../../../MacOS/libcrypto.dylib Contents/Frameworks/QtNetwork.framework/Versions/4/QtNetwork`
+`rm Contents/Frameworks/libssl.1.0.0.dylib`
+`rm Contents/Frameworks/libcrypto.1.0.0.dylib`
 
 #change id of all libraries that match patterns
 def change_id(patterns, lib_path)
@@ -310,9 +319,13 @@ search_patterns.each do |pattern|
     dependencies.split("\n").each do |dependency|
       if dependency.include? "/usr/local/"
         p "issue with library: #{library} linked against: #{dependency}"
-        exit 1
+        #exit 1
       end
       if( "@MAKE_VATES@" == "ON" )
+        if dependency.include? "@loader_path" && dependency.include? "libvtk"
+          p "ParaView libraries found Contents/Libraries. Is the vatesfiles list is complete?
+          exit 1
+        end
         if dependency.include? "#{ParaView_dir}"
           p "issue with library: #{library} linking against: #{dependency}"
           exit 1

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -319,7 +319,7 @@ search_patterns.each do |pattern|
     dependencies.split("\n").each do |dependency|
       if dependency.include? "/usr/local/"
         p "issue with library: #{library} linked against: #{dependency}"
-        #exit 1
+        exit 1
       end
       if( "@MAKE_VATES@" == "ON" )
         if dependency.include? "@loader_path"

--- a/MantidQt/API/CMakeLists.txt
+++ b/MantidQt/API/CMakeLists.txt
@@ -152,7 +152,7 @@ add_library ( MantidQtAPI ${ALL_SRC} ${INC_FILES} ${UI_HDRS} )
 set_target_properties ( MantidQtAPI PROPERTIES COMPILE_DEFINITIONS IN_MANTIDQT_API )
 
 if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties ( MantidQtAPI PROPERTIES INSTALL_RPATH "@loader_path/../MacOS")
+  set_target_properties ( MantidQtAPI PROPERTIES INSTALL_RPATH "@loader_path/../MacOS;@loader_path/../Libraries")
 endif ()
 
 target_link_libraries ( MantidQtAPI LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}


### PR DESCRIPTION
Description of work.

This adds the `libhdf5_hl_cpp.dylib` library to the OS X packaging script. Apparently it is now required and the lack of it is causing the system tests to fail. (`macdeployqt` did copy it into `Contents/Frameworks`, but that apparently isn't sufficient.)

I also noticed that `macdeployqt` copied a lot of ParaView libraries into `Contents/Frameworks`. The `vatesfiles` list has been updated to include dependencies added in PR #16511. 

I'm also including the changes from PR #17133.

**To test:**

Review changes. Download artifact from the OS X buildserver and verify that MantidPlot opens. Look inside the app bundle and verify that there are only Qt dependencies in `Contents/Frameworks`.

<!-- Instructions for testing. -->

There is no issue associated with this PR.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
