### PR TITLE
Vesuvio - Internal ties for mass profiles

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/VesuvioTOFFit.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioTOFFit.py
@@ -44,6 +44,9 @@ class VesuvioTOFFit(VesuvioBase):
                              doc="A semi-colon separated list of intensity constraints defined "
                                  "as lists e.g [0,1,0,-4];[1,0,-2,0]")
 
+        self.declareProperty("Ties", "",
+                             doc="A string representing the ties to be applied to the fit")
+
         self.declareProperty("FitMode", "bank", StringListValidator(list(_FIT_MODES)),
                              doc="Fit either bank-by-bank or detector-by-detector")
 
@@ -111,6 +114,9 @@ class VesuvioTOFFit(VesuvioBase):
             function_str = fit_options.create_function_str()
             constraints = fit_options.create_constraints_str()
             ties = fit_options.create_ties_str()
+            user_ties = self.getProperty('Ties').value
+            if user_ties != "":
+                ties = ties + ',' + user_ties
 
             _, params, fitted_data = self._do_fit(function_str, data_ws, workspace_index,
                                                   constraints, ties,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioTOFFitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioTOFFitTest.py
@@ -60,6 +60,25 @@ class VesuvioTOFFitTest(unittest.TestCase):
         self.assertTrue(self._equal_within_tolerance(expected_bin_index_spec2, bin_index_spec2))
 
 
+    def test_single_run_index0_kfixed_no_background_with_ties(self):
+        profiles = "function=GramCharlier,width=[2, 5, 7],hermite_coeffs=[1, 0, 0],k_free=0,sears_flag=1;"\
+                   "function=Gaussian,width=10;function=Gaussian,width=13;function=Gaussian,width=30;"
+        ties = "f2.Intensity=f3.Intensity"
+
+        alg = self._create_algorithm(InputWorkspace=self._test_ws, WorkspaceIndex=0,
+                                     Masses=[1.0079, 16, 27, 133],
+                                     MassProfiles=profiles,
+                                     Ties=ties,
+                                     IntensityConstraints="[0,1,0,-4]")
+        alg.execute()
+        fit_params = alg.getProperty("FitParameters").value
+        f2_intensity = fit_params.row(9)
+        f3_intesnity = fit_params.row(12)
+
+        # Ensure the value of the f2.Intensity and f3.Intensity fit parameters are tied
+        self.assertAlmostEqual(f2_intensity['Value'], f3_intensity['Value'])
+
+
     def test_single_run_produces_correct_output_workspace_index1_kfixed_no_background(self):
         profiles = "function=GramCharlier,width=[2, 5, 7],hermite_coeffs=[1, 0, 0],k_free=0,sears_flag=1;"\
                    "function=Gaussian,width=10;function=Gaussian,width=13;function=Gaussian,width=30;"

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioTOFFitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioTOFFitTest.py
@@ -73,7 +73,7 @@ class VesuvioTOFFitTest(unittest.TestCase):
         alg.execute()
         fit_params = alg.getProperty("FitParameters").value
         f2_intensity = fit_params.row(9)
-        f3_intesnity = fit_params.row(12)
+        f3_intensity = fit_params.row(12)
 
         # Ensure the value of the f2.Intensity and f3.Intensity fit parameters are tied
         self.assertAlmostEqual(f2_intensity['Value'], f3_intensity['Value'])

--- a/docs/source/release/v3.8.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.8.0/indirect_inelastic.rst
@@ -60,6 +60,14 @@ Load nMoldyn
 
 - New algorithm :ref:`LoadNMoldyn4Ascii1D <algm-LoadNMoldyn4Ascii1D>` has been added to allow 1D nmoldyn data to be loaded in Mantid
 
+VESUVIO
+#######
+
+- Add the functionality for ties between internal parameters within each mass profile. This allows for the creation of a BivariateGaussian profile from the MultivariateGaussian profile
+  Ties can be added within the defintion of the mass profile with the following:
+    flags['masses'] = [{'value':1.0079, 'function': 'MultivariateGaussian', 'SigmaX': 5, 'SigmaY': 5, 'SigmaZ': 5, 'ties': 'SigmaX=SigmaY'}]
+  The above will tie SigmaX to SigmaY for this MultivariateGaussian in the driver script
+
 
 Improvements
 ------------

--- a/scripts/Inelastic/vesuvio/commands.py
+++ b/scripts/Inelastic/vesuvio/commands.py
@@ -106,6 +106,7 @@ def fit_tof_iteration(sample_data, container_data, runs, flags):
         mass_values, profiles_strs = _create_profile_strs_and_mass_list(flags['masses'])
     background_str = _create_background_str(flags.get('background', None))
     intensity_constraints = _create_intensity_constraint_str(flags['intensity_constraints'])
+    ties = _create_user_defined_ties_str(flags['masses'])
 
     num_spec = sample_data.getNumberHistograms()
     pre_correct_pars_workspace = None
@@ -138,6 +139,7 @@ def fit_tof_iteration(sample_data, container_data, runs, flags):
                          MassProfiles=profiles,
                          Background=background_str,
                          IntensityConstraints=intensity_constraints,
+                         Ties=ties,
                          OutputWorkspace=corrections_fit_name,
                          FitParameters=pre_correction_pars_name,
                          MaxIterations=max_fit_iterations,
@@ -181,6 +183,7 @@ def fit_tof_iteration(sample_data, container_data, runs, flags):
                                       MassProfiles=profiles,
                                       Background=background_str,
                                       IntensityConstraints=intensity_constraints,
+                                      Ties=ties,
                                       OutputWorkspace=fit_ws_name,
                                       FitParameters=pars_name,
                                       MaxIterations=max_fit_iterations,
@@ -428,3 +431,23 @@ def _create_intensity_constraint_str(intensity_constraints):
         intensity_constraints_str = ""
 
     return intensity_constraints_str
+
+def _create_user_defined_ties_str(masses):
+    """
+    Creates the internal ties for each mass profile as defined by the user to be used when fitting the data
+    @param masses   :: The mass profiles for the data which contain the the ties
+    @return         :: A string to be passed as the Ties input to fitting
+    """
+    user_defined_ties = []
+    for index, mass in enumerate(masses):
+        if 'ties' in mass:
+           ties = mass['ties'].split(',')
+           function_dependant_ties= []
+           function_indentifier = 'f' + str(index) + '.'
+           for t in ties:
+               tie_str = function_indentifier + t
+               equal_pos = tie_str.index('=') + 1
+               tie_str = tie_str[:equal_pos] + function_indentifier + tie_str[equal_pos:]
+               user_defined_ties.append(tie_str)
+    user_defined_ties = ','.join(user_defined_ties)
+    return user_defined_ties


### PR DESCRIPTION
Ties for variables in VesuvioTOFFit have been implemented as well as accounting for this in the driver script and its parsing of input flags

**To test:**
- Tie two parameters together in any VESUVIO driver script using the syntax shown in the Release notes. 
- Run the script and ensure the parameters shown are tied as expected
- Ensure the updated system and unit test cases pass
- The following script can be used to test ties:

```
import vesuvio.commands
reload(vesuvio.commands)
from vesuvio.commands import fit_tof

# --------------------------------------------------------------------------------
# Standard flags to modify processing
# --------------------------------------------------------------------------------

# Specify the run(s) to process
runs = "15039"

# Holds flags to alter how processing occurs
flags = dict()

# Fitting mode
flags['fit_mode'] = 'spectra'

# Spectra selection
flags['spectra'] = '143'#-150'

# Binning options
flags['bin_parameters'] = None


# Masses profiles
mass1 = {'value': 1.0079, 'function': 'MultivariateGaussian', 'SigmaX':5, 'SigmaY':5, 'SigmaZ':5, 'ties':'SigmaX=SigmaY'}
mass2 = {'value': 12.011, 'function': 'Gaussian', 'width': 10}
mass3 = {'value': 15.9, 'function': 'Gaussian', 'width': 13}
flags['masses'] = [mass1, mass2, mass3]

# Intensity constraints
flags['intensity_constraints'] = None

# Background
flags['background'] = {'function': 'Polynomial', 'order': 2}

# --------------------------------------------------------------------------------
# Corrections flags
# --------------------------------------------------------------------------------

# Corrections
flags['container_runs'] = None

# Fixes the scale factor for the container
flags['fixed_container_scaling'] = None

# Outputs workspaces
flags['output_verbose_corrections'] = True

# Enable gamma correction
flags['gamma_correct'] = True

# Scale factor for gamma correction
flags['fixed_gamma_scaling'] = 0.0

# Holds flags specific to multiple scattering
flags['ms_flags'] = dict()

# Sample size in cm
flags['ms_flags']['SampleWidth'] = 10.0
flags['ms_flags']['SampleHeight'] = 10.0
flags['ms_flags']['SampleDepth'] = 0.5

# Sample density in g/cm^3
flags['ms_flags']['SampleDensity'] = 241

# --------------------------------------------------------------------------------
# Advanced flags
# --------------------------------------------------------------------------------

# Differencing mode
flags['diff_mode'] = 'single'

# Maximum number of iterations to use in fitting
flags['max_fit_iterations'] = 1000000

# Configuration of the minimizer to use in fitting
flags['fit_minimizer'] = 'Levenberg-Marquardt,AbsError=1e-08,RelError=1e-08'

# Number of iterations
flags['iterations'] = 1

# Convergence
flags['convergence'] = None

# --------------------------------------------------------------------------------
# Run fit
# --------------------------------------------------------------------------------
fit_tof(runs, flags, flags['iterations'], flags['convergence'])
```

Fixes #17196 

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/0550f3c9873269923b4183b730c444907b7db31d/docs/source/release/v3.8.0/indirect_inelastic.rst#vesuvio)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
