### PR TITLE
Suppress -Wundefined-var-template warnings from clang 3.9.

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
@@ -18,8 +18,18 @@ using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(IMDHistoWorkspace)
 
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
+extern template int NDArrayTypeIndex<float>::typenum;
+extern template int NDArrayTypeIndex<double>::typenum;
+}
+}
+}
+
 namespace {
 /**
+
  * Determine the sizes of each dimensions
  * @param array :: the C++ array
  * @param dims :: the dimensions vector (Py_intptr_t type)

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
@@ -10,6 +10,17 @@
 namespace Mantid {
 namespace PythonInterface {
 namespace Converters {
+
+extern template int NDArrayTypeIndex<bool>::typenum;
+extern template int NDArrayTypeIndex<int>::typenum;
+extern template int NDArrayTypeIndex<long>::typenum;
+extern template int NDArrayTypeIndex<long long>::typenum;
+extern template int NDArrayTypeIndex<unsigned int>::typenum;
+extern template int NDArrayTypeIndex<unsigned long>::typenum;
+extern template int NDArrayTypeIndex<unsigned long long>::typenum;
+extern template int NDArrayTypeIndex<float>::typenum;
+extern template int NDArrayTypeIndex<double>::typenum;
+
 namespace Impl {
 /**
  * Returns a new numpy array with the a copy of the data from 1D vector with the

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
@@ -8,6 +8,19 @@
 
 namespace Mantid {
 namespace PythonInterface {
+namespace Converters {
+
+extern template int NDArrayTypeIndex<bool>::typenum;
+extern template int NDArrayTypeIndex<int>::typenum;
+extern template int NDArrayTypeIndex<long>::typenum;
+extern template int NDArrayTypeIndex<long long>::typenum;
+extern template int NDArrayTypeIndex<unsigned int>::typenum;
+extern template int NDArrayTypeIndex<unsigned long>::typenum;
+extern template int NDArrayTypeIndex<unsigned long long>::typenum;
+extern template int NDArrayTypeIndex<float>::typenum;
+extern template int NDArrayTypeIndex<double>::typenum;
+}
+
 namespace {
 //-------------------------------------------------------------------------
 // Template helpers


### PR DESCRIPTION
Description of work.

Building Mantid with clang 3.9-rc3 generates several warnings from `-Wundefined-var-template`. I suppressed the warnings with explicit instantiation declarations. Is this what we want to do?  

```
[505/3156] Building CXX object Framework/PythonInterface/mantid/kernel/CMakeFiles/PythonKernelModule.dir/src/Converters/CloneToNumpy.cpp.o
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:34:42: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<bool>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<bool>::typenum;
                                         ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:34:42: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<bool>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<bool>::typenum;
                                         ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<int>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<int>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long long>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long long>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned int>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned int>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long long>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long long>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<double>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<double>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<float>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp:57:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<float>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
9 warnings generated.
[507/3156] Building CXX object Framework/PythonInterface/mantid/kernel/CMakeFiles/PythonKernelModule.dir/src/Converters/NDArrayToVector.cpp.o
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<int>::typenum' required here, but no definition is available [-Wundefined-var-template]
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:135:11: note: in instantiation of member function 'Mantid::PythonInterface::(anonymous namespace)::coerce_type<int>::operator()' requested here
  m_arr = coerce_type<DestElementType>()(m_arr);
          ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<int>::typenum' is explicitly instantiated in another translation unit
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long>::typenum' required here, but no definition is available [-Wundefined-var-template]
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:135:11: note: in instantiation of member function 'Mantid::PythonInterface::(anonymous namespace)::coerce_type<long>::operator()' requested here
  m_arr = coerce_type<DestElementType>()(m_arr);
          ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long>::typenum' is explicitly instantiated in another translation unit
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long long>::typenum' required here, but no definition is available [-Wundefined-var-template]
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:135:11: note: in instantiation of member function 'Mantid::PythonInterface::(anonymous namespace)::coerce_type<long long>::operator()' requested here
  m_arr = coerce_type<DestElementType>()(m_arr);
          ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long long>::typenum' is explicitly instantiated in another translation unit
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned int>::typenum' required here, but no definition is available [-Wundefined-var-template]
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:135:11: note: in instantiation of member function 'Mantid::PythonInterface::(anonymous namespace)::coerce_type<unsigned int>::operator()' requested here
  m_arr = coerce_type<DestElementType>()(m_arr);
          ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned int>::typenum' is explicitly instantiated in another translation unit
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long>::typenum' required here, but no definition is available [-Wundefined-var-template]
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:135:11: note: in instantiation of member function 'Mantid::PythonInterface::(anonymous namespace)::coerce_type<unsigned long>::operator()' requested here
  m_arr = coerce_type<DestElementType>()(m_arr);
          ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long>::typenum' is explicitly instantiated in another translation unit
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long long>::typenum' required here, but no definition is available [-Wundefined-var-template]
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:135:11: note: in instantiation of member function 'Mantid::PythonInterface::(anonymous namespace)::coerce_type<unsigned long long>::operator()' requested here
  m_arr = coerce_type<DestElementType>()(m_arr);
          ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long long>::typenum' is explicitly instantiated in another translation unit
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<double>::typenum' required here, but no definition is available [-Wundefined-var-template]
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:135:11: note: in instantiation of member function 'Mantid::PythonInterface::(anonymous namespace)::coerce_type<double>::operator()' requested here
  m_arr = coerce_type<DestElementType>()(m_arr);
          ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<double>::typenum' is explicitly instantiated in another translation unit
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<bool>::typenum' required here, but no definition is available [-Wundefined-var-template]
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:135:11: note: in instantiation of member function 'Mantid::PythonInterface::(anonymous namespace)::coerce_type<bool>::operator()' requested here
  m_arr = coerce_type<DestElementType>()(m_arr);
          ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp:66:67: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<bool>::typenum' is explicitly instantiated in another translation unit
    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
                                                                  ^
8 warnings generated.
[514/3156] Building CXX object Framework/PythonInterface/mantid/kernel/CMakeFiles/PythonKernelModule.dir/src/Converters/WrapWithNumpy.cpp.o
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<int>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<int>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long long>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<long long>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned int>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned int>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long long>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<unsigned long long>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<double>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<double>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<float>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp:48:49: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<float>::typenum' is explicitly instantiated in another translation unit
  int datatype = NDArrayTypeIndex<ElementType>::typenum;
                                                ^
8 warnings generated.
[625/3156] Building CXX object Framework/PythonInterface/mantid/api/CMakeFiles/PythonAPIModule.dir/src/Exports/IMDHistoWorkspace.cpp.o
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp:30:66: warning: instantiation of variable 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<double>::typenum' required here, but no definition is available [-Wundefined-var-template]
  int datatype = Converters::NDArrayTypeIndex<Mantid::signal_t>::typenum;
                                                                 ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayTypeIndex.h:42:14: note: forward declaration of template entity is here
  static int typenum;
             ^
/Users/svh/Documents/MantidProject/mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp:30:66: note: add an explicit instantiation declaration to suppress this warning if 'Mantid::PythonInterface::Converters::NDArrayTypeIndex<double>::typenum' is explicitly instantiated in another translation unit
  int datatype = Converters::NDArrayTypeIndex<Mantid::signal_t>::typenum;
                                                                 ^
1 warning generated.
```

**To test:**

<!-- Instructions for testing. -->

Assuming the builds still pass, code review is probably sufficient.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
