### PR TITLE
Fix run status log for aborted runs

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/LogParser.h
+++ b/Framework/Kernel/inc/MantidKernel/LogParser.h
@@ -100,7 +100,7 @@ private:
       Kernel::TimeSeriesProperty<bool> *status);
 
   /// Available commands.
-  enum commands { NONE = 0, BEGIN, END, CHANGE_PERIOD };
+  enum class commands { NONE = 0, BEGIN, END, CHANGE_PERIOD, ABORT };
 
   /// Typedef for a map of string commands to an enum of strongly typed
   /// commands.

--- a/Framework/Kernel/src/LogParser.cpp
+++ b/Framework/Kernel/src/LogParser.cpp
@@ -128,21 +128,22 @@ LogParser::CommandMap LogParser::createCommandMap(bool newStyle) const {
   CommandMap command_map;
 
   if (newStyle) {
-    command_map["START_COLLECTION"] = BEGIN;
-    command_map["STOP_COLLECTION"] = END;
-    command_map["CHANGE"] = CHANGE_PERIOD;
-    command_map["CHANGE_PERIOD"] = CHANGE_PERIOD;
+    command_map["START_COLLECTION"] = commands::BEGIN;
+    command_map["STOP_COLLECTION"] = commands::END;
+    command_map["CHANGE"] = commands::CHANGE_PERIOD;
+    command_map["CHANGE_PERIOD"] = commands::CHANGE_PERIOD;
+    command_map["ABORT"] = commands::ABORT;
   } else {
-    command_map["BEGIN"] = BEGIN;
-    command_map["RESUME"] = BEGIN;
-    command_map["END_SE_WAIT"] = BEGIN;
-    command_map["PAUSE"] = END;
-    command_map["END"] = END;
-    command_map["ABORT"] = END;
-    command_map["UPDATE"] = END;
-    command_map["START_SE_WAIT"] = END;
-    command_map["CHANGE"] = CHANGE_PERIOD;
-    command_map["CHANGE_PERIOD"] = CHANGE_PERIOD;
+    command_map["BEGIN"] = commands::BEGIN;
+    command_map["RESUME"] = commands::BEGIN;
+    command_map["END_SE_WAIT"] = commands::BEGIN;
+    command_map["PAUSE"] = commands::END;
+    command_map["END"] = commands::END;
+    command_map["ABORT"] = commands::ABORT;
+    command_map["UPDATE"] = commands::END;
+    command_map["START_SE_WAIT"] = commands::END;
+    command_map["CHANGE"] = commands::CHANGE_PERIOD;
+    command_map["CHANGE_PERIOD"] = commands::CHANGE_PERIOD;
   }
   return command_map;
 }
@@ -218,11 +219,18 @@ LogParser::LogParser(const Kernel::Property *log) : m_nOfPeriods(1) {
     std::istringstream idata(it->second);
     idata >> scom;
     commands com = command_map[scom];
-    if (com == CHANGE_PERIOD) {
+    if (com == commands::CHANGE_PERIOD) {
       tryParsePeriod(scom, it->first, idata, periods);
-    } else if (com == BEGIN) {
+    } else if (com == commands::BEGIN) {
       status->addValue(it->first, true);
-    } else if (com == END) {
+    } else if (com == commands::END) {
+      status->addValue(it->first, false);
+    } else if (com == commands::ABORT) {
+      // Set all previous values to false
+      const auto &times = status->timesAsVector();
+      const std::vector<bool> values(times.size(), false);
+      status->replaceValues(times, values);
+      // Add a new value at the present time
       status->addValue(it->first, false);
     }
   };

--- a/Framework/Kernel/test/LogParserTest.h
+++ b/Framework/Kernel/test/LogParserTest.h
@@ -6,6 +6,7 @@
 #include <fstream>
 
 #include "MantidKernel/LogParser.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include <boost/scoped_ptr.hpp>
@@ -670,6 +671,51 @@ public:
     TS_ASSERT_EQUALS(it->second, "   Second line Third line");
     ++it;
     delete prop;
+  }
+
+  /// If a run is aborted and then restarted, the "running" log should be set to
+  /// false at all times during the aborted run.
+  void test_abort_runningLogAlwaysFalseBeforeRestart() {
+    auto log = Mantid::Kernel::make_unique<TimeSeriesProperty<std::string>>(
+        "MyICPevent");
+
+    // (This is a cut-down version of EMU66122)
+    const DateAndTime timeZero{"2016-10-01T10:01:44"};
+    const std::vector<DateAndTime> times{
+        timeZero,        timeZero + 3.0,  timeZero + 3.0,   timeZero + 3.0,
+        timeZero + 51.0, timeZero + 51.0, timeZero + 57.0,  timeZero + 60.0,
+        timeZero + 60.0, timeZero + 60.0, timeZero + 111.0, timeZero + 111.0};
+    const std::vector<std::string> values{
+        "CHANGE_PERIOD 1",
+        "CHANGE_PERIOD 1",
+        "START_COLLECTION PERIOD 1 GF 0 RF 0 GUAH 0.000000",
+        "BEGIN",
+        "STOP_COLLECTION PERIOD 1 GF 1931 RF 1933 GUAH 0.000000 DUR 48",
+        "ABORT",
+        "CHANGE_PERIOD 1",
+        "CHANGE_PERIOD 1",
+        "START_COLLECTION PERIOD 1 GF 0 RF 0 GUAH 0.000000",
+        "BEGIN",
+        "STOP_COLLECTION PERIOD 1 GF 2062 RF 2064 GUAH 0.000000 DUR 51",
+        "END"};
+    log->addValues(times, values);
+
+    const std::multimap<DateAndTime, bool> expectedRunning{
+        {timeZero + 3.0, false},    // start - run later aborted
+        {timeZero + 51.0, false},   // stop
+        {timeZero + 51.0, false},   // abort
+        {timeZero + 60.0, true},    // start
+        {timeZero + 111.0, false}}; // stop
+
+    const LogParser logparser(log.get());
+
+    const auto prop = std::unique_ptr<Property>(logparser.createRunningLog());
+    const auto *runningProp =
+        dynamic_cast<const TimeSeriesProperty<bool> *>(prop.get());
+    TS_ASSERT(runningProp);
+    TS_ASSERT_EQUALS(expectedRunning.size(), runningProp->size());
+    const auto &runningMap = runningProp->valueAsMultiMap();
+    TS_ASSERT_EQUALS(expectedRunning, runningMap);
   }
 
 private:

