### PR TITLE
Re #17844 Should fix the issue.

### DIFF
--- a/scripts/Inelastic/Direct/PropertiesDescriptors.py
+++ b/scripts/Inelastic/Direct/PropertiesDescriptors.py
@@ -472,33 +472,39 @@ class SaveFileName(PropDescriptor):
         self._custom_print = None
 
     def __get__(self,instance,owner=None):
-
+        # getter functional interface.
         if instance is None:
             return self
+
+        # if custom file name provided, use it
+        if self._file_name:
+            return self._file_name
+
+        # if custom function to generate file name is proivede, use this function
         if self._custom_print is not None:
             return self._custom_print()
 
-        if self._file_name:
-            return self._file_name
+        # user provided nothing.
+        # calculate default target file name from 
+        # instrument, energy and run number.
+        if instance.instr_name:
+            name = instance.short_inst_name
         else:
-            if instance.instr_name:
-                name = instance.short_inst_name
-            else:
-                name = '_EMPTY'
+            name = '_EMPTY'
 
-            sr = owner.sample_run.run_number()
-            if not sr:
-                sr = 0
-            try:
-                ei = owner.incident_energy.get_current()
-                name +='{0:0<5}Ei{1:<4.2f}meV'.format(sr,ei)
-                if instance.sum_runs:
-                    name +='sum'
-                if owner.monovan_run.run_number():
-                    name +='_Abs'
-                name = name.replace('.','d')
+        sr = owner.sample_run.run_number()
+        if not sr:
+            sr = 0
+        try:
+            ei = owner.incident_energy.get_current()
+            name +='{0:0<5}Ei{1:<_4.2f}meV'.format(sr,ei)
+            if instance.sum_runs:
+                name +='sum'
+            if owner.monovan_run.run_number():
+                name +='_Abs'
+            name = name.replace('.','d')
 #pylint: disable=bare-except
-            except:
+        except:
                 name = None
         return name
 
@@ -506,6 +512,8 @@ class SaveFileName(PropDescriptor):
 
         if value is None:
             self._file_name = None
+        elif callable(value):
+            self._custom_print = value
         else:
             self._file_name = str(value)
 

--- a/scripts/Inelastic/Direct/PropertiesDescriptors.py
+++ b/scripts/Inelastic/Direct/PropertiesDescriptors.py
@@ -499,7 +499,7 @@ class SaveFileName(PropDescriptor):
             sr = 0
         try:
             ei = owner.incident_energy.get_current()
-            name +='{0:0<5}Ei{1:<_4.2f}meV'.format(sr,ei)
+            name +='{0:0<5}Ei{1:_<4.2f}meV'.format(sr,ei)
             if instance.sum_runs:
                 name +='sum'
             if owner.monovan_run.run_number():

--- a/scripts/Inelastic/Direct/PropertiesDescriptors.py
+++ b/scripts/Inelastic/Direct/PropertiesDescriptors.py
@@ -114,6 +114,13 @@ class AvrgAccuracy(PropDescriptor):
             vallist = [value]
         rez = []
         lim = 10**(self._accuracy-1)
+
+        def out(a,b,mult):
+            if mult>1:
+                return a<b
+            else:
+                return false
+
         for val in vallist:
             if abs(val) > lim:
                 rez.append(round(val,0))
@@ -123,14 +130,9 @@ class AvrgAccuracy(PropDescriptor):
             else:
                 mult = 1
 
-            def out(a,b):
-                if mult>1:
-                    return a<b
-                else:
-                    return false
             tv = abs(val)
             fin_mult  = 1
-            while out(tv,lim):
+            while out(tv,lim,mult):
                 fin_mult*=mult
                 tv      *= mult
             fin_rez = math.copysign(round(tv,0)/fin_mult,val)
@@ -315,7 +317,7 @@ class IncidentEnergy(PropDescriptor):
                 ei_ref,_,_,_=GetEi(InputWorkspace=monitor_ws,
                                    Monitor1Spec=ei_mon_spec[0], Monitor2Spec=ei_mon_spec[1], EnergyEstimate=ei)
                 fin_ei.append(ei_ref)
-#pylint: disable=broad-except
+#pylint: disable=bare-except
             except:
                 instance.log("Can not refine guess energy {0:f}. Ignoring it.".format(ei),'warning')
         if len(fin_ei) == 0:
@@ -485,7 +487,7 @@ class SaveFileName(PropDescriptor):
             return self._custom_print()
 
         # user provided nothing.
-        # calculate default target file name from 
+        # calculate default target file name from
         # instrument, energy and run number.
         if instance.instr_name:
             name = instance.short_inst_name
@@ -505,7 +507,7 @@ class SaveFileName(PropDescriptor):
             name = name.replace('.','d')
 #pylint: disable=bare-except
         except:
-                name = None
+            name = None
         return name
 
     def __set__(self,instance,value):
@@ -775,6 +777,7 @@ class DetCalFile(PropDescriptor):
             file_hint = inst_short_name+str(dcf_val).zfill(zero_padding)
             try:
                 file_name = FileFinder.findRuns(file_hint)[0]
+#pylint: disable=bare-except
             except:
                 return (False,"Can not find run file corresponding to run N: {0}".format(file_hint))
             self._det_cal_file = file_name


### PR DESCRIPTION
This should be very easy ticket to test. See #17844

To satisfy user requests I've just moved around two getters and, if both file name and custom function are defined, instead of calculating custom function first, I am returning the file name. 

No need in release notes -- 12 min on fixing the issue and request is just trivial, though it took an hour to understand what they are actually want because the real problem behind their requests is unreliable reload of a Python package.  This solution solves particular user request, but I have no idea how reload package issue can be addressed. 

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
