### PR TITLE
Fix project modification notifications

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -15859,6 +15859,8 @@ void ApplicationWindow::addMdiSubWindow(MdiSubWindow *w, bool showFloating,
       sw->showMinimized();
     }
   }
+
+  modifiedProject(w);
 }
 
 /**

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -197,6 +197,8 @@ MantidUI::MantidUI(ApplicationWindow *aw)
           m_exploreAlgorithms,
           SLOT(updateProgress(void *, double, const QString &, double, int)),
           Qt::QueuedConnection);
+
+  connect(this, SIGNAL(ADS_updated()), appWindow(), SLOT(modifiedProject()));
   m_algMonitor->start();
 
   mantidMenu = new QMenu(m_appWindow);
@@ -770,6 +772,7 @@ void MantidUI::showVatesSimpleInterface() {
         m_vatesSubWindow->setWidget(vsui);
         m_vatesSubWindow->widget()->show();
         vsui->renderWorkspace(wsName, wsType, instrumentName);
+        appWindow()->modifiedProject();
       } else {
         delete m_vatesSubWindow;
         m_vatesSubWindow = NULL;
@@ -819,6 +822,7 @@ void MantidUI::showSpectrumViewer() {
 
       viewer->show();
       viewer->renderWorkspace(wksp);
+      appWindow()->modifiedProject();
     } else {
       g_log.information()
           << "Only event or matrix workspaces are currently supported.\n"
@@ -880,6 +884,7 @@ void MantidUI::showSliceViewer() {
 
     // Pop up the window
     w->show();
+    appWindow()->modifiedProject();
     // And add it
     // appWindow()->d_workspace->addSubWindow(w);
   }


### PR DESCRIPTION
There was an issue with application window sometimes not being notified when a workspace changes (for example when it is deleted). I also noticed that opening windows which are not MdiSubWindows will also cause the project to not appear modified. 

**To test:**
This has been changed now so that everything the ADS notifies that it has been changed in MantidUI the project is marked as modified. Also when opening the slice viewer, instrument window, spectrum viewer, and VSI the project will be marked as modified (as they will now be serialised, see issues #16961, #16963, #17368, #17249 

Fixes #11605 .

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

This causes the project to appear as modified after the ADS changes or
after a window (including windows other than MdiSubWindows) are shown.
