### PR TITLE
Resolve exceptions in contour lines insertion

### DIFF
--- a/MantidPlot/src/ContourLinesEditor.cpp
+++ b/MantidPlot/src/ContourLinesEditor.cpp
@@ -176,7 +176,7 @@ void ContourLinesEditor::insertLevel() {
 
   DoubleSpinBox *sb;
   QwtDoubleInterval range = d_spectrogram->data().range();
-  double val = (range.maxValue() + range.minValue())/2.0;
+  double val = (range.maxValue() + range.minValue()) / 2.0;
   if (row >= 0) {
     sb = table_cellWidget<DoubleSpinBox>(row, 0);
 
@@ -186,10 +186,8 @@ void ContourLinesEditor::insertLevel() {
     if (sb)
       previous_value = sb->value();
     val = 0.5 * (current_value + previous_value);
-  } 
-  else
-  {
-    //no rows at present, set insertion point
+  } else {
+    // no rows at present, set insertion point
     row = 0;
   }
 

--- a/MantidPlot/src/ContourLinesEditor.cpp
+++ b/MantidPlot/src/ContourLinesEditor.cpp
@@ -173,16 +173,25 @@ void ContourLinesEditor::insertLevel() {
     return;
 
   int row = table->currentRow();
-  DoubleSpinBox *sb = table_cellWidget<DoubleSpinBox>(row, 0);
 
+  DoubleSpinBox *sb;
   QwtDoubleInterval range = d_spectrogram->data().range();
-  double current_value = sb->value();
-  double previous_value = range.minValue();
-  sb = dynamic_cast<DoubleSpinBox *>(table->cellWidget(row - 1, 0));
-  if (sb)
-    previous_value = sb->value();
+  double val = (range.maxValue() + range.minValue())/2.0;
+  if (row >= 0) {
+    sb = table_cellWidget<DoubleSpinBox>(row, 0);
 
-  double val = 0.5 * (current_value + previous_value);
+    double current_value = sb->value();
+    double previous_value = range.minValue();
+    sb = dynamic_cast<DoubleSpinBox *>(table->cellWidget(row - 1, 0));
+    if (sb)
+      previous_value = sb->value();
+    val = 0.5 * (current_value + previous_value);
+  } 
+  else
+  {
+    //no rows at present, set insertion point
+    row = 0;
+  }
 
   table->blockSignals(true);
   table->insertRow(row);
@@ -214,6 +223,7 @@ void ContourLinesEditor::insertLevel() {
   lbl->setPixmap(pix);
 
   table->setCellWidget(row, 1, lbl);
+  table->setCurrentCell(row, 1);
   table->blockSignals(false);
 
   enableButtons(table->currentRow());


### PR DESCRIPTION
Fixed issues that were occurring when the insertion point was 0 (the start of the list) or -1 (empty).

**To test:**

1. Load SANSLOQCan2D.nxs data (from the training data).
1. Right click on the workspace and select Color Fill Plot
1. Go to graph Properties->Layer Details->Contour Lines.
1. Enable the Show Contour Lines check box.
1. Delete all predefined default levels
1. Attempting to insert a new level will result in an exception. - this will now work
1. Also fiddle around with creating and deleting contour levels and check all is good.

Fixes #17504

### RELEASE NOTES
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

