### PR TITLE
fix lattice UB

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Crystal/OrientedLattice.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/OrientedLattice.h
@@ -88,6 +88,7 @@ private:
   void recalculateFromGstar(const Kernel::DblMatrix &NewGstar) override {
     UnitCell::recalculateFromGstar(NewGstar);
   }
+  void recalculate();
 };
 } // namespace Mantid
 } // namespace Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/OrientedLattice.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/OrientedLattice.h
@@ -88,7 +88,7 @@ private:
   void recalculateFromGstar(const Kernel::DblMatrix &NewGstar) override {
     UnitCell::recalculateFromGstar(NewGstar);
   }
-  void recalculate();
+  void recalculate() override;
 };
 } // namespace Mantid
 } // namespace Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/UnitCell.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/UnitCell.h
@@ -142,7 +142,7 @@ public:
   double recVolume() const;
   virtual void recalculateFromGstar(const Kernel::Matrix<double> &NewGstar);
 
-private:
+protected:
   /// Lattice parameter a,b,c,alpha,beta,gamma (in \f$ \mbox{ \AA } \f$ and
   /// radians)
   std::vector<double> da;
@@ -177,11 +177,13 @@ private:
   Kernel::DblMatrix Binv;
 
   // Private functions
-  void recalculate();
+
   void calculateG();
   void calculateGstar();
   void calculateReciprocalLattice();
   void calculateB();
+
+  virtual void recalculate();
 };
 
 MANTID_GEOMETRY_DLL std::ostream &operator<<(std::ostream &out,

--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -314,5 +314,18 @@ bool OrientedLattice::GetABC(const DblMatrix &UB, V3D &a_dir, V3D &b_dir,
 
   return true;
 }
+/// Private function, called at initialization or whenever lattice parameters
+/// are changed
+void OrientedLattice::recalculate() {
+  if ((da[3] > da[4] + da[5]) || (da[4] > da[3] + da[5]) ||
+      (da[5] > da[4] + da[3])) {
+    throw std::invalid_argument("Invalid angles");
+  }
+  UnitCell::calculateG();
+  UnitCell::calculateGstar();
+  UnitCell::calculateReciprocalLattice();
+  UnitCell::calculateB();
+  UB = U * getB();
+}
 } // Namespace Geometry
 } // Namespace Mantid

--- a/Framework/Geometry/src/Crystal/UnitCell.cpp
+++ b/Framework/Geometry/src/Crystal/UnitCell.cpp
@@ -5,7 +5,6 @@
 #include <stdexcept>
 #include <iomanip>
 #include <ios>
-//#include <iostream>
 #include <cfloat>
 
 #include <boost/lexical_cast.hpp>

--- a/Framework/Geometry/src/Crystal/UnitCell.cpp
+++ b/Framework/Geometry/src/Crystal/UnitCell.cpp
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <iomanip>
 #include <ios>
-#include <iostream>
+//#include <iostream>
 #include <cfloat>
 
 #include <boost/lexical_cast.hpp>

--- a/Framework/Geometry/test/OrientedLatticeTest.h
+++ b/Framework/Geometry/test/OrientedLatticeTest.h
@@ -23,10 +23,10 @@ public:
     TS_ASSERT_DELTA(u2.b1(), 1. / 3., 1e-10);
     TS_ASSERT_DELTA(u2.alphastar(), 90, 1e-10);
     TS_ASSERT_DELTA(u4.volume(), 1. / u2.recVolume(), 1e-10);
-    TS_ASSERT_DELTA(u2.getUB()[0][0], 1./3., 1e-10);
+    TS_ASSERT_DELTA(u2.getUB()[0][0], 1. / 3., 1e-10);
     u2.seta(13);
     TS_ASSERT_DELTA(u2.a(), 13, 1e-10);
-    TS_ASSERT_DELTA(u2.getUB()[0][0], 1./13., 1e-10);
+    TS_ASSERT_DELTA(u2.getUB()[0][0], 1. / 13., 1e-10);
   }
 
   void test_hklFromQ() {

--- a/Framework/Geometry/test/OrientedLatticeTest.h
+++ b/Framework/Geometry/test/OrientedLatticeTest.h
@@ -23,8 +23,10 @@ public:
     TS_ASSERT_DELTA(u2.b1(), 1. / 3., 1e-10);
     TS_ASSERT_DELTA(u2.alphastar(), 90, 1e-10);
     TS_ASSERT_DELTA(u4.volume(), 1. / u2.recVolume(), 1e-10);
-    u2.seta(3);
-    TS_ASSERT_DELTA(u2.a(), 3, 1e-10);
+    TS_ASSERT_DELTA(u2.getUB()[0][0], 1./3., 1e-10);
+    u2.seta(13);
+    TS_ASSERT_DELTA(u2.a(), 13, 1e-10);
+    TS_ASSERT_DELTA(u2.getUB()[0][0], 1./13., 1e-10);
   }
 
   void test_hklFromQ() {


### PR DESCRIPTION
Description of work.
UB matrix is now correct for OrientedLattice after seta, setb, setc.  Before only B was recalculated in the UnitCell.  Test was changed to check this in C++.

**To test:**

``` python
w=CreateSingleValuedWorkspace(5)
SetUB(w,10,10,10,90,90,90,"1,0,1","0,1,1")
print w.sample().getOrientedLattice().getUB()
w.sample().getOrientedLattice().seta(20)
print w.sample().getOrientedLattice().getUB()
```

Fixes #17303.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