--- a/Framework/Kernel/test/LogParserTest.h
+++ b/Framework/Kernel/test/LogParserTest.h
@@ -496,10 +496,14 @@ public:
         {"2013-10-16T19:13:09", 1}};
 
     const std::vector<std::pair<std::string, bool>> checkRunning{
-        {"2013-10-16T19:04:48", true}, {"2013-10-16T19:06:53", false},
-        {"2013-10-16T19:06:53", true}, {"2013-10-16T19:08:58", false},
-        {"2013-10-16T19:08:59", true}, {"2013-10-16T19:11:03", false},
-        {"2013-10-16T19:11:04", true}, {"2013-10-16T19:13:09", false}};
+        {"2013-10-16T19:04:48", true},
+        {"2013-10-16T19:06:53", false},
+        {"2013-10-16T19:06:53", true},
+        {"2013-10-16T19:08:58", false},
+        {"2013-10-16T19:08:59", true},
+        {"2013-10-16T19:11:03", false},
+        {"2013-10-16T19:11:04", true},
+        {"2013-10-16T19:13:09", false}};
 
     const LogParser logparser(log.get());
 
@@ -622,18 +626,12 @@ public:
         timeZero + 51.0, timeZero + 51.0, timeZero + 57.0,  timeZero + 60.0,
         timeZero + 60.0, timeZero + 60.0, timeZero + 111.0, timeZero + 111.0};
     const std::vector<std::string> values{
-        "CHANGE_PERIOD 1",
-        "CHANGE_PERIOD 1",
-        "START_COLLECTION PERIOD 1 GF 0 RF 0 GUAH 0.000000",
-        "BEGIN",
+        "CHANGE_PERIOD 1", "CHANGE_PERIOD 1",
+        "START_COLLECTION PERIOD 1 GF 0 RF 0 GUAH 0.000000", "BEGIN",
         "STOP_COLLECTION PERIOD 1 GF 1931 RF 1933 GUAH 0.000000 DUR 48",
-        "ABORT",
-        "CHANGE_PERIOD 1",
-        "CHANGE_PERIOD 1",
-        "START_COLLECTION PERIOD 1 GF 0 RF 0 GUAH 0.000000",
-        "BEGIN",
-        "STOP_COLLECTION PERIOD 1 GF 2062 RF 2064 GUAH 0.000000 DUR 51",
-        "END"};
+        "ABORT", "CHANGE_PERIOD 1", "CHANGE_PERIOD 1",
+        "START_COLLECTION PERIOD 1 GF 0 RF 0 GUAH 0.000000", "BEGIN",
+        "STOP_COLLECTION PERIOD 1 GF 2062 RF 2064 GUAH 0.000000 DUR 51", "END"};
     log->addValues(times, values);
 
     const std::multimap<DateAndTime, bool> expectedRunning{

--- a/Framework/Kernel/test/LogParserTest.h
+++ b/Framework/Kernel/test/LogParserTest.h
@@ -4,12 +4,12 @@
 #include <cxxtest/TestSuite.h>
 
 #include <fstream>
+#include <numeric>
 
 #include "MantidKernel/LogParser.h"
 #include "MantidKernel/make_unique.h"
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/TimeSeriesProperty.h"
-#include <boost/scoped_ptr.hpp>
 
 #include <Poco/File.h>
 
@@ -46,41 +46,37 @@ public:
   void testGood() {
     mkICP();
     mkGood();
-    Property *icp_log =
-        LogParser::createLogProperty(icp_file.path(), "icpevent");
-    LogParser lp(icp_log);
-    Property *p1 = lp.createLogProperty(log_num_good.path(), "good");
+    const auto &icp_log = std::unique_ptr<Property>(
+        LogParser::createLogProperty(icp_file.path(), "icpevent"));
+    const LogParser lp(icp_log.get());
+    const auto &p1 = std::unique_ptr<Property>(
+        lp.createLogProperty(log_num_good.path(), "good"));
     TS_ASSERT(p1);
     TimeSeriesProperty<double> *tp1 =
-        dynamic_cast<TimeSeriesProperty<double> *>(p1);
+        dynamic_cast<TimeSeriesProperty<double> *>(p1.get());
     std::map<DateAndTime, double> vmap = tp1->valueAsMap();
     std::map<DateAndTime, double>::iterator v = vmap.begin();
     // time 1
     TS_ASSERT_EQUALS(vmap.size(), 9);
     TS_ASSERT_EQUALS(v->second, 1);
-    ti_data = v->first.to_tm();
-    ti = &ti_data;
-
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 22);
+    const auto &ti_data1 = v->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data1.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_data1.tm_min, 22);
     v++;
     v++;
     v++;
     v++;
     // time 5
-    // TS_ASSERT(isNaN(v->second));
-    ti_data = v->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 22);
+    const auto &ti_data5 = v->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data5.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_data5.tm_min, 22);
     // last time
     std::map<DateAndTime, double>::reverse_iterator rv = vmap.rbegin();
     TS_ASSERT_EQUALS(rv->second, 9);
-    ti_data = rv->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 14);
-    TS_ASSERT_EQUALS(ti->tm_min, 3);
-    TS_ASSERT_DELTA(timeMean(p1), 8.4904, 0.001);
+    const auto &ti_data_last = rv->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data_last.tm_hour, 14);
+    TS_ASSERT_EQUALS(ti_data_last.tm_min, 3);
+    TS_ASSERT_DELTA(timeMean(p1.get()), 8.4904, 0.001);
 
     TS_ASSERT_EQUALS(tp1->nthValue(0), 1);
     TS_ASSERT_EQUALS(tp1->nthValue(1), 2);
@@ -92,23 +88,20 @@ public:
     TS_ASSERT_EQUALS(tp1->nthValue(7), 8);
 
     TS_ASSERT_EQUALS(tp1->firstValue(), 1);
-    // TS_ASSERT_EQUALS(secondValue(p1),2);
     TS_ASSERT_EQUALS(tp1->lastValue(), 9);
-
-    delete p1;
-    delete icp_log;
   }
 
   void testLate() {
     mkICP();
     mkLate();
-    Property *icp_log =
-        LogParser::createLogProperty(icp_file.path(), "icpevent");
-    LogParser lp(icp_log);
-    Property *p1 = lp.createLogProperty(log_num_late.path(), "late");
+    const auto &icp_log = std::unique_ptr<Property>(
+        LogParser::createLogProperty(icp_file.path(), "icpevent"));
+    const LogParser lp(icp_log.get());
+    const auto &p1 = std::unique_ptr<Property>(
+        lp.createLogProperty(log_num_late.path(), "late"));
     TS_ASSERT(p1);
     TimeSeriesProperty<double> *tp1 =
-        dynamic_cast<TimeSeriesProperty<double> *>(p1);
+        dynamic_cast<TimeSeriesProperty<double> *>(p1.get());
     std::map<DateAndTime, double> vmap = tp1->valueAsMap();
     std::map<DateAndTime, double>::iterator v = vmap.begin();
 
@@ -116,171 +109,148 @@ public:
     TS_ASSERT_EQUALS(vmap.size(), 8);
     TS_ASSERT_EQUALS(v->second, 2);
 
-    ti_data = v->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 22);
+    const auto &ti_data1 = v->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data1.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_data1.tm_min, 22);
     v++;
     v++;
     v++;
     v++;
     // time 5
