### PR TITLE
Only restrict TOF range for TOPAZ in SCD Interface

### DIFF
--- a/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
@@ -155,7 +155,8 @@ bool MantidEVWorker::loadAndConvertToMD(
     if (load_data) {
       bool topaz = false;
       // Limits and filtering only done for topaz
-      if (file_name.find("TOPAZ") != std::string::npos) topaz = true;
+      if (file_name.find("TOPAZ") != std::string::npos)
+        topaz = true;
       IAlgorithm_sptr alg = AlgorithmManager::Instance().create("Load");
       alg->setProperty("Filename", file_name);
       alg->setProperty("OutputWorkspace", ev_ws_name);

--- a/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
@@ -153,23 +153,30 @@ bool MantidEVWorker::loadAndConvertToMD(
   try {
     IAlgorithm_sptr alg;
     if (load_data) {
+      bool topaz = false;
+      // Limits and filtering only done for topaz
+      if (file_name.find("TOPAZ") != std::string::npos) topaz = true;
       IAlgorithm_sptr alg = AlgorithmManager::Instance().create("Load");
       alg->setProperty("Filename", file_name);
       alg->setProperty("OutputWorkspace", ev_ws_name);
-      alg->setProperty("FilterByTofMin", 1000.0);
-      alg->setProperty("FilterByTofMax", 16666.0);
+      if (topaz) {
+        alg->setProperty("FilterByTofMin", 1000.0);
+        alg->setProperty("FilterByTofMax", 16666.0);
+      }
       alg->setProperty("LoadMonitors", true);
 
       if (!alg->execute())
         return false;
 
-      alg = AlgorithmManager::Instance().create("FilterBadPulses");
-      alg->setProperty("InputWorkspace", ev_ws_name);
-      alg->setProperty("OutputWorkspace", ev_ws_name);
-      alg->setProperty("LowerCutoff", 25.0);
+      if (topaz) {
+        alg = AlgorithmManager::Instance().create("FilterBadPulses");
+        alg->setProperty("InputWorkspace", ev_ws_name);
+        alg->setProperty("OutputWorkspace", ev_ws_name);
+        alg->setProperty("LowerCutoff", 25.0);
 
-      if (!alg->execute())
-        return false;
+        if (!alg->execute())
+          return false;
+      }
 
       if (load_det_cal) {
         alg = AlgorithmManager::Instance().create("LoadIsawDetCal");


### PR DESCRIPTION
Description of work.
TOF range should be fixed for TOPAZ to prevent TOF=0 events.  Instrument scientist says users should not have to specify range so interface will be simple as possible.  MANDI does not want TOF range limits or filter for pulses.

**To test:**

<!-- Instructions for testing. -->

Load TOPAZ file with first tab of SCD Event Data Reduction Interface.  Show instrument and check that TOF range is approximately 1000 to 16666.  Also check log that FilterBadPulses ran after Load.  Next load MANDI or other SNS event file.  Check that TOF range is larger than 16666 and FilterBadPulses did not run.

Fixes #17524 

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
