### PR TITLE
Files without an extension can not be seen in load/save dialogues

### DIFF
--- a/MantidPlot/src/FitDialog.cpp
+++ b/MantidPlot/src/FitDialog.cpp
@@ -659,7 +659,7 @@ void FitDialog::saveUserFunction() {
           "Parent of FitDialog is not ApplicationWindow as expected.");
     }
     QString filter = tr("MantidPlot fit model") + " (*.fit);;";
-    filter += tr("All files") + " (*.*)";
+    filter += tr("All files") + " (*)";
     QString fn = MantidQt::API::FileDialogHandler::getSaveFileName(
         app, tr("MantidPlot") + " - " + tr("Save Fit Model As"),
         app->fitModelsPath + "/" + name, filter);
@@ -1420,7 +1420,7 @@ void FitDialog::saveInitialGuesses() {
           "Parent of FitDialog is not ApplicationWindow as expected.");
     }
     QString filter = tr("MantidPlot fit model") + " (*.fit);;";
-    filter += tr("All files") + " (*.*)";
+    filter += tr("All files") + " (*)";
     QString fn = MantidQt::API::FileDialogHandler::getSaveFileName(
         app, tr("MantidPlot") + " - " + tr("Save Fit Model As"),
         app->fitModelsPath + "/" + d_current_fit->objectName(), filter);

--- a/MantidQt/API/src/FilePropertyWidget.cpp
+++ b/MantidQt/API/src/FilePropertyWidget.cpp
@@ -105,7 +105,7 @@ QString getFileDialogFilter(const std::vector<std::string> &exts,
     }
     filter = filter.trimmed();
   }
-  filter.append("All Files (*.*)");
+  filter.append("All Files (*)");
   return filter;
 }
 

--- a/MantidQt/API/src/UserSubWindow.cpp
+++ b/MantidQt/API/src/UserSubWindow.cpp
@@ -125,7 +125,7 @@ QString UserSubWindow::openFileDialog(const bool save,
     }
     filter = filter.trimmed();
   }
-  filter.append(";;All Files (*.*)");
+  filter.append(";;All Files (*)");
 
   QString filename;
   if (save) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingViewQtWidget.cpp
@@ -34,7 +34,7 @@ const std::string EnggDiffFittingViewQtWidget::g_settingsGroup =
 const std::string EnggDiffFittingViewQtWidget::g_peaksListExt =
     "Peaks list File: CSV "
     "(*.csv *.txt);;"
-    "Other extensions/all files (*.*)";
+    "Other extensions/all files (*)";
 
 bool EnggDiffFittingViewQtWidget::m_fittingMutliRunMode = false;
 bool EnggDiffFittingViewQtWidget::m_fittingSingleRunMode = false;

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -33,7 +33,7 @@ int EnggDiffractionViewQtGUI::g_currentCropCalibBankName = 0;
 const std::string EnggDiffractionViewQtGUI::g_iparmExtStr =
     "GSAS instrument parameters, IPARM file: PRM, PAR, IPAR, IPARAM "
     "(*.prm *.par *.ipar *.iparam);;"
-    "Other extensions/all files (*.*)";
+    "Other extensions/all files (*)";
 
 const std::string EnggDiffractionViewQtGUI::g_pixelCalibExt =
     "Comma separated values text file with calibration table, CSV"
@@ -42,12 +42,12 @@ const std::string EnggDiffractionViewQtGUI::g_pixelCalibExt =
     "(*.nxs *.nexus);;"
     "Supported formats: CSV, NXS "
     "(*.csv *.nxs *.nexus);;"
-    "Other extensions/all files (*.*)";
+    "Other extensions/all files (*)";
 
 const std::string EnggDiffractionViewQtGUI::g_DetGrpExtStr =
     "Detector Grouping File: CSV "
     "(*.csv *.txt);;"
-    "Other extensions/all files (*.*)";
+    "Other extensions/all files (*)";
 
 const std::string EnggDiffractionViewQtGUI::g_settingsGroup =
     "CustomInterfaces/EnggDiffractionView";

