### PR TITLE
Extend unit tests for PlotAsymmetryByLogValue

### DIFF
--- a/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -162,7 +162,10 @@ void PlotAsymmetryByLogValue::exec() {
   for (size_t i = is; i <= ie; i++) {
 
     // Check if run i was already loaded
-    if (!m_logValue.count(i)) {
+    std::ostringstream logMessage;
+    if (m_logValue.count(i)) {
+      logMessage << "Found run " << i;
+    } else {
       // Load run, apply dead time corrections and detector grouping
       Workspace_sptr loadedWs = doLoad(i);
 
@@ -170,8 +173,9 @@ void PlotAsymmetryByLogValue::exec() {
         // Analyse loadedWs
         doAnalysis(loadedWs, i);
       }
+      logMessage << "Loaded run " << i;
     }
-    progress.report();
+    progress.report(logMessage.str());
   }
 
   // Create the 2D workspace for the output

--- a/Framework/Algorithms/test/PlotAsymmetryByLogValueTest.h
+++ b/Framework/Algorithms/test/PlotAsymmetryByLogValueTest.h
@@ -30,11 +30,21 @@ public:
   /// Constructor: rename the file and store its original name
   explicit TemporaryRenamer(const std::string &fileName)
       : m_originalName(fileName), m_file(fileName) {
-    TS_ASSERT(m_file.exists() && m_file.canWrite() && m_file.isFile());
-    m_file.renameTo(Poco::TemporaryFile::tempName());
+    try {
+      TS_ASSERT(m_file.exists() && m_file.canWrite() && m_file.isFile());
+      m_file.renameTo(Poco::TemporaryFile::tempName());
+    } catch (const Poco::FileException &ex) {
+      TS_FAIL(ex.displayText());
+    }
   }
   /// Destructor: restore the file's original name
-  ~TemporaryRenamer() { m_file.renameTo(m_originalName); }
+  ~TemporaryRenamer() {
+    try {
+      m_file.renameTo(m_originalName);
+    } catch (const Poco::FileException &ex) { // Do not throw in the destructor!
+      TS_FAIL(ex.displayText());
+    }
+  }
 
 private:
   const std::string m_originalName;


### PR DESCRIPTION
Added tests for two features of `PlotAsymmetryByLogValue` that were previously not tested.

These are:
1.  Algorithm can skip a missing file
2. Given the algorithm has already loaded a sequence of runs, when the user extends the run sequence, then the algorithm should only load the new files - it should not reload the files it has already loaded.

**To test:**

Review the new tests and satisfy yourself that they do what they are intended to do.
Both new tests should pass.

Fixes #13152 
Fixes #13072 
Fixes #12469 

No release notes - changes are to test code, not user-visible.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
