### PR TITLE
Fix exception and just return empty string

### DIFF
--- a/MantidPlot/src/MdiSubWindow.cpp
+++ b/MantidPlot/src/MdiSubWindow.cpp
@@ -133,8 +133,8 @@ MdiSubWindow::loadFromProject(const std::string &lines, ApplicationWindow *app,
 
 std::string MdiSubWindow::saveToProject(ApplicationWindow *app) {
   Q_UNUSED(app);
-  throw std::runtime_error(
-      "SaveToProject not implemented for raw MdiSubWindow");
+  // By default this is unimplemented and so should return nothing
+  return "";
 }
 
 void MdiSubWindow::resizeEvent(QResizeEvent *e) {

--- a/docs/source/release/v3.9.0/ui.rst
+++ b/docs/source/release/v3.9.0/ui.rst
@@ -52,6 +52,7 @@ Bugs Resolved
 - Fixed a bug where checking or unchecking "show invisible workspaces" in View->Preferences->Mantid->Options would have no effect on workspaces loaded in the dock.
 - The Spectrum Viewer now reports two theta and azimuthal angle correctly.
 - Fixed crash when clicking "Help->Ask for Help" on Linux-based systems with Firefox set as the default browser.  
+- Fixed exception being thrown when saving project with custom interfaces open
 
 SliceViewer Improvements
 ------------------------


### PR DESCRIPTION
Remove the the exception thrown when a MdiSubWindow without any further implementation is used. UserSubWindows are not subclasses of MdiSubWindow but there parent widget is a vanilla MdiSubWindow, therefore is registered with application window as a window to be serialised.

**To test:**
Repeat the instructions in #17932 and you should no longer see an exception. The project should save/load correct as well now.

Fixes #17932.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
