### PR TITLE
Move from boost nans and infs

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -16,7 +16,7 @@
 #include "MantidKernel/MDUnit.h"
 #include "MantidKernel/make_unique.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 #include <numeric>
 
@@ -699,7 +699,7 @@ void MatrixWorkspace::getXMinMax(double &xmin, double &xmax) const {
     const MantidVec &dataX = this->readX(workspaceIndex);
     const double xfront = dataX.front();
     const double xback = dataX.back();
-    if (boost::math::isfinite(xfront) && boost::math::isfinite(xback)) {
+    if (std::isfinite(xfront) && std::isfinite(xback)) {
       if (xfront < xmin)
         xmin = xfront;
       if (xback > xmax)
@@ -1019,8 +1019,8 @@ bool MatrixWorkspace::isCommonBins() const {
         }
 
         // handle Nan's and inf's
-        if ((boost::math::isinf(first) != boost::math::isinf(last)) ||
-            (boost::math::isnan(first) != boost::math::isnan(last))) {
+        if ((std::isinf(first) != std::isinf(last)) ||
+            (std::isnan(first) != std::isnan(last))) {
           m_isCommonBinsFlag = false;
         }
       }

--- a/Framework/API/src/NumericAxis.cpp
+++ b/Framework/API/src/NumericAxis.cpp
@@ -6,7 +6,7 @@
 #include "MantidKernel/VectorHelper.h"
 
 #include <boost/format.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 #include "MantidKernel/Logger.h"
 namespace {
@@ -16,9 +16,9 @@ class EqualWithinTolerance {
 public:
   explicit EqualWithinTolerance(double tolerance) : m_tolerance(tolerance){};
   bool operator()(double a, double b) {
-    if (boost::math::isnan(a) && boost::math::isnan(b))
+    if (std::isnan(a) && std::isnan(b))
       return true;
-    if (boost::math::isinf(a) && boost::math::isinf(b))
+    if (std::isinf(a) && std::isinf(b))
       return true;
     return std::abs(a - b) <= m_tolerance;
   }

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -443,7 +443,7 @@ void Run::calculateGoniometerMatrix() {
         getLogAsSingleValue(axisName, Kernel::Math::Maximum);
     const double angle = getLogAsSingleValue(axisName, Kernel::Math::Mean);
     if (minAngle != maxAngle &&
-        !(boost::math::isnan(minAngle) && boost::math::isnan(maxAngle))) {
+        !(std::isnan(minAngle) && std::isnan(maxAngle))) {
       const double lastAngle =
           getLogAsSingleValue(axisName, Kernel::Math::LastValue);
       g_log.warning("Goniometer angle changed in " + axisName + " log from " +

--- a/Framework/API/src/WorkspaceOpOverloads.cpp
+++ b/Framework/API/src/WorkspaceOpOverloads.cpp
@@ -420,15 +420,14 @@ bool WorkspaceHelpers::commonBoundaries(const MatrixWorkspace_const_sptr WS) {
   const double commonSum =
       std::accumulate(WS->readX(0).begin(), WS->readX(0).end(), 0.);
   // If this results in infinity or NaN, then we can't tell - return false
-  if (commonSum == std::numeric_limits<double>::infinity() ||
-      commonSum != commonSum)
+  if (!std::isfinite(commonSum))
     return false;
   const size_t numHist = WS->getNumberHistograms();
   for (size_t j = 1; j < numHist; ++j) {
     const double sum =
         std::accumulate(WS->readX(j).begin(), WS->readX(j).end(), 0.);
     // If this results in infinity or NaN, then we can't tell - return false
-    if (sum == std::numeric_limits<double>::infinity() || sum != sum)
+    if (!std::isfinite(sum))
       return false;
 
     if (std::abs(commonSum) < 1.0E-7 && std::abs(sum) < 1.0E-7) {

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -674,7 +674,7 @@ const std::vector<double> ConvertUnits::calculateRebinParams(
         auto &XData = workspace->x(i);
         double xfront = XData.front();
         double xback = XData.back();
-        if (boost::math::isfinite(xfront) && boost::math::isfinite(xback)) {
+        if (std::isfinite(xfront) && std::isfinite(xback)) {
           if (xfront < XMin)
             XMin = xfront;
           if (xback > XMax)

--- a/Framework/Algorithms/src/ConvertUnitsUsingDetectorTable.cpp
+++ b/Framework/Algorithms/src/ConvertUnitsUsingDetectorTable.cpp
@@ -12,12 +12,10 @@
 
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 #include <algorithm>
 #include <numeric>
 #include <cfloat>
-#include <limits>
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/src/DetectorEfficiencyVariation.cpp
+++ b/Framework/Algorithms/src/DetectorEfficiencyVariation.cpp
@@ -3,8 +3,6 @@
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidKernel/BoundedValidator.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
-
 namespace Mantid {
 namespace Algorithms {
 
@@ -236,8 +234,7 @@ int DetectorEfficiencyVariation::doDetectorTests(
     const double signal2 = counts2->y(i)[0];
 
     // Mask out NaN and infinite
-    if (boost::math::isinf(signal1) || boost::math::isnan(signal1) ||
-        boost::math::isinf(signal2) || boost::math::isnan(signal2)) {
+    if (!std::isfinite(signal1) || !std::isfinite(signal2)) {
       maskWS->mutableY(i)[0] = deadValue;
       PARALLEL_ATOMIC
       ++numFailed;

--- a/Framework/Algorithms/src/DiffractionFocussing.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing.cpp
@@ -210,8 +210,7 @@ void DiffractionFocussing::calculateRebinParams(
     auto &xVec = workspace->x(i);
     const double &localMin = xVec.front();
     const double &localMax = xVec.back();
-    if (localMin != std::numeric_limits<double>::infinity() &&
-        localMax != std::numeric_limits<double>::infinity()) {
+    if (std::isfinite(localMin) && std::isfinite(localMax)) {
       min = std::min(min, localMin);
       max = std::max(max, localMax);
     }

--- a/Framework/Algorithms/src/FindDetectorsOutsideLimits.cpp
+++ b/Framework/Algorithms/src/FindDetectorsOutsideLimits.cpp
@@ -5,8 +5,6 @@
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/MultiThreaded.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
-
 #include <fstream>
 #include <cmath>
 
@@ -145,7 +143,7 @@ void FindDetectorsOutsideLimits::exec() {
 
     const double &yValue = countsWS->y(countsInd)[0];
     // Mask out NaN and infinite
-    if (boost::math::isinf(yValue) || boost::math::isnan(yValue)) {
+    if (!std::isfinite(yValue)) {
       keepData = false;
     } else {
       if (yValue <= lowThreshold) {

--- a/Framework/Algorithms/src/GetDetectorOffsets.cpp
+++ b/Framework/Algorithms/src/GetDetectorOffsets.cpp
@@ -178,7 +178,7 @@ double GetDetectorOffsets::fitSpectra(const int64_t s, bool isAbsolbute) {
   const double peakLoc = inputW->x(s)[it - yValues.begin()];
   // Return if peak of Cross Correlation is nan (Happens when spectra is zero)
   // Pixel with large offset will be masked
-  if (boost::math::isnan(peakHeight))
+  if (std::isnan(peakHeight))
     return (1000.);
 
   IAlgorithm_sptr fit_alg;

--- a/Framework/Algorithms/src/IntegrateByComponent.cpp
+++ b/Framework/Algorithms/src/IntegrateByComponent.cpp
@@ -4,7 +4,6 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/BoundedValidator.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <gsl/gsl_statistics.h>
 #include <unordered_map>
 
@@ -91,9 +90,7 @@ void IntegrateByComponent::exec() {
         const double yValue = integratedWS->readY(hists[i])[0];
         const double eValue = integratedWS->readE(hists[i])[0];
 
-        if (boost::math::isnan(yValue) || boost::math::isinf(yValue) ||
-            boost::math::isnan(eValue) ||
-            boost::math::isinf(eValue)) // NaNs/Infs
+        if (!std::isfinite(yValue) || !std::isfinite(eValue)) // NaNs/Infs
           continue;
 
         // Now we have a good value
@@ -128,9 +125,7 @@ void IntegrateByComponent::exec() {
 
         const double yValue = integratedWS->readY(hists[i])[0];
         const double eValue = integratedWS->readE(hists[i])[0];
-        if (boost::math::isnan(yValue) || boost::math::isinf(yValue) ||
-            boost::math::isnan(eValue) ||
-            boost::math::isinf(eValue)) // NaNs/Infs
+        if (!std::isfinite(yValue) || !std::isfinite(eValue)) // NaNs/Infs
           continue;
 
         // Now we have a good value

--- a/Framework/Algorithms/src/MedianDetectorTest.cpp
+++ b/Framework/Algorithms/src/MedianDetectorTest.cpp
@@ -2,7 +2,7 @@
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidKernel/BoundedValidator.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 namespace Mantid {
 namespace Algorithms {
@@ -347,7 +347,7 @@ int MedianDetectorTest::doDetectorTests(
       const double signal = countsWS->y(hists.at(i))[0];
 
       // Mask out NaN and infinite
-      if (boost::math::isinf(signal) || boost::math::isnan(signal)) {
+      if (!std::isfinite(signal)) {
         maskWS->mutableY(hists.at(i))[0] = deadValue;
         PARALLEL_ATOMIC
         ++numFailed;

--- a/Framework/Algorithms/src/Qxy.cpp
+++ b/Framework/Algorithms/src/Qxy.cpp
@@ -13,7 +13,6 @@
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/VectorHelper.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 
 namespace Mantid {
 namespace Algorithms {
@@ -235,7 +234,7 @@ void Qxy::exec() {
         double &outputBinY = outputWorkspace->dataY(yIndex)[xIndex];
         double &outputBinE = outputWorkspace->dataE(yIndex)[xIndex];
 
-        if (boost::math::isnan(outputBinY)) {
+        if (std::isnan(outputBinY)) {
           outputBinY = outputBinE = 0;
         }
         // Add the contents of the current bin to the 2D array.

--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -15,7 +15,6 @@
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/VectorHelper.h"
 
-
 namespace Mantid {
 namespace Algorithms {
 

--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -15,7 +15,6 @@
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/VectorHelper.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/src/ReplaceSpecialValues.cpp
+++ b/Framework/Algorithms/src/ReplaceSpecialValues.cpp
@@ -3,7 +3,6 @@
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/ReplaceSpecialValues.h"
 #include "MantidKernel/Exception.h"
-#include "boost/math/special_functions/fpclassify.hpp"
 #include <limits>
 #include <cmath>
 
@@ -84,11 +83,11 @@ void ReplaceSpecialValues::performUnaryOperation(const double XIn,
 }
 
 bool ReplaceSpecialValues::checkIfNan(const double &value) const {
-  return (boost::math::isnan(value));
+  return (std::isnan(value));
 }
 
 bool ReplaceSpecialValues::checkIfInfinite(const double &value) const {
-  return (std::abs(value) == std::numeric_limits<double>::infinity());
+  return (std::isinf(value));
 }
 
 bool ReplaceSpecialValues::checkIfBig(const double &value) const {

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -6,7 +6,6 @@
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/VectorHelper.h"
 
-
 #include <sstream>
 
 namespace Mantid {

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -6,7 +6,6 @@
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/VectorHelper.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
 
 #include <sstream>
 
@@ -135,14 +134,14 @@ string determineXMinMax(MatrixWorkspace_sptr inputWS, vector<double> &xmins,
     if (updateXMins || updateXMaxs) {
       const MantidVec &xvalues = inputWS->getSpectrum(i).dataX();
       if (updateXMins) {
-        if (boost::math::isnan(xvalues.front())) {
+        if (std::isnan(xvalues.front())) {
           xmins.push_back(xmin_wksp);
         } else {
           xmins.push_back(xvalues.front());
         }
       }
       if (updateXMaxs) {
-        if (boost::math::isnan(xvalues.back())) {
+        if (std::isnan(xvalues.back())) {
           xmaxs.push_back(xmax_wksp);
         } else {
           xmaxs.push_back(xvalues.back());

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -573,8 +573,7 @@ void Stitch1D::exec() {
     }
     scaleFactor = ratio->readY(0).front();
     errorScaleFactor = ratio->readE(0).front();
-    if (scaleFactor < 1e-2 || scaleFactor > 1e2 ||
-        std::isnan(scaleFactor)) {
+    if (scaleFactor < 1e-2 || scaleFactor > 1e2 || std::isnan(scaleFactor)) {
       std::stringstream messageBuffer;
       messageBuffer << "Stitch1D calculated scale factor is: " << scaleFactor
                     << ". Check that in both input workspaces the integrated "

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -30,12 +30,6 @@ MinMaxTuple calculateXIntersection(MatrixWorkspace_sptr lhsWS,
 }
 
 bool isNonzero(double i) { return (0 != i); }
-
-bool isNan(const double &value) { return boost::math::isnan(value); }
-
-bool isInf(const double &value) {
-  return std::abs(value) == std::numeric_limits<double>::infinity();
-}
 }
 
 namespace Mantid {
@@ -318,18 +312,18 @@ MatrixWorkspace_sptr Stitch1D::rebin(MatrixWorkspace_sptr &input,
     for (size_t j = 0; j < sourceY.size(); ++j) {
       const double &value = sourceY[j];
       const double &eValue = sourceE[j];
-      if (isNan(value)) {
+      if (std::isnan(value)) {
         nanYIndexes.push_back(j);
         sourceY[j] = 0;
-      } else if (isInf(value)) {
+      } else if (std::isinf(value)) {
         infYIndexes.push_back(j);
         sourceY[j] = 0;
       }
 
-      if (isNan(eValue)) {
+      if (std::isnan(eValue)) {
         nanEIndexes.push_back(j);
         sourceE[j] = 0;
-      } else if (isInf(eValue)) {
+      } else if (std::isinf(eValue)) {
         infEIndexes.push_back(j);
         sourceE[j] = 0;
       }
@@ -580,7 +574,7 @@ void Stitch1D::exec() {
     scaleFactor = ratio->readY(0).front();
     errorScaleFactor = ratio->readE(0).front();
     if (scaleFactor < 1e-2 || scaleFactor > 1e2 ||
-        boost::math::isnan(scaleFactor)) {
+        std::isnan(scaleFactor)) {
       std::stringstream messageBuffer;
       messageBuffer << "Stitch1D calculated scale factor is: " << scaleFactor
                     << ". Check that in both input workspaces the integrated "

--- a/Framework/Algorithms/src/TOFSANSResolution.cpp
+++ b/Framework/Algorithms/src/TOFSANSResolution.cpp
@@ -12,8 +12,6 @@
 #include "MantidKernel/RebinParamsValidator.h"
 #include "MantidKernel/VectorHelper.h"
 
-#include "boost/math/special_functions/fpclassify.hpp"
-
 namespace Mantid {
 namespace Algorithms {
 
@@ -203,7 +201,7 @@ void TOFSANSResolution::exec() {
       // By using only events with a positive weight, we use only the data
       // distribution and leave out the background events.
       // Note: we are looping over bins, therefore the xLength-1.
-      if (iq >= 0 && iq < xLength - 1 && !boost::math::isnan(dq_over_q) &&
+      if (iq >= 0 && iq < xLength - 1 && !std::isnan(dq_over_q) &&
           dq_over_q > 0 && YIn[j] > 0) {
         _dx[iq] += q * dq_over_q * YIn[j];
         _norm[iq] += YIn[j];

--- a/Framework/Algorithms/src/TOFSANSResolutionByPixel.cpp
+++ b/Framework/Algorithms/src/TOFSANSResolutionByPixel.cpp
@@ -13,7 +13,6 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/make_unique.h"
 
-#include "boost/math/special_functions/fpclassify.hpp"
 #include "boost/lexical_cast.hpp"
 
 namespace Mantid {

--- a/Framework/Algorithms/src/WeightedMeanOfWorkspace.cpp
+++ b/Framework/Algorithms/src/WeightedMeanOfWorkspace.cpp
@@ -4,8 +4,6 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
-
 namespace Mantid {
 using namespace API;
 using namespace DataObjects;
@@ -67,8 +65,7 @@ void WeightedMeanOfWorkspace::exec() {
     MantidVec e = inputWS->dataE(i);
     double weight = 0.0;
     for (std::size_t j = 0; j < y.size(); ++j) {
-      if (!boost::math::isnan(y[j]) && !boost::math::isinf(y[j]) &&
-          !boost::math::isnan(e[j]) && !boost::math::isinf(e[j])) {
+      if (std::isfinite(y[j]) && std::isfinite(e[j])) {
         weight = 1.0 / (e[j] * e[j]);
         averageValue += (y[j] * weight);
         weightSum += weight;

--- a/Framework/Algorithms/test/AverageLogDataTest.h
+++ b/Framework/Algorithms/test/AverageLogDataTest.h
@@ -6,7 +6,6 @@
 #include "MantidAlgorithms/AverageLogData.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 
 using Mantid::Algorithms::AverageLogData;
 
@@ -102,8 +101,8 @@ public:
     // check average
     const double av = alg.getProperty("Average"),
                  err = alg.getProperty("Error");
-    TS_ASSERT(boost::math::isnan(av));
-    TS_ASSERT(boost::math::isnan(err));
+    TS_ASSERT(std::isnan(av));
+    TS_ASSERT(std::isnan(err));
 
     // Remove workspace from the data service.*/
     Mantid::API::AnalysisDataService::Instance().remove(inputWS);

--- a/Framework/Algorithms/test/GetAllEiTest.h
+++ b/Framework/Algorithms/test/GetAllEiTest.h
@@ -2,7 +2,6 @@
 #define GETALLEI_TEST_H_
 
 #include <memory>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cxxtest/TestSuite.h>
 #include "MantidAlgorithms/GetAllEi.h"
 #include "MantidGeometry/Instrument.h"
@@ -443,8 +442,8 @@ public:
     auto Xsp2 = wws->getSpectrum(1).mutableX();
     size_t nSpectra = Xsp2.size();
     TS_ASSERT_EQUALS(nSpectra, 101);
-    TS_ASSERT(boost::math::isinf(Xsp1[nSpectra - 1]));
-    TS_ASSERT(boost::math::isinf(Xsp2[nSpectra - 1]));
+    TS_ASSERT(std::isinf(Xsp1[nSpectra - 1]));
+    TS_ASSERT(std::isinf(Xsp2[nSpectra - 1]));
 
     // for(size_t i=0;i<Xsp1.size();i++){
     //  TS_ASSERT_DELTA(Xsp1[i],Xsp2[i],1.e-6);

--- a/Framework/Algorithms/test/MultiplyDivideTest.in.h
+++ b/Framework/Algorithms/test/MultiplyDivideTest.in.h
@@ -970,7 +970,7 @@ public:
         TS_ASSERT_EQUALS(det->isMasked(), true);
         double yValue = output->readY(i)[0];
         TS_ASSERT_EQUALS(yValue, yValue );
-        TS_ASSERT_DIFFERS(yValue, std::numeric_limits<double>::infinity() );
+        TS_ASSERT( !std::isinf(yValue) );
       }
     }
     AnalysisDataService::Instance().remove(lhs);

--- a/Framework/Algorithms/test/PDFFourierTransformTest.h
+++ b/Framework/Algorithms/test/PDFFourierTransformTest.h
@@ -1,9 +1,9 @@
 #ifndef MANTID_ALGORITHMS_PDFFOURIERTRANSFORMTEST_H_
 #define MANTID_ALGORITHMS_PDFFOURIERTRANSFORMTEST_H_
 
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cxxtest/TestSuite.h>
 #include <numeric>
+#include <cmath>
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/UnitFactory.h"
@@ -116,7 +116,7 @@ public:
     TS_ASSERT_DELTA(R[249], 2.5, 0.0001);
     // make sure that nan didn' slip in
     TS_ASSERT(std::find_if(GofR.begin(), GofR.end(),
-                           boost::math::isnan<double>) == GofR.end());
+                           static_cast<bool (*)(double)>(std::isnan)) == GofR.end());
   }
 
   void test_filter() {

--- a/Framework/Algorithms/test/PDFFourierTransformTest.h
+++ b/Framework/Algorithms/test/PDFFourierTransformTest.h
@@ -116,7 +116,8 @@ public:
     TS_ASSERT_DELTA(R[249], 2.5, 0.0001);
     // make sure that nan didn' slip in
     TS_ASSERT(std::find_if(GofR.begin(), GofR.end(),
-                           static_cast<bool (*)(double)>(std::isnan)) == GofR.end());
+                           static_cast<bool (*)(double)>(std::isnan)) ==
+              GofR.end());
   }
 
   void test_filter() {

--- a/Framework/Algorithms/test/Q1D2Test.h
+++ b/Framework/Algorithms/test/Q1D2Test.h
@@ -10,7 +10,6 @@
 #include "MantidDataHandling/LoadRaw3.h"
 #include "MantidDataHandling/LoadRKH.h"
 #include "MantidDataHandling/MaskDetectors.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
@@ -93,12 +92,12 @@ public:
     // empty bins are 0/0
     TS_ASSERT_DELTA(result->readY(0).front(), 2226533, 1)
     TS_ASSERT_DELTA(result->readY(0)[4], 946570.8, 0.1)
-    TS_ASSERT(boost::math::isnan(result->readY(0)[18]))
-    TS_ASSERT(boost::math::isnan(result->readY(0).back()))
+    TS_ASSERT(std::isnan(result->readY(0)[18]))
+    TS_ASSERT(std::isnan(result->readY(0).back()))
 
     TS_ASSERT_DELTA(result->readE(0)[1], 57964.04, 0.01)
     TS_ASSERT_DELTA(result->readE(0)[5], 166712.6, 0.1)
-    TS_ASSERT(boost::math::isnan(result->readE(0).back()))
+    TS_ASSERT(std::isnan(result->readE(0).back()))
 
     Mantid::API::AnalysisDataService::Instance().remove(outputWS);
   }
@@ -196,12 +195,12 @@ public:
     TS_ASSERT_DELTA(result->readY(0).front(), 944237.8, 0.1)
     TS_ASSERT_DELTA(result->readY(0)[3], 1009296, 1)
     TS_ASSERT_DELTA(result->readY(0)[12], 620952.6, 0.1)
-    TS_ASSERT(boost::math::isnan(result->readY(0).back()))
+    TS_ASSERT(std::isnan(result->readY(0).back()))
 
     // empty bins are 0/0
     TS_ASSERT_DELTA(result->readE(0)[2], 404981, 10)
     TS_ASSERT_DELTA(result->readE(0)[10], 489710.39, 100)
-    TS_ASSERT(boost::math::isnan(result->readE(0)[7]))
+    TS_ASSERT(std::isnan(result->readE(0)[7]))
 
     TSM_ASSERT("Should not have a DX value", !result->hasDx(0))
   }
@@ -276,11 +275,11 @@ public:
 
     TS_ASSERT_DELTA(gravity->readY(0)[3], 1009296.4, 0.8)
     TS_ASSERT_DELTA(gravity->readY(0)[10], 891346.9, 0.1)
-    TS_ASSERT(boost::math::isnan(gravity->readY(0)[78]))
+    TS_ASSERT(std::isnan(gravity->readY(0)[78]))
 
     TS_ASSERT_DELTA(gravity->readE(0).front(), 329383, 1)
     TS_ASSERT_DELTA(gravity->readE(0)[10], 489708, 1) // 489710
-    TS_ASSERT(boost::math::isnan(gravity->readE(0)[77]))
+    TS_ASSERT(std::isnan(gravity->readE(0)[77]))
 
     Mantid::API::AnalysisDataService::Instance().remove(outputWS);
   }
@@ -315,13 +314,13 @@ public:
     TS_ASSERT_EQUALS(result->readX(0).back(), 0.5)
 
     TS_ASSERT_DELTA(result->readY(0).front(), 1192471.95, 0.1)
-    TS_ASSERT(boost::math::isnan(result->readY(0)[3]))
+    TS_ASSERT(std::isnan(result->readY(0)[3]))
     TS_ASSERT_DELTA(result->readY(0)[12], 503242.79, 0.1)
-    TS_ASSERT(boost::math::isnan(result->readY(0).back()))
+    TS_ASSERT(std::isnan(result->readY(0).back()))
 
     TS_ASSERT_DELTA(result->readE(0)[2], 404980, 1)
     TS_ASSERT_DELTA(result->readE(0)[10], 489708, 100)
-    TS_ASSERT(boost::math::isnan(result->readE(0)[7]))
+    TS_ASSERT(std::isnan(result->readE(0)[7]))
   }
 
   // here the cut parameters are set but should only affect detectors with lower
@@ -356,8 +355,8 @@ public:
 
     for (size_t i = 0; i < nocuts->readY(0).size(); ++i) {
       TS_ASSERT_EQUALS(nocuts->readX(0)[i], noGrav->readX(0)[i])
-      if (!boost::math::isnan(nocuts->readY(0)[i]) &&
-          !boost::math::isnan(nocuts->readE(0)[i])) {
+      if (!std::isnan(nocuts->readY(0)[i]) &&
+          !std::isnan(nocuts->readE(0)[i])) {
         TS_ASSERT_EQUALS(nocuts->readY(0)[i], noGrav->readY(0)[i])
 
         TS_ASSERT_EQUALS(nocuts->readE(0)[i], noGrav->readE(0)[i])

--- a/Framework/Algorithms/test/ReplaceSpecialValuesTest.h
+++ b/Framework/Algorithms/test/ReplaceSpecialValuesTest.h
@@ -205,24 +205,21 @@ public:
         TS_ASSERT_EQUALS(result->dataX(i)[j - 1], inputWS->dataX(i)[j - 1]);
 
         if (infCheck &&
-            std::abs(inputWS->dataY(i)[j - 1]) ==
-                std::numeric_limits<double>::infinity()) {
-          if (std::abs(result->dataY(i)[j - 1]) ==
-              std::numeric_limits<double>::infinity()) {
+            std::isinf(inputWS->dataY(i)[j - 1])) {
+          if (std::isinf(result->dataY(i)[j - 1])) {
             TS_FAIL("Infinity detected that shold have been replaced");
           } else {
             TS_ASSERT_DELTA(result->dataY(i)[j - 1], 999.0, 1e-8);
             TS_ASSERT_DELTA(result->dataE(i)[j - 1], 0.00005, 1e-8);
           }
         } else if (naNCheck &&
-                   inputWS->dataY(i)[j - 1] !=
-                       inputWS->dataY(i)[j - 1]) // not equal to self == NaN
+                   std::isnan(inputWS->dataY(i)[j - 1]))
         {
           TS_ASSERT_DELTA(result->dataY(i)[j - 1], -99.0, 1e-8);
           TS_ASSERT_DELTA(result->dataE(i)[j - 1], -50.0, 1e-8);
         } else {
           if (!naNCheck &&
-              inputWS->dataY(i)[j - 1] != inputWS->dataY(i)[j - 1]) {
+              std::isnan(inputWS->dataY(i)[j - 1])) {
             TS_ASSERT_DIFFERS(result->dataY(i)[j - 1], result->dataY(i)[j - 1]);
           } else {
             TS_ASSERT_EQUALS(result->dataY(i)[j - 1], inputWS->dataY(i)[j - 1]);

--- a/Framework/Algorithms/test/ReplaceSpecialValuesTest.h
+++ b/Framework/Algorithms/test/ReplaceSpecialValuesTest.h
@@ -204,22 +204,18 @@ public:
       for (int j = 1; j < 5; ++j) {
         TS_ASSERT_EQUALS(result->dataX(i)[j - 1], inputWS->dataX(i)[j - 1]);
 
-        if (infCheck &&
-            std::isinf(inputWS->dataY(i)[j - 1])) {
+        if (infCheck && std::isinf(inputWS->dataY(i)[j - 1])) {
           if (std::isinf(result->dataY(i)[j - 1])) {
             TS_FAIL("Infinity detected that shold have been replaced");
           } else {
             TS_ASSERT_DELTA(result->dataY(i)[j - 1], 999.0, 1e-8);
             TS_ASSERT_DELTA(result->dataE(i)[j - 1], 0.00005, 1e-8);
           }
-        } else if (naNCheck &&
-                   std::isnan(inputWS->dataY(i)[j - 1]))
-        {
+        } else if (naNCheck && std::isnan(inputWS->dataY(i)[j - 1])) {
           TS_ASSERT_DELTA(result->dataY(i)[j - 1], -99.0, 1e-8);
           TS_ASSERT_DELTA(result->dataE(i)[j - 1], -50.0, 1e-8);
         } else {
-          if (!naNCheck &&
-              std::isnan(inputWS->dataY(i)[j - 1])) {
+          if (!naNCheck && std::isnan(inputWS->dataY(i)[j - 1])) {
             TS_ASSERT_DIFFERS(result->dataY(i)[j - 1], result->dataY(i)[j - 1]);
           } else {
             TS_ASSERT_EQUALS(result->dataY(i)[j - 1], inputWS->dataY(i)[j - 1]);

--- a/Framework/Algorithms/test/Stitch1DTest.h
+++ b/Framework/Algorithms/test/Stitch1DTest.h
@@ -626,8 +626,7 @@ public:
 
     double scaleFactor = ret.get<1>();
 
-    TSM_ASSERT("ScaleFactor should not be NAN",
-               !std::isnan(scaleFactor));
+    TSM_ASSERT("ScaleFactor should not be NAN", !std::isnan(scaleFactor));
   }
 
   void test_patch_inf_y_value_for_scaling() {
@@ -656,8 +655,7 @@ public:
 
     double scaleFactor = ret.get<1>();
 
-    TSM_ASSERT("ScaleFactor should not be Infinity",
-               !std::isinf(scaleFactor));
+    TSM_ASSERT("ScaleFactor should not be Infinity", !std::isinf(scaleFactor));
   }
 
   void test_reset_nans() {
@@ -687,8 +685,7 @@ public:
     MatrixWorkspace_sptr outWs = ret.get<0>();
     double scaleFactor = ret.get<1>();
 
-    TSM_ASSERT("ScaleFactor should not be Infinity",
-               !std::isinf(scaleFactor));
+    TSM_ASSERT("ScaleFactor should not be Infinity", !std::isinf(scaleFactor));
 
     auto outY = outWs->readY(0);
     TSM_ASSERT("Nans should be put back", std::isnan(outY[0]));

--- a/Framework/Algorithms/test/Stitch1DTest.h
+++ b/Framework/Algorithms/test/Stitch1DTest.h
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <math.h>
 #include <boost/tuple/tuple.hpp>
-#include <boost/math/special_functions.hpp>
 #include <boost/make_shared.hpp>
 
 using namespace Mantid::API;
@@ -628,7 +627,7 @@ public:
     double scaleFactor = ret.get<1>();
 
     TSM_ASSERT("ScaleFactor should not be NAN",
-               !boost::math::isnan(scaleFactor));
+               !std::isnan(scaleFactor));
   }
 
   void test_patch_inf_y_value_for_scaling() {
@@ -658,7 +657,7 @@ public:
     double scaleFactor = ret.get<1>();
 
     TSM_ASSERT("ScaleFactor should not be Infinity",
-               !boost::math::isinf(scaleFactor));
+               !std::isinf(scaleFactor));
   }
 
   void test_reset_nans() {
@@ -674,7 +673,7 @@ public:
     auto e = MantidVec(nspectrum * (x.size() - 1), 1);
 
     double nan = std::numeric_limits<double>::quiet_NaN();
-    y[0] = nan; // Add a Infinity
+    y[0] = nan; // Add a nan
     MatrixWorkspace_sptr lhsWS =
         createWorkspace(x, y, e, static_cast<int>(nspectrum));
 
@@ -689,10 +688,10 @@ public:
     double scaleFactor = ret.get<1>();
 
     TSM_ASSERT("ScaleFactor should not be Infinity",
-               !boost::math::isinf(scaleFactor));
+               !std::isinf(scaleFactor));
 
     auto outY = outWs->readY(0);
-    TSM_ASSERT("Nans should be put back", boost::math::isnan(outY[0]));
+    TSM_ASSERT("Nans should be put back", std::isnan(outY[0]));
   }
 };
 

--- a/Framework/Algorithms/test/TransposeTest.h
+++ b/Framework/Algorithms/test/TransposeTest.h
@@ -2,7 +2,6 @@
 #define TRANSPOSETEST_H_
 
 #include <cxxtest/TestSuite.h>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
@@ -121,8 +120,8 @@ public:
     TS_ASSERT_EQUALS(outputWS->dataF(0).size(), 4);
     TS_ASSERT_EQUALS(outputWS->dataF(3)[1], inputWS->dataF(1)[3]);
     // Check a nan
-    bool inNan = boost::math::isnan(inputWS->dataY(0)[5]);
-    bool outNan = boost::math::isnan(outputWS->dataY(5)[0]);
+    bool inNan = std::isnan(inputWS->dataY(0)[5]);
+    bool outNan = std::isnan(outputWS->dataY(5)[0]);
     TS_ASSERT_EQUALS(outNan, inNan);
 
     delete transpose;

--- a/Framework/Crystal/src/IntegratePeaksHybrid.cpp
+++ b/Framework/Crystal/src/IntegratePeaksHybrid.cpp
@@ -51,7 +51,7 @@
 #include "MantidDataObjects/PeaksWorkspace.h"
 
 #include <boost/format.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -232,7 +232,7 @@ void IntegratePeaksHybrid::exec() {
     const Mantid::signal_t signalValue = localProjection.signalAtPeakCenter(
         peak); // No normalization when extracting label ids!
 
-    if (boost::math::isnan(signalValue)) {
+    if (std::isnan(signalValue)) {
       g_log.warning()
           << "Warning: image for integration is off edge of detector for peak "
           << i << '\n';

--- a/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
+++ b/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
@@ -13,7 +13,7 @@
 #include "MantidKernel/Utils.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -156,7 +156,7 @@ void IntegratePeaksUsingClusters::exec() {
     Geometry::IPeak &peak = peakWS->getPeak(i);
     const Mantid::signal_t signalValue = projection.signalAtPeakCenter(
         peak); // No normalization when extracting label ids!
-    if (boost::math::isnan(signalValue)) {
+    if (std::isnan(signalValue)) {
       g_log.warning()
           << "Warning: image for integration is off edge of detector for peak "
           << i << '\n';

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -11,7 +11,7 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/VisibleWhenProperty.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 #include <boost/math/special_functions/round.hpp>
 
 namespace Mantid {
@@ -250,7 +250,7 @@ void PeakIntegration::exec() {
 
       // Calculate intensity
       for (iTOF = 0; iTOF < n; iTOF++)
-        if (!boost::math::isnan(y[iTOF]) && !boost::math::isinf(y[iTOF]))
+        if (std::isfinite(y[iTOF]))
           I += y[iTOF];
     } else
       for (iTOF = TOFmin; iTOF <= TOFmax; iTOF++)

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -11,7 +11,7 @@
 #include <fstream>
 
 #include <Poco/File.h>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 using namespace Mantid::Geometry;
 using namespace Mantid::DataObjects;
@@ -321,8 +321,7 @@ void SaveHKL::exec() {
       for (auto wi : ids) {
 
         Peak &p = peaks[wi];
-        if (p.getIntensity() == 0.0 || boost::math::isnan(p.getIntensity()) ||
-            boost::math::isnan(p.getSigmaIntensity())) {
+        if (p.getIntensity() == 0.0 || !(std::isfinite(p.getSigmaIntensity()))) {
           banned.insert(wi);
           continue;
         }

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -321,8 +321,7 @@ void SaveHKL::exec() {
       for (auto wi : ids) {
 
         Peak &p = peaks[wi];
-        if (p.getIntensity() == 0.0 ||
-            !(std::isfinite(p.getIntensity())) ||
+        if (p.getIntensity() == 0.0 || !(std::isfinite(p.getIntensity())) ||
             !(std::isfinite(p.getSigmaIntensity()))) {
           banned.insert(wi);
           continue;

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -321,7 +321,8 @@ void SaveHKL::exec() {
       for (auto wi : ids) {
 
         Peak &p = peaks[wi];
-        if (p.getIntensity() == 0.0 || !(std::isfinite(p.getSigmaIntensity()))) {
+        if (p.getIntensity() == 0.0 ||
+            !(std::isfinite(p.getSigmaIntensity()))) {
           banned.insert(wi);
           continue;
         }

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -322,6 +322,7 @@ void SaveHKL::exec() {
 
         Peak &p = peaks[wi];
         if (p.getIntensity() == 0.0 ||
+            !(std::isfinite(p.getIntensity())) ||
             !(std::isfinite(p.getSigmaIntensity()))) {
           banned.insert(wi);
           continue;

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -10,7 +10,7 @@
 #include <fstream>
 #include <Poco/File.h>
 #include <Poco/Path.h>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 using namespace Mantid::Geometry;
 using namespace Mantid::DataObjects;
@@ -119,8 +119,7 @@ void SaveLauenorm::exec() {
     Peak &p = peaks[wi];
     double intensity = p.getIntensity();
     double sigI = p.getSigmaIntensity();
-    if (intensity == 0.0 || boost::math::isnan(intensity) ||
-        boost::math::isnan(sigI))
+    if (intensity == 0.0 || !(std::isfinite(sigI)))
       continue;
     if (minIsigI != EMPTY_DBL() && intensity < std::abs(minIsigI * sigI))
       continue;

--- a/Framework/Crystal/src/TOFExtinction.cpp
+++ b/Framework/Crystal/src/TOFExtinction.cpp
@@ -7,7 +7,7 @@
 #include "MantidKernel/Utils.h"
 #include "MantidKernel/ListValidator.h"
 #include <fstream>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 using namespace Mantid::Geometry;
 using namespace Mantid::DataObjects;
@@ -168,7 +168,7 @@ void TOFExtinction::exec() {
     double ys = fsq / y_corr;
     // std::cout << fsq << "  " << y_corr<<"  "<<wl<<"  "<<twoth<<"  "<<tbar<< "
     // " << ys <<"\n";
-    if (!boost::math::isnan(ys))
+    if (!std::isnan(ys))
       peak1.setIntensity(ys);
     else
       peak1.setIntensity(0.0);

--- a/Framework/Crystal/test/PeakClusterProjectionTest.h
+++ b/Framework/Crystal/test/PeakClusterProjectionTest.h
@@ -16,8 +16,7 @@
 #include "MantidTestHelpers/ComponentCreationHelper.h"
 #include "MantidKernel/UnitLabelTypes.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
-#include <math.h>
+#include <cmath>
 
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
@@ -139,7 +138,7 @@ public:
     Mantid::signal_t value = projection.signalAtPeakCenter(outOfBoundsPeak);
 
     TSM_ASSERT("Should indicate is out of bounds via a NAN.",
-               boost::math::isnan(value));
+               std::isnan(value));
   }
 
   void test_labelAtPeakCenter_with_peak_at_0_0_0() {
@@ -207,7 +206,7 @@ public:
 
     PeakClusterProjection projection(inWS);
     Mantid::signal_t value = projection.signalAtPeakCenter(outOfBoundsPeak);
-    TS_ASSERT(boost::math::isnan(value));
+    TS_ASSERT(std::isnan(value));
   }
 };
 

--- a/Framework/CurveFitting/src/AugmentedLagrangianOptimizer.cpp
+++ b/Framework/CurveFitting/src/AugmentedLagrangianOptimizer.cpp
@@ -2,7 +2,7 @@
 #include "MantidKernel/Exception.h"
 
 #include <boost/make_shared.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 #include <gsl/gsl_multimin.h>
 
@@ -109,7 +109,7 @@ int relstopX(const std::vector<double> &xvOld, const std::vector<double> &xvNew,
 int relstopX(const std::vector<double> &xvOld, const gsl_vector *xvNew,
              double reltol, double abstol) {
   for (size_t i = 0; i < xvOld.size(); ++i) {
-    if (boost::math::isnan(gsl_vector_get(xvNew, i)))
+    if (std::isnan(gsl_vector_get(xvNew, i)))
       return 1;
     if (!relstop(xvOld[i], gsl_vector_get(xvNew, i), reltol, abstol))
       return 0;

--- a/Framework/CurveFitting/src/FitMW.cpp
+++ b/Framework/CurveFitting/src/FitMW.cpp
@@ -20,7 +20,7 @@
 #include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/Matrix.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 #include <algorithm>
 
 namespace Mantid {
@@ -183,12 +183,12 @@ void FitMW::createDomain(boost::shared_ptr<API::FunctionDomain> &domain,
       error /= binWidth;
     }
 
-    if (!boost::math::isfinite(y)) // nan or inf data
+    if (!std::isfinite(y)) // nan or inf data
     {
       if (!m_ignoreInvalidData)
         throw std::runtime_error("Infinte number or NaN found in input data.");
       y = 0.0; // leaving inf or nan would break the fit
-    } else if (!boost::math::isfinite(error)) // nan or inf error
+    } else if (!std::isfinite(error)) // nan or inf error
     {
       if (!m_ignoreInvalidData)
         throw std::runtime_error("Infinte number or NaN found in input data.");

--- a/Framework/CurveFitting/src/FitMW.cpp
+++ b/Framework/CurveFitting/src/FitMW.cpp
@@ -187,7 +187,7 @@ void FitMW::createDomain(boost::shared_ptr<API::FunctionDomain> &domain,
     {
       if (!m_ignoreInvalidData)
         throw std::runtime_error("Infinte number or NaN found in input data.");
-      y = 0.0; // leaving inf or nan would break the fit
+      y = 0.0;                        // leaving inf or nan would break the fit
     } else if (!std::isfinite(error)) // nan or inf error
     {
       if (!m_ignoreInvalidData)

--- a/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp
@@ -26,7 +26,7 @@
 #include <boost/random/variate_generator.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/version.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 namespace Mantid {
 namespace CurveFitting {
@@ -338,7 +338,7 @@ bool FABADAMinimizer::iterate(size_t) {
     // the user should be aware of that.
 
     // Set the new value in order to calculate the new Chi square value
-    if (boost::math::isnan(new_value)) {
+    if (std::isnan(new_value)) {
       throw std::runtime_error("Parameter value is NaN.");
     }
     new_parameters.set(i, new_value);
@@ -773,7 +773,7 @@ void FABADAMinimizer::TieApplication(const size_t &ParameterIndex,
       API::ParameterTie *tie = m_FitFunction->getTie(j);
       if (tie) {
         new_value = tie->eval();
-        if (boost::math::isnan(new_value)) { // maybe not needed
+        if (std::isnan(new_value)) { // maybe not needed
           throw std::runtime_error("Parameter value is NaN.");
         }
         new_parameters.set(j, new_value);
@@ -785,7 +785,7 @@ void FABADAMinimizer::TieApplication(const size_t &ParameterIndex,
   API::ParameterTie *tie = m_FitFunction->getTie(i);
   if (tie) {
     new_value = tie->eval();
-    if (boost::math::isnan(new_value)) { // maybe not needed
+    if (std::isnan(new_value)) { // maybe not needed
       throw std::runtime_error("Parameter value is NaN.");
     }
     new_parameters.set(i, new_value);

--- a/Framework/CurveFitting/src/Functions/BackToBackExponential.cpp
+++ b/Framework/CurveFitting/src/Functions/BackToBackExponential.cpp
@@ -6,7 +6,6 @@
 
 #include <gsl/gsl_sf_erf.h>
 #include <gsl/gsl_multifit_nlin.h>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cmath>
 #include <limits>
 
@@ -64,7 +63,7 @@ void BackToBackExponential::setHeight(const double h) {
   if (area <= 0.0) {
     area = 1e-6;
   }
-  if (boost::math::isnan(area) || boost::math::isinf(area)) {
+  if (!std::isfinite(area)) {
     area = std::numeric_limits<double>::max() / 2;
   }
   setParameter(0, area);

--- a/Framework/CurveFitting/src/Functions/Gaussian.cpp
+++ b/Framework/CurveFitting/src/Functions/Gaussian.cpp
@@ -3,7 +3,6 @@
 //----------------------------------------------------------------------
 #include "MantidCurveFitting/Functions/Gaussian.h"
 #include "MantidAPI/FunctionFactory.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 
 #include <cmath>
 #include <numeric>
@@ -83,7 +82,7 @@ double Gaussian::intensity() const {
   auto sigma = getParameter("Sigma");
   if (sigma == 0.0) {
     auto height = getParameter("Height");
-    if (boost::math::isfinite(height)) {
+    if (std::isfinite(height)) {
       m_intensityCache = height;
     }
   } else {

--- a/Framework/CurveFitting/src/HistogramDomainCreator.cpp
+++ b/Framework/CurveFitting/src/HistogramDomainCreator.cpp
@@ -84,12 +84,12 @@ void HistogramDomainCreator::createDomain(
       error *= dx;
     }
 
-    if (!boost::math::isfinite(y)) // nan or inf data
+    if (!std::isfinite(y)) // nan or inf data
     {
       if (!m_ignoreInvalidData)
         throw std::runtime_error("Infinte number or NaN found in input data.");
       y = 0.0; // leaving inf or nan would break the fit
-    } else if (!boost::math::isfinite(error)) // nan or inf error
+    } else if (!std::isfinite(error)) // nan or inf error
     {
       if (!m_ignoreInvalidData)
         throw std::runtime_error("Infinte number or NaN found in input data.");

--- a/Framework/CurveFitting/src/HistogramDomainCreator.cpp
+++ b/Framework/CurveFitting/src/HistogramDomainCreator.cpp
@@ -88,7 +88,7 @@ void HistogramDomainCreator::createDomain(
     {
       if (!m_ignoreInvalidData)
         throw std::runtime_error("Infinte number or NaN found in input data.");
-      y = 0.0; // leaving inf or nan would break the fit
+      y = 0.0;                        // leaving inf or nan would break the fit
     } else if (!std::isfinite(error)) // nan or inf error
     {
       if (!m_ignoreInvalidData)

--- a/Framework/CurveFitting/src/IMWDomainCreator.cpp
+++ b/Framework/CurveFitting/src/IMWDomainCreator.cpp
@@ -20,7 +20,6 @@
 #include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/Matrix.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <algorithm>
 
 namespace Mantid {

--- a/Framework/CurveFitting/test/Algorithms/CalculateChiSquaredTest.h
+++ b/Framework/CurveFitting/test/Algorithms/CalculateChiSquaredTest.h
@@ -14,8 +14,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidKernel/EmptyValues.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
-
+#include <cmath>
 #include <algorithm>
 #include <limits>
 
@@ -310,8 +309,7 @@ private:
 
     bool isGoodValue(double y, double e) {
       return !ignoreInvalidData ||
-             (!boost::math::isnan(y) && !boost::math::isinf(y) &&
-              !boost::math::isnan(e) && !boost::math::isinf(e) && e > 0);
+             (std::isfinite(y) && std::isfinite(e) && e > 0);
     }
 
   public:

--- a/Framework/DataHandling/inc/MantidDataHandling/AsciiPointBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/AsciiPointBase.h
@@ -62,10 +62,6 @@ private:
   void init() override;
   /// Overwrites Algorithm method
   void exec() override;
-  /// returns true if the value is NaN
-  bool checkIfNan(const double &value) const;
-  /// returns true if the value if + or - infinity
-  bool checkIfInfinite(const double &value) const;
   /// print the appropriate value to file
   void outputval(double val, std::ofstream &file, bool leadingSep = true);
   /// write the top of the file

--- a/Framework/DataHandling/src/AsciiPointBase.cpp
+++ b/Framework/DataHandling/src/AsciiPointBase.cpp
@@ -13,8 +13,7 @@ GUI
 
 #include <boost/tokenizer.hpp>
 #include <boost/regex.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
-
+#include <cmath>
 #include <fstream>
 
 namespace Mantid {
@@ -112,8 +111,8 @@ void AsciiPointBase::data(std::ofstream &file, const std::vector<double> &XData,
  */
 void AsciiPointBase::outputval(double val, std::ofstream &file,
                                bool leadingSep) {
-  bool nancheck = checkIfNan(val);
-  bool infcheck = checkIfInfinite(val);
+  bool nancheck = std::isnan(val);
+  bool infcheck = std::isinf(val);
   if (leadingSep) {
     file << sep();
   }
@@ -128,18 +127,5 @@ void AsciiPointBase::outputval(double val, std::ofstream &file,
   }
 }
 
-/** checks if a value is Not A Number
- *  @returns boolean true if the supplied value was Not a Number
- */
-bool AsciiPointBase::checkIfNan(const double &value) const {
-  return (boost::math::isnan(value));
-}
-
-/** checks if a value is Infinite
- *  @returns boolean true if the supplied value was Infinite
- */
-bool AsciiPointBase::checkIfInfinite(const double &value) const {
-  return (std::abs(value) == std::numeric_limits<double>::infinity());
-}
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -17,7 +17,6 @@
 #include "MantidGeometry/Surfaces/Sphere.h"
 
 #include <boost/regex.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 #include <map>
 #include <sstream>
@@ -290,7 +289,7 @@ void LoadNXSPE::exec() {
     itdataend = itdata + numBins;
     iterrorend = iterror + numBins;
     outputWS->dataX(i) = energies;
-    if ((!boost::math::isfinite(*itdata)) || (*itdata <= -1e10)) // masked bin
+    if ((!std::isfinite(*itdata)) || (*itdata <= -1e10)) // masked bin
     {
       outputWS->dataY(i) = std::vector<double>(numBins, 0);
       outputWS->dataE(i) = std::vector<double>(numBins, 0);

--- a/Framework/DataHandling/src/LoadQKK.cpp
+++ b/Framework/DataHandling/src/LoadQKK.cpp
@@ -14,8 +14,6 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidNexus/NexusClasses.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
-
 #include <Poco/File.h>
 
 #include <fstream>

--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -498,7 +498,8 @@ inline void writeBankLine(std::stringstream &out, const std::string &bintype,
 /** Fix error if value is less than zero or infinity
   */
 inline double fixErrorValue(const double value) {
-  if (value <= 0. || !std::isfinite(value)) // Negative errors cannot be read by GSAS
+  if (value <= 0. ||
+      !std::isfinite(value)) // Negative errors cannot be read by GSAS
     return 0.;
   else
     return value;

--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -10,10 +10,10 @@
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/ListValidator.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <Poco/File.h>
 #include <Poco/Path.h>
 #include <fstream>
+#include <cmath>
 
 namespace Mantid {
 namespace DataHandling {
@@ -498,8 +498,7 @@ inline void writeBankLine(std::stringstream &out, const std::string &bintype,
 /** Fix error if value is less than zero or infinity
   */
 inline double fixErrorValue(const double value) {
-  if (value <= 0. || boost::math::isnan(value) ||
-      boost::math::isinf(value)) // Negative errors cannot be read by GSAS
+  if (value <= 0. || !std::isfinite(value)) // Negative errors cannot be read by GSAS
     return 0.;
   else
     return value;
@@ -516,7 +515,7 @@ void SaveGSS::writeRALFdata(const int bank, const bool MultiplyByBinWidth,
   double bc2 = (X[1] - X[0]) * 32;
   // Logarithmic step
   double bc4 = (X[1] - X[0]) / X[0];
-  if (boost::math::isnan(fabs(bc4)) || boost::math::isinf(bc4))
+  if (!std::isfinite(bc4))
     bc4 = 0; // If X is zero for BANK
 
   // Write out the data header

--- a/Framework/DataHandling/src/SaveSPE.cpp
+++ b/Framework/DataHandling/src/SaveSPE.cpp
@@ -12,7 +12,7 @@
 #include "MantidKernel/CompositeValidator.h"
 
 #include "Poco/File.h"
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 #include <cstdio>
 #include <cmath>
@@ -272,7 +272,7 @@ void SaveSPE::check_and_copy_spectra(const MantidVec &inSignal,
     Error.resize(inSignal.size());
   }
   for (size_t i = 0; i < inSignal.size(); i++) {
-    if (boost::math::isnan(inSignal[i]) || boost::math::isinf(inSignal[i])) {
+    if (!std::isfinite(inSignal[i])) {
       Signal[i] = SaveSPE::MASK_FLAG;
       Error[i] = SaveSPE::MASK_ERROR;
     } else {

--- a/Framework/DataHandling/test/SaveNXSPETest.h
+++ b/Framework/DataHandling/test/SaveNXSPETest.h
@@ -11,7 +11,6 @@
 #include "MantidDataHandling/LoadInstrument.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/shared_array.hpp>
 #include "boost/tuple/tuple.hpp"
 
@@ -73,7 +72,7 @@ public:
     TS_ASSERT_DELTA(9.0, signal[9], tolerance);
     TS_ASSERT_DELTA(18.0, error[9], tolerance);
     // element 1,2 in 2D flat buffer
-    TS_ASSERT(boost::math::isnan(signal[1 * dims[1] + 2]));
+    TS_ASSERT(std::isnan(signal[1 * dims[1] + 2]));
     TS_ASSERT_DELTA(0.0, error[1 * dims[1] + 2], tolerance);
     // final element
     TS_ASSERT_DELTA(29.0, signal[dims[0] * dims[1] - 1], tolerance);
@@ -99,7 +98,7 @@ public:
     TS_ASSERT_DELTA(99.0, signal[99], tolerance);
     TS_ASSERT_DELTA(198.0, error[99], tolerance);
     // element 1,2 in 2D flat buffer
-    TS_ASSERT(boost::math::isnan(signal[1 * dims[1] + 2]));
+    TS_ASSERT(std::isnan(signal[1 * dims[1] + 2]));
     TS_ASSERT_DELTA(0.0, error[1 * dims[1] + 2], tolerance);
     // final element
     TS_ASSERT_DELTA(524999.0, signal[dims[0] * dims[1] - 1], tolerance);

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -908,7 +908,7 @@ TMDE(API::IMDWorkspace::LinePlot MDEventWorkspace)
         if (!box->getIsMasked()) {
           line.x.push_back(line_pos);
           signal_t signal = this->getNormalizedSignal(box, normalize);
-          if (boost::math::isinf(signal)) {
+          if (std::isinf(signal)) {
             // The plotting library (qwt) doesn't like infs.
             signal = std::numeric_limits<signal_t>::quiet_NaN();
           }

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -198,10 +198,6 @@ void EventList::createFromHistogram(const ISpectrum *inSpec, bool GenerateZeros,
   // Fresh start
   this->clear(true);
 
-  // Cached values for later checks
-  double inf = std::numeric_limits<double>::infinity();
-  double ninf = -inf;
-
   // Get the input histogram
   const MantidVec &X = inSpec->readX();
   const MantidVec &Y = inSpec->readY();
@@ -219,12 +215,10 @@ void EventList::createFromHistogram(const ISpectrum *inSpec, bool GenerateZeros,
 
   for (size_t i = 0; i < X.size() - 1; i++) {
     double weight = Y[i];
-    if ((weight != 0.0 || GenerateZeros) && (weight == weight) /*NAN check*/
-        && (weight != inf) && (weight != ninf)) {
+    if ((weight != 0.0 || GenerateZeros) && std::isfinite(weight)) {
       double error = E[i];
       // Also check that the error is not a bad number
-      if ((error == error) /*NAN check*/
-          && (error != inf) && (error != ninf)) {
+      if (std::isfinite(error)) {
         if (GenerateMultipleEvents) {
           // --------- Multiple events per bin ----------
           double errorSquared = error * error;

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -6,7 +6,7 @@
 #include "MantidGeometry/Math/PolygonIntersection.h"
 #include "MantidKernel/V2D.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 namespace Mantid {
 
@@ -140,7 +140,7 @@ void rebinToOutput(const Quadrilateral &inputQ,
       const Quadrilateral outputQ(ll, lr, ur, ul);
 
       double yValue = inY[j];
-      if (boost::math::isnan(yValue)) {
+      if (std::isnan(yValue)) {
         continue;
       }
       intersectOverlap.clear();
@@ -208,7 +208,7 @@ void rebinToFractionalOutput(const Quadrilateral &inputQ,
       const Quadrilateral outputQ(ll, lr, ur, ul);
 
       double yValue = inY[j];
-      if (boost::math::isnan(yValue)) {
+      if (std::isnan(yValue)) {
         continue;
       }
       intersectOverlap.clear();

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -14,8 +14,8 @@
 #include "MantidAPI/IMDIterator.h"
 #include <boost/scoped_array.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/optional.hpp>
+#include <cmath>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
@@ -611,7 +611,7 @@ IMDWorkspace::LinePlot MDHistoWorkspace::getLinePoints(
         auto normalizer = getNormalizationFactor(normalize, linearIndex);
         // And add the normalized signal/error to the list too
         auto signal = this->getSignalAt(linearIndex) * normalizer;
-        if (boost::math::isinf(signal)) {
+        if (std::isinf(signal)) {
           // The plotting library (qwt) doesn't like infs.
           signal = std::numeric_limits<signal_t>::quiet_NaN();
         }

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -6,7 +6,6 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidKernel/Timer.h"
 #include <cmath>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include "MantidKernel/CPUTimer.h"
 
 using namespace Mantid;
@@ -555,8 +554,8 @@ public:
           int bini = static_cast<int>(tof / step);
           if (bini == 7) {
             // That was zeros
-            TS_ASSERT(boost::math::isnan(el.getEvent(i).weight()));
-            TS_ASSERT(boost::math::isnan(el.getEvent(i).errorSquared()));
+            TS_ASSERT(std::isnan(el.getEvent(i).weight()));
+            TS_ASSERT(std::isnan(el.getEvent(i).errorSquared()));
           } else {
             // Same weight error as dividing by a scalar with error before,
             // since we divided by 2+-0.5 again

--- a/Framework/DataObjects/test/MDBoxIteratorTest.h
+++ b/Framework/DataObjects/test/MDBoxIteratorTest.h
@@ -12,7 +12,6 @@
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
@@ -618,7 +617,7 @@ public:
     // Now mask the box
     it->getBox()->mask();
     // For masked boxes, getNormalizedSignal() should return NaN.
-    TS_ASSERT(boost::math::isnan(it->getNormalizedSignal()));
+    TS_ASSERT(std::isnan(it->getNormalizedSignal()));
   }
 };
 

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -28,7 +28,7 @@
 #include <memory>
 #include <vector>
 #include <typeinfo>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 using namespace Mantid;
 using namespace Mantid::Kernel;
@@ -287,10 +287,10 @@ public:
         "The box with 2 events",
         ew->getSignalAtCoord(coords2, Mantid::API::NoNormalization), 3.0, 1e-5);
     TSM_ASSERT("Out of bounds returns NAN",
-               boost::math::isnan(ew->getSignalAtCoord(
+               std::isnan(ew->getSignalAtCoord(
                    coords3, Mantid::API::NoNormalization)));
     TSM_ASSERT("Out of bounds returns NAN",
-               boost::math::isnan(ew->getSignalAtCoord(
+               std::isnan(ew->getSignalAtCoord(
                    coords4, Mantid::API::NoNormalization)));
   }
 
@@ -416,7 +416,7 @@ public:
         "Value ignoring mask is 0.0 as masking deletes the events",
         ew->getSignalAtCoord(coords1, Mantid::API::NoNormalization), 0.0, 1e-5);
     TSM_ASSERT("Masked returns NaN",
-               boost::math::isnan(ew->getSignalWithMaskAtCoord(
+               std::isnan(ew->getSignalWithMaskAtCoord(
                    coords1, Mantid::API::NoNormalization)));
   }
 

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -287,11 +287,11 @@ public:
         "The box with 2 events",
         ew->getSignalAtCoord(coords2, Mantid::API::NoNormalization), 3.0, 1e-5);
     TSM_ASSERT("Out of bounds returns NAN",
-               std::isnan(ew->getSignalAtCoord(
-                   coords3, Mantid::API::NoNormalization)));
+               std::isnan(ew->getSignalAtCoord(coords3,
+                                               Mantid::API::NoNormalization)));
     TSM_ASSERT("Out of bounds returns NAN",
-               std::isnan(ew->getSignalAtCoord(
-                   coords4, Mantid::API::NoNormalization)));
+               std::isnan(ew->getSignalAtCoord(coords4,
+                                               Mantid::API::NoNormalization)));
   }
 
   void test_getBoxBoundaryBisectsOnLine() {

--- a/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -14,7 +14,7 @@
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 using namespace Mantid;
 using namespace Mantid::DataObjects;
@@ -175,7 +175,7 @@ public:
                       3.0, histoIt->getNormalizedSignal());
     histoIt->jumpTo(2);
     TSM_ASSERT("Should return NaN here as data at the iterator are masked",
-               boost::math::isnan(histoIt->getNormalizedSignal()));
+               std::isnan(histoIt->getNormalizedSignal()));
     histoIt->jumpTo(3);
     TSM_ASSERT_EQUALS("Should get the signal value here as data at the iterator"
                       " are unmasked",

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -566,8 +566,8 @@ public:
     TS_ASSERT(std::isnan(iws->getSignalAtVMD(VMD(0.5, 0.5))));
     TS_ASSERT(std::isnan(iws->getSignalWithMaskAtVMD(VMD(0.5, 0.5))));
 
-    TS_ASSERT(std::isnan(
-        iws->getSignalAtVMD(VMD(3.5, 0.5), VolumeNormalization)));
+    TS_ASSERT(
+        std::isnan(iws->getSignalAtVMD(VMD(3.5, 0.5), VolumeNormalization)));
     TS_ASSERT(std::isnan(
         iws->getSignalWithMaskAtVMD(VMD(3.5, 0.5), VolumeNormalization)));
   }

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -13,7 +13,7 @@
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidDataObjects/MDHistoWorkspaceIterator.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 #include <boost/scoped_array.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <cxxtest/TestSuite.h>
@@ -123,10 +123,10 @@ public:
 
     // The values are cleared at the start
     for (size_t i = 0; i < ws.getNPoints(); i++) {
-      TS_ASSERT(boost::math::isnan(ws.getSignalAt(i)));
-      TS_ASSERT(boost::math::isnan(ws.getErrorAt(i)));
-      TS_ASSERT(boost::math::isnan(ws.getSignalNormalizedAt(i)));
-      TS_ASSERT(boost::math::isnan(ws.getErrorNormalizedAt(i)));
+      TS_ASSERT(std::isnan(ws.getSignalAt(i)));
+      TS_ASSERT(std::isnan(ws.getErrorAt(i)));
+      TS_ASSERT(std::isnan(ws.getSignalNormalizedAt(i)));
+      TS_ASSERT(std::isnan(ws.getErrorNormalizedAt(i)));
       TS_ASSERT(!ws.getIsMaskedAt(i));
     }
 
@@ -511,10 +511,10 @@ public:
     TS_ASSERT_DELTA(iws->getSignalAtVMD(VMD(1.5, 1.5)), 11.0, 1e-6);
     TS_ASSERT_DELTA(iws->getSignalAtVMD(VMD(9.5, 9.5)), 99.0, 1e-6);
     // Out of range = NaN
-    TS_ASSERT(boost::math::isnan(iws->getSignalAtVMD(VMD(-0.01, 2.5))));
-    TS_ASSERT(boost::math::isnan(iws->getSignalAtVMD(VMD(3.5, -0.02))));
-    TS_ASSERT(boost::math::isnan(iws->getSignalAtVMD(VMD(10.01, 2.5))));
-    TS_ASSERT(boost::math::isnan(iws->getSignalAtVMD(VMD(3.5, 10.02))));
+    TS_ASSERT(std::isnan(iws->getSignalAtVMD(VMD(-0.01, 2.5))));
+    TS_ASSERT(std::isnan(iws->getSignalAtVMD(VMD(3.5, -0.02))));
+    TS_ASSERT(std::isnan(iws->getSignalAtVMD(VMD(10.01, 2.5))));
+    TS_ASSERT(std::isnan(iws->getSignalAtVMD(VMD(3.5, 10.02))));
   }
 
   //---------------------------------------------------------------------------------------------------
@@ -563,12 +563,12 @@ public:
     // when MDMaskValue is NaN.
     // TS_ASSERT_DELTA(iws->getSignalWithMaskAtVMD(VMD(0.5, 0.5)), MDMaskValue,
     // 1e-6);
-    TS_ASSERT(boost::math::isnan(iws->getSignalAtVMD(VMD(0.5, 0.5))));
-    TS_ASSERT(boost::math::isnan(iws->getSignalWithMaskAtVMD(VMD(0.5, 0.5))));
+    TS_ASSERT(std::isnan(iws->getSignalAtVMD(VMD(0.5, 0.5))));
+    TS_ASSERT(std::isnan(iws->getSignalWithMaskAtVMD(VMD(0.5, 0.5))));
 
-    TS_ASSERT(boost::math::isnan(
+    TS_ASSERT(std::isnan(
         iws->getSignalAtVMD(VMD(3.5, 0.5), VolumeNormalization)));
-    TS_ASSERT(boost::math::isnan(
+    TS_ASSERT(std::isnan(
         iws->getSignalWithMaskAtVMD(VMD(3.5, 0.5), VolumeNormalization)));
   }
 
@@ -679,7 +679,7 @@ public:
 
     TS_ASSERT_EQUALS(line.y.size(), 10);
     // Masked value should be zero
-    TS_ASSERT(boost::math::isnan(line.y[2]));
+    TS_ASSERT(std::isnan(line.y[2]));
     // Unmasked value
     TS_ASSERT_DELTA(line.y[9], 9.0, 1e-5);
   }

--- a/Framework/DataObjects/test/TofEventTest.h
+++ b/Framework/DataObjects/test/TofEventTest.h
@@ -5,7 +5,6 @@
 #include "MantidDataObjects/Events.h"
 #include "MantidKernel/Timer.h"
 #include <cmath>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 using namespace Mantid;
 using namespace Mantid::Kernel;

--- a/Framework/DataObjects/test/WeightedEventNoTimeTest.h
+++ b/Framework/DataObjects/test/WeightedEventNoTimeTest.h
@@ -5,7 +5,6 @@
 #include "MantidDataObjects/Events.h"
 #include "MantidKernel/Timer.h"
 #include <cmath>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 using namespace Mantid;
 using namespace Mantid::Kernel;

--- a/Framework/DataObjects/test/WeightedEventTest.h
+++ b/Framework/DataObjects/test/WeightedEventTest.h
@@ -5,7 +5,6 @@
 #include "MantidDataObjects/Events.h"
 #include "MantidKernel/Timer.h"
 #include <cmath>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 using namespace Mantid;
 using namespace Mantid::Kernel;

--- a/Framework/Geometry/src/Crystal/IndexingUtils.cpp
+++ b/Framework/Geometry/src/Crystal/IndexingUtils.cpp
@@ -3,7 +3,7 @@
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidKernel/Quat.h"
 #include <algorithm>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <stdexcept>
@@ -723,7 +723,7 @@ double IndexingUtils::Optimize_UB(DblMatrix &UB,
 
     for (size_t i = 0; i < 3; i++) {
       double value = gsl_vector_get(UB_row, i);
-      if (gsl_isnan(value) || gsl_isinf(value))
+      if (!std::isfinite(value))
         found_UB = false;
     }
 
@@ -843,7 +843,7 @@ double IndexingUtils::Optimize_Direction(V3D &best_vec,
 
   for (size_t i = 0; i < 3; i++) {
     double value = gsl_vector_get(x, i);
-    if (gsl_isnan(value) || gsl_isinf(value))
+    if (!std::isfinite(value))
       found_best_vec = false;
   }
 
@@ -1773,7 +1773,7 @@ void IndexingUtils::DiscardDuplicates(std::vector<V3D> &new_list,
           if ((length_diff / current_length) < len_tol) // continue scan
           {
             angle = current_dir.angle(next_dir) * RAD_TO_DEG;
-            if ((boost::math::isnan)(angle))
+            if ((std::isnan)(angle))
               angle = 0;
             if ((angle < ang_tol) || (angle > (180.0 - ang_tol))) {
               temp.push_back(next_dir);
@@ -1951,8 +1951,7 @@ bool IndexingUtils::CheckUB(const DblMatrix &UB) {
 
   for (size_t row = 0; row < 3; row++)
     for (size_t col = 0; col < 3; col++) {
-      if ((boost::math::isnan)(UB[row][col]) ||
-          (boost::math::isinf)(UB[row][col])) {
+      if (!std::isfinite(UB[row][col])) {
         return false;
       }
     }

--- a/Framework/Geometry/src/Crystal/NiggliCell.cpp
+++ b/Framework/Geometry/src/Crystal/NiggliCell.cpp
@@ -1,7 +1,6 @@
 #include "MantidGeometry/Crystal/NiggliCell.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidKernel/Quat.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include <stdexcept>
 #include <algorithm>

--- a/Framework/Geometry/src/MDGeometry/MDPlane.cpp
+++ b/Framework/Geometry/src/MDGeometry/MDPlane.cpp
@@ -4,7 +4,6 @@
 #include "MantidKernel/VMD.h"
 #include <gsl/gsl_linalg.h>
 #include "MantidKernel/Matrix.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 
 using namespace Mantid::Kernel;
 

--- a/Framework/Kernel/src/Atom.cpp
+++ b/Framework/Kernel/src/Atom.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include "MantidKernel/Atom.h"
 #include "MantidKernel/PhysicalConstants.h"
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 namespace Mantid {
 namespace PhysicalConstants {
@@ -3151,7 +3151,7 @@ static const size_t NUM_ATOMS = 2845;
 bool AtomEqualsWithNaN(const double left, const double right) {
   if (left == right)
     return true;
-  if ((boost::math::isnan)(left) && (boost::math::isnan)(right))
+  if ((std::isnan)(left) && (std::isnan)(right))
     return true;
   return false;
 }

--- a/Framework/Kernel/src/NeutronAtom.cpp
+++ b/Framework/Kernel/src/NeutronAtom.cpp
@@ -6,8 +6,7 @@
 #include <algorithm>
 #include <sstream>
 #include <stdexcept>
-#include <boost/math/special_functions/fpclassify.hpp>
-#include <math.h>
+#include <cmath>
 
 namespace Mantid {
 
@@ -589,7 +588,7 @@ static const size_t NUM_ATOMS = 371;
 bool NeutronAtomEqualsWithNaN(const double left, const double right) {
   if (left == right)
     return true;
-  if ((boost::math::isnan)(left) && (boost::math::isnan)(right))
+  if ((std::isnan)(left) && (std::isnan)(right))
     return true;
   return false;
 }

--- a/Framework/Kernel/test/StatisticsTest.h
+++ b/Framework/Kernel/test/StatisticsTest.h
@@ -2,7 +2,6 @@
 #define STATISTICSTEST_H_
 
 #include "MantidKernel/Statistics.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <cxxtest/TestSuite.h>
 #include <algorithm>
 #include <cmath>
@@ -44,10 +43,10 @@ public:
     Statistics stats =
         getStatistics(data, (StatOptions::Median | StatOptions::SortedData));
 
-    TS_ASSERT(boost::math::isnan(stats.mean));
-    TS_ASSERT(boost::math::isnan(stats.standard_deviation));
-    TS_ASSERT(boost::math::isnan(stats.minimum));
-    TS_ASSERT(boost::math::isnan(stats.maximum));
+    TS_ASSERT(std::isnan(stats.mean));
+    TS_ASSERT(std::isnan(stats.standard_deviation));
+    TS_ASSERT(std::isnan(stats.minimum));
+    TS_ASSERT(std::isnan(stats.maximum));
     TS_ASSERT_EQUALS(stats.median, 17.2);
   }
 
@@ -63,10 +62,10 @@ public:
     Statistics stats =
         getStatistics(data, (StatOptions::Median | StatOptions::SortedData));
 
-    TS_ASSERT(boost::math::isnan(stats.mean));
-    TS_ASSERT(boost::math::isnan(stats.standard_deviation));
-    TS_ASSERT(boost::math::isnan(stats.minimum));
-    TS_ASSERT(boost::math::isnan(stats.maximum));
+    TS_ASSERT(std::isnan(stats.mean));
+    TS_ASSERT(std::isnan(stats.standard_deviation));
+    TS_ASSERT(std::isnan(stats.minimum));
+    TS_ASSERT(std::isnan(stats.maximum));
     TS_ASSERT_EQUALS(stats.median, 16.5);
   }
 
@@ -85,7 +84,7 @@ public:
     TS_ASSERT_DELTA(stats.standard_deviation, 2.3179, 0.0001);
     TS_ASSERT_EQUALS(stats.minimum, 12.6);
     TS_ASSERT_EQUALS(stats.maximum, 18.3);
-    TS_ASSERT(boost::math::isnan(stats.median));
+    TS_ASSERT(std::isnan(stats.median));
   }
 
   void test_Types_Can_Be_Disabled_With_Flags() {
@@ -98,10 +97,10 @@ public:
 
     Statistics justMean = getStatistics(data, StatOptions::Mean);
     TS_ASSERT_EQUALS(justMean.mean, 16.54);
-    TS_ASSERT(boost::math::isnan(justMean.standard_deviation));
-    TS_ASSERT(boost::math::isnan(justMean.minimum));
-    TS_ASSERT(boost::math::isnan(justMean.maximum));
-    TS_ASSERT(boost::math::isnan(justMean.median));
+    TS_ASSERT(std::isnan(justMean.standard_deviation));
+    TS_ASSERT(std::isnan(justMean.minimum));
+    TS_ASSERT(std::isnan(justMean.maximum));
+    TS_ASSERT(std::isnan(justMean.median));
   }
 
   void testZscores() {

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -7,7 +7,7 @@
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/TimeSplitter.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
@@ -565,7 +565,7 @@ public:
     TS_ASSERT_DELTA(intLog->averageValueInFilter(filter), 1.75, 0.001);
 
     // Check the correct behaviour of empty of single value logs.
-    TS_ASSERT(boost::math::isnan(dProp->averageValueInFilter(filter)));
+    TS_ASSERT(std::isnan(dProp->averageValueInFilter(filter)));
     iProp->addValue(DateAndTime("2010-11-30T16:17:25"), 99);
     TS_ASSERT_EQUALS(iProp->averageValueInFilter(filter), 99.0);
 
@@ -710,12 +710,12 @@ public:
     TimeSeriesProperty<double> *log =
         new TimeSeriesProperty<double>("MydoubleLog");
     TimeSeriesPropertyStatistics stats = log->getStatistics();
-    TS_ASSERT(boost::math::isnan(stats.minimum));
-    TS_ASSERT(boost::math::isnan(stats.maximum));
-    TS_ASSERT(boost::math::isnan(stats.median));
-    TS_ASSERT(boost::math::isnan(stats.mean));
-    TS_ASSERT(boost::math::isnan(stats.standard_deviation));
-    TS_ASSERT(boost::math::isnan(stats.duration));
+    TS_ASSERT(std::isnan(stats.minimum));
+    TS_ASSERT(std::isnan(stats.maximum));
+    TS_ASSERT(std::isnan(stats.median));
+    TS_ASSERT(std::isnan(stats.mean));
+    TS_ASSERT(std::isnan(stats.standard_deviation));
+    TS_ASSERT(std::isnan(stats.duration));
 
     delete log;
   }

--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -63,7 +63,7 @@ std::string convert_units_check_range(const Unit &aUnit,
   const size_t nSteps(100);
 
   double step = (range.second - range.first) / nSteps;
-  if (step == std::numeric_limits<double>::infinity()) {
+  if (std::isinf(step)) {
     step = (DBL_MAX / nSteps) * 2;
   }
 

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -465,9 +465,7 @@ void FindPeaksMD::findPeaksHisto(
     double thresholdDensity =
         (totalSignal * ws->getInverseVolume() / double(numBoxes)) *
         DensityThresholdFactor * m_densityScaleFactor;
-    if ((thresholdDensity != thresholdDensity) ||
-        (thresholdDensity == std::numeric_limits<double>::infinity()) ||
-        (thresholdDensity == -std::numeric_limits<double>::infinity())) {
+    if (!std::isfinite(thresholdDensity)) {
       g_log.warning()
           << "Infinite or NaN overall density found. Your input data "
              "may be invalid. Using a 0 threshold instead.\n";

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -5,7 +5,7 @@
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidKernel/VMD.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 #include <boost/type_traits/integral_constant.hpp>
 
 #include <map>
@@ -269,9 +269,7 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     // peak.
     signal_t thresholdDensity = ws->getBox()->getSignalNormalized() *
                                 DensityThresholdFactor * m_densityScaleFactor;
-    if (boost::math::isnan(thresholdDensity) ||
-        (thresholdDensity == std::numeric_limits<double>::infinity()) ||
-        (thresholdDensity == -std::numeric_limits<double>::infinity())) {
+    if (std::isfinite(thresholdDensity)) {
       g_log.warning()
           << "Infinite or NaN overall density found. Your input data "
              "may be invalid. Using a 0 threshold instead.\n";

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -143,7 +143,7 @@ Integrate3DEvents::ellipseIntegrateEvents(
 
   bool invalid_peak = false;
   for (int i = 0; i < 3; i++) {
-    if ((boost::math::isnan)(sigmas[i])) {
+    if ((std::isnan)(sigmas[i])) {
       invalid_peak = true;
     } else if (sigmas[i] <= 0) {
       invalid_peak = true;

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
@@ -19,7 +19,7 @@
 #include "MantidAPI/FunctionValues.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IPeakFunction.h"
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 #include <gsl/gsl_integration.h>
 #include <fstream>
 
@@ -556,7 +556,7 @@ void IntegratePeaksMD::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         if (integrationOption.compare("Sum") == 0) {
 
           for (size_t j = peakMin; j <= peakMax; j++)
-            if (!boost::math::isnan(yy[j]) && !boost::math::isinf(yy[j]))
+            if (std::isfinite(yy[j]))
               signal += yy[j];
         } else {
           gsl_integration_workspace *w = gsl_integration_workspace_alloc(1000);

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -21,7 +21,7 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/Progress.h"
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 #include <gsl/gsl_integration.h>
 #include <fstream>
 
@@ -587,7 +587,7 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         signal = 0.0;
         if (integrationOption.compare("Sum") == 0) {
           for (size_t j = peakMin; j <= peakMax; j++)
-            if (!boost::math::isnan(yy[j]) && !boost::math::isinf(yy[j]))
+            if (std::isfinite(yy[j]))
               signal += yy[j];
         } else {
           gsl_integration_workspace *w = gsl_integration_workspace_alloc(1000);

--- a/Framework/MDAlgorithms/src/UnitsConversionHelper.cpp
+++ b/Framework/MDAlgorithms/src/UnitsConversionHelper.cpp
@@ -2,7 +2,7 @@
 #include "MantidAPI/NumericAxis.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/Strings.h"
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 namespace Mantid {
 namespace MDAlgorithms {
@@ -180,7 +180,7 @@ UnitsConversionHelper::getConversionRange(double x1, double x2) const {
     }
     double tof1 = m_SourceWSUnit->singleToTOF(range.first);
     double tof2 = m_SourceWSUnit->singleToTOF(range.second);
-    if (boost::math::isnan(tof1) || boost::math::isnan(tof2)) {
+    if (std::isnan(tof1) || std::isnan(tof2)) {
       if (range.first < source_range.first)
         range.first = source_range.first;
       if (range.second > source_range.second)

--- a/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Framework/MDAlgorithms/test/BinMDTest.h
@@ -20,7 +20,7 @@
 #include "MantidMDAlgorithms/SaveMD2.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 #include <cxxtest/TestSuite.h>
 
@@ -185,7 +185,7 @@ public:
         TS_ASSERT_DELTA(out->getErrorAt(i), sqrt(expected_signal), 1e-5);
       } else if (functionXML != "NO_FUNCTION") {
         // All NAN cause of implicit function
-        TS_ASSERT(boost::math::isnan(out->getSignalAt(i))); // The implicit
+        TS_ASSERT(std::isnan(out->getSignalAt(i))); // The implicit
         // function should
         // have ensured that
         // no bins were

--- a/Framework/MDAlgorithms/test/CentroidPeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/CentroidPeaksMD2Test.h
@@ -16,7 +16,6 @@
 #include "MantidKernel/UnitLabelTypes.h"
 
 #include <boost/math/distributions/normal.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/math/special_functions/pow.hpp>
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/mersenne_twister.hpp>

--- a/Framework/MDAlgorithms/test/CentroidPeaksMDTest.h
+++ b/Framework/MDAlgorithms/test/CentroidPeaksMDTest.h
@@ -16,7 +16,6 @@
 #include "MantidKernel/UnitLabelTypes.h"
 
 #include <boost/math/distributions/normal.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/math/special_functions/pow.hpp>
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/mersenne_twister.hpp>

--- a/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -17,7 +17,6 @@
 #include "MantidKernel/UnitLabelTypes.h"
 
 #include <boost/math/distributions/normal.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/math/special_functions/pow.hpp>
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/mersenne_twister.hpp>

--- a/Framework/MDAlgorithms/test/IntegratePeaksMDHKLTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMDHKLTest.h
@@ -16,7 +16,6 @@
 #include "MantidKernel/UnitLabelTypes.h"
 
 #include <boost/math/distributions/normal.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/math/special_functions/pow.hpp>
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/mersenne_twister.hpp>

--- a/Framework/MDAlgorithms/test/IntegratePeaksMDTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMDTest.h
@@ -16,7 +16,6 @@
 #include "MantidKernel/UnitLabelTypes.h"
 
 #include <boost/math/distributions/normal.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/math/special_functions/pow.hpp>
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/mersenne_twister.hpp>

--- a/Framework/MDAlgorithms/test/SmoothMDTest.h
+++ b/Framework/MDAlgorithms/test/SmoothMDTest.h
@@ -7,7 +7,7 @@
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
 #include <vector>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 using Mantid::MDAlgorithms::SmoothMD;
 using namespace Mantid::API;
@@ -370,7 +370,7 @@ public:
                       out->getSignalAt(8));
 
     TSM_ASSERT("Last index should have a smoothed Value of NaN",
-               boost::math::isnan(out->getSignalAt(9)));
+               std::isnan(out->getSignalAt(9)));
   }
 
   void test_gaussian_kernel_sigma_1() {

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -27,7 +27,6 @@
 #include <limits>
 #include <cmath>
 
-
 using namespace Mantid;
 using namespace Mantid::API;
 using namespace Mantid::Kernel;

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -1146,7 +1146,7 @@ void findYRange(MatrixWorkspace_const_sptr ws, double &miny, double &maxy) {
 
       for (size_t i = 0; i < Y.size(); i++) {
         double aux = Y[i];
-        if (fabs(aux) == std::numeric_limits<double>::infinity() || aux != aux)
+        if (!std::isfinite(aux))
           continue;
         if (aux < local_min)
           local_min = aux;

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -25,8 +25,9 @@
 #include <stdlib.h>
 #include <algorithm>
 #include <limits>
+#include <cmath>
 
-#include <boost/math/special_functions/fpclassify.hpp>
+
 using namespace Mantid;
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -206,11 +207,6 @@ void MantidMatrix::viewChanged(int index) {
     activeView()->horizontalScrollBar()->setValue(hValue);
     activeView()->verticalScrollBar()->setValue(vValue);
   }
-}
-
-/// Checks if d is not infinity or a NaN
-bool isANumber(volatile const double &d) {
-  return d != std::numeric_limits<double>::infinity() && !boost::math::isnan(d);
 }
 
 void MantidMatrix::setup(Mantid::API::MatrixWorkspace_const_sptr ws, int start,
@@ -590,7 +586,7 @@ QwtDoubleRect MantidMatrix::boundingRect() {
         x_end = X[m_workspace->blocksize()];
       else
         x_end = X[m_workspace->blocksize() - 1];
-      if (!isANumber(x_start) || !isANumber(x_end)) {
+      if (!std::isfinite(x_start) || !std::isfinite(x_end)) {
         x_start = x_end = 0;
       }
       i0++;
@@ -619,13 +615,13 @@ QwtDoubleRect MantidMatrix::boundingRect() {
           const Mantid::MantidVec &X = m_workspace->readX(i);
           if (X.front() < x_start) {
             double xs = X.front();
-            if (!isANumber(xs))
+            if (!std::isfinite(xs))
               continue;
             x_start = xs;
           }
           if (X.back() > x_end) {
             double xe = X.back();
-            if (!isANumber(xe))
+            if (!std::isfinite(xe))
               continue;
             x_end = xe;
           }

--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -969,8 +969,7 @@ QImage Spectrogram::renderImage(const QwtScaleMap &xMap,
       double xmin, xmax;
       mantidFun->getRowXRange(row, xmin, xmax);
       int jmin = -1;
-      if (xmin != std::numeric_limits<double>::infinity() && xmin == xmin &&
-          xmax != std::numeric_limits<double>::infinity() && xmax == xmax) {
+      if (std::isfinite(xmin) && std::isfinite(xmax)) {
         jmin = xMap.transform(xmin) - rect.left();
       } else {
         continue;

--- a/MantidQt/API/src/MantidColorMap.cpp
+++ b/MantidQt/API/src/MantidColorMap.cpp
@@ -13,7 +13,6 @@
 #include <QRgb>
 #include <limits>
 
-#include <boost/math/special_functions/fpclassify.hpp>
 #include "MantidKernel/ConfigService.h"
 #include <qfiledialog.h>
 
@@ -255,7 +254,7 @@ void MantidColorMap::setupDefaultMap() {
 double MantidColorMap::normalize(const QwtDoubleInterval &interval,
                                  double value) const {
   // nan numbers have the property that nan != nan, treat nan as being invalid
-  if (interval.isNull() || m_num_colors == 0 || boost::math::isnan(value))
+  if (interval.isNull() || m_num_colors == 0 || std::isnan(value))
     return m_nan;
 
   const double width = interval.width();

--- a/MantidQt/API/src/MantidQwtWorkspaceData.cpp
+++ b/MantidQt/API/src/MantidQwtWorkspaceData.cpp
@@ -1,6 +1,6 @@
 #include "MantidQtAPI/MantidQwtWorkspaceData.h"
 
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 MantidQwtWorkspaceData::MantidQwtWorkspaceData(bool logScaleY)
     : m_logScaleY(logScaleY), m_minY(0), m_minPositive(0), m_maxY(0),
@@ -35,7 +35,7 @@ void MantidQwtWorkspaceData::calculateYMinAndMax() const {
   for (size_t i = 0; i < size(); ++i) {
     auto val = y(i);
     // skip NaNs
-    if ((boost::math::isnan)(val) || (boost::math::isinf)(val))
+    if (!std::isfinite(val))
       continue;
 
     // Update our values as appropriate

--- a/MantidQt/API/src/SignalRange.cpp
+++ b/MantidQt/API/src/SignalRange.cpp
@@ -131,7 +131,7 @@ QwtDoubleInterval SignalRange::getRange(Mantid::API::IMDIterator *it) {
   do {
     double signal = it->getNormalizedSignal();
     // Skip any 'infs' as it screws up the color scale
-    if (signal != inf) {
+    if (!std::isinf(signal)) {
       if (signal < minSignal)
         minSignal = signal;
       if (signal > maxSignal)

--- a/MantidQt/API/src/SignalRange.cpp
+++ b/MantidQt/API/src/SignalRange.cpp
@@ -1,7 +1,7 @@
 #include "MantidQtAPI/SignalRange.h"
 #include "MantidAPI/IMDIterator.h"
 #include "MantidKernel/MultiThreaded.h"
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 namespace MantidQt {
 namespace API {
 //-------------------------------------------------------------------------
@@ -85,13 +85,13 @@ QwtDoubleInterval SignalRange::getRange(
 
         double signal;
         signal = intervals[i].minValue();
-        if (boost::math::isnan(signal) || boost::math::isinf(signal))
+        if (!std::isfinite(signal))
           continue;
         if (signal < minSignal)
           minSignal = signal;
 
         signal = intervals[i].maxValue();
-        if (boost::math::isnan(signal) || boost::math::isinf(signal))
+        if (!std::isfinite(signal))
           continue;
         if (signal > maxSignal)
           maxSignal = signal;

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentActor.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentActor.cpp
@@ -134,8 +134,7 @@ void InstrumentActor::setUpWorkspace(
   for (size_t i = 0; i < nHist; ++i) {
     const Mantid::MantidVec &values = sharedWorkspace->readX(i);
     double xtest = values.front();
-    if (xtest != std::numeric_limits<double>::infinity()) {
-
+    if (!std::isinf(xtest)) {
       if (xtest < m_WkspBinMinValue) {
         m_WkspBinMinValue = xtest;
       } else if (xtest > m_WkspBinMaxValue) {
@@ -145,7 +144,7 @@ void InstrumentActor::setUpWorkspace(
     }
 
     xtest = values.back();
-    if (xtest != std::numeric_limits<double>::infinity()) {
+    if (!std::isinf(xtest)) {
       if (xtest < m_WkspBinMinValue) {
         m_WkspBinMinValue = xtest;
       } else if (xtest > m_WkspBinMaxValue) {

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentActor.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentActor.cpp
@@ -29,7 +29,7 @@
 #include "MantidKernel/V3D.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <cmath>
 
 #include <QMessageBox>
 #include <QSettings>
@@ -1152,7 +1152,7 @@ void InstrumentActor::setDataIntegrationRange(const double &xmin,
         continue;
       }
       double sum = m_specIntegrs[i];
-      if (boost::math::isinf(sum) || boost::math::isnan(sum)) {
+      if (!std::isfinite(sum)) {
         throw std::runtime_error(
             "The workspace contains values that cannot be displayed (infinite "
             "or NaN).\n"

--- a/MantidQt/MantidWidgets/src/InstrumentView/RotationSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/RotationSurface.cpp
@@ -160,17 +160,13 @@ void RotationSurface::init() {
                         double dV = fabs(m_v_max - m_v_min);
                         double du = dU * 0.05;
                         double dv = dV * 0.05;
-                        if (m_width_max > du &&
-                            m_width_max !=
-                                std::numeric_limits<double>::infinity()) {
+                        if (m_width_max > du && std::isfinite(m_width_max)) {
                           if (du > 0 && !(dU >= m_width_max)) {
                             m_width_max = dU;
                           }
                           du = m_width_max;
                         }
-                        if (m_height_max > dv &&
-                            m_height_max !=
-                                std::numeric_limits<double>::infinity()) {
+                        if (m_height_max > dv && std::isfinite( m_height_max)) {
                           if (dv > 0 && !(dV >= m_height_max)) {
                             m_height_max = dV;
                           }

--- a/MantidQt/MantidWidgets/src/InstrumentView/RotationSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/RotationSurface.cpp
@@ -166,7 +166,7 @@ void RotationSurface::init() {
                           }
                           du = m_width_max;
                         }
-                        if (m_height_max > dv && std::isfinite( m_height_max)) {
+                        if (m_height_max > dv && std::isfinite(m_height_max)) {
                           if (dv > 0 && !(dV >= m_height_max)) {
                             m_height_max = dV;
                           }

--- a/MantidQt/MantidWidgets/src/MWView.cpp
+++ b/MantidQt/MantidWidgets/src/MWView.cpp
@@ -1,5 +1,4 @@
 #include "MantidQtMantidWidgets/MWView.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 // includes for workspace handling
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
@@ -16,6 +15,7 @@
 #include <qwt_color_map.h>
 #include <qwt_double_rect.h>
 // system includes
+#include <cmath>
 
 namespace {
 Mantid::Kernel::Logger g_log("MWView");
@@ -219,8 +219,7 @@ void MWView::checkRangeLimits() {
       max = min;
       min = tmp;
     }
-    if (boost::math::isnan(min) || boost::math::isinf(min) ||
-        boost::math::isnan(max) || boost::math::isinf(max)) {
+    if (!std::isfinite(min) || !std::isfinite(max)) {
       mess << "Dimension " << m_workspace->getDimension(d)->getName()
            << " has a bad range: (";
       mess << min << ", " << max << ")\n";

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -3,7 +3,6 @@
 #include <sstream>
 #include <vector>
 #include <boost/make_shared.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 
 #include "MantidKernel/UsageService.h"
 #include "MantidAPI/CoordTransform.h"
@@ -728,8 +727,7 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
       max = min;
       min = tmp;
     }
-    if (boost::math::isnan(min) || boost::math::isinf(min) ||
-        boost::math::isnan(max) || boost::math::isinf(max)) {
+    if (!std::isfinite(min) || !std::isfinite(max)) {
       mess << "Dimension " << m_ws->getDimension(d)->getName()
            << " has a bad range: (";
       mess << min << ", " << max << ")\n";

--- a/Vates/VatesAPI/src/MetaDataExtractorUtils.cpp
+++ b/Vates/VatesAPI/src/MetaDataExtractorUtils.cpp
@@ -96,17 +96,16 @@ MetaDataExtractorUtils::getMinAndMax(Mantid::API::IMDWorkspace_sptr workspace) {
       double minSignal = DBL_MAX;
       double maxSignal = -DBL_MAX;
 
-      auto inf = std::numeric_limits<double>::infinity();
       for (size_t i = 0; i < iterators.size(); i++) {
         delete iterators[i];
 
         double signal;
         signal = intervals[i].minValue();
-        if (signal != inf && signal < minSignal)
+        if (!std::isinf(signal) && signal < minSignal)
           minSignal = signal;
 
         signal = intervals[i].maxValue();
-        if (signal != inf && signal > maxSignal)
+        if (!std::isinf(signal) && signal > maxSignal)
           maxSignal = signal;
       }
 
@@ -157,7 +156,7 @@ MetaDataExtractorUtils::getRange(Mantid::API::IMDIterator *it) {
     double signal = it->getNormalizedSignal();
 
     // Skip any 'infs' as it screws up the color scale
-    if (signal != inf) {
+    if (!std::isinf(signal)) {
       if (signal == 0.0)
         minSignalZeroCheck = signal;
       if (signal < minSignal && signal > 0.0)

--- a/Vates/VatesAPI/src/vtkMDHistoHex4DFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHex4DFactory.cpp
@@ -5,7 +5,6 @@
 #include "MantidVatesAPI/TimeToTimeStep.h"
 #include "MantidVatesAPI/vtkMDHistoHex4DFactory.h"
 #include "MantidVatesAPI/ProgressAction.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 
 using Mantid::API::IMDWorkspace;
 using Mantid::Kernel::CPUTimer;

--- a/Vates/VatesAPI/src/vtkPeakMarkerFactory.cpp
+++ b/Vates/VatesAPI/src/vtkPeakMarkerFactory.cpp
@@ -1,6 +1,5 @@
 #include "MantidVatesAPI/vtkPeakMarkerFactory.h"
 #include "MantidVatesAPI/ProgressAction.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 #include "MantidAPI/Workspace.h"
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidGeometry/Crystal/PeakShape.h"

--- a/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
+++ b/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
@@ -30,7 +30,6 @@
 #include <vtkVertex.h>
 
 #include <algorithm>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <iterator>
 #include <qwt_double_interval.h>
 


### PR DESCRIPTION
Replace `boost::math::isnan`, `boost:math::isinf` with the appropriate `std` variants.

**To test:**
Tests should pass and code review.
- One should not have includes for `boost/math/special_functions/fpclassify.hpp`
- There should be no `boost::math::is...` in the code
- No check if number is equal to `std::numeric_limits<double>::infinity()`

Fixes #17695.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
