### PR TITLE
Fix display of data in Splatterplot View (VSI)

### DIFF
--- a/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
@@ -193,7 +193,7 @@ void SplatterPlotView::render() {
       builder->createDataRepresentation(src->getOutputPort(0), this->m_view);
   vtkSMPropertyHelper(drep->getProxy(), "Representation").Set(renderType);
   if (!isPeaksWorkspace) {
-    vtkSMPropertyHelper(drep->getProxy(), "Opacity").Set(0.5);
+    vtkSMPropertyHelper(drep->getProxy(), "Opacity").Set(1.0);
     vtkSMPropertyHelper(drep->getProxy(), "GaussianRadius").Set(0.005);
   } else {
     vtkSMPropertyHelper(drep->getProxy(), "LineWidth").Set(2);
@@ -459,7 +459,7 @@ void SplatterPlotView::createPeaksFilter() {
         .Set("Point Gaussian");
     vtkSMPropertyHelper(dataRepresentation->getProxy(), "GaussianRadius")
         .Set(0.005);
-    vtkSMPropertyHelper(dataRepresentation->getProxy(), "Opacity").Set(0.5);
+    vtkSMPropertyHelper(dataRepresentation->getProxy(), "Opacity").Set(1.0);
     dataRepresentation->getProxy()->UpdateVTKObjects();
 
     if (!this->isPeaksWorkspace(this->origSrc)) {


### PR DESCRIPTION
Fixes #17640

The opacity is set to 0.5 by default in the SplatterPlot mode. Apparently there is some issue with the depth peeling in PV5.1.0 when more than view is present. The same faulty behaviour we are seeing in the splatterplot view can be re-created in PV when a data set is opened in two views. 

Setting the opacity to 1.0 avoids any depth peeling and displays the data correctly in the splatterplot view. For now this is probably the easiest solution. 

I still need to verify this, but I think that PV5.1.2 has the fix for this issue. See [here](https://blog.kitware.com/paraview-5-1-2-release-notes/). If this is the case we should switch to this version and reset the old opacity default value.

**To test:**
1. Open the an MDEventWorkspace in the VSI and switch to the splatterplot
   - Confirm that the data is displayed
2. Switch to another view and back
   - Confirm that the data is still being displayed
3. Set the opacity control to anything other than 1.0
   - Confirm that the rendered image disappears
4. Set it back to 1.0
   - Confirm that the rendered image reappears

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
