### PR TITLE
Throw C++ runtime_exception if Python RuntimeError raised

### DIFF
--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/CallMethod.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/CallMethod.h
@@ -41,7 +41,8 @@ struct UndefinedAttributeError {
  * Wrapper around boost::python::call_method to acquire GIL for duration
  * of call. If the attribute does not exist then an UndefinedAttributeError
  * is thrown, if the call raises a Python error then this is translated to
- * a C++ exception object inheriting from std::exception
+ * a C++ exception object inheriting from std::exception or std::runtime_error
+ * depending on the type of Python error.
  * @param obj Pointer to Python object
  * @param methodName Name of the method call
  * @param args A list of arguments to forward to call_method
@@ -55,7 +56,13 @@ ReturnType callMethod(PyObject *obj, const char *methodName,
       return boost::python::call_method<ReturnType, Args...>(obj, methodName,
                                                              args...);
     } catch (boost::python::error_already_set &) {
-      throw PythonException();
+      PyObject *exception = PyErr_Occurred();
+      assert(exception);
+      if (PyErr_GivenExceptionMatches(exception, PyExc_RuntimeError)) {
+        throw PythonRuntimeError();
+      } else {
+        throw PythonException();
+      }
     }
   } else {
     throw UndefinedAttributeError();

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/ErrorHandling.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Environment/ErrorHandling.h
@@ -32,18 +32,29 @@
 namespace Mantid {
 namespace PythonInterface {
 namespace Environment {
-/// Exception type that captures the current Python error state
-/// as a C++ exception
+
+/**
+ * Exception type that captures the current Python error state
+ * as a generic C++ exception for any general Python exception
+ */
 class DLLExport PythonException : public std::exception {
 public:
   PythonException(bool withTrace = true);
+
   const char *what() const noexcept override { return m_msg.c_str(); }
 
 private:
   std::string m_msg;
 };
+
+/// Exception type that captures the current Python error state
+/// as a C++ std::runtime exception
+class DLLExport PythonRuntimeError : public std::runtime_error {
+public:
+  PythonRuntimeError(bool withTrace = true);
+};
 }
 }
 }
 
-#endif /* MANTID_PYTHONINTERFACE_CALLMETHOD_H_ */
+#endif /* MANTID_PYTHONINTERFACE_ERRORHANDLING_H_ */

--- a/Framework/PythonInterface/mantid/kernel/src/Environment/ErrorHandling.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Environment/ErrorHandling.cpp
@@ -18,8 +18,15 @@ namespace Mantid {
 namespace PythonInterface {
 namespace Environment {
 namespace {
-void tracebackToMsg(std::stringstream &msg, PyTracebackObject *traceback,
-                    bool root = true) {
+
+/**
+ * Unroll a traceback as a string reprsentation and append it to the stream
+ * @param msg A stream reference for building up the msg
+ * @param traceback A Python traceback object
+ * @param root True if this is the root of the traceback, false otherwise
+ */
+void tracebackToStream(std::ostream &msg, PyTracebackObject *traceback,
+                       bool root = true) {
   if (traceback == nullptr)
     return;
   msg << "\n  ";
@@ -31,23 +38,24 @@ void tracebackToMsg(std::stringstream &msg, PyTracebackObject *traceback,
   msg << " line " << traceback->tb_lineno << " in \'"
       << extract<const char *>(traceback->tb_frame->f_code->co_filename)()
       << "\'";
-  tracebackToMsg(msg, traceback->tb_next, false);
-}
+  tracebackToStream(msg, traceback->tb_next, false);
 }
 
 /**
- * Construct an exception object where the message is populated from the
- * current Python exception state
- * @param withTrace If true, include the full traceback in the message
+ * Create a string representation of the current Python exception state. Note
+ *that
+ * the python error state is *not* checked and it is undefined what happens if
+ * called in this state.
+ *
+ * The GIL is held for the duration of this call.
+ * @param withTrace If true then provide a full traceback as part of the
+ * string message.
  */
-PythonException::PythonException(bool withTrace) : std::exception(), m_msg() {
+std::string exceptionToString(bool withTrace) {
   GlobalInterpreterLock gil;
-  if (!PyErr_Occurred()) {
-    throw std::runtime_error(
-        "PythonException thrown but no Python error state set!");
-  }
   PyObject *exception(nullptr), *value(nullptr), *traceback(nullptr);
   PyErr_Fetch(&exception, &value, &traceback);
+  assert(exception);
   PyErr_NormalizeException(&exception, &value, &traceback);
   PyErr_Clear();
   PyObject *strRepr = PyObject_Str(value);
@@ -58,7 +66,8 @@ PythonException::PythonException(bool withTrace) : std::exception(), m_msg() {
     builder << "Unknown exception has occurred.";
   }
   if (withTrace) {
-    tracebackToMsg(builder, reinterpret_cast<PyTracebackObject *>(traceback));
+    tracebackToStream(builder,
+                      reinterpret_cast<PyTracebackObject *>(traceback));
   }
 
   // Ensure we decrement the reference count on the traceback and exception
@@ -69,8 +78,33 @@ PythonException::PythonException(bool withTrace) : std::exception(), m_msg() {
   Py_XDECREF(traceback);
   Py_XDECREF(exception);
   Py_XDECREF(value);
-  m_msg = builder.str();
+  return builder.str();
 }
+}
+
+// -----------------------------------------------------------------------------
+// PythonException
+// -----------------------------------------------------------------------------
+
+/**
+ * Construct an exception object where the message is populated from the
+ * current Python exception state.
+ * @param withTrace If true, include the full traceback in the message
+ */
+PythonException::PythonException(bool withTrace)
+    : std::exception(), m_msg(exceptionToString(withTrace)) {}
+
+// -----------------------------------------------------------------------------
+// PythonRuntimeError
+// -----------------------------------------------------------------------------
+
+/**
+ * Construct an exception object where the message is populated from the
+ * current Python exception state.
+ * @param withTrace If true, include the full traceback in the message
+ */
+PythonRuntimeError::PythonRuntimeError(bool withTrace)
+    : std::runtime_error(exceptionToString(withTrace)) {}
 }
 }
 }


### PR DESCRIPTION
Changes #17171 introduced a C++ exception type for Python errors. The base was `std::exception` but parts of the framework expected a `runtime_error` if a Python `RuntimeError` was raised. These changes check the exception typeand throw a c++ `runtime_error` if the Python exception type is an instance of `RuntimeError`.  

**To test:**

Code review. All builds should of course pass. I have checked the Python 3 tests manually. 

No issue

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
