### PR TITLE
Engg:: Enable fitting file input to be plotted to canvas before Fit

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -76,6 +76,8 @@ public:
   void doFitting(const std::string &focusedRunNo,
                  const std::string &expectedPeaks);
 
+  void runLoadAlg(const std::string focusedFile);
+
   void runFittingAlgs(std::string FocusedFitPeaksTableName,
                       std::string FocusedWSName);
 
@@ -83,6 +85,8 @@ public:
   functionStrFactory(Mantid::API::ITableWorkspace_sptr &paramTableWS,
                      std::string tableName, size_t row, std::string &startX,
                      std::string &endX);
+
+  void plotFocusedFile();
 
   void plotFitPeaksCurves();
 
@@ -125,6 +129,7 @@ public:
 
 protected:
   void processStart();
+  void processLoad();
   void processFitPeaks();
   void processFitAllPeaks();
   void processShutDown();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -76,7 +76,8 @@ public:
   void doFitting(const std::string &focusedRunNo,
                  const std::string &expectedPeaks);
 
-  void runLoadAlg(const std::string focusedFile);
+  void runLoadAlg(const std::string focusedFile,
+                  Mantid::API::MatrixWorkspace_sptr &focusedWS);
 
   void runFittingAlgs(std::string FocusedFitPeaksTableName,
                       std::string FocusedWSName);
@@ -86,7 +87,7 @@ public:
                      std::string tableName, size_t row, std::string &startX,
                      std::string &endX);
 
-  void plotFocusedFile();
+  void plotFocusedFile(bool plotSinglePeaks);
 
   void plotFitPeaksCurves();
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -124,6 +124,8 @@ public:
 
   void setBankEmit() override;
 
+  void resetCanvas() override;
+
   void setDataVector(std::vector<boost::shared_ptr<QwtData>> &data,
                      bool focused, bool plotSinglePeaks) override;
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -180,6 +180,7 @@ private slots:
   void setBankIdComboBox(int idx) override;
   void setPeakPick();
   void clearPeakList();
+  void loadClicked();
   void fitClicked();
   void fitAllClicked();
   void FittingRunNo();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -68,6 +68,13 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_load">
