### PR TITLE
IMAT Reconstructed images will now be in separate folder

### DIFF
--- a/scripts/Imaging/IMAT/tomorec/reconstruction_command.py
+++ b/scripts/Imaging/IMAT/tomorec/reconstruction_command.py
@@ -874,8 +874,9 @@ class ReconstructionCommand(object):
         # slices along the vertical (z) axis
         # output_dir = 'output_recon_tomopy'
         output_dir = cfg.postproc_cfg.output_dir
-        print "* Saving slices of the reconstructed volume in: {0}".format(output_dir)
-        tomoio.save_recon_as_vertical_slices(recon_data, output_dir,
+        out_recon_dir = os.path.join(output_dir, 'reconstructed')
+        print "* Saving slices of the reconstructed volume in: {0}".format(out_recon_dir)
+        tomoio.save_recon_as_vertical_slices(recon_data, out_recon_dir,
                                              name_prefix=self._OUT_SLICES_FILENAME_PREFIX,
                                              img_format=cfg.preproc_cfg.out_img_format)
 


### PR DESCRIPTION
## Description of work.

Reconstructed images will now be in `/processed/reconstructed/`, while the main `tomo_recon_vol.nc` file will still be in the main directory.
## To test:

Run a reconstruction job using the changes from the script in the PR

<!-- Instructions for testing. -->

Fixes #17208 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state

-->

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
