### PR TITLE
Tiled plot option for "Plot spectrum"

### DIFF
--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -2834,9 +2834,9 @@ PlotCurve *Graph::insertCurve(Table *w, const QString &xColName,
 }
 
 PlotCurve *Graph::insertCurve(QString workspaceName, int index, bool err,
-                              Graph::CurveType style) {
+                              Graph::CurveType style, bool distribution) {
   return (new MantidMatrixCurve(workspaceName, this, index,
-                                MantidMatrixCurve::Spectrum, err, false,
+                                MantidMatrixCurve::Spectrum, err, distribution,
                                 style));
 }
 

--- a/MantidPlot/src/Graph.h
+++ b/MantidPlot/src/Graph.h
@@ -290,7 +290,8 @@ public slots:
                          const QString &yColName, int style, int startRow = 0,
                          int endRow = -1);
   PlotCurve *insertCurve(QString workspaceName, int index, bool err = false,
-                         Graph::CurveType style = Graph::Unspecified);
+                         Graph::CurveType style = Graph::Unspecified,
+                         bool distribution = false);
   PlotCurve *insertCurve(PlotCurve *c, int lineWidth = -1,
                          int curveType = User);
   void insertPlotItem(QwtPlotItem *i, int type);

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1353,7 +1353,7 @@ void MantidDockWidget::doPlotSpectra(bool errors) {
   if (userInput.plots.empty())
     return;
 
-  constexpr bool spectrumPlot(true), clearWindow(false);
+  constexpr bool spectrumPlot(true);
   MultiLayer *window(NULL);
 
   if (userInput.tiled) {
@@ -1361,8 +1361,8 @@ void MantidDockWidget::doPlotSpectra(bool errors) {
                              MantidQt::DistributionDefault, errors, window);
   } else {
     m_mantidUI->plot1D(userInput.plots, spectrumPlot,
-                       MantidQt::DistributionDefault, errors, window,
-                       clearWindow, userInput.waterfall);
+                       MantidQt::DistributionDefault, errors, window, false,
+                       userInput.waterfall);
   }
 }
 

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1356,12 +1356,14 @@ void MantidDockWidget::doPlotSpectra(bool errors) {
   constexpr bool spectrumPlot(true), clearWindow(false);
   MultiLayer *window(NULL);
 
-  if (!userInput.tiled) {
+  if (userInput.tiled) {
+    m_mantidUI->plotSubplots(userInput.plots, spectrumPlot,
+                             MantidQt::DistributionDefault, errors, window,
+                             clearWindow);
+  } else {
     m_mantidUI->plot1D(userInput.plots, spectrumPlot,
                        MantidQt::DistributionDefault, errors, window,
                        clearWindow, userInput.waterfall);
-  } else {
-    throw std::runtime_error("TODO: implement tiled plots on right-click!");
   }
 }
 

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1358,8 +1358,7 @@ void MantidDockWidget::doPlotSpectra(bool errors) {
 
   if (userInput.tiled) {
     m_mantidUI->plotSubplots(userInput.plots, spectrumPlot,
-                             MantidQt::DistributionDefault, errors, window,
-                             clearWindow);
+                             MantidQt::DistributionDefault, errors, window);
   } else {
     m_mantidUI->plot1D(userInput.plots, spectrumPlot,
                        MantidQt::DistributionDefault, errors, window,

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1357,8 +1357,8 @@ void MantidDockWidget::doPlotSpectra(bool errors) {
   MultiLayer *window(NULL);
 
   if (userInput.tiled) {
-    m_mantidUI->plotSubplots(userInput.plots, spectrumPlot,
-                             MantidQt::DistributionDefault, errors, window);
+    m_mantidUI->plotSubplots(userInput.plots, MantidQt::DistributionDefault,
+                             errors);
   } else {
     m_mantidUI->plot1D(userInput.plots, spectrumPlot,
                        MantidQt::DistributionDefault, errors, window, false,

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1353,16 +1353,12 @@ void MantidDockWidget::doPlotSpectra(bool errors) {
   if (userInput.plots.empty())
     return;
 
-  constexpr bool spectrumPlot(true);
-  MultiLayer *window(NULL);
-
   if (userInput.tiled) {
     m_mantidUI->plotSubplots(userInput.plots, MantidQt::DistributionDefault,
                              errors);
   } else {
-    m_mantidUI->plot1D(userInput.plots, spectrumPlot,
-                       MantidQt::DistributionDefault, errors, window, false,
-                       userInput.waterfall);
+    m_mantidUI->plot1D(userInput.plots, true, MantidQt::DistributionDefault,
+                       errors, nullptr, false, userInput.waterfall);
   }
 }
 

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1336,33 +1336,33 @@ void MantidDockWidget::groupingButtonClick() {
 }
 
 /// Plots a single spectrum from each selected workspace
-void MantidDockWidget::plotSpectra() {
-  const auto userInput = m_tree->chooseSpectrumFromSelected();
-  // An empty map will be returned if the user clicks cancel in the spectrum
-  // selection
-  if (userInput.plots.empty())
-    return;
-
-  bool spectrumPlot(true), errs(false), clearWindow(false);
-  MultiLayer *window(NULL);
-  m_mantidUI->plot1D(userInput.plots, spectrumPlot,
-                     MantidQt::DistributionDefault, errs, window, clearWindow,
-                     userInput.waterfall);
-}
+void MantidDockWidget::plotSpectra() { doPlotSpectra(false); }
 
 /// Plots a single spectrum from each selected workspace with errors
-void MantidDockWidget::plotSpectraErr() {
+void MantidDockWidget::plotSpectraErr() { doPlotSpectra(true); }
+
+/**
+ * Plots a single spectrum from each selected workspace.
+ * Option to plot errors or not.
+ * @param errors :: [input] True if errors should be plotted, else false
+ */
+void MantidDockWidget::doPlotSpectra(bool errors) {
   const auto userInput = m_tree->chooseSpectrumFromSelected();
   // An empty map will be returned if the user clicks cancel in the spectrum
   // selection
   if (userInput.plots.empty())
     return;
 
-  bool spectrumPlot(true), errs(true), clearWindow(false);
+  constexpr bool spectrumPlot(true), clearWindow(false);
   MultiLayer *window(NULL);
-  m_mantidUI->plot1D(userInput.plots, spectrumPlot,
-                     MantidQt::DistributionDefault, errs, window, clearWindow,
-                     userInput.waterfall);
+
+  if (!userInput.tiled) {
+    m_mantidUI->plot1D(userInput.plots, spectrumPlot,
+                       MantidQt::DistributionDefault, errors, window,
+                       clearWindow, userInput.waterfall);
+  } else {
+    throw std::runtime_error("TODO: implement tiled plots on right-click!");
+  }
 }
 
 /**
@@ -1719,12 +1719,12 @@ MantidTreeWidget::getSelectedMatrixWorkspaces() const {
 * @param showWaterfallOpt If true, show the waterfall option on the dialog
 * @param showPlotAll :: [input] If true, show the "Plot All" button on the
 * dialog
+* @param showTiledOpt :: [input] If true, show the "Tiled" option on the dialog
 * @return :: A MantidWSIndexDialog::UserInput structure listing the selected
 * options
 */
-MantidWSIndexWidget::UserInput
-MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt,
-                                             bool showPlotAll) const {
+MantidWSIndexWidget::UserInput MantidTreeWidget::chooseSpectrumFromSelected(
+    bool showWaterfallOpt, bool showPlotAll, bool showTiledOpt) const {
   auto selectedMatrixWsList = getSelectedMatrixWorkspaces();
   QList<QString> selectedMatrixWsNameList;
   foreach (const auto matrixWs, selectedMatrixWsList) {
@@ -1751,12 +1751,14 @@ MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt,
     MantidWSIndexWidget::UserInput selections;
     selections.plots = spectrumToPlot;
     selections.waterfall = false;
+    selections.tiled = false;
     return selections;
   }
 
   // Else, one or more workspaces
-  MantidWSIndexDialog *dio = new MantidWSIndexDialog(
-      m_mantidUI, 0, selectedMatrixWsNameList, showWaterfallOpt, showPlotAll);
+  MantidWSIndexDialog *dio =
+      new MantidWSIndexDialog(m_mantidUI, 0, selectedMatrixWsNameList,
+                              showWaterfallOpt, showPlotAll, showTiledOpt);
   dio->exec();
   return dio->getSelections();
 }

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -120,6 +120,7 @@ private:
   void addClearMenuItems(QMenu *menu, const QString &wsName);
 
   void excludeItemFromSort(MantidTreeWidgetItem *item);
+  void doPlotSpectra(bool errors);
 
 protected:
   MantidTreeWidget *m_tree;
@@ -175,7 +176,8 @@ public:
   QStringList getSelectedWorkspaceNames() const;
   MantidWSIndexWidget::UserInput
   chooseSpectrumFromSelected(bool showWaterfallOpt = true,
-                             bool showPlotAll = true) const;
+                             bool showPlotAll = true,
+                             bool showTiledOpt = true) const;
   void setSortScheme(MantidItemSortScheme);
   void setSortOrder(Qt::SortOrder);
   MantidItemSortScheme getSortScheme() const;

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3452,6 +3452,7 @@ MantidUI::plotSubplots(const QMultiMap<QString, std::set<int>> &toPlot,
     }
   }
 
+  multi->setCommonAxisScales();
   multi->arrangeLayers(true, true);
   // Check if window does not contain any curves and should be closed
   multi->maybeNeedToClose();

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -2173,7 +2173,7 @@ MultiLayer *MantidUI::plotInstrumentSpectrum(const QString &wsName, int spec) {
 
 /// Catches the signal from InstrumentWindow to plot a spectrum.
 MultiLayer *MantidUI::plotInstrumentSpectrumList(const QString &wsName,
-                                                 std::set<int> spec) {
+                                                 const std::set<int> &spec) {
   return plot1D(wsName, spec, true, MantidQt::DistributionDefault, false);
 }
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3341,10 +3341,10 @@ MultiLayer *MantidUI::plotSelectedColumns(const MantidMatrix *const m,
  * @param plotWindow :: Window to plot to. If null a new one will be created
  * @return created MultiLayer, or null on failure
  */
-MultiLayer *MantidUI::plotSubplots(
-    const QMultiMap<QString, std::set<int>> &toPlot, bool spectrumPlot,
-    MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
-    bool errs = false, MultiLayer *plotWindow) {
+MultiLayer *
+MantidUI::plotSubplots(const QMultiMap<QString, std::set<int>> &toPlot,
+                       bool spectrumPlot, MantidQt::DistributionFlag distr,
+                       bool errs, MultiLayer *plotWindow) {
   // Check if nothing to plot
   if (toPlot.size() == 0)
     return nullptr;
@@ -3397,7 +3397,7 @@ MultiLayer *MantidUI::plotSubplots(
     const auto &wsName = toPlot.begin().key();
     const auto &spectra = toPlot.begin().value();
     for (const int spec : spectra) {
-      auto *layer = multi->layer(layerIndex++);
+      auto *layer = multi->layer(++layerIndex);
       layer->insertCurve(wsName, spec, errs, Graph::Unspecified,
                          plotAsDistribution);
       QString legendText = wsName + '\n';
@@ -3410,12 +3410,13 @@ MultiLayer *MantidUI::plotSubplots(
     for (auto iter = toPlot.constBegin(); iter != toPlot.constEnd(); ++iter) {
       const auto &wsName = iter.key();
       const auto &spectra = iter.value();
-      auto *layer = multi->layer(layerIndex++);
+      auto *layer = multi->layer(++layerIndex);
       QString legendText = wsName + '\n';
+      int curveIndex(0);
       for (const int spec : spectra) {
         layer->insertCurve(wsName, spec, errs, Graph::Unspecified,
                            plotAsDistribution);
-        legendText += "\\l(" + QString::number(layerIndex) + ") " +
+        legendText += "\\l(" + QString::number(++curveIndex) + ") " +
                       getLegendKey(wsName, spec) + "\n";
       }
       layer->newLegend(legendText);
@@ -3441,10 +3442,10 @@ MultiLayer *MantidUI::plotSubplots(
  * @param plotWindow :: Window to plot to. If null a new one will be created
  * @return created MultiLayer, or null on failure
  */
-MultiLayer *MantidUI::plotSubplots(
-    const QMultiMap<QString, int> &toPlot, bool spectrumPlot,
-    MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
-    bool errs = false, MultiLayer *plotWindow) {
+MultiLayer *MantidUI::plotSubplots(const QMultiMap<QString, int> &toPlot,
+                                   bool spectrumPlot,
+                                   MantidQt::DistributionFlag distr, bool errs,
+                                   MultiLayer *plotWindow) {
 
   // Convert the input map into a map of workspace->spectra
   QMultiMap<QString, std::set<int>> spectraByWorkspace;
@@ -3453,7 +3454,7 @@ MultiLayer *MantidUI::plotSubplots(
       auto entry = spectraByWorkspace.find(it.key());
       entry.value().insert(it.value());
     } else { // add a new entry
-      spectraByWorkspace[it.key] = std::set<int>{it.value()};
+      spectraByWorkspace.insert(it.key(), std::set<int>{it.value()});
     }
   }
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -676,7 +676,6 @@ MantidUI::plotMDList(const QStringList &wsNames, const int plotAxis,
   // Check if window does not contain any curves and should be closed
   ml->maybeNeedToClose();
 
-
   return ml;
 }
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3347,16 +3347,13 @@ MultiLayer *MantidUI::plotSelectedColumns(const MantidMatrix *const m,
  * If just one workspace, put each spectrum in its own subplot
  * If multiple workspaces, each ws gets its own subplot
  * @param toPlot :: Map of form ws -> [spectra_list]
- * @param spectrumPlot :: True if indices should be interpreted as row indices
  * @param distr :: if true, workspace plot as distribution (y data/bin width)
  * @param errs :: if true, plot the errors on the graph
- * @param plotWindow :: Window to plot to. If null a new one will be created
  * @return created MultiLayer, or null on failure
  */
 MultiLayer *MantidUI::plotSubplots(const QMultiMap<QString, set<int>> &toPlot,
-                                   bool spectrumPlot,
-                                   MantidQt::DistributionFlag distr, bool errs,
-                                   MultiLayer *plotWindow) {
+                                   MantidQt::DistributionFlag distr,
+                                   bool errs) {
   // Check if nothing to plot
   if (toPlot.size() == 0)
     return nullptr;
@@ -3491,16 +3488,13 @@ void MantidUI::plotLayerOfMultilayer(MultiLayer *multi, const bool plotErrors,
  * If just one workspace, put each spectrum in its own subplot
  * If multiple workspaces, each ws gets its own subplot
  * @param toPlot :: A list of workspace/spectra to be shown in the graph
- * @param spectrumPlot :: True if indices should be interpreted as row indices
  * @param distr :: if true, workspace plot as distribution (y data/bin width)
  * @param errs :: if true, plot the errors on the graph
- * @param plotWindow :: Window to plot to. If null a new one will be created
  * @return created MultiLayer, or null on failure
  */
 MultiLayer *MantidUI::plotSubplots(const QMultiMap<QString, int> &toPlot,
-                                   bool spectrumPlot,
-                                   MantidQt::DistributionFlag distr, bool errs,
-                                   MultiLayer *plotWindow) {
+                                   MantidQt::DistributionFlag distr,
+                                   bool errs) {
 
   // Convert the input map into a map of workspace->spectra
   QMultiMap<QString, std::set<int>> spectraByWorkspace;
@@ -3514,8 +3508,7 @@ MultiLayer *MantidUI::plotSubplots(const QMultiMap<QString, int> &toPlot,
   }
 
   // Pass over to the overloaded method
-  return plotSubplots(spectraByWorkspace, spectrumPlot, distr, errs,
-                      plotWindow);
+  return plotSubplots(spectraByWorkspace, distr, errs);
 }
 
 Table *MantidUI::createTableFromBins(

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3358,6 +3358,28 @@ MultiLayer *MantidUI::plotSelectedColumns(const MantidMatrix *const m,
                 errs);
 }
 
+/**
+ * Plot a "tiled" plot (with subplots).
+ * Ask user for confirmation if lots of plots are chosen.
+ * If just one workspace, put each spectrum in its own subplot
+ * If multiple workspaces, each ws gets its own subplot
+ * @param toPlot :: Map of form ws -> [spectra_list]
+ * @param spectrumPlot :: True if indices should be interpreted as row indices
+ * @param distr :: if true, workspace plot as distribution (y data/bin width)
+ * @param errs :: if true, plot the errors on the graph
+ * @param plotWindow :: Window to plot to. If null a new one will be created
+ * @param clearWindow :: Whether to clear specified plotWindow before plotting.
+ * Ignored if plotWindow is null.
+ * @return created MultiLayer, or null on failure
+ */
+MultiLayer *MantidUI::plotSubplots(
+    const QMultiMap<QString, std::set<int>> &toPlot, bool spectrumPlot,
+    MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
+    bool errs = false, MultiLayer *plotWindow = NULL,
+    bool clearWindow = false) {
+  throw std::runtime_error("TODO: implement this!");
+}
+
 Table *MantidUI::createTableFromBins(
     const QString &wsName, Mantid::API::MatrixWorkspace_const_sptr workspace,
     const QList<int> &bins, bool errs, int fromRow, int toRow) {

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -616,6 +616,12 @@ private:
   /// Set initial autoscale for graph, then reset user autoscale option
   void setInitialAutoscale(Graph *graph);
 
+  /// Plot a layer in a multilayer plot
+  void plotLayerOfMultilayer(MultiLayer *multi, const bool plotErrors,
+                             const bool plotDist, int &row, int &col,
+                             const QString &wsName,
+                             const std::set<int> &spectra);
+
   // Private variables
 
   ApplicationWindow *m_appWindow;    // QtiPlot main ApplicationWindow

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -221,14 +221,12 @@ public:
   plotSubplots(const QMultiMap<QString, std::set<int>> &toPlot,
                bool spectrumPlot,
                MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
-               bool errs = false, MultiLayer *plotWindow = NULL,
-               bool clearWindow = false);
+               bool errs = false, MultiLayer *plotWindow = NULL);
 
   MultiLayer *
   plotSubplots(const QMultiMap<QString, int> &toPlot, bool spectrumPlot,
                MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
-               bool errs = false, MultiLayer *plotWindow = NULL,
-               bool clearWindow = false);
+               bool errs = false, MultiLayer *plotWindow = NULL);
 
 public slots:
   // Create a 1d graph form specified MatrixWorkspace and index
@@ -609,6 +607,12 @@ private:
   // The name comes from: these plots are normally opened from the context menu
   // of the workspaces dock window
   bool workspacesDockPlot1To1();
+
+  /// Get the title to use for a plot - name of selected group
+  QString getSelectedGroupName() const;
+
+  /// Set initial autoscale for graph, then reset user autoscale option
+  void setInitialAutoscale(Graph *graph);
 
   // Private variables
 

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -499,7 +499,8 @@ public slots:
 
   // Plot a spectrum in response from a InstrumentWindow signal
   MultiLayer *plotInstrumentSpectrum(const QString &, int);
-  MultiLayer *plotInstrumentSpectrumList(const QString &, std::set<int>);
+  MultiLayer *plotInstrumentSpectrumList(const QString &,
+                                         const std::set<int> &);
 
   void importString(const QString &logName, const QString &data);
   void importString(const QString &logName, const QString &data,

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -224,6 +224,12 @@ public:
                bool errs = false, MultiLayer *plotWindow = NULL,
                bool clearWindow = false);
 
+  MultiLayer *
+  plotSubplots(const QMultiMap<QString, int> &toPlot, bool spectrumPlot,
+               MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
+               bool errs = false, MultiLayer *plotWindow = NULL,
+               bool clearWindow = false);
+
 public slots:
   // Create a 1d graph form specified MatrixWorkspace and index
   MultiLayer *
@@ -656,6 +662,18 @@ private:
 
   // prevents some repeated code realtating to log names
   void formatLogName(QString &label, const QString &wsName);
+};
+
+/**
+ * This object sets the "busy" cursor while it is in scope, then restores the
+ * original cursor when destroyed.
+ */
+class ScopedOverrideCursor {
+public:
+  /// Constructor sets wait cursor
+  ScopedOverrideCursor() { QApplication::setOverrideCursor(Qt::WaitCursor); }
+  /// Destructor restores original cursor
+  virtual ~ScopedOverrideCursor() { QApplication::restoreOverrideCursor(); }
 };
 
 #endif

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -216,6 +216,14 @@ public:
                          const bool showError, MultiLayer *plotWindow = NULL,
                          bool clearWindow = false);
 
+  /// Plot a "tiled" plot (with subplots)
+  MultiLayer *
+  plotSubplots(const QMultiMap<QString, std::set<int>> &toPlot,
+               bool spectrumPlot,
+               MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
+               bool errs = false, MultiLayer *plotWindow = NULL,
+               bool clearWindow = false);
+
 public slots:
   // Create a 1d graph form specified MatrixWorkspace and index
   MultiLayer *

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -220,14 +220,13 @@ public:
   /// Plot a "tiled" plot (with subplots)
   MultiLayer *
   plotSubplots(const QMultiMap<QString, std::set<int>> &toPlot,
-               bool spectrumPlot,
                MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
-               bool errs = false, MultiLayer *plotWindow = NULL);
+               bool errs = false);
 
   MultiLayer *
-  plotSubplots(const QMultiMap<QString, int> &toPlot, bool spectrumPlot,
+  plotSubplots(const QMultiMap<QString, int> &toPlot,
                MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
-               bool errs = false, MultiLayer *plotWindow = NULL);
+               bool errs = false);
 
 public slots:
   // Create a 1d graph form specified MatrixWorkspace and index

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -24,6 +24,7 @@
 
 #include <Poco/NObserver.h>
 
+#include <QApplication>
 #include <QDockWidget>
 #include <QTreeWidget>
 #include <QProgressDialog>

--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
@@ -23,14 +23,16 @@
  * @param flags :: Window flags that are passed the the QWidget constructor
  * @param wsNames :: the names of the workspaces to be plotted
  * @param showWaterfallOption :: If true the waterfall checkbox is created
+ * @param showTiledOption :: If true the "Tiled" checkbox is created
  */
 MantidWSIndexWidget::MantidWSIndexWidget(QWidget *parent, Qt::WFlags flags,
                                          QList<QString> wsNames,
-                                         const bool showWaterfallOption)
+                                         const bool showWaterfallOption,
+                                         const bool showTiledOption)
     : QWidget(parent, flags), m_spectra(false),
-      m_waterfall(showWaterfallOption), m_wsNames(wsNames),
-      m_wsIndexIntervals(), m_spectraNumIntervals(), m_wsIndexChoice(),
-      m_spectraIdChoice() {
+      m_waterfall(showWaterfallOption), m_tiled(showTiledOption),
+      m_wsNames(wsNames), m_wsIndexIntervals(), m_spectraNumIntervals(),
+      m_wsIndexChoice(), m_spectraIdChoice() {
   checkForSpectraAxes();
   // Generate the intervals allowed to be plotted by the user.
   generateWsIndexIntervals();
@@ -47,7 +49,8 @@ MantidWSIndexWidget::MantidWSIndexWidget(QWidget *parent, Qt::WFlags flags,
 MantidWSIndexWidget::UserInput MantidWSIndexWidget::getSelections() const {
   UserInput options;
   options.plots = getPlots();
-  options.waterfall = waterfallPlotRequested();
+  options.waterfall = isWaterfallPlotSelected();
+  options.tiled = isTiledPlotSelected();
   return options;
 }
 
@@ -103,8 +106,16 @@ QMultiMap<QString, std::set<int>> MantidWSIndexWidget::getPlots() const {
  * Whether the user checked the "waterfall" box
  * @returns True if waterfall plot selected
  */
-bool MantidWSIndexWidget::waterfallPlotRequested() const {
-  return m_waterfallOpt->isChecked();
+bool MantidWSIndexWidget::isWaterfallPlotSelected() const {
+  return m_waterfallOpt ? m_waterfallOpt->isChecked() : false;
+}
+
+/**
+ * Whether the user checked the "tiled" box
+ * @returns True if tiled plot selected
+ */
+bool MantidWSIndexWidget::isTiledPlotSelected() const {
+  return m_tiledOpt ? m_tiledOpt->isChecked() : false;
 }
 
 /**
@@ -231,11 +242,15 @@ void MantidWSIndexWidget::initSpectraBox() {
  */
 void MantidWSIndexWidget::initOptionsBoxes() {
   m_optionsBox = new QHBoxLayout;
-  m_waterfallOpt = new QCheckBox("Waterfall Plot");
-  if (m_waterfall)
+  if (m_waterfall) {
+    m_waterfallOpt = new QCheckBox("Waterfall Plot");
     m_optionsBox->addWidget(m_waterfallOpt);
-  else
-    m_waterfallOpt->setChecked(true);
+  }
+
+  if (m_tiled) {
+    m_tiledOpt = new QCheckBox("Tiled Plot");
+    m_optionsBox->addWidget(m_tiledOpt);
+  }
 
   m_outer->addItem(m_optionsBox);
 }
@@ -349,14 +364,16 @@ bool MantidWSIndexWidget::usingSpectraNumbers() const {
  * @param wsNames :: the names of the workspaces to be plotted
  * @param showWaterfallOption :: If true the waterfall checkbox is created
  * @param showPlotAll :: If true the "Plot all" button is created
+ * @param showTiledOption :: If true the "Tiled" checkbox is created
  */
 MantidWSIndexDialog::MantidWSIndexDialog(MantidUI *mui, Qt::WFlags flags,
                                          QList<QString> wsNames,
                                          const bool showWaterfallOption,
-                                         const bool showPlotAll)
+                                         const bool showPlotAll,
+                                         const bool showTiledOption)
     : QDialog(mui->appWindow(), flags),
-      m_widget(this, flags, wsNames, showWaterfallOption), m_mantidUI(mui),
-      m_plotAll(showPlotAll) {
+      m_widget(this, flags, wsNames, showWaterfallOption, showTiledOption),
+      m_mantidUI(mui), m_plotAll(showPlotAll) {
   // Set up UI.
   init();
 }
@@ -382,8 +399,16 @@ QMultiMap<QString, std::set<int>> MantidWSIndexDialog::getPlots() const {
  * Whether the user checked the "waterfall" box
  * @returns True if waterfall plot selected
  */
-bool MantidWSIndexDialog::waterfallPlotRequested() const {
-  return m_widget.waterfallPlotRequested();
+bool MantidWSIndexDialog::isWaterfallPlotSelected() const {
+  return m_widget.isWaterfallPlotSelected();
+}
+
+/**
+ * Whether the user checked the "tiled" box
+ * @returns True if tiled plot selected
+ */
+bool MantidWSIndexDialog::isTiledPlotSelected() const {
+  return m_widget.isTiledPlotSelected();
 }
 
 //----------------------------------

--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.h
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.h
@@ -228,13 +228,15 @@ public:
   struct UserInput {
     QMultiMap<QString, std::set<int>> plots;
     bool waterfall;
+    bool tiled;
   };
 
   /// Constructor - same parameters as one of the parent constructors, along
   /// with a
   /// list of the names of workspaces to be plotted.
   MantidWSIndexWidget(QWidget *parent, Qt::WFlags flags, QList<QString> wsNames,
-                      const bool showWaterfallOption = false);
+                      const bool showWaterfallOption = false,
+                      const bool showTiledOption = false);
 
   /// Returns a structure holding all of the selected options
   UserInput getSelections() const;
@@ -243,11 +245,13 @@ public:
   /// mapped to the set of workspace indices.
   QMultiMap<QString, std::set<int>> getPlots() const;
   /// Returns whether the waterfall option has been selected
-  bool waterfallPlotRequested() const;
+  bool isWaterfallPlotSelected() const;
   /// Called by dialog when plot requested
   bool plotRequested();
   /// Called by dialog when plot all requested
   void plotAllRequested();
+  /// Returns whether the tiled plot option has been selected
+  bool isTiledPlotSelected() const;
 
 private slots:
   /// Called when the wsField has been edited.
@@ -285,12 +289,15 @@ private:
   /// Do we allow the display of the waterfall option
   bool m_waterfall;
 
+  /// Do we allow the display of the tiled option
+  bool m_tiled;
+
   /// Pointers to the obligatory Qt objects:
   QLabel *m_wsMessage, *m_spectraMessage, *m_orMessage;
   QLineEditWithErrorMark *m_wsField, *m_spectraField;
   QVBoxLayout *m_outer, *m_wsBox, *m_spectraBox;
   QHBoxLayout *m_optionsBox;
-  QCheckBox *m_waterfallOpt;
+  QCheckBox *m_waterfallOpt, *m_tiledOpt;
 
   /// A list of names of workspaces which are to be plotted.
   QList<QString> m_wsNames;
@@ -304,13 +311,12 @@ class MantidWSIndexDialog : public QDialog {
   Q_OBJECT
 
 public:
-  /// Constructor - same parameters as one of the parent constructors, along
-  /// with a
-  /// list of the names of workspaces to be plotted.
+  /// Constructor - has a list of the names of workspaces to be plotted.
   MantidWSIndexDialog(MantidUI *parent, Qt::WFlags flags,
                       QList<QString> wsNames,
                       const bool showWaterfallOption = false,
-                      const bool showPlotAll = true);
+                      const bool showPlotAll = true,
+                      const bool showTiledOption = false);
   /// Returns a structure holding all of the selected options
   MantidWSIndexWidget::UserInput getSelections() const;
   /// Returns the QMultiMap that contains all the workspaces that are to be
@@ -318,7 +324,9 @@ public:
   /// mapped to the set of workspace indices.
   QMultiMap<QString, std::set<int>> getPlots() const;
   /// Returns whether the waterfall option has been selected
-  bool waterfallPlotRequested() const;
+  bool isWaterfallPlotSelected() const;
+  /// Returns whether the tiled plot option has been selected
+  bool isTiledPlotSelected() const;
 private slots:
   /// Called when the OK button is pressed.
   void plot();

--- a/MantidPlot/src/MultiLayer.cpp
+++ b/MantidPlot/src/MultiLayer.cpp
@@ -568,8 +568,8 @@ QSize MultiLayer::arrangeLayers(bool userSize) {
       gr->setAutoscaleFonts(false);
     }
 
-    gr->setGeometry(QRect(x, y, w, h));
-    gr->plotWidget()->resize(QSize(w, h));
+    gr->setGeometry(QRect(x, y, std::abs(w), std::abs(h)));
+    gr->plotWidget()->resize(QSize(std::abs(w), std::abs(h)));
 
     if (!userSize)
       gr->setAutoscaleFonts(autoscaleFonts); // restore user settings

--- a/MantidPlot/src/MultiLayer.cpp
+++ b/MantidPlot/src/MultiLayer.cpp
@@ -43,6 +43,7 @@
 #include <QSpinBox>
 #include <QSize>
 
+#include <cmath>
 #include <limits>
 #include <set>
 
@@ -588,32 +589,19 @@ QSize MultiLayer::arrangeLayers(bool userSize) {
   return size;
 }
 
+/**
+ * Find best layout for a multilayer plot, given the number of layers
+ * @param d_rows :: [output] Number of rows
+ * @param d_cols :: [output] Number of columns
+ */
 void MultiLayer::findBestLayout(int &d_rows, int &d_cols) {
-  int NumGraph = graphsList.size();
-  if (NumGraph % 2 == 0) // NumGraph is an even number
-  {
-    if (NumGraph <= 2)
-      d_cols = NumGraph / 2 + 1;
-    else if (NumGraph > 2)
-      d_cols = NumGraph / 2;
-
-    if (NumGraph < 8)
-      d_rows = NumGraph / 4 + 1;
-    if (NumGraph >= 8)
-      d_rows = NumGraph / 4;
-  } else if (NumGraph % 2 != 0) // NumGraph is an odd number
-  {
-    int Num = NumGraph + 1;
-
-    if (Num <= 2)
-      d_cols = 1;
-    else if (Num > 2)
-      d_cols = Num / 2;
-
-    if (Num < 8)
-      d_rows = Num / 4 + 1;
-    if (Num >= 8)
-      d_rows = Num / 4;
+  const int numGraphs = graphsList.size();
+  const int root =
+      static_cast<int>(std::ceil(std::sqrt(static_cast<double>(numGraphs))));
+  d_rows = root;
+  d_cols = root;
+  if (d_rows * d_cols - numGraphs > d_rows) {
+    --d_rows;
   }
 }
 

--- a/MantidPlot/src/MultiLayer.h
+++ b/MantidPlot/src/MultiLayer.h
@@ -109,6 +109,8 @@ public:
                                                const int fileVersion);
   std::string saveToProject(ApplicationWindow *app) override;
 
+  void setCommonAxisScales();
+
 public slots:
   Graph *addLayer(int x = 0, int y = 0, int width = 0, int height = 0);
   void setLayersNumber(int n);

--- a/docs/source/release/v3.8.0/ui.rst
+++ b/docs/source/release/v3.8.0/ui.rst
@@ -32,6 +32,10 @@ Workspace Matrix View
 
 Plotting Improvements
 #####################
+* A new option has been added to the "Plot Spectrum" and "Plot Spectrum with Errors" dialogs. The "Tiled plot" checkbox enables such a plot to be produced as a simple right-click option.
+
+  - When this option is used for a workspace group, each workspace will its own subplot, with all specified spectra in it.
+  - When the option is used for a single workspace, each of the specified spectra will have its own subplot.
 
 Algorithm Toolbox
 #################


### PR DESCRIPTION
Enable the easy creation of a MultiLayer plot from right-clicking on a workspace.

At present, it is possible to create such a plot, but you have to plot each spectrum individually and then drag them onto a tiled plot, or write a Python script. This PR provides a way to do it from right-clicking a workspace in the GUI.

When used on a WorkspaceGroup, each workspace gets its own subplot, with the specified spectra in each. When used on a single workspace, each of the specified spectra is plotted in its own subplot.

**Example use case:**
After fitting several workspaces at once, the results are contained in a WorkspaceGroup. There is currently no easy way to visualise the results - you have to plot each fit individually in its own window, or have them all on the same axes (messy). With the new option, you can create a multiple plot of {data, fit, difference} for each workspace in its own subplot.

**To test:**
- Create a GroupWorkspace containing several multi-spectra MatrixWorkspaces.
- Right-click on the GroupWorkspace and choose "Plot Spectrum..."
- In the dialog, check the "Tiled Plot" option. Select a range of spectra to plot (or choose to plot all).
- (If there are a large number of workspaces in the group, it should warn you about this).
- Should get a plot of each workspace in its own subplot:
  - Axis titles should only be present on the leftmost column and bottom row (or second-to-last row if there is no plot underneath).
  - Axis scales should be the same for all subplots, and the scale should be large enough to show all the data in each plot. 
  - Font size of axis titles, labels and legends should be the same for all subplots.
  - There should not be excessive white space between the subplots.
  - Each subplot should have a legend to show which workspace it came from.
- Now right-click on one of the MatrixWorkspaces from the group, and do a tiled plot of this.
  - Each spectrum (from those selected) should be shown in its own subplot.

Fixes #9239.

[Release notes](https://github.com/mantidproject/mantid/blob/39583c9aa21c316b36e05de9d2ffbaffa8eac995/docs/source/release/v3.8.0/ui.rst#plotting-improvements) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
