### PR TITLE
Fix spectrum viewer not releasing memory on workspace deletion

### DIFF
--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -800,7 +800,9 @@ void MantidUI::showSpectrumViewer() {
                       << "\n";
         throw std::runtime_error(e);
       }
-      viewer->setAttribute(Qt::WA_DeleteOnClose, false);
+      // Delete on close so we don't hold a shared pointer to a workspace
+      // which has been deleted in the ADS and is "inaccessible"
+      viewer->setAttribute(Qt::WA_DeleteOnClose, true);
       viewer->resize(1050, 800);
       connect(m_appWindow, SIGNAL(shutting_down()), viewer, SLOT(close()));
 


### PR DESCRIPTION
Description of work.
If users had the spectrum viewer open and deleted a workspace the memory used by that workspace was not released. This change ensures the memory is correctly deallocated when the workspace is deleted

**To test:**
Open a large workspace so the additional memory usage is visible for example under system test data:
`PG3_2538_event.nxs` (or rebin a workspace with an extremely small bin width).

Open the spectrum viewer for that workspace
Without closing the spectrum viewer delete the workspace

If the memory usage goes down to the usage before the workspace was opened the test has succeeded.

Fixes #17384 .

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
