### PR TITLE
SelectNexusFilesByMetadata treat summed files

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SelectNexusFilesByMetadata.py
+++ b/Framework/PythonInterface/plugins/algorithms/SelectNexusFilesByMetadata.py
@@ -69,9 +69,6 @@ class SelectNexusFilesByMetadata(PythonAlgorithm):
                 with h5py.File(run, 'r') as nexusfile:
                     if self.checkCriteria(run, nexusfile):
                         filestosum += run + '+'
-                    else:
-                        filestosum = ''
-                        break
 
             if filestosum:
                 # trim the last +

--- a/Framework/PythonInterface/plugins/algorithms/SelectNexusFilesByMetadata.py
+++ b/Framework/PythonInterface/plugins/algorithms/SelectNexusFilesByMetadata.py
@@ -58,53 +58,71 @@ class SelectNexusFilesByMetadata(PythonAlgorithm):
         except ImportError:
             raise RuntimeError('This algorithm requires h5py package. See https://pypi.python.org/pypi/h5py')
 
-        outputfiles = []
-        # for the purpose here + is meaningless, so they will be silently replaced with ,
-        for run in self.getPropertyValue('FileList').replace('+', ',').split(','):
-            with h5py.File(run,'r') as nexusfile:
-                toeval = ''
-                item = None # for pylint
-                for i, item in enumerate(self._criteria_splitted):
-                    if i % 2 == 1: # at odd indices will always be the nexus entry names
-                        try:
-                            # try to get the entry from the file
-                            entry = nexusfile.get(item)
+        outputfiles = ''
+        # first split by ,
+        for runs in self.getPropertyValue('FileList').split(','):
 
-                            if len(entry.shape) > 1 or len(entry) > 1:
-                                self.log().warning('Nexus entry %s has more than one dimension or more than one element'
-                                                   'in file %s. Skipping the file.' % (item,run))
-                                toeval = '0'
-                                break
+            filestosum = ''
+            # then split each by +
+            for run in runs.split('+'):
 
-                            # replace entry name by it's value
-                            value = entry[0]
-
-                            if str(value.dtype).startswith('|S'):
-                                # string value, need to quote for eval
-                                toeval += '\"'+ value + '\"'
-                            else:
-                                toeval += str(value)
-
-                        except (TypeError,AttributeError):
-                            self.log().warning('Nexus entry %s does not exist in file %s. Skipping the file.' % (item,run))
-                            toeval = '0'
-                            break
+                with h5py.File(run, 'r') as nexusfile:
+                    if self.checkCriteria(run, nexusfile):
+                        filestosum += run + '+'
                     else:
-                        # keep other portions intact
-                        toeval += item
-                self.log().debug('Expression to be evaluated for file %s :\n %s' % (run, toeval))
-                try:
-                    if eval(toeval):
-                        outputfiles.append(run)
-                except (NameError,ValueError,SyntaxError):
-                    # even if syntax is validated, eval can still throw, since
-                    # the nexus entry value itself can be spurious for a given file
-                    self.log().warning('Invalid value for the nexus entry %s in file %s. Skipping the file.' % (item, run))
+                        filestosum = ''
+                        break
 
-        if not outputfiles:
+            if filestosum:
+                # trim the last +
+                filestosum = filestosum[:-1]
+                outputfiles += filestosum + ','
+
+        # trim the last ,
+        if outputfiles:
+            outputfiles = outputfiles[:-1]
+        else:
             self.log().notice('No files where found to satisfy the criteria, check the FileList and/or NexusCriteria')
 
-        self.setPropertyValue('Result',','.join(outputfiles))
+        self.setPropertyValue('Result',outputfiles)
+
+    def checkCriteria(self, run, nexusfile):
+        toeval = ''
+        item = None  # for pylint
+        for i, item in enumerate(self._criteria_splitted):
+            if i % 2 == 1:  # at odd indices will always be the nexus entry names
+                try:
+                    # try to get the entry from the file
+                    entry = nexusfile.get(item)
+
+                    if len(entry.shape) > 1 or len(entry) > 1:
+                        self.log().warning('Nexus entry %s has more than one dimension or more than one element'
+                                           'in file %s. Skipping the file.' % (item, run))
+                        return False
+
+                    # replace entry name by it's value
+                    value = entry[0]
+
+                    if str(value.dtype).startswith('|S'):
+                        # string value, need to quote for eval
+                        toeval += '\"' + value + '\"'
+                    else:
+                        toeval += str(value)
+
+                except (TypeError, AttributeError):
+                    self.log().warning('Nexus entry %s does not exist in file %s. Skipping the file.' % (item, run))
+                    return False
+            else:
+                # keep other portions intact
+                toeval += item
+        self.log().debug('Expression to be evaluated for file %s :\n %s' % (run, toeval))
+        try:
+            return eval(toeval)
+        except (NameError, ValueError, SyntaxError):
+            # even if syntax is validated, eval can still throw, since
+            # the nexus entry value itself can be spurious for a given file
+            self.log().warning('Invalid value for the nexus entry %s in file %s. Skipping the file.' % (item, run))
+            return False
 
 # Register algorithm with Mantid
 AlgorithmFactory.subscribe(SelectNexusFilesByMetadata)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SelectNexusFilesByMetadataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SelectNexusFilesByMetadataTest.py
@@ -7,7 +7,7 @@ from mantid.simpleapi import *
 class SelectNexusFilesByMetadataTest(unittest.TestCase):
 
     _fileslist = 'INTER00013460,13463,13464.nxs'
