### PR TITLE
Fix order of GIL acquisition for validateInputs

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -147,9 +147,9 @@ AlgorithmAdapter<BaseAlgorithm>::validateInputs() {
   std::map<std::string, std::string> resultMap;
 
   try {
+    Environment::GlobalInterpreterLock gil;
     dict resultDict = callMethod<dict>(getSelf(), "validateInputs");
     // convert to a map<string,string>
-    Environment::GlobalInterpreterLock gil;
     boost::python::list keys = resultDict.keys();
     size_t numItems = boost::python::len(keys);
     for (size_t i = 0; i < numItems; ++i) {


### PR DESCRIPTION
Move GIL acquisition to before the call into `PythonAlgorithm::validateInputs()` avoids a segfault on Python 3. 

**To test:**

Build with Python 3 and run some of the tests in [this comment](https://github.com/mantidproject/mantid/issues/16739#issuecomment-240428978) on issue #16739. The tests should not segfault.

No issue number

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Python 3 requires the GIL for any operations on a dict type.
