### PR TITLE
Change logging level in FindPeaks

### DIFF
--- a/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Framework/Algorithms/src/FindPeaks.cpp
@@ -218,9 +218,9 @@ void FindPeaks::processAlgorithmProperties() {
   singleSpectrum = !isEmpty(m_wsIndex);
   if (singleSpectrum &&
       m_wsIndex >= static_cast<int>(m_dataWS->getNumberHistograms())) {
-    g_log.error() << "The value of WorkspaceIndex provided (" << m_wsIndex
-                  << ") is larger than the size of this workspace ("
-                  << m_dataWS->getNumberHistograms() << ")\n";
+    g_log.warning() << "The value of WorkspaceIndex provided (" << m_wsIndex
+                    << ") is larger than the size of this workspace ("
+                    << m_dataWS->getNumberHistograms() << ")\n";
     throw Kernel::Exception::IndexError(m_wsIndex,
                                         m_dataWS->getNumberHistograms() - 1,
                                         "FindPeaks WorkspaceIndex property");
@@ -237,7 +237,7 @@ void FindPeaks::processAlgorithmProperties() {
              "postive and make sense). "
           << "User inputs are min = " << t1 << ", max = " << t2
           << ", step = " << t3;
-    g_log.error(errss.str());
+    g_log.warning(errss.str());
     throw std::runtime_error(errss.str());
   }
 
@@ -787,13 +787,13 @@ int FindPeaks::getIndex(const HistogramX &vecX, double x) {
       std::stringstream errss;
       errss << "Returned index = 0 for x = " << x << " with X[0] = " << vecX[0]
             << ". This situation is ruled out in this algorithm.";
-      g_log.error(errss.str());
+      g_log.warning(errss.str());
       throw std::runtime_error(errss.str());
     } else if (x < vecX[index - 1] || x > vecX[index]) {
       std::stringstream errss;
       errss << "Returned x = " << x << " is not between " << vecX[index - 1]
             << " and " << vecX[index] << ", which are returned by lower_bound.";
-      g_log.error(errss.str());
+      g_log.warning(errss.str());
       throw std::runtime_error(errss.str());
     }
 
@@ -893,7 +893,7 @@ void FindPeaks::fitPeakInWindow(const API::MatrixWorkspace_sptr &input,
                       << centre_guess << "  x-min = " << xmin
                       << ", x-max = " << xmax << "\n";
   if (xmin >= centre_guess || xmax <= centre_guess) {
-    g_log.error("Peak centre is on the edge of Fit window. ");
+    g_log.warning("Peak centre is on the edge of Fit window. ");
     addNonFitRecord(wsIndex, centre_guess);
     return;
   }
@@ -907,10 +907,10 @@ void FindPeaks::fitPeakInWindow(const API::MatrixWorkspace_sptr &input,
   // The left index
   int i_min = getIndex(vecX, xmin);
   if (i_min >= i_centre) {
-    g_log.error() << "Input peak centre @ " << centre_guess
-                  << " is out side of minimum x = " << xmin
-                  << ".  Input X ragne = " << vecX.front() << ", "
-                  << vecX.back() << "\n";
+    g_log.warning() << "Input peak centre @ " << centre_guess
+                    << " is out side of minimum x = " << xmin
+                    << ".  Input X ragne = " << vecX.front() << ", "
+                    << vecX.back() << "\n";
     addNonFitRecord(wsIndex, centre_guess);
     return;
   }
@@ -918,8 +918,8 @@ void FindPeaks::fitPeakInWindow(const API::MatrixWorkspace_sptr &input,
   // The right index
   int i_max = getIndex(vecX, xmax);
   if (i_max < i_centre) {
-    g_log.error() << "Input peak centre @ " << centre_guess
-                  << " is out side of maximum x = " << xmax << "\n";
+    g_log.warning() << "Input peak centre @ " << centre_guess
+                    << " is out side of maximum x = " << xmax << "\n";
     addNonFitRecord(wsIndex, centre_guess);
     return;
   }
@@ -988,7 +988,7 @@ void FindPeaks::fitSinglePeak(const API::MatrixWorkspace_sptr &input,
     i_obscentre = i_centre;
     est_fwhm = 1.;
     est_height = 1.;
-    g_log.error(errmsg);
+    g_log.warning(errmsg);
   }
 
   // Set peak parameters to


### PR DESCRIPTION
`FindPeaks` logs too much to the `error` level. Move these down one to `warning`

**To test:**

A simple review and the builds passing should be enough.

_There is no associated issue_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
