### PR TITLE
Indirect ConvFit - Missing Lorentzian Parameters

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1547,6 +1547,9 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
   } else {
     IFunction_sptr func = FunctionFactory::Instance().createFunction(
         currentFitFunction.toStdString());
+    for (size_t i = 0; i < func->nParams(); i++) {
+      parameters << QString::fromStdString(func->parameterName(i));
+    }
   }
   return parameters;
 }


### PR DESCRIPTION
The parameters are now populated for the second Lorentzian function.

**To test:**

Interfaces > Indirect > Data Analysis > ConvFit

Sample: ` \\olympic\babylon5\Public\Louise McCann\DataAnalysis\ConvFit\irs26176_graphite002_red`
Res: ` \\olympic\babylon5\Public\Louise McCann\DataAnalysis\ConvFit\irs26173_graphite002_res`

Select `Two Lorentzians` as the Fit Type
Ensure the parameters for both Lorentzian functions are present and can be edited.

Fixes #18044.


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

