### PR TITLE
Move interpolation from VectorHelper to HistogramData

### DIFF
--- a/Framework/Algorithms/src/AbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrection.cpp
@@ -176,7 +176,7 @@ void AbsorptionCorrection::exec() {
     const auto lambdas = m_inputWS->points(i);
     // Get a reference to the Y's in the output WS for storing the factors
     auto &Y = correctionFactors->mutableY(i);
-    
+
     // Loop through the bins in the current spectrum every m_xStep
     for (int64_t j = 0; j < specSize; j = j + m_xStep) {
       const double lambda = lambdas[j];

--- a/Framework/Algorithms/src/AbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrection.cpp
@@ -7,6 +7,7 @@
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
+#include "MantidHistogramData/Interpolate.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/Fast_Exponential.h"
@@ -14,14 +15,14 @@
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
-#include "MantidKernel/VectorHelper.h"
 
 namespace Mantid {
 namespace Algorithms {
 
-using namespace Kernel;
-using namespace Geometry;
 using namespace API;
+using namespace Geometry;
+using HistogramData::interpolateLinearInplace;
+using namespace Kernel;
 using namespace Mantid::PhysicalConstants;
 
 AbsorptionCorrection::AbsorptionCorrection()
@@ -144,7 +145,7 @@ void AbsorptionCorrection::exec() {
   for (int64_t i = 0; i < int64_t(numHists); ++i) {
     PARALLEL_START_INTERUPT_REGION
 
-    // Copy over bin boundaries
+    // Copy over bins
     correctionFactors->setSharedX(i, m_inputWS->sharedX(i));
 
     if (!spectrumInfo.hasDetectors(i))
@@ -172,11 +173,11 @@ void AbsorptionCorrection::exec() {
       }
     }
 
-    // Get a reference to the Y's in the output WS for storing the factors
-    auto &Y = correctionFactors->dataY(i);
-
-    // Loop through the bins in the current spectrum every m_xStep
     const auto lambdas = m_inputWS->points(i);
+    // Get a reference to the Y's in the output WS for storing the factors
+    auto &Y = correctionFactors->mutableY(i);
+    
+    // Loop through the bins in the current spectrum every m_xStep
     for (int64_t j = 0; j < specSize; j = j + m_xStep) {
       const double lambda = lambdas[j];
       if (m_emode == 0) // Elastic
@@ -197,14 +198,12 @@ void AbsorptionCorrection::exec() {
       }
     }
 
-    if (m_xStep >
-        1) // Interpolate linearly between points separated by m_xStep,
-           // last point required
-    {
-      // TODO linearlyInterpolateY should be implemented in HistogramData
-      // Until then use old interface
-      VectorHelper::linearlyInterpolateY(m_inputWS->x(i).rawData(), Y,
-                                         static_cast<double>(m_xStep));
+    // Interpolate linearly between points separated by m_xStep,
+    // last point required
+    if (m_xStep > 1) {
+      auto histnew = correctionFactors->histogram(i);
+      interpolateLinearInplace(histnew, m_xStep);
+      correctionFactors->setHistogram(i, histnew);
     }
 
     prog.report();

--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -163,7 +163,7 @@ MonteCarloAbsorption::doSimulation(const MatrixWorkspace &inputWS,
     PARALLEL_START_INTERUPT_REGION
 
     auto &outE = outputWS->mutableE(i);
-    //    // The input was cloned so clear the errors out
+    // The input was cloned so clear the errors out
     outE = 0.0;
     // Final detector position
     IDetector_const_sptr detector;

--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -22,11 +22,13 @@
 #include "MantidKernel/VectorHelper.h"
 
 #include "MantidHistogramData/HistogramX.h"
+#include "MantidHistogramData/Interpolate.h"
 
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
 using Mantid::HistogramData::HistogramX;
+using Mantid::HistogramData::interpolateLinearInplace;
 namespace PhysicalConstants = Mantid::PhysicalConstants;
 
 /// @cond
@@ -160,13 +162,9 @@ MonteCarloAbsorption::doSimulation(const MatrixWorkspace &inputWS,
   for (int64_t i = 0; i < nhists; ++i) {
     PARALLEL_START_INTERUPT_REGION
 
-    auto xvalues = outputWS->points(i);
-    auto &signal = outputWS->mutableY(i);
-    auto &errors = outputWS->mutableE(i);
-    // The input was cloned so clear the errors out
-    // Y values are all overwritten later
-    errors = 0.0;
-
+    auto &outE = outputWS->mutableE(i);
+    //    // The input was cloned so clear the errors out
+    outE = 0.0;
     // Final detector position
     IDetector_const_sptr detector;
     try {
@@ -179,10 +177,12 @@ MonteCarloAbsorption::doSimulation(const MatrixWorkspace &inputWS,
     const double lambdaFixed = toWavelength(efixed.value(detector));
     MersenneTwister rng(seed);
 
+    auto &outY = outputWS->mutableY(i);
+    const auto lambdas = outputWS->points(i);
     // Simulation for each requested wavelength point
     for (int j = 0; j < nbins; j += lambdaStepSize) {
       prog.report(reportMsg);
-      const double lambdaStep = xvalues[j];
+      const double lambdaStep = lambdas[j];
       double lambdaIn(lambdaStep), lambdaOut(lambdaStep);
       if (efixed.emode() == DeltaEMode::Direct) {
         lambdaIn = lambdaFixed;
@@ -191,7 +191,7 @@ MonteCarloAbsorption::doSimulation(const MatrixWorkspace &inputWS,
       } else {
         // elastic case already initialized
       }
-      std::tie(signal[j], std::ignore) =
+      std::tie(outY[j], std::ignore) =
           strategy.calculate(rng, detPos, lambdaIn, lambdaOut);
 
       // Ensure we have the last point for the interpolation
@@ -202,8 +202,9 @@ MonteCarloAbsorption::doSimulation(const MatrixWorkspace &inputWS,
 
     // Interpolate through points not simulated
     if (lambdaStepSize > 1) {
-      Kernel::VectorHelper::linearlyInterpolateY(
-          xvalues.rawData(), outputWS->dataY(i), lambdaStepSize);
+      auto histnew = outputWS->histogram(i);
+      interpolateLinearInplace(histnew, lambdaStepSize);
+      outputWS->setHistogram(i, histnew);
     }
 
     PARALLEL_END_INTERUPT_REGION

--- a/Framework/Algorithms/test/MonteCarloAbsorptionTest.h
+++ b/Framework/Algorithms/test/MonteCarloAbsorptionTest.h
@@ -169,6 +169,22 @@ public:
     TS_ASSERT_DELTA(6.5735e-05, outputWS->y(0).back(), delta);
   }
 
+  void test_Linear_Interpolation() {
+    using Mantid::Kernel::DeltaEMode;
+    TestWorkspaceDescriptor wsProps = {1, 10, Environment::SampleOnly,
+                                       DeltaEMode::Elastic, -1, -1};
+    const int nlambda(5);
+    auto outputWS = runAlgorithm(wsProps, nlambda);
+
+    verifyDimensions(wsProps, outputWS);
+    const double delta(1e-05);
+    const size_t middle_index(4);
+
+    TS_ASSERT_DELTA(0.019012, outputWS->y(0).front(), delta);
+    TS_ASSERT_DELTA(0.0026940, outputWS->y(0)[middle_index], delta);
+    TS_ASSERT_DELTA(0.00042886, outputWS->y(0).back(), delta);
+  }
+
   //---------------------------------------------------------------------------
   // Failure cases
   //---------------------------------------------------------------------------
@@ -198,10 +214,14 @@ public:
 
 private:
   Mantid::API::MatrixWorkspace_const_sptr
-  runAlgorithm(const TestWorkspaceDescriptor &wsProps) {
+  runAlgorithm(const TestWorkspaceDescriptor &wsProps, int nlambda = -1) {
     auto inputWS = setUpWS(wsProps);
     auto mcabs = createAlgorithm();
     TS_ASSERT_THROWS_NOTHING(mcabs->setProperty("InputWorkspace", inputWS));
+    if (nlambda > 0) {
+      TS_ASSERT_THROWS_NOTHING(
+          mcabs->setProperty("NumberOfWavelengthPoints", nlambda));
+    }
     mcabs->execute();
     return getOutputWorkspace(mcabs);
   }

--- a/Framework/HistogramData/CMakeLists.txt
+++ b/Framework/HistogramData/CMakeLists.txt
@@ -108,7 +108,8 @@ endif ()
 # Add to the 'Framework' group in VS
 set_property ( TARGET HistogramData PROPERTY FOLDER "MantidFramework" )
 
-target_link_libraries ( HistogramData LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${MANTIDLIBS} )
+target_link_libraries ( HistogramData LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} 
+                        ${GSL_LIBRARIES} ${MANTIDLIBS} )
 
 # Add the unit tests directory
 add_subdirectory ( test )

--- a/Framework/HistogramData/CMakeLists.txt
+++ b/Framework/HistogramData/CMakeLists.txt
@@ -8,8 +8,9 @@ set ( SRC_FILES
 	src/FrequencyVariances.cpp
 	src/Histogram.cpp
 	src/HistogramMath.cpp
-	src/Rebin.cpp
+	src/Interpolate.cpp
 	src/Points.cpp
+	src/Rebin.cpp
 )
 
 set ( INC_FILES
@@ -27,9 +28,9 @@ set ( INC_FILES
 	inc/MantidHistogramData/HistogramDx.h
 	inc/MantidHistogramData/HistogramE.h
 	inc/MantidHistogramData/HistogramMath.h
-	inc/MantidHistogramData/Rebin.h
 	inc/MantidHistogramData/HistogramX.h
 	inc/MantidHistogramData/HistogramY.h
+	inc/MantidHistogramData/Interpolate.h
 	inc/MantidHistogramData/Iterable.h
 	inc/MantidHistogramData/LinearGenerator.h
 	inc/MantidHistogramData/LogarithmicGenerator.h
@@ -38,6 +39,7 @@ set ( INC_FILES
 	inc/MantidHistogramData/PointStandardDeviations.h
 	inc/MantidHistogramData/PointVariances.h
 	inc/MantidHistogramData/Points.h
+	inc/MantidHistogramData/Rebin.h
 	inc/MantidHistogramData/Scalable.h
 	inc/MantidHistogramData/StandardDeviationVectorOf.h
 	inc/MantidHistogramData/Validation.h
@@ -61,10 +63,10 @@ set ( TEST_FILES
 	HistogramDxTest.h
 	HistogramETest.h
 	HistogramMathTest.h
-	RebinTest.h
 	HistogramTest.h
 	HistogramXTest.h
 	HistogramYTest.h
+	InterpolateTest.h
 	IterableTest.h
 	LinearGeneratorTest.h
 	LogarithmicGeneratorTest.h
@@ -73,6 +75,7 @@ set ( TEST_FILES
 	PointStandardDeviationsTest.h
 	PointVariancesTest.h
 	PointsTest.h
+	RebinTest.h
 	ScalableTest.h
 	StandardDeviationVectorOfTest.h
 	VarianceVectorOfTest.h

--- a/Framework/HistogramData/inc/MantidHistogramData/Interpolate.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Interpolate.h
@@ -38,6 +38,12 @@ interpolateLinear(const Histogram &input, const size_t stepSize);
 MANTID_HISTOGRAMDATA_DLL void interpolateLinearInplace(Histogram &inOut,
                                                        const size_t stepSize);
 
+MANTID_HISTOGRAMDATA_DLL Histogram
+interpolateCSpline(const Histogram &input, const size_t stepSize);
+
+MANTID_HISTOGRAMDATA_DLL void interpolateCSplineInplace(Histogram &inOut,
+                                                        const size_t stepSize);
+
 } // namespace HistogramData
 } // namespace Mantid
 

--- a/Framework/HistogramData/inc/MantidHistogramData/Interpolate.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Interpolate.h
@@ -1,0 +1,44 @@
+#ifndef MANTID_HISTOGRAMDATA_INTERPOLATE_H_
+#define MANTID_HISTOGRAMDATA_INTERPOLATE_H_
+
+#include "MantidHistogramData/DllConfig.h"
+
+namespace Mantid {
+namespace HistogramData {
+class Histogram;
+
+/**
+  Defines public functions to perform interpolation of histogram data.
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+
+MANTID_HISTOGRAMDATA_DLL Histogram
+interpolateLinear(const Histogram &input, const size_t stepSize);
+
+MANTID_HISTOGRAMDATA_DLL void interpolateLinearInplace(Histogram &inOut,
+                                                       const size_t stepSize);
+
+} // namespace HistogramData
+} // namespace Mantid
+
+#endif /* MANTID_HISTOGRAMDATA_INTERPOLATE_H_ */

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -113,7 +113,7 @@ void interpolateYCSplineInplace(const Histogram &input, const size_t stepSize,
     yc[i] = yold[step];
   }
   // Ensure we have the last value
-  xc.back() = xold[nypts - 1];
+  xc.back() = xold.back();
   yc.back() = yold.back();
 
   gsl_interp_accel *acc = gsl_interp_accel_alloc();

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -69,16 +69,16 @@ void sanityCheck(const Histogram &input, const size_t stepSize,
  */
 void interpolateYLinearInplace(const Histogram &input, const size_t stepSize,
                                HistogramY &ynew) {
-  auto xold = input.points();
-  auto &yold = input.y();
-  auto nypts = yold.size();
+  const auto xold = input.points();
+  const auto &yold = input.y();
+  const auto nypts = yold.size();
   size_t step(stepSize), index2(0);
   double x1(0.), x2(0.), y1(0.), y2(0.), overgap(0.);
   // Copy over end value skipped by loop
   ynew.back() = yold.back();
   for (size_t i = 0; i < nypts - 1; ++i) // Last point has been calculated
   {
-    double xp = xold[i];
+    const double xp = xold[i];
     if (step == stepSize) {
       x1 = xp;
       index2 = ((i + stepSize) >= nypts ? nypts - 1 : (i + stepSize));
@@ -96,6 +96,7 @@ void interpolateYLinearInplace(const Histogram &input, const size_t stepSize,
     step++;
   }
 }
+
 /**
  * Perform cubic spline interpolation. It is assumed all sanity checks have been
  * performed by the interpolateCSpline entry point.
@@ -105,13 +106,13 @@ void interpolateYLinearInplace(const Histogram &input, const size_t stepSize,
  */
 void interpolateYCSplineInplace(const Histogram &input, const size_t stepSize,
                                 HistogramY &ynew) {
-  auto xold = input.points();
-  auto &yold = input.y();
-  auto nypts = yold.size();
+  const auto xold = input.points();
+  const auto &yold = input.y();
+  const auto nypts = yold.size();
 
   const auto ncalc = numberCalculated(nypts, stepSize);
   std::vector<double> xc(ncalc), yc(ncalc);
-  for (size_t step = 0, i = 0; step < nypts; step += stepSize, i += 1) {
+  for (size_t step = 0, i = 0; step < nypts; step += stepSize, ++i) {
     xc[i] = xold[step];
     yc[i] = yold[step];
   }

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -21,7 +21,7 @@ constexpr const char *CSPLINE_NAME = "CSpline";
  * @param stepSize The step size between each calculated point
  * @return The number of calculated nodes
  */
-inline size_t numberCalculated(const size_t ysize, const size_t stepSize) {
+constexpr size_t numberCalculated(const size_t ysize, const size_t stepSize) {
   // First and last points are always assumed to be calculated
   return 1 + ((ysize - 1) / stepSize);
 }

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -32,6 +32,11 @@ constexpr size_t numberCalculated(const size_t ysize, const size_t stepSize) {
  * @param stepSize See interpolateLinear
  * @param minCalculated The minimum number of calculated values required
  * by the routine
+ * @param method A string providing the name of the interpolation method. Used
+ * in error messages
+ * @throws std::runtime_error if input.yMode() == Uninitialized or
+ * stepSize is invalid or the number of calculated points is less than the
+ * the required value
  */
 void sanityCheck(const Histogram &input, const size_t stepSize,
                  const size_t minCalculated, const char *method) {
@@ -61,7 +66,6 @@ void sanityCheck(const Histogram &input, const size_t stepSize,
  * @param input See interpolateLinear
  * @param stepSize See interpolateLinear
  * @param ynew A reference to the output Y values
- * @return See interpolateLinear
  */
 void interpolateYLinearInplace(const Histogram &input, const size_t stepSize,
                                HistogramY &ynew) {
@@ -98,7 +102,6 @@ void interpolateYLinearInplace(const Histogram &input, const size_t stepSize,
  * @param input See interpolateCSpline
  * @param stepSize See interpolateCSpline
  * @param ynew A reference to the output Y values
- * @return See interpolateCSpline
  */
 void interpolateYCSplineInplace(const Histogram &input, const size_t stepSize,
                                 HistogramY &ynew) {

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -1,0 +1,117 @@
+#include "MantidHistogramData/Interpolate.h"
+
+#include "MantidHistogramData/Histogram.h"
+
+using Mantid::HistogramData::Histogram;
+using Mantid::HistogramData::HistogramX;
+using Mantid::HistogramData::HistogramY;
+
+namespace {
+
+/**
+ * Perform common sanity checks for interpolations
+ * @param input See interpolateLinear
+ * @param stepSize See interpolateLinear
+ */
+void sanityCheck(const Histogram &input, const size_t stepSize) {
+  if (input.yMode() == Histogram::YMode::Uninitialized) {
+    throw std::runtime_error(
+        "interpolateLinear() - YMode must be defined for input histogram.");
+  }
+  if (input.y().size() < 3) {
+    throw std::runtime_error("interpolateLinear() - At least 3 values are "
+                             "required for interpolation");
+  }
+  if (stepSize >= input.y().size()) {
+    throw std::runtime_error("interpolateLinear() - Step size must be smaller "
+                             "than the number of points");
+  }
+}
+
+/**
+ * Perform linear interpolation assuming the input data set to be a Histogram
+ * with XMode=Points. It is assumed all sanity cheks have been performed
+ * by the interpolateLinear entry point.
+ * @param input See interpolateLinear
+ * @param stepSize See interpolateLinear
+ * @param ynew A reference to the output Y values
+ * @return See interpolateLinear
+ */
+void interpolateYLinearInplace(const Histogram &input, const size_t stepSize,
+                               HistogramY &ynew) {
+  auto binCentre = input.xMode() == Histogram::XMode::BinEdges
+                       ? [](const HistogramX &x,
+                            size_t i) { return 0.5 * (x[i] + x[i + 1]); }
+                       : [](const HistogramX &x, size_t i) { return x[i]; };
+
+  auto &xold = input.x();
+  auto &yold = input.y();
+  auto nypts = yold.size();
+  size_t step(stepSize), index2(0);
+  double x1(0.), x2(0.), y1(0.), y2(0.), overgap(0.);
+  // Copy over end value skipped by loop
+  ynew.back() = yold.back();
+  for (size_t i = 0; i < nypts - 1; ++i) // Last point has been calculated
+  {
+    double xp = binCentre(xold, i);
+    if (step == stepSize) {
+      x1 = xp;
+      index2 = ((i + stepSize) >= nypts ? nypts - 1 : (i + stepSize));
+      x2 = binCentre(xold, index2);
+      overgap = 1.0 / (x2 - x1);
+      y1 = yold[i];
+      y2 = yold[index2];
+      step = 1;
+      ynew[i] = yold[i];
+      continue;
+    }
+    // Linear interpolation
+    ynew[i] = (xp - x1) * y2 + (x2 - xp) * y1;
+    ynew[i] *= overgap;
+    step++;
+  }
+}
+
+} // end anonymous namespace
+
+namespace Mantid {
+namespace HistogramData {
+
+/**
+ * Linearly interpolate through the y values of a histogram assuming that the
+ * calculated "nodes" are stepSize apart. Currently errors are not treated.
+ * @param input Input histogram defining x values and containing calculated
+ * Y values at stepSize intervals. It is assumed that the first/last points
+ * are always calculated points.
+ * @param stepSize The space, in indices, between the calculated points
+ * @return A new Histogram with the y-values from the result of a linear
+ * interpolation. If the XMode of the output will match that of the input
+ */
+Histogram interpolateLinear(const Histogram &input, const size_t stepSize) {
+  sanityCheck(input, stepSize);
+
+  HistogramY ynew(input.y().size());
+  interpolateYLinearInplace(input, stepSize, ynew);
+  // Cheap copy
+  Histogram output(input);
+  if (output.yMode() == Histogram::YMode::Counts) {
+    output.setCounts(ynew);
+  } else {
+    output.setFrequencies(ynew);
+  }
+  return output;
+}
+
+/**
+ * Linearly interpolate across a set of data. (In-place version). See
+ * interpolateLinear.
+ * @param inOut Input histogram whose points are interpolated in place
+ * @param stepSize See interpolateLinear
+ */
+void interpolateLinearInplace(Histogram &inOut, const size_t stepSize) {
+  sanityCheck(inOut, stepSize);
+  interpolateYLinearInplace(inOut, stepSize, inOut.mutableY());
+}
+
+} // namespace HistogramData
+} // namespace Mantid

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -151,7 +151,7 @@ namespace HistogramData {
  * are always calculated points.
  * @param stepSize The space, in indices, between the calculated points
  * @return A new Histogram with the y-values from the result of a linear
- * interpolation. If the XMode of the output will match that of the input
+ * interpolation. The XMode of the output will match the input histogram.
  */
 Histogram interpolateLinear(const Histogram &input, const size_t stepSize) {
   sanityCheck(input, stepSize, 2, LINEAR_NAME);
@@ -188,7 +188,7 @@ void interpolateLinearInplace(Histogram &inOut, const size_t stepSize) {
  * are always calculated points.
  * @param stepSize The space, in indices, between the calculated points
  * @return A new Histogram with the y-values from the result of a linear
- * interpolation. If the XMode of the output will match that of the input
+ * interpolation. The XMode of the output will match the input histogram.
  */
 Histogram interpolateCSpline(const Histogram &input, const size_t stepSize) {
   sanityCheck(input, stepSize, 4, CSPLINE_NAME);

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -124,15 +124,14 @@ void interpolateYCSplineInplace(const Histogram &input, const size_t stepSize,
   // Manage gsl memory with unique_ptrs
   using gsl_spline_uptr = std::unique_ptr<gsl_spline, void (*)(gsl_spline *)>;
   auto spline = gsl_spline_uptr(gsl_spline_alloc(gsl_interp_cspline, ncalc),
-                                [](gsl_spline *sp) { gsl_spline_free(sp); });
+                                gsl_spline_free);
   // Compute spline
   gsl_spline_init(spline.get(), xc.data(), yc.data(), ncalc);
   // Evaluate each point for the full range
   using gsl_interp_accel_uptr =
       std::unique_ptr<gsl_interp_accel, void (*)(gsl_interp_accel *)>;
-  auto lookupTable = gsl_interp_accel_uptr(
-      gsl_interp_accel_alloc(),
-      [](gsl_interp_accel *acc) { gsl_interp_accel_free(acc); });
+  auto lookupTable =
+      gsl_interp_accel_uptr(gsl_interp_accel_alloc(), gsl_interp_accel_free);
   for (size_t i = 0; i < nypts; ++i) {
     ynew[i] = gsl_spline_eval(spline.get(), xold[i], lookupTable.get());
   }

--- a/Framework/HistogramData/test/InterpolateTest.h
+++ b/Framework/HistogramData/test/InterpolateTest.h
@@ -318,7 +318,7 @@ public:
 
 private:
   const size_t binSize = 10000;
-  const size_t nIters = 1000;
+  const size_t nIters = 5000;
   Histogram hist;
 };
 

--- a/Framework/HistogramData/test/InterpolateTest.h
+++ b/Framework/HistogramData/test/InterpolateTest.h
@@ -101,11 +101,11 @@ public:
   // ---------------------------------------------------------------------------
   void test_interpolateCSplinePointDataSet_Minimum_Calculated_Points() {
     Histogram input(Points(7, LinearGenerator(0, 0.5)),
-                    {-3, 0, -1, 0, 1, 0, 3});
+                    Counts({-3, 0, -4, 0, 4, 0, 3}));
     auto output = interpolateCSpline(input, 2);
 
     checkSizesUnchanged(input, output);
-    std::vector<double> expectedY = {-3, -2, -1, 0, 1, 2, 3};
+    std::vector<double> expectedY = {-3, -4.625, -4, 0., 4, 4.625, 3};
     checkData(input, output, expectedY);
 
     // Inplace

--- a/Framework/HistogramData/test/InterpolateTest.h
+++ b/Framework/HistogramData/test/InterpolateTest.h
@@ -18,6 +18,19 @@ public:
   static void destroySuite(InterpolateTest *suite) { delete suite; }
 
   // ---------------------------------------------------------------------------
+  // Success cases - linear in-place no copy
+  // ---------------------------------------------------------------------------
+  void test_interpolateLinearInPlaceDoes_Not_Copy() {
+    Histogram input(Points(5, LinearGenerator(0, 0.5)), {-2, 0, 0, 0, 2});
+    auto xAddrBefore = &input.x();
+    auto yAddrBefore = &input.y();
+    TS_ASSERT_THROWS_NOTHING(interpolateLinearInplace(input, 4));
+
+    TS_ASSERT_EQUALS(xAddrBefore, &input.x());
+    TS_ASSERT_EQUALS(yAddrBefore, &input.y());
+  }
+
+  // ---------------------------------------------------------------------------
   // Success cases - linear, point X data
   // ---------------------------------------------------------------------------
   void test_interpolateLinearPointDataSet_Stepsize_One_Less_Point_Size() {
@@ -67,6 +80,20 @@ public:
 
     checkSizesUnchanged(input, inOut);
     checkData(input, inOut, expectedY);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Success cases - cspline in-place no copy
+  // ---------------------------------------------------------------------------
+  void test_interpolateCSplineInPlaceDoes_Not_Copy() {
+    Histogram input(Points(7, LinearGenerator(0, 0.5)),
+                    {-3, 0, -1, 0, 1, 0, 3});
+    auto xAddrBefore = &input.x();
+    auto yAddrBefore = &input.y();
+    TS_ASSERT_THROWS_NOTHING(interpolateCSplineInplace(input, 2));
+
+    TS_ASSERT_EQUALS(xAddrBefore, &input.x());
+    TS_ASSERT_EQUALS(yAddrBefore, &input.y());
   }
 
   // ---------------------------------------------------------------------------

--- a/Framework/HistogramData/test/InterpolateTest.h
+++ b/Framework/HistogramData/test/InterpolateTest.h
@@ -1,0 +1,197 @@
+#ifndef MANTID_HISTOGRAMDATA_INTERPOLATETEST_H_
+#define MANTID_HISTOGRAMDATA_INTERPOLATETEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidHistogramData/Histogram.h"
+#include "MantidHistogramData/Interpolate.h"
+#include "MantidHistogramData/LinearGenerator.h"
+#include "MantidTestHelpers/HistogramDataTestHelper.h"
+
+using namespace Mantid::HistogramData;
+
+class InterpolateTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static InterpolateTest *createSuite() { return new InterpolateTest(); }
+  static void destroySuite(InterpolateTest *suite) { delete suite; }
+
+  // ---------------------------------------------------------------------------
+  // Success cases - point X data
+  // ---------------------------------------------------------------------------
+  void test_interpolateLinearPointDataSet_Stepsize_One_Less_Point_Size() {
+    Histogram input(Points(5, LinearGenerator(0, 0.5)), {-2, 0, 0, 0, 2});
+    auto output = interpolateLinear(input, 4);
+
+    checkSizesUnchanged(input, output);
+    std::vector<double> expectedY = {-2., -1., 0., 1., 2.};
+    checkData(input, output, expectedY);
+
+    // Inplace
+    Histogram inOut(input);
+    TS_ASSERT_THROWS_NOTHING(interpolateLinearInplace(inOut, 4));
+
+    checkSizesUnchanged(input, inOut);
+    checkData(input, inOut, expectedY);
+  }
+
+  void test_interpolateLinearPointDataSet_Even_StepSize() {
+    Histogram input(Points(5, LinearGenerator(0, 0.5)), {-2, 0, 0.5, 0, 2});
+    auto output = interpolateLinear(input, 2);
+
+    checkSizesUnchanged(input, output);
+    std::vector<double> expectedY = {-2., -0.75, 0.5, 1.25, 2.};
+    checkData(input, output, expectedY);
+
+    // Inplace
+    Histogram inOut(input);
+    TS_ASSERT_THROWS_NOTHING(interpolateLinearInplace(inOut, 2));
+
+    checkSizesUnchanged(input, inOut);
+    checkData(input, inOut, expectedY);
+  }
+
+  void test_interpolateLinearPointDataSet_Odd_StepSize() {
+    Histogram input(Points(5, LinearGenerator(0, 0.5)), {-2, 0, 0.0, 0.5, 2});
+    auto output = interpolateLinear(input, 3);
+
+    checkSizesUnchanged(input, output);
+    std::vector<double> expectedY = {-2., -2 + (2.5 / 1.5) * 0.5, -1. / 3., 0.5,
+                                     2.};
+    checkData(input, output, expectedY);
+
+    // Inplace
+    Histogram inOut(input);
+    TS_ASSERT_THROWS_NOTHING(interpolateLinearInplace(inOut, 3));
+
+    checkSizesUnchanged(input, inOut);
+    checkData(input, inOut, expectedY);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Success cases - edge X data
+  // ---------------------------------------------------------------------------
+  void test_interpolateLinearEdgeDataSet_Stepsize_One_Less_Point_Size() {
+    Histogram input(BinEdges(6, LinearGenerator(-0.25, 0.5)),
+                    Counts({-2, 0, 0, 0, 2}));
+    auto output = interpolateLinear(input, 4);
+
+    checkSizesUnchanged(input, output);
+    std::vector<double> expectedY = {-2., -1., 0., 1., 2.};
+    checkData(input, output, expectedY);
+
+    // Inplace
+    Histogram inOut(input);
+    TS_ASSERT_THROWS_NOTHING(interpolateLinearInplace(inOut, 4));
+
+    checkSizesUnchanged(input, inOut);
+    checkData(input, inOut, expectedY);
+  }
+
+  void test_interpolateLinearEdgeDataSet_Even_StepSize() {
+    Histogram input(BinEdges(6, LinearGenerator(-0.25, 0.5)),
+                    {-2, 0, 0.5, 0, 2});
+    auto output = interpolateLinear(input, 2);
+
+    checkSizesUnchanged(input, output);
+    std::vector<double> expectedY = {-2., -0.75, 0.5, 1.25, 2.};
+    checkData(input, output, expectedY);
+
+    // Inplace
+    Histogram inOut(input);
+    TS_ASSERT_THROWS_NOTHING(interpolateLinearInplace(inOut, 2));
+
+    checkSizesUnchanged(input, inOut);
+    checkData(input, inOut, expectedY);
+  }
+
+  void test_interpolateLinearEdgeDataSet_Odd_StepSize() {
+    Histogram input(BinEdges(6, LinearGenerator(-0.25, 0.5)),
+                    {-2, 0, 0.0, 0.5, 2});
+    Histogram output = interpolateLinear(input, 3);
+
+    checkSizesUnchanged(input, output);
+    std::vector<double> expectedY = {-2., -2 + (2.5 / 1.5) * 0.5, -1. / 3., 0.5,
+                                     2.};
+    checkData(input, output, expectedY);
+
+    // Inplace
+    Histogram inOut(input);
+    TS_ASSERT_THROWS_NOTHING(interpolateLinearInplace(inOut, 3));
+
+    checkSizesUnchanged(input, inOut);
+    checkData(input, inOut, expectedY);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Success cases - Point data with frequencies
+  //                 single test case as whitebox testing tells us the algorithm
+  //                 is the same
+  // ---------------------------------------------------------------------------
+
+  void test_interpolateLinearPointFrequencyData_Stepsize_One_Less_Point_Size() {
+    Histogram input(Points(5, LinearGenerator(0., 0.5)),
+                    Frequencies({-2, 0, 0, 0, 2}));
+    auto output = interpolateLinear(input, 4);
+
+    checkSizesUnchanged(input, output);
+    std::vector<double> expectedY = {-2., -1., 0., 1., 2.};
+    checkData(input, output, expectedY);
+
+    // Inplace
+    Histogram inOut(input);
+    TS_ASSERT_THROWS_NOTHING(interpolateLinearInplace(inOut, 4));
+
+    checkSizesUnchanged(input, inOut);
+    checkData(input, inOut, expectedY);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Common checking code
+  // ---------------------------------------------------------------------------
+  void checkSizesUnchanged(const Histogram &input, const Histogram &output) {
+    TS_ASSERT_EQUALS(input.y().size(), output.y().size());
+    TS_ASSERT_EQUALS(input.x().size(), output.x().size());
+  }
+
+  void checkData(const Histogram &input, const Histogram &output,
+                 const std::vector<double> &expectedY) {
+    TS_ASSERT_EQUALS(input.x(), output.x());
+    TS_ASSERT_EQUALS(input.xMode(), output.xMode());
+    TS_ASSERT_EQUALS(input.yMode(), output.yMode());
+    const auto &outY = output.y();
+    for (size_t i = 0; i < expectedY.size(); ++i) {
+      TS_ASSERT_DELTA(expectedY[i], outY[i], 1e-14);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Failure cases
+  // ---------------------------------------------------------------------------
+  void test_interpolatelinear_throws_for_undefined_ymode_type() {
+    TS_ASSERT_THROWS(
+        interpolateLinear(Histogram(Points(10, LinearGenerator(0, 0.5))), 10),
+        std::runtime_error);
+  }
+
+  void test_interpolatelinear_throws_if_number_points_less_than_3() {
+    TS_ASSERT_THROWS(
+        interpolateLinear(Histogram(Points(2, LinearGenerator(0, 0.5))), 1),
+        std::runtime_error);
+    TS_ASSERT_THROWS(
+        interpolateLinear(Histogram(Points(2, LinearGenerator(0, 0.5))), 1),
+        std::runtime_error);
+  }
+  void
+  test_interpolatelinear_throws_if_stepsize_greater_or_equal_number_points() {
+    TS_ASSERT_THROWS(
+        interpolateLinear(Histogram(Points(6, LinearGenerator(0, 0.5))), 6),
+        std::runtime_error);
+    TS_ASSERT_THROWS(
+        interpolateLinear(Histogram(Points(6, LinearGenerator(0, 0.5))), 7),
+        std::runtime_error);
+  }
+};
+
+#endif /* MANTID_HISTOGRAMDATA_INTERPOLATETEST_H_ */

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -96,11 +96,7 @@ splitStringIntoVector(std::string listString);
 
 MANTID_KERNEL_DLL int getBinIndex(const std::vector<double> &bins,
                                   const double value);
-// Linearly interpolate between a set of Y values. Assumes the values are set
-// for the calculated nodes
-MANTID_KERNEL_DLL void linearlyInterpolateY(const std::vector<double> &x,
-                                            std::vector<double> &y,
-                                            const double stepSize);
+
 // Do running average of input vector within specified range, considering
 // heterogeneous bin-boundaries
 // if such boundaries are provided

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -489,43 +489,6 @@ int getBinIndex(const std::vector<double> &bins, const double value) {
 }
 
 //-------------------------------------------------------------------------------------------------
-/**
- * Linearly interpolates between Y points separated by the given step size.
- * @param x :: The X array
- * @param y :: The Y array with end points and values at stepSize intervals
- * calculated
- * @param stepSize :: The distance between each pre-calculated point
- */
-void linearlyInterpolateY(const std::vector<double> &x, std::vector<double> &y,
-                          const double stepSize) {
-  int specSize = static_cast<int>(y.size());
-  int xSize = static_cast<int>(x.size());
-  bool isHistogram(xSize == specSize + 1);
-  int step(static_cast<int>(stepSize)), index2(0);
-  double x1 = 0, x2 = 0, y1 = 0, y2 = 0, xp = 0, overgap = 0;
-
-  for (int i = 0; i < specSize - 1; ++i) // Last point has been calculated
-  {
-    if (step ==
-        stepSize) // Point numerically integrated, does not need interpolation
-    {
-      x1 = (isHistogram ? (0.5 * (x[i] + x[i + 1])) : x[i]);
-      index2 = static_cast<int>(
-          ((i + stepSize) >= specSize ? specSize - 1 : (i + stepSize)));
-      x2 = (isHistogram ? (0.5 * (x[index2] + x[index2 + 1])) : x[index2]);
-      overgap = 1.0 / (x2 - x1);
-      y1 = y[i];
-      y2 = y[index2];
-      step = 1;
-      continue;
-    }
-    xp = (isHistogram ? (0.5 * (x[i] + x[i + 1])) : x[i]);
-    // Linear interpolation
-    y[i] = (xp - x1) * y2 + (x2 - xp) * y1;
-    y[i] *= overgap;
-    step++;
-  }
-}
 
 namespace {
 /** internal function converted from Lambda to identify interval around


### PR DESCRIPTION
Moves the interpolation function from `VectorHelper` to the `HistogramData` module and adds cubic spline interpolation. The routines rely on understanding the type of data they are dealing with and therefore belong with the HistogramData module.

The `VectorHelper` function has been removed.

**To test:**

Code review. Current tests check that the behaviour has not changed for the existing absorption
correction algorithms.

Fixes #17913 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
