### PR TITLE
Fixed assignment issue in ConvertUnits.

### DIFF
--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -813,18 +813,18 @@ API::MatrixWorkspace_sptr ConvertUnits::removeUnphysicalBins(
       auto edges = workspace->binEdges(j);
       auto k = lastBins[j];
 
-      result->mutableX(j).assign(edges.cbegin(), edges.cbegin() + k);
+      auto &X = result->mutableX(j);
+      std::copy(edges.cbegin(), edges.cbegin() + k, X.begin());
 
       // If the entire X range is not covered, generate fake values.
       if (k < maxBins) {
-        std::iota(result->mutableX(j).begin() + k, result->mutableX(j).end(),
-                  workspace->x(j)[k] + 1);
+        std::iota(X.begin() + k, X.end(), workspace->x(j)[k] + 1);
       }
 
-      result->mutableY(j)
-          .assign(workspace->y(j).cbegin(), workspace->y(j).cbegin() + (k - 1));
-      result->mutableE(j)
-          .assign(workspace->e(j).cbegin(), workspace->e(j).cbegin() + (k - 1));
+      std::copy(workspace->y(j).cbegin(), workspace->y(j).cbegin() + (k - 1),
+                result->mutableY(j).begin());
+      std::copy(workspace->e(j).cbegin(), workspace->e(j).cbegin() + (k - 1),
+                result->mutableE(j).begin());
     }
   }
 


### PR DESCRIPTION
See issue for description of the problem. I tried adding a regression test but could not figure out a way to trigger the code section that causes the issue (ideas welcome).

**To test:**

One way to test this is as follows:

``` python
Load(Filename='/home/simon/data/TrainingCourseData/MAR11015.raw', OutputWorkspace='MAR11015')
converted = ConvertUnits(InputWorkspace='MAR11015',Target='DeltaE',EMode='Indirect',EFixed=10)
```

Before the fix this fails with a size mismatch error from FixedLengthVector. After the fix this should work.
Of course MARI is not an indirect instrument so this actually should not work, i.e., I would not want to add this as a system test.

<!-- Instructions for testing. -->

Fixes #17821.

This issue was released as part of v3.8 and might need to be in a patch release, so I am not adding release notes for now.

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
