### PR TITLE
Use const string reference to remove cpp check warning

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -23,7 +23,7 @@ std::string getUnit(Projection &p, size_t nd) {
   return (p.getUnit(nd) == RLU ? "r" : "a");
 }
 
-void setUnit(Projection &p, size_t nd, std::string unit) {
+void setUnit(Projection &p, size_t nd, const std::string &unit) {
   if (unit == "r")
     p.setUnit(nd, RLU);
   else if (unit == "a")


### PR DESCRIPTION
Description of work.
This changes a small function which only passes a string for a comparison to be a const reference avoiding the overhead of copying the string into the function. 

**To test:**
The CI test should pass - specifically `ProjectionTest`

Fixes #17447 .

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
