### PR TITLE
Fix Vesuvio fitting when no intensity constraints applied.

### DIFF
--- a/scripts/Inelastic/vesuvio/fitting.py
+++ b/scripts/Inelastic/vesuvio/fitting.py
@@ -86,7 +86,7 @@ class FittingOptions(object):
         """
         all_free = (default_vals is not None)
 
-        if all_free:
+        if all_free or (self.intensity_constraints is None):
             function_str = "composite=CompositeFunction,NumDeriv=1;"
         else:
             function_str = "composite=ComptonScatteringCountRate,NumDeriv=1%s;"


### PR DESCRIPTION
Removes the use of a special Vesuvio composite function type when there are no intensity constraints to apply.

The changes are entirely isolated to Vesuvio at ISIS.

**To test:**

The script is in the issue. It will need to be tested at ISIS.

Fixes #17734 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
