### PR TITLE
IndirectBayes - Quasi - Update progress bar

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -271,21 +271,21 @@ class BayesQuasi(PythonAlgorithm):
             reals = [efix, theta[m], rscl, bnorm]
 
             if prog == 'QLr':
-                workflow_prog.report('Processing Sample number %i as Lorentzian' % nsam)
+                workflow_prog.report('Processing Sample number %i as Lorentzian' % m)
                 nd,xout,yout,eout,yfit,yprob=QLr.qlres(numb,Xv,Yv,Ev,reals,fitOp,
                                                        Xdat,Xb,Yb,Wy,We,dtn,xsc,
                                                        wrks,wrkr,lwrk)
                 message = ' Log(prob) : '+str(yprob[0])+' '+str(yprob[1])+' '+str(yprob[2])+' '+str(yprob[3])
                 logger.information(message)
             if prog == 'QLd':
-                workflow_prog.report('Processing Sample number %i' % nsam)
+                workflow_prog.report('Processing Sample number %i' % m)
                 nd,xout,yout,eout,yfit,yprob=QLd.qldata(numb,Xv,Yv,Ev,reals,fitOp,
                                                         Xdat,Xb,Yb,Eb,Wy,We,
                                                         wrks,wrkr,lwrk)
                 message = ' Log(prob) : '+str(yprob[0])+' '+str(yprob[1])+' '+str(yprob[2])+' '+str(yprob[3])
                 logger.information(message)
             if prog == 'QSe':
-                workflow_prog.report('Processing Sample number %i as Stretched Exp' % nsam)
+                workflow_prog.report('Processing Sample number %i as Stretched Exp' % m)
                 nd,xout,yout,eout,yfit,yprob=Qse.qlstexp(numb,Xv,Yv,Ev,reals,fitOp,\
                                                         Xdat,Xb,Yb,Wy,We,dtn,xsc,\
                                                         wrks,wrkr,lwrk)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -253,39 +253,39 @@ class BayesQuasi(PythonAlgorithm):
 
         group = ''
         workflow_prog = Progress(self, start=0.3, end=0.7, nreports=nsam*3)
-        for m in range(0,nsam):
-            logger.information('Group ' +str(m)+ ' at angle '+ str(theta[m]))
-            nsp = m+1
+        for spectrum in range(0,nsam):
+            logger.information('Group ' +str(spectrum)+ ' at angle '+ str(theta[spectrum]))
+            nsp = spectrum+1
 
-            nout,bnorm,Xdat,Xv,Yv,Ev = CalcErange(self._samWS,m,erange,nbin)
+            nout,bnorm,Xdat,Xv,Yv,Ev = CalcErange(self._samWS,spectrum,erange,nbin)
             Ndat = nout[0]
             Imin = nout[1]
             Imax = nout[2]
             if prog == 'QLd':
-                mm = m
+                mm = spectrum
             else:
                 mm = 0
             Nb,Xb,Yb,Eb = GetXYE(self._resWS,mm,array_len)     # get resolution data
             numb = [nsam, nsp, ntc, Ndat, nbin, Imin, Imax, Nb, nrbin]
             rscl = 1.0
-            reals = [efix, theta[m], rscl, bnorm]
+            reals = [efix, theta[spectrum], rscl, bnorm]
 
             if prog == 'QLr':
-                workflow_prog.report('Processing Sample number %i as Lorentzian' % m)
+                workflow_prog.report('Processing Sample number %i as Lorentzian' % spectrum)
                 nd,xout,yout,eout,yfit,yprob=QLr.qlres(numb,Xv,Yv,Ev,reals,fitOp,
                                                        Xdat,Xb,Yb,Wy,We,dtn,xsc,
                                                        wrks,wrkr,lwrk)
                 message = ' Log(prob) : '+str(yprob[0])+' '+str(yprob[1])+' '+str(yprob[2])+' '+str(yprob[3])
                 logger.information(message)
             if prog == 'QLd':
-                workflow_prog.report('Processing Sample number %i' % m)
+                workflow_prog.report('Processing Sample number %i' % spectrum)
                 nd,xout,yout,eout,yfit,yprob=QLd.qldata(numb,Xv,Yv,Ev,reals,fitOp,
                                                         Xdat,Xb,Yb,Eb,Wy,We,
                                                         wrks,wrkr,lwrk)
                 message = ' Log(prob) : '+str(yprob[0])+' '+str(yprob[1])+' '+str(yprob[2])+' '+str(yprob[3])
                 logger.information(message)
             if prog == 'QSe':
-                workflow_prog.report('Processing Sample number %i as Stretched Exp' % m)
+                workflow_prog.report('Processing Sample number %i as Stretched Exp' % spectrum)
                 nd,xout,yout,eout,yfit,yprob=Qse.qlstexp(numb,Xv,Yv,Ev,reals,fitOp,\
                                                         Xdat,Xb,Yb,Wy,We,dtn,xsc,\
                                                         wrks,wrkr,lwrk)
@@ -328,7 +328,7 @@ class BayesQuasi(PythonAlgorithm):
 
             # create result workspace
             fitWS = fname+'_Workspaces'
-            fout = fname+'_Workspace_'+ str(m)
+            fout = fname+'_Workspace_'+ str(spectrum)
 
             workflow_prog.report('Creating OutputWorkspace')
             s_api.CreateWorkspace(OutputWorkspace=fout, DataX=datX, DataY=datY, DataE=datE,

--- a/docs/source/release/v3.8.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.8.0/indirect_inelastic.rst
@@ -105,5 +105,6 @@ Bugfixes
 * The *ResNorm* interface should no longer crash when using workspaces (rather than files) as input.
 * Fix bug showing incorrect doublet peaks in :ref:`ISISIndirectDiffractionReduction <algm-ISISIndirectDiffractionReduction>`
 * Fix end of line issue when loading ascii files in *LoadILL* interface
+* *BayesQuasi* now displays correct spectrum number in progress bar
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.8%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
The progress bar now correctly shows the individual spectrum number instead of the total number of spectra.

**To test:**

In python interface:

```
sampleWs = Load('irs26176_graphite002_red.nxs')
resWs = Load('irs26173_graphite002_red.nxs')

fit_ws, result_ws, prob_ws = BayesQuasi(Program='QL', SampleWorkspace=sampleWs, ResolutionWorkspace=resWs,
                                        MinRange=-0.547607, MaxRange=0.543216, SampleBins=1, ResolutionBins=1,
                                        Elastic=False, Background='Sloping', FixedWidth=False, UseResNorm=False,
                                        WidthFile='', Loop=True)
```

Progress bar should show spectrum numbers 0 through 10.

Fixes #17261.

[Release Notes](https://github.com/mantidproject/mantid/blob/90f6a39a7b63ebf76621be8b3d6d0c14a08960d5/docs/source/release/v3.8.0/indirect_inelastic.rst)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
