### PR TITLE
Python export for ConfigService::appendDataSearchSubdir

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -87,10 +87,9 @@ void export_ConfigService() {
            arg("self"), return_value_policy<reference_existing_object>(),
            "Returns the default facility")
 
-      .def("getFacility",
-           (const FacilityInfo &(ConfigServiceImpl::*)(const std::string &)
-                const) &
-               ConfigServiceImpl::getFacility,
+      .def("getFacility", (const FacilityInfo &(
+                              ConfigServiceImpl::*)(const std::string &)const) &
+                              ConfigServiceImpl::getFacility,
            (arg("self"), arg("facilityName")),
            return_value_policy<reference_existing_object>(),
            "Returns the named facility. Raises an RuntimeError if it does not "
@@ -133,6 +132,11 @@ void export_ConfigService() {
       .def("appendDataSearchDir", &ConfigServiceImpl::appendDataSearchDir,
            (arg("self"), arg("path")),
            "Append a directory to the current list of data search paths")
+
+      .def("appendDataSearchSubDir", &ConfigServiceImpl::appendDataSearchSubDir,
+           (arg("self"), arg("subdir")),
+           "Appends a sub-directory to each data search directory "
+           "and appends the new paths back to datasearch directories")
 
       .def("setDataSearchDirs",
            (void (ConfigServiceImpl::*)(const std::string &)) &

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -87,9 +87,10 @@ void export_ConfigService() {
            arg("self"), return_value_policy<reference_existing_object>(),
            "Returns the default facility")
 
-      .def("getFacility", (const FacilityInfo &(
-                              ConfigServiceImpl::*)(const std::string &)const) &
-                              ConfigServiceImpl::getFacility,
+      .def("getFacility",
+                       (const FacilityInfo &(ConfigServiceImpl::*)(const std::string &)
+                            const) &
+                           ConfigServiceImpl::getFacility,
            (arg("self"), arg("facilityName")),
            return_value_policy<reference_existing_object>(),
            "Returns the named facility. Raises an RuntimeError if it does not "

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -88,9 +88,9 @@ void export_ConfigService() {
            "Returns the default facility")
 
       .def("getFacility",
-                       (const FacilityInfo &(ConfigServiceImpl::*)(const std::string &)
-                            const) &
-                           ConfigServiceImpl::getFacility,
+           (const FacilityInfo &(ConfigServiceImpl::*)(const std::string &)
+                const) &
+               ConfigServiceImpl::getFacility,
            (arg("self"), arg("facilityName")),
            return_value_policy<reference_existing_object>(),
            "Returns the named facility. Raises an RuntimeError if it does not "


### PR DESCRIPTION
This PR adds a python export for the `ConfigService::appendDataSearchSubdir` method.

Does not need to be in the release notes.

**To test:**
In mantid python window:
`print config['datasearch.directories']`
`config.appendDataSearchSubDir("ILL/IN16B/")`
`print config['datasearch.directories']`

You should see that ILL/IN16B will be added for UnitTests (it's the only subdirectory that exists).

Fixes #17425.

<!-- Instructions for testing. -->
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
