### PR TITLE
ConvertUnits now works with Point Workspaces

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
@@ -106,6 +106,14 @@ private:
   void setupMemberVariables(const API::MatrixWorkspace_const_sptr inputWS);
   API::MatrixWorkspace_sptr
   setupOutputWorkspace(const API::MatrixWorkspace_const_sptr inputWS);
+  API::MatrixWorkspace_sptr
+  executeUnitConversion(const API::MatrixWorkspace_sptr inputWS);
+
+  API::MatrixWorkspace_sptr
+  convertToHistogram(const API::MatrixWorkspace_sptr inputWS);
+
+  API::MatrixWorkspace_sptr
+  convertToPointData(const API::MatrixWorkspace_sptr inputWS);
 
   /// Convert the workspace units according to a simple output = a * (input^b)
   /// relationship

--- a/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
@@ -106,14 +106,11 @@ private:
   void setupMemberVariables(const API::MatrixWorkspace_const_sptr inputWS);
   API::MatrixWorkspace_sptr
   setupOutputWorkspace(const API::MatrixWorkspace_const_sptr inputWS);
+
+  /// Executes the main part of the algorithm that handles the conversion of the
+  /// units
   API::MatrixWorkspace_sptr
   executeUnitConversion(const API::MatrixWorkspace_sptr inputWS);
-
-  API::MatrixWorkspace_sptr
-  convertToHistogram(const API::MatrixWorkspace_sptr inputWS);
-
-  API::MatrixWorkspace_sptr
-  convertToPointData(const API::MatrixWorkspace_sptr inputWS);
 
   /// Convert the workspace units according to a simple output = a * (input^b)
   /// relationship

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -75,10 +75,11 @@ void ConvertUnits::init() {
                   "recommended (see "
                   "http://www.mantidproject.org/ConvertUnits).");
 
