### PR TITLE
Add more places to download data from

### DIFF
--- a/buildconfig/CMake/MantidExternalData.cmake
+++ b/buildconfig/CMake/MantidExternalData.cmake
@@ -33,8 +33,11 @@ set(ExternalData_URL_TEMPLATES "" CACHE STRING
 file:///var/bigharddrive/%(algo)/%(hash)")
 mark_as_advanced(ExternalData_URL_TEMPLATES)
 list(APPEND ExternalData_URL_TEMPLATES
-  "http://198.74.56.37/ftp/external-data/%(algo)/%(hash)"
-)
+     "file:///home/builder/MantidExternalData-readonly/%(algo)/%(hash)" )
+list(APPEND ExternalData_URL_TEMPLATES
+     "file:///Users/builder/MantidExternalData-readonly/%(algo)/%(hash)" )
+list(APPEND ExternalData_URL_TEMPLATES
+     "http://198.74.56.37/ftp/external-data/%(algo)/%(hash)" )
 
 # Increase network timeout defaults to avoid our slow server connection but don't override what a user provides
 if(NOT ExternalData_TIMEOUT_INACTIVITY)


### PR DESCRIPTION
In order to ease the load on build servers, add more locations to "download" external data from. In this case, two locations on local disk (one for osx, one for linux).

**To test:**

Look over the change and see that it makes sense. All the builds should pass too. `ornl-mac` is the only machine that is currently configured to take advantage of this.

_There is no associated issue_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
