### PR TITLE
Engg:: Fix hang when using invalid data on load

### DIFF
--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -546,10 +546,12 @@ void EnggDiffFittingPresenter::processLoad() {
                           "Please select a focused file to load");
       m_view->showStatus("Error while plotting the focused workspace");
     }
-  } catch (std::invalid_argument) {
+  } catch (std::invalid_argument &ia) {
     m_view->userWarning(
         "Error loading file",
         "Unable to load the selected focused file, Please try again.");
+    g_log.error("Failed to load file. Error message: ");
+    g_log.error(ia.what());
   }
 }
 
@@ -1530,6 +1532,19 @@ void EnggDiffFittingPresenter::plotFocusedFile(bool plotSinglePeaks) {
     auto focusedPeaksWS =
         ADS.retrieveWS<MatrixWorkspace>(g_focusedFittingWSName);
     auto focusedData = ALCHelper::curveDataFromWs(focusedPeaksWS);
+
+    // Check that the number of curves to plot isn't excessive
+    // lets cap it at 20 to begin with - this number could need
+    // raising but each curve creates about ~5 calls on the stack
+    // so keep the limit low. This will stop users using unfocused
+    // files which have 200+ curves to plot and will "freeze" Mantid
+    constexpr int maxCurves = 20;
+
+    if (focusedData.size() > maxCurves) {
+      throw std::invalid_argument("Too many curves to plot."
+                                  " Is this a focused file?");
+    }
+
     m_view->setDataVector(focusedData, true, plotSinglePeaks);
 
   } catch (std::runtime_error &re) {


### PR DESCRIPTION
Description of work.
This PR fixes an issue where if the user tried to use an unfocused file the GUI would freeze whilst it tried (and failed) to plot 200+ curves.
**To test:**
Open the Engineering Diffraction Interface
Go to the `Fitting` Tab
Use an unfocused file such as `ENGINX00193749.nxs` and select Load
If Mantid doesn't freeze and stops with an error this PR works

Fixes #17419 .

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
