### PR TITLE
Include distribution in Ubuntu package filename

### DIFF
--- a/buildconfig/CMake/CPackCommon.cmake
+++ b/buildconfig/CMake/CPackCommon.cmake
@@ -21,5 +21,6 @@ set ( CPACK_RPM_PACKAGE_LICENSE GPLv3+ )
 set ( CPACK_RPM_PACKAGE_RELEASE 1 )
 set ( CPACK_RPM_PACKAGE_GROUP Applications/Engineering )
 
-# DEB information - only used if generating a deb
-set ( CPACK_DEBIAN_PACKAGE_RELEASE 1 )
+# DEB informatin - the package does not have an original
+# in debian archives so the debian release is 0
+set ( CPACK_DEBIAN_PACKAGE_RELEASE 0 )

--- a/buildconfig/CMake/CPackLinuxSetup.cmake
+++ b/buildconfig/CMake/CPackLinuxSetup.cmake
@@ -25,9 +25,10 @@ if ( "${UNIX_DIST}" MATCHES "Ubuntu" )
     execute_process( COMMAND ${DPKG_CMD} --print-architecture
       OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
       OUTPUT_STRIP_TRAILING_WHITESPACE )
-    # according to debian <foo>_<VersionNumber>-<DebianRevisionNumber>_<DebianArchitecture>.deb
-    set( CPACK_PACKAGE_FILE_NAME
-      "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
+    # following Ubuntu convention <foo>_<VersionNumber>-<DebianRevisionNumber>ubuntu1~<UbuntuCodeName>1_<DebianArchitecture>.deb
+    set ( UBUNTU_PACKAGE_RELEASE "ubuntu1~${UNIX_CODENAME}1" )
+    set ( CPACK_PACKAGE_FILE_NAME
+          "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE}${UBUNTU_PACKAGE_RELEASE}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
   endif ( DPKG_CMD )
 endif ( "${UNIX_DIST}" MATCHES "Ubuntu" )
 


### PR DESCRIPTION
Package name generated by CPack for `.deb` packages now follows the Ubuntu convention and also includes the release codename following the ppa convention. This will allow us to release a binary built for different releases that would otherwise have the same filename. 

**To test:**

On an Ubuntu machine run `cmake -DENABLE_CPACK=ON .` and make note of the package name it generates. Verify that it follows the `mantid_X.Y.Z-0ubuntu1~release1` where `X.Y.Z` is the package version and release will be replaced by the codename of the distribution.

Fixes #10574 .

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
