### PR TITLE
Add option to replace small values in ReplaceSpecialValues

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReplaceSpecialValues.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReplaceSpecialValues.h
@@ -96,7 +96,7 @@ private:
   bool m_performBigCheck; ///< Flag to indicate if the 'big number' check is to
   /// be performed
   bool m_performSmallCheck; ///< Flag to indicate if the 'small number' check is
-                            ///to
+  /// to
   /// be performed
 };
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReplaceSpecialValues.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReplaceSpecialValues.h
@@ -13,25 +13,10 @@ namespace Algorithms {
  numbers.
  If a replacement value is not provided the check will not occur.
 
- Required Properties:
- <UL>
- <LI> InputWorkspace  - The name of the workspace to correct</LI>
- <LI> OutputWorkspace - The name of the corrected workspace (can be the same as
- the input one)</LI>
- <LI> NaNValue        - The value used to replace occurances of NaN (default do
- not check)</LI>
- <LI> NaNError        - The error value used when replacing a value of NaN
- (default 0)</LI>
- <LI> InfinityValue   - The value used to replace occurances of positive or
- negative infinity (default do not check)</LI>
- <LI> InfinityError   - The error value used when replacing a value of infinity
- (default 0)</LI>
- </UL>
-
  @author Nicholas Draper, Tessella plc
  @date 18/06/2009
 
- Copyright &copy; 2009-2010 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+ Copyright &copy; 2009-2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
  National Laboratory & European Spallation Source
 
  This file is part of Mantid.
@@ -81,13 +66,15 @@ private:
                              double &EOut) override;
 
   /// returns true if the value is NaN
-  bool checkIfNan(const double &value) const;
+  bool checkIfNan(const double value) const;
   /// returns true if the value if + or - infinity
-  bool checkIfInfinite(const double &value) const;
+  bool checkIfInfinite(const double value) const;
   /// Returns true if the absolute value is larger than the 'big' threshold
-  bool checkIfBig(const double &value) const;
+  bool checkIfBig(const double value) const;
+  /// Returns true is the absolute value is smaller than the 'small' threshold
+  bool checkIfSmall(const double value) const;
   /// returns true if the value has been set
-  bool checkifPropertyEmpty(const double &value) const;
+  bool checkifPropertyEmpty(const double value) const;
 
   double m_NaNValue;      ///< The replacement value for NaN
   double m_NaNError;      ///< The replacement error value for NaN
@@ -97,12 +84,17 @@ private:
   /// considered 'big'
   double m_bigValue; ///< The replacement value for big numbers
   double m_bigError; ///< The replacement error value for big numbers
+  double m_smallThreshold; ///< The threshold value below which a value is 'small'
+  double m_smallValue; ///< The replacement value for small numbers
+  double m_smallError; ///< The replacement error value for small numbers
 
   bool m_performNaNCheck; ///< Flag to indicate if the NaN check is to be
   /// performed
   bool m_performInfiniteCheck; ///< Flag to indicate if the infinity check is to
   /// be performed
   bool m_performBigCheck; ///< Flag to indicate if the 'big number' check is to
+  /// be performed
+  bool m_performSmallCheck; ///< Flag to indicate if the 'small number' check is to
   /// be performed
 };
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReplaceSpecialValues.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReplaceSpecialValues.h
@@ -84,9 +84,10 @@ private:
   /// considered 'big'
   double m_bigValue; ///< The replacement value for big numbers
   double m_bigError; ///< The replacement error value for big numbers
-  double m_smallThreshold; ///< The threshold value below which a value is 'small'
-  double m_smallValue; ///< The replacement value for small numbers
-  double m_smallError; ///< The replacement error value for small numbers
+  double
+      m_smallThreshold; ///< The threshold value below which a value is 'small'
+  double m_smallValue;  ///< The replacement value for small numbers
+  double m_smallError;  ///< The replacement error value for small numbers
 
   bool m_performNaNCheck; ///< Flag to indicate if the NaN check is to be
   /// performed
@@ -94,7 +95,8 @@ private:
   /// be performed
   bool m_performBigCheck; ///< Flag to indicate if the 'big number' check is to
   /// be performed
