### PR TITLE
LoadILLTOF add pulse interval for IN4 and IN6

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF.h
@@ -68,6 +68,7 @@ private:
   void initInstrumentSpecific();
   void addAllNexusFieldsAsProperties(std::string filename);
   void addEnergyToRun();
+  void addPulseInterval();
 
   int getDetectorElasticPeakPosition(const NeXus::NXInt &data);
   void loadTimeDetails(NeXus::NXEntry &entry);

--- a/Framework/DataHandling/src/LoadILLTOF.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF.cpp
@@ -359,9 +359,11 @@ void LoadILLTOF::addEnergyToRun() {
 void LoadILLTOF::addPulseInterval() {
   API::Run &runDetails = m_localWorkspace->mutableRun();
   double pulseInterval;
+  double n_pulses;
+  double fermiChopperSpeed;
 
   if (m_instrumentName == "IN4") {
-    double fermiChopperSpeed = runDetails.getPropertyAsSingleValue("FC.rotation_speed");
+    fermiChopperSpeed = runDetails.getPropertyAsSingleValue("FC.rotation_speed");
     double bkgChopper1Speed = runDetails.getPropertyAsSingleValue("BC1.rotation_speed");
     double bkgChopper2Speed = runDetails.getPropertyAsSingleValue("BC2.rotation_speed");
 
@@ -369,16 +371,15 @@ void LoadILLTOF::addPulseInterval() {
       throw std::invalid_argument("Background choppers 1 and 2 have different speeds");
     }
 
-    double n = fermiChopperSpeed / bkgChopper1Speed / 4;
-    pulseInterval = 60.0 / (2 * fermiChopperSpeed) * n;
+    n_pulses = fermiChopperSpeed / bkgChopper1Speed / 4;
   } else if (m_instrumentName == "IN6") {
-    double fermiChopperSpeed = runDetails.getPropertyAsSingleValue("Fermi.rotation_speed");
+    fermiChopperSpeed = runDetails.getPropertyAsSingleValue("Fermi.rotation_speed");
     double suppressorSpeed = runDetails.getPropertyAsSingleValue("Suppressor.rotation_speed");
 
-    double n = fermiChopperSpeed / suppressorSpeed;
-    pulseInterval = 60.0 / (2 * fermiChopperSpeed) * n;
+    n_pulses = fermiChopperSpeed / suppressorSpeed;
   }
 
+  pulseInterval = 60.0 / (2 * fermiChopperSpeed) * n_pulses;
   runDetails.addProperty<double>("pulse_interval", pulseInterval);
 }
 

--- a/Framework/DataHandling/src/LoadILLTOF.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF.cpp
@@ -377,6 +377,8 @@ void LoadILLTOF::addPulseInterval() {
     double suppressorSpeed = runDetails.getPropertyAsSingleValue("Suppressor.rotation_speed");
 
     n_pulses = fermiChopperSpeed / suppressorSpeed;
+  } else {
+    return;
   }
 
   pulseInterval = 60.0 / (2 * fermiChopperSpeed) * n_pulses;

--- a/Framework/DataHandling/src/LoadILLTOF.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF.cpp
@@ -363,18 +363,24 @@ void LoadILLTOF::addPulseInterval() {
   double fermiChopperSpeed;
 
   if (m_instrumentName == "IN4") {
-    fermiChopperSpeed = runDetails.getPropertyAsSingleValue("FC.rotation_speed");
-    double bkgChopper1Speed = runDetails.getPropertyAsSingleValue("BC1.rotation_speed");
-    double bkgChopper2Speed = runDetails.getPropertyAsSingleValue("BC2.rotation_speed");
+    fermiChopperSpeed =
+        runDetails.getPropertyAsSingleValue("FC.rotation_speed");
+    double bkgChopper1Speed =
+        runDetails.getPropertyAsSingleValue("BC1.rotation_speed");
+    double bkgChopper2Speed =
+        runDetails.getPropertyAsSingleValue("BC2.rotation_speed");
 
     if (std::abs(bkgChopper1Speed - bkgChopper2Speed) > 1) {
-      throw std::invalid_argument("Background choppers 1 and 2 have different speeds");
+      throw std::invalid_argument(
+          "Background choppers 1 and 2 have different speeds");
     }
 
     n_pulses = fermiChopperSpeed / bkgChopper1Speed / 4;
   } else if (m_instrumentName == "IN6") {
-    fermiChopperSpeed = runDetails.getPropertyAsSingleValue("Fermi.rotation_speed");
-    double suppressorSpeed = runDetails.getPropertyAsSingleValue("Suppressor.rotation_speed");
+    fermiChopperSpeed =
+        runDetails.getPropertyAsSingleValue("Fermi.rotation_speed");
+    double suppressorSpeed =
+        runDetails.getPropertyAsSingleValue("Suppressor.rotation_speed");
 
     n_pulses = fermiChopperSpeed / suppressorSpeed;
   } else {

--- a/Framework/DataHandling/test/LoadILLTOFTest.h
+++ b/Framework/DataHandling/test/LoadILLTOFTest.h
@@ -16,9 +16,7 @@ public:
   static LoadILLTOFTest *createSuite() { return new LoadILLTOFTest(); }
   static void destroySuite(LoadILLTOFTest *suite) { delete suite; }
 
-  void tearDown() override {
-    AnalysisDataService::Instance().clear();
-  }
+  void tearDown() override { AnalysisDataService::Instance().clear(); }
 
   void testName() {
     LoadILLTOF loader;
@@ -40,7 +38,8 @@ public:
    * This test only loads the Sample Data
    * The elastic peak is obtained on the fly from the sample data.
    */
-  MatrixWorkspace_sptr loadDataFile(const std::string dataFile, const int numberOfHistograms) {
+  MatrixWorkspace_sptr loadDataFile(const std::string dataFile,
+                                    const int numberOfHistograms) {
     LoadILLTOF loader;
     loader.initialize();
     loader.setPropertyValue("Filename", dataFile);
@@ -67,9 +66,7 @@ public:
     TS_ASSERT_DELTA(0.003, pulseInterval, 1e-10);
   }
 
-  void test_IN5_load() {
-    loadDataFile("ILL/IN5/104007.nxs", 98305);
-  }
+  void test_IN5_load() { loadDataFile("ILL/IN5/104007.nxs", 98305); }
 
   void test_IN6_load() {
     MatrixWorkspace_sptr ws = loadDataFile("ILL/IN6/164192.nxs", 340);

--- a/Framework/DataHandling/test/LoadILLTOFTest.h
+++ b/Framework/DataHandling/test/LoadILLTOFTest.h
@@ -16,6 +16,10 @@ public:
   static LoadILLTOFTest *createSuite() { return new LoadILLTOFTest(); }
   static void destroySuite(LoadILLTOFTest *suite) { delete suite; }
 
+  void tearDown() override {
+    AnalysisDataService::Instance().clear();
+  }
+
   void testName() {
     LoadILLTOF loader;
     TS_ASSERT_EQUALS(loader.name(), "LoadILLTOF");
@@ -36,7 +40,7 @@ public:
    * This test only loads the Sample Data
    * The elastic peak is obtained on the fly from the sample data.
    */
-  void loadDataFile(const std::string dataFile, const int numberOfHistograms) {
+  MatrixWorkspace_sptr loadDataFile(const std::string dataFile, const int numberOfHistograms) {
     LoadILLTOF loader;
     loader.initialize();
     loader.setPropertyValue("Filename", dataFile);
@@ -53,12 +57,26 @@ public:
 
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), numberOfHistograms);
 
-    AnalysisDataService::Instance().clear();
+    return output2D;
   }
 
-  void test_IN4_load() { loadDataFile("ILL/IN4/084446.nxs", 397); }
-  void test_IN5_load() { loadDataFile("ILL/IN5/104007.nxs", 98305); }
-  void test_IN6_load() { loadDataFile("ILL/IN6/164192.nxs", 340); }
+  void test_IN4_load() {
+    MatrixWorkspace_sptr ws = loadDataFile("ILL/IN4/084446.nxs", 397);
+
+    double pulseInterval = ws->run().getLogAsSingleValue("pulse_interval");
+    TS_ASSERT_DELTA(0.003, pulseInterval, 1e-10);
+  }
+
+  void test_IN5_load() {
+    loadDataFile("ILL/IN5/104007.nxs", 98305);
+  }
+
+  void test_IN6_load() {
+    MatrixWorkspace_sptr ws = loadDataFile("ILL/IN6/164192.nxs", 340);
+
+    double pulseInterval = ws->run().getLogAsSingleValue("pulse_interval");
+    TS_ASSERT_DELTA(0.0060337892, pulseInterval, 1e-10);
+  }
 };
 
 //------------------------------------------------------------------------------

--- a/docs/source/algorithms/LoadILLTOF-v1.rst
+++ b/docs/source/algorithms/LoadILLTOF-v1.rst
@@ -21,6 +21,23 @@ be loaded from the Vanadium data.
 
 To date this algorithm only supports: IN4, IN5 and IN6
 
+Pulse Intervals
+---------------
+
+For IN4 and IN6 the algorithm also calculates the pulse interval.
+
+For the number of pulses:
+
+* **IN4:** :math:`n_{pulses} = \frac{v_{fc}}{4 v_{bc}}`
+   where :math:`n_{pulses}` is the number of pulses from the chopper per rotation, :math:`v_{fc}` the Fermi chopper speed and :math:`v_{bc}` the background chopper speed. Background chopper 1 and background chopper 2 must have the same speeds. All speeds are in units of rpm.
+
+* **IN6:** :math:`n_{pulses} = \frac{v_{fc}}{v_{sc}}`
+   where :math:`n_{pulses}` is the number of pulses from the chopper per rotation, :math:`v_{fc}` the Fermi chopper speed and :math:`v_{sc}` the suppressor chopper speed. All speeds are in units of rpm.
+
+The pulse interval, :math:`T_{pulse}` is then given by,
+
+:math:`T_{pulse} = \frac{60}{2 v_{fc}} n_{pulses}`.
+
 Usage
 -----
 

--- a/docs/source/algorithms/LoadILLTOF-v1.rst
+++ b/docs/source/algorithms/LoadILLTOF-v1.rst
@@ -34,9 +34,9 @@ For the number of pulses:
 * **IN6:** :math:`n_{pulses} = \frac{v_{fc}}{v_{sc}}`
    where :math:`n_{pulses}` is the number of pulses from the chopper per rotation, :math:`v_{fc}` the Fermi chopper speed and :math:`v_{sc}` the suppressor chopper speed. All speeds are in units of rpm.
 
-The pulse interval, :math:`T_{pulse}` is then given by,
+The pulse interval, :math:`T_{pulse}` in seconds, is then given by,
 
-:math:`T_{pulse} = \frac{60}{2 v_{fc}} n_{pulses}`.
+:math:`T_{pulse} = \frac{60 \textrm{s}}{2 v_{fc}} n_{pulses}`.
 
 Usage
 -----


### PR DESCRIPTION
`LoadILLTOF` should now add the pulse interval to the sample log for IN4 and IN6 instruments.

**To test:**

Check the tests pass.

To run these tests manually use the unit test data in `ILL/IN6/164192.nxs` and `ILL/IN4/084446.nxs`. These files should have `pulse_interval` sample logs of 0.0060337892 and 0.003 respectively. Loading `ILL/IN5/104007.nxs` should result in no `pulse_interval` sample log being created.

Fixes #17681.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
