### PR TITLE
Fix LR autoreduction regex

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -154,7 +154,7 @@ class LRAutoReduction(PythonAlgorithm):
                 first_run_of_set = m.group(1)
                 sequence_number = int(m.group(2))
             else:
-                m = re.search(r"-(\d+)\.", title)
+                m = re.search(r"-(\d+)\.$", title)
                 if m is not None:
                     sequence_number = int(m.group(1))
                     first_run_of_set = int(run_number) - int(sequence_number) + 1


### PR DESCRIPTION
The regex used to get the sequence number of a LR run should match the end of the title string.

**To test:**
- review the code
- make sure tests pass

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
