### PR TITLE
Fix for Larmor batch mode bug

### DIFF
--- a/docs/source/release/v3.9.0/sans.rst
+++ b/docs/source/release/v3.9.0/sans.rst
@@ -9,6 +9,7 @@ Bug Fixes
 ---------
 
 |
+- IDF bug when using Larmor in batch mode was resolved.
 
 X uncertainties (delta-Q)
 -------------------------

--- a/scripts/SANS/isis_reducer.py
+++ b/scripts/SANS/isis_reducer.py
@@ -773,7 +773,7 @@ class ISISReducer(Reducer):
 
         # Now check both underlying files. If they are equal, then don't do anything
         # else switch the underlying instrument
-        if su.are_two_files_identical(idf_path_reducer, idf_path_reducer):
+        if su.are_two_files_identical(idf_path_workspace, idf_path_reducer):
             return
         else:
             logger.notice("Updating the IDF of the Reducer. Switching from " +

--- a/scripts/SANS/isis_reducer.py
+++ b/scripts/SANS/isis_reducer.py
@@ -18,8 +18,11 @@ import SANSUtility as su
 import os
 import copy
 import sys
+from collections import namedtuple
 
 logger = Logger("ISISReducer")
+
+temp_reduction_framework_settings = namedtuple('temp_reduction_framework_settings', 'incident_monitor')
 
 ################################################################################
 # Avoid a bug with deepcopy in python 2.6, details and workaround here:
@@ -783,6 +786,10 @@ class ISISReducer(Reducer):
             old_detector_selection = old_instrument.get_detector_selection()
 
             if instrument is not None:
+                # Read the values of some variables which are set on the reduction
+                # framework.
+                temp_settings = self.get_values_from_reduction_framework()
+
                 self.set_instrument(instrument)
 
                 # We need to update the instrument, by reloading the user file.
@@ -790,8 +797,27 @@ class ISISReducer(Reducer):
                 # seems to be the only reasonable way to do this.
                 self.user_settings.execute(self)
 
+                # Apply the settings to reloaded reduction framework
+                self.apply_values_from_reduction_framework(temp_settings)
+
                 # Now we set the correct detector, this is also being done in the GUI
                 self.get_instrument().setDetector(old_detector_selection)
+
+    def get_values_from_reduction_framework(self):
+        """
+        This method extracts some settings of the current reduction framework which
+        we want to apply later on.
+        """
+        # Get the incident monitor
+        incident_monitor = self.instrument.get_incident_mon()
+        temp_settings = temp_reduction_framework_settings(incident_monitor=incident_monitor)
+
+        return temp_settings
+
+    def apply_values_from_reduction_framework(self, temp_settings):
+        # Set the incident monitor
+        incident_monitor = temp_settings.incident_monitor
+        self.instrument.set_incident_mon(incident_monitor)
 
     def _get_correct_instrument(self, instrument_name, idf_path = None):
         '''

--- a/scripts/SANS/isis_reducer.py
+++ b/scripts/SANS/isis_reducer.py
@@ -771,9 +771,9 @@ class ISISReducer(Reducer):
         idf_path_reducer = self.get_idf_file_path()
         idf_path_reducer = os.path.normpath(idf_path_reducer)
 
-        # Now check if both idf paths and underlying files. If they are, then don't do anything
+        # Now check both underlying files. If they are equal, then don't do anything
         # else switch the underlying instrument
-        if idf_path_reducer == idf_path_workspace and su.are_two_files_identical(idf_path_reducer, idf_path_reducer):
+        if su.are_two_files_identical(idf_path_reducer, idf_path_reducer):
             return
         else:
             logger.notice("Updating the IDF of the Reducer. Switching from " +


### PR DESCRIPTION
Fixes #17757 

The problem that Rob reported stemmed from a check that we perform when loading data. When the ISIS SANS Gui loads the first time, it generates an empty instrument and extracts information from it. The empty instrument is based on `Instrument_Definition.xml`.

This means that older IDFs cannot be used (this has lead to the SANS2DTubes option I believe). When loading data we check if the IDF that was used in the initial SANS setup is the same as the one which is associated with the data set. If not we swap the one of the SANS setup for the one fo the data file (which is the one to use). It also means that we need to read in the user file again. In batch mode this rereading missed the monitor spectrum. This is now being set manually. Also we only reload the IDF if the two files are not identical in content and we don't care about file location.
# To Test

Test this on Windows
Please find the test material here: \olympic\Babylon5\Scratch\Anton\Testing\17757\LARMOR_BUG
1. Open the ISIS SANS Gui
2. Set the instrument to LARMOR
3. Load the user file
4. Select the batch mode
5. Load the batch mode file
6. Run a 1D reduction
7. Switch to single mode (the data entries should be prepopulated from the batch run)
8. Run a 1D reduction 
9. Compare the output workspaces for both reductions (Workspaces `A 1 mM LAS  Ca` and `12931rear_1D_0.9_12.5`). 
   - Confirm that they are identical (plot the two spectra on top of each other for example).
10. Go to your AppData\Roaming\mantidproject folder. Copy the contain `mantid` folder into a secure location. Place the `mantid` folder from the test data into the location
11. Follow steps 3 to 9 and confirm that the reduced workspaces are still the same.
12. Replace the `mantid` folder with your old `mantid` folder.

For release notes see [here](https://github.com/mantidproject/mantid/pull/17758/commits/2f793ad14519859aa794794bd9050f6afe5bf90b)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