--- a/MantidQt/CustomInterfaces/src/Homer.cpp
+++ b/MantidQt/CustomInterfaces/src/Homer.cpp
@@ -387,7 +387,7 @@ QString Homer::openFileDia(const bool save, const QStringList &exts) {
     }
     filter = filter.trimmed();
   }
-  filter.append(";;All Files (*.*)");
+  filter.append(";;All Files (*)");
 
   QString filename;
   if (save) {

--- a/MantidQt/CustomInterfaces/src/MantidEV.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEV.cpp
@@ -631,7 +631,7 @@ void MantidEV::loadEventFile_slot() {
   QString file_path = getFilePath(last_event_file);
   QString Qfile_name =
       QFileDialog::getOpenFileName(this, tr("Load event file"), file_path,
-                                   tr("Nexus Files (*.nxs);; All files(*.*)"));
+                                   tr("Nexus Files (*.nxs);; All files(*)"));
 
   if (Qfile_name.length() > 0) {
     m_uiForm.EventFileName_ledt->setText(Qfile_name);
@@ -647,7 +647,7 @@ void MantidEV::selectDetCalFile_slot() {
   QString file_path = getFilePath(last_cal_file);
   QString Qfile_name = QFileDialog::getOpenFileName(
       this, tr("Load calibration file"), file_path,
-      tr("ISAW .DetCal Files (*.DetCal);; All files(*.*)"));
+      tr("ISAW .DetCal Files (*.DetCal);; All files(*)"));
 
   if (Qfile_name.length() > 0) {
     m_uiForm.CalFileName_ledt->setText(Qfile_name);
@@ -663,7 +663,7 @@ void MantidEV::selectDetCalFile2_slot() {
   QString file_path = getFilePath(last_cal_file2);
   QString Qfile_name = QFileDialog::getOpenFileName(
       this, tr("Load calibration file"), file_path,
-      tr("ISAW .DetCal Files (*.DetCal);; All files(*.*)"));
+      tr("ISAW .DetCal Files (*.DetCal);; All files(*)"));
 
   if (Qfile_name.length() > 0) {
     m_uiForm.CalFileName2_ledt->setText(Qfile_name);
@@ -762,7 +762,7 @@ void MantidEV::getLoadPeaksFileName_slot() {
   QString file_path = getFilePath(last_peaks_file);
   QString Qfile_name = QFileDialog::getOpenFileName(
       this, tr("Load peaks file"), file_path,
-      tr("Peaks Files (*.peaks *.integrate *.nxs *.h5);; All files(*.*)"));
+      tr("Peaks Files (*.peaks *.integrate *.nxs *.h5);; All files(*)"));
 
   if (Qfile_name.length() > 0) {
     last_peaks_file = Qfile_name.toStdString();
@@ -778,7 +778,7 @@ void MantidEV::getSavePeaksFileName() {
   QString file_path = getFilePath(last_peaks_file);
   QString Qfile_name = QFileDialog::getSaveFileName(
       this, tr("Save peaks file"), file_path,
-      tr("Peaks Files (*.peaks *.integrate *.nxs *.h5);; All files(*.*)"), 0,
+      tr("Peaks Files (*.peaks *.integrate *.nxs *.h5);; All files(*)"), 0,
       QFileDialog::DontConfirmOverwrite);
 
   if (Qfile_name.length() > 0) {
@@ -926,7 +926,7 @@ void MantidEV::getLoadUB_FileName_slot() {
   QString file_path = getFilePath(last_UB_file);
   QString Qfile_name =
       QFileDialog::getOpenFileName(this, tr("Load matrix file"), file_path,
-                                   tr("Matrix Files (*.mat);; All files(*.*)"));
+                                   tr("Matrix Files (*.mat);; All files(*)"));
   if (Qfile_name.length() > 0) {
     last_UB_file = Qfile_name.toStdString();
     m_uiForm.SelectUBFile_ledt->setText(Qfile_name);
@@ -940,7 +940,7 @@ void MantidEV::getSaveUB_FileName() {
   QString file_path = getFilePath(last_UB_file);
   QString Qfile_name =
       QFileDialog::getSaveFileName(this, tr("Save matrix file"), file_path,
-                                   tr("Matrix Files (*.mat);; All files(*.*)"));
+                                   tr("Matrix Files (*.mat);; All files(*)"));
 
   if (Qfile_name.length() > 0) {
     last_UB_file = Qfile_name.toStdString();
@@ -1271,7 +1271,7 @@ void MantidEV::saveState_slot() {
   QString file_path = getFilePath(last_ini_file);
   QString Qfile_name = QFileDialog::getSaveFileName(
       this, tr("Save Settings File(.ini)"), file_path,
-      tr("Settings Files (*.ini);; All files(*.*) "));
+      tr("Settings Files (*.ini);; All files(*) "));
 
   if (Qfile_name.length() > 0) {
     last_ini_file = Qfile_name.toStdString();
@@ -1286,7 +1286,7 @@ void MantidEV::loadState_slot() {
   QString file_path = getFilePath(last_ini_file);
   QString Qfile_name = QFileDialog::getOpenFileName(
       this, tr("Load Settings File(.ini)"), file_path,
-      tr("Settings Files (*.ini);; All files(*.*)"));
+      tr("Settings Files (*.ini);; All files(*)"));
 
   if (Qfile_name.length() > 0) {
     last_ini_file = Qfile_name.toStdString();

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -564,7 +564,7 @@ void MuonAnalysis::runSaveGroupButton() {
 
   QString filter;
   filter.append("Files (*.xml *.XML)");
-  filter += ";;AllFiles (*.*)";
+  filter += ";;AllFiles (*)";
   QString groupingFile = MantidQt::API::FileDialogHandler::getSaveFileName(
       this, "Save Grouping file as", prevPath, filter);
 
@@ -603,7 +603,7 @@ void MuonAnalysis::runLoadGroupButton() {
 
   QString filter;
   filter.append("Files (*.xml *.XML)");
-  filter += ";;AllFiles (*.*)";
+  filter += ";;AllFiles (*)";
   QString groupingFile = QFileDialog::getOpenFileName(
       this, "Load Grouping file", prevPath, filter);
   if (groupingFile.isEmpty() || QFileInfo(groupingFile).isDir())

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -1940,7 +1940,7 @@ void SANSRunWindow::saveFileBrowse() {
                                   ConfigService::Instance().getString(
                                       "defaultsave.directory"))).toString();
 
-  const QString filter = ";;AllFiles (*.*)";
+  const QString filter = ";;AllFiles (*)";
 
   QString oFile = FileDialogHandler::getSaveFileName(
       this, title, prevPath + "/" + m_uiForm.outfile_edit->text());
@@ -1971,7 +1971,7 @@ bool SANSRunWindow::browseForFile(const QString &box_title,
   if (box_text.isEmpty()) {
     start_path = m_last_dir;
   }
-  file_filter += ";;AllFiles (*.*)";
+  file_filter += ";;AllFiles (*)";
   QString file_path =
       QFileDialog::getOpenFileName(this, box_title, start_path, file_filter);
   if (file_path.isEmpty() || QFileInfo(file_path).isDir())

--- a/MantidQt/CustomInterfaces/src/Tomography/ImageROIViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/ImageROIViewQtWidget.cpp
@@ -340,7 +340,7 @@ std::string ImageROIViewQtWidget::askImgOrStackPath() {
                             "(*.tif *.tiff);;"
                             "PNG, Portable Network Graphics "
                             "(*.png);;"
-                            "Other extensions/all files (*.*)");
+                            "Other extensions/all files (*)");
   QString prevPath =
       MantidQt::API::AlgorithmInputHistory::Instance().getPreviousDirectory();
   QString path(QFileDialog::getExistingDirectory(
@@ -364,7 +364,7 @@ std::string ImageROIViewQtWidget::askSingleImagePath() {
                             "(*.tif *.tiff);;"
                             "PNG, Portable Network Graphics "
                             "(*.png);;"
-                            "Other extensions/all files (*.*)");
+                            "Other extensions/all files (*)");
   QString prevPath =
       MantidQt::API::AlgorithmInputHistory::Instance().getPreviousDirectory();
   QString filepath(

--- a/MantidQt/CustomInterfaces/src/Tomography/ImggFormatsConvertViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/ImggFormatsConvertViewQtWidget.cpp
@@ -355,7 +355,7 @@ std::string ImggFormatsConvertViewQtWidget::askImgOrStackPath() {
                             "(*.tif *.tiff);;"
                             "PNG, Portable Network Graphics "
                             "(*.png);;"
-                            "Other extensions/all files (*.*)");
+                            "Other extensions/all files (*)");
   QString prevPath =
       MantidQt::API::AlgorithmInputHistory::Instance().getPreviousDirectory();
   QString path(QFileDialog::getExistingDirectory(

--- a/MantidQt/CustomInterfaces/src/Tomography/SavuConfigDialog.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/SavuConfigDialog.cpp
@@ -242,7 +242,7 @@ void TomographyIfaceViewQtGUI::removeClicked() {
 void TomographyIfaceViewQtGUI::menuOpenClicked() {
   QString s =
       QFileDialog::getOpenFileName(0, "Open file", QDir::currentPath(),
-                                   "NeXus files (*.nxs);;All files (*.*)",
+                                   "NeXus files (*.nxs);;All files (*)",
                                    new QString("NeXus files (*.nxs)"));
   std::string name = s.toStdString();
 
@@ -301,7 +301,7 @@ void TomographyIfaceViewQtGUI::menuSaveClicked() {
 void TomographyIfaceViewQtGUI::menuSaveAsClicked() {
   QString s =
       QFileDialog::getSaveFileName(0, "Save file", QDir::currentPath(),
-                                   "NeXus files (*.nxs);;All files (*.*)",
+                                   "NeXus files (*.nxs);;All files (*)",
                                    new QString("NeXus files (*.nxs)"));
   std::string name = s.toStdString();
   if ("" == name)

--- a/MantidQt/CustomInterfaces/src/Tomography/SavuConfigDialog.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/SavuConfigDialog.cpp
@@ -240,10 +240,9 @@ void TomographyIfaceViewQtGUI::removeClicked() {
 }
 
 void TomographyIfaceViewQtGUI::menuOpenClicked() {
-  QString s =
-      QFileDialog::getOpenFileName(0, "Open file", QDir::currentPath(),
-                                   "NeXus files (*.nxs);;All files (*)",
-                                   new QString("NeXus files (*.nxs)"));
+  QString s = QFileDialog::getOpenFileName(0, "Open file", QDir::currentPath(),
+                                           "NeXus files (*.nxs);;All files (*)",
+                                           new QString("NeXus files (*.nxs)"));
   std::string name = s.toStdString();
 
   if ("" == name)
@@ -299,10 +298,9 @@ void TomographyIfaceViewQtGUI::menuSaveClicked() {
 }
 
 void TomographyIfaceViewQtGUI::menuSaveAsClicked() {
-  QString s =
-      QFileDialog::getSaveFileName(0, "Save file", QDir::currentPath(),
-                                   "NeXus files (*.nxs);;All files (*)",
-                                   new QString("NeXus files (*.nxs)"));
+  QString s = QFileDialog::getSaveFileName(0, "Save file", QDir::currentPath(),
+                                           "NeXus files (*.nxs);;All files (*)",
+                                           new QString("NeXus files (*.nxs)"));
   std::string name = s.toStdString();
   if ("" == name)
     return;

--- a/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceViewQtGUI.cpp
@@ -1319,7 +1319,7 @@ void TomographyIfaceViewQtGUI::browseImageClicked() {
                             "(*.tif *.tiff);;"
                             "PNG, Portable Network Graphics "
                             "(*.png);;"
-                            "Other extensions/all files (*.*)");
+                            "Other extensions/all files (*)");
   // Note that this could be done using UserSubWindow::openFileDialog(),
   // but that method doesn't give much control over the text used for the
   // allowed extensions.

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorWidget.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorWidget.cpp
@@ -186,7 +186,7 @@ std::string QDataProcessorWidget::requestNotebookPath() {
   // causes problems on MacOS.
   QString qfilename = API::FileDialogHandler::getSaveFileName(
       this, "Save notebook file", QDir::currentPath(),
-      "IPython Notebook files (*.ipynb);;All files (*.*)",
+      "IPython Notebook files (*.ipynb);;All files (*)",
       new QString("IPython Notebook files (*.ipynb)"));
 
   // There is a Qt bug (QTBUG-27186) which means the filename returned

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
@@ -678,7 +678,7 @@ void InstrumentWidget::saveImage(QString filename) {
 QString InstrumentWidget::getSaveGroupingFilename() {
   QString filename = MantidQt::API::FileDialogHandler::getSaveFileName(
       this, "Save grouping file", m_savedialog_dir,
-      "Grouping (*.xml);;All files (*.*)");
+      "Grouping (*.xml);;All files (*)");
 
   // If its empty, they cancelled the dialog
   if (!filename.isEmpty()) {

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
@@ -754,8 +754,8 @@ void InstrumentWidgetMaskTab::sumDetsToWorkspace() {
 }
 
 void InstrumentWidgetMaskTab::saveIncludeGroupToFile() {
-  QString fname = m_instrWidget->getSaveFileName(
-      "Save grouping file", "XML files (*.xml);;All (*)");
+  QString fname = m_instrWidget->getSaveFileName("Save grouping file",
+                                                 "XML files (*.xml);;All (*)");
   if (!fname.isEmpty()) {
     QList<int> dets;
     m_instrWidget->getSurface()->getMaskedDetectors(dets);
@@ -764,8 +764,8 @@ void InstrumentWidgetMaskTab::saveIncludeGroupToFile() {
 }
 
 void InstrumentWidgetMaskTab::saveExcludeGroupToFile() {
-  QString fname = m_instrWidget->getSaveFileName(
-      "Save grouping file", "XML files (*.xml);;All (*)");
+  QString fname = m_instrWidget->getSaveFileName("Save grouping file",
+                                                 "XML files (*.xml);;All (*)");
   if (!fname.isEmpty()) {
     QList<int> dets;
     m_instrWidget->getSurface()->getMaskedDetectors(dets);

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
@@ -755,7 +755,7 @@ void InstrumentWidgetMaskTab::sumDetsToWorkspace() {
 
 void InstrumentWidgetMaskTab::saveIncludeGroupToFile() {
   QString fname = m_instrWidget->getSaveFileName(
-      "Save grouping file", "XML files (*.xml);;All (*.* *)");
+      "Save grouping file", "XML files (*.xml);;All (*)");
   if (!fname.isEmpty()) {
     QList<int> dets;
     m_instrWidget->getSurface()->getMaskedDetectors(dets);
@@ -765,7 +765,7 @@ void InstrumentWidgetMaskTab::saveIncludeGroupToFile() {
 
 void InstrumentWidgetMaskTab::saveExcludeGroupToFile() {
   QString fname = m_instrWidget->getSaveFileName(
-      "Save grouping file", "XML files (*.xml);;All (*.* *)");
+      "Save grouping file", "XML files (*.xml);;All (*)");
   if (!fname.isEmpty()) {
     QList<int> dets;
     m_instrWidget->getSurface()->getMaskedDetectors(dets);
@@ -845,7 +845,7 @@ void InstrumentWidgetMaskTab::saveMaskingToFile(bool invertMask) {
     QApplication::restoreOverrideCursor();
     QString fileName = m_instrWidget->getSaveFileName(
         "Select location and name for the mask file",
-        "XML files (*.xml);;All (*.* *)");
+        "XML files (*.xml);;All (*)");
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
     if (!fileName.isEmpty()) {

--- a/MantidQt/MantidWidgets/src/MWDiag.cpp
+++ b/MantidQt/MantidWidgets/src/MWDiag.cpp
@@ -488,7 +488,7 @@ QString MWDiag::openFileDialog(const bool save, const QStringList &exts) {
     }
     filter = filter.trimmed();
   }
-  filter.append(";;All Files (*.*)");
+  filter.append(";;All Files (*)");
 
   QString filename;
   if (save) {

--- a/MantidQt/MantidWidgets/src/MWRunFiles.cpp
+++ b/MantidQt/MantidWidgets/src/MWRunFiles.cpp
@@ -870,7 +870,7 @@ QString MWRunFiles::createFileFilter() {
     }
   }
 
-  QString allFiles("All Files (*.*)");
+  QString allFiles("All Files (*)");
   if (!fileExts.isEmpty()) {
 
     // The list may contain upper and lower cased versions, ensure these are on

--- a/MantidQt/MantidWidgets/src/SaveWorkspaces.cpp
+++ b/MantidQt/MantidWidgets/src/SaveWorkspaces.cpp
@@ -369,7 +369,7 @@ void SaveWorkspaces::saveFileBrowse() {
                                   ConfigService::Instance().getString(
                                       "defaultsave.directory"))).toString();
 
-  QString filter = ";;AllFiles (*.*)";
+  QString filter = ";;AllFiles (*)";
   QFileDialog::Option userCon = m_append->isChecked()
                                     ? QFileDialog::DontConfirmOverwrite
                                     : static_cast<QFileDialog::Option>(0);

--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -635,7 +635,7 @@ class MainWindow(QtGui.QMainWindow):
         """ Open a file dialog to get file
         """
         filename = QtGui.QFileDialog.getOpenFileName(self, 'Input File Dialog',
-                                                     self._defaultdir, "Data (*.nxs *.dat);;All files (*.*)")
+                                                     self._defaultdir, "Data (*.nxs *.dat);;All files (*)")
 
         self.ui.lineEdit.setText(str(filename))
 

--- a/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
+++ b/scripts/HFIRPowderReduction/HfirPDReductionGUI.py
@@ -453,7 +453,7 @@ class MainWindow(QtGui.QMainWindow):
         Return :: None
         """
         # Get file name
-        filefilter = "Text (*.txt);;Data (*.dat);;All files (*.*)"
+        filefilter = "Text (*.txt);;Data (*.dat);;All files (*)"
         curDir = os.getcwd()
         excldetfnames = QtGui.QFileDialog.getOpenFileNames(self, 'Open File(s)', curDir, filefilter)
         try:
@@ -736,7 +736,7 @@ class MainWindow(QtGui.QMainWindow):
             # Apply detector efficiency correction
             if vancorrfname is None:
                 # browse vanadium correction file
-                filefilter = "Text (*.txt);;Data (*.dat);;All files (*.*)"
+                filefilter = "Text (*.txt);;Data (*.dat);;All files (*)"
                 curDir = os.getcwd()
                 vancorrfnames = QtGui.QFileDialog.getOpenFileNames(self, 'Open File(s)', curDir, filefilter)
                 if len(vancorrfnames) > 0:
@@ -1423,7 +1423,7 @@ class MainWindow(QtGui.QMainWindow):
             else:
                 homedir = os.getcwd()
             # launch a dialog to get data
-            filefilter = "All files (*.*);;Fullprof (*.dat);;GSAS (*.gsa)"
+            filefilter = "All files (*);;Fullprof (*.dat);;GSAS (*.gsa)"
             sfilename = str(QtGui.QFileDialog.getSaveFileName(self, 'Save File', homedir, filefilter))
         except NotImplementedError as e:
             self._logError(str(e))

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleGUI.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleGUI.py
@@ -1343,7 +1343,7 @@ class MainWindow(QtGui.QMainWindow):
         num_rows = int(self.ui.lineEdit_numSurveyOutput.text())
 
         # get the csv file
-        file_filter = 'CSV Files (*.csv);;All Files (*.*)'
+        file_filter = 'CSV Files (*.csv);;All Files (*)'
         csv_file_name = str(QtGui.QFileDialog.getOpenFileName(self, 'Open Exp-Scan Survey File', self._homeDir,
                                                               file_filter))
         if csv_file_name is None or len(csv_file_name) == 0:
@@ -1932,7 +1932,7 @@ class MainWindow(QtGui.QMainWindow):
         :return:
         """
         # Get file name
-        file_filter = 'CSV Files (*.csv);;All Files (*.*)'
+        file_filter = 'CSV Files (*.csv);;All Files (*)'
         out_file_name = str(QtGui.QFileDialog.getSaveFileName(self, 'Save scan survey result',
                                                               self._homeDir, file_filter))
 
@@ -1946,7 +1946,7 @@ class MainWindow(QtGui.QMainWindow):
         :return:
         """
         # get file name
-        file_filter = 'Data Files (*.dat);;All Files (*.*)'
+        file_filter = 'Data Files (*.dat);;All Files (*)'
         ub_file_name = str(QtGui.QFileDialog.getSaveFileName(self, 'ASCII File To Save UB Matrix', self._homeDir,
                                                              file_filter))
 
@@ -2098,7 +2098,7 @@ class MainWindow(QtGui.QMainWindow):
         """ Get UB matrix from an Ascii file
         :return:
         """
-        file_filter = 'Data Files (*.dat);;Text Files (*.txt);;All Files (*.*)'
+        file_filter = 'Data Files (*.dat);;Text Files (*.txt);;All Files (*)'
         file_name = QtGui.QFileDialog.getOpenFileName(self, 'Open UB ASCII File', self._homeDir,
                                                       file_filter)
         # quit if cancelled

--- a/scripts/Interface/reduction_gui/instruments/dgs_interface_dev.py
+++ b/scripts/Interface/reduction_gui/instruments/dgs_interface_dev.py
@@ -13,7 +13,7 @@ class DgsInterface(InstrumentInterface):
         Defines the widgets for direct geometry spectrometer reduction
     """
     # Allowed extensions for loading data files
-    data_type = "Data files *.* (*.*)"
+    data_type = "Data files *.* (*)"
 
     def __init__(self, name, settings):
         super(DgsInterface, self).__init__(name, settings)

--- a/scripts/Interface/reduction_gui/instruments/dgs_interface_dev.py
+++ b/scripts/Interface/reduction_gui/instruments/dgs_interface_dev.py
@@ -13,7 +13,7 @@ class DgsInterface(InstrumentInterface):
         Defines the widgets for direct geometry spectrometer reduction
     """
     # Allowed extensions for loading data files
-    data_type = "Data files *.* (*)"
+    data_type = "Data files * (*)"
 
     def __init__(self, name, settings):
         super(DgsInterface, self).__init__(name, settings)

--- a/scripts/Interface/reduction_gui/instruments/diffraction_interface_dev.py
+++ b/scripts/Interface/reduction_gui/instruments/diffraction_interface_dev.py
@@ -13,7 +13,7 @@ class DiffractionInterface(InstrumentInterface):
         Defines the widgets for direct geometry spectrometer reduction
     """
     # Allowed extensions for loading data files
-    data_type = "Data files *.* (*.*)"
+    data_type = "Data files *.* (*)"
 
     def __init__(self, name, settings):
         """

--- a/scripts/Interface/reduction_gui/instruments/diffraction_interface_dev.py
+++ b/scripts/Interface/reduction_gui/instruments/diffraction_interface_dev.py
@@ -13,7 +13,7 @@ class DiffractionInterface(InstrumentInterface):
         Defines the widgets for direct geometry spectrometer reduction
     """
     # Allowed extensions for loading data files
-    data_type = "Data files *.* (*)"
+    data_type = "Data files * (*)"
 
     def __init__(self, name, settings):
         """

--- a/scripts/Interface/reduction_gui/widgets/diffraction/diffraction_run_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/diffraction/diffraction_run_setup.py
@@ -309,7 +309,7 @@ class RunSetupWidget(BaseWidget):
     def _calfile_browse(self):
         """ Event handing for browsing calibrtion file
         """
-        fname = self.data_browse_dialog(data_type="*.h5;;*.cal;;*.hd5;;*.hdf;;*.*")
+        fname = self.data_browse_dialog(data_type="*.h5;;*.cal;;*.hd5;;*.hdf;;*")
         if fname:
             self._content.calfile_edit.setText(fname)
 
@@ -318,7 +318,7 @@ class RunSetupWidget(BaseWidget):
     def _charfile_browse(self):
         """ Event handing for browsing calibrtion file
         """
-        fname = self.data_browse_dialog("*.txt;;*.*")
+        fname = self.data_browse_dialog("*.txt;;*")
         if fname:
             self._content.charfile_edit.setText(fname)
 
@@ -328,7 +328,7 @@ class RunSetupWidget(BaseWidget):
         """ Event handling for browsing Exp Ini file
         :return:
         """
-        exp_ini_file_name = self.data_browse_dialog(data_type="*.ini;;*.*")
+        exp_ini_file_name = self.data_browse_dialog(data_type="*.ini;;*")
         if exp_ini_file_name:
             self._content.lineEdit_expIniFile.setText(exp_ini_file_name)
 

--- a/scripts/Interface/reduction_gui/widgets/sans/stitcher.py
+++ b/scripts/Interface/reduction_gui/widgets/sans/stitcher.py
@@ -344,7 +344,7 @@ class StitcherWidget(BaseWidget):
         fname = QtCore.QFileInfo(QtGui.QFileDialog.getOpenFileName(self, title,
                                                                    self._output_dir,
                                                                    "Reduced XML files (*.xml);; Reduced Nexus files"
-                                                                   " (*.nxs);; All files (*.*)")).filePath()
+                                                                   " (*.nxs);; All files (*)")).filePath()
         if fname:
             # Store the location of the loaded file
             self._output_dir = str(QtCore.QFileInfo(fname).path())

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -1116,7 +1116,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
             else:
                 saveDialog = QtGui.QFileDialog(self.widgetMainRow.parent(), "Save Table")
                 saveDialog.setFileMode(QtGui.QFileDialog.AnyFile)
-                saveDialog.setNameFilter("Table Files (*.tbl);;All files (*.*)")
+                saveDialog.setNameFilter("Table Files (*.tbl);;All files (*)")
                 saveDialog.setDefaultSuffix("tbl")
                 saveDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
                 if saveDialog.exec_():
@@ -1131,7 +1131,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
         """
         saveDialog = QtGui.QFileDialog(self.widgetMainRow.parent(), "Save Table")
         saveDialog.setFileMode(QtGui.QFileDialog.AnyFile)
-        saveDialog.setNameFilter("Table Files (*.tbl);;All files (*.*)")
+        saveDialog.setNameFilter("Table Files (*.tbl);;All files (*)")
         saveDialog.setDefaultSuffix("tbl")
         saveDialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
         if saveDialog.exec_():
@@ -1145,7 +1145,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
         self.loading = True
         loadDialog = QtGui.QFileDialog(self.widgetMainRow.parent(), "Open Table")
         loadDialog.setFileMode(QtGui.QFileDialog.ExistingFile)
-        loadDialog.setNameFilter("Table Files (*.tbl);;All files (*.*)")
+        loadDialog.setNameFilter("Table Files (*.tbl);;All files (*)")
         if loadDialog.exec_():
             try:
                 #before loading make sure you give them a chance to save


### PR DESCRIPTION
This PR replaces most file filter instances of `*.*` with `*`. This should mean files with no extension are shown in load and save dialogues.

**To test:**

Take a look at the dialogues changed. For a few of them try browsing to a file with no extension, and check it can now be seen.

This needs to be tested on a selection of platforms, at least one for Windows, one for Mac and one for Linux. Please add a comment if you have tested on one of the platforms.

A review of the changes should also be made to make sure there are no potential problems with this, as it changes a large number of dialogues.

Fixes #17807 .

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
