### PR TITLE
ToFConverter wavevector bugfix 

### DIFF
--- a/scripts/TofConverter/convertUnits.py
+++ b/scripts/TofConverter/convertUnits.py
@@ -15,7 +15,7 @@ def input2energy(inputval, inOption, theta, flightpath):
     e2lam = 81.787 #using lambda=h/p  p: momentum, h: planck's const, lambda: wavelength
     e2nu = 4.139 # using h/(m*lambda^2) m: mass of neutron
     e2v = 0.0000052276 # using v = h/(m*lambda)
-    e2k = 2.717 #using k = 2*pi/(lambda) k:momentum
+    e2k = 2.0717 #using k = 2*pi/(lambda) k:momentum
     e2t = 0.086165 #using t = (m*v^2)/(2kb) kb: Boltzmann const
     e2cm = 0.123975 #cm = 8.06554465*E E:energy
     iv2 = inputval ** 2
@@ -70,7 +70,7 @@ def energy2output(Energy, outOption, theta, flightpath):
     e2lam = 81.787 #using lambda=h/p  p: momentum, h: planck's const, lambda: wavelength
     e2nu = 4.139 # using h/(m*lambda^2) m: mass of neutron
     e2v = 0.0000052276 # using v = h/(m*lambda)
-    e2k = 2.717 #using k = 2*pi/(lambda) k:momentum
+    e2k = 2.0717 #using k = 2*pi/(lambda) k:momentum
     e2t = 0.086165 #using t = (m*v^2)/(2kb) kb: Boltzmann const
     e2cm = 0.123975 #cm = 8.06554465*E E:energy
 


### PR DESCRIPTION
Description of work.

Fixes bug in ToFConverter for converting from/to neutron wavevector - due to typo in `e2k` conversion factor.

**To test:**

Check that conversion to / from wavevector are now correct, using another calculator, e.g. https://www.ill.eu/instruments-support/instruments-groups/groups/dif/links/web-tools/ 

Fixes #17849 

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
