### PR TITLE
Histogram Rollout - Algorithms 66-70

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters.h
@@ -14,6 +14,8 @@
 #include "MantidCurveFitting/Functions/ThermalNeutronDtoTOFFunction.h"
 #include "MantidAPI/FunctionDomain.h"
 #include "MantidAPI/FunctionValues.h"
+#include "MantidHistogramData/HistogramX.h"
+#include "MantidHistogramData/HistogramY.h"
 
 namespace Mantid {
 namespace CurveFitting {
@@ -138,15 +140,15 @@ private:
   double calculateD2TOFFunction(API::IFunction_sptr func,
                                 API::FunctionDomain1DVector domain,
                                 API::FunctionValues &values,
-                                const Mantid::MantidVec &rawY,
-                                const Mantid::MantidVec &rawE);
+                                const Mantid::HistogramData::HistogramY &rawY,
+                                const Mantid::HistogramData::HistogramE &rawE);
 
   /// Calculate d-space value from peak's miller index for thermal neutron
   // double calculateDspaceValue(std::vector<int> hkl, double lattice);
 
-  /// Calcualte value n for thermal neutron peak profile
+  /// Calculate value n for thermal neutron peak profile
   void calculateThermalNeutronSpecial(API::IFunction_sptr m_Function,
-                                      std::vector<double> vec_d,
+                                      const HistogramX &xVals,
                                       std::vector<double> &vec_n);
 
   //--------------- Class Variables -------------------

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters.h
@@ -147,9 +147,10 @@ private:
   // double calculateDspaceValue(std::vector<int> hkl, double lattice);
 
   /// Calculate value n for thermal neutron peak profile
-  void calculateThermalNeutronSpecial(API::IFunction_sptr m_Function,
-                                      const HistogramX &xVals,
-                                      std::vector<double> &vec_n);
+  void
+  calculateThermalNeutronSpecial(API::IFunction_sptr m_Function,
+                                 const Mantid::HistogramData::HistogramX &xVals,
+                                 std::vector<double> &vec_n);
 
   //--------------- Class Variables -------------------
   /// Output Workspace containing the dspacing ~ TOF peak positions

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
@@ -47,7 +47,7 @@ public:
   const std::string category() const override;
   /// Summary of algorithms purpose
   const std::string summary() const override {
-    return "Smoothes a set of spectra using a cubic spline. Optionally, this "
+    return "Smooths a set of spectra using a cubic spline. Optionally, this "
            "algorithm can also calculate derivatives up to order 2 as a side "
            "product";
   }
@@ -56,7 +56,7 @@ private:
   /// number of smoothing points to start with
   const int M_START_SMOOTH_POINTS;
 
-  // Overriden methods
+  // Overridden methods
   void init() override;
   void exec() override;
 
@@ -69,7 +69,7 @@ private:
   /// setup an output workspace using meta data from inws and taking a number of
   /// spectra
   API::MatrixWorkspace_sptr
-  setupOutputWorkspace(API::MatrixWorkspace_const_sptr inws,
+  setupOutputWorkspace(const API::MatrixWorkspace_sptr &inws,
                        const int size) const;
 
   /// convert a binned workspace to point data. Uses mean of the bins as point
@@ -80,21 +80,17 @@ private:
   /// Handle converting point data back to histograms
   void convertToHistogram();
 
-  /// set the points used in the spline for smoothing
-  void setSmoothingPoint(const int index, const double xpoint,
-                         const double ypoint) const;
-
   /// choose points to define a spline and smooth the data
-  void selectSmoothingPoints(API::MatrixWorkspace_const_sptr inputWorkspace,
+  void selectSmoothingPoints(const API::MatrixWorkspace_sptr &inputWorkspace,
                              const size_t row);
 
   /// calculate the spline based on the smoothing points chosen
-  void calculateSmoothing(API::MatrixWorkspace_const_sptr inputWorkspace,
+  void calculateSmoothing(const API::MatrixWorkspace_sptr &inputWorkspace,
                           API::MatrixWorkspace_sptr outputWorkspace,
                           const size_t row) const;
 
   /// calculate the derivatives for a set of points on the spline
-  void calculateDerivatives(API::MatrixWorkspace_const_sptr inputWorkspace,
+  void calculateDerivatives(const API::MatrixWorkspace_sptr &inputWorkspace,
                             API::MatrixWorkspace_sptr outputWorkspace,
                             const int order, const size_t row) const;
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
@@ -72,11 +72,6 @@ private:
   setupOutputWorkspace(const API::MatrixWorkspace_sptr &inws,
                        const int size) const;
 
-  /// convert a binned workspace to point data. Uses mean of the bins as point
-  API::MatrixWorkspace_sptr
-
-  convertBinnedData(API::MatrixWorkspace_sptr workspace);
-
   /// Handle converting point data back to histograms
   void convertToHistogram();
 
@@ -86,12 +81,12 @@ private:
 
   /// calculate the spline based on the smoothing points chosen
   void calculateSmoothing(const API::MatrixWorkspace &inputWorkspace,
-                          API::MatrixWorkspace_sptr outputWorkspace,
+                          API::MatrixWorkspace &outputWorkspace,
                           const size_t row) const;
 
   /// calculate the derivatives for a set of points on the spline
   void calculateDerivatives(const API::MatrixWorkspace &inputWorkspace,
-                            API::MatrixWorkspace_sptr outputWorkspace,
+                            API::MatrixWorkspace &outputWorkspace,
                             const int order, const size_t row) const;
 
   /// add a set of smoothing points to the spline
@@ -105,6 +100,11 @@ private:
 
   /// Use an existing fit function to tidy smoothing
   void performAdditionalFitting(API::MatrixWorkspace_sptr ws, const int row);
+
+  /// Converts histogram data to point data later processing
+  /// convert a binned workspace to point data. Uses mean of the bins as point
+  API::MatrixWorkspace_sptr
+  convertBinnedData(API::MatrixWorkspace_sptr workspace);
 
   /// CubicSpline member used to perform smoothing
   boost::shared_ptr<Functions::BSpline> m_cspline;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
@@ -61,22 +61,24 @@ private:
   void exec() override;
 
   /// smooth a single spectrum of the workspace
-  void smoothSpectrum(int index);
-
-  /// Handle converting point data back to histograms
-  void convertToHistogram();
+  void smoothSpectrum(const int index);
 
   /// calculate derivatives for a single spectrum
-  void calculateSpectrumDerivatives(int index, int order);
+  void calculateSpectrumDerivatives(const int index, const int order);
 
   /// setup an output workspace using meta data from inws and taking a number of
   /// spectra
   API::MatrixWorkspace_sptr
-  setupOutputWorkspace(API::MatrixWorkspace_const_sptr inws, int size) const;
+  setupOutputWorkspace(API::MatrixWorkspace_const_sptr inws,
+                       const int size) const;
 
   /// convert a binned workspace to point data. Uses mean of the bins as point
   API::MatrixWorkspace_sptr
+
   convertBinnedData(API::MatrixWorkspace_sptr workspace);
+
+  /// Handle converting point data back to histograms
+  void convertToHistogram();
 
   /// set the points used in the spline for smoothing
   void setSmoothingPoint(const int index, const double xpoint,
@@ -84,17 +86,17 @@ private:
 
   /// choose points to define a spline and smooth the data
   void selectSmoothingPoints(API::MatrixWorkspace_const_sptr inputWorkspace,
-                             size_t row);
+                             const size_t row);
 
   /// calculate the spline based on the smoothing points chosen
   void calculateSmoothing(API::MatrixWorkspace_const_sptr inputWorkspace,
                           API::MatrixWorkspace_sptr outputWorkspace,
-                          size_t row) const;
+                          const size_t row) const;
 
   /// calculate the derivatives for a set of points on the spline
   void calculateDerivatives(API::MatrixWorkspace_const_sptr inputWorkspace,
                             API::MatrixWorkspace_sptr outputWorkspace,
-                            int order, size_t row) const;
+                            const int order, const size_t row) const;
 
   /// add a set of smoothing points to the spline
   void addSmoothingPoints(const std::set<int> &points, const double *xs,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
@@ -63,6 +63,9 @@ private:
   /// smooth a single spectrum of the workspace
   void smoothSpectrum(int index);
 
+  /// Handle converting point data back to histograms
+  void convertToHistogram();
+
   /// calculate derivatives for a single spectrum
   void calculateSpectrumDerivatives(int index, int order);
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
@@ -81,16 +81,16 @@ private:
   void convertToHistogram();
 
   /// choose points to define a spline and smooth the data
-  void selectSmoothingPoints(const API::MatrixWorkspace_sptr &inputWorkspace,
+  void selectSmoothingPoints(const API::MatrixWorkspace &inputWorkspace,
                              const size_t row);
 
   /// calculate the spline based on the smoothing points chosen
-  void calculateSmoothing(const API::MatrixWorkspace_sptr &inputWorkspace,
+  void calculateSmoothing(const API::MatrixWorkspace &inputWorkspace,
                           API::MatrixWorkspace_sptr outputWorkspace,
                           const size_t row) const;
 
   /// calculate the derivatives for a set of points on the spline
-  void calculateDerivatives(const API::MatrixWorkspace_sptr &inputWorkspace,
+  void calculateDerivatives(const API::MatrixWorkspace &inputWorkspace,
                             API::MatrixWorkspace_sptr outputWorkspace,
                             const int order, const size_t row) const;
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
@@ -23,6 +23,7 @@ namespace Algorithms {
 //---------------------------------------------------------------------------
 struct DetectorParams;
 
+
 /**
 
 Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
@@ -91,8 +92,8 @@ private:
       const DetectorParams &detPar,
       const CurveFitting::Functions::ResolutionParams &detRes);
   /// Compute a TOF spectrum for the given inputs & spectrum
-  void
-  calculateTofSpectrum(std::vector<double> &result,
+  std::vector<double>
+  calculateTofSpectrum(const std::vector<double> &result,
                        std::vector<double> &tmpWork, const size_t wsIndex,
                        const DetectorParams &detpar,
                        const CurveFitting::Functions::ResolutionParams &respar);

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
@@ -23,7 +23,6 @@ namespace Algorithms {
 //---------------------------------------------------------------------------
 struct DetectorParams;
 
-
 /**
 
 Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
@@ -92,7 +92,7 @@ private:
       const CurveFitting::Functions::ResolutionParams &detRes);
   /// Compute a TOF spectrum for the given inputs & spectrum
   std::vector<double>
-  calculateTofSpectrum(const std::vector<double> &result,
+  calculateTofSpectrum(const std::vector<double> &inSpectrum,
                        std::vector<double> &tmpWork, const size_t wsIndex,
                        const DetectorParams &detpar,
                        const CurveFitting::Functions::ResolutionParams &respar);

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
@@ -793,11 +793,10 @@ void RefinePowderInstrumentParameters::getD2TOFFuncParamNames(
 
 /** Calculate the function
   */
-double RefinePowderInstrumentParameters::calculateD2TOFFunction(API::IFunction_sptr func,
-                              API::FunctionDomain1DVector domain,
-                              API::FunctionValues &values,
-                              const Mantid::HistogramData::HistogramY &rawY,
-                              const Mantid::HistogramData::HistogramE &rawE) {
+double RefinePowderInstrumentParameters::calculateD2TOFFunction(
+    API::IFunction_sptr func, API::FunctionDomain1DVector domain,
+    API::FunctionValues &values, const Mantid::HistogramData::HistogramY &rawY,
+    const Mantid::HistogramData::HistogramE &rawE) {
   // 1. Check validity
   if (!func) {
     throw std::runtime_error("m_Function has not been initialized!");

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
@@ -323,8 +323,8 @@ void RefinePowderInstrumentParameters::fitInstrumentParameters() {
     m_dataWS->mutableY(2)[i] = m_dataWS->y(0)[i] - values[i];
   }
 
-  double selfchi2 = calculateD2TOFFunction(m_Function, domain, values,
-                                           rawY.rawData(), rawE.rawData());
+  double selfchi2 =
+      calculateD2TOFFunction(m_Function, domain, values, rawY, rawE);
   cout << "Homemade Chi^2 = " << selfchi2 << '\n';
 
   // 5. Update fitted parameters

--- a/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
@@ -98,7 +98,7 @@ void SplineBackground::exec() {
   for (MantidVec::size_type i = 0; i < yInputVals.size(); ++i) {
     if (isMasked && masked[i])
       continue;
-	gsl_vector_set(x, j, xInputPoints[i]);
+    gsl_vector_set(x, j, xInputPoints[i]);
     gsl_vector_set(y, j, yInputVals[i]);
     gsl_vector_set(
         w, j, eInputVals[i] > 0. ? 1. / (eInputVals[i] * eInputVals[i]) : 0.);

--- a/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
@@ -47,8 +47,6 @@ void SplineBackground::exec() {
     throw std::out_of_range("WorkspaceIndex is out of range.");
 
   const auto &yInputVals = inWS->y(spec);
-  const bool isHistogram = inWS->isHistogramData();
-
   const int ncoeffs = getProperty("NCoeff");
   const int k = 4; // order of the spline + 1 (cubic)
   const int nbreak = ncoeffs - (k - 2);

--- a/Framework/CurveFitting/src/Algorithms/SplineInterpolation.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineInterpolation.cpp
@@ -105,7 +105,7 @@ void SplineInterpolation::exec() {
 
     // compare the data set against our spline
     calculateSpline(mwspt, outputWorkspace, i);
-    outputWorkspace->setX(i, mws->refX(0));
+    outputWorkspace->setSharedX(i, mws->sharedX(0));
 
     // check if we want derivatives
     if (order > 0) {
@@ -115,7 +115,7 @@ void SplineInterpolation::exec() {
       // calculate the derivatives for each order chosen
       for (int j = 0; j < order; ++j) {
         vAxis->setValue(j, j + 1);
-        derivs[i]->setX(j, mws->refX(0));
+        derivs[i]->setSharedX(j, mws->sharedX(0));
         calculateDerivatives(mwspt, derivs[i], j + 1);
       }
 
@@ -169,8 +169,8 @@ SplineInterpolation::setupOutputWorkspace(API::MatrixWorkspace_sptr mws,
 MatrixWorkspace_sptr
 SplineInterpolation::convertBinnedData(MatrixWorkspace_sptr workspace) const {
   if (workspace->isHistogramData()) {
-    size_t histNo = workspace->getNumberHistograms();
-    size_t size = workspace->readY(0).size();
+    const size_t histNo = workspace->getNumberHistograms();
+    const size_t size = workspace->y(0).size();
 
     // make a new workspace for the point data
     MatrixWorkspace_sptr pointWorkspace =
@@ -178,16 +178,14 @@ SplineInterpolation::convertBinnedData(MatrixWorkspace_sptr workspace) const {
 
     // loop over each histogram
     for (size_t i = 0; i < histNo; ++i) {
-      const auto &xValues = workspace->readX(i);
-      const auto &yValues = workspace->readY(i);
+      const auto &xValues = workspace->x(i);
+      pointWorkspace->setSharedY(i, workspace->sharedY(i));
 
-      auto &newXValues = pointWorkspace->dataX(i);
-      auto &newYValues = pointWorkspace->dataY(i);
+      auto &newXValues = pointWorkspace->mutableX(i);
 
       // set x values to be average of bin bounds
       for (size_t j = 0; j < size; ++j) {
         newXValues[j] = (xValues[j] + xValues[j + 1]) / 2;
-        newYValues[j] = yValues[j];
       }
     }
 
@@ -205,8 +203,8 @@ SplineInterpolation::convertBinnedData(MatrixWorkspace_sptr workspace) const {
  */
 void SplineInterpolation::setInterpolationPoints(
     MatrixWorkspace_const_sptr inputWorkspace, const int row) const {
-  const auto &xIn = inputWorkspace->readX(row);
-  const auto &yIn = inputWorkspace->readY(row);
+  const auto &xIn = inputWorkspace->x(row);
+  const auto &yIn = inputWorkspace->y(row);
   int size = static_cast<int>(xIn.size());
 
   // pass x attributes and y parameters to CubicSpline
@@ -228,9 +226,9 @@ void SplineInterpolation::calculateDerivatives(
     API::MatrixWorkspace_const_sptr inputWorkspace,
     API::MatrixWorkspace_sptr outputWorkspace, int order) const {
   // get x and y parameters from workspaces
-  size_t nData = inputWorkspace->readY(0).size();
-  const double *xValues = inputWorkspace->readX(0).data();
-  double *yValues = outputWorkspace->dataY(order - 1).data();
+  const size_t nData = inputWorkspace->y(0).size();
+  const double *xValues = &(inputWorkspace->x(0)[0]);
+  double *yValues = &(outputWorkspace->mutableY(order - 1)[0]);
 
   // calculate the derivatives
   m_cspline->derivative1D(yValues, xValues, nData, order);
@@ -246,9 +244,9 @@ void SplineInterpolation::calculateSpline(
     MatrixWorkspace_const_sptr inputWorkspace,
     MatrixWorkspace_sptr outputWorkspace, int row) const {
   // setup input parameters
-  size_t nData = inputWorkspace->readY(0).size();
-  const double *xValues = inputWorkspace->readX(0).data();
-  double *yValues = outputWorkspace->dataY(row).data();
+  const size_t nData = inputWorkspace->y(0).size();
+  const double *xValues = &(inputWorkspace->x(0)[0]);
+  double *yValues = &(outputWorkspace->mutableY(row)[0]);
 
   // calculate the interpolation
   m_cspline->function1D(yValues, xValues, nData);

--- a/Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
@@ -113,7 +113,7 @@ void SplineSmoothing::exec() {
  *
  * @param index :: index of the spectrum to smooth
  */
-void SplineSmoothing::smoothSpectrum(int index) {
+void SplineSmoothing::smoothSpectrum(const int index) {
   m_cspline = boost::make_shared<BSpline>();
   m_cspline->setAttributeValue("Uniform", false);
 
@@ -131,19 +131,13 @@ void SplineSmoothing::smoothSpectrum(int index) {
   calculateSmoothing(m_inputWorkspacePointData, m_outputWorkspace, index);
 }
 
-void SplineSmoothing::convertToHistogram() {
-  auto alg = createChildAlgorithm("ConvertToHistogram");
-  alg->setProperty("InputWorkspace", m_outputWorkspace);
-  alg->execute();
-  m_outputWorkspace = alg->getProperty("OutputWorkspace");
-}
-
 /** Calculate the derivatives for each spectrum in the input workspace
  *
  * @param index :: index of the spectrum
  * @param order :: order of derivatives to calculate
  */
-void SplineSmoothing::calculateSpectrumDerivatives(int index, int order) {
+void SplineSmoothing::calculateSpectrumDerivatives(const int index,
+                                                   const int order) {
   if (order > 0) {
     API::MatrixWorkspace_sptr derivs =
         setupOutputWorkspace(m_inputWorkspace, order);
@@ -184,7 +178,7 @@ void SplineSmoothing::performAdditionalFitting(MatrixWorkspace_sptr ws,
  */
 API::MatrixWorkspace_sptr
 SplineSmoothing::setupOutputWorkspace(API::MatrixWorkspace_const_sptr inws,
-                                      int size) const {
+                                      const int size) const {
   MatrixWorkspace_sptr outputWorkspace =
       WorkspaceFactory::Instance().create(inws, size);
 
@@ -214,6 +208,17 @@ SplineSmoothing::convertBinnedData(MatrixWorkspace_sptr workspace) {
   } else {
     return workspace;
   }
+}
+
+/**
+* Converts the output workspace back to histogram data if it was
+* converted to point data previously
+*/
+void SplineSmoothing::convertToHistogram() {
+  auto alg = createChildAlgorithm("ConvertToHistogram");
+  alg->setProperty("InputWorkspace", m_outputWorkspace);
+  alg->execute();
+  m_outputWorkspace = alg->getProperty("OutputWorkspace");
 }
 
 /** Calculate smoothing of the data using the spline
@@ -246,7 +251,8 @@ void SplineSmoothing::calculateSmoothing(
  */
 void SplineSmoothing::calculateDerivatives(
     API::MatrixWorkspace_const_sptr inputWorkspace,
-    API::MatrixWorkspace_sptr outputWorkspace, int order, size_t row) const {
+    API::MatrixWorkspace_sptr outputWorkspace, const int order,
+    const size_t row) const {
   const auto &xIn = inputWorkspace->x(row);
   const double *xValues = &(xIn[0]);
   double *yValues = &(outputWorkspace->mutableY(order - 1)[0]);
@@ -318,7 +324,7 @@ void SplineSmoothing::addSmoothingPoints(const std::set<int> &points,
  * @param row :: The row of spectra to use
  */
 void SplineSmoothing::selectSmoothingPoints(
-    MatrixWorkspace_const_sptr inputWorkspace, size_t row) {
+    MatrixWorkspace_const_sptr inputWorkspace, const size_t row) {
   std::set<int> smoothPts;
   const auto &xs = inputWorkspace->x(row);
   const auto &ys = inputWorkspace->y(row);

--- a/Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
@@ -121,12 +121,7 @@ void SplineSmoothing::smoothSpectrum(const int index) {
   selectSmoothingPoints(m_inputWorkspacePointData, index);
   performAdditionalFitting(m_inputWorkspacePointData, index);
 
-  if (m_inputWorkspace->isHistogramData()) {
-    m_outputWorkspace->setSharedX(index,
-                                  m_inputWorkspacePointData->sharedX(index));
-  } else {
-    m_outputWorkspace->setSharedX(index, m_inputWorkspace->sharedX(index));
-  }
+  m_outputWorkspace->setPoints(index, m_inputWorkspace->points(index));
 
   calculateSmoothing(m_inputWorkspacePointData, m_outputWorkspace, index);
 }
@@ -177,7 +172,7 @@ void SplineSmoothing::performAdditionalFitting(MatrixWorkspace_sptr ws,
  * @return The pointer to the newly created workspace
  */
 API::MatrixWorkspace_sptr
-SplineSmoothing::setupOutputWorkspace(API::MatrixWorkspace_const_sptr inws,
+SplineSmoothing::setupOutputWorkspace(const API::MatrixWorkspace_sptr &inws,
                                       const int size) const {
   MatrixWorkspace_sptr outputWorkspace =
       WorkspaceFactory::Instance().create(inws, size);
@@ -229,7 +224,7 @@ void SplineSmoothing::convertToHistogram() {
  * @param row :: The row of spectra to use
  */
 void SplineSmoothing::calculateSmoothing(
-    MatrixWorkspace_const_sptr inputWorkspace,
+    const MatrixWorkspace_sptr &inputWorkspace,
     MatrixWorkspace_sptr outputWorkspace, size_t row) const {
   // define the spline's parameters
   const auto &xIn = inputWorkspace->x(row);
@@ -250,7 +245,7 @@ void SplineSmoothing::calculateSmoothing(
  * @param row :: The row of spectra to use
  */
 void SplineSmoothing::calculateDerivatives(
-    API::MatrixWorkspace_const_sptr inputWorkspace,
+    const API::MatrixWorkspace_sptr &inputWorkspace,
     API::MatrixWorkspace_sptr outputWorkspace, const int order,
     const size_t row) const {
   const auto &xIn = inputWorkspace->x(row);
@@ -324,7 +319,7 @@ void SplineSmoothing::addSmoothingPoints(const std::set<int> &points,
  * @param row :: The row of spectra to use
  */
 void SplineSmoothing::selectSmoothingPoints(
-    MatrixWorkspace_const_sptr inputWorkspace, const size_t row) {
+    const MatrixWorkspace_sptr &inputWorkspace, const size_t row) {
   std::set<int> smoothPts;
   const auto &xs = inputWorkspace->x(row);
   const auto &ys = inputWorkspace->y(row);

--- a/Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
@@ -118,12 +118,12 @@ void SplineSmoothing::smoothSpectrum(const int index) {
   m_cspline->setAttributeValue("Uniform", false);
 
   // choose some smoothing points from input workspace
-  selectSmoothingPoints(m_inputWorkspacePointData, index);
+  selectSmoothingPoints(*m_inputWorkspacePointData, index);
   performAdditionalFitting(m_inputWorkspacePointData, index);
 
   m_outputWorkspace->setPoints(index, m_inputWorkspace->points(index));
 
-  calculateSmoothing(m_inputWorkspacePointData, m_outputWorkspace, index);
+  calculateSmoothing(*m_inputWorkspacePointData, m_outputWorkspace, index);
 }
 
 /** Calculate the derivatives for each spectrum in the input workspace
@@ -139,7 +139,7 @@ void SplineSmoothing::calculateSpectrumDerivatives(const int index,
 
     for (int j = 0; j < order; ++j) {
       derivs->setSharedX(j, m_inputWorkspace->sharedX(index));
-      calculateDerivatives(m_inputWorkspacePointData, derivs, j + 1, index);
+      calculateDerivatives(*m_inputWorkspacePointData, derivs, j + 1, index);
     }
 
     m_derivativeWorkspaceGroup->addWorkspace(derivs);
@@ -172,7 +172,7 @@ void SplineSmoothing::performAdditionalFitting(MatrixWorkspace_sptr ws,
  * @return The pointer to the newly created workspace
  */
 API::MatrixWorkspace_sptr
-SplineSmoothing::setupOutputWorkspace(const API::MatrixWorkspace_sptr &inws,
+SplineSmoothing::setupOutputWorkspace(const MatrixWorkspace_sptr &inws,
                                       const int size) const {
   MatrixWorkspace_sptr outputWorkspace =
       WorkspaceFactory::Instance().create(inws, size);
@@ -223,11 +223,11 @@ void SplineSmoothing::convertToHistogram() {
  * @param outputWorkspace :: The output workspace
  * @param row :: The row of spectra to use
  */
-void SplineSmoothing::calculateSmoothing(
-    const MatrixWorkspace_sptr &inputWorkspace,
-    MatrixWorkspace_sptr outputWorkspace, size_t row) const {
+void SplineSmoothing::calculateSmoothing(const MatrixWorkspace &inputWorkspace,
+                                         MatrixWorkspace_sptr outputWorkspace,
+                                         size_t row) const {
   // define the spline's parameters
-  const auto &xIn = inputWorkspace->x(row);
+  const auto &xIn = inputWorkspace.x(row);
   const size_t nData = xIn.size();
   const double *xValues = &(xIn[0]);
   double *yValues = &(outputWorkspace->mutableY(row)[0]);
@@ -245,10 +245,10 @@ void SplineSmoothing::calculateSmoothing(
  * @param row :: The row of spectra to use
  */
 void SplineSmoothing::calculateDerivatives(
-    const API::MatrixWorkspace_sptr &inputWorkspace,
+    const MatrixWorkspace &inputWorkspace,
     API::MatrixWorkspace_sptr outputWorkspace, const int order,
     const size_t row) const {
-  const auto &xIn = inputWorkspace->x(row);
+  const auto &xIn = inputWorkspace.x(row);
   const double *xValues = &(xIn[0]);
   double *yValues = &(outputWorkspace->mutableY(order - 1)[0]);
   const size_t nData = xIn.size();
@@ -319,10 +319,10 @@ void SplineSmoothing::addSmoothingPoints(const std::set<int> &points,
  * @param row :: The row of spectra to use
  */
 void SplineSmoothing::selectSmoothingPoints(
-    const MatrixWorkspace_sptr &inputWorkspace, const size_t row) {
+    const MatrixWorkspace &inputWorkspace, const size_t row) {
   std::set<int> smoothPts;
-  const auto &xs = inputWorkspace->x(row);
-  const auto &ys = inputWorkspace->y(row);
+  const auto &xs = inputWorkspace.x(row);
+  const auto &ys = inputWorkspace.y(row);
 
   // retrieving number of breaks
   int maxBreaks = static_cast<int>(getProperty("MaxNumberOfBreaks"));

--- a/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
@@ -148,10 +148,10 @@ void VesuvioCalculateGammaBackground::exec() {
 bool VesuvioCalculateGammaBackground::calculateBackground(
     const size_t inputIndex, const size_t outputIndex) {
   // Copy X values
-  m_backgroundWS->setX(outputIndex, m_inputWS->refX(inputIndex));
-  m_correctedWS->setX(outputIndex, m_inputWS->refX(inputIndex));
+  m_backgroundWS->setSharedX(outputIndex, m_inputWS->sharedX(inputIndex));
+  m_correctedWS->setSharedX(outputIndex, m_inputWS->sharedX(inputIndex));
   // Copy errors to corrected
-  m_correctedWS->dataE(outputIndex) = m_inputWS->readE(inputIndex);
+  m_correctedWS->setSharedE(outputIndex, m_inputWS->sharedE(inputIndex));
 
   try {
     const auto &inSpec = m_inputWS->getSpectrum(inputIndex);
@@ -166,7 +166,7 @@ bool VesuvioCalculateGammaBackground::calculateBackground(
       g_log.information("Spectrum " + std::to_string(spectrumNo) +
                         " not in forward scatter range. Skipping correction.");
       // Leave background at 0 and just copy data to corrected
-      m_correctedWS->dataY(outputIndex) = m_inputWS->readY(inputIndex);
+      m_correctedWS->setSharedY(outputIndex, m_inputWS->sharedY(inputIndex));
     }
     return true;
   } catch (Exception::NotFoundError &) {
@@ -196,11 +196,11 @@ void VesuvioCalculateGammaBackground::applyCorrection(
   // Compute total counts from input data, (detector-foil) contributions
   // assume constant binning
   const size_t nbins = m_correctedWS->blocksize();
-  const auto &inY = m_inputWS->readY(inputIndex);
-  auto &detY = m_correctedWS->dataY(outputIndex);
-  auto &foilY = m_backgroundWS->dataY(outputIndex);
-  const double deltaT = m_correctedWS->readX(outputIndex)[1] -
-                        m_correctedWS->readX(outputIndex)[0];
+  const auto &inY = m_inputWS->y(inputIndex);
+  auto &detY = m_correctedWS->mutableY(outputIndex);
+  auto &foilY = m_backgroundWS->mutableY(outputIndex);
+  const double deltaT =
+      m_correctedWS->x(outputIndex)[1] - m_correctedWS->x(outputIndex)[0];
 
   double dataCounts(0.0), simulCounts(0.0);
   for (size_t j = 0; j < nbins; ++j) {
@@ -241,9 +241,10 @@ void VesuvioCalculateGammaBackground::calculateSpectrumFromDetector(
   // Compute a time of flight spectrum convolved with a Voigt resolution
   // function for each mass
   // at the detector point & sum to a single spectrum
-  auto &ctdet = m_correctedWS->dataY(outputIndex);
+  auto &ctdet = m_correctedWS->mutableY(outputIndex);
   std::vector<double> tmpWork(ctdet.size());
-  calculateTofSpectrum(ctdet, tmpWork, outputIndex, detPar, detRes);
+  ctdet = calculateTofSpectrum(ctdet.rawData(), tmpWork, outputIndex, detPar,
+                               detRes);
   // Correct for distance to the detector: 0.5/l2^2
   const double detDistCorr = 0.5 / detPar.l2 / detPar.l2;
   std::transform(ctdet.begin(), ctdet.end(), ctdet.begin(),
@@ -268,7 +269,7 @@ void VesuvioCalculateGammaBackground::calculateBackgroundFromFoils(
 
   const size_t nxvalues = m_backgroundWS->blocksize();
   std::vector<double> foilSpectrum(nxvalues);
-  auto &ctfoil = m_backgroundWS->dataY(outputIndex);
+  auto &ctfoil = m_backgroundWS->mutableY(outputIndex);
 
   // Compute (C1 - C0) where C1 is counts in pos 1 and C0 counts in pos 0
   assert(m_foils0.size() == m_foils1.size());
@@ -351,7 +352,8 @@ void VesuvioCalculateGammaBackground::calculateBackgroundSingleFoil(
 
       // Spectrum for this position
       singleElement.assign(nvalues, 0.0);
-      calculateTofSpectrum(singleElement, tmpWork, wsIndex, foilPar, foilRes);
+      singleElement = calculateTofSpectrum(singleElement, tmpWork, wsIndex,
+                                           foilPar, foilRes);
 
       // Correct for absorption & distance
       const double den = (elementPos.Z() * cos(thetaZeroRad) +
@@ -372,21 +374,21 @@ void VesuvioCalculateGammaBackground::calculateBackgroundSingleFoil(
 
 /**
 * Uses the compton profile functions to compute a particular mass spectrum
-* @param result [Out] The value of the computed spectrum
-* @param tmpWork [In] Pre-allocated working area that will be overwritten
+* @param inSpectrum The value of the computed spectrum
+* @param tmpWork Pre-allocated working area that will be overwritten
 * @param wsIndex Index on the output background workspace that gives the X
 * values to use
 * @param detpar Struct containing parameters about the detector
 * @param respar Struct containing parameters about the resolution
 */
-void VesuvioCalculateGammaBackground::calculateTofSpectrum(
-    std::vector<double> &result, std::vector<double> &tmpWork,
+std::vector<double> VesuvioCalculateGammaBackground::calculateTofSpectrum(
+    const std::vector<double> &result, std::vector<double> &tmpWork,
     const size_t wsIndex, const DetectorParams &detpar,
     const ResolutionParams &respar) {
   assert(result.size() == tmpWork.size());
 
   // Assumes the input is in seconds, transform it temporarily
-  auto &tseconds = m_backgroundWS->dataX(wsIndex);
+  auto &tseconds = m_backgroundWS->mutableX(wsIndex);
   std::transform(tseconds.begin(), tseconds.end(), tseconds.begin(),
                  std::bind2nd(std::multiplies<double>(), 1e-6));
 
@@ -395,6 +397,8 @@ void VesuvioCalculateGammaBackground::calculateTofSpectrum(
   // we can't static_cast though due to the virtual inheritance with IFunction
   auto profileFunction = boost::dynamic_pointer_cast<CompositeFunction>(
       FunctionFactory::Instance().createInitialized(m_profileFunction));
+
+  std::vector<double> correctedVals(result);
 
   for (size_t i = 0; i < m_npeaks; ++i) {
     auto profile =
@@ -406,17 +410,19 @@ void VesuvioCalculateGammaBackground::calculateTofSpectrum(
     // Fix the Mass parameter
     profile->fix(0);
 
-    profile->cacheYSpaceValues(tseconds, false, detpar, respar);
+    profile->cacheYSpaceValues(tseconds.rawData(), false, detpar, respar);
 
     profile->massProfile(tmpWork.data(), tmpWork.size());
     // Add to final result
-    std::transform(result.begin(), result.end(), tmpWork.begin(),
-                   result.begin(), std::plus<double>());
+
+    std::transform(correctedVals.begin(), correctedVals.end(), tmpWork.begin(),
+                   correctedVals.begin(), std::plus<double>());
     m_progress->report();
   }
   // Put X back microseconds
   std::transform(tseconds.begin(), tseconds.end(), tseconds.begin(),
                  std::bind2nd(std::multiplies<double>(), 1e6));
+  return correctedVals;
 }
 
 /**

--- a/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
@@ -382,7 +382,7 @@ void VesuvioCalculateGammaBackground::calculateBackgroundSingleFoil(
 * @param respar Struct containing parameters about the resolution
 */
 std::vector<double> VesuvioCalculateGammaBackground::calculateTofSpectrum(
-    const std::vector<double> &result, std::vector<double> &tmpWork,
+    const std::vector<double> &inSpectrum, std::vector<double> &tmpWork,
     const size_t wsIndex, const DetectorParams &detpar,
     const ResolutionParams &respar) {
   assert(result.size() == tmpWork.size());

--- a/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
@@ -385,7 +385,7 @@ std::vector<double> VesuvioCalculateGammaBackground::calculateTofSpectrum(
     const std::vector<double> &inSpectrum, std::vector<double> &tmpWork,
     const size_t wsIndex, const DetectorParams &detpar,
     const ResolutionParams &respar) {
-  assert(result.size() == tmpWork.size());
+  assert(inSpectrum.size() == tmpWork.size());
 
   // Assumes the input is in seconds, transform it temporarily
   auto &tseconds = m_backgroundWS->mutableX(wsIndex);
@@ -398,7 +398,7 @@ std::vector<double> VesuvioCalculateGammaBackground::calculateTofSpectrum(
   auto profileFunction = boost::dynamic_pointer_cast<CompositeFunction>(
       FunctionFactory::Instance().createInitialized(m_profileFunction));
 
-  std::vector<double> correctedVals(result);
+  std::vector<double> correctedVals(inSpectrum);
 
   for (size_t i = 0; i < m_npeaks; ++i) {
     auto profile =

--- a/Framework/CurveFitting/test/Algorithms/SplineBackgroundTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SplineBackgroundTest.h
@@ -57,61 +57,59 @@ public:
   }
 };
 
-class SplineBackgroundTestPerformance : public CxxTest::TestSuite
-{
+class SplineBackgroundTestPerformance : public CxxTest::TestSuite {
 
 public:
-	void setUp() {
-		constexpr size_t nspec = 1;
-		constexpr double xRangeStart = 0.1;
-		constexpr double xRangeEnd = 2500.1;
-		constexpr double xRangeStep = 0.1;
+  void setUp() {
+    constexpr size_t nspec = 1;
+    constexpr double xRangeStart = 0.1;
+    constexpr double xRangeEnd = 2500.1;
+    constexpr double xRangeStep = 0.1;
 
+    ws = WorkspaceCreationHelper::Create2DWorkspaceFromFunction(
+        SinFunction(), nspec, xRangeStart, xRangeEnd, xRangeStep, true);
+    WorkspaceCreationHelper::addNoise(ws, 0.1);
+    // Mask some bins out to test that functionality
+    const size_t nbins = 101;
+    int toMask(static_cast<int>(0.75 * nbins));
 
-		ws = WorkspaceCreationHelper::Create2DWorkspaceFromFunction(
-			SinFunction(), nspec, xRangeStart, xRangeEnd, xRangeStep, true);
-		WorkspaceCreationHelper::addNoise(ws, 0.1);
-		// Mask some bins out to test that functionality
-		const size_t nbins = 101;
-		int toMask(static_cast<int>(0.75*nbins));
+    ws->maskBin(0, toMask - 1);
+    ws->maskBin(0, toMask);
+    ws->maskBin(0, toMask + 1);
 
-		ws->maskBin(0, toMask - 1);
-		ws->maskBin(0, toMask);
-		ws->maskBin(0, toMask + 1);
+    ws->getAxis(0)->unit() = Kernel::UnitFactory::Instance().create("TOF");
 
-		ws->getAxis(0)->unit() = Kernel::UnitFactory::Instance().create("TOF");
-		
-		WorkspaceCreationHelper::storeWS(inputWsName, ws);
+    WorkspaceCreationHelper::storeWS(inputWsName, ws);
 
-		SplineBackgroundAlg = Mantid::API::FrameworkManager::Instance().createAlgorithm(
-			"SplineBackground");
-		SplineBackgroundAlg->initialize();
-		SplineBackgroundAlg->setPropertyValue("InputWorkspace", inputWsName);
-		SplineBackgroundAlg->setPropertyValue("OutputWorkspace", outputWsName);
-		SplineBackgroundAlg->setPropertyValue("WorkspaceIndex", "0");
-		
-		SplineBackgroundAlg->setRethrows(true);
-	}
+    SplineBackgroundAlg =
+        Mantid::API::FrameworkManager::Instance().createAlgorithm(
+            "SplineBackground");
+    SplineBackgroundAlg->initialize();
+    SplineBackgroundAlg->setPropertyValue("InputWorkspace", inputWsName);
+    SplineBackgroundAlg->setPropertyValue("OutputWorkspace", outputWsName);
+    SplineBackgroundAlg->setPropertyValue("WorkspaceIndex", "0");
 
-	void testSplineBackgroundPerformance() {
-		TS_ASSERT_THROWS_NOTHING(SplineBackgroundAlg->execute());
-	}
+    SplineBackgroundAlg->setRethrows(true);
+  }
 
-	void tearDown() {
-		WorkspaceCreationHelper::removeWS(inputWsName);
-		WorkspaceCreationHelper::removeWS(outputWsName);
-	}
+  void testSplineBackgroundPerformance() {
+    TS_ASSERT_THROWS_NOTHING(SplineBackgroundAlg->execute());
+  }
+
+  void tearDown() {
+    WorkspaceCreationHelper::removeWS(inputWsName);
+    WorkspaceCreationHelper::removeWS(outputWsName);
+  }
 
 private:
-	IAlgorithm *SplineBackgroundAlg;
+  IAlgorithm *SplineBackgroundAlg;
 
-	Mantid::DataObjects::Workspace2D_sptr ws;
-	const std::string inputWsName = "SplineBackground_points";
-	const std::string outputWsName = "SplineBackground_out";
+  Mantid::DataObjects::Workspace2D_sptr ws;
+  const std::string inputWsName = "SplineBackground_points";
+  const std::string outputWsName = "SplineBackground_out";
 
-	struct SinFunction {
-		double operator()(double x, int) { return std::sin(x); }
-	};
-
+  struct SinFunction {
+    double operator()(double x, int) { return std::sin(x); }
+  };
 };
 #endif /*SPLINEBACKGROUNDTEST_H_*/

--- a/Framework/CurveFitting/test/Algorithms/SplineBackgroundTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SplineBackgroundTest.h
@@ -47,8 +47,8 @@ public:
     MatrixWorkspace_sptr outWS =
         WorkspaceCreationHelper::getWS<MatrixWorkspace>("SplineBackground_out");
 
-    const MantidVec &X = outWS->readX(0);
-    const MantidVec &Y = outWS->readY(0);
+    const auto &X = outWS->x(0);
+    const auto &Y = outWS->y(0);
 
     for (size_t i = 0; i < outWS->blocksize(); i++) {
       TS_ASSERT_DELTA(Y[i], std::sin(X[i]), 0.2);

--- a/Framework/CurveFitting/test/Algorithms/SplineInterpolationTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SplineInterpolationTest.h
@@ -129,10 +129,10 @@ public:
           TS_ASSERT_EQUALS((*derivVAxis)(i), i + 1);
       }
 
-      const auto &xs = ows->readX(i);
-      const auto &ys = ows->readY(i);
-      const auto &d1 = derivsWs->readY(0);
-      const auto &d2 = derivsWs->readY(1);
+      const auto &xs = ows->x(i);
+      const auto &ys = ows->y(i);
+      const auto &d1 = derivsWs->y(0);
+      const auto &d2 = derivsWs->y(1);
 
       // check output for consistency
       for (size_t j = 0; j < ys.size(); ++j) {

--- a/Framework/CurveFitting/test/Algorithms/SplineInterpolationTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SplineInterpolationTest.h
@@ -162,4 +162,58 @@ public:
   }
 };
 
+class SplineInterpolationTestPerformance : public CxxTest::TestSuite {
+public:
+  void setUp() {
+
+    constexpr int order(2), spectra(1);
+    constexpr int xStartVal(0), xEndVal(100);
+    constexpr int xStepVal(1);
+
+    MatrixWorkspace_sptr matWs =
+        WorkspaceCreationHelper::Create2DWorkspaceFromFunction(
+            SplineFunc(), spectra, xStartVal, xEndVal, xStepVal, false);
+
+    MatrixWorkspace_sptr inWs =
+        WorkspaceCreationHelper::Create2DWorkspaceFromFunction(
+            SplineFunc(), spectra, xStartVal, xEndVal, (xStepVal * 0.1), false);
+
+    inputWs = inWs;
+    matrixWs = matWs;
+
+    splineInterpAlg.initialize();
+    splineInterpAlg.setPropertyValue("OutputWorkspace", outputWsName);
+    splineInterpAlg.setPropertyValue("OutputWorkspaceDeriv", outDerivWsName);
+
+    splineInterpAlg.setProperty("DerivOrder", order);
+
+    splineInterpAlg.setProperty("WorkspaceToInterpolate", inputWs);
+    splineInterpAlg.setProperty("WorkspaceToMatch", matrixWs);
+
+    splineInterpAlg.setRethrows(true);
+  }
+
+  void testSplineInterpolationPerformance() {
+    TS_ASSERT_THROWS_NOTHING(splineInterpAlg.execute());
+  }
+
+  void tearDown() {
+    AnalysisDataService::Instance().remove(outputWsName);
+    AnalysisDataService::Instance().remove(outDerivWsName);
+  }
+
+private:
+  SplineInterpolation splineInterpAlg;
+
+  MatrixWorkspace_sptr inputWs;
+  MatrixWorkspace_sptr matrixWs;
+
+  const std::string outputWsName = "outputWs";
+  const std::string outDerivWsName = "outputDerivativeWs";
+
+  // Functor to generate spline values
+  struct SplineFunc {
+    double operator()(double x, int) { return x * 2; }
+  };
+};
 #endif /* MANTID_CURVEFITTING_SPLINEINTERPOLATIONTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/SplineSmoothingTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SplineSmoothingTest.h
@@ -87,10 +87,10 @@ public:
       MatrixWorkspace_const_sptr derivsWs =
           boost::dynamic_pointer_cast<const MatrixWorkspace>(
               derivs->getItem(i));
-      const auto &xs = ows->readX(i);
-      const auto &ys = ows->readY(i);
-      const auto &d1 = derivsWs->readY(0);
-      const auto &d2 = derivsWs->readY(1);
+      const auto &xs = ows->x(i);
+      const auto &ys = ows->y(i);
+      const auto &d1 = derivsWs->y(0);
+      const auto &d2 = derivsWs->y(1);
 
       // check output for consistency
       for (size_t j = 0; j < ys.size(); ++j) {

--- a/Framework/CurveFitting/test/Algorithms/VesuvioCalculateGammaBackgroundTest.h
+++ b/Framework/CurveFitting/test/Algorithms/VesuvioCalculateGammaBackgroundTest.h
@@ -37,9 +37,9 @@ public:
 
     // Test some values in the range
     const size_t npts(inputWS->blocksize());
-    const auto &inX(inputWS->readX(0));
-    const auto &backX(backgroundWS->readX(0));
-    const auto &corrX(backgroundWS->readX(0));
+    const auto &inX(inputWS->x(0));
+    const auto &backX(backgroundWS->x(0));
+    const auto &corrX(backgroundWS->x(0));
 
     // X values are just straight copy
     TS_ASSERT_DELTA(backX.front(), inX.front(), 1e-08);
@@ -50,23 +50,24 @@ public:
     TS_ASSERT_DELTA(corrX.back(), inX.back(), 1e-08);
 
     // E values are zero for background & copy for corrected
-    const auto &backE(backgroundWS->readE(0));
+    const auto &backE(backgroundWS->e(0));
     TS_ASSERT_DELTA(backE.front(), 0.0, 1e-08);
     TS_ASSERT_DELTA(backE[npts / 2], 0.0, 1e-08);
     TS_ASSERT_DELTA(backE.back(), 0.0, 1e-08);
-    const auto &corrE(correctedWS->readE(0));
-    const auto &inE(inputWS->readE(0));
+
+    const auto &corrE(correctedWS->e(0));
+    const auto &inE(inputWS->e(0));
     TS_ASSERT_DELTA(corrE.front(), inE.front(), 1e-08);
     TS_ASSERT_DELTA(corrE[npts / 2], inE[npts / 2], 1e-08);
     TS_ASSERT_DELTA(corrE.back(), inE.back(), 1e-08);
 
-    const auto &corrY(correctedWS->readY(0));
+    const auto &corrY(correctedWS->y(0));
     TS_ASSERT_DELTA(corrY.front(), -0.00253802, 1e-08);
     TS_ASSERT_DELTA(corrY[npts / 2], 0.15060372, 1e-08);
     TS_ASSERT_DELTA(corrY.back(), -0.01696477, 1e-08);
 
     // Background Y values = 0.0
-    const auto &backY(backgroundWS->readY(0));
+    const auto &backY(backgroundWS->y(0));
     TS_ASSERT_DELTA(backY.front(), -0.00000138, 1e-08);
     TS_ASSERT_DELTA(backY[npts / 2], -0.00015056, 1e-08);
     TS_ASSERT_DELTA(backY.back(), 0.01650629, 1e-08);
@@ -86,9 +87,9 @@ public:
 
     // Test some values in the range
     const size_t npts(inputWS->blocksize());
-    const auto &inX(inputWS->readX(0));
-    const auto &backX(backgroundWS->readX(0));
-    const auto &corrX(backgroundWS->readX(0));
+    const auto &inX(inputWS->x(0));
+    const auto &backX(backgroundWS->x(0));
+    const auto &corrX(backgroundWS->x(0));
 
     // X values are just straight copy
     TS_ASSERT_DELTA(backX.front(), inX.front(), 1e-08);
@@ -100,14 +101,14 @@ public:
 
     // Corrected matches input the detector is not defined as forward scatter
     // range - Currently hardcoded in algorithm
-    const auto &inY(inputWS->readY(0));
-    const auto &corrY(correctedWS->readY(0));
+    const auto &inY(inputWS->y(0));
+    const auto &corrY(correctedWS->y(0));
     TS_ASSERT_DELTA(corrY.front(), inY.front(), 1e-08);
     TS_ASSERT_DELTA(corrY[npts / 2], inY[npts / 2], 1e-08);
     TS_ASSERT_DELTA(corrY.back(), inY.back(), 1e-08);
 
     // Background Y values = 0.0
-    const auto &backY(backgroundWS->readY(0));
+    const auto &backY(backgroundWS->y(0));
     TS_ASSERT_DELTA(backY.front(), 0.0, 1e-08);
     TS_ASSERT_DELTA(backY[npts / 2], 0.0, 1e-08);
     TS_ASSERT_DELTA(backY.back(), 0.0, 1e-08);
@@ -133,9 +134,9 @@ public:
 
     // Test some values in the range
     const size_t npts(inputWS->blocksize());
-    const auto &inX(inputWS->readX(0));
-    const auto &backX(backgroundWS->readX(0));
-    const auto &corrX(backgroundWS->readX(0));
+    const auto &inX(inputWS->x(0));
+    const auto &backX(backgroundWS->x(0));
+    const auto &corrX(backgroundWS->x(0));
 
     // X values are just straight copy
     TS_ASSERT_DELTA(backX.front(), inX.front(), 1e-08);
@@ -146,24 +147,24 @@ public:
     TS_ASSERT_DELTA(corrX.back(), inX.back(), 1e-08);
 
     // E values are zero for background & copy for corrected
-    const auto &backE(backgroundWS->readE(0));
+    const auto &backE(backgroundWS->e(0));
     TS_ASSERT_DELTA(backE.front(), 0.0, 1e-08);
     TS_ASSERT_DELTA(backE[npts / 2], 0.0, 1e-08);
     TS_ASSERT_DELTA(backE.back(), 0.0, 1e-08);
-    const auto &corrE(correctedWS->readE(0));
-    const auto &inE(inputWS->readE(0));
+    const auto &corrE(correctedWS->e(0));
+    const auto &inE(inputWS->e(0));
     TS_ASSERT_DELTA(corrE.front(), inE.front(), 1e-08);
     TS_ASSERT_DELTA(corrE[npts / 2], inE[npts / 2], 1e-08);
     TS_ASSERT_DELTA(corrE.back(), inE.back(), 1e-08);
 
     // Corrected values
-    const auto &corrY(correctedWS->readY(0));
+    const auto &corrY(correctedWS->y(0));
     TS_ASSERT_DELTA(corrY.front(), -0.00253802, 1e-08);
     TS_ASSERT_DELTA(corrY[npts / 2], 0.15060372, 1e-08);
     TS_ASSERT_DELTA(corrY.back(), -0.01696477, 1e-08);
 
     // Background Y values = 0.0
-    const auto &backY(backgroundWS->readY(0));
+    const auto &backY(backgroundWS->y(0));
     TS_ASSERT_DELTA(backY.front(), -0.00000138, 1e-08);
     TS_ASSERT_DELTA(backY[npts / 2], -0.00015056, 1e-08);
     TS_ASSERT_DELTA(backY.back(), 0.01650629, 1e-08);
@@ -251,9 +252,9 @@ private:
         Mantid::API::WorkspaceFactory::Instance().create(singleSpectrum, nhist);
     // Copy data
     for (size_t i = 0; i < nhist; ++i) {
-      twoSpectrum->setX(i, singleSpectrum->refX(0));
-      twoSpectrum->dataY(i) = singleSpectrum->readY(0);
-      twoSpectrum->dataE(i) = singleSpectrum->readE(0);
+      twoSpectrum->setSharedX(i, singleSpectrum->sharedX(0));
+      twoSpectrum->setSharedY(i, singleSpectrum->sharedY(0));
+      twoSpectrum->setSharedE(i, singleSpectrum->sharedE(0));
     }
     return twoSpectrum;
   }

--- a/Framework/CurveFitting/test/Algorithms/VesuvioCalculateGammaBackgroundTest.h
+++ b/Framework/CurveFitting/test/Algorithms/VesuvioCalculateGammaBackgroundTest.h
@@ -252,9 +252,7 @@ private:
         Mantid::API::WorkspaceFactory::Instance().create(singleSpectrum, nhist);
     // Copy data
     for (size_t i = 0; i < nhist; ++i) {
-      twoSpectrum->setSharedX(i, singleSpectrum->sharedX(0));
-      twoSpectrum->setSharedY(i, singleSpectrum->sharedY(0));
-      twoSpectrum->setSharedE(i, singleSpectrum->sharedE(0));
+      twoSpectrum->setHistogram(i, singleSpectrum->histogram(0));
     }
     return twoSpectrum;
   }
@@ -275,9 +273,7 @@ public:
         Mantid::API::WorkspaceFactory::Instance().create(singleSpectrum, nhist);
 
     for (size_t i = 0; i < nhist; ++i) {
-      inWs->setSharedX(i, singleSpectrum->sharedX(0));
-      inWs->setSharedY(i, singleSpectrum->sharedY(0));
-      inWs->setSharedE(i, singleSpectrum->sharedE(0));
+      inWs->setHistogram(i, singleSpectrum->histogram(0));
     }
 
     // Bring spectrum numbers into checked range


### PR DESCRIPTION
HistogramData rollout: algorithms 66-70
## Description of work.

This PR is part of refactoring effort to use the new interface of the HistogramData module.
See https://github.com/mantidproject/mantid/issues/17641 for details.

The following algorithms were refactored to use HistogramData:

```
Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
Framework/CurveFitting/src/Algorithms/SplineInterpolation.cpp
Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
```

Performance tests were added for:

```
SplineBackground
SplineInterpolation
VesuvioCalculateGammaBackground
```

The following algorithms have improved performance:
None
## To test.

Code review.

Fixes #17705 .
Internal change, no release notes (potential performance improvements will be added to release notes as part of the umbrella issue).
