### PR TITLE
Add LOQ option for mask line

### DIFF
--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -1053,9 +1053,12 @@ class Mask_ISIS(ReductionStep):
             MaskDetectorsInShape(Workspace=workspace, ShapeXML=self._lim_phi_xml)
 
         if self.arm_width and self.arm_angle:
-            if instrument.name() == "SANS2D":
+            # Currently SANS2D and LOQ are supported
+            instrument_name = instrument.name()
+            if instrument_name == "SANS2D" or instrument_name == "LOQ":
+                component_name = 'rear-detector' if instrument_name == "SANS2D" else 'main-detector-bank'
                 ws = mtd[str(workspace)]
-                det = ws.getInstrument().getComponentByName('rear-detector')
+                det = ws.getInstrument().getComponentByName(component_name)
                 det_Z = det.getPos().getZ()
                 start_point = [self.arm_x, self.arm_y, det_Z]
                 MaskDetectorsInShape(Workspace=workspace, ShapeXML= \


### PR DESCRIPTION
Fixes #17624

Description of work.

This PR allows the LOQ users to mask the arm of the beam stop. This was found by Stephen King during beta testing and is a problem for LOQ

**To test:**
Please find the test data/material here: \olympic\Babylon5\Scratch\Anton\Testing\LOQ_Mask_Line
1. Open the ISIS SANS GUI
2. Set the instrument to LOQ
3. Load the user file User_File_With_Line_Mask.txt
   - You can confirm that the user file contains the line MASK/LINE 20 60, which means that a beam stop arm will be masked with a width of 20mm at 60 degree. 
4. For Sample Scattering select LOQ98128.nxs and press Load
5. Go to the Masking tab and press Display Mask
   - Confirm that the instrument view pops up and that there is a straight section masked out on the main detector bank. You should see it as a light blue line
6. Go to the Run Numbers tab and press 1D Reduce 
   - confirm that the reduction executes without issues

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
