### PR TITLE
Re #18014 Changed loader for XML version 1.03

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSpice2D.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSpice2D.h
@@ -113,6 +113,8 @@ private:
   void setMetadataAsRunProperties(std::map<std::string, std::string> &metadata);
   void rotateDetector(const double &);
   void setTimes();
+  void
+  setSansSpiceXmlFormatVersion(std::map<std::string, std::string> &metadata);
 
   // Member variables:
   DataObjects::Workspace2D_sptr m_workspace;
@@ -121,6 +123,7 @@ private:
   Mantid::DataHandling::XmlHandler m_xmlHandler;
   double m_wavelength{0.0};
   double m_dwavelength{0.0};
+  double m_sansSpiceXmlFormatVersion{0.0};
   Mantid::Kernel::DateAndTime m_startTime;
   Mantid::Kernel::DateAndTime m_endTime;
 };

--- a/Framework/DataHandling/src/LoadSpice2D.cpp
+++ b/Framework/DataHandling/src/LoadSpice2D.cpp
@@ -168,6 +168,8 @@ void LoadSpice2D::exec() {
   setTimes();
   std::map<std::string, std::string> metadata =
       m_xmlHandler.get_metadata("Detector");
+
+  setSansSpiceXmlFormatVersion(metadata);
   setWavelength(metadata);
 
   std::vector<int> data = getData("//Data");
@@ -503,6 +505,18 @@ void LoadSpice2D::setMetadataAsRunProperties(
   m_workspace->mutableRun().setStartAndEndTime(m_startTime, m_endTime);
 
   // sample thickness
+  // XML 1.03: source distance is now in meters
+  double sample_thickness;
+  from_string<double>(sample_thickness, metadata["Header/Sample_Thickness"],
+                      std::dec);
+  if (m_sansSpiceXmlFormatVersion >= 1.03) {
+    g_log.debug()
+        << "sans_spice_xml_format_version >= 1.03 :: sample_thickness "
+           "in mm. Converting to cm...";
+    sample_thickness *= 0.1;
+  }
+  addRunProperty<double>("sample-thickness", sample_thickness, "cm");
+
   addRunProperty<double>(metadata, "Header/Sample_Thickness",
                          "sample-thickness", "mm");
 
@@ -510,8 +524,18 @@ void LoadSpice2D::setMetadataAsRunProperties(
                          "source-aperture-diameter", "mm");
   addRunProperty<double>(metadata, "Header/sample_aperture_size",
                          "sample-aperture-diameter", "mm");
-  addRunProperty<double>(metadata, "Header/source_distance",
-                         "source-sample-distance", "mm");
+
+  // XML 1.03: source distance is now in meters
+  double source_distance;
+  from_string<double>(source_distance, metadata["Header/source_distance"],
+                      std::dec);
+  if (m_sansSpiceXmlFormatVersion >= 1.03) {
+    g_log.debug() << "sans_spice_xml_format_version >= 1.03 :: source_distance "
+                     "in meters. Converting to mm...";
+    source_distance *= 1000.0;
+  }
+  addRunProperty<double>("source-sample-distance", source_distance, "mm");
+
   addRunProperty<int>(metadata, "Motor_Positions/nguides", "number-of-guides",
                       "");
 
@@ -717,6 +741,23 @@ void LoadSpice2D::rotateDetector(const double &angle) {
 
   p->addValue(DateAndTime::getCurrentTime(), angle);
   runDetails.addLogData(p);
+}
+
+/***
+ * 2016/11/09 : There is a new tag sans_spice_xml_format_version in the XML
+ * It identifies changes in the XML format.
+ * Useful to test tags rather than using the date.
+ * @param metadata
+ */
+void LoadSpice2D::setSansSpiceXmlFormatVersion(
+    std::map<std::string, std::string> &metadata) {
+
+  if (metadata.find("Header/sans_spice_xml_format_version") != metadata.end()) {
+    m_sansSpiceXmlFormatVersion = boost::lexical_cast<double>(
+        metadata["Header/sans_spice_xml_format_version"]);
+  }
+  g_log.debug() << "Sans_spice_xml_format_version == "
+                << m_sansSpiceXmlFormatVersion << "\n";
 }
 }
 }


### PR DESCRIPTION
See ticket #18014 

No release notes.


**To test:**

1) Tests should pass. They can also be launched manually:
`ctest -VV --output-on-failure -R DataHandlingTest_LoadSpice`

2) The file attached can also be loaded.

[BioSANS_exp337_scan0050_0001.xml.zip](https://github.com/mantidproject/mantid/files/581555/BioSANS_exp337_scan0050_0001.xml.zip)
