### PR TITLE
Remove deprecated vtkTypeTemplate.

### DIFF
--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
@@ -38,11 +38,12 @@ namespace Mantid {
 namespace VATES {
 
 template <class Scalar>
-class vtkMDHWSignalArray : public vtkTypeTemplate<vtkMDHWSignalArray<Scalar>,
-                                                  vtkMappedDataArray<Scalar>> {
+class vtkMDHWSignalArray : public vtkMappedDataArray<Scalar> {
 public:
-  vtkMappedDataArrayNewInstanceMacro(
-      vtkMDHWSignalArray<Scalar>) static vtkMDHWSignalArray *New();
+  vtkAbstractTemplateTypeMacro(vtkMDHWSignalArray<Scalar>,
+                               vtkMappedDataArray<Scalar>)
+      vtkMappedDataArrayNewInstanceMacro(
+          vtkMDHWSignalArray<Scalar>) static vtkMDHWSignalArray *New();
   void PrintSelf(ostream &os, vtkIndent indent) override;
 
   void InitializeArray(

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
@@ -25,8 +25,6 @@
 #define vtkMDHWSignalArray_h
 
 #include "vtkMappedDataArray.h"
-
-#include "vtkTypeTemplate.h"  // For templated vtkObject API
 #include "vtkObjectFactory.h" // for vtkStandardNewMacro
 #include "vtkIdList.h"
 #include "vtkVariant.h"

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
@@ -40,10 +40,12 @@ namespace VATES {
 template <class Scalar>
 class vtkMDHWSignalArray : public vtkMappedDataArray<Scalar> {
 public:
+  // clang-format off
   vtkAbstractTemplateTypeMacro(vtkMDHWSignalArray<Scalar>,
                                vtkMappedDataArray<Scalar>)
-      vtkMappedDataArrayNewInstanceMacro(
-          vtkMDHWSignalArray<Scalar>) static vtkMDHWSignalArray *New();
+  vtkMappedDataArrayNewInstanceMacro(vtkMDHWSignalArray<Scalar>)
+  static vtkMDHWSignalArray *New();
+  // clang-format on
   void PrintSelf(ostream &os, vtkIndent indent) override;
 
   void InitializeArray(


### PR DESCRIPTION
Description of work.

In ParaView v5.1, `vtkTypeTemplate` was deprecated and replaced with `vtkTemplateTypeMacro`. [This commit](https://github.com/Kitware/VTK/commit/f49bbb760b81164ae32cebad7f54e8380d50719f#diff-e763c17cbe28c1a8681af6454f5d327a) shows the changes in VTK. I made similar changes to `vtkMDHWSignalArray`. 

**To test:**

<!-- Instructions for testing. -->

Open a MDHistoWorkspace and view it in the VSI. Verify that no VTK warnings appear. 

This fixes an issue raised in #16646.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
