### PR TITLE
Fix error in not subtracting vanadium background

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -1262,7 +1262,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                     van_bkgd_ws_name = self._loadAndSum([van_bkgd_run_number], van_bkgd_ws_name, **vanFilterWall)
 
                 van_bkgd_ws = get_workspace(van_bkgd_ws_name)
-                if van_bkgd_ws.id() == EVENT_WORKSPACE_ID and van_bkgd_ws.getNumberEvents() > 0:
+                if van_bkgd_ws.id() == EVENT_WORKSPACE_ID and van_bkgd_ws.getNumberEvents() <= 0:
                     # skip if background run is empty
                     pass
                 else:

--- a/docs/source/release/v3.9.0/diffraction.rst
+++ b/docs/source/release/v3.9.0/diffraction.rst
@@ -11,7 +11,11 @@ Crystal Improvements
 Engineering Diffraction
 -----------------------
 
-|
+Powder Diffraction
+------------------
+
+:ref:`algm-SNSPowderReduction` had an error in logic of subtracting the vanadium background. It was not being subtracted when ``PreserveEvents=True``.
+
 
 Full list of `diffraction <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.9%22+is%3Amerged+label%3A%22Component%3A+Diffraction%22>`_
 and


### PR DESCRIPTION
The logic of the second half of the `if` was wrong. It has been corrected to be "if there are events, subtract them."

The bug was introduced on [Aug 10, 2016](https://github.com/mantidproject/mantid/commit/7e349a5643a98d81dfffe66aa4f8ee446f4b3781).

**To test:**

This should be verified by looking over the code.

_There is no associated issue_

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
