### PR TITLE
VSI loads slowly due to color presets

### DIFF
--- a/Vates/VatesSimpleGui/ViewWidgets/src/ColorSelectionWidget.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/ColorSelectionWidget.cpp
@@ -81,10 +81,10 @@ void ColorSelectionWidget::loadBuiltinColorPresets() {
   // the destructor of vtkSMTransferFunctionPresets copies these colormaps to
   // the vtkSMSettings singleton.
   vtkNew<vtkSMTransferFunctionPresets> presets;
-  // Check for colormap "Viridis". If preset, assume custom colormaps have
+  // Check for colormap "hot". If preset, assume custom colormaps have
   // already been loaded.
-  auto viridisColormap = presets->GetFirstPresetWithName("Viridis");
-  if (viridisColormap.empty()) {
+  auto colorMapName = presets->GetFirstPresetWithName("hot");
+  if (colorMapName.empty()) {
     const std::string filenames[3] = {"All_slice_viewer_cmaps_for_vsi.json",
                                       "All_idl_cmaps.json",
                                       "All_mpl_cmaps.json"};


### PR DESCRIPTION
VSI loaded slowly due to Viridis moving from a custom preset to a default between preview versions. This is also consistent with `MdPlottingCmapsProvider.cpp`

**To test:**
Easiest way is to debug and check that when loading the colormap name os not empty and VSI does not load all custom colormaps.

Fixes #17488 .

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
