### PR TITLE
Make files python3 compatible

### DIFF
--- a/scripts/Interface/reduction_gui/reduction/reflectometer/refl_data_series.py
+++ b/scripts/Interface/reduction_gui/reduction/reflectometer/refl_data_series.py
@@ -3,12 +3,13 @@
     from the the interface class so that the HFIRReduction class could
     be used independently of the interface implementation
 """
+from __future__ import (absolute_import, division, print_function)
 import xml.dom.minidom
 import os
 import time
 from reduction_gui.reduction.scripter import BaseScriptElement
-from refl_data_script import DataSets as REFLDataSets
-from refm_data_script import DataSets as REFMDataSets
+from reduction_gui.reduction.reflectometer.refl_data_script import DataSets as REFLDataSets
+from reduction_gui.reduction.reflectometer.refm_data_script import DataSets as REFMDataSets
 
 class DataSeries(BaseScriptElement):
 

--- a/scripts/Interface/reduction_gui/reduction/scripter.py
+++ b/scripts/Interface/reduction_gui/reduction/scripter.py
@@ -3,6 +3,7 @@
     Reduction scripter used to take reduction parameters
     end produce a Mantid reduction script
 """
+from __future__ import (absolute_import, division, print_function)
 # Check whether Mantid is available
 # Disable unused import warning
 # pylint: disable=W0611
@@ -612,7 +613,7 @@ class BaseReductionScripter(object):
         if HAS_MANTIDPLOT:
             mantidplot.runPythonScript(script, True)
         else:
-            exec script
+            exec(script)
 
     def reset(self):
         """


### PR DESCRIPTION
When using mantid compiled with python3, `LRAutoReduction` failed to load because it was incompatible. This fixes that (startup) issue.

**To test:**

Just see that the builds pass.

_There is no associated issue_

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