-    // TS_ASSERT(isNaN(v->second));
-    ti_data = v->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 22);
+    const auto &ti_data5 = v->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data5.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_data5.tm_min, 22);
     // last time
     std::map<DateAndTime, double>::reverse_iterator rv = vmap.rbegin();
     TS_ASSERT_EQUALS(rv->second, 9);
-    ti_data = rv->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 14);
-    TS_ASSERT_EQUALS(ti->tm_min, 3);
-    TS_ASSERT_DELTA(timeMean(p1), 8.4941, 0.001);
-
-    delete p1;
-    delete icp_log;
+    const auto &ti_dataLast = rv->first.to_tm();
+    TS_ASSERT_EQUALS(ti_dataLast.tm_hour, 14);
+    TS_ASSERT_EQUALS(ti_dataLast.tm_min, 3);
+    TS_ASSERT_DELTA(timeMean(p1.get()), 8.4941, 0.001);
   }
 
   void testEarly() {
     mkICP();
     mkEarly();
-    Property *icp_log =
-        LogParser::createLogProperty(icp_file.path(), "icpevent");
-    LogParser lp(icp_log);
-    Property *p1 = lp.createLogProperty(log_num_early.path(), "early");
+    const auto &icp_log = std::unique_ptr<Property>(
+        LogParser::createLogProperty(icp_file.path(), "icpevent"));
+    const LogParser lp(icp_log.get());
+    const auto &p1 = std::unique_ptr<Property>(
+        lp.createLogProperty(log_num_early.path(), "early"));
     TS_ASSERT(p1);
     TimeSeriesProperty<double> *tp1 =
-        dynamic_cast<TimeSeriesProperty<double> *>(p1);
+        dynamic_cast<TimeSeriesProperty<double> *>(p1.get());
     std::map<DateAndTime, double> vmap = tp1->valueAsMap();
     std::map<DateAndTime, double>::iterator v = vmap.begin();
 
     // time 1
     TS_ASSERT_EQUALS(vmap.size(), 8);
     TS_ASSERT_EQUALS(v->second, 1);
-    ti_data = v->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 22);
+    const auto &ti_data1 = v->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data1.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_data1.tm_min, 22);
     v++;
     v++;
     v++;
     v++;
     // time 5
-    // TS_ASSERT(isNaN(v->second));
-    ti_data = v->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 22);
+    const auto &ti_data5 = v->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data5.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_data5.tm_min, 22);
     // last time
     std::map<DateAndTime, double>::reverse_iterator rv = vmap.rbegin();
     TS_ASSERT_EQUALS(rv->second, 8);
-    ti_data = rv->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 23);
-    TS_ASSERT_DELTA(timeMean(p1), 4.9090, 0.001);
-
-    delete p1;
-    delete icp_log;
+    const auto &ti_dataLast = rv->first.to_tm();
+    TS_ASSERT_EQUALS(ti_dataLast.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_dataLast.tm_min, 23);
+    TS_ASSERT_DELTA(timeMean(p1.get()), 4.9090, 0.001);
   }
 
   void testSingle() {
     mkICP();
     mkSingle();
-    Property *icp_log =
-        LogParser::createLogProperty(icp_file.path(), "icpevent");
-    LogParser lp(icp_log);
-    Property *p1 = lp.createLogProperty(log_num_single.path(), "single");
+    const auto &icp_log = std::unique_ptr<Property>(
+        LogParser::createLogProperty(icp_file.path(), "icpevent"));
+    const LogParser lp(icp_log.get());
+    const auto &p1 = std::unique_ptr<Property>(
+        lp.createLogProperty(log_num_single.path(), "single"));
     TS_ASSERT(p1);
     TimeSeriesProperty<double> *tp1 =
-        dynamic_cast<TimeSeriesProperty<double> *>(p1);
+        dynamic_cast<TimeSeriesProperty<double> *>(p1.get());
     std::map<DateAndTime, double> vmap = tp1->valueAsMap();
     std::map<DateAndTime, double>::iterator v = vmap.begin();
 
     // time 1
     TS_ASSERT_EQUALS(vmap.size(), 1);
     TS_ASSERT_EQUALS(v->second, 4);
-    ti_data = v->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 22);
+    const auto &ti_data1 = v->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data1.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_data1.tm_min, 22);
     // Can't get a valid mean with a single time and no intervals in it.
     // TS_ASSERT_DELTA(timeMean(p1),4., 0.001);
-
-    delete p1;
-    delete icp_log;
   }
 
   void testStr() {
     mkICP();
     mkStr();
-    Property *icp_log =
-        LogParser::createLogProperty(icp_file.path(), "icpevent");
-    LogParser lp(icp_log);
-    Property *p1 = lp.createLogProperty(log_str.path(), "str");
+    const auto &icp_log = std::unique_ptr<Property>(
+        LogParser::createLogProperty(icp_file.path(), "icpevent"));
+    const LogParser lp(icp_log.get());
+    const auto &p1 =
+        std::unique_ptr<Property>(lp.createLogProperty(log_str.path(), "str"));
     TS_ASSERT(p1);
     TimeSeriesProperty<std::string> *tp1 =
-        dynamic_cast<TimeSeriesProperty<std::string> *>(p1);
+        dynamic_cast<TimeSeriesProperty<std::string> *>(p1.get());
     std::map<DateAndTime, std::string> vmap = tp1->valueAsMap();
     std::map<DateAndTime, std::string>::iterator v = vmap.begin();
     // time 1
     TS_ASSERT_EQUALS(vmap.size(), 9);
     TS_ASSERT_EQUALS(v->second, "   line 1");
-    ti_data = v->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 22);
+    const auto &ti_data1 = v->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data1.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_data1.tm_min, 22);
     v++;
     v++;
     v++;
     // time 4
     TS_ASSERT_EQUALS(v->second, "   line 4");
-    ti_data = v->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 22);
+    const auto &ti_data4 = v->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data4.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_data4.tm_min, 22);
     // last time
     std::map<DateAndTime, std::string>::reverse_iterator rv = vmap.rbegin();
     TS_ASSERT_EQUALS(rv->second, "   line 9");
