### PR TITLE
Fix for saving transmission data as CanSAS1D via the ISIS SANS GUI

### DIFF
--- a/docs/source/release/v3.8.0/sans.rst
+++ b/docs/source/release/v3.8.0/sans.rst
@@ -27,5 +27,6 @@ Bug Fixes
 - Fix the loading of RKH files
 - Fix wrong initial position of LARMOR data in the beam centre finder
 - Allow loading of CanSAS data without error data
+- Fix saving CanSAS with transmission data from the ISIS SANS GUI
 
 `Full list of changes on github <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.8%22+is%3Amerged+label%3A%22Component%3A+SANS%22>`__

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -1764,6 +1764,14 @@ def quaternion_to_angle_and_axis(quaternion):
         axis.append(quaternion[3]/s_parameter)
     return math.degrees(angle), axis
 
+def get_unfitted_transmission_workspace_name(workspace_name):
+    suffix = "_unfitted"
+    if workspace_name.endswith(suffix):
+        unfitted_workspace_name = workspace_name
+    else:
+        unfitted_workspace_name = workspace_name + suffix
+    return unfitted_workspace_name
+
 
 ###############################################################################
 ######################### Start of Deprecated Code ############################

--- a/scripts/SANS/isis_reducer.py
+++ b/scripts/SANS/isis_reducer.py
@@ -497,11 +497,13 @@ class ISISReducer(Reducer):
         # to the SampleLog, to be connected to the workspace, and be available outside. These values
         # are current being used for saving CanSAS (ticket #6929)
         if self.__transmission_sample:
+            unfitted_transmission_workspace_name = su.get_unfitted_transmission_workspace_name(self.__transmission_sample)
             AddSampleLog(Workspace=self.output_wksp, LogName="Transmission",
-                         LogText=self.__transmission_sample + str('_unfitted'))
+                         LogText=unfitted_transmission_workspace_name)
         if self.__transmission_can:
+            unfitted_transmission_workspace_name = su.get_unfitted_transmission_workspace_name(self.__transmission_can)
             AddSampleLog(Workspace=self.output_wksp, LogName="TransmissionCan",
-                         LogText=self.__transmission_can + str('_unfitted'))
+                         LogText=unfitted_transmission_workspace_name)
 
         # clean these values for subsequent executions
         self.__transmission_sample = ""

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -1571,6 +1571,23 @@ class TestQuaternionToAngleAndAxis(unittest.TestCase):
         # There shouldn't be an axis for angle 0
         self._do_test_quaternion(angle, axis)
 
+class TestTransmissionName(unittest.TestCase):
+    def test_that_suffix_is_added_if_not_exists(self):
+        # Arrange
+        workspace_name = "test_workspace_name"
+        # Act
+        unfitted_workspace_name = su.get_unfitted_transmission_workspace_name(workspace_name)
+        # Assert
+        expected = workspace_name + "_unfitted"
+        self.assertTrue(unfitted_workspace_name == expected)
+    def test_that_suffix_is_not_added_if_exists(self):
+        # Arrange
+        workspace_name = "test_workspace_name_unfitted"
+        # Act
+        unfitted_workspace_name = su.get_unfitted_transmission_workspace_name(workspace_name)
+        # Assert
+        expected = workspace_name
+        self.assertTrue(unfitted_workspace_name == expected)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Context**
When trying to save reduced data in the CanSAS1D format via the ISIS GUI, there was an issue of a non-existing transmission data set. Essentially it tried to look up the incorrect name on the ADS. This only occurred when fitting during the transmission calculation was set to `OFF`. Strangely, this has never been reported before.

Fixes #17546 
## To test:

The user file is [USER_LOQ_163A_M3_Changer.txt](https://github.com/mantidproject/mantid/files/483044/USER_LOQ_163A_M3_Changer.txt)
The other required files are:
- [DIRECT_LOQ_HAB_983.txt](https://github.com/mantidproject/mantid/files/483046/DIRECT_LOQ_HAB_983.txt)
- [DIRECT_LOQ_MAIN_143B.txt](https://github.com/mantidproject/mantid/files/483047/DIRECT_LOQ_MAIN_143B.txt)
- [FLAT_CELL_LOQ_MAIN_143.txt](https://github.com/mantidproject/mantid/files/483048/FLAT_CELL_LOQ_MAIN_143.txt)

The data is sample=LOQ98128, trans=LOQ98129, direct=LOQ98130
- Open the ISIS SANS GUI
- Set the instrument to LOQ
- Load the user file
- Load the data files
- Click _Reduce 1D_
  - Confirm that the reduction happens without any issues
- On the _Run Numbers_ tab check only Save->Formats->CanSAS
- Click _Save Results_
  - Confirm that the reduced data was saved without any issues. You should be able to find it in your save directory. Previously it could not find `98129_trans_sample_2.2_10.0_unfitted` as it was looking for `98129_trans_sample_2.2_10.0_unfitted_unfitted`.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
