### PR TITLE
SumSpecta fast again

### DIFF
--- a/Framework/API/inc/MantidAPI/DetectorInfo.h
+++ b/Framework/API/inc/MantidAPI/DetectorInfo.h
@@ -83,7 +83,7 @@ public:
   Kernel::V3D samplePosition() const;
   double l1() const;
 
-  const std::vector<detid_t> detectorIDs() const;
+  const std::vector<detid_t>& detectorIDs() const;
   /// Returns the index of the detector with the given detector ID.
   size_t indexOf(const detid_t id) const { return m_detIDToIndex.at(id); }
 

--- a/Framework/API/inc/MantidAPI/DetectorInfo.h
+++ b/Framework/API/inc/MantidAPI/DetectorInfo.h
@@ -83,7 +83,7 @@ public:
   Kernel::V3D samplePosition() const;
   double l1() const;
 
-  const std::vector<detid_t>& detectorIDs() const;
+  const std::vector<detid_t> &detectorIDs() const;
   /// Returns the index of the detector with the given detector ID.
   size_t indexOf(const detid_t id) const { return m_detIDToIndex.at(id); }
 

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -180,7 +180,7 @@ double DetectorInfo::l1() const {
 }
 
 /// Returns a sorted vector of all detector IDs.
-const std::vector<detid_t>& DetectorInfo::detectorIDs() const {
+const std::vector<detid_t> &DetectorInfo::detectorIDs() const {
   return m_detectorIDs;
 }
 

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -180,7 +180,7 @@ double DetectorInfo::l1() const {
 }
 
 /// Returns a sorted vector of all detector IDs.
-const std::vector<detid_t> DetectorInfo::detectorIDs() const {
+const std::vector<detid_t>& DetectorInfo::detectorIDs() const {
   return m_detectorIDs;
 }
 


### PR DESCRIPTION
Description of work.
Return a reference for DetectorInfo

**To test:**
```python
Load(Filename='TOPAZ_3132_event.nxs', OutputWorkspace='TOPAZ_3132_event')
SumSpectra(InputWorkspace='TOPAZ_3132_event', OutputWorkspace='sum')
```
Should run in seconds now instead of hours


Fixes #17990


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

