### PR TITLE
Re #17557 - added check for mpl in PyChop/__init__.py

### DIFF
--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -2,6 +2,7 @@
 # pylint: disable=line-too-long, invalid-name, unused-argument, unused-import, multiple-statements
 # pylint: disable=attribute-defined-outside-init, protected-access, super-on-old-class, redefined-outer-name
 # pylint: disable=too-many-statements, too-many-instance-attributes, too-many-locals, too-many-branches
+# pylint: disable=too-many-public-methods
 
 """
 This module contains a class to create a graphical user interface for PyChop.
@@ -187,7 +188,7 @@ class PyChopGui(QtGui.QMainWindow):
             self.resaxes.hold(True)
             for ie, Ei in enumerate(Eis):
                 # For LET ignore reps above 40 meV in energy as there is no flux there.
-                if 'LET' in inst and Ei>40:
+                if 'LET' in inst and Ei > 40:
                     continue
                 en = np.linspace(0, 0.95*Ei, 200)
                 line, = self.resaxes.plot(en, self.res[ie])
@@ -479,6 +480,9 @@ class PyChopGui(QtGui.QMainWindow):
         fid.close()
 
     def onHelp(self):
+        """
+        Shows the help page
+        """
         try:
             from pymantidplot.proxies import showCustomInterfaceHelp
             showCustomInterfaceHelp("PyChop")

--- a/scripts/PyChop/__init__.py
+++ b/scripts/PyChop/__init__.py
@@ -17,9 +17,12 @@ resolution, flux = PyChop2.calculate(inst='maps', chtyp='a', freq=500, ei=600, e
 PyChop2.showGUI()
 """
 
+import warnings
 from .PyChop2 import PyChop2
 # If the system doesn't have matplotlib, don't import the GUI.
 try:
     from .PyChopGui import show as showGUI
 except ImportError:
-    pass
+    def showGUI():
+        warnings.warn("PyChop GUI disabled: Cannot import Matplotlib.", RuntimeWarning)
+        return None

--- a/scripts/PyChop/__init__.py
+++ b/scripts/PyChop/__init__.py
@@ -1,4 +1,4 @@
-# pylint: disable=line-too-long
+# pylint: disable=line-too-long, invalid-name
 
 """
 Module containing classes to calculate the flux and resolution of direct geometry neutron time-of-flight spectrometers.

--- a/scripts/PyChop/__init__.py
+++ b/scripts/PyChop/__init__.py
@@ -18,4 +18,8 @@ PyChop2.showGUI()
 """
 
 from .PyChop2 import PyChop2
-from .PyChopGui import show as showGUI
+# If the system doesn't have matplotlib, don't import the GUI.
+try:
+    from .PyChopGui import show as showGUI
+except ImportError:
+    pass


### PR DESCRIPTION
Adds an additional test to not load Matplotlib on systems that don't have it - e.g. the build servers for running unit tests which doesn't test the GUI.

**To test:**

Check that unit tests run cleanly on systems without mpl.

<!-- Instructions for testing. -->

Fixes #17557 .

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
