### PR TITLE
Fix incorrect use of std::move

### DIFF
--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -1219,9 +1219,9 @@ GenericDataProcessorPresenter::getTableList() {
   std::vector<DataProcessorCommand_uptr> workspaces;
 
   // Create a command for each of the workspaces in the ADS
-  for (auto it = m_workspaceList.begin(); it != m_workspaceList.end(); ++it) {
-    workspaces.push_back(std::move(
-        Mantid::Kernel::make_unique<DataProcessorWorkspaceCommand>(this, *it)));
+  for (const auto &name : m_workspaceList) {
+    workspaces.push_back(
+        Mantid::Kernel::make_unique<DataProcessorWorkspaceCommand>(this, name));
   }
   return workspaces;
 }

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -1217,7 +1217,7 @@ std::vector<DataProcessorCommand_uptr>
 GenericDataProcessorPresenter::getTableList() {
 
   std::vector<DataProcessorCommand_uptr> workspaces;
-
+  workspaces.reserve(m_workspaceList.size());
   // Create a command for each of the workspaces in the ADS
   for (const auto &name : m_workspaceList) {
     workspaces.push_back(


### PR DESCRIPTION
Description of work.

This fixes a warning from [recent versions of clang](http://builds.mantidproject.org/job/master_clean-archlinux-clang/131/warnings13Result/new/).

**To test:**

<!-- Instructions for testing. -->

If the builds pass :squirrel:.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
