### PR TITLE
Add save/load function for tube calibration table

### DIFF
--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -138,6 +138,7 @@ Python
   individual atoms.
 - :py:obj:`mantid.geometry.OrientedLattice` set U with determinant -1 exposed to python
 - The setDisplayNormalization and setDisplayNormalizationHisto methods for MDEventWorkspaces are now exposed to Python
+- Tube calibration now has ``saveCalibration`` and ``readCalibrationFile`` functions similar to ``savePeak`` and ``readPeakFile``.
 
 Python Algorithms
 #################

--- a/scripts/Calibration/tube.py
+++ b/scripts/Calibration/tube.py
@@ -670,11 +670,6 @@ def readPeakFile(file_name):
 
     """
     loaded_file = []
-    # split the entries to the main values:
-    # For example:
-    # MERLIN/door1/tube_1_1 [34.199347724575574, 525.5864438725401, 1001.7456248836971]
-    # Will be splited as:
-    # ['MERLIN/door1/tube_1_1', '', '34.199347724575574', '', '525.5864438725401', '', '1001.7456248836971', '', '', '']
     pattern = re.compile(r'[\[\],\s\r]')
     saveDirectory = config['defaultsave.directory']
     pfile = os.path.join(saveDirectory, file_name)
@@ -690,7 +685,8 @@ def readPeakFile(file_name):
         try:
             f_values = [float(v) for v in line_vals[1:] if v != '']
         except ValueError:
-            # print 'Wrong format: we expected only numbers, but receive this line ',str(line_vals[1:])
+            # print 'Wrong format: we expected only numbers,
+            # but receive this line ',str(line_vals[1:])
             continue
 
         loaded_file.append((id_, f_values))
@@ -700,13 +696,13 @@ def readPeakFile(file_name):
 def saveCalibration(table_name, out_path):
     """Save the calibration table to file
 
-    This creates a CSV file for the calibration TableWorkspace. The first 
+    This creates a CSV file for the calibration TableWorkspace. The first
     column is the detector number and the second column is the detector position
 
     Example of usage:
 
     .. code-block:: python
-       
+
        saveCalibration('CalibTable','/tmp/myCalibTable.txt')
 
     :param table_name: name of the TableWorkspace to save
@@ -717,7 +713,7 @@ def saveCalibration(table_name, out_path):
     POS = 'Detector Position'
     with open(out_path, 'w') as file_p:
         table = mtd[table_name]
-        for row in table: 
+        for row in table:
             row_data = [row[DET], row[POS]]
             line = ','.join(map(str, row_data)) + '\n'
             file_p.write(line)
@@ -731,16 +727,16 @@ def readCalibrationFile(table_name, in_path):
     Example of usage:
 
     .. code-block:: python
-       
+
        saveCalibration('CalibTable','/tmp/myCalibTable.txt')
 
     :param table_name: name to call the TableWorkspace
-    :param in_path: the path to the calibration file 
+    :param in_path: the path to the calibration file
 
     """
     DET = 'Detector ID'
     POS = 'Detector Position'
-    re_float = re.compile("[+-]? *(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?")
+    re_float = re.compile(r"[+-]? *(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?")
     calibTable = CreateEmptyTableWorkspace(OutputWorkspace=table_name)
     calibTable.addColumn(type='int', name=DET)
     calibTable.addColumn(type='V3D', name=POS)
@@ -752,8 +748,8 @@ def readCalibrationFile(table_name, in_path):
                 continue
 
             nextRow = {
-                DET: int(values[0]), 
-                POS: V3D(float(values[1]), float(values[2]), float(values[3])) 
+                DET: int(values[0]),
+                POS: V3D(float(values[1]), float(values[2]), float(values[3]))
             }
 
             calibTable.addRow(nextRow)


### PR DESCRIPTION
This adds support to writing out a calibration table to a CSV file in tube calibration. This is similar to the `savePeak` function already in that module. 

**To test:**

Here's a script showing the usage:

``` python
import tube
from tube import calibrate
ws = Load('WISH17701')
ws = Integration(ws)
known_pos = [-0.41,-0.31,-0.21,-0.11,-0.02, 0.09, 0.18, 0.28, 0.39 ]
peaks_form = 9*[1] # all the peaks are gaussian peaks
calibTable = calibrate(ws,'WISH/panel03',known_pos, peaks_form)

reload(tube)
tube.saveCalibration('CalibTable', '/tmp/test.csv')
tube.readCalibrationFile('CalibTable2', '/tmp/test.csv')
```

Then code inspection.

Fixes #17414  .

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
