### PR TITLE
Fix multidomainfunctiontest with gsl2

### DIFF
--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -301,7 +301,8 @@ public:
   /** Zero all matrix elements.
   */
   void zero() override {
-      throw Kernel::Exception::NotImplementedError("zero() is not implemented for PartialJacobian");
+    throw Kernel::Exception::NotImplementedError(
+        "zero() is not implemented for PartialJacobian");
   }
   /**  Add number to all iY (data) Jacobian elements for a given iP (parameter)
    *   @param value :: Value to add

--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -298,6 +298,11 @@ public:
   double get(size_t iY, size_t iP) override {
     return m_J->get(m_iY0 + iY, m_iP0 + iP);
   }
+  /** Zero all matrix elements.
+  */
+  void zero() override {
+      throw Kernel::Exception::NotImplementedError("zero() is not implemented for PartialJacobian");
+  }
   /**  Add number to all iY (data) Jacobian elements for a given iP (parameter)
    *   @param value :: Value to add
    *   @param iP :: The index of an active parameter.

--- a/Framework/API/inc/MantidAPI/Jacobian.h
+++ b/Framework/API/inc/MantidAPI/Jacobian.h
@@ -50,6 +50,10 @@ public:
   */
   virtual double get(size_t iY, size_t iP) = 0;
 
+  /** Zero all matrix elements.
+  */
+  virtual void zero() = 0;
+
   ///@cond do not document
   /**  Add number to all iY (data) Jacobian elements for a given iP (parameter)
   *   @param value :: Value to add

--- a/Framework/API/src/IPeakFunction.cpp
+++ b/Framework/API/src/IPeakFunction.cpp
@@ -45,7 +45,8 @@ public:
   /** Zero all matrix elements.
   */
   void zero() override {
-      throw Kernel::Exception::NotImplementedError("zero() is not implemented for PartialJacobian1");
+    throw Kernel::Exception::NotImplementedError(
+        "zero() is not implemented for PartialJacobian1");
   }
 };
 
@@ -69,9 +70,7 @@ public:
 
     return maxIndex;
   }
-  void zero() override {
-      m_J.assign(m_J.size(), 0.0);
-  }
+  void zero() override { m_J.assign(m_J.size(), 0.0); }
 
 protected:
   size_t m_y;

--- a/Framework/API/src/IPeakFunction.cpp
+++ b/Framework/API/src/IPeakFunction.cpp
@@ -42,6 +42,11 @@ public:
    * @param iP :: The parameter index of an individual function.
    */
   double get(size_t iY, size_t iP) override { return m_J->get(m_iY0 + iY, iP); }
+  /** Zero all matrix elements.
+  */
+  void zero() override {
+      throw Kernel::Exception::NotImplementedError("zero() is not implemented for PartialJacobian1");
+  }
 };
 
 class TempJacobian : public Jacobian {
@@ -63,6 +68,9 @@ public:
     }
 
     return maxIndex;
+  }
+  void zero() override {
+      m_J.assign(m_J.size(), 0.0);
   }
 
 protected:

--- a/Framework/API/src/MultiDomainFunction.cpp
+++ b/Framework/API/src/MultiDomainFunction.cpp
@@ -168,6 +168,7 @@ void MultiDomainFunction::functionDeriv(const FunctionDomain &domain,
                                   std::to_string(m_maxIndex) + ").");
     }
 
+    jacobian.zero();
     countValueOffsets(cd);
     // evaluate member functions derivatives
     for (size_t iFun = 0; iFun < nFunctions(); ++iFun) {

--- a/Framework/API/test/IFunction1DTest.h
+++ b/Framework/API/test/IFunction1DTest.h
@@ -44,6 +44,9 @@ public:
     m_data[iY * m_np + iP] = value;
   }
   double get(size_t iY, size_t iP) override { return m_data[iY * m_np + iP]; }
+  void zero() override {
+    m_data.assign(m_data.size(), 0.0);
+  }
 
 private:
   size_t m_np;

