### PR TITLE
Get systemtests running with python3

### DIFF
--- a/Testing/SystemTests/lib/systemtests/xmlreporter.py
+++ b/Testing/SystemTests/lib/systemtests/xmlreporter.py
@@ -1,3 +1,4 @@
+from __future__ import (absolute_import, division, print_function)
 import os
 import sys
 from xml.dom.minidom import getDOMImplementation
@@ -20,15 +21,15 @@ class XmlResultReporter(stresstesting.ResultReporter):
 		# print the command line summary version of the results
 		self._failures.sort()
 		self._skipped.sort()
-		print
+		print()
 		if self._show_skipped and len(self._skipped) > 0:
-			print "SKIPPED:"
+			print("SKIPPED:")
 			for test in self._skipped:
-				print test.name
+				print(test.name)
 		if len(self._failures) > 0:
-			print "FAILED:"
+			print("FAILED:")
 			for test in self._failures:
-				print test.name
+				print(test.name)
 
 		# return the xml document version
 		docEl = self._doc.documentElement

--- a/Testing/SystemTests/scripts/runSystemTests.py
+++ b/Testing/SystemTests/scripts/runSystemTests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import (absolute_import, division, print_function)
 import optparse
 import os
 import sys
@@ -97,15 +98,15 @@ xml_report.close()
 if options.makeprop:
   mtdconf.restoreconfig()
 
-print
+print()
 if mgr.skippedTests == mgr.totalTests:
-  print "All tests were skipped"
+  print("All tests were skipped")
   success = False # fail if everything was skipped
 else:
   percent = 1.-float(mgr.failedTests)/float(mgr.totalTests-mgr.skippedTests)
   percent = int(100. * percent)
-  print "%d%s tests passed, %d tests failed out of %d (%d skipped)" % \
-      (percent, '%', mgr.failedTests, (mgr.totalTests-mgr.skippedTests), mgr.skippedTests)
-print 'All tests passed? ' + str(success)
+  print("%d%s tests passed, %d tests failed out of %d (%d skipped)" % \
+      (percent, '%', mgr.failedTests, (mgr.totalTests-mgr.skippedTests), mgr.skippedTests))
+print('All tests passed? ' + str(success))
 if not success:
   sys.exit(1)


### PR DESCRIPTION
This should allows you to run the systemtests with python 3, *i.e.* `./systemtest`

This **does not** fix the systemtests for python 3 and most of them will fail but at least now they should run.

**To test:**
 * Compile with python 3 and try running `./systemtest` with different options, *e.g.*
   * `./systemtest -R LoadTest` should pass
   * `./systemtest --showskipped -R DOSTest` should fail and show skipped tests
 * Make sure the systemtests still run for python 2


*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

