### PR TITLE
IndirectDataReduction - post plot and save 

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectTransmissionMonitor.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectTransmissionMonitor.py
@@ -42,7 +42,7 @@ class IndirectTransmissionMonitor(PythonAlgorithm):
         trans_prog = Progress(self, start=0.05, end=0.04, nreports=2)
         trans_prog.report('Transforming monitor for Sample')
         self._trans_mon(ws_basename, 'Sam', self._sample_ws_in)
-        trans_prog.report('Transforming monitor for Contianer')
+        trans_prog.report('Transforming monitor for Container')
         self._trans_mon(ws_basename, 'Can', self._can_ws_in)
 
         workflow_prog = Progress(self, start=0.4, end=1.0, nreports=4)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMoments.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMoments.py
@@ -28,11 +28,6 @@ class SofQWMoments(DataProcessorAlgorithm):
                              doc='Maximum energy for fit. Default=0.5')
         self.declareProperty(name='Scale', defaultValue=1.0,
                              doc='Scale factor to multiply y(Q,w). Default=1.0')
-        self.declareProperty(name='Plot', defaultValue=False,
-                             doc='Switch Plot Off/On')
-        self.declareProperty(name='Save', defaultValue=False,
-                             doc='Switch Save result to nxs file Off/On')
-
         self.declareProperty(WorkspaceGroupProperty("OutputWorkspace", "", Direction.Output),
                              doc="group_workspace workspace that includes all calculated moments.")
 
@@ -48,10 +43,6 @@ class SofQWMoments(DataProcessorAlgorithm):
         emin = self.getProperty('EnergyMin').value
         emax = self.getProperty('EnergyMax').value
         erange = [emin, emax]
-
-        Plot = self.getProperty('Plot').value
-        Save = self.getProperty('Save').value
-
         workflow_prog.report('Validating input')
         num_spectra,num_w = CheckHistZero(sample_workspace)
 
@@ -134,27 +125,8 @@ class SofQWMoments(DataProcessorAlgorithm):
         group_workspaces = ','.join([output_workspace+ext for ext in extensions])
         GroupWorkspaces(InputWorkspaces=group_workspaces, OutputWorkspace=output_workspace)
 
-        if Save:
-            workflow_prog.report('Saving Workspace')
-            workdir = getDefaultWorkingDirectory()
-            opath = os.path.join(workdir,output_workspace+'.nxs')
-            SaveNexusProcessed(InputWorkspace=output_workspace, Filename=opath)
-            logger.information('Output file : ' + opath)
-
-        if Plot:
-            workflow_prog.report('Plotting Workspace')
-            self._plot_moments(output_workspace)
-
         self.setProperty("OutputWorkspace", output_workspace)
         workflow_prog.report('Algorithm complete')
-
-
-    def _plot_moments(self, inputWS):
-        from IndirectImport import import_mantidplot
-        mtd_plot = import_mantidplot()
-
-        mtd_plot.plotSpectrum(inputWS+'_M0', 0)
-        mtd_plot.plotSpectrum([inputWS+'_M2', inputWS+'_M4'], 0)
 
 
 # Register algorithm with Mantid

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISCalibration.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISCalibration.h
@@ -62,6 +62,9 @@ private slots:
   void pbRunFinding();  //< Called when the FileFinder starts finding the files.
   void pbRunFinished(); //< Called when the FileFinder has finished finding the
   // files.
+  /// Handles saving and plotting
+  void saveClicked();
+  void plotClicked();
 
 private:
   void createRESfile(const QString &file);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISCalibration.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISCalibration.ui
@@ -92,17 +92,17 @@
           </property>
          </widget>
         </item>
-         <item>
-           <widget class="QCheckBox" name="ckLoadLogFiles">
-             <property name="text">
-               <string>Load Log Files</string>
-             </property>
-             <property name="checked">
-               <bool>false</bool>
-             </property>
-           </widget>
-         </item>
-         <item>
+        <item>
+         <widget class="QCheckBox" name="ckLoadLogFiles">
+          <property name="text">
+           <string>Load Log Files</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -230,7 +230,10 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QCheckBox" name="ckPlot">
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="toolTip">
          <string>Plot resulting calibration file when created.</string>
         </property>
@@ -253,7 +256,10 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckSave">
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Save Result</string>
         </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
@@ -83,7 +83,6 @@ private slots:
 
 private:
   Ui::ISISDiagnostics m_uiForm;
-  QString m_outputWs;
 };
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
@@ -83,6 +83,7 @@ private slots:
 
 private:
   Ui::ISISDiagnostics m_uiForm;
+  QString m_outputWs;
 };
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
@@ -78,6 +78,8 @@ private slots:
   void pbRunFinding();  //< Called when the FileFinder starts finding the files.
   void pbRunFinished(); //< Called when the FileFinder has finished finding the
   // files.
+  void saveClicked();
+  void plotClicked();
 
 private:
   Ui::ISISDiagnostics m_uiForm;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.ui
@@ -153,7 +153,10 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
-       <widget class="QCheckBox" name="ckPlot">
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Plot Result</string>
         </property>
@@ -173,7 +176,10 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckSave">
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Save Result</string>
         </property>
@@ -204,8 +210,8 @@
  </customwidgets>
  <tabstops>
   <tabstop>ckUseCalibration</tabstop>