-    ti_data = rv->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 14);
-    TS_ASSERT_EQUALS(ti->tm_min, 3);
-    // assert_throws(timeMean(p1));
-    delete p1;
-    delete icp_log;
+    const auto &ti_dataLast = rv->first.to_tm();
+    TS_ASSERT_EQUALS(ti_dataLast.tm_hour, 14);
+    TS_ASSERT_EQUALS(ti_dataLast.tm_min, 3);
+    TS_ASSERT_THROWS(timeMean(p1.get()), std::runtime_error);
   }
 
   // Test a variant of the log file containing CHANGE_PERIOD flags
   void testConstructionFromFileUsingICPVariant_CHANGE_PERIOD() {
     mkICPVariant();
-    Property *icp_log =
-        LogParser::createLogProperty(icp_file.path(), "icpevent");
-    LogParser lp(icp_log);
-    const Property *prop = lp.createAllPeriodsLog();
+    const auto &icp_log = std::unique_ptr<Property>(
+        LogParser::createLogProperty(icp_file.path(), "icpevent"));
+    const LogParser lp(icp_log.get());
+    const auto &prop = std::unique_ptr<Property>(lp.createAllPeriodsLog());
     const auto *timeseriesprop =
-        dynamic_cast<const TimeSeriesProperty<int> *>(prop);
+        dynamic_cast<const TimeSeriesProperty<int> *>(prop.get());
     TS_ASSERT(timeseriesprop);
     // Check the size
     TS_ASSERT_EQUALS(4, timeseriesprop->size());
     // Check the exact time stamps
-    TS_ASSERT_EQUALS(DateAndTime("2000-09-05T12:22:55").toSimpleString(),
-                     timeseriesprop->nthTime(0).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2000-09-05T12:23:08").toSimpleString(),
-                     timeseriesprop->nthTime(1).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2000-09-05T12:23:22").toSimpleString(),
-                     timeseriesprop->nthTime(2).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2000-09-05T12:23:37").toSimpleString(),
-                     timeseriesprop->nthTime(3).toSimpleString());
-
-    delete prop;
-    delete icp_log;
+    TS_ASSERT_EQUALS(DateAndTime("2000-09-05T12:22:55"),
+                     timeseriesprop->nthTime(0));
+    TS_ASSERT_EQUALS(DateAndTime("2000-09-05T12:23:08"),
+                     timeseriesprop->nthTime(1));
+    TS_ASSERT_EQUALS(DateAndTime("2000-09-05T12:23:22"),
+                     timeseriesprop->nthTime(2));
+    TS_ASSERT_EQUALS(DateAndTime("2000-09-05T12:23:37"),
+                     timeseriesprop->nthTime(3));
   }
 
   void testConstructionFromPropertyUsingICPVariant_CHANGE_PERIOD() {
-    auto *log = new TimeSeriesProperty<std::string>("ICPLog");
+    auto log = make_unique<TimeSeriesProperty<std::string>>("ICPLog");
     // Notice we are using "CHANGE_PERIOD"
     TS_ASSERT_THROWS_NOTHING(
         log->addValue("2007-11-30T16:15:00", "CHANGE_PERIOD 1"));
@@ -291,30 +261,28 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         log->addValue("2007-11-30T16:18:00", "CHANGE_PERIOD 2"));
 
-    LogParser logparser(log);
+    const LogParser logparser(log.get());
 
-    const Property *prop = logparser.createAllPeriodsLog();
+    const auto &prop =
+        std::unique_ptr<Property>(logparser.createAllPeriodsLog());
     const auto *timeseriesprop =
-        dynamic_cast<const TimeSeriesProperty<int> *>(prop);
+        dynamic_cast<const TimeSeriesProperty<int> *>(prop.get());
     TS_ASSERT(timeseriesprop);
     // Check the size
     TS_ASSERT_EQUALS(4, timeseriesprop->size());
     // Check the exact time stamps
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:15:00").toSimpleString(),
-                     timeseriesprop->nthTime(0).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:16:00").toSimpleString(),
-                     timeseriesprop->nthTime(1).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:17:00").toSimpleString(),
-                     timeseriesprop->nthTime(2).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:18:00").toSimpleString(),
-                     timeseriesprop->nthTime(3).toSimpleString());
-
-    delete log;
-    delete prop;
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:15:00"),
+                     timeseriesprop->nthTime(0));
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:16:00"),
+                     timeseriesprop->nthTime(1));
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:17:00"),
+                     timeseriesprop->nthTime(2));
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:18:00"),
+                     timeseriesprop->nthTime(3));
   }
 
   void testConstructionFromPropertyUsingICPVariant_CHANGE_SPACE_PERIOD() {
-    auto *log = new TimeSeriesProperty<std::string>("ICPLog");
+    auto log = make_unique<TimeSeriesProperty<std::string>>("ICPLog");
     // Notice we are using "CHANGE PERIOD"
     TS_ASSERT_THROWS_NOTHING(
         log->addValue("2007-11-30T16:15:00", "CHANGE PERIOD 1"));
@@ -325,32 +293,30 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         log->addValue("2007-11-30T16:18:00", "CHANGE PERIOD 2"));
 
-    LogParser logparser(log);
+    const LogParser logparser(log.get());
 
-    const Property *prop = logparser.createAllPeriodsLog();
+    const auto &prop =
+        std::unique_ptr<Property>(logparser.createAllPeriodsLog());
     const auto *timeseriesprop =
-        dynamic_cast<const TimeSeriesProperty<int> *>(prop);
+        dynamic_cast<const TimeSeriesProperty<int> *>(prop.get());
     TS_ASSERT(timeseriesprop);
     // Check the size
     TS_ASSERT_EQUALS(4, timeseriesprop->size());
     // Check the exact time stamps
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:15:00").toSimpleString(),
-                     timeseriesprop->nthTime(0).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:16:00").toSimpleString(),
-                     timeseriesprop->nthTime(1).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:17:00").toSimpleString(),
-                     timeseriesprop->nthTime(2).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:18:00").toSimpleString(),
-                     timeseriesprop->nthTime(3).toSimpleString());
-
-    delete log;
-    delete prop;
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:15:00"),
+                     timeseriesprop->nthTime(0));
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:16:00"),
+                     timeseriesprop->nthTime(1));
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:17:00"),
+                     timeseriesprop->nthTime(2));
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:18:00"),
+                     timeseriesprop->nthTime(3));
   }
 
   // Check that periods that don't have a full "CHANGE PERIOD" flag are not
   // added.
   void testWontAddPeriodWithoutPERIODpartOfCHANGE_SPACE_PERIOD() {
-    auto *log = new TimeSeriesProperty<std::string>("ICPLog");
+    auto log = make_unique<TimeSeriesProperty<std::string>>("ICPLog");
     // Notice we are using "CHANGE PERIOD"
     TS_ASSERT_THROWS_NOTHING(
         log->addValue("2007-11-30T16:15:00", "CHANGE PERIOD 1"));
@@ -362,24 +328,22 @@ public:
         "2007-11-30T16:18:00",
         "CHANGE 2")); // This is a duff entry. Shouldn't get added.
 
-    LogParser logparser(log);
+    const LogParser logparser(log.get());
 
