### PR TITLE
Extract monitors bug when input WS and detector WS have the same name

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ExtractMonitors.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExtractMonitors.py
@@ -78,9 +78,11 @@ class ExtractMonitors(DataProcessorAlgorithm):
 
         if detector_ws_name and detectors:
             self.setProperty("DetectorWorkspace", detector_ws)
+            DeleteWorkspace(detector_ws)
 
         if monitor_ws_name and monitors:
             self.setProperty("MonitorWorkspace", monitor_ws)
+            DeleteWorkspace(monitor_ws)
 
         if detector_ws_name and detectors and monitor_ws_name and monitors:
             detector_ws.setMonitorWorkspace(monitor_ws)

--- a/Framework/PythonInterface/plugins/algorithms/ExtractMonitors.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExtractMonitors.py
@@ -65,20 +65,22 @@ class ExtractMonitors(DataProcessorAlgorithm):
         if detector_ws_name:
             if detectors:
                 detector_ws = ExtractSpectra(InputWorkspace=in_ws,
-                                             OutputWorkspace=detector_ws_name,
                                              WorkspaceIndexList=detectors)
-                self.setProperty("DetectorWorkspace", detector_ws)
             else:
                 self.log().error("No detectors found in input workspace. No detector output workspace created.")
 
         if monitor_ws_name:
             if monitors:
                 monitor_ws = ExtractSpectra(InputWorkspace=in_ws,
-                                            OutputWorkspace=monitor_ws_name,
                                             WorkspaceIndexList=monitors)
-                self.setProperty("MonitorWorkspace", monitor_ws)
             else:
                 self.log().error("No monitors found in input workspace. No monitor output workspace created.")
+
+        if detector_ws_name and detectors:
+            self.setProperty("DetectorWorkspace", detector_ws)
+
+        if monitor_ws_name and monitors:
+            self.setProperty("MonitorWorkspace", monitor_ws)
 
         if detector_ws_name and detectors and monitor_ws_name and monitors:
             detector_ws.setMonitorWorkspace(monitor_ws)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ExtractMonitorsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ExtractMonitorsTest.py
@@ -73,5 +73,21 @@ class ExtractMonitorsTest(unittest.TestCase):
 
         self.assertEquals(detectors.getNumberHistograms(), 200)
 
+    def test_workspace_with_same_input_ws_and_detector_ws_names(self):
+        CreateSampleWorkspace(OutputWorkspace='testWS', NumMonitors = 3)
+        ExtractMonitors(InputWorkspace = 'testWS', DetectorWorkspace = 'testWS', MonitorWorkspace = 'mon')
+        detectors = mtd['testWS']
+        monitors = mtd['mon']
+
+        self.assertEquals(detectors.getNumberHistograms(), 200)
+        self.assertEquals(monitors.getNumberHistograms(), 3)
+        self.assertEquals(detectors.getMonitorWorkspace().name(), "mon")
+
+        for i in range(monitors.getNumberHistograms()):
+            self.assertTrue(monitors.getDetector(i).isMonitor())
+
+        for i in range(detectors.getNumberHistograms()):
+            self.assertFalse(detectors.getDetector(i).isMonitor())
+
 if __name__=="__main__":
     unittest.main()


### PR DESCRIPTION
Fix a bug in extract monitors where using the same input workspace name and detector workspace name resulted in the monitor workspace having the wrong entries.

A unit test was added to check this.

**To test:**

Either load a file or use `CreateSampleWorkspace` to create a workspace containing monitor and detectors. Then use `ExtractMonitors` with the input workspace and output workspace having the same name (see example below).

```python
ws = CreateSampleWorkspace(NumMonitors = 3)
ExtractMonitors(InputWorkspace = 'ws', 
                DetectorWorkspace = 'ws', 
                MonitorWorkspace = 'monitors')
```

Fixes #18012 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
