### PR TITLE
Faster SCDCalibratePanels

### DIFF
--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -155,7 +155,8 @@ public:
 
   virtual std::vector<std::pair<std::string, std::string>>
   peakInfo(const Kernel::V3D &QFrame, bool labCoords) const = 0;
-  virtual int peakInfoNumber(const Kernel::V3D &qLabFrame, bool labCoords) const = 0;
+  virtual int peakInfoNumber(const Kernel::V3D &qLabFrame,
+                             bool labCoords) const = 0;
 
   std::string convention;
 

--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -110,7 +110,7 @@ public:
    * @return a pointer to a new Peak object.
    */
   virtual Mantid::Geometry::IPeak *
-  createPeak(Mantid::Kernel::V3D QLabFrame,
+  createPeak(const Mantid::Kernel::V3D &QLabFrame,
              boost::optional<double> detectorDistance) const = 0;
 
   /**
@@ -119,7 +119,7 @@ public:
    * @return a pointer to a new Peak object.
    */
   virtual Mantid::Geometry::IPeak *
-  createPeakHKL(Mantid::Kernel::V3D HKL) const = 0;
+  createPeakHKL(const Mantid::Kernel::V3D &HKL) const = 0;
 
   //---------------------------------------------------------------------------------------------
   /** Determine if the workspace has been integrated using a peaks integration
@@ -154,8 +154,8 @@ public:
   getSpecialCoordinateSystem() const = 0;
 
   virtual std::vector<std::pair<std::string, std::string>>
-  peakInfo(Kernel::V3D QFrame, bool labCoords) const = 0;
-  virtual int peakInfoNumber(Kernel::V3D qLabFrame, bool labCoords) const = 0;
+  peakInfo(const Kernel::V3D &QFrame, bool labCoords) const = 0;
+  virtual int peakInfoNumber(const Kernel::V3D &qLabFrame, bool labCoords) const = 0;
 
   std::string convention;
 

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels.h
@@ -207,9 +207,9 @@ private:
    * @param instrument   The instrument with the new values for the banks in
    *Groups
    */
-  void saveXmlFile(std::string const FileName,
-                   boost::container::flat_set<std::string> const AllBankNames,
-                   Geometry::Instrument_const_sptr const instrument) const;
+  void saveXmlFile(const std::string &FileName,
+                   const boost::container::flat_set<std::string> &AllBankNames,
+                   const Geometry::Instrument &instrument) const;
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels.h
@@ -180,8 +180,8 @@ private:
                              const std::vector<double> &params,
                              const std::vector<double> &errs);
   /// Function to find peaks near detector edge