--- a/Framework/API/test/IFunction1DTest.h
+++ b/Framework/API/test/IFunction1DTest.h
@@ -44,9 +44,7 @@ public:
     m_data[iY * m_np + iP] = value;
   }
   double get(size_t iY, size_t iP) override { return m_data[iY * m_np + iP]; }
-  void zero() override {
-    m_data.assign(m_data.size(), 0.0);
-  }
+  void zero() override { m_data.assign(m_data.size(), 0.0); }
 
 private:
   size_t m_np;

--- a/Framework/API/test/ILatticeFunctionTest.h
+++ b/Framework/API/test/ILatticeFunctionTest.h
@@ -94,6 +94,7 @@ private:
   public:
     MOCK_METHOD3(set, void(size_t, size_t, double));
     MOCK_METHOD2(get, double(size_t, size_t));
+    MOCK_METHOD0(zero, void());
   };
 
   // Mock domain to simulate a wrong domain type

--- a/Framework/API/test/MultiDomainFunctionTest.h
+++ b/Framework/API/test/MultiDomainFunctionTest.h
@@ -81,6 +81,7 @@ public:
       off_diag += value;
   }
   double get(size_t, size_t) override { return 0.0; }
+  void zero() override {}
 };
 }
 

--- a/Framework/Crystal/test/PeakHKLErrorsTest.h
+++ b/Framework/Crystal/test/PeakHKLErrorsTest.h
@@ -35,6 +35,8 @@ public:
   void set(size_t iY, size_t iP, double value) override { M[iP][iY] = value; }
 
   double get(size_t iY, size_t iP) override { return M[iP][iY]; }
+
+  void zero() override { M.zeroMatrix(); }
 };
 
 class PeakHKLErrorsTest : public CxxTest::TestSuite {

--- a/Framework/CurveFitting/inc/MantidCurveFitting/GSLJacobian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/GSLJacobian.h
@@ -94,9 +94,7 @@ public:
     return 0.0;
   }
   /// overwrite base method
-  void zero() override {
-      m_J.zero();
-  }
+  void zero() override { m_J.zero(); }
 };
 
 /// The implementation of Jacobian
@@ -141,9 +139,7 @@ public:
     return 0.0;
   }
   /// overwrite base method
-  void zero() override {
-      gsl_matrix_set_zero(m_J);
-  }
+  void zero() override { gsl_matrix_set_zero(m_J); }
 };
 
 } // namespace CurveFitting

--- a/Framework/CurveFitting/inc/MantidCurveFitting/GSLJacobian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/GSLJacobian.h
@@ -93,6 +93,10 @@ public:
       return m_J.get(iY, j);
     return 0.0;
   }
+  /// overwrite base method
+  void zero() override {
+      m_J.zero();
+  }
 };
 
 /// The implementation of Jacobian
@@ -135,6 +139,10 @@ public:
     if (j >= 0)
       return gsl_matrix_get(m_J, iY, j);
     return 0.0;
+  }
+  /// overwrite base method
+  void zero() override {
+      gsl_matrix_set_zero(m_J);
   }
 };
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Jacobian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Jacobian.h
@@ -89,9 +89,7 @@ public:
     return m_data[iY * m_np + iP];
   }
   /// overwrite base method
-  void zero() override {
-      m_data.assign(m_data.size(), 0.0);
-  }
+  void zero() override { m_data.assign(m_data.size(), 0.0); }
 };
 
 } // namespace CurveFitting

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Jacobian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Jacobian.h
@@ -88,6 +88,10 @@ public:
     }
     return m_data[iY * m_np + iP];
   }
+  /// overwrite base method
+  void zero() override {
+      m_data.assign(m_data.size(), 0.0);
+  }
 };
 
 } // namespace CurveFitting

--- a/Framework/CurveFitting/src/Algorithms/Fit1D.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit1D.cpp
@@ -67,9 +67,7 @@ public:
   }
   /** Zero all matrix elements.
   */
-  void zero() override {
-      gsl_matrix_set_zero(m_J);
-  }
+  void zero() override { gsl_matrix_set_zero(m_J); }
   /// Set the pointer to the GSL's jacobian
   void setJ(gsl_matrix *J) { m_J = J; }
 

