### PR TITLE
Hide packages from rhel6

### DIFF
--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -1,5 +1,5 @@
 Name:           mantid-developer
-Version:        1.18
+Version:        1.19
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -31,7 +31,11 @@ Requires: muParser-devel
 Requires: mxml-devel
 Requires: nexus >= 4.2
 Requires: nexus-devel >= 4.2
+%if 0%{?el6}
+Requires: ninja
+%else
 Requires: ninja-build
+%endif
 Requires: numpy
 Requires: OCE-devel
 Requires: poco-devel >= 1.4.6
@@ -41,7 +45,7 @@ Requires: python-ipython >= 1.1
 %{?el6:Conflicts: python-ipython >= 2.0}
 Requires: python-matplotlib
 %{?fedora:Requires: python2-matplotlib-qt4}
-%{?rhel:Requires: python-matplotlib-qt4}
+%{?el7:Requires: python-matplotlib-qt4}
 Requires: python-pip
 Requires: python-sphinx
 Requires: python-sphinx-theme-bootstrap


### PR DESCRIPTION
 The developer rpm not upgrading on rhel6 because package names were different. The builds can be completely ignored since the only change is a `.spec` file that nothing looks at.

**To test:**

Be @rosswhitfield and say that this is awesome.

Fixes #17512.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
