### PR TITLE
Grouping file parameter in SNSPowderReduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -160,6 +160,8 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                              doc="If specified overrides value in CharacterizationRunsFile. If -1 turns off correction.")
         self.declareProperty(FileProperty(name="CalibrationFile",defaultValue="",action=FileAction.Load,\
                                       extensions = [".h5", ".hd5", ".hdf", ".cal"]))
+        self.declareProperty(FileProperty(name="GroupingFile",defaultValue="",action=FileAction.OptionalLoad,\
+                                          extensions = [".xml"]), "Overrides grouping from CalibrationFile")
         self.declareProperty(FileProperty(name="CharacterizationRunsFile",defaultValue="",action=FileAction.OptionalLoad,\
                                       extensions = ["txt"]),"File with characterization runs denoted")
         self.declareProperty(FileProperty(name="ExpIniFilename", defaultValue="", action=FileAction.OptionalLoad,
@@ -830,7 +832,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
 
             # Do align and focus
             num_out_wksp = len(output_ws_name_list)
-            for split_index in range(num_out_wksp):
+            for split_index in xrange(num_out_wksp):
                 # Get workspace name
                 out_ws_name_chunk_split = output_ws_name_list[split_index]
                 # Align and focus
@@ -839,6 +841,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                 api.AlignAndFocusPowder(InputWorkspace=out_ws_name_chunk_split,
                                         OutputWorkspace=out_ws_name_chunk_split,
                                         CalFileName=calib,
+                                        GroupFilename=self.getProperty("GroupingFile").value,
                                         Params=self._binning,
                                         ResampleX=self._resampleX,
                                         Dspacing=self._bin_in_dspace,
@@ -1296,6 +1299,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             api.AlignAndFocusPowder(InputWorkspace=van_run_ws_name,
                                     OutputWorkspace=van_run_ws_name,
                                     CalFileName=calib,
+                                    GroupFilename=self.getProperty("GroupingFile").value,
                                     Params=self._binning,
                                     ResampleX=self._resampleX,
                                     Dspacing=self._bin_in_dspace,

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
@@ -83,7 +83,8 @@ private:
   // Overridden Algorithm methods
   void init() override;
   void exec() override;
-  void loadCalFile(const std::string &calFileName);
+  void loadCalFile(const std::string &calFilename,
+                   const std::string &groupFilename);
   API::MatrixWorkspace_sptr rebin(API::MatrixWorkspace_sptr matrixws);
 
   API::MatrixWorkspace_sptr conjoinWorkspaces(API::MatrixWorkspace_sptr ws1,

--- a/docs/source/algorithms/LoadDiffCal-v1.rst
+++ b/docs/source/algorithms/LoadDiffCal-v1.rst
@@ -10,9 +10,17 @@
 Description
 -----------
 
-This algorithm loads a :ref:`diffraction calibration workspace
-<DiffractionCalibrationWorkspace>`, ``MaskWorkspace``, and
-``GroupingWorkspace`` from a hdf5 file.
+This algorithm creates up to three workspaces from a hdf5 file:
+
+* :ref:`diffraction calibration workspace
+  <DiffractionCalibrationWorkspace>` contains information on
+  converting from time-of-flight to d-spacing
+
+* ``MaskWorkspace`` contains which pixels to use (by deleting the
+  unused ones)
+
+* ``GroupingWorkspace`` describes which pixels get added together by
+  :ref:`algm-DiffractionFocussing`
 
 .. categories::
 

--- a/docs/source/algorithms/SNSPowderReduction-v1.rst
+++ b/docs/source/algorithms/SNSPowderReduction-v1.rst
@@ -12,22 +12,68 @@ Description
 About Filter Wall
 #################
 
-Filter wall is enabled by setting *FilterCharacterizations* property to true. 
-Then the \_getTimeFilterWall routine is used to build the filter wall from the data defined by 
-*SplitInformationWorkspace* and  *SplittersWorkspace* properties.
-Time filter wall is used in \_loadData to load data in a certain range
-of time. Here is how the filter is used:
+Filter wall is enabled by setting ``FilterCharacterizations`` property
+to true.  Then the ``_getTimeFilterWall`` routine is used to build the
+filter wall from the data defined by ``SplitInformationWorkspace`` and
+``SplittersWorkspace`` properties.  Time filter wall is used in
+``_loadData`` to load data in a certain range of time. Here is how the
+filter is used:
 
-| ``   1. There is NO filter if filter wall is NONE``
-| ``   2. There is NO lower boundary of the filter wall if wall[0] is ZERO;``
-| ``   3. There is NO upper boundary of the filter wall if wall[1] is ZERO;``
+1. There is NO filter if filter wall is ``NONE``
+
+2. There is NO lower boundary of the filter wall if ``wall[0]`` is
+   ``ZERO``
+
+3. There is NO upper boundary of the filter wall if ``wall[1]`` is
+   ZERO;``
+
+More information is found in :ref:`_EventFiltering`.
+
+Calibration, grouping, and masking
+##################################
+
+There are two properties related to calibration (``CalibrationFile``
+and ``GroupingFile``) and three implicit workspace dependencies
+(``<instrument>_mask``, ``<instrument>_group``, and
+``<instrument>_cal``). If the workspaces do not exist, they will be
+created during the algorithm's execution.
+
+If specified, the ``CalibrationFile`` is loaded using
+:ref:`algm-LoadDiffCal`. If the ``GroupingFile`` is specified, the
+grouping it specifies takes precidence over the one that is in the
+``CalibrationFile``. :ref:`algm-LoadDetectorsGroupingFile` performs
+the loading. The order of preference in which to use is (first found wins):
+
+* Calibration: ``<instrument>_cal``, then ``CalibrationFile``
+
+* Grouping: ``<instrument>_group`` workspace, then ``GroupingFile``,
+  then ``CalibrationFile``
+
+* Masking: ``<instrument>_mask``, then ``CalibrationFile``
+
+
+:ref:`algm-AlignAndFocusPowder` does the actual resolution of which information to use.
+
+Characterization runs
+#####################
+
+The ``CharacterizationRunsFile``, ``ExpIniFilename``,
+``BackgroundNumber``, ``VanadiumNumber``, ``VanadiumBackgroundNumber``
+all contribute to determine which runs to use for background
+subtraction and normalization. Specifying the various ``*Number``
+properties as ``0``, indicates using the values found in the
+files. Specifying ``-1`` indicates to not do the corrections at
+all. The files are loaded using :ref:`algm-PDLoadCharacterizations`
+which also contains the focus positions. Which runs to used are
+determined by :ref:`algm-PDDetermineCharacterizations`.
+
 
 
 Workflow
 --------
 
 .. diagram:: SNSPowderReduction-v1_workflow.dot
- 
+
 .. diagram:: SNSPowderReduction-v1_vanadium.dot
 
 .. diagram:: SNSPowderReduction-v1_process_container.dot
@@ -41,8 +87,10 @@ Workflow
 Usage
 -----
 
-This is a worksflow algorithm used to process and the results of scattering experimens on powders on SNS instruments.
-Its usage sample can be found in `Mantid System tests repository <https://github.com/mantidproject/systemtests/blob/master/SystemTests/AnalysisTests/SNSPowderRedux.py>`_.
+This is a worksflow algorithm used to process and the results of
+powder diffraction scattering experimens on SNS
+instruments. Processing data from instruments not at SNS is
+unsupported. Sample usage can be found in the `system tests <https://github.com/mantidproject/mantid/blob/master/Testing/SystemTests/tests/analysis/SNSPowderRedux.py>`_.
 
 .. categories::
 

--- a/docs/source/release/v3.8.0/diffraction.rst
+++ b/docs/source/release/v3.8.0/diffraction.rst
@@ -42,7 +42,7 @@ Single Crystal Diffraction
   calculated and printed in a log file and on the plots.
 
 - Given a PeaksWorkspace or MatrixWorkspace with an instrument,
-  :ref:`SetDetScale <algm-SetDetScale>` 
+  :ref:`SetDetScale <algm-SetDetScale>`
   will set or change the detector bank scales that are used in SaveHKL and AnvredCorrection.  The input format is the same as
   used in anvred3.py, so DetScaleList input can be pasted from the definition of detScale there.  The default values can be
   set in the instrument parameter file. Default values are in the parameter file for the TOPAZ instrument.
@@ -78,7 +78,10 @@ Powder Diffraction
   well. There were also a variety of bugfixes related to the output
   workspaces. While it did not affect the saved data files, the output
   workspaces were not always correctly normalized or in the requested
-  units.
+  units. There is also an additional ``GroupingFile`` parameter which
+  allows overriding the grouping that is specified in the
+  ``CalibrationFile``. The documentation for this algorithm has been
+  greatly expanded as well.
 
 - :ref:`PDFFourierTransformSNSPowderReduction
   <algm-PDFFourierTransformSNSPowderReduction>` has been modified to


### PR DESCRIPTION
A frequent instrument debugging case is to use a different grouping than what is specified in the calibration file. This adds the extra parameter and the surrounding logic for it.

**To test:**

Try running `SNSPowderReduction` with and without a grouping file.

An example grouping file is found at `/SNS/NOM/shared/CALIBRATION/2016_2_1B_CAL/NOM_grouping_798banks_16x8.xml`. It won't save to gsas because it defines 798 banks and gsas only allows up to 99.

_There is no associated issue_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
