### PR TITLE
IndirectDataAnalysis - post plot and save

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -1,387 +1,371 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-  <class>ContainerSubtraction</class>
-  <widget class="QWidget" name="ContainerSubtraction">
-    <property name="geometry">
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>420</width>
-        <height>420</height>
-      </rect>
-    </property>
-    <property name="windowTitle">
-      <string>Form</string>
-    </property>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-        <widget class="QGroupBox" name="fileInput">
-          <property name="title">
-            <string>Input</string>
+ <class>ContainerSubtraction</class>
+ <widget class="QWidget" name="ContainerSubtraction">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>420</width>
+    <height>420</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="fileInput">
+     <property name="title">
+      <string>Input</string>
+     </property>
+     <layout class="QGridLayout" name="gbTest">
+      <item row="0" column="0">
+       <widget class="QLabel" name="sampleLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Sample</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="containerLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Container</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="autoLoad" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="workspaceSuffixes" stdset="0">
+         <stringlist>
+          <string>_red</string>
+          <string>_sqw</string>
+         </stringlist>
+        </property>
+        <property name="fileBrowserSuffixes" stdset="0">
+         <stringlist>
+          <string>_red.nxs</string>
+          <string>_sqw.nxs</string>
+         </stringlist>
+        </property>
+        <property name="showLoad" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="autoLoad" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="workspaceSuffixes" stdset="0">
+         <stringlist>
+          <string>_red</string>
+          <string>_sqw</string>
+         </stringlist>
+        </property>
+        <property name="fileBrowserSuffixes" stdset="0">
+         <stringlist>
+          <string>_red.nxs</string>
+          <string>_sqw.nxs</string>
+         </stringlist>
+        </property>
+        <property name="showLoad" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbOptions">
+     <property name="title">
+      <string>Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="ckScaleCan">
+        <property name="text">
+         <string>Scale Container by factor:</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="loScaleFactor">
+        <item>
+         <widget class="QDoubleSpinBox" name="spCanScale">
+          <property name="enabled">
+           <bool>false</bool>
           </property>
-          <layout class="QGridLayout" name="gbTest">
-            <item row="0" column="0">
-              <widget class="QLabel" name="sampleLabel">
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="text">
-                  <string>Sample</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="0">
-              <widget class="QLabel" name="containerLabel">
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="text">
-                  <string>Container</string>
-                </property>
-              </widget> 
-            </item>
-            <item row="0" column="1">
-                <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
-                  <property name="sizePolicy">
-                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                    </sizepolicy>
-                  </property>
-                  <property name="autoLoad" stdset="0">
-                    <bool>true</bool>
-                  </property>
-                  <property name="workspaceSuffixes" stdset="0">
-                    <stringlist>
-                      <string>_red</string>
-                      <string>_sqw</string>
-                    </stringlist>
-                  </property>
-                  <property name="fileBrowserSuffixes" stdset="0">
-                    <stringlist>
-                      <string>_red.nxs</string>
-                      <string>_sqw.nxs</string>
-                    </stringlist>
-                  </property>
-                  <property name="showLoad" stdset="0">
-                    <bool>false</bool>
-                  </property>
-                </widget>
-            </item>
-            <item row="1" column="1">
-                <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
-                  <property name="sizePolicy">
-                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                    </sizepolicy>
-                  </property>
-                  <property name="autoLoad" stdset="0">
-                    <bool>true</bool>
-                  </property>
-                  <property name="workspaceSuffixes" stdset="0">
-                    <stringlist>
-                      <string>_red</string>
-                      <string>_sqw</string>
-                    </stringlist>
-                  </property>
-                  <property name="fileBrowserSuffixes" stdset="0">
-                    <stringlist>
-                      <string>_red.nxs</string>
-                      <string>_sqw.nxs</string>
-                    </stringlist>
-                  </property>
-                  <property name="showLoad" stdset="0">
-                    <bool>false</bool>
-                  </property>
-                </widget>
-            </item>
-          </layout>
-        </widget>
+          <property name="decimals">
+           <number>5</number>
+          </property>
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>999.990000000000009</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="ckShiftCan">
+        <property name="text">
+         <string>Shift x-values of container by adding:</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <layout class="QHBoxLayout" name="loShift">
+        <item>
+         <widget class="QDoubleSpinBox" name="spShift">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
+          <property name="minimum">
+           <double>-999.990000000000009</double>
+          </property>
+          <property name="maximum">
+           <double>999.990000000000009</double>
+          </property>
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="value">
+           <double>0.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbPreview">
+     <property name="title">
+      <string>Preview</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_11">
+      <item>
+       <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
+        <property name="canvasColour" stdset="0">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="showLegend" stdset="0">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
       <item>