-    _sumfileslist = 'INTER00013460,13463+13464.nxs'
+    _sumfileslist = 'INTER00013460+13463+13464.nxs'
 
     def test_happy_case(self):
 
@@ -21,7 +21,10 @@ class SelectNexusFilesByMetadataTest(unittest.TestCase):
     def test_sum(self):
         criteria = '$raw_data_1/duration$ > 1000 or $raw_data_1/good_frames$ > 10000'
         res = SelectNexusFilesByMetadata(FileList=self._sumfileslist, NexusCriteria=criteria)
-        self.assertTrue(res.endswith('INTER00013460.nxs'), 'Should be first file name')
+        outfiles = res.split('+')
+        self.assertEqual(len(outfiles), 2, "Only 1st and 3rd files satisfy.")
+        self.assertTrue(outfiles[0].endswith('INTER00013460.nxs'), 'Should be first file name')
+        self.assertTrue(outfiles[1].endswith('INTER00013464.nxs'), 'Should be second file name')
 
     def test_invalid_syntax(self):
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SelectNexusFilesByMetadataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SelectNexusFilesByMetadataTest.py
@@ -7,6 +7,7 @@ from mantid.simpleapi import *
 class SelectNexusFilesByMetadataTest(unittest.TestCase):
 
     _fileslist = 'INTER00013460,13463,13464.nxs'
+    _sumfileslist = 'INTER00013460,13463+13464.nxs'
 
     def test_happy_case(self):
 
@@ -16,6 +17,11 @@ class SelectNexusFilesByMetadataTest(unittest.TestCase):
         self.assertEqual(len(outfiles), 2, "Only 1st and 3rd files satisfy.")
         self.assertTrue(outfiles[0].endswith('INTER00013460.nxs'),'Should be first file name')
         self.assertTrue(outfiles[1].endswith('INTER00013464.nxs'),'Should be second file name')
+
+    def test_sum(self):
+        criteria = '$raw_data_1/duration$ > 1000 or $raw_data_1/good_frames$ > 10000'
+        res = SelectNexusFilesByMetadata(FileList=self._sumfileslist, NexusCriteria=criteria)
+        self.assertTrue(res.endswith('INTER00013460.nxs'), 'Should be first file name')
 
     def test_invalid_syntax(self):
 

--- a/docs/source/algorithms/SelectNexusFilesByMetadata-v1.rst
+++ b/docs/source/algorithms/SelectNexusFilesByMetadata-v1.rst
@@ -12,11 +12,11 @@ Description
 This algorithm returns the nexus (HDF) files in the given files list that satisfy the specified criteria.
 This is done without actually loading the data, but just the needed metadata.
 Input files need to exist and be specified following the Mantid rules in `MultiFileLoading <http://www.mantidproject.org/MultiFileLoading>`_.
-Note, that the summed lists (``+``) will be fully excluded from the output list, if one of the runs in the sum does not satisfy the criteria.
 Criteria could be any python logical expression involving the nexus entry names enclosed with ``$`` symbol.
 Arbitrary number of criteria can be combined. The metadata entry should contain only one element.
 Note, that if the entry is of string type, string comparison will be performed.
-As a result, a string of the fully resolved file names satisfying the criteria will be returned.
+As a result, a string of the fully resolved file names satisfying the criteria
+(and following the same algebra as in input, i.e. ``+`` or ``,``) will be returned.
 Note, that this algorithm requires `h5py <https://pypi.python.org/pypi/h5py>`_ package installed.
 
 **Example - Running SelectNexusFilesByMetadata**

--- a/docs/source/algorithms/SelectNexusFilesByMetadata-v1.rst
+++ b/docs/source/algorithms/SelectNexusFilesByMetadata-v1.rst
@@ -12,11 +12,11 @@ Description
 This algorithm returns the nexus (HDF) files in the given files list that satisfy the specified criteria.
 This is done without actually loading the data, but just the needed metadata.
 Input files need to exist and be specified following the Mantid rules in `MultiFileLoading <http://www.mantidproject.org/MultiFileLoading>`_.
-Note, that the ``+`` and ``-`` rules will act as ``,`` and ``:`` correspondingly, since the summing does not make sense for the given purpose.
+Note, that the summed lists (``+``) will be fully excluded from the output list, if one of the runs in the sum does not satisfy the criteria.
 Criteria could be any python logical expression involving the nexus entry names enclosed with ``$`` symbol.
 Arbitrary number of criteria can be combined. The metadata entry should contain only one element.
 Note, that if the entry is of string type, string comparison will be performed.
-As a result, a plain comma separated list of fully resolved file names satisfying the criteria will be returned.
+As a result, a string of the fully resolved file names satisfying the criteria will be returned.
 Note, that this algorithm requires `h5py <https://pypi.python.org/pypi/h5py>`_ package installed.
 
 **Example - Running SelectNexusFilesByMetadata**


### PR DESCRIPTION
This PR modifies the treatment of the summed files in the input files list in the `SelectNexusFilesByMetadata` algorithm. 
The files to sum will be now excluded from the list if not satisfying the criteria, but the algebra of the whole list will be preserved.

To test:

<!-- Instructions for testing. -->

Run `SelectNexusFilesByMetadata`with some criteria  over some nexus files given as `+` and `,` combined lists, e.g.
`FileList = A,B+C,D+E`. If only `D` is not satisfying the given criteria, `A,B+C,E` should be returned.

Fixes #17357.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
## Does not need to be in the release notes.
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