-  declareProperty("ConvertFromPointData", true,
-                  "When checked, if the Input Workspace contains Points\n"
-                  "the algorithm ConvertToHistogram will be run to convert\n"
-                  "the Points to Bins. The Output Workspace will contains Bins."
+  declareProperty(
+      "ConvertFromPointData", true,
+      "When checked, if the Input Workspace contains Points\n"
+      "the algorithm ConvertToHistogram will be run to convert\n"
+      "the Points to Bins. The Output Workspace will contains Bins.")
 }
 
 /** Executes the algorithm

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -41,45 +41,45 @@ ConvertUnits::ConvertUnits()
 
 /// Initialisation method
 void ConvertUnits::init() {
-  auto wsValidator = boost::make_shared<CompositeValidator>();
-  wsValidator->add<WorkspaceUnitValidator>();
-  declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
-                      "InputWorkspace", "", Direction::Input, wsValidator),
-                  "Name of the input workspace");
-  declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
-                      "OutputWorkspace", "", Direction::Output),
-                  "Name of the output workspace, can be the same as the input");
+	auto wsValidator = boost::make_shared<CompositeValidator>();
+	wsValidator->add<WorkspaceUnitValidator>();
+	declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+		"InputWorkspace", "", Direction::Input, wsValidator),
+		"Name of the input workspace");
+	declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+		"OutputWorkspace", "", Direction::Output),
+		"Name of the output workspace, can be the same as the input");
 
-  // Extract the current contents of the UnitFactory to be the allowed values of
-  // the Target property
-  declareProperty("Target", "", boost::make_shared<StringListValidator>(
-                                    UnitFactory::Instance().getKeys()),
-                  "The name of the units to convert to (must be one of those "
-                  "registered in\n"
-                  "the Unit Factory)");
-  std::vector<std::string> propOptions{"Elastic", "Direct", "Indirect"};
-  declareProperty("EMode", "Elastic",
-                  boost::make_shared<StringListValidator>(propOptions),
-                  "The energy mode (default: elastic)");
-  auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
-  mustBePositive->setLower(0.0);
-  declareProperty("EFixed", EMPTY_DBL(), mustBePositive,
-                  "Value of fixed energy in meV : EI (EMode=Direct) or EF "
-                  "(EMode=Indirect) . Must be\n"
-                  "set if the target unit requires it (e.g. DeltaE)");
+	// Extract the current contents of the UnitFactory to be the allowed values of
+	// the Target property
+	declareProperty("Target", "", boost::make_shared<StringListValidator>(
+		UnitFactory::Instance().getKeys()),
+		"The name of the units to convert to (must be one of those "
+		"registered in\n"
+		"the Unit Factory)");
+	std::vector<std::string> propOptions{ "Elastic", "Direct", "Indirect" };
+	declareProperty("EMode", "Elastic",
+		boost::make_shared<StringListValidator>(propOptions),
+		"The energy mode (default: elastic)");
+	auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
+	mustBePositive->setLower(0.0);
+	declareProperty("EFixed", EMPTY_DBL(), mustBePositive,
+		"Value of fixed energy in meV : EI (EMode=Direct) or EF "
+		"(EMode=Indirect) . Must be\n"
+		"set if the target unit requires it (e.g. DeltaE)");
 
-  declareProperty("AlignBins", false,
-                  "If true (default is false), rebins after conversion to "
-                  "ensure that all spectra in the output workspace\n"
-                  "have identical bin boundaries. This option is not "
-                  "recommended (see "
-                  "http://www.mantidproject.org/ConvertUnits).");
+	declareProperty("AlignBins", false,
+		"If true (default is false), rebins after conversion to "
+		"ensure that all spectra in the output workspace\n"
+		"have identical bin boundaries. This option is not "
+		"recommended (see "
+		"http://www.mantidproject.org/ConvertUnits).");
 
-  declareProperty(
-      "ConvertFromPointData", true,
-      "When checked, if the Input Workspace contains Points\n"
-      "the algorithm ConvertToHistogram will be run to convert\n"
-      "the Points to Bins. The Output Workspace will contains Bins.")
+	declareProperty(
+		"ConvertFromPointData", true,
+		"When checked, if the Input Workspace contains Points\n"
+		"the algorithm ConvertToHistogram will be run to convert\n"
+		"the Points to Bins. The Output Workspace will contains Bins.");
 }
 
 /** Executes the algorithm

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -76,9 +76,9 @@ void ConvertUnits::init() {
                   "http://www.mantidproject.org/ConvertUnits).");
 
   declareProperty("ConvertFromPointData", true,
-                  "If true (default is true) the Algorithm "
-                  "will run ConvertToHistogram\n"
-                  "and then proceed with ConvertUnits.");
+                  "When checked, if the Input Workspace contains Points\n"
+                  "the algorithm ConvertToHistogram will be run to convert\n"
+                  "the Points to Bins. The Output Workspace will contains Bins."
 }
 
 /** Executes the algorithm

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -41,45 +41,45 @@ ConvertUnits::ConvertUnits()
 
 /// Initialisation method
 void ConvertUnits::init() {
-	auto wsValidator = boost::make_shared<CompositeValidator>();
-	wsValidator->add<WorkspaceUnitValidator>();
-	declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
-		"InputWorkspace", "", Direction::Input, wsValidator),
-		"Name of the input workspace");
-	declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
-		"OutputWorkspace", "", Direction::Output),
-		"Name of the output workspace, can be the same as the input");
+  auto wsValidator = boost::make_shared<CompositeValidator>();
+  wsValidator->add<WorkspaceUnitValidator>();
+  declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+                      "InputWorkspace", "", Direction::Input, wsValidator),
+                  "Name of the input workspace");
+  declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+                      "OutputWorkspace", "", Direction::Output),
+                  "Name of the output workspace, can be the same as the input");
 
-	// Extract the current contents of the UnitFactory to be the allowed values of
-	// the Target property
-	declareProperty("Target", "", boost::make_shared<StringListValidator>(
-		UnitFactory::Instance().getKeys()),
-		"The name of the units to convert to (must be one of those "
-		"registered in\n"
-		"the Unit Factory)");
-	std::vector<std::string> propOptions{ "Elastic", "Direct", "Indirect" };
-	declareProperty("EMode", "Elastic",
-		boost::make_shared<StringListValidator>(propOptions),
-		"The energy mode (default: elastic)");
-	auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
-	mustBePositive->setLower(0.0);
-	declareProperty("EFixed", EMPTY_DBL(), mustBePositive,
-		"Value of fixed energy in meV : EI (EMode=Direct) or EF "
-		"(EMode=Indirect) . Must be\n"
-		"set if the target unit requires it (e.g. DeltaE)");
+  // Extract the current contents of the UnitFactory to be the allowed values of
+  // the Target property
+  declareProperty("Target", "", boost::make_shared<StringListValidator>(
+                                    UnitFactory::Instance().getKeys()),
+                  "The name of the units to convert to (must be one of those "
+                  "registered in\n"
+                  "the Unit Factory)");
+  std::vector<std::string> propOptions{"Elastic", "Direct", "Indirect"};
+  declareProperty("EMode", "Elastic",
+                  boost::make_shared<StringListValidator>(propOptions),
+                  "The energy mode (default: elastic)");
+  auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
+  mustBePositive->setLower(0.0);
+  declareProperty("EFixed", EMPTY_DBL(), mustBePositive,
+                  "Value of fixed energy in meV : EI (EMode=Direct) or EF "
+                  "(EMode=Indirect) . Must be\n"
+                  "set if the target unit requires it (e.g. DeltaE)");
 
-	declareProperty("AlignBins", false,
-		"If true (default is false), rebins after conversion to "
-		"ensure that all spectra in the output workspace\n"
-		"have identical bin boundaries. This option is not "
-		"recommended (see "
-		"http://www.mantidproject.org/ConvertUnits).");
+  declareProperty("AlignBins", false,
+                  "If true (default is false), rebins after conversion to "
+                  "ensure that all spectra in the output workspace\n"
+                  "have identical bin boundaries. This option is not "
+                  "recommended (see "
+                  "http://www.mantidproject.org/ConvertUnits).");
 
-	declareProperty(
-		"ConvertFromPointData", true,
-		"When checked, if the Input Workspace contains Points\n"
-		"the algorithm ConvertToHistogram will be run to convert\n"
-		"the Points to Bins. The Output Workspace will contains Bins.");
+  declareProperty(
+      "ConvertFromPointData", true,
+      "When checked, if the Input Workspace contains Points\n"
+      "the algorithm ConvertToHistogram will be run to convert\n"
+      "the Points to Bins. The Output Workspace will contains Bins.");
 }
 
 /** Executes the algorithm

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -198,8 +198,7 @@ ConvertUnits::executeUnitConversion(const API::MatrixWorkspace_sptr inputWS) {
     std::stringstream msg;
     msg << "Input workspace has invalid X axis binning parameters. Should "
            "have "
-           "at least 2 values. Found "
-        << inputWS->x(0).size() << ".";
+           "at least 2 values. Found " << inputWS->x(0).size() << ".";
     throw std::runtime_error(msg.str());
   }
   if (inputWS->x(0).front() > inputWS->x(0).back() ||
@@ -601,8 +600,8 @@ ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUnit,
 
       // EventWorkspace part, modifying the EventLists.
       if (m_inputEvents) {
-        eventWS->getSpectrum(i).convertUnitsViaTof(localFromUnit.get(),
-                                                   localOutputUnit.get());
+        eventWS->getSpectrum(i)
+            .convertUnitsViaTof(localFromUnit.get(), localOutputUnit.get());
       }
     } else {
       // Get to here if exception thrown when calculating distance to detector
@@ -816,10 +815,10 @@ API::MatrixWorkspace_sptr ConvertUnits::removeUnphysicalBins(
                   workspace->x(j)[k] + 1);
       }
 
-      result->mutableY(j).assign(workspace->y(j).cbegin(),
-                                 workspace->y(j).cbegin() + (k - 1));
-      result->mutableE(j).assign(workspace->e(j).cbegin(),
-                                 workspace->e(j).cbegin() + (k - 1));
+      result->mutableY(j)
+          .assign(workspace->y(j).cbegin(), workspace->y(j).cbegin() + (k - 1));
+      result->mutableE(j)
+          .assign(workspace->e(j).cbegin(), workspace->e(j).cbegin() + (k - 1));
     }
   }
 

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -181,6 +181,10 @@ void ConvertUnits::exec() {
   setProperty("OutputWorkspace", outputWS);
 }
 
+/**Executes the main part of the algorithm that handles the conversion of the units
+* @param inputWS :: the input workspace that will be converted
+* @return A pointer to a MatrixWorkspace_sptr that contains the converted units
+*/
 MatrixWorkspace_sptr
 ConvertUnits::executeUnitConversion(const API::MatrixWorkspace_sptr inputWS) {
 

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -157,8 +157,7 @@ void ConvertUnits::exec() {
   if (correctWS->x(0).size() < 2) {
     std::stringstream msg;
     msg << "Input workspace has invalid X axis binning parameters. Should have "
-           "at least 2 values. Found "
-        << correctWS->x(0).size() << ".";
+           "at least 2 values. Found " << correctWS->x(0).size() << ".";
     throw std::runtime_error(msg.str());
   }
   if (correctWS->x(0).front() > correctWS->x(0).back() ||
@@ -391,9 +390,9 @@ bool ConvertUnits::getDetectorValues(
               g_log.debug() << "Detector: " << det->getID()
                             << " EFixed: " << efixed << "\n";
             }
-          } catch (std::runtime_error
-                       &) { /* Throws if a DetectorGroup, use
-                                                        single provided value */
+          } catch (std::runtime_error &) { /* Throws if a DetectorGroup, use
+                                                                       single
+                                              provided value */
           }
         }
       }
