### PR TITLE
Histogram Rollout - Algorithms 30-35

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
@@ -85,11 +85,11 @@ private:
   double muR(const double flightPath, const double tof) const;
   double muR(const double sigt) const;
   double sigmaTotal(const double flightPath, const double tof) const;
-  double tof(const size_t i) const;
   void seedRNG(const size_t seed);
 
   // Holds histogram to process
   const HistogramData::Histogram &m_histogram;
+  const HistogramData::Points m_tofVals;
 
   /// A copy of the correction parameters
   const Parameters m_pars;

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
@@ -68,8 +68,7 @@ public:
   ~MayersSampleCorrectionStrategy();
 
   /// Return the correction factors
-  Mantid::HistogramData::Histogram
-  apply(const Mantid::HistogramData::Histogram &inputXVals);
+  Mantid::HistogramData::Histogram getCorrectedHisto();
 
   /// Calculate the self-attenuation factor for a single mu*r value
   double calculateSelfAttenuation(const double muR);
@@ -89,16 +88,13 @@ private:
   double tof(const size_t i) const;
   void seedRNG(const size_t seed);
 
+  // Holds histogram to process
+  const HistogramData::Histogram &m_histogram;
+
   /// A copy of the correction parameters
   const Parameters m_pars;
-  /// A reference to the tof vluaes
-  const std::vector<double> &m_tof;
-  /// A reference to the input signal values
-  const std::vector<double> &m_sigin;
-  /// A reference to the input error values
-  const std::vector<double> &m_errin;
-  // True if we have binned TOF values
-  const bool m_histogram;
+  /// Holds the number of Y vals to process
+  const size_t m_histoYSize;
   /// Limits for the range of mu*r values to cover
   const std::pair<double, double> m_muRrange;
   /// Random number generator

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
@@ -23,6 +23,7 @@
   Code Documentation is available at: <http://doxygen.mantidproject.org>
   */
 #include "MantidKernel/System.h"
+#include "MantidHistogramData/Histogram.h"
 #include <memory>
 #include <utility>
 #include <vector>
@@ -61,15 +62,15 @@ public:
   /// Constructor
   MayersSampleCorrectionStrategy(
       MayersSampleCorrectionStrategy::Parameters params,
-      const std::vector<double> &tof, const std::vector<double> &sigIn,
-      const std::vector<double> &errIn);
+      const Mantid::HistogramData::Histogram &histogram);
   /// Destructor - defined in cpp file to use forward declaration with
   /// unique_ptr
   ~MayersSampleCorrectionStrategy();
 
   /// Return the correction factors
-  void apply(std::vector<double> &sigOut, std::vector<double> &errOut);
-  /// Calculate the self-attentation factor for a single mu*r value
+  void apply(Mantid::HistogramData::HistogramY &histoY,
+             Mantid::HistogramData::HistogramE &histoE);
+  /// Calculate the self-attenuation factor for a single mu*r value
   double calculateSelfAttenuation(const double muR);
   /// Calculate the multiple scattering factor for a single mu*r value &
   /// absorption value

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
@@ -62,14 +62,15 @@ public:
   /// Constructor
   MayersSampleCorrectionStrategy(
       MayersSampleCorrectionStrategy::Parameters params,
-      const Mantid::HistogramData::Histogram &histogram);
+      const Mantid::HistogramData::Histogram &inputHist);
   /// Destructor - defined in cpp file to use forward declaration with
   /// unique_ptr
   ~MayersSampleCorrectionStrategy();
 
   /// Return the correction factors
-  void apply(Mantid::HistogramData::HistogramY &histoY,
-             Mantid::HistogramData::HistogramE &histoE);
+  Mantid::HistogramData::Histogram
+  apply(const Mantid::HistogramData::Histogram &inputXVals);
+
   /// Calculate the self-attenuation factor for a single mu*r value
   double calculateSelfAttenuation(const double muR);
   /// Calculate the multiple scattering factor for a single mu*r value &

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
@@ -87,12 +87,11 @@ private:
   double sigmaTotal(const double flightPath, const double tof) const;
   void seedRNG(const size_t seed);
 
+  /// A copy of the correction parameters
+  const Parameters m_pars;
   // Holds histogram to process
   const HistogramData::Histogram &m_histogram;
   const HistogramData::Points m_tofVals;
-
-  /// A copy of the correction parameters
-  const Parameters m_pars;
   /// Holds the number of Y vals to process
   const size_t m_histoYSize;
   /// Limits for the range of mu*r values to cover

