### PR TITLE
Clean up intermediate workspaces

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -147,7 +147,7 @@ class BASISReduction(PythonAlgorithm):
         self.setPropertySettings("NormWavelengthRange", ifDivideByVanadium)
         self.setPropertyGroup("NormWavelengthRange", titleDivideByVanadium)
 
-    #pylint: disable-msg=too-many-branches
+    #pylint: disable=too-many-branches
     def PyExec(self):
         config['default.facility'] = "SNS"
         config['default.instrument'] = self._long_inst

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -147,6 +147,7 @@ class BASISReduction(PythonAlgorithm):
         self.setPropertySettings("NormWavelengthRange", ifDivideByVanadium)
         self.setPropertyGroup("NormWavelengthRange", titleDivideByVanadium)
 
+    #pylint: disable-msg=too-many-branches
     def PyExec(self):
         config['default.facility'] = "SNS"
         config['default.instrument'] = self._long_inst
@@ -259,7 +260,6 @@ class BASISReduction(PythonAlgorithm):
                 sapi.DeleteWorkspace("BASIS_NORM_MASK")  # delete vanadium mask
                 sapi.DeleteWorkspace(self._normWs)  # Delete vanadium S(Q)
 
-            
     def _getRuns(self, rlist, doIndiv=True):
         """
         Create sets of run numbers for analysis. A semicolon indicates a


### PR DESCRIPTION
By default, intermediate workspaces generated during the reduction are now removed at the end. This prevents the user from saving intermediate workspace "BSS_XXXX" (with XXXX some run number) into file BSS_XXXX.nxs. Generation of this file will happen if user saves the Mantid session.

**To test:**
Run the following to normalize separately runs 59671, 59672, and 59673:
`BASISReduction(RunNumbers="59671,59689,59707", DoIndividual=1, EnergyBins=[-120,0.4,120], MomentumTransferBins=[0.3, 0.2, 1.9], DivideByVanadium=1, NormRunNumbers="58183")`

As the algorithm progresses, you will see certain workspaces (`BASIS_NORM_MASK, BSS_58183_norm*, BASIS_MASK, BSS_XXXX, BSS_XXXX_monitors,`), but at the end only the following workspaces should survive:
`BSS_59671_divided_sqw, BSS_59689_divided_sqw, BSS_59707_divided_sqw`

Fixes #17698.

_Does not need to be in the release notes._
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