-        <widget class="QGroupBox" name="gbOptions">
-          <property name="title">
-            <string>Options</string>
+       <layout class="QVBoxLayout" name="loPlotOptions">
+        <item>
+         <spacer name="verticalSpacer_0">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
           </property>
-          <layout class="QGridLayout" name="gridLayout">
-            <item row="0" column="0">
-              <widget class="QCheckBox" name="ckScaleCan">
-                <property name="text">
-                  <string>Scale Container by factor:</string>
-                </property>
-                <property name="checked">
-                  <bool>false</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="1">
-              <layout class="QHBoxLayout" name="loScaleFactor">
-                <item>
-                  <widget class="QDoubleSpinBox" name="spCanScale">
-                    <property name="enabled">
-                      <bool>false</bool>
-                    </property>
-                    <property name="decimals">
-                      <number>5</number>
-                    </property>
-                    <property name="maximum">
-                      <double>999.990000000000009</double>
-                    </property>
-                    <property name="minimum">
-                      <double>-0.000000000000000</double>
-                    </property>
-                    <property name="singleStep">
-                      <double>0.100000000000000</double>
-                    </property>
-                    <property name="value">
-                      <double>1.000000000000000</double>
-                    </property>
-                  </widget>
-                </item>
-              </layout>
-            </item>
-            <item row="1" column="0">
-              <widget class="QCheckBox" name="ckShiftCan">
-                <property name="text">
-                  <string>Shift x-values of container by adding:</string>
-                </property>
-                <property name="checked">
-                  <bool>false</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="1">
-              <layout class="QHBoxLayout" name="loShift">
-                <item>
-                  <widget class="QDoubleSpinBox" name="spShift">
-                    <property name="enabled">
-                      <bool>false</bool>
-                    </property>
-                    <property name="decimals">
-                      <number>5</number>
-                    </property>
-                    <property name="maximum">
-                      <double>999.990000000000009</double>
-                    </property>
-                    <property name="minimum">
-                      <double>-999.990000000000009</double>
-                    </property>
-                    <property name="singleStep">
-                      <double>0.010000000000000</double>
-                    </property>
-                    <property name="value">
-                      <double>0.000000000000000</double>
-                    </property>
-                  </widget>
-                </item>
-              </layout>
-            </item>
-          </layout>
-        </widget>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="lbPreviewSpec">
+          <property name="text">
+           <string>Spectrum:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spPreviewSpec"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbOutput">
+     <property name="title">
+      <string>Output Options</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="lbPlotOutput">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Plot Output:</string>
+        </property>
+       </widget>
       </item>
       <item>
-        <widget class="QGroupBox" name="gbPreview">
-          <property name="title">
-            <string>Preview</string>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_11">
-            <item>
-              <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
-                <property name="canvasColour" stdset="0">
-                  <color>
-                    <red>255</red>
-                    <green>255</green>
-                    <blue>255</blue>
-                  </color>
-                </property>
-                <property name="showLegend" stdset="0">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <layout class="QVBoxLayout" name="loPlotOptions">
-                <item>
-                  <spacer name="verticalSpacer_0">
-                    <property name="orientation">
-                      <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                      <size>
-                        <width>20</width>
-                        <height>40</height>
-                      </size>
-                    </property>
-                  </spacer>
-                </item>
-                <item>
-                  <widget class="QLabel" name="lbPreviewSpec">
-                    <property name="text">
-                      <string>Spectrum:</string>
-                    </property>
-                  </widget>
-                </item>
-                <item>
-                  <widget class="QSpinBox" name="spPreviewSpec"/>
-                </item>
-              </layout>
-            </item>
-          </layout>
-        </widget>
+       <widget class="QComboBox" name="cbPlotOutput">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Contour</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Spectra</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Both</string>
+         </property>
+        </item>
+       </widget>
       </item>
       <item>
