### PR TITLE
Beta fixes for Muon Analysis: keep selections on tab change

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisFitDataPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisFitDataPresenter.h
@@ -117,7 +117,7 @@ public slots:
   /// Open sequential fit dialog
   void openSequentialFitDialog();
   /// Updates label to avoid overwriting existing results
-  void checkAndUpdateFitLabel(bool seq);
+  void checkAndUpdateFitLabel(bool sequentialFit);
 
 private:
   /// Generate names of workspaces to be created

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisFitDataPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisFitDataPresenter.h
@@ -145,6 +145,8 @@ private:
   void setUpDataSelector(const QString &wsName);
   /// Check if multiple runs are selected
   bool isMultipleRuns() const;
+  /// Update fit label to match run number(s)
+  void updateFitLabelFromRuns();
   /// Fit browser to update (non-owning pointer)
   MantidQt::MantidWidgets::IWorkspaceFitControl *m_fitBrowser;
   /// Data selector to get input from (non-owning pointer)

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -139,6 +139,7 @@ void MuonAnalysisFitDataPresenter::handleSelectedDataChanged(bool overwrite) {
     createWorkspacesToFit(names);
     updateWorkspaceNames(names);
     m_fitBrowser->allowSequentialFits(!isMultipleRuns());
+    updateFitLabelFromRuns();
   }
 }
 
