### PR TITLE
Contour Labels in Color Fill Plot should now appear at the correct place

### DIFF
--- a/MantidPlot/src/PlotCurve.cpp
+++ b/MantidPlot/src/PlotCurve.cpp
@@ -26,6 +26,7 @@
  *   Boston, MA  02110-1301  USA                                           *
  *                                                                         *
  ***************************************************************************/
+#include "PlotCurve.h"
 #include "Graph.h"
 #include "Grid.h"
 #include "Mantid/ErrorBarSettings.h"
@@ -35,7 +36,6 @@
 #include "MantidQtAPI/QwtWorkspaceSpectrumData.h"
 #include "MantidQtAPI/ScaleEngine.h"
 #include "PatternBox.h"
-#include "PlotCurve.h"
 #include "ScaleDraw.h"
 #include "SymbolBox.h"
 #include <QDateTime>
@@ -1043,10 +1043,10 @@ PlotMarker::PlotMarker(int index, double angle)
 void PlotMarker::draw(QPainter *p, const QwtScaleMap &xMap,
                       const QwtScaleMap &yMap, const QRect &) const {
   p->save();
+  int x = xMap.transform(xValue());
+  int y = yMap.transform(yValue());
 
-  xMap.transform(xValue());
-  yMap.transform(yValue());
-
+  p->translate(x, y);
   p->rotate(-d_angle);
 
   QwtText text = label();


### PR DESCRIPTION
## Description of work.

The Contour Labels were always being added to the top left corner, this is now fixed and they should appear at the correct values/places.

**To test:**

You could follow this introduction course:
http://www.mantidproject.org/MBC_Displaying_data_2D

Test that the output results are the same as the training course ones.

<!-- Instructions for testing. -->

Fixes #17497 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
-->

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
