### PR TITLE
Fix crash in Data Analysis tab of MuonAnalysis interface

### DIFF
--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -93,6 +93,16 @@ void MuonFitPropertyBrowser::init() {
   bool plotDiff = settings.value("Plot Difference", QVariant(true)).toBool();
   m_boolManager->setValue(m_plotDiff, plotDiff);
 
+  m_evaluationType = m_enumManager->addProperty("Evaluate Function As");
+  m_evaluationType->setToolTip(
+      "Consider using Histogram fit which may produce more accurate results.");
+  m_evaluationTypes << "CentrePoint"
+                    << "Histogram";
+  m_enumManager->setEnumNames(m_evaluationType, m_evaluationTypes);
+  int evaluationType =
+      settings.value(m_evaluationType->propertyName(), 0).toInt();
+  m_enumManager->setValue(m_evaluationType, evaluationType);
+
   settingsGroup->addSubProperty(m_workspace);
   settingsGroup->addSubProperty(m_workspaceIndex);
   settingsGroup->addSubProperty(m_startX);
@@ -124,6 +134,7 @@ void MuonFitPropertyBrowser::init() {
   customSettingsGroup->addSubProperty(m_plotDiff);
   customSettingsGroup->addSubProperty(m_rawData);
   customSettingsGroup->addSubProperty(m_showParamErrors);
+  customSettingsGroup->addSubProperty(m_evaluationType);
 
   m_customSettingsGroup = m_browser->addProperty(customSettingsGroup);
 


### PR DESCRIPTION
Add "evaluation type" setting to MuonFitPropertyBrowser to avoid crash observed.

(The new setting comes from recent changes to Fit, the MuonFitPropertyBrowser needed to be updated to include it)

**To test:**
- Open _Interfaces/Muon/Muon Analysis_
- Load any muon NeXus file (e.g. `MUSR00015189.nxs` from unit tests)
- Go to "Data Analysis" tab
- Verify that Mantid does not crash

(_Package available at `\\olympic\babylon5\Scratch\TomPerkins\PR17542`_)

Fixes #17539.

_Does not need to be in the release notes_ - bug introduced since last release.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