--- a/Framework/Algorithms/src/RRFMuon.cpp
+++ b/Framework/Algorithms/src/RRFMuon.cpp
@@ -71,8 +71,7 @@ void RRFMuon::exec() {
   const double twoPiFreq = 2. * M_PI * freq * factor;
   const auto time = inputWs->x(0);  // X axis: time
   const auto labRe = inputWs->y(0); // Lab-frame polarization (real part)
-  const auto labIm =
-      inputWs->y(1); // Lab-frame polarization (imaginary part)
+  const auto labIm = inputWs->y(1); // Lab-frame polarization (imaginary part)
 
   MantidVec rrfRe(nData),
       rrfIm(nData); // Rotating Reference frame (RRF) polarizations

--- a/Framework/Algorithms/src/RRFMuon.cpp
+++ b/Framework/Algorithms/src/RRFMuon.cpp
@@ -69,9 +69,9 @@ void RRFMuon::exec() {
 
   // Compute the RRF polarization
   const double twoPiFreq = 2. * M_PI * freq * factor;
-  const auto time = inputWs->x(0);  // X axis: time
-  const auto labRe = inputWs->y(0); // Lab-frame polarization (real part)
-  const auto labIm = inputWs->y(1); // Lab-frame polarization (imaginary part)
+  const auto &time = inputWs->x(0);  // X axis: time
+  const auto &labRe = inputWs->y(0); // Lab-frame polarization (real part)
+  const auto &labIm = inputWs->y(1); // Lab-frame polarization (imaginary part)
 
   MantidVec rrfRe(nData),
       rrfIm(nData); // Rotating Reference frame (RRF) polarizations

--- a/Framework/Algorithms/src/RRFMuon.cpp
+++ b/Framework/Algorithms/src/RRFMuon.cpp
@@ -60,19 +60,20 @@ void RRFMuon::exec() {
   // Get phase
   double phase = getProperty("Phase");
   // Get number of histograms
-  size_t nHisto = inputWs->getNumberHistograms();
+  const size_t nHisto = inputWs->getNumberHistograms();
   if (nHisto != 2) {
     throw std::runtime_error("Invalid number of spectra in input workspace");
   }
   // Set number of data points
-  size_t nData = inputWs->blocksize();
+  const size_t nData = inputWs->blocksize();
 
   // Compute the RRF polarization
   const double twoPiFreq = 2. * M_PI * freq * factor;
-  MantidVec time = inputWs->readX(0);  // X axis: time
-  MantidVec labRe = inputWs->readY(0); // Lab-frame polarization (real part)
-  MantidVec labIm =
-      inputWs->readY(1); // Lab-frame polarization (imaginary part)
+  const auto time = inputWs->x(0);  // X axis: time
+  const auto labRe = inputWs->y(0); // Lab-frame polarization (real part)
+  const auto labIm =
+      inputWs->y(1); // Lab-frame polarization (imaginary part)
+
   MantidVec rrfRe(nData),
       rrfIm(nData); // Rotating Reference frame (RRF) polarizations
   for (size_t t = 0; t < nData; t++) {
@@ -92,12 +93,12 @@ void RRFMuon::exec() {
   // Put results into output workspace
   // Real RRF polarization
   outputWs->getSpectrum(0).setSpectrumNo(1);
-  outputWs->dataX(0) = inputWs->readX(0);
-  outputWs->dataY(0) = rrfRe;
+  outputWs->setSharedX(0, inputWs->sharedX(0));
+  outputWs->mutableY(0) = rrfRe;
   // Imaginary RRF polarization
   outputWs->getSpectrum(1).setSpectrumNo(2);
-  outputWs->dataX(1) = inputWs->readX(1);
-  outputWs->dataY(1) = rrfIm;
+  outputWs->setSharedX(1, inputWs->sharedX(1));
+  outputWs->mutableY(1) = rrfIm;
 
   // Set output workspace
   setProperty("OutputWorkspace", outputWs);

--- a/Framework/Algorithms/src/SANSDirectBeamScaling.cpp
+++ b/Framework/Algorithms/src/SANSDirectBeamScaling.cpp
@@ -83,11 +83,11 @@ void SANSDirectBeamScaling::exec() {
   Progress progress(this, 0.0, 1.0, numHists);
 
   // Number of X bins
-  const int64_t xLength = inputWS->readY(0).size();
+  const int64_t xLength = inputWS->y(0).size();
 
   // Monitor counts
   double monitor = 0.0;
-  const MantidVec &MonIn = inputWS->readY(index[0]);
+  const auto &MonIn = inputWS->y(index[0]);
   for (int64_t j = 0; j < xLength; j++)
     monitor += MonIn[j];
 
@@ -111,8 +111,8 @@ void SANSDirectBeamScaling::exec() {
     if (spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i))
       continue;
 
-    const MantidVec &YIn = inputWS->readY(i);
-    const MantidVec &EIn = inputWS->readE(i);
+    const auto &YIn = inputWS->y(i);
+    const auto &EIn = inputWS->e(i);
 
     // Sum up all the counts
     V3D pos = spectrumInfo.position(i) - V3D(sourcePos.X(), sourcePos.Y(), 0.0);

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
@@ -111,8 +111,6 @@ void MayersSampleCorrection::exec() {
   for (int64_t i = 0; i < static_cast<int64_t>(nhist); ++i) {
     PARALLEL_START_INTERUPT_REGION
 
-    // Copy the X values over
-    outputWS->setSharedX(i, inputWS->sharedX(i));
     IDetector_const_sptr det;
     try {
       det = inputWS->getDetector(i);
@@ -135,7 +133,7 @@ void MayersSampleCorrection::exec() {
     params.cylHeight = height;
 
     MayersSampleCorrectionStrategy correction(params, inputWS->histogram(i));
-    correction.apply(outputWS->mutableY(i), outputWS->mutableE(i));
+    outputWS->setHistogram(i, correction.apply(std::move(inputWS->histogram(i))));
     prog.report();
 
     PARALLEL_END_INTERUPT_REGION

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
@@ -112,8 +112,7 @@ void MayersSampleCorrection::exec() {
     PARALLEL_START_INTERUPT_REGION
 
     // Copy the X values over
-    const auto &inX = inputWS->readX(i);
-    outputWS->dataX(i) = inX;
+    outputWS->setSharedX(i, inputWS->sharedX(i));
     IDetector_const_sptr det;
     try {
       det = inputWS->getDetector(i);
@@ -134,9 +133,9 @@ void MayersSampleCorrection::exec() {
     params.sigmaSc = sampleMaterial.totalScatterXSection();
     params.cylRadius = radius;
     params.cylHeight = height;
-    MayersSampleCorrectionStrategy correction(params, inX, inputWS->readY(i),
-                                              inputWS->readE(i));
-    correction.apply(outputWS->dataY(i), outputWS->dataE(i));
+
+    MayersSampleCorrectionStrategy correction(params, inputWS->histogram(i));
+    correction.apply(outputWS->mutableY(i), outputWS->mutableE(i));
     prog.report();
 
     PARALLEL_END_INTERUPT_REGION

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
@@ -133,7 +133,8 @@ void MayersSampleCorrection::exec() {
     params.cylHeight = height;
 
     MayersSampleCorrectionStrategy correction(params, inputWS->histogram(i));
-    outputWS->setHistogram(i, correction.apply(std::move(inputWS->histogram(i))));
+    outputWS->setHistogram(i,
+                           correction.apply(std::move(inputWS->histogram(i))));
     prog.report();
 
     PARALLEL_END_INTERUPT_REGION

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
@@ -133,8 +133,7 @@ void MayersSampleCorrection::exec() {
     params.cylHeight = height;
 
     MayersSampleCorrectionStrategy correction(params, inputWS->histogram(i));
-    outputWS->setHistogram(i,
-                           correction.apply(std::move(inputWS->histogram(i))));
+    outputWS->setHistogram(i, correction.getCorrectedHisto());
     prog.report();
 
     PARALLEL_END_INTERUPT_REGION

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
@@ -2,10 +2,10 @@
 // Includes
 //-----------------------------------------------------------------------------
 #include "MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h"
-#include "MantidKernel/MersenneTwister.h"
-#include "MantidKernel/Statistics.h"
 #include "MantidKernel/Math/ChebyshevPolyFit.h"
 #include "MantidKernel/Math/Distributions/ChebyshevSeries.h"
+#include "MantidKernel/MersenneTwister.h"
+#include "MantidKernel/Statistics.h"
 #include <cassert>
 #include <cmath>
 
@@ -178,7 +178,6 @@ Mantid::HistogramData::Histogram MayersSampleCorrectionStrategy::apply(
     }
     // apply correction
     const double yin(m_sigin[i]), ein(m_errin[i]);
-    const double errVal = yin * corrfact;
     sigOut[i] = yin * corrfact;
     errOut[i] = sigOut[i] * ein / yin;
   }

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
@@ -73,10 +73,9 @@ namespace Algorithms {
 /**
  * Constructor
  * @param params Defines the required parameters for the correction
- * @param tof The TOF values corresponding to the signals to correct.
- *      Number of tof values must match number of signal/error or be 1 greater
- * @param sigIn Values of the signal that will be corrected
- * @param errIn Values of the errors that will be corrected
+ * @param inputHist A histogram containing the TOF values corresponding
+ * to the values to be corrected. The number of tof values must match
+ * number of signal/error or be 1 greater
  */
 MayersSampleCorrectionStrategy::MayersSampleCorrectionStrategy(
     MayersSampleCorrectionStrategy::Parameters params,
@@ -105,8 +104,9 @@ MayersSampleCorrectionStrategy::~MayersSampleCorrectionStrategy() = default;
  * Correct the data for absorption and multiple scattering effects. Allows
  * both histogram or point data. For histogram the TOF is taken to be
  * the mid point of a bin
- * @param sigOut Signal values to correct [In/Out]
- * @param errOut Error values to correct [In/Out]
+ *
+ * @param inputXVals A histogram containing the tof values to use
+ * @return A histogram containing corrected values
  */
 Mantid::HistogramData::Histogram MayersSampleCorrectionStrategy::apply(
     const Mantid::HistogramData::Histogram &inputXVals) {
@@ -179,8 +179,8 @@ Mantid::HistogramData::Histogram MayersSampleCorrectionStrategy::apply(
     // apply correction
     const double yin(m_sigin[i]), ein(m_errin[i]);
     const double errVal = yin * corrfact;
-	sigOut[i] = yin * corrfact;
-	errOut[i] = sigOut[i] * ein / yin;
+    sigOut[i] = yin * corrfact;
+    errOut[i] = sigOut[i] * ein / yin;
   }
   return outputHistogram;
 }

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
@@ -83,7 +83,7 @@ MayersSampleCorrectionStrategy::MayersSampleCorrectionStrategy(
       m_histoYSize(inputHist.y().size()), m_muRrange(calculateMuRange()),
       m_rng(new MersenneTwister(1)) {
 
-	const auto &xVals = m_histogram.x();
+  const auto &xVals = m_histogram.x();
   if (!(xVals.front() < xVals.back())) {
     throw std::invalid_argument(
         "TOF values are expected to be monotonically increasing");

--- a/Framework/Algorithms/src/SetUncertainties.cpp
+++ b/Framework/Algorithms/src/SetUncertainties.cpp
@@ -122,8 +122,7 @@ void SetUncertainties::exec() {
     if (errorType.compare(ONE_IF_ZERO) == 0) {
       outputWorkspace->setSharedE(i, inputWorkspace->sharedE(i));
     } else {
-      auto &errVals = outputWorkspace->mutableE(i);
-      std::fill(errVals.begin(), errVals.end(), 0);
+      outputWorkspace->mutableE(i) = 0.0;
     }
 
     // ZERO mode doesn't calculate anything further

--- a/Framework/Algorithms/src/SetUncertainties.cpp
+++ b/Framework/Algorithms/src/SetUncertainties.cpp
@@ -122,8 +122,8 @@ void SetUncertainties::exec() {
     if (errorType.compare(ONE_IF_ZERO) == 0) {
       outputWorkspace->setSharedE(i, inputWorkspace->sharedE(i));
     } else {
-		auto &errVals = outputWorkspace->mutableE(i);
-		std::fill(errVals.begin(), errVals.end(), 0);
+      auto &errVals = outputWorkspace->mutableE(i);
+      std::fill(errVals.begin(), errVals.end(), 0);
     }
 
     // ZERO mode doesn't calculate anything further
@@ -134,7 +134,7 @@ void SetUncertainties::exec() {
         std::transform(Y.begin(), Y.end(), E.begin(),
                        sqrterror(resetOne ? 1. : 0.));
       } else {
-        std::for_each(E.begin(), E.end(), resetzeroerror(1.));
+        std::transform(E.begin(), E.end(), E.begin(), resetzeroerror(1.));
       }
     }
 

--- a/Framework/Algorithms/src/SetUncertainties.cpp
+++ b/Framework/Algorithms/src/SetUncertainties.cpp
@@ -116,21 +116,21 @@ void SetUncertainties::exec() {
     PARALLEL_START_INTERUPT_REGION
 
     // copy the X/Y
-    outputWorkspace->setX(i, inputWorkspace->refX(i));
-    outputWorkspace->dataY(i) = inputWorkspace->readY(i);
+    outputWorkspace->setSharedX(i, inputWorkspace->sharedX(i));
+    outputWorkspace->setSharedY(i, inputWorkspace->sharedY(i));
     // copy the E or set to zero depending on the mode
     if (errorType.compare(ONE_IF_ZERO) == 0) {
-      outputWorkspace->dataE(i) = inputWorkspace->readE(i);
+      outputWorkspace->setSharedE(i, inputWorkspace->sharedE(i));
     } else {
-      outputWorkspace->dataE(i) =
-          std::vector<double>(inputWorkspace->readE(i).size(), 0.);
+		auto &errVals = outputWorkspace->mutableE(i);
+		std::fill(errVals.begin(), errVals.end(), 0);
     }
 
     // ZERO mode doesn't calculate anything further
     if ((!zeroError) && (!isMasked(inputWorkspace, i))) {
-      MantidVec &E = outputWorkspace->dataE(i);
+      auto &E = outputWorkspace->mutableE(i);
       if (takeSqrt) {
-        const MantidVec &Y = outputWorkspace->readY(i);
+        const auto &Y = outputWorkspace->y(i);
         std::transform(Y.begin(), Y.end(), E.begin(),
                        sqrterror(resetOne ? 1. : 0.));
       } else {

--- a/Framework/Algorithms/src/SmoothData.cpp
+++ b/Framework/Algorithms/src/SmoothData.cpp
@@ -92,17 +92,17 @@ void SmoothData::exec() {
 
     // Copy the X data over. Preserves data sharing if present in input
     // workspace.
-    outputWorkspace->setX(i, inputWorkspace->refX(i));
+    outputWorkspace->setSharedX(i, inputWorkspace->sharedX(i));
 
     // Now get references to the Y & E vectors in the input and output
     // workspaces
-    const MantidVec &Y = inputWorkspace->readY(i);
-    const MantidVec &E = inputWorkspace->readE(i);
-    MantidVec &newY = outputWorkspace->dataY(i);
-    MantidVec &newE = outputWorkspace->dataE(i);
+    const auto &Y = inputWorkspace->y(i);
+    const auto &E = inputWorkspace->e(i);
+    auto &newY = outputWorkspace->mutableY(i);
+    auto &newE = outputWorkspace->mutableE(i);
     if (npts == 0) {
-      newY = Y;
-      newE = E;
+      outputWorkspace->setSharedY(i, inputWorkspace->sharedY(i));
+      outputWorkspace->setSharedE(i, inputWorkspace->sharedE(i));
       continue;
     }
     // Use total to help hold our moving average

--- a/Framework/Algorithms/src/SmoothData.cpp
+++ b/Framework/Algorithms/src/SmoothData.cpp
@@ -96,15 +96,15 @@ void SmoothData::exec() {
 
     // Now get references to the Y & E vectors in the input and output
     // workspaces
-    const auto &Y = inputWorkspace->y(i);
-    const auto &E = inputWorkspace->e(i);
-    auto &newY = outputWorkspace->mutableY(i);
-    auto &newE = outputWorkspace->mutableE(i);
     if (npts == 0) {
       outputWorkspace->setSharedY(i, inputWorkspace->sharedY(i));
       outputWorkspace->setSharedE(i, inputWorkspace->sharedE(i));
       continue;
     }
+    const auto &Y = inputWorkspace->y(i);
+    const auto &E = inputWorkspace->e(i);
+    auto &newY = outputWorkspace->mutableY(i);
+    auto &newE = outputWorkspace->mutableE(i);
     // Use total to help hold our moving average
     double total = 0.0, totalE = 0.0;
     // First push the values ahead of the current point onto total

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -25,7 +25,7 @@ public:
   void test_Attentuaton_Correction_For_Fixed_Mur() {
     Histogram histo(Points(2, LinearGenerator(0, 1)), Counts(2, 0));
     MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
-    auto absFactor = mscat.calculateSelfAttenuation(0.01);
+    double absFactor = mscat.calculateSelfAttenuation(0.01);
 
     const double delta = 1e-8;
     TS_ASSERT_DELTA(0.00030887, absFactor, delta);
@@ -62,9 +62,9 @@ public:
 
     auto outHisto = mscat.apply(histo);
 
-    auto tofVals = outHisto.x();
-    auto signalVals = outHisto.y();
-    auto errVals = outHisto.e();
+    const auto &tofVals = outHisto.x();
+    const auto &signalVals = outHisto.y();
+    const auto &errVals = outHisto.e();
 
     // Check some values
     const double delta(1e-06);
@@ -96,9 +96,9 @@ public:
 
     auto outHisto = mscat.apply(histo);
 
-    auto tofVals = outHisto.x();
-    auto signalVals = outHisto.y();
-    auto errVals = outHisto.e();
+    const auto &tofVals = outHisto.x();
+    const auto &signalVals = outHisto.y();
+    const auto &errVals = outHisto.e();
 
     // Check some values
     const double delta(1e-06);

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -23,9 +23,9 @@ public:
   }
 
   void test_Attentuaton_Correction_For_Fixed_Mur() {
-    Histogram histo(Points(2, LinearGenerator(0, 1)), Counts(2, 0));
+    Histogram histo(Points{0, 1}, Counts{0, 1});
     MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
-    double absFactor = mscat.calculateSelfAttenuation(0.01);
+    auto absFactor = mscat.calculateSelfAttenuation(0.01);
 
     const double delta = 1e-8;
     TS_ASSERT_DELTA(0.00030887, absFactor, delta);
@@ -33,7 +33,7 @@ public:
 
   void
   test_Multiple_Scattering_With_Fixed_Mur_And_Absorption_Correction_Factor() {
-    Histogram histo(Points(2, LinearGenerator(0, 1)), Counts(2, 0));
+    Histogram histo(Points{0, 1}, Counts{0, 1});
     MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
     const size_t irp(1);
     const double muR(0.01), abs(0.0003);
@@ -45,119 +45,84 @@ public:
   }
 
   void test_Corrects_Both_Absorption_And_Multiple_Scattering_For_Point_Data() {
-    using std::sqrt;
     const size_t nypts(100);
-    std::vector<double> signal(nypts, 2.0), tof(nypts), error(nypts);
-
-    std::transform(signal.begin(), signal.end(), error.begin(),
-                   (double (*)(double))sqrt);
-    std::generate(tof.begin(), tof.end(), Incrementer(100.0));
-
-    Points tofPoints(tof);
-    Histogram histo(tofPoints, Counts(signal), CountStandardDeviations(error));
-
+    Histogram histo(Points(nypts, LinearGenerator(100.0, 1.0)),
+                    Counts(nypts, 2.0));
     MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
-
-    // Correct it
 
     auto outHisto = mscat.getCorrectedHisto();
 
-    const auto &tofVals = outHisto.x();
-    const auto &signalVals = outHisto.y();
-    const auto &errVals = outHisto.e();
+    const auto &tof = outHisto.x();
+    const auto &signal = outHisto.y();
+    const auto &error = outHisto.e();
 
     // Check some values
     const double delta(1e-06);
-    TS_ASSERT_DELTA(100.0, tofVals.front(), delta);
-    TS_ASSERT_DELTA(199.0, tofVals.back(), delta);
+    TS_ASSERT_DELTA(100.0, tof.front(), delta);
+    TS_ASSERT_DELTA(199.0, tof.back(), delta);
 
-    TS_ASSERT_DELTA(0.37497317, signalVals.front(), delta);
-    TS_ASSERT_DELTA(0.37629282, signalVals.back(), delta);
+    TS_ASSERT_DELTA(0.37497317, signal.front(), delta);
+    TS_ASSERT_DELTA(0.37629282, signal.back(), delta);
 
-    TS_ASSERT_DELTA(0.26514607, errVals.front(), delta);
-    TS_ASSERT_DELTA(0.2660792, errVals.back(), delta);
+    TS_ASSERT_DELTA(0.26514607, error.front(), delta);
+    TS_ASSERT_DELTA(0.2660792, error.back(), delta);
   }
 
   void
   test_Corrects_Both_Absorption_And_Multiple_Scattering_For_Histogram_Data() {
-    using std::sqrt;
     const size_t nypts(100);
-    std::vector<double> signal(nypts, 2.0), tof(nypts + 1), error(nypts);
-    std::transform(signal.begin(), signal.end(), error.begin(),
-                   (double (*)(double))sqrt);
-    // Generate a histogram with the same mid points as the point data example
-    std::generate(tof.begin(), tof.end(), Incrementer(99.5));
-
-    BinEdges tofPoints(tof);
-    Histogram histo(tofPoints, Counts(signal), CountStandardDeviations(error));
+    Histogram histo(BinEdges(nypts + 1, LinearGenerator(99.5, 1.0)),
+                    Counts(nypts, 2.0));
     MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
-
-    // Correct it
 
     auto outHisto = mscat.getCorrectedHisto();
 
-    const auto &tofVals = outHisto.x();
-    const auto &signalVals = outHisto.y();
-    const auto &errVals = outHisto.e();
+    const auto &tof = outHisto.x();
+    const auto &signal = outHisto.y();
+    const auto &error = outHisto.e();
 
     // Check some values
     const double delta(1e-06);
-    TS_ASSERT_DELTA(99.5, tofVals.front(), delta);
-    TS_ASSERT_DELTA(199.5, tofVals.back(), delta);
+    TS_ASSERT_DELTA(99.5, tof.front(), delta);
+    TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(0.37497317, signalVals.front(), delta);
-    TS_ASSERT_DELTA(0.37629281, signalVals.back(), delta);
+    TS_ASSERT_DELTA(0.37497317, signal.front(), delta);
+    TS_ASSERT_DELTA(0.37629282, signal.back(), delta);
 
-    TS_ASSERT_DELTA(0.26514607, errVals.front(), delta);
-    TS_ASSERT_DELTA(0.26607920, errVals.back(), delta);
+    TS_ASSERT_DELTA(0.26514607, error.front(), delta);
+    TS_ASSERT_DELTA(0.2660792, error.back(), delta);
   }
 
   void test_Corrects_For_Absorption_For_Histogram_Data() {
-    using std::sqrt;
     const size_t nypts(100);
-    std::vector<double> signal(nypts, 2.0), tof(nypts + 1), error(nypts);
-    std::transform(signal.begin(), signal.end(), error.begin(),
-                   (double (*)(double))sqrt);
-    // Generate a histogram with the same mid points as the point data example
-    std::generate(tof.begin(), tof.end(), Incrementer(99.5));
     bool mscatOn(false);
-
-    BinEdges tofPoints(tof);
-    Histogram histo(tofPoints, Counts(signal), CountStandardDeviations(error));
-
+    Histogram histo(BinEdges(nypts + 1, LinearGenerator(99.5, 1.0)),
+                    Counts(nypts, 2.0));
     MayersSampleCorrectionStrategy mscat(createTestParameters(mscatOn), histo);
-
-    // Correct it
 
     auto outHisto = mscat.getCorrectedHisto();
 
-    auto tofVals = outHisto.x();
-    auto signalVals = outHisto.y();
-    auto errVals = outHisto.e();
+    auto tof = outHisto.x();
+    auto signal = outHisto.y();
+    auto error = outHisto.e();
 
     // Check some values
     const double delta(1e-06);
-    TS_ASSERT_DELTA(99.5, tofVals.front(), delta);
-    TS_ASSERT_DELTA(199.5, tofVals.back(), delta);
+    TS_ASSERT_DELTA(99.5, tof.front(), delta);
+    TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(2.3440378, signalVals.front(), delta);
-    TS_ASSERT_DELTA(2.3489418, signalVals.back(), delta);
+    TS_ASSERT_DELTA(2.3440379, signal.front(), delta);
+    TS_ASSERT_DELTA(2.3489418, signal.back(), delta);
 
-    TS_ASSERT_DELTA(1.6574850, errVals.front(), delta);
-    TS_ASSERT_DELTA(1.6609527, errVals.back(), delta);
+    TS_ASSERT_DELTA(1.6574851, error.front(), delta);
+    TS_ASSERT_DELTA(1.6609527, error.back(), delta);
   }
 
   // ---------------------- Failure tests -----------------------------
   void test_Tof_Not_Monotonically_Increasing_Throws_Invalid_Argument() {
-    using std::sqrt;
     const size_t nypts(10);
-    std::vector<double> signal(nypts, 2.0), tof(nypts + 1), error(nypts);
-    std::transform(signal.begin(), signal.end(), error.begin(),
-                   (double (*)(double))sqrt);
-    std::generate(tof.begin(), tof.end(), Decrementer(199.5));
-
-    BinEdges tofPoints(tof);
-    Histogram histo(tofPoints, Counts(signal), CountStandardDeviations(error));
+    Histogram histo(BinEdges(nypts + 1, LinearGenerator(199.5, -1.0)),
+                    Counts(nypts, 2.0));
 
     TS_ASSERT_THROWS(
         MayersSampleCorrectionStrategy(createTestParameters(), histo),
@@ -165,17 +130,6 @@ public:
   }
 
 private:
-  struct Incrementer {
-    Incrementer(double start) : current(start) {}
-    double operator()() { return current++; }
-    double current;
-  };
-  struct Decrementer {
-    Decrementer(double start) : current(start) {}
-    double operator()() { return current--; }
-    double current;
-  };
-
   MayersSampleCorrectionStrategy::Parameters
   createTestParameters(bool mscatOn = true) {
     // A bit like a POLARIS spectrum

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -82,13 +82,13 @@ public:
   test_Corrects_Both_Absorption_And_Multiple_Scattering_For_Histogram_Data() {
     using std::sqrt;
     const size_t nypts(100);
-    std::vector<double> signal(nypts, 2.0), tof(nypts), error(nypts);
+    std::vector<double> signal(nypts, 2.0), tof(nypts + 1), error(nypts);
     std::transform(signal.begin(), signal.end(), error.begin(),
                    (double (*)(double))sqrt);
     // Generate a histogram with the same mid points as the point data example
     std::generate(tof.begin(), tof.end(), Incrementer(99.5));
 
-    Points tofPoints(tof);
+    BinEdges tofPoints(tof);
     Histogram histo(tofPoints, Counts(signal), CountStandardDeviations(error));
     MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
 
@@ -103,26 +103,26 @@ public:
     // Check some values
     const double delta(1e-06);
     TS_ASSERT_DELTA(99.5, tofVals.front(), delta);
-    TS_ASSERT_DELTA(198.5, tofVals.back(), delta);
+    TS_ASSERT_DELTA(199.5, tofVals.back(), delta);
 
-    TS_ASSERT_DELTA(0.37496898, signalVals.front(), delta);
-    TS_ASSERT_DELTA(0.37628861, signalVals.back(), delta);
+    TS_ASSERT_DELTA(0.37497317, signalVals.front(), delta);
+    TS_ASSERT_DELTA(0.37629281, signalVals.back(), delta);
 
-    TS_ASSERT_DELTA(0.26514310, errVals.front(), delta);
-    TS_ASSERT_DELTA(0.26607623, errVals.back(), delta);
+    TS_ASSERT_DELTA(0.26514607, errVals.front(), delta);
+    TS_ASSERT_DELTA(0.26607920, errVals.back(), delta);
   }
 
   void test_Corrects_For_Absorption_For_Histogram_Data() {
     using std::sqrt;
     const size_t nypts(100);
-    std::vector<double> signal(nypts, 2.0), tof(nypts), error(nypts);
+    std::vector<double> signal(nypts, 2.0), tof(nypts + 1), error(nypts);
     std::transform(signal.begin(), signal.end(), error.begin(),
                    (double (*)(double))sqrt);
     // Generate a histogram with the same mid points as the point data example
     std::generate(tof.begin(), tof.end(), Incrementer(99.5));
     bool mscatOn(false);
 
-    Points tofPoints(tof);
+    BinEdges tofPoints(tof);
     Histogram histo(tofPoints, Counts(signal), CountStandardDeviations(error));
 
     MayersSampleCorrectionStrategy mscat(createTestParameters(mscatOn), histo);
@@ -138,13 +138,13 @@ public:
     // Check some values
     const double delta(1e-06);
     TS_ASSERT_DELTA(99.5, tofVals.front(), delta);
-    TS_ASSERT_DELTA(198.5, tofVals.back(), delta);
+    TS_ASSERT_DELTA(199.5, tofVals.back(), delta);
 
-    TS_ASSERT_DELTA(2.3440131, signalVals.front(), delta);
-    TS_ASSERT_DELTA(2.3489170, signalVals.back(), delta);
+    TS_ASSERT_DELTA(2.3440378, signalVals.front(), delta);
+    TS_ASSERT_DELTA(2.3489418, signalVals.back(), delta);
 
-    TS_ASSERT_DELTA(1.6574675, errVals.front(), delta);
-    TS_ASSERT_DELTA(1.6609351, errVals.back(), delta);
+    TS_ASSERT_DELTA(1.6574850, errVals.front(), delta);
+    TS_ASSERT_DELTA(1.6609527, errVals.back(), delta);
   }
 
   // ---------------------- Failure tests -----------------------------

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -60,7 +60,7 @@ public:
 
     // Correct it
 
-    auto outHisto = mscat.apply(histo);
+    auto outHisto = mscat.getCorrectedHisto();
 
     const auto &tofVals = outHisto.x();
     const auto &signalVals = outHisto.y();
@@ -94,7 +94,7 @@ public:
 
     // Correct it
 
-    auto outHisto = mscat.apply(histo);
+    auto outHisto = mscat.getCorrectedHisto();
 
     const auto &tofVals = outHisto.x();
     const auto &signalVals = outHisto.y();
@@ -129,7 +129,7 @@ public:
 
     // Correct it
 
-    auto outHisto = mscat.apply(histo);
+    auto outHisto = mscat.getCorrectedHisto();
 
     auto tofVals = outHisto.x();
     auto signalVals = outHisto.y();

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -151,12 +151,12 @@ public:
   void test_Tof_Not_Monotonically_Increasing_Throws_Invalid_Argument() {
     using std::sqrt;
     const size_t nypts(10);
-    std::vector<double> signal(nypts, 2.0), tof(nypts), error(nypts);
+    std::vector<double> signal(nypts, 2.0), tof(nypts + 1), error(nypts);
     std::transform(signal.begin(), signal.end(), error.begin(),
                    (double (*)(double))sqrt);
     std::generate(tof.begin(), tof.end(), Decrementer(199.5));
 
-    Points tofPoints(tof);
+    BinEdges tofPoints(tof);
     Histogram histo(tofPoints, Counts(signal), CountStandardDeviations(error));
 
     TS_ASSERT_THROWS(

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -22,9 +22,9 @@ public:
 
   void test_Attentuaton_Correction_For_Fixed_Mur() {
     std::vector<double> dummy(2, 0.0);
+    Mantid::HistogramData::Histogram histo(dummy, dummy);
     dummy[1] = 1.0;
-    MayersSampleCorrectionStrategy mscat(createTestParameters(), dummy, dummy,
-                                         dummy);
+    MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
     auto absFactor = mscat.calculateSelfAttenuation(0.01);
 
     const double delta = 1e-8;
@@ -34,9 +34,9 @@ public:
   void
   test_Multiple_Scattering_With_Fixed_Mur_And_Absorption_Correction_Factor() {
     std::vector<double> dummy(2, 0.0);
+    Mantid::HistogramData::Histogram histo(dummy, dummy);
     dummy[1] = 1.0;
-    MayersSampleCorrectionStrategy mscat(createTestParameters(), dummy, dummy,
-                                         dummy);
+    MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
     const size_t irp(1);
     const double muR(0.01), abs(0.0003);
     auto absFactor = mscat.calculateMS(irp, muR, abs);
@@ -53,11 +53,15 @@ public:
     std::transform(signal.begin(), signal.end(), error.begin(),
                    (double (*)(double))sqrt);
     std::generate(tof.begin(), tof.end(), Incrementer(100.0));
-    MayersSampleCorrectionStrategy mscat(createTestParameters(), tof, signal,
-                                         error);
 
+    Mantid::HistogramData::Histogram histo(tof, signal, error);
+
+    MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
+
+    Mantid::HistogramData::HistogramY signalHistogram(signal);
+    Mantid::HistogramData::HistogramE errorHistogram(error);
     // Correct it
-    mscat.apply(signal, error);
+    mscat.apply(signalHistogram, errorHistogram);
 
     // Check some values
     const double delta(1e-06);
@@ -80,11 +84,13 @@ public:
                    (double (*)(double))sqrt);
     // Generate a histogram with the same mid points as the point data example
     std::generate(tof.begin(), tof.end(), Incrementer(99.5));
-    MayersSampleCorrectionStrategy mscat(createTestParameters(), tof, signal,
-                                         error);
+    Mantid::HistogramData::Histogram histo(tof, signal, error);
+    MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
 
+    Mantid::HistogramData::HistogramY signalHistogram(signal);
+    Mantid::HistogramData::HistogramE errorHistogram(error);
     // Correct it
-    mscat.apply(signal, error);
+    mscat.apply(signalHistogram, errorHistogram);
 
     // Check some values
     const double delta(1e-06);
@@ -107,11 +113,13 @@ public:
     // Generate a histogram with the same mid points as the point data example
     std::generate(tof.begin(), tof.end(), Incrementer(99.5));
     bool mscatOn(false);
-    MayersSampleCorrectionStrategy mscat(createTestParameters(mscatOn), tof,
-                                         signal, error);
+    Mantid::HistogramData::Histogram histo(tof, signal, error);
+    MayersSampleCorrectionStrategy mscat(createTestParameters(mscatOn), histo);
 
+    Mantid::HistogramData::HistogramY signalHistogram(signal);
+    Mantid::HistogramData::HistogramE errorHistogram(error);
     // Correct it
-    mscat.apply(signal, error);
+    mscat.apply(signalHistogram, errorHistogram);
 
     // Check some values
     const double delta(1e-06);
@@ -133,9 +141,10 @@ public:
     std::transform(signal.begin(), signal.end(), error.begin(),
                    (double (*)(double))sqrt);
     std::generate(tof.begin(), tof.end(), Decrementer(199.5));
-    TS_ASSERT_THROWS(MayersSampleCorrectionStrategy(createTestParameters(), tof,
-                                                    signal, error),
-                     std::invalid_argument);
+    Mantid::HistogramData::Histogram histo(tof, signal, error);
+    TS_ASSERT_THROWS(
+        MayersSampleCorrectionStrategy(createTestParameters(), histo),
+        std::invalid_argument);
   }
 
 private:

--- a/Framework/Algorithms/test/MayersSampleCorrectionTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionTest.h
@@ -33,9 +33,9 @@ public:
     TS_ASSERT(alg->isExecuted());
 
     MatrixWorkspace_sptr corrected = alg->getProperty("OutputWorkspace");
-    const auto &tof = corrected->readX(0);
-    const auto &signal = corrected->readY(0);
-    const auto &error = corrected->readE(0);
+    const auto &tof = corrected->x(0);
+    const auto &signal = corrected->y(0);
+    const auto &error = corrected->e(0);
     const double delta(1e-06);
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);
@@ -56,9 +56,9 @@ public:
     TS_ASSERT(alg->isExecuted());
 
     MatrixWorkspace_sptr corrected = alg->getProperty("OutputWorkspace");
-    const auto &tof = corrected->readX(0);
-    const auto &signal = corrected->readY(0);
-    const auto &error = corrected->readE(0);
+    const auto &tof = corrected->x(0);
+    const auto &signal = corrected->y(0);
+    const auto &error = corrected->e(0);
     const double delta(1e-06);
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);

--- a/Framework/Algorithms/test/RRFMuonTest.h
+++ b/Framework/Algorithms/test/RRFMuonTest.h
@@ -7,6 +7,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidTestHelpers/HistogramDataTestHelper.h"
 
 using namespace Mantid::Algorithms;
 using namespace Mantid::API;
@@ -46,11 +47,11 @@ public:
 
     // Checks
     // X values
-    TS_ASSERT_EQUALS(ws->readX(0), ows->readX(0));
-    TS_ASSERT_EQUALS(ws->readX(1), ows->readX(1));
+    TS_ASSERT_EQUALS(ws->x(0), ows->x(0));
+    TS_ASSERT_EQUALS(ws->x(1), ows->x(1));
     // Y values
-    TS_ASSERT_EQUALS(ws->readY(0), ows->readY(0));
-    TS_ASSERT_EQUALS(ws->readY(1), ows->readY(1));
+    TS_ASSERT_EQUALS(ws->y(0), ows->y(0));
+    TS_ASSERT_EQUALS(ws->y(1), ows->y(1));
   }
 
   void testRRFMuonNonZeroFrequency() {
@@ -80,19 +81,19 @@ public:
 
     // Checks
     // X values
-    TS_ASSERT_EQUALS(ws->readX(0), ows->readX(0));
-    TS_ASSERT_EQUALS(ws->readX(1), ows->readX(1));
+    TS_ASSERT_EQUALS(ws->x(0), ows->x(0));
+    TS_ASSERT_EQUALS(ws->x(1), ows->x(1));
     // Y values
     // The input frequency is close to the precession frequency, so:
     // The real part of the RRF polarization should be close to 1 for all X
     // values
     // The imaginary part should be close to 0 for all X values
-    TS_ASSERT_DELTA(ows->readY(0)[0], 1, 0.001);
-    TS_ASSERT_DELTA(ows->readY(0)[100], 1, 0.001);
-    TS_ASSERT_DELTA(ows->readY(0)[200], 1, 0.001);
-    TS_ASSERT_DELTA(ows->readY(1)[0], 0, 0.001);
-    TS_ASSERT_DELTA(ows->readY(1)[100], 0, 0.001);
-    TS_ASSERT_DELTA(ows->readY(1)[200], 0, 0.001);
+    TS_ASSERT_DELTA(ows->y(0)[0], 1, 0.001);
+    TS_ASSERT_DELTA(ows->y(0)[100], 1, 0.001);
+    TS_ASSERT_DELTA(ows->y(0)[200], 1, 0.001);
+    TS_ASSERT_DELTA(ows->y(1)[0], 0, 0.001);
+    TS_ASSERT_DELTA(ows->y(1)[100], 0, 0.001);
+    TS_ASSERT_DELTA(ows->y(1)[200], 0, 0.001);
   }
 
   void testRRFMuonUnits() {
@@ -154,27 +155,27 @@ public:
     // Check Y values
     // ows1 vs ows2
     // Results with different frequency units should be very similar
-    TS_ASSERT_DELTA(ows1->readY(0)[5], ows2->readY(0)[5], 0.000001);
-    TS_ASSERT_DELTA(ows1->readY(0)[98], ows2->readY(0)[98], 0.000001);
-    TS_ASSERT_DELTA(ows1->readY(0)[276], ows2->readY(0)[276], 0.000001);
+    TS_ASSERT_DELTA(ows1->y(0)[5], ows2->y(0)[5], 0.000001);
+    TS_ASSERT_DELTA(ows1->y(0)[98], ows2->y(0)[98], 0.000001);
+    TS_ASSERT_DELTA(ows1->y(0)[276], ows2->y(0)[276], 0.000001);
     // But not exactly the same
     // (They should only be the same if the input frequency in rrfMuon2 were
     // exactly 1/2/M_PI)
-    TS_ASSERT_DIFFERS(ows1->readY(0)[5], ows2->readY(0)[5]);
-    TS_ASSERT_DIFFERS(ows1->readY(0)[98], ows2->readY(0)[98]);
-    TS_ASSERT_DIFFERS(ows1->readY(0)[276], ows2->readY(0)[276]);
+    TS_ASSERT_DIFFERS(ows1->y(0)[5], ows2->y(0)[5]);
+    TS_ASSERT_DIFFERS(ows1->y(0)[98], ows2->y(0)[98]);
+    TS_ASSERT_DIFFERS(ows1->y(0)[276], ows2->y(0)[276]);
     // ows1 vs ows3
     // Results with different frequency units should be very similar
-    TS_ASSERT_DELTA(ows1->readY(0)[8], ows3->readY(0)[8], 0.000001);
-    TS_ASSERT_DELTA(ows1->readY(0)[109], ows3->readY(0)[109], 0.000001);
-    TS_ASSERT_DELTA(ows1->readY(0)[281], ows3->readY(0)[281], 0.000001);
+    TS_ASSERT_DELTA(ows1->y(0)[8], ows3->y(0)[8], 0.000001);
+    TS_ASSERT_DELTA(ows1->y(0)[109], ows3->y(0)[109], 0.000001);
+    TS_ASSERT_DELTA(ows1->y(0)[281], ows3->y(0)[281], 0.000001);
     // But not exactly the same
     // (They should only be the same if the input frequency in rrfMuon3 were
     // exactly 1/2/M_PI/MU
     // being MU the muon gyromagnetic ratio)
-    TS_ASSERT_DIFFERS(ows1->readY(0)[8], ows3->readY(0)[8]);
-    TS_ASSERT_DIFFERS(ows1->readY(0)[109], ows3->readY(0)[109]);
-    TS_ASSERT_DIFFERS(ows1->readY(0)[281], ows3->readY(0)[281]);
+    TS_ASSERT_DIFFERS(ows1->y(0)[8], ows3->y(0)[8]);
+    TS_ASSERT_DIFFERS(ows1->y(0)[109], ows3->y(0)[109]);
+    TS_ASSERT_DIFFERS(ows1->y(0)[281], ows3->y(0)[281]);
   }
 
 private:
@@ -188,14 +189,14 @@ private:
 
     for (int i = 0; i < nBins; i++) {
       double x = i / static_cast<double>(nBins);
-      ws->dataX(0)[i] = x;
-      ws->dataY(0)[i] = cos(2 * M_PI * x);
-      ws->dataX(1)[i] = x;
-      ws->dataY(1)[i] = sin(2 * M_PI * x);
+      ws->mutableX(0)[i] = x;
+      ws->mutableY(0)[i] = cos(2 * M_PI * x);
+      ws->mutableX(1)[i] = x;
+      ws->mutableY(1)[i] = sin(2 * M_PI * x);
     }
 
-    ws->dataX(0)[nBins] = nBins;
-    ws->dataX(1)[nBins] = nBins;
+    ws->mutableX(0)[nBins] = nBins;
+    ws->mutableX(1)[nBins] = nBins;
 
     // Units
     ws->getAxis(0)->unit() =

--- a/Framework/Algorithms/test/SetUncertaintiesTest.h
+++ b/Framework/Algorithms/test/SetUncertaintiesTest.h
@@ -86,8 +86,8 @@ public:
   void test_sqrtOrOne() {
     const auto outWS = runAlg("sqrtOrOne");
 
-    const auto E = outWS->e(0);
-    const auto Y = outWS->y(0);
+    const auto &E = outWS->e(0);
+    const auto &Y = outWS->y(0);
     for (size_t i = 0; i < E.size(); ++i) {
       if (Y[i] == 0.) {
         TS_ASSERT_EQUALS(E[i], 1.);

--- a/Framework/Algorithms/test/SetUncertaintiesTest.h
+++ b/Framework/Algorithms/test/SetUncertaintiesTest.h
@@ -98,4 +98,41 @@ public:
   }
 };
 
+class SetUncertaintiesTestPerformance : public CxxTest::TestSuite {
+public:
+  void setUp() {
+    algZero.initialize();
+    algCalc.initialize();
+
+    // This size controls the test time - and aims for
+    // 0.1-0.2 seconds for the algorithm execution time
+    constexpr size_t wsSize(1000000);
+
+    // random data mostly works
+    inputWs = WorkspaceCreationHelper::Create1DWorkspaceRand(wsSize);
+    algZero.setProperty("InputWorkspace", inputWs);
+    algZero.setProperty("SetError", "zero");
+    algZero.setProperty("OutputWorkspace", wsName);
+
+    algCalc.setProperty("InputWorkspace", inputWs);
+    algCalc.setProperty("SetError", "zero");
+    algCalc.setProperty("OutputWorkspace", wsName);
+
+    algZero.setRethrows(true);
+    algCalc.setRethrows(true);
+  }
+
+  void testSetUncertaintiesPerformance() {
+    // First run zeroing all errors
+    TS_ASSERT_THROWS_NOTHING(algZero.execute());
+    TS_ASSERT_THROWS_NOTHING(algCalc.execute());
+  }
+
+private:
+  SetUncertainties algZero;
+  SetUncertainties algCalc;
+  boost::shared_ptr<Mantid::DataObjects::Workspace2D> inputWs;
+  const std::string wsName = "outputWs";
+};
+
 #endif /* MANTID_ALGORITHMS_SETUNCERTAINTIESTEST_H_ */

--- a/Framework/Algorithms/test/SmoothDataTest.h
+++ b/Framework/Algorithms/test/SmoothDataTest.h
@@ -24,9 +24,13 @@ public:
     // Set up a small workspace for testing
     MatrixWorkspace_sptr space =
         WorkspaceFactory::Instance().create("Workspace2D", 2, 10, 10);
+
+    auto &yVals = space->mutableY(0);
+    auto &eVals = space->mutableE(0);
+
     for (int i = 0; i < 10; ++i) {
-      space->dataY(0)[i] = i + 1.0;
-      space->dataE(0)[i] = sqrt(i + 1.0);
+      yVals[i] = i + 1.0;
+      eVals[i] = sqrt(i + 1.0);
     }
 
     // Register the workspace in the data service
@@ -110,9 +114,9 @@ public:
 
     MatrixWorkspace_const_sptr output = smooth.getProperty("OutputWorkspace");
     // as alg child is set true, wouldnt need to use AnalysisDataService
-    const Mantid::MantidVec &Y = output->dataY(0);
-    const Mantid::MantidVec &X = output->dataX(0);
-    const Mantid::MantidVec &E = output->dataE(0);
+    const auto Y = output->y(0);
+    const auto X = output->x(0);
+    const auto E = output->e(0);
     TS_ASSERT_EQUALS(Y[0], 0.3);
     TS_ASSERT_EQUALS(X[6], 1200);
     TS_ASSERT_DIFFERS(E[2], Y[2]);
@@ -132,7 +136,7 @@ public:
     TS_ASSERT_DIFFERS(X[0], Y[0]);
     TS_ASSERT_DIFFERS(E[5], Y[5]);
     // Check X vectors are shared
-    TS_ASSERT_EQUALS(&(output->dataX(0)), &(output->dataX(1)));
+    TS_ASSERT_EQUALS(&(output->x(0)), &(output->x(1)));
   }
 
   void testExec() {
@@ -154,8 +158,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputWS));
-    const Mantid::MantidVec &Y = output->dataY(0);
-    const Mantid::MantidVec &E = output->dataE(0);
+    const auto Y = output->y(0);
+    const auto E = output->e(0);
     TS_ASSERT_EQUALS(Y[0], 2);
     TS_ASSERT_DELTA(E[0], sqrt(Y[0] / 3.0), 0.0001);
     TS_ASSERT_EQUALS(Y[1], 2.5);
@@ -170,7 +174,7 @@ public:
     TS_ASSERT_DELTA(E[9], sqrt(Y[9] / 3.0), 0.0001);
 
     // Check X vectors are shared
-    TS_ASSERT_EQUALS(&(output->dataX(0)), &(output->dataX(1)));
+    TS_ASSERT_EQUALS(&(output->x(0)), &(output->x(1)));
 
     AnalysisDataService::Instance().remove(outputWS);
   }
@@ -204,6 +208,8 @@ public:
   void testSmoothDataPerformance() {
     TS_ASSERT_THROWS_NOTHING(smoothAlg.execute());
   }
+
+  void tearDown() { AnalysisDataService::Instance().remove("outputWS"); }
 
 private:
   Workspace2D_sptr inputWs;

--- a/Framework/Algorithms/test/SmoothDataTest.h
+++ b/Framework/Algorithms/test/SmoothDataTest.h
@@ -1,14 +1,14 @@
 #ifndef SMOOTHDATATEST_H_
 #define SMOOTHDATATEST_H_
 
-#include <cxxtest/TestSuite.h>
-#include "MantidAlgorithms/CreateSampleWorkspace.h"
-#include "MantidAlgorithms/CreateGroupingWorkspace.h"
-#include "MantidAlgorithms/SmoothData.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAlgorithms/CreateGroupingWorkspace.h"
+#include "MantidAlgorithms/CreateSampleWorkspace.h"
+#include "MantidAlgorithms/SmoothData.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include <cxxtest/TestSuite.h>
 
 using namespace Mantid::API;
 using namespace Mantid::Algorithms;
@@ -194,7 +194,7 @@ public:
     auto &yVals = inputWs->mutableY(0);
     auto &eVals = inputWs->mutableE(0);
 
-    for (int i = 0; i < numBins; ++i) {
+    for (size_t i = 0; i < numBins; ++i) {
       yVals[i] = i + 1.0;
       eVals[i] = sqrt(i + 1.0);
     }

--- a/Framework/Algorithms/test/SmoothDataTest.h
+++ b/Framework/Algorithms/test/SmoothDataTest.h
@@ -114,9 +114,9 @@ public:
 
     MatrixWorkspace_const_sptr output = smooth.getProperty("OutputWorkspace");
     // as alg child is set true, wouldnt need to use AnalysisDataService
-    const auto Y = output->y(0);
-    const auto X = output->x(0);
-    const auto E = output->e(0);
+    const auto &Y = output->y(0);
+    const auto &X = output->x(0);
+    const auto &E = output->e(0);
     TS_ASSERT_EQUALS(Y[0], 0.3);
     TS_ASSERT_EQUALS(X[6], 1200);
     TS_ASSERT_DIFFERS(E[2], Y[2]);
@@ -158,8 +158,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputWS));
-    const auto Y = output->y(0);
-    const auto E = output->e(0);
+    const auto &Y = output->y(0);
+    const auto &E = output->e(0);
     TS_ASSERT_EQUALS(Y[0], 2);
     TS_ASSERT_DELTA(E[0], sqrt(Y[0] / 3.0), 0.0001);
     TS_ASSERT_EQUALS(Y[1], 2.5);

--- a/Framework/Algorithms/test/SmoothDataTest.h
+++ b/Framework/Algorithms/test/SmoothDataTest.h
@@ -8,6 +8,7 @@
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 using namespace Mantid::API;
 using namespace Mantid::Algorithms;
@@ -173,6 +174,40 @@ public:
 
     AnalysisDataService::Instance().remove(outputWS);
   }
+};
+
+class SmoothDataTestPerformance : public CxxTest::TestSuite {
+public:
+  void setUp() {
+
+    // Set up a small workspace for testing
+    constexpr size_t numHistograms(1);
+    constexpr size_t numBins(1000000);
+
+    inputWs =
+        WorkspaceCreationHelper::Create2DWorkspace(numHistograms, numBins);
+
+    auto &yVals = inputWs->mutableY(0);
+    auto &eVals = inputWs->mutableE(0);
+
+    for (int i = 0; i < numBins; ++i) {
+      yVals[i] = i + 1.0;
+      eVals[i] = sqrt(i + 1.0);
+    }
+
+    smoothAlg.initialize();
+    smoothAlg.setProperty("InputWorkspace", inputWs);
+    smoothAlg.setPropertyValue("OutputWorkspace", "outputWS");
+    smoothAlg.setRethrows(true);
+  }
+
+  void testSmoothDataPerformance() {
+    TS_ASSERT_THROWS_NOTHING(smoothAlg.execute());
+  }
+
+private:
+  Workspace2D_sptr inputWs;
+  SmoothData smoothAlg;
 };
 
 #endif /*SMOOTHDATATEST_H_*/

--- a/Framework/Algorithms/test/SmoothDataTest.h
+++ b/Framework/Algorithms/test/SmoothDataTest.h
@@ -194,9 +194,11 @@ public:
     auto &yVals = inputWs->mutableY(0);
     auto &eVals = inputWs->mutableE(0);
 
+    double currentVal(0.0);
     for (size_t i = 0; i < numBins; ++i) {
-      yVals[i] = i + 1.0;
-      eVals[i] = sqrt(i + 1.0);
+      yVals[i] = currentVal + 1.0;
+      eVals[i] = sqrt(currentVal + 1.0);
+      currentVal++;
     }
 
     smoothAlg.initialize();


### PR DESCRIPTION
HistogramData rollout: algorithms 30-35
## Description of work.

This PR is part of refactoring effort to use the new interface of the HistogramData module.
See https://github.com/mantidproject/mantid/issues/17641 for details.

The following algorithms were refactored to use HistogramData:

```
Framework/Algorithms/src/RRFMuon.cpp
Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
Framework/Algorithms/src/SANSDirectBeamScaling.cpp
Framework/Algorithms/src/SetUncertainties.cpp
Framework/Algorithms/src/SmoothData.cpp
```

Performance tests were added for:

```
SetUncertainties
SmoothData
```

The following algorithms have improved performance:

```
SetUncertainties (Approx 30%)
```
## To test.

Code review.

Fixes #17669.
Internal change, no release notes (potential performance improvements will be added to release notes as part of the umbrella issue).
