### PR TITLE
Fix warnings from -Wpessimizing-move.

### DIFF
--- a/MantidQt/MantidWidgets/src/WorkspacePresenter/ADSAdapter.cpp
+++ b/MantidQt/MantidWidgets/src/WorkspacePresenter/ADSAdapter.cpp
@@ -63,7 +63,7 @@ Presenter_sptr ADSAdapter::lockPresenter() {
   if (psptr == nullptr)
     throw std::runtime_error("Unable to obtain reference to presenter");
 
-  return std::move(psptr);
+  return psptr;
 }
 
 std::string ADSAdapter::getOldName() const { return m_oldName; }

--- a/MantidQt/MantidWidgets/src/WorkspacePresenter/WorkspacePresenter.cpp
+++ b/MantidQt/MantidWidgets/src/WorkspacePresenter/WorkspacePresenter.cpp
@@ -16,7 +16,7 @@ WorkspacePresenter::~WorkspacePresenter() {}
 
 /// Initialises the view weak pointer for the Workspace Provider.
 void WorkspacePresenter::init() {
-  m_adapter->registerPresenter(std::move(m_view.lock()->getPresenterWeakPtr()));
+  m_adapter->registerPresenter(m_view.lock()->getPresenterWeakPtr());
 }
 
 /// Handle WorkspaceProvider (ADS) notifications
@@ -442,7 +442,7 @@ DockView_sptr WorkspacePresenter::lockView() {
   if (view_sptr == nullptr)
     throw std::runtime_error("Could not obtain pointer to DockView.");
 
-  return std::move(view_sptr);
+  return view_sptr;
 }
 
 /// Update the view by publishing the ADS contents.


### PR DESCRIPTION
Description of work.

This fixes several warnings from -Wpessimizing-move. 

```
/Users/svh/Documents/MantidProject/mantid/MantidQt/MantidWidgets/src/WorkspacePresenter/WorkspacePresenter.cpp:19:32: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
  m_adapter->registerPresenter(std::move(m_view.lock()->getPresenterWeakPtr()));
                               ^
/Users/svh/Documents/MantidProject/mantid/MantidQt/MantidWidgets/src/WorkspacePresenter/WorkspacePresenter.cpp:19:32: note: remove std::move call here
  m_adapter->registerPresenter(std::move(m_view.lock()->getPresenterWeakPtr()));
                               ^~~~~~~~~~                                    ~
/Users/svh/Documents/MantidProject/mantid/MantidQt/MantidWidgets/src/WorkspacePresenter/WorkspacePresenter.cpp:445:10: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
  return std::move(view_sptr);
         ^
/Users/svh/Documents/MantidProject/mantid/MantidQt/MantidWidgets/src/WorkspacePresenter/WorkspacePresenter.cpp:445:10: note: remove std::move call here
  return std::move(view_sptr);
         ^~~~~~~~~~         ~
2 warnings generated.
[2237/3498] Building CXX object MantidQt/MantidWidgets/CMakeFiles/MantidWidgets.dir/src/WorkspacePresenter/ADSAdapter.cpp.o
/Users/svh/Documents/MantidProject/mantid/MantidQt/MantidWidgets/src/WorkspacePresenter/ADSAdapter.cpp:66:10: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
  return std::move(psptr);
         ^
/Users/svh/Documents/MantidProject/mantid/MantidQt/MantidWidgets/src/WorkspacePresenter/ADSAdapter.cpp:66:10: note: remove std::move call here
  return std::move(psptr);
         ^~~~~~~~~~     ~
1 warning generated.
```

**To test:**

<!-- Instructions for testing. -->

Code review is sufficient.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

