### PR TITLE
group workspaces allowed in SCD interface

### DIFF
--- a/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
@@ -5,6 +5,7 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/Workspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/IEventWorkspace.h"
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/IPeaksWorkspace.h"
@@ -56,9 +57,19 @@ std::string MantidEVWorker::workspaceType(const std::string &ws_name) {
   if (!ADS.doesExist(ws_name))
     return std::string("");
 
-  Workspace_const_sptr outWS = ADS.retrieveWS<Workspace>(ws_name);
+  WorkspaceGroup_const_sptr wsgroup = ADS.retrieveWS<WorkspaceGroup>(ws_name);
+  if (wsgroup) {
 
-  return outWS->id();
+    std::vector<std::string> group = wsgroup->getNames();
+    Workspace_const_sptr outWS = ADS.retrieveWS<Workspace>(group[0]);
+
+    return outWS->id();
+  } else {
+
+    Workspace_const_sptr outWS = ADS.retrieveWS<Workspace>(ws_name);
+
+    return outWS->id();
+  }
 }
 
 /**
@@ -220,10 +231,12 @@ bool MantidEVWorker::loadAndConvertToMD(
 
     if (!alg->execute())
       return false;
-  } catch (std::exception &e) {
+  }
+  catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  } catch (...) {
+  }
+  catch (...) {
     g_log.error() << "Error: Could Not load file and convert to MD\n";
     return false;
   }
@@ -331,10 +344,12 @@ bool MantidEVWorker::findPeaks(const std::string &ev_ws_name,
       }
       return true;
     }
-  } catch (std::exception &e) {
+  }
+  catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  } catch (...) {
+  }
+  catch (...) {
     g_log.error() << "Error: Could Not findPeaks\n";
     return false;
   }
@@ -370,10 +385,12 @@ bool MantidEVWorker::predictPeaks(const std::string &peaks_ws_name,
 
     if (alg->execute())
       return true;
-  } catch (std::exception &e) {
+  }
+  catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  } catch (...) {
+  }
+  catch (...) {
     g_log.error() << "Error: Could Not predictPeaks\n";
     return false;
   }
@@ -837,10 +854,12 @@ bool MantidEVWorker::sphereIntegrate(
 
     std::cout << "Integrated temporary MD workspace FAILED\n";
     return false;
-  } catch (std::exception &e) {
+  }
+  catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  } catch (...) {
+  }
+  catch (...) {
     g_log.error() << "Error: Could Not Integrated temporary MD workspace\n";
     return false;
   }
@@ -910,10 +929,12 @@ bool MantidEVWorker::fitIntegrate(const std::string &peaks_ws_name,
     }
 
     std::cout << "Integrated temporary FIT workspace FAILED\n";
-  } catch (std::exception &e) {
+  }
+  catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  } catch (...) {
+  }
+  catch (...) {
     g_log.error() << "Error: Could Not Integrated temporary FIT workspace\n";
     return false;
   }
@@ -971,10 +992,12 @@ bool MantidEVWorker::ellipsoidIntegrate(const std::string &peaks_ws_name,
     }
 
     std::cout << "IntegrateEllipsoids FAILED\n";
-  } catch (std::exception &e) {
+  }
+  catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  } catch (...) {
+  }
+  catch (...) {
     g_log.error() << "Error: Could Not IntegratedEllipsoids\n";
     return false;
   }
@@ -1043,7 +1066,8 @@ bool MantidEVWorker::showUB(const std::string &peaks_ws_name) {
             o_lattice.errorgamma());
 
     g_log.notice(std::string(logInfo));
-  } catch (...) {
+  }
+  catch (...) {
     return false;
   }
 
@@ -1087,7 +1111,8 @@ bool MantidEVWorker::getUB(const std::string &peaks_ws_name, bool lab_coords,
       auto goniometer_matrix = peak.getGoniometerMatrix();
       UB = goniometer_matrix * UB;
     }
-  } catch (...) {
+  }
+  catch (...) {
     return false;
   }
 
@@ -1108,9 +1133,7 @@ bool MantidEVWorker::getUB(const std::string &peaks_ws_name, bool lab_coords,
  */
 bool MantidEVWorker::copyLattice(const std::string &peaks_ws_name,
                                  const std::string &md_ws_name,
-                                 const std::string &event_ws_name)
-
-{
+                                 const std::string &event_ws_name) {
   // fail if peaks workspace is not there
   if (!isPeaksWorkspace(peaks_ws_name)) {
     return false;
@@ -1137,7 +1160,8 @@ bool MantidEVWorker::copyLattice(const std::string &peaks_ws_name,
       alg->setProperty("CopyShape", false);
       alg->setProperty("CopyLattice", true);
       alg->execute();
-    } catch (...) {
+    }
+    catch (...) {
       g_log.notice() << "\n";
       g_log.notice() << "CopySample from " << peaks_ws_name << " to "
                      << md_ws_name << " FAILED\n\n";
@@ -1161,7 +1185,8 @@ bool MantidEVWorker::copyLattice(const std::string &peaks_ws_name,
       alg->setProperty("CopyShape", false);
       alg->setProperty("CopyLattice", true);
       alg->execute();
-    } catch (...) {
+    }
+    catch (...) {
       g_log.notice() << "\n";
       g_log.notice() << "CopySample from " << peaks_ws_name << " to "
                      << event_ws_name << " FAILED\n\n";
@@ -1182,7 +1207,7 @@ bool MantidEVWorker::copyLattice(const std::string &peaks_ws_name,
  *                         it is in sample coordinates.
  * @param  Q               The Q-vector.
  */
-std::vector<std::pair<std::string, std::string>>
+std::vector<std::pair<std::string, std::string> >
 MantidEVWorker::PointInfo(const std::string &peaks_ws_name, bool lab_coords,
                           Mantid::Kernel::V3D Q) {
   IPeaksWorkspace_sptr peaks_ws =

--- a/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
@@ -231,12 +231,10 @@ bool MantidEVWorker::loadAndConvertToMD(
 
     if (!alg->execute())
       return false;
-  }
-  catch (std::exception &e) {
+  } catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  }
-  catch (...) {
+  } catch (...) {
     g_log.error() << "Error: Could Not load file and convert to MD\n";
     return false;
   }
@@ -344,12 +342,10 @@ bool MantidEVWorker::findPeaks(const std::string &ev_ws_name,
       }
       return true;
     }
-  }
-  catch (std::exception &e) {
+  } catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  }
-  catch (...) {
+  } catch (...) {
     g_log.error() << "Error: Could Not findPeaks\n";
     return false;
   }
@@ -385,12 +381,10 @@ bool MantidEVWorker::predictPeaks(const std::string &peaks_ws_name,
 
     if (alg->execute())
       return true;
-  }
-  catch (std::exception &e) {
+  } catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  }
-  catch (...) {
+  } catch (...) {
     g_log.error() << "Error: Could Not predictPeaks\n";
     return false;
   }
@@ -854,12 +848,10 @@ bool MantidEVWorker::sphereIntegrate(
 
     std::cout << "Integrated temporary MD workspace FAILED\n";
     return false;
-  }
-  catch (std::exception &e) {
+  } catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  }
-  catch (...) {
+  } catch (...) {
     g_log.error() << "Error: Could Not Integrated temporary MD workspace\n";
     return false;
   }
