### PR TITLE
Disable grouping and fitting tabs when no data is loaded

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
@@ -549,6 +549,9 @@ private:
 
   /// Check if next/previous run should be appended
   void checkAppendingRun(const int direction);
+
+  /// Set the Grouping and Data Analysis tabs enabled/disabled
+  void setAnalysisTabsEnabled(const bool enabled);
 };
 }
 }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1933,10 +1933,13 @@ void MuonAnalysis::startUpLook() {
       m_uiForm.groupTable->setItem(i, 0, it);
     }
   }
+
+  // When first started, no data has yet been loaded
+  noDataAvailable();
 }
 
 /**
-* Time zero returend in ms
+* Time zero returned in ms
 */
 double MuonAnalysis::timeZero() {
   return getValidatedDouble(m_uiForm.timeZeroFront, TIME_ZERO_DEFAULT,
@@ -2823,6 +2826,7 @@ void MuonAnalysis::noDataAvailable() {
   m_uiForm.groupTablePlotButton->setEnabled(false);
   m_uiForm.pairTablePlotButton->setEnabled(false);
   m_uiForm.guessAlphaButton->setEnabled(false);
+  setAnalysisTabsEnabled(false);
 }
 
 /**
@@ -2833,6 +2837,7 @@ void MuonAnalysis::nowDataAvailable() {
   m_uiForm.groupTablePlotButton->setEnabled(true);
   m_uiForm.pairTablePlotButton->setEnabled(true);
   m_uiForm.guessAlphaButton->setEnabled(true);
+  setAnalysisTabsEnabled(true);
 }
 
 void MuonAnalysis::openDirectoryDialog() {
@@ -2975,6 +2980,22 @@ void MuonAnalysis::updateDataPresenterOverwrite(int state) {
   Q_UNUSED(state);
   if (m_fitDataPresenter) {
     m_fitDataPresenter->setOverwrite(isOverwriteEnabled());
+  }
+}
+
+/**
+ * Set the following tabs enabled/disabled:
+ * - Grouping Options
+ * - Data Analysis
+ * (based on whether data is available or not)
+ * @param enabled :: [input] Whether to enable or disable tabs
+ */
+void MuonAnalysis::setAnalysisTabsEnabled(const bool enabled) {
+  const std::vector<QWidget *> tabs{m_uiForm.DataAnalysis,
+                                    m_uiForm.GroupingOptions};
+  for (auto *tab : tabs) {
+    const auto &index = m_uiForm.tabWidget->indexOf(tab);
+    m_uiForm.tabWidget->setTabEnabled(index, enabled);
   }
 }
 

--- a/docs/source/interfaces/Muon_Analysis_unscripted_testing_guide.rst
+++ b/docs/source/interfaces/Muon_Analysis_unscripted_testing_guide.rst
@@ -17,10 +17,12 @@ The tests follow real use cases provided by scientists and are intended to exerc
 Setup
 ^^^^^
 - Set your facility to ISIS
-- Download ``EMU00020918-20`` 
+- Ensure the files ``EMU00020918-20`` are in Mantid's path
 - Open *Interfaces/Muon/Muon Analysis*
+- At this point, before loading any data, the *Grouping Options* and *Data Analysis* tabs should be disabled.
 - On *Settings* tab, uncheck "Compatibility mode" if checked
 - Set instrument to EMU, type "20918" in the "Load run" box and hit return
+- Now that data has been loaded, all tabs on the interface should be enabled.
 
 Fitting tests
 ^^^^^^^^^^^^^

--- a/docs/source/release/v3.9.0/muon.rst
+++ b/docs/source/release/v3.9.0/muon.rst
@@ -16,6 +16,7 @@ Muon Analysis
 
 
 - Fixed a bug where the "load next/previous" buttons appended runs in certain cases where this was not the intended behaviour.
+- The *Grouping Options* and *Data Analysis* tabs now only become enabled once data has been loaded on the *Home* tab. Data should first be loaded on the *Home* tab, then it can be grouped/fitted. After the first dataset has been loaded, additional datasets can of course be added (for a multi-dataset fit) using the *Data Analysis* tab.
 
 Algorithms
 ----------


### PR DESCRIPTION
Several bugs were seen in Muon Analysis where users tried to use functionality on the *Data Analysis* tab before having loaded a dataset on the *Home* tab. The cleanest solution to this is to disable the fitting tab until some data is loaded - you can't do any fitting until there is some data to fit! 

The same applies to the *Grouping Options* tab as it doesn't make sense to look at the grouping until there is some data to group.

No automated test is possible for this change, but the [unscripted testing guide](https://github.com/mantidproject/mantid/blob/c8f34cb13dc30357ccd0bfc82458952d4d33626f/docs/source/interfaces/Muon_Analysis_unscripted_testing_guide.rst#setup) has been updated with a test for this.

**To test:**

- Open *Interfaces/Muon/Muon Analysis*
- Note that the *Grouping Options* and *Data Analysis* tabs are disabled.
- Load any muon NeXus file. (e.g. `MUSR00015189.nxs` from test data) All tabs should now be enabled.

Fixes #17968.

[Release notes](https://github.com/mantidproject/mantid/blob/c4fd0e17d008862d094a536e2f45db7da58784ad/docs/source/release/v3.9.0/muon.rst#id1) have been updated.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