-  <tabstop>ckPlot</tabstop>
-  <tabstop>ckSave</tabstop>
+  <tabstop>pbPlot</tabstop>
+  <tabstop>pbSave</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMoments.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMoments.h
@@ -58,6 +58,9 @@ protected slots:
   void updateProperties(QtProperty *prop, double val);
   /// Called when the algorithm completes to update preview plot
   void momentsAlgComplete(bool error);
+  /// Slots for plot and save
+  void saveClicked();
+  void plotClicked();
 
 private:
   Ui::IndirectMoments m_uiForm;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMoments.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMoments.ui
@@ -76,7 +76,7 @@
            <double>0.100000000000000</double>
           </property>
           <property name="value">
-            <double>1.000000000000000</double>
+           <double>1.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -163,9 +163,12 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QCheckBox" name="ckPlot">
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
-         <string>Plot</string>
+         <string>Plot Result</string>
         </property>
        </widget>
       </item>
@@ -183,9 +186,12 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckSave">
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
-         <string>Save</string>
+         <string>Save Result</string>
         </property>
        </widget>
       </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.h
@@ -48,6 +48,8 @@ public:
 private slots:
   void plotContour();
   void sqwAlgDone(bool error);
+  void plotClicked();
+  void saveClicked();
 
 private:
   Ui::IndirectSqw m_uiForm;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
@@ -429,11 +429,6 @@
         </property>
         <item>
          <property name="text">
-          <string>None</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
           <string>Contour</string>
          </property>
         </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
@@ -412,6 +412,9 @@
       </item>
       <item>
        <widget class="QComboBox" name="cbPlotType">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -442,6 +445,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Plot</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer_1">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -455,7 +468,10 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckSave">
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Save Result</string>
         </property>
@@ -483,7 +499,7 @@
   <tabstop>spEWidth</tabstop>
   <tabstop>spEHigh</tabstop>
   <tabstop>cbPlotType</tabstop>
-  <tabstop>ckSave</tabstop>
+  <tabstop>pbSave</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSymmetrise.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSymmetrise.h
@@ -75,6 +75,8 @@ private slots:
   void previewAlgDone(bool error);
   void xRangeMaxChanged(double value);
   void xRangeMinChanged(double value);
+  void plotClicked();
+  void saveClicked();
 
 private:
   Ui::IndirectSymmetrise m_uiForm;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSymmetrise.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSymmetrise.ui
@@ -118,7 +118,10 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QCheckBox" name="ckPlot">
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Plot Result</string>
         </property>
@@ -138,7 +141,10 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckSave">
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Save Result</string>
         </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmission.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmission.h
@@ -54,6 +54,8 @@ private slots:
   void previewPlot();
   void transAlgDone(bool error);
   void instrumentSet();
+  void plotClicked();
+  void saveClicked();
 
 private:
   Ui::IndirectTransmission m_uiForm;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmission.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmission.ui
@@ -133,7 +133,10 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QCheckBox" name="ckPlot">
+       <widget class="QPushButton" name="pbPlot">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Plot Result</string>
         </property>
@@ -153,7 +156,10 @@
        </spacer>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckSave">
