### PR TITLE
Added deltaE-mode detection to LoadNXSPE

### DIFF
--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -273,24 +273,22 @@ void LoadNXSPE::exec() {
       // We just want to get whether the instrument is direct or indirect
       // and the source position (because we can!).
       // Nothing else is really needed, and also the physical detectors may not
-      // correspond to the data in the nxspe files because they may have been grouped
-      // to get each nxspe spectrum - and this group mapping is not stored.
+      // correspond to the data in the nxspe files because they may have been
+      // grouped to get each nxspe spectrum - and this mapping is not stored.
       Geometry::Instrument_const_sptr inst = instrumentWS->getInstrument();
       l12 = fabs(inst->getSource()->getDistance(*(inst->getSample())));
       outputWS->mutableRun().addLogData(new PropertyWithValue<std::string>(
-          "deltaE-mode", Kernel::DeltaEMode::asString(instrumentWS->getEMode())));
+          "deltaE-mode",
+          Kernel::DeltaEMode::asString(instrumentWS->getEMode())));
     } catch (...) {
       g_log.information("Cannot load the instrument definition.");
       instrument_name.clear();
     }
   }
 
-  if (instrument_name.empty()) {
-    instrument_name.assign("NXSPE");
-  }
-
   // generate instrument
-  Geometry::Instrument_sptr instrument(new Geometry::Instrument(instrument_name));
+  Geometry::Instrument_sptr instrument(new Geometry::Instrument(
+      instrument_name.empty() ? "NXSPE" : instrument_name));
   outputWS->setInstrument(instrument);
 
   Geometry::ObjComponent *source = new Geometry::ObjComponent("source");

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -319,14 +319,15 @@ void LoadNXSPE::exec() {
   // If an instrument name is defined, load instrument parameter file for Emode
   // NB. LoadParameterFile must be used on a workspace with an instrument
   if (!instrument_name.empty()) {
-    std::string IDF_filename = 
-	ExperimentInfo::getInstrumentFilename(instrument_name);
-    std::string instrument_parfile = 
-	IDF_filename.substr(0, IDF_filename.find("_Definition"))
-        + "_Parameters.xml";
+    std::string IDF_filename =
+        ExperimentInfo::getInstrumentFilename(instrument_name);
+    std::string instrument_parfile =
+        IDF_filename.substr(0, IDF_filename.find("_Definition")) +
+        "_Parameters.xml";
     if (Poco::File(instrument_parfile).exists()) {
       try {
-        IAlgorithm_sptr loadParamAlg = createChildAlgorithm("LoadParameterFile");
+        IAlgorithm_sptr loadParamAlg =
+            createChildAlgorithm("LoadParameterFile");
         loadParamAlg->setProperty("Filename", instrument_parfile);
         loadParamAlg->setProperty("Workspace", outputWS);
         loadParamAlg->execute();

--- a/Framework/DataHandling/test/LoadNXSPETest.h
+++ b/Framework/DataHandling/test/LoadNXSPETest.h
@@ -3,6 +3,8 @@
 
 #include <cxxtest/TestSuite.h>
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidKernel/DeltaEMode.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/System.h"
 
@@ -35,13 +37,17 @@ public:
     TS_ASSERT(alg.isExecuted());
 
     // Retrieve the workspace from data service.
-    Workspace_sptr ws;
+    MatrixWorkspace_sptr ws;
     TS_ASSERT_THROWS_NOTHING(
         ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outWSName));
     TS_ASSERT(ws);
     if (!ws)
       return;
+
+    // Checks that the instrument name and deltaE-mode is correct
+    TS_ASSERT_EQUALS(ws->getInstrument()->getName(), "IRIS");
+    TS_ASSERT_EQUALS(ws->getEMode(), Kernel::DeltaEMode::Indirect);
 
     AnalysisDataService::Instance().remove(outWSName);
   }

--- a/docs/source/algorithms/LoadNXSPE-v1.rst
+++ b/docs/source/algorithms/LoadNXSPE-v1.rst
@@ -13,6 +13,9 @@ Algorithm to load an NXSPE file into a workspace2D. It will create a new
 instrument, that can be overwritten later by the LoadInstrument
 algorithm.
 
+**NOTE:** The final energy of indirect geometry data is not saved to this file.
+For indirect data, we recommend to save the data in NXS format instead.
+
 **NOTE:** In the current implementation, the rendering of the NXSPE
 instrument is VERY memory intensive.
 


### PR DESCRIPTION
Modifies `LoadNXSPE` to get the instrument name from the file to be loaded, run `LoadInstrument` and get whether the instrument is `Direct` or `Indirect` geometry. If the instrument name is not recognised, continues with previous default (`Elastic`).

This is mainly to fix loading of NXSPE files (especially for `Indirect` instruments) in `mslice`.

**To test:**

Load an `nxspe` file, and check (`print ws.getEMode()`) that the correct energy analysis mode is returned (e.g. for Arcs / CNCS / LET / Mari / Maps / Merlin / Sequoia it should be `Direct` and for Basis / Iris / Osiris it should be `Indirect`).

Fixes #17417.

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
