### PR TITLE
LoadEventNexus should no longer leak memory when cancelled

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -488,13 +488,13 @@ public:
 
     // Abort if anything failed
     if (m_loadError) {
-      prog->reportIncrement(4, entry_name + ": skipping");
       delete[] m_event_id;
       delete[] m_event_time_of_flight;
       if (m_have_weight) {
         delete[] m_event_weight;
       }
       delete event_index_ptr;
+
       return;
     }
 
@@ -1911,9 +1911,10 @@ void LoadEventNexus::runLoadMonitorsAsEvents(API::Progress *const prog) {
     // Note the reuse of the m_ws member variable below. Means I need to grab a
     // copy of its current value.
     auto dataWS = m_ws;
-    m_ws = boost::make_shared<
-        EventWorkspaceCollection>(); // Algorithm currently relies on an
-                                     // object-level workspace ptr
+    m_ws = boost::make_shared<EventWorkspaceCollection>(); // Algorithm
+                                                           // currently relies
+                                                           // on an
+    // object-level workspace ptr
     // add filename
     m_ws->mutableRun().addProperty("Filename", m_filename);
 

--- a/docs/source/release/v3.9.0/framework.rst
+++ b/docs/source/release/v3.9.0/framework.rst
@@ -45,6 +45,7 @@ Bug Fixes
 ---------
 
 - Bin masking information was wrongly saved when saving workspaces into nexus files, which is now fixed.
+- :ref:`LoadEventNexus <algm-LoadEventNexus>` should no longer leak memory when the execution is cancelled.
 
 Full list of
 `Framework <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.9%22+is%3Amerged+label%3A%22Component%3A+Framework%22>`__


### PR DESCRIPTION
## Description of work.

Removed the unnecessary progress report in the fail condition. The report throws a `CancelledException` if the algorithms is cancelled **(perhaps unnecessary?)**, and it this case all of the `delete` functions were after the exception was throws. Everything that was allocated dynamically and passed into the inner class on the call [here at line 1584](https://github.com/mantidproject/mantid/blob/112a13f0c994020ec3eb759999f3be1e086ca1b9/Framework/DataHandling/src/LoadEventNexus.cpp#L1584), and everything after that line would have been a leak. 

LoadEventNexus algorithm functionality should not be changed.

**To test:**
- See that LoadEventNexus algorithm functionality is unchanged
- Run in debug mode, Visual Studio has a convenient memory tracking window that can show the memory usage

<!-- Instructions for testing. -->

Fixes #17565.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

Added to release notes bug fixes in [framework.rst](https://github.com/mantidproject/mantid/pull/17858/commits/b3084662126f1181511df23710979caa6190392a#diff-f7793b747fb7ac7103dcdcb26c5d7ca5R48)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
