### PR TITLE
Update class_maker scripts

### DIFF
--- a/buildconfig/class_maker.py
+++ b/buildconfig/class_maker.py
@@ -167,7 +167,7 @@ namespace {subproject} {{
 #======================================================================
 def write_test(subproject, classname, filename, args):
     """Write a class test file"""
-    print("Writing test file to",filename)
+    print("Writing test file to", filename)
     f = open(filename, 'w')
 
     guard = "MANTID_{}_{}TEST_H_".format(subproject.upper(), classname.upper())

--- a/buildconfig/class_maker.py
+++ b/buildconfig/class_maker.py
@@ -345,25 +345,16 @@ def generate(subproject, classname, overwrite, args):
     if args.rst and args.alg:
         write_rst(subproject, classname, rstfile, args)
 
-    # Insert into the cmake list
-    add_to_cmake(subproject, classname, args, args.subfolder)
-
-    print "\n   Files were added to Framework/%s/CMakeLists.txt !" % (subproject)
+    # Insert into the cmake list if required
+    if args.cmake:
+        add_to_cmake(subproject, classname, args, args.subfolder)
+        print "\n   Files were added to Framework/%s/CMakeLists.txt !" % (subproject)
     print
 
     if args.alg:
         print "Note: if this is a WorkflowAlgorithm, please subclass DataProcessorAlgorithm"
         print "Note: if this algorithm operates on a WorkspaceGroup, please override processGroups()"
         print
-
-
-#    if not test_only:
-#        print "\tsrc/%s.cpp" % (classname)
-#        print "\tinc/Mantid%s/%s.h" % (subproject, classname)
-#    print "\ttest/%sTest.h" % (classname)
-#    print
-
-
 
 #======================================================================
 if __name__ == "__main__":
@@ -390,6 +381,9 @@ if __name__ == "__main__":
         parser.add_argument('--no-rst', dest='rst', action='store_const',
                             const=False, default=True,
                             help="Don't create the rst file")
+        parser.add_argument('--no-cmake', dest='cmake', action='store_const',
+                            const=False, default=True,
+                            help="Don't modify cmake files")
         parser.add_argument('--alg', dest='alg', action='store_const',
                             const=True, default=False,
                             help='Create an Algorithm stub. This adds some methods common to algorithms.')
@@ -417,6 +411,9 @@ if __name__ == "__main__":
         parser.add_option('--no-rst', dest='rst', action='store_const',
                             const=False, default=True,
                             help="Don't create the rst file")
+        parser.add_option('--no-cmake', dest='cmake', action='store_const',
+                            const=False, default=True,
+                            help="Don't modify cmake files")
         parser.add_option('--alg', dest='alg', action='store_const',
                             const=True, default=False,
                             help='Create an Algorithm stub. This adds some methods common to algorithms.')

--- a/buildconfig/class_maker.py
+++ b/buildconfig/class_maker.py
@@ -2,14 +2,9 @@
 """ Utility for generating a class file, header, and test file """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
+import argparse
 import sys
 import os
-try:
-    import argparse
-    useArgparse = True
-except ImportError as e:
-    import optparse # deprecated in v2.7
-    useArgparse = False
 import datetime
 import re
 import cmakelists_utils
@@ -355,81 +350,41 @@ def generate(subproject, classname, overwrite, args):
 
 #======================================================================
 if __name__ == "__main__":
-    parser = None
 
-    if useArgparse:
-        parser = argparse.ArgumentParser(description='Utility to create Mantid class files: header, source and test. version ' + VERSION)
-        parser.add_argument('subproject', metavar='SUBPROJECT', type=str,
-                            help='The subproject under Framework/; e.g. Kernel')
-        parser.add_argument('classname', metavar='CLASSNAME', type=str,
-                            help='Name of the class to create')
-        parser.add_argument('--force', dest='force', action='store_const',
-                            const=True, default=False,
-                            help='Force overwriting existing files. Use with caution!')
-        parser.add_argument('--no-header', dest='header', action='store_const',
-                            const=False, default=True,
-                            help="Don't create the header file")
-        parser.add_argument('--no-test', dest='test', action='store_const',
-                            const=False, default=True,
-                            help="Don't create the test file")
-        parser.add_argument('--no-cpp', dest='cpp', action='store_const',
-                            const=False, default=True,
-                            help="Don't create the cpp file")
-        parser.add_argument('--no-rst', dest='rst', action='store_const',
-                            const=False, default=True,
-                            help="Don't create the rst file")
-        parser.add_argument('--no-cmake', dest='cmake', action='store_const',
-                            const=False, default=True,
-                            help="Don't modify cmake files")
-        parser.add_argument('--alg', dest='alg', action='store_const',
-                            const=True, default=False,
-                            help='Create an Algorithm stub. This adds some methods common to algorithms.')
-        parser.add_argument('--subfolder', dest='subfolder',
-                            default="",
-                            help='Put the source under a subfolder below the main part of the project, e.g. Geometry/Instrument.')
-        parser.add_argument('--project', dest='project',
-                            default="Framework",
-                            help='The project in which this goes. Default: Framework. Can be MantidQt, Vates')
-    else:
-        parser = optparse.OptionParser("Usage: %prog SUBPROJECT CLASSNAME [options]", None,
-                                       optparse.Option, VERSION, 'error', 'Utility to create Mantid class files: header, source and test.')
-        parser.add_option('--force', dest='force', action='store_const',
-                            const=True, default=False,
-                            help='Force overwriting existing files. Use with caution!')
-        parser.add_option('--no-header', dest='header', action='store_const',
-                            const=False, default=True,
-                            help="Don't create the header file")
-        parser.add_option('--no-test', dest='test', action='store_const',
-                            const=False, default=True,
-                            help="Don't create the test file")
-        parser.add_option('--no-cpp', dest='cpp', action='store_const',
-                            const=False, default=True,
-                            help="Don't create the cpp file")
-        parser.add_option('--no-rst', dest='rst', action='store_const',
-                            const=False, default=True,
-                            help="Don't create the rst file")
-        parser.add_option('--no-cmake', dest='cmake', action='store_const',
-                            const=False, default=True,
-                            help="Don't modify cmake files")
-        parser.add_option('--alg', dest='alg', action='store_const',
-                            const=True, default=False,
-                            help='Create an Algorithm stub. This adds some methods common to algorithms.')
-        parser.add_option('--subfolder', dest='subfolder',
-                            default="",
-                            help='Put the source under a subfolder below the main part of the project, e.g. Geometry/Instrument.')
-        parser.add_option('--project', dest='project',
-                            default="Framework",
-                            help='The project in which this goes. Default: Framework. Can be MantidQt, Vates')
+    parser = argparse.ArgumentParser(description='Utility to create Mantid class files: header, source and test. version ' + VERSION)
+    parser.add_argument('subproject', metavar='SUBPROJECT', type=str,
+                        help='The subproject under Framework/; e.g. Kernel')
+    parser.add_argument('classname', metavar='CLASSNAME', type=str,
+                        help='Name of the class to create')
+    parser.add_argument('--force', dest='force', action='store_const',
+                        const=True, default=False,
+                        help='Force overwriting existing files. Use with caution!')
+    parser.add_argument('--no-header', dest='header', action='store_const',
+                        const=False, default=True,
+                        help="Don't create the header file")
+    parser.add_argument('--no-test', dest='test', action='store_const',
+                        const=False, default=True,
+                        help="Don't create the test file")
+    parser.add_argument('--no-cpp', dest='cpp', action='store_const',
+                        const=False, default=True,
+                        help="Don't create the cpp file")
+    parser.add_argument('--no-rst', dest='rst', action='store_const',
+                        const=False, default=True,
+                        help="Don't create the rst file")
+    parser.add_argument('--no-cmake', dest='cmake', action='store_const',
+                        const=False, default=True,
+                        help="Don't modify cmake files")
+    parser.add_argument('--alg', dest='alg', action='store_const',
+                        const=True, default=False,
+                        help='Create an Algorithm stub. This adds some methods common to algorithms.')
+    parser.add_argument('--subfolder', dest='subfolder',
+                        default="",
+                        help='Put the source under a subfolder below the main part of the project, e.g. Geometry/Instrument.')
+    parser.add_argument('--project', dest='project',
+                        default="Framework",
+                        help='The project in which this goes. Default: Framework. Can be MantidQt, Vates')
 
-    args = None
-    if useArgparse:
-        args = parser.parse_args()
-    else:
-        (options, myargs) = parser.parse_args()
-        args = options
-        args.subproject = myargs[0]
-        args.classname = myargs[1]
-
+    args = parser.parse_args()
     subproject = args.subproject
     classname = args.classname
     overwrite = args.force

--- a/buildconfig/class_maker.py
+++ b/buildconfig/class_maker.py
@@ -47,18 +47,18 @@ private:
         alg_include = ""
 
     # The full text
-    s = r"""#ifndef {}
-#define {}
+    s = r"""#ifndef {guard}
+#define {guard}
 
-#include "Mantid{}/DllConfig.h"
-{}
+#include "Mantid{subproject}/DllConfig.h"
+{alg_include}
 
 namespace Mantid {{
-namespace {} {{
+namespace {subproject} {{
 
-/** {} : TODO: DESCRIPTION
+/** {classname} : TODO: DESCRIPTION
 
-  Copyright &copy; {} ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  Copyright &copy; {today} ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source
 
   This file is part of Mantid.
@@ -79,22 +79,19 @@ namespace {} {{
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_{}_DLL {}{} {{
-public:{}}};
+class MANTID_{subproject_upper}_DLL {classname}{alg_class_declare} {{
+public:{algorithm_header}}};
 
-}} // namespace {}
+}} // namespace {subproject}
 }} // namespace Mantid
 
-#endif /* {} */""".format(guard, guard, subproject,
-       alg_include, subproject, classname,
-       datetime.datetime.now().date().year, subproject_upper, classname, alg_class_declare,
-       algorithm_header, subproject, guard)
+#endif /* {guard} */""".format(guard=guard, subproject=subproject,
+       alg_include=alg_include, classname=classname,
+       today=datetime.datetime.now().date().year, subproject_upper=subproject_upper,
+       alg_class_declare=alg_class_declare, algorithm_header=algorithm_header)
 
     f.write(s)
     f.close()
-
-
-
 
 
 #======================================================================
@@ -157,16 +154,16 @@ void {algname}::exec() {{
         algorithm_source = ""
 
     # ------- Now the normal class text ------------------------------
-    s = """#include "Mantid{}/{}{}.h"
+    s = """#include "Mantid{subproject}/{subfolder}{classname}.h"
 
 namespace Mantid {{
-namespace {} {{
-{}{}
-}} // namespace {}
+namespace {subproject} {{
+{algorithm_top}{algorithm_source}
+}} // namespace {subproject}
 }} // namespace Mantid
 """.format(
-        subproject, args.subfolder, classname, subproject, algorithm_top,
-        algorithm_source, subproject)
+        subproject=subproject, subfolder=args.subfolder, classname=classname, algorithm_top=algorithm_top,
+        algorithm_source=algorithm_source)
     f.write(s)
     f.close()
 
@@ -214,23 +211,23 @@ def write_test(subproject, classname, filename, args):
     if not args.alg:
         algorithm_test = ""
 
-    s = """#ifndef {}
-#define {}
+    s = """#ifndef {guard}
+#define {guard}
 
 #include <cxxtest/TestSuite.h>
 
-#include "Mantid{}/{}{}.h"
+#include "Mantid{subproject}/{subfolder}{classname}.h"
 
-using Mantid::{}::{};
+using Mantid::{subproject}::{classname};
 
-class {}Test : public CxxTest::TestSuite {{
+class {classname}Test : public CxxTest::TestSuite {{
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static {}Test *createSuite() {{ return new {}Test(); }}
-  static void destroySuite( {}Test *suite ) {{ delete suite; }}
+  static {classname}Test *createSuite() {{ return new {classname}Test(); }}
+  static void destroySuite( {classname}Test *suite ) {{ delete suite; }}
 
-{}
+{algorithm_test}
   void test_Something()
   {{
     TS_FAIL( "You forgot to write a test!");
@@ -240,10 +237,9 @@ public:
 }};
 
 
-#endif /* {} */""".format(
-          guard, guard, subproject, args.subfolder, classname,
-          subproject, classname, classname, classname, classname, classname,
-          algorithm_test, guard)
+#endif /* {guard} */""".format(
+          guard=guard, subproject=subproject, subfolder=args.subfolder, classname=classname,
+          algorithm_test=algorithm_test)
     f.write(s)
     f.close()
 

--- a/buildconfig/cmakelists_utils.py
+++ b/buildconfig/cmakelists_utils.py
@@ -37,8 +37,8 @@ def redo_cmake_section(lines, cmake_tag, add_this_line, remove_this_line=""):
     rewrite. Only touches first section found to avoid messing up any other set
     sections in the rest of the file
     """
-    search_for1 = "set ( %s" % cmake_tag
-    search_for2 = "set (%s" % cmake_tag
+    search_for1 = "set ( " + cmake_tag
+    search_for2 = "set (" + cmake_tag
     # List of files in the thingie
     files = []
     lines_before = []
@@ -89,7 +89,7 @@ def redo_cmake_section(lines, cmake_tag, add_this_line, remove_this_line=""):
     files.sort()
 
     lines = lines_before
-    lines.append("set ( %s" % cmake_tag)
+    lines.append("set ( " + cmake_tag)
     for file in files:
         lines.append("\t" + file)
     lines.append(")") # close the parentheses

--- a/buildconfig/cmakelists_utils.py
+++ b/buildconfig/cmakelists_utils.py
@@ -28,12 +28,13 @@ def find_basedir(project, subproject):
 
 #======================================================================================
 def redo_cmake_section(lines, cmake_tag, add_this_line, remove_this_line=""):
-    """ Read the LINES of a file. Find "set ( cmake_tag",
+    """ Read the LINES of a file. Find first "set ( cmake_tag",
     read all the lines to get all the files,
     add your new line,
     sort them,
-    rewrite. Yay!"""
-
+    rewrite. Only touches first section found to avoid messing up any other set
+    sections in the rest of the file
+    """
     search_for1 = "set ( %s" % cmake_tag
     search_for2 = "set (%s" % cmake_tag
     # List of files in the thingie
@@ -41,6 +42,7 @@ def redo_cmake_section(lines, cmake_tag, add_this_line, remove_this_line=""):
     lines_before = []
     lines_after = []
     section_num = 0
+    section_processed = False
     for line in lines:
         if line.strip().startswith(search_for1): section_num = 1
         if line.strip().startswith(search_for2): section_num = 1
@@ -48,7 +50,7 @@ def redo_cmake_section(lines, cmake_tag, add_this_line, remove_this_line=""):
         if section_num == 0:
             # These are the lines before
             lines_before.append(line)
-        elif section_num == 1:
+        elif not section_processed and section_num == 1:
             #this is a line with the name of a file
             line = line.strip()
             # Take off the tag
@@ -57,6 +59,7 @@ def redo_cmake_section(lines, cmake_tag, add_this_line, remove_this_line=""):
             # Did we reach the last one?
             if line.endswith(")"):
                 section_num = 2
+                section_processed = True
                 line = line[0:len(line) - 1].strip()
 
             if len(line) > 0:

--- a/buildconfig/cmakelists_utils.py
+++ b/buildconfig/cmakelists_utils.py
@@ -1,7 +1,9 @@
-import sys
-import os
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+
 import datetime
+import os
 import re
+import sys
 
 #======================================================================================
 def find_basedir(project, subproject):

--- a/buildconfig/delete_class.py
+++ b/buildconfig/delete_class.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
 """ Utility for deleting a class file """
+from __future__ import (absolute_import, division, print_function, unicode_literals)
 
-import sys
-import os
 import argparse
 import datetime
+import os
 import re
+import sys
 from cmakelists_utils import *
-
 
 
 #======================================================================
 def delete_one(oldfilename):
     cmd = "git rm " + oldfilename
-    print "Running:", cmd
+    print("Running:", cmd)
     os.system(cmd)
 
 #======================================================================
@@ -26,7 +26,7 @@ def delete_all(subproject, classname, args):
     sourcefile = os.path.join(basedir, "src/" + args.source_subfolder + classname + ".cpp")
     testfile = os.path.join(basedir, "test/" + classname + "Test.h")
 
-    print
+    print()
     if args.header:
         delete_one(headerfile)
     if args.cpp:
@@ -37,8 +37,8 @@ def delete_all(subproject, classname, args):
     # Insert into the cmake list
     remove_from_cmake(subproject, classname, args, args.source_subfolder)
 
-    print "   Files were removed to Framework/%s/CMakeLists.txt !" % subproject
-    print
+    print("   Files were removed to Framework/%s/CMakeLists.txt !" % subproject)
+    print()
 
 
 

--- a/buildconfig/delete_class.py
+++ b/buildconfig/delete_class.py
@@ -37,7 +37,7 @@ def delete_all(subproject, classname, args):
     # Insert into the cmake list
     remove_from_cmake(subproject, classname, args, args.source_subfolder)
 
-    print("   Files were removed to Framework/%s/CMakeLists.txt !" % subproject)
+    print("   Files were removed to Framework/{}/CMakeLists.txt !".format(subproject))
     print()
 
 

--- a/buildconfig/move_class.py
+++ b/buildconfig/move_class.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 """ Utility for moving a class file to a different project."""
+from __future__ import (absolute_import, division, print_function, unicode_literals)
 
-import sys
-import os
 import argparse
 import datetime
+import os
 import re
+import sys
+
 from cmakelists_utils import *
-
-
 
 #======================================================================
 def move_one(subproject, classname, newproject, newclassname, oldfilename, newfilename, args):
@@ -20,7 +20,7 @@ def move_one(subproject, classname, newproject, newclassname, oldfilename, newfi
         cmd = cmd.replace("\\","/")
         if not args.no_vcs:
             cmd = "git " + cmd
-        print "Running:", cmd
+        print("Running:", cmd)
         retval = os.system(cmd)
         if retval != 0:
             raise RuntimeError("Error executing cmd '%s'" % cmd)
@@ -44,7 +44,7 @@ def move_one(subproject, classname, newproject, newclassname, oldfilename, newfi
         f = open(newfilename, 'w')
         f.write(text)
     except RuntimeError as err:
-        print err
+        print(err)
 
 
 
@@ -64,16 +64,16 @@ def move_all(subproject, classname, newproject, newclassname, args):
     newtestfile = os.path.join(newbasedir, "test/" + args.dest_subfolder + newclassname + "Test.h")
 
     if args.header and not overwrite and os.path.exists(newheaderfile):
-        print "\nError! Header file %s already exists. Use --force to overwrite.\n" % newheaderfile
+        print("\nError! Header file %s already exists. Use --force to overwrite.\n" % newheaderfile)
         return
     if args.cpp and not overwrite and os.path.exists(newsourcefile):
-        print "\nError! Source file %s already exists. Use --force to overwrite.\n" % newsourcefile
+        print("\nError! Source file %s already exists. Use --force to overwrite.\n" % newsourcefile)
         return
     if args.test and not overwrite and os.path.exists(newtestfile):
-        print "\nError! Test file %s already exists. Use --force to overwrite.\n" % newtestfile
+        print("\nError! Test file %s already exists. Use --force to overwrite.\n" % newtestfile)
         return
 
-    print
+    print()
     if args.header:
         move_one(subproject, classname, newproject, newclassname, headerfile, newheaderfile, args)
     if args.cpp:
@@ -85,15 +85,9 @@ def move_all(subproject, classname, newproject, newclassname, args):
     remove_from_cmake(subproject, classname, args, args.source_subfolder)
     add_to_cmake(newproject, newclassname, args, args.dest_subfolder)
 
-    print "   Files were removed to Framework/%s/CMakeLists.txt !" % subproject
-    print "   Files were added to Framework/%s/CMakeLists.txt !" % newproject
-    print
-#    if not test_only:
-#        print "\tsrc/%s.cpp" % (classname)
-#        print "\tinc/Mantid%s/%s.h" % (subproject, classname)
-#    print "\ttest/%sTest.h" % (classname)
-#    print
-
+    print("   Files were removed to Framework/%s/CMakeLists.txt !" % subproject)
+    print("   Files were added to Framework/%s/CMakeLists.txt !" % newproject)
+    print()
 
 #======================================================================
 if __name__ == "__main__":

--- a/buildconfig/move_class.py
+++ b/buildconfig/move_class.py
@@ -23,7 +23,7 @@ def move_one(subproject, classname, newproject, newclassname, oldfilename, newfi
         print("Running:", cmd)
         retval = os.system(cmd)
         if retval != 0:
-            raise RuntimeError("Error executing cmd '%s'" % cmd)
+            raise RuntimeError("Error executing cmd '{}'".format(cmd))
 
         f = open(newfilename, 'r')
         text = f.read()
@@ -34,8 +34,8 @@ def move_one(subproject, classname, newproject, newclassname, oldfilename, newfi
                             "Mantid" + newproject + "/" + args.dest_subfolder + newclassname + ".h")
 
         #Replace the guard
-        old_guard = "MANTID_%s_%s_H_" % (subproject.upper(), classname.upper())
-        new_guard = "MANTID_%s_%s_H_" % (newproject.upper(), newclassname.upper())
+        old_guard = "MANTID_{}_{}_H_".format(subproject.upper(), classname.upper())
+        new_guard = "MANTID_{}_{}_H_".format(newproject.upper(), newclassname.upper())
         text = text.replace(old_guard, new_guard)
 
         # Replace the namespace declaration
@@ -64,13 +64,13 @@ def move_all(subproject, classname, newproject, newclassname, args):
     newtestfile = os.path.join(newbasedir, "test/" + args.dest_subfolder + newclassname + "Test.h")
 
     if args.header and not overwrite and os.path.exists(newheaderfile):
-        print("\nError! Header file %s already exists. Use --force to overwrite.\n" % newheaderfile)
+        print("\nError! Header file {} already exists. Use --force to overwrite.\n".format(newheaderfile))
         return
     if args.cpp and not overwrite and os.path.exists(newsourcefile):
-        print("\nError! Source file %s already exists. Use --force to overwrite.\n" % newsourcefile)
+        print("\nError! Source file {} already exists. Use --force to overwrite.\n".format(newsourcefile))
         return
     if args.test and not overwrite and os.path.exists(newtestfile):
-        print("\nError! Test file %s already exists. Use --force to overwrite.\n" % newtestfile)
+        print("\nError! Test file {} already exists. Use --force to overwrite.\n".format(newtestfile))
         return
 
     print()
@@ -85,8 +85,8 @@ def move_all(subproject, classname, newproject, newclassname, args):
     remove_from_cmake(subproject, classname, args, args.source_subfolder)
     add_to_cmake(newproject, newclassname, args, args.dest_subfolder)
 
-    print("   Files were removed to Framework/%s/CMakeLists.txt !" % subproject)
-    print("   Files were added to Framework/%s/CMakeLists.txt !" % newproject)
+    print("   Files were removed to Framework/{}/CMakeLists.txt !".format(subproject))
+    print("   Files were added to Framework/{}/CMakeLists.txt !".format(newproject))
     print()
 
 #======================================================================


### PR DESCRIPTION
Fixes an issue with `class_maker` where if a `CMakeLists.txt` file contained more than 1 reference to a variable such as `SRC_FILES` then the tool would try to modify all instances and the file would be corrupted. The script now only modifies the first instance of `set ( SRC_FILES` etc found. In addition there is also a new `--no-cmake` argument to prevent any modifications to cmake files.

I have also taken the opportunity to modify the scripts to be compatible with Python 2 & 3.

**To test:**

Use `class_maker` to generate a file in the `Geometry` library. The files should be created and the modifications to the `CMakeLists.txt` should only touch the expected lines at the top and **not** modify lines referencing opencascade later in the file.

Try out the `--no-cmake` option to confirm no cmake files are touched.

No issue. Internal change.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