-        <widget class="QGroupBox" name="gbOutput">
-          <property name="title">
-            <string>Output Options</string>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-              <widget class="QLabel" name="lbPlotOutput">
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="text">
-                  <string>Plot Output:</string>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <widget class="QComboBox" name="cbPlotOutput">
-                <item>
-                  <property name="text">
-                    <string>None</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Contour</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Spectra</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Both</string>
-                  </property>
-                </item>
-              </widget>
-            </item>
-            <item>
-              <spacer name="horizontalSpacer_1">
-                <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                  <size>
-                    <width>40</width>
-                    <height>20</height>
-                  </size>
-                </property>
-              </spacer>
-            </item>
-            <item>
-              <widget class="QCheckBox" name="ckSave">
-                <property name="text">
-                  <string>Save Result</string>
-                </property>
-              </widget>
-            </item>
-          </layout>
-        </widget>
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Plot</string>
+        </property>
+       </widget>
       </item>
-    </layout>
-  </widget>
-  <customwidgets>
-    <customwidget>
-      <class>MantidQt::MantidWidgets::DataSelector</class>
-      <extends>QWidget</extends>
-      <header>MantidQtMantidWidgets/DataSelector.h</header>
-    </customwidget>
-    <customwidget>
-      <class>MantidQt::MantidWidgets::PreviewPlot</class>
-      <extends>QWidget</extends>
-      <header>MantidQtMantidWidgets/PreviewPlot.h</header>
-      <container>1</container>
-    </customwidget>
-  </customwidgets>
-  <resources/>
-  <connections>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>ckScaleCan</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>50</x>
-          <y>111</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>61</x>
-          <y>142</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckScaleCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>spCanScale</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>133</x>
-          <y>143</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>251</x>
-          <y>147</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckUseCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>dsContainer</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>119</x>
-          <y>114</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>324</x>
-          <y>114</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>ckShiftCan</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>spShift</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>119</x>
-          <y>167</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>324</x>
-          <y>167</y>
-        </hint>
-      </hints>
-    </connection>
-  </connections>
+      <item>
+       <spacer name="horizontalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Save Result</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtMantidWidgets/DataSelector.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::PreviewPlot</class>
+   <extends>QWidget</extends>
+   <header>MantidQtMantidWidgets/PreviewPlot.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>ckScaleCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spCanScale</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>133</x>
+     <y>143</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>251</x>
+     <y>147</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ckShiftCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spShift</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>119</x>
+     <y>167</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>324</x>
+     <y>167</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -1,371 +1,387 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ContainerSubtraction</class>
- <widget class="QWidget" name="ContainerSubtraction">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>420</width>
-    <height>420</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
-    <widget class="QGroupBox" name="fileInput">
-     <property name="title">
-      <string>Input</string>
-     </property>
-     <layout class="QGridLayout" name="gbTest">
-      <item row="0" column="0">
-       <widget class="QLabel" name="sampleLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Sample</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="containerLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Container</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="autoLoad" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="workspaceSuffixes" stdset="0">
-         <stringlist>
-          <string>_red</string>
-          <string>_sqw</string>
-         </stringlist>
-        </property>
-        <property name="fileBrowserSuffixes" stdset="0">
-         <stringlist>
-          <string>_red.nxs</string>
-          <string>_sqw.nxs</string>
-         </stringlist>
-        </property>
-        <property name="showLoad" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="autoLoad" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="workspaceSuffixes" stdset="0">
-         <stringlist>
-          <string>_red</string>
-          <string>_sqw</string>
-         </stringlist>
-        </property>
-        <property name="fileBrowserSuffixes" stdset="0">
-         <stringlist>
-          <string>_red.nxs</string>
-          <string>_sqw.nxs</string>
-         </stringlist>
-        </property>
-        <property name="showLoad" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbOptions">
-     <property name="title">
-      <string>Options</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="ckScaleCan">
-        <property name="text">
-         <string>Scale Container by factor:</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <layout class="QHBoxLayout" name="loScaleFactor">
-        <item>
-         <widget class="QDoubleSpinBox" name="spCanScale">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="decimals">
-           <number>5</number>
-          </property>
-          <property name="minimum">
-           <double>0.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>999.990000000000009</double>
-          </property>
-          <property name="singleStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="ckShiftCan">
-        <property name="text">
-         <string>Shift x-values of container by adding:</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <layout class="QHBoxLayout" name="loShift">
-        <item>
-         <widget class="QDoubleSpinBox" name="spShift">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="decimals">
-           <number>5</number>
-          </property>
-          <property name="minimum">
-           <double>-999.990000000000009</double>
-          </property>
-          <property name="maximum">
-           <double>999.990000000000009</double>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbPreview">
-     <property name="title">
-      <string>Preview</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_11">
+  <class>ContainerSubtraction</class>
+  <widget class="QWidget" name="ContainerSubtraction">
+    <property name="geometry">
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>420</width>
+        <height>420</height>
+      </rect>
+    </property>
+    <property name="windowTitle">
+      <string>Form</string>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
-        <property name="canvasColour" stdset="0">
-         <color>
-          <red>255</red>
-          <green>255</green>
-          <blue>255</blue>
-         </color>
-        </property>
-        <property name="showLegend" stdset="0">
-         <bool>true</bool>
-        </property>
-       </widget>
+        <widget class="QGroupBox" name="fileInput">
+          <property name="title">
+            <string>Input</string>
+          </property>
+          <layout class="QGridLayout" name="gbTest">
+            <item row="0" column="0">
+              <widget class="QLabel" name="sampleLabel">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="text">
+                  <string>Sample</string>
+                </property>
+              </widget>
+            </item>
+            <item row="1" column="0">
+              <widget class="QLabel" name="containerLabel">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="text">
+                  <string>Container</string>
+                </property>
+              </widget> 
+            </item>
+            <item row="0" column="1">
+                <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
+                  <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="autoLoad" stdset="0">
+                    <bool>true</bool>
+                  </property>
+                  <property name="workspaceSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red</string>
+                      <string>_sqw</string>
+                    </stringlist>
+                  </property>
+                  <property name="fileBrowserSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red.nxs</string>
+                      <string>_sqw.nxs</string>
+                    </stringlist>
+                  </property>
+                  <property name="showLoad" stdset="0">
+                    <bool>false</bool>
+                  </property>
+                </widget>
+            </item>
+            <item row="1" column="1">
+                <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
+                  <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="autoLoad" stdset="0">
+                    <bool>true</bool>
+                  </property>
+                  <property name="workspaceSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red</string>
+                      <string>_sqw</string>
+                    </stringlist>
+                  </property>
+                  <property name="fileBrowserSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red.nxs</string>
+                      <string>_sqw.nxs</string>
+                    </stringlist>
+                  </property>
+                  <property name="showLoad" stdset="0">
+                    <bool>false</bool>
+                  </property>
+                </widget>
+            </item>
+          </layout>
+        </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="loPlotOptions">
-        <item>
-         <spacer name="verticalSpacer_0">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+        <widget class="QGroupBox" name="gbOptions">
+          <property name="title">
+            <string>Options</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
+          <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="0">
+              <widget class="QCheckBox" name="ckScaleCan">
+                <property name="text">
+                  <string>Scale Container by factor:</string>
+                </property>
+                <property name="checked">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="0" column="1">
+              <layout class="QHBoxLayout" name="loScaleFactor">
+                <item>
+                  <widget class="QDoubleSpinBox" name="spCanScale">
+                    <property name="enabled">
+                      <bool>false</bool>
+                    </property>
+                    <property name="decimals">
+                      <number>5</number>
+                    </property>
+                    <property name="maximum">
+                      <double>999.990000000000009</double>
+                    </property>
+                    <property name="minimum">
+                      <double>-0.000000000000000</double>
+                    </property>
+                    <property name="singleStep">
+                      <double>0.100000000000000</double>
+                    </property>
+                    <property name="value">
+                      <double>1.000000000000000</double>
+                    </property>
+                  </widget>
+                </item>
+              </layout>
+            </item>
+            <item row="1" column="0">
+              <widget class="QCheckBox" name="ckShiftCan">
+                <property name="text">
+                  <string>Shift x-values of container by adding:</string>
+                </property>
+                <property name="checked">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="1" column="1">
+              <layout class="QHBoxLayout" name="loShift">
+                <item>
+                  <widget class="QDoubleSpinBox" name="spShift">
+                    <property name="enabled">
+                      <bool>false</bool>
+                    </property>
+                    <property name="decimals">
+                      <number>5</number>
+                    </property>
+                    <property name="maximum">
+                      <double>999.990000000000009</double>
+                    </property>
+                    <property name="minimum">
+                      <double>-999.990000000000009</double>
+                    </property>
+                    <property name="singleStep">
+                      <double>0.010000000000000</double>
+                    </property>
+                    <property name="value">
+                      <double>0.000000000000000</double>
+                    </property>
+                  </widget>
+                </item>
+              </layout>
+            </item>
+          </layout>
+        </widget>
+      </item>
+      <item>
+        <widget class="QGroupBox" name="gbPreview">
+          <property name="title">
+            <string>Preview</string>
           </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="lbPreviewSpec">
