### PR TITLE
fit function to model QENS data with Teixeira water

### DIFF
--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -109,6 +109,7 @@ set ( SRC_FILES
 	src/Functions/StretchExp.cpp
 	src/Functions/StretchExpMuon.cpp
 	src/Functions/TabulatedFunction.cpp
+	src/Functions/TeixeiraWaterSQE.cpp
 	src/Functions/ThermalNeutronBk2BkExpAlpha.cpp
 	src/Functions/ThermalNeutronBk2BkExpBeta.cpp
 	src/Functions/ThermalNeutronBk2BkExpConvPVoigt.cpp
@@ -255,6 +256,7 @@ set ( INC_FILES
 	inc/MantidCurveFitting/Functions/StretchExp.h
 	inc/MantidCurveFitting/Functions/StretchExpMuon.h
 	inc/MantidCurveFitting/Functions/TabulatedFunction.h
+	inc/MantidCurveFitting/Functions/TeixeiraWaterSQE.h
 	inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpAlpha.h
 	inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpBeta.h
 	inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpConvPVoigt.h
@@ -392,6 +394,7 @@ set ( TEST_FILES
 	Functions/StretchExpMuonTest.h
 	Functions/StretchExpTest.h
 	Functions/TabulatedFunctionTest.h
+    Functions/TeixeiraWaterSQETest.h
 	Functions/ThermalNeutronBk2BkExpAlphaTest.h
 	Functions/ThermalNeutronBk2BkExpBetaTest.h
 	Functions/ThermalNeutronBk2BkExpConvPVoigtTest.h

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/TeixeiraWaterSQE.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/TeixeiraWaterSQE.h
@@ -42,7 +42,7 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
  * @brief Teixeira's model to describe the translational diffusion of water
  */
 class DLLExport TeixeiraWaterSQE : public API::ParamFunction,
-  public API::IFunction1D {
+                                   public API::IFunction1D {
 public:
   TeixeiraWaterSQE();
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/TeixeiraWaterSQE.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/TeixeiraWaterSQE.h
@@ -1,0 +1,67 @@
+#ifndef MANTID_TEIXEIRAWATERSQE_H_
+#define MANTID_TEIXEIRAWATERSQE_H_
+
+// Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
+// Mantid Headers from the same project
+// Mantid headers from other projects
+#include "MantidAPI/ParamFunction.h"
+#include "MantidAPI/IFunction1D.h"
+// 3rd party library headers (N/A)
+// standard library headers (N/A)
+
+namespace Mantid {
+namespace CurveFitting {
+namespace Functions {
+/**
+@author Jose Borreguero, NScD
+@date 25/09/2016
+
+Copyright &copy; 2007-8 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+National Laboratory & European Spallation Source
+
+This file is part of Mantid.
+
+Mantid is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Mantid is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+File change history is stored at: <https://github.com/mantidproject/mantid>
+Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+
+/**
+ * @brief Teixeira's model to describe the translational diffusion of water
+ */
+class DLLExport TeixeiraWaterSQE : public API::ParamFunction,
+  public API::IFunction1D {
+public:
+  TeixeiraWaterSQE();
+
+  /// overwrite IFunction base class methods
+  void init() override;
+
+  /// overwrite IFunction base class methods
+  std::string name() const override { return "TeixeiraWaterSQE"; }
+
+  /// overwrite IFunction base class methods
+  const std::string category() const override { return "QuasiElastic"; }
+
+protected:
+  void function1D(double *out, const double *xValues,
+                  const size_t nData) const override;
+};
+
+} // namespace Functions
+} // namespace CurveFitting
+} // namespace Mantid
+
+#endif // MANTID_TEIXEIRAWATERSQE_H_

--- a/Framework/CurveFitting/src/Functions/TeixeiraWaterSQE.cpp
+++ b/Framework/CurveFitting/src/Functions/TeixeiraWaterSQE.cpp
@@ -1,0 +1,91 @@
+// Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
+// Main Module Header
+#include "MantidCurveFitting/Functions/TeixeiraWaterSQE.h"
+// Mantid Headers from the same project
+#include "MantidCurveFitting/Constraints/BoundaryConstraint.h"
+// Mantid headers from other projects
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/IFunction.h"
+// third party library headers
+// standard library headers
+#include <cmath>
+#include <limits>
+
+using BConstraint = Mantid::CurveFitting::Constraints::BoundaryConstraint;
+
+namespace {
+Mantid::Kernel::Logger g_log("TeixeiraWaterSQE");
+}
+
+namespace Mantid {
+namespace CurveFitting {
+namespace Functions {
+
+DECLARE_FUNCTION(TeixeiraWaterSQE)
+
+/**
+ * @brief Constructor where parameters and attributes are declared
+ */
+TeixeiraWaterSQE::TeixeiraWaterSQE() {
+  this->declareParameter("Height", 1.0, "scaling factor");
+  this->declareParameter("Length", 0.98, "jump length (Angstroms)");
+  this->declareParameter("Tau", 10.0, "Residence time (ps)");
+  this->declareParameter("Centre", 0.0, "Shift along the X-axis");
+  // Momentum transfer Q, an attribute (not a fitting parameter)
+  this->declareAttribute("Q", API::IFunction::Attribute(0.3));
+}
+
+/**
+ * @brief Set constraints on fitting parameters
+ */
+void TeixeiraWaterSQE::init() {
+  // Ensure positive values for Height, Length, and Tau
+  auto HeightConstraint = new BConstraint(
+      this, "Height", std::numeric_limits<double>::epsilon(), true);
+  this->addConstraint(HeightConstraint);
+  auto LengthConstraint = new BConstraint(
+      this, "Length", std::numeric_limits<double>::epsilon(), true);
+  this->addConstraint(LengthConstraint);
+  auto TauConstraint = new BConstraint(
+      this, "Tau", std::numeric_limits<double>::epsilon(), true);
+  this->addConstraint(TauConstraint);
+}
+
+/**
+ * @brief Calculate function values on an energy domain
+ * @param out array to store function values
+ * @param xValues energy domain where function is evaluated
+ * @param nData size of the energy domain
+ */
+void TeixeiraWaterSQE::function1D(double *out, const double *xValues,
+  const size_t nData) const {
+  double hbar(0.658211626);  // ps*meV
+  auto H = this->getParameter("Height");
+  auto L = this->getParameter("Length");
+  auto T = this->getParameter("Tau");
+  auto C = this->getParameter("Centre");
+  auto Q = this->getAttribute("Q").asDouble();
+
+  // Penalize negative parameters, just in case they show up
+  // when calculating the numeric derivative
+  if (H < std::numeric_limits<double>::epsilon() ||
+      L < std::numeric_limits<double>::epsilon() ||
+      T < std::numeric_limits<double>::epsilon()   ) {
+    for (size_t j = 0; j<nData; j++) {
+        out[j] = std::numeric_limits<double>::infinity();
+    }
+    return;
+  }
+
+  // Lorentzian intensities and HWHM
+  auto G = hbar/T * pow(Q*L,2)/(1+pow(Q*L,2));
+  for (size_t j=0; j<nData; j++) {
+    auto E = xValues[j] - C;
+    out[j] += H * G/(G*G+E*E ) / M_PI;
+  }
+}
+
+
+} // namespace Functions
+} // namespace CurveFitting
+} // namespace Mantid

--- a/Framework/CurveFitting/src/Functions/TeixeiraWaterSQE.cpp
+++ b/Framework/CurveFitting/src/Functions/TeixeiraWaterSQE.cpp
@@ -58,8 +58,8 @@ void TeixeiraWaterSQE::init() {
  * @param nData size of the energy domain
  */
 void TeixeiraWaterSQE::function1D(double *out, const double *xValues,
-  const size_t nData) const {
-  double hbar(0.658211626);  // ps*meV
+                                  const size_t nData) const {
+  double hbar(0.658211626); // ps*meV
   auto H = this->getParameter("Height");
   auto L = this->getParameter("Length");
   auto T = this->getParameter("Tau");
@@ -70,21 +70,20 @@ void TeixeiraWaterSQE::function1D(double *out, const double *xValues,
   // when calculating the numeric derivative
   if (H < std::numeric_limits<double>::epsilon() ||
       L < std::numeric_limits<double>::epsilon() ||
-      T < std::numeric_limits<double>::epsilon()   ) {
-    for (size_t j = 0; j<nData; j++) {
-        out[j] = std::numeric_limits<double>::infinity();
+      T < std::numeric_limits<double>::epsilon()) {
+    for (size_t j = 0; j < nData; j++) {
+      out[j] = std::numeric_limits<double>::infinity();
     }
     return;
   }
 
   // Lorentzian intensities and HWHM
-  auto G = hbar/T * pow(Q*L,2)/(1+pow(Q*L,2));
-  for (size_t j=0; j<nData; j++) {
+  auto G = hbar / T * pow(Q * L, 2) / (1 + pow(Q * L, 2));
+  for (size_t j = 0; j < nData; j++) {
     auto E = xValues[j] - C;
-    out[j] += H * G/(G*G+E*E ) / M_PI;
+    out[j] += H * G / (G * G + E * E) / M_PI;
   }
 }
-
 
 } // namespace Functions
 } // namespace CurveFitting

--- a/Framework/CurveFitting/src/Functions/TeixeiraWaterSQE.cpp
+++ b/Framework/CurveFitting/src/Functions/TeixeiraWaterSQE.cpp
@@ -28,7 +28,8 @@ DECLARE_FUNCTION(TeixeiraWaterSQE)
  */
 TeixeiraWaterSQE::TeixeiraWaterSQE() {
   this->declareParameter("Height", 1.0, "scaling factor");
-  this->declareParameter("DiffCoeff", 2.3, "Diffusion coefficient (10^(-5)cm^2/s)");
+  this->declareParameter("DiffCoeff", 2.3,
+                         "Diffusion coefficient (10^(-5)cm^2/s)");
   this->declareParameter("Tau", 1.25, "Residence time (ps)");
   this->declareParameter("Centre", 0.0, "Shift along the X-axis");
   // Momentum transfer Q, an attribute (not a fitting parameter)
@@ -78,7 +79,7 @@ void TeixeiraWaterSQE::function1D(double *out, const double *xValues,
   }
 
   // Lorentzian intensities and HWHM
-  auto G = hbar * D*Q*Q/(1+D*Q*Q*T);
+  auto G = hbar * D * Q * Q / (1 + D * Q * Q * T);
   for (size_t j = 0; j < nData; j++) {
     auto E = xValues[j] - C;
     out[j] += H * G / (G * G + E * E) / M_PI;

--- a/Framework/CurveFitting/src/Functions/TeixeiraWaterSQE.cpp
+++ b/Framework/CurveFitting/src/Functions/TeixeiraWaterSQE.cpp
@@ -79,6 +79,7 @@ void TeixeiraWaterSQE::function1D(double *out, const double *xValues,
   }
 
   // Lorentzian intensities and HWHM
+  D *= 0.10;  // conversion from 10^{-5}cm^2/s to Angstrom^2/ps, the internal units used
   auto G = hbar * D * Q * Q / (1 + D * Q * Q * T);
   for (size_t j = 0; j < nData; j++) {
     auto E = xValues[j] - C;

--- a/Framework/CurveFitting/src/Functions/TeixeiraWaterSQE.cpp
+++ b/Framework/CurveFitting/src/Functions/TeixeiraWaterSQE.cpp
@@ -79,7 +79,8 @@ void TeixeiraWaterSQE::function1D(double *out, const double *xValues,
   }
 
   // Lorentzian intensities and HWHM
-  D *= 0.10;  // conversion from 10^{-5}cm^2/s to Angstrom^2/ps, the internal units used
+  D *= 0.10; // conversion from 10^{-5}cm^2/s to Angstrom^2/ps, the internal
+             // units used
   auto G = hbar * D * Q * Q / (1 + D * Q * Q * T);
   for (size_t j = 0; j < nData; j++) {
     auto E = xValues[j] - C;

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -88,10 +88,10 @@ private:
     auto func = boost::make_shared<TestableTeixeiraWaterSQE>();
     func->initialize();
     func->setParameter("Height", 1.0);
-    func->setParameter("DiffCoeff", 1.0);   // 1Angstrom
-    func->setParameter("Tau", 1.0);      // 1ps
-    func->setParameter("Centre", 0.001); // shifted by 1micro-eV
-    func->setAttributeValue("Q", 1.0);   // 1Angstrom^{-1}
+    func->setParameter("DiffCoeff", 1.0); // 1Angstrom
+    func->setParameter("Tau", 1.0);       // 1ps
+    func->setParameter("Centre", 0.001);  // shifted by 1micro-eV
+    func->setAttributeValue("Q", 1.0);    // 1Angstrom^{-1}
     // HWHM=0.329105813
     return func;
   }

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -57,7 +57,7 @@ public:
     auto func = createTestTeixeiraWaterSQE();
     func->setParameter("Tau", 50.0); // make it peaky
     double dE(0.0001);               // dE is 1micro-eV
-    const size_t nData(20000); // number of energy values to evaluate the function
+    const size_t nData(20000);
     // Create the domain of energy values
     std::vector<double> xValues(nData, 0);
     std::iota(xValues.begin(), xValues.end(), -10000.0);

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -55,9 +55,10 @@ public:
    */
   void test_normalization() {
     auto func = createTestTeixeiraWaterSQE();
+    func->setParameter("Tau", 50.0);  // make it peaky
     double dE(0.0001); // dE is 1micro-eV
     const size_t nData(
-        2E5); //  number of energy values to evaluate the function
+        2E4); //  number of energy values to evaluate the function
     // Create the domain of energy values
     std::vector<double> xValues(nData, 0);
     std::iota(xValues.begin(), xValues.end(), -1E5);
@@ -72,7 +73,7 @@ public:
                    std::bind1st(std::multiplies<double>(), dE));
     auto integral =
         std::accumulate(calculatedValues.begin(), calculatedValues.end(), 0.0);
-    TS_ASSERT_DELTA(integral, 1.0, 1e-8);
+    TS_ASSERT_DELTA(integral, 1.0, 0.01);
   }
 
 private:

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -1,0 +1,100 @@
+#ifndef TEIXEIRAWATERSQETEST_H_
+#define TEIXEIRAWATERSQETEST_H_
+
+// Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
+// Main Module Header
+#include "MantidCurveFitting/Functions/TeixeiraWaterSQE.h"
+// Mantid Headers from the same project (n/a)
+// Mantid headers from other projects
+#include "MantidAPI/FunctionDomain1D.h"
+#include "MantidAPI/FunctionValues.h"
+#include <cxxtest/TestSuite.h>
+// third party library headers (n/a)
+// standard library headers (n/a)
+#include <random>
+#include <numeric>
+
+#include <boost/make_shared.hpp>
+using Mantid::CurveFitting::Functions::TeixeiraWaterSQE;
+
+class TeixeiraWaterSQETest : public CxxTest::TestSuite {
+public:
+
+void test_categories() {
+  TeixeiraWaterSQE func;
+  const std::vector<std::string> categories = func.categories();
+  TS_ASSERT(categories.size() == 1);
+  TS_ASSERT(categories[0] == "Quasielastic");
+}
+
+/**
+ * @brief Parameters can be set and read
+ */
+  void test_parameters() {
+    auto func = createTestTeixeiraWaterSQE();
+    TS_ASSERT_EQUALS(func->nParams(), 4);
+    TS_ASSERT_EQUALS(func->getParameter("Heigth"), 1);
+    TS_ASSERT_EQUALS(func->getParameter("Length"), 1);
+    TS_ASSERT_EQUALS(func->getParameter("Tau"), 1);
+    TS_ASSERT_EQUALS(func->getParameter("Centre"), 0.001);
+  }
+
+/**
+ * @brief Evaluate the function at one particular enery value
+ */
+void test_function_gives_expected_value_for_given_input() {
+  auto func = createTestTeixeiraWaterSQE();
+  const size_t nData(1);
+  std::vector<double> xValues(nData, 0.1);  // Evaluate at E=0.1meV
+  std::vector<double> calculatedValues(nData, 0);
+  func->function1D(calculatedValues.data(), xValues.data(), nData);
+  TS_ASSERT_DELTA(calculatedValues[0], 0.88693745, 1e-8);
+}
+
+/**
+ * @brief Test function is normalized in the Energy axis
+ */
+void test_normalization() {
+  auto func = createTestTeixeiraWaterSQE();
+  double dE(0.0001);  // dE is 1micro-eV
+  const size_t nData(2E5);  //  number of energy values to evaluate the function
+  // Create the domain of energy values
+  std::vector<double> xValues(nData, 0);
+  std::iota(xValues.begin(), xValues.end(), -1E5);
+  std::transform(xValues.begin(), xValues.end(), xValues.begin(),
+    std::bind1st(std::multiplies<double>(),dE));
+  // Evaluate the function on the domain
+  std::vector<double> calculatedValues(nData, 0);
+  func->function1D(calculatedValues.data(), xValues.data(), nData);
+  // Integrate the evaluation
+  std::transform(calculatedValues.begin(), calculatedValues.end(), calculatedValues.begin(),
+    std::bind1st(std::multiplies<double>(),dE));
+  auto integral = std::accumulate(calculatedValues.begin(), calculatedValues.end(), 0.0);
+  TS_ASSERT_DELTA(integral, 1.0, 1e-8);
+}
+
+private:
+
+class TestableTeixeiraWaterSQE : public TeixeiraWaterSQE {
+  public:
+  void function1D(double *out, const double *xValues,
+    const size_t nData) const override {
+    TeixeiraWaterSQE::function1D(out, xValues, nData);
+  }
+};
+
+boost::shared_ptr<TestableTeixeiraWaterSQE> createTestTeixeiraWaterSQE() {
+ auto func = boost::make_shared<TestableTeixeiraWaterSQE>();
+ func->initialize();
+ func->setParameter("Heigth", 1.0);
+ func->setParameter("Length", 1.0);  // 1Angstrom
+ func->setParameter("Tau", 1.0);  // 1ps
+ func->setParameter("Centre", 0.001);  // shifted by 1micro-eV
+ func->setAttributeValue("Q", 1.0);  // 1Angstrom^{-1}
+ // HWHM=0.329105813
+ return func;
+}
+
+};
+
+#endif /*TEIXEIRAWATERSQETEST_H_*/

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -57,11 +57,10 @@ public:
     auto func = createTestTeixeiraWaterSQE();
     func->setParameter("Tau", 50.0); // make it peaky
     double dE(0.0001);               // dE is 1micro-eV
-    const size_t nData(
-        2E4); //  number of energy values to evaluate the function
+    const size_t nData(2E4);         // number of energy values to evaluate the function
     // Create the domain of energy values
     std::vector<double> xValues(nData, 0);
-    std::iota(xValues.begin(), xValues.end(), -1E5);
+    std::iota(xValues.begin(), xValues.end(), -1E4);
     std::transform(xValues.begin(), xValues.end(), xValues.begin(),
                    std::bind1st(std::multiplies<double>(), dE));
     // Evaluate the function on the domain

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -32,9 +32,9 @@ public:
   void test_parameters() {
     auto func = createTestTeixeiraWaterSQE();
     TS_ASSERT_EQUALS(func->nParams(), 4);
-    TS_ASSERT_EQUALS(func->getParameter("Height"), 1);
-    TS_ASSERT_EQUALS(func->getParameter("Length"), 1);
-    TS_ASSERT_EQUALS(func->getParameter("Tau"), 1);
+    TS_ASSERT_EQUALS(func->getParameter("Height"), 1.0);
+    TS_ASSERT_EQUALS(func->getParameter("DiffCoeff"), 1.0);
+    TS_ASSERT_EQUALS(func->getParameter("Tau"), 1.0);
     TS_ASSERT_EQUALS(func->getParameter("Centre"), 0.001);
   }
 
@@ -88,7 +88,7 @@ private:
     auto func = boost::make_shared<TestableTeixeiraWaterSQE>();
     func->initialize();
     func->setParameter("Height", 1.0);
-    func->setParameter("Length", 1.0);   // 1Angstrom
+    func->setParameter("DiffCoeff", 1.0);   // 1Angstrom
     func->setParameter("Tau", 1.0);      // 1ps
     func->setParameter("Centre", 0.001); // shifted by 1micro-eV
     func->setAttributeValue("Q", 1.0);   // 1Angstrom^{-1}

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -47,7 +47,7 @@ public:
     std::vector<double> xValues(nData, 0.1); // Evaluate at E=0.1meV
     std::vector<double> calculatedValues(nData, 0);
     func->function1D(calculatedValues.data(), xValues.data(), nData);
-    TS_ASSERT_DELTA(calculatedValues[0], 0.88693745, 1e-8);
+    TS_ASSERT_DELTA(calculatedValues[0], 1.423369463, 1e-8);
   }
 
   /**

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -55,8 +55,8 @@ public:
    */
   void test_normalization() {
     auto func = createTestTeixeiraWaterSQE();
-    func->setParameter("Tau", 50.0);  // make it peaky
-    double dE(0.0001); // dE is 1micro-eV
+    func->setParameter("Tau", 50.0); // make it peaky
+    double dE(0.0001);               // dE is 1micro-eV
     const size_t nData(
         2E4); //  number of energy values to evaluate the function
     // Create the domain of energy values

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -57,7 +57,7 @@ public:
     auto func = createTestTeixeiraWaterSQE();
     func->setParameter("Tau", 50.0); // make it peaky
     double dE(0.0001);               // dE is 1micro-eV
-    const size_t nData(2E4);         // number of energy values to evaluate the function
+    const size_t nData(2E4); // number of energy values to evaluate the function
     // Create the domain of energy values
     std::vector<double> xValues(nData, 0);
     std::iota(xValues.begin(), xValues.end(), -1E4);

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -57,10 +57,9 @@ public:
     auto func = createTestTeixeiraWaterSQE();
     func->setParameter("Tau", 50.0); // make it peaky
     double dE(0.0001);               // dE is 1micro-eV
-    const size_t nData(2E4); // number of energy values to evaluate the function
+    const size_t nData(20000); // number of energy values to evaluate the function
     // Create the domain of energy values
     std::vector<double> xValues(nData, 0);
-    std::iota(xValues.begin(), xValues.end(), -1E4);
     std::transform(xValues.begin(), xValues.end(), xValues.begin(),
                    std::bind1st(std::multiplies<double>(), dE));
     // Evaluate the function on the domain

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -60,6 +60,7 @@ public:
     const size_t nData(20000); // number of energy values to evaluate the function
     // Create the domain of energy values
     std::vector<double> xValues(nData, 0);
+    std::iota(xValues.begin(), xValues.end(), -10000.0);
     std::transform(xValues.begin(), xValues.end(), xValues.begin(),
                    std::bind1st(std::multiplies<double>(), dE));
     // Evaluate the function on the domain

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -19,17 +19,16 @@ using Mantid::CurveFitting::Functions::TeixeiraWaterSQE;
 
 class TeixeiraWaterSQETest : public CxxTest::TestSuite {
 public:
+  void test_categories() {
+    TeixeiraWaterSQE func;
+    const std::vector<std::string> categories = func.categories();
+    TS_ASSERT(categories.size() == 1);
+    TS_ASSERT(categories[0] == "Quasielastic");
+  }
 
-void test_categories() {
-  TeixeiraWaterSQE func;
-  const std::vector<std::string> categories = func.categories();
-  TS_ASSERT(categories.size() == 1);
-  TS_ASSERT(categories[0] == "Quasielastic");
-}
-
-/**
- * @brief Parameters can be set and read
- */
+  /**
+   * @brief Parameters can be set and read
+   */
   void test_parameters() {
     auto func = createTestTeixeiraWaterSQE();
     TS_ASSERT_EQUALS(func->nParams(), 4);
@@ -39,62 +38,63 @@ void test_categories() {
     TS_ASSERT_EQUALS(func->getParameter("Centre"), 0.001);
   }
 
-/**
- * @brief Evaluate the function at one particular enery value
- */
-void test_function_gives_expected_value_for_given_input() {
-  auto func = createTestTeixeiraWaterSQE();
-  const size_t nData(1);
-  std::vector<double> xValues(nData, 0.1);  // Evaluate at E=0.1meV
-  std::vector<double> calculatedValues(nData, 0);
-  func->function1D(calculatedValues.data(), xValues.data(), nData);
-  TS_ASSERT_DELTA(calculatedValues[0], 0.88693745, 1e-8);
-}
+  /**
+   * @brief Evaluate the function at one particular enery value
+   */
+  void test_function_gives_expected_value_for_given_input() {
+    auto func = createTestTeixeiraWaterSQE();
+    const size_t nData(1);
+    std::vector<double> xValues(nData, 0.1); // Evaluate at E=0.1meV
+    std::vector<double> calculatedValues(nData, 0);
+    func->function1D(calculatedValues.data(), xValues.data(), nData);
+    TS_ASSERT_DELTA(calculatedValues[0], 0.88693745, 1e-8);
+  }
 
-/**
- * @brief Test function is normalized in the Energy axis
- */
-void test_normalization() {
-  auto func = createTestTeixeiraWaterSQE();
-  double dE(0.0001);  // dE is 1micro-eV
-  const size_t nData(2E5);  //  number of energy values to evaluate the function
-  // Create the domain of energy values
-  std::vector<double> xValues(nData, 0);
-  std::iota(xValues.begin(), xValues.end(), -1E5);
-  std::transform(xValues.begin(), xValues.end(), xValues.begin(),
-    std::bind1st(std::multiplies<double>(),dE));
-  // Evaluate the function on the domain
-  std::vector<double> calculatedValues(nData, 0);
-  func->function1D(calculatedValues.data(), xValues.data(), nData);
-  // Integrate the evaluation
-  std::transform(calculatedValues.begin(), calculatedValues.end(), calculatedValues.begin(),
-    std::bind1st(std::multiplies<double>(),dE));
-  auto integral = std::accumulate(calculatedValues.begin(), calculatedValues.end(), 0.0);
-  TS_ASSERT_DELTA(integral, 1.0, 1e-8);
-}
+  /**
+   * @brief Test function is normalized in the Energy axis
+   */
+  void test_normalization() {
+    auto func = createTestTeixeiraWaterSQE();
+    double dE(0.0001); // dE is 1micro-eV
+    const size_t nData(
+        2E5); //  number of energy values to evaluate the function
+    // Create the domain of energy values
+    std::vector<double> xValues(nData, 0);
+    std::iota(xValues.begin(), xValues.end(), -1E5);
+    std::transform(xValues.begin(), xValues.end(), xValues.begin(),
+                   std::bind1st(std::multiplies<double>(), dE));
+    // Evaluate the function on the domain
+    std::vector<double> calculatedValues(nData, 0);
+    func->function1D(calculatedValues.data(), xValues.data(), nData);
+    // Integrate the evaluation
+    std::transform(calculatedValues.begin(), calculatedValues.end(),
+                   calculatedValues.begin(),
+                   std::bind1st(std::multiplies<double>(), dE));
+    auto integral =
+        std::accumulate(calculatedValues.begin(), calculatedValues.end(), 0.0);
+    TS_ASSERT_DELTA(integral, 1.0, 1e-8);
+  }
 
 private:
-
-class TestableTeixeiraWaterSQE : public TeixeiraWaterSQE {
+  class TestableTeixeiraWaterSQE : public TeixeiraWaterSQE {
   public:
-  void function1D(double *out, const double *xValues,
-    const size_t nData) const override {
-    TeixeiraWaterSQE::function1D(out, xValues, nData);
+    void function1D(double *out, const double *xValues,
+                    const size_t nData) const override {
+      TeixeiraWaterSQE::function1D(out, xValues, nData);
+    }
+  };
+
+  boost::shared_ptr<TestableTeixeiraWaterSQE> createTestTeixeiraWaterSQE() {
+    auto func = boost::make_shared<TestableTeixeiraWaterSQE>();
+    func->initialize();
+    func->setParameter("Heigth", 1.0);
+    func->setParameter("Length", 1.0);   // 1Angstrom
+    func->setParameter("Tau", 1.0);      // 1ps
+    func->setParameter("Centre", 0.001); // shifted by 1micro-eV
+    func->setAttributeValue("Q", 1.0);   // 1Angstrom^{-1}
+    // HWHM=0.329105813
+    return func;
   }
-};
-
-boost::shared_ptr<TestableTeixeiraWaterSQE> createTestTeixeiraWaterSQE() {
- auto func = boost::make_shared<TestableTeixeiraWaterSQE>();
- func->initialize();
- func->setParameter("Heigth", 1.0);
- func->setParameter("Length", 1.0);  // 1Angstrom
- func->setParameter("Tau", 1.0);  // 1ps
- func->setParameter("Centre", 0.001);  // shifted by 1micro-eV
- func->setAttributeValue("Q", 1.0);  // 1Angstrom^{-1}
- // HWHM=0.329105813
- return func;
-}
-
 };
 
 #endif /*TEIXEIRAWATERSQETEST_H_*/

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -23,7 +23,7 @@ public:
     TeixeiraWaterSQE func;
     const std::vector<std::string> categories = func.categories();
     TS_ASSERT(categories.size() == 1);
-    TS_ASSERT(categories[0] == "Quasielastic");
+    TS_ASSERT(categories[0] == "QuasiElastic");
   }
 
   /**

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -32,7 +32,7 @@ public:
   void test_parameters() {
     auto func = createTestTeixeiraWaterSQE();
     TS_ASSERT_EQUALS(func->nParams(), 4);
-    TS_ASSERT_EQUALS(func->getParameter("Heigth"), 1);
+    TS_ASSERT_EQUALS(func->getParameter("Height"), 1);
     TS_ASSERT_EQUALS(func->getParameter("Length"), 1);
     TS_ASSERT_EQUALS(func->getParameter("Tau"), 1);
     TS_ASSERT_EQUALS(func->getParameter("Centre"), 0.001);
@@ -87,7 +87,7 @@ private:
   boost::shared_ptr<TestableTeixeiraWaterSQE> createTestTeixeiraWaterSQE() {
     auto func = boost::make_shared<TestableTeixeiraWaterSQE>();
     func->initialize();
-    func->setParameter("Heigth", 1.0);
+    func->setParameter("Height", 1.0);
     func->setParameter("Length", 1.0);   // 1Angstrom
     func->setParameter("Tau", 1.0);      // 1ps
     func->setParameter("Centre", 0.001); // shifted by 1micro-eV

--- a/docs/source/fitfunctions/TeixeiraWaterSQE.rst
+++ b/docs/source/fitfunctions/TeixeiraWaterSQE.rst
@@ -47,7 +47,7 @@ with a fit to the following model:
 
 :math:`S(Q,E) = I \cdot R(Q,E) \otimes [EISF\delta(E) + (1-EISF)\cdot TeixeiraWaterSQE(Q,E)] + (a+bE)`
 
-.. testcode:: TeixeiraWaterSQE
+.. testcode:: ExampleTeixeiraWaterSQE
 
     from __future__ import (absolute_import, division, print_function)
     import numpy as np
@@ -150,7 +150,7 @@ with a fit to the following model:
 
 Output:
 
-.. testoutput:: ExampleIsoRotDiff
+.. testoutput:: ExampleTeixeiraWaterSQE
 
     Optimal Length within 10% of nominal value
     Optimal Tau within 10% of nominal value

--- a/docs/source/fitfunctions/TeixeiraWaterSQE.rst
+++ b/docs/source/fitfunctions/TeixeiraWaterSQE.rst
@@ -1,0 +1,166 @@
+.. _func-TeixeiraWaterSQE:
+
+==========
+TeixeiraWaterSQE
+==========
+
+.. index:: TeixeiraWaterSQE
+
+This fitting function models the dynamic structure factor
+for a particle undergoing jump diffusion [1]_.
+
+.. math::
+
+   S(Q,E) = Height \cdot \frac{1}{\pi} \frac{\Gamma}{\Gamma^2+(E-Centre)^2}
+
+   \Gamma = \frac{\hbar}{Tau} \cdot \frac{(Q\cdot Length)^2}{1+(Q\cdot Length)^2}
+
+where:
+
+-  :math:`Height` - Intensity scaling, a fit parameter
+-  :math:`Length` - jump length, a fit parameter
+-  :math:`Centre` - Centre of peak, a fit parameter
+-  :math:`Tau` - Residence time, a fit parameter
+-  :math:`Q` - Momentum transfer, an attribute (non-fitting)
+
+.. attributes::
+
+:math:`Q` (double, default=0.3) Momentum transfer
+
+References
+----------
+
+.. [1] J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
+
+Usage
+-----
+
+**Example - Global fit to a synthetic signal:**
+
+The signal is modeled by the convolution of a resolution function
+with an elastic signal plus this jump-diffusion model.
+The resolution is modeled as a normal distribution.
+We insert a random noise in the jump-diffusion model.
+Finally, we choose a linear background noise.
+The goal is to find out the residence time and the jump length
+with a fit to the following model:
+
+:math:`S(Q,E) = I \cdot R(Q,E) \otimes [EISF\delta(E) + (1-EISF)\cdot TeixeiraWaterSQE(Q,E)] + (a+bE)`
+
+.. testcode:: TeixeiraWaterSQE
+
+    from __future__ import (absolute_import, division, print_function)
+    import numpy as np
+    """Generate resolution function with the following properties:
+        1. Gaussian in Energy
+        2. Dynamic range = [-0.1, 0.1] meV with spacing 0.0004 meV
+        3. FWHM = 0.005 meV
+    """
+    dE=0.0004;  FWHM=0.005
+    sigma = FWHM/(2*np.sqrt(2*np.log(2)))
+    dataX = np.arange(-0.1,0.1,dE)
+    nE=len(dataX)
+    rdataY = np.exp(-0.5*(dataX/sigma)**2)  # the resolution function
+    Qs = np.array([0.3, 0.5, 0.7, 0.9, 1.1, 1.3, 1.5, 1.9])  # Q-values
+    nQ = len(Qs)
+    resolution=CreateWorkspace(np.tile(dataX,nQ), np.tile(rdataY,nQ), NSpec=nQ, UnitX="deltaE",
+        VerticalAxisUnit="MomentumTransfer", VerticalAxisValues=Qs)
+    """Generate the signal of a particle undergoing jump diffusion.
+        1. jump length = 2.6 Angstroms
+        2. residence time = 4.3 ps
+        3. linear background noise, up to 10% of the inelastic intensity
+        4. Up to 10% of noise in the quasi-elastic signal
+        5. Assume <u^2>=0.8 Angstroms^2 for the Debye-Waller factor
+    """
+    length=2.6;  tau=4.3;  u2=0.8;  hbar=0.658211626  # units of hbar are ps*meV
+    qdataY=np.empty(0)  # will hold all Q-values (all spectra)
+    for Q in Qs:
+        centre=2*dE*(0.5-np.random.random())  # some shift along the energy axis
+        EISF = np.exp(-u2*Q**2)  # Debye Waller factor
+        HWHM = hbar/tau * (Q*length)**2 / (1+(Q*length)**2)
+        dataY = (1-EISF)/np.pi * HWHM/(HWHM**2+(dataX-centre)**2)  # inelastic component
+        dataY = dE*np.convolve(rdataY, dataY, mode="same")  # convolve with resolution
+        dataYmax = max(dataY)  # maximum of the inelastic component
+        dataY += EISF*rdataY  # add elastic component
+        noise = dataY*np.random.random(nE)*0.1 # noise is up to 10% of the signal
+        background = np.random.random()+np.random.random()*dataX # linear background
+        background = 0.1*dataYmax*(background/max(np.abs(background))) # up to 10%
+        dataY += background
+        qdataY=np.append(qdataY, dataY)
+    data=CreateWorkspace(np.tile(dataX,nQ), qdataY, NSpec=nQ, UnitX="deltaE",
+        VerticalAxisUnit="MomentumTransfer", VerticalAxisValues=Qs)
+    """Our model is:
+        S(Q,E) = Convolution(resolution, TeixeiraWaterSQE) + LinearBackground
+        We do a global fit (all spectra) to find out the radius and relaxation times.
+    """
+    # This is the template fitting model for each spectrum (each Q-value):
+    # Our initial guesses are length=1.0 and  tau=10
+    single_model_template="""(composite=Convolution,FixResolution=true,NumDeriv=true;
+    name=TabulatedFunction,Workspace=resolution,WorkspaceIndex=_WI_,Scaling=1,Shift=0,XScaling=1;
+    (name=DeltaFunction,Height=0.5,Centre=0,constraints=(0<Height<1);
+    name=TeixeiraWaterSQE,Q=_Q_,Height=0.5,Tau=10,Length=1.0,Centre=0;
+    ties=(f1.Height=1-f0.Height,f1.Centre=f0.Centre)));
+    name=LinearBackground,A0=0,A1=0"""
+    # Now create the string representation of the global model (all spectra, all Q-values):
+    global_model="composite=MultiDomainFunction,NumDeriv=true;"
+    wi=0  # current workspace index
+    for Q in Qs:
+        single_model = single_model_template.replace("_Q_", str(Q))  # insert Q-value
+        single_model = single_model.replace("_WI_", str(wi))  # insert workspace index
+        global_model += "(composite=CompositeFunction,NumDeriv=true,$domains=i;{0});\n".format(single_model)
+        wi+=1
+    # Parameters Length and Tau are the same for all spectra, thus tie them:
+    ties=['='.join(["f{0}.f0.f1.f1.Length".format(wi) for wi in reversed(range(nQ))]),
+        '='.join(["f{0}.f0.f1.f1.Tau".format(wi) for wi in reversed(range(nQ))]) ]
+    global_model += "ties=("+','.join(ties)+')'  # insert ties in the global model string
+    # Now relate each domain(i.e. spectrum) to each single model
+    domain_model=dict()
+    for wi in range(nQ):
+        if wi == 0:
+            domain_model.update({"InputWorkspace": data.name(), "WorkspaceIndex": str(wi),
+                "StartX": "-0.09", "EndX": "0.09"})
+        else:
+            domain_model.update({"InputWorkspace_"+str(wi): data.name(), "WorkspaceIndex_"+str(wi): str(wi),
+                "StartX_"+str(wi): "-0.09", "EndX_"+str(wi): "0.09"})
+    # Invoke the Fit algorithm using global_model and domain_model:
+    output_workspace = "glofit_"+data.name()
+    Fit(Function=global_model, Output=output_workspace, CreateOutput=True, MaxIterations=500, **domain_model)
+    # Extract Length and Tau from workspace glofit_data_Parameters, the output of Fit:
+    nparms=0
+    parameter_ws = mtd[output_workspace+"_Parameters"]
+    for irow in range(parameter_ws.rowCount()):
+        row = parameter_ws.row(irow)
+        if row["Name"]=="f0.f0.f1.f1.Length":
+            Length=row["Value"]
+            nparms+=1
+        elif row["Name"]=="f0.f0.f1.f1.Tau":
+            Tau=row["Value"]
+            nparms+=1
+        if nparms==2:
+            break  # We got the three parameters we are interested in
+    # Check nominal and optimal values are within error ranges:
+    if abs(length-Length)/length < 0.1:
+        print("Optimal Length within 10% of nominal value")
+    else:
+        print("Error. Obtained Length=",Length," instead of",length)
+    if abs(tau-Tau)/tau < 0.1:
+        print("Optimal Tau within 10% of nominal value")
+    else:
+        print("Error. Obtained Tau=",Tau," instead of",tau)
+
+Output:
+
+.. testoutput:: ExampleIsoRotDiff
+
+    Optimal Length within 10% of nominal value
+    Optimal Tau within 10% of nominal value
+
+.. categories::
+
+.. sourcelink::
+
+
+
+
+
+

--- a/docs/source/fitfunctions/TeixeiraWaterSQE.rst
+++ b/docs/source/fitfunctions/TeixeiraWaterSQE.rst
@@ -82,7 +82,8 @@ with a fit to the following model:
         4. Up to 10% of noise in the quasi-elastic signal
         5. Assume <u^2>=0.8 Angstroms^2 for the Debye-Waller factor
     """
-    diffCoeff=1.0;  tau=50.0;  u2=0.8;  hbar=0.658211626  # units of hbar are ps*meV
+    diffCoeff=1.0  # Units are Angstroms^2/ps
+    tau=50.0;  u2=0.8;  hbar=0.658211626  # units of hbar are ps*meV
     qdataY=np.empty(0)  # will hold all Q-values (all spectra)
     for Q in Qs:
         centre=2*dE*(0.5-np.random.random())  # some shift along the energy axis
@@ -149,6 +150,7 @@ with a fit to the following model:
         if nparms==2:
             break  # We got the three parameters we are interested in
     # Check nominal and optimal values are within error ranges:
+    DiffCoeff = DiffCoeff/10.0  # change units from 10^{-5}cm^2/s to Angstroms^2/ps
     if abs(diffCoeff-DiffCoeff)/diffCoeff < 0.1:
         print("Optimal Length within 10% of nominal value")
     else:

--- a/docs/source/fitfunctions/TeixeiraWaterSQE.rst
+++ b/docs/source/fitfunctions/TeixeiraWaterSQE.rst
@@ -1,10 +1,13 @@
 .. _func-TeixeiraWaterSQE:
 
-==========
+================
 TeixeiraWaterSQE
-==========
+================
 
 .. index:: TeixeiraWaterSQE
+
+Description
+-----------
 
 This fitting function models the dynamic structure factor
 for a particle undergoing jump diffusion [1]_.
@@ -25,14 +28,19 @@ where:
 
 At 298K and 1atm, water has :math:`DiffCoeff=2.30 10^{-5} cm^2/s` and :math:`Tau=1.25 ps`.
 
-.. attributes::
-
-:math:`Q` (double, default=0.3) Momentum transfer
+A jump length :math:`l` can be associated: :math:`l^2=2N\cdot DiffCoeff\cdot Tau`, where :math:`N` is the
+dimensionality of the diffusion problem (:math:`N=3` for diffusion in a volume).
 
 References
 ----------
 
 .. [1] J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
+
+.. properties::
+
+.. attributes::
+
+:math:`Q` (double, default=0.3) Momentum transfer
 
 Usage
 -----

--- a/docs/source/release/v3.9.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.9.0/indirect_inelastic.rst
@@ -14,6 +14,8 @@ Algorithms
 Data Analysis
 #############
 
+- :ref:`TeixeiraWaterSQE <func-TeixeiraWaterSQE>` models translation of water-like molecules (jump diffusion).
+
 Jump Fit
 ~~~~~~~~
 


### PR DESCRIPTION
Fit function to model QENS data assuming a particle undergoing jump-diffusion.

**To test:**
- Review  the code.
- In a MantidPlot session, run the example included in the document page.
- After you run the example, use workspaces "data" and "resolution" to do a manual fit using the "Fit Function" tool of MantidPlot. You may want to import the following string as the model:
  `(composite=Convolution,FixResolution=true,NumDeriv=true;
  name=TabulatedFunction,Workspace=resolution,WorkspaceIndex=0,Scaling=1,Shift=0,XScaling=1;
  (name=DeltaFunction,Height=0.5,Centre=0,constraints=(0<Height<1);
  name=TeixeiraWaterSQE,Q=0.3,Height=0.5,Tau=10,Length=1.0,Centre=0;
  ties=(f1.Height=1-f0.Height,f1.Centre=f0.Centre)));
  name=LinearBackground,A0=0,A1=0`

Fixes #17597.

[Release notes](https://github.com/mantidproject/mantid/blob/e6612e0148ae209af2dd2a75e6852cf445cece6b/docs/source/release/v3.9.0/indirect_inelastic.rst) have been updated

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
