### PR TITLE
ILL Loader without file extension

### DIFF
--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -492,7 +492,9 @@ FileFinderImpl::findRun(const std::string &hintstr,
     filename = hint.substr(0, hint.rfind(extension));
   if (hintPath.depth() == 0) {
     try {
-      filename = makeFileName(filename, instrument);
+      if (!facility.noFilePrefix()) {
+        filename = makeFileName(filename, instrument);
+      }
     } catch (std::invalid_argument &) {
       if (filename.length() >= hint.length()) {
         g_log.information() << "Could not form filename from standard rules '"

--- a/Framework/DataHandling/test/LoadTest.h
+++ b/Framework/DataHandling/test/LoadTest.h
@@ -304,7 +304,6 @@ public:
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 397);
   }
 
-
   void test_EventPreNeXus_WithNoExecute() {
     Load loader;
     loader.initialize();

--- a/Framework/DataHandling/test/LoadTest.h
+++ b/Framework/DataHandling/test/LoadTest.h
@@ -279,6 +279,32 @@ public:
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 397);
   }
 
+  /*
+   * This test loads and sums 2 IN4 runs from ILL
+   * without instrument prefix and extension in the file names.
+   */
+  void test_ILLLoadMultipleFilesNoPrefixNoExt() {
+
+    ConfigService::Instance().setString("default.instrument", "IN4");
+    ConfigService::Instance().appendDataSearchSubDir("ILL/IN4/");
+
+    Load loader;
+    loader.initialize();
+    loader.setPropertyValue("Filename", "084446-084447");
+
+    std::string outputWS = "LoadTest_out";
+    loader.setPropertyValue("OutputWorkspace", outputWS);
+    TS_ASSERT_THROWS_NOTHING(loader.execute());
+
+    MatrixWorkspace_sptr output =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outputWS);
+    MatrixWorkspace_sptr output2D =
+        boost::dynamic_pointer_cast<MatrixWorkspace>(output);
+
+    TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 397);
+  }
+
+
   void test_EventPreNeXus_WithNoExecute() {
     Load loader;
     loader.initialize();


### PR DESCRIPTION
This PR fixes the issue in `FileFinder` with facilities that require no instrument prefix in the file name (for the moment ILL). See  #16707.

**To test:**

<!-- Instructions for testing. -->
1. Set some ILL instrument as default.
2. Load a nexus file from that instrument by just specifying the run number (make sure that the directory is in the data search directories).
3. Try the same with multiple files.

Fixes #17150.

Does not need to be in the release notes.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
