### PR TITLE
ColorFillPlot contour labels should now always show upon showing contour lines

### DIFF
--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -62,7 +62,10 @@ Spectrogram::Spectrogram(const QString &wsName,
                          const Mantid::API::IMDWorkspace_const_sptr &workspace)
     : QObject(), QwtPlotSpectrogram(), d_matrix(NULL), d_funct(NULL),
       d_wsData(NULL), d_wsName(), color_axis(QwtPlot::yRight),
-      color_map_policy(Default), mColorMap(), d_color_map_autoscale(true) {
+      color_map_policy(Default), d_show_labels(true), d_white_out_labels(true),
+      d_labels_x_offset(0), d_labels_y_offset(0),
+      d_labels_align(Qt::AlignHCenter), mColorMap(),
+      d_color_map_autoscale(true) {
   d_wsData = dataFromWorkspace(workspace);
   setData(*d_wsData);
   d_wsName = wsName.toStdString();
@@ -73,7 +76,6 @@ Spectrogram::Spectrogram(const QString &wsName,
   for (double level = data().range().minValue() + step;
        level < data().range().maxValue(); level += step)
     contourLevels += level;
-
   setContourLevels(contourLevels);
 
   observePostDelete();


### PR DESCRIPTION
## Description of work.

The label values were initialised using the GUI values, which would sometimes hold the wrong value, leading to the labels not being shown. This was fixed by giving the labels default values in the Spectrogram constructor.
## To test:

Follow the steps in the training guide here:
http://www.mantidproject.org/MBC_Displaying_data_2D
When the contour lines are selected the option under labels is enabled
Press apply
The labels will _should_ appear

<!-- Instructions for testing. -->

Fixes #17523.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
-->

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
