### PR TITLE
Fix BinMD assuming orthogonal basis vectors

### DIFF
--- a/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
+++ b/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
@@ -949,6 +949,43 @@ SlicingAlgorithm::getGeneralImplicitFunction(const size_t *const chunkMin,
     vectors.push_back(t);
     func->addPlane(MDPlane(vectors, o1, insidePoint));
     func->addPlane(MDPlane(vectors, o2, insidePoint));
+  } else if (boxDim == 4 && nd == 4) {
+
+    // 8 planes defined by 4 basis vectors, in 4D world. (General to
+    // non-orthogonal basis vectors)
+
+    std::vector<VMD> vectors;
+
+    // XY plane
+    vectors.clear();
+    vectors.push_back(x);
+    vectors.push_back(y);
+    vectors.push_back(z);
+    func->addPlane(MDPlane(vectors, o1, insidePoint));
+    func->addPlane(MDPlane(vectors, o2, insidePoint));
+
+    // XZ plane
+    vectors.clear();
+    vectors.push_back(x);
+    vectors.push_back(z);
+    vectors.push_back(t);
+    func->addPlane(MDPlane(vectors, o1, insidePoint));
+    func->addPlane(MDPlane(vectors, o2, insidePoint));
+
+    // YZ plane
+    vectors.clear();
+    vectors.push_back(y);
+    vectors.push_back(z);
+    vectors.push_back(t);
+    func->addPlane(MDPlane(vectors, o1, insidePoint));
+    func->addPlane(MDPlane(vectors, o2, insidePoint));
+
+    vectors.clear();
+    vectors.push_back(x);
+    vectors.push_back(y);
+    vectors.push_back(t);
+    func->addPlane(MDPlane(vectors, o1, insidePoint));
+    func->addPlane(MDPlane(vectors, o2, insidePoint));
   } else {
     // Last-resort, totally general case
     // 2*N planes defined by N basis vectors, in any dimensionality workspace.

--- a/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
+++ b/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
@@ -733,56 +733,6 @@ void SlicingAlgorithm::createTransform() {
     m_inWS = m_originalWS;
   }
 
-  //
-  //    if (m_inWS->hasOriginalWorkspace())
-  //    {
-  //      // A was transformed to B
-  //      // Now we transform B to C
-  //      // So we come up with the A -> C transformation
-  //
-  //      IMDWorkspace_sptr origWS = m_inWS->getOriginalWorkspace();
-  //      g_log.notice() << "Performing " << this->name() << " on the original
-  //      workspace, '" << origWS->getName() << "'\n";
-  //
-  //      if (origWS->getNumDims() != m_inWS->getNumDims())
-  //        throw std::runtime_error("SlicingAlgorithm::createTransform():
-  //        Cannot propagate a transformation if the number of dimensions has
-  //        changed.");
-  //
-  //      // A->C transformation
-  //      CoordTransform * fromOrig =
-  //      CoordTransformAffine::combineTransformations(
-  //      m_inWS->getTransformFromOriginal(), m_transformFromOriginal );
-  //      // C->A transformation
-  //      CoordTransform * toOrig =
-  //      CoordTransformAffine::combineTransformations( m_transformToOriginal,
-  //      m_inWS->getTransformToOriginal() );
-  //      // A->C binning transformation
-  //      CoordTransform * binningTransform =
-  //      CoordTransformAffine::combineTransformations(
-  //      m_inWS->getTransformFromOriginal(), m_transform );
-  //
-  //      // Replace the transforms
-  //      delete m_transformFromOriginal;
-  //      delete m_transformToOriginal;
-  //      delete m_transform;
-  //      m_transformFromOriginal = fromOrig;
-  //      m_transformToOriginal = toOrig;
-  //      m_transform = binningTransform;
-  //
-  //      coord_t in[2] = {0,0};
-  //      coord_t out[2] = {0,0};
-  //      m_transform->apply(in, out);
-  //      std::cout << "0,0 gets binningTransformed to  " << VMD(2, out) <<
-  //      '\n';
-  //      in[0] = 10; in[1] = 10;
-  //      m_transform->apply(in, out);
-  //      std::cout << "10,10 gets binningTransformed to  " << VMD(2, out) <<
-  //      '\n';
-  //
-  //      // Replace the input workspace
-  //      m_inWS = origWS;
-  //    }
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
+++ b/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
@@ -732,7 +732,6 @@ void SlicingAlgorithm::createTransform() {
     // for future binning
     m_inWS = m_originalWS;
   }
-
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
+++ b/Framework/MDAlgorithms/test/SlicingAlgorithmTest.h
@@ -1063,6 +1063,49 @@ public:
         0.))); // This point would NOT be contained if using orthogonal bases
   }
 
