### PR TITLE
Save Nexus from the Workspace Dock will now properly run SaveMD for MD Workspaces

### DIFF
--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -21,7 +21,6 @@
 #include <MantidQtAPI/InterfaceManager.h>
 
 #include <Poco/Path.h>
-#include <boost/shared_ptr.hpp>
 
 #ifdef MAKE_VATES
 #include "vtkPVDisplayInformation.h"
@@ -934,7 +933,7 @@ void MantidDockWidget::handleShowSaveAlgorithm() {
   const QAction *sendingAction = dynamic_cast<QAction *>(sender());
 
   if (sendingAction) {
-    auto inputWorkspace = getSelectedWorkspace();
+    const auto inputWorkspace = getSelectedWorkspace();
     const QString wsName = QString::fromStdString(inputWorkspace->getName());
     const QVariant data = sendingAction->data();
 
@@ -943,7 +942,7 @@ void MantidDockWidget::handleShowSaveAlgorithm() {
       int version = -1;
 
       // Check if workspace is MD, this is the same check used in
-      // SaveNexusProcessed.cpp line 175 to determine if the WS is MD
+      // SaveNexusProcessed.cpp in the doExec()
       if (bool(boost::dynamic_pointer_cast<const IMDEventWorkspace>(
               inputWorkspace)) ||
           bool(boost::dynamic_pointer_cast<const IMDHistoWorkspace>(
@@ -959,6 +958,7 @@ void MantidDockWidget::handleShowSaveAlgorithm() {
         switch (splitData.length()) {
         case 2:
           version = splitData[1].toInt();
+        /* intentional fall through to get algorithm name */
         case 1:
           algorithmName = splitData[0];
           break;

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -948,7 +948,10 @@ void MantidDockWidget::handleShowSaveAlgorithm() {
               inputWorkspace)) ||
           bool(boost::dynamic_pointer_cast<const IMDHistoWorkspace>(
               inputWorkspace))) {
-
+        // This will also be executed if the user clicks Save to ASCII or ASCII
+        // v1, therefore overwriting their choice and running
+        // SaveMD. SaveASCII doesn't support MD Workspaces, but if an issue,
+        // move the MD check to case 1: below
         algorithmName = "SaveMD";
 
       } else {

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -958,7 +958,7 @@ void MantidDockWidget::handleShowSaveAlgorithm() {
         switch (splitData.length()) {
         case 2:
           version = splitData[1].toInt();
-        /* intentional fall through to get algorithm name */
+        // intentional fall through to get algorithm name
         case 1:
           algorithmName = splitData[0];
           break;

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -429,7 +429,6 @@ void MantidUI::deleteWorkspace(const QString &workspaceName) {
   executeAlgorithmAsync(alg);
 }
 
-
 QString MantidUI::getSelectedWorkspaceName() {
   QString str = m_exploreMantid->getSelectedWorkspaceName();
   if (str.isEmpty()) {
@@ -1454,7 +1453,11 @@ QStringList MantidUI::extractPyFiles(const QList<QUrl> &urlList) const {
 }
 
 /**
-executes Save Nexus from the right click context menu
+Executes the Save Nexus dialogue from the right click context menu.
+
+The Save > Nexus function from the button in the Dock (with Load, Delete, Group,
+Sort, Save buttons) is in MantidDock at line 933
+
 saveNexus Input Dialog is a generic dialog.Below code is added to remove
 the workspaces except the selected workspace from the InputWorkspace combo
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -1456,7 +1456,7 @@ QStringList MantidUI::extractPyFiles(const QList<QUrl> &urlList) const {
 Executes the Save Nexus dialogue from the right click context menu.
 
 The Save > Nexus function from the button in the Dock (with Load, Delete, Group,
-Sort, Save buttons) is in MantidDock at line 933
+Sort, Save buttons) is in MantidDock in function handleShowSaveAlgorithm()
 
 saveNexus Input Dialog is a generic dialog.Below code is added to remove
 the workspaces except the selected workspace from the InputWorkspace combo

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -429,9 +429,7 @@ void MantidUI::deleteWorkspace(const QString &workspaceName) {
   executeAlgorithmAsync(alg);
 }
 
-/**
-getSelectedWorkspaceName
-*/
+
 QString MantidUI::getSelectedWorkspaceName() {
   QString str = m_exploreMantid->getSelectedWorkspaceName();
   if (str.isEmpty()) {
@@ -1456,7 +1454,7 @@ QStringList MantidUI::extractPyFiles(const QList<QUrl> &urlList) const {
 }
 
 /**
-executes Save Nexus
+executes Save Nexus, but only the one from the right click context menu
 saveNexus Input Dialog is a generic dialog.Below code is added to remove
 the workspaces except the selected workspace from the InputWorkspace combo
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -429,9 +429,7 @@ void MantidUI::deleteWorkspace(const QString &workspaceName) {
   executeAlgorithmAsync(alg);
 }
 
-/**
-getSelectedWorkspaceName
-*/
+
 QString MantidUI::getSelectedWorkspaceName() {
   QString str = m_exploreMantid->getSelectedWorkspaceName();
   if (str.isEmpty()) {
@@ -1456,7 +1454,7 @@ QStringList MantidUI::extractPyFiles(const QList<QUrl> &urlList) const {
 }
 
 /**
-executes Save Nexus
+executes Save Nexus from the right click context menu
 saveNexus Input Dialog is a generic dialog.Below code is added to remove
 the workspaces except the selected workspace from the InputWorkspace combo
 


### PR DESCRIPTION
## Description of work.

`Save` > `Nexus` from the Workspaces Dock menus will now properly run `SaveMD` to save MD workspaces instead of trying to run `SaveNexus` on them and then fail. Now there is a check to see if the workspace is MD, and if so it will run `SaveMD`. However currently picking Save to `ASCII` or `ASCII v1` will still run `SaveMD` basically overwriting the user's choice. This shouldn't be an issue because `SaveASCII` doesn't work with MD workspaces anyway, however it might be confusing.
## To test:

MD Workspaces -> `SEQ_MDEW` or `SEQ_MDHW` from build testing data, or on Olympic `Public\DimitarTasev`
- [x] Test 2D Workspaces, functionality should be unchanged for all options, Save > Nexus, ASCII, ASCII v1, and all workspace types
- [x] Test MD Workspace (Event and Histogram)
- Load a MD Workspace into mantid
- From the Save button above (in the Workspaces Dock) click Save > Nexus
- It _should_ save successfully

<!-- Instructions for testing. -->

Fixes #17345.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
-->

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
