### PR TITLE
Disable log file flushing by default

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -641,7 +641,11 @@ void ConfigServiceImpl::createUserPropertiesFile() const {
         << "## Valid values are: error, warning, notice, information, debug\n";
     filestr << "#logging.channels.fileFilterChannel.level=debug\n\n";
     filestr << "## Sets the file to write logs to\n";
-    filestr << "#logging.channels.fileChannel.path=../mantid.log\n\n";
+    filestr << "#logging.channels.fileChannel.path=../mantid.log\n";
+    filestr << "## Uncomment the following line to flush log messages to disk "
+               "immediately.\n";
+    filestr << "## Useful for debugging crashes but it will hurt performance\n";
+    filestr << "#logging.channels.fileChannel.flush = true\n\n";
     filestr << "##\n";
     filestr << "## MantidPlot\n";
     filestr << "##\n\n";

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -691,7 +691,7 @@ public:
 
     std::vector<std::string> keys = ConfigService::Instance().keys();
 
-    TS_ASSERT_EQUALS(keys.size(), 17);
+    TS_ASSERT_EQUALS(keys.size(), 18);
   }
 
   void testRemovingProperty() {

--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -186,6 +186,8 @@ logging.channels.fileFilterChannel.level= information
 logging.channels.fileChannel.class = FileChannel
 # Blank entry uses default path of HOME/.mantid/mantid.log on Linux/OSX and %APPDATA%\\mantidproject\\mantid
 logging.channels.fileChannel.path =
+# Do not flush file buffers for each newline
+logging.channels.fileChannel.flush = false
 logging.channels.fileChannel.rotation = 1 M
 logging.channels.fileChannel.purgeCount = 9
 logging.channels.fileChannel.formatter.class = PatternFormatter

--- a/Framework/Properties/MantidTest.properties
+++ b/Framework/Properties/MantidTest.properties
@@ -10,6 +10,7 @@ logging.channels.filterChannel.channel = fileChannel
 logging.channels.filterChannel.level = warning
 logging.channels.fileChannel.class = FileChannel
 logging.channels.fileChannel.path = KernelTest.log
+logging.channels.fileChannel.flush = false
 logging.channels.fileChannel.formatter.class = PatternFormatter
 logging.channels.fileChannel.formatter.pattern = %Y-%m-%d %H:%M:%S,%i [%I] %p %s - %t
 

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -15,7 +15,7 @@ Framework Changes
 
 - A race condition when accessing a singleton from multiple threads was fixed.
 
-- Log file buffers are no longer flushed by default for each newline received, increasing the speed of some system tests on Windows by 3x. 
+- Log file buffers are no longer flushed by default for each newline received, increasing the speed of some system tests on Windows by 4.5x.
 
 HistogramData
 -------------

--- a/docs/source/release/v3.8.0/framework.rst
+++ b/docs/source/release/v3.8.0/framework.rst
@@ -13,7 +13,9 @@ Framework Changes
   is almost identical, but a small number of cases (such as adding the workspaces ``Z`` and ``z``) will work
   in a more predictable manner.
 
-- A race condition when accessing a singleton from multiple threads was fixed. 
+- A race condition when accessing a singleton from multiple threads was fixed.
+
+- Log file buffers are no longer flushed by default for each newline received, increasing the speed of some system tests on Windows by 3x. 
 
 HistogramData
 -------------


### PR DESCRIPTION
The Poco `FileChannel` requests that `LogFile` buffers are flushed on receipt of each newline character. These changes set the `.flush` property to `false` to leave this decision up to the OS.

**To test:**

See instructions in the issue to reproduce the issue.

Fixes #17513

[Release notes updated](https://github.com/mantidproject/mantid/commit/6d1bc6fe16453aea8c02708600acc2a64f9b14c2)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
