### PR TITLE
IndirectDataReduction - Calibration saving

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -171,27 +171,11 @@ void ISISCalibration::run() {
   // Get properties
   QStringList filenameList = m_uiForm.leRunNo->getFilenames();
   QString filenames = filenameList.join(",");
-  QString userInFiles = m_uiForm.leRunNo->getText();
-  QString firstFileNumber("");
-  auto cutIndexDash = userInFiles.indexOf("-");
-  auto cutIndexComma = userInFiles.indexOf(",");
-
-  if (cutIndexDash == -1 && cutIndexComma == -1) {
-    firstFileNumber = userInFiles;
-  } else {
-    if (cutIndexDash != -1) {
-      firstFileNumber = userInFiles.left(cutIndexDash);
-    } else {
-      firstFileNumber = userInFiles.left(cutIndexComma);
-    }
-    if (cutIndexDash != -1 && cutIndexComma != -1) {
-      if (cutIndexDash < cutIndexComma) {
-        firstFileNumber = userInFiles.left(cutIndexDash);
-      } else {
-        firstFileNumber = userInFiles.left(cutIndexComma);
-      }
-    }
-  }
+  QString rawFile = m_uiForm.leRunNo->getFirstFilename();
+  auto pos = rawFile.lastIndexOf(".");
+  auto extension = rawFile.right(rawFile.length() - pos);
+  QFileInfo rawFileInfo(rawFile);
+  QString name = rawFileInfo.baseName();
 
   auto instDetails = getInstrumentDetails();
   QString instDetectorRange =
@@ -203,8 +187,7 @@ void ISISCalibration::run() {
                             m_properties["CalBackMax"]->valueText();
 
   QString outputWorkspaceNameStem =
-      getInstrumentConfiguration()->getInstrumentName() + firstFileNumber +
-      QString::fromStdString("_") +
+      name + QString::fromStdString("_") +
       getInstrumentConfiguration()->getAnalyserName() +
       getInstrumentConfiguration()->getReflectionName();
 
@@ -237,7 +220,6 @@ void ISISCalibration::run() {
 
   // Initially take the calibration workspace as the result
   m_pythonExportWsName = m_outputCalibrationName.toStdString();
-
   // Configure the resolution algorithm
   if (m_uiForm.ckCreateResolution->isChecked()) {
     m_outputResolutionName = outputWorkspaceNameStem;

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -172,8 +172,6 @@ void ISISCalibration::run() {
   QStringList filenameList = m_uiForm.leRunNo->getFilenames();
   QString filenames = filenameList.join(",");
   QString rawFile = m_uiForm.leRunNo->getFirstFilename();
-  auto pos = rawFile.lastIndexOf(".");
-  auto extension = rawFile.right(rawFile.length() - pos);
   QFileInfo rawFileInfo(rawFile);
   QString name = rawFileInfo.baseName();
 

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -110,7 +110,7 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
   connect(resPeak, SIGNAL(rangeChanged(double, double)), resBackground,
           SLOT(setRange(double, double)));
 
-  // Update property map when a range seclector is moved
+  // Update property map when a range selector is moved
   connect(calPeak, SIGNAL(minValueChanged(double)), this,
           SLOT(calMinChanged(double)));
   connect(calPeak, SIGNAL(maxValueChanged(double)), this,
@@ -128,7 +128,7 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
   connect(resBackground, SIGNAL(maxValueChanged(double)), this,
           SLOT(calMaxChanged(double)));
 
-  // Update range selctor positions when a value in the double manager changes
+  // Update range selector positions when a value in the double manager changes
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
           SLOT(calUpdateRS(QtProperty *, double)));
   // Plot miniplots after a file has loaded
@@ -139,7 +139,7 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
   connect(m_uiForm.ckCreateResolution, SIGNAL(toggled(bool)), this,
           SLOT(resCheck(bool)));
 
-  // Shows message on run buton when user is inputting a run number
+  // Shows message on run button when user is inputting a run number
   connect(m_uiForm.leRunNo, SIGNAL(fileTextChanged(const QString &)), this,
           SLOT(pbRunEditing()));
   // Shows message on run button when Mantid is finding the file for a given run
@@ -527,10 +527,10 @@ void ISISCalibration::calPlotEnergy() {
 }
 
 /**
- * Set default background and rebinning properties for a given instument
+ * Set default background and rebinning properties for a given instrument
  * and analyser
  *
- * @param ws :: Mantid workspace containing the loaded instument
+ * @param ws :: Mantid workspace containing the loaded instrument
  */
 void ISISCalibration::calSetDefaultResolution(MatrixWorkspace_const_sptr ws) {
   auto inst = ws->getInstrument();
@@ -567,10 +567,10 @@ void ISISCalibration::calSetDefaultResolution(MatrixWorkspace_const_sptr ws) {
 }
 
 /**
- * Handles a range selector having it's minumum value changed.
+ * Handles a range selector having it's minimum value changed.
  * Updates property in property map.
  *
- * @param val :: New minumum value
+ * @param val :: New minimum value
  */
 void ISISCalibration::calMinChanged(double val) {
   auto calPeak = m_uiForm.ppCalibration->getRangeSelector("CalPeak");
@@ -594,10 +594,10 @@ void ISISCalibration::calMinChanged(double val) {
 }
 
 /**
- * Handles a range selector having it's maxumum value changed.
+ * Handles a range selector having it's maximum value changed.
  * Updates property in property map.
  *
- * @param val :: New maxumum value
+ * @param val :: New maximum value
  */
 void ISISCalibration::calMaxChanged(double val) {
   auto calPeak = m_uiForm.ppCalibration->getRangeSelector("CalPeak");
@@ -671,7 +671,7 @@ void ISISCalibration::resCheck(bool state) {
  */
 void ISISCalibration::pbRunEditing() {
   emit updateRunButton(false, "Editing...",
-                       "Run numbers are curently being edited.");
+                       "Run numbers are currently being edited.");
 }
 
 /**
@@ -680,7 +680,7 @@ void ISISCalibration::pbRunEditing() {
 void ISISCalibration::pbRunFinding() {
   emit updateRunButton(
       false, "Finding files...",
-      "Searchig for data files for the run numbers entered...");
+      "Searching for data files for the run numbers entered...");
   m_uiForm.leRunNo->setEnabled(false);
 }
 
@@ -691,7 +691,7 @@ void ISISCalibration::pbRunFinished() {
   if (!m_uiForm.leRunNo->isValid()) {
     emit updateRunButton(
         false, "Invalid Run(s)",
-        "Cannot find data files for some of the run numbers enetered.");
+        "Cannot find data files for some of the run numbers entered.");
   } else {
     emit updateRunButton();
   }
@@ -704,8 +704,12 @@ void ISISCalibration::pbRunFinished() {
 void ISISCalibration::saveClicked() {
   checkADSForPlotSaveWorkspace(m_outputCalibrationName.toStdString(), false);
   addSaveWorkspaceToQueue(m_outputCalibrationName);
-  checkADSForPlotSaveWorkspace(m_outputResolutionName.toStdString(), false);
-  addSaveWorkspaceToQueue(m_outputResolutionName);
+
+  if (m_uiForm.ckCreateResolution->isChecked()) {
+    auto output = m_outputResolutionName.toStdString();
+    checkADSForPlotSaveWorkspace(m_outputResolutionName.toStdString(), false);
+    addSaveWorkspaceToQueue(m_outputResolutionName);
+  }
   m_batchAlgoRunner->executeBatchAsync();
 }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -706,7 +706,6 @@ void ISISCalibration::saveClicked() {
   addSaveWorkspaceToQueue(m_outputCalibrationName);
 
   if (m_uiForm.ckCreateResolution->isChecked()) {
-    auto output = m_outputResolutionName.toStdString();
     checkADSForPlotSaveWorkspace(m_outputResolutionName.toStdString(), false);
     addSaveWorkspaceToQueue(m_outputResolutionName);
   }

--- a/docs/source/release/v3.9.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.9.0/indirect_inelastic.rst
@@ -14,7 +14,7 @@ Algorithms
 Data Reduction
 ##############
 
-- Q-vaues in :ref:`BASISReduction <algm-BASISReduction>` output are now point data so that their values display correctly when plotted
+- Q-values in :ref:`BASISReduction <algm-BASISReduction>` output are now point data so that their values display correctly when plotted
 
 Data Analysis
 #############
@@ -31,7 +31,7 @@ Improvements
 
 Bugfixes
 --------
-
+- Clicking 'Save' without creating a res file in *ISISCalibration* no longer causes an error
 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.9%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
When `save` is clicked, the res file is not saved if the option to create a res file has not been checked.

**To test:**

Interfaces > Indirect > Data Reduction > Calibration
Check instrument is `IRIS`
Run no: `26173`
Once algorithm is complete click `Save`
Ensure relevant file is is default save directory.
Repeat with `Create res file` checked.

Change instrument to OSIRIS and repeat with run `121434`

Fixes #17861.

[Release Notes](https://github.com/mantidproject/mantid/blob/cc928fc02f13ca797adff4e853299e562171954d/docs/source/release/v3.9.0/indirect_inelastic.rst)

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