+       <widget class="QPushButton" name="pbSave">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string>Save Result</string>
         </property>

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -702,7 +702,9 @@ void ISISCalibration::pbRunFinished() {
  * Handle saving of workspace
  */
 void ISISCalibration::saveClicked() {
+  checkADSForPlotSaveWorkspace(m_outputCalibrationName.toStdString(), false);
   addSaveWorkspaceToQueue(m_outputCalibrationName);
+  checkADSForPlotSaveWorkspace(m_outputResolutionName.toStdString(), false);
   addSaveWorkspaceToQueue(m_outputResolutionName);
   m_batchAlgoRunner->executeBatchAsync();
 }
@@ -711,10 +713,12 @@ void ISISCalibration::saveClicked() {
  * Handle mantid plotting
  */
 void ISISCalibration::plotClicked() {
-  plotTimeBin(m_outputCalibrationName);
 
+  plotTimeBin(m_outputCalibrationName);
+  checkADSForPlotSaveWorkspace(m_outputCalibrationName.toStdString(), true);
   QStringList plotWorkspaces;
   if (m_uiForm.ckCreateResolution->isChecked()) {
+    checkADSForPlotSaveWorkspace(m_outputResolutionName.toStdString(), true);
     plotWorkspaces << m_outputResolutionName;
     if (m_uiForm.ckSmoothResolution->isChecked())
       plotWorkspaces << m_outputResolutionName + "_pre_smooth";

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -155,6 +155,9 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
+  // Handle plotting and saving
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
 }
 
 //----------------------------------------------------------------------------------------------

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -339,6 +339,8 @@ void ISISCalibration::algorithmComplete(bool error) {
     }
     plotSpectrum(plotWorkspaces);
   }
+  m_uiForm.pbSave->setEnabled(true);
+  m_uiForm.pbPlot->setEnabled(true);
 }
 
 bool ISISCalibration::validate() {

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -233,17 +233,10 @@ void ISISCalibration::run() {
     double scale = m_uiForm.spScale->value();
     calibrationAlg->setProperty("ScaleFactor", scale);
   }
-
-  bool save = m_uiForm.ckSave->isChecked();
-
   m_batchAlgoRunner->addAlgorithm(calibrationAlg);
 
   // Initially take the calibration workspace as the result
   m_pythonExportWsName = m_outputCalibrationName.toStdString();
-
-  // Add save algorithm to queue if ticked
-  if (save)
-    addSaveWorkspaceToQueue(m_outputCalibrationName);
 
   // Configure the resolution algorithm
   if (m_uiForm.ckCreateResolution->isChecked()) {
@@ -312,9 +305,6 @@ void ISISCalibration::run() {
       m_batchAlgoRunner->addAlgorithm(smoothAlg, smoothAlgInputProps);
     }
 
-    if (save)
-      addSaveWorkspaceToQueue(m_outputResolutionName);
-
     // When creating resolution file take the resolution workspace as the result
     m_pythonExportWsName = m_outputResolutionName.toStdString();
   }
@@ -331,7 +321,7 @@ void ISISCalibration::algorithmComplete(bool error) {
   if (error)
     return;
 
-  if (m_uiForm.ckPlot->isChecked()) {
+  /*if (m_uiForm.ckPlot->isChecked()) {
     plotTimeBin(m_outputCalibrationName);
 
     QStringList plotWorkspaces;
@@ -341,7 +331,7 @@ void ISISCalibration::algorithmComplete(bool error) {
         plotWorkspaces << m_outputResolutionName + "_pre_smooth";
     }
     plotSpectrum(plotWorkspaces);
-  }
+  }*/
   m_uiForm.pbSave->setEnabled(true);
   m_uiForm.pbPlot->setEnabled(true);
 }
@@ -719,6 +709,13 @@ void ISISCalibration::pbRunFinished() {
 
   m_uiForm.leRunNo->setEnabled(true);
 }
-
+/** 
+ * Handle saving of workspace
+ */
+void ISISCalibration::saveClicked() {
+  addSaveWorkspaceToQueue(m_outputCalibrationName);
+  addSaveWorkspaceToQueue(m_outputResolutionName);
+  m_batchAlgoRunner->executeBatchAsync();
+}
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -698,7 +698,7 @@ void ISISCalibration::pbRunFinished() {
 
   m_uiForm.leRunNo->setEnabled(true);
 }
-/** 
+/**
  * Handle saving of workspace
  */
 void ISISCalibration::saveClicked() {

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -719,9 +719,9 @@ void ISISCalibration::plotClicked() {
   QStringList plotWorkspaces;
   if (m_uiForm.ckCreateResolution->isChecked()) {
     checkADSForPlotSaveWorkspace(m_outputResolutionName.toStdString(), true);
-    plotWorkspaces << m_outputResolutionName;
+    plotWorkspaces.append(m_outputResolutionName);
     if (m_uiForm.ckSmoothResolution->isChecked())
-      plotWorkspaces << m_outputResolutionName + "_pre_smooth";
+      plotWorkspaces.append(m_outputResolutionName + "_pre_smooth");
   }
   plotSpectrum(plotWorkspaces);
 }

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -321,17 +321,6 @@ void ISISCalibration::algorithmComplete(bool error) {
   if (error)
     return;
 
-  /*if (m_uiForm.ckPlot->isChecked()) {
-    plotTimeBin(m_outputCalibrationName);
-
-    QStringList plotWorkspaces;
-    if (m_uiForm.ckCreateResolution->isChecked()) {
-      plotWorkspaces << m_outputResolutionName;
-      if (m_uiForm.ckSmoothResolution->isChecked())
-        plotWorkspaces << m_outputResolutionName + "_pre_smooth";
-    }
-    plotSpectrum(plotWorkspaces);
-  }*/
   m_uiForm.pbSave->setEnabled(true);
   m_uiForm.pbPlot->setEnabled(true);
 }
@@ -716,6 +705,21 @@ void ISISCalibration::saveClicked() {
   addSaveWorkspaceToQueue(m_outputCalibrationName);
   addSaveWorkspaceToQueue(m_outputResolutionName);
   m_batchAlgoRunner->executeBatchAsync();
+}
+
+/**
+ * Handle mantid plotting
+ */
+void ISISCalibration::plotClicked() {
+  plotTimeBin(m_outputCalibrationName);
+
+  QStringList plotWorkspaces;
+  if (m_uiForm.ckCreateResolution->isChecked()) {
+    plotWorkspaces << m_outputResolutionName;
+    if (m_uiForm.ckSmoothResolution->isChecked())
+      plotWorkspaces << m_outputResolutionName + "_pre_smooth";
+  }
+  plotSpectrum(plotWorkspaces);
 }
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
@@ -237,11 +237,8 @@ void ISISDiagnostics::algorithmComplete(bool error) {
   }
 
   for (size_t i = 0; i < sliceOutputGroup->size(); i++) {
-    QString m_outputWs =
-        QString::fromStdString(sliceOutputGroup->getItem(i)->name());
-
-    if (m_uiForm.ckSave->isChecked())
-      addSaveWorkspaceToQueue(m_outputWs);
+    QString wsName =
+      QString::fromStdString(sliceOutputGroup->getItem(i)->name());
   }
   // Enable plot and save buttons
   m_uiForm.pbSave->setEnabled(true);
@@ -474,9 +471,19 @@ void ISISDiagnostics::pbRunFinished() {
  * Handles mantid plotting
  */
 void ISISDiagnostics::plotClicked() {
-  bool plot = checkADSForPlotSaveWorkspace(m_outputWs.toStdString, false);
+  bool plot = checkADSForPlotSaveWorkspace(m_pythonExportWsName, true);
   if (plot)
-    plotSpectrum(m_outputWs);
+    plotSpectrum(QString::fromStdString(m_pythonExportWsName));
+}
+
+/**
+ * Handles saving workspace
+ */
+void ISISDiagnostics::saveClicked() {
+  bool save = checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
+  if (save)
+    addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
+  m_batchAlgoRunner->executeBatchAsync();
 }
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
@@ -471,8 +471,7 @@ void ISISDiagnostics::pbRunFinished() {
  * Handles mantid plotting
  */
 void ISISDiagnostics::plotClicked() {
-  bool plot = checkADSForPlotSaveWorkspace(m_pythonExportWsName, true);
-  if (plot)
+  if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, true))
     plotSpectrum(QString::fromStdString(m_pythonExportWsName));
 }
 
@@ -480,8 +479,7 @@ void ISISDiagnostics::plotClicked() {
  * Handles saving workspace
  */
 void ISISDiagnostics::saveClicked() {
-  bool save = checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
-  if (save)
+  if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
     addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
   m_batchAlgoRunner->executeBatchAsync();
 }

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
@@ -117,6 +117,9 @@ ISISDiagnostics::ISISDiagnostics(IndirectDataReduction *idrUI, QWidget *parent)
   // Reverts run button back to normal when file finding has finished
   connect(m_uiForm.dsInputFiles, SIGNAL(fileFindingFinished()), this,
           SLOT(pbRunFinished()));
+  // Handles plotting and saving
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
 
   // Set default UI state
   sliceTwoRanges(0, false);

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
@@ -243,6 +243,9 @@ void ISISDiagnostics::algorithmComplete(bool error) {
     if (m_uiForm.ckSave->isChecked())
       addSaveWorkspaceToQueue(wsName);
   }
+  // Enable plot and save buttons
+  m_uiForm.pbSave->setEnabled(true);
+  m_uiForm.pbPlot->setEnabled(true);
 
   // Update the preview plots
   sliceAlgDone(false);

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
@@ -237,14 +237,11 @@ void ISISDiagnostics::algorithmComplete(bool error) {
   }
 
   for (size_t i = 0; i < sliceOutputGroup->size(); i++) {
-    QString wsName =
+    QString m_outputWs =
         QString::fromStdString(sliceOutputGroup->getItem(i)->name());
 
-    if (m_uiForm.ckPlot->isChecked())
-      plotSpectrum(wsName);
-
     if (m_uiForm.ckSave->isChecked())
-      addSaveWorkspaceToQueue(wsName);
+      addSaveWorkspaceToQueue(m_outputWs);
   }
   // Enable plot and save buttons
   m_uiForm.pbSave->setEnabled(true);
@@ -473,5 +470,13 @@ void ISISDiagnostics::pbRunFinished() {
   m_uiForm.dsInputFiles->setEnabled(true);
 }
 
+/**
+ * Handles mantid plotting
+ */
+void ISISDiagnostics::plotClicked() {
+  bool plot = checkADSForPlotSaveWorkspace(m_outputWs.toStdString, false);
+  if (plot)
+    plotSpectrum(m_outputWs);
+}
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
@@ -238,7 +238,7 @@ void ISISDiagnostics::algorithmComplete(bool error) {
 
   for (size_t i = 0; i < sliceOutputGroup->size(); i++) {
     QString wsName =
-      QString::fromStdString(sliceOutputGroup->getItem(i)->name());
+        QString::fromStdString(sliceOutputGroup->getItem(i)->name());
   }
   // Enable plot and save buttons
   m_uiForm.pbSave->setEnabled(true);

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -207,8 +207,7 @@ void IndirectMoments::momentsAlgComplete(bool error) {
 void IndirectMoments::plotClicked() {
   QString outputWs =
       getWorkspaceBasename(m_uiForm.dsInput->getCurrentDataName()) + "_Moments";
-  bool plot = checkADSForPlotSaveWorkspace(outputWs.toStdString(), true);
-  if (plot) {
+  if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), true)) {
     plotSpectrum(outputWs + "_M0");
     plotSpectrum({outputWs + "_M0", outputWs + "_M2"});
   }
@@ -220,8 +219,7 @@ void IndirectMoments::plotClicked() {
 void IndirectMoments::saveClicked() {
   QString outputWs =
       getWorkspaceBasename(m_uiForm.dsInput->getCurrentDataName()) + "_Moments";
-  bool save = checkADSForPlotSaveWorkspace(outputWs.toStdString(), false);
-  if (save)
+  if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), false))
     addSaveWorkspaceToQueue(outputWs);
   m_batchAlgoRunner->executeBatchAsync();
 }

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -127,6 +127,9 @@ void IndirectMoments::handleSampleInputReady(const QString &filename) {
 
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
           SLOT(updateProperties(QtProperty *, double)));
+
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -203,6 +203,7 @@ void IndirectMoments::momentsAlgComplete(bool error) {
   m_uiForm.pbPlot->setEnabled(true);
   m_uiForm.pbSave->setEnabled(true);
 }
+
 /**
  * Handle mantid plotting
  */
@@ -214,5 +215,16 @@ void IndirectMoments::plotClicked() {
     plotSpectrum({ outputWs + "_M0", outputWs + "_M2" });
   }
 }
+
+/**
+ * Handles saving of workspaces
+ */
+void IndirectMoments::saveClicked() {
+  QString outputWs = getWorkspaceBasename(m_uiForm.dsInput->getCurrentDataName()) + "_Moments";
+  bool save = checkADSForPlotSaveWorkspace(outputWs.toStdString(), false);
+  addSaveWorkspaceToQueue(outputWs);
+  m_batchAlgoRunner->executeBatchAsync();
+}
+
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -68,7 +68,6 @@ void IndirectMoments::run() {
   double eMin = m_dblManager->value(m_properties["EMin"]);
   double eMax = m_dblManager->value(m_properties["EMax"]);
 
-
   std::string outputWorkspaceName = outputName.toStdString() + "_Moments";
 
   IAlgorithm_sptr momentsAlg =
@@ -206,11 +205,12 @@ void IndirectMoments::momentsAlgComplete(bool error) {
  * Handle mantid plotting
  */
 void IndirectMoments::plotClicked() {
-  QString outputWs = getWorkspaceBasename(m_uiForm.dsInput->getCurrentDataName()) + "_Moments";
+  QString outputWs =
+      getWorkspaceBasename(m_uiForm.dsInput->getCurrentDataName()) + "_Moments";
   bool plot = checkADSForPlotSaveWorkspace(outputWs.toStdString(), true);
   if (plot) {
     plotSpectrum(outputWs + "_M0");
-    plotSpectrum({ outputWs + "_M0", outputWs + "_M2" });
+    plotSpectrum({outputWs + "_M0", outputWs + "_M2"});
   }
 }
 
@@ -218,7 +218,8 @@ void IndirectMoments::plotClicked() {
  * Handles saving of workspaces
  */
 void IndirectMoments::saveClicked() {
-  QString outputWs = getWorkspaceBasename(m_uiForm.dsInput->getCurrentDataName()) + "_Moments";
+  QString outputWs =
+      getWorkspaceBasename(m_uiForm.dsInput->getCurrentDataName()) + "_Moments";
   bool save = checkADSForPlotSaveWorkspace(outputWs.toStdString(), false);
   addSaveWorkspaceToQueue(outputWs);
   m_batchAlgoRunner->executeBatchAsync();

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -221,7 +221,8 @@ void IndirectMoments::saveClicked() {
   QString outputWs =
       getWorkspaceBasename(m_uiForm.dsInput->getCurrentDataName()) + "_Moments";
   bool save = checkADSForPlotSaveWorkspace(outputWs.toStdString(), false);
-  addSaveWorkspaceToQueue(outputWs);
+  if (save)
+    addSaveWorkspaceToQueue(outputWs);
   m_batchAlgoRunner->executeBatchAsync();
 }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -77,8 +77,6 @@ void IndirectMoments::run() {
   momentsAlg->setProperty("Sample", workspaceName.toStdString());
   momentsAlg->setProperty("EnergyMin", eMin);
   momentsAlg->setProperty("EnergyMax", eMax);
-  momentsAlg->setProperty("Plot", false);
-  momentsAlg->setProperty("Save", false);
   momentsAlg->setProperty("OutputWorkspace", outputWorkspaceName);
 
   if (m_uiForm.ckScale->isChecked())

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -199,6 +199,10 @@ void IndirectMoments::momentsAlgComplete(bool error) {
   m_uiForm.ppMomentsPreview->addSpectrum(
       "M2", QString::fromStdString(resultWsNames[3]), 0, Qt::red);
   m_uiForm.ppMomentsPreview->resizeX();
+
+  // Enable plot and save buttons
+  m_uiForm.pbPlot->setEnabled(true);
+  m_uiForm.pbSave->setEnabled(true);
 }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -119,22 +119,6 @@ void IndirectSqw::run() {
 
   m_batchAlgoRunner->addAlgorithm(sampleLogAlg, inputToAddSampleLogProps);
 
-  // Save S(Q, w) workspace
-  if (m_uiForm.ckSave->isChecked()) {
-    QString saveFilename = sqwWsName + ".nxs";
-
-    IAlgorithm_sptr saveNexusAlg =
-        AlgorithmManager::Instance().create("SaveNexus");
-    saveNexusAlg->initialize();
-
-    saveNexusAlg->setProperty("Filename", saveFilename.toStdString());
-
-    BatchAlgorithmRunner::AlgorithmRuntimeProps inputToSaveNexusProps;
-    inputToSaveNexusProps["InputWorkspace"] = sqwWsName.toStdString();
-
-    m_batchAlgoRunner->addAlgorithm(saveNexusAlg, inputToSaveNexusProps);
-  }
-
   // Set the name of the result workspace for Python export
   m_pythonExportWsName = sqwWsName.toStdString();
 
@@ -191,7 +175,7 @@ void IndirectSqw::plotContour() {
  */
 void IndirectSqw::plotClicked() {
   QString plotType = m_uiForm.cbPlotType->currentText();
-
+  checkADSForPlotSaveWorkspace(m_pythonExportWsName, true);
   if (plotType == "Contour")
     plot2D(QString::fromStdString(m_pythonExportWsName));
 
@@ -203,5 +187,14 @@ void IndirectSqw::plotClicked() {
   }
 }
 
+/**
+ * Handles saving of workspaces
+ */
+void IndirectSqw::saveClicked() {
+  bool save = checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
+  if (save)
+    addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
+  m_batchAlgoRunner->executeBatch();
+}
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -150,22 +150,6 @@ void IndirectSqw::sqwAlgDone(bool error) {
   if (error)
     return;
 
-  // Get the workspace name
-  QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
-  QString sqwWsName = sampleWsName.left(sampleWsName.length() - 4) + "_sqw";
-
-  QString plotType = m_uiForm.cbPlotType->currentText();
-
-  if (plotType == "Contour")
-    plot2D(sqwWsName);
-
-  else if (plotType == "Spectra") {
-    auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-        sqwWsName.toStdString());
-    int numHist = static_cast<int>(ws->getNumberHistograms());
-    plotSpectrum(sqwWsName, 0, numHist - 1);
-  }
-
   // Enable save and plot
   m_uiForm.pbPlot->setEnabled(true);
   m_uiForm.pbSave->setEnabled(true);
@@ -199,6 +183,23 @@ void IndirectSqw::plotContour() {
     m_pythonRunner.runPythonCode(pyInput);
   } else {
     emit showMessageBox("Invalid filename.");
+  }
+}
+
+/**
+ * Handles mantid plotting
+ */
+void IndirectSqw::plotClicked() {
+  QString plotType = m_uiForm.cbPlotType->currentText();
+
+  if (plotType == "Contour")
+    plot2D(QString::fromStdString(m_pythonExportWsName));
+
+  else if (plotType == "Spectra") {
+    auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+      m_pythonExportWsName);
+    int numHist = static_cast<int>(ws->getNumberHistograms());
+    plotSpectrum(QString::fromStdString(m_pythonExportWsName), 0, numHist - 1);
   }
 }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -165,6 +165,10 @@ void IndirectSqw::sqwAlgDone(bool error) {
     int numHist = static_cast<int>(ws->getNumberHistograms());
     plotSpectrum(sqwWsName, 0, numHist - 1);
   }
+
+  // Enable save and plot
+  m_uiForm.pbPlot->setEnabled(true);
+  m_uiForm.pbSave->setEnabled(true);
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -176,10 +176,12 @@ void IndirectSqw::plotContour() {
  */
 void IndirectSqw::plotClicked() {
   QString plotType = m_uiForm.cbPlotType->currentText();
-  if (plotType == "Contour" && (checkADSForPlotSaveWorkspace(m_pythonExportWsName, true)))
+  if (plotType == "Contour" &&
+      (checkADSForPlotSaveWorkspace(m_pythonExportWsName, true)))
     plot2D(QString::fromStdString(m_pythonExportWsName));
 
-  else if (plotType == "Spectra" && (checkADSForPlotSaveWorkspace(m_pythonExportWsName, true))) {
+  else if (plotType == "Spectra" &&
+           (checkADSForPlotSaveWorkspace(m_pythonExportWsName, true))) {
     auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
         m_pythonExportWsName);
     int numHist = static_cast<int>(ws->getNumberHistograms());

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -21,6 +21,9 @@ IndirectSqw::IndirectSqw(IndirectDataReduction *idrUI, QWidget *parent)
           SLOT(plotContour()));
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(sqwAlgDone(bool)));
+
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
 }
 
 //----------------------------------------------------------------------------------------------

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -182,7 +182,7 @@ void IndirectSqw::plotClicked() {
 
   else if (plotType == "Spectra") {
     auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-      m_pythonExportWsName);
+        m_pythonExportWsName);
     int numHist = static_cast<int>(ws->getNumberHistograms());
     plotSpectrum(QString::fromStdString(m_pythonExportWsName), 0, numHist - 1);
   }

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -176,11 +176,10 @@ void IndirectSqw::plotContour() {
  */
 void IndirectSqw::plotClicked() {
   QString plotType = m_uiForm.cbPlotType->currentText();
-  checkADSForPlotSaveWorkspace(m_pythonExportWsName, true);
-  if (plotType == "Contour")
+  if (plotType == "Contour" && (checkADSForPlotSaveWorkspace(m_pythonExportWsName, true)))
     plot2D(QString::fromStdString(m_pythonExportWsName));
 
-  else if (plotType == "Spectra") {
+  else if (plotType == "Spectra" && (checkADSForPlotSaveWorkspace(m_pythonExportWsName, true))) {
     auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
         m_pythonExportWsName);
     int numHist = static_cast<int>(ws->getNumberHistograms());
@@ -192,8 +191,7 @@ void IndirectSqw::plotClicked() {
  * Handles saving of workspaces
  */
 void IndirectSqw::saveClicked() {
-  bool save = checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
-  if (save)
+  if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
     addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
   m_batchAlgoRunner->executeBatch();
 }

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -137,6 +137,7 @@ void IndirectSqw::sqwAlgDone(bool error) {
   // Enable save and plot
   m_uiForm.pbPlot->setEnabled(true);
   m_uiForm.pbSave->setEnabled(true);
+  m_uiForm.cbPlotType->setEnabled(true);
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
@@ -523,8 +523,8 @@ void IndirectSymmetrise::xRangeMaxChanged(double value) {
 void IndirectSymmetrise::plotClicked() {
 
   QStringList workspaces;
-  workspaces << m_uiForm.dsInput->getCurrentDataName()
-             << QString::fromStdString(m_pythonExportWsName);
+  workspaces.append(m_uiForm.dsInput->getCurrentDataName());
+  workspaces.append(QString::fromStdString(m_pythonExportWsName));
   plotSpectrum(workspaces);
 }
 
@@ -532,8 +532,7 @@ void IndirectSymmetrise::plotClicked() {
  * Handles saving of workspace
  */
 void IndirectSymmetrise::saveClicked() {
-  bool save = checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
-  if (save)
+  if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
     plotSpectrum(QString::fromStdString(m_pythonExportWsName));
 }
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
@@ -215,12 +215,6 @@ void IndirectSymmetrise::algorithmComplete(bool error) {
   if (error)
     return;
 
-  if (m_uiForm.ckPlot->isChecked()) {
-    QStringList workspaces;
-    workspaces << m_uiForm.dsInput->getCurrentDataName()
-               << QString::fromStdString(m_pythonExportWsName);
-    plotSpectrum(workspaces);
-  }
   // Enable save and plot
   uiForm.pbPlot->setEnabled(true);
   uiForm.pbSave->setEnabled(true);
@@ -526,6 +520,16 @@ void IndirectSymmetrise::xRangeMaxChanged(double value) {
     m_dblManager->setValue(m_properties["EMin"], std::abs(value));
   }
 }
+/**
+ * Handles mantid plotting
+ */
+void IndirectSymmetrise::plotClicked() {
 
+  QStringList workspaces;
+  workspaces << m_uiForm.dsInput->getCurrentDataName()
+    << QString::fromStdString(m_pythonExportWsName);
+  plotSpectrum(workspaces);
+
+}
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
@@ -135,8 +135,8 @@ IndirectSymmetrise::IndirectSymmetrise(IndirectDataReduction *idrUI,
   connect(negativeERaw, SIGNAL(maxValueChanged(double)), this,
           SLOT(xRangeMaxChanged(double)));
   // Handle plotting and saving
-  connect(uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-  connect(uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
 
   // Set default X range values
   m_dblManager->setValue(m_properties["EMin"], 0.1);
@@ -213,8 +213,8 @@ void IndirectSymmetrise::algorithmComplete(bool error) {
     return;
 
   // Enable save and plot
-  uiForm.pbPlot->setEnabled(true);
-  uiForm.pbSave->setEnabled(true);
+  m_uiForm.pbPlot->setEnabled(true);
+  m_uiForm.pbSave->setEnabled(true);
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
@@ -524,9 +524,8 @@ void IndirectSymmetrise::plotClicked() {
 
   QStringList workspaces;
   workspaces << m_uiForm.dsInput->getCurrentDataName()
-    << QString::fromStdString(m_pythonExportWsName);
+             << QString::fromStdString(m_pythonExportWsName);
   plotSpectrum(workspaces);
-
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
@@ -189,9 +189,6 @@ void IndirectSymmetrise::run() {
 
   m_batchAlgoRunner->addAlgorithm(symmetriseAlg);
 
-  if (m_uiForm.ckSave->isChecked())
-    addSaveWorkspaceToQueue(outputWorkspaceName);
-
   // Set the workspace name for Python script export
   m_pythonExportWsName = outputWorkspaceName.toStdString();
 
@@ -530,6 +527,15 @@ void IndirectSymmetrise::plotClicked() {
     << QString::fromStdString(m_pythonExportWsName);
   plotSpectrum(workspaces);
 
+}
+
+/**
+ * Handles saving of workspace
+ */
+void IndirectSymmetrise::saveClicked() {
+  bool save = checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
+  if (save)
+    plotSpectrum(QString::fromStdString(m_pythonExportWsName));
 }
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
@@ -134,6 +134,9 @@ IndirectSymmetrise::IndirectSymmetrise(IndirectDataReduction *idrUI,
           SLOT(xRangeMinChanged(double)));
   connect(negativeERaw, SIGNAL(maxValueChanged(double)), this,
           SLOT(xRangeMaxChanged(double)));
+  // Handle plotting and saving
+  connect(uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+  connect(uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
 
   // Set default X range values
   m_dblManager->setValue(m_properties["EMin"], 0.1);

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
@@ -221,6 +221,9 @@ void IndirectSymmetrise::algorithmComplete(bool error) {
                << QString::fromStdString(m_pythonExportWsName);
     plotSpectrum(workspaces);
   }
+  // Enable save and plot
+  uiForm.pbPlot->setEnabled(true);
+  uiForm.pbSave->setEnabled(true);
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
@@ -50,11 +50,8 @@ void IndirectTransmission::run() {
   transAlg->setProperty("OutputWorkspace", outWsName.toStdString());
 
   m_batchAlgoRunner->addAlgorithm(transAlg);
-
-  if (m_uiForm.ckSave->isChecked())
-    addSaveWorkspaceToQueue(outWsName);
-
   m_batchAlgoRunner->executeBatchAsync();
+
 }
 
 bool IndirectTransmission::validate() {
@@ -139,5 +136,15 @@ void IndirectTransmission::instrumentSet() {
   m_uiForm.dsCanInput->setInstrumentOverride(instDetails["instrument"]);
 }
 
+/**
+ * Handle saving of workspace
+ */
+void IndirectTransmission::saveClicked() {
+  QString outputWs = (m_uiForm.dsSampleInput->getCurrentDataName() + "_trans");
+  bool save = checkADSForPlotSaveWorkspace(outputWs.toStdString(), false);
+  if (save)
+    addSaveWorkspaceToQueue(outputWs);
+  m_batchAlgoRunner->executeBatchAsync();
+}
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
@@ -25,6 +25,8 @@ IndirectTransmission::IndirectTransmission(IndirectDataReduction *idrUI,
           SLOT(dataLoaded()));
   connect(m_uiForm.dsCanInput, SIGNAL(dataReady(QString)), this,
           SLOT(dataLoaded()));
+  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
 }
 
 //----------------------------------------------------------------------------------------------

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
@@ -123,6 +123,10 @@ void IndirectTransmission::transAlgDone(bool error) {
   m_uiForm.ppPlot->addSpectrum(
       "Transmission", QString::fromStdString(resultWsNames[2]), 0, Qt::green);
   m_uiForm.ppPlot->resizeX();
+
+  // Enable plot and save
+  m_uiForm.pbPlot->setEnabled(true);
+  m_uiForm.pbSave->setEnabled(true);
 }
 
 void IndirectTransmission::instrumentSet() {

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
@@ -137,8 +137,8 @@ void IndirectTransmission::instrumentSet() {
  */
 void IndirectTransmission::saveClicked() {
   QString outputWs = (m_uiForm.dsSampleInput->getCurrentDataName() + "_trans");
-  bool save = checkADSForPlotSaveWorkspace(outputWs.toStdString(), false);
-  if (save)
+
+  if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), false))
     addSaveWorkspaceToQueue(outputWs);
   m_batchAlgoRunner->executeBatchAsync();
 }
@@ -148,8 +148,7 @@ void IndirectTransmission::saveClicked() {
  */
 void IndirectTransmission::plotClicked() {
   QString outputWs = (m_uiForm.dsSampleInput->getCurrentDataName() + "_trans");
-  bool plot = checkADSForPlotSaveWorkspace(outputWs.toStdString(), true);
-  if (plot)
+  if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), true))
     plotSpectrum(outputWs);
 }
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
@@ -102,9 +102,6 @@ void IndirectTransmission::transAlgDone(bool error) {
   QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
   QString outWsName = sampleWsName + "_trans";
 
-  if (m_uiForm.ckPlot->isChecked())
-    plotSpectrum(outWsName);
-
   WorkspaceGroup_sptr resultWsGroup =
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
           outWsName.toStdString());
@@ -145,6 +142,16 @@ void IndirectTransmission::saveClicked() {
   if (save)
     addSaveWorkspaceToQueue(outputWs);
   m_batchAlgoRunner->executeBatchAsync();
+}
+
+/**
+ * Handle mantid plotting
+ */
+void IndirectTransmission::plotClicked() {
+  QString outputWs = (m_uiForm.dsSampleInput->getCurrentDataName() + "_trans");
+  bool plot = checkADSForPlotSaveWorkspace(outputWs.toStdString(), true);
+  if (plot)
+    plotSpectrum(outputWs);
 }
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
@@ -51,7 +51,6 @@ void IndirectTransmission::run() {
 
   m_batchAlgoRunner->addAlgorithm(transAlg);
   m_batchAlgoRunner->executeBatchAsync();
-
 }
 
 bool IndirectTransmission::validate() {

--- a/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
@@ -674,7 +674,7 @@ class ISISIndirectInelasticMoments(ISISIndirectInelasticBase):
 
         SofQWMoments(Sample=self.input_workspace, EnergyMin=self.e_min,
                      EnergyMax=self.e_max, Scale=self.scale,
-                     Plot=False, Save=False, OutputWorkspace=self.input_workspace + '_Moments')
+                     OutputWorkspace=self.input_workspace + '_Moments')
 
         self.result_names = [self.input_workspace + '_Moments']
 
@@ -741,7 +741,7 @@ class ISISIndirectInelasticElwinAndMSDFit(ISISIndirectInelasticBase):
             Load(Filename=filename, OutputWorkspace=filename)
         GroupWorkspaces(InputWorkspaces=self.files, OutputWorkspace=elwin_input)
 
-        ElasticWindowMultiple(InputWorkspaces=elwin_input, Plot=False,
+        ElasticWindowMultiple(InputWorkspaces=elwin_input,
                               IntegrationRangeStart=self.eRange[0], IntegrationRangeEnd=self.eRange[1],
                               OutputInQ=elwin_results[0], OutputInQSquared=elwin_results[1],
                               OutputELF=elwin_results[2])
@@ -758,8 +758,7 @@ class ISISIndirectInelasticElwinAndMSDFit(ISISIndirectInelasticBase):
         msdfit_result = MSDFit(InputWorkspace=eq2_file,
                                XStart=self.startX,
                                XEnd=self.endX,
-                               SpecMax=1,
-                               Plot=False)
+                               SpecMax=1)
 
         # Clean up the intermediate files.
         for filename in int_files:


### PR DESCRIPTION
The plotting and saving of the results workspace has been changed to after the execution of the algorithm for all Indirect Data Reduction tabs, apart from EnergyTransfer.

**To Test:**
Files to test with: \olympic\babylon5\Public\Louise McCann\DataReduction
For each tab load relevant files and run algorithm. Check each plot option plots a suitable graph and that the appropriate workspaces have been saved in your save directory.
- [x] ISIS Energy Transfer
- [x] ISIS Calibration
- [x] ISIS Diagnostic
- [x] Transmission
- [x] Symmetrise
- [x] S(Q, w)
- [x] Moments

Fixes #17023 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
