### PR TITLE
Work around gcc 5 internal compiler error

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -51,6 +51,9 @@ public:
 #if defined(_MSC_VER) && _MSC_VER <= 1900
   Peak(Peak &&);
   Peak &operator=(Peak &&);
+#elif defined(__GNUC__) && (__GNUC__ == 5)
+  Peak(Peak &&) noexcept = default;
+  Peak &operator=(Peak &&) noexcept = default;
 #else
   Peak(Peak &&) noexcept;
   Peak &operator=(Peak &&) noexcept;

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -234,6 +234,8 @@ Peak::Peak(const Geometry::IPeak &ipeak)
 #if defined(_MSC_VER) && _MSC_VER <= 1900
 Peak::Peak(Peak &&) = default;
 Peak &Peak::operator=(Peak &&) = default;
+#elif defined(__GNUC__) && (__GNUC__ == 5)
+// already defined in the header
 #else
 Peak::Peak(Peak &&) noexcept = default;
 Peak &Peak::operator=(Peak &&) noexcept = default;


### PR DESCRIPTION
With gcc 5.3.1 there was an error associated with `DataObjects::Peak`:

```
Framework/DataObjects/src/Peak.cpp:239:7: error: function 'Mantid::DataObjects::Peak& 
Mantid::DataObjects::Peak::operator=(Mantid::DataObjects::Peak&&)' defaulted on its 
redeclaration with an exception-specification that differs from the implicit exception-specification ''
Peak &Peak::operator=(Peak &&) noexcept = default;
```

It appears to be exercising an [internal compiler error](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58265). Moving the `default` into the header fixes gcc 5, but breaks gcc 4. gcc 6 is happy with the existing code as well. This PR is a work-around specific to gcc 5.

**To test:**

If the builds pass, it is good.

_No associated issue_

_Does not need to be in the release notes_ since it isn't user facing

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
