### PR TITLE
SelectNexusFilesByMetadata to require h5py

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SelectNexusFilesByMetadata.py
+++ b/Framework/PythonInterface/plugins/algorithms/SelectNexusFilesByMetadata.py
@@ -1,7 +1,6 @@
 #pylint: disable=eval-used
 from __future__ import (absolute_import, division, print_function)
 
-import h5py
 from mantid.simpleapi import *
 from mantid.kernel import *
 from mantid.api import *
@@ -52,6 +51,13 @@ class SelectNexusFilesByMetadata(PythonAlgorithm):
                              doc='Comma separated list of the fully resolved file names satisfying the given criteria.')
 
     def PyExec(self):
+
+        # run only if h5py is present
+        try:
+            import h5py
+        except ImportError:
+            raise RuntimeError('This algorithm requires h5py package')
+
         outputfiles = []
         # for the purpose here + is meaningless, so they will be silently replaced with ,
         for run in self.getPropertyValue('FileList').replace('+', ',').split(','):

--- a/Framework/PythonInterface/plugins/algorithms/SelectNexusFilesByMetadata.py
+++ b/Framework/PythonInterface/plugins/algorithms/SelectNexusFilesByMetadata.py
@@ -56,7 +56,7 @@ class SelectNexusFilesByMetadata(PythonAlgorithm):
         try:
             import h5py
         except ImportError:
-            raise RuntimeError('This algorithm requires h5py package')
+            raise RuntimeError('This algorithm requires h5py package. See https://pypi.python.org/pypi/h5py')
 
         outputfiles = []
         # for the purpose here + is meaningless, so they will be silently replaced with ,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SelectNexusFilesByMetadataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SelectNexusFilesByMetadataTest.py
@@ -60,7 +60,7 @@ if __name__=="__main__":
     # run the test if only if the required package is present
     try:
         import h5py
+        unittest.main()
     except ImportError:
         pass
-    else:
-        unittest.main()
+

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SelectNexusFilesByMetadataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SelectNexusFilesByMetadataTest.py
@@ -1,3 +1,4 @@
+#pylint: disable=unused-import
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
@@ -56,4 +57,10 @@ class SelectNexusFilesByMetadataTest(unittest.TestCase):
         self.assertTrue(outfiles[0].endswith('ILLD33_001030.nxs'),'Should be the file name')
 
 if __name__=="__main__":
-    unittest.main()
+    # run the test if only if the required package is present
+    try:
+        import h5py
+    except ImportError:
+        pass
+    else:
+        unittest.main()

--- a/docs/source/algorithms/SelectNexusFilesByMetadata-v1.rst
+++ b/docs/source/algorithms/SelectNexusFilesByMetadata-v1.rst
@@ -17,7 +17,7 @@ Criteria could be any python logical expression involving the nexus entry names 
 Arbitrary number of criteria can be combined. The metadata entry should contain only one element.
 Note, that if the entry is of string type, string comparison will be performed.
 As a result, a plain comma separated list of fully resolved file names satisfying the criteria will be returned.
-Note, that this requires ``h5py`` package installed.
+Note, that this algorithm requires `h5py <https://pypi.python.org/pypi/h5py>`_ package installed.
 
 **Example - Running SelectNexusFilesByMetadata**
 

--- a/docs/source/algorithms/SelectNexusFilesByMetadata-v1.rst
+++ b/docs/source/algorithms/SelectNexusFilesByMetadata-v1.rst
@@ -17,10 +17,11 @@ Criteria could be any python logical expression involving the nexus entry names 
 Arbitrary number of criteria can be combined. The metadata entry should contain only one element.
 Note, that if the entry is of string type, string comparison will be performed.
 As a result, a plain comma separated list of fully resolved file names satisfying the criteria will be returned.
+Note, that this requires ``h5py`` package installed.
 
 **Example - Running SelectNexusFilesByMetadata**
 
-.. testcode:: ExSelectNexusFilesByMetadata
+.. code-block:: ExSelectNexusFilesByMetadata
 
     res = SelectNexusFilesByMetadata(FileList='INTER00013460,13463,13464.nxs',
                                      NexusCriteria='$raw_data_1/duration$ > 1000 or $raw_data_1/good_frames$ > 10000')
@@ -28,7 +29,7 @@ As a result, a plain comma separated list of fully resolved file names satisfyin
 
 Output:
 
-.. testoutput:: ExSelectNexusFilesByMetadata
+.. code-block:: ExSelectNexusFilesByMetadata
 
    res is now a string containing comma separated paths of 2 file names that satisfy the criteria
 


### PR DESCRIPTION
This PR makes aforementioned algorithm to run only if `h5py` package is present. 
The algorithm will be subscribed (and documented) regardless, but it will not run (neither be tested) if the required package is missing.

Fixes #17335.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
## Does not need to be in the release notes.
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
