### PR TITLE
Change name of the vanadium background workspace

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -992,8 +992,8 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             prefix = self._outPrefix
         filename = os.path.join(self._outDir, prefix)
         if pdfgetn:
-            self.log().notice("Saving 'pdfgetn' is deprecated. Use PDtoPDFgetN instead.")
             if "pdfgetn" in self._outTypes:
+                self.log().notice("Saving 'pdfgetn' is deprecated. Use PDtoPDFgetN instead.")
                 pdfwksp = str(wksp)+"_norm"
                 api.SetUncertainties(InputWorkspace=wksp, OutputWorkspace=pdfwksp, SetError="sqrt")
                 api.SaveGSS(InputWorkspace=pdfwksp, Filename=filename+".getn", SplitFiles=False, Append=False,
@@ -1245,7 +1245,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                     van_bkgd_run_number = van_bkgd_run_number_list[0]
                 else:
                     van_bkgd_run_number = van_bkgd_run_number_list[samRunIndex]
-                van_bkgd_ws_name = getBasename(van_bkgd_run_number)
+                van_bkgd_ws_name = getBasename(van_bkgd_run_number) + "_vanbg"
 
                 # load background runs and sum if necessary
                 if self.getProperty("Sum").value:


### PR DESCRIPTION
Description of work.

**To test:**

Run using `mantidpython /SNS/NOM/shared/autoreduction/reduce_NOM.py /SNS/NOM/IPTS-17335/nexus/NOM_78309.nxs.h5 /tmp` before and after merging this branch. You'll fail to post the image, but the rest should work.

_There is no associated issue_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

The issue was if it matched the sample background
one workspace was clobbered
