### PR TITLE
Fix many cppcheck v1.76 warnings.

### DIFF
--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -683,7 +683,7 @@ class DummyException {
 public:
   std::string m_validFrom;
   std::string m_validTo;
-  DummyException(std::string validFrom, std::string validTo)
+  DummyException(const std::string &validFrom, const std::string &validTo)
       : m_validFrom(validFrom), m_validTo(validTo) {}
 };
 

--- a/Framework/Algorithms/src/CalculateCountRate.cpp
+++ b/Framework/Algorithms/src/CalculateCountRate.cpp
@@ -212,14 +212,13 @@ void CalculateCountRate::calcRateLog(
   double dTRangeMin = static_cast<double>(m_TRangeMin.totalNanoseconds());
   double dTRangeMax = static_cast<double>(m_TRangeMax.totalNanoseconds());
   std::vector<MantidVec> Buff;
-  int nThreads;
 
 #pragma omp parallel
   {
+    int nThreads = PARALLEL_NUMBER_OF_THREADS;
 #pragma omp single
     {
       // initialize thread's histogram buffer
-      nThreads = PARALLEL_NUMBER_OF_THREADS;
       Buff.resize(nThreads);
     }
     auto nThread = PARALLEL_THREAD_NUMBER;

--- a/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
+++ b/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
@@ -36,9 +36,12 @@ DECLARE_ALGORITHM(OptimizeCrystalPlacement)
 
 class OrEnabledWhenProperties : public Kernel::IPropertySettings {
 public:
-  OrEnabledWhenProperties(std::string prop1Name, ePropertyCriterion prop1Crit,
-                          std::string prop1Value, std::string prop2Name,
-                          ePropertyCriterion prop2Crit, std::string prop2Value)
+  OrEnabledWhenProperties(const std::string &prop1Name,
+                          ePropertyCriterion prop1Crit,
+                          const std::string &prop1Value,
+                          const std::string &prop2Name,
+                          ePropertyCriterion prop2Crit,
+                          const std::string &prop2Value)
       : IPropertySettings(), propName1(prop1Name), propName2(prop2Name),
         Criteria1(prop1Crit), Criteria2(prop2Crit), value1(prop1Value),
         value2(prop2Value)

--- a/Framework/DataHandling/inc/MantidDataHandling/StartAndEndTimeFromNexusFileExtractor.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/StartAndEndTimeFromNexusFileExtractor.h
@@ -29,8 +29,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-Mantid::Kernel::DateAndTime DLLExport extractStartTime(std::string filename);
-Mantid::Kernel::DateAndTime DLLExport extractEndTime(std::string filename);
+Mantid::Kernel::DateAndTime DLLExport
+extractStartTime(const std::string &filename);
+Mantid::Kernel::DateAndTime DLLExport
+extractEndTime(const std::string &filename);
 } // namespace DataHandling
 } // namespace Mantid
 

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -689,12 +689,13 @@ void LoadBBY::loadEvents(API::Progress &prog, const char *progMsg,
     case 5:
     case 6:
     case 7:
-    case 8:
       event_ended = (c & 0xC0) != 0xC0;
       if (!event_ended)
         c &= 0x3F;
-
-      dt |= (c & 0xFF) << (5 + 6 * (state - 3)); // set bit 6...
+      // avoid shifting by > 32 bits
+      // identical to dt |= 0
+      if (state != 8)
+        dt |= (c & 0xFF) << (5 + 6 * (state - 3)); // set bit 6...
       break;
     }
     state++;

--- a/Framework/DataHandling/src/StartAndEndTimeFromNexusFileExtractor.cpp
+++ b/Framework/DataHandling/src/StartAndEndTimeFromNexusFileExtractor.cpp
@@ -139,7 +139,7 @@ Mantid::Kernel::DateAndTime extractDateAndTime(TimeType type,
  * @return the start time
  * @throws if the the start time cannot be extracted
  */
-Mantid::Kernel::DateAndTime extractStartTime(std::string filename) {
+Mantid::Kernel::DateAndTime extractStartTime(const std::string &filename) {
   return extractDateAndTime(TimeType::StartTime, filename);
 }
 
@@ -149,7 +149,7 @@ Mantid::Kernel::DateAndTime extractStartTime(std::string filename) {
  * @return the start time
  * @throws if the the start time cannot be extracted
  */
-Mantid::Kernel::DateAndTime extractEndTime(std::string filename) {
+Mantid::Kernel::DateAndTime extractEndTime(const std::string &filename) {
   return extractDateAndTime(TimeType::EndTime, filename);
 }
 

--- a/Framework/DataObjects/src/ReflectometryTransform.cpp
+++ b/Framework/DataObjects/src/ReflectometryTransform.cpp
@@ -48,33 +48,32 @@ void writeRow(boost::shared_ptr<Mantid::DataObjects::TableWorkspace> &vertexes,
 *  Adds the column headings to a table
 *  @param vertexes : Table to which the columns are written to.
 */
-void addColumnHeadings(
-    boost::shared_ptr<Mantid::DataObjects::TableWorkspace> &vertexes,
-    std::string outputDimensions) {
+void addColumnHeadings(Mantid::DataObjects::TableWorkspace &vertexes,
+                       const std::string &outputDimensions) {
 
   if (outputDimensions == "Q (lab frame)") {
-    vertexes->addColumn("double", "Qx");
-    vertexes->addColumn("double", "Qy");
-    vertexes->addColumn("int", "OriginIndex");
-    vertexes->addColumn("int", "OriginBin");
-    vertexes->addColumn("double", "CellSignal");
-    vertexes->addColumn("double", "CellError");
+    vertexes.addColumn("double", "Qx");
+    vertexes.addColumn("double", "Qy");
+    vertexes.addColumn("int", "OriginIndex");
+    vertexes.addColumn("int", "OriginBin");
+    vertexes.addColumn("double", "CellSignal");
+    vertexes.addColumn("double", "CellError");
   }
   if (outputDimensions == "P (lab frame)") {
-    vertexes->addColumn("double", "Pi+Pf");
-    vertexes->addColumn("double", "Pi-Pf");
-    vertexes->addColumn("int", "OriginIndex");
-    vertexes->addColumn("int", "OriginBin");
-    vertexes->addColumn("double", "CellSignal");
-    vertexes->addColumn("double", "CellError");
+    vertexes.addColumn("double", "Pi+Pf");
+    vertexes.addColumn("double", "Pi-Pf");
+    vertexes.addColumn("int", "OriginIndex");
+    vertexes.addColumn("int", "OriginBin");
+    vertexes.addColumn("double", "CellSignal");
+    vertexes.addColumn("double", "CellError");
   }
   if (outputDimensions == "K (incident, final)") {
-    vertexes->addColumn("double", "Ki");
-    vertexes->addColumn("double", "Kf");
-    vertexes->addColumn("int", "OriginIndex");
-    vertexes->addColumn("int", "OriginBin");
-    vertexes->addColumn("double", "CellSignal");
-    vertexes->addColumn("double", "CellError");
+    vertexes.addColumn("double", "Ki");
+    vertexes.addColumn("double", "Kf");
+    vertexes.addColumn("int", "OriginIndex");
+    vertexes.addColumn("int", "OriginBin");
+    vertexes.addColumn("double", "CellSignal");
+    vertexes.addColumn("double", "CellError");
   }
 }
 }
@@ -464,7 +463,7 @@ MatrixWorkspace_sptr ReflectometryTransform::executeNormPoly(
   std::vector<specnum_t> specNumberMapping;
   std::vector<detid_t> detIDMapping;
   // Create a table for the output if we want to debug vertex positioning
-  addColumnHeadings(vertexes, outputDimensions);
+  addColumnHeadings(*vertexes, outputDimensions);
   for (size_t i = 0; i < nHistos; ++i) {
     IDetector_const_sptr detector = inputWS->getDetector(i);
     if (!detector || detector->isMasked() || detector->isMonitor()) {

--- a/Framework/Geometry/src/Surfaces/SurfaceFactory.cpp
+++ b/Framework/Geometry/src/Surfaces/SurfaceFactory.cpp
@@ -88,7 +88,7 @@ void SurfaceFactory::registerSurface()
 namespace {
 class KeyEquals {
 public:
-  explicit KeyEquals(std::string key) : m_key(std::move(key)) {}
+  explicit KeyEquals(const std::string &key) : m_key(key) {}
   bool
   operator()(const std::pair<std::string, std::unique_ptr<Surface>> &element) {
     return m_key == element.first;

--- a/Framework/Kernel/inc/MantidKernel/Strings.h
+++ b/Framework/Kernel/inc/MantidKernel/Strings.h
@@ -144,7 +144,7 @@ template <typename T> int sectionMCNPX(std::string &A, T &out);
 MANTID_KERNEL_DLL void writeMCNPX(const std::string &Line, std::ostream &OX);
 
 /// Split tring into spc deliminated components
-MANTID_KERNEL_DLL std::vector<std::string> StrParts(std::string Ln);
+MANTID_KERNEL_DLL std::vector<std::string> StrParts(const std::string &Ln);
 
 /// Splits a string into key value pairs
 MANTID_KERNEL_DLL std::map<std::string, std::string>

--- a/Framework/Kernel/src/MaterialXMLParser.cpp
+++ b/Framework/Kernel/src/MaterialXMLParser.cpp
@@ -68,7 +68,8 @@ struct TypedBuilderHandle final : public BuilderHandle {
   typedef typename std::remove_const<
       typename std::remove_reference<ArgType>::type>::type ValueType;
 
-  TypedBuilderHandle(BuilderMethod<ArgType> m) : BuilderHandle(), m_method(m) {}
+  explicit TypedBuilderHandle(BuilderMethod<ArgType> m)
+      : BuilderHandle(), m_method(m) {}
 
   void operator()(MaterialBuilder &builder,
                   const std::string &value) const override {

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -411,7 +411,7 @@ void writeMCNPX(const std::string &Line, std::ostream &OX) {
  *  @param Ln :: line component to strip
  *  @return vector of components
  */
-std::vector<std::string> StrParts(std::string Ln) {
+std::vector<std::string> StrParts(const std::string &Ln) {
   std::vector<std::string> Out;
   std::string Part;
   while (section(Ln, Part))

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -412,11 +412,10 @@ void writeMCNPX(const std::string &Line, std::ostream &OX) {
  *  @return vector of components
  */
 std::vector<std::string> StrParts(const std::string &Ln) {
-  std::vector<std::string> Out;
-  std::string Part;
-  while (section(Ln, Part))
-    Out.push_back(Part);
-  return Out;
+  auto tokenizer = Mantid::Kernel::StringTokenizer(
+      Ln, " ", Mantid::Kernel::StringTokenizer::TOK_TRIM |
+                   Mantid::Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
+  return tokenizer.asVector();
 }
 
 /**

--- a/Framework/MatlabAPI/src/MatlabInterface.cpp
+++ b/Framework/MatlabAPI/src/MatlabInterface.cpp
@@ -302,8 +302,8 @@ mxArray *ixbcreateclassarray(const char *class_name, int *n) {
   */
 int CreateFrameworkManager(int nlhs, mxArray *plhs[], int nrhs,
                            const mxArray *prhs[]) {
-  mwSize dims[2] = {1, 1};
   try {
+    mwSize dims[2] = {1, 1};
     FrameworkManagerImpl &fmgr = FrameworkManager::Instance();
     plhs[0] = mxCreateNumericArray(2, dims, mxUINT64_CLASS, mxREAL);
     uint64_t *data = (uint64_t *)mxGetData(plhs[0]);

--- a/Framework/TestHelpers/inc/MantidTestHelpers/MDEventsTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/MDEventsTestHelper.h
@@ -164,7 +164,7 @@ makeFakeMDEventWorkspace(const std::string &wsName, long numEvents = 10000,
 MDHistoWorkspace_sptr
 makeFakeMDHistoWorkspace(double signal, size_t numDims, size_t numBins = 10,
                          coord_t max = 10.0, double errorSquared = 1.0,
-                         std::string name = "", double numEvents = 1.0);
+                         const std::string &name = "", double numEvents = 1.0);
 
 Mantid::DataObjects::MDHistoWorkspace_sptr makeFakeMDHistoWorkspaceWithMDFrame(
     double signal, size_t numDims, const Mantid::Geometry::MDFrame &frame,

--- a/Framework/TestHelpers/src/MDEventsTestHelper.cpp
+++ b/Framework/TestHelpers/src/MDEventsTestHelper.cpp
@@ -216,8 +216,8 @@ std::vector<MDLeanEvent<1>> makeMDEvents1(size_t num) {
  */
 Mantid::DataObjects::MDHistoWorkspace_sptr
 makeFakeMDHistoWorkspace(double signal, size_t numDims, size_t numBins,
-                         coord_t max, double errorSquared, std::string name,
-                         double numEvents) {
+                         coord_t max, double errorSquared,
+                         const std::string &name, double numEvents) {
   // Create MDFrame of General Frame type
   Mantid::Geometry::GeneralFrame frame(
       Mantid::Geometry::GeneralFrame::GeneralFrameDistance, "m");

--- a/MantidPlot/src/QwtBarCurve.cpp
+++ b/MantidPlot/src/QwtBarCurve.cpp
@@ -32,10 +32,8 @@
 
 QwtBarCurve::QwtBarCurve(BarStyle style, Table *t, const QString &xColName,
                          const QString &name, int startRow, int endRow)
-    : DataCurve(t, xColName, name, startRow, endRow) {
-  bar_offset = 0;
-  bar_gap = 0;
-  bar_style = style;
+    : DataCurve(t, xColName, name, startRow, endRow), bar_gap{0}, bar_offset{0},
+      bar_style{style} {
 
   setPen(QPen(Qt::black, 1, Qt::SolidLine));
   setBrush(QBrush(Qt::red));

--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -1022,6 +1022,7 @@ void Spectrogram::loadFromProject(const std::string &lines) {
     std::string policyStr = tsv.sections("ColorPolicy").front();
     int policy = 0;
     Strings::convert<int>(policyStr, policy);
+    // cppcheck-suppress knownConditionTrueFalse
     if (policy == GrayScale)
       setGrayScale();
     else if (policy == Default)

--- a/MantidQt/API/src/ScriptRepositoryView.cpp
+++ b/MantidQt/API/src/ScriptRepositoryView.cpp
@@ -154,7 +154,7 @@ ScriptRepositoryView::ScriptRepositoryView(QWidget *parent)
     // create the model
     model = new RepoModel(this);
 
-  } catch (EXC_OPTIONS ex) {
+  } catch (EXC_OPTIONS &ex) {
     if (ex == NODIRECTORY)
       // probably the user change mind. He does not want to install any more.
       QMessageBox::warning(this, "Installation Failed",

--- a/Vates/VatesAPI/inc/MantidVatesAPI/FactoryChains.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/FactoryChains.h
@@ -39,7 +39,7 @@ vtkSmartPointer<vtkPVClipDataSet> DLLExport
 getClippedDataSet(vtkSmartPointer<vtkDataSet> dataSet);
 
 /// Create name with timestamp attached.
-std::string DLLExport createTimeStampedName(std::string name);
+std::string DLLExport createTimeStampedName(const std::string &name);
 }
 }
 

--- a/Vates/VatesAPI/src/PresenterUtilities.cpp
+++ b/Vates/VatesAPI/src/PresenterUtilities.cpp
@@ -125,7 +125,7 @@ createFactoryChainForHistoWorkspace(ThresholdRange_scptr threshold,
 * @param name: the input name
 * @return a name with a time stamp
 */
-std::string createTimeStampedName(std::string name) {
+std::string createTimeStampedName(const std::string &name) {
   auto currentTime =
       std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
   std::string timeInReadableFormat = std::string(std::ctime(&currentTime));

--- a/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
@@ -711,8 +711,7 @@ std::string RebinnedSourcesManager::saveToProject() {
 void RebinnedSourcesManager::loadFromProject(const std::string &lines) {
   MantidQt::API::TSVSerialiser tsv(lines);
 
-  std::string rebinWorkspaceName, originalWorkspaceName, rebinProxyName,
-      originalProxyName;
+  std::string rebinWorkspaceName, originalWorkspaceName, rebinProxyName;
   tsv.selectLine("RebinnedWorkspaceName");
   tsv >> rebinWorkspaceName;
   tsv.selectLine("OriginalWorkspaceName");


### PR DESCRIPTION
Description of work.

This fixes many warnings found by cppcheck 1.76. Most are best described as linting. We'll leave the more interesting ones for another time.

**To test:**

<!-- Instructions for testing. -->

13 cppcheck warnings should remain.

There is no issue associated with the pull request.

*Does not need to be in the release notes.*

@mantidproject/gatekeepers After merging the PR, please adjust the number of allowed cppcheck warnings.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

