### PR TITLE
Use unique temporary file in unit test helpers

### DIFF
--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -1,16 +1,19 @@
 #ifndef MANTID_DATAHANDLINGTEST_NXCANSASTESTHELPER_H
 #define MANTID_DATAHANDLINGTEST_NXCANSASTESTHELPER_H
 
+#include "MantidAPI/MatrixWorkspace_fwd.h"
+#include <Poco/TemporaryFile.h>
 #include <string>
 #include <vector>
-#include "MantidAPI/MatrixWorkspace_fwd.h"
 
 namespace NXcanSASTestHelper {
 struct NXcanSASTestParameters {
   NXcanSASTestParameters() { initParameters(); }
 
   void initParameters() {
-    filename = "SaveNXcanSASTestFile.h5";
+    Poco::TemporaryFile tmpFile;
+    tmpFile.keep();
+    filename = tmpFile.path();
     size = 10;
     value = 10.23;
     error = 3.45;


### PR DESCRIPTION
The NXcanSAS unit tests, both loading & saving, were using the same filenames. This caused a race condition when running the load/save tests in parallel through ctest and has been the cause of the recent instability in builds involving `SaveNXcanSASTest` & `SaveNXcanSASTest`

**To test:**

Code review and all tests should pass

_No issue number_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
