### PR TITLE
Reflectometry Polref interface transfer bar fix

### DIFF
--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflRunsTabPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflRunsTabPresenter.cpp
@@ -28,6 +28,11 @@ using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace MantidQt::MantidWidgets;
 
+namespace {
+  /// static logger
+  Logger g_log("ReflRunsTabPresenter");
+}
+
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -214,6 +219,11 @@ void ReflRunsTabPresenter::transfer() {
   // Build the input for the transfer strategy
   SearchResultMap runs;
   auto selectedRows = m_view->getSelectedSearchRows();
+
+  // Do not begin transfer if nothing is selected
+  if (selectedRows.size() == 0) {
+    return;
+  }
 
   for (auto rowIt = selectedRows.begin(); rowIt != selectedRows.end();
        ++rowIt) {

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflRunsTabPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflRunsTabPresenter.cpp
@@ -28,11 +28,6 @@ using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace MantidQt::MantidWidgets;
 
-namespace {
-  /// static logger
-  Logger g_log("ReflRunsTabPresenter");
-}
-
 namespace MantidQt {
 namespace CustomInterfaces {
 

--- a/docs/source/release/v3.8.0/reflectometry.rst
+++ b/docs/source/release/v3.8.0/reflectometry.rst
@@ -25,6 +25,7 @@ ISIS Reflectometry (Polref)
 
 - Interface now displays information in a tree where groups are parent items and runs are children. For more details, please check the updated documentation.
 - Global settings have been moved to a separate tab ("Settings")
+- Transfer progress bar no longer gives impression of running when clicked if no runs are selected
 
 ISIS Reflectometry
 ##################


### PR DESCRIPTION
In the Reflectometry Polref interface, clicking the transfer button with no runs selected causes activity to be shown in the transfer progress bar, as though a transfer was occurring. This should not happen, and this pull request fixes that bug.

Fixes #17057 .

Release notes have been updated.

**To test:**

Open the interface from Interfaces->Reflectometry->ISIS Reflectometry (Polref). Without selecting any runs from the 'Search Runs' dock, click on the 'Transfer' button. Unlike before, the transfer progress bar should not show any activity.
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
