### PR TITLE
Physical constants for muParsers

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -100,6 +100,7 @@ set ( SRC_FILES
 	src/MultiPeriodGroupWorker.cpp
 	src/MultipleExperimentInfos.cpp
 	src/MultipleFileProperty.cpp
+	src/MuParserUtils.cpp
 	src/NotebookBuilder.cpp
 	src/NotebookWriter.cpp
 	src/NullCoordTransform.cpp
@@ -283,6 +284,7 @@ set ( INC_FILES
 	inc/MantidAPI/MultiPeriodGroupWorker.h
 	inc/MantidAPI/MultipleExperimentInfos.h
 	inc/MantidAPI/MultipleFileProperty.h
+	inc/MantidAPI/MuParserUtils.h
 	inc/MantidAPI/NotebookBuilder.h
 	inc/MantidAPI/NotebookWriter.h
 	inc/MantidAPI/NullCoordTransform.h
@@ -394,6 +396,7 @@ set ( TEST_FILES
 	MultiPeriodGroupWorkerTest.h
 	MultipleExperimentInfosTest.h
 	MultipleFilePropertyTest.h
+	MuParserUtilsTest.h
 	NotebookBuilderTest.h
 	NotebookWriterTest.h
 	NumericAxisTest.h

--- a/Framework/API/inc/MantidAPI/MuParserUtils.h
+++ b/Framework/API/inc/MantidAPI/MuParserUtils.h
@@ -36,7 +36,7 @@ namespace MuParserUtils {
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 
-/// A map from constants to their names in the default parser.
+/// A map from constants to their muParser names.
 extern const MANTID_API_DLL std::map<double, std::string> MUPARSER_CONSTANTS;
 
 /// Add a set of default constants to a muParser.

--- a/Framework/API/inc/MantidAPI/MuParserUtils.h
+++ b/Framework/API/inc/MantidAPI/MuParserUtils.h
@@ -1,19 +1,50 @@
 #ifndef MANTID_API_MUPARSERUTILS_H_
 #define MANTID_API_MUPARSERUTILS_H_
 
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
 #include "MantidAPI/DllConfig.h"
 #include "MantidGeometry/muParser_Silent.h"
-
-#include <boost/shared_ptr.hpp>
 
 namespace Mantid {
 namespace API {
 namespace MuParserUtils {
-// A map from constant values to their names in the default parser.
+
+/** Defines convenience methods to be used with the muParser mathematical
+    expression parser.
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+
+/// A map from constants to their names in the default parser.
 extern const MANTID_API_DLL std::map<double, std::string> MUPARSER_CONSTANTS;
 
+/// Allocates and initializes a default muParser.
 std::unique_ptr<mu::Parser> MANTID_API_DLL allocateDefaultMuParser();
+
+/// Returns a default muParser.
 mu::Parser MANTID_API_DLL createDefaultMuParser();
+
 } // namespace MuParserUtils
 } // namespace API
 } // namespace Mantid

--- a/Framework/API/inc/MantidAPI/MuParserUtils.h
+++ b/Framework/API/inc/MantidAPI/MuParserUtils.h
@@ -39,11 +39,8 @@ namespace MuParserUtils {
 /// A map from constants to their names in the default parser.
 extern const MANTID_API_DLL std::map<double, std::string> MUPARSER_CONSTANTS;
 
-/// Allocates and initializes a default muParser.
-std::unique_ptr<mu::Parser> MANTID_API_DLL allocateDefaultMuParser();
-
-/// Returns a default muParser.
-mu::Parser MANTID_API_DLL createDefaultMuParser();
+/// Add a set of default constants to a muParser.
+void MANTID_API_DLL addDefaultConstants(mu::Parser &parser);
 
 } // namespace MuParserUtils
 } // namespace API

--- a/Framework/API/inc/MantidAPI/MuParserUtils.h
+++ b/Framework/API/inc/MantidAPI/MuParserUtils.h
@@ -1,0 +1,21 @@
+#ifndef MANTID_API_MUPARSERUTILS_H_
+#define MANTID_API_MUPARSERUTILS_H_
+
+#include "MantidAPI/DllConfig.h"
+#include "MantidGeometry/muParser_Silent.h"
+
+#include <boost/shared_ptr.hpp>
+
+namespace Mantid {
+namespace API {
+namespace MuParserUtils {
+// A map from constant values to their names in the default parser.
+extern const MANTID_API_DLL std::map<double, std::string> MUPARSER_CONSTANTS;
+
+std::unique_ptr<mu::Parser> MANTID_API_DLL allocateDefaultMuParser();
+mu::Parser MANTID_API_DLL createDefaultMuParser();
+} // namespace MuParserUtils
+} // namespace API
+} // namespace Mantid
+
+#endif /* MANTID_API_MUPARSERUTILS_H_ */

--- a/Framework/API/src/MuParserUtils.cpp
+++ b/Framework/API/src/MuParserUtils.cpp
@@ -31,32 +31,15 @@ const std::map<double, std::string> MUPARSER_CONSTANTS = {
   {StandardAtmosphere, "atm"}
 };
 
-/** Adds the constants from MUPARSER_CONSTANTS to the parser.
+/** The added constants are defined in MUPARSER_CONSTANTS.
  *  @param parser The parser to be initialized.
  */
-void initParser(mu::Parser& parser) {
+void DLLExport addDefaultConstants(mu::Parser& parser) {
   for (const auto constant : MUPARSER_CONSTANTS) {
     parser.DefineConst(constant.second, constant.first);
   }
 }
 
-/** Populates the parser with the default constants etc.
- *  @return A unique pointer to the default muParser.
- */
-std::unique_ptr<mu::Parser> DLLExport allocateDefaultMuParser() {
-  auto p = Kernel::make_unique<mu::Parser>();
-  initParser(*p);
-  return p;
-}
-
-/** Populates the parser with the default constants etc.
- *  @return A default muParser.
- */
-mu::Parser DLLExport createDefaultMuParser() {
-  mu::Parser p;
-  initParser(p);
-  return p;
-}
 } // namespace MuParserUtils
 } // namespace API
 } // namespace Mantid

--- a/Framework/API/src/MuParserUtils.cpp
+++ b/Framework/API/src/MuParserUtils.cpp
@@ -1,0 +1,51 @@
+#include "MantidAPI/MuParserUtils.h"
+
+#include "MantidKernel/make_unique.h"
+#include "MantidKernel/PhysicalConstants.h"
+
+using namespace Mantid::PhysicalConstants;
+
+namespace Mantid {
+namespace API {
+namespace MuParserUtils {
+// In addition to these, muParser defines "_e" for the Euler's number and
+// "_pi" for pi.
+const std::map<double, std::string> MUPARSER_CONSTANTS = {
+  {AtomicMassUnit, "atomic_mass"},
+  {BoltzmannConstant, "k"},
+  {E_mev_toNeutronWavenumberSq, "meV_squared_wave_number_relationship"},
+  {h, "h"},
+  {h_bar, "hbar"},
+  {g, "g"},
+  {meV, "meV"},
+  {meVtoKelvin, "meV_kelvin_relationship"},
+  {meVtoWavenumber, "meV_wave_number_relationship"},
+  {MuonGyromagneticRatio, "muon_gyromagnetic_ratio"},
+  {MuonLifetime, "muon_life_time"},
+  {N_A, "N_A"},
+  {NeutronMass, "m_n"},
+  {NeutronMassAMU, "m_n_AMU"},
+  {M_PI, "pi"},                // Another pi, without the leading '_'.
+  {StandardAtmosphere, "atm"}
+};
+
+void initParser(mu::Parser& parser) {
+  for (const auto constant : MUPARSER_CONSTANTS) {
+    parser.DefineConst(constant.second, constant.first);
+  }
+}
+
+std::unique_ptr<mu::Parser> DLLExport allocateDefaultMuParser() {
+  auto p = Kernel::make_unique<mu::Parser>();
+  initParser(*p);
+  return p;
+}
+
+mu::Parser DLLExport createDefaultMuParser() {
+  mu::Parser p;
+  initParser(p);
+  return p;
+}
+} // namespace MuParserUtils
+} // namespace API
+} // namespace Mantid

--- a/Framework/API/src/MuParserUtils.cpp
+++ b/Framework/API/src/MuParserUtils.cpp
@@ -13,28 +13,27 @@ namespace MuParserUtils {
 // In addition to these, muParser defines "_e" for the Euler's number and
 // "_pi" for pi.
 const std::map<double, std::string> MUPARSER_CONSTANTS = {
-  {AtomicMassUnit, "atomic_mass"},
-  {BoltzmannConstant, "k"},
-  {E_mev_toNeutronWavenumberSq, "meV_squared_wave_number_relationship"},
-  {h, "h"},
-  {h_bar, "hbar"},
-  {g, "g"},
-  {meV, "meV"},
-  {meVtoKelvin, "meV_kelvin_relationship"},
-  {meVtoWavenumber, "meV_wave_number_relationship"},
-  {MuonGyromagneticRatio, "muon_gyromagnetic_ratio"},
-  {MuonLifetime, "muon_life_time"},
-  {N_A, "N_A"},
-  {NeutronMass, "m_n"},
-  {NeutronMassAMU, "m_n_AMU"},
-  {M_PI, "pi"},                // Another pi, without the leading '_'.
-  {StandardAtmosphere, "atm"}
-};
+    {AtomicMassUnit, "atomic_mass"},
+    {BoltzmannConstant, "k"},
+    {E_mev_toNeutronWavenumberSq, "meV_squared_wave_number_relationship"},
+    {h, "h"},
+    {h_bar, "hbar"},
+    {g, "g"},
+    {meV, "meV"},
+    {meVtoKelvin, "meV_kelvin_relationship"},
+    {meVtoWavenumber, "meV_wave_number_relationship"},
+    {MuonGyromagneticRatio, "muon_gyromagnetic_ratio"},
+    {MuonLifetime, "muon_life_time"},
+    {N_A, "N_A"},
+    {NeutronMass, "m_n"},
+    {NeutronMassAMU, "m_n_AMU"},
+    {M_PI, "pi"}, // Another pi, without the leading '_'.
+    {StandardAtmosphere, "atm"}};
 
 /** The added constants are defined in MUPARSER_CONSTANTS.
  *  @param parser The parser to be initialized.
  */
-void DLLExport addDefaultConstants(mu::Parser& parser) {
+void DLLExport addDefaultConstants(mu::Parser &parser) {
   for (const auto constant : MUPARSER_CONSTANTS) {
     parser.DefineConst(constant.second, constant.first);
   }

--- a/Framework/API/src/MuParserUtils.cpp
+++ b/Framework/API/src/MuParserUtils.cpp
@@ -8,6 +8,8 @@ using namespace Mantid::PhysicalConstants;
 namespace Mantid {
 namespace API {
 namespace MuParserUtils {
+// The constant names below try to follow the naming scheme of the
+// scipy.constants Python module.
 // In addition to these, muParser defines "_e" for the Euler's number and
 // "_pi" for pi.
 const std::map<double, std::string> MUPARSER_CONSTANTS = {
@@ -29,18 +31,27 @@ const std::map<double, std::string> MUPARSER_CONSTANTS = {
   {StandardAtmosphere, "atm"}
 };
 
+/** Adds the constants from MUPARSER_CONSTANTS to the parser.
+ *  @param parser The parser to be initialized.
+ */
 void initParser(mu::Parser& parser) {
   for (const auto constant : MUPARSER_CONSTANTS) {
     parser.DefineConst(constant.second, constant.first);
   }
 }
 
+/** Populates the parser with the default constants etc.
+ *  @return A unique pointer to the default muParser.
+ */
 std::unique_ptr<mu::Parser> DLLExport allocateDefaultMuParser() {
   auto p = Kernel::make_unique<mu::Parser>();
   initParser(*p);
   return p;
 }
 
+/** Populates the parser with the default constants etc.
+ *  @return A default muParser.
+ */
 mu::Parser DLLExport createDefaultMuParser() {
   mu::Parser p;
   initParser(p);

--- a/Framework/API/test/CMakeLists.txt
+++ b/Framework/API/test/CMakeLists.txt
@@ -21,6 +21,7 @@ if ( CXXTEST_FOUND )
             ${NEXUS_LIBRARIES}
             ${Boost_LIBRARIES}
             ${POCO_LIBRARIES}
+            ${MUPARSER_LIBRARIES}
             ${GMOCK_LIBRARIES}
             ${GTEST_LIBRARIES}  )
 

--- a/Framework/API/test/MuParserUtilsTest.h
+++ b/Framework/API/test/MuParserUtilsTest.h
@@ -11,16 +11,11 @@ public:
   static MuParserUtilsTest *createSuite() { return new MuParserUtilsTest(); }
   static void destroySuite(MuParserUtilsTest *suite) { delete suite; }
 
-  void test_CreateDefaultMuParser_Gives_Whats_Promised() {
-    const auto parser = MuParserUtils::createDefaultMuParser();
+  void test_addDefaultConstants_Only_MUPARSER_CONSTANTS_IsAdded() {
+    mu::Parser parser;
+    MuParserUtils::addDefaultConstants(parser);
     TS_ASSERT(defaultConstantsDefined(parser));
     TS_ASSERT(noVariablesDefined(parser));
-  }
-
-  void test_AllocateDefaultMuParser_Gives_Whats_Promised() {
-    const auto parser = MuParserUtils::allocateDefaultMuParser();
-    TS_ASSERT(defaultConstantsDefined(*parser));
-    TS_ASSERT(noVariablesDefined(*parser));
   }
 
 private:

--- a/Framework/API/test/MuParserUtilsTest.h
+++ b/Framework/API/test/MuParserUtilsTest.h
@@ -1,0 +1,54 @@
+#ifndef MANTID_API_MUPARSERUTILSTEST_H_
+#define MANTID_API_MUPARSERUTILSTEST_H_
+
+#include "MantidAPI/MuParserUtils.h"
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid::API;
+
+class MuParserUtilsTest : public CxxTest::TestSuite {
+public:
+  static MuParserUtilsTest *createSuite() { return new MuParserUtilsTest(); }
+  static void destroySuite(MuParserUtilsTest *suite) { delete suite; }
+
+  void test_CreateDefaultMuParser_Gives_Whats_Promised() {
+    const auto parser = MuParserUtils::createDefaultMuParser();
+    TS_ASSERT(constantsDefined(parser));
+  }
+
+  void test_AllocateDefaultMuParser_Gives_Whats_Promised() {
+    const auto parser = MuParserUtils::allocateDefaultMuParser();
+    TS_ASSERT(constantsDefined(*parser));
+  }
+
+private:
+  static bool constantsDefined(const mu::Parser &parser) {
+    const auto constantMap = parser.GetConst();
+    // muParser defines two extra constants: "_e" and "_pi".
+    size_t extraConstants = 0;
+    if (constantMap.find("_e") != constantMap.end()) {
+      ++extraConstants;
+    }
+    if (constantMap.find("_pi") != constantMap.end()) {
+      ++extraConstants;
+    }
+    if (constantMap.size() - extraConstants != MuParserUtils::MUPARSER_CONSTANTS.size()) {
+      return false;
+    }
+    //Note: the keys in constantMap are values in MUPARSER_CONSTANTS and
+    //vice versa.
+    for (const auto constant : MuParserUtils::MUPARSER_CONSTANTS) {
+      const auto iterator = constantMap.find(constant.second);
+      if (iterator == constantMap.end()) {
+        return false;
+      }
+      if (iterator->second != constant.first) {
+        return false;
+     }
+    }
+
+    return true;
+  }
+};
+
+#endif /* MANTID_API_MUPARSERUTILSTEST_H_ */

--- a/Framework/API/test/MuParserUtilsTest.h
+++ b/Framework/API/test/MuParserUtilsTest.h
@@ -13,16 +13,18 @@ public:
 
   void test_CreateDefaultMuParser_Gives_Whats_Promised() {
     const auto parser = MuParserUtils::createDefaultMuParser();
-    TS_ASSERT(constantsDefined(parser));
+    TS_ASSERT(defaultConstantsDefined(parser));
+    TS_ASSERT(noVariablesDefined(parser));
   }
 
   void test_AllocateDefaultMuParser_Gives_Whats_Promised() {
     const auto parser = MuParserUtils::allocateDefaultMuParser();
-    TS_ASSERT(constantsDefined(*parser));
+    TS_ASSERT(defaultConstantsDefined(*parser));
+    TS_ASSERT(noVariablesDefined(*parser));
   }
 
 private:
-  static bool constantsDefined(const mu::Parser &parser) {
+  static bool defaultConstantsDefined(const mu::Parser &parser) {
     const auto constantMap = parser.GetConst();
     // muParser defines two extra constants: "_e" and "_pi".
     size_t extraConstants = 0;
@@ -48,6 +50,10 @@ private:
     }
 
     return true;
+  }
+
+  static bool noVariablesDefined(const mu::Parser &parser) {
+    return parser.GetVar().size() == 0;
   }
 };
 

--- a/Framework/API/test/MuParserUtilsTest.h
+++ b/Framework/API/test/MuParserUtilsTest.h
@@ -29,11 +29,12 @@ private:
     if (constantMap.find("_pi") != constantMap.end()) {
       ++extraConstants;
     }
-    if (constantMap.size() - extraConstants != MuParserUtils::MUPARSER_CONSTANTS.size()) {
+    if (constantMap.size() - extraConstants !=
+        MuParserUtils::MUPARSER_CONSTANTS.size()) {
       return false;
     }
-    //Note: the keys in constantMap are values in MUPARSER_CONSTANTS and
-    //vice versa.
+    // Note: the keys in constantMap are values in MUPARSER_CONSTANTS and
+    // vice versa.
     for (const auto constant : MuParserUtils::MUPARSER_CONSTANTS) {
       const auto iterator = constantMap.find(constant.second);
       if (iterator == constantMap.end()) {
@@ -41,7 +42,7 @@ private:
       }
       if (iterator->second != constant.first) {
         return false;
-     }
+      }
     }
 
     return true;


### PR DESCRIPTION
This PR adds MuParserUtils namespace to Mantid for muParser related utility functions. At the moment only one function is defined there, namely `addDefaultConstants` which adds the constants defined in Mantid::PhysicalConstants + pi to a muParser object. The idea is to provide a common set of constants for the muParsers used throughout the project.

Implements #17328

_Does not need to be in the release notes._ This is an internal change and the functionality is not yet used.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focused classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
