### PR TITLE
Restore "tiled plot" option lost from MantidPlot

### DIFF
--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3933,17 +3933,23 @@ MantidUI::createSurfacePlotDialog(int flags, QStringList wsNames,
                                      names, plotType);
 }
 
+/**
+ * Create a new MantidWSIndexDialog
+ * @param flags :: [input] Qt::WindowFlags enum as an integer
+ * @param wsNames :: [input] Names of workspaces
+ * @param showWaterfall :: [input] Whether to show "plot as waterfall" option
+ * @param showPlotAll :: [input] Whether to show "plot all" button
+ * @param showTiledOpt :: [input] Whether to show "tiled plot" option
+ * @returns :: New dialog
+ */
 MantidWSIndexDialog *MantidUI::createWorkspaceIndexDialog(int flags,
                                                           QStringList wsNames,
                                                           bool showWaterfall,
-                                                          bool showPlotAll) {
-  QList<QString> names;
-
-  for (auto &name : wsNames)
-    names.append(name);
-
+                                                          bool showPlotAll,
+                                                          bool showTiledOpt) {
   return new MantidWSIndexDialog(m_appWindow, static_cast<Qt::WFlags>(flags),
-                                 names, showWaterfall, showPlotAll);
+                                 wsNames, showWaterfall, showPlotAll,
+                                 showTiledOpt);
 }
 
 void MantidUI::showSurfacePlot() {

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -244,7 +244,7 @@ public:
   MultiLayer *
   plotSubplots(const QMultiMap<QString, std::set<int>> &toPlot,
                MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
-               bool errs = false, MultiLayer *plotWindow = nullptr);
+               bool errs = false, MultiLayer *plotWindow = nullptr) override;
 
   MultiLayer *
   plotSubplots(const QMultiMap<QString, int> &toPlot,

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -214,7 +214,7 @@ public:
                           const QString &plotType) override;
   MantidQt::MantidWidgets::MantidWSIndexDialog *
   createWorkspaceIndexDialog(int flags, QStringList wsNames, bool showWaterfall,
-                             bool showPlotAll) override;
+                             bool showPlotAll, bool showTiledOpt) override;
 
   /// Create a 1d graph form a Table
   MultiLayer *createGraphFromTable(Table *t, int type = 0);

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MantidDisplayBase.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MantidDisplayBase.h
@@ -122,10 +122,9 @@ public:
   virtual MantidSurfacePlotDialog *
   createSurfacePlotDialog(int flags, QStringList wsNames,
                           const QString &plotType) = 0;
-  virtual MantidWSIndexDialog *createWorkspaceIndexDialog(int flags,
-                                                          QStringList wsNames,
-                                                          bool showWaterfall,
-                                                          bool showPlotAll) = 0;
+  virtual MantidWSIndexDialog *
+  createWorkspaceIndexDialog(int flags, QStringList wsNames, bool showWaterfall,
+                             bool showPlotAll, bool showTiledOpt) = 0;
 
   virtual void updateProject() = 0;
 #ifdef MAKE_VATES

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MantidDisplayBase.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MantidDisplayBase.h
@@ -110,6 +110,10 @@ public:
   virtual void showMDPlot() = 0;
   virtual void showSurfacePlot() = 0;
   virtual void showContourPlot() = 0;
+  virtual MultiLayer *
+  plotSubplots(const QMultiMap<QString, std::set<int>> &toPlot,
+               MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
+               bool errs = false, MultiLayer *plotWindow = nullptr) = 0;
 
   // Interface Methods
   virtual void showVatesSimpleInterface() = 0;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MantidTreeWidget.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MantidTreeWidget.h
@@ -29,7 +29,8 @@ public:
   QStringList getSelectedWorkspaceNames() const;
   MantidWSIndexWidget::UserInput
   chooseSpectrumFromSelected(bool showWaterfallOpt = true,
-                             bool showPlotAll = true) const;
+                             bool showPlotAll = true,
+                             bool showTiledOpt = true) const;
   void setSortScheme(MantidItemSortScheme);
   void setSortOrder(Qt::SortOrder);
   MantidItemSortScheme getSortScheme() const;

