### PR TITLE
Indirect Absorption - plot to interface

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectAnnulusAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectAnnulusAbsorption.py
@@ -20,7 +20,6 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
     _can_scale = 0.
     _sample_chemical_formula = ''
     _acc_ws = None
-    _plot = False
     _sample_number_density = 0.
     _sample_inner_radius = 0.
 
@@ -75,8 +74,6 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
         self.declareProperty(name='Events', defaultValue=5000,
                              validator=IntBoundedValidator(0),
                              doc='Number of neutron events')
-        self.declareProperty(name='Plot', defaultValue=False,
-                             doc='Plot options')
 
         # Output options
         self.declareProperty(MatrixWorkspaceProperty('OutputWorkspace', '', direction=Direction.Output),
@@ -119,8 +116,6 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
                               NumberOfWavelengthPoints=10,
                               EventsPerPoint=self._events)
 
-        plot_data = [self._output_ws, self._sample_ws_name]
-        plot_corr = [self._ass_ws]
         group = self._ass_ws
 
         if self._can_ws_name is not None:
@@ -171,7 +166,6 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
 
                 Divide(LHSWorkspace=can1_wave_ws, RHSWorkspace=self._acc_ws, OutputWorkspace=can1_wave_ws)
                 Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can1_wave_ws, OutputWorkspace=sample_wave_ws)
-                plot_corr.append(self._acc_ws)
                 group += ',' + self._acc_ws
 
             else:
@@ -181,7 +175,6 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
 
             DeleteWorkspace(can1_wave_ws)
             DeleteWorkspace(can2_wave_ws)
-            plot_data.append(self._can_ws_name)
 
         else:
             Divide(LHSWorkspace=sample_wave_ws,
@@ -229,14 +222,6 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
             GroupWorkspaces(InputWorkspaces=group, OutputWorkspace=self._abs_ws)
             self.setProperty('CorrectionsWorkspace', self._abs_ws)
 
-        if self._plot:
-            from IndirectImport import import_mantidplot
-            mantid_plot = import_mantidplot()
-            mantid_plot.plotSpectrum(plot_data, 0)
-            if self._abs_ws != '':
-                mantid_plot.plotSpectrum(plot_corr, 0)
-
-
     def _setup(self):
         """
         Get algorithm properties.
@@ -259,7 +244,6 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
         self._can_scale = self.getProperty('CanScaleFactor').value
 
         self._events = self.getProperty('Events').value
-        self._plot = self.getProperty('Plot').value
         self._output_ws = self.getPropertyValue('OutputWorkspace')
 
         self._abs_ws = self.getPropertyValue('CorrectionsWorkspace')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
@@ -17,7 +17,6 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
     _can_radius = None
     _can_scale = None
     _events = None
-    _plot = None
     _output_ws = None
     _abs_ws = None
     _ass_ws = None
@@ -67,8 +66,6 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
         self.declareProperty(name='Events', defaultValue=5000,
                              validator=IntBoundedValidator(0),
                              doc='Number of neutron events')
-        self.declareProperty(name='Plot', defaultValue=False,
-                             doc='Plot options')
 
         # Output options
         self.declareProperty(MatrixWorkspaceProperty('OutputWorkspace', '', direction=Direction.Output),
@@ -108,8 +105,6 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
                            NumberOfSlices=1,
                            NumberOfAnnuli=10)
 
-        plot_data = [self._output_ws, self._sample_ws_name]
-        plot_corr = [self._ass_ws]
         group = self._ass_ws
 
         if self._can_ws_name is not None:
@@ -142,7 +137,6 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
 
                 Divide(LHSWorkspace=can_wave_ws, RHSWorkspace=self._acc_ws, OutputWorkspace=can_wave_ws)
                 Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can_wave_ws, OutputWorkspace=sample_wave_ws)
-                plot_corr.append(self._acc_ws)
                 group += ',' + self._acc_ws
 
             else:
@@ -152,7 +146,6 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
                 Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
 
             DeleteWorkspace(can_wave_ws)
-            plot_data.append(self._can_ws_name)
 
         else:
             Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
@@ -193,14 +186,6 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
             GroupWorkspaces(InputWorkspaces=group, OutputWorkspace=self._abs_ws)
             self.setProperty('CorrectionsWorkspace', self._abs_ws)
 
-        if self._plot:
-            from IndirectImport import import_mantidplot
-            mantid_plot = import_mantidplot()
-            mantid_plot.plotSpectrum(plot_data, 0)
-            if self._abs_ws != '':
-                mantid_plot.plotSpectrum(plot_corr, 0)
-
-
     def _setup(self):
         """
         Get algorithm properties.
@@ -222,7 +207,6 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
         self._can_scale = self.getProperty('CanScaleFactor').value
 
         self._events = self.getPropertyValue('Events')
-        self._plot = self.getProperty('Plot').value
 
         self._output_ws = self.getPropertyValue('OutputWorkspace')
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectFlatPlateAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectFlatPlateAbsorption.py
@@ -20,7 +20,6 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
     _can_back_thickness = None
     _can_scale = None
     _element_size = None
-    _plot = None
     _output_ws = None
     _abs_ws = None
     _ass_ws = None
@@ -80,8 +79,6 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
         self.declareProperty(name='ElementSize', defaultValue=0.1,
                              validator=FloatBoundedValidator(0.0),
                              doc='Element size in mm')
-        self.declareProperty(name='Plot', defaultValue=False,
-                             doc='Plot options')
 
         # Output
         self.declareProperty(MatrixWorkspaceProperty('OutputWorkspace', '', direction=Direction.Output),
@@ -122,8 +119,6 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
                             EFixed=efixed,
                             NumberOfWavelengthPoints=10)
 
-        plot_data = [self._output_ws, self._sample_ws]
-        plot_corr = [self._ass_ws]
         group = self._ass_ws
 
         if self._can_ws_name is not None:
@@ -151,7 +146,6 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
 
                 Divide(LHSWorkspace=can_wave_ws, RHSWorkspace=self._acc_ws, OutputWorkspace=can_wave_ws)
                 Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can_wave_ws, OutputWorkspace=sample_wave_ws)
