### PR TITLE
Add units of MomentumTransfer to the vertical axis of reduced BASIS files

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -237,10 +237,15 @@ class BASISReduction(PythonAlgorithm):
                                     OutputWorkspace=self._samSqwWs)  # from histo to point
             sapi.Transpose(InputWorkspace=self._samSqwWs,
                            OutputWorkspace=self._samSqwWs)  # Q-values back to vertical axis
-            # Output Dave and Nexus files
+            # Assign units of MomentumTransfer to the vertical axis
+            ws = sapi.mtd[self._samSqwWs]
+            axis = ws.getAxis(1)
+            axis.setUnit("MomentumTransfer")
+            # Output Dave file
             extension = "_divided.dat" if self._doNorm else ".dat"
             dave_grp_filename = self._makeRunName(self._samWsRun, False) + extension
             sapi.SaveDaveGrp(Filename=dave_grp_filename, InputWorkspace=self._samSqwWs, ToMicroEV=True)
+            # Output Nexus file
             extension = "_divided_sqw.nxs" if self._doNorm else "_sqw.nxs"
             processed_filename = self._makeRunName(self._samWsRun, False) + extension
             sapi.SaveNexus(Filename=processed_filename, InputWorkspace=self._samSqwWs)

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -238,8 +238,8 @@ class BASISReduction(PythonAlgorithm):
             sapi.Transpose(InputWorkspace=self._samSqwWs,
                            OutputWorkspace=self._samSqwWs)  # Q-values back to vertical axis
             # Assign units of MomentumTransfer to the vertical axis
-            ws = sapi.mtd[self._samSqwWs]
-            axis = ws.getAxis(1)
+            workspace = sapi.mtd[self._samSqwWs]
+            axis = workspace.getAxis(1)
             axis.setUnit("MomentumTransfer")
             # Output Dave file
             extension = "_divided.dat" if self._doNorm else ".dat"


### PR DESCRIPTION
Unit "MomentumTransfer" added to the vertical axis of the output workspace

**To test:**
Run this simple script to assert units have been correctly assigned:

```
BASISReduction(RunNumbers="59671", ReflectionType="silicon111", EnergyBins=[-120,0.4,120], MomentumTransferBins=[-0.3, 0.2, 1.9])
workspace=mtd["BSS_59671_sqw"]
axis=workspace.getAxis(1)
unit=axis.getUnit()
assert(unit.label()=='Angstrom^-1')
assert(unit.name()=='q')
```

Fixes #17836.
## _Does not need to be in the release notes._
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
