### PR TITLE
Re #17220. Remove useless duplicate checks.

### DIFF
--- a/Framework/MDAlgorithms/test/MergeMDTest.h
+++ b/Framework/MDAlgorithms/test/MergeMDTest.h
@@ -82,9 +82,7 @@ public:
     // Name of the output workspace.
     std::string outWSName("MergeMDTest_OutputWS");
 
-    auto ws = execute_merge(outWSName);
-    if (!ws)
-      return;
+    auto ws = execute_merge(outWSName); // cannot be nullptr
 
     // Number of events is the sum of the 3 input ones.
     TS_ASSERT_EQUALS(ws->getNPoints(), 2 * 2 + 6 * 6 + 10 * 10);
@@ -109,9 +107,7 @@ public:
                                       "Dimensions", "Axis0,Axis1", "Extents",
                                       "0,10,0,20");
 
-    auto ws = execute_merge(outWSName);
-    if (!ws)
-      return;
+    auto ws = execute_merge(outWSName); // cannot be nullptr
 
     // Number of events is the sum of the 3 input ones, minus the masked events
     TS_ASSERT_EQUALS(ws->getNPoints(), 2 * 2 + 6 * 6 + 10 * 10 - 5 * 10);
@@ -135,9 +131,7 @@ public:
     ws0->setDisplayNormalization(API::MDNormalization::NoNormalization);
     ws0->setDisplayNormalizationHisto(
         API::MDNormalization::NumEventsNormalization);
-    auto ws = execute_merge(outWSName);
-    if (!ws)
-      return;
+    auto ws = execute_merge(outWSName); // cannot be nullptr
 
     TS_ASSERT_EQUALS(API::MDNormalization::NoNormalization,
                      ws->displayNormalization());


### PR DESCRIPTION
Remove duplicate checks. The pointers cannot be nullptr in tests, since it will cause `execute_merge` function to fail

**To test:**

Code review. Test should pass

Fixes #17220.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
