### PR TITLE
Fix instrument definitions updating in parallel with new version check on startup 

### DIFF
--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -138,7 +138,7 @@ void FrameworkManagerImpl::UpdateInstrumentDefinitions() {
     IAlgorithm *algDownloadInstrument =
         this->createAlgorithm("DownloadInstrument");
     algDownloadInstrument->setAlgStartupLogging(false);
-    Poco::ActiveResult<bool> result = algDownloadInstrument->executeAsync();
+    algDownloadInstrument->executeAsync();
   } catch (Kernel::Exception::NotFoundError &) {
     g_log.debug() << "DowndloadInstrument algorithm is not available - cannot "
                      "update instrument definitions.\n";
@@ -150,7 +150,7 @@ void FrameworkManagerImpl::CheckIfNewerVersionIsAvailable() {
   try {
     IAlgorithm *algCheckVersion = this->createAlgorithm("CheckMantidVersion");
     algCheckVersion->setAlgStartupLogging(false);
-    Poco::ActiveResult<bool> result = algCheckVersion->executeAsync();
+    algCheckVersion->executeAsync();
   } catch (Kernel::Exception::NotFoundError &) {
     g_log.debug() << "CheckMantidVersion algorithm is not available - cannot "
                      "check if a newer version is available.\n";


### PR DESCRIPTION
These changes ensure that the initialization of the SSL context with Poco only happens the first time
a `https` request is sent.

**To test:**

See the related issue for testing instructions.

Fixes #17611

_Does not need to be in the release notes as this worked last release_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
