### PR TITLE
SANS 2D output: Only write valid Q bins

### DIFF
--- a/Framework/DataHandling/src/SaveNISTDAT.cpp
+++ b/Framework/DataHandling/src/SaveNISTDAT.cpp
@@ -58,6 +58,9 @@ void SaveNISTDAT::exec() {
       const MantidVec &EIn = inputWS->readE(i);
 
       for (size_t j = 0; j < XIn.size() - 1; j++) {
+        // Don't write out Q bins without data
+        if (YIn[j] == 0 && EIn[j] == 0)
+          continue;
         // Exclude NaNs
         if (YIn[j] == YIn[j]) {
           out_File << (XIn[j] + XIn[j + 1]) / 2.0;


### PR DESCRIPTION
At the moment, SaveNISTDat saves all the Qxy bins regardless of whether there is data in them.
Because areas of the detector can be masked, some Qxy bins may not get populated. Those will have an intensity of 0+-0. If a Qxy point has a valid I(Qxy)=0, its error will not be 0.

Change SaveNISTDat so that it saves only Qxy points that are not 0+-0.

**To test:**
- Inspect the code.
- Make sure tests pass.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