--- a/Framework/CurveFitting/src/Algorithms/Fit1D.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit1D.cpp
@@ -65,6 +65,11 @@ public:
       return gsl_matrix_get(m_J, iY, j);
     return 0.0;
   }
+  /** Zero all matrix elements.
+  */
+  void zero() override {
+      gsl_matrix_set_zero(m_J);
+  }
   /// Set the pointer to the GSL's jacobian
   void setJ(gsl_matrix *J) { m_J = J; }
 

--- a/Framework/CurveFitting/src/IMWDomainCreator.cpp
+++ b/Framework/CurveFitting/src/IMWDomainCreator.cpp
@@ -44,9 +44,7 @@ public:
     return m_data[iY * m_nParams + iP];
   }
   /// Zero
-  void zero() override {
-      m_data.assign(m_data.size(), 0.0);
-  }
+  void zero() override { m_data.assign(m_data.size(), 0.0); }
 
 private:
   size_t m_nParams;           ///< number of parameters / second dimension

--- a/Framework/CurveFitting/src/IMWDomainCreator.cpp
+++ b/Framework/CurveFitting/src/IMWDomainCreator.cpp
@@ -43,6 +43,10 @@ public:
   double get(size_t iY, size_t iP) override {
     return m_data[iY * m_nParams + iP];
   }
+  /// Zero
+  void zero() override {
+      m_data.assign(m_data.size(), 0.0);
+  }
 
 private:
   size_t m_nParams;           ///< number of parameters / second dimension

--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -21,7 +21,6 @@
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 #include <Poco/File.h>
-#include <gsl/gsl_version.h>
 
 using namespace Mantid;
 using namespace Mantid::API;
@@ -1103,7 +1102,6 @@ public:
     TS_ASSERT_DELTA(fun->getParameter("f1.B"), -20, 1e-8);
     TS_ASSERT_DELTA(fun->getParameter("f2.A"), 4, 1e-8);
     TS_ASSERT_DELTA(fun->getParameter("f2.B"), 16, 1e-8);
