### PR TITLE
Added missing parameters to ReflectometryReductionOne and CreateTransmissionWorkspace diagrams

### DIFF
--- a/docs/source/diagrams/CreateTransmissionWorkspace_ConvertToWavelength-v1_wkflw.dot
+++ b/docs/source/diagrams/CreateTransmissionWorkspace_ConvertToWavelength-v1_wkflw.dot
@@ -12,6 +12,8 @@ subgraph params {
   wavMax              [label="WavelengthMax"]
   monIntWavMin        [label="MonitorIntegration-\nWavelengthMin"]
   monIntWavMax        [label="MonitorIntegration-\nWavelengthMax"]
+  monBgWavMax         [label="MonitorBackground-\nWavelengthMax"]
+  monBgWavMin         [label="MonitorBackground-\nWavelengthMin"]
   outputWS            [label="TransmissionRun\nin wavelength"]
 
   detWS               [label="DetectorWorkspace"]
@@ -68,6 +70,8 @@ convertMon	     -> valMon
 valMon		     -> cropMon
 monitorIndex	     -> cropMon
 cropMon		     -> checkBgMinMax
+monBgWavMax    -> checkBgMinMax
+monBgWavMin    -> checkBgMinMax
 checkBgMinMax	     -> calcFlatBg	[label="Yes"]
 calcFlatBg	     -> rebinToWS
 checkBgMinMax	     -> rebinToWS	[label="No"]

--- a/docs/source/diagrams/CreateTransmissionWorkspace_ConvertToWavelength-v1_wkflw.dot
+++ b/docs/source/diagrams/CreateTransmissionWorkspace_ConvertToWavelength-v1_wkflw.dot
@@ -22,7 +22,7 @@ subgraph params {
 
 subgraph decisions {
  $decision_style
-  checkMon        [label="Monitors?"]
+  checkMon        [label="I0MonitorIndex and\nMonitorBackground-\nWavelengthMin\Max\nprovided?"]
   checkBgMinMax   [label="MonitorBackground-\nWavelength\nMin/Max non-zero?"]
   checkMonInt	  [label="Normalize by\nIntegrated Monitors?"]
 }
@@ -65,13 +65,13 @@ wavMax               -> cropDet
 cropDet              -> detWS
 
 firstRun	     -> checkMon	[label="Monitors"]
+monBgWavMax         -> checkMon
+monBgWavMin         -> checkMon
+monitorIndex        -> checkMon
 checkMon             -> convertMon      [label="Yes"]
 convertMon	     -> valMon
 valMon		     -> cropMon
-monitorIndex	     -> cropMon
 cropMon		     -> checkBgMinMax
-monBgWavMax    -> checkBgMinMax
-monBgWavMin    -> checkBgMinMax
 checkBgMinMax	     -> calcFlatBg	[label="Yes"]
 calcFlatBg	     -> rebinToWS
 checkBgMinMax	     -> rebinToWS	[label="No"]
@@ -92,7 +92,7 @@ monWS		     -> divideDetMon
 
 divideDetMon	     -> outputWS
 
-{rank = same; convertDet; convertMon}
+{rank = same; convertDet; monBgWavMax; monBgWavMin; monitorIndex;}
 {rank = same; valDet; valMon; valUnity}
 {rank = same; detWS; rebinToWS}
 }

--- a/docs/source/diagrams/ReflectometryReductionOne_ConvertToWavelength-v1_wkflw.dot
+++ b/docs/source/diagrams/ReflectometryReductionOne_ConvertToWavelength-v1_wkflw.dot
@@ -23,7 +23,7 @@ subgraph params {
 
 subgraph decisions {
  $decision_style
-  checkMonUnity   [label="Monitors?"]
+  checkMonUnity   [label="I0MonitorIndex and\nMonitorBackground-\nWavelengthMin\Max\nprovided?"]
   checkNormDetMon [label="Normalize by\nIntegrated Monitors?"]
   checkBgMinMax   [label="Monitor background\nwavelength\nmin/max non-zero?"]
   checkMultRDB    [label="MultidetectorAnalysis\nand\nRegionOfDirectBeam\ngiven?"]
@@ -61,6 +61,9 @@ subgraph values {
 
 inputWS             -> convertDet     [label="Detectors"]
 inputWS             -> checkMonUnity  [label="Monitors"]
+monBgWavMax         -> checkMonUnity
+monBgWavMin         -> checkMonUnity
+monitorIndex        -> checkMonUnity
 checkMonUnity       -> convertMon     [label="Yes"]
 checkMonUnity       -> valUnity       [label="No"]
 convertDet          -> valDet
@@ -77,10 +80,7 @@ wavMax              -> cropDetWS
 cropDetWS           -> detWS
 detWS               -> rebinToWS
 valMon              -> cropMonWS
-monitorIndex        -> cropMonWS
 cropMonWS           -> checkBgMinMax
-monBgWavMax         -> checkBgMinMax
-monBgWavMin         -> checkBgMinMax
 checkBgMinMax       -> calcFlatBg     [label="Yes"]
 checkBgMinMax       -> rebinToWS      [label="No"]
 calcFlatBg          -> rebinToWS
@@ -101,7 +101,7 @@ rebinToWSRDB        -> divideDetRDB
 divideDetRDB	    -> divideDetMon
 divideDetMon        -> outputWS
 
-{rank = same; convertDet; convertMon}
+{rank = same; convertDet; monBgWavMax; monBgWavMin; monitorIndex;}
 {rank = same; valUnity; valDet; valMon}
 {rank = same; cropDetWS; cropMonWS}
 {rank = same; detWS; calcFlatBg}

--- a/docs/source/diagrams/ReflectometryReductionOne_ConvertToWavelength-v1_wkflw.dot
+++ b/docs/source/diagrams/ReflectometryReductionOne_ConvertToWavelength-v1_wkflw.dot
@@ -15,6 +15,8 @@ subgraph params {
   regionOfDirectBeam  [label="RegionOf-\nDirectBeam"]
   monIntWavMax        [label="MonitorIntegration-\nWavelengthMax"]
   monIntWavMin        [label="MonitorIntegration-\nWavelengthMin"]
+  monBgWavMax         [label="MonitorBackground-\nWavelengthMax"]
+  monBgWavMin         [label="MonitorBackground-\nWavelengthMin"]
   wavMaxRDB           [label="WavelengthMax"]
   wavMinRDB           [label="WavelengthMin"]
 }
@@ -77,6 +79,8 @@ detWS               -> rebinToWS
 valMon              -> cropMonWS
 monitorIndex        -> cropMonWS
 cropMonWS           -> checkBgMinMax
+monBgWavMax         -> checkBgMinMax
+monBgWavMin         -> checkBgMinMax
 checkBgMinMax       -> calcFlatBg     [label="Yes"]
 checkBgMinMax       -> rebinToWS      [label="No"]
 calcFlatBg          -> rebinToWS


### PR DESCRIPTION
Analysis of both algorithms `ConvertToWavelength` step diagram showed that it was misleading one could infer that monitors could be taken into account by providing `I0MonitorIndex`. In fact, monitors are only accounted for if  `I0MonitorIndex` AND `MonitorBackgroundWavelengthMin` and `MonitorBackgroundWavelengthMax` are provided. This PR fixes the workflow diagrams to reflect this.

**To test:**

Ensure the altered diagrams reflect what actually occurs in the algorithms they represent.

Fixes #17451 .

_Does not need to be in the release notes._
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
