### PR TITLE
17454 build without ph

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -14,7 +14,11 @@
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidDataHandling/EventWorkspaceCollection.h"
 
+#ifdef _WIN32 // fixing windows issue causing conflict between
+// winnt char and nexus char
 #undef CHAR
+#endif
+
 #include <nexus/NeXusFile.hpp>
 #include <nexus/NeXusException.hpp>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -7,14 +7,17 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/BankPulseTimes.h"
 #include "MantidDataObjects/EventWorkspace.h"
-#include <nexus/NeXusFile.hpp>
-#include <nexus/NeXusException.hpp>
 #include "MantidDataObjects/Events.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidDataHandling/EventWorkspaceCollection.h"
+
+#undef CHAR
+#include <nexus/NeXusFile.hpp>
+#include <nexus/NeXusException.hpp>
+
 #include <memory>
 #include <mutex>
 #include <boost/lexical_cast.hpp>

--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
@@ -1,13 +1,14 @@
 #ifndef MANTID_DATAHANDLING_PROCESSBANKDATA_H
 #define MANTID_DATAHANDLING_PROCESSBANKDATA_H
 
-// Process bank data
-#include "MantidKernel/Task.h"
+
 // #include "MantidAPI/IFileLoader.h"
 #include "MantidGeometry/IDTypes.h"
-#include "MantidDataHandling/BankPulseTimes.h"
-#include "MantidDataHandling/LoadEventNexus.h"
+// Process bank data
+#include "MantidKernel/Task.h"
 #include "MantidKernel/Timer.h"
+#include "MantidDataHandling/LoadEventNexus.h"
+#include "MantidDataHandling/BankPulseTimes.h"
 
 #include <boost/shared_array.hpp>
 
@@ -15,7 +16,6 @@ namespace Mantid {
 namespace DataHandling {
 
 using namespace Mantid;
-
 //==============================================================================================
 // Class ProcessBankData
 //==============================================================================================

--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
@@ -1,7 +1,6 @@
 #ifndef MANTID_DATAHANDLING_PROCESSBANKDATA_H
 #define MANTID_DATAHANDLING_PROCESSBANKDATA_H
 
-
 // #include "MantidAPI/IFileLoader.h"
 #include "MantidGeometry/IDTypes.h"
 // Process bank data

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -1,7 +1,5 @@
 #include "MantidDataHandling/ProcessBankData.h"
 
-//#include "MantidDataObjects/Events.h"
-
 using namespace Mantid::DataObjects;
 
 namespace Mantid {

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -1,6 +1,6 @@
 #include "MantidDataHandling/ProcessBankData.h"
-#include "MantidDataHandling/LoadEventNexus.h"
-#include "MantidDataObjects/Events.h"
+
+//#include "MantidDataObjects/Events.h"
 
 using namespace Mantid::DataObjects;
 

--- a/MantidPlot/src/WindowFactory.h
+++ b/MantidPlot/src/WindowFactory.h
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <map>
 #include <vector>
+#include <iterator>
 
 #ifndef Q_MOC_RUN
 #include <boost/shared_ptr.hpp>


### PR DESCRIPTION
This should enable building Mantid under windows without precompiled headers enabled. 

**To test:**
Test by code review. Changes are trivial. 

You probably need windows, VS2015 SP3 to test it properly, then when building with cmake you should disable precompiled headers. Current mantid build fails before changes but you can trust me -- it works after the changes. 

<!-- Instructions for testing. -->

Fixes #17454.

Internal, no release notes are necessary.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
