### PR TITLE
AlgorithmHistory start time

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmHistory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmHistory.h
@@ -77,14 +77,14 @@ public:
   /// The date-and-time will be stored as the Mantid::Kernel::DateAndTime type
   explicit AlgorithmHistory(
       const Algorithm *const alg,
-      const Kernel::DateAndTime &start = Kernel::DateAndTime::defaultTime(),
+      const Kernel::DateAndTime &start = Kernel::DateAndTime::getCurrentTime(),
       const double &duration = -1.0, std::size_t uexeccount = 0);
   ~AlgorithmHistory();
   AlgorithmHistory &operator=(const AlgorithmHistory &);
   AlgorithmHistory(const AlgorithmHistory &);
   AlgorithmHistory(
       const std::string &name, int vers,
-      const Kernel::DateAndTime &start = Kernel::DateAndTime::defaultTime(),
+      const Kernel::DateAndTime &start = Kernel::DateAndTime::getCurrentTime(),
       const double &duration = -1.0, std::size_t uexeccount = 0);
   void addExecutionInfo(const Kernel::DateAndTime &start,
                         const double &duration);
@@ -141,7 +141,7 @@ public:
   /// Set data on history after it is created
   void fillAlgorithmHistory(
       const Algorithm *const alg,
-      const Kernel::DateAndTime &start = Kernel::DateAndTime::defaultTime(),
+      const Kernel::DateAndTime &start = Kernel::DateAndTime::getCurrentTime(),
       const double &duration = -1.0, std::size_t uexeccount = 0);
   // Allow Algorithm::execute to change the exec count & duration after the
   // algorithm was executed

--- a/Framework/API/inc/MantidAPI/AlgorithmHistory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmHistory.h
@@ -139,10 +139,9 @@ public:
   // Set the execution count
   void setExecCount(std::size_t execCount) { m_execCount = execCount; }
   /// Set data on history after it is created
-  void fillAlgorithmHistory(
-      const Algorithm *const alg,
-      const Kernel::DateAndTime &start = Kernel::DateAndTime::getCurrentTime(),
-      const double &duration = -1.0, std::size_t uexeccount = 0);
+  void fillAlgorithmHistory(const Algorithm *const alg,
+                            const Kernel::DateAndTime &start,
+                            const double &duration, std::size_t uexeccount);
   // Allow Algorithm::execute to change the exec count & duration after the
   // algorithm was executed
   friend class Algorithm;

--- a/Framework/API/src/AlgorithmHistory.cpp
+++ b/Framework/API/src/AlgorithmHistory.cpp
@@ -211,10 +211,8 @@ void AlgorithmHistory::printSelf(std::ostream &os, const int indent) const {
 
   os << std::string(indent, ' ')
      << "Execution Date: " << m_executionDate.toFormattedString() << '\n';
-  if (m_executionDuration > 0.) {
-    os << std::string(indent, ' ')
-       << "Execution Duration: " << m_executionDuration << " seconds\n";
-  }
+  os << std::string(indent, ' ')
+     << "Execution Duration: " << m_executionDuration << " seconds\n";
 
   os << std::string(indent, ' ') << "Parameters:\n";
 

--- a/Framework/API/src/AlgorithmHistory.cpp
+++ b/Framework/API/src/AlgorithmHistory.cpp
@@ -211,8 +211,10 @@ void AlgorithmHistory::printSelf(std::ostream &os, const int indent) const {
 
   os << std::string(indent, ' ')
      << "Execution Date: " << m_executionDate.toFormattedString() << '\n';
-  os << std::string(indent, ' ')
-     << "Execution Duration: " << m_executionDuration << " seconds\n";
+  if (m_executionDuration > 0.) {
+    os << std::string(indent, ' ')
+       << "Execution Duration: " << m_executionDuration << " seconds\n";
+  }
 
   os << std::string(indent, ' ') << "Parameters:\n";
 


### PR DESCRIPTION
Fix an ancient bug with algorithm start times as they are reported in logging at information level.

**To test:**
1. Set logging to `information`
2. Run any algorithm
3. Observe the line about `Execution Date` mentioning a time that looks like your system clock rather than the unix epoch
4. Observe that the execution time (at the end of the algorithm running) is a reasonable value

_There is no associated issue._

_Does not need to be in the release notes_ as only developers notice this sort of thing. It will make it easier to track down issues since you will know _when_ things happened, rather than just how long they took.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
