### PR TITLE
Correct zero padding and prefix for CRISP

### DIFF
--- a/docs/source/release/v3.8.0/reflectometry.rst
+++ b/docs/source/release/v3.8.0/reflectometry.rst
@@ -21,6 +21,11 @@ CreateTransmissionWorkspace
 - A workflow diagram has been added to the documentation.
 - The rebinning in wavelength has been removed
 
+Instrument & IDF
+----------------
+
+- New CRISP data files are now recognised
+- POLREF IDF has been updated
 
 ISIS Reflectometry (Polref)
 ###########################

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -27,6 +27,7 @@
   </instrument>
 
   <instrument name="CRISP" shortname="CSP">
+    <zeropadding size="8" startRunNumber="99778" prefix="CRISP"/>
     <technique>Reflectometry</technique>
     <livedata address="NDXCRISP:6789" />
   </instrument>


### PR DESCRIPTION
**To test:**
- Open MantidPlot
- Open "First time setup" and set facility to ISIS and instrument to CRISP. In "Manage User Directories" make sure "Search Data Archive" is checked.
- Open `Load` dialog
- Old format (no zero padding and `CSP` prefix): enter `99776` and hit `Run`. Workspace `CSP99776` should be loaded into Mantid
- New format (padding and `CRISP` prefix): enter `99778` and hit `Run`. Workspace `CRISP00099778` should be loaded into Mantid

Fixes #17586.

Release notes were updated with this change and with changes merged in PR https://github.com/mantidproject/mantid/pull/17476

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
