### PR TITLE
Engg:: Fix pressing enter on the fit input box traps the user

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -203,6 +203,9 @@ private:
   // input run number - used for output file name
   std::vector<std::string> g_multi_run;
 
+  // Holds the previous user input so we can short circuit further checks
+  std::string m_previousInput;
+
   /// true if the last fitting completed successfully
   bool m_fittingFinishedOK;
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -198,6 +198,17 @@ void EnggDiffFittingPresenter::fittingRunNoChanged() {
     // receive the run number from the text-field
     auto strFocusedFile = m_view->getFittingRunNo();
 
+    if (m_previousInput == strFocusedFile) {
+      // Short circuit the checks and skip any warnings
+      // or errors as the user has not changed anything
+      // just clicked the box. Additionally this resolves an
+      // issue where QT will return the cursor and produce a new
+      // warning when the current warning is closed
+      return;
+    } else {
+      m_previousInput = strFocusedFile;
+    }
+
     // file name
     Poco::Path selectedfPath(strFocusedFile);
     Poco::Path bankDir;


### PR DESCRIPTION
Description of work.
Previously if the user hit enter whilst having the input box selected in the Engineering Diffraction interface it would constantly open new dialog boxes trapping the user. This was because QT would move the focus back to the text box when the dialog box was closed, perform the checks again then open a new dialog box.

This change makes it so that if the user does not change the values in the field we completely skip all the logic and do nothing. This also has the added bonus that if the user clicks in and out of the box we don't recreate warning messages every time. 

**To test:**

Open the Engineering Diffraction Interface
Go to the `Fitting Tab`
Select an invalid input such as `ENGINX00193749.nxs` 
Select the text box and press enter
Only one warning should appear
Clicking into and out of the text box will not create additional logging entries/ dialog boxes
Changing the value in the text box will retrigger the checks and they should continue as normal

Fixes #17446 .

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
