### PR TITLE
Engg: Fix crash on RB number change and closing interface

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -222,6 +222,9 @@ private:
 
   /// Associated view for this presenter (MVP pattern)
   IEnggDiffFittingView *const m_view;
+
+  /// Holds if the view is in the process of being closed
+  bool m_viewHasClosed;
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -368,6 +368,9 @@ private:
   /// Associated view for this presenter (MVP pattern)
   IEnggDiffractionView *const m_view;
 
+  /// Tracks if the view has started to shut down following a close signal
+  bool m_viewHasClosed;
+
   /// Associated model for this presenter (MVP pattern)
   // const boost::scoped_ptr<EnggDiffractionModel> m_model;
 };

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -43,7 +43,8 @@ EnggDiffFittingPresenter::EnggDiffFittingPresenter(
     boost::shared_ptr<IEnggDiffractionCalibration> mainCalib,
     boost::shared_ptr<IEnggDiffractionParam> mainParam)
     : m_fittingFinishedOK(false), m_workerThread(nullptr),
-      m_mainCalib(mainCalib), m_mainParam(mainParam), m_view(view) {}
+      m_mainCalib(mainCalib), m_mainParam(mainParam), m_view(view),
+      m_viewHasClosed(false) {}
 
 EnggDiffFittingPresenter::~EnggDiffFittingPresenter() { cleanup(); }
 
@@ -68,6 +69,16 @@ void EnggDiffFittingPresenter::cleanup() {
 
 void EnggDiffFittingPresenter::notify(
     IEnggDiffFittingPresenter::Notification notif) {
+
+  // Check the view is valid - QT can send multiple notification
+  // signals in any order at any time. This means that it is possible
+  // to receive a shutdown signal and subsequently an input example
+  // for example. As we can't guarantee the state of the viewer
+  // after calling shutdown instead we shouldn't do anything after
+  if (m_viewHasClosed) {
+    return;
+  }
+
   switch (notif) {
 
   case IEnggDiffFittingPresenter::Start:
@@ -572,6 +583,7 @@ void EnggDiffFittingPresenter::processLoad() {
 }
 
 void EnggDiffFittingPresenter::processShutDown() {
+  m_viewHasClosed = true;
   m_view->saveSettings();
   cleanup();
 }

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -66,12 +66,12 @@ std::string EnggDiffractionPresenter::g_sumOfFilesFocus = "";
 
 EnggDiffractionPresenter::EnggDiffractionPresenter(IEnggDiffractionView *view)
     : m_workerThread(nullptr), m_calibFinishedOK(false),
-      m_focusFinishedOK(false), m_rebinningFinishedOK(false),
-      m_view(view) /*, m_model(new EnggDiffractionModel()), */ {
+      m_focusFinishedOK(false), m_rebinningFinishedOK(false), m_view(view),
+      m_viewHasClosed(false) {
   if (!m_view) {
     throw std::runtime_error(
         "Severe inconsistency found. Presenter created "
-        "with an empty/null view (engineeering diffraction interface). "
+        "with an empty/null view (Engineering diffraction interface). "
         "Cannot continue.");
   }
 }
@@ -99,6 +99,15 @@ void EnggDiffractionPresenter::cleanup() {
 
 void EnggDiffractionPresenter::notify(
     IEnggDiffractionPresenter::Notification notif) {
+
+  // Check the view is valid - QT can send multiple notification
+  // signals in any order at any time. This means that it is possible
+  // to receive a shutdown signal and subsequently an input example
+  // for example. As we can't guarantee the state of the viewer
+  // after calling shutdown instead we shouldn't do anything after
+  if (m_viewHasClosed) {
+    return;
+  }
 
   switch (notif) {
 
@@ -608,6 +617,10 @@ void EnggDiffractionPresenter::processRBNumberChange() {
 }
 
 void EnggDiffractionPresenter::processShutDown() {
+  // Set that the view has closed in case QT attempts to fire another
+  // signal whilst we are shutting down. This stops notify before
+  // it hits the switch statement as the view could be in any state.
+  m_viewHasClosed = true;
   m_view->showStatus("Closing...");
   m_view->saveSettings();
   cleanup();

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -1099,6 +1099,7 @@ void EnggDiffractionViewQtGUI::closeEvent(QCloseEvent *event) {
   if (answer == QMessageBox::AcceptRole && m_ui.pushButton_close->isEnabled()) {
     m_presenter->notify(IEnggDiffractionPresenter::ShutDown);
     delete m_splashMsg;
+	m_splashMsg = nullptr;
     event->accept();
   } else {
     event->ignore();

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -1099,7 +1099,7 @@ void EnggDiffractionViewQtGUI::closeEvent(QCloseEvent *event) {
   if (answer == QMessageBox::AcceptRole && m_ui.pushButton_close->isEnabled()) {
     m_presenter->notify(IEnggDiffractionPresenter::ShutDown);
     delete m_splashMsg;
-	m_splashMsg = nullptr;
+    m_splashMsg = nullptr;
     event->accept();
   } else {
     event->ignore();


### PR DESCRIPTION
Description of work.
This PR fixes an issue where QT would attempt to deference a dangling pointer to the view (MVP pattern) if a notification was fired after processing a shutdown signal. 
The very first thing we now do when the view is being shutdown is set a flag in the presenter telling it that we are in the process of shutting down the view. If QT attempts to fire another notification we just return without performing any actions as we can't guarantee the state after. 

**To test:**
Open the Engineering Diffraction Interface.
Change the RB number at the top of the interface
Immediately close the interface - if it closes without crashing this PR works.

Fixes #17096 and possibly the random crashes when closing the interface described in #17423 .

Does not need to be in the release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
