### PR TITLE
Use recalculate from UnitCell

### DIFF
--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -321,10 +321,7 @@ void OrientedLattice::recalculate() {
       (da[5] > da[4] + da[3])) {
     throw std::invalid_argument("Invalid angles");
   }
-  UnitCell::calculateG();
-  UnitCell::calculateGstar();
-  UnitCell::calculateReciprocalLattice();
-  UnitCell::calculateB();
+  UnitCell::recalculate();
   UB = U * getB();
 }
 } // Namespace Geometry

--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -317,10 +317,6 @@ bool OrientedLattice::GetABC(const DblMatrix &UB, V3D &a_dir, V3D &b_dir,
 /// Private function, called at initialization or whenever lattice parameters
 /// are changed
 void OrientedLattice::recalculate() {
-  if ((da[3] > da[4] + da[5]) || (da[4] > da[3] + da[5]) ||
-      (da[5] > da[4] + da[3])) {
-    throw std::invalid_argument("Invalid angles");
-  }
   UnitCell::recalculate();
   UB = U * getB();
 }


### PR DESCRIPTION
Description of work.
Use recalulate from UnitCell to reduce coding

**To test:**

``` python
w=CreateSingleValuedWorkspace(5)
SetUB(w,10,10,10,90,90,90,"1,0,1","0,1,1")
print w.sample().getOrientedLattice().getUB()
w.sample().getOrientedLattice().seta(20)
print w.sample().getOrientedLattice().getUB()
```

Fixes #17340 

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
