### PR TITLE
EnggVanadiumCorrections now has an optional output workspace

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function)
 from mantid.kernel import *
 from mantid.api import *
-from mantid.api import PythonAlgorithm
 import mantid.simpleapi as sapi
 
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
@@ -31,7 +31,8 @@ class EnggVanadiumCorrections(PythonAlgorithm):
                              "will be applied on it.")
 
         self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", Direction.Output, PropertyMode.Optional),
-                             "Workspace with the diffraction data to correct. The Vanadium corrections "
+                             "Optional output workspace, if an output workspace is provided then the"
+                             "input workspace will not be changed. The Vanadium corrections "
                              "will be applied on it.")
 
         self.declareProperty(MatrixWorkspaceProperty("VanadiumWorkspace", "", Direction.Input,

--- a/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
@@ -90,9 +90,6 @@ class EnggVanadiumCorrections(PythonAlgorithm):
         The sums and fits are done in d-spacing.
         """
 
-        import pydevd
-        pydevd.settrace('localhost', port=49988, stdoutToServer=True, stderrToServer=True)
-
         ws = self.getProperty('Workspace').value
         outWS = self.getPropertyValue('OutputWorkspace')
         vanWS = self.getProperty('VanadiumWorkspace').value

--- a/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
@@ -123,12 +123,10 @@ class EnggVanadiumCorrections(PythonAlgorithm):
 
             self._applyVanadiumCorrections(outWS, integWS, curvesWS)
             self.setProperty('OutputWorkspace', outWS)
-            
         else:
             self._applyVanadiumCorrections(ws, integWS, curvesWS)
             self.setProperty('Workspace', ws)
                 
-
     def _applyVanadiumCorrections(self, ws, integWS, curvesWS):
         """
         Applies the corrections on a workspace. The integration and curves workspaces may have

--- a/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
@@ -1,3 +1,4 @@
+
 #pylint: disable=no-init,invalid-name
 from __future__ import (absolute_import, division, print_function)
 from mantid.kernel import *
@@ -126,7 +127,7 @@ class EnggVanadiumCorrections(PythonAlgorithm):
         else:
             self._applyVanadiumCorrections(ws, integWS, curvesWS)
             self.setProperty('Workspace', ws)
-                
+
     def _applyVanadiumCorrections(self, ws, integWS, curvesWS):
         """
         Applies the corrections on a workspace. The integration and curves workspaces may have


### PR DESCRIPTION
Description of work.

EnggVanadiumCorrections now has an additional field for an output workspace. If a name for the output workspace is provided then the input workspace is left unchanged, and the result with the vanadium corrections is in the Output Workspace.

**To test:**
- Run EnggVanadiumCorrections with an OutputWorkspace parameter, the original workspace should be left unchanged, the OutputWorkspace should hold the result with the van corrections
- Run EnggVanadiumCorrections without an OutputWorkspace parameter, then the result should be stored in the input workspace

Sample testing script:
```
ref = mtd['ENGINX00249918']
van_curves = mtd['van_curves']
van_int = mtd['van_integ']

# shouldn't overwrite values in input workspace
EnggVanadiumCorrections(Workspace=ref, OutputWorkspace="test", IntegrationWorkspace=van_int, CurvesWorkspace=van_curves)

EnggVanadiumCorrections(Workspace=ref, IntegrationWorkspace=van_int, CurvesWorkspace=van_curves)
```

<!-- Instructions for testing. -->

Fixes #17935 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

