### PR TITLE
Fix slice viewer auto rebin issue with HistoWorkspaces

### DIFF
--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -2174,15 +2174,8 @@ void SliceViewer::rebinParamsChanged() {
     double min = 0;
     double max = 1;
     int numBins = 1;
-    if (m_ws->isMDHistoWorkspace()) {
-      // If rebinning from an existing MDHistoWorkspaces we should take exents
-      // from the existing workspace.
-      auto dim = m_ws->getDimension(d);
-      min = dim->getMinimum();
-      max = dim->getMaximum();
-      // And the user-entered number of bins
-      numBins = widget->getNumBins();
-    } else if (widget->getShownDim() < 0) {
+
+    if (widget->getShownDim() < 0) {
       // Slice point. So integrate with a thickness
       min = widget->getSlicePoint() - widget->getThickness();
       max = widget->getSlicePoint() + widget->getThickness();
@@ -2251,11 +2244,13 @@ void SliceViewer::dynamicRebinComplete(bool error) {
 
   if (m_overlayWS) {
     // Position the outline according to the position of the workspace.
-    double yMin = m_overlayWS->getDimension(m_dimY)->getMinimum();
-    double yMax = m_overlayWS->getDimension(m_dimY)->getMaximum();
+    auto xBinWidth = m_overlayWS->getDimension(m_dimY)->getBinWidth();
+    auto yBinWidth = m_overlayWS->getDimension(m_dimY)->getBinWidth();
+    double yMin = m_overlayWS->getDimension(m_dimY)->getMinimum() - yBinWidth;
+    double yMax = m_overlayWS->getDimension(m_dimY)->getMaximum() + yBinWidth;
     double yMiddle = (yMin + yMax) / 2.0;
-    QPointF pointA(m_overlayWS->getDimension(m_dimX)->getMinimum(), yMiddle);
-    QPointF pointB(m_overlayWS->getDimension(m_dimX)->getMaximum(), yMiddle);
+    QPointF pointA(m_overlayWS->getDimension(m_dimX)->getMinimum() - xBinWidth, yMiddle);
+    QPointF pointB(m_overlayWS->getDimension(m_dimX)->getMaximum() + xBinWidth, yMiddle);
     m_overlayWSOutline->setPointA(pointA);
     m_overlayWSOutline->setPointB(pointB);
     m_overlayWSOutline->setWidth((yMax - yMin) / 2.0);

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -2244,13 +2244,13 @@ void SliceViewer::dynamicRebinComplete(bool error) {
 
   if (m_overlayWS) {
     // Position the outline according to the position of the workspace.
-    auto xBinWidth = m_overlayWS->getDimension(m_dimY)->getBinWidth();
-    auto yBinWidth = m_overlayWS->getDimension(m_dimY)->getBinWidth();
-    double yMin = m_overlayWS->getDimension(m_dimY)->getMinimum() - yBinWidth;
-    double yMax = m_overlayWS->getDimension(m_dimY)->getMaximum() + yBinWidth;
+    double yMin = m_overlayWS->getDimension(m_dimY)->getMinimum();
+    double yMax = m_overlayWS->getDimension(m_dimY)->getMaximum();
     double yMiddle = (yMin + yMax) / 2.0;
-    QPointF pointA(m_overlayWS->getDimension(m_dimX)->getMinimum() - xBinWidth, yMiddle);
-    QPointF pointB(m_overlayWS->getDimension(m_dimX)->getMaximum() + xBinWidth, yMiddle);
+    QPointF pointA(m_overlayWS->getDimension(m_dimX)->getMinimum(),
+                   yMiddle);
+    QPointF pointB(m_overlayWS->getDimension(m_dimX)->getMaximum(),
+                   yMiddle);
     m_overlayWSOutline->setPointA(pointA);
     m_overlayWSOutline->setPointB(pointB);
     m_overlayWSOutline->setWidth((yMax - yMin) / 2.0);

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -2247,10 +2247,8 @@ void SliceViewer::dynamicRebinComplete(bool error) {
     double yMin = m_overlayWS->getDimension(m_dimY)->getMinimum();
     double yMax = m_overlayWS->getDimension(m_dimY)->getMaximum();
     double yMiddle = (yMin + yMax) / 2.0;
-    QPointF pointA(m_overlayWS->getDimension(m_dimX)->getMinimum(),
-                   yMiddle);
-    QPointF pointB(m_overlayWS->getDimension(m_dimX)->getMaximum(),
-                   yMiddle);
+    QPointF pointA(m_overlayWS->getDimension(m_dimX)->getMinimum(), yMiddle);
+    QPointF pointB(m_overlayWS->getDimension(m_dimX)->getMaximum(), yMiddle);
     m_overlayWSOutline->setPointA(pointA);
     m_overlayWSOutline->setPointB(pointB);
     m_overlayWSOutline->setWidth((yMax - yMin) / 2.0);

--- a/MantidQt/SliceViewer/test/SliceViewerPythonInterfaceTest.py
+++ b/MantidQt/SliceViewer/test/SliceViewerPythonInterfaceTest.py
@@ -480,8 +480,8 @@ class SliceViewerPythonInterfaceTest(unittest.TestCase):
         self.assertEqual(ws.getNumDims(), 3)
         self.assertEqual(ws.getDimension(0).getNBins(), 10)
         self.assertEqual(ws.getDimension(1).getNBins(), 10)
-        self.assertEqual(ws.getDimension(2).getNBins(), 30)
-        self.assertEqual(ws.getNPoints(), 10*10*30)
+        self.assertEqual(ws.getDimension(2).getNBins(), 1)
+        self.assertEqual(ws.getNPoints(), 10*10)
 
         svw.deleteLater()
 

--- a/docs/source/release/v3.9.0/ui.rst
+++ b/docs/source/release/v3.9.0/ui.rst
@@ -56,6 +56,7 @@ Bugs Resolved
 - Fixed crash when loading data and the algorithm widget is hidden
 - Fixed exception being thrown when saving project with custom interfaces open
 - The "Plot Surface from Group" and "Plot Contour from Group" options have been fixed and now work for both histogram and point data. Note that all workspaces in the group must have the same X data.
+- Fixed a bug where enabling auto rebinning in the slice viewer and zooming would not rebin the workspace if it was a histogram workspace.
 
 SliceViewer Improvements
 ------------------------


### PR DESCRIPTION
This fixes auto rebinning on the slice viewer for histo workspaces.

**To test:**
Run the script and follow the steps to reproduce in the issue description. Check that HistoWorkspace can be rebinned using the auto rebin option when zooming.

Fixes #18035.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