-    const Property *prop = logparser.createAllPeriodsLog();
+    const auto &prop =
+        std::unique_ptr<Property>(logparser.createAllPeriodsLog());
     const auto *timeseriesprop =
-        dynamic_cast<const TimeSeriesProperty<int> *>(prop);
+        dynamic_cast<const TimeSeriesProperty<int> *>(prop.get());
     TS_ASSERT(timeseriesprop);
     // Check the size
     TS_ASSERT_EQUALS(3, timeseriesprop->size());
     // Check the exact time stamps
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:15:00").toSimpleString(),
-                     timeseriesprop->nthTime(0).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:16:00").toSimpleString(),
-                     timeseriesprop->nthTime(1).toSimpleString());
-    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:17:00").toSimpleString(),
-                     timeseriesprop->nthTime(2).toSimpleString());
-
-    delete log;
-    delete prop;
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:15:00"),
+                     timeseriesprop->nthTime(0));
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:16:00"),
+                     timeseriesprop->nthTime(1));
+    TS_ASSERT_EQUALS(DateAndTime("2007-11-30T16:17:00"),
+                     timeseriesprop->nthTime(2));
   }
 
   void testCreatesCurrentPeriodLog() {
@@ -393,23 +357,23 @@ public:
     if (icp_file.exists())
       icp_file.remove();
     mkGood();
-    Property *icp_log =
-        LogParser::createLogProperty(icp_file.path(), "icpevent");
-    LogParser lp(icp_log);
-    Property *p1 = lp.createLogProperty(log_num_good.path(), "good");
+    const auto &icp_log = std::unique_ptr<Property>(
+        LogParser::createLogProperty(icp_file.path(), "icpevent"));
+    const LogParser lp(icp_log.get());
+    const auto &p1 = std::unique_ptr<Property>(
+        lp.createLogProperty(log_num_good.path(), "good"));
     TS_ASSERT(p1);
     TimeSeriesProperty<double> *tp1 =
-        dynamic_cast<TimeSeriesProperty<double> *>(p1);
+        dynamic_cast<TimeSeriesProperty<double> *>(p1.get());
     std::map<DateAndTime, double> vmap = tp1->valueAsMap();
     std::map<DateAndTime, double>::iterator v = vmap.begin();
 
     // time 1
     TS_ASSERT_EQUALS(vmap.size(), 9);
     TS_ASSERT_EQUALS(v->second, 1);
-    ti_data = v->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 12);
-    TS_ASSERT_EQUALS(ti->tm_min, 22);
+    const auto &ti_data1 = v->first.to_tm();
+    TS_ASSERT_EQUALS(ti_data1.tm_hour, 12);
+    TS_ASSERT_EQUALS(ti_data1.tm_min, 22);
     v++;
     v++;
     v++;
@@ -419,95 +383,76 @@ public:
     // last time
     std::map<DateAndTime, double>::reverse_iterator rv = vmap.rbegin();
     TS_ASSERT_EQUALS(rv->second, 9);
