### PR TITLE
Enabled SavePlot1D to turn on/off the option to pop out canvas.

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
@@ -58,6 +58,9 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
                              'Override with custom names for spectra')
         self.declareProperty('Result', '', Direction.Output)
 
+        self.declareProperty('PopCanvas', False, 'If true, a Matplotlib canvas will be popped out '
+                             ', which contains the saved plot.')
+
     def validateInputs(self):
         messages = {}
         outputType = self.getProperty('OutputType').value
@@ -174,6 +177,8 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
         return (data, xlabel, ylabel)
 
     def saveImage(self):
+        """ Save image
+        """
         ok2run = ''
         try:
             import matplotlib
@@ -198,8 +203,12 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
             fig, ax = plt.subplots()
             self.doPlotImage(ax, self._wksp)
 
+        # get the flag to pop out canvas or not
+        pop_canvas = self.getProperty('PopCanvas').value
+
         plt.tight_layout(1.08)
-        plt.show()
+        if pop_canvas:
+            plt.show()
         filename = self.getProperty("OutputFilename").value
         fig.savefig(filename, bbox_inches='tight')
 


### PR DESCRIPTION
Added an option to enable SavePlot1D to pop out a matplotlib canvas.

**To test:**

Execute SavePlot1D with PopCanvas to be True and False respectively in IPython console or a Python script.

Fixes #17915.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

