### PR TITLE
HistogramData rollout: algorithms 71 to 75

### DIFF
--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -199,8 +199,7 @@ void SCDCalibratePanels::exec() {
     auto &yVec = outSpec.mutableY();
     auto &eVec = outSpec.mutableE();
     auto &xVec = outSpec.mutableX();
-    const std::vector<double> zeros(yVec.size(), 0.0);
-    yVec = std::move(zeros);
+    yVec = 0.0;
 
     for (int i = 0; i < nBankPeaks; i++) {
       const DataObjects::Peak &peak = local->getPeak(i);
@@ -438,8 +437,7 @@ void SCDCalibratePanels::findL1(int nPeaks,
   auto &yVec = outSp.mutableY();
   auto &eVec = outSp.mutableE();
   auto &xVec = outSp.mutableX();
-  const std::vector<double> zeros(yVec.size(), 0.0);
-  yVec = std::move(zeros);
+  yVec = 0.0;
 
   for (int i = 0; i < nPeaks; i++) {
     const DataObjects::Peak &peak = peaksWs->getPeak(i);

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -196,10 +196,11 @@ void SCDCalibratePanels::exec() {
             "Workspace2D", 1, 3 * nBankPeaks, 3 * nBankPeaks));
 
     auto &outSpec = q3DWS->getSpectrum(0);
-    MantidVec &yVec = outSpec.dataY();
-    MantidVec &eVec = outSpec.dataE();
-    MantidVec &xVec = outSpec.dataX();
-    std::fill(yVec.begin(), yVec.end(), 0.0);
+    auto &yVec = outSpec.mutableY();
+    auto &eVec = outSpec.mutableE();
+    auto &xVec = outSpec.mutableX();
+    const std::vector<double> zeros(yVec.size(), 0.0);
+    yVec = std::move(zeros);
 
     for (int i = 0; i < nBankPeaks; i++) {
       const DataObjects::Peak &peak = local->getPeak(i);
@@ -381,12 +382,12 @@ void SCDCalibratePanels::exec() {
     ColWksp->getSpectrum(i).setSpectrumNo(specnum_t(bank));
     RowWksp->getSpectrum(i).setSpectrumNo(specnum_t(bank));
     TofWksp->getSpectrum(i).setSpectrumNo(specnum_t(bank));
-    Mantid::MantidVec &ColX = ColWksp->dataX(i);
-    Mantid::MantidVec &ColY = ColWksp->dataY(i);
-    Mantid::MantidVec &RowX = RowWksp->dataX(i);
-    Mantid::MantidVec &RowY = RowWksp->dataY(i);
-    Mantid::MantidVec &TofX = TofWksp->dataX(i);
-    Mantid::MantidVec &TofY = TofWksp->dataY(i);
+    auto &ColX = ColWksp->mutableX(i);
+    auto &ColY = ColWksp->mutableY(i);
+    auto &RowX = RowWksp->mutableX(i);
+    auto &RowY = RowWksp->mutableY(i);
+    auto &TofX = TofWksp->mutableX(i);
+    auto &TofY = TofWksp->mutableY(i);
     int icount = 0;
     for (int j = 0; j < nPeaks; j++) {
       Peak peak = peaksWs->getPeak(j);
@@ -434,10 +435,11 @@ void SCDCalibratePanels::findL1(int nPeaks,
                                                3 * nPeaks));
 
   auto &outSp = L1WS->getSpectrum(0);
-  MantidVec &yVec = outSp.dataY();
-  MantidVec &eVec = outSp.dataE();
-  MantidVec &xVec = outSp.dataX();
-  std::fill(yVec.begin(), yVec.end(), 0.0);
+  auto &yVec = outSp.mutableY();
+  auto &eVec = outSp.mutableE();
+  auto &xVec = outSp.mutableX();
+  const std::vector<double> zeros(yVec.size(), 0.0);
+  yVec = std::move(zeros);
 
   for (int i = 0; i < nPeaks; i++) {
     const DataObjects::Peak &peak = peaksWs->getPeak(i);

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -351,7 +351,7 @@ void SaveIsawPeaks::exec() {
           Workspace2D_sptr wsProfile2D = getProperty("ProfileWorkspace");
           if (wsProfile2D) {
             out << "8";
-            const Mantid::MantidVec &yValues = wsProfile2D->readY(wi);
+            const auto &yValues = wsProfile2D->y(wi);
             for (size_t j = 0; j < yValues.size(); j++) {
               out << std::setw(8) << static_cast<int>(yValues[j]);
               if ((j + 1) % 10 == 0) {

--- a/Framework/CurveFitting/src/Algorithms/ConvertToYSpace.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvertToYSpace.cpp
@@ -235,12 +235,12 @@ bool ConvertToYSpace::convert(const size_t index) {
     const double k1 = std::sqrt(detPar.efixed /
                                 PhysicalConstants::E_mev_toNeutronWavenumberSq);
 
-    auto &outX = m_outputWS->dataX(index);
-    auto &outY = m_outputWS->dataY(index);
-    auto &outE = m_outputWS->dataE(index);
-    const auto &inX = m_inputWS->readX(index);
-    const auto &inY = m_inputWS->readY(index);
-    const auto &inE = m_inputWS->readE(index);
+    auto &outX = m_outputWS->mutableX(index);
+    auto &outY = m_outputWS->mutableY(index);
+    auto &outE = m_outputWS->mutableE(index);
+    const auto &inX = m_inputWS->x(index);
+    const auto &inY = m_inputWS->y(index);
+    const auto &inE = m_inputWS->e(index);
 
     // The t->y mapping flips the order of the axis so we need to reverse it to
     // have a monotonically increasing axis
@@ -255,8 +255,8 @@ bool ConvertToYSpace::convert(const size_t index) {
       outE[outIndex] = prefactor * inE[j];
 
       if (m_qOutputWS) {
-        m_qOutputWS->dataX(index)[outIndex] = ys;
-        m_qOutputWS->dataY(index)[outIndex] = qs;
+        m_qOutputWS->mutableX(index)[outIndex] = ys;
+        m_qOutputWS->mutableY(index)[outIndex] = qs;
       }
     }
     return true;

--- a/Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
@@ -52,9 +52,8 @@ void ConvolveWorkspaces::exec() {
 
   // Cache a few things for later use
   const size_t numHists = ws1->getNumberHistograms();
-  const size_t numBins = ws1->blocksize();
   Workspace2D_sptr outputWS = boost::dynamic_pointer_cast<Workspace2D>(
-      WorkspaceFactory::Instance().create(ws1, numHists, numBins + 1, numBins));
+      WorkspaceFactory::Instance().create(ws1));
 
   // First check that the workspace are the same size
   if (numHists != ws2->getNumberHistograms()) {
@@ -67,10 +66,8 @@ void ConvolveWorkspaces::exec() {
   for (int l = 0; l < static_cast<int>(numHists); ++l) {
     PARALLEL_START_INTERUPT_REGION
     prog->report();
-    const MantidVec &X1 = ws1->readX(l);
-    MantidVec &x = outputWS->dataX(l);
-    x = X1;
-    MantidVec &Yout = outputWS->dataY(l);
+    outputWS->setSharedX(l, ws1->sharedX(l));
+    auto &Yout = outputWS->mutableY(l);
     Convolution conv;
 
     auto res = boost::make_shared<TabulatedFunction>();
@@ -85,7 +82,8 @@ void ConvolveWorkspaces::exec() {
 
     conv.addFunction(fun);
     size_t N = Yout.size();
-    FunctionDomain1DView xView(&x[0], N);
+    const double *firstX = &outputWS->mutableX(l)[0];
+    FunctionDomain1DView xView(firstX, N);
     FunctionValues out(xView);
     conv.function(xView, out);
 

--- a/Framework/CurveFitting/test/Algorithms/ConvertToYSpaceTest.h
+++ b/Framework/CurveFitting/test/Algorithms/ConvertToYSpaceTest.h
@@ -54,9 +54,9 @@ public:
     const size_t npts = ySpOutputWs->blocksize();
 
     // Test a few y-Space values
-    const auto &ySpOutX = ySpOutputWs->readX(0);
-    const auto &ySpOutY = ySpOutputWs->readY(0);
-    const auto &ySpOutE = ySpOutputWs->readE(0);
+    const auto &ySpOutX = ySpOutputWs->x(0);
+    const auto &ySpOutY = ySpOutputWs->y(0);
+    const auto &ySpOutE = ySpOutputWs->e(0);
 
     // X
     TS_ASSERT_DELTA(-18.71348856, ySpOutX.front(), 1e-08);
@@ -72,9 +72,9 @@ public:
     TS_ASSERT_DELTA(138.38603736, ySpOutE.back(), 1e-08);
 
     // Test a few q-Space values
-    const auto &qSpOutX = qSpOutputWs->readX(0);
-    const auto &qSpOutY = qSpOutputWs->readY(0);
-    const auto &qSpOutE = qSpOutputWs->readE(0);
+    const auto &qSpOutX = qSpOutputWs->x(0);
+    const auto &qSpOutY = qSpOutputWs->y(0);
+    const auto &qSpOutE = qSpOutputWs->e(0);
 
     // X
     TS_ASSERT_DELTA(-18.71348856, qSpOutX.front(), 1e-08);

--- a/Framework/CurveFitting/test/Algorithms/ConvolveWorkspacesTest.h
+++ b/Framework/CurveFitting/test/Algorithms/ConvolveWorkspacesTest.h
@@ -23,22 +23,25 @@ using namespace Mantid::DataObjects;
 using namespace Mantid::CurveFitting;
 using namespace Mantid::CurveFitting::Algorithms;
 
+namespace {
+// Functor to generate spline values
+struct NormGaussianFunc1 {
+  double operator()(double x, int) {
+    double sig = 0.1;
+    return exp(-pow(x, 2) / (2 * pow(sig, 2))) / (sqrt(2 * M_PI) * sig);
+  }
+};
+// Functor to generate spline values
+struct NormGaussianFunc2 {
+  double operator()(double x, int) {
+    double sig = sqrt(0.1 * 0.1 + 0.1 * 0.1);
+    return exp(-pow(x, 2) / (2 * pow(sig, 2))) / (sqrt(2 * M_PI) * sig);
+  }
+};
+}
+
 class ConvolveWorkspacesTest : public CxxTest::TestSuite {
 public:
-  // Functor to generate spline values
-  struct NormGaussianFunc1 {
-    double operator()(double x, int) {
-      double sig = 0.1;
-      return exp(-pow(x, 2) / (2 * pow(sig, 2))) / (sqrt(2 * M_PI) * sig);
-    }
-  };
-  // Functor to generate spline values
-  struct NormGaussianFunc2 {
-    double operator()(double x, int) {
-      double sig = sqrt(0.1 * 0.1 + 0.1 * 0.1);
-      return exp(-pow(x, 2) / (2 * pow(sig, 2))) / (sqrt(2 * M_PI) * sig);
-    }
-  };
   void testFunction() {
     ConvolveWorkspaces alg;
 
@@ -82,6 +85,43 @@ public:
     AnalysisDataService::Instance().remove("wksp1");
     AnalysisDataService::Instance().remove("wksp2");
   }
+};
+
+class ConvolveWorkspacesTestPerformance : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ConvolveWorkspacesTestPerformance *createSuite() {
+    return new ConvolveWorkspacesTestPerformance();
+  }
+  static void destroySuite(ConvolveWorkspacesTestPerformance *suite) {
+    delete suite;
+  }
+
+  ConvolveWorkspacesTestPerformance() { FrameworkManager::Instance(); }
+
+  void setUp() override {
+    ws1 = WorkspaceCreationHelper::Create2DWorkspaceFromFunction(
+        NormGaussianFunc1(), 1000, -5.0, 5.0, 0.005, false);
+    ws2 = WorkspaceCreationHelper::Create2DWorkspaceFromFunction(
+        NormGaussianFunc2(), 1000, -5.0, 5.0, 0.005, false);
+    AnalysisDataService::Instance().addOrReplace("wksp1", ws1);
+    AnalysisDataService::Instance().addOrReplace("wksp2", ws2);
+  }
+
+  void tearDown() override { AnalysisDataService::Instance().clear(); }
+
+  void testExec() {
+    ConvolveWorkspaces alg;
+    alg.initialize();
+    alg.setPropertyValue("OutputWorkspace", "Conv");
+    alg.setProperty("Workspace1", "wksp1");
+    alg.setProperty("Workspace2", "wksp2");
+    alg.execute();
+  }
+
+private:
+  Workspace2D_sptr ws1, ws2;
 };
 
 #endif /*ConvolveWorkspacesTEST_H_*/

--- a/Framework/CurveFitting/test/Algorithms/ConvolveWorkspacesTest.h
+++ b/Framework/CurveFitting/test/Algorithms/ConvolveWorkspacesTest.h
@@ -68,10 +68,10 @@ public:
     Workspace2D_sptr ows = alg.getProperty("OutputWorkspace");
 
     for (size_t i = 0; i < ows->getNumberHistograms(); ++i) {
-      const auto &xs2 = ws2->readX(i);
-      const auto &xs = ows->readX(i);
-      const auto &ys2 = ws2->readY(i);
-      const auto &ys = ows->readY(i);
+      const auto &xs2 = ws2->x(i);
+      const auto &xs = ows->x(i);
+      const auto &ys2 = ws2->y(i);
+      const auto &ys = ows->y(i);
 
       // check output for consistency
       for (size_t j = 0; j < ys.size(); ++j) {


### PR DESCRIPTION
#### Description of work

This PR is part of refactoring effort to use the new interface of the HistogramData module.
See https://github.com/mantidproject/mantid/issues/17641 for details.

The following algorithms were refactored to use HistogramData:

```
Framework/Crystal/src/SaveIsawPeaks.cpp
Framework/Crystal/src/SCDCalibratePanels.cpp
Framework/CurveFitting/src/Algorithms/ConvertToYSpace.cpp
Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
```

The following algorithm was _not_ refactored, because it is deprecated:
~~`Framework/CurveFitting/src/Algorithms/Fit1D.cpp`~~

Performance tests were added for:
`Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp`
(because X sharing was added).
No significant performance improvement was observed.
#### To test

Code review.

Fixes #17709 
Internal change, no release notes (potential performance improvements will be added to release notes as part of the umbrella issue).

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
