### PR TITLE
Fix bug in spectra map

### DIFF
--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -1255,6 +1255,10 @@ void SNSLiveEventDataListener::initWorkspacePart2() {
   auto tmp = createWorkspace<DataObjects::EventWorkspace>(
       m_eventBuffer->getInstrument()->getDetectorIDs(true).size(), 2, 1);
   WorkspaceFactory::Instance().initializeFromParent(m_eventBuffer, tmp, true);
+  if (m_eventBuffer->getNumberHistograms() != tmp->getNumberHistograms()) {
+    // need to generate the spectra to detector map
+    tmp->rebuildSpectraMapping();
+  }
   m_eventBuffer = std::move(tmp);
 
   // Set the units


### PR DESCRIPTION
Description of work.

**To test:**

Run `StartLiveData` with the script below for the "Processing Step" and `AccumulationMethod="add"`.

``` python
SumSpectra(InputWorkspace=input, OutputWorkspace=output)
Rebin(InputWorkspace=output, OutputWorkspace=output, Params='300,20,17000')
```

_There is no associated issue_

_Does not need to be in the release notes_ since we're thinking nobody noticed it was broken.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
