### PR TITLE
Engg:: Use current instrument prefix if numerical only filename

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -149,6 +149,11 @@ private:
                const std::string &ceriaNo, const std::string &outFilename,
                const std::string &specNos);
 
+  void appendCalibInstPrefix(const std::string vanNo, std::string &outVanName);
+
+  void appendCalibInstPrefix(const std::string vanNo, const std::string cerNo,
+	  std::string &outVanName, std::string &outCerName) const;
+
   std::string
   buildCalibrateSuggestedFilename(const std::string &vanNo,
                                   const std::string &ceriaNo,

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -152,7 +152,8 @@ private:
   void appendCalibInstPrefix(const std::string vanNo, std::string &outVanName);
 
   void appendCalibInstPrefix(const std::string vanNo, const std::string cerNo,
-	  std::string &outVanName, std::string &outCerName) const;
+                             std::string &outVanName,
+                             std::string &outCerName) const;
 
   std::string
   buildCalibrateSuggestedFilename(const std::string &vanNo,

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -149,7 +149,8 @@ private:
                const std::string &ceriaNo, const std::string &outFilename,
                const std::string &specNos);
 
-  void appendCalibInstPrefix(const std::string vanNo, std::string &outVanName);
+  void appendCalibInstPrefix(const std::string vanNo,
+                             std::string &outVanName) const;
 
   void appendCalibInstPrefix(const std::string vanNo, const std::string cerNo,
                              std::string &outVanName,

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1224,43 +1224,42 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
   * @param vanNo The user input for the vanadium run
   * @param outVanName The fixed filename for the vanadium run
   */
-void EnggDiffractionPresenter::appendCalibInstPrefix(const std::string vanNo, std::string & outVanName)
-{
-	// Use a single non numeric digit so we are guaranteed to skip
-	// generating cerium file names
-	const std::string cer = "-";
-	std::string outCerName;
-	appendCalibInstPrefix(vanNo, cer, outVanName, outCerName);
+void EnggDiffractionPresenter::appendCalibInstPrefix(const std::string vanNo,
+                                                     std::string &outVanName) {
+  // Use a single non numeric digit so we are guaranteed to skip
+  // generating cerium file names
+  const std::string cer = "-";
+  std::string outCerName;
+  appendCalibInstPrefix(vanNo, cer, outVanName, outCerName);
 }
 
 /**
   * Appends the current instrument as a filename prefix for numeric
   * only inputs of both the Vanadium and Cerium Oxide runs so Load
   * can find the files.
-  * 
+  *
   * @param vanNo The user input for the vanadium run
   * @param cerNo The user input for the cerium run
   * @param outVanName The fixed filename for the vanadium run
   * @param outCerName The fixed filename for the cerium run
   */
-void EnggDiffractionPresenter::appendCalibInstPrefix(const std::string vanNo, const std::string cerNo, std::string &outVanName, std::string &outCerName) const
-{
-	// If the file is numerical only we need to append
-	// it in case the favorite instrument isn't set to ENGINX
-	const std::string currentInst = m_view->currentInstrument();
-	// Vanadium file
-	if (std::all_of(vanNo.begin(), vanNo.end(), ::isdigit)) {
-		// This only has digits - append prefix
-		outVanName = currentInst + vanNo;
-	}
+void EnggDiffractionPresenter::appendCalibInstPrefix(
+    const std::string vanNo, const std::string cerNo, std::string &outVanName,
+    std::string &outCerName) const {
+  // If the file is numerical only we need to append
+  // it in case the favorite instrument isn't set to ENGINX
+  const std::string currentInst = m_view->currentInstrument();
+  // Vanadium file
+  if (std::all_of(vanNo.begin(), vanNo.end(), ::isdigit)) {
+    // This only has digits - append prefix
+    outVanName = currentInst + vanNo;
+  }
 
-	// Cerium file
-	if (std::all_of(cerNo.begin(), cerNo.end(), ::isdigit)) {
-		// All digits - append inst prefix
-		outCerName = currentInst + cerNo;
-	}
-
-
+  // Cerium file
+  if (std::all_of(cerNo.begin(), cerNo.end(), ::isdigit)) {
+    // All digits - append inst prefix
+    outCerName = currentInst + cerNo;
+  }
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1060,20 +1060,21 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
   MatrixWorkspace_sptr ceriaWS;
 
   // Append current instrument name if numerical only entry
-  std::string vanFileName, cerFileName;
-  appendCalibInstPrefix(vanNo, ceriaNo, vanFileName, cerFileName);
+  // to help Load algorithm determine instrument
+  std::string vanFileHint, cerFileHint;
+  appendCalibInstPrefix(vanNo, ceriaNo, vanFileHint, cerFileHint);
 
   // save vanIntegWS and vanCurvesWS as open genie
   // see where spec number comes from
 
-  loadOrCalcVanadiumWorkspaces(vanFileName, cs.m_inputDirCalib, vanIntegWS,
+  loadOrCalcVanadiumWorkspaces(vanFileHint, cs.m_inputDirCalib, vanIntegWS,
                                vanCurvesWS, cs.m_forceRecalcOverwrite, specNos);
 
   try {
     auto load =
         Mantid::API::AlgorithmManager::Instance().createUnmanaged("Load");
     load->initialize();
-    load->setPropertyValue("Filename", cerFileName);
+    load->setPropertyValue("Filename", cerFileHint);
     const std::string ceriaWSName = "engggui_calibration_sample_ws";
     load->setPropertyValue("OutputWorkspace", ceriaWSName);
     load->execute();
@@ -1715,13 +1716,13 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
 
   const std::string vanNo = m_view->currentVanadiumNo();
 
-  // Append instrument name if numerical only entry
-  std::string vanFileName;
+  // Append instrument name if numerical only entry to help load
+  std::string vanFileHint;
   // We dont need cerium file name so just pass vanadium number twice and
   // ignore return
-  appendCalibInstPrefix(vanNo, vanFileName);
+  appendCalibInstPrefix(vanNo, vanFileHint);
 
-  loadOrCalcVanadiumWorkspaces(vanFileName, cs.m_inputDirCalib, vanIntegWS,
+  loadOrCalcVanadiumWorkspaces(vanFileHint, cs.m_inputDirCalib, vanIntegWS,
                                vanCurvesWS, cs.m_forceRecalcOverwrite, "");
 
   const std::string inWSName = "engggui_focusing_input_ws";

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1224,8 +1224,8 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
   * @param vanNo The user input for the vanadium run
   * @param outVanName The fixed filename for the vanadium run
   */
-void EnggDiffractionPresenter::appendCalibInstPrefix(const std::string vanNo,
-                                                     std::string &outVanName) {
+void EnggDiffractionPresenter::appendCalibInstPrefix(
+    const std::string vanNo, std::string &outVanName) const {
   // Use a single non numeric digit so we are guaranteed to skip
   // generating cerium file names
   const std::string cer = "-";


### PR DESCRIPTION
Description of work.

Previously unless the user set their favourite instrument to `ENGIN-X` the load algorithm would fail to find numerical only runs e.g. `236516` as an input. 
This PR checks if the entry only contains numeric digits and appends the selected instrument under Engineering Diffraction as a prefix for the `Load` algorithm.

**To test:**
All test nxs files are located under system test data.

Ensure your favourite instrument is set to something other than `ENGIN-X`.
Open Engineering Diffraction under Interfaces
Enter the following run numbers (or any substitute):
Van: 236516
Calibration: 241391
Select calibrate
If Mantid manages to find all files and run the calibration regardless of the success of that calibration this means this test is successful.

Next select the Focus tab
Enter file: 194547
Start the focus process
If Mantid manages to find the file to focus and runs the algorithm regardless of the success of the focussing means this test is successful .

Next 

Fixes #17140 .

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
