### PR TITLE
Module level import not at top of file

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/RefLReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/RefLReduction.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function)
 from mantid.api import *
 from mantid.simpleapi import *
+from mantid.kernel import *
 
 # import sfCalculator
 import sys
@@ -9,8 +10,6 @@ import os
 sys.path.insert(0,os.path.dirname(__file__))
 import sfCalculator # noqa
 sys.path.pop(0)
-
-from mantid.kernel import * # noqa
 
 
 class RefLReduction(PythonAlgorithm):

--- a/Framework/PythonInterface/plugins/algorithms/RefLReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/RefLReduction.py
@@ -7,10 +7,10 @@ from mantid.simpleapi import *
 import sys
 import os
 sys.path.insert(0,os.path.dirname(__file__))
-import sfCalculator
+import sfCalculator # noqa
 sys.path.pop(0)
 
-from mantid.kernel import *
+from mantid.kernel import * # noqa
 
 
 class RefLReduction(PythonAlgorithm):

--- a/Testing/SystemTests/tests/analysis/SANS2DReductionGUI.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DReductionGUI.py
@@ -13,12 +13,6 @@ The first 2 Tests ensures that the result provided by the GUI are the same for t
 Test was first created to apply to Mantid Release 3.0.
 """
 
-import sys
-
-if __name__ == "__main__":
-  # it is just to allow running this test in Mantid, allowing the following import
-    sys.path.append('/apps/mantid/systemtests/StressTestFramework/')
-
 import stresstesting
 from mantid.simpleapi import *
 import isis_reducer

--- a/Testing/SystemTests/tests/analysis/SANS2DReductionGUIAdded.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DReductionGUIAdded.py
@@ -1,10 +1,4 @@
 #pylint: disable=invalid-name
-import sys
-
-if __name__ == "__main__":
-  # it is just to allow running this test in Mantid, allowing the following import
-    sys.path.append('/apps/mantid/systemtests/StressTestFramework/')
-
 from mantid.simpleapi import *
 import ISISCommandInterface as i
 import copy

--- a/Testing/SystemTests/tests/analysis/SANS2DSearchCentreGUI.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DSearchCentreGUI.py
@@ -1,8 +1,4 @@
 ﻿#pylint: disable=invalid-name
-import sys
-if __name__ == "__main__":
-  # it is just to allow running this test in Mantid, allowing the following import
-    sys.path.append('/apps/mantid/systemtests/StressTestFramework/')
 from mantid.simpleapi import *
 import ISISCommandInterface as i
 import isis_reducer

--- a/Testing/SystemTests/tests/analysis/SANS2DSlicing.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DSlicing.py
@@ -1,9 +1,4 @@
 #pylint: disable=invalid-name,attribute-defined-outside-init
-import sys
-
-if __name__ == "__main__":
-  # it is just to allow running this test in Mantid, allowing the following import
-    sys.path.append('/apps/mantid/systemtests/StressTestFramework/')
 
 import stresstesting
 

--- a/scripts/Calibration/Examples/TubeCalibDemoWish1.py
+++ b/scripts/Calibration/Examples/TubeCalibDemoWish1.py
@@ -6,7 +6,7 @@
 # We base the ideal tube on one tube of this door.
 #
 import tube
-reload(tube)
+reload(tube) # noqa
 from tube_spec import TubeSpec
 import tube_calib #from tube_calib import constructIdealTubeFromRealTube
 from tube_calib_fit_params import TubeCalibFitParams

--- a/scripts/DGSPlanner/InstrumentSetupWidget.py
+++ b/scripts/DGSPlanner/InstrumentSetupWidget.py
@@ -6,10 +6,10 @@ import numpy
 import matplotlib
 matplotlib.use('Qt4Agg')
 matplotlib.rcParams['backend.qt4']='PyQt4'
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.figure import Figure
-from mpl_toolkits.mplot3d import Axes3D
-import matplotlib.pyplot
+from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas # noqa
+from matplotlib.figure import Figure # noqa
+from mpl_toolkits.mplot3d import Axes3D # noqa
+import matplotlib.pyplot # noqa
 try:
     from PyQt4.QtCore import QString
 except ImportError:

--- a/scripts/HFIRPowderReduction/HfirPDReductionControl.py
+++ b/scripts/HFIRPowderReduction/HfirPDReductionControl.py
@@ -5,7 +5,6 @@
 # Key Words: FUTURE
 #
 ############################################################################
-import sys
 import os
 import urllib2
 import math
@@ -15,11 +14,6 @@ import numpy
 import HfirUtility as hutil
 
 # Import mantid
-curdir = os.getcwd()
-libpath = os.path.join(curdir.split('Code')[0], 'Code/debug/bin')
-if os.path.exists(libpath) is False:
-    libpath = os.path.join(curdir.split('Code')[0], 'Code/release/bin')
-sys.path.append(libpath)
 import mantid.simpleapi as api
 from mantid.simpleapi import AnalysisDataService
 #from mantid.kernel import ConfigService

--- a/scripts/HFIR_4Circle_Reduction/peakprocesshelper.py
+++ b/scripts/HFIR_4Circle_Reduction/peakprocesshelper.py
@@ -1,9 +1,5 @@
 #pylint: disable=W0403,R0902
 from fourcircle_utility import *
-
-import sys
-sys.path.append('/Users/wzz/MantidBuild/debug/bin/')
-
 from mantid.api import AnalysisDataService
 from mantid.kernel import V3D
 

--- a/scripts/Imaging/IMAT/tomo_reconstruct.py
+++ b/scripts/Imaging/IMAT/tomo_reconstruct.py
@@ -54,7 +54,7 @@ from sys import path
 import os
 from os import path
 # So insert in the path the directory that contains this file
-sys.path.insert(0, os.path.split(path.dirname(__file__))[0])
+sys.path.insert(0, os.path.split(path.dirname(__file__))[0]) # noqa
 
 from IMAT.tomorec import reconstruction_command as tomocmd
 import IMAT.tomorec.configs as tomocfg

--- a/scripts/Inelastic/IndirectBayes.py
+++ b/scripts/Inelastic/IndirectBayes.py
@@ -8,7 +8,7 @@ Output : the Fortran numpy array is sliced to Python length using dataY = yout[:
 """
 
 from IndirectImport import *
