### PR TITLE
Fix package version for Poco on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,7 +319,7 @@ if ( ENABLE_CPACK )
                            "python-matplotlib,"
                            "python-scipy,"
                            "libtbb2,"
-                           "libpocofoundation31,libpocoutil31,libpoconet31,libpoconetssl31,libpococrypto31,libpocoxml31,"
+                           "libpocofoundation${POCO_SOLIB_VERSION},libpocoutil${POCO_SOLIB_VERSION},libpoconet${POCO_SOLIB_VERSION},libpoconetssl${POCO_SOLIB_VERSION},libpococrypto${POCO_SOLIB_VERSION},libpocoxml${POCO_SOLIB_VERSION},"
                            "python-pycifrw (>= 4.2.1)" )
         set ( PERFTOOLS_DEB_PACKAGE "libgoogle-perftools4 (>= 1.7)" )
         if( "${UNIX_CODENAME}" STREQUAL "xenial")

--- a/buildconfig/CMake/FindPoco.cmake
+++ b/buildconfig/CMake/FindPoco.cmake
@@ -47,9 +47,9 @@ set ( POCO_LIBRARIES ${POCO_LIB_FOUNDATION}
 
 endif()
 
-# Set a version string by examining either the Poco/Version.h header or 
+# Set a version string by examining either the Poco/Version.h header or
 # the Poco/Foundation.h header if Version.h does not exist
-if( POCO_INCLUDE_DIR ) 
+if( POCO_INCLUDE_DIR )
   if ( EXISTS ${POCO_INCLUDE_DIR}/Poco/Version.h )
     set ( VERSION_FILE ${POCO_INCLUDE_DIR}/Poco/Version.h )
   else ()
@@ -72,12 +72,22 @@ if( POCO_INCLUDE_DIR )
   set ( POCO_VERSION "${POCO_VERSION_MAJOR}.${POCO_VERSION_MINOR}.${POCO_VERSION_PATCH}" )
 endif()
 
+# Also set a shared libarary version number. This is different to the main version number
+# and can form part of the package name on some Linux systems
+if( POCO_LIB_FOUNDATION )
+  set ( POCO_SOLIB_VERSION "" )
+  # The library path is usually a symlink to the actually library
+  get_filename_component ( POCO_REAL_LIB_FOUNDATION ${POCO_LIB_FOUNDATION} REALPATH )
+  set ( _LIB_REGEX "^.*.so.([0-9]+)$" )
+  string( REGEX REPLACE ${_LIB_REGEX} "\\1" POCO_SOLIB_VERSION ${POCO_REAL_LIB_FOUNDATION} )
+endif()
 
-# handle the QUIETLY and REQUIRED arguments and set POCO_FOUND to TRUE if 
+
+# handle the QUIETLY and REQUIRED arguments and set POCO_FOUND to TRUE if
 # all listed variables are TRUE
 include ( FindPackageHandleStandardArgs )
 if (POCO_VERSION)
-  find_package_handle_standard_args( Poco REQUIRED_VARS POCO_LIBRARIES POCO_INCLUDE_DIR 
+  find_package_handle_standard_args( Poco REQUIRED_VARS POCO_LIBRARIES POCO_INCLUDE_DIR
                                      VERSION_VAR POCO_VERSION )
 else ()
   message (status "Failed to determine Poco version: Ignoring requirement")


### PR DESCRIPTION
The package name for Poco on Debian/Ubuntu contains the library version number. This work determines this dynamically and sets the appropriate package name based on the version
used for the build.

**To test:**

Merge this branch and run `make package`.

In `_CPack_Packages/Linux/DEB/mantid_[MANTID_VERSION].-1_amd64/control` there is a list of package requirements. The number at the end of the Poco packages should match the number at the end of the poco libraries used for the build. This can be found by simply running `ls -l /usr/lib/libPocoFoundation.so` on Ubuntu or `ls -l /usr/lib64/libPocoFoundation.so` on RedHat.

_No issue number_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