-  bool m_performSmallCheck; ///< Flag to indicate if the 'small number' check is to
+  bool m_performSmallCheck; ///< Flag to indicate if the 'small number' check is
+                            ///to
   /// be performed
 };
 

--- a/Framework/Algorithms/src/ReplaceSpecialValues.cpp
+++ b/Framework/Algorithms/src/ReplaceSpecialValues.cpp
@@ -22,26 +22,38 @@ ReplaceSpecialValues::ReplaceSpecialValues()
       m_performBigCheck(false) {}
 
 void ReplaceSpecialValues::defineProperties() {
+  // NaN properties
   declareProperty("NaNValue", Mantid::EMPTY_DBL(),
-                  "The value used to replace occurrances of NaN "
+                  "The value used to replace occurrences of NaN "
                   "(default: do not check).");
   declareProperty("NaNError", 0.0,
                   "The error value used when replacing a value of NaN ");
+  // Infinity properties
   declareProperty(
       "InfinityValue", Mantid::EMPTY_DBL(),
-      "The value used to replace occurrances of positive or negative infinity "
+      "The value used to replace occurrences of positive or negative infinity "
       "(default: do not check).");
   declareProperty("InfinityError", 0.0,
                   "The error value used when replacing a value of infinity ");
+  // Big number properties
   declareProperty("BigNumberThreshold", Mantid::EMPTY_DBL(),
                   "The threshold above which a number (positive or negative) "
                   "should be replaced. "
                   "(default: do not check)");
   declareProperty(
       "BigNumberValue", 0.0,
-      "The value with which to replace occurrances of 'big' numbers.");
+      "The value with which to replace occurrences of 'big' numbers.");
   declareProperty("BigNumberError", 0.0,
                   "The error value used when replacing a 'big' number");
