### PR TITLE
Make listener properties in StartLiveData dynamic

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/StartLiveData.h
+++ b/Framework/LiveData/inc/MantidLiveData/StartLiveData.h
@@ -56,6 +56,7 @@ public:
 private:
   void init() override;
   void exec() override;
+  void afterPropertySet(const std::string &) override;
 };
 
 } // namespace LiveData

--- a/Framework/LiveData/inc/MantidLiveData/StartLiveData.h
+++ b/Framework/LiveData/inc/MantidLiveData/StartLiveData.h
@@ -57,6 +57,10 @@ private:
   void init() override;
   void exec() override;
   void afterPropertySet(const std::string &) override;
+
+  void copyListenerProperties(
+          const boost::shared_ptr<Mantid::API::ILiveListener> &listener);
+  void removeListenerProperties();
 };
 
 } // namespace LiveData

--- a/Framework/LiveData/inc/MantidLiveData/StartLiveData.h
+++ b/Framework/LiveData/inc/MantidLiveData/StartLiveData.h
@@ -59,7 +59,7 @@ private:
   void afterPropertySet(const std::string &) override;
 
   void copyListenerProperties(
-          const boost::shared_ptr<Mantid::API::ILiveListener> &listener);
+      const boost::shared_ptr<Mantid::API::ILiveListener> &listener);
   void removeListenerProperties();
 };
 

