### PR TITLE
FindPeaks logging

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -247,7 +247,11 @@ public:
   /// returns the status of logging, True = enabled
   bool isLogging() const override { return g_log.getEnabled(); }
 
-  /// sets the logging priority offset
+  /* Sets the logging priority offset. Values are subtracted from the log level.
+   *
+   * Example value=1 will turn warning into notice
+   * Example value=-1 will turn notice into warning
+   */
   void setLoggingOffset(const int value) override {
     g_log.setLevelOffset(value);
   }

--- a/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Framework/Algorithms/src/FindPeaks.cpp
@@ -1053,6 +1053,7 @@ int FindPeaks::findPeakBackground(const MatrixWorkspace_sptr &input,
 
   // Call FindPeakBackground
   IAlgorithm_sptr estimate = createChildAlgorithm("FindPeakBackground");
+  estimate->setLoggingOffset(1);
   estimate->setProperty("InputWorkspace", input);
   estimate->setProperty("WorkspaceIndex", spectrum);
   // estimate->setProperty("SigmaConstant", 1.0);

--- a/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
+++ b/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
@@ -886,6 +886,7 @@ int GetDetOffsetsMultiPeaks::fitSpectra(
   // Fit peaks
   API::IAlgorithm_sptr findpeaks =
       createChildAlgorithm("FindPeaks", -1, -1, false);
+  findpeaks->setLoggingOffset(2);
   findpeaks->setProperty("InputWorkspace", inputW);
   findpeaks->setProperty<int>("FWHM", 7);
   findpeaks->setProperty<int>("Tolerance", 4);

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -337,6 +337,7 @@ void PDCalibration::exec() {
       continue;
 
     auto alg = createChildAlgorithm("FindPeaks");
+    alg->setLoggingOffset(2);
     alg->setProperty("InputWorkspace", m_uncalibratedWS);
     alg->setProperty("WorkspaceIndex", static_cast<int>(wkspIndex));
     alg->setProperty("PeakPositions", peaks.inTofPos);


### PR DESCRIPTION
`GetDetOffsetsMultiPeaks` and `PDCalibration` were printing out too much information to logs and would make the calibration take significantly longer.This will reduce the logging in the child algorithm calls of those.

**To test:**

I suggest looking at the diffs and running only the new version as the old one took a long time due unless logging was essentially turned off.

_There is no associated issue_

_Does not need to be in the release notes,_ because it is only a change to logging.

**Do not merge until #17421 has been.**

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
