### PR TITLE
IndirectDataReduction - Transmission - plotPreview crash

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
@@ -39,7 +39,7 @@ void IndirectTransmission::setup() {}
 void IndirectTransmission::run() {
   QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
   QString canWsName = m_uiForm.dsCanInput->getCurrentDataName();
-  QString outWsName = sampleWsName + "_trans";
+  QString outWsName = sampleWsName + "_transmission";
 
   IAlgorithm_sptr transAlg =
       AlgorithmManager::Instance().create("IndirectTransmissionMonitor", -1);
@@ -78,7 +78,7 @@ void IndirectTransmission::dataLoaded() {
 void IndirectTransmission::previewPlot() {
   QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
   QString canWsName = m_uiForm.dsCanInput->getCurrentDataName();
-  QString outWsName = sampleWsName + "_trans";
+  QString outWsName = sampleWsName + "_transmission";
 
   IAlgorithm_sptr transAlg =
       AlgorithmManager::Instance().create("IndirectTransmissionMonitor", -1);
@@ -99,7 +99,7 @@ void IndirectTransmission::transAlgDone(bool error) {
     return;
 
   QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
-  QString outWsName = sampleWsName + "_trans";
+  QString outWsName = sampleWsName + "_transmission";
 
   WorkspaceGroup_sptr resultWsGroup =
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
@@ -136,7 +136,7 @@ void IndirectTransmission::instrumentSet() {
  * Handle saving of workspace
  */
 void IndirectTransmission::saveClicked() {
-  QString outputWs = (m_uiForm.dsSampleInput->getCurrentDataName() + "_trans");
+  QString outputWs = (m_uiForm.dsSampleInput->getCurrentDataName() + "_transmission");
 
   if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), false))
     addSaveWorkspaceToQueue(outputWs);
@@ -147,7 +147,7 @@ void IndirectTransmission::saveClicked() {
  * Handle mantid plotting
  */
 void IndirectTransmission::plotClicked() {
-  QString outputWs = (m_uiForm.dsSampleInput->getCurrentDataName() + "_trans");
+  QString outputWs = (m_uiForm.dsSampleInput->getCurrentDataName() + "_transmission");
   if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), true))
     plotSpectrum(outputWs);
 }

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
@@ -136,7 +136,8 @@ void IndirectTransmission::instrumentSet() {
  * Handle saving of workspace
  */
 void IndirectTransmission::saveClicked() {
-  QString outputWs = (m_uiForm.dsSampleInput->getCurrentDataName() + "_transmission");
+  QString outputWs =
+      (m_uiForm.dsSampleInput->getCurrentDataName() + "_transmission");
 
   if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), false))
     addSaveWorkspaceToQueue(outputWs);
@@ -147,7 +148,8 @@ void IndirectTransmission::saveClicked() {
  * Handle mantid plotting
  */
 void IndirectTransmission::plotClicked() {
-  QString outputWs = (m_uiForm.dsSampleInput->getCurrentDataName() + "_transmission");
+  QString outputWs =
+      (m_uiForm.dsSampleInput->getCurrentDataName() + "_transmission");
   if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), true))
     plotSpectrum(outputWs);
 }


### PR DESCRIPTION
The name of the result group workspace has been changed to avoid clashing with the output workspace, hence the plotPreview no longer attempts to plot a group workspace.

**To test:**
Indirect < Data Reduction < Transmission
Sample: IRS26176
Background: IRS26173

Fixes #17543.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