-    ti_data = rv->first.to_tm();
-    ti = &ti_data;
-    TS_ASSERT_EQUALS(ti->tm_hour, 14);
-    TS_ASSERT_EQUALS(ti->tm_min, 3);
-    TS_ASSERT_DELTA(timeMean(p1), 8.4904, 0.001);
-
-    delete p1;
+    const auto &ti_dataLast = rv->first.to_tm();
+    TS_ASSERT_EQUALS(ti_dataLast.tm_hour, 14);
+    TS_ASSERT_EQUALS(ti_dataLast.tm_min, 3);
+    TS_ASSERT_DELTA(timeMean(p1.get()), 8.4904, 0.001);
   }
 
   //----------------------------------------------------------------------------
   void test_timeMean() {
-    TimeSeriesProperty<double> *log =
-        new TimeSeriesProperty<double>("MydoubleLog");
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:17:00", 1));
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:17:10", 2));
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:17:20", 3));
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:17:30", 4));
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:17:40", 5));
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:17:50", 6));
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:18:00", 7));
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:18:10", 8));
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:18:20", 9));
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:18:30", 10));
-    TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:18:40", 11));
-    TS_ASSERT_EQUALS(log->realSize(), 11);
-
-    TS_ASSERT_DELTA(timeMean(log), 6.0, 1e-3);
-    delete log;
+    constexpr size_t logSize(11);
+    auto log = make_unique<TimeSeriesProperty<double>>("MydoubleLog");
+    std::vector<double> values(logSize);
+    std::iota(values.begin(), values.end(), 1);
+    DateAndTime firstTime("2007-11-30T16:17:00");
+    std::vector<DateAndTime> times(logSize);
+    std::generate(times.begin(), times.end(),
+                  [&firstTime] { return firstTime += 10.0; });
+    TS_ASSERT_THROWS_NOTHING(log->addValues(times, values));
+    TS_ASSERT_EQUALS(log->realSize(), logSize);
+    TS_ASSERT_DELTA(timeMean(log.get()), 6.0, 1e-3);
   }
 
   void test_timeMean_one_Value() {
-    TimeSeriesProperty<double> *log =
-        new TimeSeriesProperty<double>("MydoubleLog");
+    auto log = make_unique<TimeSeriesProperty<double>>("MydoubleLog");
     TS_ASSERT_THROWS_NOTHING(log->addValue("2007-11-30T16:17:00", 56));
     TS_ASSERT_EQUALS(log->realSize(), 1);
 
-    TS_ASSERT_DELTA(timeMean(log), 56.0, 1e-3);
-    delete log;
+    TS_ASSERT_DELTA(timeMean(log.get()), 56.0, 1e-3);
   }
 
   /// Tests to see if we can cope with duplicate log values that have the same
   /// time.
   void test_timeMean_duplicate_values_with_same_timestamp() {
-    TimeSeriesProperty<double> *log =
-        new TimeSeriesProperty<double>("MydoubleLog");
+    auto log = make_unique<TimeSeriesProperty<double>>("MydoubleLog");
     // Add the same value twice
     TS_ASSERT_THROWS_NOTHING(log->addValue("2012-07-19T20:00:00", 666));
     TS_ASSERT_THROWS_NOTHING(log->addValue("2012-07-19T20:00:00", 666));
     TS_ASSERT_EQUALS(log->realSize(), 2);
-    TS_ASSERT_DELTA(timeMean(log), 666, 1e-3);
-    delete log;
+    TS_ASSERT_DELTA(timeMean(log.get()), 666, 1e-3);
   }
 
   void test_isICPEventLogNewStyle_works() {
-    TimeSeriesProperty<std::string> *oldlog =
-        new TimeSeriesProperty<std::string>("MyOldICPevent");
+    auto oldlog = make_unique<TimeSeriesProperty<std::string>>("MyOldICPevent");
     TS_ASSERT_THROWS_NOTHING(oldlog->addValue("2012-07-19T20:00:00", "START"));
     TS_ASSERT_THROWS_NOTHING(oldlog->addValue("2012-07-19T20:00:01", "BEGIN"));
     TS_ASSERT_THROWS_NOTHING(oldlog->addValue("2012-07-19T20:00:02", "PAUSE"));
 
-    auto logm = oldlog->valueAsMultiMap();
-    TS_ASSERT(!LogParser::isICPEventLogNewStyle(logm));
-    delete oldlog;
+    const auto &oldLogm = oldlog->valueAsMultiMap();
+    TS_ASSERT(!LogParser::isICPEventLogNewStyle(oldLogm));
 
-    TimeSeriesProperty<std::string> *newlog =
-        new TimeSeriesProperty<std::string>("MyNewICPevent");
+    auto newlog = make_unique<TimeSeriesProperty<std::string>>("MyNewICPevent");
     TS_ASSERT_THROWS_NOTHING(newlog->addValue("2012-07-19T20:00:00", "START"));
     TS_ASSERT_THROWS_NOTHING(
         newlog->addValue("2012-07-19T20:00:01", "START_COLLECTION PERIOD 1"));
     TS_ASSERT_THROWS_NOTHING(newlog->addValue("2012-07-19T20:00:02", "PAUSE"));
 
-    logm = newlog->valueAsMultiMap();
+    const auto &logm = newlog->valueAsMultiMap();
     TS_ASSERT(LogParser::isICPEventLogNewStyle(logm));
-    delete newlog;
 
-    newlog = new TimeSeriesProperty<std::string>("MyNewICPevent1");
+    newlog.reset(new TimeSeriesProperty<std::string>("MyNewICPevent1"));
     TS_ASSERT_THROWS_NOTHING(newlog->addValue("2012-07-19T20:00:00", "START"));
     TS_ASSERT_THROWS_NOTHING(
         newlog->addValue("2012-07-19T20:00:01", "STOP_COLLECTION PERIOD 1"));
     TS_ASSERT_THROWS_NOTHING(newlog->addValue("2012-07-19T20:00:02", "PAUSE"));
 
-    logm = newlog->valueAsMultiMap();
-    TS_ASSERT(LogParser::isICPEventLogNewStyle(logm));
-    delete newlog;
+    const auto &newLogm = newlog->valueAsMultiMap();
+    TS_ASSERT(LogParser::isICPEventLogNewStyle(newLogm));
   }
 
   void test_new_style_command_parsing() {
-    TimeSeriesProperty<std::string> *log =
-        new TimeSeriesProperty<std::string>("MyICPevent");
+    auto log = make_unique<TimeSeriesProperty<std::string>>("MyICPevent");
     log->addValue("2013-10-16T19:04:47", "CHANGE_PERIOD 1");
     log->addValue("2013-10-16T19:04:48", "RESUME");
     log->addValue("2013-10-16T19:04:48",
@@ -543,28 +488,24 @@ public:
     log->addValue("2013-10-16T19:13:09", "CHANGE_PERIOD 1");
     log->addValue("2013-10-16T19:13:09", "RESUME");
 
-    std::vector<std::pair<std::string, int>> checkPeriod(5);
-    checkPeriod[0] = std::make_pair("2013-10-16T19:04:47", 1);
-    checkPeriod[1] = std::make_pair("2013-10-16T19:06:53", 2);
-    checkPeriod[2] = std::make_pair("2013-10-16T19:08:58", 1);
-    checkPeriod[3] = std::make_pair("2013-10-16T19:11:03", 2);
-    checkPeriod[4] = std::make_pair("2013-10-16T19:13:09", 1);
+    const std::vector<std::pair<std::string, int>> checkPeriod{
+        {"2013-10-16T19:04:47", 1},
+        {"2013-10-16T19:06:53", 2},
+        {"2013-10-16T19:08:58", 1},
+        {"2013-10-16T19:11:03", 2},
+        {"2013-10-16T19:13:09", 1}};
 
-    std::vector<std::pair<std::string, bool>> checkRunning(8);
-    checkRunning[0] = std::make_pair("2013-10-16T19:04:48", true);
-    checkRunning[1] = std::make_pair("2013-10-16T19:06:53", false);
-    checkRunning[2] = std::make_pair("2013-10-16T19:06:53", true);
-    checkRunning[3] = std::make_pair("2013-10-16T19:08:58", false);
-    checkRunning[4] = std::make_pair("2013-10-16T19:08:59", true);
-    checkRunning[5] = std::make_pair("2013-10-16T19:11:03", false);
-    checkRunning[6] = std::make_pair("2013-10-16T19:11:04", true);
-    checkRunning[7] = std::make_pair("2013-10-16T19:13:09", false);
+    const std::vector<std::pair<std::string, bool>> checkRunning{
+        {"2013-10-16T19:04:48", true}, {"2013-10-16T19:06:53", false},
+        {"2013-10-16T19:06:53", true}, {"2013-10-16T19:08:58", false},
+        {"2013-10-16T19:08:59", true}, {"2013-10-16T19:11:03", false},
+        {"2013-10-16T19:11:04", true}, {"2013-10-16T19:13:09", false}};
 
-    LogParser logparser(log);
+    const LogParser logparser(log.get());
 
-    const Property *prop = logparser.createAllPeriodsLog();
+    auto prop = std::unique_ptr<Property>(logparser.createAllPeriodsLog());
     const auto *allPeriodsProp =
-        dynamic_cast<const TimeSeriesProperty<int> *>(prop);
+        dynamic_cast<const TimeSeriesProperty<int> *>(prop.get());
     TS_ASSERT(allPeriodsProp);
 
     TS_ASSERT_EQUALS(5, allPeriodsProp->size());
@@ -576,10 +517,9 @@ public:
       ++i;
     }
 
-    delete prop;
-    prop = logparser.createRunningLog();
+    prop.reset(logparser.createRunningLog());
     const auto *runningProp =
-        dynamic_cast<const TimeSeriesProperty<bool> *>(prop);
+        dynamic_cast<const TimeSeriesProperty<bool> *>(prop.get());
     TS_ASSERT(runningProp);
 
     TS_ASSERT_EQUALS(8, runningProp->size());
@@ -590,18 +530,16 @@ public:
       TS_ASSERT_EQUALS(it->second, checkRunning[i].second);
       ++i;
     }
