### PR TITLE
EnggVanadiumCorrections fixed using the wrong bank index 

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
@@ -155,7 +155,7 @@ class EnggVanadiumCorrections(PythonAlgorithm):
         divides by a curve fitted to the sum of the set of spectra of the corresponding bank.
 
         @param ws :: workspace to work on / correct
-        @param curvesWS :: a workspace with the per-bank curves for Vanadium data, 
+        @param curvesWS :: a workspace with the per-bank curves for Vanadium data,
                 this will contain 3 histograms per instrument bank
         """
         curvesDict = self._precalcWStoDict(curvesWS)

--- a/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
@@ -83,6 +83,7 @@ class EnggVanadiumCorrections(PythonAlgorithm):
 
         The sums and fits are done in d-spacing.
         """
+
         ws = self.getProperty('Workspace').value
         vanWS = self.getProperty('VanadiumWorkspace').value
         integWS = self.getProperty('IntegrationWorkspace').value
@@ -154,7 +155,8 @@ class EnggVanadiumCorrections(PythonAlgorithm):
         divides by a curve fitted to the sum of the set of spectra of the corresponding bank.
 
         @param ws :: workspace to work on / correct
-        @param curvesWS :: a workspace with the per-bank curves for Vanadium data
+        @param curvesWS :: a workspace with the per-bank curves for Vanadium data, 
+                this will contain 3 histograms per instrument bank
         """
         curvesDict = self._precalcWStoDict(curvesWS)
 
@@ -390,14 +392,16 @@ class EnggVanadiumCorrections(PythonAlgorithm):
         curves = {}
 
         if 0 != (ws.getNumberHistograms() % 3):
-            raise RuntimeError("A workspace without instrument definition has ben passed, so it is "
+            raise RuntimeError("A workspace without instrument definition has been passed, so it is "
                                "expected to have fitting results, but it does not have a number of "
                                "histograms multiple of 3. Number of hsitograms found: %d"%
                                ws.getNumberHistograms())
 
         for wi in range(0, int(ws.getNumberHistograms()/3)):
             indiv = EnggUtils.cropData(self, ws, [wi, wi+2])
-            curves.update({wi: indiv})
+            # the bank id is +1 because wi starts from 0
+            bankid = wi + 1
+            curves.update({bankid: indiv})
 
         return curves
 


### PR DESCRIPTION
Description of work.

The function `_divideByCurves` no longer has the problem with the wrong bank id, because the proper id is being set while the `curves` dictionary is being created.

**To test:**
Adding a helpful `print(idxs)` in `_divideByCurves` can help make sure the indices are correct.

- Run vanadium calibrations with both banks selected
- the `print(idxs)` in `_divideByCurves` will now show the proper indices being iterated
  - 0-1200 on first loop, 1200-2400 on second
- Compare ids to those without the fix the `print(idxs)` 
    - that should show 2413-2512 on first loop and 0-1200 on second
<!-- Instructions for testing. -->

Fixes #17934 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state

-->
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

