### PR TITLE
Change psi to 0 if found to be NaN in LoadNXSPE 

### DIFF
--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -134,7 +134,7 @@ void LoadNXSPE::exec() {
     file.getData(temporary);
     psi = temporary.at(0);
     file.closeData();
-    if (!isfinite(psi)) {
+    if (!std::isfinite(psi)) {
       psi = 0;
       g_log.warning() << "Value of psi found in file was NaN, changing to 0"
                       << "\n";

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -134,7 +134,7 @@ void LoadNXSPE::exec() {
     file.getData(temporary);
     psi = temporary.at(0);
     file.closeData();
-    if (!std::isfinite(psi)) {
+    if (!boost::math::isfinite(psi)) {
       psi = 0;
       g_log.warning() << "Value of psi found in file was NaN, changing to 0"
                       << "\n";

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -17,7 +17,6 @@
 #include "MantidGeometry/Surfaces/Sphere.h"
 
 #include <boost/regex.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 #include <map>
 #include <sstream>

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -135,6 +135,10 @@ void LoadNXSPE::exec() {
     file.getData(temporary);
     psi = temporary.at(0);
     file.closeData();
+	if (!isfinite(psi)) {
+		psi = 0;
+		g_log.warning() << "Value of psi found in file was NaN, changing to 0" << "\n";
+	}
   }
 
   int kikfscaling = 0;

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -135,10 +135,11 @@ void LoadNXSPE::exec() {
     file.getData(temporary);
     psi = temporary.at(0);
     file.closeData();
-	if (!isfinite(psi)) {
-		psi = 0;
-		g_log.warning() << "Value of psi found in file was NaN, changing to 0" << "\n";
-	}
+    if (!isfinite(psi)) {
+      psi = 0;
+      g_log.warning() << "Value of psi found in file was NaN, changing to 0"
+                      << "\n";
+    }
   }
 
   int kikfscaling = 0;

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -134,11 +134,6 @@ void LoadNXSPE::exec() {
     file.getData(temporary);
     psi = temporary.at(0);
     file.closeData();
-    if (!boost::math::isfinite(psi)) {
-      psi = 0;
-      g_log.warning() << "Value of psi found in file was NaN, changing to 0"
-                      << "\n";
-    }
   }
 
   int kikfscaling = 0;
@@ -249,10 +244,18 @@ void LoadNXSPE::exec() {
   outputWS->mutableRun().addLogData(new PropertyWithValue<std::string>(
       "ki_over_kf_scaling", kikfscaling == 1 ? "true" : "false"));
 
-  // Set Goniometer
-  Geometry::Goniometer gm;
-  gm.pushAxis("psi", 0, 1, 0, psi);
-  outputWS->mutableRun().setGoniometer(gm, true);
+  // Set Goniometer if psi is not nan
+      if (boost::math::isfinite(psi)) {
+		  Geometry::Goniometer gm;
+		  gm.pushAxis("psi", 0, 1, 0, psi);
+		  outputWS->mutableRun().setGoniometer(gm, true);
+    }
+	  else {
+		  g_log.warning() << "Value of psi found in file was NaN. The goniometer was not set"<<'\n';
+	  }
+
+
+
 
   // generate instrument
   Geometry::Instrument_sptr instrument(new Geometry::Instrument("NXSPE"));

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -17,6 +17,7 @@
 #include "MantidGeometry/Surfaces/Sphere.h"
 
 #include <boost/regex.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
 
 #include <map>
 #include <sstream>
@@ -244,18 +245,10 @@ void LoadNXSPE::exec() {
   outputWS->mutableRun().addLogData(new PropertyWithValue<std::string>(
       "ki_over_kf_scaling", kikfscaling == 1 ? "true" : "false"));
 
-  // Set Goniometer if psi is not nan
-      if (boost::math::isfinite(psi)) {
-		  Geometry::Goniometer gm;
-		  gm.pushAxis("psi", 0, 1, 0, psi);
-		  outputWS->mutableRun().setGoniometer(gm, true);
-    }
-	  else {
-		  g_log.warning() << "Value of psi found in file was NaN. The goniometer was not set"<<'\n';
-	  }
-
-
-
+  // Set Goniometer
+  Geometry::Goniometer gm;
+  gm.pushAxis("psi", 0, 1, 0, psi);
+  outputWS->mutableRun().setGoniometer(gm, true);
 
   // generate instrument
   Geometry::Instrument_sptr instrument(new Geometry::Instrument("NXSPE"));

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -7,6 +7,7 @@
 #include <boost/algorithm/string.hpp>
 #include <cstdlib>
 #include "MantidKernel/Strings.h"
+#include "MantidKernel/Logger.h"
 
 using namespace Mantid::Kernel;
 using Mantid::Kernel::Strings::toString;
@@ -124,8 +125,8 @@ void Goniometer::pushAxis(std::string name, double axisx, double axisy,
     throw std::runtime_error(
         "Initialized from a rotation matrix, so no axes can be pushed.");
   } else {
-    if (!boost::math::isfinite(axisx) || !boost::math::isfinite(axisy) ||
-        !boost::math::isfinite(axisz) || !boost::math::isfinite(angle)) {
+    if (!std::isfinite(axisx) || !std::isfinite(axisy) ||
+        !std::isfinite(axisz) || !std::isfinite(angle)) {
       g_log.warning() << "NaN encountered while trying to push axis to "
                          "goniometer, Operation aborted"
                       << "\naxis name" << name << "\naxisx" << axisx

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -75,7 +75,13 @@ const Kernel::DblMatrix &Goniometer::getR() const { return R; }
 void Goniometer::setR(Kernel::DblMatrix rot) { R = rot; }
 
 /// Function reports if the goniometer is defined
-bool Goniometer::isDefined() const { return initFromR || (!motors.empty()); }
+bool Goniometer::isDefined() const {
+	bool r_contains_nan = false;
+	std::vector<double> vec = R.getVector();
+	for (std::vector<double>::iterator it = vec.begin(); it != vec.end(); ++it)
+		r_contains_nan = r_contains_nan || (!std::isfinite(*it));
+	return (!r_contains_nan) && ( initFromR || (!motors.empty())); 
+}
 
 /// Return information about axes.
 /// @return str :: string that contains on each line one motor information (axis

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -76,11 +76,11 @@ void Goniometer::setR(Kernel::DblMatrix rot) { R = rot; }
 
 /// Function reports if the goniometer is defined
 bool Goniometer::isDefined() const {
-	bool r_contains_nan = false;
-	std::vector<double> vec = R.getVector();
-	for (std::vector<double>::iterator it = vec.begin(); it != vec.end(); ++it)
-		r_contains_nan = r_contains_nan || (!std::isfinite(*it));
-	return (!r_contains_nan) && ( initFromR || (!motors.empty())); 
+  bool r_contains_nan = false;
+  std::vector<double> vec = R.getVector();
+  for (std::vector<double>::iterator it = vec.begin(); it != vec.end(); ++it)
+    r_contains_nan = r_contains_nan || (!std::isfinite(*it));
+  return (!r_contains_nan) && (initFromR || (!motors.empty()));
 }
 
 /// Return information about axes.

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -149,7 +149,7 @@ Bug Fixes
 - Scripts generated from history including algorithms that added dynamic properties at run time (for example Fit, and Load) will not not include those dynamic properties in their script.  This means they will execute without warnings.
 - Cloning a ``MultiDomainFunction``, or serializing to a string and recreating it, now preserves the domains.
 - :ref:`EvaluateFunction <algm-EvaluateFunction>` now works from its dialog in the GUI as well as from a script
-
+- :ref:`LoadNXSPE <algm-LoadNXSPE>` LoadNXSPE will now change psi to 0 if its value in the .nxspe file was NaN. Now ConvertToMD will work on powder diffraction data stored in .nxspe files
 
 |
 

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -149,7 +149,7 @@ Bug Fixes
 - Scripts generated from history including algorithms that added dynamic properties at run time (for example Fit, and Load) will not not include those dynamic properties in their script.  This means they will execute without warnings.
 - Cloning a ``MultiDomainFunction``, or serializing to a string and recreating it, now preserves the domains.
 - :ref:`EvaluateFunction <algm-EvaluateFunction>` now works from its dialog in the GUI as well as from a script
-- :ref:`LoadNXSPE <algm-LoadNXSPE>` LoadNXSPE will now change psi to 0 if its value in the .nxspe file was NaN. Now ConvertToMD will work on powder diffraction data stored in .nxspe files
+- :ref:`ConvertToMD <algm-ConvertToMD>` ConvertToMD will now work on powder diffraction samples stored .nxspe files. This is because if a Goniometer contains a NaN value it will report itself as undefined.
 
 |
 


### PR DESCRIPTION
Powder diffraction stored in .nxspe files may have an entry of `psi` with valuen `NaN`. This would cause running `ConvertToMD` with the property `QDimensions` set to `|Q|` on the workspaces to fail. I have added a check to LoadNXSPE to force `psi` to `0` (the defualt value) if it is found to be equal to `NaN` in the file

**To test:**
1. Load a powder diffraction sample such as that at `\\olympic\Babylon5\Public\EltayebAhmed\MAR21335_Ei60.00meV.nxspe`
2. Convert to an MD workspace in |Q| vs `E` by invoking
`md_workspace = ConvertToMD(InputWorkspace="MAR21335_Ei60.00meV", QDimensions="|Q|")`
3. Verify that a new workspace called `md_workspace` appeared
4. Verify that workspace is not empty by executing in the Script interpreter 
`md_workspace.getNPoints()` and verifying it is not `0`
Fixes #17409 

Release notes updated
## https://github.com/mantidproject/mantid/blob/4ae1c682a49bb9881ec78bbc21e6f3117377e6a2/docs/source/release/v3.8.0/framework.rst#id76
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
