### PR TITLE
Fixes for building against Boost 1.62.

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
@@ -25,7 +25,6 @@ using namespace API;
 using namespace Kernel;
 using namespace CurveFitting;
 using namespace CurveFitting::Functions;
-using namespace BOOST_FUNCTION_STD_NS;
 using namespace std;
 
 // Subscription


### PR DESCRIPTION
Description of work.

Homebrew upgraded to Boost 1.62 this weekend and I encountered a compiler error when building Mantid against it. Removing the line below was sufficient to get Mantid to build.

If there is a v3.8.1 patch release, this would be a nice addition.

**To test:**

<!-- Instructions for testing. -->

If the builds pass :squirrel:

There is no GitHub issue associated with this pull request.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
