### PR TITLE
Fix gcc warnings on Ubuntu 16.04

### DIFF
--- a/Framework/Algorithms/test/MonitorEfficiencyCorUserTest.h
+++ b/Framework/Algorithms/test/MonitorEfficiencyCorUserTest.h
@@ -155,7 +155,7 @@ public:
     API::AnalysisDataService::Instance().addOrReplace("input", input);
   }
 
-  void tearDown() {
+  void tearDown() override {
     API::AnalysisDataService::Instance().remove("input");
     API::AnalysisDataService::Instance().remove("ouput");
   }

--- a/Framework/Algorithms/test/Stitch1DTest.h
+++ b/Framework/Algorithms/test/Stitch1DTest.h
@@ -640,7 +640,7 @@ public:
     delete suite;
   }
 
-  void setUp() {
+  void setUp() override {
     HistogramX x1(1000, LinearGenerator(0, 0.02));
     HistogramX x2(1000, LinearGenerator(19, 0.02));
     HistogramY y1(999, 1);

--- a/Framework/Crystal/test/MaskPeaksWorkspaceTest.h
+++ b/Framework/Crystal/test/MaskPeaksWorkspaceTest.h
@@ -146,7 +146,7 @@ public:
 
 class MaskPeaksWorkspaceTestPerformance : public CxxTest::TestSuite {
 public:
-  void setUp() {
+  void setUp() override {
     EventWorkspace_sptr inputWS = Mantid::DataObjects::MDEventsTestHelper::
         createDiffractionEventWorkspace(1000, 10000, 16000);
     AnalysisDataService::Instance().addOrReplace(inputWSName, inputWS);
@@ -162,7 +162,9 @@ public:
 
   void testPerformance() { mpwAlg.execute(); }
 
-  void tearDown() { AnalysisDataService::Instance().remove(inputWSName); }
+  void tearDown() override {
+    AnalysisDataService::Instance().remove(inputWSName);
+  }
 
 private:
   MaskPeaksWorkspace mpwAlg;

--- a/Framework/CurveFitting/test/Algorithms/SplineBackgroundTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SplineBackgroundTest.h
@@ -60,7 +60,7 @@ public:
 class SplineBackgroundTestPerformance : public CxxTest::TestSuite {
 
 public:
-  void setUp() {
+  void setUp() override {
     constexpr size_t nspec = 1;
     constexpr double xRangeStart = 0.1;
     constexpr double xRangeEnd = 2500.1;
@@ -96,7 +96,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(SplineBackgroundAlg->execute());
   }
 
-  void tearDown() {
+  void tearDown() override {
     WorkspaceCreationHelper::removeWS(inputWsName);
     WorkspaceCreationHelper::removeWS(outputWsName);
   }

--- a/Framework/CurveFitting/test/Algorithms/SplineInterpolationTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SplineInterpolationTest.h
@@ -164,7 +164,7 @@ public:
 
 class SplineInterpolationTestPerformance : public CxxTest::TestSuite {
 public:
-  void setUp() {
+  void setUp() override {
 
     constexpr int order(2), spectra(1);
     constexpr int xStartVal(0), xEndVal(100);
@@ -197,7 +197,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(splineInterpAlg.execute());
   }
 
-  void tearDown() {
+  void tearDown() override {
     AnalysisDataService::Instance().remove(outputWsName);
     AnalysisDataService::Instance().remove(outDerivWsName);
   }

--- a/Framework/CurveFitting/test/Algorithms/VesuvioCalculateGammaBackgroundTest.h
+++ b/Framework/CurveFitting/test/Algorithms/VesuvioCalculateGammaBackgroundTest.h
@@ -263,7 +263,7 @@ using namespace CxxTest;
 
 class VesuvioCalculateGammaBackgroundTestPerformance : public TestSuite {
 public:
-  void setUp() {
+  void setUp() override {
     double x0(50.0), x1(300.0), dx(0.5);
     constexpr int nhist = 1;
 

--- a/Framework/DataHandling/src/LoadHelper.cpp
+++ b/Framework/DataHandling/src/LoadHelper.cpp
@@ -307,8 +307,9 @@ void LoadHelper::recurseAndAddNexusFieldsToWsRun(NXhandle nxfileID,
             int units_len = NX_MAXNAMELEN;
             int units_type = NX_CHAR;
 
-            units_status = NXgetattr(nxfileID, "units", units_sbuf, &units_len,
-                                     &units_type);
+            char unitsAttrName[] = "units";
+            units_status = NXgetattr(nxfileID, unitsAttrName, units_sbuf,
+                                     &units_len, &units_type);
             if (units_status != NX_ERROR) {
               g_log.debug() << indent_str << "[ " << property_name
                             << " has unit " << units_sbuf << " ]\n";

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -982,8 +982,9 @@ int NexusFileIO::getWorkspaceSize(int &numberOfSpectra, int &numberOfChannels,
   int len = NX_MAXNAMELEN;
   type = NX_CHAR;
 
-  if (checkAttributeName("units")) {
-    status = NXgetattr(fileID, "units", sbuf, &len, &type);
+  char unitsAttrName[] = "units";
+  if (checkAttributeName(unitsAttrName)) {
+    status = NXgetattr(fileID, unitsAttrName, sbuf, &len, &type);
     if (status != NX_ERROR)
       yUnits = sbuf;
     NXclosedata(fileID);
@@ -995,7 +996,7 @@ int NexusFileIO::getWorkspaceSize(int &numberOfSpectra, int &numberOfChannels,
     return (4);
   len = NX_MAXNAMELEN;
   type = NX_CHAR;
-  NXgetattr(fileID, "units", sbuf, &len, &type);
+  NXgetattr(fileID, unitsAttrName, sbuf, &len, &type);
   axesUnits = std::string(sbuf, len);
   NXgetinfo(fileID, &rank, dim, &type);
   // non-uniform X has 2D axis1 data
@@ -1010,7 +1011,7 @@ int NexusFileIO::getWorkspaceSize(int &numberOfSpectra, int &numberOfChannels,
   NXopendata(fileID, "axis2");
   len = NX_MAXNAMELEN;
   type = NX_CHAR;
-  NXgetattr(fileID, "units", sbuf, &len, &type);
+  NXgetattr(fileID, unitsAttrName, sbuf, &len, &type);
   axesUnits += std::string(":") + std::string(sbuf, len);
   NXclosedata(fileID);
   NXclosegroup(fileID);

--- a/MantidQt/CustomInterfaces/test/MuonAnalysisFitDataPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/MuonAnalysisFitDataPresenterTest.h
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidAPI/GroupingLoader.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -36,6 +37,7 @@ using namespace testing;
 /// Mock data selector widget
 class MockDataSelector : public IMuonFitDataSelector {
 public:
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_CONST_METHOD0(getFilenames, QStringList());
   MOCK_CONST_METHOD0(getWorkspaceIndex, unsigned int());
   MOCK_CONST_METHOD0(getStartTime, double());
@@ -61,11 +63,13 @@ public:
   MOCK_METHOD1(setDatasetNames, void(const QStringList &));
   MOCK_CONST_METHOD0(getDatasetName, QString());
   MOCK_METHOD0(askUserWhetherToOverwrite, bool());
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 /// Mock fit property browser
 class MockFitBrowser : public IWorkspaceFitControl {
 public:
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(setWorkspaceName, void(const QString &));
   MOCK_METHOD1(setStartX, void(double));
   MOCK_METHOD1(setEndX, void(double));
@@ -76,6 +80,7 @@ public:
   MOCK_METHOD1(setSimultaneousLabel, void(const std::string &));
   MOCK_METHOD1(userChangedDataset, void(int));
   MOCK_CONST_METHOD0(rawData, bool());
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class MuonAnalysisFitDataPresenterTest : public CxxTest::TestSuite {

--- a/MantidQt/CustomInterfaces/test/MuonAnalysisFitFunctionPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/MuonAnalysisFitFunctionPresenterTest.h
@@ -4,6 +4,7 @@
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
@@ -23,6 +24,7 @@ public:
     m_func =
         Mantid::API::FunctionFactory::Instance().createFunction("Gaussian");
   }
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD0(getFunctionString, QString());
   Mantid::API::IFunction_sptr getGlobalFunction() override { return m_func; }
   MOCK_METHOD0(functionStructureChanged, void());
@@ -43,6 +45,7 @@ public:
   MOCK_METHOD3(setLocalParameterFixed, void(const QString &, int, bool));
   MOCK_METHOD3(setLocalParameterTie, void(const QString &, int, QString));
   MOCK_METHOD1(setCurrentDataset, void(int));
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 
 private:
   Mantid::API::IFunction_sptr m_func;
@@ -51,6 +54,7 @@ private:
 // Mock muon fit property browser
 class MockFitFunctionControl : public IMuonFitFunctionControl {
 public:
+  GCC_DIAG_OFF_SUGGEST_OVERRIDE
   MOCK_METHOD1(setFunction, void(const Mantid::API::IFunction_sptr));
   MOCK_METHOD0(runFit, void());
   MOCK_METHOD0(runSequentialFit, void());
@@ -61,6 +65,7 @@ public:
   MOCK_METHOD1(userChangedDatasetIndex, void(int));
   MOCK_METHOD1(setCompatibilityMode, void(bool));
   MOCK_METHOD1(fitRawDataClicked, void(bool));
+  GCC_DIAG_ON_SUGGEST_OVERRIDE
 };
 
 class MuonAnalysisFitFunctionPresenterTest : public CxxTest::TestSuite {


### PR DESCRIPTION
Fixed some warnings such that we can move our build servers to 16.04.

Tried this on my Ubuntu 16.04 workstation with `-Werror` and enabled performance tests (no Vates though), and it compiles now. I hope that catches everything.

**To test:**

Code review.

Fixes #17785.
No release notes.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
