### PR TITLE
IndirectDataReduction - Moments - bugfixes

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -191,9 +191,9 @@ void IndirectMoments::momentsAlgComplete(bool error) {
   m_uiForm.ppMomentsPreview->addSpectrum(
       "M0", QString::fromStdString(resultWsNames[0]), 0, Qt::green);
   m_uiForm.ppMomentsPreview->addSpectrum(
-      "M1", QString::fromStdString(resultWsNames[2]), 0, Qt::black);
+      "M1", QString::fromStdString(resultWsNames[1]), 0, Qt::black);
   m_uiForm.ppMomentsPreview->addSpectrum(
-      "M2", QString::fromStdString(resultWsNames[3]), 0, Qt::red);
+      "M2", QString::fromStdString(resultWsNames[2]), 0, Qt::red);
   m_uiForm.ppMomentsPreview->resizeX();
 
   // Enable plot and save buttons

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -209,7 +209,7 @@ void IndirectMoments::plotClicked() {
       getWorkspaceBasename(m_uiForm.dsInput->getCurrentDataName()) + "_Moments";
   if (checkADSForPlotSaveWorkspace(outputWs.toStdString(), true)) {
     plotSpectrum(outputWs + "_M0");
-    plotSpectrum({outputWs + "_M0", outputWs + "_M2"});
+    plotSpectrum({outputWs + "_M2", outputWs + "_M4"});
   }
 }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -84,7 +84,7 @@ void IndirectMoments::run() {
   // Set the workspace name for Python script export
   m_pythonExportWsName = outputWorkspaceName + "_M0";
 
-  // Execute algorithm on seperate thread
+  // Execute algorithm on separate thread
   runAlgorithm(momentsAlg);
 }
 
@@ -119,11 +119,10 @@ void IndirectMoments::handleSampleInputReady(const QString &filename) {
   QPair<double, double> range = m_uiForm.ppRawPlot->getCurveRange("Raw");
 
   auto xRangeSelector = m_uiForm.ppRawPlot->getRangeSelector("XRange");
-  setRangeSelector(xRangeSelector, m_properties["EMin"], m_properties["EMax"],
-                   range);
   setPlotPropertyRange(xRangeSelector, m_properties["EMin"],
                        m_properties["EMax"], range);
-
+  setRangeSelector(xRangeSelector, m_properties["EMin"], m_properties["EMax"],
+                   range);
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
           SLOT(updateProperties(QtProperty *, double)));
 }
@@ -142,7 +141,7 @@ void IndirectMoments::rangeChanged(double min, double max) {
 /**
  * Handles when properties in the property manager are updated.
  *
- * Performs validation and uodated preview plot.
+ * Performs validation and updated preview plot.
  *
  * @param prop :: The property being updated
  * @param val :: The new value for the property


### PR DESCRIPTION
- Fixed preview plot bars being at wrong position when data is initially loaded
- Labels on the results graph now match the lines plotted
- Pressing "plot" when the algorithm is complete plots M0, then M2 & M4 on a seperate graph

**To test:**
Interfaces > Indirect > Data Reduction > Moments
//olympic/babylon5/Public/Louise McCann/DataReduction/Moments/ws_sqw.nxs
Scale factor: 0.0001
Check that results graph labels match lines by right-clicking group workspace "ws_Moments" -> "Plot Spectrum" and comparing plots.
Fixes #17573 .

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
