### PR TITLE
Change PVPython tests to only check the major version number

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/PVPythonTest.py
+++ b/Framework/PythonInterface/test/python/mantid/PVPythonTest.py
@@ -2,11 +2,11 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 from paraview.simple import *
 
+
 class PVPythonTest(unittest.TestCase):
 
     def test_PVPython(self):
-        self.assertEquals(str(GetParaViewVersion()),'5.1')
+        self.assertEqual(GetParaViewVersion().major, 5)
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/MantidPlot/test/MantidPlotPVPythonTest.py
+++ b/MantidPlot/test/MantidPlotPVPythonTest.py
@@ -4,6 +4,7 @@ Test one can import paraview.simple in MantidPlot
 import mantidplottests
 from mantidplottests import *
 
+
 class MantidPlotPVPythonTest(unittest.TestCase):
 
     def setUp(self):
@@ -14,8 +15,7 @@ class MantidPlotPVPythonTest(unittest.TestCase):
 
     def test_PVPython(self):
         from paraview.simple import *
-        self.assertEquals(str(GetParaViewVersion()),'5.1')
+        self.assertEqual(GetParaViewVersion().major, 5)
 
 # Run the unit tests
 mantidplottests.runTests(MantidPlotPVPythonTest)
-

--- a/Testing/SystemTests/tests/analysis/PVPythonTest.py
+++ b/Testing/SystemTests/tests/analysis/PVPythonTest.py
@@ -6,4 +6,4 @@ from paraview.simple import *
 class PVPythonTest(stresstesting.MantidStressTest):
 
     def runTest(self):
-        self.assertEquals(str(GetParaViewVersion()),'5.1')
+        self.assertEqual(GetParaViewVersion().major, 5)


### PR DESCRIPTION
The check on paraview version is stricter than it needs to be, this makes it hard to work with newer versions of paraview. These tests are only really testing if `paraview.simple` is able to be imported, so checking just the major version number is more than enough.

**To test:**
- The test should now pass with any `5.*` paraview version

_Does not need to be in the release notes._

---
#### Reviewer

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):
##### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?
##### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?
- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
