### PR TITLE
Add git pre-push hook to check and confirm before pushing to master

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+protected_branch='master'  
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [ $protected_branch = $current_branch ]  
+then  
+    read -p "You're about to push master, is that what you intended? [y|n] " -n 1 -r < /dev/tty
+        echo
+	    if echo $REPLY | grep -E '^[Yy]$' > /dev/null
+	        then
+		        exit 0 # push will execute
+			    fi
+			        exit 1 # push will not execute
+				else  
+				    exit 0 # push will execute
+				    fi  

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
 
-protected_branch='master'  
+declare -a protected_branches=("master" "release.*") # Add branches which you want to confirm here. Standard REGEX applies
 current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 
-if [ $protected_branch = $current_branch ]  
-then  
-    read -p "You're about to push master, is that what you intended? [y|n] " -n 1 -r < /dev/tty
-        echo
-	    if echo $REPLY | grep -E '^[Yy]$' > /dev/null
-	        then
-		        exit 0 # push will execute
-			    fi
-			        exit 1 # push will not execute
-				else  
-				    exit 0 # push will execute
-				    fi  
+for i in "${protected_branches[@]}"; do
+    if [ "echo $i | grep -q -E $current_branch" ] # '=~' Operator not available in git bash (msysgit)
+    then  
+        read -p "You're about to push to $current_branch, is that what you intended? [y|n] " -n 1 -r < /dev/tty
+            echo
+            if echo $REPLY | grep -q -E '^[Yy]$' 
+            then
+                exit 0 # push will execute
+            else
+                exit 1 # push will not execute
+                fi
+    fi
+    # Check all remaining before continuing
+done
+exit 0 # No branches matched so not 'protected'

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -185,11 +185,15 @@ if ( GIT_FOUND )
                                                                       ${GIT_TOP_LEVEL}/.git/hooks )
       execute_process ( COMMAND ${CMAKE_COMMAND} -E copy_if_different ${GIT_TOP_LEVEL}/.githooks/commit-msg
                                                                       ${GIT_TOP_LEVEL}/.git/hooks )
+      execute_process ( COMMAND ${CMAKE_COMMAND} -E copy_if_different ${GIT_TOP_LEVEL}/.githooks/pre-push
+                                                                      ${GIT_TOP_LEVEL}/.git/hooks )
     else ()
       execute_process ( COMMAND ${CMAKE_COMMAND} -E create_symlink ${GIT_TOP_LEVEL}/.githooks/pre-commit
                                                                    ${GIT_TOP_LEVEL}/.git/hooks/pre-commit )
       execute_process ( COMMAND ${CMAKE_COMMAND} -E create_symlink ${GIT_TOP_LEVEL}/.githooks/commit-msg
                                                                    ${GIT_TOP_LEVEL}/.git/hooks/commit-msg )
+      execute_process ( COMMAND ${CMAKE_COMMAND} -E create_symlink ${GIT_TOP_LEVEL}/.githooks/pre-push
+                                                                   ${GIT_TOP_LEVEL}/.git/hooks/pre-push )
     endif ()
 
   endif()


### PR DESCRIPTION
Description of work.
This PR asks you if you are sure you want to push directly to master for those times you forgot to checkout the branch you were meant to be working on.
It may require someone with more experience of the hooks in git to check that this will work correctly as I have tested it on a private project with `.git/hooks/pre-push` but not in Mantid with `.githooks/pre-push`

**To test:**
On attempting to push to Mantid it should prompt the user saying they are about to push directly to master are they sure. 

Go to the .githooks folder and execute the script as follows
`bash -x ./pre-push` it should perform exactly as described (prompt if on Master/Release) and exit with `0` if it was meant to push or `1` if not. Checkout various branches with protected names and ensure it correctly selects between 0 and 1

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
