### PR TITLE
Remove Histogram Validator from ConvertSpectrumAxis

### DIFF
--- a/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
@@ -1,5 +1,4 @@
 #include "MantidAlgorithms/ConvertSpectrumAxis.h"
-#include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/Run.h"

--- a/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
@@ -32,7 +32,6 @@ constexpr double rad2deg = 180. / M_PI;
 void ConvertSpectrumAxis::init() {
   // Validator for Input Workspace
   auto wsVal = boost::make_shared<CompositeValidator>();
-  wsVal->add<HistogramValidator>();
   wsVal->add<SpectraAxisValidator>();
   wsVal->add<InstrumentValidator>();
 

--- a/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
@@ -27,7 +27,6 @@ using namespace Geometry;
 void ConvertSpectrumAxis2::init() {
   // Validator for Input Workspace
   auto wsVal = boost::make_shared<CompositeValidator>();
-  wsVal->add<HistogramValidator>();
   wsVal->add<SpectraAxisValidator>();
   wsVal->add<InstrumentValidator>();
 

--- a/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
@@ -1,5 +1,4 @@
 #include "MantidAlgorithms/ConvertSpectrumAxis2.h"
-#include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/Run.h"

--- a/Framework/Algorithms/test/ConvertSpectrumAxis2Test.h
+++ b/Framework/Algorithms/test/ConvertSpectrumAxis2Test.h
@@ -16,7 +16,8 @@ using namespace Mantid::HistogramData::detail;
 class ConvertSpectrumAxis2Test : public CxxTest::TestSuite {
 private:
   void do_algorithm_run(std::string target, std::string inputWS,
-                        std::string outputWS, bool startYNegative = true, bool isHistogram = true) {
+                        std::string outputWS, bool startYNegative = true,
+                        bool isHistogram = true) {
     auto testWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
         3, 1, false, startYNegative, isHistogram);
     AnalysisDataService::Instance().addOrReplace(inputWS, testWS);
@@ -126,7 +127,8 @@ public:
     clean_up_workspaces(inputWS, outputSignedThetaAxisWS);
 
     // No histogram
-    do_algorithm_run("signed_theta", inputWS, outputSignedThetaAxisWS, true, false);
+    do_algorithm_run("signed_theta", inputWS, outputSignedThetaAxisWS, true,
+                     false);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_signed_theta_conversion(outputSignedThetaAxisWS);
@@ -140,7 +142,8 @@ public:
     clean_up_workspaces(inputWS, outputSignedThetaAxisWS2);
 
     // No histogram
-    do_algorithm_run("SignedTheta", inputWS, outputSignedThetaAxisWS2, true, false);
+    do_algorithm_run("SignedTheta", inputWS, outputSignedThetaAxisWS2, true,
+                     false);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_signed_theta_conversion(outputSignedThetaAxisWS2);

--- a/Framework/Algorithms/test/ConvertSpectrumAxis2Test.h
+++ b/Framework/Algorithms/test/ConvertSpectrumAxis2Test.h
@@ -240,7 +240,7 @@ public:
     std::string inputWS("inWS");
     const std::string outputWS("outWS");
 
-    ("ElasticQSquared", inputWS, outputWS, false, true);
+    do_algorithm_run("ElasticQSquared", inputWS, outputWS, false, true);
 
     MatrixWorkspace_const_sptr input, output;
     TS_ASSERT_THROWS_NOTHING(

--- a/Framework/Algorithms/test/ConvertSpectrumAxis2Test.h
+++ b/Framework/Algorithms/test/ConvertSpectrumAxis2Test.h
@@ -16,7 +16,7 @@ using namespace Mantid::HistogramData::detail;
 class ConvertSpectrumAxis2Test : public CxxTest::TestSuite {
 private:
   void do_algorithm_run(std::string target, std::string inputWS,
-                        std::string outputWS, bool startYNegative = true, bool isHistogram) {
+                        std::string outputWS, bool startYNegative = true, bool isHistogram = true) {
     auto testWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
         3, 1, false, startYNegative, isHistogram);
     AnalysisDataService::Instance().addOrReplace(inputWS, testWS);
@@ -119,28 +119,28 @@ public:
     const std::string outputSignedThetaAxisWS2("outSignedThetaWS2");
 
     // Histogram
-    do_algorithm_run("signed_theta", inputWS, outputSignedThetaAxisWS, true);
+    do_algorithm_run("signed_theta", inputWS, outputSignedThetaAxisWS);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_signed_theta_conversion(outputSignedThetaAxisWS);
     clean_up_workspaces(inputWS, outputSignedThetaAxisWS);
 
     // No histogram
-    do_algorithm_run("signed_theta", inputWS, outputSignedThetaAxisWS, false);
+    do_algorithm_run("signed_theta", inputWS, outputSignedThetaAxisWS, true, false);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_signed_theta_conversion(outputSignedThetaAxisWS);
     clean_up_workspaces(inputWS, outputSignedThetaAxisWS);
 
     // Histogram
-    do_algorithm_run("SignedTheta", inputWS, outputSignedThetaAxisWS2, true);
+    do_algorithm_run("SignedTheta", inputWS, outputSignedThetaAxisWS2);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_signed_theta_conversion(outputSignedThetaAxisWS2);
     clean_up_workspaces(inputWS, outputSignedThetaAxisWS2);
 
     // No histogram
-    do_algorithm_run("SignedTheta", inputWS, outputSignedThetaAxisWS2, false);
+    do_algorithm_run("SignedTheta", inputWS, outputSignedThetaAxisWS2, true, false);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_signed_theta_conversion(outputSignedThetaAxisWS2);
@@ -152,13 +152,13 @@ public:
     const std::string outputWS("outWS");
     const std::string outputWS2("outWS2");
 
-    do_algorithm_run("theta", inputWS, outputWS, true);
+    do_algorithm_run("theta", inputWS, outputWS, true, true);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_theta_conversion(inputWS, outputWS);
     clean_up_workspaces(inputWS, outputWS);
 
-    do_algorithm_run("Theta", inputWS, outputWS2, true);
+    do_algorithm_run("Theta", inputWS, outputWS2, true, true);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_theta_conversion(inputWS, outputWS2);
@@ -237,7 +237,7 @@ public:
     std::string inputWS("inWS");
     const std::string outputWS("outWS");
 
-    do_algorithm_run("ElasticQSquared", inputWS, outputWS, false, true);
+    ("ElasticQSquared", inputWS, outputWS, false, true);
 
     MatrixWorkspace_const_sptr input, output;
     TS_ASSERT_THROWS_NOTHING(

--- a/Framework/Algorithms/test/ConvertSpectrumAxis2Test.h
+++ b/Framework/Algorithms/test/ConvertSpectrumAxis2Test.h
@@ -16,9 +16,9 @@ using namespace Mantid::HistogramData::detail;
 class ConvertSpectrumAxis2Test : public CxxTest::TestSuite {
 private:
   void do_algorithm_run(std::string target, std::string inputWS,
-                        std::string outputWS, bool startYNegative = true) {
+                        std::string outputWS, bool startYNegative = true, bool isHistogram) {
     auto testWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
-        3, 1, false, startYNegative);
+        3, 1, false, startYNegative, isHistogram);
     AnalysisDataService::Instance().addOrReplace(inputWS, testWS);
 
     Mantid::Algorithms::ConvertSpectrumAxis2 conv;
@@ -118,13 +118,29 @@ public:
     const std::string outputSignedThetaAxisWS("outSignedThetaWS");
     const std::string outputSignedThetaAxisWS2("outSignedThetaWS2");
 
-    do_algorithm_run("signed_theta", inputWS, outputSignedThetaAxisWS);
+    // Histogram
+    do_algorithm_run("signed_theta", inputWS, outputSignedThetaAxisWS, true);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_signed_theta_conversion(outputSignedThetaAxisWS);
     clean_up_workspaces(inputWS, outputSignedThetaAxisWS);
 
-    do_algorithm_run("SignedTheta", inputWS, outputSignedThetaAxisWS2);
+    // No histogram
+    do_algorithm_run("signed_theta", inputWS, outputSignedThetaAxisWS, false);
+
+    // Check output values for the workspace then clean up.
+    check_output_values_for_signed_theta_conversion(outputSignedThetaAxisWS);
+    clean_up_workspaces(inputWS, outputSignedThetaAxisWS);
+
+    // Histogram
+    do_algorithm_run("SignedTheta", inputWS, outputSignedThetaAxisWS2, true);
+
+    // Check output values for the workspace then clean up.
+    check_output_values_for_signed_theta_conversion(outputSignedThetaAxisWS2);
+    clean_up_workspaces(inputWS, outputSignedThetaAxisWS2);
+
+    // No histogram
+    do_algorithm_run("SignedTheta", inputWS, outputSignedThetaAxisWS2, false);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_signed_theta_conversion(outputSignedThetaAxisWS2);
@@ -136,13 +152,13 @@ public:
     const std::string outputWS("outWS");
     const std::string outputWS2("outWS2");
 
-    do_algorithm_run("theta", inputWS, outputWS);
+    do_algorithm_run("theta", inputWS, outputWS, true);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_theta_conversion(inputWS, outputWS);
     clean_up_workspaces(inputWS, outputWS);
 
-    do_algorithm_run("Theta", inputWS, outputWS2);
+    do_algorithm_run("Theta", inputWS, outputWS2, true);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_theta_conversion(inputWS, outputWS2);
@@ -179,7 +195,7 @@ public:
     std::string inputWS("inWS");
     const std::string outputWS("outWS");
 
-    do_algorithm_run("ElasticQ", inputWS, outputWS, false);
+    do_algorithm_run("ElasticQ", inputWS, outputWS, false, true);
 
     MatrixWorkspace_const_sptr input, output;
     TS_ASSERT_THROWS_NOTHING(
@@ -221,7 +237,7 @@ public:
     std::string inputWS("inWS");
     const std::string outputWS("outWS");
 
-    do_algorithm_run("ElasticQSquared", inputWS, outputWS, false);
+    do_algorithm_run("ElasticQSquared", inputWS, outputWS, false, true);
 
     MatrixWorkspace_const_sptr input, output;
     TS_ASSERT_THROWS_NOTHING(

--- a/Framework/Algorithms/test/ConvertSpectrumAxis2Test.h
+++ b/Framework/Algorithms/test/ConvertSpectrumAxis2Test.h
@@ -155,13 +155,13 @@ public:
     const std::string outputWS("outWS");
     const std::string outputWS2("outWS2");
 
-    do_algorithm_run("theta", inputWS, outputWS, true, true);
+    do_algorithm_run("theta", inputWS, outputWS);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_theta_conversion(inputWS, outputWS);
     clean_up_workspaces(inputWS, outputWS);
 
-    do_algorithm_run("Theta", inputWS, outputWS2, true, true);
+    do_algorithm_run("Theta", inputWS, outputWS2);
 
     // Check output values for the workspace then clean up.
     check_output_values_for_theta_conversion(inputWS, outputWS2);
@@ -175,7 +175,7 @@ public:
     const std::string target("ElasticQ");
 
     auto testWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
-        3, 1, false, true);
+        3, 1, false);
     AnalysisDataService::Instance().addOrReplace(inputWS, testWS);
 
     Mantid::Algorithms::ConvertSpectrumAxis2 conv;
@@ -198,7 +198,7 @@ public:
     std::string inputWS("inWS");
     const std::string outputWS("outWS");
 
-    do_algorithm_run("ElasticQ", inputWS, outputWS, false, true);
+    do_algorithm_run("ElasticQ", inputWS, outputWS, false);
 
     MatrixWorkspace_const_sptr input, output;
     TS_ASSERT_THROWS_NOTHING(
@@ -240,7 +240,7 @@ public:
     std::string inputWS("inWS");
     const std::string outputWS("outWS");
 
-    do_algorithm_run("ElasticQSquared", inputWS, outputWS, false, true);
+    do_algorithm_run("ElasticQSquared", inputWS, outputWS, false);
 
     MatrixWorkspace_const_sptr input, output;
     TS_ASSERT_THROWS_NOTHING(


### PR DESCRIPTION
The histogram validator got removed from ConvertSpectrumaxis version 1 and 2. This allows to convert the spectrum axis not only for histograms.

I added unit tests for non-histogram data. I found boolean variables as function parameters (some of them). This is due to Workspace2D_sptr WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument taking boolean function parameters as well. I decided to don't have a deeper look since the unit test remains readable.

**To test:**

Load histogram data and run the algorithm `ConvertToPointData` to generate a distribution or load a distribution if available. Then run `ConvertSpectrumAxis`.

Fixes #17931.

_Does not need to be in the release notes._


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
