### PR TITLE
Update to ParaView 5.1.2

### DIFF
--- a/buildconfig/CMake/ParaViewSetup.cmake
+++ b/buildconfig/CMake/ParaViewSetup.cmake
@@ -1,7 +1,7 @@
 # This file will setup some common items that later setups depend on
 
 # Set the version of ParaView that is compatible with the Mantid code base
-set ( COMPATIBLE_PARAVIEW_VERSION "5.1.0" )
+set ( COMPATIBLE_PARAVIEW_VERSION "5.1.2" )
 
 # Set the name of the OSX application as this tends to be different
 set ( OSX_PARAVIEW_APP "paraview.app" )

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -14,9 +14,9 @@ SCRIPT_DIR=$(dirname "$0")
 BUILDPKG=true
 
 ###############################################################################
-# All node currently have PARAVIEW_DIR=5.1.0 and PARAVIEW_NEXT_DIR=5.0.0
+# All nodes currently have PARAVIEW_DIR=5.1.0 and PARAVIEW_NEXT_DIR=5.1.2
 ###############################################################################
-#export PARAVIEW_DIR=${PARAVIEW_NEXT_DIR}
+export PARAVIEW_DIR=${PARAVIEW_NEXT_DIR}
 
 ###############################################################################
 # Print out the versions of things we are using

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -28,7 +28,7 @@ echo %sha1%
 set VS_VERSION=14
 call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" amd64
 set CM_GENERATOR=Visual Studio 14 2015 Win64
-:: set PARAVIEW_DIR=%PARAVIEW_NEXT_DIR%
+set PARAVIEW_DIR=%PARAVIEW_NEXT_DIR%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Set up the location for local object store outside of the build and source

--- a/docs/source/release/v3.8.0/ui.rst
+++ b/docs/source/release/v3.8.0/ui.rst
@@ -79,7 +79,7 @@ SliceViewer Improvements
 
 VSI Improvements
 ----------------
-* ParaView updated to version 5.1.0
+* ParaView updated to version 5.1.2
 
 Multi-dataset fitting interface improvements
 --------------------------------------------


### PR DESCRIPTION
Updates build scripts to build mantid against ParaView 5.1.2 and bring in fixes for depth peeling (see https://blog.kitware.com/paraview-5-1-2-release-notes/). These fixes address the issue of the broken splatter plot view.

**To test:**

Build Mantid against ParaView 5.1.2 and verify that the splatter plot works.

Fixes #17640 

[RELEASE NOTES](https://github.com/mantidproject/mantid/commit/a887a15d1a1a4da266d46a9e54df3f6ad9f2e10b#diff-1137cc04919456968c181ff05b738d84R82)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
