### PR TITLE
Bump minimum Poco version to 1.4.6

### DIFF
--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -46,7 +46,7 @@ add_definitions ( -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB )
 # Need this defined globally for our log time values
 add_definitions ( -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG )
 
-find_package ( Poco 1.4.2 REQUIRED )
+find_package ( Poco 1.4.6 REQUIRED )
 include_directories( SYSTEM ${POCO_INCLUDE_DIRS} )
 
 find_package ( Nexus 4.3.1 REQUIRED )


### PR DESCRIPTION
Bumped minimum required poco version to 1.4.6

Fixes #17588 

_Does not need to be in the release notes._
