### PR TITLE
More OSX floating window issues

### DIFF
--- a/MantidPlot/src/FloatingWindow.cpp
+++ b/MantidPlot/src/FloatingWindow.cpp
@@ -42,9 +42,13 @@ FloatingWindow::FloatingWindow(ApplicationWindow *appWindow, Qt::WindowFlags f)
 #ifdef Q_OS_MAC
   // Work around to ensure that floating windows remain on top of the main
   // application window, but below other applications on Mac
-  Qt::WindowFlags flags = windowFlags();
-  Qt::WindowFlags new_flags = flags | Qt::Tool;
-  setWindowFlags(new_flags);
+  // Note: Qt::Tool cannot have both a max and min button on OSX
+  auto flags = windowFlags();
+  flags |= Qt::Tool;
+  flags |= Qt::CustomizeWindowHint;
+  flags |= Qt::WindowMinimizeButtonHint;
+  flags |= Qt::WindowCloseButtonHint;
+  setWindowFlags(flags);
 #endif
 }
 

--- a/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
@@ -197,8 +197,12 @@ AlgorithmHistoryWindow::AlgorithmHistoryWindow(
 #ifdef Q_OS_MAC
   // Work around to ensure that floating windows remain on top of the main
   // application window, but below other applications on Mac
+  // Note: Qt::Tool cannot have both a max and min button on OSX
   Qt::WindowFlags flags = windowFlags();
   flags |= Qt::Tool;
+  flags |= Qt::CustomizeWindowHint;
+  flags |= Qt::WindowMinimizeButtonHint;
+  flags |= Qt::WindowCloseButtonHint;
   setWindowFlags(flags);
 #endif
 

--- a/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
@@ -194,6 +194,14 @@ AlgorithmHistoryWindow::AlgorithmHistoryWindow(
   setMinimumWidth(750);
   setGeometry(50, 150, 540, 380);
 
+#ifdef Q_OS_MAC
+  // Work around to ensure that floating windows remain on top of the main
+  // application window, but below other applications on Mac
+  Qt::WindowFlags flags = windowFlags();
+  flags |= Qt::Tool;
+  setWindowFlags(flags);
+#endif
+
   // Create a tree widget to display the algorithm names in the workspace
   // history
   m_Historytree = new AlgHistoryTreeWidget(this);

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -749,6 +749,17 @@ void MantidUI::showVatesSimpleInterface() {
     } else {
       m_vatesSubWindow = new QMdiSubWindow;
       m_vatesSubWindow->setAttribute(Qt::WA_DeleteOnClose, false);
+#ifdef Q_OS_MAC
+      // Work around to ensure that floating windows remain on top of the main
+      // application window, but below other applications on Mac
+      // Note: Qt::Tool cannot have both a max and min button on OSX
+      Qt::WindowFlags flags = m_vatesSubWindow->windowFlags();
+      flags |= Qt::Tool;
+      flags |= Qt::CustomizeWindowHint;
+      flags |= Qt::WindowMinimizeButtonHint;
+      flags |= Qt::WindowCloseButtonHint;
+      m_vatesSubWindow->setWindowFlags(flags);
+#endif
       QIcon icon;
       icon.addFile(
           QString::fromUtf8(":/VatesSimpleGuiViewWidgets/icons/pvIcon.png"),

--- a/MantidPlot/src/ScriptingWindow.cpp
+++ b/MantidPlot/src/ScriptingWindow.cpp
@@ -69,6 +69,14 @@ ScriptingWindow::ScriptingWindow(ScriptingEnv *env, bool capturePrint,
 
   setWindowIcon(QIcon(":/MantidPlot_Icon_32offset.png"));
   setWindowTitle("MantidPlot: " + env->languageName() + " Window");
+
+#ifdef Q_OS_MAC
+  // Work around to ensure that floating windows remain on top of the main
+  // application window, but below other applications on Mac
+  flags |= Qt::Tool;
+  flags |= Qt::WindowMinMaxButtonsHint;
+  setWindowFlags(flags);
+#endif
 }
 
 /**
@@ -304,6 +312,11 @@ void ScriptingWindow::updateWindowFlags() {
   if (m_alwaysOnTop->isChecked()) {
     flags |= Qt::WindowStaysOnTopHint;
   }
+#ifdef Q_OS_MAC
+  // Work around to ensure that floating windows remain on top of the main
+  // application window, but below other applications on Mac
+  flags |= Qt::Tool;
+#endif
   setWindowFlags(flags);
   // This is necessary due to the setWindowFlags function reparenting the window
   // and causing is

--- a/MantidPlot/src/ScriptingWindow.cpp
+++ b/MantidPlot/src/ScriptingWindow.cpp
@@ -72,9 +72,13 @@ ScriptingWindow::ScriptingWindow(ScriptingEnv *env, bool capturePrint,
 
 #ifdef Q_OS_MAC
   // Work around to ensure that floating windows remain on top of the main
-  // application window, but below other applications on Mac
+  // application window, but below other applications on Mac.
+  // Note: Qt::Tool cannot have both a max and min button on OSX
   flags |= Qt::Tool;
-  flags |= Qt::WindowMinMaxButtonsHint;
+  flags |= Qt::Dialog;
+  flags |= Qt::CustomizeWindowHint;
+  flags |= Qt::WindowMinimizeButtonHint;
+  flags |= Qt::WindowCloseButtonHint;
   setWindowFlags(flags);
 #endif
 }
@@ -314,8 +318,13 @@ void ScriptingWindow::updateWindowFlags() {
   }
 #ifdef Q_OS_MAC
   // Work around to ensure that floating windows remain on top of the main
-  // application window, but below other applications on Mac
+  // application window, but below other applications on Mac.
+  // Note: Qt::Tool cannot have both a max and min button on OSX
   flags |= Qt::Tool;
+  flags |= Qt::CustomizeWindowHint;
+  flags |= Qt::WindowMinimizeButtonHint;
+  flags |= Qt::WindowCloseButtonHint;
+  setWindowFlags(flags);
 #endif
   setWindowFlags(flags);
   // This is necessary due to the setWindowFlags function reparenting the window

--- a/MantidQt/API/src/InterfaceManager.cpp
+++ b/MantidQt/API/src/InterfaceManager.cpp
@@ -79,7 +79,12 @@ AlgorithmDialog *InterfaceManager::createDialog(
 #ifdef Q_OS_MAC
   // Work around to ensure that floating windows remain on top of the main
   // application window, but below other applications on Mac
+  // Note: Qt::Tool cannot have both a max and min button on OSX
+  flags = 0;
   flags |= Qt::Tool;
+  flags |= Qt::CustomizeWindowHint;
+  flags |= Qt::WindowMinimizeButtonHint;
+  flags |= Qt::WindowCloseButtonHint;
 #endif
   dlg->setWindowFlags(flags);
 

--- a/MantidQt/API/src/InterfaceManager.cpp
+++ b/MantidQt/API/src/InterfaceManager.cpp
@@ -76,6 +76,11 @@ AlgorithmDialog *InterfaceManager::createDialog(
   Qt::WindowFlags flags = 0;
   flags |= Qt::Dialog;
   flags |= Qt::WindowContextHelpButtonHint;
+#ifdef Q_OS_MAC
+  // Work around to ensure that floating windows remain on top of the main
+  // application window, but below other applications on Mac
+  flags |= Qt::Tool;
+#endif
   dlg->setWindowFlags(flags);
 
   // Set the content

--- a/MantidQt/SliceViewer/src/SliceViewerWindow.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewerWindow.cpp
@@ -36,11 +36,13 @@ SliceViewerWindow::SliceViewerWindow(const QString &wsName,
 #ifdef Q_OS_MAC
   // Work around to ensure that floating windows remain on top of the main
   // application window, but below other applications on Mac
-  Qt::WindowFlags flags = windowFlags();
-  Qt::WindowFlags new_flags = flags | Qt::Tool;
-  setWindowFlags(new_flags);
+  auto flags = windowFlags();
+  flags |= Qt::Tool;
+  flags |= Qt::CustomizeWindowHint;
+  flags |= Qt::WindowMinimizeButtonHint;
+  flags |= Qt::WindowCloseButtonHint;
+  setWindowFlags(flags);
 #endif
-
   // Set the window icon
   QIcon icon;
   icon.addFile(

--- a/MantidQt/SpectrumViewer/src/SpectrumView.cpp
+++ b/MantidQt/SpectrumViewer/src/SpectrumView.cpp
@@ -47,6 +47,13 @@ SpectrumView::SpectrumView(QWidget *parent)
   observeADSClear();
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
       "Interface", "SpectrumView", false);
+#ifdef Q_OS_MAC
+  // Work around to ensure that floating windows remain on top of the main
+  // application window, but below other applications on Mac
+  Qt::WindowFlags flags = windowFlags();
+  flags |= Qt::Tool;
+  setWindowFlags(flags);
+#endif
 }
 
 SpectrumView::~SpectrumView() {

--- a/MantidQt/SpectrumViewer/src/SpectrumView.cpp
+++ b/MantidQt/SpectrumViewer/src/SpectrumView.cpp
@@ -47,11 +47,16 @@ SpectrumView::SpectrumView(QWidget *parent)
   observeADSClear();
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
       "Interface", "SpectrumView", false);
+
 #ifdef Q_OS_MAC
   // Work around to ensure that floating windows remain on top of the main
   // application window, but below other applications on Mac
-  Qt::WindowFlags flags = windowFlags();
+  // Note: Qt::Tool cannot have both a max and min button on OSX
+  auto flags = windowFlags();
   flags |= Qt::Tool;
+  flags |= Qt::CustomizeWindowHint;
+  flags |= Qt::WindowMinimizeButtonHint;
+  flags |= Qt::WindowCloseButtonHint;
   setWindowFlags(flags);
 #endif
 }

--- a/docs/source/release/v3.8.0/ui.rst
+++ b/docs/source/release/v3.8.0/ui.rst
@@ -71,7 +71,7 @@ Options Window
 
 Bugs Resolved
 -------------
-- Floating windows now always stay on top of the main window in OSX
+- Floating windows now always stay on top of the main window in OSX.
 - The sliceviewer will now rebin an existing binned workspace correctly.
 - 2D plots now display correctly for point data workspaces as well as for histogram data
 - Cuts aligned with an axis no longer generate an empty integrated line plot.


### PR DESCRIPTION
I missed a few interfaces in earlier issues. I believe this makes all interfaces consistent across Mantid. Floating windows in OSX will no always be on top of the main window and will not "disappear" behind the main window. The penalty we pay for this that Qt + OSX cannot have both a minimise and maximise button on the floating windows (despite trying all the flag combinations of flags...), so here we force the window to offer the minimise button.

**To test:**

The following windows should now properly appear as floating in OSX:
- Instrument View
- Spectrum viewer
- Slice viewer
- VSI
- Algorithm Dialogs
- Algorithm History window
- Scripting window

Fixes #17465 .

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
