### PR TITLE
Fix I/O of bin masking info when saving/loading nexus processed.

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1836,7 +1836,7 @@ void LoadNexusProcessed::readBinMasking(
   }
   NXInt spec = wksp_cls.openNXInt("masked_spectra");
   spec.load();
-  NXInt bins = wksp_cls.openNXInt("masked_bins");
+  NXSize bins = wksp_cls.openNXSize("masked_bins");
   bins.load();
   NXDouble weights = wksp_cls.openNXDouble("mask_weights");
   weights.load();

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -478,6 +478,8 @@ typedef NXDataSetTyped<float> NXFloat;
 typedef NXDataSetTyped<double> NXDouble;
 /// The char dataset type
 typedef NXDataSetTyped<char> NXChar;
+/// The size_t dataset type
+typedef NXDataSetTyped<size_t> NXSize;
 
 //-------------------- classes --------------------------//
 
@@ -576,6 +578,13 @@ public:
   */
   NXChar openNXChar(const std::string &name) const {
     return openNXDataSet<char>(name);
+  }
+  /**  Creates and opens a size_t dataset
+  *   @param name :: The name of the dataset
+  *   @return The size_t
+  */
+  NXSize openNXSize(const std::string &name) const {
+    return openNXDataSet<size_t>(name);
   }
   /**  Returns a string
   *   @param name :: The name of the NXChar dataset

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -479,7 +479,7 @@ typedef NXDataSetTyped<double> NXDouble;
 /// The char dataset type
 typedef NXDataSetTyped<char> NXChar;
 /// The size_t dataset type
-typedef NXDataSetTyped<size_t> NXSize;
+typedef NXDataSetTyped<std::size_t> NXSize;
 
 //-------------------- classes --------------------------//
 
@@ -584,7 +584,7 @@ public:
   *   @return The size_t
   */
   NXSize openNXSize(const std::string &name) const {
-    return openNXDataSet<size_t>(name);
+    return openNXDataSet<std::size_t>(name);
   }
   /**  Returns a string
   *   @param name :: The name of the NXChar dataset

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -1156,7 +1156,7 @@ bool NexusFileIO::checkEntryAtLevelByAttribute(const std::string &attribute,
 bool NexusFileIO::writeNexusBinMasking(
     API::MatrixWorkspace_const_sptr ws) const {
   std::vector<int> spectra;
-  std::vector<std::size_t> bins;
+  std::vector<int> bins;
   std::vector<double> weights;
   int spectra_count = 0;
   int offset = 0;
@@ -1166,7 +1166,7 @@ bool NexusFileIO::writeNexusBinMasking(
       spectra.push_back(spectra_count);
       spectra.push_back(offset);
       for (const auto &mask : mList) {
-        bins.push_back(mask.first);
+        bins.push_back(static_cast<int>(mask.first));
         weights.push_back(mask.second);
       }
       ++spectra_count;

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -1156,7 +1156,7 @@ bool NexusFileIO::checkEntryAtLevelByAttribute(const std::string &attribute,
 bool NexusFileIO::writeNexusBinMasking(
     API::MatrixWorkspace_const_sptr ws) const {
   std::vector<int> spectra;
-  std::vector<int> bins;
+  std::vector<size_t> bins;
   std::vector<double> weights;
   int spectra_count = 0;
   int offset = 0;
@@ -1166,7 +1166,7 @@ bool NexusFileIO::writeNexusBinMasking(
       spectra.push_back(spectra_count);
       spectra.push_back(offset);
       for (const auto &mask : mList) {
-        bins.push_back(static_cast<int>(mask.first));
+        bins.push_back(mask.first);
         weights.push_back(mask.second);
       }
       ++spectra_count;
@@ -1194,7 +1194,7 @@ bool NexusFileIO::writeNexusBinMasking(
 
   // save masked bin indices
   dimensions[0] = static_cast<int>(bins.size());
-  status = NXmakedata(fileID, "masked_bins", NX_INT32, 1, dimensions);
+  status = NXmakedata(fileID, "masked_bins", NX_UINT64, 1, dimensions);
   if (status == NX_ERROR)
     return false;
   NXopendata(fileID, "masked_bins");

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -1156,7 +1156,7 @@ bool NexusFileIO::checkEntryAtLevelByAttribute(const std::string &attribute,
 bool NexusFileIO::writeNexusBinMasking(
     API::MatrixWorkspace_const_sptr ws) const {
   std::vector<int> spectra;
-  std::vector<size_t> bins;
+  std::vector<std::size_t> bins;
   std::vector<double> weights;
   int spectra_count = 0;
   int offset = 0;

--- a/Testing/SystemTests/tests/analysis/SaveLoadNexusProcessed.py
+++ b/Testing/SystemTests/tests/analysis/SaveLoadNexusProcessed.py
@@ -1,0 +1,37 @@
+import os
+import stresstesting
+from mantid.simpleapi import *
+from mantid import config
+
+def create_file_name(base_name):
+    temp_save_dir = config['defaultsave.directory']
+    if temp_save_dir == '':
+        temp_save_dir = os.getcwd()
+    filename = os.path.join(temp_save_dir, base_name + '.nxs')
+    return filename
+
+class SaveLoadNexusProcessedTest(stresstesting.MantidStressTest):
+
+    filename = create_file_name('tmp_saveload_nexusprocessed')
+
+    def __init__(self):
+        super(SaveLoadNexusProcessedTest, self).__init__()
+
+    def runTest(self):
+
+        CreateSampleWorkspace(OutputWorkspace='ws', Function='Flat background', BankPixelWidth=1, XMax=15,
+                              BinWidth=0.75, NumBanks=4)
+        MaskBins(InputWorkspace='ws', OutputWorkspace='ws', XMin=0, XMax=2, SpectraList='0')
+        MaskBins(InputWorkspace='ws', OutputWorkspace='ws', XMin=0, XMax=1.5, SpectraList='1')
+        SaveNexusProcessed(InputWorkspace='ws',Filename=self.filename)
+        LoadNexusProcessed(Filename=self.filename,OutputWorkspace='loaded')
+
+        self.tearDown()
+
+    def tearDown(self):
+        if os.path.exists(self.filename):
+            os.remove(self.filename)
+
+    def validate(self):
+        result = CompareWorkspaces('ws','loaded',CheckInstrument=False)
+        return result[0]

--- a/docs/source/release/v3.9.0/framework.rst
+++ b/docs/source/release/v3.9.0/framework.rst
@@ -41,7 +41,7 @@ Python Algorithms
 MatchPeaks is a new Python algorithm that transforms a MatrixWorkspace: while keeping the x-values, y-values and e-values can be shifted in order to newly align its peak positions of each spectrum. The algorithm cannot take into account multiple peaks present in single spectrum. It's use is to centre each spectrum or to shift spectra according to peak positions of a compatible, second workspace. Workspaces are compatible by means of number of spectra and bins as well as identical x-values. In particular, this algorithm will be used for data reduction workflow algorithms.
 
 Bug Fixes
-_________
+---------
 
 - Bin masking information was wrongly saved when saving workspaces into nexus files, which is now fixed.
 

--- a/docs/source/release/v3.9.0/framework.rst
+++ b/docs/source/release/v3.9.0/framework.rst
@@ -40,7 +40,10 @@ Python Algorithms
 
 MatchPeaks is a new Python algorithm that transforms a MatrixWorkspace: while keeping the x-values, y-values and e-values can be shifted in order to newly align its peak positions of each spectrum. The algorithm cannot take into account multiple peaks present in single spectrum. It's use is to centre each spectrum or to shift spectra according to peak positions of a compatible, second workspace. Workspaces are compatible by means of number of spectra and bins as well as identical x-values. In particular, this algorithm will be used for data reduction workflow algorithms.
 
-|
+Bug Fixes
+_________
+
+- Bin masking information was wrongly saved when saving workspaces into nexus files, which is now fixed.
 
 Full list of
 `Framework <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.9%22+is%3Amerged+label%3A%22Component%3A+Framework%22>`__


### PR DESCRIPTION
Bin masking information was not correctly preserved when saving nexus processed due to a type mismatch. 

**To test:**
1. Create a sample workspace
2. Mask some bins
3. Save the workspace as nexus file
4. Open the file with HDFView and examine the masked bins to be correct
5. Load the file back to mantid
6. Compare the loaded workspace with the original masked workspaces using `CompareWorkspaces` with `CheckMasking` enabled.

<!-- Instructions for testing. -->

Fixes #17701 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
