### PR TITLE
Fix clang/linux build

### DIFF
--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -348,7 +348,10 @@ void ParameterMap::add(const IComponent *comp,
   if (existing_par != m_map.end()) {
     existing_par->second = par;
   } else {
-#if TBB_VERSION_MAJOR >= 4 && TBB_VERSION_MINOR >= 4
+// When using Clang & Linux, TBB 4.4 doesn't detect C++11 features.
+// https://software.intel.com/en-us/forums/intel-threading-building-blocks/topic/641658
+#define CLANG_ON_LINUX defined(__clang__) && !defined(__APPLE__)
+#if TBB_VERSION_MAJOR >= 4 && TBB_VERSION_MINOR >= 4 && !CLANG_ON_LINUX
     m_map.emplace(comp->getComponentID(), par);
 #else
     m_map.insert(std::make_pair(comp->getComponentID(), par));
@@ -1026,7 +1029,7 @@ void ParameterMap::copyFromParameterMap(const IComponent *oldComp,
   for (const auto &oldParameterName : oldParameterNames) {
     Parameter_sptr thisParameter = oldPMap->get(oldComp, oldParameterName);
 // Insert the fetched parameter in the m_map
-#if TBB_VERSION_MAJOR >= 4 && TBB_VERSION_MINOR >= 4
+#if TBB_VERSION_MAJOR >= 4 && TBB_VERSION_MINOR >= 4 && !CLANG_ON_LINUX
     m_map.emplace(newComp->getComponentID(), thisParameter);
 #else
     m_map.insert(std::make_pair(newComp->getComponentID(), thisParameter));


### PR DESCRIPTION
Description of work.

@rosswhitfield found that `tbb::concurrent_unordered_map::emplace` is missing when using clang on Arch Linux. The issue appears to be with TBB's C++11 feature detection  

https://software.intel.com/en-us/forums/intel-threading-building-blocks/topic/641658

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