-                plot_corr.append(self._acc_ws)
                 group += ',' + self._acc_ws
 
             else:
@@ -160,7 +154,6 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
                 Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
 
             DeleteWorkspace(can_wave_ws)
-            plot_data.append(self._can_ws_name)
 
         else:
             Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
@@ -203,14 +196,6 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
             GroupWorkspaces(InputWorkspaces=group, OutputWorkspace=self._abs_ws)
             self.setProperty('CorrectionsWorkspace', self._abs_ws)
 
-        if self._plot:
-            from IndirectImport import import_mantidplot
-            mantid_plot = import_mantidplot()
-            mantid_plot.plotSpectrum(plot_data, 0)
-            if self._abs_ws != '':
-                mantid_plot.plotSpectrum(plot_corr, 0)
-
-
     def _setup(self):
         """
         Get algorithm properties.
@@ -234,7 +219,6 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
         self._can_scale = self.getProperty('CanScaleFactor').value
 
         self._element_size = self.getProperty('ElementSize').value
-        self._plot = self.getProperty('Plot').value
         self._output_ws = self.getPropertyValue('OutputWorkspace')
 
         self._abs_ws = self.getPropertyValue('CorrectionsWorkspace')

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.h
@@ -29,6 +29,8 @@ private:
                                   QString shape);
 
   Ui::AbsorptionCorrections m_uiForm;
+  /// alg
+  Mantid::API::IAlgorithm_sptr m_absCorAlgo;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -1,387 +1,371 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-  <class>ContainerSubtraction</class>
-  <widget class="QWidget" name="ContainerSubtraction">
-    <property name="geometry">
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>420</width>
-        <height>420</height>
-      </rect>
-    </property>
-    <property name="windowTitle">
-      <string>Form</string>
-    </property>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-        <widget class="QGroupBox" name="fileInput">
-          <property name="title">
-            <string>Input</string>
+ <class>ContainerSubtraction</class>
+ <widget class="QWidget" name="ContainerSubtraction">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>420</width>
+    <height>420</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="fileInput">
+     <property name="title">
+      <string>Input</string>
+     </property>
+     <layout class="QGridLayout" name="gbTest">
+      <item row="0" column="0">
+       <widget class="QLabel" name="sampleLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Sample</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="containerLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Container</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="autoLoad" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="workspaceSuffixes" stdset="0">
+         <stringlist>
+          <string>_red</string>
+          <string>_sqw</string>
+         </stringlist>
+        </property>
+        <property name="fileBrowserSuffixes" stdset="0">
+         <stringlist>
+          <string>_red.nxs</string>
+          <string>_sqw.nxs</string>
+         </stringlist>
+        </property>
+        <property name="showLoad" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="autoLoad" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="workspaceSuffixes" stdset="0">
+         <stringlist>
+          <string>_red</string>
+          <string>_sqw</string>
+         </stringlist>
+        </property>
+        <property name="fileBrowserSuffixes" stdset="0">
+         <stringlist>
+          <string>_red.nxs</string>
+          <string>_sqw.nxs</string>
+         </stringlist>
+        </property>
+        <property name="showLoad" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbOptions">
+     <property name="title">
+      <string>Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="ckScaleCan">
+        <property name="text">
+         <string>Scale Container by factor:</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="loScaleFactor">
+        <item>
+         <widget class="QDoubleSpinBox" name="spCanScale">
+          <property name="enabled">
+           <bool>false</bool>
           </property>
-          <layout class="QGridLayout" name="gbTest">
-            <item row="0" column="0">
-              <widget class="QLabel" name="sampleLabel">
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="text">
-                  <string>Sample</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="0">
-              <widget class="QLabel" name="containerLabel">
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="text">
-                  <string>Container</string>
-                </property>
-              </widget> 
-            </item>
-            <item row="0" column="1">
-                <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
-                  <property name="sizePolicy">
-                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                    </sizepolicy>
-                  </property>
-                  <property name="autoLoad" stdset="0">
-                    <bool>true</bool>
-                  </property>
-                  <property name="workspaceSuffixes" stdset="0">
-                    <stringlist>
-                      <string>_red</string>
-                      <string>_sqw</string>
-                    </stringlist>
-                  </property>
-                  <property name="fileBrowserSuffixes" stdset="0">
-                    <stringlist>
-                      <string>_red.nxs</string>
-                      <string>_sqw.nxs</string>
-                    </stringlist>
-                  </property>
-                  <property name="showLoad" stdset="0">
-                    <bool>false</bool>
-                  </property>
-                </widget>
-            </item>
-            <item row="1" column="1">
-                <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
-                  <property name="sizePolicy">
-                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                    </sizepolicy>
-                  </property>
-                  <property name="autoLoad" stdset="0">
-                    <bool>true</bool>
-                  </property>
-                  <property name="workspaceSuffixes" stdset="0">
-                    <stringlist>
-                      <string>_red</string>
-                      <string>_sqw</string>
-                    </stringlist>
-                  </property>
-                  <property name="fileBrowserSuffixes" stdset="0">
-                    <stringlist>
-                      <string>_red.nxs</string>
-                      <string>_sqw.nxs</string>
-                    </stringlist>
-                  </property>
-                  <property name="showLoad" stdset="0">
-                    <bool>false</bool>
-                  </property>
-                </widget>
-            </item>
-          </layout>
-        </widget>
+          <property name="decimals">
+           <number>5</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>999.990000000000009</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="ckShiftCan">
+        <property name="text">
+         <string>Shift x-values of container by adding:</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="loShift">
+        <item>
+         <widget class="QDoubleSpinBox" name="spShift">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
+          <property name="minimum">
+           <double>-999.990000000000009</double>
+          </property>
+          <property name="maximum">
+           <double>999.990000000000009</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbPreview">
+     <property name="title">
+      <string>Preview</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_11">
+      <item>
+       <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
+        <property name="canvasColour" stdset="0">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="showLegend" stdset="0">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
       <item>
-        <widget class="QGroupBox" name="gbOptions">
-          <property name="title">
-            <string>Options</string>
+       <layout class="QVBoxLayout" name="loPlotOptions">
+        <item>
+         <spacer name="verticalSpacer_0">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
           </property>
-          <layout class="QGridLayout" name="gridLayout">
-            <item row="0" column="0">
-              <widget class="QCheckBox" name="ckScaleCan">
-                <property name="text">
-                  <string>Scale Container by factor:</string>
-                </property>
-                <property name="checked">
-                  <bool>false</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="1">
-              <layout class="QHBoxLayout" name="loScaleFactor">
-                <item>
-                  <widget class="QDoubleSpinBox" name="spCanScale">
-                    <property name="enabled">
-                      <bool>false</bool>
-                    </property>
-                    <property name="decimals">
-                      <number>5</number>
-                    </property>
-                    <property name="maximum">
-                      <double>999.990000000000009</double>
-                    </property>
-                    <property name="minimum">
-                      <double>-0.000000000000000</double>
-                    </property>
-                    <property name="singleStep">
-                      <double>0.100000000000000</double>
-                    </property>
-                    <property name="value">
-                      <double>1.000000000000000</double>
-                    </property>
-                  </widget>
-                </item>
-              </layout>
-            </item>
-            <item row="1" column="0">
-              <widget class="QCheckBox" name="ckShiftCan">
-                <property name="text">
-                  <string>Shift x-values of container by adding:</string>
-                </property>
-                <property name="checked">
-                  <bool>false</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="1">
-              <layout class="QHBoxLayout" name="loShift">
-                <item>
-                  <widget class="QDoubleSpinBox" name="spShift">
-                    <property name="enabled">
-                      <bool>false</bool>
-                    </property>
-                    <property name="decimals">
-                      <number>5</number>
-                    </property>
-                    <property name="maximum">
-                      <double>999.990000000000009</double>
-                    </property>
-                    <property name="minimum">
-                      <double>-999.990000000000009</double>
-                    </property>
-                    <property name="singleStep">
-                      <double>0.010000000000000</double>
-                    </property>
-                    <property name="value">
-                      <double>0.000000000000000</double>
-                    </property>
-                  </widget>
-                </item>
-              </layout>
-            </item>
-          </layout>
-        </widget>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="lbPreviewSpec">
+          <property name="text">
+           <string>Spectrum:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spPreviewSpec"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbOutput">
+     <property name="title">
+      <string>Output Options</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="lbPlotOutput">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Plot Output:</string>
+        </property>
+       </widget>
       </item>
       <item>
-        <widget class="QGroupBox" name="gbPreview">
-          <property name="title">
-            <string>Preview</string>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_11">
-            <item>
-              <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
-                <property name="canvasColour" stdset="0">
-                  <color>
-                    <red>255</red>
-                    <green>255</green>
-                    <blue>255</blue>
-                  </color>
-                </property>
-                <property name="showLegend" stdset="0">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <layout class="QVBoxLayout" name="loPlotOptions">
-                <item>
-                  <spacer name="verticalSpacer_0">
-                    <property name="orientation">
-                      <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                      <size>
-                        <width>20</width>
-                        <height>40</height>
-                      </size>
-                    </property>
-                  </spacer>
-                </item>
-                <item>
-                  <widget class="QLabel" name="lbPreviewSpec">
-                    <property name="text">
-                      <string>Spectrum:</string>
-                    </property>
-                  </widget>
-                </item>
-                <item>
-                  <widget class="QSpinBox" name="spPreviewSpec"/>
-                </item>
-              </layout>
-            </item>
-          </layout>
-        </widget>
+       <widget class="QComboBox" name="cbPlotOutput">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Contour</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Spectra</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Both</string>
+         </property>
+        </item>
+       </widget>
       </item>
       <item>
-        <widget class="QGroupBox" name="gbOutput">
-          <property name="title">
-            <string>Output Options</string>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-              <widget class="QLabel" name="lbPlotOutput">
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="text">
-                  <string>Plot Output:</string>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <widget class="QComboBox" name="cbPlotOutput">
-                <item>
-                  <property name="text">
-                    <string>None</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Contour</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Spectra</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Both</string>
-                  </property>
-                </item>
-              </widget>
-            </item>
-            <item>
-              <spacer name="horizontalSpacer_1">
-                <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                  <size>
-                    <width>40</width>
-                    <height>20</height>
-                  </size>
-                </property>
-              </spacer>
-            </item>
-            <item>
-              <widget class="QCheckBox" name="ckSave">
-                <property name="text">
-                  <string>Save Result</string>
-                </property>
-              </widget>
-            </item>
-          </layout>
-        </widget>
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Plot</string>
+        </property>
+       </widget>
       </item>
-    </layout>
-  </widget>
-  <customwidgets>
-    <customwidget>
-      <class>MantidQt::MantidWidgets::DataSelector</class>
-      <extends>QWidget</extends>
-      <header>MantidQtMantidWidgets/DataSelector.h</header>
-    </customwidget>
-    <customwidget>
-      <class>MantidQt::MantidWidgets::PreviewPlot</class>
-      <extends>QWidget</extends>
-      <header>MantidQtMantidWidgets/PreviewPlot.h</header>
-      <container>1</container>
-    </customwidget>
-  </customwidgets>
-  <resources/>
-  <connections>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>ckScaleCan</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>50</x>
-          <y>111</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>61</x>
-          <y>142</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckScaleCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>spCanScale</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>133</x>
-          <y>143</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>251</x>
-          <y>147</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>dsContainer</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>119</x>
-          <y>114</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>324</x>
-          <y>114</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckShiftCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>spShift</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>119</x>
-          <y>167</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>324</x>
-          <y>167</y>
-        </hint>
-      </hints>
-    </connection>
-  </connections>
+      <item>
+       <spacer name="horizontalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Save Result</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtMantidWidgets/DataSelector.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::PreviewPlot</class>
+   <extends>QWidget</extends>
+   <header>MantidQtMantidWidgets/PreviewPlot.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>ckScaleCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spCanScale</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>133</x>
+     <y>143</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>251</x>
+     <y>147</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ckShiftCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spShift</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>119</x>
+     <y>167</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>324</x>
+     <y>167</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -1,371 +1,387 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ContainerSubtraction</class>
- <widget class="QWidget" name="ContainerSubtraction">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>420</width>
-    <height>420</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
-    <widget class="QGroupBox" name="fileInput">
-     <property name="title">
-      <string>Input</string>
-     </property>
-     <layout class="QGridLayout" name="gbTest">
-      <item row="0" column="0">
-       <widget class="QLabel" name="sampleLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Sample</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="containerLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Container</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="autoLoad" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="workspaceSuffixes" stdset="0">
-         <stringlist>
-          <string>_red</string>
-          <string>_sqw</string>
-         </stringlist>
-        </property>
-        <property name="fileBrowserSuffixes" stdset="0">
-         <stringlist>
-          <string>_red.nxs</string>
-          <string>_sqw.nxs</string>
-         </stringlist>
-        </property>
-        <property name="showLoad" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="autoLoad" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="workspaceSuffixes" stdset="0">
-         <stringlist>
-          <string>_red</string>
-          <string>_sqw</string>
-         </stringlist>
-        </property>
-        <property name="fileBrowserSuffixes" stdset="0">
-         <stringlist>
-          <string>_red.nxs</string>
-          <string>_sqw.nxs</string>
-         </stringlist>
-        </property>
-        <property name="showLoad" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbOptions">
-     <property name="title">
-      <string>Options</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="ckScaleCan">
-        <property name="text">
-         <string>Scale Container by factor:</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <layout class="QHBoxLayout" name="loScaleFactor">
-        <item>
-         <widget class="QDoubleSpinBox" name="spCanScale">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="decimals">
-           <number>5</number>
-          </property>
-          <property name="minimum">
-           <double>0.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>999.990000000000009</double>
-          </property>
-          <property name="singleStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="ckShiftCan">
-        <property name="text">
-         <string>Shift x-values of container by adding:</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <layout class="QHBoxLayout" name="loShift">
-        <item>
-         <widget class="QDoubleSpinBox" name="spShift">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="decimals">
-           <number>5</number>
-          </property>
-          <property name="minimum">
-           <double>-999.990000000000009</double>
-          </property>
-          <property name="maximum">
-           <double>999.990000000000009</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbPreview">
-     <property name="title">
-      <string>Preview</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_11">
+  <class>ContainerSubtraction</class>
+  <widget class="QWidget" name="ContainerSubtraction">
+    <property name="geometry">
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>420</width>
+        <height>420</height>
+      </rect>
+    </property>
+    <property name="windowTitle">
+      <string>Form</string>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
-        <property name="canvasColour" stdset="0">
-         <color>
-          <red>255</red>
-          <green>255</green>
-          <blue>255</blue>
-         </color>
-        </property>
-        <property name="showLegend" stdset="0">
-         <bool>true</bool>
-        </property>
-       </widget>
+        <widget class="QGroupBox" name="fileInput">
+          <property name="title">
+            <string>Input</string>
+          </property>
+          <layout class="QGridLayout" name="gbTest">
+            <item row="0" column="0">
+              <widget class="QLabel" name="sampleLabel">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="text">
+                  <string>Sample</string>
+                </property>
+              </widget>
+            </item>
+            <item row="1" column="0">
+              <widget class="QLabel" name="containerLabel">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="text">
+                  <string>Container</string>
+                </property>
+              </widget> 
+            </item>
+            <item row="0" column="1">
+                <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
+                  <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="autoLoad" stdset="0">
+                    <bool>true</bool>
+                  </property>
+                  <property name="workspaceSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red</string>
+                      <string>_sqw</string>
+                    </stringlist>
+                  </property>
+                  <property name="fileBrowserSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red.nxs</string>
+                      <string>_sqw.nxs</string>
+                    </stringlist>
+                  </property>
+                  <property name="showLoad" stdset="0">
+                    <bool>false</bool>
+                  </property>
+                </widget>
+            </item>
+            <item row="1" column="1">
+                <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
+                  <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="autoLoad" stdset="0">
+                    <bool>true</bool>
+                  </property>
+                  <property name="workspaceSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red</string>
+                      <string>_sqw</string>
+                    </stringlist>
+                  </property>
+                  <property name="fileBrowserSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red.nxs</string>
+                      <string>_sqw.nxs</string>
+                    </stringlist>
+                  </property>
+                  <property name="showLoad" stdset="0">
+                    <bool>false</bool>
+                  </property>
+                </widget>
+            </item>
+          </layout>
+        </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="loPlotOptions">
-        <item>
-         <spacer name="verticalSpacer_0">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+        <widget class="QGroupBox" name="gbOptions">
+          <property name="title">
+            <string>Options</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
+          <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="0">
+              <widget class="QCheckBox" name="ckScaleCan">
+                <property name="text">
+                  <string>Scale Container by factor:</string>
+                </property>
+                <property name="checked">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="0" column="1">
+              <layout class="QHBoxLayout" name="loScaleFactor">
+                <item>
+                  <widget class="QDoubleSpinBox" name="spCanScale">
+                    <property name="enabled">
+                      <bool>false</bool>
+                    </property>
+                    <property name="decimals">
+                      <number>5</number>
+                    </property>
+                    <property name="maximum">
+                      <double>999.990000000000009</double>
+                    </property>
+                    <property name="minimum">
+                      <double>-0.000000000000000</double>
+                    </property>
+                    <property name="singleStep">
+                      <double>0.100000000000000</double>
+                    </property>
+                    <property name="value">
+                      <double>1.000000000000000</double>
+                    </property>
+                  </widget>
+                </item>
+              </layout>
+            </item>
+            <item row="1" column="0">
+              <widget class="QCheckBox" name="ckShiftCan">
+                <property name="text">
+                  <string>Shift x-values of container by adding:</string>
+                </property>
+                <property name="checked">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="1" column="1">
+              <layout class="QHBoxLayout" name="loShift">
+                <item>
+                  <widget class="QDoubleSpinBox" name="spShift">
+                    <property name="enabled">
+                      <bool>false</bool>
+                    </property>
+                    <property name="decimals">
+                      <number>5</number>
+                    </property>
+                    <property name="maximum">
+                      <double>999.990000000000009</double>
+                    </property>
+                    <property name="minimum">
+                      <double>-999.990000000000009</double>
+                    </property>
+                    <property name="singleStep">
+                      <double>0.010000000000000</double>
+                    </property>
+                    <property name="value">
+                      <double>0.000000000000000</double>
+                    </property>
+                  </widget>
+                </item>
+              </layout>
+            </item>
+          </layout>
+        </widget>
+      </item>
+      <item>
+        <widget class="QGroupBox" name="gbPreview">
+          <property name="title">
+            <string>Preview</string>
           </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="lbPreviewSpec">
-          <property name="text">
-           <string>Spectrum:</string>
+          <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <item>
+              <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
+                <property name="canvasColour" stdset="0">
+                  <color>
+                    <red>255</red>
+                    <green>255</green>
+                    <blue>255</blue>
+                  </color>
+                </property>
+                <property name="showLegend" stdset="0">
+                  <bool>true</bool>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <layout class="QVBoxLayout" name="loPlotOptions">
+                <item>
+                  <spacer name="verticalSpacer_0">
+                    <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                      <size>
+                        <width>20</width>
+                        <height>40</height>
+                      </size>
+                    </property>
+                  </spacer>
+                </item>
+                <item>
+                  <widget class="QLabel" name="lbPreviewSpec">
+                    <property name="text">
+                      <string>Spectrum:</string>
+                    </property>
+                  </widget>
+                </item>
+                <item>
+                  <widget class="QSpinBox" name="spPreviewSpec"/>
+                </item>
+              </layout>
+            </item>
+          </layout>
+        </widget>
+      </item>
+      <item>
+        <widget class="QGroupBox" name="gbOutput">
+          <property name="title">
+            <string>Output Options</string>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="spPreviewSpec"/>
-        </item>
-       </layout>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+              <widget class="QLabel" name="lbPlotOutput">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="text">
+                  <string>Plot Output:</string>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QComboBox" name="cbPlotOutput">
+                <item>
+                  <property name="text">
+                    <string>None</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Contour</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Spectra</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Both</string>
+                  </property>
+                </item>
+              </widget>
+            </item>
+            <item>
+              <spacer name="horizontalSpacer_1">
+                <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                  <size>
+                    <width>40</width>
+                    <height>20</height>
+                  </size>
+                </property>
+              </spacer>
+            </item>
+            <item>
+              <widget class="QCheckBox" name="ckSave">
+                <property name="text">
+                  <string>Save Result</string>
+                </property>
+              </widget>
+            </item>
+          </layout>
+        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbOutput">
-     <property name="title">
-      <string>Output Options</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="lbPlotOutput">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Plot Output:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="cbPlotOutput">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <item>
-         <property name="text">
-          <string>None</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Contour</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Spectra</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Both</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbPlot">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Plot</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_1">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbSave">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Save Result</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-  </layout>
- </widget>
- <customwidgets>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtMantidWidgets/DataSelector.h</header>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::PreviewPlot</class>
-   <extends>QWidget</extends>
-   <header>MantidQtMantidWidgets/PreviewPlot.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
- <resources/>
- <connections>
-  <connection>
-   <sender>ckScaleCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spCanScale</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>133</x>
-     <y>143</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>251</x>
-     <y>147</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckShiftCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spShift</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>119</x>
-     <y>167</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>324</x>
-     <y>167</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+    </layout>
+  </widget>
+  <customwidgets>
+    <customwidget>
+      <class>MantidQt::MantidWidgets::DataSelector</class>
+      <extends>QWidget</extends>
+      <header>MantidQtMantidWidgets/DataSelector.h</header>
+    </customwidget>
+    <customwidget>
+      <class>MantidQt::MantidWidgets::PreviewPlot</class>
+      <extends>QWidget</extends>
+      <header>MantidQtMantidWidgets/PreviewPlot.h</header>
+      <container>1</container>
+    </customwidget>
+  </customwidgets>
+  <resources/>
+  <connections>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>ckScaleCan</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>50</x>
+          <y>111</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>61</x>
+          <y>142</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckScaleCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spCanScale</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>133</x>
+          <y>143</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>251</x>
+          <y>147</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>dsContainer</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>119</x>
+          <y>114</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>324</x>
+          <y>114</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckShiftCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spShift</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>119</x>
+          <y>167</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>324</x>
+          <y>167</y>
+        </hint>
+      </hints>
+    </connection>
+  </connections>
 </ui>

--- a/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
@@ -37,7 +37,7 @@ void AbsorptionCorrections::run() {
   QString algorithmName = "Indirect" + sampleShape + "Absorption";
 
   IAlgorithm_sptr absCorAlgo =
-    AlgorithmManager::Instance().create(algorithmName.toStdString());
+      AlgorithmManager::Instance().create(algorithmName.toStdString());
   absCorAlgo->initialize();
 
   // Sample details
@@ -49,7 +49,7 @@ void AbsorptionCorrections::run() {
 
   QString sampleChemicalFormula = m_uiForm.leSampleChemicalFormula->text();
   absCorAlgo->setProperty("SampleChemicalFormula",
-    sampleChemicalFormula.toStdString());
+                          sampleChemicalFormula.toStdString());
 
   addShapeSpecificSampleOptions(absCorAlgo, sampleShape);
 
@@ -57,18 +57,18 @@ void AbsorptionCorrections::run() {
   bool useCan = m_uiForm.ckUseCan->isChecked();
   if (useCan) {
     std::string canWsName =
-      m_uiForm.dsCanInput->getCurrentDataName().toStdString();
+        m_uiForm.dsCanInput->getCurrentDataName().toStdString();
     std::string shiftedCanName = canWsName + "_shifted";
     IAlgorithm_sptr clone =
-      AlgorithmManager::Instance().create("CloneWorkspace");
+        AlgorithmManager::Instance().create("CloneWorkspace");
     clone->initialize();
     clone->setProperty("InputWorkspace", canWsName);
     clone->setProperty("OutputWorkspace", shiftedCanName);
     clone->execute();
 
     MatrixWorkspace_sptr shiftedCan =
-      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-        shiftedCanName);
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            shiftedCanName);
     if (m_uiForm.ckShiftCan->isChecked()) {
       IAlgorithm_sptr scaleX = AlgorithmManager::Instance().create("ScaleX");
       scaleX->initialize();
@@ -78,7 +78,7 @@ void AbsorptionCorrections::run() {
       scaleX->setProperty("Operation", "Add");
       scaleX->execute();
       IAlgorithm_sptr rebin =
-        AlgorithmManager::Instance().create("RebinToWorkspace");
+          AlgorithmManager::Instance().create("RebinToWorkspace");
       rebin->initialize();
       rebin->setProperty("WorkspaceToRebin", shiftedCan);
       rebin->setProperty("WorkspaceToMatch", sampleWsName.toStdString());
@@ -96,12 +96,11 @@ void AbsorptionCorrections::run() {
 
       QString canChemicalFormula = m_uiForm.leCanChemicalFormula->text();
       absCorAlgo->setProperty("CanChemicalFormula",
-        canChemicalFormula.toStdString());
+                              canChemicalFormula.toStdString());
     }
 
     addShapeSpecificCanOptions(absCorAlgo, sampleShape);
   }
-
 
   // Generate workspace names
   int nameCutIndex = sampleWsName.lastIndexOf("_");
@@ -118,7 +117,7 @@ void AbsorptionCorrections::run() {
   QString outputFactorsWsName = outputBaseName + "_" + sampleShape + "_Factors";
   if (keepCorrectionFactors)
     absCorAlgo->setProperty("CorrectionsWorkspace",
-      outputFactorsWsName.toStdString());
+                            outputFactorsWsName.toStdString());
 
   // Add correction algorithm to batch
   m_batchAlgoRunner->addAlgorithm(absCorAlgo);
@@ -136,7 +135,6 @@ void AbsorptionCorrections::run() {
 
   // Set the result workspace for Python script export
   m_pythonExportWsName = outputWsName.toStdString();
-
 }
 
 /**
@@ -303,24 +301,28 @@ void AbsorptionCorrections::algorithmComplete(bool error) {
                                          m_uiForm.spCanShift->value()));
     shiftLog->execute();
   }
-  //Plot output
+  // Plot output
 
   bool plot = m_uiForm.ckPlot->isChecked();
   if (plot) {
-    QStringList plotData = { QString::fromStdString(m_pythonExportWsName),  m_uiForm.dsSampleInput->getCurrentDataName() };
-    auto outputFactorsWsName = m_absCorAlgo->getPropertyValue("CorrectionsWorkspace");
+    QStringList plotData = {QString::fromStdString(m_pythonExportWsName),
+                            m_uiForm.dsSampleInput->getCurrentDataName()};
+    auto outputFactorsWsName =
+        m_absCorAlgo->getPropertyValue("CorrectionsWorkspace");
     if (m_uiForm.ckKeepFactors->isChecked()) {
-      QStringList plotCorr = { QString::fromStdString(outputFactorsWsName) + "_ass" };
+      QStringList plotCorr = {QString::fromStdString(outputFactorsWsName) +
+                              "_ass"};
       if (m_uiForm.ckUseCanCorrections->isChecked()) {
-        plotCorr.push_back(QString::fromStdString(outputFactorsWsName) + "_acc");
-        QString shiftedWs = QString::fromStdString(m_absCorAlgo->getPropertyValue("CanWorkspace"));
+        plotCorr.push_back(QString::fromStdString(outputFactorsWsName) +
+                           "_acc");
+        QString shiftedWs = QString::fromStdString(
+            m_absCorAlgo->getPropertyValue("CanWorkspace"));
         plotData.push_back(shiftedWs);
       }
       plotSpectrum(plotCorr, 0);
     }
     IndirectTab::plotSpectrum(plotData, 0);
   }
-
 }
 
 } // namespace CustomInterfaces

--- a/docs/source/release/v3.8.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.8.0/indirect_inelastic.rst
@@ -22,14 +22,22 @@ Stretch
 
 - Previously the Quest script was used to drive the Bayes stretch interface. This functionality has been ported to the algorithm :ref:`BayesStretch <algm-BayesStretch>`.
 
+Corrections
+###########
+
+Absorption
+~~~~~~~~~~
+
+- Mantid plotting is now handled in the interface rather than the respective algorithm
+
 
 Data Reduction
 ##############
 
 ISIS Calibration
 ~~~~~~~~~~~~~~~~
-- Add load log option to ISIS calibration interface
 
+- Add load log option to ISIS calibration interface
 
 Data Analysis
 #############


### PR DESCRIPTION
The mantid plotting for the Indirect Absorption tab has been refactored to the interface.

**To test:**

Indirect > Corrections > Absorption
File: irs26176_graphite002_red.nxs
Container: irs26173_graphite002_red.nxs
Ensure "plot result" is checked.

Fixes #17227.

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/6f8c2ce3425e3b5ff6eea3e3499d6acfe44b16db/docs/source/release/v3.8.0/indirect_inelastic.rst)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
