### PR TITLE
Fix clang-tidy warnings that recently appeared in master.

### DIFF
--- a/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp
@@ -783,7 +783,7 @@ void FABADAMinimizer::TieApplication(const size_t &ParameterIndex,
   }
   // After all the other variables, the current one is updated to the ties
   API::ParameterTie *tie = m_FitFunction->getTie(i);
-  if (tie != 0) {
+  if (tie) {
     new_value = tie->eval();
     if (boost::math::isnan(new_value)) { // maybe not needed
       throw std::runtime_error("Parameter value is NaN.");
@@ -1020,13 +1020,9 @@ bool FABADAMinimizer::IterationContinuation() {
                    "(MaxIterations property).");
     }
   } else {
-    // If convergence has been reached, continue until complete the chain
-    // length.
-    if (m_counter < m_ChainIterations) {
-      return true;
-    }
-    // nothing else to do, stop interations
-    return false;
+    // If convergence has been reached, continue until we complete the chain
+    // length. Otherwise, stop interations.
+    return m_counter < m_ChainIterations;
   }
   // can we even get here? -> Nope (we should not, so we do not want it to
   // continue)

--- a/Framework/DataHandling/src/MaskDetectors.cpp
+++ b/Framework/DataHandling/src/MaskDetectors.cpp
@@ -424,8 +424,8 @@ void MaskDetectors::fillIndexListFromSpectra(
   }
 
   auto SpecID2IndMap = WS->getSpectrumToWorkspaceIndexMap();
-  for (auto it = spectraList.begin(); it != spectraList.end(); it++) {
-    auto element = SpecID2IndMap.find(*it);
+  for (auto specnum : spectraList) {
+    auto element = SpecID2IndMap.find(specnum);
     if (element == SpecID2IndMap.end()) {
       continue;
     }


### PR DESCRIPTION
Description of work.

This fixes three clang-tidy warnings that [appeared on 9/16](http://builds.mantidproject.org/view/Static%20Analysis/job/clang-tidy_fixed/). 

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request.
_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
