### PR TITLE
Fix occasionally empty integrated line plot

### DIFF
--- a/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -208,7 +208,7 @@ MDHistoWorkspace_sptr createShapedOutput(IMDHistoWorkspace const *const inWS,
     }
     dimensions[i] = outDim;
   }
-  return MDHistoWorkspace_sptr(new MDHistoWorkspace(dimensions));
+  return boost::make_shared<MDHistoWorkspace>(dimensions);
 }
 
 /**

--- a/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
+++ b/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
@@ -38,14 +38,12 @@ MantidQwtIMDWorkspaceData::MantidQwtIMDWorkspaceData(
   if (start.getNumDims() == 1 && end.getNumDims() == 1) {
     if (start[0] == 0.0 && end[0] == 0.0) {
       // Default start and end. Find the limits
-      Mantid::Geometry::VecIMDDimension_const_sptr nonIntegDims =
-          m_workspace->getNonIntegratedDimensions();
+      auto nonIntegDims = m_workspace->getNonIntegratedDimensions();
       std::string alongDim;
       if (!nonIntegDims.empty())
         alongDim = nonIntegDims[0]->getName();
       else
         alongDim = m_workspace->getDimension(0)->getName();
-
       size_t nd = m_workspace->getNumDims();
       m_start = VMD(nd);
       m_end = VMD(nd);

--- a/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
+++ b/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
@@ -40,7 +40,7 @@ MantidQwtIMDWorkspaceData::MantidQwtIMDWorkspaceData(
       // Default start and end. Find the limits
       Mantid::Geometry::VecIMDDimension_const_sptr nonIntegDims =
           m_workspace->getNonIntegratedDimensions();
-      std::string alongDim = "";
+      std::string alongDim;
       if (!nonIntegDims.empty())
         alongDim = nonIntegDims[0]->getName();
       else
@@ -51,7 +51,7 @@ MantidQwtIMDWorkspaceData::MantidQwtIMDWorkspaceData(
       m_end = VMD(nd);
       for (size_t d = 0; d < nd; d++) {
         IMDDimension_const_sptr dim = m_workspace->getDimension(d);
-        if (dim->getDimensionId() == alongDim) {
+        if (dim->getName() == alongDim) {
           // All the way through in the single dimension
           m_start[d] = dim->getMinimum();
           m_end[d] = dim->getMaximum();

--- a/MantidQt/SliceViewer/src/LineViewer.cpp
+++ b/MantidQt/SliceViewer/src/LineViewer.cpp
@@ -408,7 +408,7 @@ LineViewer::applyMDWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   double dy = m_end[m_freeDimY] - m_start[m_freeDimY];
   // Angle of the line
   double angle = atan2(dy, dx);
-  double perpAngle = angle + M_PI / 2.0;
+  double perpAngle = angle + M_PI_2;
 
   // Check if this is a axis-aligned cut of a histogram workspace with at most
   // 5 dimensions. If so, we'll use IntegrateMDHistoWorkspace.

--- a/docs/source/release/v3.8.0/ui.rst
+++ b/docs/source/release/v3.8.0/ui.rst
@@ -74,6 +74,7 @@ Bugs Resolved
 - Floating windows now always stay on top of the main window in OSX
 - The sliceviewer will now rebin an existing binned workspace correctly.
 - 2D plots now display correctly for point data workspaces as well as for histogram data
+- Cuts aligned with an axis no longer generate an empty integrated line plot.
 
 SliceViewer Improvements
 ------------------------


### PR DESCRIPTION
Description of work.

The non-integrated dimension's name was being compared against its dimension ID, causing the start and end position to be identical. This caused the integrated line plot to occasionally be empty. Comparing names fixes this issue.

**To test:**

<!-- Instructions for testing. -->

View a MDHistoWorkspace in the slice viewer. Using the pen toolbar button, create a line plot along one of the two axes. On master, the integrated line plot should be blank. On this branch, the integrated line plot should be visible.

There is no GitHub issue associated with this pull request.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
