### PR TITLE
Framework packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ endif ()
 install ( DIRECTORY installers/colormaps/ DESTINATION ${INBUNDLE}colormaps)
 
 # Install the files (.desktop and icon) to create a menu item, but only if installing to /opt/Mantid
-if ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND CMAKE_INSTALL_PREFIX STREQUAL "/opt/Mantid" )
+if ( ENABLE_MANTIDPLOT AND ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND CMAKE_INSTALL_PREFIX STREQUAL "/opt/Mantid" )
   install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/installers/LinuxInstaller/mantidplot.desktop
             DESTINATION /usr/share/applications )
   install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/images/MantidPlot_Icon_32offset.png

--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -135,12 +135,14 @@ endif ()
 
 # Local dev version
 set ( EXTRA_LDPATH "${ParaView_DIR}/lib" )
-set ( MANTIDPLOT_EXEC MantidPlot )
-configure_file ( ${CMAKE_MODULE_PATH}/Packaging/launch_mantidplot.sh.in
-                 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/launch_mantidplot.sh @ONLY )
-# Needs to be executable
-execute_process ( COMMAND "chmod" "+x" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/launch_mantidplot.sh"
-                  OUTPUT_QUIET ERROR_QUIET )
+if (ENABLE_MANTIDPLOT)
+  set ( MANTIDPLOT_EXEC MantidPlot )
+  configure_file ( ${CMAKE_MODULE_PATH}/Packaging/launch_mantidplot.sh.in
+                   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/launch_mantidplot.sh @ONLY )
+  # Needs to be executable
+  execute_process ( COMMAND "chmod" "+x" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/launch_mantidplot.sh"
+                    OUTPUT_QUIET ERROR_QUIET )
+endif ()
 configure_file ( ${CMAKE_MODULE_PATH}/Packaging/mantidpython.in
                  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mantidpython @ONLY )
 # Needs to be executable
@@ -149,15 +151,17 @@ execute_process ( COMMAND "chmod" "+x" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/mantid
 
 # Package version
 set ( EXTRA_LDPATH "\${INSTALLDIR}/../lib/paraview-5.1" )
-set ( MANTIDPLOT_EXEC MantidPlot_exe )
-configure_file ( ${CMAKE_MODULE_PATH}/Packaging/launch_mantidplot.sh.in
-                 ${CMAKE_CURRENT_BINARY_DIR}/launch_mantidplot.sh.install @ONLY )
-install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/launch_mantidplot.sh.install
-          DESTINATION ${BIN_DIR} RENAME launch_mantidplot.sh
-          PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
-          GROUP_EXECUTE GROUP_READ
-          WORLD_EXECUTE WORLD_READ
-)
+if (ENABLE_MANTIDPLOT)
+  set ( MANTIDPLOT_EXEC MantidPlot_exe )
+  configure_file ( ${CMAKE_MODULE_PATH}/Packaging/launch_mantidplot.sh.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/launch_mantidplot.sh.install @ONLY )
+  install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/launch_mantidplot.sh.install
+            DESTINATION ${BIN_DIR} RENAME launch_mantidplot.sh
+            PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+            GROUP_EXECUTE GROUP_READ
+            WORLD_EXECUTE WORLD_READ
+  )
+endif ()
 configure_file ( ${CMAKE_MODULE_PATH}/Packaging/mantidpython.in
                  ${CMAKE_CURRENT_BINARY_DIR}/mantidpython.install @ONLY )
 install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/mantidpython.install


### PR DESCRIPTION
Don't install gui elements in framework only `tar.gz` builds

**To test:**

In a clean build area run:

``` shell
cmake -G Ninja -DENABLE_MANTIDPLOT=FALSE -DENABLE_CPACK=TRUE ...
cmake --build . -- -j 20
cpack -G TGZ --config CPackConfig.cmake
```

There shouldn't be a `launch_mantidplot.sh`, `MantidPlot_Icon_32offset.png`, or `mantidplot.desktop` in the `tar.gz` file that is generated.

Fixes #17251.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
