### PR TITLE
Removed Parallel statements from SANSSolidAngleCorrection

### DIFF
--- a/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
@@ -110,9 +110,7 @@ void SANSSolidAngleCorrection::exec() {
   // Number of X bins
   const int xLength = static_cast<int>(inputWS->readY(0).size());
 
-  PARALLEL_FOR2(outputWS, inputWS)
   for (int i = 0; i < numHists; ++i) {
-    PARALLEL_START_INTERUPT_REGION
     outputWS->dataX(i) = inputWS->readX(i);
 
     IDetector_const_sptr det;
@@ -166,9 +164,7 @@ void SANSSolidAngleCorrection::exec() {
       EOut[j] = fabs(EIn[j] * corr);
     }
     progress.report("Solid Angle Correction");
-    PARALLEL_END_INTERUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
   setProperty("OutputMessage", "Solid angle correction applied");
 }
 
@@ -188,9 +184,7 @@ void SANSSolidAngleCorrection::execEvent() {
   Progress progress(this, 0.0, 1.0, numberOfSpectra);
   progress.report("Solid Angle Correction");
 
-  PARALLEL_FOR1(outputEventWS)
   for (int i = 0; i < numberOfSpectra; i++) {
-    PARALLEL_START_INTERUPT_REGION
     IDetector_const_sptr det;
     try {
       det = outputEventWS->getDetector(i);
@@ -225,9 +219,7 @@ void SANSSolidAngleCorrection::execEvent() {
     EventList &el = outputEventWS->getSpectrum(i);
     el *= corr;
     progress.report("Solid Angle Correction");
-    PARALLEL_END_INTERUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
 
   setProperty("OutputMessage", "Solid angle correction applied");
 }


### PR DESCRIPTION
The `HFIRTestsAPIv2.HFIRTestsAPIv2` system test is failing after:
https://github.com/mantidproject/mantid/pull/17346

I have removed the Parallel statements as quick fix. For HFIR instruments, this is now 2 seconds slower. More time is needed to find the problem.

All tests should pass.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
