### PR TITLE
EnggCalibrate can now handle both banks at the same time

### DIFF
--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -10,7 +10,6 @@ ENGINX_BANKS = ['', 'North', 'South', 'Both: North, South', '1', '2']
 ENGINX_MASK_BIN_MINS = [0, 19930, 39960, 59850, 79930]
 ENGINX_MASK_BIN_MAXS = [5300, 20400, 40450, 62000, 82670]
 
-print("EnggUtils running")
 
 def default_ceria_expected_peaks():
 
@@ -29,7 +28,6 @@ def default_ceria_expected_peaks():
                              0.637740216, 0.624855346, 0.620730846, 0.605013529
                             ]
 
-    print("EnggUtils running")
     return _CERIA_EXPECTED_PEAKS
 
 def read_in_expected_peaks(filename, expectedGiven):

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -10,9 +10,7 @@ ENGINX_BANKS = ['', 'North', 'South', 'Both: North, South', '1', '2']
 ENGINX_MASK_BIN_MINS = [0, 19930, 39960, 59850, 79930]
 ENGINX_MASK_BIN_MAXS = [5300, 20400, 40450, 62000, 82670]
 
-
 def default_ceria_expected_peaks():
-
     """
     Get the list of expected Ceria peaks, which can be a good default for the expected peaks
     properties of algorithms like EnggCalibrate and EnggCalibrateFull
@@ -97,10 +95,8 @@ def getWsIndicesFromInProperties(ws, bank, detIndices):
                          "'DetectorIndices', as they overlap. Please use either of them. Got Bank: '%s', "
                          "and DetectorIndices: '%s'"%(bank, detIndices))
     elif bank:
-        # Handle banks as a list, we have bank 1, 2, or both [1, 2]
-        bankAliases = {'North': [1], 'South': [2], 'Both: North, South': [1, 2]}
-        # if not found in dictionary convert input to int list as well
-        bank = bankAliases.get(bank, [int(bank)])
+        bankAliases = {'North': '1', 'South': '2', 'Both: North, South': '-1'}
+        bank = bankAliases.get(bank, bank)
         indices = getWsIndicesForBank(ws, bank)
         if not indices:
             raise RuntimeError("Unable to find a meaningful list of workspace indices for the "
@@ -191,8 +187,16 @@ def getDetIDsForBank(bank):
 
     detIDs = set()
 
+    bank_int = int(bank)
+    if(bank_int < 0):
+        # both banks, north and south
+        bank_int = [1, 2]
+    else:
+        # make into list so that the `if in` check works
+        bank_int = [bank_int]
+
     for i in range(grouping.getNumberHistograms()):
-        if grouping.readY(i)[0] in bank:
+        if grouping.readY(i)[0] in bank_int:
             detIDs.add(grouping.getDetector(i).getID())
 
     sapi.DeleteWorkspace(grouping)

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -188,8 +188,8 @@ def getDetIDsForBank(bank):
     detIDs = set()
 
    
-	# less then zero indicates both banks, from line 98
-	bank_int = int(bank)
+    # less then zero indicates both banks, from line 98
+    bank_int = int(bank)
     if(bank_int < 0):
         # both banks, north and south
         bank_int = [1, 2]

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -10,7 +10,10 @@ ENGINX_BANKS = ['', 'North', 'South', 'Both: North, South', '1', '2']
 ENGINX_MASK_BIN_MINS = [0, 19930, 39960, 59850, 79930]
 ENGINX_MASK_BIN_MAXS = [5300, 20400, 40450, 62000, 82670]
 
+print("EnggUtils running")
+
 def default_ceria_expected_peaks():
+
     """
     Get the list of expected Ceria peaks, which can be a good default for the expected peaks
     properties of algorithms like EnggCalibrate and EnggCalibrateFull
@@ -26,6 +29,7 @@ def default_ceria_expected_peaks():
                              0.637740216, 0.624855346, 0.620730846, 0.605013529
                             ]
 
+    print("EnggUtils running")
     return _CERIA_EXPECTED_PEAKS
 
 def read_in_expected_peaks(filename, expectedGiven):
@@ -95,8 +99,10 @@ def getWsIndicesFromInProperties(ws, bank, detIndices):
                          "'DetectorIndices', as they overlap. Please use either of them. Got Bank: '%s', "
                          "and DetectorIndices: '%s'"%(bank, detIndices))
     elif bank:
-        bankAliases = {'North': '1', 'South': '2', 'Both: North, South': '-1'}
-        bank = bankAliases.get(bank, bank)
+        # Handle banks as a list, we have bank 1, 2, or both [1, 2]
+        bankAliases = {'North': [1], 'South': [2], 'Both: North, South': [1, 2]}
+        # if not found in dictionary convert input to int list as well
+        bank = bankAliases.get(bank, [int(bank)])
         indices = getWsIndicesForBank(ws, bank)
         if not indices:
             raise RuntimeError("Unable to find a meaningful list of workspace indices for the "
@@ -187,9 +193,8 @@ def getDetIDsForBank(bank):
 
     detIDs = set()
 
-    bank_int = int(bank)
     for i in range(grouping.getNumberHistograms()):
-        if bank_int < 0 or grouping.readY(i)[0] == bank_int:
+        if grouping.readY(i)[0] in bank:
             detIDs.add(grouping.getDetector(i).getID())
 
     sapi.DeleteWorkspace(grouping)

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -187,7 +187,9 @@ def getDetIDsForBank(bank):
 
     detIDs = set()
 
-    bank_int = int(bank)
+   
+	# less then zero indicates both banks, from line 98
+	bank_int = int(bank)
     if(bank_int < 0):
         # both banks, north and south
         bank_int = [1, 2]


### PR DESCRIPTION
## Description of work.

`EnggUtils` can now handle the `Both: North, South` string properly when used from other algorithms (`EnggCalibrate`, etc), meaning the `Both: North, South` can now be used correctly and will not fail anymore.

**To test:**
- Load ENGINX Workspace and Vanadium workspace
- Compute corrections with `EnggVanadiumCorrections`
- Run `EnggCalibrate` using corrections

<!-- Instructions for testing. -->

Fixes #17377 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
-->

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
