### PR TITLE
Remove final occurence of HAS_UNORDERED_MAP_H

### DIFF
--- a/Framework/API/inc/MantidAPI/SpectraDetectorTypes.h
+++ b/Framework/API/inc/MantidAPI/SpectraDetectorTypes.h
@@ -4,29 +4,16 @@
 // Includes
 //------------------------------------------------------------------------------
 #include "MantidGeometry/IDTypes.h"
-
-#ifndef HAS_UNORDERED_MAP_H
-#include <map>
-#else
-#include <tr1/unordered_map>
-#endif
+#include <unordered_map>
 
 namespace Mantid {
 
-#ifndef HAS_UNORDERED_MAP_H
 /// Map with key = spectrum number, value = workspace index
-typedef std::map<specnum_t, size_t> spec2index_map;
+typedef std::unordered_map<specnum_t, size_t> spec2index_map;
 /// Map with key = detector ID, value = workspace index
-typedef std::map<detid_t, size_t> detid2index_map;
-#else
-/// Map with key = spectrum number, value = workspace index
-typedef std::tr1::unordered_map<specnum_t, size_t> spec2index_map;
-/// Map with key = detector ID, value = workspace index
-typedef std::tr1::unordered_map<detid_t, size_t> detid2index_map;
-#endif
-
+typedef std::unordered_map<detid_t, size_t> detid2index_map;
 /// Map single det ID of group to its members
-typedef std::map<detid_t, std::vector<detid_t>> det2group_map;
+typedef std::unordered_map<detid_t, std::vector<detid_t>> det2group_map;
 }
 
 #endif // MANTID_API_SPECTRADETECTORMAP_TYPES

--- a/Framework/API/inc/MantidAPI/SpectraDetectorTypes.h
+++ b/Framework/API/inc/MantidAPI/SpectraDetectorTypes.h
@@ -5,6 +5,7 @@
 //------------------------------------------------------------------------------
 #include "MantidGeometry/IDTypes.h"
 #include <unordered_map>
+#include <vector>
 
 namespace Mantid {
 

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -11,7 +11,6 @@
 #include "MantidKernel/SingletonHolder.h"
 #include "MantidKernel/Matrix.h"
 
-//#include "MantidNexus/NexusClasses.h"
 #include "MantidAPI/FileFinder.h"
 
 #include "MantidTestHelpers/ComponentCreationHelper.h"
@@ -430,7 +429,7 @@ public:
 
   void test_Setting_Group_Lookup_To_Empty_Map_Does_Not_Throw() {
     ExperimentInfo expt;
-    std::map<Mantid::detid_t, std::vector<Mantid::detid_t>> mappings;
+    Mantid::det2group_map mappings;
 
     TS_ASSERT_THROWS_NOTHING(expt.cacheDetectorGroupings(mappings));
   }
@@ -444,7 +443,7 @@ public:
   void
   test_Setting_Group_Lookup_To_Non_Empty_Map_Allows_Retrieval_Of_Correct_IDs() {
     ExperimentInfo expt;
-    std::map<Mantid::detid_t, std::vector<Mantid::detid_t>> mappings;
+    Mantid::det2group_map mappings;
     mappings.emplace(1, std::vector<Mantid::detid_t>(1, 2));
     expt.cacheDetectorGroupings(mappings);
 

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -604,12 +604,10 @@ public:
   void test_getSpectrumToWorkspaceIndexMap() {
     WorkspaceTester ws;
     ws.initialize(2, 1, 1);
-    const auto map = ws.getSpectrumToWorkspaceIndexMap();
+    auto map = ws.getSpectrumToWorkspaceIndexMap();
+    TS_ASSERT_EQUALS(0, map[1]);
+    TS_ASSERT_EQUALS(1, map[2]);
     TS_ASSERT_EQUALS(map.size(), 2);
-    TS_ASSERT_EQUALS(map.begin()->first, 1);
-    TS_ASSERT_EQUALS(map.begin()->second, 0);
-    TS_ASSERT_EQUALS(map.rbegin()->first, 2);
-    TS_ASSERT_EQUALS(map.rbegin()->second, 1);
 
     // Check it throws for non-spectra axis
     ws.replaceAxis(1, new NumericAxis(1));

--- a/Framework/Algorithms/test/PDCalibrationTest.h
+++ b/Framework/Algorithms/test/PDCalibrationTest.h
@@ -8,6 +8,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAlgorithms/CreateSampleWorkspace.h"
 #include "MantidAlgorithms/PDCalibration.h"
+#include "MantidDataObjects/TableColumn.h"
 
 using Mantid::Algorithms::PDCalibration;
 using Mantid::API::Workspace_sptr;
@@ -76,12 +77,20 @@ public:
         AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("cal");
 
     TS_ASSERT(calTable);
-    TS_ASSERT_DELTA(calTable->cell<double>(180, 1), 31.5, 0.05); // difc
-    TS_ASSERT_EQUALS(calTable->cell<double>(180, 2), 0);         // difa
-    TS_ASSERT_EQUALS(calTable->cell<double>(180, 3), 0);         // tzero
-    TS_ASSERT_DELTA(calTable->cell<double>(181, 1), 31.5, 0.05); // difc
-    TS_ASSERT_EQUALS(calTable->cell<double>(181, 2), 0);         // difa
-    TS_ASSERT_EQUALS(calTable->cell<double>(181, 3), 0);         // tzero
+
+    Mantid::DataObjects::TableColumn_ptr<int> col0 = calTable->getColumn(0);
+    std::vector<int> detIDs = col0->data();
+
+    size_t index =
+        std::find(detIDs.begin(), detIDs.end(), 280) - detIDs.begin();
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 1), 31.5, 0.05); // difc
+    TS_ASSERT_EQUALS(calTable->cell<double>(index, 2), 0);         // difa
+    TS_ASSERT_EQUALS(calTable->cell<double>(index, 3), 0);         // tzero
+
+    index = std::find(detIDs.begin(), detIDs.end(), 281) - detIDs.begin();
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 1), 31.5, 0.05); // difc
+    TS_ASSERT_EQUALS(calTable->cell<double>(index, 2), 0);         // difa
+    TS_ASSERT_EQUALS(calTable->cell<double>(index, 3), 0);         // tzero
 
     MatrixWorkspace_const_sptr mask =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("cal_mask");
