### PR TITLE
Fix theta value in POLREF GUI

### DIFF
--- a/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -699,6 +699,7 @@ void ReflectometryReductionOne::exec() {
   setProperty("OutputWorkspace", IvsQ);
   // setting these values so the Interface can retrieve them from
   // ReflectometryReductionOneAuto.
+  setProperty("ThetaIn", theta.get() / 2.);
   setProperty("MomentumTransferMinimum", momentumTransferMinimum);
   setProperty("MomentumTransferStep", momentumTransferStep);
   setProperty("MomentumTransferMaximum", momentumTransferMaximum);

--- a/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -699,7 +699,6 @@ void ReflectometryReductionOne::exec() {
   setProperty("OutputWorkspace", IvsQ);
   // setting these values so the Interface can retrieve them from
   // ReflectometryReductionOneAuto.
-  setProperty("ThetaIn", theta.get() / 2.);
   setProperty("MomentumTransferMinimum", momentumTransferMinimum);
   setProperty("MomentumTransferStep", momentumTransferStep);
   setProperty("MomentumTransferMaximum", momentumTransferMaximum);

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -568,8 +568,10 @@ void ReflectometryReductionOneAuto::exec() {
     setProperty("MomentumTransferMaximum",
                 boost::lexical_cast<double>(
                     refRedOne->getPropertyValue("MomentumTransferMaximum")));
-    setProperty("ThetaIn", boost::lexical_cast<double>(
-                               refRedOne->getPropertyValue("ThetaIn")));
+    if (theta_in.is_initialized())
+      setProperty("ThetaIn", theta_in.get());
+    else
+      setProperty("ThetaIn", thetaOut1);
 
   } else {
     throw std::runtime_error(

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -571,7 +571,7 @@ void ReflectometryReductionOneAuto::exec() {
     if (theta_in.is_initialized())
       setProperty("ThetaIn", theta_in.get());
     else
-      setProperty("ThetaIn", thetaOut1);
+      setProperty("ThetaIn", thetaOut1 / 2.);
 
   } else {
     throw std::runtime_error(


### PR DESCRIPTION
**To test:**

Open "Interfaces" > "Reflectometry" > "ISIS Reflectometry (Polref)". Populate the table like this (you'll have to add a new row using the fifth icon above the table):

![polref](https://cloud.githubusercontent.com/assets/8956985/19029859/b2677d1a-8941-11e6-8e29-eb2d9c8d2e99.png)

Select the first row and hit "Process". Column "Angle" should be populated with ~ 0.70. Select the second row and hit "Process". Value in column "Angle" should not change.

Fixes #17657.

I don't think this needs to be in the release notes, it was reported by Jos during beta testing.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