@@ -720,6 +721,27 @@ void MuonAnalysisFitDataPresenter::setUpDataSelector(const QString &wsName) {
  */
 bool MuonAnalysisFitDataPresenter::isMultipleRuns() const {
   return m_dataSelector->getRuns().contains(QRegExp("-|,"));
+}
+
+/**
+ * When run numbers are changed, update the simultaneous fit label.
+ * If it's a user-set label, leave it alone, otherwise set the label to the run
+ * number string.
+ *
+ * Assume labels with digits, '-', ',' are default (e.g. "15189-91") and
+ * anything else is user-set.
+ */
+void MuonAnalysisFitDataPresenter::updateFitLabelFromRuns() {
+  // Don't change the fit label if it's a user-set one
+  const auto &label = m_dataSelector->getSimultaneousFitLabel().toStdString();
+  const bool isDefault =
+      label.find_first_not_of("0123456789-,") == std::string::npos;
+  if (isDefault) {
+    // replace with current run string
+    const auto &runString = m_dataSelector->getRuns();
+    m_dataSelector->setSimultaneousFitLabel(runString);
+    m_fitBrowser->setSimultaneousLabel(runString.toStdString());
+  }
 }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -615,10 +615,16 @@ void MuonAnalysisFitDataPresenter::openSequentialFitDialog() {
  * If user chooses not to overwrite, increment the label to avoid overwriting
  * the previous fit.
  *
- * @param seq :: [input] Whether fit is sequential (UNUSED)
+ * If fit is sequential, do nothing because we will not use this label. Instead,
+ * user will choose a label in the sequential fit dialog.
+ *
+ * @param sequentialFit :: [input] Whether fit is sequential or not
  */
-void MuonAnalysisFitDataPresenter::checkAndUpdateFitLabel(bool seq) {
-  Q_UNUSED(seq);
+void MuonAnalysisFitDataPresenter::checkAndUpdateFitLabel(bool sequentialFit) {
+  if (sequentialFit) {
+    return; // label not used so no need to check it
+  }
+
   if (isSimultaneousFit()) {
     auto &ads = AnalysisDataService::Instance();
     const auto &label = m_dataSelector->getSimultaneousFitLabel().toStdString();

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -710,7 +710,7 @@ void MuonAnalysisFitDataPresenter::setUpDataSelector(const QString &wsName) {
   if (!groups.contains(groupToSet)) {
     m_dataSelector->setChosenGroup(groupToSet);
   }
-  if (!periods.contains(periodToSet)) {
+  if (!periodToSet.isEmpty() && !periods.contains(periodToSet)) {
     m_dataSelector->setChosenPeriod(periodToSet);
   }
 }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -700,8 +700,18 @@ void MuonAnalysisFitDataPresenter::setUpDataSelector(const QString &wsName) {
   m_dataSelector->setWorkspaceIndex(0u); // always has only one spectrum
 
   // Set selected groups/pairs and periods here too
-  m_dataSelector->setChosenGroup(QString::fromStdString(wsParams.itemName));
-  m_dataSelector->setChosenPeriod(QString::fromStdString(wsParams.periods));
+  // (unless extra groups/periods are already selected, in which case don't
+  // unselect them)
+  const QString &groupToSet = QString::fromStdString(wsParams.itemName);
+  const QString &periodToSet = QString::fromStdString(wsParams.periods);
+  const auto &groups = m_dataSelector->getChosenGroups();
+  const auto &periods = m_dataSelector->getPeriodSelections();
+  if (!groups.contains(groupToSet)) {
+    m_dataSelector->setChosenGroup(groupToSet);
+  }
+  if (!periods.contains(periodToSet)) {
+    m_dataSelector->setChosenPeriod(periodToSet);
+  }
 }
 
 /**

--- a/MantidQt/CustomInterfaces/test/MuonAnalysisFitDataPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/MuonAnalysisFitDataPresenterTest.h
@@ -507,6 +507,16 @@ public:
                                   {"1", "2"}, true, true);
   }
 
+  void test_checkAndUpdateFitLabel_SequentialFit_ShouldDoNothing() {
+    EXPECT_CALL(*m_dataSelector, getFitType()).Times(0);
+    EXPECT_CALL(*m_dataSelector, getChosenGroups()).Times(0);
+    EXPECT_CALL(*m_dataSelector, getPeriodSelections()).Times(0);
+    EXPECT_CALL(*m_dataSelector, askUserWhetherToOverwrite()).Times(0);
+    EXPECT_CALL(*m_fitBrowser, setSimultaneousLabel(_)).Times(0);
+    EXPECT_CALL(*m_dataSelector, setSimultaneousFitLabel(_)).Times(0);
+    m_presenter->checkAndUpdateFitLabel(true);
+  }
+
 private:
   void doTest_handleSelectedDataChanged(IMuonFitDataSelector::FitType fitType) {
     auto &ads = AnalysisDataService::Instance();

--- a/MantidQt/CustomInterfaces/test/MuonAnalysisFitDataPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/MuonAnalysisFitDataPresenterTest.h
@@ -560,9 +560,8 @@ public:
     EXPECT_CALL(*m_dataSelector, setDatasetNames(wsNameList)).Times(1);
 
     // Expect it will update the UI from workspace details
-    EXPECT_CALL(*m_dataSelector,
-                setWorkspaceDetails(QString("00015189-91"), QString("MUSR")))
-        .Times(1);
+    EXPECT_CALL(*m_dataSelector, setWorkspaceDetails(QString("00015189-91"),
+                                                     QString("MUSR"))).Times(1);
     EXPECT_CALL(*m_dataSelector, setWorkspaceIndex(0)).Times(1);
     EXPECT_CALL(*m_dataSelector, setChosenGroup(QString("fwd"))).Times(1);
     EXPECT_CALL(*m_dataSelector, setChosenPeriod(QString("1"))).Times(1);

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitDataSelector.ui
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitDataSelector.ui
@@ -303,7 +303,7 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>Label</string>
+           <string>0</string>
           </property>
          </widget>
         </item>

--- a/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
@@ -403,7 +403,9 @@ QStringList MuonFitDataSelector::getChosenGroups() const {
 void MuonFitDataSelector::setChosenGroup(const QString &group) {
   for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
        ++iter) {
-    iter.value()->setChecked(iter.key() == group);
+    if (iter.key() == group) {
+      iter.value()->setChecked(true);
+    }
   }
 }
 

--- a/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
@@ -115,6 +115,17 @@ void MuonFitDataSelector::userChangedRuns() {
  * @param groups :: [input] List of group names
  */
 void MuonFitDataSelector::setAvailableGroups(const QStringList &groups) {
+  // If it's the same list, do nothing
+  if (groups.size() == m_groupBoxes.size()) {
+    auto existingGroups = m_groupBoxes.keys();
+    auto newGroups = groups;
+    qSort(existingGroups);
+    qSort(newGroups);
+    if (existingGroups == newGroups) {
+      return;
+    }
+  }
+
   clearGroupCheckboxes();
   for (const auto group : groups) {
     addGroupCheckbox(group);

--- a/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
@@ -251,8 +251,8 @@ void MuonFitDataSelector::setDefaultValues() {
   this->setStartTime(0.0);
   this->setEndTime(0.0);
   setPeriodCombination(false);
-  m_ui.txtSimFitLabel->setText("Label");
-  emit simulLabelChanged(); // make sure default "Label" is set
+  m_ui.txtSimFitLabel->setText("0");
+  emit simulLabelChanged(); // make sure default "0" is set
 }
 
 /**

--- a/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
@@ -111,7 +111,7 @@ void MuonFitDataSelector::userChangedRuns() {
 
 /**
  * Sets group names and updates checkboxes on UI
- * By default sets all checked
+ * By default sets all unchecked
  * @param groups :: [input] List of group names
  */
 void MuonFitDataSelector::setAvailableGroups(const QStringList &groups) {
@@ -266,13 +266,13 @@ void MuonFitDataSelector::setPeriodVisibility(bool visible) {
 
 /**
  * Add a new checkbox to the list of groups with given name
- * The new checkbox is checked by default
+ * The new checkbox is unchecked by default
  * @param name :: [input] Name of group to add
  */
 void MuonFitDataSelector::addGroupCheckbox(const QString &name) {
   auto checkBox = new QCheckBox(name);
   m_groupBoxes.insert(name, checkBox);
-  checkBox->setChecked(true);
+  checkBox->setChecked(false);
   m_ui.verticalLayoutGroups->addWidget(checkBox);
   connect(checkBox, SIGNAL(clicked(bool)), this,
           SIGNAL(selectedGroupsChanged()));


### PR DESCRIPTION
Fix points raised by beta testers:
- Group selection forgotten on switching between tabs
- Fit label should be auto-set to run number
- Remove unnecessary warning about labels on sequential fit

Unit tests have been added to cover these changes.

**To test:**
_Data sets: `MUSR00015189-90` from unit test data_
- Set facility to ISIS, open _Interfaces/Muon/Muon Analysis_ and load `MUSR00015190.nxs`.
- Go to "Data Analysis" tab. 
  - The simultaneous fit label (centre of page) should be the run number, greyed out.
  - Tick checkboxes for groups `fwd` and `long` (label will be enabled)
- Switch to another tab, then back to "Data Analysis"
  - Verify the groups `fwd` and `long` are still selected
- Go to "Home" tab and load `MUSR00015189.nxs`
- Return to "Data Analysis" tab
  - The fit label should have changed to "15189" to match the run number
  - The group selection should be the same (`fwd` and `long`)
  - Change the fit label to "hello"
- Switch to "Home" tab and load `MUSR00015190.nxs` again
- Return to "Data Analysis" tab
  - This time the fit label should not have changed (as it won't replace a user-supplied one)

Re #17602 (does not close that issue as it contains more points)

No release notes. The new fitting UI is already in the release notes for 3.8.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