@@ -115,12 +124,20 @@ public:
         AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("cal");
 
     TS_ASSERT(calTable);
-    TS_ASSERT_DELTA(calTable->cell<double>(156, 1), 31.5, 0.01); // difc
-    TS_ASSERT_EQUALS(calTable->cell<double>(156, 2), 0);         // difa
-    TS_ASSERT_DELTA(calTable->cell<double>(156, 3), 2, 0.01);    // tzero
-    TS_ASSERT_DELTA(calTable->cell<double>(165, 1), 31.5, 0.01); // difc
-    TS_ASSERT_EQUALS(calTable->cell<double>(165, 2), 0);         // difa
-    TS_ASSERT_DELTA(calTable->cell<double>(165, 3), 2, 0.01);    // tzero
+
+    Mantid::DataObjects::TableColumn_ptr<int> col0 = calTable->getColumn(0);
+    std::vector<int> detIDs = col0->data();
+
+    size_t index =
+        std::find(detIDs.begin(), detIDs.end(), 256) - detIDs.begin();
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 1), 31.5, 0.01); // difc
+    TS_ASSERT_EQUALS(calTable->cell<double>(index, 2), 0);         // difa
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 3), 2, 0.01);    // tzero
+
+    index = std::find(detIDs.begin(), detIDs.end(), 265) - detIDs.begin();
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 1), 31.5, 0.01); // difc
+    TS_ASSERT_EQUALS(calTable->cell<double>(index, 2), 0);         // difa
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 3), 2, 0.01);    // tzero
 
     MatrixWorkspace_const_sptr mask =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("cal_mask");
@@ -155,15 +172,25 @@ public:
         AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("cal");
 
     TS_ASSERT(calTable);
-    TS_ASSERT_DELTA(calTable->cell<double>(182, 1), 35.9, 0.1);  // difc
-    TS_ASSERT_DELTA(calTable->cell<double>(182, 2), 0.0, 0.01);  // difa
-    TS_ASSERT_DELTA(calTable->cell<double>(182, 3), -35.4, 0.1); // tzero
-    TS_ASSERT_DELTA(calTable->cell<double>(183, 1), 31.5, 0.1);  // difc
-    TS_ASSERT_DELTA(calTable->cell<double>(183, 2), 0.1, 0.01);  // difa
-    TS_ASSERT_DELTA(calTable->cell<double>(183, 3), 2, 0.2);     // tzero
-    TS_ASSERT_DELTA(calTable->cell<double>(184, 1), 31.5, 0.1);  // difc
-    TS_ASSERT_DELTA(calTable->cell<double>(184, 2), 0.1, 0.01);  // difa
-    TS_ASSERT_DELTA(calTable->cell<double>(184, 3), 2, 0.2);     // tzero
+
+    Mantid::DataObjects::TableColumn_ptr<int> col0 = calTable->getColumn(0);
+    std::vector<int> detIDs = col0->data();
+
+    size_t index =
+        std::find(detIDs.begin(), detIDs.end(), 282) - detIDs.begin();
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 1), 35.9, 0.1);  // difc
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 2), 0.0, 0.01);  // difa
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 3), -35.4, 0.1); // tzero
+
+    index = std::find(detIDs.begin(), detIDs.end(), 283) - detIDs.begin();
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 1), 31.5, 0.1); // difc
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 2), 0.1, 0.01); // difa
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 3), 2, 0.2);    // tzero
+
+    index = std::find(detIDs.begin(), detIDs.end(), 284) - detIDs.begin();
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 1), 31.5, 0.1); // difc
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 2), 0.1, 0.01); // difa
+    TS_ASSERT_DELTA(calTable->cell<double>(index, 3), 2, 0.2);    // tzero
 
     MatrixWorkspace_const_sptr mask =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("cal_mask");


### PR DESCRIPTION
`HAS_UNORDERED_MAP_H` is a hangover from the days where `unordered_map` was in `tr1`. This is now standard across all compilers so the check is no longer necessary and has been removed.

**To test:**

Code review and check all tests pass.

_No issue number_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
