### PR TITLE
Use std::call_once to ensure pInstance isn't initialized multiple times

### DIFF
--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -9,6 +9,8 @@ Framework Changes
 
 - A cmake parameter ``ENABLE_MANTIDPLOT`` (default ``True``) was added to facilitate framework only builds.
 
+- A race condition when accessing a singleton from multiple threads was fixed. 
+
 HistogramData
 -------------
 


### PR DESCRIPTION
Description of work.

This changes `SingletonHolder<T>::Instance` to use[ `std::call_once`](http://www.cplusplus.com/reference/mutex/call_once/). The current implementation with a single check is not necessarily thread-safe.

**To test:**

<!-- Instructions for testing. -->

Thorough code review. This function is a core piece of the Mantid Framework.

Fixes #17364.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
