### PR TITLE
Reduce memory consumption of Histogram performance test.

### DIFF
--- a/Framework/HistogramData/test/HistogramTest.h
+++ b/Framework/HistogramData/test/HistogramTest.h
@@ -964,42 +964,34 @@ public:
   }
   static void destroySuite(HistogramTestPerformance *suite) { delete suite; }
 
-  HistogramTestPerformance() : copy(histSize, LinearGenerator(0, 2)) {
-    for (size_t i = 0; i < nHists; i++)
-      hists.push_back(Histogram(BinEdges(histSize, LinearGenerator(0, 1))));
-
+  HistogramTestPerformance() : xData(histSize, LinearGenerator(0, 2)) {
     BinEdges edges(histSize, LinearGenerator(0, 2));
-
     for (size_t i = 0; i < nHists; i++)
-      hists2.push_back(Histogram(edges));
-
-    // hists is stored to avoid benchmarking deallocation
-    histsCopy = hists;
+      hists.push_back(Histogram(edges));
   }
 
   void test_copy_X() {
     for (auto &i : hists)
-      i.mutableX() = copy;
+      i.mutableX() = xData;
   }
 
   void test_share_X_with_deallocation() {
-    hists[0].mutableX() = copy;
+    auto x = Mantid::Kernel::make_cow<HistogramX>(xData);
     for (auto &i : hists)
-      i.setSharedX(hists[0].sharedX());
+      i.setSharedX(x);
   }
 
   void test_share_X() {
-    for (auto &i : hists2)
-      i.setSharedX(hists[0].sharedX());
+    auto x = Mantid::Kernel::make_cow<HistogramX>(xData);
+    for (auto &i : hists)
+      i.setSharedX(x);
   }
 
 private:
   const size_t nHists = 100000;
-  const size_t histSize = 10000;
+  const size_t histSize = 4000;
   std::vector<Histogram> hists;
-  std::vector<Histogram> hists2;
-  std::vector<Histogram> histsCopy;
-  HistogramX copy;
+  HistogramX xData;
 };
 
 #endif /* MANTID_HISTOGRAMDATA_HISTOGRAMTEST_H_ */


### PR DESCRIPTION
See https://github.com/mantidproject/mantid/pull/17121#issuecomment-247519671.
`master_performancetests` has been failing since that PR has been merged, this should fix the issue (too much memory).

**To test:**

Code review, no issue, no release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Probably this also fixes an issue with one of the tests: test_share_X
would previously test self-assignment, which was probably faster than
actually setting a new X pointer.
