### PR TITLE
Bring back old delete behaviour for Mantid Dock

### DIFF
--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -459,8 +459,11 @@ void MantidUI::saveNexusWorkspace() { executeSaveNexus(); }
 @param workspaceName :: Name of the workspace to delete
 */
 void MantidUI::deleteWorkspace(const QString &workspaceName) {
+  auto workspaceNameStdString = workspaceName.toStdString();
   auto &ads = Mantid::API::AnalysisDataService::Instance();
-  ads.remove(workspaceName.toStdString());
+  if (ads.doesExist(workspaceNameStdString)) {
+    ads.remove(workspaceNameStdString);
+  }
 }
 
 /**

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -459,11 +459,10 @@ void MantidUI::saveNexusWorkspace() { executeSaveNexus(); }
 @param workspaceName :: Name of the workspace to delete
 */
 void MantidUI::deleteWorkspace(const QString &workspaceName) {
-  auto workspaceNameStdString = workspaceName.toStdString();
-  auto& ads = Mantid::API::AnalysisDataService::Instance();
-  if (ads.doesExist(workspaceNameStdString)) {
-    ads.remove(workspaceNameStdString);
-  }
+  auto alg = createAlgorithm("DeleteWorkspace");
+  alg->setLogging(false);
+  alg->setPropertyValue("Workspace", workspaceName.toStdString());
+  executeAlgorithmAsync(alg);
 }
 
 /**

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -460,7 +460,7 @@ void MantidUI::saveNexusWorkspace() { executeSaveNexus(); }
 */
 void MantidUI::deleteWorkspace(const QString &workspaceName) {
   auto workspaceNameStdString = workspaceName.toStdString();
-  auto &ads = Mantid::API::AnalysisDataService::Instance();
+  auto& ads = Mantid::API::AnalysisDataService::Instance();
   if (ads.doesExist(workspaceNameStdString)) {
     ads.remove(workspaceNameStdString);
   }


### PR DESCRIPTION
Reverts the recent changes to the workspace deletion via the MantidDock.
## To test

Make sure that the changes have reverted to the old code.

Fixes #17748
_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
