### PR TITLE
EQSANS multiple load issue

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSReduction.py
@@ -71,9 +71,9 @@ class SANSReduction(PythonAlgorithm):
                     output_str += self._load_data(data_file[i], workspace, property_manager, property_manager_name)
                     continue
                 output_str += self._load_data(data_file[i], '__tmp_wksp', property_manager, property_manager_name)
-                api.Plus(LHSWorkspace=workspace, RHSWorkspace='__tmp_wksp', OutputWorkspace=workspace)
                 api.RebinToWorkspace(WorkspaceToRebin='__tmp_wksp', WorkspaceToMatch=workspace,
                                      OutputWorkspace='__tmp_wksp')
+                api.Plus(LHSWorkspace=workspace, RHSWorkspace='__tmp_wksp', OutputWorkspace=workspace)
             if AnalysisDataService.doesExist('__tmp_wksp'):
                 AnalysisDataService.remove('__tmp_wksp')
         else:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSReduction.py
@@ -72,6 +72,8 @@ class SANSReduction(PythonAlgorithm):
                     continue
                 output_str += self._load_data(data_file[i], '__tmp_wksp', property_manager, property_manager_name)
                 api.Plus(LHSWorkspace=workspace, RHSWorkspace='__tmp_wksp', OutputWorkspace=workspace)
+                api.RebinToWorkspace(WorkspaceToRebin='__tmp_wksp', WorkspaceToMatch=workspace,
+                                     OutputWorkspace='__tmp_wksp')
             if AnalysisDataService.doesExist('__tmp_wksp'):
                 AnalysisDataService.remove('__tmp_wksp')
         else:


### PR DESCRIPTION
There is a rare case where SANSReduction.py is not adding up workspaces because of a rebinning issue. For EQSANS, if you give it two input files to add up and the wavelength ranges of the two files are different, the load won't proceed. This is fine, except when they are different only because of rounding. A better option is to always rebin the added file to match the first.

**To test:**
- Make sure the tests pass.
- Inspect the code.
- Run this script and it shouldn't fail: [ipts16663r2.py](https://github.com/mantidproject/mantid/files/432405/ipts16663r2.py)

There's not GitHub issue for this PR. All the info is here.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
