### PR TITLE
MergeRuns to accept single workspace

### DIFF
--- a/Framework/API/inc/MantidAPI/MultiPeriodGroupWorker.h
+++ b/Framework/API/inc/MantidAPI/MultiPeriodGroupWorker.h
@@ -69,6 +69,7 @@ private:
   /// Try ot add a workspace to the group of input workspaces.
   void
   tryAddInputWorkspaceToInputGroups(Workspace_sptr ws,
+                                    VecWSGroupType &vecMultiPeriodWorkspaceGroups,
                                     VecWSGroupType &vecWorkspaceGroups) const;
 
   /// Copy input workspace properties to spawned algorithm.

--- a/Framework/API/inc/MantidAPI/MultiPeriodGroupWorker.h
+++ b/Framework/API/inc/MantidAPI/MultiPeriodGroupWorker.h
@@ -67,10 +67,9 @@ private:
   MultiPeriodGroupWorker &operator=(const MultiPeriodGroupWorker &);
 
   /// Try ot add a workspace to the group of input workspaces.
-  void
-  tryAddInputWorkspaceToInputGroups(Workspace_sptr ws,
-                                    VecWSGroupType &vecMultiPeriodWorkspaceGroups,
-                                    VecWSGroupType &vecWorkspaceGroups) const;
+  void tryAddInputWorkspaceToInputGroups(
+      Workspace_sptr ws, VecWSGroupType &vecMultiPeriodWorkspaceGroups,
+      VecWSGroupType &vecWorkspaceGroups) const;
 
   /// Copy input workspace properties to spawned algorithm.
   void copyInputWorkspaceProperties(IAlgorithm *targetAlg,

--- a/Framework/API/src/MultiPeriodGroupWorker.cpp
+++ b/Framework/API/src/MultiPeriodGroupWorker.cpp
@@ -22,7 +22,9 @@ MultiPeriodGroupWorker::MultiPeriodGroupWorker(
 /**
  * Try to add the input workspace to the multiperiod input group list.
  * @param ws: candidate workspace
- * @param vecWorkspaceGroups: Vector of multi period workspace groups.
+ * @param vecMultiPeriodWorkspaceGroups: Vector of multi period workspace
+ * groups.
+ * @param vecWorkspaceGroups: Vector of non-multi period workspace groups.
  */
 void MultiPeriodGroupWorker::tryAddInputWorkspaceToInputGroups(
     Workspace_sptr ws,

--- a/Framework/API/src/MultiPeriodGroupWorker.cpp
+++ b/Framework/API/src/MultiPeriodGroupWorker.cpp
@@ -26,11 +26,14 @@ MultiPeriodGroupWorker::MultiPeriodGroupWorker(
  */
 void MultiPeriodGroupWorker::tryAddInputWorkspaceToInputGroups(
     Workspace_sptr ws,
+    MultiPeriodGroupWorker::VecWSGroupType &vecMultiPeriodWorkspaceGroups,
     MultiPeriodGroupWorker::VecWSGroupType &vecWorkspaceGroups) const {
   WorkspaceGroup_sptr inputGroup =
       boost::dynamic_pointer_cast<WorkspaceGroup>(ws);
   if (inputGroup) {
     if (inputGroup->isMultiperiod()) {
+      vecMultiPeriodWorkspaceGroups.push_back(inputGroup);
+    } else {
       vecWorkspaceGroups.push_back(inputGroup);
     }
   }
@@ -42,6 +45,7 @@ MultiPeriodGroupWorker::findMultiPeriodGroups(
   if (!sourceAlg->isInitialized()) {
     throw std::invalid_argument("Algorithm must be initialized");
   }
+  VecWSGroupType vecMultiPeriodWorkspaceGroups;
   VecWSGroupType vecWorkspaceGroups;
 
   // Handles the case in which the algorithm is providing a non-workspace
@@ -72,7 +76,7 @@ MultiPeriodGroupWorker::findMultiPeriodGroups(
       if (!ws) {
         throw Kernel::Exception::NotFoundError("Workspace", workspace);
       }
-      tryAddInputWorkspaceToInputGroups(ws, vecWorkspaceGroups);
+      tryAddInputWorkspaceToInputGroups(ws, vecMultiPeriodWorkspaceGroups, vecWorkspaceGroups);
     }
   } else {
     typedef std::vector<boost::shared_ptr<Workspace>> WorkspaceVector;
@@ -81,13 +85,17 @@ MultiPeriodGroupWorker::findMultiPeriodGroups(
     sourceAlg->findWorkspaceProperties(inWorkspaces, outWorkspaces);
     UNUSED_ARG(outWorkspaces);
     for (auto &inWorkspace : inWorkspaces) {
-      tryAddInputWorkspaceToInputGroups(inWorkspace, vecWorkspaceGroups);
+      tryAddInputWorkspaceToInputGroups(inWorkspace, vecMultiPeriodWorkspaceGroups, vecWorkspaceGroups);
     }
   }
 
-  validateMultiPeriodGroupInputs(vecWorkspaceGroups);
+  if ((vecMultiPeriodWorkspaceGroups.size() != 0) && (vecWorkspaceGroups.size() != 0)) {
+    throw std::invalid_argument("The input contains a mix of multi-period and other workspaces.");
+  }
 
-  return vecWorkspaceGroups;
+  validateMultiPeriodGroupInputs(vecMultiPeriodWorkspaceGroups);
+
+  return vecMultiPeriodWorkspaceGroups;
 }
 
 bool MultiPeriodGroupWorker::useCustomWorkspaceProperty() const {

--- a/Framework/API/src/MultiPeriodGroupWorker.cpp
+++ b/Framework/API/src/MultiPeriodGroupWorker.cpp
@@ -76,7 +76,8 @@ MultiPeriodGroupWorker::findMultiPeriodGroups(
       if (!ws) {
         throw Kernel::Exception::NotFoundError("Workspace", workspace);
       }
-      tryAddInputWorkspaceToInputGroups(ws, vecMultiPeriodWorkspaceGroups, vecWorkspaceGroups);
+      tryAddInputWorkspaceToInputGroups(ws, vecMultiPeriodWorkspaceGroups,
+                                        vecWorkspaceGroups);
     }
   } else {
     typedef std::vector<boost::shared_ptr<Workspace>> WorkspaceVector;
@@ -85,12 +86,15 @@ MultiPeriodGroupWorker::findMultiPeriodGroups(
     sourceAlg->findWorkspaceProperties(inWorkspaces, outWorkspaces);
     UNUSED_ARG(outWorkspaces);
     for (auto &inWorkspace : inWorkspaces) {
-      tryAddInputWorkspaceToInputGroups(inWorkspace, vecMultiPeriodWorkspaceGroups, vecWorkspaceGroups);
+      tryAddInputWorkspaceToInputGroups(
+          inWorkspace, vecMultiPeriodWorkspaceGroups, vecWorkspaceGroups);
     }
   }
 
-  if ((vecMultiPeriodWorkspaceGroups.size() != 0) && (vecWorkspaceGroups.size() != 0)) {
-    throw std::invalid_argument("The input contains a mix of multi-period and other workspaces.");
+  if ((vecMultiPeriodWorkspaceGroups.size() != 0) &&
+      (vecWorkspaceGroups.size() != 0)) {
+    throw std::invalid_argument(
+        "The input contains a mix of multi-period and other workspaces.");
   }
 
   validateMultiPeriodGroupInputs(vecMultiPeriodWorkspaceGroups);

--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -107,8 +107,7 @@ void MergeRuns::exec() {
   }
 
   if (inputs.size() == 1) {
-    g_log.error("Only one input workspace specified");
-    throw std::invalid_argument("Only one input workspace specified");
+    g_log.warning("Only one input workspace specified");
   }
 
   // First, try as event workspaces

--- a/Framework/Algorithms/test/MergeRunsTest.h
+++ b/Framework/Algorithms/test/MergeRunsTest.h
@@ -1340,6 +1340,23 @@ public:
         SampleLogsBehaviour::LIST_MERGE, "1, 2, 6, 7");
   }
 
+  void test_merging_single_workspace() {
+    std::string mergeType = SampleLogsBehaviour::TIME_SERIES_MERGE;
+
+    auto ws = create_group_workspace_with_sample_logs<double>(
+        mergeType, "prop1", 1.0, 2.0, 3.0, 4.0);
+
+    ws->remove("b1");
+
+    MergeRuns alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspaces", ws->name());
+    alg.setPropertyValue("OutputWorkspace", "outWS1");
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    do_test_mergeSampleLogs(ws, "prop1", mergeType, "2013-Jun-25 10:59:15  1\n", 1);
+  }
+
 private:
   MergeRuns merge;
 };

--- a/Framework/Algorithms/test/MergeRunsTest.h
+++ b/Framework/Algorithms/test/MergeRunsTest.h
@@ -1354,7 +1354,8 @@ public:
     alg.setPropertyValue("OutputWorkspace", "outWS1");
     TS_ASSERT_THROWS_NOTHING(alg.execute());
 
-    do_test_mergeSampleLogs(ws, "prop1", mergeType, "2013-Jun-25 10:59:15  1\n", 1);
+    do_test_mergeSampleLogs(ws, "prop1", mergeType, "2013-Jun-25 10:59:15  1\n",
+                            1);
   }
 
 private:


### PR DESCRIPTION
MergeRuns should work fine for a single workspace. This is to make workflow algorithms which rely on MergeRuns more straightforward to write.

The test `test_mixed_multiperiod_group_and_non_multiperiod_group_inputs_throws` failed after this change. There is also a fix to make sure mixed multiperiod group and non multiperiod group inputs now generate an error as expected (previously they were only generating an error because MergeRuns was being passed single workspaces).

**To test:**

Run MergeRuns on a single workspace. A single workspace should result. If any sample logs are specified to merge for time series or log the extra entry in the sample logs should be created.

Fixes #17521.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
