### PR TITLE
Reduce memory consumption in Histogram performance test by another 2x

### DIFF
--- a/Framework/HistogramData/test/HistogramTest.h
+++ b/Framework/HistogramData/test/HistogramTest.h
@@ -988,7 +988,7 @@ public:
   }
 
 private:
-  const size_t nHists = 100000;
+  const size_t nHists = 50000;
   const size_t histSize = 4000;
   std::vector<Histogram> hists;
   HistogramX xData;


### PR DESCRIPTION
See https://github.com/mantidproject/mantid/pull/17514. The performance test build server has 3.6 GB RAM. Previously we got very close to this and the test ran extremely slow. Reducing this by 2x should bring the memory consumption below 2 GB.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
