### PR TITLE
Histogram Rollout - Algorithms 93-97

### DIFF
--- a/Framework/Algorithms/test/MonitorEfficiencyCorUserTest.h
+++ b/Framework/Algorithms/test/MonitorEfficiencyCorUserTest.h
@@ -155,7 +155,7 @@ public:
     API::AnalysisDataService::Instance().addOrReplace("input", input);
   }
 
-  void tearDown() {
+  void tearDown() override {
     API::AnalysisDataService::Instance().remove("input");
     API::AnalysisDataService::Instance().remove("ouput");
   }

--- a/Framework/CurveFitting/src/IMWDomainCreator.cpp
+++ b/Framework/CurveFitting/src/IMWDomainCreator.cpp
@@ -138,7 +138,7 @@ void IMWDomainCreator::declareDatasetProperties(const std::string &suffix,
  */
 std::pair<size_t, size_t> IMWDomainCreator::getXInterval() const {
 
-  const Mantid::MantidVec &X = m_matrixWorkspace->readX(m_workspaceIndex);
+  const auto &X = m_matrixWorkspace->x(m_workspaceIndex);
   if (X.empty()) {
     throw std::runtime_error("Workspace contains no data.");
   }
@@ -318,8 +318,8 @@ boost::shared_ptr<API::Workspace> IMWDomainCreator::createOutputWorkspace(
   }
 
   // Set the difference spectrum
-  MantidVec &Ycal = ws->dataY(1);
-  MantidVec &Diff = ws->dataY(2);
+  auto &Ycal = ws->mutableY(1);
+  auto &Diff = ws->mutableY(2);
   const size_t nData = values->size();
   for (size_t i = 0; i < nData; ++i) {
     Diff[i] = values->getFitData(i) - Ycal[i];
@@ -467,8 +467,8 @@ void IMWDomainCreator::addFunctionValuesToWS(
     }
 
     double chi2 = function->getChiSquared();
-    MantidVec &yValues = ws->dataY(wsIndex);
-    MantidVec &eValues = ws->dataE(wsIndex);
+    auto &yValues = ws->mutableY(wsIndex);
+    auto &eValues = ws->mutableE(wsIndex);
     for (size_t i = 0; i < nData; i++) {
       yValues[i] = resultValues->getCalculated(i);
       eValues[i] = std::sqrt(E[i] * chi2);
@@ -477,8 +477,8 @@ void IMWDomainCreator::addFunctionValuesToWS(
   } else {
     // otherwise use the parameter errors which is OK for uncorrelated
     // parameters
-    MantidVec &yValues = ws->dataY(wsIndex);
-    MantidVec &eValues = ws->dataE(wsIndex);
+    auto &yValues = ws->mutableY(wsIndex);
+    auto &eValues = ws->mutableE(wsIndex);
     for (size_t i = 0; i < nData; i++) {
       yValues[i] = resultValues->getCalculated(i);
       double err = 0.0;

--- a/Framework/CurveFitting/src/SeqDomainSpectrumCreator.cpp
+++ b/Framework/CurveFitting/src/SeqDomainSpectrumCreator.cpp
@@ -136,7 +136,7 @@ Workspace_sptr SeqDomainSpectrumCreator::createOutputWorkspace(
     if (spectrumDomain) {
       size_t wsIndex = spectrumDomain->getWorkspaceIndex();
 
-      MantidVec &yValues = outputWs->dataY(wsIndex);
+      auto &yValues = outputWs->mutableY(wsIndex);
       for (size_t j = 0; j < yValues.size(); ++j) {
         yValues[j] = localValues->getCalculated(j);
       }
@@ -145,10 +145,7 @@ Workspace_sptr SeqDomainSpectrumCreator::createOutputWorkspace(
 
   // Assign x-values on all histograms
   for (size_t i = 0; i < m_matrixWorkspace->getNumberHistograms(); ++i) {
-    const MantidVec &originalXValue = m_matrixWorkspace->readX(i);
-    MantidVec &xValues = outputWs->dataX(i);
-    assert(xValues.size() == originalXValue.size());
-    xValues.assign(originalXValue.begin(), originalXValue.end());
+	outputWs->setSharedX(i, m_matrixWorkspace->sharedX(i));
   }
 
   if (m_manager && !outputWorkspacePropertyName.empty()) {
@@ -188,7 +185,7 @@ size_t SeqDomainSpectrumCreator::getDomainSize() const {
   size_t totalSize = 0;
 
   for (size_t i = 0; i < nHist; ++i) {
-    totalSize += m_matrixWorkspace->dataY(i).size();
+    totalSize += m_matrixWorkspace->y(i).size();
   }
 
   return totalSize;

--- a/Framework/CurveFitting/src/SeqDomainSpectrumCreator.cpp
+++ b/Framework/CurveFitting/src/SeqDomainSpectrumCreator.cpp
@@ -145,7 +145,7 @@ Workspace_sptr SeqDomainSpectrumCreator::createOutputWorkspace(
 
   // Assign x-values on all histograms
   for (size_t i = 0; i < m_matrixWorkspace->getNumberHistograms(); ++i) {
-	outputWs->setSharedX(i, m_matrixWorkspace->sharedX(i));
+    outputWs->setSharedX(i, m_matrixWorkspace->sharedX(i));
   }
 
   if (m_manager && !outputWorkspacePropertyName.empty()) {

--- a/Framework/CurveFitting/test/Algorithms/SeqDomainSpectrumCreatorTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SeqDomainSpectrumCreatorTest.h
@@ -18,6 +18,8 @@
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/AlgorithmManager.h"
 
+#include "MantidTestHelpers/HistogramDataTestHelper.h"
+
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::CurveFitting;

--- a/Framework/CurveFitting/test/Algorithms/SeqDomainSpectrumCreatorTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SeqDomainSpectrumCreatorTest.h
@@ -192,10 +192,10 @@ public:
     // Spectrum 0: 0 + 2 * 1 -> All y-values should be 2
     // Spectrum 1: 1 + 2 * 1 -> All y-values should be 3...etc.
     for (size_t i = 0; i < outputWsMatrix->getNumberHistograms(); ++i) {
-      const std::vector<double> &x = outputWsMatrix->readX(i);
-      const std::vector<double> &y = outputWsMatrix->readY(i);
+      const auto &x = outputWsMatrix->x(i);
+      const auto &y = outputWsMatrix->y(i);
 
-      TS_ASSERT_EQUALS(x, matrixWs->readX(i));
+      TS_ASSERT_EQUALS(x, matrixWs->x(i));
       for (size_t j = 0; j < x.size(); ++j) {
         TS_ASSERT_EQUALS(y[j], static_cast<double>(i) + slope * x[j]);
       }
@@ -237,10 +237,10 @@ public:
     // Spectrum 0: 0 + 2 * 1 -> All y-values should be 2
     // Spectrum 1: 1 + 2 * 1 -> All y-values should be 3...etc.
     for (size_t i = 0; i < outputWsMatrix->getNumberHistograms(); ++i) {
-      const std::vector<double> &x = outputWsMatrix->readX(i);
-      const std::vector<double> &y = outputWsMatrix->readY(i);
+      const auto &x = outputWsMatrix->x(i);
+      const auto &y = outputWsMatrix->y(i);
 
-      TS_ASSERT_EQUALS(x, matrixWs->readX(i));
+      TS_ASSERT_EQUALS(x, matrixWs->x(i));
       for (size_t j = 0; j < x.size(); ++j) {
         // If detector is not masked, there should be values, otherwise 0.
         if (!outputWsMatrix->getDetector(i)->isMasked()) {
@@ -286,9 +286,9 @@ public:
     MatrixWorkspace_sptr matrixWs =
         WorkspaceCreationHelper::Create2DWorkspace123(400, 500);
     for (size_t i = 0; i < matrixWs->getNumberHistograms(); ++i) {
-      std::vector<double> &x = matrixWs->dataX(i);
-      std::vector<double> &y = matrixWs->dataY(i);
-      std::vector<double> &e = matrixWs->dataE(i);
+      auto &x = matrixWs->mutableX(i);
+      auto &y = matrixWs->mutableY(i);
+      auto &e = matrixWs->mutableE(i);
 
       for (size_t j = 0; j < x.size(); ++j) {
         x[j] = static_cast<double>(j);
@@ -329,9 +329,9 @@ public:
     MatrixWorkspace_sptr matrixWs =
         WorkspaceCreationHelper::Create2DWorkspace123(400, 50);
     for (size_t i = 0; i < matrixWs->getNumberHistograms(); ++i) {
-      std::vector<double> &x = matrixWs->dataX(i);
-      std::vector<double> &y = matrixWs->dataY(i);
-      std::vector<double> &e = matrixWs->dataE(i);
+      auto &x = matrixWs->mutableX(i);
+      auto &y = matrixWs->mutableY(i);
+      auto &e = matrixWs->mutableE(i);
 
       for (size_t j = 0; j < x.size(); ++j) {
         x[j] = static_cast<double>(j);

--- a/Framework/DataHandling/inc/MantidDataHandling/GroupDetectors2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/GroupDetectors2.h
@@ -217,8 +217,9 @@ private:
                          DataObjects::EventWorkspace_sptr outputWS,
                          const double prog4Copy);
 
-  /// Returns if the detector is masked or false if its impossible
-  bool isMaskedDetector(const Geometry::IDetector &detector) const;
+  /// Returns true if detectors exists and is masked
+  bool isMaskedDetector(const API::SpectrumInfo &detector,
+                        const size_t index) const;
 
   /// Copy the ungrouped spectra from the input workspace to the output
   template <class TIn, class TOut>

--- a/Framework/DataHandling/inc/MantidDataHandling/GroupDetectors2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/GroupDetectors2.h
@@ -217,6 +217,9 @@ private:
                          DataObjects::EventWorkspace_sptr outputWS,
                          const double prog4Copy);
 
+  /// Returns if the detector is masked or false if its impossible
+  bool isMaskedDetector(const Geometry::IDetector &detector) const;
+
   /// Copy the ungrouped spectra from the input workspace to the output
   template <class TIn, class TOut>
   void moveOthers(const std::set<int64_t> &unGroupedSet, const TIn &inputWS,

--- a/Framework/DataHandling/src/AsciiPointBase.cpp
+++ b/Framework/DataHandling/src/AsciiPointBase.cpp
@@ -59,7 +59,7 @@ void AsciiPointBase::exec() {
  */
 std::vector<double> AsciiPointBase::header(std::ofstream &file) {
   auto title = '#' + m_ws->getTitle();
-  const std::vector<double> &xTemp = m_ws->readX(0);
+  const auto &xTemp = m_ws->x(0);
   m_xlength = xTemp.size() - 1;
   std::vector<double> XData(m_xlength, 0);
   for (size_t i = 0; i < m_xlength; ++i) {
@@ -82,8 +82,8 @@ std::vector<double> AsciiPointBase::header(std::ofstream &file) {
 void AsciiPointBase::data(std::ofstream &file, const std::vector<double> &XData,
                           bool exportDeltaQ) {
 
-  const std::vector<double> &yData = m_ws->readY(0);
-  const std::vector<double> &eData = m_ws->readE(0);
+  const auto &yData = m_ws->y(0);
+  const auto &eData = m_ws->e(0);
   if (exportDeltaQ) {
     for (size_t i = 0; i < m_xlength; ++i) {
       double dq = XData[i] * m_qres;

--- a/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
+++ b/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
@@ -187,11 +187,9 @@ void CreateSimulationWorkspace::createOutputWorkspace() {
   PARALLEL_FOR1(m_outputWS)
   for (int64_t i = 0; i < static_cast<int64_t>(nhistograms); ++i) {
     m_outputWS->setBinEdges(i, binBoundaries);
-    MantidVec &yOut = m_outputWS->dataY(i);
-    for (size_t j = 0; j < ylength; ++j) {
-      yOut[j] = 1.0; // Set everything to a value so that you can visualize the
-                     // output sensibly
-    }
+    Mantid::HistogramData::HistogramY yOut(ylength, 1.0);
+    m_outputWS->mutableY(i) = yOut;
+
     m_progress->report("Setting X values");
   }
   applyDetectorMapping();

--- a/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
+++ b/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
@@ -187,8 +187,7 @@ void CreateSimulationWorkspace::createOutputWorkspace() {
   PARALLEL_FOR1(m_outputWS)
   for (int64_t i = 0; i < static_cast<int64_t>(nhistograms); ++i) {
     m_outputWS->setBinEdges(i, binBoundaries);
-    Mantid::HistogramData::HistogramY yOut(ylength, 1.0);
-    m_outputWS->mutableY(i) = yOut;
+    m_outputWS->mutableY(i) = 1.0;
 
     m_progress->report("Setting X values");
   }

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -938,28 +938,16 @@ size_t GroupDetectors2::formGroups(API::MatrixWorkspace_const_sptr inputWS,
     // are assumed to be the same here
     outSpec.setSharedX(inputWS->sharedX(0));
 
-    // the Y values and errors from spectra being grouped are combined in the
-    // output spectrum
-    auto &firstY = outSpec.mutableY();
     // Keep track of number of detectors required for masking
     size_t nonMaskedSpectra(0);
-    beh->mutableX(outIndex)[0] = 0.0;
-    beh->mutableE(outIndex)[0] = 0.0;
+
     for (auto originalWI : it->second) {
       // detectors to add to firstSpecNum
       const auto &fromSpectrum = inputWS->getSpectrum(originalWI);
 
       // Add up all the Y spectra and store the result in the first one
 
-      firstY += fromSpectrum.y();
-
-      auto fEit = outSpec.mutableE().begin();
-      auto Eit = fromSpectrum.e().cbegin();
-      for (auto fYit = firstY.begin(); fYit != firstY.end();
-           ++fYit, ++fEit, ++Eit) {
-        // Assume 'normal' (i.e. Gaussian) combination of errors
-        *fEit = std::sqrt((*fEit) * (*fEit) + (*Eit) * (*Eit));
-      }
+      outSpec.setHistogram(outSpec.histogram() += fromSpectrum.histogram());
 
       // detectors to add to the output spectrum
       outSpec.addDetectorIDs(fromSpectrum.getDetectorIDs());

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -240,8 +240,8 @@ void GroupDetectors2::execEvent() {
   }
 
   // Set all X bins on the output
-  auto &XValues = HistogramData::BinEdges(inputWS->x(0));
-  outputWS->setAllX(XValues);
+  auto &binEdges = inputWS->binEdges(0);
+  outputWS->setAllX(binEdges);
 
   g_log.information() << name() << " algorithm has finished\n";
 
@@ -950,9 +950,9 @@ size_t GroupDetectors2::formGroups(API::MatrixWorkspace_const_sptr inputWS,
       const auto &fromSpectrum = inputWS->getSpectrum(originalWI);
 
       // Add up all the Y spectra and store the result in the first one
-      auto &fEit = outSpec.mutableE().begin();
-      auto &Yit = fromSpectrum.y().cbegin();
-      auto &Eit = fromSpectrum.e().cbegin();
+      auto fEit = outSpec.mutableE().begin();
+      auto Yit = fromSpectrum.y().cbegin();
+      auto Eit = fromSpectrum.e().cbegin();
       for (auto fYit = firstY.begin(); fYit != firstY.end();
            ++fYit, ++fEit, ++Yit, ++Eit) {
         *fYit += *Yit;

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataHandling/LoadDetectorsGroupingFile.h"
 #include "MantidGeometry/Instrument/DetectorGroup.h"
+#include "MantidHistogramData/HistogramMath.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/ListValidator.h"
@@ -240,8 +241,7 @@ void GroupDetectors2::execEvent() {
   }
 
   // Set all X bins on the output
-  auto binEdges = inputWS->binEdges(0);
-  outputWS->setAllX(binEdges);
+  outputWS->setAllX(inputWS->binEdges(0));
 
   g_log.information() << name() << " algorithm has finished\n";
 
@@ -950,12 +950,13 @@ size_t GroupDetectors2::formGroups(API::MatrixWorkspace_const_sptr inputWS,
       const auto &fromSpectrum = inputWS->getSpectrum(originalWI);
 
       // Add up all the Y spectra and store the result in the first one
+
+      firstY += fromSpectrum.y();
+
       auto fEit = outSpec.mutableE().begin();
-      auto Yit = fromSpectrum.y().cbegin();
       auto Eit = fromSpectrum.e().cbegin();
       for (auto fYit = firstY.begin(); fYit != firstY.end();
-           ++fYit, ++fEit, ++Yit, ++Eit) {
-        *fYit += *Yit;
+           ++fYit, ++fEit, ++Eit) {
         // Assume 'normal' (i.e. Gaussian) combination of errors
         *fEit = std::sqrt((*fEit) * (*fEit) + (*Eit) * (*Eit));
       }

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -240,7 +240,7 @@ void GroupDetectors2::execEvent() {
   }
 
   // Set all X bins on the output
-  auto &binEdges = inputWS->binEdges(0);
+  auto binEdges = inputWS->binEdges(0);
   outputWS->setAllX(binEdges);
 
   g_log.information() << name() << " algorithm has finished\n";

--- a/Framework/DataHandling/test/CreateSimulationWorkspaceTest.h
+++ b/Framework/DataHandling/test/CreateSimulationWorkspaceTest.h
@@ -227,7 +227,7 @@ private:
 
 class CreateSimulationWorkspaceTestPerformance : public CxxTest::TestSuite {
 public:
-  void setUp() {
+  void setUp() override{
 
     // Starting bin, bin width, last bin
     const std::string binParams("-30,3,279");
@@ -245,7 +245,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.execute());
   }
 
-  void tearDown() {
+  void tearDown() override{
     Mantid::API::AnalysisDataService::Instance().remove(outWsName);
   }
 

--- a/Framework/DataHandling/test/CreateSimulationWorkspaceTest.h
+++ b/Framework/DataHandling/test/CreateSimulationWorkspaceTest.h
@@ -227,7 +227,7 @@ private:
 
 class CreateSimulationWorkspaceTestPerformance : public CxxTest::TestSuite {
 public:
-  void setUp() override{
+  void setUp() override {
 
     // Starting bin, bin width, last bin
     const std::string binParams("-30,3,279");
@@ -245,7 +245,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.execute());
   }
 
-  void tearDown() override{
+  void tearDown() override {
     Mantid::API::AnalysisDataService::Instance().remove(outWsName);
   }
 

--- a/Framework/DataHandling/test/CreateSimulationWorkspaceTest.h
+++ b/Framework/DataHandling/test/CreateSimulationWorkspaceTest.h
@@ -155,7 +155,7 @@ private:
   runAlgorithm(const std::string &inst, const std::string &unitx = "",
                const std::string &maptable = "") {
     using namespace Mantid::API;
-    Mantid::API::IAlgorithm_sptr alg = createAlgorithm(m_wsName);
+    IAlgorithm_sptr alg = createAlgorithm(m_wsName);
 
     TS_ASSERT_THROWS_NOTHING(alg->setPropertyValue("Instrument", inst));
     TS_ASSERT_THROWS_NOTHING(alg->setPropertyValue("BinParams", "-30,3,279"));
@@ -225,4 +225,33 @@ private:
   std::string m_wsName;
 };
 
+class CreateSimulationWorkspaceTestPerformance : public CxxTest::TestSuite {
+public:
+  void setUp() {
+
+    // Starting bin, bin width, last bin
+    const std::string binParams("-30,3,279");
+
+    alg.initialize();
+
+    alg.setPropertyValue("Instrument", "HET");
+    alg.setPropertyValue("BinParams", "-30,3,279");
+    alg.setPropertyValue("OutputWorkspace", outWsName);
+
+    alg.setRethrows(true);
+  }
+
+  void testCreateSimulationWorkspacePerformance() {
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+  }
+
+  void tearDown() {
+    Mantid::API::AnalysisDataService::Instance().remove(outWsName);
+  }
+
+private:
+  CreateSimulationWorkspace alg;
+
+  const std::string outWsName = "outTestWs";
+};
 #endif /* MANTID_DATAHANDLING_CREATESIMULATIONWORKSPACETEST_H_ */

--- a/Framework/DataHandling/test/GroupDetectors2Test.h
+++ b/Framework/DataHandling/test/GroupDetectors2Test.h
@@ -20,6 +20,8 @@
 #include "MantidDataHandling/LoadMuonNexus1.h"
 #include "MantidDataHandling/MaskDetectors.h"
 
+#include "MantidTestHelpers/HistogramDataTestHelper.h"
+
 #include <Poco/Path.h>
 
 #include <fstream>
@@ -30,6 +32,7 @@ using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
 using namespace Mantid::DataObjects;
+using namespace Mantid::HistogramData;
 using Mantid::detid_t;
 using Mantid::HistogramData::BinEdges;
 using Mantid::HistogramData::Histogram;
@@ -116,7 +119,7 @@ public:
     MatrixWorkspace_sptr outputWS = grouper.getProperty("OutputWorkspace");
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
     for (size_t i = 0; i < 3; ++i) {
-      TS_ASSERT_DELTA(outputWS->readY(0)[0], 2.0, 1e-12);
+      TS_ASSERT_DELTA(outputWS->y(0)[0], 2.0, 1e-12);
     }
   }
 
@@ -136,12 +139,12 @@ public:
         boost::dynamic_pointer_cast<MatrixWorkspace>(
             AnalysisDataService::Instance().retrieve(output));
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
-    std::vector<double> tens{10, 11, 12, 13, 14};
+    HistogramX tens{10, 11, 12, 13, 14};
     std::vector<double> ones(NBINS, 1.0);
-    TS_ASSERT_EQUALS(outputWS->dataX(0), tens);
-    TS_ASSERT_EQUALS(outputWS->dataY(0), std::vector<double>(NBINS, 1 + 4));
+    TS_ASSERT_EQUALS(outputWS->x(0), tens);
+    TS_ASSERT_EQUALS(outputWS->y(0), HistogramY(NBINS, 1 + 4));
     for (int i = 0; i < NBINS; ++i) {
-      TS_ASSERT_DELTA(outputWS->dataE(0)[i], std::sqrt(double(2)), 0.0001);
+      TS_ASSERT_DELTA(outputWS->e(0)[i], std::sqrt(double(2)), 0.0001);
     }
 
     boost::shared_ptr<const IDetector> det;
@@ -171,13 +174,12 @@ public:
         boost::dynamic_pointer_cast<MatrixWorkspace>(
             AnalysisDataService::Instance().retrieve(output));
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
-    std::vector<double> tens{10, 11, 12, 13, 14};
+    HistogramX tens{10, 11, 12, 13, 14};
     std::vector<double> ones(NBINS, 1.0);
-    TS_ASSERT_EQUALS(outputWS->dataX(0), tens);
-    TS_ASSERT_EQUALS(outputWS->dataY(0),
-                     std::vector<double>(NBINS, (3 + 4 + 5 + 6)));
+    TS_ASSERT_EQUALS(outputWS->x(0), tens);
+    TS_ASSERT_EQUALS(outputWS->y(0), HistogramY(NBINS, (3 + 4 + 5 + 6)));
     for (int i = 0; i < NBINS; ++i) {
-      TS_ASSERT_DELTA(outputWS->dataE(0)[i], std::sqrt(4.0), 0.0001);
+      TS_ASSERT_DELTA(outputWS->e(0)[i], std::sqrt(4.0), 0.0001);
     }
 
     boost::shared_ptr<const IDetector> det;
@@ -204,16 +206,15 @@ public:
         boost::dynamic_pointer_cast<MatrixWorkspace>(
             AnalysisDataService::Instance().retrieve(output));
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1);
-    std::vector<double> tens{10, 11, 12, 13, 14};
+    HistogramX tens{10, 11, 12, 13, 14};
     std::vector<double> ones(NBINS, 1.0);
-    TS_ASSERT_EQUALS(outputWS->dataX(0), tens);
-    TS_ASSERT_EQUALS(outputWS->dataY(0),
-                     std::vector<double>(NBINS, (3 + 1) + (1 + 1) + (4 + 1) +
-                                                    (0 + 1) + (2 + 1) +
-                                                    (5 + 1)));
+    TS_ASSERT_EQUALS(outputWS->x(0), tens);
+    TS_ASSERT_EQUALS(outputWS->y(0),
+                     HistogramY(NBINS, (3 + 1) + (1 + 1) + (4 + 1) + (0 + 1) +
+                                           (2 + 1) + (5 + 1)));
     for (int i = 0; i < NBINS; ++i) { // assume that we have grouped all the
                                       // spectra in the input workspace
-      TS_ASSERT_DELTA(outputWS->dataE(0)[i], std::sqrt(double(NHIST)), 0.0001);
+      TS_ASSERT_DELTA(outputWS->e(0)[i], std::sqrt(double(NHIST)), 0.0001);
     }
 
     boost::shared_ptr<const IDetector> det;
@@ -243,42 +244,40 @@ public:
         boost::dynamic_pointer_cast<MatrixWorkspace>(
             AnalysisDataService::Instance().retrieve(output));
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), NHIST - 1);
-    std::vector<double> tens{10, 11, 12, 13, 14};
-    std::vector<double> ones(NBINS, 1.0);
+    HistogramX tens{10, 11, 12, 13, 14};
+    Mantid::HistogramData::HistogramE ones(NBINS, 1.0);
     // check the two grouped spectra
-    TS_ASSERT_EQUALS(outputWS->dataX(0), tens);
-    TS_ASSERT_EQUALS(outputWS->dataY(0),
-                     std::vector<double>(NBINS, 1 + 3)); // 1+3 = 4
+    TS_ASSERT_EQUALS(outputWS->x(0), tens);
+    TS_ASSERT_EQUALS(outputWS->y(0), HistogramY(NBINS, 1 + 3)); // 1+3 = 4
     for (int i = 0; i < NBINS; ++i) {
-      TS_ASSERT_DELTA(outputWS->dataE(0)[i], std::sqrt(static_cast<double>(2)),
+      TS_ASSERT_DELTA(outputWS->e(0)[i], std::sqrt(static_cast<double>(2)),
                       1e-6);
     }
     TS_ASSERT_EQUALS(outputWS->getAxis(1)->spectraNo(0), 1);
     TS_ASSERT_EQUALS(outputWS->getSpectrum(0).getSpectrumNo(), 1);
 
-    TS_ASSERT_EQUALS(outputWS->dataX(1), tens);
-    TS_ASSERT_EQUALS(outputWS->dataY(1),
-                     std::vector<double>(NBINS, 4)); // Directly # 4
-    TS_ASSERT_EQUALS(outputWS->dataE(1), ones);
+    TS_ASSERT_EQUALS(outputWS->x(1), tens);
+    TS_ASSERT_EQUALS(outputWS->y(1), HistogramY(NBINS, 4)); // Directly # 4
+    TS_ASSERT_EQUALS(outputWS->e(1), ones);
     TS_ASSERT_EQUALS(outputWS->getAxis(1)->spectraNo(1), 2);
     TS_ASSERT_EQUALS(outputWS->getSpectrum(1).getSpectrumNo(), 2);
 
     // check the unmoved spectra
-    TS_ASSERT_EQUALS(outputWS->dataX(2), tens);
-    TS_ASSERT_EQUALS(outputWS->dataY(2), std::vector<double>(NBINS, 2));
-    TS_ASSERT_EQUALS(outputWS->dataE(2), ones);
+    TS_ASSERT_EQUALS(outputWS->x(2), tens);
+    TS_ASSERT_EQUALS(outputWS->y(2), HistogramY(NBINS, 2));
+    TS_ASSERT_EQUALS(outputWS->e(2), ones);
     TS_ASSERT_EQUALS(outputWS->getAxis(1)->spectraNo(2), 2);
     TS_ASSERT_EQUALS(outputWS->getSpectrum(2).getSpectrumNo(), 2);
 
-    TS_ASSERT_EQUALS(outputWS->dataX(3), tens);
-    TS_ASSERT_EQUALS(outputWS->dataY(3), std::vector<double>(NBINS, 5));
-    TS_ASSERT_EQUALS(outputWS->dataE(3), ones);
+    TS_ASSERT_EQUALS(outputWS->x(3), tens);
+    TS_ASSERT_EQUALS(outputWS->y(3), HistogramY(NBINS, 5));
+    TS_ASSERT_EQUALS(outputWS->e(3), ones);
 
     TS_ASSERT_EQUALS(outputWS->getAxis(1)->spectraNo(3), 5);
     TS_ASSERT_EQUALS(outputWS->getSpectrum(3).getSpectrumNo(), 5);
 
-    TS_ASSERT_EQUALS(outputWS->dataY(4), std::vector<double>(NBINS, 6));
-    TS_ASSERT_EQUALS(outputWS->dataE(4), ones);
+    TS_ASSERT_EQUALS(outputWS->y(4), HistogramY(NBINS, 6));
+    TS_ASSERT_EQUALS(outputWS->e(4), ones);
     TS_ASSERT_EQUALS(outputWS->getAxis(1)->spectraNo(4), 6);
     TS_ASSERT_EQUALS(outputWS->getSpectrum(4).getSpectrumNo(), 6);
 
@@ -320,30 +319,30 @@ public:
         boost::dynamic_pointer_cast<MatrixWorkspace>(
             AnalysisDataService::Instance().retrieve(output));
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), NHIST - 3);
-    std::vector<double> tens{10, 11, 12, 13, 14};
-    std::vector<double> ones(NBINS, 1.0);
+    HistogramX tens{10, 11, 12, 13, 14};
+    Mantid::HistogramData::HistogramE ones(NBINS, 1.0);
     // check the first grouped spectrum
-    TS_ASSERT_EQUALS(outputWS->dataX(0), tens);
-    TS_ASSERT_EQUALS(outputWS->dataY(0), std::vector<double>(NBINS, 1 + 2 + 3));
+    TS_ASSERT_EQUALS(outputWS->x(0), tens);
+    TS_ASSERT_EQUALS(outputWS->y(0), HistogramY(NBINS, 1 + 2 + 3));
     for (int i = 0; i < NBINS; ++i) {
-      TS_ASSERT_DELTA(outputWS->dataE(0)[i], std::sqrt(static_cast<double>(3)),
+      TS_ASSERT_DELTA(outputWS->e(0)[i], std::sqrt(static_cast<double>(3)),
                       1e-6);
     }
     TS_ASSERT_EQUALS(outputWS->getAxis(1)->spectraNo(0), 1);
     TS_ASSERT_EQUALS(outputWS->getSpectrum(0).getSpectrumNo(), 1);
 
     // check the second grouped spectrum
-    TS_ASSERT_EQUALS(outputWS->dataX(1), tens);
-    TS_ASSERT_EQUALS(outputWS->dataY(1), std::vector<double>(NBINS, 4));
-    TS_ASSERT_EQUALS(outputWS->dataE(1), ones);
+    TS_ASSERT_EQUALS(outputWS->x(1), tens);
+    TS_ASSERT_EQUALS(outputWS->y(1), HistogramY(NBINS, 4));
+    TS_ASSERT_EQUALS(outputWS->e(1), ones);
     TS_ASSERT_EQUALS(outputWS->getAxis(1)->spectraNo(1), 2);
     TS_ASSERT_EQUALS(outputWS->getSpectrum(1).getSpectrumNo(), 2);
 
     // check the third grouped spectrum
-    TS_ASSERT_EQUALS(outputWS->dataX(2), tens);
-    TS_ASSERT_EQUALS(outputWS->dataY(2), std::vector<double>(NBINS, 5 + 6));
+    TS_ASSERT_EQUALS(outputWS->x(2), tens);
+    TS_ASSERT_EQUALS(outputWS->y(2), HistogramY(NBINS, 5 + 6));
     for (int i = 0; i < NBINS; ++i) {
-      TS_ASSERT_DELTA(outputWS->dataE(2)[i], std::sqrt(static_cast<double>(2)),
+      TS_ASSERT_DELTA(outputWS->e(2)[i], std::sqrt(static_cast<double>(2)),
                       1e-6);
     }
     TS_ASSERT_EQUALS(outputWS->getAxis(1)->spectraNo(2), 3);
@@ -534,7 +533,7 @@ public:
             "GroupDetectors2_testAverageBehaviour_Output");
 
     // Result should be 1 + 2  / 2 = 1.5
-    TS_ASSERT_EQUALS(output->readY(0)[1], 1.5);
+    TS_ASSERT_EQUALS(output->y(0)[1], 1.5);
 
     AnalysisDataService::Instance().remove(
         "GroupDetectors2_testAverageBehaviour_Output");
@@ -567,10 +566,9 @@ public:
     TS_ASSERT(output);
     TS_ASSERT_EQUALS(output->getNumberHistograms(), 1);
     TS_ASSERT_EQUALS(output->getNumberEvents(), (2 + 3 + 4) * numEvents);
-    TS_ASSERT_EQUALS(input->readX(0).size(), output->readX(0).size());
-    TS_ASSERT_DELTA(
-        (input->readY(2)[0] + input->readY(3)[0] + input->readY(4)[0]) / 3,
-        output->readY(0)[0], 0.00001);
+    TS_ASSERT_EQUALS(input->x(0).size(), output->x(0).size());
+    TS_ASSERT_DELTA((input->y(2)[0] + input->y(3)[0] + input->y(4)[0]) / 3,
+                    output->y(0)[0], 0.00001);
     AnalysisDataService::Instance().remove("GDEventsOut");
   }
 
@@ -643,7 +641,7 @@ public:
     }
     for (size_t pix = 0; pix < groupW->getNumberHistograms(); pix++) {
       size_t groupNo = startingGroupNo + (pix / pixPerGroup);
-      groupW->dataY(pix)[0] = static_cast<double>(groupNo);
+      groupW->mutableY(pix)[0] = static_cast<double>(groupNo);
     }
 
     // ------------ Create a grouping workspace by name -------------

--- a/Framework/DataHandling/test/GroupDetectors2Test.h
+++ b/Framework/DataHandling/test/GroupDetectors2Test.h
@@ -7,25 +7,14 @@
 
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidAPI/Axis.h"
-#include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAPI/FrameworkManager.h"
-#include "MantidDataObjects/Workspace2D.h"
-#include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Instrument/DetectorGroup.h"
-#include "MantidGeometry/Instrument.h"
-#include "MantidKernel/ArrayProperty.h"
-#include "MantidKernel/Exception.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidDataHandling/LoadMuonNexus1.h"
 #include "MantidDataHandling/MaskDetectors.h"
-
 #include "MantidTestHelpers/HistogramDataTestHelper.h"
 
 #include <Poco/Path.h>
-
-#include <fstream>
-#include <numeric>
 
 using Mantid::DataHandling::GroupDetectors2;
 using namespace Mantid::Kernel;

--- a/Framework/DataHandling/test/GroupDetectors2Test.h
+++ b/Framework/DataHandling/test/GroupDetectors2Test.h
@@ -834,7 +834,7 @@ private:
 
 class GroupDetectors2TestPerformance : public CxxTest::TestSuite {
 public:
-  void setUp() {
+  void setUp() override {
     constexpr int numGroups = 2;
     // This controls speed of test
     constexpr int bankPixelWidth = 30;
@@ -865,7 +865,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.execute());
   }
 
-  void tearDown() {
+  void tearDown() override {
     AnalysisDataService::Instance().remove(groupWSName);
     AnalysisDataService::Instance().remove(nxsWSname);
     AnalysisDataService::Instance().remove(outputws);
@@ -880,7 +880,6 @@ public:
     // fill in some groups
     constexpr size_t startingGroupNo = 1;
     const size_t targetGroupNo = numGroups;
-    const size_t targetSpectraCount = numGroups;
     size_t pixPerGroup = 0;
     pixPerGroup = groupWs->getNumberHistograms() / targetGroupNo;
 


### PR DESCRIPTION
HistogramData rollout: algorithms 93-97
## Description of work.

This PR is part of refactoring effort to use the new interface of the HistogramData module.
See https://github.com/mantidproject/mantid/issues/17641 for details.

The following algorithms were refactored to use HistogramData:

```
Framework/CurveFitting/src/IMWDomainCreator.cpp
Framework/CurveFitting/src/SeqDomainSpectrumCreator.cpp
Framework/DataHandling/src/AsciiPointBase.cpp
Framework/DataHandling/src/CreateSimulationWorkspace.cpp
Framework/DataHandling/src/GroupDetectors2.cpp
```

Performance tests were added for:

```
CreateSimulationWorkspace
GroupDetectors2
```

The following algorithms have improved performance:
None
## To test.

Code review.

Fixes #17737 .
Internal change, no release notes (potential performance improvements will be added to release notes as part of the umbrella issue).