-
-    delete prop;
-    delete log;
   }
 
   void test_str_repeat() {
     mkStrRepeat();
-    Property *prop = LogParser::createLogProperty(log_str_repeat.path(), "log");
+    const auto &prop = std::unique_ptr<Property>(
+        LogParser::createLogProperty(log_str_repeat.path(), "log"));
     const auto *log =
-        dynamic_cast<const TimeSeriesProperty<std::string> *>(prop);
+        dynamic_cast<const TimeSeriesProperty<std::string> *>(prop.get());
     TS_ASSERT(log);
-    auto logm = log->valueAsMultiMap();
+    const auto &logm = log->valueAsMultiMap();
     auto it = logm.begin();
     TS_ASSERT_EQUALS(it->first.toISO8601String(), "2000-09-05T12:22:34");
     TS_ASSERT_EQUALS(it->second, "   First line");
@@ -621,15 +559,16 @@ public:
     TS_ASSERT_EQUALS(it->first.toISO8601String(), "2000-09-05T12:23:33");
     TS_ASSERT_EQUALS(it->second, "   Fourth line");
     ++it;
-    delete prop;
   }
 
   void test_num_repeat() {
     mkNumRepeat();
-    Property *prop = LogParser::createLogProperty(log_str_repeat.path(), "log");
-    const auto *log = dynamic_cast<const TimeSeriesProperty<double> *>(prop);
+    const auto &prop = std::unique_ptr<Property>(
+        LogParser::createLogProperty(log_str_repeat.path(), "log"));
+    const auto *log =
+        dynamic_cast<const TimeSeriesProperty<double> *>(prop.get());
     TS_ASSERT(log);
-    auto logm = log->valueAsMultiMap();
+    const auto &logm = log->valueAsMultiMap();
     auto it = logm.begin();
     TS_ASSERT_EQUALS(it->first.toISO8601String(), "2000-09-05T12:22:34");
     TS_ASSERT_EQUALS(it->second, 1);
@@ -649,17 +588,16 @@ public:
     TS_ASSERT_EQUALS(it->first.toISO8601String(), "2000-09-05T12:23:33");
     TS_ASSERT_EQUALS(it->second, 6);
     ++it;
-    delete prop;
   }
 
   void test_str_continuation() {
     mkStrContinuations();
-    Property *prop =
-        LogParser::createLogProperty(log_str_continuations.path(), "log");
+    const auto &prop = std::unique_ptr<Property>(
+        LogParser::createLogProperty(log_str_continuations.path(), "log"));
     const auto *log =
-        dynamic_cast<const TimeSeriesProperty<std::string> *>(prop);
+        dynamic_cast<const TimeSeriesProperty<std::string> *>(prop.get());
     TS_ASSERT(log);
-    auto logm = log->valueAsMultiMap();
+    const auto &logm = log->valueAsMultiMap();
     auto it = logm.begin();
     TS_ASSERT_EQUALS(it->first.toISO8601String(), "2000-09-05T12:22:31");
     TS_ASSERT_EQUALS(it->second, "   First line Second line");
@@ -670,14 +608,12 @@ public:
     TS_ASSERT_EQUALS(it->first.toISO8601String(), "2000-09-05T12:22:34");
     TS_ASSERT_EQUALS(it->second, "   Second line Third line");
     ++it;
-    delete prop;
   }
 
   /// If a run is aborted and then restarted, the "running" log should be set to
   /// false at all times during the aborted run.
   void test_abort_runningLogAlwaysFalseBeforeRestart() {
-    auto log = Mantid::Kernel::make_unique<TimeSeriesProperty<std::string>>(
-        "MyICPevent");
+    auto log = make_unique<TimeSeriesProperty<std::string>>("MyICPevent");
 
     // (This is a cut-down version of EMU66122)
     const DateAndTime timeZero{"2016-10-01T10:01:44"};
@@ -709,7 +645,7 @@ public:
 
     const LogParser logparser(log.get());
 
-    const auto prop = std::unique_ptr<Property>(logparser.createRunningLog());
+    const auto &prop = std::unique_ptr<Property>(logparser.createRunningLog());
     const auto *runningProp =
         dynamic_cast<const TimeSeriesProperty<bool> *>(prop.get());
     TS_ASSERT(runningProp);
@@ -721,48 +657,34 @@ public:
 private:
   /// Helper method to run common test code for checking period logs.
   void doTestCurrentPeriodLog(const int &expected_period) {
-    auto *log = new TimeSeriesProperty<std::string>("ICPLog");
-    LogParser logparser(log);
-    Property *prop = logparser.createCurrentPeriodLog(expected_period);
-    PropertyWithValue<int> *prop_with_value =
-        dynamic_cast<PropertyWithValue<int> *>(prop);
+    const auto &log = make_unique<TimeSeriesProperty<std::string>>("ICPLog");
+    const LogParser logparser(log.get());
+    const auto prop = std::unique_ptr<Property>(
+        logparser.createCurrentPeriodLog(expected_period));
+    const auto *prop_with_value =
+        dynamic_cast<PropertyWithValue<int> *>(prop.get());
 
     int value;
     TS_ASSERT(prop_with_value != NULL);
     Mantid::Kernel::toValue<int>(prop_with_value->value(), value);
     TS_ASSERT_EQUALS(expected_period, value);
-    delete prop;
-    delete log;
   }
 
   void mkICP() {
     std::ofstream f(icp_file.path().c_str());
-    int dt = 0;
     f << "2000-09-05T12:22:28   START_SE_WAIT\n";
     f << "2000-09-05T12:22:33   BEGIN\n";
-    dt += 8;
     f << "2000-09-05T12:22:41   PAUSE\n";
-    dt += 4;
     f << "2000-09-05T12:22:55   CHANGE PERIOD 2\n";
-    dt += 3;
     f << "2000-09-05T12:22:58   RESUME\n";
-    dt += 6;
     f << "2000-09-05T12:23:04   PAUSE\n";
-    dt += 4;
     f << "2000-09-05T12:23:08   CHANGE PERIOD 1\n";
-    dt += 2;
     f << "2000-09-05T12:23:10   RESUME\n";
-    dt += 8;
     f << "2000-09-05T12:23:18   START_SE_WAIT\n";
-    dt += 4;
     f << "2000-09-05T12:23:22   CHANGE PERIOD 2\n";
-    dt += 5;
     f << "2000-09-05T12:23:27   RESUME\n";
-    dt += 7;
     f << "2000-09-05T12:23:34   ABORT\n";
-    dt += 3;
     f << "2000-09-05T12:23:37   CHANGE PERIOD 1\n";
-    dt += 5;
     f << "2000-09-05T12:23:42   END_SE_WAIT\n";
     f << "2000-09-05T14:03:54   END\n";
     f.close();
@@ -770,32 +692,19 @@ private:
 
   void mkICPVariant() {
     std::ofstream f(icp_file.path().c_str());
-    int dt = 0;
     f << "2000-09-05T12:22:28   START_SE_WAIT\n";
     f << "2000-09-05T12:22:33   BEGIN\n";
-    dt += 8;
     f << "2000-09-05T12:22:41   PAUSE\n";
-    dt += 4;
     f << "2000-09-05T12:22:55   CHANGE_PERIOD 2\n";
-    dt += 3;
     f << "2000-09-05T12:22:58   RESUME\n";
-    dt += 6;
     f << "2000-09-05T12:23:04   PAUSE\n";
-    dt += 4;
     f << "2000-09-05T12:23:08   CHANGE_PERIOD 1\n";
-    dt += 2;
     f << "2000-09-05T12:23:10   RESUME\n";
-    dt += 8;
     f << "2000-09-05T12:23:18   START_SE_WAIT\n";
-    dt += 4;
     f << "2000-09-05T12:23:22   CHANGE_PERIOD 2\n";
-    dt += 5;
     f << "2000-09-05T12:23:27   RESUME\n";
-    dt += 7;
     f << "2000-09-05T12:23:34   ABORT\n";
-    dt += 3;
     f << "2000-09-05T12:23:37   CHANGE_PERIOD 1\n";
-    dt += 5;
     f << "2000-09-05T12:23:42   END_SE_WAIT\n";
     f << "2000-09-05T14:03:54   END\n";
     f.close();
@@ -803,20 +712,13 @@ private:
 
   void mkGood() {
     std::ofstream f(log_num_good.path().c_str());
-    int dt = 4;
     f << "2000-09-05T12:22:31   " << 1 << '\n';
     f << "2000-09-05T12:22:37   " << 2 << '\n';
-    dt += 1;
     f << "2000-09-05T12:22:38   " << 3 << '\n';
-    dt += 1;
     f << "2000-09-05T12:22:39   " << 4 << '\n';
-    dt += 3;
     f << "2000-09-05T12:22:42   " << 5 << '\n';
-    dt += 5;
     f << "2000-09-05T12:22:47   " << 6 << '\n';
-    dt += 9;
     f << "2000-09-05T12:22:56   " << 7 << '\n';
-    dt += 4;
     f << "2000-09-05T12:23:00   " << 8 << '\n';
     f << "2000-09-05T14:03:56   " << 9 << '\n';
     f.close();
@@ -824,19 +726,12 @@ private:
 
   void mkLate() {
     std::ofstream f(log_num_late.path().c_str());
-    int dt = 4;
     f << "2000-09-05T12:22:37   " << 2 << '\n';
-    dt += 1;
     f << "2000-09-05T12:22:38   " << 3 << '\n';
-    dt += 1;
     f << "2000-09-05T12:22:39   " << 4 << '\n';
-    dt += 3;
     f << "2000-09-05T12:22:42   " << 5 << '\n';
-    dt += 5;
     f << "2000-09-05T12:22:47   " << 6 << '\n';
-    dt += 9;
     f << "2000-09-05T12:22:56   " << 7 << '\n';
-    dt += 4;
     f << "2000-09-05T12:23:00   " << 8 << '\n';
     f << "2000-09-05T14:03:56   " << 9 << '\n';
     f.close();
@@ -844,20 +739,13 @@ private:
 
   void mkEarly() {
     std::ofstream f(log_num_early.path().c_str());
-    int dt = 4;
     f << "2000-09-05T12:22:31   " << 1 << '\n';
     f << "2000-09-05T12:22:37   " << 2 << '\n';
-    dt += 1;
     f << "2000-09-05T12:22:38   " << 3 << '\n';
-    dt += 1;
     f << "2000-09-05T12:22:39   " << 4 << '\n';
-    dt += 3;
     f << "2000-09-05T12:22:42   " << 5 << '\n';
-    dt += 5;
     f << "2000-09-05T12:22:47   " << 6 << '\n';
-    dt += 9;
     f << "2000-09-05T12:22:56   " << 7 << '\n';
-    dt += 4;
     f << "2000-09-05T12:23:00   " << 8 << '\n';
     f.close();
   }
@@ -870,20 +758,13 @@ private:
 
   void mkStr() {
     std::ofstream f(log_str.path().c_str());
-    int dt = 4;
     f << "2000-09-05T12:22:31   line " << 1 << '\n';
     f << "2000-09-05T12:22:37   line " << 2 << '\n';
-    dt += 1;
     f << "2000-09-05T12:22:38   line " << 3 << '\n';
-    dt += 1;
     f << "2000-09-05T12:22:39   line " << 4 << '\n';
-    dt += 3;
     f << "2000-09-05T12:22:42   line " << 5 << '\n';
-    dt += 5;
     f << "2000-09-05T12:22:47   line " << 6 << '\n';
-    dt += 9;
     f << "2000-09-05T12:22:56   line " << 7 << '\n';
-    dt += 4;
     f << "2000-09-05T12:23:00   line " << 8 << '\n';
     f << "2000-09-05T14:03:56   line " << 9 << '\n';
     f.close();
@@ -931,9 +812,6 @@ private:
   TmpFile log_str_repeat;        // string log with repeating lines
   TmpFile log_num_repeat;        // num log with repeating lines
   TmpFile log_str_continuations; // string log with continuation lines
-
-  tm ti_data;
-  tm *ti;
 };
 
 #endif /*LOGPARSERTEST_H_*/

--- a/docs/source/release/v3.9.0/framework.rst
+++ b/docs/source/release/v3.9.0/framework.rst
@@ -46,6 +46,7 @@ Bug Fixes
 
 - Bin masking information was wrongly saved when saving workspaces into nexus files, which is now fixed.
 - :ref:`LoadEventNexus <algm-LoadEventNexus>` should no longer leak memory when the execution is cancelled.
+- If a run is aborted and restarted, the ``running`` log in the workspace will correctly reflect this. (``running`` will be false at all times before the abort.)
 
 Full list of
 `Framework <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.9%22+is%3Amerged+label%3A%22Component%3A+Framework%22>`__


### PR DESCRIPTION
Correct the generation of the `running` log on loading a file: if the run was aborted and then restarted, the `running` log should only show that it was running after the restart. At all times before the restart, `running` should be false. (This is important for filtering other logs by `running`, and was requested by scientists).

Add tests for old and new style logs, and also did some maintenance on the other tests in `LogParserTest`.

**To test:**

Use any datafile where the run was aborted, then restarted. For example, try `EMU00066122.nxs`, which can be found at `\\olympic\babylon5\Scratch\TomPerkins\test_tsp_filtering`:

```python
tuple = Load('EMU00066122')
ws = tuple[0]
run = ws.run()
log = run.getProperty("running")
for i in range(log.size()):
    print log.nthTime(i), log.nthValue(i)
```
Before the fix, `running` would be `True` from the start time (10:01:47) until the run was aborted at 10:02:35.
After the fix, at all times before the abort, `running` should be `False`.

Fixes #17924.

[Release notes](https://github.com/mantidproject/mantid/blob/6de56f59dafe1c8ba1aea8bcc3b2e31af2d72924/docs/source/release/v3.9.0/framework.rst#bug-fixes) have been updated.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
