### PR TITLE
Fix LR autoreduce logic

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -489,7 +489,7 @@ class LRAutoReduction(PythonAlgorithm):
         # Copy over the existing series, up to the point we are at
         new_data_sets = []
         for i in range(int(run_number) - int(first_run_of_set) + 1):
-            if i > len(self.data_series_template.data_sets):
+            if i >= len(self.data_series_template.data_sets):
                 break
             d = self.data_series_template.data_sets[i]
             d.data_files = [int(first_run_of_set) + i]

--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -490,7 +490,7 @@ class LRAutoReduction(PythonAlgorithm):
         new_data_sets = []
         for i in range(int(run_number) - int(first_run_of_set) + 1):
             if i >= len(self.data_series_template.data_sets):
-                logger.notice("Sequence is corrupted: run=%s, first run of set=%s" % (str(run_number),
+                logger.warning("Sequence is corrupted: run=%s, first run of set=%s" % (str(run_number),
                                                                                       str(first_run_of_set)))
                 break
             d = self.data_series_template.data_sets[i]

--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -490,8 +490,8 @@ class LRAutoReduction(PythonAlgorithm):
         new_data_sets = []
         for i in range(int(run_number) - int(first_run_of_set) + 1):
             if i >= len(self.data_series_template.data_sets):
-                logger.notice("Sequence information is corrupted: run=%s, first run of set=%s",
-                              str(run_number), str(first_run_of_set))
+                logger.notice("Sequence is corrupted: run=%s, first run of set=%s" % (str(run_number),
+                                                                                      str(first_run_of_set))
                 break
             d = self.data_series_template.data_sets[i]
             d.data_files = [int(first_run_of_set) + i]

--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -491,7 +491,7 @@ class LRAutoReduction(PythonAlgorithm):
         for i in range(int(run_number) - int(first_run_of_set) + 1):
             if i >= len(self.data_series_template.data_sets):
                 logger.notice("Sequence is corrupted: run=%s, first run of set=%s" % (str(run_number),
-                                                                                      str(first_run_of_set))
+                                                                                      str(first_run_of_set)))
                 break
             d = self.data_series_template.data_sets[i]
             d.data_files = [int(first_run_of_set) + i]

--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -490,6 +490,8 @@ class LRAutoReduction(PythonAlgorithm):
         new_data_sets = []
         for i in range(int(run_number) - int(first_run_of_set) + 1):
             if i >= len(self.data_series_template.data_sets):
+                logger.notice("Sequence information is corrupted: run=%s, first run of set=%s",
+                              str(run_number), str(first_run_of_set))
                 break
             d = self.data_series_template.data_sets[i]
             d.data_files = [int(first_run_of_set) + i]

--- a/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
@@ -177,7 +177,8 @@ class LRReflectivityOutput(PythonAlgorithm):
                 w = 1.0 / e_values[i]**2
                 total += w * y_values[i]
                 weights += w
-            scaling_factor = total / weights
+            if weights > 0:
+                scaling_factor = total / weights
 
         Scale(InputWorkspace=scaled_ws_list[0] + '_histo', OutputWorkspace=scaled_ws_list[0] + '_scaled',
               Factor=1.0 / scaling_factor, Operation='Multiply')
@@ -202,6 +203,7 @@ class LRReflectivityOutput(PythonAlgorithm):
         content += '# Run start time: %s\n' % start_time
         content += '# Reduction time: %s\n' % time.ctime()
         content += '# Mantid version: %s\n' % mantid.__version__
+        content += '# Scaling factor: %s\n' % scaling_factor
         content += header_info
 
         try:


### PR DESCRIPTION
This PR takes care of two minor issues. 

1- When the meta-data related to the measurement sequence is bad, there was an instance where the algorithm was trying to access a non-existent item in a list. That should be protected against.

2- When normalizing to 1 under the critical edge, there is the possibility of dividing by zero if there is no data under the cut-off we asked for. In this case, just skip the normalization.

**To test:**
- Review the code
- Make sure tests pass
- Run reduction for run REFL_144854, which should bring up both problems. You should get a warning about the sequence information, and the reduced file should have a meta-data entry stating that the scaling factor is 1.

There is no GitHub Issue for this PR. All the info is here.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
