### PR TITLE
Histogram data rollout 51 to 55

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/UnwrapMonitor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/UnwrapMonitor.h
@@ -3,6 +3,7 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/cow_ptr.h"
+#include "MantidHistogramData/HistogramX.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -69,13 +70,13 @@ private:
   void init() override;
   void exec() override;
 
-  const std::vector<int> unwrapX(const API::MatrixWorkspace_sptr &tempWS,
+  const std::vector<int> unwrapX(MantidVec & newX,
                                  const int &spectrum, const double &Ld);
-  std::pair<int, int> handleFrameOverlapped(const MantidVec &xdata,
+  std::pair<int, int> handleFrameOverlapped(const Mantid::HistogramData::HistogramX &xdata,
                                             const double &Ld,
                                             std::vector<double> &tempX);
   void unwrapYandE(const API::MatrixWorkspace_sptr &tempWS, const int &spectrum,
-                   const std::vector<int> &rangeBounds);
+                   const std::vector<int> &rangeBounds, MantidVec &newY, MantidVec& newE);
   API::MatrixWorkspace_sptr rebin(const API::MatrixWorkspace_sptr &workspace,
                                   const double &min, const double &max,
                                   const int &numBins);

--- a/Framework/Algorithms/inc/MantidAlgorithms/UnwrapMonitor.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/UnwrapMonitor.h
@@ -70,13 +70,14 @@ private:
   void init() override;
   void exec() override;
 
-  const std::vector<int> unwrapX(MantidVec & newX,
-                                 const int &spectrum, const double &Ld);
-  std::pair<int, int> handleFrameOverlapped(const Mantid::HistogramData::HistogramX &xdata,
-                                            const double &Ld,
-                                            std::vector<double> &tempX);
+  const std::vector<int> unwrapX(MantidVec &newX, const int &spectrum,
+                                 const double &Ld);
+  std::pair<int, int>
+  handleFrameOverlapped(const Mantid::HistogramData::HistogramX &xdata,
+                        const double &Ld, std::vector<double> &tempX);
   void unwrapYandE(const API::MatrixWorkspace_sptr &tempWS, const int &spectrum,
-                   const std::vector<int> &rangeBounds, MantidVec &newY, MantidVec& newE);
+                   const std::vector<int> &rangeBounds, MantidVec &newY,
+                   MantidVec &newE);
   API::MatrixWorkspace_sptr rebin(const API::MatrixWorkspace_sptr &workspace,
                                   const double &min, const double &max,
                                   const int &numBins);

--- a/Framework/Algorithms/inc/MantidAlgorithms/UnwrapSNS.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/UnwrapSNS.h
@@ -68,7 +68,8 @@ private:
   void execEvent();
   void runMaskDetectors();
 
-  int unwrapX(const Mantid::HistogramData::HistogramX &, MantidVec &, const double &Ld);
+  int unwrapX(const Mantid::HistogramData::HistogramX &, MantidVec &,
+              const double &Ld);
   void getTofRangeData(const bool);
   double m_conversionConstant; ///< The constant used in the conversion from TOF
   /// to wavelength

--- a/Framework/Algorithms/inc/MantidAlgorithms/UnwrapSNS.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/UnwrapSNS.h
@@ -68,7 +68,7 @@ private:
   void execEvent();
   void runMaskDetectors();
 
-  int unwrapX(const MantidVec &, MantidVec &, const double &Ld);
+  int unwrapX(const Mantid::HistogramData::HistogramX &, MantidVec &, const double &Ld);
   void getTofRangeData(const bool);
   double m_conversionConstant; ///< The constant used in the conversion from TOF
   /// to wavelength

--- a/Framework/Algorithms/inc/MantidAlgorithms/WienerSmooth.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/WienerSmooth.h
@@ -3,6 +3,7 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/cow_ptr.h"
+#include "MantidHistogramData/HistogramX.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -43,7 +44,7 @@ private:
   void init() override;
   void exec() override;
 
