### PR TITLE
Limit scope of changes to global config option

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
@@ -534,6 +534,10 @@ private:
 
   /// Get period number string in subtracted set
   std::string getSubtractedPeriods() const;
+
+  /// Cached value of config setting
+  std::string m_cachedPeakRadius;
+  static const std::string PEAK_RADIUS_CONFIG;
 };
 }
 }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -82,6 +82,7 @@ Mantid::Kernel::Logger g_log("MuonAnalysis");
 const QString MuonAnalysis::NOT_AVAILABLE("N/A");
 const QString MuonAnalysis::TIME_ZERO_DEFAULT("0.2");
 const QString MuonAnalysis::FIRST_GOOD_BIN_DEFAULT("0.3");
+const std::string MuonAnalysis::PEAK_RADIUS_CONFIG("curvefitting.peakRadius");
 
 //----------------------
 // Public member functions
@@ -298,10 +299,6 @@ void MuonAnalysis::initLayout() {
   connectAutoUpdate();
 
   connectAutoSave();
-
-  // Muon scientists never fits peaks, hence they want the following parameter,
-  // set to a high number
-  ConfigService::Instance().setString("curvefitting.peakRadius", "99");
 
   connect(m_uiForm.deadTimeType, SIGNAL(currentIndexChanged(int)), this,
           SLOT(onDeadTimeTypeChanged(int)));
@@ -2481,6 +2478,9 @@ void MuonAnalysis::changeTab(int newTabIndex) {
     // Say MantidPlot to use default fit prop. browser
     emit setFitPropertyBrowser(NULL);
 
+    // Reset cached config option
+    ConfigService::Instance().setString(PEAK_RADIUS_CONFIG, m_cachedPeakRadius);
+
     // Remove PP tool from any plots it was attached to
     disableAllTools();
 
@@ -2499,6 +2499,12 @@ void MuonAnalysis::changeTab(int newTabIndex) {
 
     // Say MantidPlot to use Muon Analysis fit prop. browser
     emit setFitPropertyBrowser(m_uiForm.fitBrowser);
+
+    // Muon scientists never fit peaks, hence they want the following
+    // parameter set to a high number
+    m_cachedPeakRadius =
+        ConfigService::Instance().getString(PEAK_RADIUS_CONFIG);
+    ConfigService::Instance().setString(PEAK_RADIUS_CONFIG, "99");
 
     // Show connected plot and attach PP tool to it (if has been assigned)
     if (m_currentDataName != NOT_AVAILABLE)


### PR DESCRIPTION
Fix the failing doc tests:

Failure caused by generating the Muon Analysis rst documentation. When starting the interface to get screenshots, a global config option was set.

Limit the scope of this option - it should only be applied while the "data analysis" tab of the interface is open. (During this time, the FitPropertyBrowser on this tab takes over as Mantid's default, so other fitting will not be done). When leaving the tab, the previous value should be restored.

**To test:**

If the Ubuntu build passes this should be OK.

For a manual test:
- In `mantid.user.properties` ensure the option `curvefitting.peakRadius` is set to a sensible low value
- Start MantidPlot and open _Interfaces/Muon/Muon Analysis_
- Check: `ConfigService.Instance().getString("curvefitting.peakRadius")` should still give the sensible value you set
- In the interface, go to the "Data Analysis" tab
  - Now `curvefitting.peakRadius` will be 99
- Leave the "Data Analysis" tab
  - `curvefitting.peakRadius` should be restored to its previous value
- Close the interface and the value should not be changed.

No issue number or release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
