### PR TITLE
Bugfix for saving in SANS Gui

### DIFF
--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -4038,7 +4038,7 @@ bool SANSRunWindow::isValidWsForRemovingZeroErrors(QString &wsName) {
   bool isValid = true;
   if (result != m_constants.getPythonSuccessKeyword()) {
     result.replace(m_constants.getPythonSuccessKeyword(), "");
-    g_log.warning("Not a valid workspace for zero error replacement. Will save "
+    g_log.notice("Not a valid workspace for zero error replacement. Will save "
                   "original workspace. More info: " +
                   result.toStdString());
     isValid = false;

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -4039,8 +4039,8 @@ bool SANSRunWindow::isValidWsForRemovingZeroErrors(QString &wsName) {
   if (result != m_constants.getPythonSuccessKeyword()) {
     result.replace(m_constants.getPythonSuccessKeyword(), "");
     g_log.notice("Not a valid workspace for zero error replacement. Will save "
-                  "original workspace. More info: " +
-                  result.toStdString());
+                 "original workspace. More info: " +
+                 result.toStdString());
     isValid = false;
   }
   return isValid;

--- a/MantidQt/MantidWidgets/src/SaveWorkspaces.cpp
+++ b/MantidQt/MantidWidgets/src/SaveWorkspaces.cpp
@@ -276,8 +276,8 @@ QString SaveWorkspaces::saveList(const QList<QListWidgetItem *> &wspaces,
         emit updateGeometryInformation();
         // Remove the first three characters, since they are unwanted
         saveCommands += ", Geometry='" + m_geometryID + "', SampleHeight=" +
-          m_sampleHeight + ", SampleWidth=" + m_sampleWidth +
-          ", SampleThickness=" + m_sampleThickness;
+                        m_sampleHeight + ", SampleWidth=" + m_sampleWidth +
+                        ", SampleThickness=" + m_sampleThickness;
       }
     }
 

--- a/MantidQt/MantidWidgets/src/SaveWorkspaces.cpp
+++ b/MantidQt/MantidWidgets/src/SaveWorkspaces.cpp
@@ -265,20 +265,22 @@ QString SaveWorkspaces::saveList(const QList<QListWidgetItem *> &wspaces,
       MatrixWorkspace_sptr matrix_workspace =
           boost::dynamic_pointer_cast<MatrixWorkspace>(workspace_ptr);
       if (matrix_workspace) {
-        if (matrix_workspace->getInstrument()->getName() == "SANS2D")
+        if (matrix_workspace->getInstrument()->getName() == "SANS2D") {
           saveCommands += "'front-detector, rear-detector'";
-        if (matrix_workspace->getInstrument()->getName() == "LOQ")
+        }
+        if (matrix_workspace->getInstrument()->getName() == "LOQ") {
           saveCommands += "'HAB, main-detector-bank'";
-      } else {
-        // g_log.wa
+        }
+
+        // Add the geometry information
+        emit updateGeometryInformation();
+        // Remove the first three characters, since they are unwanted
+        saveCommands += ", Geometry='" + m_geometryID + "', SampleHeight=" +
+          m_sampleHeight + ", SampleWidth=" + m_sampleWidth +
+          ", SampleThickness=" + m_sampleThickness;
       }
     }
-    // Add the geometry information
-    emit updateGeometryInformation();
-    // Remove the first three characters, since they are unwanted
-    saveCommands += ", Geometry='" + m_geometryID + "', SampleHeight=" +
-                    m_sampleHeight + ", SampleWidth=" + m_sampleWidth +
-                    ", SampleThickness=" + m_sampleThickness;
+
     saveCommands += ")\n";
   }
   return saveCommands;


### PR DESCRIPTION
Fixes #17663

See details in the issue description.

**To test:**

Please find the relevant test data here: //olympic/babylon5/Scratch/Anton/Testing/17663_Bugfix_save_options

**Test that can save reduced workspace via the Save Other option**
1. Open the ISIS SANS GUI and select the Instrument=SANS2DTUBES
2. Load the user file: `USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger.txt`
3. Set the SANS2D00034484 for the sample scatter
4. Press Load
5. Press 1D Reduce
6. In the save box select CanSAS and press save Result. Confirm that a file was generated
7. Open the Save Other dialog. Select all checkboxes (ie Nexus, NIST Qxy, CanSAS, RKH, CSV). Select the workspace 34484_rear_1D_1.75_16.5 (this is the reduced workspace).
   - Confirm that there are no warnings etc. Confirm that 5 files are generated.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
