### PR TITLE
RRO: Removed unused property and method

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne.h
@@ -76,11 +76,6 @@ private:
   correctPosition(API::MatrixWorkspace_sptr &toCorrect,
                   const double &thetaInDeg, const bool isPointDetector);
 
-  /// Sum spectra.
-  Mantid::API::MatrixWorkspace_sptr
-  sumSpectraOverRange(API::MatrixWorkspace_sptr inWS, const int startIndex,
-                      const int endIndex);
-
   /// Perform a transmission correction on the input IvsLam workspace
   API::MatrixWorkspace_sptr transmissonCorrection(
       API::MatrixWorkspace_sptr IvsLam, const MinMax &wavelengthInterval,

--- a/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -131,10 +131,6 @@ void ReflectometryReductionOne::init() {
       boost::make_shared<StringListValidator>(propOptions),
       "The type of analysis to perform. Point detector or multi detector.");
 
-  declareProperty(make_unique<ArrayProperty<int>>("RegionOfInterest"),
-                  "Indices of the spectra a pair (lower, upper) that mark the "
-                  "ranges that correspond to the region of interest (reflected "
-                  "beam) in multi-detector mode.");
   declareProperty(make_unique<ArrayProperty<int>>("RegionOfDirectBeam"),
                   "Indices of the spectra a pair (lower, upper) that mark the "
                   "ranges that correspond to the direct beam in multi-detector "
@@ -483,25 +479,6 @@ ReflectometryReductionOne::getDetectorComponent(
                                 " does not exist. Check input properties.");
   }
   return searchResult;
-}
-
-/**
-* Sum spectra over a specified range.
-* @param inWS
-* @param startIndex
-* @param endIndex
-* @return Workspace with spectra summed over the specified range.
-*/
-MatrixWorkspace_sptr ReflectometryReductionOne::sumSpectraOverRange(
-    MatrixWorkspace_sptr inWS, const int startIndex, const int endIndex) {
-  auto sumSpectra = this->createChildAlgorithm("SumSpectra");
-  sumSpectra->initialize();
-  sumSpectra->setProperty("InputWorkspace", inWS);
-  sumSpectra->setProperty("StartWorkspaceIndex", startIndex);
-  sumSpectra->setProperty("EndWorkspaceIndex", endIndex);
-  sumSpectra->execute();
-  MatrixWorkspace_sptr outWS = sumSpectra->getProperty("OutputWorkspace");
-  return outWS;
 }
 
 //----------------------------------------------------------------------------------------------


### PR DESCRIPTION
As stated in the issue, it was suspected that the `RegionOfInterest` property in the `ReflectometryReductionOne` algorithm was never used, and neither was the `ReflectometryReductionOne::sumSpectraOverRange` method. I confirmed this to be the case and removed both.

**To test:**

Ensure all tests pass.

Fixes #17312.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
