### PR TITLE
Get Mantid building against ParaView master

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -669,6 +669,10 @@ qt4_add_resources ( RES_FILES ${PROJECT_SOURCE_DIR}/Vates/VatesSimpleGui/ViewWid
 # Add the dependencies
 ###########################################################################
 
+if(MAKE_VATES)
+  include( ${PARAVIEW_USE_FILE} )
+endif()
+
 include_directories ( SYSTEM ${MUPARSER_INCLUDE_DIR} )
 include_directories ( ${ZLIB_INCLUDE_DIRS} )
 

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/CMakeLists.txt
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/CMakeLists.txt
@@ -15,7 +15,9 @@ ${vtkjsoncpp_LIBRARIES}
 ${MANTID_SUBPROJECT_LIBS} 
 ${POCO_LIBRARIES}
 ${Boost_LIBRARIES}
-${QWT_LIBRARIES})
+${QWT_LIBRARIES}
+Qt4::QtCore
+)
 
 if (OSX_VERSION VERSION_GREATER 10.8)
   set_target_properties ( MantidParaViewMDEWNexusReaderSMPlugin PROPERTIES INSTALL_RPATH "@loader_path/../../Contents/Libraries;@loader_path/../../Contents/MacOS")

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/CMakeLists.txt
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/CMakeLists.txt
@@ -15,7 +15,9 @@ ${MANTID_SUBPROJECT_LIBS}
 ${POCO_LIBRARIES}
 ${Boost_LIBRARIES}
 ${vtkjsoncpp_LIBRARIES}
-${QWT_LIBRARIES})
+${QWT_LIBRARIES}
+Qt4::QtCore
+)
 
 if (OSX_VERSION VERSION_GREATER 10.8)
   set_target_properties ( MantidParaViewMDHWNexusReaderSMPlugin PROPERTIES INSTALL_RPATH "@loader_path/../../Contents/Libraries;@loader_path/../../Contents/MacOS")

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/CMakeLists.txt
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/CMakeLists.txt
@@ -13,7 +13,9 @@ ${MANTID_SUBPROJECT_LIBS}
 ${POCO_LIBRARIES}
 ${Boost_LIBRARIES}
 ${vtkjsoncpp_LIBRARIES}
-${QWT_LIBRARIES})
+${QWT_LIBRARIES}
+Qt4::QtCore
+)
 
 if (OSX_VERSION VERSION_GREATER 10.8)
   set_target_properties ( MantidParaViewMDEWSourceSMPlugin PROPERTIES INSTALL_RPATH "@loader_path/../../Contents/Libraries;@loader_path/../../Contents/MacOS")

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/CMakeLists.txt
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/CMakeLists.txt
@@ -14,7 +14,9 @@ ${MANTID_SUBPROJECT_LIBS}
 ${POCO_LIBRARIES}
 ${Boost_LIBRARIES}
 ${vtkjsoncpp_LIBRARIES}
-${QWT_LIBRARIES})
+${QWT_LIBRARIES}
+Qt4::QtCore
+)
 
 if (OSX_VERSION VERSION_GREATER 10.8)
   set_target_properties ( MantidParaViewMDHWSourceSMPlugin PROPERTIES INSTALL_RPATH "@loader_path/../../Contents/Libraries;@loader_path/../../Contents/MacOS")

--- a/Vates/VatesAPI/CMakeLists.txt
+++ b/Vates/VatesAPI/CMakeLists.txt
@@ -282,6 +282,7 @@ if( CXXTEST_FOUND AND GMOCK_FOUND AND GTEST_FOUND )
   ${Boost_LIBRARIES}
   ${GMOCK_LIBRARIES} 
   ${QWT_LIBRARIES}
+  Qt4::QtCore
   ${GTEST_LIBRARIES} )
   add_dependencies( AllTests VatesAPITest )
   # Add to the 'UnitTests' group in VS

--- a/Vates/VatesAPI/CMakeLists.txt
+++ b/Vates/VatesAPI/CMakeLists.txt
@@ -228,6 +228,7 @@ vtkFiltersSources
 ${vtkjsoncpp_LIBRARIES}
 vtkPVVTKExtensionsDefault
 ${QWT_LIBRARIES}
+Qt4::QtCore
 ${POCO_LIBRARIES}
 ${Boost_LIBRARIES}
 ${NEXUS_LIBRARIES}


### PR DESCRIPTION
Description of work.

Our builds of Mantid against the master branch of ParaView recently started failing due to a missing include file in QtCore.  Adding `Qt4::QtCore` as a dependency appears to fix this.

**To test:**

<!-- Instructions for testing. -->

Check the [build servers](http://builds.mantidproject.org/view/ParaView/job/paraview-master/)

There is no GitHub issue associated with this pull request.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
