### PR TITLE
Fix gcc 5 suggest-override warnings

### DIFF
--- a/Framework/Algorithms/test/SetUncertaintiesTest.h
+++ b/Framework/Algorithms/test/SetUncertaintiesTest.h
@@ -102,7 +102,7 @@ public:
 
 class SetUncertaintiesTestPerformance : public CxxTest::TestSuite {
 public:
-  void setUp() {
+  void setUp() override {
     algZero.initialize();
     algCalc.initialize();
 

--- a/Framework/Algorithms/test/SmoothDataTest.h
+++ b/Framework/Algorithms/test/SmoothDataTest.h
@@ -182,7 +182,7 @@ public:
 
 class SmoothDataTestPerformance : public CxxTest::TestSuite {
 public:
-  void setUp() {
+  void setUp() override {
 
     // Set up a small workspace for testing
     constexpr size_t numHistograms(1);
@@ -211,7 +211,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(smoothAlg.execute());
   }
 
-  void tearDown() { AnalysisDataService::Instance().remove("outputWS"); }
+  void tearDown() override {
+    AnalysisDataService::Instance().remove("outputWS");
+  }
 
 private:
   Workspace2D_sptr inputWs;


### PR DESCRIPTION
Fixes remaining gcc 5 warnings: http://builds.mantidproject.org/job/master_clean-ubuntu-16.04/323/warnings26Result/

**To test:**

Build tests with gcc 5 and there should be no warnings.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