-
   }
 
   void test_function_Multidomain_one_function_to_two_parts_of_workspace() {

--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -1069,12 +1069,15 @@ public:
 
   void test_function_Multidomain_Fit() {
     auto multi = Mantid::TestHelpers::makeMultiDomainFunction3();
-    multi->getFunction(0)->setParameter("A", 0);
-    multi->getFunction(0)->setParameter("B", 0);
-    multi->getFunction(1)->setParameter("A", 0);
-    multi->getFunction(1)->setParameter("B", 0);
-    multi->getFunction(2)->setParameter("A", 0);
-    multi->getFunction(2)->setParameter("B", 0);
+    multi->getFunction(0)->setParameter("A", 1);
+    multi->getFunction(0)->setParameter("B", 1);
+    multi->getFunction(0)->setAttributeValue("Order", 1);
+    multi->getFunction(1)->setParameter("A", 1);
+    multi->getFunction(1)->setParameter("B", 1);
+    multi->getFunction(1)->setAttributeValue("Order", 3);
+    multi->getFunction(2)->setParameter("A", 1);
+    multi->getFunction(2)->setParameter("B", 1);
+    multi->getFunction(2)->setAttributeValue("Order", 5);
 
     Algorithms::Fit fit;
     fit.initialize();
@@ -1093,15 +1096,14 @@ public:
     fit.execute();
     TS_ASSERT(fit.isExecuted());
 
-#if GSL_MAJOR_VERSION < 2
     IFunction_sptr fun = fit.getProperty("Function");
-    TS_ASSERT_DELTA(fun->getParameter("f0.A"), 0, 1e-8);
-    TS_ASSERT_DELTA(fun->getParameter("f0.B"), 1, 1e-8);
-    TS_ASSERT_DELTA(fun->getParameter("f1.A"), 1, 1e-8);
-    TS_ASSERT_DELTA(fun->getParameter("f1.B"), 2, 1e-8);
-    TS_ASSERT_DELTA(fun->getParameter("f2.A"), 2, 1e-8);
-    TS_ASSERT_DELTA(fun->getParameter("f2.B"), 3, 1e-8);
-#endif
+    TS_ASSERT_DELTA(fun->getParameter("f0.A"), 0.5, 1e-8);
+    TS_ASSERT_DELTA(fun->getParameter("f0.B"), 5, 1e-8);
+    TS_ASSERT_DELTA(fun->getParameter("f1.A"), -4, 1e-8);
+    TS_ASSERT_DELTA(fun->getParameter("f1.B"), -20, 1e-8);
+    TS_ASSERT_DELTA(fun->getParameter("f2.A"), 4, 1e-8);
+    TS_ASSERT_DELTA(fun->getParameter("f2.B"), 16, 1e-8);
+
   }
 
   void test_function_Multidomain_one_function_to_two_parts_of_workspace() {

--- a/Framework/CurveFitting/test/Functions/BivariateNormalTest.h
+++ b/Framework/CurveFitting/test/Functions/BivariateNormalTest.h
@@ -45,6 +45,8 @@ public:
   void set(size_t iY, size_t iP, double value) override { M[iP][iY] = value; }
 
   double get(size_t iY, size_t iP) override { return M[iP][iY]; }
+
+  void zero() override { M.zeroMatrix(); }
 };
 
 class BivariateNormalTest : public CxxTest::TestSuite {

--- a/Framework/CurveFitting/test/Functions/ResolutionTest.h
+++ b/Framework/CurveFitting/test/Functions/ResolutionTest.h
@@ -71,6 +71,9 @@ public:
   double get(size_t, size_t) override {
     throw std::runtime_error("Get method shouldn't be called.");
   }
+  void zero() override {
+      throw std::runtime_error("Zero method shouldn't be called.");
+  }
 };
 
 DECLARE_FUNCTION(ResolutionTest_Gauss)

--- a/Framework/CurveFitting/test/Functions/ResolutionTest.h
+++ b/Framework/CurveFitting/test/Functions/ResolutionTest.h
@@ -72,7 +72,7 @@ public:
     throw std::runtime_error("Get method shouldn't be called.");
   }
   void zero() override {
-      throw std::runtime_error("Zero method shouldn't be called.");
+    throw std::runtime_error("Zero method shouldn't be called.");
   }
 };
 

--- a/Framework/CurveFitting/test/Functions/StretchExpTest.h
+++ b/Framework/CurveFitting/test/Functions/StretchExpTest.h
@@ -13,9 +13,7 @@ public:
   StretchExpTest_Jacobian() { m_values.resize(3); }
   void set(size_t, size_t iP, double value) override { m_values[iP] = value; }
   double get(size_t, size_t iP) override { return m_values[iP]; }
-  void zero() override {
-      m_values.assign(m_values.size(), 0.0);
-  }
+  void zero() override { m_values.assign(m_values.size(), 0.0); }
 };
 
 class StretchExpTest : public CxxTest::TestSuite {

--- a/Framework/CurveFitting/test/Functions/StretchExpTest.h
+++ b/Framework/CurveFitting/test/Functions/StretchExpTest.h
@@ -13,6 +13,9 @@ public:
   StretchExpTest_Jacobian() { m_values.resize(3); }
   void set(size_t, size_t iP, double value) override { m_values[iP] = value; }
   double get(size_t, size_t iP) override { return m_values[iP]; }
+  void zero() override {
+      m_values.assign(m_values.size(), 0.0);
+  }
 };
 
 class StretchExpTest : public CxxTest::TestSuite {

--- a/Framework/CurveFitting/test/Functions/UserFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/UserFunctionTest.h
@@ -27,6 +27,9 @@ public:
     double get(size_t iY, size_t iP) override {
       return m_buffer[iY * m_nParams + iP];
     }
+    void zero() override {
+        m_buffer.assign(m_buffer.size(), 0.0);
+    }
   };
 
   void testIt() {

--- a/Framework/CurveFitting/test/Functions/UserFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/UserFunctionTest.h
@@ -27,9 +27,7 @@ public:
     double get(size_t iY, size_t iP) override {
       return m_buffer[iY * m_nParams + iP];
     }
-    void zero() override {
-        m_buffer.assign(m_buffer.size(), 0.0);
-    }
+    void zero() override { m_buffer.assign(m_buffer.size(), 0.0); }
   };
 
   void testIt() {

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
@@ -116,6 +116,10 @@ public:
                                   value * m_factors[m_factorOffset + iY]);
   }
 