-  bool edgePixel(DataObjects::PeaksWorkspace_sptr ws, std::string bankName,
-                 int col, int row, int Edge);
+  bool edgePixel(const DataObjects::PeaksWorkspace &ws,
+                 const std::string &bankName, int col, int row, int Edge);
   /// Function to calculate U
   void findU(DataObjects::PeaksWorkspace_sptr peaksWs);
   /// save workspaces

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -423,7 +423,7 @@ void PredictPeaks::calculateQAndAddToOutput(const V3D &hkl,
   V3D q = orientedUB * hkl * (2.0 * M_PI * m_qConventionFactor);
 
   // Create the peak using the Q in the lab framewith all its info:
-  Peak p(m_inst, q, boost::optional<double>());
+  Peak p(m_inst, q);
 
   /* The constructor calls setQLabFrame, which already calls findDetector, which
      is expensive. It's not necessary to call it again, instead it's enough to

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -96,22 +96,20 @@ void SCDCalibratePanels::Quat2RotxRotyRotz(const Quat Q, double &Rotx,
   @param  Edge         Number of edge points for each bank
   @return True if peak is on edge
 */
-bool SCDCalibratePanels::edgePixel(PeaksWorkspace_sptr ws, std::string bankName,
-                                   int col, int row, int Edge) {
+bool SCDCalibratePanels::edgePixel(const PeaksWorkspace &ws,
+                                   const std::string &bankName, int col,
+                                   int row, int Edge) {
   if (bankName.compare("None") == 0)
     return false;
-  Geometry::Instrument_const_sptr Iptr = ws->getInstrument();
-  boost::shared_ptr<const IComponent> parent =
-      Iptr->getComponentByName(bankName);
+  auto Iptr = ws.getInstrument();
+  auto parent = Iptr->getComponentByName(bankName);
   if (parent->type().compare("RectangularDetector") == 0) {
-    boost::shared_ptr<const RectangularDetector> RDet =
-        boost::dynamic_pointer_cast<const RectangularDetector>(parent);
-
+    auto RDet = boost::dynamic_pointer_cast<const RectangularDetector>(parent);
     return col < Edge || col >= (RDet->xpixels() - Edge) || row < Edge ||
            row >= (RDet->ypixels() - Edge);
   } else {
     std::vector<Geometry::IComponent_const_sptr> children;
-    boost::shared_ptr<const Geometry::ICompAssembly> asmb =
+    auto asmb =
         boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(parent);
     asmb->getChildren(children, false);
     int startI = 1;
@@ -119,11 +117,11 @@ bool SCDCalibratePanels::edgePixel(PeaksWorkspace_sptr ws, std::string bankName,
       startI = 0;
       parent = children[0];
       children.clear();
-      boost::shared_ptr<const Geometry::ICompAssembly> asmb =
+      auto asmb =
           boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(parent);
       asmb->getChildren(children, false);
     }
-    boost::shared_ptr<const Geometry::ICompAssembly> asmb2 =
+    auto asmb2 =
         boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(children[0]);
     std::vector<Geometry::IComponent_const_sptr> grandchildren;
     asmb2->getChildren(grandchildren, false);
@@ -139,29 +137,27 @@ bool SCDCalibratePanels::edgePixel(PeaksWorkspace_sptr ws, std::string bankName,
 void SCDCalibratePanels::exec() {
   PeaksWorkspace_sptr peaksWs = getProperty("PeakWorkspace");
   // We must sort the peaks
-  std::vector<std::pair<std::string, bool>> criteria;
-  criteria.push_back(std::pair<std::string, bool>("BankName", true));
+  std::vector<std::pair<std::string, bool>> criteria{{"BankName", true}};
   peaksWs->sort(criteria);
   // Remove peaks on edge
   int edge = this->getProperty("EdgePixels");
   if (edge > 0) {
-    for (int i = int(peaksWs->getNumberPeaks()) - 1; i >= 0; --i) {
-      const std::vector<Peak> &peaks = peaksWs->getPeaks();
-      if (edgePixel(peaksWs, peaks[i].getBankName(), peaks[i].getCol(),
-                    peaks[i].getRow(), edge)) {
-        peaksWs->removePeak(i);
-      }
-    }
+    std::vector<Peak> &peaks = peaksWs->getPeaks();
+    auto it = std::remove_if(
+        peaks.begin(), peaks.end(), [&peaksWs, edge, this](const Peak &pk) {
+          return this->edgePixel(*peaksWs, pk.getBankName(), pk.getCol(),
+                                 pk.getRow(), edge);
+        });
+    peaks.erase(it, peaks.end());
   }
   findU(peaksWs);
 
-  // Remove peaks that were not indexed
-  for (int i = static_cast<int>(peaksWs->getNumberPeaks()) - 1; i >= 0; --i) {
-    Peak peak = peaksWs->getPeak(i);
-    if (peak.getHKL() == V3D(0, 0, 0)) {
-      peaksWs->removePeak(i);
-    }
-  }
+  std::vector<Peak> &peaks = peaksWs->getPeaks();
+  auto it = std::remove_if(peaks.begin(), peaks.end(), [](const Peak &pk) {
+    return pk.getHKL() == V3D(0, 0, 0);
+  });
+  peaks.erase(it, peaks.end());
+
   int nPeaks = static_cast<int>(peaksWs->getNumberPeaks());
   bool changeL1 = getProperty("ChangeL1");
   bool changeSize = getProperty("ChangePanelSize");
@@ -178,18 +174,16 @@ void SCDCalibratePanels::exec() {
   PARALLEL_FOR1(peaksWs)
   for (int i = 0; i < static_cast<int>(MyBankNames.size()); ++i) {
     PARALLEL_START_INTERUPT_REGION
-    boost::container::flat_set<string>::iterator it = MyBankNames.begin();
-    advance(it, i);
-    std::string iBank = *it;
+    const std::string &iBank = *std::next(MyBankNames.begin(), i);
     const std::string bankName = "__PWS_" + iBank;
     PeaksWorkspace_sptr local = peaksWs->clone();
     AnalysisDataService::Instance().addOrReplace(bankName, local);
-    for (int j = nPeaks - 1; j >= 0; --j) {
-      Peak peak = local->getPeak(j);
-      if (peak.getBankName() != iBank) {
-        local->removePeak(j);
-      }
-    }
+    std::vector<Peak> &localPeaks = local->getPeaks();
+    auto lit = std::remove_if(
+        localPeaks.begin(), localPeaks.end(),
+        [&iBank](const Peak &pk) { return pk.getBankName() != iBank; });
+    localPeaks.erase(lit, localPeaks.end());
+
     int nBankPeaks = local->getNumberPeaks();
     if (nBankPeaks < 6) {
       g_log.notice() << "Too few peaks for " << iBank << "\n";

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -342,7 +342,7 @@ void SCDCalibratePanels::exec() {
   string DetCalFileName = getProperty("DetCalFilename");
   saveIsawDetCal(inst, MyBankNames, 0.0, DetCalFileName);
   string XmlFileName = getProperty("XmlFilename");
-  saveXmlFile(XmlFileName, MyBankNames, inst);
+  saveXmlFile(XmlFileName, MyBankNames, *inst);
   // create table of theoretical vs calculated
   //----------------- Calculate & Create Calculated vs Theoretical
   // workspaces------------------,);
@@ -1011,9 +1011,9 @@ void writeXmlParameter(ofstream &ostream, const string &name,
 }
 
 void SCDCalibratePanels::saveXmlFile(
-    string const FileName,
-    boost::container::flat_set<string> const AllBankNames,
-    Instrument_const_sptr const instrument) const {
+    const string &FileName,
+    const boost::container::flat_set<string> &AllBankNames,
+    const Instrument &instrument) const {
   if (FileName.empty())
     return;
 
@@ -1022,19 +1022,18 @@ void SCDCalibratePanels::saveXmlFile(
   // create the file and add the header
   ofstream oss3(FileName.c_str());
   oss3 << "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n";
-  oss3 << " <parameter-file instrument=\"" << instrument->getName()
-       << "\" valid-from=\"" << instrument->getValidFromDate().toISO8601String()
+  oss3 << " <parameter-file instrument=\"" << instrument.getName()
+       << "\" valid-from=\"" << instrument.getValidFromDate().toISO8601String()
        << "\">\n";
-  ParameterMap_sptr pmap = instrument->getParameterMap();
+  ParameterMap_sptr pmap = instrument.getParameterMap();
 
   // write out the detector banks
-  for (auto it = AllBankNames.rbegin(); it != AllBankNames.rend(); ++it) {
-    std::string bankName = *it;
-    if (instrument->getName().compare("CORELLI") == 0.0)
+  for (auto bankName : AllBankNames) {
+    if (instrument.getName().compare("CORELLI") == 0.0)
       bankName.append("/sixteenpack");
     oss3 << "<component-link name=\"" << bankName << "\">\n";
     boost::shared_ptr<const IComponent> bank =
-        instrument->getComponentByName(bankName);
+        instrument.getComponentByName(bankName);
 
     Quat RelRot = bank->getRelativeRot();
 
@@ -1074,10 +1073,10 @@ void SCDCalibratePanels::saveXmlFile(
   } // for each bank in the group
 
   // write out the source
-  IComponent_const_sptr source = instrument->getSource();
+  IComponent_const_sptr source = instrument.getSource();
 
   oss3 << "<component-link name=\"" << source->getName() << "\">\n";
-  IComponent_const_sptr sample = instrument->getSample();
+  IComponent_const_sptr sample = instrument.getSample();
   V3D sourceRelPos = source->getRelativePos();
 
   writeXmlParameter(oss3, "x", sourceRelPos.X());

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -365,9 +365,7 @@ void SCDCalibratePanels::exec() {
   PARALLEL_FOR3(ColWksp, RowWksp, TofWksp)
   for (int i = 0; i < static_cast<int>(MyBankNames.size()); ++i) {
     PARALLEL_START_INTERUPT_REGION
-    boost::container::flat_set<string>::iterator it = MyBankNames.begin();
-    advance(it, i);
-    std::string bankName = *it;
+    const std::string &bankName = *std::next(MyBankNames.begin(), i);
     size_t k = bankName.find_last_not_of("0123456789");
     int bank = 0;
     if (k < bankName.length())

--- a/Framework/Crystal/src/SCDPanelErrors.cpp
+++ b/Framework/Crystal/src/SCDPanelErrors.cpp
@@ -165,14 +165,13 @@ void SCDPanelErrors::eval(double xshift, double yshift, double zshift,
   moveDetector(xshift, yshift, zshift, xrotate, yrotate, zrotate, scalex,
                scaley, m_bank, m_workspace);
 
-  DataObjects::PeaksWorkspace_sptr inputP =
+  auto inputP =
       boost::dynamic_pointer_cast<DataObjects::PeaksWorkspace>(m_workspace);
-  Geometry::Instrument_sptr inst =
-      boost::const_pointer_cast<Geometry::Instrument>(inputP->getInstrument());
+  auto inst = inputP->getInstrument();
   Geometry::OrientedLattice lattice =
       inputP->mutableSample().getOrientedLattice();
   for (int i = 0; i < inputP->getNumberPeaks(); i++) {
-    DataObjects::Peak peak = inputP->getPeak(i);
+    const DataObjects::Peak &peak = inputP->getPeak(i);
     V3D hkl =
         V3D(boost::math::iround(peak.getH()), boost::math::iround(peak.getK()),
             boost::math::iround(peak.getL()));

--- a/Framework/Crystal/test/IndexSXPeaksTest.h
+++ b/Framework/Crystal/test/IndexSXPeaksTest.h
@@ -119,9 +119,9 @@ public:
     for (int i = 0; i < m_masterPeaks->getNumberPeaks(); i++) {
       IPeak &peak = m_masterPeaks->getPeak(i);
       Mantid::Kernel::V3D v(1, 0, 0);
-      peak.setQSampleFrame(v,boost::none); // Overwrite all Q
-                               // samples to be
-                               // co-linear.
+      peak.setQSampleFrame(v, boost::none); // Overwrite all Q
+                                            // samples to be
+                                            // co-linear.
     }
 
     TS_ASSERT_THROWS(doTest(6, "1, 2, 3, 4, 5, 6", 14.131, 19.247, 8.606, 90.0,

--- a/Framework/Crystal/test/IndexSXPeaksTest.h
+++ b/Framework/Crystal/test/IndexSXPeaksTest.h
@@ -119,7 +119,7 @@ public:
     for (int i = 0; i < m_masterPeaks->getNumberPeaks(); i++) {
       IPeak &peak = m_masterPeaks->getPeak(i);
       Mantid::Kernel::V3D v(1, 0, 0);
-      peak.setQSampleFrame(v); // Overwrite all Q
+      peak.setQSampleFrame(v,boost::none); // Overwrite all Q
                                // samples to be
                                // co-linear.
     }

--- a/Framework/Crystal/test/IndexSXPeaksTest.h
+++ b/Framework/Crystal/test/IndexSXPeaksTest.h
@@ -119,9 +119,9 @@ public:
     for (int i = 0; i < m_masterPeaks->getNumberPeaks(); i++) {
       IPeak &peak = m_masterPeaks->getPeak(i);
       Mantid::Kernel::V3D v(1, 0, 0);
-      peak.setQSampleFrame(v, boost::optional<double>()); // Overwrite all Q
-                                                          // samples to be
-                                                          // co-linear.
+      peak.setQSampleFrame(v); // Overwrite all Q
+                               // samples to be
+                               // co-linear.
     }
 
     TS_ASSERT_THROWS(doTest(6, "1, 2, 3, 4, 5, 6", 14.131, 19.247, 8.606, 90.0,

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -48,7 +48,7 @@ public:
 // MSVC 2015 won't build with noexcept.
 // error C2610: 'Mantid::DataObjects::Peak::Peak(Mantid::DataObjects::Peak &&)
 // noexcept': is not a special member function which can be defaulted
-#if defined(_MSC_VER) && _MSC_VER <= 1700
+#if defined(_MSC_VER) && _MSC_VER <= 1900
   Peak(Peak &&);
   Peak &operator=(Peak &&);
 #else

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -43,6 +43,8 @@ public:
 
   /// Copy constructor
   Peak(const Peak &other);
+  Peak(Peak &&) noexcept = default;
+  Peak &operator=(Peak &&) noexcept = default;
 
   // Construct a peak from a reference to the interface
 
@@ -54,7 +56,7 @@ public:
   void removeContributingDetector(const int id);
   const std::set<int> &getContributingDetIDs() const;
 
-  void setInstrument(Geometry::Instrument_const_sptr inst) override;
+  void setInstrument(const Geometry::Instrument_const_sptr &inst) override;
   Geometry::IDetector_const_sptr getDetector() const override;
   Geometry::Instrument_const_sptr getInstrument() const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -28,9 +28,11 @@ public:
   Peak();
   Peak(Geometry::Instrument_const_sptr m_inst, Mantid::Kernel::V3D QLabFrame,
        boost::optional<double> detectorDistance = boost::optional<double>());
-  Peak(Geometry::Instrument_const_sptr m_inst, Mantid::Kernel::V3D QSampleFrame,
-       Mantid::Kernel::Matrix<double> goniometer,
-       boost::optional<double> detectorDistance = boost::optional<double>());
+  Peak(const Geometry::Instrument_const_sptr &m_inst,
+       const Mantid::Kernel::V3D &QSampleFrame,
+       const Mantid::Kernel::Matrix<double> &goniometer,
+       const boost::optional<double> &detectorDistance =
+           boost::optional<double>());
   Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
        double m_Wavelength);
   Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
@@ -77,7 +79,7 @@ public:
   void setL(double m_L) override;
   void setBankName(std::string m_bankName);
   void setHKL(double H, double K, double L) override;
-  void setHKL(Mantid::Kernel::V3D HKL) override;
+  void setHKL(const Mantid::Kernel::V3D &HKL) override;
   void resetHKL();
 
   Mantid::Kernel::V3D getQLabFrame() const override;
@@ -85,11 +87,11 @@ public:
   Mantid::Kernel::V3D getDetectorPosition() const override;
   Mantid::Kernel::V3D getDetectorPositionNoCheck() const override;
 
-  void setQSampleFrame(Mantid::Kernel::V3D QSampleFrame,
-                       boost::optional<double> detectorDistance =
+  void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
+                       const boost::optional<double> &detectorDistance =
                            boost::optional<double>()) override;
-  void setQLabFrame(Mantid::Kernel::V3D QLabFrame,
-                    boost::optional<double> detectorDistance =
+  void setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,
+                    const boost::optional<double> &detectorDistance =
                         boost::optional<double>()) override;
 
   void setWavelength(double wavelength) override;
@@ -113,8 +115,8 @@ public:
   void setBinCount(double m_binCount) override;
 
   Mantid::Kernel::Matrix<double> getGoniometerMatrix() const override;
-  void
-  setGoniometerMatrix(Mantid::Kernel::Matrix<double> goniometerMatrix) override;
+  void setGoniometerMatrix(
+      const Mantid::Kernel::Matrix<double> &goniometerMatrix) override;
 
   std::string getBankName() const override;
   int getRow() const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -26,13 +26,13 @@ public:
   friend class PeakColumn;
 
   Peak();
-  Peak(Geometry::Instrument_const_sptr m_inst, Mantid::Kernel::V3D QLabFrame,
-       boost::optional<double> detectorDistance = boost::optional<double>());
+  Peak(const Geometry::Instrument_const_sptr &m_inst,
+       const Mantid::Kernel::V3D &QLabFrame,
+       boost::optional<double> detectorDistance = boost::none);
   Peak(const Geometry::Instrument_const_sptr &m_inst,
        const Mantid::Kernel::V3D &QSampleFrame,
        const Mantid::Kernel::Matrix<double> &goniometer,
-       const boost::optional<double> &detectorDistance =
-           boost::optional<double>());
+       boost::optional<double> detectorDistance = boost::none);
   Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
        double m_Wavelength);
   Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
@@ -45,8 +45,8 @@ public:
 
   /// Copy constructor
   Peak(const Peak &other);
-  Peak(Peak &&) = default;
-  Peak &operator=(Peak &&) = default;
+  Peak(Peak &&) noexcept;
+  Peak &operator=(Peak &&) noexcept;
 
   // Construct a peak from a reference to the interface
 
@@ -87,12 +87,12 @@ public:
   Mantid::Kernel::V3D getDetectorPosition() const override;
   Mantid::Kernel::V3D getDetectorPositionNoCheck() const override;
 
-  void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
-                       const boost::optional<double> &detectorDistance =
-                           boost::optional<double>()) override;
-  void setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,
-                    const boost::optional<double> &detectorDistance =
-                        boost::optional<double>()) override;
+  void setQSampleFrame(
+      const Mantid::Kernel::V3D &QSampleFrame,
+      boost::optional<double> detectorDistance = boost::none) override;
+  void
+  setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,
+               boost::optional<double> detectorDistance = boost::none) override;
 
   void setWavelength(double wavelength) override;
   double getWavelength() const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -43,8 +43,8 @@ public:
 
   /// Copy constructor
   Peak(const Peak &other);
-  Peak(Peak &&) noexcept = default;
-  Peak &operator=(Peak &&) noexcept = default;
+  Peak(Peak &&) = default;
+  Peak &operator=(Peak &&) = default;
 
   // Construct a peak from a reference to the interface
 

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -33,14 +33,14 @@ public:
        const Mantid::Kernel::V3D &QSampleFrame,
        const Mantid::Kernel::Matrix<double> &goniometer,
        boost::optional<double> detectorDistance = boost::none);
-  Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
+  Peak(const Geometry::Instrument_const_sptr &m_inst, int m_detectorID,
        double m_Wavelength);
-  Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
-       double m_Wavelength, Mantid::Kernel::V3D HKL);
-  Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
-       double m_Wavelength, Mantid::Kernel::V3D HKL,
-       Mantid::Kernel::Matrix<double> goniometer);
-  Peak(Geometry::Instrument_const_sptr m_inst, double scattering,
+  Peak(const Geometry::Instrument_const_sptr &m_inst, int m_detectorID,
+       double m_Wavelength, const Mantid::Kernel::V3D &HKL);
+  Peak(const Geometry::Instrument_const_sptr &m_inst, int m_detectorID,
+       double m_Wavelength, const Mantid::Kernel::V3D &HKL,
+       const Mantid::Kernel::Matrix<double> &goniometer);
+  Peak(const Geometry::Instrument_const_sptr &m_inst, double scattering,
        double m_Wavelength);
 
   /// Copy constructor

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -45,8 +45,16 @@ public:
 
   /// Copy constructor
   Peak(const Peak &other);
+// MSVC 2015 won't build with noexcept.
+// error C2610: 'Mantid::DataObjects::Peak::Peak(Mantid::DataObjects::Peak &&)
+// noexcept': is not a special member function which can be defaulted
+#if defined(_MSC_VER) && _MSC_VER <= 1700
+  Peak(Peak &&);
+  Peak &operator=(Peak &&);
+#else
   Peak(Peak &&) noexcept;
   Peak &operator=(Peak &&) noexcept;
+#endif
 
   // Construct a peak from a reference to the interface
 

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -107,14 +107,14 @@ public:
   const Peak &getPeak(int peakNum) const override;
 
   Geometry::IPeak *createPeak(
-      Kernel::V3D QLabFrame,
+      const Kernel::V3D &QLabFrame,
       boost::optional<double> detectorDistance = boost::none) const override;
   std::vector<std::pair<std::string, std::string>>
-  peakInfo(Kernel::V3D qFrame, bool labCoords) const override;
+  peakInfo(const Kernel::V3D &qFrame, bool labCoords) const override;
 
-  Peak *createPeakHKL(Kernel::V3D HKL) const override;
+  Peak *createPeakHKL(const Kernel::V3D &HKL) const override;
 
-  int peakInfoNumber(Kernel::V3D qFrame, bool labCoords) const override;
+  int peakInfoNumber(const Kernel::V3D &qFrame, bool labCoords) const override;
 
   std::vector<Peak> &getPeaks();
   const std::vector<Peak> &getPeaks() const;

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -106,9 +106,9 @@ public:
   Peak &getPeak(int peakNum) override;
   const Peak &getPeak(int peakNum) const override;
 
-  Geometry::IPeak *createPeak(Kernel::V3D QLabFrame,
-                              boost::optional<double> detectorDistance =
-                                  boost::optional<double>()) const override;
+  Geometry::IPeak *createPeak(
+      Kernel::V3D QLabFrame,
+      boost::optional<double> detectorDistance = boost::none) const override;
   std::vector<std::pair<std::string, std::string>>
   peakInfo(Kernel::V3D qFrame, bool labCoords) const override;
 

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -94,7 +94,7 @@ Peak::Peak(const Geometry::Instrument_const_sptr &m_inst,
  * @param m_Wavelength :: incident neutron wavelength, in Angstroms
  * @return
  */
-Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
+Peak::Peak(const Geometry::Instrument_const_sptr &m_inst, int m_detectorID,
            double m_Wavelength)
     : m_H(0), m_K(0), m_L(0), m_intensity(0), m_sigmaIntensity(0),
       m_binCount(0), m_GoniometerMatrix(3, 3, true),
@@ -116,8 +116,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
  * @param HKL :: vector with H,K,L position of the peak
  * @return
  */
-Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
-           double m_Wavelength, Mantid::Kernel::V3D HKL)
+Peak::Peak(const Geometry::Instrument_const_sptr &m_inst, int m_detectorID,
+           double m_Wavelength, const Mantid::Kernel::V3D &HKL)
     : m_H(HKL[0]), m_K(HKL[1]), m_L(HKL[2]), m_intensity(0),
       m_sigmaIntensity(0), m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
@@ -139,9 +139,9 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
  * @param goniometer :: a 3x3 rotation matrix
  * @return
  */
-Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
-           double m_Wavelength, Mantid::Kernel::V3D HKL,
-           Mantid::Kernel::Matrix<double> goniometer)
+Peak::Peak(const Geometry::Instrument_const_sptr &m_inst, int m_detectorID,
+           double m_Wavelength, const Mantid::Kernel::V3D &HKL,
+           const Mantid::Kernel::Matrix<double> &goniometer)
     : m_H(HKL[0]), m_K(HKL[1]), m_L(HKL[2]), m_intensity(0),
       m_sigmaIntensity(0), m_binCount(0), m_GoniometerMatrix(goniometer),
       m_InverseGoniometerMatrix(goniometer), m_runNumber(0), m_monitorCount(0),
@@ -163,7 +163,7 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
  * @param m_Wavelength :: incident neutron wavelength, in Angstroms
  * @return
  */
-Peak::Peak(Geometry::Instrument_const_sptr m_inst, double scattering,
+Peak::Peak(const Geometry::Instrument_const_sptr &m_inst, double scattering,
            double m_Wavelength)
     : m_H(0), m_K(0), m_L(0), m_intensity(0), m_sigmaIntensity(0),
       m_binCount(0), m_GoniometerMatrix(3, 3, true),

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -121,7 +121,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
     : m_H(HKL[0]), m_K(HKL[1]), m_L(HKL[2]), m_intensity(0),
       m_sigmaIntensity(0), m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
-      m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
+      m_orig_H(0), m_orig_K(0), m_orig_L(0),
+      m_peakShape(boost::make_shared<NoShape>()) {
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setDetectorID(m_detectorID);
@@ -144,7 +145,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
     : m_H(HKL[0]), m_K(HKL[1]), m_L(HKL[2]), m_intensity(0),
       m_sigmaIntensity(0), m_binCount(0), m_GoniometerMatrix(goniometer),
       m_InverseGoniometerMatrix(goniometer), m_runNumber(0), m_monitorCount(0),
-      m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
+      m_orig_H(0), m_orig_K(0), m_orig_L(0),
+      m_peakShape(boost::make_shared<NoShape>()) {
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
   if (fabs(m_InverseGoniometerMatrix.Invert()) < 1e-8)
     throw std::invalid_argument(
@@ -167,7 +169,7 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, double scattering,
       m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_row(-1), m_col(-1), m_orig_H(0), m_orig_K(0), m_orig_L(0),
-      m_peakShape(new NoShape) {
+      m_peakShape(boost::make_shared<NoShape>()) {
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setWavelength(m_Wavelength);

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -231,9 +231,13 @@ Peak::Peak(const Geometry::IPeak &ipeak)
   }
 }
 
+#if defined(_MSC_VER) && _MSC_VER <= 1700
+Peak::Peak(Peak &&) = default;
+Peak &Peak::operator=(Peak &&) = default;
+#else
 Peak::Peak(Peak &&) noexcept = default;
 Peak &Peak::operator=(Peak &&) noexcept = default;
-
+#endif
 //----------------------------------------------------------------------------------------------
 /** Set the incident wavelength of the neutron. Calculates the energy from this.
  * Assumes elastic scattering.

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -43,9 +43,9 @@ Peak::Peak()
  *detector. Calculated if not explicitly provided.
  *        Used to give a valid TOF. Default 1.0 meters.
  */
-Peak::Peak(Geometry::Instrument_const_sptr m_inst,
-           Mantid::Kernel::V3D QLabFrame,
-           boost::optional<double> detectorDistance)
+Peak::Peak(const Geometry::Instrument_const_sptr &m_inst,
+           const Mantid::Kernel::V3D &QLabFrame,
+           const boost::optional<double> &detectorDistance)
     : m_H(0), m_K(0), m_L(0), m_intensity(0), m_sigmaIntensity(0),
       m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -231,7 +231,7 @@ Peak::Peak(const Geometry::IPeak &ipeak)
   }
 }
 
-#if defined(_MSC_VER) && _MSC_VER <= 1700
+#if defined(_MSC_VER) && _MSC_VER <= 1900
 Peak::Peak(Peak &&) = default;
 Peak &Peak::operator=(Peak &&) = default;
 #else

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -8,6 +8,8 @@
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/System.h"
 
+#include "boost/make_shared.hpp"
+
 #include <algorithm>
 #include <cctype>
 #include <string>
@@ -27,7 +29,7 @@ Peak::Peak()
       m_finalEnergy(0.), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_row(-1), m_col(-1), m_orig_H(0), m_orig_K(0), m_orig_L(0),
-      m_peakShape(new NoShape) {
+      m_peakShape(boost::make_shared<NoShape>()) {
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
 }
 
@@ -47,7 +49,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst,
     : m_H(0), m_K(0), m_L(0), m_intensity(0), m_sigmaIntensity(0),
       m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
-      m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
+      m_orig_H(0), m_orig_K(0), m_orig_L(0),
+      m_peakShape(boost::make_shared<NoShape>()) {
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setQLabFrame(QLabFrame, detectorDistance);
@@ -73,7 +76,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst,
     : m_H(0), m_K(0), m_L(0), m_intensity(0), m_sigmaIntensity(0),
       m_binCount(0), m_GoniometerMatrix(goniometer),
       m_InverseGoniometerMatrix(goniometer), m_runNumber(0), m_monitorCount(0),
-      m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
+      m_orig_H(0), m_orig_K(0), m_orig_L(0),
+      m_peakShape(boost::make_shared<NoShape>()) {
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
   if (fabs(m_InverseGoniometerMatrix.Invert()) < 1e-8)
     throw std::invalid_argument(
@@ -95,7 +99,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
     : m_H(0), m_K(0), m_L(0), m_intensity(0), m_sigmaIntensity(0),
       m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
-      m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
+      m_orig_H(0), m_orig_K(0), m_orig_L(0),
+      m_peakShape(boost::make_shared<NoShape>()) {
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setDetectorID(m_detectorID);
@@ -189,11 +194,7 @@ Peak::Peak(const Peak &other)
       samplePos(other.samplePos), detPos(other.detPos),
       m_orig_H(other.m_orig_H), m_orig_K(other.m_orig_K),
       m_orig_L(other.m_orig_L), m_detIDs(other.m_detIDs),
-      m_peakShape(other.m_peakShape->clone())
-
-{
-  convention = Kernel::ConfigService::Instance().getString("Q.convention");
-}
+      m_peakShape(other.m_peakShape->clone()), convention(other.convention) {}
 
 //----------------------------------------------------------------------------------------------
 /** Constructor making a Peak from IPeak interface
@@ -213,7 +214,7 @@ Peak::Peak(const Geometry::IPeak &ipeak)
       m_runNumber(ipeak.getRunNumber()),
       m_monitorCount(ipeak.getMonitorCount()), m_row(ipeak.getRow()),
       m_col(ipeak.getCol()), m_orig_H(0.), m_orig_K(0.), m_orig_L(0.),
-      m_peakShape(new NoShape) {
+      m_peakShape(boost::make_shared<NoShape>()) {
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
   if (fabs(m_InverseGoniometerMatrix.Invert()) < 1e-8)
     throw std::invalid_argument(
@@ -343,7 +344,7 @@ const std::set<int> &Peak::getContributingDetIDs() const { return m_detIDs; }
  *
  * @param inst :: Instrument sptr to use
  */
-void Peak::setInstrument(Geometry::Instrument_const_sptr inst) {
+void Peak::setInstrument(const Geometry::Instrument_const_sptr &inst) {
   m_inst = inst;
   if (!inst)
     throw std::runtime_error("Peak::setInstrument(): No instrument is set!");

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -69,10 +69,10 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst,
  *detector. Calculated if not explicitly provided.
  *        Used to give a valid TOF. Default 1.0 meters.
  */
-Peak::Peak(Geometry::Instrument_const_sptr m_inst,
-           Mantid::Kernel::V3D QSampleFrame,
-           Mantid::Kernel::Matrix<double> goniometer,
-           boost::optional<double> detectorDistance)
+Peak::Peak(const Geometry::Instrument_const_sptr &m_inst,
+           const Mantid::Kernel::V3D &QSampleFrame,
+           const Mantid::Kernel::Matrix<double> &goniometer,
+           const boost::optional<double> &detectorDistance)
     : m_H(0), m_K(0), m_L(0), m_intensity(0), m_sigmaIntensity(0),
       m_binCount(0), m_GoniometerMatrix(goniometer),
       m_InverseGoniometerMatrix(goniometer), m_runNumber(0), m_monitorCount(0),
@@ -492,8 +492,8 @@ Mantid::Kernel::V3D Peak::getQSampleFrame() const {
  * @param detectorDistance :: distance between the sample and the detector.
  *        Used to give a valid TOF. You do NOT need to explicitly set this.
  */
-void Peak::setQSampleFrame(Mantid::Kernel::V3D QSampleFrame,
-                           boost::optional<double> detectorDistance) {
+void Peak::setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
+                           const boost::optional<double> &detectorDistance) {
   V3D Qlab = m_GoniometerMatrix * QSampleFrame;
   this->setQLabFrame(Qlab, detectorDistance);
 }
@@ -514,8 +514,8 @@ void Peak::setQSampleFrame(Mantid::Kernel::V3D QSampleFrame,
  *this is provided. Then we do not
  * ray trace to find the intersecing detector.
  */
-void Peak::setQLabFrame(Mantid::Kernel::V3D QLabFrame,
-                        boost::optional<double> detectorDistance) {
+void Peak::setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,
+                        const boost::optional<double> &detectorDistance) {
   // Clear out the detector = we can't know them
   m_detectorID = -1;
   m_det = IDetector_sptr();
@@ -743,7 +743,7 @@ void Peak::resetHKL() {
  *
  * @param HKL :: vector with x,y,z -> h,k,l
  */
-void Peak::setHKL(Mantid::Kernel::V3D HKL) {
+void Peak::setHKL(const Mantid::Kernel::V3D &HKL) {
   if (m_orig_H == 0 && m_orig_K == 0 && m_orig_L == 0) {
     m_orig_H = m_H;
     m_orig_K = m_K;
@@ -801,7 +801,7 @@ Mantid::Kernel::Matrix<double> Peak::getGoniometerMatrix() const {
  * the goniometer
  * @throw std::invalid_argument if matrix is not 3x3*/
 void Peak::setGoniometerMatrix(
-    Mantid::Kernel::Matrix<double> goniometerMatrix) {
+    const Mantid::Kernel::Matrix<double> &goniometerMatrix) {
   if ((goniometerMatrix.numCols() != 3) || (goniometerMatrix.numRows() != 3))
     throw std::invalid_argument(
         "Peak::setGoniometerMatrix(): Goniometer matrix must be 3x3.");

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -45,7 +45,7 @@ Peak::Peak()
  */
 Peak::Peak(const Geometry::Instrument_const_sptr &m_inst,
            const Mantid::Kernel::V3D &QLabFrame,
-           const boost::optional<double> &detectorDistance)
+           boost::optional<double> detectorDistance)
     : m_H(0), m_K(0), m_L(0), m_intensity(0), m_sigmaIntensity(0),
       m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
@@ -72,7 +72,7 @@ Peak::Peak(const Geometry::Instrument_const_sptr &m_inst,
 Peak::Peak(const Geometry::Instrument_const_sptr &m_inst,
            const Mantid::Kernel::V3D &QSampleFrame,
            const Mantid::Kernel::Matrix<double> &goniometer,
-           const boost::optional<double> &detectorDistance)
+           boost::optional<double> detectorDistance)
     : m_H(0), m_K(0), m_L(0), m_intensity(0), m_sigmaIntensity(0),
       m_binCount(0), m_GoniometerMatrix(goniometer),
       m_InverseGoniometerMatrix(goniometer), m_runNumber(0), m_monitorCount(0),
@@ -230,6 +230,9 @@ Peak::Peak(const Geometry::IPeak &ipeak)
     this->m_detIDs = peak->m_detIDs;
   }
 }
+
+Peak::Peak(Peak &&) noexcept = default;
+Peak &Peak::operator=(Peak &&) noexcept = default;
 
 //----------------------------------------------------------------------------------------------
 /** Set the incident wavelength of the neutron. Calculates the energy from this.
@@ -495,7 +498,7 @@ Mantid::Kernel::V3D Peak::getQSampleFrame() const {
  *        Used to give a valid TOF. You do NOT need to explicitly set this.
  */
 void Peak::setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
-                           const boost::optional<double> &detectorDistance) {
+                           boost::optional<double> detectorDistance) {
   V3D Qlab = m_GoniometerMatrix * QSampleFrame;
   this->setQLabFrame(Qlab, detectorDistance);
 }
@@ -517,7 +520,7 @@ void Peak::setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
  * ray trace to find the intersecing detector.
  */
 void Peak::setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,
-                        const boost::optional<double> &detectorDistance) {
+                        boost::optional<double> detectorDistance) {
   // Clear out the detector = we can't know them
   m_detectorID = -1;
   m_det = IDetector_sptr();
@@ -922,7 +925,7 @@ void Peak::setPeakShape(Mantid::Geometry::PeakShape *shape) {
  * @param shape : Desired shape
  */
 void Peak::setPeakShape(Mantid::Geometry::PeakShape_const_sptr shape) {
-  this->m_peakShape = shape;
+  this->m_peakShape = std::move(shape);
 }
 
 /**

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -190,7 +190,7 @@ const Peak &PeaksWorkspace::getPeak(const int peakNum) const {
  * @return a pointer to a new Peak object.
  */
 Geometry::IPeak *
-PeaksWorkspace::createPeak(Kernel::V3D QLabFrame,
+PeaksWorkspace::createPeak(const Kernel::V3D &QLabFrame,
                            boost::optional<double> detectorDistance) const {
   Geometry::Goniometer goniometer = this->run().getGoniometer();
 
@@ -222,7 +222,7 @@ PeaksWorkspace::createPeak(Kernel::V3D QLabFrame,
  *         value.
  */
 std::vector<std::pair<std::string, std::string>>
-PeaksWorkspace::peakInfo(Kernel::V3D qFrame, bool labCoords) const {
+PeaksWorkspace::peakInfo(const Kernel::V3D &qFrame, bool labCoords) const {
   std::vector<std::pair<std::string, std::string>> Result;
   std::ostringstream oss;
   oss << std::setw(12) << std::fixed << std::setprecision(3) << (qFrame.norm());
@@ -393,7 +393,7 @@ PeaksWorkspace::peakInfo(Kernel::V3D qFrame, bool labCoords) const {
  * @param HKL : reciprocal lattice vector coefficients
  * @return Fully formed peak.
  */
-Peak *PeaksWorkspace::createPeakHKL(V3D HKL) const {
+Peak *PeaksWorkspace::createPeakHKL(const V3D &HKL) const {
   /*
    The following allows us to add peaks where we have a single UB to work from.
    */
@@ -437,7 +437,8 @@ Peak *PeaksWorkspace::createPeakHKL(V3D HKL) const {
  *form for the corresponding
  *         value.
  */
-int PeaksWorkspace::peakInfoNumber(Kernel::V3D qFrame, bool labCoords) const {
+int PeaksWorkspace::peakInfoNumber(const Kernel::V3D &qFrame,
+                                   bool labCoords) const {
   std::vector<std::pair<std::string, std::string>> Result;
   std::ostringstream oss;
   oss << std::setw(12) << std::fixed << std::setprecision(3) << (qFrame.norm());

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
@@ -21,7 +21,7 @@ class MANTID_GEOMETRY_DLL IPeak {
 public:
   virtual ~IPeak() = default;
 
-  virtual void setInstrument(Geometry::Instrument_const_sptr inst) = 0;
+  virtual void setInstrument(const Geometry::Instrument_const_sptr &inst) = 0;
 
   virtual int getDetectorID() const = 0;
   virtual void setDetectorID(int m_DetectorID) = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
@@ -50,12 +50,10 @@ public:
   virtual Mantid::Kernel::V3D getQSampleFrame() const = 0;
   virtual bool findDetector() = 0;
 
-  virtual void
-  setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
-                  const boost::optional<double> &detectorDistance) = 0;
-  virtual void
-  setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,
-               const boost::optional<double> &detectorDistance) = 0;
+  virtual void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
+                               boost::optional<double> detectorDistance) = 0;
+  virtual void setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,
+                            boost::optional<double> detectorDistance) = 0;
 
   virtual void setWavelength(double wavelength) = 0;
   virtual double getWavelength() const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
@@ -42,7 +42,7 @@ public:
   virtual void setK(double m_K) = 0;
   virtual void setL(double m_L) = 0;
   virtual void setHKL(double H, double K, double L) = 0;
-  virtual void setHKL(Mantid::Kernel::V3D HKL) = 0;
+  virtual void setHKL(const Mantid::Kernel::V3D &HKL) = 0;
   virtual Mantid::Kernel::V3D getDetectorPosition() const = 0;
   virtual Mantid::Kernel::V3D getDetectorPositionNoCheck() const = 0;
 
@@ -50,10 +50,12 @@ public:
   virtual Mantid::Kernel::V3D getQSampleFrame() const = 0;
   virtual bool findDetector() = 0;
 
-  virtual void setQSampleFrame(Mantid::Kernel::V3D QSampleFrame,
-                               boost::optional<double> detectorDistance) = 0;
-  virtual void setQLabFrame(Mantid::Kernel::V3D QLabFrame,
-                            boost::optional<double> detectorDistance) = 0;
+  virtual void
+  setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
+                  const boost::optional<double> &detectorDistance) = 0;
+  virtual void
+  setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,
+               const boost::optional<double> &detectorDistance) = 0;
 
   virtual void setWavelength(double wavelength) = 0;
   virtual double getWavelength() const = 0;
@@ -76,8 +78,8 @@ public:
   virtual void setBinCount(double m_BinCount) = 0;
 
   virtual Mantid::Kernel::Matrix<double> getGoniometerMatrix() const = 0;
-  virtual void
-  setGoniometerMatrix(Mantid::Kernel::Matrix<double> m_GoniometerMatrix) = 0;
+  virtual void setGoniometerMatrix(
+      const Mantid::Kernel::Matrix<double> &m_GoniometerMatrix) = 0;
 
   virtual std::string getBankName() const = 0;
   virtual int getRow() const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -256,7 +256,7 @@ public:
 private:
   /// Save information about a set of detectors to Nexus
   void saveDetectorSetInfoToNexus(::NeXus::File *file,
-                                  std::vector<detid_t> detIDs) const;
+                                  const std::vector<detid_t> &detIDs) const;
 
   /// Private copy assignment operator
   Instrument &operator=(const Instrument &);

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1067,10 +1067,8 @@ void Instrument::saveNexus(::NeXus::File *file,
   }
 
   // Add physical detector and monitor data
-  std::vector<detid_t> detectorIDs;
-  std::vector<detid_t> detmonIDs;
-  detectorIDs = getDetectorIDs(true);
-  detmonIDs = getDetectorIDs(false);
+  auto detectorIDs = getDetectorIDs(true);
+  auto detmonIDs = getDetectorIDs(false);
   if (!detmonIDs.empty()) {
     // Add detectors group
     file->makeGroup("physical_detectors", "NXdetector", true);
@@ -1079,8 +1077,7 @@ void Instrument::saveNexus(::NeXus::File *file,
     file->closeGroup(); // detectors
 
     // Create Monitor IDs vector
-    std::vector<IDetector_const_sptr> detmons;
-    detmons = getDetectors(detmonIDs);
+    auto detmons = getDetectors(detmonIDs);
     std::vector<detid_t> monitorIDs;
     for (size_t i = 0; i < detmonIDs.size(); i++) {
       if (detmons[i]->isMonitor())
@@ -1104,14 +1101,13 @@ void Instrument::saveNexus(::NeXus::File *file,
 *                 a group must be open that has only one call of this function.
 *  @param detIDs :: the dectector IDs of the detectors belonging to the set
 */
-void Instrument::saveDetectorSetInfoToNexus(::NeXus::File *file,
-                                            std::vector<detid_t> detIDs) const {
+void Instrument::saveDetectorSetInfoToNexus(
+    ::NeXus::File *file, const std::vector<detid_t> &detIDs) const {
 
   size_t nDets = detIDs.size();
   if (nDets == 0)
     return;
-  std::vector<IDetector_const_sptr> detectors;
-  detectors = getDetectors(detIDs);
+  auto detectors = getDetectors(detIDs);
 
   Geometry::IComponent_const_sptr sample = getSample();
   Kernel::V3D sample_pos;

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -162,9 +162,8 @@ ParameterMap::getShortDescription(const std::string &compName,
   pmap_cit it;
   std::string result;
   for (it = m_map.begin(); it != m_map.end(); ++it) {
-    if (compName.compare(((const IComponent *)(*it).first)->getName()) == 0) {
-      boost::shared_ptr<Parameter> param =
-          get((const IComponent *)(*it).first, name);
+    if (compName.compare(it->first->getName()) == 0) {
+      boost::shared_ptr<Parameter> param = get(it->first, name);
       if (param) {
         result = param->getShortDescription();
         if (!result.empty())
@@ -642,8 +641,6 @@ void ParameterMap::addQuat(const IComponent *comp, const std::string &name,
  */
 bool ParameterMap::contains(const IComponent *comp, const std::string &name,
                             const std::string &type) const {
-  if (m_map.empty())
-    return false;
   return contains(comp, name.c_str(), type.c_str());
 }
 
@@ -663,7 +660,7 @@ bool ParameterMap::contains(const IComponent *comp, const char *name,
   std::pair<pmap_cit, pmap_cit> components = m_map.equal_range(id);
   bool anytype = (strlen(type) == 0);
   for (auto itr = components.first; itr != components.second; ++itr) {
-    boost::shared_ptr<Parameter> param = itr->second;
+    const auto &param = itr->second;
     if (boost::iequals(param->name(), name) &&
         (anytype || param->type() == type)) {
       return true;
@@ -685,9 +682,8 @@ bool ParameterMap::contains(const IComponent *comp,
   const ComponentID id = comp->getComponentID();
   auto it_found = m_map.find(id);
   if (it_found != m_map.end()) {
-    auto itr = m_map.lower_bound(id);
-    auto itr_end = m_map.upper_bound(id);
-    for (; itr != itr_end; ++itr) {
+    auto itrs = m_map.equal_range(id);
+    for (auto itr = itrs.first; itr != itrs.second; ++itr) {
       const Parameter_sptr &param = itr->second;
       if (*param == parameter)
         return true;
@@ -750,10 +746,9 @@ component_map_it ParameterMap::positionOf(const IComponent *comp,
     const ComponentID id = comp->getComponentID();
     auto it_found = m_map.find(id);
     if (it_found != m_map.end()) {
-      auto itr = m_map.lower_bound(id);
-      auto itr_end = m_map.upper_bound(id);
-      for (; itr != itr_end; ++itr) {
-        Parameter_sptr param = itr->second;
+      auto itrs = m_map.equal_range(id);
+      for (auto itr = itrs.first; itr != itrs.second; ++itr) {
+        const auto &param = itr->second;
         if (boost::iequals(param->nameAsCString(), name) &&
             (anytype || param->type() == type)) {
           result = itr;
@@ -783,10 +778,9 @@ component_map_cit ParameterMap::positionOf(const IComponent *comp,
     const ComponentID id = comp->getComponentID();
     auto it_found = m_map.find(id);
     if (it_found != m_map.end()) {
-      auto itr = m_map.lower_bound(id);
-      auto itr_end = m_map.upper_bound(id);
-      for (; itr != itr_end; ++itr) {
-        Parameter_sptr param = itr->second;
+      auto itrs = m_map.equal_range(id);
+      for (auto itr = itrs.first; itr != itrs.second; ++itr) {
+        const auto &param = itr->second;
         if (boost::iequals(param->nameAsCString(), name) &&
             (anytype || param->type() == type)) {
           result = itr;
@@ -805,21 +799,18 @@ component_map_cit ParameterMap::positionOf(const IComponent *comp,
 */
 Parameter_sptr ParameterMap::getByType(const IComponent *comp,
                                        const std::string &type) const {
-  Parameter_sptr result = Parameter_sptr();
+  Parameter_sptr result;
   PARALLEL_CRITICAL(m_mapAccess) {
     if (!m_map.empty()) {
       const ComponentID id = comp->getComponentID();
       auto it_found = m_map.find(id);
-      if (it_found != m_map.end()) {
-        if (it_found->first) {
-          auto itr = m_map.lower_bound(id);
-          auto itr_end = m_map.upper_bound(id);
-          for (; itr != itr_end; ++itr) {
-            Parameter_sptr param = itr->second;
-            if (boost::iequals(param->type(), type)) {
-              result = param;
-              break;
-            }
+      if (it_found != m_map.end() && it_found->first) {
+        auto itrs = m_map.equal_range(id);
+        for (auto itr = itrs.first; itr != itrs.second; ++itr) {
+          const auto &param = itr->second;
+          if (boost::iequals(param->type(), type)) {
+            result = param;
+            break;
           }
         } // found->firdst
       }   // it_found != m_map.end()
@@ -922,9 +913,8 @@ std::set<std::string> ParameterMap::names(const IComponent *comp) const {
     return paramNames;
   }
 
-  auto itr = m_map.lower_bound(id);
-  auto itr_end = m_map.upper_bound(id);
-  for (auto it = itr; it != itr_end; ++it) {
+  auto itrs = m_map.equal_range(id);
+  for (auto it = itrs.first; it != itrs.second; ++it) {
     paramNames.insert(it->second->name());
   }
 
@@ -942,11 +932,11 @@ std::string ParameterMap::asString() const {
   for (const auto &mappair : m_map) {
     const boost::shared_ptr<Parameter> &p = mappair.second;
     if (p && mappair.first) {
-      const IComponent *comp = (const IComponent *)(mappair.first);
+      const IComponent *comp = dynamic_cast<const IComponent *>(mappair.first);
       const IDetector *det = dynamic_cast<const IDetector *>(comp);
       if (det) {
         out << "detID:" << det->getID();
-      } else {
+      } else if (comp) {
         out << comp->getFullName(); // Use full path name to ensure unambiguous
                                     // naming
       }

--- a/Framework/Geometry/test/MockObjects.h
+++ b/Framework/Geometry/test/MockObjects.h
@@ -58,7 +58,8 @@ Mock IPeak
 ------------------------------------------------------------*/
 class MockIPeak : public Mantid::Geometry::IPeak {
 public:
-  MOCK_METHOD1(setInstrument, void(Geometry::Instrument_const_sptr inst));
+  MOCK_METHOD1(setInstrument,
+               void(const Geometry::Instrument_const_sptr &inst));
   MOCK_CONST_METHOD0(getDetectorID, int());
   MOCK_METHOD1(setDetectorID, void(int m_DetectorID));
   MOCK_CONST_METHOD0(getDetector, Geometry::IDetector_const_sptr());

--- a/Framework/Geometry/test/MockObjects.h
+++ b/Framework/Geometry/test/MockObjects.h
@@ -76,13 +76,13 @@ public:
   MOCK_METHOD1(setK, void(double m_K));
   MOCK_METHOD1(setL, void(double m_L));
   MOCK_METHOD3(setHKL, void(double H, double K, double L));
-  MOCK_METHOD1(setHKL, void(Mantid::Kernel::V3D HKL));
+  MOCK_METHOD1(setHKL, void(const Mantid::Kernel::V3D &HKL));
   MOCK_CONST_METHOD0(getQLabFrame, Mantid::Kernel::V3D());
   MOCK_CONST_METHOD0(getQSampleFrame, Mantid::Kernel::V3D());
   MOCK_METHOD0(findDetector, bool());
-  MOCK_METHOD2(setQSampleFrame, void(Mantid::Kernel::V3D QSampleFrame,
+  MOCK_METHOD2(setQSampleFrame, void(const Mantid::Kernel::V3D &QSampleFrame,
                                      boost::optional<double> detectorDistance));
-  MOCK_METHOD2(setQLabFrame, void(Mantid::Kernel::V3D QLabFrame,
+  MOCK_METHOD2(setQLabFrame, void(const Mantid::Kernel::V3D &QLabFrame,
                                   boost::optional<double> detectorDistance));
   MOCK_METHOD1(setWavelength, void(double wavelength));
   MOCK_CONST_METHOD0(getWavelength, double());
@@ -101,7 +101,7 @@ public:
   MOCK_METHOD1(setBinCount, void(double m_BinCount));
   MOCK_CONST_METHOD0(getGoniometerMatrix, Mantid::Kernel::Matrix<double>());
   MOCK_METHOD1(setGoniometerMatrix,
-               void(Mantid::Kernel::Matrix<double> m_GoniometerMatrix));
+               void(const Mantid::Kernel::Matrix<double> &m_GoniometerMatrix));
   MOCK_CONST_METHOD0(getBankName, std::string());
   MOCK_CONST_METHOD0(getRow, int());
   MOCK_CONST_METHOD0(getCol, int());

--- a/Framework/Kernel/inc/MantidKernel/Matrix.h
+++ b/Framework/Kernel/inc/MantidKernel/Matrix.h
@@ -68,6 +68,8 @@ public:
 
   Matrix(const Matrix<T> &);
   Matrix<T> &operator=(const Matrix<T> &);
+  Matrix(Matrix<T> &&) noexcept;
+  Matrix<T> &operator=(Matrix<T> &&) noexcept;
   ~Matrix();
 
   /// const Array accessor

--- a/Framework/Kernel/src/Matrix.cpp
+++ b/Framework/Kernel/src/Matrix.cpp
@@ -215,8 +215,9 @@ Matrix<T> &Matrix<T>::operator=(const Matrix<T> &A)
 }
 
 template <typename T>
-Matrix<T>::Matrix(Matrix<T> &&other) noexcept
-    : nx(other.nx), ny(other.ny), V(other.V) {
+Matrix<T>::Matrix(Matrix<T> &&other) noexcept : nx(other.nx),
+                                                ny(other.ny),
+                                                V(other.V) {
   other.nx = 0;
   other.ny = 0;
   other.V = nullptr;

--- a/Framework/Kernel/src/Matrix.cpp
+++ b/Framework/Kernel/src/Matrix.cpp
@@ -215,6 +215,27 @@ Matrix<T> &Matrix<T>::operator=(const Matrix<T> &A)
 }
 
 template <typename T>
+Matrix<T>::Matrix(Matrix<T> &&other) noexcept
+    : nx(other.nx), ny(other.ny), V(other.V) {
+  other.nx = 0;
+  other.ny = 0;
+  other.V = nullptr;
+}
+
+template <typename T>
+Matrix<T> &Matrix<T>::operator=(Matrix<T> &&other) noexcept {
+  nx = other.nx;
+  ny = other.ny;
+  V = other.V;
+
+  other.nx = 0;
+  other.ny = 0;
+  other.V = nullptr;
+
+  return *this;
+}
+
+template <typename T>
 Matrix<T>::~Matrix()
 /**
   Delete operator :: removes memory for

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -18,7 +18,7 @@ Mantid::Geometry::PeakShape_sptr getPeakShape(IPeak &peak) {
 }
 void setQLabFrame1(IPeak &peak, Mantid::Kernel::V3D qLabFrame) {
   // Set the q lab frame. No explicit detector distance.
-  return peak.setQLabFrame(qLabFrame, boost::optional<double>());
+  return peak.setQLabFrame(qLabFrame, boost::none);
 }
 void setQLabFrame2(IPeak &peak, Mantid::Kernel::V3D qLabFrame,
                    double distance) {
@@ -28,7 +28,7 @@ void setQLabFrame2(IPeak &peak, Mantid::Kernel::V3D qLabFrame,
 
 void setQSampleFrame1(IPeak &peak, Mantid::Kernel::V3D qSampleFrame) {
   // Set the qsample frame. No explicit detector distance.
-  return peak.setQSampleFrame(qSampleFrame, boost::optional<double>());
+  return peak.setQSampleFrame(qSampleFrame, boost::none);
 }
 
 void setQSampleFrame2(IPeak &peak, Mantid::Kernel::V3D qSampleFrame,

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
@@ -26,8 +26,7 @@ IPeak *createPeakHKL(IPeaksWorkspace &self, const object &data) {
 /// Create a peak via it's QLab value from a list or numpy array
 IPeak *createPeakQLab(IPeaksWorkspace &self, const object &data) {
   return self.createPeak(
-      Mantid::PythonInterface::Converters::PyObjectToV3D(data)(),
-      boost::optional<double>());
+      Mantid::PythonInterface::Converters::PyObjectToV3D(data)(), boost::none);
 }
 
 /// Create a peak via it's QLab value from a list or numpy array

--- a/MantidQt/SliceViewer/test/MockObjects.h
+++ b/MantidQt/SliceViewer/test/MockObjects.h
@@ -182,13 +182,13 @@ public:
   MOCK_METHOD1(setK, void(double m_K));
   MOCK_METHOD1(setL, void(double m_L));
   MOCK_METHOD3(setHKL, void(double H, double K, double L));
-  MOCK_METHOD1(setHKL, void(Mantid::Kernel::V3D HKL));
+  MOCK_METHOD1(setHKL, void(const Mantid::Kernel::V3D &HKL));
   MOCK_CONST_METHOD0(getQLabFrame, Mantid::Kernel::V3D());
   MOCK_CONST_METHOD0(getQSampleFrame, Mantid::Kernel::V3D());
   MOCK_METHOD0(findDetector, bool());
-  MOCK_METHOD2(setQSampleFrame, void(Mantid::Kernel::V3D QSampleFrame,
+  MOCK_METHOD2(setQSampleFrame, void(const Mantid::Kernel::V3D &QSampleFrame,
                                      boost::optional<double> detectorDistance));
-  MOCK_METHOD2(setQLabFrame, void(Mantid::Kernel::V3D QLabFrame,
+  MOCK_METHOD2(setQLabFrame, void(const Mantid::Kernel::V3D &QLabFrame,
                                   boost::optional<double> detectorDistance));
   MOCK_METHOD1(setWavelength, void(double wavelength));
   MOCK_CONST_METHOD0(getWavelength, double());
@@ -207,7 +207,7 @@ public:
   MOCK_METHOD1(setBinCount, void(double m_BinCount));
   MOCK_CONST_METHOD0(getGoniometerMatrix, Mantid::Kernel::Matrix<double>());
   MOCK_METHOD1(setGoniometerMatrix,
-               void(Mantid::Kernel::Matrix<double> m_GoniometerMatrix));
+               void(const Mantid::Kernel::Matrix<double> &m_GoniometerMatrix));
   MOCK_CONST_METHOD0(getBankName, std::string());
   MOCK_CONST_METHOD0(getRow, int());
   MOCK_CONST_METHOD0(getCol, int());

--- a/MantidQt/SliceViewer/test/MockObjects.h
+++ b/MantidQt/SliceViewer/test/MockObjects.h
@@ -164,7 +164,8 @@ Mock IPeak
 ------------------------------------------------------------*/
 class MockIPeak : public Mantid::Geometry::IPeak {
 public:
-  MOCK_METHOD1(setInstrument, void(Geometry::Instrument_const_sptr inst));
+  MOCK_METHOD1(setInstrument,
+               void(const Geometry::Instrument_const_sptr &inst));
   MOCK_CONST_METHOD0(getDetectorID, int());
   MOCK_METHOD1(setDetectorID, void(int m_DetectorID));
   MOCK_CONST_METHOD0(getDetector, Geometry::IDetector_const_sptr());


### PR DESCRIPTION
Description of work.

Much of the time in `SCDCalibratePanels` is spent running `PeaksWorkspace::removePeak(int )`. This can be done more efficiently with `std::remove_if` 
followed by `std::vector::erase`. Adding move constructors and move assignment operators for `DataObjects::Peak` makes this step even faster. Passing parameters by const reference also helps. 

On my mac, the test script which was taking 4 minutes, 22 seconds now takes 2 minute 29 seconds. On ndav3 with `OMP_NUM_THREADS=1`, the same script goes from taking 2 minutes 38 seconds to 1 minute 56 seconds.

**To test:**

<!-- Instructions for testing. -->

Build branch `16199_SCD_calib_issues` and time the test script suggested in #17153.
Build branch `16199_SCD_calib_issues` and time the same test script.
**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
