### PR TITLE
Pass std::vector by const reference

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/DetectorDiagnostic.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetectorDiagnostic.h
@@ -85,7 +85,7 @@ protected:
   /// workspace contains
   /// integrated counts
   std::vector<double>
-  calculateMedian(API::MatrixWorkspace_sptr input, bool excludeZeroes,
+  calculateMedian(const API::MatrixWorkspace &input, bool excludeZeroes,
                   const std::vector<std::vector<size_t>> &indexmap);
   /// Convert to a distribution
   API::MatrixWorkspace_sptr convertToRate(API::MatrixWorkspace_sptr workspace);
@@ -94,7 +94,7 @@ protected:
   std::vector<std::vector<size_t>> makeMap(API::MatrixWorkspace_sptr countsWS);
   /// method to create the map with all spectra
   std::vector<std::vector<size_t>>
-  makeInstrumentMap(API::MatrixWorkspace_sptr countsWS);
+  makeInstrumentMap(const API::MatrixWorkspace &countsWS);
 
   /** @name Progress reporting */
   //@{

--- a/Framework/Algorithms/inc/MantidAlgorithms/DetectorDiagnostic.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DetectorDiagnostic.h
@@ -86,7 +86,7 @@ protected:
   /// integrated counts
   std::vector<double>
   calculateMedian(API::MatrixWorkspace_sptr input, bool excludeZeroes,
-                  std::vector<std::vector<size_t>> indexmap);
+                  const std::vector<std::vector<size_t>> &indexmap);
   /// Convert to a distribution
   API::MatrixWorkspace_sptr convertToRate(API::MatrixWorkspace_sptr workspace);
   /// method to check which spectra should be grouped when calculating the

--- a/Framework/Algorithms/src/DetectorDiagnostic.cpp
+++ b/Framework/Algorithms/src/DetectorDiagnostic.cpp
@@ -621,7 +621,7 @@ std::vector<double> DetectorDiagnostic::calculateMedian(
                       (instrument->getSample() != nullptr));
     }
 