-  std::pair<double, double> getStartEnd(const MantidVec &X,
+  std::pair<double, double> getStartEnd(const Mantid::HistogramData::HistogramX &X,
                                         bool isHistogram) const;
   API::MatrixWorkspace_sptr copyInput(API::MatrixWorkspace_sptr inputWS,
                                       size_t wsIndex);

--- a/Framework/Algorithms/inc/MantidAlgorithms/WienerSmooth.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/WienerSmooth.h
@@ -44,8 +44,9 @@ private:
   void init() override;
   void exec() override;
 
-  std::pair<double, double> getStartEnd(const Mantid::HistogramData::HistogramX &X,
-                                        bool isHistogram) const;
+  std::pair<double, double>
+  getStartEnd(const Mantid::HistogramData::HistogramX &X,
+              bool isHistogram) const;
   API::MatrixWorkspace_sptr copyInput(API::MatrixWorkspace_sptr inputWS,
                                       size_t wsIndex);
   API::MatrixWorkspace_sptr

--- a/Framework/Algorithms/src/UnwrapMonitor.cpp
+++ b/Framework/Algorithms/src/UnwrapMonitor.cpp
@@ -135,15 +135,15 @@ void UnwrapMonitor::exec() {
     // Now set the new X, Y and E values on the Histogram
     auto histogram = tempWS->histogram(i);
     if (histogram.yMode() == Mantid::HistogramData::Histogram::YMode::Counts) {
-        tempWS->setHistogram(
-            i, Mantid::HistogramData::BinEdges(std::move(newX)),
-            Mantid::HistogramData::Counts(std::move(newY)),
-            Mantid::HistogramData::CountStandardDeviations(std::move(newE)));
+      tempWS->setHistogram(
+          i, Mantid::HistogramData::BinEdges(std::move(newX)),
+          Mantid::HistogramData::Counts(std::move(newY)),
+          Mantid::HistogramData::CountStandardDeviations(std::move(newE)));
     } else {
-        tempWS->setHistogram(
-            i, Mantid::HistogramData::BinEdges(std::move(newX)),
-            Mantid::HistogramData::Frequencies(std::move(newY)),
-            Mantid::HistogramData::FrequencyStandardDeviations(std::move(newE)));
+      tempWS->setHistogram(
+          i, Mantid::HistogramData::BinEdges(std::move(newX)),
+          Mantid::HistogramData::Frequencies(std::move(newY)),
+          Mantid::HistogramData::FrequencyStandardDeviations(std::move(newE)));
     }
 
     // Get the maximum number of bins (excluding monitors) for the rebinning
@@ -176,7 +176,8 @@ void UnwrapMonitor::exec() {
 }
 
 /** Unwraps an X array, converting the units to wavelength along the way.
- *  @param newX ::   A reference to a container which stores our unwrapped x data.
+ *  @param newX ::   A reference to a container which stores our unwrapped x
+ * data.
  *  @param spectrum :: The workspace index
  *  @param Ld ::       The flightpath for the detector related to this spectrum
  *  @return A 3-element vector containing the bins at which the upper and lower

--- a/Framework/Algorithms/src/UnwrapMonitor.cpp
+++ b/Framework/Algorithms/src/UnwrapMonitor.cpp
@@ -175,8 +175,7 @@ void UnwrapMonitor::exec() {
  * ranges start & end
  */
 const std::vector<int>
-UnwrapMonitor::unwrapX(MantidVec &newX,
-                       const int &spectrum, const double &Ld) {
+UnwrapMonitor::unwrapX(MantidVec &newX, const int &spectrum, const double &Ld) {
   // Create and initalise the vector that will store the bin ranges, and will be
   // returned
   // Elements are: 0 - Lower range start, 1 - Lower range end, 2 - Upper range
@@ -258,9 +257,9 @@ UnwrapMonitor::unwrapX(MantidVec &newX,
 /** Deals with the (rare) case where the flightpath is longer than the reference
  *  Note that in this case both T1 & T2 will be greater than Tmax
  */
-std::pair<int, int>
-UnwrapMonitor::handleFrameOverlapped(const Mantid::HistogramData::HistogramX &xdata, const double &Ld,
-                                     std::vector<double> &tempX) {
+std::pair<int, int> UnwrapMonitor::handleFrameOverlapped(
+    const Mantid::HistogramData::HistogramX &xdata, const double &Ld,
+    std::vector<double> &tempX) {
   // Calculate the interval to exclude
   const double Dt = (m_Tmax - m_Tmin) * (1 - (m_LRef / Ld));
   // This gives us new minimum & maximum tof values
@@ -300,8 +299,7 @@ UnwrapMonitor::handleFrameOverlapped(const Mantid::HistogramData::HistogramX &xd
 void UnwrapMonitor::unwrapYandE(const API::MatrixWorkspace_sptr &tempWS,
                                 const int &spectrum,
                                 const std::vector<int> &rangeBounds,
-                                MantidVec &newY,
-                                MantidVec& newE) {
+                                MantidVec &newY, MantidVec &newE) {
   // Copy over the relevant ranges of Y & E data
   MantidVec &Y = newY;
   MantidVec &E = newE;

--- a/Framework/Algorithms/src/UnwrapMonitor.cpp
+++ b/Framework/Algorithms/src/UnwrapMonitor.cpp
@@ -134,17 +134,9 @@ void UnwrapMonitor::exec() {
 
     // Now set the new X, Y and E values on the Histogram
     auto histogram = tempWS->histogram(i);
-    if (histogram.yMode() == Mantid::HistogramData::Histogram::YMode::Counts) {
-      tempWS->setHistogram(
-          i, Mantid::HistogramData::BinEdges(std::move(newX)),
-          Mantid::HistogramData::Counts(std::move(newY)),
-          Mantid::HistogramData::CountStandardDeviations(std::move(newE)));
-    } else {
-      tempWS->setHistogram(
-          i, Mantid::HistogramData::BinEdges(std::move(newX)),
-          Mantid::HistogramData::Frequencies(std::move(newY)),
-          Mantid::HistogramData::FrequencyStandardDeviations(std::move(newE)));
-    }
+    tempWS->setHistogram(i, Mantid::HistogramData::BinEdges(std::move(newX)),
+                         Mantid::HistogramData::Counts(std::move(newY)),
+                         Mantid::HistogramData::CountStandardDeviations(std::move(newE)));
 
     // Get the maximum number of bins (excluding monitors) for the rebinning
     // below
@@ -304,7 +296,7 @@ std::pair<int, int> UnwrapMonitor::handleFrameOverlapped(
  *  @param spectrum ::    The workspace index
  *  @param rangeBounds :: The upper and lower ranges for the unwrapping
  *  @param newY :: A reference to a container which stores our unwrapped y data.
- *  @param newY :: A reference to a container which stores our unwrapped e data.
+ *  @param newE :: A reference to a container which stores our unwrapped e data.
  */
 void UnwrapMonitor::unwrapYandE(const API::MatrixWorkspace_sptr &tempWS,
                                 const int &spectrum,

--- a/Framework/Algorithms/src/UnwrapMonitor.cpp
+++ b/Framework/Algorithms/src/UnwrapMonitor.cpp
@@ -134,9 +134,10 @@ void UnwrapMonitor::exec() {
 
     // Now set the new X, Y and E values on the Histogram
     auto histogram = tempWS->histogram(i);
-    tempWS->setHistogram(i, Mantid::HistogramData::BinEdges(std::move(newX)),
-                         Mantid::HistogramData::Counts(std::move(newY)),
-                         Mantid::HistogramData::CountStandardDeviations(std::move(newE)));
+    tempWS->setHistogram(
+        i, Mantid::HistogramData::BinEdges(std::move(newX)),
+        Mantid::HistogramData::Counts(std::move(newY)),
+        Mantid::HistogramData::CountStandardDeviations(std::move(newE)));
 
     // Get the maximum number of bins (excluding monitors) for the rebinning
     // below

--- a/Framework/Algorithms/src/UnwrapSNS.cpp
+++ b/Framework/Algorithms/src/UnwrapSNS.cpp
@@ -145,14 +145,14 @@ void UnwrapSNS::exec() {
       g_log.debug() << "Detector information for workspace index "
                     << workspaceIndex << " is not available.\n";
       outputWS->setSharedX(workspaceIndex, m_inputWS->sharedX(workspaceIndex));
-      outputWS->mutableY(workspaceIndex).assign(m_XSize - 1, 0.0);
-      outputWS->mutableE(workspaceIndex).assign(m_XSize - 1, 0.0);
+      outputWS->mutableY(workspaceIndex) = 0.0;
+      outputWS->mutableE(workspaceIndex) = 0.0;
     } else {
       const double Ld = L1 + spectrumInfo.l2(workspaceIndex);
       // fix the x-axis
       MantidVec timeBins;
       size_t pivot = this->unwrapX(m_inputWS->x(workspaceIndex), timeBins, Ld);
-      outputWS->setBinEdges(workspaceIndex, timeBins);
+      outputWS->setBinEdges(workspaceIndex, std::move(timeBins));
 
       pivot++; // one-off difference between x and y
 
@@ -217,7 +217,7 @@ void UnwrapSNS::execEvent() {
     MantidVec time_bins;
     if (outW->x(0).size() > 2) {
       this->unwrapX(m_inputWS->x(workspaceIndex), time_bins, Ld);
-      outW->setBinEdges(workspaceIndex, time_bins);
+      outW->setBinEdges(workspaceIndex, std::move(time_bins));
     } else {
       outW->setSharedX(workspaceIndex, m_inputWS->sharedX(workspaceIndex));
     }

--- a/Framework/Algorithms/src/UnwrapSNS.cpp
+++ b/Framework/Algorithms/src/UnwrapSNS.cpp
@@ -151,8 +151,7 @@ void UnwrapSNS::exec() {
       const double Ld = L1 + spectrumInfo.l2(workspaceIndex);
       // fix the x-axis
       MantidVec timeBins;
-      size_t pivot = this->unwrapX(m_inputWS->x(workspaceIndex),
-                                   timeBins, Ld);
+      size_t pivot = this->unwrapX(m_inputWS->x(workspaceIndex), timeBins, Ld);
       outputWS->setBinEdges(workspaceIndex, timeBins);
 
       pivot++; // one-off difference between x and y
@@ -163,7 +162,8 @@ void UnwrapSNS::exec() {
 
       auto lengthFirstPartY = std::distance(yIn.begin() + pivot, yIn.end());
       std::copy(yIn.begin() + pivot, yIn.end(), yOut.begin());
-      std::copy(yIn.begin(), yIn.begin() + pivot, yOut.begin() + lengthFirstPartY);
+      std::copy(yIn.begin(), yIn.begin() + pivot,
+                yOut.begin() + lengthFirstPartY);
 
       // fix the uncertainties using the pivot point
       auto &eIn = m_inputWS->e(workspaceIndex);
@@ -171,7 +171,8 @@ void UnwrapSNS::exec() {
 
       auto lengthFirstPartE = std::distance(eIn.begin() + pivot, eIn.end());
       std::copy(eIn.begin() + pivot, eIn.end(), eOut.begin());
-      std::copy(eIn.begin(), eIn.begin() + pivot, eOut.begin() + lengthFirstPartE);
+      std::copy(eIn.begin(), eIn.begin() + pivot,
+                eOut.begin() + lengthFirstPartE);
     }
     m_progress->report();
     PARALLEL_END_INTERUPT_REGION
@@ -241,8 +242,8 @@ void UnwrapSNS::execEvent() {
   this->runMaskDetectors();
 }
 
-int UnwrapSNS::unwrapX(const Mantid::HistogramData::HistogramX &datain, MantidVec &dataout,
-                       const double &Ld) {
+int UnwrapSNS::unwrapX(const Mantid::HistogramData::HistogramX &datain,
+                       MantidVec &dataout, const double &Ld) {
   MantidVec tempX_L; // lower half - to be frame wrapped
   tempX_L.reserve(m_XSize);
   tempX_L.clear();

--- a/Framework/Algorithms/src/VesuvioL1ThetaResolution.cpp
+++ b/Framework/Algorithms/src/VesuvioL1ThetaResolution.cpp
@@ -201,24 +201,24 @@ void VesuvioL1ThetaResolution::exec() {
 
     // Set values in output workspace
     const int specNo = m_instWorkspace->getSpectrum(i).getSpectrumNo();
-    m_outputWorkspace->dataX(0)[i] = specNo;
-    m_outputWorkspace->dataX(1)[i] = specNo;
-    m_outputWorkspace->dataX(2)[i] = specNo;
-    m_outputWorkspace->dataX(3)[i] = specNo;
-    m_outputWorkspace->dataY(0)[i] = l1Stats.mean;
-    m_outputWorkspace->dataY(1)[i] = l1Stats.standard_deviation;
-    m_outputWorkspace->dataY(2)[i] = thetaStats.mean;
-    m_outputWorkspace->dataY(3)[i] = thetaStats.standard_deviation;
+    m_outputWorkspace->mutableX(0)[i] = specNo;
+    m_outputWorkspace->mutableX(1)[i] = specNo;
+    m_outputWorkspace->mutableX(2)[i] = specNo;
+    m_outputWorkspace->mutableX(3)[i] = specNo;
+    m_outputWorkspace->mutableY(0)[i] = l1Stats.mean;
+    m_outputWorkspace->mutableY(1)[i] = l1Stats.standard_deviation;
+    m_outputWorkspace->mutableY(2)[i] = thetaStats.mean;
+    m_outputWorkspace->mutableY(3)[i] = thetaStats.standard_deviation;
 
     // Process data for L1 distribution
     if (m_l1DistributionWs) {
-      std::vector<double> &x = m_l1DistributionWs->dataX(i);
+      auto &x = m_l1DistributionWs->mutableX(i);
       std::vector<double> y(numEvents, 1.0);
 
       std::sort(l1.begin(), l1.end());
       std::copy(l1.begin(), l1.end(), x.begin());
 
-      m_l1DistributionWs->dataY(i) = y;
+      m_l1DistributionWs->mutableY(i) = y;
 
       auto &spec = m_l1DistributionWs->getSpectrum(i);
       spec.setSpectrumNo(specNo);
@@ -227,13 +227,13 @@ void VesuvioL1ThetaResolution::exec() {
 
     // Process data for theta distribution
     if (m_thetaDistributionWs) {
-      std::vector<double> &x = m_thetaDistributionWs->dataX(i);
+      auto &x = m_thetaDistributionWs->mutableX(i);
       std::vector<double> y(numEvents, 1.0);
 
       std::sort(theta.begin(), theta.end());
       std::copy(theta.begin(), theta.end(), x.begin());
 
-      m_thetaDistributionWs->dataY(i) = y;
+      m_thetaDistributionWs->mutableY(i) = y;
 
       auto &spec = m_thetaDistributionWs->getSpectrum(i);
       spec.setSpectrumNo(specNo);
@@ -429,7 +429,7 @@ VesuvioL1ThetaResolution::processDistribution(MatrixWorkspace_sptr ws,
   double xMin(DBL_MAX);
   double xMax(DBL_MIN);
   for (size_t i = 0; i < numHist; i++) {
-    const std::vector<double> &x = ws->readX(i);
+    auto &x = ws->x(i);
     xMin = std::min(xMin, x.front());
     xMax = std::max(xMax, x.back());
   }
@@ -448,8 +448,8 @@ VesuvioL1ThetaResolution::processDistribution(MatrixWorkspace_sptr ws,
   ws = rebin->getProperty("OutputWorkspace");
 
   for (size_t i = 0; i < numHist; i++) {
-    const std::vector<double> &y = ws->readY(i);
-    std::vector<double> &e = ws->dataE(i);
+    auto &y = ws->y(i);
+    auto &e = ws->mutableE(i);
 
     std::transform(y.begin(), y.end(), e.begin(), SquareRoot());
   }

--- a/Framework/Algorithms/src/WeightedMeanOfWorkspace.cpp
+++ b/Framework/Algorithms/src/WeightedMeanOfWorkspace.cpp
@@ -61,8 +61,8 @@ void WeightedMeanOfWorkspace::exec() {
     if (spectrumInfo.hasDetectors(i))
       if (spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i))
         continue;
-    auto &y = inputWS->mutableY(i);
-    auto &e = inputWS->mutableE(i);
+    auto &y = inputWS->y(i);
+    auto &e = inputWS->e(i);
     double weight = 0.0;
     for (std::size_t j = 0; j < y.size(); ++j) {
       if (std::isfinite(y[j]) && std::isfinite(e[j])) {

--- a/Framework/Algorithms/src/WeightedMeanOfWorkspace.cpp
+++ b/Framework/Algorithms/src/WeightedMeanOfWorkspace.cpp
@@ -61,8 +61,8 @@ void WeightedMeanOfWorkspace::exec() {
     if (spectrumInfo.hasDetectors(i))
       if (spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i))
         continue;
-    MantidVec y = inputWS->dataY(i);
-    MantidVec e = inputWS->dataE(i);
+    auto &y = inputWS->mutableY(i);
+    auto &e = inputWS->mutableE(i);
     double weight = 0.0;
     for (std::size_t j = 0; j < y.size(); ++j) {
       if (std::isfinite(y[j]) && std::isfinite(e[j])) {
@@ -72,9 +72,9 @@ void WeightedMeanOfWorkspace::exec() {
       }
     }
   }
-  singleValued->dataX(0)[0] = 0.0;
-  singleValued->dataY(0)[0] = averageValue / weightSum;
-  singleValued->dataE(0)[0] = std::sqrt(weightSum);
+  singleValued->mutableX(0)[0] = 0.0;
+  singleValued->mutableY(0)[0] = averageValue / weightSum;
+  singleValued->mutableE(0)[0] = std::sqrt(weightSum);
   this->setProperty("OutputWorkspace", singleValued);
 }
 

--- a/Framework/Algorithms/src/WienerSmooth.cpp
+++ b/Framework/Algorithms/src/WienerSmooth.cpp
@@ -366,14 +366,19 @@ WienerSmooth::smoothSingleSpectrum(API::MatrixWorkspace_sptr inputWS,
 
   // copy the x-values and errors from the original spectrum
   // remove the last values for odd-sized inputs
+
   if (isOddSize) {
     auto histogram = out->histogram(0);
+    histogram.setSharedX(inputWS->sharedX(wsIndex));
+    histogram.setSharedE(inputWS->sharedE(wsIndex));
     auto newSize = histogram.y().size() - 1;
+
     histogram.resize(newSize);
     out->setHistogram(0, histogram);
-  }
-  out->setSharedX(0, inputWS->sharedX(wsIndex));
-  out->setSharedE(0, inputWS->sharedE(wsIndex));
+  } else {
+    out->setSharedX(0, inputWS->sharedX(wsIndex));
+    out->setSharedE(0, inputWS->sharedE(wsIndex));
+}
 
   return out;
 }

--- a/Framework/Algorithms/src/WienerSmooth.cpp
+++ b/Framework/Algorithms/src/WienerSmooth.cpp
@@ -169,7 +169,7 @@ WienerSmooth::smoothSingleSpectrum(API::MatrixWorkspace_sptr inputWS,
     auto lastX = x.back();
     auto dx = x[dataSize - 1] - x[dataSize - 2];
 
-    auto& y = inputWS->y(wsIndex);
+    auto &y = inputWS->y(wsIndex);
     size_t newSize = y.size() + 1;
 
     auto histogram = inputWS->histogram(wsIndex);
@@ -182,9 +182,9 @@ WienerSmooth::smoothSingleSpectrum(API::MatrixWorkspace_sptr inputWS,
     auto sizeYResized = yResized.size();
     auto sizeEResized = eResized.size();
 
-    xResized[sizeXResized-1] = lastX + dx;
-    yResized[sizeYResized-1] = yResized[sizeYResized-2];
-    eResized[sizeEResized-1] = eResized[sizeEResized-2];
+    xResized[sizeXResized - 1] = lastX + dx;
+    yResized[sizeYResized - 1] = yResized[sizeYResized - 2];
+    eResized[sizeEResized - 1] = eResized[sizeEResized - 2];
     inputWS->setHistogram(wsIndex, histogram);
   }
 
@@ -384,13 +384,13 @@ WienerSmooth::smoothSingleSpectrum(API::MatrixWorkspace_sptr inputWS,
     histogram.resize(newSize);
     out->setHistogram(0, histogram);
 
-    auto& xOut = out->mutableX(0);
+    auto &xOut = out->mutableX(0);
     xOut.assign(X.begin(), X.end() - 1);
-    auto& eOut = out->mutableE(0);
+    auto &eOut = out->mutableE(0);
     eOut.assign(E.begin(), E.end() - 1);
   } else {
     out->mutableX(0) = X;
-    auto& eOut = out->mutableE(0);
+    auto &eOut = out->mutableE(0);
     eOut.assign(E.begin(), E.end());
   }
 
@@ -405,8 +405,9 @@ WienerSmooth::smoothSingleSpectrum(API::MatrixWorkspace_sptr inputWS,
  *   centres are used.
  * @return :: A pair of start x and end x.
  */
-std::pair<double, double> WienerSmooth::getStartEnd(const Mantid::HistogramData::HistogramX &X,
-                                                    bool isHistogram) const {
+std::pair<double, double>
+WienerSmooth::getStartEnd(const Mantid::HistogramData::HistogramX &X,
+                          bool isHistogram) const {
   const size_t n = X.size();
   if (n < 3) {
     // 3 is the smallest number for this method to work without breaking

--- a/Framework/Algorithms/src/WienerSmooth.cpp
+++ b/Framework/Algorithms/src/WienerSmooth.cpp
@@ -378,7 +378,7 @@ WienerSmooth::smoothSingleSpectrum(API::MatrixWorkspace_sptr inputWS,
   } else {
     out->setSharedX(0, inputWS->sharedX(wsIndex));
     out->setSharedE(0, inputWS->sharedE(wsIndex));
-}
+  }
 
   return out;
 }

--- a/Framework/Algorithms/test/UnwrapSNSTest.h
+++ b/Framework/Algorithms/test/UnwrapSNSTest.h
@@ -87,9 +87,9 @@ public:
     TS_ASSERT(min_eventN < ws->getSpectrum(NUMPIXELS - 1).getTofMin());
     TS_ASSERT(max_eventN < ws->getSpectrum(NUMPIXELS - 1).getTofMax());
 
-    TS_ASSERT_EQUALS(ws->getSpectrum(0).dataX()[0], 0.0);
-    TS_ASSERT_EQUALS(ws->getSpectrum(0).dataX()[1], 2.0);
-    TS_ASSERT_EQUALS(ws->getSpectrum(0).dataX()[2], 4.0);
+    TS_ASSERT_EQUALS(ws->getSpectrum(0).x()[0], 0.0);
+    TS_ASSERT_EQUALS(ws->getSpectrum(0).x()[1], 2.0);
+    TS_ASSERT_EQUALS(ws->getSpectrum(0).x()[2], 4.0);
   }
 };
 

--- a/Framework/Algorithms/test/WeightedMeanOfWorkspaceTest.h
+++ b/Framework/Algorithms/test/WeightedMeanOfWorkspaceTest.h
@@ -54,8 +54,8 @@ public:
       return;
 
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(ws->readY(0)[0], 2.0);
-    TS_ASSERT_EQUALS(ws->readE(0)[0], 1.0);
+    TS_ASSERT_EQUALS(ws->y(0)[0], 2.0);
+    TS_ASSERT_EQUALS(ws->e(0)[0], 1.0);
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
@@ -66,9 +66,9 @@ public:
     MatrixWorkspace_sptr inputWS = createWorkspace(false);
 
     // Put bad values into workspace
-    inputWS->dataY(1)[0] = std::numeric_limits<double>::quiet_NaN();
-    inputWS->dataE(1)[1] = std::numeric_limits<double>::quiet_NaN();
-    inputWS->dataY(1)[2] = std::numeric_limits<double>::infinity();
+    inputWS->mutableY(1)[0] = std::numeric_limits<double>::quiet_NaN();
+    inputWS->mutableE(1)[1] = std::numeric_limits<double>::quiet_NaN();
+    inputWS->mutableY(1)[2] = std::numeric_limits<double>::infinity();
 
     // Name of the output workspace.
     std::string outWSName("WeightedMeanOfWorkspaceTest_OutputWS");
@@ -88,8 +88,8 @@ public:
       return;
 
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(ws->readY(0)[0], 2.0);
-    TS_ASSERT_EQUALS(ws->readE(0)[0], 1.0);
+    TS_ASSERT_EQUALS(ws->y(0)[0], 2.0);
+    TS_ASSERT_EQUALS(ws->e(0)[0], 1.0);
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);

--- a/Framework/Algorithms/test/WienerSmoothTest.h
+++ b/Framework/Algorithms/test/WienerSmoothTest.h
@@ -522,9 +522,9 @@ private:
                double *ysmooth) {
 
     auto dataWS = WorkspaceFactory::Instance().create("Workspace2D", 1, nx, ny);
-    auto &X = dataWS->dataX(0);
-    auto &Y = dataWS->dataY(0);
-    auto &E = dataWS->dataE(0);
+    auto &X = dataWS->mutableX(0);
+    auto &Y = dataWS->mutableY(0);
+    auto &E = dataWS->mutableE(0);
     X.assign(x, x + nx);
     Y.assign(y, y + ny);
     E.assign(e, e + ny);
@@ -532,11 +532,10 @@ private:
     std::vector<int> wsIndexList(1, 0);
     auto outputWs = runWienerSmooth(dataWS, wsIndexList);
 
-    auto &outY = outputWs->readY(0);
+    auto &outY = outputWs->y(0);
 
     for (size_t i = 0; i < outY.size(); ++i) {
       TS_ASSERT_DELTA(outY[i], ysmooth[i], 1e-5);
-      // std::cerr << outY[i] << '\n';
     }
 
     AnalysisDataService::Instance().clear();
@@ -557,8 +556,8 @@ private:
 
     for (size_t outSpec = 0; outSpec < nSpec; ++outSpec) {
       size_t inSpec = wsIndexList.empty() ? outSpec : wsIndexList[outSpec];
-      auto &inY = inputWS->readY(inSpec);
-      auto &outY = outputWS->readY(outSpec);
+      auto &inY = inputWS->y(inSpec);
+      auto &outY = outputWS->y(outSpec);
       TS_ASSERT(!std::equal(outY.begin(), outY.end(), inY.begin()));
 
       std::vector<double> diff(inY.size());
@@ -599,13 +598,13 @@ private:
             outWSName));
     TS_ASSERT(ws);
 
-    auto &inX = inputWS->readX(0);
-    auto &inE = inputWS->readE(0);
+    auto &inX = inputWS->x(0);
+    auto &inE = inputWS->e(0);
 
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
 
-      auto outX = ws->readX(i);
-      auto outE = ws->readE(i);
+      auto outX = ws->x(i);
+      auto outE = ws->e(i);
 
       TS_ASSERT(std::equal(outX.begin(), outX.end(), inX.begin()));
       TS_ASSERT(std::equal(outE.begin(), outE.end(), inE.begin()));
@@ -634,9 +633,9 @@ private:
         WorkspaceFactory::Instance().create("Workspace2D", nSpec, nx, ny);
 
     for (size_t i = 0; i < nSpec; ++i) {
-      auto &X = dataWS->dataX(i);
-      auto &Y = dataWS->dataY(i);
-      auto &E = dataWS->dataE(i);
+      auto &X = dataWS->mutableX(i);
+      auto &Y = dataWS->mutableY(i);
+      auto &E = dataWS->mutableE(i);
       X.assign(x, x + nx);
       Y.assign(y, y + ny);
       E.assign(e, e + ny);

--- a/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
@@ -137,6 +137,13 @@ public:
   void setSharedE(const Kernel::cow_ptr<HistogramE> &e) & ;
   void setSharedDx(const Kernel::cow_ptr<HistogramDx> &Dx) & ;
 
+  /// Returns the size of the histogram, i.e., the number of Y data points.
+  size_t size() const {
+    if (xMode() == XMode::BinEdges)
+      return m_x->size() - 1;
+    return m_x->size();
+  }
+
   void resize(size_t n);
 
   // Temporary legacy interface to X
@@ -198,12 +205,6 @@ private:
   template <class... T> bool selfAssignmentE(const T &...) { return false; }
   void switchDxToBinEdges();
   void switchDxToPoints();
-
-  size_t size() const {
-    if (xMode() == XMode::BinEdges)
-      return m_x->size() - 1;
-    return m_x->size();
-  }
 
   XMode m_xMode;
   YMode m_yMode{YMode::Uninitialized};


### PR DESCRIPTION
HistogramData rollout: algorithms 51 to 55
## Description of work.

This PR is part of refactoring effort to use the new interface of the HistogramData module.
See https://github.com/mantidproject/mantid/issues/17641 for details.

The following algorithms were refactored to use HistogramData:

Performance tests were added for:

The following algorithms have improved performance:
## To test.

Note that `WienerSmooth`, `UnwrapMonitor` and `UnwrapSNS` all modify the length of the histograms. Have a very very close look at those algorithms. Triple check `UnwrapMonitor` since this does not even come with a unit test by itself, although it is partially and indirectly tested via `IndirectTransmissionMonitorTest`

Code review.

Fixes #17692.
Internal change, no release notes (potential performance improvements will be added to release notes as part of the umbrella issue).
