### PR TITLE
Correct the angles in the spectrum viewer

### DIFF
--- a/MantidQt/SpectrumViewer/src/MatrixWSDataSource.cpp
+++ b/MantidQt/SpectrumViewer/src/MatrixWSDataSource.cpp
@@ -285,8 +285,8 @@ std::vector<std::string> MatrixWSDataSource::getInfoList(double x, double y) {
       azi = det->getPhi();
     }
     SVUtils::PushNameValue("L2", 8, 4, l2, list);
-    SVUtils::PushNameValue("TwoTheta", 8, 2, two_theta * deg2rad, list);
-    SVUtils::PushNameValue("Azimuthal", 8, 2, azi * deg2rad, list);
+    SVUtils::PushNameValue("TwoTheta", 8, 2, two_theta * rad2deg, list);
+    SVUtils::PushNameValue("Azimuthal", 8, 2, azi * rad2deg, list);
 
     /* For now, only support diffractometers and monitors. */
     /* We need a portable way to determine emode and */

--- a/docs/source/release/v3.9.0/ui.rst
+++ b/docs/source/release/v3.9.0/ui.rst
@@ -42,6 +42,7 @@ Bugs Resolved
 -------------
 
 - Fixed a bug where checking or unchecking "show invisible workspaces" in View->Preferences->Mantid->Options would have no effect on workspaces loaded in the dock.
+- The Spectrum Viewer now reports two theta and azimuthal angle correctly.
 
 SliceViewer Improvements
 ------------------------


### PR DESCRIPTION
The angles in the spectrum viewer were being calculated incorrectly, this should fix them

**To test:**
1. Start mantidplot
2. Load some data
3. right click ws show detectors
4. right click ws spectrum viewer
5. Compare the TwoTheta, and Azumithal values from the spectrumviewer with the corresponding row in the detectors table using the theta and phi columns

Fixes #16792.

**RELEASE NOTES**
docs/source/release/.../ui.rst

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