+  void test_createGeneralTransform_4D_to_4D_nonOrthogonal() {
+    SlicingAlgorithmImpl *alg = do_createGeneralTransform(
+        ws4, "OutX,m, 1,0,0,0", "OutY,m, 1,1,0,0", "OutZ,m, 0,0,1,0",
+        "OutE,m, 0,0,0,1", VMD(0., 0., 0., 0.), "0,10,0,10,0,10,0,10",
+        "5,5,5,5");
+    TS_ASSERT_EQUALS(alg->m_bases.size(), 4);
+
+    // The implicit function
+    MDImplicitFunction *func(NULL);
+    TS_ASSERT_THROWS_NOTHING(func =
+                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+    TS_ASSERT(func);
+    TS_ASSERT_EQUALS(func->getNumPlanes(), 8);
+    TS_ASSERT(func->isPointContained(VMD(2., 1., 0., 0.)));
+    TS_ASSERT(!func->isPointContained(VMD(8., 7.5, 0., 0.)));
+    TS_ASSERT(!func->isPointContained(VMD(0., 1., 0., 0.)));
+    // This point would be contained if using orthogonal bases
+    TS_ASSERT(!func->isPointContained(VMD(5., 6., 0., 0.)));
+    // This point would be contained if using orthogonal bases
+    TS_ASSERT(func->isPointContained(VMD(12., 3., 0., 0.)));
+  }
+
+  void test_createGeneralTransform_4D_to_3D_nonOrthogonal() {
+    SlicingAlgorithmImpl *alg = do_createGeneralTransform(
+        ws4, "OutX,m, 1,0,0,0", "OutY,m, 1,1,0,0", "OutZ,m, 0,0,1,0", "",
+        VMD(0., 0., 0., 0.), "0,10,0,10,0,10", "5,5,5");
+    TS_ASSERT_EQUALS(alg->m_bases.size(), 3);
+
+    // The implicit function
+    MDImplicitFunction *func(NULL);
+    TS_ASSERT_THROWS_NOTHING(func =
+                                 alg->getImplicitFunctionForChunk(NULL, NULL));
+    TS_ASSERT(func);
+    TS_ASSERT_EQUALS(func->getNumPlanes(), 6);
+    TS_ASSERT(func->isPointContained(VMD(2., 1., 0., 0.)));
+    TS_ASSERT(!func->isPointContained(VMD(8., 7.5, 0., 0.)));
+    TS_ASSERT(!func->isPointContained(VMD(0., 1., 0., 0.)));
+    // This point would be contained if using orthogonal bases
+    TS_ASSERT(!func->isPointContained(VMD(5., 6., 0., 0.)));
+    // This point would NOT be contained if using orthogonal bases
+    TS_ASSERT(func->isPointContained(VMD(12., 3., 0., 0.)));
+  }
+
   void test_createGeneralTransform_4D_to_1D() {
     SlicingAlgorithmImpl *alg = do_createGeneralTransform(
         ws4, "OutX,m, 1,0,0,0", "", "", "", VMD(1, 1, 0, 0), "0,10", "5");

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -97,6 +97,8 @@ MD Algorithms (VATES CLI)
 
 - :ref:`MergeMD <algm-MergeMD>` now preserves the display normalization from the first workspace in the list
 
+- :ref:`BinMD <algm-BinMD>` fixed bug where algorithm would default to using orthogonal basis vectors when supplied with 4 bases and 4 dimensions
+
 Performance
 -----------
 


### PR DESCRIPTION
In #16999 it was found that BinMD was defaulting to assuming orthogonal basis vectors in the specific case that 4 basis vectors were supplied.

**To test:**
Several things should be tested here
- Check that the following tests are passing:
  - BinMD
  - SlicingAlgorithm
- Check that the following two scripts produce almost identical output and that `slice ~= sliceA` and `slice2 ~= sliceB` :

``` python
from mantid.api import Projection

to_cut = CreateMDWorkspace(Dimensions=4, Extents=[-1,1,-1,1,-1,1,-10,10], Names="H,K,L,E", Units="U,U,U,V")
# Add two fake peaks so that we can see the effect of the basis transformation
FakeMDEventData(InputWorkspace='to_cut', PeakParams=[10000,-0.5,0,0,0,0.1])
FakeMDEventData(InputWorkspace='to_cut', PeakParams=[10000,0.5,0,0,0,0.1])


#Good slicing
projection = Projection([1,0,0], [0.5,-1,0], [0, 0, 1])
proj_ws = projection.createWorkspace()
#out_md = CutMD(to_cut, Projection=proj_ws, PBins=([0.1], [0.1], [0.1], [-5,5]), NoPix=True)
BinMD(InputWorkspace='to_cut', AxisAligned=False, 
BasisVector0='A, r, 1, 0, 0, 0', 
BasisVector1='B, r, 0.5, 1, 0, 0', 
BasisVector2='C, r, 0, 0, 1, 0', 
BasisVector3='E, V, 0, 0, 0, 1', 
OutputExtents='-1,1,-1,1,-1,1,-5,5', OutputBins='200,300,200,1', NormalizeBasisVectors=False, 
OutputWorkspace='slicedA')


#Bad slicing
projection = Projection([1,0,0], [-0.5,1,0], [0, 0, 1])
proj_ws = projection.createWorkspace()
#out_md2 = CutMD(to_cut, Projection=proj_ws, PBins=([0.1], [0.1], [0.1], [-5,5]), NoPix=True)
BinMD(InputWorkspace='to_cut', AxisAligned=False, 
BasisVector0='A, r, 1, 0, 0, 0', 
BasisVector1='B, r, -0.5, 1, 0, 0', 
BasisVector2='C, r, 0, 0, 1, 0', 
BasisVector3='E, V, 0, 0, 0, 1', 
OutputExtents='-1,1,-1,1,-1,1,-5,5', OutputBins='200,300,200,1', NormalizeBasisVectors=False, 
OutputWorkspace='slicedB')
```

``` python
from mantid.api import Projection

to_cut = CreateMDWorkspace(Dimensions=4, Extents=[-1,1,-1,1,-1,1,-10,10], Names="H,K,L,E", Units="U,U,U,V")
# Add two fake peaks so that we can see the effect of the basis transformation
FakeMDEventData(InputWorkspace='to_cut', PeakParams=[10000,-0.5,0,0,0,0.1])
FakeMDEventData(InputWorkspace='to_cut', PeakParams=[10000,0.5,0,0,0,0.1])

#Good slicing
projection = Projection([1,0,0], [0.5,-1,0], [0, 0, 1])
proj_ws = projection.createWorkspace()
#out_md = CutMD(to_cut, Projection=proj_ws, PBins=([0.1], [0.1], [0.1], [-5,5]), NoPix=True)
BinMD(InputWorkspace='to_cut', AxisAligned=False, 
BasisVector0='A, r, 1, 0, 0, 0', 
BasisVector1='B, r, 0.5, 1, 0, 0', 
BasisVector2='C, r, 0, 0, 1, 0',  
OutputExtents='-1,1,-1,1,-1,1', OutputBins='200,300,200', NormalizeBasisVectors=False, 
OutputWorkspace='sliced')


#Bad slicing
projection = Projection([1,0,0], [-0.5,1,0], [0, 0, 1])
proj_ws = projection.createWorkspace()
#out_md2 = CutMD(to_cut, Projection=proj_ws, PBins=([0.1], [0.1], [0.1], [-5,5]), NoPix=True)
BinMD(InputWorkspace='to_cut', AxisAligned=False, 
BasisVector0='A, r, 1, 0, 0, 0', 
BasisVector1='B, r, -0.5, 1, 0, 0', 
BasisVector2='C, r, 0, 0, 1, 0', 
OutputExtents='-1,1,-1,1,-1,1', OutputBins='200,300,200', NormalizeBasisVectors=False, 
OutputWorkspace='sliced2')
```

Looking in the slice viewer you should see something that looks like this:
![screen shot 2016-09-05 at 08 46 49](https://cloud.githubusercontent.com/assets/2487781/18240786/b7da40b4-7345-11e6-9df8-93e1bb34467e.png)
- Finally, check that [Andrei's script](https://github.com/mantidproject/mantid/issues/16999) from the bug description now produces identical output in the slice viewer.

Fixes #16999.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