@@ -929,12 +921,10 @@ bool MantidEVWorker::fitIntegrate(const std::string &peaks_ws_name,
     }
 
     std::cout << "Integrated temporary FIT workspace FAILED\n";
-  }
-  catch (std::exception &e) {
+  } catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  }
-  catch (...) {
+  } catch (...) {
     g_log.error() << "Error: Could Not Integrated temporary FIT workspace\n";
     return false;
   }
@@ -992,12 +982,10 @@ bool MantidEVWorker::ellipsoidIntegrate(const std::string &peaks_ws_name,
     }
 
     std::cout << "IntegrateEllipsoids FAILED\n";
-  }
-  catch (std::exception &e) {
+  } catch (std::exception &e) {
     g_log.error() << "Error:" << e.what() << '\n';
     return false;
-  }
-  catch (...) {
+  } catch (...) {
     g_log.error() << "Error: Could Not IntegratedEllipsoids\n";
     return false;
   }
@@ -1066,8 +1054,7 @@ bool MantidEVWorker::showUB(const std::string &peaks_ws_name) {
             o_lattice.errorgamma());
 
     g_log.notice(std::string(logInfo));
-  }
-  catch (...) {
+  } catch (...) {
     return false;
   }
 
@@ -1111,8 +1098,7 @@ bool MantidEVWorker::getUB(const std::string &peaks_ws_name, bool lab_coords,
       auto goniometer_matrix = peak.getGoniometerMatrix();
       UB = goniometer_matrix * UB;
     }
-  }
-  catch (...) {
+  } catch (...) {
     return false;
   }
 
@@ -1160,8 +1146,7 @@ bool MantidEVWorker::copyLattice(const std::string &peaks_ws_name,
       alg->setProperty("CopyShape", false);
       alg->setProperty("CopyLattice", true);
       alg->execute();
-    }
-    catch (...) {
+    } catch (...) {
       g_log.notice() << "\n";
       g_log.notice() << "CopySample from " << peaks_ws_name << " to "
                      << md_ws_name << " FAILED\n\n";
@@ -1185,8 +1170,7 @@ bool MantidEVWorker::copyLattice(const std::string &peaks_ws_name,
       alg->setProperty("CopyShape", false);
       alg->setProperty("CopyLattice", true);
       alg->execute();
-    }
-    catch (...) {
+    } catch (...) {
       g_log.notice() << "\n";
       g_log.notice() << "CopySample from " << peaks_ws_name << " to "
                      << event_ws_name << " FAILED\n\n";
@@ -1207,7 +1191,7 @@ bool MantidEVWorker::copyLattice(const std::string &peaks_ws_name,
  *                         it is in sample coordinates.
  * @param  Q               The Q-vector.
  */
-std::vector<std::pair<std::string, std::string> >
+std::vector<std::pair<std::string, std::string>>
 MantidEVWorker::PointInfo(const std::string &peaks_ws_name, bool lab_coords,
                           Mantid::Kernel::V3D Q) {
   IPeaksWorkspace_sptr peaks_ws =


### PR DESCRIPTION
Description of work.
Allow groups of event workspaces as input to SCD Interface so ouput from filtering temperatures can be used. 

**To test:**
Filter Event Interface
File/Run TOPAZ_21271
Load
Sample Log CryocoolerActualTemp
Plot
Output Name TOPAZ_21271_event
Filter
SCD Event Data Reduction Interface
Filename TOPAZ_21271
Uncheck Load Event Data
Apply
Then rerun with Load Event Data checked to check that EventWorkspaces still work.

Fixes #17964


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

