### PR TITLE
Indirect Data Analysis - post execution plot and save

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MSDFit.py
+++ b/Framework/PythonInterface/plugins/algorithms/MSDFit.py
@@ -12,7 +12,6 @@ class MSDFit(DataProcessorAlgorithm):
     _x_range = None
     _input_ws = None
     _output_param_ws = None
-    _plot = None
     _output_msd_ws = None
 
     def category(self):
@@ -36,9 +35,6 @@ class MSDFit(DataProcessorAlgorithm):
                              doc='Start of spectra range to be fit')
         self.declareProperty(name='SpecMax', defaultValue=0,
                              doc='End of spectra range to be fit')
-
-        self.declareProperty(name='Plot', defaultValue=False,
-                             doc='Plots results after fit')
 
         self.declareProperty(WorkspaceGroupProperty('OutputWorkspace', '',direction=Direction.Output),
                              doc='Output mean squared displacement')
@@ -159,10 +155,6 @@ class MSDFit(DataProcessorAlgorithm):
         self.setProperty('ParameterWorkspace', self._output_param_ws)
         self.setProperty('FitWorkspaces', self._output_fit_ws)
 
-        if self._plot:
-            self._plot_result()
-
-
     def _setup(self):
         """
         Gets algorithm properties.
@@ -183,29 +175,5 @@ class MSDFit(DataProcessorAlgorithm):
 
         self._spec_range = [self.getProperty('SpecMin').value,
                             self.getProperty('SpecMax').value]
-
-        self._plot = self.getProperty('Plot').value
-
-
-    def _plot_result(self):
-        """
-        Handles plotting result workspaces.
-        """
-
-        from IndirectImport import import_mantidplot
-        mtd_plot = import_mantidplot()
-
-        x_label = ''
-        ws_run = mtd[self._input_ws].getRun()
-        if 'vert_axis' in ws_run:
-            x_label = ws_run.getLogData('vert_axis').value
-
-        result_ws = mtd[self._output_msd_ws + '_A1']
-        if len(result_ws.readX(0)) > 1:
-            msd_plot = mtd_plot.plotSpectrum(result_ws, 0, True)
-            msd_layer = msd_plot.activeLayer()
-            msd_layer.setAxisTitle(mtd_plot.Layer.Bottom, x_label)
-            msd_layer.setAxisTitle(mtd_plot.Layer.Left, '<u2>')
-
 
 AlgorithmFactory.subscribe(MSDFit)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -23,7 +23,6 @@ def _normalize_to_lowest_temp(elt_ws_name):
 
 class ElasticWindowMultiple(DataProcessorAlgorithm):
 
-    _plot = None
     _sample_log_name = None
     _sample_log_value = None
     _input_workspaces = None
@@ -35,7 +34,6 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
     _integration_range_end = None
     _background_range_start = None
     _background_range_end = None
-    _mtd_plot = None
 
 
     def category(self):
@@ -81,8 +79,6 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
         self.declareProperty(WorkspaceProperty('OutputELT', '', Direction.Output,
                                                PropertyMode.Optional),
                              doc='Output workspace ELT')
-
-        self.declareProperty(name='Plot', defaultValue=False, doc='Plot result spectra')
 
 
     def validateInputs(self):
@@ -256,26 +252,12 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
         self.setProperty('OutputInQ', self._q_workspace)
         self.setProperty('OutputInQSquared', self._q2_workspace)
 
-        # Plot spectra plots
-        if self._plot:
-            self._mtd_plot = import_mantidplot()
-
-            self._plot_spectra(self._q_workspace)
-            self._plot_spectra(self._q2_workspace)
-
-            if self._elf_workspace != '':
-                self._plot_spectra(self._elf_workspace)
-
-            if self._elt_workspace != '':
-                self._plot_spectra(self._elt_workspace)
-
 
     def _setup(self):
         """
         Gets algorithm properties.
         """
 
-        self._plot = self.getProperty('Plot').value
         self._sample_log_name = self.getPropertyValue('SampleEnvironmentLogName')
         self._sample_log_value = self.getPropertyValue('SampleEnvironmentLogValue')
 
@@ -290,27 +272,6 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
 
         self._background_range_start = self.getProperty('BackgroundRangeStart').value
         self._background_range_end = self.getProperty('BackgroundRangeEnd').value
-
-
-    def _plot_spectra(self, ws_name):
-        """
-        Plots up to the first 10 spectra from a workspace.
-
-        @param ws_name Name of workspace to plot
-        """
-
-        num_hist = mtd[ws_name].getNumberHistograms()
-
-        # Limit number of plotted histograms to 10
-        if num_hist > 10:
-            num_hist = 10
-
-        # Build plot list
-        plot_list = []
-        for i in range(0, num_hist):
-            plot_list.append(i)
-
-        self._mtd_plot.plotSpectrum(ws_name, plot_list)
 
 
     def _get_temperature(self, ws_name):

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -32,6 +32,8 @@ private slots:
   void maxChanged(double val);
   void updateRS(QtProperty *prop, double val);
   void unGroupInput(bool error);
+  void saveClicked();
+  void plotClicked();
 
 private:
   void addSaveAlgorithm(const std::string &workspaceName,

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -36,7 +36,6 @@ private slots:
   void plotClicked();
 
 private:
-
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;
 };

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -36,13 +36,9 @@ private slots:
   void plotClicked();
 
 private:
-  void addSaveAlgorithm(const std::string &workspaceName,
-                        std::string filename = "");
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;
-  // alg
-  Mantid::API::IAlgorithm_sptr m_elwinAlg;
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.h
@@ -39,6 +39,8 @@ private:
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;
+  // alg
+  Mantid::API::IAlgorithm_sptr m_elwinAlg;
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.ui
@@ -47,12 +47,12 @@
       </item>
       <item>
        <widget class="QCheckBox" name="ckGroupInput">
-         <property name="text">
-           <string>Group Input</string>
-         </property>
-         <property name="checked">
-           <bool>true</bool>
-         </property>
+        <property name="text">
+         <string>Group Input</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
      </layout>
@@ -167,7 +167,10 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_5">
       <item>
-       <widget class="QCheckBox" name="ckPlot">
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Plot Result</string>
         </property>
@@ -187,7 +190,10 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckSave">
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Save Result</string>
         </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.h
@@ -31,7 +31,6 @@ private slots:
   void PlotTiled();
 
 private:
-
   Ui::Iqt m_uiForm;
   QtTreePropertyBrowser *m_iqtTree;
   bool m_iqtResFileType;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.h
@@ -26,9 +26,11 @@ private slots:
   void updateRS(QtProperty *prop, double val);
   void updatePropertyValues(QtProperty *prop, double val);
   void calculateBinning();
+  void saveClicked();
+  void plotClicked();
+  void PlotTiled();
 
 private:
-  void PlotTiled();
 
   Ui::Iqt m_uiForm;
   QtTreePropertyBrowser *m_iqtTree;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.ui
@@ -135,18 +135,24 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_9">
       <item>
-       <widget class="QCheckBox" name="ckPlot">
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Plot Result</string>
         </property>
        </widget>
       </item>
       <item>
-        <widget class="QCheckBox" name="ckTile">
-          <property name="text">
-            <string>TiledPlot</string>
-          </property>
-        </widget>
+       <widget class="QPushButton" name="pbTile">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Tiled Plot</string>
+        </property>
+       </widget>
       </item>
       <item>
        <spacer name="horizontalSpacer_1">
@@ -162,7 +168,10 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckSave">
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Save Result</string>
         </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.h
@@ -48,8 +48,8 @@ private slots:
   void unFixItem();
   void singleFitComplete(bool error);
   void algorithmComplete(bool error);
-  void saveClicked();
-  void plotClicked();
+  void plotWorkspace();
+  void saveResult();
 
 private:
   boost::shared_ptr<Mantid::API::CompositeFunction>
@@ -65,8 +65,6 @@ private:
   std::string constructBaseName(const std::string &inputName,
                                 const std::string &fitType, const bool &multi,
                                 const long &specMin, const long &specMax);
-  void plotWorkspace();
-  void saveResult();
 
   Ui::IqtFit m_uiForm;
   QtStringPropertyManager *m_stringManager;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.h
@@ -48,6 +48,8 @@ private slots:
   void unFixItem();
   void singleFitComplete(bool error);
   void algorithmComplete(bool error);
+  void saveClicked();
+  void plotClicked();
 
 private:
   boost::shared_ptr<Mantid::API::CompositeFunction>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>719</width>
-    <height>251</height>
+    <width>777</width>
+    <height>579</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -260,6 +260,9 @@
       </item>
       <item>
        <widget class="QComboBox" name="cbPlotType">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <item>
          <property name="text">
           <string>None</string>
@@ -281,10 +284,20 @@
          </property>
         </item>
         <item>
-          <property name="text">
-            <string>All</string>
-          </property>
+         <property name="text">
+          <string>All</string>
+         </property>
         </item>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Plot Result</string>
+        </property>
        </widget>
       </item>
       <item>
@@ -301,7 +314,10 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckSave">
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Save Result</string>
         </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.ui
@@ -265,11 +265,6 @@
         </property>
         <item>
          <property name="text">
-          <string>None</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
           <string>Intensity</string>
          </property>
         </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
@@ -17,7 +17,6 @@ public:
   void setup() override;
   bool validate() override;
   void run() override;
-  void runImpl(bool plot = false, bool save = false);
   /// Load default settings into the interface
   void loadSettings(const QSettings &settings) override;
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
@@ -40,6 +40,9 @@ private slots:
   void generatePlotGuess();
   /// Add the plot guess to the mini plot
   void plotGuess(bool error);
+  /// Handles plotting and saving
+  void saveClicked();
+  void plotClicked();
 
 private:
   /// Gets a list of parameter names for a given fit function

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
@@ -65,9 +65,6 @@ private:
   QtTreePropertyBrowser *m_jfTree;
 
   Mantid::API::IAlgorithm_sptr m_fitAlg;
-
-  // The state of plot result when the algorithm was run
-  bool m_plotResult;
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
@@ -32,7 +32,7 @@
         </sizepolicy>
        </property>
        <property name="showLoad" stdset="0">
-         <bool>false</bool>
+        <bool>false</bool>
        </property>
        <property name="workspaceSuffixes" stdset="0">
         <stringlist>
@@ -102,7 +102,7 @@
      <item row="2" column="0">
       <widget class="QCheckBox" name="ckPlotGuess">
        <property name="text">
-         <string>Plot Guess</string>
+        <string>Plot Guess</string>
        </property>
       </widget>
      </item>
@@ -146,7 +146,10 @@
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QCheckBox" name="chkPlot">
+         <widget class="QPushButton" name="pbPlot">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="text">
            <string>Plot Result</string>
           </property>
@@ -166,7 +169,10 @@
          </spacer>
         </item>
         <item>
-         <widget class="QCheckBox" name="chkSave">
+         <widget class="QPushButton" name="pbSave">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="text">
            <string>Save Result</string>
           </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/MSDFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/MSDFit.h
@@ -29,6 +29,8 @@ private slots:
   void minChanged(double val);
   void maxChanged(double val);
   void updateRS(QtProperty *prop, double val);
+  void saveClicked();
+  void plotClicked();
 
 private:
   Ui::MSDFit m_uiForm;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/MSDFit.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/MSDFit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>422</width>
-    <height>265</height>
+    <width>803</width>
+    <height>547</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -190,7 +190,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_8">
       <item>
-       <widget class="QCheckBox" name="ckPlot">
+       <widget class="QPushButton" name="pbPlot">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -216,7 +216,7 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckSave">
+       <widget class="QPushButton" name="pbSave">
         <property name="text">
          <string>Save Result</string>
         </property>

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -244,7 +244,7 @@ void Elwin::unGroupInput(bool error) {
     ungroupAlg->execute();
   }
 
-  //Enable plot and save
+  // Enable plot and save
   m_uiForm.pbPlot->setEnabled(true);
   m_uiForm.pbSave->setEnabled(true);
 }

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -98,6 +98,9 @@ void Elwin::setup() {
           SLOT(newPreviewFileSelected(int)));
   connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this,
           SLOT(plotInput()));
+  // Handle plot and save
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked())):
 
   // Set any default values
   m_dblManager->setValue(m_properties["IntegrationStart"], -0.02);
@@ -268,6 +271,7 @@ void Elwin::unGroupInput(bool error) {
       checkADSForPlotSaveWorkspace(eltWs, true);
       plotSpectrum(QString::fromStdString(eltWs), 0, 9);
     }
+  }
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -218,16 +218,6 @@ void Elwin::run() {
 
   m_batchAlgoRunner->addAlgorithm(elwinMultAlg, elwinInputProps);
 
-  // Configure Save algorithms
-  if (m_uiForm.ckSave->isChecked()) {
-    addSaveAlgorithm(qWorkspace);
-    addSaveAlgorithm(qSquaredWorkspace);
-    addSaveAlgorithm(elfWorkspace);
-
-    if (m_blnManager->value(m_properties["Normalise"]))
-      addSaveAlgorithm(eltWorkspace);
-  }
-
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(unGroupInput(bool)));
   m_batchAlgoRunner->executeBatchAsync();
@@ -255,8 +245,6 @@ void Elwin::unGroupInput(bool error) {
   //Enable plot and save
   m_uiForm.pbPlot->setEnabled(true);
   m_uiForm.pbSave->setEnabled(true);
-
-
 }
 
 /**
@@ -506,9 +494,7 @@ void Elwin::updateRS(QtProperty *prop, double val) {
 /**
  * Handles mantid plotting
  */
-void Elwin::saveClicked() {
-
-  if (m_uiForm.ckPlot->isChecked()) {
+void Elwin::plotClicked() {
 
     auto outputWs = m_elwinAlg->getPropertyValue("OutputInQ");
     checkADSForPlotSaveWorkspace(outputWs, true);
@@ -527,7 +513,31 @@ void Elwin::saveClicked() {
       checkADSForPlotSaveWorkspace(eltWs, true);
       plotSpectrum(QString::fromStdString(eltWs), 0, 9);
     }
+}
+
+/**
+ * Handles saving of workspaces
+ */
+void Elwin::saveClicked() {
+
+  auto outputWs = m_elwinAlg->getPropertyValue("OutputInQ");
+  checkADSForPlotSaveWorkspace(outputWs, false);
+  addSaveWorkspaceToQueue(QString::fromStdString(outputWs));
+
+  auto outputWsSquared = m_elwinAlg->getPropertyValue("OutputInQSquared");
+  checkADSForPlotSaveWorkspace(outputWsSquared, true);
+  addSaveWorkspaceToQueue(QString::fromStdString(outputWsSquared));
+
+  auto elfWs = m_elwinAlg->getPropertyValue("OutputELF");
+  checkADSForPlotSaveWorkspace(elfWs, true);
+  addSaveWorkspaceToQueue(QString::fromStdString(elfWs));
+
+  if (m_blnManager->value(m_properties["Normalise"])) {
+    auto eltWs = m_elwinAlg->getPropertyValue("OutputELT");
+    checkADSForPlotSaveWorkspace(eltWs, true);
+    addSaveWorkspaceToQueue(QString::fromStdString(eltWs));
   }
+  m_batchAlgoRunner->executeBatchAsync();
 }
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -181,8 +181,6 @@ void Elwin::run() {
       AlgorithmManager::Instance().create("ElasticWindowMultiple");
   elwinMultAlg->initialize();
 
-  elwinMultAlg->setProperty("Plot", m_uiForm.ckPlot->isChecked());
-
   elwinMultAlg->setProperty("OutputInQ", qWorkspace);
   elwinMultAlg->setProperty("OutputInQSquared", qSquaredWorkspace);
   elwinMultAlg->setProperty("OutputELF", elfWorkspace);

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -224,8 +224,6 @@ void Elwin::run() {
 
   // Set the result workspace for Python script export
   m_pythonExportWsName = qSquaredWorkspace;
-
-  m_elwinAlg = elwinMultAlg;
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -251,6 +251,11 @@ void Elwin::unGroupInput(bool error) {
     ungroupAlg->setProperty("InputWorkspace", "IDA_Elwin_Input");
     ungroupAlg->execute();
   }
+
+  //Enable plot and save
+  m_uiForm.pbPlot->setEnabled(true);
+  m_uiForm.pbSave->setEnabled(true);
+
   // Handle mantid plotting
   if (m_uiForm.ckPlot->isChecked()) {
 

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -100,7 +100,7 @@ void Elwin::setup() {
           SLOT(plotInput()));
   // Handle plot and save
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked())):
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
 
   // Set any default values
   m_dblManager->setValue(m_properties["IntegrationStart"], -0.02);
@@ -224,6 +224,8 @@ void Elwin::run() {
 
   // Set the result workspace for Python script export
   m_pythonExportWsName = qSquaredWorkspace;
+
+  m_elwinAlg = elwinMultAlg;
 }
 
 /**
@@ -496,23 +498,23 @@ void Elwin::updateRS(QtProperty *prop, double val) {
  */
 void Elwin::plotClicked() {
 
-    auto outputWs = m_elwinAlg->getPropertyValue("OutputInQ");
-    checkADSForPlotSaveWorkspace(outputWs, true);
-    plotSpectrum(QString::fromStdString(outputWs));
+  auto outputWs = m_elwinAlg->getPropertyValue("OutputInQ");
+  checkADSForPlotSaveWorkspace(outputWs, true);
+  plotSpectrum(QString::fromStdString(outputWs));
 
-    auto outputWsSquared = m_elwinAlg->getPropertyValue("OutputInQSquared");
-    checkADSForPlotSaveWorkspace(outputWsSquared, true);
-    plotSpectrum(QString::fromStdString(outputWsSquared));
+  auto outputWsSquared = m_elwinAlg->getPropertyValue("OutputInQSquared");
+  checkADSForPlotSaveWorkspace(outputWsSquared, true);
+  plotSpectrum(QString::fromStdString(outputWsSquared));
 
-    auto elfWs = m_elwinAlg->getPropertyValue("OutputELF");
-    checkADSForPlotSaveWorkspace(elfWs, true);
-    plotSpectrum(QString::fromStdString(elfWs), 0, 9);
+  auto elfWs = m_elwinAlg->getPropertyValue("OutputELF");
+  checkADSForPlotSaveWorkspace(elfWs, true);
+  plotSpectrum(QString::fromStdString(elfWs), 0, 9);
 
-    if (m_blnManager->value(m_properties["Normalise"])) {
-      auto eltWs = m_elwinAlg->getPropertyValue("OutputELT");
-      checkADSForPlotSaveWorkspace(eltWs, true);
-      plotSpectrum(QString::fromStdString(eltWs), 0, 9);
-    }
+  if (m_blnManager->value(m_properties["Normalise"])) {
+    auto eltWs = m_elwinAlg->getPropertyValue("OutputELT");
+    checkADSForPlotSaveWorkspace(eltWs, true);
+    plotSpectrum(QString::fromStdString(eltWs), 0, 9);
+  }
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -250,6 +250,26 @@ void Elwin::unGroupInput(bool error) {
     ungroupAlg->setProperty("InputWorkspace", "IDA_Elwin_Input");
     ungroupAlg->execute();
   }
+  // Handle mantid plotting
+  if (m_uiForm.ckPlot->isChecked()) {
+
+    auto outputWs = m_elwinAlg->getPropertyValue("OutputInQ");
+    checkADSForPlotSaveWorkspace(outputWs, true);
+    plotSpectrum(QString::fromStdString(outputWs));
+
+    auto outputWsSquared = m_elwinAlg->getPropertyValue("OutputInQSquared");
+    checkADSForPlotSaveWorkspace(outputWsSquared, true);
+    plotSpectrum(QString::fromStdString(outputWsSquared));
+
+    auto elfWs = m_elwinAlg->getPropertyValue("OutputELF");
+    checkADSForPlotSaveWorkspace(elfWs, true);
+    plotSpectrum(QString::fromStdString(elfWs), 0, 9);
+
+    if (m_blnManager->value(m_properties["Normalise"])) {
+      auto eltWs = m_elwinAlg->getPropertyValue("OutputELT");
+      checkADSForPlotSaveWorkspace(eltWs, true);
+      plotSpectrum(QString::fromStdString(eltWs), 0, 9);
+    }
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -256,27 +256,7 @@ void Elwin::unGroupInput(bool error) {
   m_uiForm.pbPlot->setEnabled(true);
   m_uiForm.pbSave->setEnabled(true);
 
-  // Handle mantid plotting
-  if (m_uiForm.ckPlot->isChecked()) {
 
-    auto outputWs = m_elwinAlg->getPropertyValue("OutputInQ");
-    checkADSForPlotSaveWorkspace(outputWs, true);
-    plotSpectrum(QString::fromStdString(outputWs));
-
-    auto outputWsSquared = m_elwinAlg->getPropertyValue("OutputInQSquared");
-    checkADSForPlotSaveWorkspace(outputWsSquared, true);
-    plotSpectrum(QString::fromStdString(outputWsSquared));
-
-    auto elfWs = m_elwinAlg->getPropertyValue("OutputELF");
-    checkADSForPlotSaveWorkspace(elfWs, true);
-    plotSpectrum(QString::fromStdString(elfWs), 0, 9);
-
-    if (m_blnManager->value(m_properties["Normalise"])) {
-      auto eltWs = m_elwinAlg->getPropertyValue("OutputELT");
-      checkADSForPlotSaveWorkspace(eltWs, true);
-      plotSpectrum(QString::fromStdString(eltWs), 0, 9);
-    }
-  }
 }
 
 /**
@@ -523,6 +503,32 @@ void Elwin::updateRS(QtProperty *prop, double val) {
     backgroundRangeSelector->setMaximum(val);
 }
 
+/**
+ * Handles mantid plotting
+ */
+void Elwin::saveClicked() {
+
+  if (m_uiForm.ckPlot->isChecked()) {
+
+    auto outputWs = m_elwinAlg->getPropertyValue("OutputInQ");
+    checkADSForPlotSaveWorkspace(outputWs, true);
+    plotSpectrum(QString::fromStdString(outputWs));
+
+    auto outputWsSquared = m_elwinAlg->getPropertyValue("OutputInQSquared");
+    checkADSForPlotSaveWorkspace(outputWsSquared, true);
+    plotSpectrum(QString::fromStdString(outputWsSquared));
+
+    auto elfWs = m_elwinAlg->getPropertyValue("OutputELF");
+    checkADSForPlotSaveWorkspace(elfWs, true);
+    plotSpectrum(QString::fromStdString(elfWs), 0, 9);
+
+    if (m_blnManager->value(m_properties["Normalise"])) {
+      auto eltWs = m_elwinAlg->getPropertyValue("OutputELT");
+      checkADSForPlotSaveWorkspace(eltWs, true);
+      plotSpectrum(QString::fromStdString(eltWs), 0, 9);
+    }
+  }
+}
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -249,29 +249,6 @@ void Elwin::unGroupInput(bool error) {
   m_uiForm.pbSave->setEnabled(true);
 }
 
-/**
- * Configures and adds a SaveNexus algorithm to the batch runner.
- *
- * @param workspaceName Name of the workspace to save
- * @param filename Name of the file to save it as
- */
-void Elwin::addSaveAlgorithm(const std::string &workspaceName,
-                             std::string filename) {
-  // Set a default filename if none provided
-  if (filename.length() == 0)
-    filename = workspaceName + ".nxs";
-
-  // Configure the algorithm
-  IAlgorithm_sptr loadAlg = AlgorithmManager::Instance().create("SaveNexus");
-  loadAlg->initialize();
-  loadAlg->setProperty("Filename", filename);
-
-  BatchAlgorithmRunner::AlgorithmRuntimeProps saveAlgProps;
-  saveAlgProps["InputWorkspace"] = workspaceName;
-
-  // Add it to the batch runner
-  m_batchAlgoRunner->addAlgorithm(loadAlg, saveAlgProps);
-}
 
 bool Elwin::validate() {
   UserInputValidator uiv;

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -499,15 +499,15 @@ void Elwin::saveClicked() {
       getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
 
   if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq").toStdString(),
-                                   true))
+                                   false))
     addSaveWorkspaceToQueue(workspaceBaseName + "_eq");
 
   if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq2").toStdString(),
-                                   true))
+                                   false))
     addSaveWorkspaceToQueue(workspaceBaseName + "_eq2");
 
   if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elf").toStdString(),
-                                   true))
+                                   false))
     addSaveWorkspaceToQueue(workspaceBaseName + "_elf");
 
   m_batchAlgoRunner->executeBatchAsync();

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -249,7 +249,6 @@ void Elwin::unGroupInput(bool error) {
   m_uiForm.pbSave->setEnabled(true);
 }
 
-
 bool Elwin::validate() {
   UserInputValidator uiv;
 
@@ -475,15 +474,19 @@ void Elwin::updateRS(QtProperty *prop, double val) {
  */
 void Elwin::plotClicked() {
 
-  auto workspaceBaseName = getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
+  auto workspaceBaseName =
+      getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
 
-  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq").toStdString(), true))
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq").toStdString(),
+                                   true))
     plotSpectrum(workspaceBaseName + "_eq");
 
-  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq2").toStdString(), true))
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq2").toStdString(),
+                                   true))
     plotSpectrum(workspaceBaseName + "_eq2");
 
-  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elf").toStdString(), true))
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elf").toStdString(),
+                                   true))
     plotSpectrum((workspaceBaseName + "_elf"), 0, 9);
 }
 
@@ -492,15 +495,19 @@ void Elwin::plotClicked() {
  */
 void Elwin::saveClicked() {
 
-  auto workspaceBaseName = getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
+  auto workspaceBaseName =
+      getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
 
-  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq").toStdString(), true))
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq").toStdString(),
+                                   true))
     addSaveWorkspaceToQueue(workspaceBaseName + "_eq");
 
-  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq2").toStdString(), true))
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq2").toStdString(),
+                                   true))
     addSaveWorkspaceToQueue(workspaceBaseName + "_eq2");
 
-  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elf").toStdString(), true))
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elf").toStdString(),
+                                   true))
     addSaveWorkspaceToQueue(workspaceBaseName + "_elf");
 
   m_batchAlgoRunner->executeBatchAsync();

--- a/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -475,23 +475,16 @@ void Elwin::updateRS(QtProperty *prop, double val) {
  */
 void Elwin::plotClicked() {
 
-  auto outputWs = m_elwinAlg->getPropertyValue("OutputInQ");
-  checkADSForPlotSaveWorkspace(outputWs, true);
-  plotSpectrum(QString::fromStdString(outputWs));
+  auto workspaceBaseName = getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
 
-  auto outputWsSquared = m_elwinAlg->getPropertyValue("OutputInQSquared");
-  checkADSForPlotSaveWorkspace(outputWsSquared, true);
-  plotSpectrum(QString::fromStdString(outputWsSquared));
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq").toStdString(), true))
+    plotSpectrum(workspaceBaseName + "_eq");
 
-  auto elfWs = m_elwinAlg->getPropertyValue("OutputELF");
-  checkADSForPlotSaveWorkspace(elfWs, true);
-  plotSpectrum(QString::fromStdString(elfWs), 0, 9);
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq2").toStdString(), true))
+    plotSpectrum(workspaceBaseName + "_eq2");
 
-  if (m_blnManager->value(m_properties["Normalise"])) {
-    auto eltWs = m_elwinAlg->getPropertyValue("OutputELT");
-    checkADSForPlotSaveWorkspace(eltWs, true);
-    plotSpectrum(QString::fromStdString(eltWs), 0, 9);
-  }
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elf").toStdString(), true))
+    plotSpectrum((workspaceBaseName + "_elf"), 0, 9);
 }
 
 /**
@@ -499,23 +492,17 @@ void Elwin::plotClicked() {
  */
 void Elwin::saveClicked() {
 
-  auto outputWs = m_elwinAlg->getPropertyValue("OutputInQ");
-  checkADSForPlotSaveWorkspace(outputWs, false);
-  addSaveWorkspaceToQueue(QString::fromStdString(outputWs));
+  auto workspaceBaseName = getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
 
-  auto outputWsSquared = m_elwinAlg->getPropertyValue("OutputInQSquared");
-  checkADSForPlotSaveWorkspace(outputWsSquared, true);
-  addSaveWorkspaceToQueue(QString::fromStdString(outputWsSquared));
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq").toStdString(), true))
+    addSaveWorkspaceToQueue(workspaceBaseName + "_eq");
 
-  auto elfWs = m_elwinAlg->getPropertyValue("OutputELF");
-  checkADSForPlotSaveWorkspace(elfWs, true);
-  addSaveWorkspaceToQueue(QString::fromStdString(elfWs));
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq2").toStdString(), true))
+    addSaveWorkspaceToQueue(workspaceBaseName + "_eq2");
 
-  if (m_blnManager->value(m_properties["Normalise"])) {
-    auto eltWs = m_elwinAlg->getPropertyValue("OutputELT");
-    checkADSForPlotSaveWorkspace(eltWs, true);
-    addSaveWorkspaceToQueue(QString::fromStdString(eltWs));
-  }
+  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elf").toStdString(), true))
+    addSaveWorkspaceToQueue(workspaceBaseName + "_elf");
+
   m_batchAlgoRunner->executeBatchAsync();
 }
 } // namespace IDA

--- a/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
@@ -81,7 +81,6 @@ void Iqt::setup() {
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
   connect(m_uiForm.pbTile, SIGNAL(clicked()), this, SLOT(PlotTiled()));
-
 }
 
 void Iqt::run() {

--- a/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
@@ -78,6 +78,10 @@ void Iqt::setup() {
           SLOT(calculateBinning()));
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbTile, SIGNAL(clicked()), this, SLOT(PlotTiled()));
+
 }
 
 void Iqt::run() {

--- a/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
@@ -116,11 +116,6 @@ void Iqt::run() {
   IqtAlg->setProperty("DryRun", false);
 
   m_batchAlgoRunner->addAlgorithm(IqtAlg);
-
-  // Add save step
-  if (m_uiForm.ckSave->isChecked())
-    addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
-
   m_batchAlgoRunner->executeBatchAsync();
 }
 
@@ -132,15 +127,21 @@ void Iqt::run() {
 void Iqt::algorithmComplete(bool error) {
   if (error)
     return;
+}
+/**
+ * Handle saving of workspace
+ */
+void Iqt::saveClicked() {
+  checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
+  addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
+}
 
-  // Regular Plot
-  if (m_uiForm.ckPlot->isChecked())
-    plotSpectrum(QString::fromStdString(m_pythonExportWsName));
-
-  // Tiled plot
-  if (m_uiForm.ckTile->isChecked()) {
-    PlotTiled();
-  }
+/**
+ * Handle mantid plotting
+ */
+void Iqt::plotClicked() {
+  checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
+  plotSpectrum(QString::fromStdString(m_pythonExportWsName));
 }
 
 void Iqt::PlotTiled() {

--- a/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
@@ -137,6 +137,7 @@ void Iqt::algorithmComplete(bool error) {
 void Iqt::saveClicked() {
   checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
   addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
+  m_batchAlgoRunner->executeBatchAsync();
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
@@ -127,6 +127,9 @@ void Iqt::run() {
 void Iqt::algorithmComplete(bool error) {
   if (error)
     return;
+  m_uiForm.pbPlot->setEnabled(true);
+  m_uiForm.pbSave->setEnabled(true);
+  m_uiForm.pbTile->setEnabled(true);
 }
 /**
  * Handle saving of workspace

--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -147,7 +147,6 @@ void IqtFit::setup() {
           SLOT(checkBoxUpdate(QtProperty *, bool)));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotWorkspace()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveResult()));
-
 }
 
 void IqtFit::run() {
@@ -263,11 +262,11 @@ void IqtFit::plotWorkspace() {
  */
 void IqtFit::saveResult() {
   const auto workingdirectory =
-    Mantid::Kernel::ConfigService::Instance().getString(
-      "defaultsave.directory");
+      Mantid::Kernel::ConfigService::Instance().getString(
+          "defaultsave.directory");
   const auto filepath = workingdirectory + m_baseName + "_Result.nxs";
   addSaveWorkspaceToQueue(QString::fromStdString(m_baseName + "_Result"),
-    QString::fromStdString(filepath));
+                          QString::fromStdString(filepath));
   m_batchAlgoRunner->executeBatchAsync();
 }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -145,8 +145,8 @@ void IqtFit::setup() {
 
   connect(m_blnManager, SIGNAL(valueChanged(QtProperty *, bool)), this,
           SLOT(checkBoxUpdate(QtProperty *, bool)));
-  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotWorkspace()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveResult()));
 
 }
 
@@ -283,8 +283,6 @@ void IqtFit::algorithmComplete(bool error) {
   if (error)
     return;
   updatePlot();
-  plotWorkspace();
-  saveResult();
   m_uiForm.pbPlot->setEnabled(true);
   m_uiForm.pbSave->setEnabled(true);
   m_uiForm.cbPlotType->setEnabled(true);

--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -145,6 +145,9 @@ void IqtFit::setup() {
 
   connect(m_blnManager, SIGNAL(valueChanged(QtProperty *, bool)), this,
           SLOT(checkBoxUpdate(QtProperty *, bool)));
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+
 }
 
 void IqtFit::run() {

--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -262,15 +262,13 @@ void IqtFit::plotWorkspace() {
  * Save the result of the algorithm
  */
 void IqtFit::saveResult() {
-  if (m_uiForm.ckSave->isChecked()) {
-    const auto workingdirectory =
-        Mantid::Kernel::ConfigService::Instance().getString(
-            "defaultsave.directory");
-    const auto filepath = workingdirectory + m_baseName + "_Result.nxs";
-    addSaveWorkspaceToQueue(QString::fromStdString(m_baseName + "_Result"),
-                            QString::fromStdString(filepath));
-    m_batchAlgoRunner->executeBatchAsync();
-  }
+  const auto workingdirectory =
+    Mantid::Kernel::ConfigService::Instance().getString(
+      "defaultsave.directory");
+  const auto filepath = workingdirectory + m_baseName + "_Result.nxs";
+  addSaveWorkspaceToQueue(QString::fromStdString(m_baseName + "_Result"),
+    QString::fromStdString(filepath));
+  m_batchAlgoRunner->executeBatchAsync();
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -285,6 +285,9 @@ void IqtFit::algorithmComplete(bool error) {
   updatePlot();
   plotWorkspace();
   saveResult();
+  m_uiForm.pbPlot->setEnabled(true);
+  m_uiForm.pbSave->setEnabled(true);
+  m_uiForm.cbPlotType->setEnabled(true);
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -17,7 +17,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 JumpFit::JumpFit(QWidget *parent)
-    : IndirectDataAnalysisTab(parent), m_jfTree(nullptr), m_plotResult(false) {
+    : IndirectDataAnalysisTab(parent), m_jfTree(nullptr), {
   m_uiForm.setupUi(parent);
 }
 
@@ -105,7 +105,6 @@ bool JumpFit::validate() {
  * script that runs JumpFit
  */
 void JumpFit::run() {
-  bool plot = m_uiForm.chkPlot->isChecked();
   bool save = m_uiForm.chkSave->isChecked();
   // Do noting with invalid data
   if (!m_uiForm.dsSample->isValid())
@@ -147,8 +146,6 @@ void JumpFit::run() {
     QString outWsName = outputName + "_Workspace";
     addSaveWorkspaceToQueue(outWsName);
   }
-  // update plot result state when run
-  m_plotResult = plot;
 
   // Connect algorithm runner to completion handler function
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
@@ -192,12 +189,6 @@ void JumpFit::fitAlgDone(bool error) {
     if (specName == "Diff")
       m_uiForm.ppPlot->addSpectrum("Diff", outputWorkspace, histIndex,
                                    Qt::blue);
-  }
-
-  // plot result
-  if (m_plotResult) {
-    std::string outWsName = m_fitAlg->getPropertyValue("Output") + "_Workspace";
-    plotSpectrum(QString::fromStdString(outWsName), 0, 2);
   }
 
   // Update parameters in UI
@@ -553,6 +544,15 @@ void JumpFit::deletePlotGuessWorkspaces(const bool &removePlotGuess) {
   }
 }
 
+/** 
+ * Handles mantid plotting
+ */
+void JumpFit::plotClicked() {
+    std::string outWsName = m_fitAlg->getPropertyValue("Output") + "_Workspace";
+    checkADSForPlotSaveWorkspace(outWsName, true);
+    plotSpectrum(QString::fromStdString(outWsName), 0, 2);
+  }
+}
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -107,16 +107,6 @@ bool JumpFit::validate() {
 void JumpFit::run() {
   bool plot = m_uiForm.chkPlot->isChecked();
   bool save = m_uiForm.chkSave->isChecked();
-  runImpl(plot, save);
-}
-
-/**
- * Runs algorithm.
- *
- * @param plot Enable/disable plotting
- * @param save Enable/disable saving
- */
-void JumpFit::runImpl(bool plot, bool save) {
   // Do noting with invalid data
   if (!m_uiForm.dsSample->isValid())
     return;
@@ -132,7 +122,7 @@ void JumpFit::runImpl(bool plot, bool save) {
   int width = m_spectraList[widthText];
   const auto sample = m_uiForm.dsSample->getCurrentDataName().toStdString();
   QString outputName = getWorkspaceBasename(QString::fromStdString(sample)) +
-                       "_" + functionName + "_fit";
+    "_" + functionName + "_fit";
 
   const auto startX = m_dblManager->value(m_properties["QMin"]);
   const auto endX = m_dblManager->value(m_properties["QMax"]);
@@ -162,7 +152,7 @@ void JumpFit::runImpl(bool plot, bool save) {
 
   // Connect algorithm runner to completion handler function
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
-          SLOT(fitAlgDone(bool)));
+    SLOT(fitAlgDone(bool)));
   m_batchAlgoRunner->executeBatchAsync();
 }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -70,6 +70,10 @@ void JumpFit::setup() {
 
   connect(m_dblManager, SIGNAL(propertyChanged(QtProperty *)), this,
           SLOT(generatePlotGuess()));
+
+  // Handle plotting and saving
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(PlotClicked()));
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -17,7 +17,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 JumpFit::JumpFit(QWidget *parent)
-    : IndirectDataAnalysisTab(parent), m_jfTree(nullptr), {
+    : IndirectDataAnalysisTab(parent), m_jfTree(nullptr) {
   m_uiForm.setupUi(parent);
 }
 
@@ -73,7 +73,7 @@ void JumpFit::setup() {
 
   // Handle plotting and saving
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(PlotClicked()));
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
 }
 
 /**
@@ -543,7 +543,7 @@ void JumpFit::plotClicked() {
   std::string outWsName = m_fitAlg->getPropertyValue("Output") + "_Workspace";
   checkADSForPlotSaveWorkspace(outWsName, true);
   plotSpectrum(QString::fromStdString(outWsName), 0, 2);
-  }
+}
 
 /**
  * Handles saving of workspace
@@ -552,7 +552,7 @@ void JumpFit::saveClicked() {
   std::string outWsName = m_fitAlg->getPropertyValue("Output") + "_Workspace";
   checkADSForPlotSaveWorkspace(outWsName, false);
   addSaveWorkspaceToQueue(QString::fromStdString(outWsName));
-  }
+  m_batchAlgoRunner->executeBatchAsync();
 }
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -105,7 +105,6 @@ bool JumpFit::validate() {
  * script that runs JumpFit
  */
 void JumpFit::run() {
-  bool save = m_uiForm.chkSave->isChecked();
   // Do noting with invalid data
   if (!m_uiForm.dsSample->isValid())
     return;
@@ -140,13 +139,6 @@ void JumpFit::run() {
   m_fitAlg->setProperty("Output", outputName.toStdString());
 
   m_batchAlgoRunner->addAlgorithm(m_fitAlg);
-
-  // Add save step if required
-  if (save) {
-    QString outWsName = outputName + "_Workspace";
-    addSaveWorkspaceToQueue(outWsName);
-  }
-
   // Connect algorithm runner to completion handler function
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
     SLOT(fitAlgDone(bool)));
@@ -548,9 +540,18 @@ void JumpFit::deletePlotGuessWorkspaces(const bool &removePlotGuess) {
  * Handles mantid plotting
  */
 void JumpFit::plotClicked() {
-    std::string outWsName = m_fitAlg->getPropertyValue("Output") + "_Workspace";
-    checkADSForPlotSaveWorkspace(outWsName, true);
-    plotSpectrum(QString::fromStdString(outWsName), 0, 2);
+  std::string outWsName = m_fitAlg->getPropertyValue("Output") + "_Workspace";
+  checkADSForPlotSaveWorkspace(outWsName, true);
+  plotSpectrum(QString::fromStdString(outWsName), 0, 2);
+  }
+
+/**
+ * Handles saving of workspace
+ */
+void JumpFit::saveClicked() {
+  std::string outWsName = m_fitAlg->getPropertyValue("Output") + "_Workspace";
+  checkADSForPlotSaveWorkspace(outWsName, false);
+  addSaveWorkspaceToQueue(QString::fromStdString(outWsName));
   }
 }
 } // namespace IDA

--- a/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -120,7 +120,7 @@ void JumpFit::run() {
   int width = m_spectraList[widthText];
   const auto sample = m_uiForm.dsSample->getCurrentDataName().toStdString();
   QString outputName = getWorkspaceBasename(QString::fromStdString(sample)) +
-    "_" + functionName + "_fit";
+                       "_" + functionName + "_fit";
 
   const auto startX = m_dblManager->value(m_properties["QMin"]);
   const auto endX = m_dblManager->value(m_properties["QMax"]);
@@ -141,7 +141,7 @@ void JumpFit::run() {
   m_batchAlgoRunner->addAlgorithm(m_fitAlg);
   // Connect algorithm runner to completion handler function
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
-    SLOT(fitAlgDone(bool)));
+          SLOT(fitAlgDone(bool)));
   m_batchAlgoRunner->executeBatchAsync();
 }
 
@@ -536,7 +536,7 @@ void JumpFit::deletePlotGuessWorkspaces(const bool &removePlotGuess) {
   }
 }
 
-/** 
+/**
  * Handles mantid plotting
  */
 void JumpFit::plotClicked() {

--- a/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -167,7 +167,8 @@ void JumpFit::fitAlgDone(bool error) {
   // Ignore errors
   if (error)
     return;
-
+  m_uiForm.pbPlot->setEnabled(true);
+  m_uiForm.pbSave->setEnabled(true);
   std::string outName = m_fitAlg->getPropertyValue("Output");
 
   // Get output workspace name

--- a/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
@@ -81,7 +81,6 @@ void MSDFit::run() {
   long specMin = m_uiForm.spSpectraMin->value();
   long specMax = m_uiForm.spSpectraMax->value();
 
-
   IAlgorithm_sptr msdAlg = AlgorithmManager::Instance().create("MSDFit");
   msdAlg->initialize();
   msdAlg->setProperty("InputWorkspace", wsName.toStdString());
@@ -299,9 +298,8 @@ void MSDFit::saveClicked() {
  */
 void MSDFit::plotClicked() {
 
-    plotSpectrum(QString::fromStdString(m_pythonExportWsName) + "_A1");
+  plotSpectrum(QString::fromStdString(m_pythonExportWsName) + "_A1");
 }
-
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
@@ -297,7 +297,7 @@ void MSDFit::saveClicked() {
  * Handles mantid plotting
  */
 void MSDFit::plotClicked() {
-
+  checkADSForPlotSaveWorkspace(m_pythonExportWsName + "_A1", true);
   plotSpectrum(QString::fromStdString(m_pythonExportWsName) + "_A1");
 }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
@@ -62,6 +62,8 @@ void MSDFit::setup() {
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(plotFit()));
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
 }
 
 void MSDFit::run() {
@@ -78,8 +80,7 @@ void MSDFit::run() {
   double xEnd = m_dblManager->value(m_properties["End"]);
   long specMin = m_uiForm.spSpectraMin->value();
   long specMax = m_uiForm.spSpectraMax->value();
-  bool plot = m_uiForm.ckPlot->isChecked();
-  bool save = m_uiForm.ckSave->isChecked();
+
 
   IAlgorithm_sptr msdAlg = AlgorithmManager::Instance().create("MSDFit");
   msdAlg->initialize();
@@ -88,7 +89,7 @@ void MSDFit::run() {
   msdAlg->setProperty("XEnd", xEnd);
   msdAlg->setProperty("SpecMin", specMin);
   msdAlg->setProperty("SpecMax", specMax);
-  msdAlg->setProperty("Plot", plot);
+  msdAlg->setProperty("Plot", false);
   msdAlg->setProperty("OutputWorkspace", m_pythonExportWsName);
 
   m_batchAlgoRunner->addAlgorithm(msdAlg);
@@ -107,6 +108,7 @@ void MSDFit::run() {
   }
 
   m_batchAlgoRunner->executeBatchAsync();
+
 }
 
 void MSDFit::singleFit() {

--- a/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
@@ -287,8 +287,8 @@ void MSDFit::updateRS(QtProperty *prop, double val) {
  */
 void MSDFit::saveClicked() {
 
-  checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
-  addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
+  if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
+    addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
   m_batchAlgoRunner->executeBatchAsync();
 }
 
@@ -296,8 +296,8 @@ void MSDFit::saveClicked() {
  * Handles mantid plotting
  */
 void MSDFit::plotClicked() {
-  checkADSForPlotSaveWorkspace(m_pythonExportWsName + "_A1", true);
-  plotSpectrum(QString::fromStdString(m_pythonExportWsName) + "_A1");
+  if (checkADSForPlotSaveWorkspace(m_pythonExportWsName + "_A1", true))
+    plotSpectrum(QString::fromStdString(m_pythonExportWsName) + "_A1");
 }
 
 } // namespace IDA

--- a/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
@@ -93,22 +93,7 @@ void MSDFit::run() {
   msdAlg->setProperty("OutputWorkspace", m_pythonExportWsName);
 
   m_batchAlgoRunner->addAlgorithm(msdAlg);
-
-  // Handle saving results
-  if (save) {
-    API::BatchAlgorithmRunner::AlgorithmRuntimeProps saveInputProps;
-    saveInputProps["InputWorkspace"] = m_pythonExportWsName;
-
-    IAlgorithm_sptr saveAlg =
-        AlgorithmManager::Instance().create("SaveNexusProcessed");
-    saveAlg->initialize();
-    saveAlg->setProperty("Filename", m_pythonExportWsName + ".nxs");
-
-    m_batchAlgoRunner->addAlgorithm(saveAlg, saveInputProps);
-  }
-
   m_batchAlgoRunner->executeBatchAsync();
-
 }
 
 void MSDFit::singleFit() {
@@ -298,6 +283,25 @@ void MSDFit::updateRS(QtProperty *prop, double val) {
   else if (prop == m_properties["End"])
     fitRangeSelector->setMaximum(val);
 }
+
+/**
+ * Handles saving of workspace
+ */
+void MSDFit::saveClicked() {
+
+  checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
+  addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
+  m_batchAlgoRunner->executeBatchAsync();
+}
+
+/**
+ * Handles mantid plotting
+ */
+void MSDFit::plotClicked() {
+
+    plotSpectrum(QString::fromStdString(m_pythonExportWsName) + "_A1");
+}
+
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
@@ -88,7 +88,6 @@ void MSDFit::run() {
   msdAlg->setProperty("XEnd", xEnd);
   msdAlg->setProperty("SpecMin", specMin);
   msdAlg->setProperty("SpecMax", specMax);
-  msdAlg->setProperty("Plot", false);
   msdAlg->setProperty("OutputWorkspace", m_pythonExportWsName);
 
   m_batchAlgoRunner->addAlgorithm(msdAlg);

--- a/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
@@ -741,7 +741,7 @@ class ISISIndirectInelasticElwinAndMSDFit(ISISIndirectInelasticBase):
             Load(Filename=filename, OutputWorkspace=filename)
         GroupWorkspaces(InputWorkspaces=self.files, OutputWorkspace=elwin_input)
 
-        ElasticWindowMultiple(InputWorkspaces=elwin_input, Plot=False,
+        ElasticWindowMultiple(InputWorkspaces=elwin_input,
                               IntegrationRangeStart=self.eRange[0], IntegrationRangeEnd=self.eRange[1],
                               OutputInQ=elwin_results[0], OutputInQSquared=elwin_results[1],
                               OutputELF=elwin_results[2])
@@ -758,8 +758,7 @@ class ISISIndirectInelasticElwinAndMSDFit(ISISIndirectInelasticBase):
         msdfit_result = MSDFit(InputWorkspace=eq2_file,
                                XStart=self.startX,
                                XEnd=self.endX,
-                               SpecMax=1,
-                               Plot=False)
+                               SpecMax=1)
 
         # Clean up the intermediate files.
         for filename in int_files:


### PR DESCRIPTION
The plotting and saving of mantid workspaces has been refactored to the interface and push buttons for plotting and saving post algorithm executions have been implemented for all IndirectDataAnalysis tabs.

 **To Test:**
Files to test with: \olympic\babylon5\Public\Louise McCann\DataAnalysis
For each tab load relevant files and run algorithm. Check each plot option plots a suitable graph and that the appropriate workspaces have been saved in your save directory.
- [ ] Elwin
- [ ] MSD Fit
- [ ] I(Q, t)
- [ ] I(Q, t) Fit 
- [ ] JumpFit

Fixes #17022 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