@@ -558,8 +557,8 @@ ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUnit,
 
       // EventWorkspace part, modifying the EventLists.
       if (m_inputEvents) {
-        eventWS->getSpectrum(i).convertUnitsViaTof(localFromUnit.get(),
-                                                   localOutputUnit.get());
+        eventWS->getSpectrum(i)
+            .convertUnitsViaTof(localFromUnit.get(), localOutputUnit.get());
       }
     } else {
       // Get to here if exception thrown when calculating distance to detector
@@ -773,10 +772,10 @@ API::MatrixWorkspace_sptr ConvertUnits::removeUnphysicalBins(
                   workspace->x(j)[k] + 1);
       }
 
-      result->mutableY(j).assign(workspace->y(j).cbegin(),
-                                 workspace->y(j).cbegin() + (k - 1));
-      result->mutableE(j).assign(workspace->e(j).cbegin(),
-                                 workspace->e(j).cbegin() + (k - 1));
+      result->mutableY(j)
+          .assign(workspace->y(j).cbegin(), workspace->y(j).cbegin() + (k - 1));
+      result->mutableE(j)
+          .assign(workspace->e(j).cbegin(), workspace->e(j).cbegin() + (k - 1));
     }
   }
 

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -236,20 +236,20 @@ public:
     // check if the units are successfully converted
     TS_ASSERT_EQUALS(output2D->getAxis(0)->unit()->unitID(), "TOF");
 
