### PR TITLE
MultipleFileProperty to support OptionalLoad action

### DIFF
--- a/Framework/API/inc/MantidAPI/MultipleFileProperty.h
+++ b/Framework/API/inc/MantidAPI/MultipleFileProperty.h
@@ -139,6 +139,8 @@ public:
   std::string setValue(const std::string &propValue) override;
   std::string value() const override;
   std::string getDefault() const override;
+  /// Checks if this property is optional
+  bool isOptional() const;
 
   /// @return the vector of suggested extensions. For use in GUIs showing files.
   std::vector<std::string> getExts() const { return m_exts; }
@@ -151,6 +153,8 @@ public:
   operator=;
 
 private:
+  /// Returns a string depending on whether an empty value is valid
+  std::string isEmptyValueValid() const;
   std::string setValueAsSingleFile(const std::string &propValue);
   std::string setValueAsMultipleFiles(const std::string &propValue);
   /// Whether or not the user has turned on multifile loading.
@@ -163,6 +167,8 @@ private:
   /// The default file extension associated with the type of file this property
   /// will handle
   std::string m_defaultExt;
+  /// The action type of this property, Load (dafault) or OptionalLoad are supported
+  unsigned int m_action;
 };
 
 } // namespace API

--- a/Framework/API/inc/MantidAPI/MultipleFileProperty.h
+++ b/Framework/API/inc/MantidAPI/MultipleFileProperty.h
@@ -119,7 +119,12 @@ namespace API {
 class DLLExport MultipleFileProperty
     : public Kernel::PropertyWithValue<std::vector<std::vector<std::string>>> {
 public:
-  /// Constructor
+  /// Default constructor
+  MultipleFileProperty(
+      const std::string &name, unsigned int action,
+      const std::vector<std::string> &exts = std::vector<std::string>());
+
+  /// Alternative constructor with default action
   MultipleFileProperty(
       const std::string &name,
       const std::vector<std::string> &exts = std::vector<std::string>());

--- a/Framework/API/inc/MantidAPI/MultipleFileProperty.h
+++ b/Framework/API/inc/MantidAPI/MultipleFileProperty.h
@@ -167,7 +167,8 @@ private:
   /// The default file extension associated with the type of file this property
   /// will handle
   std::string m_defaultExt;
-  /// The action type of this property, Load (dafault) or OptionalLoad are supported
+  /// The action type of this property
+  /// Load (dafault) or OptionalLoad are supported
   unsigned int m_action;
 };
 

--- a/Framework/API/inc/MantidAPI/MultipleFileProperty.h
+++ b/Framework/API/inc/MantidAPI/MultipleFileProperty.h
@@ -119,27 +119,21 @@ namespace API {
 class DLLExport MultipleFileProperty
     : public Kernel::PropertyWithValue<std::vector<std::vector<std::string>>> {
 public:
-  /// Default constructor
   MultipleFileProperty(
       const std::string &name, unsigned int action,
       const std::vector<std::string> &exts = std::vector<std::string>());
 
-  /// Alternative constructor with default action
   MultipleFileProperty(
       const std::string &name,
       const std::vector<std::string> &exts = std::vector<std::string>());
 
-  /// 'Virtual copy constructor
   MultipleFileProperty *clone() const override {
     return new MultipleFileProperty(*this);
   }
 
-  /// Overridden functions to accomodate std::vector<std::vector<std::string>>>
-  /// structure of this property.
   std::string setValue(const std::string &propValue) override;
   std::string value() const override;
   std::string getDefault() const override;
-  /// Checks if this property is optional
   bool isOptional() const;
 
   /// @return the vector of suggested extensions. For use in GUIs showing files.

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -49,10 +49,17 @@ MultipleFileProperty::MultipleFileProperty(const std::string &name,
     : PropertyWithValue<std::vector<std::vector<std::string>>>(
           name, std::vector<std::vector<std::string>>(),
           boost::make_shared<MultiFileValidator>(
-              exts, (action != FileProperty::OptionalLoad)),
+              exts, (action == FileProperty::Load)),
           Direction::Input),
       m_multiFileLoadingEnabled(), m_exts(), m_parser(), m_defaultExt(""),
-      m_action(action) {
+      m_action() {
+  if (action != FileProperty::Load && action != FileProperty::OptionalLoad) {
+    /// raise error for unsupported actions
+    throw std::runtime_error(
+        "Specified action is not supported for MultipleFileProperty");
+  } else {
+    m_action = action;
+  }
   std::string allowMultiFileLoading =
       Kernel::ConfigService::Instance().getString("loading.multifile");
 

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -37,16 +37,20 @@ bool doesNotContainWildCard(const std::string &ext) {
 namespace Mantid {
 namespace API {
 /**
- * Constructor
+ * Default constructor with action
  *
- * @param name :: The name of the property
- * @param exts ::  The allowed/suggested extensions
+ * @param name   :: The name of the property
+ * @param action :: File action
+ * @param exts   ::  The allowed/suggested extensions
  */
 MultipleFileProperty::MultipleFileProperty(const std::string &name,
+                                           unsigned int action,
                                            const std::vector<std::string> &exts)
     : PropertyWithValue<std::vector<std::vector<std::string>>>(
           name, std::vector<std::vector<std::string>>(),
-          boost::make_shared<MultiFileValidator>(exts), Direction::Input),
+          boost::make_shared<MultiFileValidator>(
+              exts, (action != FileProperty::OptionalLoad)),
+          Direction::Input),
       m_multiFileLoadingEnabled(), m_exts(), m_parser(), m_defaultExt("") {
   std::string allowMultiFileLoading =
       Kernel::ConfigService::Instance().getString("loading.multifile");
@@ -60,6 +64,16 @@ MultipleFileProperty::MultipleFileProperty(const std::string &name,
     if (doesNotContainWildCard(ext))
       m_exts.push_back(ext);
 }
+
+/**
+ * Alternative constructor with no action
+ *
+ * @param name :: The name of the property
+ * @param exts ::  The allowed/suggested extensions
+ */
+MultipleFileProperty::MultipleFileProperty(const std::string &name,
+                                           const std::vector<std::string> &exts)
+    : MultipleFileProperty(name, FileProperty::Load, exts) {}
 
 /**
  * Convert the given propValue into a comma and plus separated list of full

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -37,7 +37,7 @@ bool doesNotContainWildCard(const std::string &ext) {
 namespace Mantid {
 namespace API {
 /**
- * Default constructor with action
+ * Alternative constructor with action
  *
  * @param name   :: The name of the property
  * @param action :: File action
@@ -50,9 +50,7 @@ MultipleFileProperty::MultipleFileProperty(const std::string &name,
           name, std::vector<std::vector<std::string>>(),
           boost::make_shared<MultiFileValidator>(
               exts, (action == FileProperty::Load)),
-          Direction::Input),
-      m_multiFileLoadingEnabled(), m_exts(), m_parser(), m_defaultExt(""),
-      m_action() {
+          Direction::Input) {
   if (action != FileProperty::Load && action != FileProperty::OptionalLoad) {
     /// raise error for unsupported actions
     throw std::runtime_error(
@@ -74,7 +72,7 @@ MultipleFileProperty::MultipleFileProperty(const std::string &name,
 }
 
 /**
- * Alternative constructor with no action
+ * Default constructor with default action
  *
  * @param name :: The name of the property
  * @param exts ::  The allowed/suggested extensions
@@ -92,7 +90,7 @@ bool MultipleFileProperty::isOptional() const {
 }
 
 /**
- * @returns a string depending on whether an empty value is valid
+ * @returns Empty string if empty value is valid, error message otherwise
  */
 std::string MultipleFileProperty::isEmptyValueValid() const {
   if (isOptional()) {

--- a/Framework/API/test/MultipleFilePropertyTest.h
+++ b/Framework/API/test/MultipleFilePropertyTest.h
@@ -1,6 +1,7 @@
 #ifndef MANTID_API_MULTIPLEFILEPROPERTYTEST_H_
 #define MANTID_API_MULTIPLEFILEPROPERTYTEST_H_
 
+#include "MantidAPI/FileProperty.h"
 #include "MantidAPI/MultipleFileProperty.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Timer.h"
@@ -17,6 +18,7 @@
 
 using namespace Mantid;
 using namespace Mantid::API;
+using Mantid::API::FileProperty;
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // Helper functions.
@@ -614,6 +616,12 @@ public:
 
     TS_ASSERT_EQUALS(fileNames.size(), 1);
     TS_ASSERT_EQUALS(fileNames[0].size(), 1);
+  }
+
+  void test_multiFileOptionalLoad() {
+    MultipleFileProperty p("Filename", FileProperty::OptionalLoad);
+    p.setValue("myJunkFile.nxs");
+    TS_ASSERT(p.isValid().empty());
   }
 
 private:

--- a/Framework/API/test/MultipleFilePropertyTest.h
+++ b/Framework/API/test/MultipleFilePropertyTest.h
@@ -624,6 +624,12 @@ public:
     TS_ASSERT(p.isValid().empty());
   }
 
+  void test_multiFileOptionalLoadEmpty() {
+    MultipleFileProperty p("Filename", FileProperty::OptionalLoad);
+    p.setValue("");
+    TS_ASSERT(p.isValid().empty());
+  }
+
 private:
   //////////////////////////////////////////////////////////////////////////////////////////////
   // Private helper functions.

--- a/Framework/Kernel/inc/MantidKernel/MultiFileValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiFileValidator.h
@@ -47,7 +47,8 @@ class MANTID_KERNEL_DLL MultiFileValidator
 public:
   MultiFileValidator();
   MultiFileValidator(const MultiFileValidator &mfv);
-  explicit MultiFileValidator(const std::vector<std::string> &extensions);
+  explicit MultiFileValidator(const std::vector<std::string> &extensions,
+                              bool testFilesExist = true);
 
   IValidator_sptr clone() const override;
 

--- a/Framework/Kernel/src/MultiFileValidator.cpp
+++ b/Framework/Kernel/src/MultiFileValidator.cpp
@@ -21,11 +21,12 @@ MultiFileValidator::MultiFileValidator(const MultiFileValidator &mfv)
 
 /** Constructor
  *  @param extensions :: The permitted file extensions (e.g. .RAW)
+ *  @param testFilesExist :: If to check if files exist
  */
 MultiFileValidator::MultiFileValidator(
-    const std::vector<std::string> &extensions)
+    const std::vector<std::string> &extensions, bool testFilesExist)
     : TypedValidator<std::vector<std::vector<std::string>>>(),
-      m_fileValidator(extensions, true) {}
+      m_fileValidator(extensions, testFilesExist) {}
 
 /// Returns the set of valid values
 std::vector<std::string> MultiFileValidator::allowedValues() const {

--- a/Framework/Kernel/test/MultiFileValidatorTest.h
+++ b/Framework/Kernel/test/MultiFileValidatorTest.h
@@ -125,6 +125,20 @@ public:
         file_val.isValid(std::vector<std::vector<std::string>>()).empty(),
         false);
   }
+
+  void testFailsOnNonExistingFiles() {
+    std::vector<std::string> vec{"foo"};
+    MultiFileValidator file_val(vec);
+    std::vector<std::vector<std::string>> file{{"myJunkFile.foo"}};
+    TS_ASSERT(!file_val.isValid(file).empty());
+  }
+
+  void testPassesOnNonExistingFiles() {
+    std::vector<std::string> vec{"foo"};
+    MultiFileValidator file_val(vec,false);
+    std::vector<std::vector<std::string>> file{{"myJunkFile.foo"}};
+    TS_ASSERT(file_val.isValid(file).empty());
+  }
 };
 
 #endif /*MULTIFILEVALIDATORTEST_H_*/

--- a/Framework/Kernel/test/MultiFileValidatorTest.h
+++ b/Framework/Kernel/test/MultiFileValidatorTest.h
@@ -135,7 +135,7 @@ public:
 
   void testPassesOnNonExistingFiles() {
     std::vector<std::string> vec{"foo"};
-    MultiFileValidator file_val(vec,false);
+    MultiFileValidator file_val(vec, false);
     std::vector<std::vector<std::string>> file{{"myJunkFile.foo"}};
     TS_ASSERT(file_val.isValid(file).empty());
   }

--- a/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
@@ -4,7 +4,6 @@
 #include "MantidPythonInterface/kernel/IsNone.h"
 #include "MantidPythonInterface/kernel/PropertyWithValueExporter.h"
 #include <boost/python/class.hpp>
-#include <boost/python/enum.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/python/str.hpp>

--- a/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
@@ -4,6 +4,7 @@
 #include "MantidPythonInterface/kernel/IsNone.h"
 #include "MantidPythonInterface/kernel/PropertyWithValueExporter.h"
 #include <boost/python/class.hpp>
+#include <boost/python/enum.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/python/str.hpp>

--- a/docs/source/concepts/Properties.rst
+++ b/docs/source/concepts/Properties.rst
@@ -50,8 +50,9 @@ or, if creating using an already existing vector:
 File Properties
 ~~~~~~~~~~~~~~~
 
-These properties are for capturing and holding the path and filename to
-an external file. File properties have a FileAction property that
+There are two file properties: ``FileProperty`` and ``MultipleFileProperty``.
+These properties are for capturing and holding the path and filenames to
+external file (s). File properties have a FileAction property that
 controls it's purpose and behaviour.
 
 Save :to specify a file to write to, the file may or may not exist
@@ -64,6 +65,8 @@ exist
 If the file property is has a FileAction of Load as is given a relative
 path (such as "input.txt" or "\\data\\input.txt" as its value it will
 search for matching files in this order:
+
+Note, that ``MultipleFileProperty`` supports only Load (default) and OptionalLoad actions.
 
 #. The current directory
 #. The entries in order from the datasearch.directories entry in the
@@ -158,6 +161,8 @@ The validators currently included in Mantid are:
    set of values.
 -  FileValidator - ensures that a file (given as a string property)
    exists (used internally by the FileProperty).
+-  MultiFileValidator - ensures that each file in a given list exists
+   (used internally by the MultipleFileProperty).
 
 In addition, there are a number of validators specifically for use with
 Workspace properties:

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -26,6 +26,8 @@ Concepts
   undefined and infinite values and errors will be zeroed.
 - ``Lattice`` : Allow setting a UB matrix with negative determinant (improper rotation)
 
+- ``MultipleFileProperty`` : will now support also ``OptionalLoad`` ``FileAction`` (similar to ``FileProperty``).
+
 Algorithms
 ----------
 


### PR DESCRIPTION
`MultipleFileProperty` does not currently support any actions of `FileProperty`, just defaulting to mandatory `Load` behaviour. This PR implements support for `OptionalLoad` action coherent to `FileProperty`.

**To test:**
1. Pick your favourite algorithm that has `MultipleFileProperty` (e.g. `Load`).
2. Make it optional by adding `action=FileAction.OptionalLoad` (python) or `action=FileProperty::FileAction::OptionalLoad` (C++)\* as a second argument to the `MultipleFileProperty` constructor in property declaration.
3. Make sure that it became optional (e.g. the empty input will now be accepted, while before it would not be)
4. Try what happens with unsupported actions, e.g. `Save`.

*Make sure simpleapi or `FileProperty.h` are imported/included.

<!-- Instructions for testing. -->

Fixes #17358 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
