### PR TITLE
Add option to sort direct beams by run numbers

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -68,7 +68,8 @@ class LRAutoReduction(PythonAlgorithm):
                              "Read the run sequence information from the file, not the title")
         self.declareProperty("ForceSequenceNumber", 0,
                              "Force the sequence number value if it's not available")
-
+        self.declareProperty("OrderDirectBeamsByRunNumber", False,
+                             "Force the sequence of direct beam files to be ordered by run number")
         self.declareProperty(FileProperty('OutputFilename', '', action=FileAction.OptionalSave, extensions=["txt"]),
                              doc='Name of the reflectivity file output')
         self.declareProperty(FileProperty("OutputDirectory", "", FileAction.Directory))
@@ -603,6 +604,7 @@ class LRAutoReduction(PythonAlgorithm):
             logger.notice("Using automated scaling factor calculator")
             output_dir = self.getProperty("OutputDirectory").value
             sf_tof_step = self.getProperty("ScalingFactorTOFStep").value
+            order_by_runs = self.getProperty("OrderDirectBeamsByRunNumber").value
 
             # The medium for these direct beam runs may not be what was set in the template,
             # so either use the medium in the data file or a default name
@@ -615,6 +617,7 @@ class LRAutoReduction(PythonAlgorithm):
                              UseLowResCut=True, ComputeScalingFactors=True, TOFSteps=sf_tof_step,
                              IncidentMedium=incident_medium,
                              SlitTolerance=slit_tolerance,
+                             OrderDirectBeamsByRunNumber=order_by_runs,
                              ScalingFactorFile=os.path.join(output_dir, "sf_%s_%s_auto.cfg" % (first_run_of_set, file_id)))
             return
         elif not do_reduction:

--- a/Framework/PythonInterface/plugins/algorithms/LRDirectBeamSort.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRDirectBeamSort.py
@@ -104,6 +104,8 @@ class LRDirectBeamSort(PythonAlgorithm):
         self.declareProperty("TOFSteps", 200.0, doc="TOF bin width")
         self.declareProperty("WavelengthOffset", 0.0, doc="Wavelength offset used for TOF range determination")
         self.declareProperty("IncidentMedium", "Air", doc="Name of the incident medium")
+        self.declareProperty("OrderDirectBeamsByRunNumber", False,
+                             "Force the sequence of direct beam files to be ordered by run number")
         self.declareProperty(FileProperty("ScalingFactorFile","",
                                           action=FileAction.OptionalSave,
                                           extensions=['cfg']),
@@ -127,7 +129,11 @@ class LRDirectBeamSort(PythonAlgorithm):
             for ws in ws_list:
                 lr_data.append(mtd[ws])
 
-        lr_data_sorted = sorted(lr_data, cmp=sorter_function)
+        sort_by_runs = self.getProperty("OrderDirectBeamsByRunNumber").value
+        if sort_by_runs is True:
+            lr_data_sorted = sorted(lr_data, key=lambda r: r.getRunNumber())
+        else:
+            lr_data_sorted = sorted(lr_data, cmp=sorter_function)
 
         # Set the output properties
         run_numbers = [r.getRunNumber() for r in lr_data_sorted]


### PR DESCRIPTION
Add an option to sort the direct beam runs by run number.
A change should be made to the direct beam sorting algorithm, and the option added to LRAutoreduction (which calls the run sorting)

**To test:**
- Make sure tests pass
- Review code



*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