+          <property name="text">
+           <string>Load</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item row="4" column="0">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingPresenter.h
@@ -44,6 +44,7 @@ public:
   enum Notification {
     Start,        ///< Start and setup interface
     FittingRunNo, ///< Creates widgets and handles multi/run numbers
+    Load,         ///< Load the focused file to the canvas
     FitPeaks,     ///< Preforms single peak fits
     FitAllPeaks,  ///< Preforms multiple runs in sequence single peak fits
     addPeaks,     ///< Adds peak to the list

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h
@@ -275,6 +275,11 @@ public:
                              bool focused, bool plotSinglePeaks) = 0;
 
   /**
+   * resets the canvas to avoid multiple plotting
+   */
+  virtual void resetCanvas() = 0;
+
+  /**
    * Messages that this view wants to send to the logging system.
    *
    * @return list of messages to log, one by one.

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -485,23 +485,31 @@ void EnggDiffFittingPresenter::processLoad() {
   // while directory vector is not empty
   // if loaded here set a global variable true so doesnt load again?
 
-  MatrixWorkspace_sptr focusedWS;
-  const std::string focusedFile = m_view->getFittingRunNo();
-  Poco::Path selectedfPath(focusedFile);
+  try {
+    MatrixWorkspace_sptr focusedWS;
+    const std::string focusedFile = m_view->getFittingRunNo();
+    Poco::Path selectedfPath(focusedFile);
 
-  if (!focusedFile.empty() && selectedfPath.isFile()) {
-    runLoadAlg(focusedFile, focusedWS);
-    setDifcTzero(focusedWS);
-    convertUnits(g_focusedFittingWSName);
-    plotFocusedFile(false);
+    if (!focusedFile.empty() && selectedfPath.isFile()) {
+      runLoadAlg(focusedFile, focusedWS);
+      setDifcTzero(focusedWS);
+      convertUnits(g_focusedFittingWSName);
+      plotFocusedFile(false);
 
-    m_view->showStatus("Focused file loaded! (Click 'Select "
-                       "Peak' to activate peak picker tool, hold Shift + Click "
-                       "Peak, Click 'Add Peak')");
+      m_view->showStatus(
+          "Focused file loaded! (Click 'Select "
+          "Peak' to activate peak picker tool, hold Shift + Click "
+          "Peak, Click 'Add Peak')");
 
-  } else {
-    m_view->userWarning("No File Found", "Please select a valid focused file!");
-    m_view->showStatus("Error while plotting the focused workspace");
+    } else {
+      m_view->userWarning("No File Found",
+                          "Please select a focused file to load");
+      m_view->showStatus("Error while plotting the focused workspace");
+    }
+  } catch (std::invalid_argument &ia) {
+    m_view->userWarning(
+        "Error loading file",
+        "Unable to load the selected focused file, Please try again.");
   }
 }
 
@@ -1507,6 +1515,10 @@ void EnggDiffFittingPresenter::plotFitPeaksCurves() {
 
   try {
 
+    // detaches previous plots from canvas
+    m_view->resetCanvas();
+
+    // plots focused workspace
     plotFocusedFile(m_fittingFinishedOK);
 
     if (m_fittingFinishedOK) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -506,7 +506,7 @@ void EnggDiffFittingPresenter::processLoad() {
                           "Please select a focused file to load");
       m_view->showStatus("Error while plotting the focused workspace");
     }
-  } catch (std::invalid_argument &ia) {
+  } catch (std::invalid_argument) {
     m_view->userWarning(
         "Error loading file",
         "Unable to load the selected focused file, Please try again.");

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -276,27 +276,33 @@ void EnggDiffFittingViewQtWidget::resetFittingMode() {
   m_fittingSingleRunMode = false;
 }
 
+void EnggDiffFittingViewQtWidget::resetCanvas() {
+  // clear vector and detach curves to avoid plot crash
+  // when only plotting focused workspace
+  for (auto curves : m_fittedDataVector) {
+    if (curves) {
+      curves->detach();
+      delete curves;
+    }
+  }
+
+  if (m_fittedDataVector.size() > 0)
+    m_fittedDataVector.clear();
+
+  // set it as false as there will be no valid workspace to plot
+  m_ui.pushButton_plot_separate_window->setEnabled(false);
+}
+
 void EnggDiffFittingViewQtWidget::setDataVector(
     std::vector<boost::shared_ptr<QwtData>> &data, bool focused,
     bool plotSinglePeaks) {
 
   if (!plotSinglePeaks) {
     // clear vector and detach curves to avoid plot crash
-    // when only plotting focused workspace
-    for (auto curves : m_fittedDataVector) {
-      if (curves) {
-        curves->detach();
-        delete curves;
-      }
-    }
-
-    if (m_fittedDataVector.size() > 0)
-      m_fittedDataVector.clear();
-
-    // set it as false as there will be no valid workspace to plot
-    m_ui.pushButton_plot_separate_window->setEnabled(false);
+    resetCanvas();
   }
 
+  // when only plotting focused workspace
   if (focused) {
     dataCurvesFactory(data, m_focusedDataVector, focused);
   } else {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -103,6 +103,8 @@ void EnggDiffFittingViewQtWidget::doSetup() {
   connect(m_ui.pushButton_fitting_browse_peaks, SIGNAL(released()), this,
           SLOT(browseClicked()));
 
+  connect(m_ui.pushButton_load, SIGNAL(released()), this, SLOT(loadClicked()));
+
   connect(m_ui.pushButton_fit, SIGNAL(released()), this, SLOT(fitClicked()));
 
   connect(m_ui.pushButton_fit_all, SIGNAL(released()), this,
@@ -171,6 +173,7 @@ void EnggDiffFittingViewQtWidget::saveSettings() const {
 
 void EnggDiffFittingViewQtWidget::enable(bool enable) {
   m_ui.pushButton_fitting_browse_run_num->setEnabled(enable);
+  m_ui.pushButton_load->setEnabled(enable);
   m_ui.lineEdit_pushButton_run_num->setEnabled(enable);
   m_ui.pushButton_fitting_browse_peaks->setEnabled(enable);
   m_ui.lineEdit_fitting_peaks->setEnabled(enable);
@@ -212,6 +215,10 @@ std::string EnggDiffFittingViewQtWidget::focusingDir() const {
 std::string
 EnggDiffFittingViewQtWidget::enggRunPythonCode(const std::string &pyCode) {
   return m_mainPythonRunner->enggRunPythonCode(pyCode);
+}
+
+void EnggDiffFittingViewQtWidget::loadClicked() {
+  m_presenter->notify(IEnggDiffFittingPresenter::Load);
 }
 
 void EnggDiffFittingViewQtWidget::fitClicked() {

--- a/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
@@ -86,6 +86,29 @@ public:
     TS_ASSERT(testing::Mock::VerifyAndClearExpectations(m_view.get()));
   }
 
+  void test_load_with_missing_param() {
+    testing::NiceMock<MockEnggDiffFittingView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffFittingPresenter pres(&mockView,
+                                                              nullptr, nullptr);
+
+    EXPECT_CALL(mockView, getFittingRunNo()).Times(1).WillOnce(Return(""));
+
+    EXPECT_CALL(mockView, setPeakList(testing::_)).Times(0);
+
+    // should not get to the point where the status is updated
+    EXPECT_CALL(mockView, showStatus(testing::_)).Times(1);
+
+    // No errors/1 warnings. There will be an error log from the algorithms
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
+
+    pres.notify(IEnggDiffFittingPresenter::Load);
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
+  }
+
   void test_fitting_with_missing_param() {
     testing::NiceMock<MockEnggDiffFittingView> mockView;
     MantidQt::CustomInterfaces::EnggDiffFittingPresenter pres(&mockView,

--- a/MantidQt/CustomInterfaces/test/EnggDiffFittingViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffFittingViewMock.h
@@ -144,6 +144,9 @@ public:
   MOCK_METHOD3(setDataVector,
                void(std::vector<boost::shared_ptr<QwtData>> &data, bool focused,
                     bool plotSinglePeaks));
+
+  // virtual void resetCanvas
+  MOCK_METHOD0(resetCanvas, void());
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/docs/source/interfaces/Engineering_Diffraction.rst
+++ b/docs/source/interfaces/Engineering_Diffraction.rst
@@ -341,12 +341,14 @@ providing a list of dSpacing values where Bragg peaks are expected.
 The algorithm :ref:`EnggFitPeaks<algm-EnggFitPeaks>` is used to
 background fit peaks in those areas using a peak fitting function.
 
-To use the Fitting tab, user is required to provide:
+To use the Fitting tab, user is required to follow these steps:
 
 1. A focused file as Focus Run input by browsing or entering single/multi
-   run number
-2. List of expected peaks which can be either by browsing a (*CSV*) file
-   or entering within the text-field
+   run number, *User may click Load button to load the focused file to the
+   canvas*
+2. List of expected peaks which can be either by browsing a (*CSV*) file,
+   manually selecting peaks from the canvas using peak picker tool after
+   loading the focused file or by entering the peaks list within the text-field
 3. Next click on the *Fit* button if you would like to fit single focused
    file or you can click *Fit All* button which will enable user to
    batch-process all the runs and banks when a range of run number is given,
@@ -437,9 +439,9 @@ Preview
 ^^^^^^^
 Once the fitting process has completed and you are able to view a
 focused workspace with listed expected peaks on the data plot, the *Select
-Peak* button should also be enabled. If the fitting fails with
-the given peaks then the focused workspace will still be plotted so
-that user can select peaks manually.
+Peak* button should also be enabled. If the user choose to load the focus
+workspace or if fitting fails with the given peaks then the focused
+workspace will be plotted so that the user can select the peaks manually.
 
 By clicking Select Peak button the peak picker tool can be activated.
 To select a peak simply hold *Shift* key and left-click on the graph

--- a/docs/source/release/v3.8.0/diffraction.rst
+++ b/docs/source/release/v3.8.0/diffraction.rst
@@ -52,6 +52,10 @@ Engineering Diffraction
   will be utilised to save *engggui_fitting_fitpeaks_param*
   TableWorkspace as a `csv` file.
 
+- New *Load* button on the Fitting Tab, will enable user to load the
+  focused file to the canvas, so that the user can select the peaks
+  manually beforehand
+
 Powder Diffraction
 ------------------
 


### PR DESCRIPTION
**Description of work.**

New _Load_ button on the Fitting Tab, will enable user to load the focused file to the canvas, so that the user can select the peaks manually Fit workflow begins. Status message box on the bottom also updates once the file has been loaded, this is to help user select the peaks manually using the `peak picker` tool.

**To test:**

Focused files can be found here: `\\olympic\Babylon5\Public\Shahroz\`

Go to: `Interfaces/Diffraction/Engineering Diffraction/Fitting Tab`
Browse any file, e.g: `ENGINX_256663_focused_bank_1.nxs`
Click `Load`
Check that the canvas has successfully loaded the focused file and has been enabled
Check status message has been updated and appropriate message is displayed
Manually select peaks and click `Fit`
Make sure peaks have been fitted correctly

[RELEASE NOTES](https://github.com/mantidproject/mantid/blob/272791c3b5572e13724f5b1949eb4ad690da77f7/docs/source/release/v3.8.0/diffraction.rst)

<!-- Instructions for testing. -->

Fixes #17274 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
