### PR TITLE
SaveDiffCal optional workspaces

### DIFF
--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -123,12 +123,11 @@ void SaveDiffCal::writeIntFieldFromSVWS(
   std::vector<int32_t> values(m_numValues, 1);
 
   if (bool(ws)) {
-    int32_t value;
     for (size_t i = 0; i < m_numValues; ++i) {
       auto &ids = ws->getSpectrum(i).getDetectorIDs();
       auto found = m_detidToIndex.find(*(ids.begin()));
       if (found != m_detidToIndex.end()) {
-        value = static_cast<int32_t>(ws->getValue(found->first));
+        int32_t value = static_cast<int32_t>(ws->getValue(found->first));
         // in maskworkspace 0=use, 1=dontuse - backwards from the file
         if (isMask) {
           if (value == 0)

--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -122,8 +122,8 @@ void SaveDiffCal::writeIntFieldFromSVWS(
   // output array defaults to all one (one group, use the pixel)
   std::vector<int32_t> values(m_numValues, 1);
 
-  int32_t value;
   if (bool(ws)) {
+    int32_t value;
     for (size_t i = 0; i < m_numValues; ++i) {
       auto &ids = ws->getSpectrum(i).getDetectorIDs();
       auto found = m_detidToIndex.find(*(ids.begin()));

--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -117,26 +117,27 @@ void SaveDiffCal::writeIntFieldFromSVWS(
     H5::Group &group, const std::string &name,
     DataObjects::SpecialWorkspace2D_const_sptr ws) {
   auto detidCol = m_calibrationWS->getColumn("detid");
-  bool isMask = bool(boost::dynamic_pointer_cast<const MaskWorkspace>(ws));
+  const bool isMask = (name == "use");
 
   // output array defaults to all one (one group, use the pixel)
-  const int32_t DEFAULT_VALUE = (isMask ? 0 : 1);
-  std::vector<int32_t> values(m_numValues, DEFAULT_VALUE);
+  std::vector<int32_t> values(m_numValues, 1);
 
   int32_t value;
-  for (size_t i = 0; i < m_numValues; ++i) {
-    auto &ids = ws->getSpectrum(i).getDetectorIDs();
-    auto found = m_detidToIndex.find(*(ids.begin()));
-    if (found != m_detidToIndex.end()) {
-      value = static_cast<int32_t>(ws->getValue(found->first));
-      // in maskworkspace 0=use, 1=dontuse
-      if (isMask) {
-        if (value == 0)
-          value = 1;
-        else
-          value = 0;
+  if (bool(ws)) {
+    for (size_t i = 0; i < m_numValues; ++i) {
+      auto &ids = ws->getSpectrum(i).getDetectorIDs();
+      auto found = m_detidToIndex.find(*(ids.begin()));
+      if (found != m_detidToIndex.end()) {
+        value = static_cast<int32_t>(ws->getValue(found->first));
+        // in maskworkspace 0=use, 1=dontuse - backwards from the file
+        if (isMask) {
+          if (value == 0)
+            value = 1;
+          else
+            value = 0;
+        }
+        values[found->second] = value;
       }
-      values[found->second] = value;
     }
   }
 

--- a/Framework/DataHandling/test/SaveDiffCalTest.h
+++ b/Framework/DataHandling/test/SaveDiffCalTest.h
@@ -106,6 +106,56 @@ public:
     TS_ASSERT(!alg.isExecuted());
   }
 
+  void test_no_mask() {
+    Instrument_sptr inst = createInstrument();
+    GroupingWorkspace_sptr groupWS = createGrouping(inst);
+    MaskWorkspace_sptr maskWS = createMasking(inst);
+    TableWorkspace_sptr calWS =
+        createCalibration(NUM_BANK * 9); // nine components per bank
+
+    SaveDiffCal alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", groupWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", FILENAME));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalibrationWorkspace", calWS));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // confirm that it exists
+    std::string filename = alg.getPropertyValue("Filename");
+    TS_ASSERT(Poco::File(filename).exists());
+
+    // cleanup
+    if (Poco::File(filename).exists())
+      Poco::File(filename).remove();
+  }
+
+  void test_no_grouping() {
+    Instrument_sptr inst = createInstrument();
+    GroupingWorkspace_sptr groupWS = createGrouping(inst);
+    MaskWorkspace_sptr maskWS = createMasking(inst);
+    TableWorkspace_sptr calWS =
+        createCalibration(NUM_BANK * 9); // nine components per bank
+
+    SaveDiffCal alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaskWorkspace", maskWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", FILENAME));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("CalibrationWorkspace", calWS));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // confirm that it exists
+    std::string filename = alg.getPropertyValue("Filename");
+    TS_ASSERT(Poco::File(filename).exists());
+
+    // cleanup
+    if (Poco::File(filename).exists())
+      Poco::File(filename).remove();
+  }
+
   void test_exec() {
     Instrument_sptr inst = createInstrument();
     GroupingWorkspace_sptr groupWS = createGrouping(inst);


### PR DESCRIPTION
The `MaskWorkspace` and `GroupingWorkspace` are not actually optional. If they are not supplied there is a null pointer de-reference that crashes mantid.

**To test:**

Since there are new unit tests that exercise the bug, just review the code and mark it :squirrel:

_There is no associate issue_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
