### PR TITLE
Move matplotlib import to plot function in ISISDisk

### DIFF
--- a/scripts/PyChop/ISISDisk.py
+++ b/scripts/PyChop/ISISDisk.py
@@ -9,7 +9,6 @@ spectrometer (LET) - using the functions in MulpyRep and additional tables of in
 import numpy as np
 from . import MulpyRep
 from .ISISFermi import ISISFermi
-from matplotlib import pyplot
 
 class ISISDisk:
     """
@@ -338,6 +337,7 @@ class ISISDisk:
         Plots the time-distance diagram into a given Matplotlib axes, i
         for a give focused incident energy (in meV) and chopper frequencies (in Hz).
         """
+        from matplotlib import pyplot
         Ei = self.Ei if Ei_in is None else Ei_in
         if Ei is None:
             raise ValueError('Incident energy has not been specified')

--- a/scripts/PyChop/ISISDisk.py
+++ b/scripts/PyChop/ISISDisk.py
@@ -337,7 +337,14 @@ class ISISDisk:
         Plots the time-distance diagram into a given Matplotlib axes, i
         for a give focused incident energy (in meV) and chopper frequencies (in Hz).
         """
-        from matplotlib import pyplot
+        if h_plt is None:
+            try:
+                from matplotlib import pyplot
+            except ImportError:
+                raise RuntimeError('ISISDisk.plotFrame: Cannot import matplotlib')
+            plt = pyplot
+        else:
+            plt = h_plt
         Ei = self.Ei if Ei_in is None else Ei_in
         if Ei is None:
             raise ValueError('Incident energy has not been specified')
@@ -349,7 +356,6 @@ class ISISDisk:
         Eis, chop_times, _, lastChopDist, lines = MulpyRep.calcChopTimes(Ei, self.freq, instpars, self.Chop2Phase)
         if frequency:
             self.setFrequency(oldfreq)
-        plt = pyplot if h_plt is None else h_plt
         dist, samDist, DetDist, fracEi = tuple([self.dist, self.chop_samp, self.samp_det, self.frac_ei])
         modSamDist = dist[-1] + samDist
         totDist = modSamDist + DetDist


### PR DESCRIPTION
This is just a quick PR to move the `import` of matplotlib into the function which needs it, so that unit tests which doesn't need matplotlib can run on machines without mpl.

_Does not need to be in the release notes._

Fixes #17557 

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