-    PARALLEL_FOR1(input)
+    PARALLEL_FOR1(&input)
     for (int i = 0; i < nhists; ++i) { // NOLINT
       PARALLEL_START_INTERUPT_REGION
 

--- a/Framework/Algorithms/src/DetectorDiagnostic.cpp
+++ b/Framework/Algorithms/src/DetectorDiagnostic.cpp
@@ -9,12 +9,12 @@
 #include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/MultiThreaded.h"
+#include "MantidKernel/Statistics.h"
 #include "MantidKernel/VisibleWhenProperty.h"
 
 #include <boost/iterator/counting_iterator.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
-#include <gsl/gsl_statistics.h>
 
+#include <algorithm>
 #include <cfloat>
 
 namespace Mantid {
@@ -563,10 +563,7 @@ DetectorDiagnostic::makeMap(API::MatrixWorkspace_sptr countsWS) {
 
   for (size_t i = 0; i < countsWS->getNumberHistograms(); i++) {
     detid_t d = (*(countsWS->getSpectrum(i).getDetectorIDs().begin()));
-    std::vector<boost::shared_ptr<const Mantid::Geometry::IComponent>> anc =
-        instrument->getDetector(d)->getAncestors();
-    // std::vector<boost::shared_ptr<const IComponent> >
-    // anc=(*(countsWS->getSpectrum(i)->getDetectorIDs().begin())).getAncestors();
+    auto anc = instrument->getDetector(d)->getAncestors();
     if (anc.size() < static_cast<size_t>(m_parents)) {
       g_log.warning("Too many levels up. Will ignore LevelsUp");
       m_parents = 0;
@@ -576,23 +573,17 @@ DetectorDiagnostic::makeMap(API::MatrixWorkspace_sptr countsWS) {
   }
 
   std::vector<std::vector<size_t>> speclist;
-  std::vector<size_t> speclistsingle;
 
   std::multimap<Mantid::Geometry::ComponentID, size_t>::iterator m_it, s_it;
-
   for (m_it = mymap.begin(); m_it != mymap.end(); m_it = s_it) {
-    Mantid::Geometry::ComponentID theKey = (*m_it).first;
-
-    std::pair<std::multimap<Mantid::Geometry::ComponentID, size_t>::iterator,
-              std::multimap<Mantid::Geometry::ComponentID, size_t>::iterator>
-        keyRange = mymap.equal_range(theKey);
-
+    Mantid::Geometry::ComponentID theKey = m_it->first;
+    auto keyRange = mymap.equal_range(theKey);
     // Iterate over all map elements with key == theKey
-    speclistsingle.clear();
+    std::vector<size_t> speclistsingle;
     for (s_it = keyRange.first; s_it != keyRange.second; ++s_it) {
-      speclistsingle.push_back((*s_it).second);
+      speclistsingle.push_back(s_it->second);
     }
-    speclist.push_back(speclistsingle);
+    speclist.push_back(std::move(speclistsingle));
   }
 
   return speclist;
@@ -611,14 +602,13 @@ DetectorDiagnostic::makeMap(API::MatrixWorkspace_sptr countsWS) {
  * to it
  * @throw out_of_range if a value is negative
  */
-std::vector<double>
-DetectorDiagnostic::calculateMedian(const API::MatrixWorkspace_sptr input,
-                                    bool excludeZeroes,
-                                    std::vector<std::vector<size_t>> indexmap) {
+std::vector<double> DetectorDiagnostic::calculateMedian(
+    const API::MatrixWorkspace_sptr input, bool excludeZeroes,
+    const std::vector<std::vector<size_t>> &indexmap) {
   std::vector<double> medianvec;
   g_log.debug("Calculating the median count rate of the spectra");
 
-  for (auto hists : indexmap) {
+  for (const auto &hists : indexmap) {
     std::vector<double> medianInput;
     const int nhists = static_cast<int>(hists.size());
     // The maximum possible length is that of workspace length
@@ -632,7 +622,7 @@ DetectorDiagnostic::calculateMedian(const API::MatrixWorkspace_sptr input,
     }
 
     PARALLEL_FOR1(input)
-    for (int i = 0; i < static_cast<int>(hists.size()); ++i) { // NOLINT
+    for (int i = 0; i < nhists; ++i) { // NOLINT
       PARALLEL_START_INTERUPT_REGION
 
       if (checkForMask) {
@@ -649,7 +639,7 @@ DetectorDiagnostic::calculateMedian(const API::MatrixWorkspace_sptr input,
         throw std::out_of_range("Negative number of counts found, could be "
                                 "corrupted raw counts or solid angle data");
       }
-      if (boost::math::isnan(yValue) || boost::math::isinf(yValue) ||
+      if (!std::isfinite(yValue) ||
           (excludeZeroes && yValue < DBL_EPSILON)) // NaNs/Infs
       {
         continue;
@@ -669,10 +659,9 @@ DetectorDiagnostic::calculateMedian(const API::MatrixWorkspace_sptr input,
       medianInput.push_back(0.);
     }
 
-    // We need a sorted array to calculate the median
-    std::sort(medianInput.begin(), medianInput.end());
-    double median = gsl_stats_median_from_sorted_data(&medianInput[0], 1,
-                                                      medianInput.size());
+    Kernel::Statistics stats =
+        Kernel::getStatistics(medianInput, StatOptions::Median);
+    double median = stats.median;
 
     if (median < 0 || median > DBL_MAX / 10.0) {
       throw std::out_of_range("The calculated value for the median was either "

--- a/Framework/Algorithms/src/DetectorDiagnostic.cpp
+++ b/Framework/Algorithms/src/DetectorDiagnostic.cpp
@@ -621,7 +621,7 @@ std::vector<double> DetectorDiagnostic::calculateMedian(
                       (instrument->getSample() != nullptr));
     }
 
-    PARALLEL_FOR1(&input)
+    PARALLEL_FOR1((&input))
     for (int i = 0; i < nhists; ++i) { // NOLINT
       PARALLEL_START_INTERUPT_REGION
 

--- a/Framework/Algorithms/src/DetectorEfficiencyVariation.cpp
+++ b/Framework/Algorithms/src/DetectorEfficiencyVariation.cpp
@@ -100,7 +100,7 @@ void DetectorEfficiencyVariation::exec() {
     throw;
   }
   double average =
-      calculateMedian(countRatio, false, makeInstrumentMap(countRatio))
+      calculateMedian(*countRatio, false, makeInstrumentMap(*countRatio))
           .at(0); // Include zeroes
   g_log.notice() << name()
                  << ": The median of the ratio of the integrated counts is: "

--- a/Framework/Algorithms/src/MedianDetectorTest.cpp
+++ b/Framework/Algorithms/src/MedianDetectorTest.cpp
@@ -116,7 +116,7 @@ void MedianDetectorTest::exec() {
 
   // 1. Calculate the median
   std::vector<double> median =
-      calculateMedian(countsWS, excludeZeroes, specmap);
+      calculateMedian(*countsWS, excludeZeroes, specmap);
   std::vector<double>::iterator medit;
   for (medit = median.begin(); medit != median.end(); ++medit) {
     g_log.debug() << "Median value = " << (*medit) << "\n";
@@ -125,7 +125,7 @@ void MedianDetectorTest::exec() {
   int numFailed = maskOutliers(median, countsWS, specmap);
 
   // 3. Recalulate the median
-  median = calculateMedian(countsWS, excludeZeroes, specmap);
+  median = calculateMedian(*countsWS, excludeZeroes, specmap);
   for (medit = median.begin(); medit != median.end(); ++medit) {
     g_log.information() << "Median value with outliers removed = " << (*medit)
                         << "\n";


### PR DESCRIPTION
Description of work.

This changes `DetectorDiagnostic::calculateMedian(...)` to pass `indexmap` by const reference instead of by value and when possible avoids copying `std::vector<size_t>` inside this function. I also changed the median calculation to use std::nth_element, which doesn't require sorting the entire array.

**To test:**

If the builds pass, :squirrel:

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
