### PR TITLE
Fix log axes on plots in MuonAnalysis

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
@@ -178,7 +178,8 @@ private slots:
   void settingsTabUpdatePlot();
 
   /// Update the plot based on changes on the grouping options tab
-  void groupTabUpdatePlot();
+  void groupTabUpdatePlotGroup();
+  void groupTabUpdatePlotPair();
 
   /// Sets plot type combo box on the Home tab to the same value as the one
   /// under Group Table
@@ -534,6 +535,9 @@ private:
 
   /// Get period number string in subtracted set
   std::string getSubtractedPeriods() const;
+
+  /// Run "Plot" button from group or pair table
+  void runTablePlotButton(ItemType itemType);
 
   /// Cached value of config setting
   std::string m_cachedPeakRadius;

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1883,6 +1883,8 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   s << "    layer.setCurveLineColor(i, color)";
   s << "  if log_scale:";
   s << "    layer.logYlinX()";
+  s << "  else:";
+  s << "    layer.linearAxes()";
   s << "  if y_auto:";
   s << "    layer.setAutoScale()";
   s << "  else:";

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -752,27 +752,6 @@ void MuonAnalysis::runLoadGroupButton() {
 void MuonAnalysis::runClearGroupingButton() { clearTablesAndCombo(); }
 
 /**
- * Group table plot button (slot)
- */
-void MuonAnalysis::runGroupTablePlotButton() {
-  if (m_updating)
-    return;
-
-  if (m_deadTimesChanged) {
-    inputFileChanged(m_previousFilenames);
-    return;
-  }
-
-  int groupNumber = getGroupNumberFromRow(m_groupTableRowInFocus);
-  if (groupNumber != -1) {
-    setGroupOrPairAndReplot(groupNumber);
-    // Update the combo box on the home tab
-    m_uiForm.frontPlotFuncs->setCurrentIndex(
-        m_uiForm.groupTablePlotChoice->currentIndex());
-  }
-}
-
-/**
  * Load current (slot)
  */
 void MuonAnalysis::runLoadCurrent() {
@@ -838,22 +817,55 @@ void MuonAnalysis::runLoadCurrent() {
 }
 
 /**
+ * Group table plot button (slot)
+ */
+void MuonAnalysis::runGroupTablePlotButton() {
+  runTablePlotButton(ItemType::Group);
+}
+
+/**
  * Pair table plot button (slot)
  */
 void MuonAnalysis::runPairTablePlotButton() {
-  if (m_updating)
+  runTablePlotButton(ItemType::Pair);
+}
+
+/**
+ * Called when one of the "Plot" buttons on the "Grouping Options" tab is
+ * pressed
+ * Update front tab and plot
+ * @param itemType :: [input] Group or pair
+ */
+void MuonAnalysis::runTablePlotButton(MuonAnalysis::ItemType itemType) {
+  if (m_updating) {
     return;
+  }
 
   if (m_deadTimesChanged) {
     inputFileChanged(m_previousFilenames);
     return;
   }
 
-  if (getPairNumberFromRow(m_pairTableRowInFocus) != -1) {
-    setGroupOrPairAndReplot(numGroups() + m_pairTableRowInFocus);
-    // Sync with selectors on the front
-    m_uiForm.frontPlotFuncs->setCurrentIndex(
-        m_uiForm.pairTablePlotChoice->currentIndex());
+  int plotChoiceIndex(-1), groupPairNumber(-1);
+  switch (itemType) {
+  case MantidQt::CustomInterfaces::MuonAnalysis::Pair:
+    plotChoiceIndex = m_uiForm.pairTablePlotChoice->currentIndex();
+    if (getPairNumberFromRow(m_pairTableRowInFocus) != -1) {
+      groupPairNumber = numGroups() + m_pairTableRowInFocus;
+    }
+    break;
+  case MantidQt::CustomInterfaces::MuonAnalysis::Group:
+  default:
+    plotChoiceIndex = m_uiForm.groupTablePlotChoice->currentIndex();
+    groupPairNumber = getGroupNumberFromRow(m_groupTableRowInFocus);
+    break;
+  }
+
+  if (groupPairNumber != -1 && plotChoiceIndex != -1) {
+    // Synchronise with selectors on the front
+    m_uiForm.frontGroupGroupPairComboBox->setCurrentIndex(groupPairNumber);
+    m_uiForm.frontPlotFuncs->setCurrentIndex(plotChoiceIndex);
+    runFrontPlotButton();
   }
 }
 
@@ -1602,7 +1614,7 @@ void MuonAnalysis::guessAlphaClicked() {
   m_updating = false;
 
   // See if auto-update is on and if so update the plot
-  groupTabUpdatePlot();
+  groupTabUpdatePlotPair();
 }
 
 /**
@@ -1630,15 +1642,18 @@ int MuonAnalysis::numPairs() {
  * now is
  */
 void MuonAnalysis::updateFront() {
-  // get current index
-  int index = getGroupOrPairToPlot();
+  // get current group/pair index
+  const int gpIndex = getGroupOrPairToPlot();
+
+  // Cache current selection of plot type
+  const int plotType = m_uiForm.frontPlotFuncs->currentIndex();
 
   m_uiForm.frontPlotFuncs->clear();
 
   int numG = numGroups();
 
-  if (index >= 0 && numG) {
-    if (index >= numG && numG >= 2) {
+  if (gpIndex >= 0 && numG) {
+    if (gpIndex >= numG && numG >= 2) {
       // i.e. index points to a pair
       m_uiForm.frontPlotFuncs->addItems(m_pairPlotFunc);
 
@@ -1646,7 +1661,7 @@ void MuonAnalysis::updateFront() {
       m_uiForm.frontAlphaNumber->setVisible(true);
 
       m_uiForm.frontAlphaNumber->setText(
-          m_uiForm.pairTable->item(m_pairToRow[index - numG], 3)->text());
+          m_uiForm.pairTable->item(m_pairToRow[gpIndex - numG], 3)->text());
 
       m_uiForm.frontAlphaNumber->setCursorPosition(0);
     } else {
@@ -1655,6 +1670,10 @@ void MuonAnalysis::updateFront() {
 
       m_uiForm.frontAlphaLabel->setVisible(false);
       m_uiForm.frontAlphaNumber->setVisible(false);
+    }
+    // Replace cached value
+    if (plotType != -1 && plotType < m_uiForm.frontPlotFuncs->count()) {
+      m_uiForm.frontPlotFuncs->setCurrentIndex(plotType);
     }
   }
 }
@@ -2568,9 +2587,9 @@ void MuonAnalysis::connectAutoUpdate() {
 
   // Grouping tab Auto Updates
   connect(m_uiForm.groupTablePlotChoice, SIGNAL(activated(int)), this,
-          SLOT(groupTabUpdatePlot()));
+          SLOT(groupTabUpdatePlotGroup()));
   connect(m_uiForm.pairTablePlotChoice, SIGNAL(activated(int)), this,
-          SLOT(groupTabUpdatePlot()));
+          SLOT(groupTabUpdatePlotPair()));
 
   // Settings tab Auto Updates
   connect(m_optionTab, SIGNAL(settingsTabUpdatePlot()), this,
@@ -2675,10 +2694,30 @@ void MuonAnalysis::homeTabUpdatePlot() {
     runFrontPlotButton();
 }
 
-void MuonAnalysis::groupTabUpdatePlot() {
+/**
+ * Update plot based on changes made in "Grouping Options" tab
+ * (e.g. plot type combo box changed)
+ * For group selected
+ */
+void MuonAnalysis::groupTabUpdatePlotGroup() {
   if (isAutoUpdateEnabled() && m_currentTab == m_uiForm.GroupingOptions &&
-      m_loaded)
-    runFrontPlotButton();
+      m_loaded) {
+    updateFront();
+    runTablePlotButton(ItemType::Group);
+  }
+}
+
+/**
+ * Update plot based on changes made in "Grouping Options" tab
+ * (e.g. plot type combo box changed)
+ * For pair selected
+ */
+void MuonAnalysis::groupTabUpdatePlotPair() {
+  if (isAutoUpdateEnabled() && m_currentTab == m_uiForm.GroupingOptions &&
+      m_loaded) {
+    updateFront();
+    runTablePlotButton(ItemType::Pair);
+  }
 }
 
 void MuonAnalysis::settingsTabUpdatePlot() {

--- a/docs/source/release/v3.8.0/muon.rst
+++ b/docs/source/release/v3.8.0/muon.rst
@@ -22,6 +22,8 @@ Muon Analysis
 
 - Documentation has been moved to the Mantid help system.
 
+- A bug was fixed where, when plotting the log of counts and then switching to plot counts or asymmetry, the y axis was left as a logarithmic axis.
+
 Algorithms
 ----------
 


### PR DESCRIPTION
_Fixes a bug found during unscripted testing for Mantid 3.8_

Fixes a bug where the y-axis of a plot was not changed back to linear when it had been logarithmic, and keep user's options in sync between tabs of the interface.

**To test:**

Use any longitudinal field muon dataset, for example `EMU00020884` from the doc test data or `MUSR00015189` from the unit test data. 
Here, the choices of detector grouping are `fwd`, `bwd` or `long`, where `long` is a group _pair_ (`fwd-bwd`). The groups (`fwd` and `bwd`) can be plotted as counts, log counts or asymmetry, but it should only be possible to plot asymmetry for the pair (`long`).
- Open _Interfaces/Muon/Muon Analysis_ and load the data set.
- It should plot asymmetry for pair `long` by default (you can see this from the title of the graph, and "Plot type" dropdown on the front tab of the interface)
- Go to _Grouping Options_ tab
- Using the dropdown on the top (group) table, select "Logarithm". The plot changes to log counts for group `fwd`, with a logarithmic y axis.
- Change to either "Counts" or "Asymmetry" and verify the y axis is linear again.
- (If the graph does not update on changing the selection, ensure that _Plot Creation_ on the _Settings_ tab is set to one of the "Auto-update" options).
- Use the plot buttons on the top and bottom tables, check that the selected plot type is always plotted.

Fixes #17534.

[Release notes](https://github.com/mantidproject/mantid/blob/e1b4b49f0e863b92685076786852b5acbfbf2355/docs/source/release/v3.8.0/muon.rst#id1) have been updated.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
