### PR TITLE
Fix broken unit test on Windows 7

### DIFF
--- a/MantidQt/CustomInterfaces/test/ALCLatestFileFinderTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCLatestFileFinderTest.h
@@ -18,7 +18,7 @@ using Mantid::Kernel::DateAndTime;
 /**
  * Temporary directory that is deleted when it goes out of scope
  */
-class ScopedDirectory {
+class ScopedDirectory final {
 public:
   /// Constructor: create directory in temp folder
   ScopedDirectory(const std::string &dirName) : m_dirName(dirName) {
@@ -28,16 +28,16 @@ public:
     m_directory.createDirectories();
   }
   /// Destructor: delete the directory
-  virtual ~ScopedDirectory() {
+  ~ScopedDirectory() {
     constexpr bool recursiveRemove(true);
     m_directory.remove(recursiveRemove);
   }
   /// Get path of directory
-  std::string getDirectoryName() const { return m_dirName; }
+  const std::string &getDirectoryName() const { return m_dirName; }
 
 private:
   Poco::File m_directory;
-  const std::string m_dirName;
+  std::string m_dirName;
 };
 
 /**
@@ -186,12 +186,11 @@ private:
    * @returns :: vector containing three files
    */
   std::vector<TestFile> generateTestFiles(const std::string &directory) {
-    std::vector<TestFile> files;
     // 100 years so it won't clash with other files in temp directory
-    files.emplace_back("2116-03-15T12:00:00", directory, "MUSR", "90000");
-    files.emplace_back("2116-03-15T13:00:00", directory, "MUSR", "90001");
-    files.emplace_back("2116-03-15T14:00:00", directory, "MUSR", "90002");
-    return files;
+    return std::vector<TestFile>{
+        {"2116-03-15T12:00:00", directory, "MUSR", "90000"},
+        {"2116-03-15T13:00:00", directory, "MUSR", "90001"},
+        {"2116-03-15T14:00:00", directory, "MUSR", "90002"}};
   }
 };
 


### PR DESCRIPTION
The test `CustomInterfacesTest.ALCLatestFileFinderTest.test_getMostRecentFile` has been broken for the past couple of builds:
http://builds.mantidproject.org/job/master_clean-win7/327/testReport/CustomInterfacesTest/ALCLatestFileFinderTest/test_getMostRecentFile/

Each test creates temporary files that are deleted at the end of the test. This breaks when the tests are run in parallel - fix this by using a separate test directory for each test.

**To test:**

If all the tests pass then this should be OK. - should be checked in Release and Debug mode on Windows? (On my Win7 machine these 4 tests all fail on current master, on `master_clean-win7` just one of the 4 tests has been failing, and on PR builds none of them seem to fail.)

No issue number or release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