+  void zero() override {
+      m_jacobian.zero();
+  }
+
 protected:
   API::Jacobian &m_jacobian;
   size_t m_offset;

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
@@ -158,6 +158,11 @@ public:
     return m_jacobian[safeIndex(iY, iP)];
   }
 
+  /// Implements API::Jacobian::zero
+  void zero() override {
+    m_jacobian.assign(m_jacobian.size(), 0.0);
+  }
+
   /// Provides raw pointer access to the underlying std::vector. Required for
   /// adept-interface.
   double *rawValues() { return &m_jacobian[0]; }

--- a/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h
@@ -116,9 +116,7 @@ public:
                                   value * m_factors[m_factorOffset + iY]);
   }
 
-  void zero() override {
-      m_jacobian.zero();
-  }
+  void zero() override { m_jacobian.zero(); }
 
 protected:
   API::Jacobian &m_jacobian;
@@ -159,9 +157,7 @@ public:
   }
 
   /// Implements API::Jacobian::zero
-  void zero() override {
-    m_jacobian.assign(m_jacobian.size(), 0.0);
-  }
+  void zero() override { m_jacobian.assign(m_jacobian.size(), 0.0); }
 
   /// Provides raw pointer access to the underlying std::vector. Required for
   /// adept-interface.

--- a/Framework/TestHelpers/src/MultiDomainFunctionHelper.cpp
+++ b/Framework/TestHelpers/src/MultiDomainFunctionHelper.cpp
@@ -8,6 +8,7 @@ MultiDomainFunctionTest_Function::MultiDomainFunctionTest_Function()
     : Mantid::API::IFunction1D(), Mantid::API::ParamFunction() {
   this->declareParameter("A", 0);
   this->declareParameter("B", 0);
+  this->declareAttribute("Order", Attribute(1));
 }
 
 void MultiDomainFunctionTest_Function::function1D(double *out,
@@ -15,18 +16,46 @@ void MultiDomainFunctionTest_Function::function1D(double *out,
                                                   const size_t nData) const {
   const double A = getParameter(0);
   const double B = getParameter(1);
+  const int order = getAttribute("Order").asInt();
 
   for (size_t i = 0; i < nData; ++i) {
     double x = xValues[i];
-    out[i] = A + B * x;
+    switch(order) {
+    case 1:
+        out[i] = A + B * x;
+        break;
+    case 3:
+        out[i] = (A + B * x) * pow(x, 2);
+        break;
+    case 5:
+        out[i] = (A + B * x) * pow(x, 4);
+        break;
+    default:
+        throw std::runtime_error("Unknown attribute value.");
+    };
   }
 }
 void MultiDomainFunctionTest_Function::functionDeriv1D(
     Mantid::API::Jacobian *out, const double *xValues, const size_t nData) {
+  const int order = getAttribute("Order").asInt();
   for (size_t i = 0; i < nData; ++i) {
     double x = xValues[i];
-    out->set(i, 1, x);
-    out->set(i, 0, 1.0);
+    switch(order) {
+    case 1:
+        out->set(i, 0, 1.0);
+        out->set(i, 1, x);
+        break;
+    case 3:
+        out->set(i, 0, pow(x, 2));
+        out->set(i, 1, pow(x, 3));
+        break;
+    case 5:
+        out->set(i, 0, pow(x, 4));
+        out->set(i, 1, pow(x, 5));
+        break;
+    default:
+        throw std::runtime_error("Unknown attribute value.");
+    };
   }
 }
 
@@ -46,13 +75,8 @@ boost::shared_ptr<Mantid::API::MultiDomainFunction> makeMultiDomainFunction3() {
   multi->getFunction(2)->setParameter("B", 0);
 
   multi->clearDomainIndices();
-  std::vector<size_t> ii(2);
-  ii[0] = 0;
-  ii[1] = 1;
-  multi->setDomainIndices(1, ii);
-  ii[0] = 0;
-  ii[1] = 2;
-  multi->setDomainIndices(2, ii);
+  multi->setDomainIndices(1, {0, 1});
+  multi->setDomainIndices(2, {0, 2});
 
   return multi;
 }
@@ -69,19 +93,22 @@ boost::shared_ptr<Mantid::API::JointDomain> makeMultiDomainDomain3() {
   return domain;
 }
 
-const double A0 = 0, A1 = 1, A2 = 2;
-const double B0 = 1, B1 = 2, B2 = 3;
+const double A0 = 0.5, A1 = -4, A2 = 4;
+const double B0 = 5, B1 = -20, B2 = 16;
+const size_t nbins = 10;
+const double dX = 0.2;
 
 Mantid::API::MatrixWorkspace_sptr makeMultiDomainWorkspace1() {
   Mantid::API::MatrixWorkspace_sptr ws1 = boost::make_shared<WorkspaceTester>();
-  ws1->initialize(1, 10, 10);
+  ws1->initialize(1, nbins, nbins);
   {
     Mantid::MantidVec &x = ws1->dataX(0);
     Mantid::MantidVec &y = ws1->dataY(0);
     // Mantid::MantidVec& e = ws1->dataE(0);
     for (size_t i = 0; i < ws1->blocksize(); ++i) {
-      x[i] = 0.1 * double(i);
-      y[i] = A0 + A1 + A2 + (B0 + B1 + B2) * x[i];
+      x[i] = -1.0 + dX*double(i);
+      const double t = x[i];
+      y[i] = A0 + B0 * t + (A1 + B1 * t) * pow(t, 2) + (A2 + B2 * t) * pow(t, 4);
     }
   }
 
@@ -90,14 +117,15 @@ Mantid::API::MatrixWorkspace_sptr makeMultiDomainWorkspace1() {
 
 Mantid::API::MatrixWorkspace_sptr makeMultiDomainWorkspace2() {
   Mantid::API::MatrixWorkspace_sptr ws2 = boost::make_shared<WorkspaceTester>();
-  ws2->initialize(1, 10, 10);
+  ws2->initialize(1, nbins, nbins);
   {
     Mantid::MantidVec &x = ws2->dataX(0);
     Mantid::MantidVec &y = ws2->dataY(0);
     // Mantid::MantidVec& e = ws2->dataE(0);
     for (size_t i = 0; i < ws2->blocksize(); ++i) {
-      x[i] = 1 + 0.1 * double(i);
-      y[i] = A0 + A1 + (B0 + B1) * x[i];
+      x[i] = -1.0 + dX*double(i);
+      const double t = x[i];
+      y[i] = A0 + B0 * t + (A1 + B1 * t) * pow(t, 2);
     }
   }
 
@@ -106,14 +134,15 @@ Mantid::API::MatrixWorkspace_sptr makeMultiDomainWorkspace2() {
 
 Mantid::API::MatrixWorkspace_sptr makeMultiDomainWorkspace3() {
   Mantid::API::MatrixWorkspace_sptr ws3 = boost::make_shared<WorkspaceTester>();
-  ws3->initialize(1, 10, 10);
+  ws3->initialize(1, nbins, nbins);
   {
     Mantid::MantidVec &x = ws3->dataX(0);
     Mantid::MantidVec &y = ws3->dataY(0);
     // Mantid::MantidVec& e = ws3->dataE(0);
     for (size_t i = 0; i < ws3->blocksize(); ++i) {
-      x[i] = 2 + 0.1 * double(i);
-      y[i] = A0 + A2 + (B0 + B2) * x[i];
+      x[i] = -1.0 + dX*double(i);
+      const double t = x[i];
+      y[i] = A0 + B0 * t + (A2 + B2 * t) * pow(t, 4);
     }
   }
 

--- a/Framework/TestHelpers/src/MultiDomainFunctionHelper.cpp
+++ b/Framework/TestHelpers/src/MultiDomainFunctionHelper.cpp
@@ -20,18 +20,18 @@ void MultiDomainFunctionTest_Function::function1D(double *out,
 
   for (size_t i = 0; i < nData; ++i) {
     double x = xValues[i];
-    switch(order) {
+    switch (order) {
     case 1:
-        out[i] = A + B * x;
-        break;
+      out[i] = A + B * x;
+      break;
     case 3:
-        out[i] = (A + B * x) * pow(x, 2);
-        break;
+      out[i] = (A + B * x) * pow(x, 2);
+      break;
     case 5:
-        out[i] = (A + B * x) * pow(x, 4);
-        break;
+      out[i] = (A + B * x) * pow(x, 4);
+      break;
     default:
-        throw std::runtime_error("Unknown attribute value.");
+      throw std::runtime_error("Unknown attribute value.");
     };
   }
 }
@@ -40,21 +40,21 @@ void MultiDomainFunctionTest_Function::functionDeriv1D(
   const int order = getAttribute("Order").asInt();
   for (size_t i = 0; i < nData; ++i) {
     double x = xValues[i];
-    switch(order) {
+    switch (order) {
     case 1:
-        out->set(i, 0, 1.0);
-        out->set(i, 1, x);
-        break;
+      out->set(i, 0, 1.0);
+      out->set(i, 1, x);
+      break;
     case 3:
-        out->set(i, 0, pow(x, 2));
-        out->set(i, 1, pow(x, 3));
-        break;
+      out->set(i, 0, pow(x, 2));
+      out->set(i, 1, pow(x, 3));
+      break;
     case 5:
-        out->set(i, 0, pow(x, 4));
-        out->set(i, 1, pow(x, 5));
-        break;
+      out->set(i, 0, pow(x, 4));
+      out->set(i, 1, pow(x, 5));
+      break;
     default:
-        throw std::runtime_error("Unknown attribute value.");
+      throw std::runtime_error("Unknown attribute value.");
     };
   }
 }
@@ -106,9 +106,10 @@ Mantid::API::MatrixWorkspace_sptr makeMultiDomainWorkspace1() {
     Mantid::MantidVec &y = ws1->dataY(0);
     // Mantid::MantidVec& e = ws1->dataE(0);
     for (size_t i = 0; i < ws1->blocksize(); ++i) {
-      x[i] = -1.0 + dX*double(i);
+      x[i] = -1.0 + dX * double(i);
       const double t = x[i];
-      y[i] = A0 + B0 * t + (A1 + B1 * t) * pow(t, 2) + (A2 + B2 * t) * pow(t, 4);
+      y[i] =
+          A0 + B0 * t + (A1 + B1 * t) * pow(t, 2) + (A2 + B2 * t) * pow(t, 4);
     }
   }
 
@@ -123,7 +124,7 @@ Mantid::API::MatrixWorkspace_sptr makeMultiDomainWorkspace2() {
     Mantid::MantidVec &y = ws2->dataY(0);
     // Mantid::MantidVec& e = ws2->dataE(0);
     for (size_t i = 0; i < ws2->blocksize(); ++i) {
-      x[i] = -1.0 + dX*double(i);
+      x[i] = -1.0 + dX * double(i);
       const double t = x[i];
       y[i] = A0 + B0 * t + (A1 + B1 * t) * pow(t, 2);
     }
@@ -140,7 +141,7 @@ Mantid::API::MatrixWorkspace_sptr makeMultiDomainWorkspace3() {
     Mantid::MantidVec &y = ws3->dataY(0);
     // Mantid::MantidVec& e = ws3->dataE(0);
     for (size_t i = 0; i < ws3->blocksize(); ++i) {
-      x[i] = -1.0 + dX*double(i);
+      x[i] = -1.0 + dX * double(i);
       const double t = x[i];
       y[i] = A0 + B0 * t + (A2 + B2 * t) * pow(t, 4);
     }


### PR DESCRIPTION
The LM optimiser of GSL2 creates the Jacobian matrix but doesn't initialise it with 0s as it is done in GSL1. The fix is to initialise the matrix in MultiDomainFunction. 

**To test:**

Unit tests must pass on gsl2 platforms.

Fixes #16684

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
