### PR TITLE
Fix crash plotting invalid spectrum number

### DIFF
--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
@@ -31,8 +31,9 @@ MantidWSIndexWidget::MantidWSIndexWidget(QWidget *parent, Qt::WFlags flags,
                                          const bool showTiledOption)
     : QWidget(parent, flags), m_spectra(false),
       m_waterfall(showWaterfallOption), m_tiled(showTiledOption),
-      m_wsNames(wsNames), m_wsIndexIntervals(), m_spectraNumIntervals(),
-      m_wsIndexChoice(), m_spectraIdChoice() {
+      m_waterfallOpt(nullptr), m_tiledOpt(nullptr), m_wsNames(wsNames),
+      m_wsIndexIntervals(), m_spectraNumIntervals(), m_wsIndexChoice(),
+      m_spectraIdChoice() {
   checkForSpectraAxes();
   // Generate the intervals allowed to be plotted by the user.
   generateWsIndexIntervals();


### PR DESCRIPTION
Fix crash seen when plotting an invalid spectrum number.
(Two pointers were uninitialized)

**To test:**

Follow the example in the issue and verify there is no crash.

Fixes #17536.

_No release notes_ (bug not present in previous release)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
