### PR TITLE
Fix crash on double click with no selection in workspace dock

### DIFF
--- a/MantidQt/MantidWidgets/src/MantidTreeWidget.cpp
+++ b/MantidQt/MantidWidgets/src/MantidTreeWidget.cpp
@@ -142,13 +142,17 @@ void MantidTreeWidget::mouseMoveEvent(QMouseEvent *e) {
 
 void MantidTreeWidget::mouseDoubleClickEvent(QMouseEvent *e) {
   try {
-    std::string wsName = m_dockWidget->getSelectedWorkspaceNames()[0];
+    auto wsNames = getSelectedWorkspaceNames();
+    if (wsNames.isEmpty()) {
+      return;
+    }
+    auto wsName = wsNames.front();
     Mantid::API::WorkspaceGroup_sptr grpWSPstr;
-    grpWSPstr =
-        boost::dynamic_pointer_cast<WorkspaceGroup>(m_ads.retrieve(wsName));
+    grpWSPstr = boost::dynamic_pointer_cast<WorkspaceGroup>(
+        m_ads.retrieve(wsName.toStdString()));
     if (!grpWSPstr) {
-      if (!wsName.empty()) {
-        m_mantidUI->importWorkspace(QString::fromStdString(wsName), false);
+      if (!wsName.isEmpty()) {
+        m_mantidUI->importWorkspace(wsName, false);
         return;
       }
     }


### PR DESCRIPTION
Adds a check that a selection exists before trying to import anything into the MantidPlot window.

**To test:**

### Test that the crash no longer occurs

* Start MantidPlot
* Double-click in the white space within the "workspaces" widget - nothing should happen

### Test old behaviour is the same

Using an installed copy of v3.8 compare that the behaviour is the same when double clicking on a workspace in the dock. This should include all workspace types including groups.

Fixes #17955.

*Does not need to be in the release notes* - this was a regression introduced after v3.8

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

Refs #17955