### PR TITLE
Only run *PVPythonTest when MAKE_VATES=ON

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/CMakeLists.txt
@@ -15,7 +15,7 @@ set ( TEST_PY_FILES
 )
 
 if ( MAKE_VATES )
- list  ( TEST_PY_FILES PVPythonTest.py )
+ list  ( APPEND TEST_PY_FILES PVPythonTest.py )
 endif ()
 
 # Prefix for test=PythonInterface

--- a/Framework/PythonInterface/test/python/mantid/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/CMakeLists.txt
@@ -8,12 +8,15 @@ add_subdirectory( dataobjects )
 
 set ( TEST_PY_FILES
   ImportModuleTest.py
-  PVPythonTest.py
   SimpleAPITest.py
   SimpleAPILoadTest.py
   SimpleAPIFitTest.py
   SimpleAPIRenameWorkspaceTest.py  
 )
+
+if ( MAKE_VATES )
+ list  ( TEST_PY_FILES PVPythonTest.py )
+endif ()
 
 # Prefix for test=PythonInterface
 pyunittest_add_test ( ${CMAKE_CURRENT_SOURCE_DIR} PythonInterface ${TEST_PY_FILES} )

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -896,7 +896,7 @@ set ( MANTIDPLOT_TEST_PY_FILES
 )
 
 if ( MAKE_VATES )
- list  ( MANTIDPLOT_TEST_PY_FILES MantidPlotPVPythonTest.py )
+ list  ( APPEND MANTIDPLOT_TEST_PY_FILES MantidPlotPVPythonTest.py )
 endif ()
 
 if ( 0 )

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -893,8 +893,11 @@ set ( MANTIDPLOT_TEST_PY_FILES
     MantidPlotTiledWindowTest.py
     MantidPlotInputArgsCheck.py
     MantidPlotPyplotGeneralTest.py
-    MantidPlotPVPythonTest.py
 )
+
+if ( MAKE_VATES )
+ list  ( MANTIDPLOT_TEST_PY_FILES MantidPlotPVPythonTest.py )
+endif ()
 
 if ( 0 )
 	message (STATUS "Your CMAKE_SYSTEM string is '${CMAKE_SYSTEM}'")


### PR DESCRIPTION
Description of work.

Checks the value of `MAKE_VATES` before adding tests that require ParaView.

**To test:**

<!-- Instructions for testing. -->

Check `PythonInterface_PVPythonTest` and `MantidPlotPVPythonTest.py` are run on the build servers ( `MAKE_VATES=ON` ) and are NOT run when `MAKE_VATES=OFF`
Errors while running CTest

Fixes #17812.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
