### PR TITLE
Use std::vector::emplace_back(...) with all compilers.

### DIFF
--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -1246,14 +1246,15 @@ void FilterEventsByLogValuePreNexus::procEventsLinear(
         if (tof > local_m_longestTof)
           local_m_longestTof = tof;
 
-// The addEventQuickly method does not clear the cache, making things slightly
-// faster.
-// workspace->getSpectrum(this->m_pixelToWkspindex[pid]).addEventQuickly(event);
+        // The addEventQuickly method does not clear the cache, making things
+        // slightly
+        // faster.
+        // workspace->getSpectrum(this->m_pixelToWkspindex[pid]).addEventQuickly(event);
 
-// - Add event to data structure
-// (This is equivalent to
-// workspace->getSpectrum(this->m_pixelToWkspindex[pid]).addEventQuickly(event))
-// (But should be faster as a bunch of these calls were cached.)
+        // - Add event to data structure
+        // (This is equivalent to
+        // workspace->getSpectrum(this->m_pixelToWkspindex[pid]).addEventQuickly(event))
+        // (But should be faster as a bunch of these calls were cached.)
         arrayOfVectors[pixelid]->emplace_back(tof, pulsetime);
         ++local_numGoodEvents;
 #if 0
@@ -1997,10 +1998,10 @@ void FilterEventsByLogValuePreNexus::filterEventsLinear(
         if (tof > local_m_longestTof)
           local_m_longestTof = tof;
 
-// Add event to vector of events
-// (This is equivalent to
-// workspace->getSpectrum(this->m_pixelToWkspindex[pid]).addEventQuickly(event))
-// (But should be faster as a bunch of these calls were cached.)
+        // Add event to vector of events
+        // (This is equivalent to
+        // workspace->getSpectrum(this->m_pixelToWkspindex[pid]).addEventQuickly(event))
+        // (But should be faster as a bunch of these calls were cached.)
         arrayOfVectors[pixelid]->emplace_back(tof, pulsetime);
         ++local_numGoodEvents;
 

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -1254,16 +1254,8 @@ void FilterEventsByLogValuePreNexus::procEventsLinear(
 // (This is equivalent to
 // workspace->getSpectrum(this->m_pixelToWkspindex[pid]).addEventQuickly(event))
 // (But should be faster as a bunch of these calls were cached.)
-#if defined(__GNUC__) && !(defined(__INTEL_COMPILER)) && !(defined(__clang__))
-        // This avoids a copy constructor call but is only available with GCC
-        // (requires variadic templates)
         arrayOfVectors[pixelid]->emplace_back(tof, pulsetime);
-#else
-        arrayOfVectors[pixelid]->push_back(TofEvent(tof, pulsetime));
-#endif
-
         ++local_numGoodEvents;
-
 #if 0
           if (fileOffset == 0 && numeventsprint < 10)
           {
@@ -2009,14 +2001,7 @@ void FilterEventsByLogValuePreNexus::filterEventsLinear(
 // (This is equivalent to
 // workspace->getSpectrum(this->m_pixelToWkspindex[pid]).addEventQuickly(event))
 // (But should be faster as a bunch of these calls were cached.)
-#if defined(__GNUC__) && !(defined(__INTEL_COMPILER)) && !(defined(__clang__))
-        // This avoids a copy constructor call but is only available with GCC
-        // (requires variadic templates)
         arrayOfVectors[pixelid]->emplace_back(tof, pulsetime);
-#else
-        arrayOfVectors[pixelid]->push_back(TofEvent(tof, pulsetime));
-#endif
-
         ++local_numGoodEvents;
 
 #ifdef DBOUT

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -1056,9 +1056,9 @@ void LoadEventPreNexus2::procEventsLinear(
       if (tof > local_longest_tof)
         local_longest_tof = tof;
 
-// This is equivalent to
-// workspace->getSpectrum(this->pixel_to_wkspindex[pid]).addEventQuickly(event);
-// But should be faster as a bunch of these calls were cached.
+      // This is equivalent to
+      // workspace->getSpectrum(this->pixel_to_wkspindex[pid]).addEventQuickly(event);
+      // But should be faster as a bunch of these calls were cached.
       arrayOfVectors[pid]->emplace_back(tof, pulsetime);
       ++local_num_good_events;
     } else {

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -1059,14 +1059,7 @@ void LoadEventPreNexus2::procEventsLinear(
 // This is equivalent to
 // workspace->getSpectrum(this->pixel_to_wkspindex[pid]).addEventQuickly(event);
 // But should be faster as a bunch of these calls were cached.
-#if defined(__GNUC__) && !(defined(__INTEL_COMPILER)) && !(defined(__clang__))
-      // This avoids a copy constructor call but is only available with GCC
-      // (requires variadic templates)
       arrayOfVectors[pid]->emplace_back(tof, pulsetime);
-#else
-      arrayOfVectors[pid]->push_back(TofEvent(tof, pulsetime));
-#endif
-
       ++local_num_good_events;
     } else {
       // Special events/Wrong detector id

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -160,14 +160,7 @@ void ProcessBankData::run() { // override {
               alg->weightedEventVectors[periodIndex][detId];
           // NULL eventVector indicates a bad spectrum lookup
           if (eventVector) {
-#if !(defined(__INTEL_COMPILER)) && !(defined(__clang__))
-            // This avoids a copy constructor call but is only available with
-            // GCC (requires variadic templates)
             eventVector->emplace_back(tof, pulsetime, weight, errorSq);
-#else
-            eventVector->push_back(
-                WeightedEvent(tof, pulsetime, weight, errorSq));
-#endif
           } else {
             ++my_discarded_events;
           }
@@ -177,13 +170,7 @@ void ProcessBankData::run() { // override {
               alg->eventVectors[periodIndex][detId];
           // NULL eventVector indicates a bad spectrum lookup
           if (eventVector) {
-#if !(defined(__INTEL_COMPILER)) && !(defined(__clang__))
-            // This avoids a copy constructor call but is only available with
-            // GCC (requires variadic templates)
             eventVector->emplace_back(tof, pulsetime);
-#else
-            eventVector->push_back(TofEvent(tof, pulsetime));
-#endif
           } else {
             ++my_discarded_events;
           }


### PR DESCRIPTION
Description of work.

I noticed that in several places `std::vector::emplace_back(...)` was not being used on one or more of our platforms. Since all now support it, there is no need for this extra preprocessor logic.

**To test:**

<!-- Instructions for testing. -->

If the builds pass :squirrel:

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
