### PR TITLE
Engg:: Add tooltip for fit peak picker tool

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -187,6 +187,7 @@ private slots:
   void browseClicked();
   void saveClicked();
   void plotSeparateWindow();
+  void showToolTipHelp();
   void setBankDir(int idx);
   void listViewFittingRun();
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -292,7 +292,96 @@
       <string>Preview</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0" colspan="2">
+      <item row="3" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_peak_button_3">
+        <item>
+         <widget class="QPushButton" name="pushButton_plot_separate_window">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Plot To Separate Window</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_19">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>38</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item row="3" column="1">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>187</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>28</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_qlist_bank">
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string>Run #:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QListWidget" name="listWidget_fitting_run_num">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0" colspan="2">
        <widget class="QwtPlot" name="dataPlot">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -314,12 +403,38 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="3">
+      <item row="4" column="0" colspan="3">
        <widget class="QGroupBox" name="groupBox_peak_tools">
         <property name="title">
          <string>Peak Tools</string>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="picker_tooltip">
+           <property name="font">
+            <font>
+             <pointsize>10</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Shift+ Left Click&lt;/span&gt; to select peak then click &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Add Peak &lt;/span&gt;to add to list of peaks.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Left Click+Drag &lt;/span&gt;to zoom into an area within the peak display.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Left Click&lt;/span&gt; to return to original zoom size.&lt;/p&gt;&lt;p&gt;Selected peaks can be removed from the top of the interface&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="autoFillBackground">
+            <bool>false</bool>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">background-color: rgb(179, 214, 255)</string>
+           </property>
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;How to use&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
          <item>
           <spacer name="horizontalSpacer_2">
            <property name="orientation">
@@ -379,95 +494,6 @@
          </item>
         </layout>
        </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_qlist_bank">
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="text">
-         <string>Run #:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>28</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="2">
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QListWidget" name="listWidget_fitting_run_num">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="1">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>187</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_peak_button_3">
-        <item>
-         <widget class="QPushButton" name="pushButton_plot_separate_window">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Plot To Separate Window</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_19">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>38</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
       </item>
      </layout>
     </widget>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFitting.ui
@@ -410,28 +410,24 @@
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="QLabel" name="picker_tooltip">
+          <widget class="QPushButton" name="pushButton_tooltip">
            <property name="font">
             <font>
              <pointsize>10</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
             </font>
            </property>
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Shift+ Left Click&lt;/span&gt; to select peak then click &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Add Peak &lt;/span&gt;to add to list of peaks.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Left Click+Drag &lt;/span&gt;to zoom into an area within the peak display.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;Left Click&lt;/span&gt; to return to original zoom size.&lt;/p&gt;&lt;p&gt;Selected peaks can be removed from the top of the interface&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
-           <property name="autoFillBackground">
-            <bool>false</bool>
-           </property>
            <property name="styleSheet">
-            <string notr="true">background-color: rgb(179, 214, 255)</string>
+            <string notr="true">border: 0px;
+background-color: rgb(179, 214, 255)</string>
            </property>
            <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;How to use&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>How to use</string>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
+           <property name="flat">
+            <bool>false</bool>
            </property>
           </widget>
          </item>

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -17,6 +17,7 @@
 #include <QFileDialog>
 #include <QSettings>
 
+#include <qevent.h>
 #include <qwt_plot_curve.h>
 #include <qwt_plot_zoomer.h>
 #include <qwt_symbol.h>
@@ -123,6 +124,9 @@ void EnggDiffFittingViewQtWidget::doSetup() {
 
   connect(m_ui.pushButton_plot_separate_window, SIGNAL(released()),
           SLOT(plotSeparateWindow()));
+
+  // Tool-tip button
+  connect(m_ui.pushButton_tooltip, SIGNAL(released()), SLOT(showToolTipHelp()));
 
   m_ui.dataPlot->setCanvasBackground(Qt::white);
   m_ui.dataPlot->setAxisTitle(QwtPlot::xBottom, "d-Spacing (A)");
@@ -529,6 +533,19 @@ void EnggDiffFittingViewQtWidget::plotSeparateWindow() {
   m_logMsgs.emplace_back("Plotted output focused data, with status string " +
                          status);
   m_presenter->notify(IEnggDiffFittingPresenter::LogMsg);
+}
+
+void EnggDiffFittingViewQtWidget::showToolTipHelp() {
+  // We need a the mouse click position relative to the widget
+  // and relative to the screen. We will set the mouse click position
+  // relative to widget to 0 as the global position of the mouse
+  // is what is considered when the tool tip is displayed
+  const QPoint relWidgetPosition(0, 0);
+  const QPoint mousePos = QCursor::pos();
+  // Now fire the generated event to show a tool tip at the cursor
+  QEvent *toolTipEvent =
+      new QHelpEvent(QEvent::ToolTip, relWidgetPosition, mousePos);
+  QCoreApplication::sendEvent(m_ui.pushButton_tooltip, toolTipEvent);
 }
 
 std::string EnggDiffFittingViewQtWidget::fittingPeaksData() const {

--- a/docs/source/release/v3.8.0/diffraction.rst
+++ b/docs/source/release/v3.8.0/diffraction.rst
@@ -67,6 +67,9 @@ Engineering Diffraction
 - New *Load* button on the Fitting Tab, will enable user to load the
   focused file to the canvas, so that the user can select the peaks
   manually beforehand
+  
+- New tool-tip *How to use* quickly tells users how to use the peak
+  picker tool by simply hovering their cursor over it.
 
 Powder Diffraction
 ------------------


### PR DESCRIPTION
Description of work.
This PR adds a tooltip to the Engineering Interface so users can quickly find how to select their peaks without having to read through the help page.

**To test:**
Open the Engineering Diffraction interface
Go to the `Fitting` tab
Hover over the `How to use` label and read the tooltip text.

Is the tooltip easy to find?
Is the tooltip text clear and informative?

Fixes #17297 .

Added to [release notes](https://github.com/mantidproject/mantid/blob/faf8ac95f8b1d926c8bdb14cbb558303a9d850e2/docs/source/release/v3.8.0/diffraction.rst#engineering-diffraction).

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