--- a/Framework/LiveData/src/StartLiveData.cpp
+++ b/Framework/LiveData/src/StartLiveData.cpp
@@ -91,7 +91,8 @@ void StartLiveData::afterPropertySet(const std::string &propName) {
         boost::dynamic_pointer_cast<IPropertyManager>(listener);
 
     if (propertyManagerListener) {
-      const std::vector<Property *> listenerProps = propertyManagerListener->getProperties();
+      const std::vector<Property *> listenerProps =
+          propertyManagerListener->getProperties();
       for (auto listenerProp : listenerProps) {
         auto prop = std::unique_ptr<Property>(listenerProp->clone());
         prop->setGroup(listenerPropertyGroup);

--- a/Framework/LiveData/src/StartLiveData.cpp
+++ b/Framework/LiveData/src/StartLiveData.cpp
@@ -94,8 +94,8 @@ void StartLiveData::afterPropertySet(const std::string &propName) {
  *
  * @param listener ILiveListener from which to copy properties
  */
-void StartLiveData::copyListenerProperties(const boost::shared_ptr<ILiveListener> &listener)
-{
+void StartLiveData::copyListenerProperties(
+    const boost::shared_ptr<ILiveListener> &listener) {
   // Add clones of listener's properties to this algorithm
   for (auto listenerProp : listener->getProperties()) {
     auto prop = std::unique_ptr<Property>(listenerProp->clone());
@@ -107,8 +107,7 @@ void StartLiveData::copyListenerProperties(const boost::shared_ptr<ILiveListener
 /**
  * Removes previously copied ILiveListener properties.
  */
-void StartLiveData::removeListenerProperties()
-{
+void StartLiveData::removeListenerProperties() {
   // Remove all properties tagged with the listener property group
   for (auto prop : getProperties()) {
     if (prop->getGroup() == listenerPropertyGroup) {

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -253,8 +253,14 @@ def StartLiveData(*args, **kwargs):
     except KeyError:
         pass
 
-    # Handle unpacking / workspace names from lhs
+    # LHS Handling currently unsupported for StartLiveData
     lhs = _kernel.funcinspect.lhs_info()
+    if lhs[0] > 0:  # Number of terms on the lhs
+        raise RuntimeError("Assigning the output of StartLiveData is currently "
+                           "unsupported due to limitations of the simpleapi. "
+                           "Please call StartLiveData without assigning it to "
+                           "to anything.")
+
     lhs_args = _get_args_from_lhs(lhs, algm)
     final_keywords = _merge_keywords_with_lhs(kwargs, lhs_args)
 

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -756,7 +756,7 @@ def _merge_keywords_with_lhs(keywords, lhs_args):
     final_keywords.update(keywords)
     return final_keywords
 
-def _gather_returns(func_name, lhs, algm_obj, ignore_regex=[]):
+def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
     """Gather the return values and ensure they are in the
        correct order as defined by the output properties and
        return them as a tuple. If their is a single return
@@ -767,6 +767,8 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=[]):
        :param algm_obj: An executed algorithm object.
        :param ignore_regex: A list of strings containing regex expressions to match against property names that will be ignored & not returned.
     """
+    if ignore_regex is None: ignore_regex = []
+
     import re
     def ignore_property(name, ignore_regex):
         for regex in ignore_regex:

--- a/docs/source/algorithms/StartLiveData-v1.rst
+++ b/docs/source/algorithms/StartLiveData-v1.rst
@@ -23,6 +23,29 @@ simply calls :ref:`algm-LoadLiveData` at a fixed interval.
 Instructions for setting up a "fake" data stream are found `here
 <http://www.mantidproject.org/MBC_Live_Data_Simple_Examples>`__.
 
+Listener Properties
+###################
+
+Specific LiveListeners may provide their own properties, in addition to
+properties provided by StartLiveData. For convenience and accessibility, these
+properties are made available through StartLiveData as well.
+
+In the StartLiveData algorithm dialog, a group box called "Listener Properties"
+will appear at the bottom of the sidebar on the left, if the currently selected
+listener provides additional properties.
+
+In the Python API, these listener properties may also be set as keyword
+arguments when calling StartLiveData. For example, in this code snippet:
+
+.. code-block:: python
+
+    StartLiveData(Instrument='ISIS_Histogram', OutputWorkspace='wsOut', UpdateEvery=1,
+                  AccumulationMethod='Replace', PeriodList=[1,3], SpectraList=[2,4,6])
+
+PeriodList and SpectraList are properties of the ISISHistoDataListener. They
+are available as arguments in this call because Instrument is set to
+'ISIS_Histogram', which uses that listener.
+
 Live Plots
 ##########
 

--- a/docs/source/release/v3.9.0/framework.rst
+++ b/docs/source/release/v3.9.0/framework.rst
@@ -41,7 +41,7 @@ Python Algorithms
 
 - :ref:`MatchPeaks <algm-MatchPeaks>` performs circular shift operation (numpy roll) along the x-axis to align the peaks in the spectra.
 - :ref:`FindEPP <algm-FindEPP>` is improved to better determine the initial parameters and range for the fitting.
-- :ref:`StartLiveData <algm-StartLiveData>` can now accept LiveListener properties as parameters, based on the Instrument parameter.
+- :ref:`StartLiveData <algm-StartLiveData>` can now accept LiveListener properties as parameters, based on the value of the "Instrument" parameter.
 
 Bug Fixes
 ---------

--- a/docs/source/release/v3.9.0/framework.rst
+++ b/docs/source/release/v3.9.0/framework.rst
@@ -16,6 +16,7 @@ Improved
 ########
 
 - :ref:`CalculateFlatBackground <algm-CalculateFlatBackground>` has now a new mode 'Moving Average' which takes the minimum of a moving window average as the flat background.
+- :ref:`StartLiveData <algm-StartLiveData>` and its dialog now support dynamic listener properties, based on the specific LiveListener being used.
 
 Deprecated
 ##########
@@ -40,6 +41,7 @@ Python Algorithms
 
 - :ref:`MatchPeaks <algm-MatchPeaks>` performs circular shift operation (numpy roll) along the x-axis to align the peaks in the spectra.
 - :ref:`FindEPP <algm-FindEPP>` is improved to better determine the initial parameters and range for the fitting.
+- :ref:`StartLiveData <algm-StartLiveData>` can now accept LiveListener properties as parameters, based on the Instrument parameter.
 
 Bug Fixes
 ---------


### PR DESCRIPTION
As required by [More Flexible LiveListener](https://github.com/mantidproject/documents/blob/master/Design/MoreFlexibleILiveListener.md) design document.

This effectively reverts #234, plus modifications and additions to still achieve its purpose.

SpectraList and PeriodList properties are no longer hard-coded as part of StartLiveData.

Instead, StartLiveData will dynamically add the properties of the specific LiveListener it uses once the Instrument is set.

The Python simpleapi has been updated with a specialized version of StartLiveData to allow evaluating other arguments based on the value of the Instrument argument.

**To test:**

See associated issue for testing GUI behaviour.

For Python interface:

1. Run a `FakeISISHistoDAE` algorithm with `NPeriods=5`, `NSpectra=10` and `NBins=100`.
1. Run the following code in the console:
```python
ConfigService.setFacility('TEST_LIVE')
StartLiveData(Instrument='ISIS_Histogram', OutputWorkspace='OutWS', AccumulationWorkspace='AccWS', UpdateEvery=1, AccumulationMethod='Replace', PeriodList=[1,3], SpectraList=[2,4,6])
```
This should work both before and after this change.

Fixes #17912.

Release notes have been updated.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
