### PR TITLE
Saving TableWorkspace with an empty string column.

### DIFF
--- a/Framework/DataHandling/test/SaveNexusProcessedTest.h
+++ b/Framework/DataHandling/test/SaveNexusProcessedTest.h
@@ -732,6 +732,85 @@ public:
     AnalysisDataService::Instance().clear();
   }
 
+  void testSaveTableEmptyColumn() {
+    std::string outputFileName = "SaveNexusProcessedTest_testSaveTable.nxs";
+
+    // Create a table which we will save
+    auto table =
+        boost::dynamic_pointer_cast<Mantid::DataObjects::TableWorkspace>(
+            WorkspaceFactory::Instance().createTable());
+    table->setRowCount(3);
+    table->addColumn("int", "IntColumn");
+    {
+      auto &data = table->getColVector<int>("IntColumn");
+      data[0] = 5;
+      data[1] = 2;
+      data[2] = 3;
+    }
+    table->addColumn("str", "EmptyColumn");
+
+    SaveNexusProcessed alg;
+    alg.initialize();
+    alg.setProperty("InputWorkspace", table);
+    alg.setPropertyValue("Filename", outputFileName);
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    if (!alg.isExecuted())
+      return; // Nothing to check
+
+    // Get full output file path
+    outputFileName = alg.getPropertyValue("Filename");
+
+    NeXus::File savedNexus(outputFileName);
+
+    savedNexus.openGroup("mantid_workspace_1", "NXentry");
+    savedNexus.openGroup("table_workspace", "NXdata");
+
+    {
+      savedNexus.openData("column_1");
+      doTestColumnInfo(savedNexus, NX_INT32, "", "IntColumn");
+      int32_t expectedData[] = {5, 2, 3};
+      doTestColumnData("IntColumn", savedNexus, expectedData);
+    }
+
+    {
+      savedNexus.openData("column_2");
+
+      NeXus::Info columnInfo = savedNexus.getInfo();
+      TS_ASSERT_EQUALS(columnInfo.dims.size(), 2);
+      TS_ASSERT_EQUALS(columnInfo.dims[0], 3);
+      TS_ASSERT_EQUALS(columnInfo.dims[1], 1);
+      TS_ASSERT_EQUALS(columnInfo.type, NX_CHAR);
+
+      std::vector<NeXus::AttrInfo> attrInfos = savedNexus.getAttrInfos();
+      TS_ASSERT_EQUALS(attrInfos.size(), 3);
+
+      if (attrInfos.size() == 3) {
+        TS_ASSERT_EQUALS(attrInfos[1].name, "interpret_as");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[1]), "A string");
+
+        TS_ASSERT_EQUALS(attrInfos[2].name, "name");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[2]), "EmptyColumn");
+
+        TS_ASSERT_EQUALS(attrInfos[0].name, "units");
+        TS_ASSERT_EQUALS(savedNexus.getStrAttr(attrInfos[0]), "N/A");
+      }
+
+      std::vector<char> data;
+      savedNexus.getData(data);
+      TS_ASSERT_EQUALS(data.size(), 3);
+      TS_ASSERT_EQUALS(data[0], ' ');
+      TS_ASSERT_EQUALS(data[1], ' ');
+      TS_ASSERT_EQUALS(data[2], ' ');
+    }
+
+    savedNexus.close();
+    Poco::File(outputFileName).remove();
+    AnalysisDataService::Instance().clear();
+  }
+
 private:
   void doTestColumnInfo(NeXus::File &file, int type,
                         const std::string &interpret_as,

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -672,6 +672,11 @@ int NexusFileIO::writeNexusTableWorkspace(
         if (col->cell<std::string>(ii).size() > maxStr)
           maxStr = col->cell<std::string>(ii).size();
       }
+      // If the column is empty fill the data with spaces.
+      // Strings containing spaces only will be read back in as empty strings.
+      if (maxStr == 0) {
+        maxStr = 1;
+      }
       int dims_array[2] = {nRows, static_cast<int>(maxStr)};
       int asize[2] = {1, dims_array[1]};
 


### PR DESCRIPTION
Fill the data set in the nexus file with space characters if all column is empty.

**To test:**

Create a table with the script:

```
CreateEmptyTableWorkspace(OutputWorkspace='MaskedCellTable')
table = mtd['MaskedCelltable']
table.addColumn("str", "SpectraList")
table.addColumn("double", "XMin")
table.addColumn("double", "XMax")
table.addRow(["", 2.0, 2.2])
table.addRow(["", 1.75, 1.9])
table.addRow(["", 1.24, 1.32])
table.addRow(["", 1.02, 1.12])
```

Save and load back the workspace.

Fixes #18052.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

