### PR TITLE
Fix segfault when calling MantidPlot -xq with python3.

### DIFF
--- a/MantidPlot/src/PythonScripting.cpp
+++ b/MantidPlot/src/PythonScripting.cpp
@@ -119,10 +119,10 @@ void PythonScripting::redirectStdOut(bool on) {
     setQObject(this, "stdout", m_sys);
     setQObject(this, "stderr", m_sys);
   } else {
-    PyDict_SetItemString(m_sys, "stdout",
-                         PyDict_GetItemString(m_sys, "__stdout__"));
-    PyDict_SetItemString(m_sys, "stderr",
-                         PyDict_GetItemString(m_sys, "__stderr__"));
+    PyDict_SetItem(m_sys, FROM_CSTRING("stdout"),
+                   PyDict_GetItemString(m_sys, "__stdout__"));
+    PyDict_SetItem(m_sys, FROM_CSTRING("stderr"),
+                   PyDict_GetItemString(m_sys, "__stderr__"));
   }
 }
 


### PR DESCRIPTION
This fixes the segfault when calling MantidPlot with the `-xq` option, _e.g._ `MantidPlot -xq file.py`

Previously you got something like:

```
********* SEGMENTATION FAULT *********
 /home/rwp/mantid/Release/py3/bin/libMantidAPI.so(+0x1555a6) [0x7f1826b5c5a6]
 /home/rwp/mantid/Release/py3/bin/libMantidAPI.so(+0x1556bf) [0x7f1826b5c6bf]
 /usr/lib/libc.so.6(+0x330b0) [0x7f181e6a50b0]
 /usr/lib/libpython3.5m.so.1.0(PyUnicode_InternInPlace+0x59) [0x7f18210e2af9]
 /usr/lib/libpython3.5m.so.1.0(PyDict_SetItemString+0x38) [0x7f1821093b58]
 /home/rwp/mantid/Release/py3/bin/MantidPlot() [0x71f0b8]
 /home/rwp/mantid/Release/py3/bin/MantidPlot() [0x50beb5]
 /home/rwp/mantid/Release/py3/bin/MantidPlot() [0x50c11e]
 /home/rwp/mantid/Release/py3/bin/MantidPlot() [0x8c4c37]
 /usr/lib/libQtCore.so.4(_ZN7QObject5eventEP6QEvent+0x1d1) [0x7f18220e4991]
 /usr/lib/libQtGui.so.4(_ZN7QWidget5eventEP6QEvent+0x6fc) [0x7f18228d5cac]
 /usr/lib/libQtGui.so.4(_ZN11QMainWindow5eventEP6QEvent+0x113) [0x7f1822cb4223]
 /home/rwp/mantid/Release/py3/bin/MantidPlot() [0x529220]
 /usr/lib/libQtGui.so.4(_ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent+0x8c) [0x7f182287ef2c]
 /usr/lib/libQtGui.so.4(_ZN12QApplication6notifyEP7QObjectP6QEvent+0x2cc) [0x7f1822885e3c]
 /home/rwp/mantid/Release/py3/bin/MantidPlot() [0x8204b7]
 /usr/lib/libQtCore.so.4(_ZN16QCoreApplication14notifyInternalEP7QObjectP6QEvent+0x8d) [0x7f18220cab2d]
 /usr/lib/libQtCore.so.4(_ZN23QCoreApplicationPrivate16sendPostedEventsEP7QObjectiP11QThreadData+0x3b6) [0x7f18220ce006]
 /usr/lib/libQtCore.so.4(+0x1ccd5e) [0x7f18220fad5e]
 /usr/lib/libglib-2.0.so.0(g_main_context_dispatch+0x2a7) [0x7f18149eb587]
 /usr/lib/libglib-2.0.so.0(+0x4a7f0) [0x7f18149eb7f0]
 /usr/lib/libglib-2.0.so.0(g_main_context_iteration+0x2c) [0x7f18149eb89c]
 /usr/lib/libQtCore.so.4(_ZN20QEventDispatcherGlib13processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE+0x7e) [0x7f18220faece]
 /usr/lib/libQtGui.so.4(+0x2aae86) [0x7f1822927e86]
 /usr/lib/libQtCore.so.4(_ZN10QEventLoop13processEventsE6QFlagsINS_17ProcessEventsFlagEE+0x3f) [0x7f18220c93ff]
 /usr/lib/libQtCore.so.4(_ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE+0x1b5) [0x7f18220c9765]
 /usr/lib/libQtCore.so.4(_ZN16QCoreApplication4execEv+0x99) [0x7f18220cf1c9]
 /home/rwp/mantid/Release/py3/bin/MantidPlot() [0x4683b2]
 /usr/lib/libc.so.6(__libc_start_main+0xf1) [0x7f181e692291]
 /home/rwp/mantid/Release/py3/bin/MantidPlot() [0x46903a]
```

You should now also be able to run the `MantidPlot*.py` unit tests without them segfaulting. They still fail because they haven't been given the python 2 to 3 treatment yet but that's the next step.

To test:
- Compile with python 3 then start a script like `MantidPlot -xq script.py`

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