+  // Small number properties
+  declareProperty("SmallNumberThreshold", Mantid::EMPTY_DBL(),
+                  "The threshold below which a number (positive or negative) "
+                  "should be replaced. (default: do not check)");
+  declareProperty(
+      "SmallNumberValue", 0.0,
+      "The value with which to replace occurrences of 'small' numbers.");
+  declareProperty("SmallNumberError", 0.0,
+                  "The error value used when replacing a 'small' number");
 }
 
 void ReplaceSpecialValues::retrieveProperties() {
@@ -52,13 +64,21 @@ void ReplaceSpecialValues::retrieveProperties() {
   m_bigThreshold = getProperty("BigNumberThreshold");
   m_bigValue = getProperty("BigNumberValue");
   m_bigError = getProperty("BigNumberError");
+  m_smallThreshold = getProperty("SmallNumberThreshold");
+  m_smallValue = getProperty("SmallNumberValue");
+  m_smallError = getProperty("SmallNumberError");
 
   m_performNaNCheck = !checkifPropertyEmpty(m_NaNValue);
   m_performInfiniteCheck = !checkifPropertyEmpty(m_InfiniteValue);
   m_performBigCheck = !checkifPropertyEmpty(m_bigThreshold);
-  if (!(m_performNaNCheck || m_performInfiniteCheck || m_performBigCheck)) {
-    throw std::invalid_argument(
-        "No value was defined for NaN, infinity or BigValueThreshold");
+  m_performSmallCheck = !checkifPropertyEmpty(m_smallThreshold);
+
+  const bool replacement_set = m_performNaNCheck || m_performInfiniteCheck ||
+                               m_performBigCheck || m_performSmallCheck;
+
+  if (!replacement_set) {
+    throw std::invalid_argument("No value was defined for NaN, infinity, "
+                                "BigValueThreshold or SmallValueThreshold");
   }
 }
 
@@ -79,22 +99,29 @@ void ReplaceSpecialValues::performUnaryOperation(const double XIn,
   } else if (m_performBigCheck && checkIfBig(YIn)) {
     YOut = m_bigValue;
     EOut = m_bigError;
+  } else if (m_performSmallCheck && checkIfSmall(YIn)) {
+    YOut = m_smallValue;
+    EOut = m_smallError;
   }
 }
 
-bool ReplaceSpecialValues::checkIfNan(const double &value) const {
+bool ReplaceSpecialValues::checkIfNan(const double value) const {
   return (std::isnan(value));
 }
 
-bool ReplaceSpecialValues::checkIfInfinite(const double &value) const {
+bool ReplaceSpecialValues::checkIfInfinite(const double value) const {
   return (std::isinf(value));
 }
 
-bool ReplaceSpecialValues::checkIfBig(const double &value) const {
+bool ReplaceSpecialValues::checkIfBig(const double value) const {
   return (std::abs(value) > m_bigThreshold);
 }
 
-bool ReplaceSpecialValues::checkifPropertyEmpty(const double &value) const {
+bool ReplaceSpecialValues::checkIfSmall(const double value) const {
+  return (std::abs(value) < m_smallThreshold);
+}
+
+bool ReplaceSpecialValues::checkifPropertyEmpty(const double value) const {
   return (std::abs(value - Mantid::EMPTY_DBL()) < 1e-08);
 }
 

--- a/Framework/Algorithms/test/ReplaceSpecialValuesTest.h
+++ b/Framework/Algorithms/test/ReplaceSpecialValuesTest.h
@@ -25,30 +25,28 @@ public:
     TS_ASSERT(alg2.isInitialized());
 
     const std::vector<Property *> props = alg2.getProperties();
-    TS_ASSERT_EQUALS(props.size(), 9);
+    TS_ASSERT_EQUALS(props.size(), 12);
 
     TS_ASSERT_EQUALS(props[0]->name(), "InputWorkspace");
-    TS_ASSERT(props[0]->isDefault());
     TS_ASSERT(dynamic_cast<WorkspaceProperty<MatrixWorkspace> *>(props[0]));
 
     TS_ASSERT_EQUALS(props[1]->name(), "OutputWorkspace");
-    TS_ASSERT(props[1]->isDefault());
     TS_ASSERT(dynamic_cast<WorkspaceProperty<MatrixWorkspace> *>(props[1]));
 
     TS_ASSERT_EQUALS(props[2]->name(), "NaNValue");
-    TS_ASSERT(props[2]->isDefault());
     TS_ASSERT_EQUALS(props[3]->name(), "NaNError");
-    TS_ASSERT(props[3]->isDefault());
     TS_ASSERT_EQUALS(props[4]->name(), "InfinityValue");
-    TS_ASSERT(props[4]->isDefault());
     TS_ASSERT_EQUALS(props[5]->name(), "InfinityError");
-    TS_ASSERT(props[5]->isDefault());
     TS_ASSERT_EQUALS(props[6]->name(), "BigNumberThreshold");
-    TS_ASSERT(props[6]->isDefault());
     TS_ASSERT_EQUALS(props[7]->name(), "BigNumberValue");
-    TS_ASSERT(props[7]->isDefault());
     TS_ASSERT_EQUALS(props[8]->name(), "BigNumberError");
-    TS_ASSERT(props[8]->isDefault());
+    TS_ASSERT_EQUALS(props[9]->name(), "SmallNumberThreshold");
+    TS_ASSERT_EQUALS(props[10]->name(), "SmallNumberValue");
+    TS_ASSERT_EQUALS(props[11]->name(), "SmallNumberError");
+
+    for (const auto prop : props) {
+      assert_property_is_default(prop);
+    }
   }
 
   void testExecCheckBoth() {
@@ -137,8 +135,8 @@ public:
   void testExecCheckBig() {
     MatrixWorkspace_sptr inputWS = createWorkspace();
     // Put in some 'big' values
-    inputWS->dataY(0)[0] = 1.0E12;
-    inputWS->dataY(0)[1] = 1.000001E10;
+    inputWS->mutableY(0)[0] = 1.0E12;
+    inputWS->mutableY(0)[1] = 1.000001E10;
     AnalysisDataService::Instance().add("InputWS", inputWS);
 
     Mantid::Algorithms::ReplaceSpecialValues alg3;
@@ -164,13 +162,60 @@ public:
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 0; j < 4; ++j) {
         if ((i == 0 && j != 3) || (i == 1 && j == 0)) {
-          TS_ASSERT_EQUALS(result->readY(i)[j], 999);
-          TS_ASSERT_EQUALS(result->readE(i)[j], 0.00005);
-        } else if (inputWS->readY(i)[j] != inputWS->readY(i)[j]) // nan
+          TS_ASSERT_EQUALS(result->y(i)[j], 999);
+          TS_ASSERT_EQUALS(result->e(i)[j], 0.00005);
+        } else if (inputWS->y(i)[j] != inputWS->y(i)[j]) // NaN
         {
-          TS_ASSERT_DIFFERS(result->readY(i)[j], result->readY(i)[j]);
+          TS_ASSERT_DIFFERS(result->y(i)[j], result->y(i)[j]);
         } else {
-          TS_ASSERT_EQUALS(result->readY(i)[j], inputWS->readY(i)[j]);
+          TS_ASSERT_EQUALS(result->y(i)[j], inputWS->y(i)[j]);
+        }
+      }
+    }
+
+    AnalysisDataService::Instance().remove("InputWS");
+    AnalysisDataService::Instance().remove("WSCor");
+  }
+
+  void testExecCheckSmall() {
+    MatrixWorkspace_sptr inputWS = createWorkspace();
+    // Put in some small values
+    inputWS->dataY(0)[0] = 2.0E-7;
+    inputWS->dataY(0)[1] = 1.99E-7;
+    AnalysisDataService::Instance().add("InputWS", inputWS);
+
+    Mantid::Algorithms::ReplaceSpecialValues alg3;
+    alg3.initialize();
+    TS_ASSERT_THROWS_NOTHING(
+        alg3.setPropertyValue("InputWorkspace", "InputWS"));
+    TS_ASSERT_THROWS_NOTHING(alg3.setPropertyValue("OutputWorkspace", "WSCor"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg3.setPropertyValue("SmallNumberThreshold", "2.0E-7"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg3.setPropertyValue("SmallNumberValue", "0.123"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg3.setPropertyValue("SmallNumberError", "0.456"));
+
+    TS_ASSERT_THROWS_NOTHING(alg3.execute());
+    TS_ASSERT(alg3.isExecuted());
+
+    MatrixWorkspace_sptr result;
+    TS_ASSERT_THROWS_NOTHING(
+        result = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            "WSCor"));
+    TS_ASSERT(result);
+
+    TS_ASSERT_EQUALS(result->y(0)[1], 0.123);
+    TS_ASSERT_EQUALS(result->e(0)[1], 0.456);
+
+    for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
+      for (int j = 0; j < 4; ++j) {
+        if (i == 0 && j == 1 || !std::isnormal(inputWS->y(i)[j])) {
+          // Skip our changed one or any we can't compare
+          continue;
+        } else {
+          TS_ASSERT_EQUALS(result->y(i)[j], inputWS->y(i)[j]);
+          TS_ASSERT_EQUALS(result->e(i)[j], inputWS->e(i)[j]);
         }
       }
     }
@@ -202,25 +247,25 @@ public:
 
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 1; j < 5; ++j) {
-        TS_ASSERT_EQUALS(result->dataX(i)[j - 1], inputWS->dataX(i)[j - 1]);
+        TS_ASSERT_EQUALS(result->x(i)[j - 1], inputWS->x(i)[j - 1]);
 
-        if (infCheck && std::isinf(inputWS->dataY(i)[j - 1])) {
-          if (std::isinf(result->dataY(i)[j - 1])) {
-            TS_FAIL("Infinity detected that shold have been replaced");
+        if (infCheck && std::isinf(inputWS->y(i)[j - 1])) {
+          if (std::isinf(result->y(i)[j - 1])) {
+            TS_FAIL("Infinity detected that should have been replaced");
           } else {
-            TS_ASSERT_DELTA(result->dataY(i)[j - 1], 999.0, 1e-8);
-            TS_ASSERT_DELTA(result->dataE(i)[j - 1], 0.00005, 1e-8);
+            TS_ASSERT_DELTA(result->y(i)[j - 1], 999.0, 1e-8);
+            TS_ASSERT_DELTA(result->e(i)[j - 1], 0.00005, 1e-8);
           }
-        } else if (naNCheck && std::isnan(inputWS->dataY(i)[j - 1])) {
-          TS_ASSERT_DELTA(result->dataY(i)[j - 1], -99.0, 1e-8);
-          TS_ASSERT_DELTA(result->dataE(i)[j - 1], -50.0, 1e-8);
+        } else if (naNCheck && std::isnan(inputWS->y(i)[j - 1])) {
+          TS_ASSERT_DELTA(result->y(i)[j - 1], -99.0, 1e-8);
+          TS_ASSERT_DELTA(result->e(i)[j - 1], -50.0, 1e-8);
         } else {
-          if (!naNCheck && std::isnan(inputWS->dataY(i)[j - 1])) {
-            TS_ASSERT_DIFFERS(result->dataY(i)[j - 1], result->dataY(i)[j - 1]);
+          if (!naNCheck && std::isnan(inputWS->y(i)[j - 1])) {
+            TS_ASSERT_DIFFERS(result->y(i)[j - 1], result->y(i)[j - 1]);
           } else {
-            TS_ASSERT_EQUALS(result->dataY(i)[j - 1], inputWS->dataY(i)[j - 1]);
+            TS_ASSERT_EQUALS(result->y(i)[j - 1], inputWS->y(i)[j - 1]);
           }
-          TS_ASSERT_EQUALS(result->dataE(i)[j - 1], inputWS->dataE(i)[j - 1]);
+          TS_ASSERT_EQUALS(result->e(i)[j - 1], inputWS->e(i)[j - 1]);
         }
       }
     }
@@ -229,7 +274,7 @@ public:
   MatrixWorkspace_sptr createWorkspace() {
     MatrixWorkspace_sptr inputWS =
         WorkspaceCreationHelper::Create2DWorkspaceBinned(4, 4, 0.5);
-    // put some infinitis and NaNs in there
+    // put some infinities and NaNs in there
     double inf = std::numeric_limits<double>::infinity();
     inputWS->dataY(0)[2] = inf;
     inputWS->dataY(1)[0] = -inf;
@@ -286,6 +331,10 @@ public:
 
 private:
   Mantid::Algorithms::ReplaceSpecialValues alg;
+
+  void assert_property_is_default(const Property *propToCheck) {
+    TS_ASSERT(propToCheck->isDefault());
+  }
 };
 
 #endif /*REPLACESPECIALVALUESTEST_H_*/

--- a/Framework/Algorithms/test/ReplaceSpecialValuesTest.h
+++ b/Framework/Algorithms/test/ReplaceSpecialValuesTest.h
@@ -210,7 +210,7 @@ public:
 
     for (size_t i = 0; i < result->getNumberHistograms(); ++i) {
       for (int j = 0; j < 4; ++j) {
-        if (i == 0 && j == 1 || !std::isnormal(inputWS->y(i)[j])) {
+        if ((i == 0 && j == 1) || !std::isnormal(inputWS->y(i)[j])) {
           // Skip our changed one or any we can't compare
           continue;
         } else {

--- a/docs/source/algorithms/ReplaceSpecialValues-v1.rst
+++ b/docs/source/algorithms/ReplaceSpecialValues-v1.rst
@@ -58,7 +58,7 @@ Output:
     1       inf     1000.0
     2       -inf    1000.0
     3       nan     0.0
-    4       8e-7    200
+    4       8e-07   200.0
 
 
 .. categories::

--- a/docs/source/algorithms/ReplaceSpecialValues-v1.rst
+++ b/docs/source/algorithms/ReplaceSpecialValues-v1.rst
@@ -10,15 +10,15 @@ Description
 -----------
 
 The algorithm searches over all of the values in a workspace and if it
-finds a value set to NaN (not a number), infinity or larger than the
-'big' threshold given then that value and the associated error is
+finds a value set to NaN (not a number), infinity, larger or smaller than the
+'big'/'small' threshold given then that value and the associated error is
 replaced by the user provided values.
 
-If no value is provided for either NaNValue, InfinityValue or
-BigValueThreshold then the algorithm will exit with an error, as in this
+If no value is provided for either NaNValue, InfinityValue, BigValueThreshold 
+or SmallValueThreshold then the algorithm will exit with an error, as in this
 case it would not be checking anything.
 
-Algorithm is now event aware.
+The algorithm can also handle event workspaces. 
 
 Usage
 -----
@@ -35,14 +35,16 @@ Usage
    yArray[1] = float("inf")
    yArray[2] = float("-inf")
    yArray[3] = float("NaN")
+   yArray[4] = 8e-7
    ws.setY(0,yArray)
   
    ws = ReplaceSpecialValues(ws,NaNValue=0,InfinityValue=1000,
-    BigNumberThreshold=1000, BigNumberValue=1000)
+    BigNumberThreshold=1000, BigNumberValue=1000, 
+    SmallNumberThreshold=1e-6, SmallNumberValue=200)
 
    print "i\tBefore\tAfter"   
    print "-\t------\t-----"
-   for i in range(4):
+   for i in range(5):
        print "%i\t%s\t%s" % (i, yArray[i],ws.readY(0)[i])     
  
 Output:
@@ -56,6 +58,7 @@ Output:
     1       inf     1000.0
     2       -inf    1000.0
     3       nan     0.0
+    4       8e-7    200
 
 
 .. categories::

--- a/docs/source/algorithms/ReplaceSpecialValues-v1.rst
+++ b/docs/source/algorithms/ReplaceSpecialValues-v1.rst
@@ -74,16 +74,16 @@ Output:
     ws.setY(0, wsYArray)
     ws = ReplaceSpecialValues(ws, SmallNumberThreshold=1e-6)
     
-    print("Before\t After")
-    print("%s\t%s", wsYArray[0], ws.readY(0)[0])
+    print("Before\t\t After")
+    print("{0}\t{1}".format(wsYArray[0], ws.readY(0)[0]))
     
 Output:
 
 .. testoutput:: replaceSVFloatingPointErrors
     :options: +NORMALIZE_WHITESPACE
 
-    Before  After
-    0       0
+    Before		  After
+    9.99999993923e-09	0.0
 
 
 .. categories::

--- a/docs/source/algorithms/ReplaceSpecialValues-v1.rst
+++ b/docs/source/algorithms/ReplaceSpecialValues-v1.rst
@@ -59,6 +59,31 @@ Output:
     2       -inf    1000.0
     3       nan     0.0
     4       8e-07   200.0
+    
+.. testcode:: replaceSVFloatingPointErrors
+
+    import numpy as np
+    ws = CreateSampleWorkspace(BankPixelWidth=1)
+
+    value1 = 1.00000004
+    value2 = 1.00000003
+    valueDiff = value1 - value2
+    
+    wsYArray = np.array(ws.readY(0))
+    wsYArray[0] = valueDiff
+    ws.setY(0, wsYArray)
+    ws = ReplaceSpecialValues(ws, SmallNumberThreshold=1e-6)
+    
+    print("Before\t After")
+    print("%s\t%s", wsYArray[0], ws.readY(0)[0])
+    
+Output:
+
+.. testoutput:: replaceSVFloatingPointErrors
+    :options: +NORMALIZE_WHITESPACE
+
+    Before  After
+    0       0
 
 
 .. categories::

--- a/docs/source/release/v3.9.0/framework.rst
+++ b/docs/source/release/v3.9.0/framework.rst
@@ -18,6 +18,7 @@ Improved
 
 - :ref:`CalculateFlatBackground <algm-CalculateFlatBackground>` has now a new mode 'Moving Average' which takes the minimum of a moving window average as the flat background.
 - :ref:`StartLiveData <algm-StartLiveData>` and its dialog now support dynamic listener properties, based on the specific LiveListener being used.
+- :ref:`ReplaceSpecialValues <algm_ReplaceSpecialValues>` now can replace 'small' values below a user specified threshold.
 
 Deprecated
 ##########


### PR DESCRIPTION
Description of work.
This PR adds an option to replace values below a user specified threshold. 
This can be useful after subtracting two workspaces to distinguish between rounding errors and actual differences in values.

**To test:**
Create a workspace with values above and below a threshold of your choice. 
Set `SmallNumberThreshold` to that threshold and `SmallNumberValue` if you wish.
Run the algorithm
Values below `SmallNumberThreshold` should be replaced with `SmallNumberValue` or 0 if not specified otherwise they should not be changed 

Fixes #18027 .

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