-	// Test that X data is still Points (it was converted back)
+    // Test that X data is still Points (it was converted back)
     TS_ASSERT_EQUALS(output2D->x(101).size(), 10);
     // Test that Y & E data is unchanged
     TS_ASSERT_EQUALS(output2D->y(101).size(), 10);
     TS_ASSERT_EQUALS(output2D->e(101).size(), 10);
 
-	// Test that their size is the same
-	TS_ASSERT_EQUALS(output2D->blocksize(), pointsWS2D->blocksize());
+    // Test that their size is the same
+    TS_ASSERT_EQUALS(output2D->blocksize(), pointsWS2D->blocksize());
 
-	// Test that spectra that should have been zeroed have been
-	TS_ASSERT_EQUALS(output2D->y(0)[1], 0);
-	TS_ASSERT_EQUALS(output2D->e(0)[8], 0);
+    // Test that spectra that should have been zeroed have been
+    TS_ASSERT_EQUALS(output2D->y(0)[1], 0);
+    TS_ASSERT_EQUALS(output2D->e(0)[8], 0);
 
-	// Compare to see if X values have changed
+    // Compare to see if X values have changed
     const size_t xsize = output2D->blocksize();
     for (size_t i = 0; i < output2D->getNumberHistograms(); ++i) {
       auto &inX = pointsWS2D->x(i);

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -104,9 +104,7 @@ class ConvertUnitsTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static ConvertUnitsTest *createSuite() {
-    return new ConvertUnitsTest();
-  }
+  static ConvertUnitsTest *createSuite() { return new ConvertUnitsTest(); }
   static void destroySuite(ConvertUnitsTest *suite) { delete suite; }
 
   void setUp() override { inputSpace = "testWorkspace"; }
@@ -817,7 +815,7 @@ public:
   void test_points_workspace() {
 
     ConvertUnits alg;
-	alg.initialize();
+    alg.initialize();
     alg.setPropertyValue("InputWorkspace", "inputWS");
     alg.setPropertyValue("OutputWorkspace", "outWS");
     alg.setPropertyValue("Target", "Wavelength");

--- a/docs/source/algorithms/ConvertUnits-v1.rst
+++ b/docs/source/algorithms/ConvertUnits-v1.rst
@@ -31,12 +31,18 @@ than is smaller than the input one. If the geometry is indirect then the
 value of EFixed will be taken, if available, from the instrument
 definition file.
 
+If ConvertFromPointData is true, an input workspace
+contains Point data will be converted using `ConvertToHistogram <http://www.mantidproject.org/ConvertToHistogram>`__
+and then the algorithm will be run on the converted workspace.
+The output workspace will contain the bins created from ConvertToHistogram.
+If AlignBins is checked, the rebin will be run after the workspace has been converted.
+
 Restrictions on the input workspace
 ###################################
 
 -  Naturally, the X values must have a unit set, and that unit must be
    known to the `Unit Factory <http://www.mantidproject.org/Units>`__.
--  Only histograms, not point data, can be handled at present.
+-  Histograms and Point data can be handled.
 -  The algorithm will also fail if the source-sample distance cannot be
    calculated (i.e. the :ref:`instrument <instrument>` has not been
    properly defined).
@@ -54,7 +60,7 @@ Usage
 **Example: Convert to wavelength**
 
 .. testcode:: ExConvertUnits
-             
+
     ws = CreateSampleWorkspace("Histogram",NumBanks=1,BankPixelWidth=1)
     wsOut = ConvertUnits(ws,Target="Wavelength")
 

--- a/docs/source/algorithms/ConvertUnits-v1.rst
+++ b/docs/source/algorithms/ConvertUnits-v1.rst
@@ -34,8 +34,6 @@ definition file.
 If ConvertFromPointData is true, an input workspace
 contains Point data will be converted using `ConvertToHistogram <http://www.mantidproject.org/ConvertToHistogram>`__
 and then the algorithm will be run on the converted workspace.
-The output workspace will contain the bins created from ConvertToHistogram.
-If AlignBins is checked, the rebin will be run after the workspace has been converted.
 
 Restrictions on the input workspace
 ###################################

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -67,7 +67,7 @@ Improved
 - :ref:`ConvertUnits <algm-ConvertUnits>` will no longer corrupt an in place workspace if the algorithm fails.
 
 - :ref:`ConvertUnits <algm-ConvertUnits>` now has the option to take a workspace with Points as input.
-  A property has been added that will make the algorithm convert the workspace to Bins automatically. The output space will also contain Bins.
+  A property has been added that will make the algorithm convert the workspace to Bins automatically. The output space will be converted back to Points.
 
 - :ref:`SetSample <algm-SetSample>`: Fixed a bug with interpreting the `Center` attribute for cylinders/annuli
 

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -66,6 +66,9 @@ Improved
 
 - :ref:`ConvertUnits <algm-ConvertUnits>` will no longer corrupt an in place workspace if the algorithm fails.
 
+- :ref:`ConvertUnits <algm-ConvertUnits>` now has the option to take a workspace with Points as input.
+  A property has been added that will make the algorithm convert the workspace to Bins automatically. The output space will also contain Bins.
+
 - :ref:`SetSample <algm-SetSample>`: Fixed a bug with interpreting the `Center` attribute for cylinders/annuli
 
 - :ref:`RenameWorkspace <algm-RenameWorkspace>` and `RenameWorkspaces <algm-RenameWorkspaces>`


### PR DESCRIPTION
## Description of work
- `ConvertUnits` now accepts workspaces with Point data.
- `ConvertUnits` has a new property that toggles that functionality on and off
- 2 new Unit Tests have been added to test the new functionality with Point data
- A new Performance Test has been added to test the new functionality with Point data
- The InputWorkspace is converted to Bins, and, at the end, back to Points
## To test:

I used the workspace [here](https://drive.google.com/file/d/0B2Mj8e56Z8xTZjNSNFNScHhBT2c/view?usp=sharing) <- can also be found from the TrainingCourseData, with the helper Python Script found [here](http://pastebin.com/mSwMzx2L)

If you want to try without the fix:
- Load the `164199` workspace into Mantid
- Run the helper Python Script
- It should fail on `ConvertUnits(points_ws, Target='Wavelength')` as `ConvertUnits` doesn't accept Point Data

Testing after applying the fix:
- Load the `164199` workspace into Mantid
- Run the helper Python Script
- Everything should be completed successfully
- You can now test the `ConvertUnits` manually from the `Algorithms` window
- The `ConvertUnits` dialogue has a new option: `ConvertFromPointData`, set by default to `True`
- Check the tooltip text of the checkbox for spelling mistakes and clarity
- Try converting a Points workspace with the option unchecked
- This should fail and an exception should be shown in the log, check the message for spelling mistakes and clarity
- Try again with the option checked, it should now run successfully

Additional:
- Run the `ConvertUnits` unit test. There are 2 new tests. All tests must pass
- Run the `ConvertUnits` performance test. There is 1 new test. All tests must pass. (they take a long time, they might need to be reworked, as they currently load files in)
- Check the documentation for spelling mistakes/clarity. The documentation has been changed both for the release notes (link) and for the algorithm itself.
- Build the documentation and check for bad formatting, any spelling mistakes or anything unclear.
- Check the code quality/readability

<!-- Instructions for testing. -->

Fixes #13280.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

Added in release notes [here](https://github.com/mantidproject/mantid/pull/17266/files#diff-fef8ac613fa6d94a43015ee70c230735R69)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
