### PR TITLE
Fix typo in FindUBUsingFFT

### DIFF
--- a/Framework/Geometry/src/Crystal/IndexingUtils.cpp
+++ b/Framework/Geometry/src/Crystal/IndexingUtils.cpp
@@ -467,7 +467,7 @@ double IndexingUtils::Find_UB(DblMatrix &UB, const std::vector<V3D> &q_vectors,
 
   if (q_vectors.size() < 4) {
     throw std::invalid_argument(
-        "Find_UB(): Three or more indexed peaks needed to find UB");
+        "Find_UB(): Four or more indexed peaks needed to find UB");
   }
 
   if (min_d >= max_d || min_d <= 0) {


### PR DESCRIPTION
Typo stated 3 peaks were required instead of 4.

**To test:**
- Trivial code review. 
- Run FindUBUsingFFT with < 4 peaks if you're keen.

Fixes #17481 .

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
