### PR TITLE
CalculateFlatBackground: supports histogram and distributions

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateFlatBackground.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateFlatBackground.h
@@ -91,7 +91,7 @@ private:
               const double startX, const double endX) const;
   double LinearFit(API::MatrixWorkspace_sptr WS, int spectrum, double startX,
                    double endX);
-  double movingAverage(API::MatrixWorkspace_const_sptr WS, int wsIndex,
+  double MovingAverage(API::MatrixWorkspace_const_sptr WS, int wsIndex,
                        size_t windowWidth) const;
 
   /// variable bin width raw count data must be converted to distributions first

--- a/Framework/Algorithms/src/CalculateFlatBackground.cpp
+++ b/Framework/Algorithms/src/CalculateFlatBackground.cpp
@@ -1,6 +1,6 @@
 #include "MantidAlgorithms/CalculateFlatBackground.h"
 #include "MantidAPI/FunctionFactory.h"
-#include "MantidAPI/HistogramValidator.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceFactory.h"
@@ -10,7 +10,6 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/ListValidator.h"
-#include "MantidKernel/MandatoryValidator.h"
 #include "MantidKernel/VectorHelper.h"
 #include "MantidHistogramData/Histogram.h"
 #include <algorithm>
@@ -32,8 +31,7 @@ enum class Modes { LINEAR_FIT, MEAN, MOVING_AVERAGE };
 void CalculateFlatBackground::init() {
   declareProperty(
       make_unique<WorkspaceProperty<>>(
-          "InputWorkspace", "", Direction::Input,
-          boost::make_shared<HistogramValidator>()),
+          "InputWorkspace", "", Direction::Input),
       "The input workspace must either have constant width bins or is a "
       "distribution\n"
       "workspace. It is also assumed that all spectra have the same X bin "
@@ -97,7 +95,8 @@ void CalculateFlatBackground::init() {
 
 void CalculateFlatBackground::exec() {
   // Retrieve the input workspace
-  MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
+  API::MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
+
   // Copy over all the data
   const int numHists = static_cast<int>(inputWS->getNumberHistograms());
   const int blocksize = static_cast<int>(inputWS->blocksize());
@@ -171,6 +170,7 @@ void CalculateFlatBackground::exec() {
     PARALLEL_CHECK_INTERUPT_REGION
   }
 
+  // Only convert histogram data to a distribution
   convertToDistribution(outputWS);
 
   // these are used to report information to the user, one progress update for
@@ -211,7 +211,7 @@ void CalculateFlatBackground::exec() {
         background = Mean(outputWS, currentSpec, startX, endX);
         break;
       case Modes::MOVING_AVERAGE:
-        background = movingAverage(outputWS, currentSpec, windowWidth);
+        background = MovingAverage(outputWS, currentSpec, windowWidth);
         break;
       }
       if (background < 0) {
@@ -297,12 +297,13 @@ void CalculateFlatBackground::convertToDistribution(
     // Calculate bin widths
     std::adjacent_difference(X.begin() + 1, X.end(), adjacents.begin());
     // the first entry from adjacent difference is just a copy of the first
-    // entry in the input vector, ignore this. The histogram validator for this
-    // algorithm ensures that X.size() > 1
-    MantidVec widths(adjacents.begin() + 1, adjacents.end());
-    if (!VectorHelper::isConstantValue(widths)) {
-      variationFound = true;
-      break;
+    // entry in the input vector, ignore this.
+    if (X.size() > 1){
+      MantidVec widths(adjacents.begin() + 1, adjacents.end());
+      if (!VectorHelper::isConstantValue(widths)) {
+        variationFound = true;
+        break;
+      }
     }
   }
 
@@ -496,7 +497,7 @@ double CalculateFlatBackground::LinearFit(API::MatrixWorkspace_sptr WS,
 * @return Minimum
 */
 double
-CalculateFlatBackground::movingAverage(API::MatrixWorkspace_const_sptr WS,
+CalculateFlatBackground::MovingAverage(API::MatrixWorkspace_const_sptr WS,
                                        int wsIndex, size_t windowWidth) const {
   const auto &ys = WS->y(wsIndex);
   double currentMin = std::numeric_limits<double>::max();

--- a/Framework/Algorithms/src/CalculateFlatBackground.cpp
+++ b/Framework/Algorithms/src/CalculateFlatBackground.cpp
@@ -30,8 +30,7 @@ enum class Modes { LINEAR_FIT, MEAN, MOVING_AVERAGE };
 
 void CalculateFlatBackground::init() {
   declareProperty(
-      make_unique<WorkspaceProperty<>>(
-          "InputWorkspace", "", Direction::Input),
+      make_unique<WorkspaceProperty<>>("InputWorkspace", "", Direction::Input),
       "The input workspace must either have constant width bins or is a "
       "distribution\n"
       "workspace. It is also assumed that all spectra have the same X bin "
@@ -298,7 +297,7 @@ void CalculateFlatBackground::convertToDistribution(
     std::adjacent_difference(X.begin() + 1, X.end(), adjacents.begin());
     // the first entry from adjacent difference is just a copy of the first
     // entry in the input vector, ignore this.
-    if (X.size() > 1){
+    if (X.size() > 1) {
       MantidVec widths(adjacents.begin() + 1, adjacents.end());
       if (!VectorHelper::isConstantValue(widths)) {
         variationFound = true;

--- a/Framework/Algorithms/test/CalculateFlatBackgroundTest.h
+++ b/Framework/Algorithms/test/CalculateFlatBackgroundTest.h
@@ -20,7 +20,6 @@ using namespace Mantid::Kernel;
 static const int NUMBINS = 31;
 static const int NUMSPECS = 4;
 
-
 class CalculateFlatBackgroundTest : public CxxTest::TestSuite {
   /// Tests each method in CalculateFlatBackground using different parameter
   /// sets to make sure the returns are as expected
@@ -205,21 +204,21 @@ public:
     }
   }
 
-  void testExecPointData(){
-      runCalculateFlatBackground(1);
+  void testExecPointData() {
+    runCalculateFlatBackground(1);
 
-      MatrixWorkspace_sptr inputWS =
-          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-              "calcFlatBGpointdata");
-      MatrixWorkspace_sptr outputWS =
-          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("Removed");
-      // The X vectors should be the same
-      //TS_ASSERT_DELTA(inputWS->x(0).rawData(), outputWS->x(0).rawData(), 1e-6)
-      // Just do a spot-check on Y & E
-      auto &Y = outputWS->y(0);
-      for (unsigned int i = 0; i < Y.size(); ++i) {
-        TS_ASSERT_LESS_THAN(Y[i], 1.5)
-      }
+    MatrixWorkspace_sptr inputWS =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            "calcFlatBGpointdata");
+    MatrixWorkspace_sptr outputWS =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("Removed");
+    // The X vectors should be the same
+    // TS_ASSERT_DELTA(inputWS->x(0).rawData(), outputWS->x(0).rawData(), 1e-6)
+    // Just do a spot-check on Y & E
+    auto &Y = outputWS->y(0);
+    for (unsigned int i = 0; i < Y.size(); ++i) {
+      TS_ASSERT_LESS_THAN(Y[i], 1.5)
+    }
   }
 
   void testExecWithReturnBackground() {

--- a/Framework/Algorithms/test/CalculateFlatBackgroundTest.h
+++ b/Framework/Algorithms/test/CalculateFlatBackgroundTest.h
@@ -6,7 +6,6 @@
 #include "MantidAlgorithms/CalculateFlatBackground.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
-#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/MersenneTwister.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
 #include <boost/lexical_cast.hpp>

--- a/Framework/Algorithms/test/CalculateFlatBackgroundTest.h
+++ b/Framework/Algorithms/test/CalculateFlatBackgroundTest.h
@@ -4,6 +4,7 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAlgorithms/CalculateFlatBackground.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidKernel/MersenneTwister.h"
@@ -19,6 +20,7 @@ using namespace Mantid::Kernel;
 static const int NUMBINS = 31;
 static const int NUMSPECS = 4;
 
+
 class CalculateFlatBackgroundTest : public CxxTest::TestSuite {
   /// Tests each method in CalculateFlatBackground using different parameter
   /// sets to make sure the returns are as expected
@@ -29,12 +31,13 @@ private:
   /// algorithm in order to set the properties
   void runCalculateFlatBackground(int functindex) {
     // functindex key
-    // 1 = exec
+    // 1 = exec (Linear Fit)
     // 2 = execwithreturnbg
     // 3 = testMeanFirst
     // 4 = testMeanFirstWithReturnBackground
     // 5 = testMeanSecond
     // 6 = testLeaveNegativeValues
+    // 7 = testExecPointData (Linear Fit)
 
     // common beginning
     Mantid::Algorithms::CalculateFlatBackground flatBG;
@@ -92,6 +95,17 @@ private:
 
         flatBG.setProperty("NullifyNegativeValues", false);
       }
+    } else if (functindex == 7) {
+      // exec for point data option Linear Fit
+      TS_ASSERT_THROWS_NOTHING(
+          flatBG.setPropertyValue("InputWorkspace", "calcFlatBGpointdata"))
+      TS_ASSERT_THROWS_NOTHING(
+          flatBG.setPropertyValue("OutputWorkspace", "Removed"))
+      TS_ASSERT_THROWS_NOTHING(
+          flatBG.setPropertyValue("WorkspaceIndexList", "0"))
+      TS_ASSERT_THROWS_NOTHING(flatBG.setPropertyValue("StartX", "9.5"))
+      TS_ASSERT_THROWS_NOTHING(flatBG.setPropertyValue("EndX", "20.5"))
+      TS_ASSERT_THROWS_NOTHING(flatBG.setPropertyValue("Mode", "Linear Fit"))
     }
 
     // common ending
@@ -109,12 +123,15 @@ public:
     FrameworkManager::Instance();
 
     bg = 100.0;
+    const size_t seed(12345);
+    const double lower(-1.0), upper(1.0);
+
+    MersenneTwister randGen(seed, lower, upper);
+
+    // histogram
     Mantid::DataObjects::Workspace2D_sptr WS(
         new Mantid::DataObjects::Workspace2D);
     WS->initialize(1, NUMBINS + 1, NUMBINS);
-    const size_t seed(12345);
-    const double lower(-1.0), upper(1.0);
-    MersenneTwister randGen(seed, lower, upper);
 
     for (int i = 0; i < NUMBINS; ++i) {
       WS->mutableX(0)[i] = i;
@@ -125,7 +142,7 @@ public:
 
     AnalysisDataService::Instance().add("calcFlatBG", WS);
 
-    // create another test workspace
+    // create another test workspace (histogram)
     Mantid::DataObjects::Workspace2D_sptr WS2D(
         new Mantid::DataObjects::Workspace2D);
     WS2D->initialize(NUMSPECS, NUMBINS + 1, NUMBINS);
@@ -144,10 +161,25 @@ public:
 
     AnalysisDataService::Instance().add("calculateflatbackgroundtest_ramp",
                                         WS2D);
+
+    // test workspace, which contains point data
+    Mantid::DataObjects::Workspace2D_sptr WSpointdata(
+        new Mantid::DataObjects::Workspace2D);
+    WSpointdata->initialize(1, NUMBINS, NUMBINS);
+
+    for (int i = 0; i < NUMBINS; ++i) {
+      WSpointdata->mutableX(0)[i] = i;
+      WSpointdata->mutableY(0)[i] = bg + randGen.nextValue();
+      WSpointdata->mutableE(0)[i] = 0.05 * WSpointdata->y(0)[i];
+    }
+
+    AnalysisDataService::Instance().add("calcFlatBGpointdata", WSpointdata);
   }
 
   ~CalculateFlatBackgroundTest() override {
+    AnalysisDataService::Instance().remove("calcFlatBG");
     AnalysisDataService::Instance().remove("calculateflatbackgroundtest_ramp");
+    AnalysisDataService::Instance().remove("calcFlatBGpointdata");
   }
 
   void testStatics() {
@@ -171,6 +203,23 @@ public:
     for (unsigned int i = 0; i < Y.size(); ++i) {
       TS_ASSERT_LESS_THAN(Y[i], 1.5)
     }
+  }
+
+  void testExecPointData(){
+      runCalculateFlatBackground(1);
+
+      MatrixWorkspace_sptr inputWS =
+          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+              "calcFlatBGpointdata");
+      MatrixWorkspace_sptr outputWS =
+          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("Removed");
+      // The X vectors should be the same
+      //TS_ASSERT_DELTA(inputWS->x(0).rawData(), outputWS->x(0).rawData(), 1e-6)
+      // Just do a spot-check on Y & E
+      auto &Y = outputWS->y(0);
+      for (unsigned int i = 0; i < Y.size(); ++i) {
+        TS_ASSERT_LESS_THAN(Y[i], 1.5)
+      }
   }
 
   void testExecWithReturnBackground() {
@@ -310,6 +359,7 @@ public:
       }
     }
   }
+
   void testLeaveNegatives() {
 
     runCalculateFlatBackground(6);

--- a/docs/source/algorithms/CalculateFlatBackground-v1.rst
+++ b/docs/source/algorithms/CalculateFlatBackground-v1.rst
@@ -35,15 +35,15 @@ is added in quadrature to the errors in each bin.
 Usage
 -----
 
-**Example - Subtracting background using Linear Fit:**
+**Example - Subtracting background using Linear Fit (using a distribution):**
 
 .. testcode:: ExSubLinFit
 
    import numpy as np
 
    y = [3, 1, 1, 1, 7, -3]
-   x = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5]
-   input = CreateWorkspace(x,y)
+   x = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5]
+   input = CreateWorkspace(x, y, Distribution=True)
 
    output = CalculateFlatBackground('input',
                                     StartX=2,
@@ -59,7 +59,7 @@ Output:
 
    Values with subtracted background: [ 2.  0.  0.  0.  6.  0.]
 
-**Example - Returning background using Mean:**
+**Example - Returning background using Mean (using a histogram):**
 
 .. testcode:: ExReturnMean
 
@@ -67,7 +67,7 @@ Output:
 
    y = [3, 4, 2, 3, -3]
    x = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5]
-   input = CreateWorkspace(x,y)
+   input = CreateWorkspace(x, y)
 
    output = CalculateFlatBackground('input',
                                     StartX=1,
@@ -83,7 +83,7 @@ Output:
 
    Calculated Mean background: [ 3.  3.  3.  3.  3.]
 
-**Example - Returning background using Moving Average:**
+**Example - Returning background using Moving Average (using a histogram):**
 
 .. testcode:: ExReturnMovingAverage
 
@@ -99,7 +99,7 @@ Output:
    x = np.arange(0.5, 9.1, 0.2)
    # y is a bin shorter than x and has to be evaluated at bin centres.
    y = spectrum(x[:-1] + 0.5 * (x[1] - x[0]))
-   input = CreateWorkspace(x,y)
+   input = CreateWorkspace(x, y)
 
    output = CalculateFlatBackground('input',
                                     AveragingWindowWidth=3,


### PR DESCRIPTION
Running `CalculateFlatBackground` with point data tells you that the InputWorkspace is required to be a histogram. The code indeed uses the histogram validator for the input workspace. However, the documentation says that in particular distributions are supported as well as histograms with constant bin width. The implementation is well designed to take histograms and distributions into account.

I deleted some includes for header files that are not necessary as well.

I will create a next issue for taking care of the input validation.

**To test:**

Run `CalculateFlatBackground` with a distribution as recommended by the documentation.
For example, run:

``` Python
# Create a test distribution
X = ([1, 2, 1, 2, 1, 2])
Y = range(2*3)
E = np.ones(2*3)
CreateWorkspace(DataX=X, DataY=Y, DataE=E, NSpec=3, OutputWorkspace='test_1', Distribution=True)
CalculateFlatBackground(InputWorkspace='test_1', OutputWorkspace='out', StartX=0, EndX=10, OutputMode='Return Background', SkipMonitors=True)
```

Fixes #18015.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
