### PR TITLE
LoadILLTOF monitor numbering

### DIFF
--- a/Framework/DataHandling/src/LoadILLTOF.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF.cpp
@@ -546,9 +546,13 @@ void LoadILLTOF::loadDataIntoTheWorkSpace(
 
   auto const &instrument = m_localWorkspace->getInstrument();
 
+  std::vector<detid_t> monitorIDs = instrument->getMonitors();
+
   for (const auto &monitor : monitors) {
-    m_localWorkspace->setHistogram(spec++, m_localWorkspace->binEdges(0),
+    m_localWorkspace->setHistogram(spec, m_localWorkspace->binEdges(0),
                                    Counts(monitor.begin(), monitor.end()));
+    m_localWorkspace->getSpectrum(spec).setDetectorID(monitorIDs[spec]);
+    spec++;
   }
 
   std::vector<detid_t> detectorIDs = instrument->getDetectorIDs(true);

--- a/Framework/DataHandling/test/LoadILLTOFTest.h
+++ b/Framework/DataHandling/test/LoadILLTOFTest.h
@@ -56,11 +56,14 @@ public:
 
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), numberOfHistograms);
 
-    // Check all detectors have a unique and defined detector ID >= 0
+    // Check all detectors have a defined detector ID >= 0
 
     Mantid::detid2index_map detectorMap;
-    TS_ASSERT_THROWS_NOTHING(
-        detectorMap = output->getDetectorIDToWorkspaceIndexMap(true));
+    TS_ASSERT_THROWS_NOTHING(detectorMap = output->getDetectorIDToWorkspaceIndexMap(true));
+
+    // Check all detectors have a unique detector ID
+    TS_ASSERT_EQUALS(detectorMap.size(), output->getNumberHistograms());
+
 
     for (auto value : detectorMap) {
       TS_ASSERT(value.first >= 0);

--- a/Framework/DataHandling/test/LoadILLTOFTest.h
+++ b/Framework/DataHandling/test/LoadILLTOFTest.h
@@ -57,13 +57,12 @@ public:
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), numberOfHistograms);
 
     // Check all detectors have a defined detector ID >= 0
-
     Mantid::detid2index_map detectorMap;
-    TS_ASSERT_THROWS_NOTHING(detectorMap = output->getDetectorIDToWorkspaceIndexMap(true));
+    TS_ASSERT_THROWS_NOTHING(
+        detectorMap = output->getDetectorIDToWorkspaceIndexMap(true));
 
     // Check all detectors have a unique detector ID
     TS_ASSERT_EQUALS(detectorMap.size(), output->getNumberHistograms());
-
 
     for (auto value : detectorMap) {
       TS_ASSERT(value.first >= 0);


### PR DESCRIPTION
Fixes issue with monitor not being loaded correctly for ILL ToF data.

**To test:**

Load a data file such as ILL/IN6/164192.nxs or ILL/IN5/104007.nxs. After loading check the detector table, to see that the monitors do not have the same detector IDs as any detectors.

Check the unit test additional now makes sense.  Can also check it fails if the line `m_localWorkspace->getSpectrum(spec).setDetectorID(monitorIDs[spec]);` (line 554) is commented out in `LoadILLTOF.cpp`

Fixes #17954 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