-if is_supported_f2py_platform():
+if is_supported_f2py_platform(): # noqa
     QLr     = import_f2py("QLres")
     QLd     = import_f2py("QLdata")
     Qse     = import_f2py("QLse")

--- a/scripts/Inelastic/IndirectMuscat.py
+++ b/scripts/Inelastic/IndirectMuscat.py
@@ -5,7 +5,7 @@ MUSIC : Version of Minus for MIDAS
 """
 
 from IndirectImport import *
-if is_supported_f2py_platform():
+if is_supported_f2py_platform(): # noqa
     muscat = import_f2py("muscat")
 else:
     unsupported_message()

--- a/scripts/Interface/reduction_application.py
+++ b/scripts/Interface/reduction_application.py
@@ -19,7 +19,7 @@ except:
     sip.setapi('QString',2)
     sip.setapi('QVariant',2)
 
-from PyQt4 import QtGui, QtCore
+from PyQt4 import QtGui, QtCore # noqa
 
 REDUCTION_WARNING = False
 WARNING_MESSAGE = ""
@@ -40,11 +40,11 @@ if IS_IN_MANTIDPLOT:
         WARNING_MESSAGE = "Please contact the Mantid team with the following message:\n\n\n"
         WARNING_MESSAGE += unicode(traceback.format_exc())
 
-from reduction_gui.instruments.instrument_factory import instrument_factory, INSTRUMENT_DICT
-from reduction_gui.settings.application_settings import GeneralSettings
-import ui.ui_reduction_main
-import ui.ui_instrument_dialog
-import ui.ui_cluster_details_dialog
+from reduction_gui.instruments.instrument_factory import instrument_factory, INSTRUMENT_DICT # noqa
+from reduction_gui.settings.application_settings import GeneralSettings # noqa
+import ui.ui_reduction_main # noqa
+import ui.ui_instrument_dialog # noqa
+import ui.ui_cluster_details_dialog # noqa
 
 
 class ReductionGUI(QtGui.QMainWindow, ui.ui_reduction_main.Ui_SANSReduction):

--- a/scripts/Interface/reduction_gui/reduction/inelastic/dgs_utils.py
+++ b/scripts/Interface/reduction_gui/reduction/inelastic/dgs_utils.py
@@ -1,3 +1,5 @@
+import os
+
 IS_IN_MANTIDPLOT = False
 try:
     import mantidplot # noqa
@@ -7,8 +9,6 @@ try:
     IS_IN_MANTIDPLOT = True
 except:
     pass
-
-import os
 
 
 class InstrumentParameters(object):

--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -6,9 +6,6 @@
 import isis_instrument
 from reducer_singleton import ReductionSingleton
 from mantid.kernel import Logger
-
-sanslog = Logger("SANS")
-
 import isis_reduction_steps
 import isis_reducer
 from centre_finder import *
@@ -20,6 +17,8 @@ from SANSadd2 import *
 import SANSUtility as su
 from SANSUtility import deprecated
 import SANSUserFileParser as UserFileParser
+
+sanslog = Logger("SANS")
 
 # disable plotting if running outside Mantidplot
 try:

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -35,12 +35,12 @@ import SANSUtility as su
 from mantid.simpleapi import *
 from mantid.api import WorkspaceGroup
 from mantid.kernel import Logger
-sanslog = Logger("SANS")
 import copy
 import sys
 import re
 from reduction_settings import REDUCTION_SETTINGS_OBJ_NAME
 from isis_reduction_steps import UserFile
+sanslog = Logger("SANS")
 ################################################################################
 # Avoid a bug with deepcopy in python 2.6, details and workaround here:
 # http://bugs.python.org/issue1515

--- a/scripts/SANS/SANSadd2.py
+++ b/scripts/SANS/SANSadd2.py
@@ -3,9 +3,9 @@ import os
 from mantid.simpleapi import *
 from mantid.kernel import Logger
 from SANSUtility import (bundle_added_event_data_as_group, AddOperation, transfer_special_sample_logs)
-sanslog = Logger("SANS")
 from shutil import copyfile
 
+sanslog = Logger("SANS")
 _NO_INDIVIDUAL_PERIODS = -1
 
 

--- a/scripts/SCD_Reduction/ReduceSCD_OneRun.py
+++ b/scripts/SCD_Reduction/ReduceSCD_OneRun.py
@@ -39,7 +39,7 @@ import os
 import sys
 import time
 import ReduceDictionary
-sys.path.append("/opt/mantidnightly/bin")
+sys.path.append("/opt/mantidnightly/bin") # noqa
 #sys.path.append("/opt/Mantid/bin")
 
 from mantid.simpleapi import *

--- a/scripts/SCD_Reduction/ReduceSCD_Parallel.py
+++ b/scripts/SCD_Reduction/ReduceSCD_Parallel.py
@@ -40,7 +40,7 @@ import threading
 import time
 import ReduceDictionary
 
-sys.path.append("/opt/mantidnightly/bin")
+sys.path.append("/opt/mantidnightly/bin") # noqa
 #sys.path.append("/opt/Mantid/bin")
 
 from mantid.simpleapi import *

--- a/scripts/SCD_Reduction/SCDCalibratePanelsResults.py
+++ b/scripts/SCD_Reduction/SCDCalibratePanelsResults.py
@@ -9,7 +9,7 @@ import os
 import math
 import sys
 import numpy as np
-sys.path.append("/opt/mantidnightly/bin")
+sys.path.append("/opt/mantidnightly/bin") # noqa
 from mantid.simpleapi import *
 
 # Make a ./plots subdirectory for the plot files.

--- a/tools/PeriodicTable/generate_atom_code.py
+++ b/tools/PeriodicTable/generate_atom_code.py
@@ -1,8 +1,6 @@
 #pylint: disable=invalid-name
 #!/usr/bin/env python
 
-VERSION = "1.0"
-
 import optparse
 import sys
 try:
@@ -13,6 +11,8 @@ try:
 except ImportError, e:
     print "*****To use this you must 'easy_install periodictable'"
     sys.exit(-1)
+
+VERSION = "1.0"
 
 # elements not to put in the output file
 BANNED = ['n', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 'No', 'Lr', 'Rf', 'Db', 'Sg',

--- a/tools/reports/facility-code-changes.py
+++ b/tools/reports/facility-code-changes.py
@@ -1,14 +1,14 @@
 #pylint: disable=invalid-name
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
-__author__ = 'Stuart Campbell'
-
 import datetime
 import subprocess
 import csv
 import argparse
 import os
 import time
+
+__author__ = 'Stuart Campbell'
 
 
 def generate_file_changes_data(year_start, year_end):


### PR DESCRIPTION
This fixes all flake8-E402 warnings about imports not being at the top of the file.

**To test:**
- Code review
# **_Does not need to be in the release notes.**_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
