### PR TITLE
Fix doc test failing on ExtractMonitors

### DIFF
--- a/docs/source/algorithms/ExtractMonitors-v1.rst
+++ b/docs/source/algorithms/ExtractMonitors-v1.rst
@@ -33,17 +33,17 @@ Usage
   monitor_ws = mtd['Monitors']
 
   # Detector histograms
-  print("Number of spectra in input workspace: {}").format(ws.getNumberHistograms())
+  print("Number of spectra in input workspace: {0}").format(ws.getNumberHistograms())
   # Detector histograms (spectra missing detectors generate warnings)
-  print("Number of spectra in detector workspace: {}").format(detector_ws.getNumberHistograms())
+  print("Number of spectra in detector workspace: {0}").format(detector_ws.getNumberHistograms())
   # Monitor histograms
-  print("Number of spectra in monitor workspace: {}").format(monitor_ws.getNumberHistograms())
+  print("Number of spectra in monitor workspace: {0}").format(monitor_ws.getNumberHistograms())
   # Check if the first spectrum in the detector workspace is a monitor
-  print("Detector workspace isMonitor for spectrum 0: {}").format(detector_ws.getDetector(0).isMonitor())
+  print("Detector workspace isMonitor for spectrum 0: {0}").format(detector_ws.getDetector(0).isMonitor())
   # Check if the first spectrum in the monitor workspace is a monitor
-  print("Monitor workspace isMonitor for spectrum 0: {}").format(monitor_ws.getDetector(0).isMonitor())
+  print("Monitor workspace isMonitor for spectrum 0: {0}").format(monitor_ws.getDetector(0).isMonitor())
   # See the monitor workspace is set
-  print("Name of monitor workspace: {}").format(detector_ws.getMonitorWorkspace().name())
+  print("Name of monitor workspace: {0}").format(detector_ws.getMonitorWorkspace().name())
 
 Output:
 


### PR DESCRIPTION
Description of work.
The example in the documentation for ExtractMonitors uses implicit positional print parameters which are incompatible with Python 2.6 hence the doc tests fail. This PR changes the print statements to explicitly state their positions. 

**To test:**
Documentation test should pass

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