--- a/MantidQt/MantidWidgets/src/MantidTreeWidget.cpp
+++ b/MantidQt/MantidWidgets/src/MantidTreeWidget.cpp
@@ -225,12 +225,12 @@ MantidTreeWidget::getSelectedMatrixWorkspaces() const {
 * @param showWaterfallOpt If true, show the waterfall option on the dialog
 * @param showPlotAll :: [input] If true, show the "Plot All" button on the
 * dialog
+* @param showTiledOpt :: [input] If true, show the "Tiled" option on the dialog
 * @return :: A MantidWSIndexDialog::UserInput structure listing the selected
 * options
 */
-MantidWSIndexWidget::UserInput
-MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt,
-                                             bool showPlotAll) const {
+MantidWSIndexWidget::UserInput MantidTreeWidget::chooseSpectrumFromSelected(
+    bool showWaterfallOpt, bool showPlotAll, bool showTiledOpt) const {
   auto selectedMatrixWsList = getSelectedMatrixWorkspaces();
   QList<QString> selectedMatrixWsNameList;
   foreach (const auto matrixWs, selectedMatrixWsList) {
@@ -257,12 +257,13 @@ MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt,
     MantidWSIndexWidget::UserInput selections;
     selections.plots = spectrumToPlot;
     selections.waterfall = false;
+    selections.tiled = false;
     return selections;
   }
 
   // Else, one or more workspaces
   auto dio = m_mantidUI->createWorkspaceIndexDialog(
-      0, selectedMatrixWsNameList, showWaterfallOpt, showPlotAll);
+      0, selectedMatrixWsNameList, showWaterfallOpt, showPlotAll, showTiledOpt);
   dio->exec();
   return dio->getSelections();
 }

--- a/MantidQt/MantidWidgets/src/WorkspacePresenter/QWorkspaceDockView.cpp
+++ b/MantidQt/MantidWidgets/src/WorkspacePresenter/QWorkspaceDockView.cpp
@@ -1505,22 +1505,25 @@ void QWorkspaceDockView::onClickPlotSpectraErr() {
   m_presenter->notifyFromView(ViewNotifiable::Flag::PlotSpectrumWithErrors);
 }
 
-/** Plots a single spectrum from each selected workspace
-* @param showErrors If true, show error bars. Otherswise no error bars are
+/** Plots one or more spectra from each selected workspace
+* @param showErrors If true, show error bars. Otherwise no error bars are
 * displayed.
 */
 void QWorkspaceDockView::plotSpectrum(bool showErrors) {
   const auto userInput = m_tree->chooseSpectrumFromSelected();
   // An empty map will be returned if the user clicks cancel in the spectrum
   // selection
-  if (userInput.plots.empty())
+  if (userInput.plots.empty()) {
     return;
+  }
 
-  bool spectrumPlot(true), clearWindow(false);
-  MultiLayer *window(NULL);
-  m_mantidUI->plot1D(userInput.plots, spectrumPlot,
-                     MantidQt::DistributionDefault, showErrors, window,
-                     clearWindow, userInput.waterfall);
+  if (userInput.tiled) {
+    m_mantidUI->plotSubplots(userInput.plots, MantidQt::DistributionDefault,
+                             showErrors);
+  } else {
+    m_mantidUI->plot1D(userInput.plots, true, MantidQt::DistributionDefault,
+                       showErrors, nullptr, false, userInput.waterfall);
+  }
 }
 
 void QWorkspaceDockView::onClickDrawColorFillPlot() {


### PR DESCRIPTION
Restore the "Tiled plot" option in the "Plot Spectrum..." dialog that was present in Mantid 3.8 but has since gone missing.

**To test:**
- Load a WorkspaceGroup or use the script below
- Right-click on the WorkspaceGroup and select "Plot Spectrum..."
- In the dialog, confirm the "Tiled Plot" option is present
- Tick the "Tiled Plot" option and plot, confirm you get a tiled plot
- This should work the same with "Plot Spectrum with Errors..."

No automated tests as this is in MantidPlot. I have added a note to http://www.mantidproject.org/Unscripted_Manual_Testing to ensure this is tested manually before each release.

Script to generate test WorkspaceGroup:
```python
import numpy as np

def func(x, a, b):
    return 0.2 + a*x + b

ws_names = []
for i in range(1, 9):
    xData = []
    yData = []
    eData = []
    for x in np.arange(0.1, 10, 0.1):
        xData.append(x)
        yData.append(func(x, i, i/2.0))
        eData.append(0.1)

    outname = 'ws' + str(i)    
    CreateWorkspace(DataX=xData + xData, DataY=yData + yData, DataE=eData + eData, NSpec=2, OutputWorkspace=outname)
    AddSampleLog(Workspace=outname, LogName='simple_log', LogText=str(i*i), LogType='Number', NumberType="Double")
    AddTimeSeriesLog(Workspace=outname, Name='time_log', Time="2010-01-01T00:00:0"+str(i), Value=str(i*i), Type="double")
    ws_names.append(outname)
    
group = GroupWorkspaces(ws_names)
```

Fixes #18009.

*No release notes* as this worked OK in release 3.8.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