-          <property name="text">
-           <string>Spectrum:</string>
+          <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <item>
+              <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
+                <property name="canvasColour" stdset="0">
+                  <color>
+                    <red>255</red>
+                    <green>255</green>
+                    <blue>255</blue>
+                  </color>
+                </property>
+                <property name="showLegend" stdset="0">
+                  <bool>true</bool>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <layout class="QVBoxLayout" name="loPlotOptions">
+                <item>
+                  <spacer name="verticalSpacer_0">
+                    <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                      <size>
+                        <width>20</width>
+                        <height>40</height>
+                      </size>
+                    </property>
+                  </spacer>
+                </item>
+                <item>
+                  <widget class="QLabel" name="lbPreviewSpec">
+                    <property name="text">
+                      <string>Spectrum:</string>
+                    </property>
+                  </widget>
+                </item>
+                <item>
+                  <widget class="QSpinBox" name="spPreviewSpec"/>
+                </item>
+              </layout>
+            </item>
+          </layout>
+        </widget>
+      </item>
+      <item>
+        <widget class="QGroupBox" name="gbOutput">
+          <property name="title">
+            <string>Output Options</string>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="spPreviewSpec"/>
-        </item>
-       </layout>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+              <widget class="QLabel" name="lbPlotOutput">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="text">
+                  <string>Plot Output:</string>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QComboBox" name="cbPlotOutput">
+                <item>
+                  <property name="text">
+                    <string>None</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Contour</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Spectra</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Both</string>
+                  </property>
+                </item>
+              </widget>
+            </item>
+            <item>
+              <spacer name="horizontalSpacer_1">
+                <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                  <size>
+                    <width>40</width>
+                    <height>20</height>
+                  </size>
+                </property>
+              </spacer>
+            </item>
+            <item>
+              <widget class="QCheckBox" name="ckSave">
+                <property name="text">
+                  <string>Save Result</string>
+                </property>
+              </widget>
+            </item>
+          </layout>
+        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbOutput">
-     <property name="title">
-      <string>Output Options</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="lbPlotOutput">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Plot Output:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="cbPlotOutput">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <item>
-         <property name="text">
-          <string>None</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Contour</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Spectra</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Both</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbPlot">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Plot</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_1">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbSave">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Save Result</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-  </layout>
- </widget>
- <customwidgets>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtMantidWidgets/DataSelector.h</header>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::PreviewPlot</class>
-   <extends>QWidget</extends>
-   <header>MantidQtMantidWidgets/PreviewPlot.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
- <resources/>
- <connections>
-  <connection>
-   <sender>ckScaleCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spCanScale</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>133</x>
-     <y>143</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>251</x>
-     <y>147</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckShiftCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spShift</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>119</x>
-     <y>167</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>324</x>
-     <y>167</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+    </layout>
+  </widget>
+  <customwidgets>
+    <customwidget>
+      <class>MantidQt::MantidWidgets::DataSelector</class>
+      <extends>QWidget</extends>
+      <header>MantidQtMantidWidgets/DataSelector.h</header>
+    </customwidget>
+    <customwidget>
+      <class>MantidQt::MantidWidgets::PreviewPlot</class>
+      <extends>QWidget</extends>
+      <header>MantidQtMantidWidgets/PreviewPlot.h</header>
+      <container>1</container>
+    </customwidget>
+  </customwidgets>
+  <resources/>
+  <connections>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>ckScaleCan</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>50</x>
+          <y>111</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>61</x>
+          <y>142</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckScaleCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spCanScale</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>133</x>
+          <y>143</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>251</x>
+          <y>147</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>dsContainer</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>119</x>
+          <y>114</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>324</x>
+          <y>114</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckShiftCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spShift</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>119</x>
+          <y>167</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>324</x>
+          <y>167</y>
+        </hint>
+      </hints>
+    </connection>
+  </connections>
 </ui>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -39,7 +39,7 @@ private:
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;
-  //alg
+  // alg
   Mantid::API::IAlgorithm_sptr m_elwinAlg;
 };
 } // namespace IDA

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -39,6 +39,8 @@ private:
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;
+  //alg
+  Mantid::API::IAlgorithm_sptr m_elwinAlg;
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -181,7 +181,7 @@ void Elwin::run() {
       AlgorithmManager::Instance().create("ElasticWindowMultiple");
   elwinMultAlg->initialize();
 
-  elwinMultAlg->setProperty("Plot", m_uiForm.ckPlot->isChecked());
+  elwinMultAlg->setProperty("Plot", false);
 
   elwinMultAlg->setProperty("OutputInQ", qWorkspace);
   elwinMultAlg->setProperty("OutputInQSquared", qSquaredWorkspace);
@@ -233,6 +233,7 @@ void Elwin::run() {
 
   // Set the result workspace for Python script export
   m_pythonExportWsName = qSquaredWorkspace;
+  m_elwinAlg = elwinMultAlg;
 }
 
 /**
@@ -249,6 +250,27 @@ void Elwin::unGroupInput(bool error) {
     ungroupAlg->initialize();
     ungroupAlg->setProperty("InputWorkspace", "IDA_Elwin_Input");
     ungroupAlg->execute();
+  }
+  // Handle mantid plotting
+  if (m_uiForm.ckPlot->isChecked()) {
+
+    auto outputWs = m_elwinAlg->getPropertyValue("OutputInQ");
+    checkADSForPlotSaveWorkspace(outputWs, true);
+    plotSpectrum(QString::fromStdString(outputWs));
+
+    auto outputWsSquared = m_elwinAlg->getPropertyValue("OutputInQSquared");
+    checkADSForPlotSaveWorkspace(outputWsSquared, true);
+    plotSpectrum(QString::fromStdString(outputWsSquared));
+
+    auto elfWs = m_elwinAlg->getPropertyValue("OutputELF");
+    checkADSForPlotSaveWorkspace(elfWs, true);
+    plotSpectrum(QString::fromStdString(elfWs), 0, 9);
+
+    if (m_blnManager->value(m_properties["Normalise"])) {
+      auto eltWs = m_elwinAlg->getPropertyValue("OutputELT");
+      checkADSForPlotSaveWorkspace(eltWs, true);
+      plotSpectrum(QString::fromStdString(eltWs), 0, 9);
+    }
   }
 }
 


### PR DESCRIPTION
The plotting and saving of mantid workspaces has been refactored to the interface and push buttons for plotting and saving post algorithm executions have been implemented for all IndirectDataAnalysis tabs.

Fixes #17022 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
