### PR TITLE
Vesuvio  - Range of Run Numbers as Input

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -585,15 +585,16 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 ms.DeleteWorkspace(out_mon, EnableLogging=_LOGGING_)
 
         # Check to see if extra data needs to be loaded to normalise in data
-        x_max = self._tof_max
-        if self._foil_out_norm_end > self._tof_max:
-            x_max = self._foil_out_norm_end
-            self._crop_required = True
+        if "Difference" in self._diff_opt:
+            x_max = self._tof_max
+            if self._foil_out_norm_end > self._tof_max:
+                x_max = self._foil_out_norm_end
+                self._crop_required = True
 
-        ms.CropWorkspace(Inputworkspace= SUMMED_WS,
-                         OutputWorkspace=SUMMED_WS,
-                         XMax=x_max,
-                         EnableLogging=_LOGGING_)
+            ms.CropWorkspace(Inputworkspace= SUMMED_WS,
+                             OutputWorkspace=SUMMED_WS,
+                             XMax=x_max,
+                             EnableLogging=_LOGGING_)
 
         summed_data, summed_mon = mtd[SUMMED_WS], mtd[SUMMED_WS + '_monitors']
 
@@ -607,8 +608,8 @@ class LoadVesuvio(LoadEmptyVesuvio):
             self._load_monitors_workspace = clone.getProperty("OutputWorkspace").value
             self._load_monitors_workspace = self._sum_monitors_in_group(summed_mon,
                                                                         self._load_monitors_workspace)
-
-        self._load_diff_mode_parameters(summed_data)
+        if "Difference" in self._diff_opt:
+            self._load_diff_mode_parameters(summed_data)
         return summed_data, summed_mon
 
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -317,8 +317,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         all_spectra = [item for sublist in self._spectra for item in sublist]
 
         self._set_spectra_type(all_spectra[0])
-        self._setup_raw(all_spectra)
-        self._create_foil_workspaces()
+        self._load_single_foil_state(all_spectra)
 
         raw_group = mtd[SUMMED_WS]
         self._nperiods = raw_group.size()
@@ -351,18 +350,37 @@ class LoadVesuvio(LoadEmptyVesuvio):
             np.sqrt(dataE, dataE)
             foil_out.setX(ws_index, x_values)
 
+            # Create monitor workspace for normalisation
+            first_mon_ws = self._raw_monitors[0]
+            nmonitor_bins = first_mon_ws.blocksize()
+            nhists = first_ws.getNumberHistograms()
+            data_kwargs = {'NVectors': nhists, 'XLength': nmonitor_bins, 'YLength': nmonitor_bins}
+            mon_out = WorkspaceFactory.create(first_mon_ws, **data_kwargs)
+
+            mon_raw_t = self._raw_monitors[0].readX(0)
+            delay = mon_raw_t[2] - mon_raw_t[1]
+            # The original EVS loader, raw.for/rawb.for, does this. Done here to match results
+            mon_raw_t = mon_raw_t - delay
+            self.mon_pt_times = mon_raw_t[1:]
+
+
             if self._nperiods == 6 and self._spectra_type == FORWARD:
                 mon_periods = (5, 6)
-            else:
-                mon_periods = foil_out_periods
-            raw_grp_indices = foil_map.get_indices(spectrum_no, mon_periods)
-            outY = self.mon_out.dataY(ws_index)
+                raw_grp_indices = foil_map.get_indices(spectrum_no, mon_periods)
+
+            outY = mon_out.dataY(ws_index)
             for grp_index in raw_grp_indices:
                 raw_ws = self._raw_monitors[grp_index]
                 outY += raw_ws.readY(self._mon_index)
 
-            self._ws_index = ws_index
-            self._normalise_by_monitor()
+            # Normalise by monitor
+            indices_in_range = np.where((self.mon_pt_times >= self._mon_norm_start) & (self.mon_pt_times < self._mon_norm_end))
+            mon_values = mon_out.readY(ws_index)
+            mon_values_sum = np.sum(mon_values[indices_in_range])
+            foil_state = foil_out.dataY(ws_index)
+            foil_state *= (self._mon_scale/mon_values_sum)
+            err = foil_out.dataE(ws_index)
+            err *= (self._mon_scale/mon_values_sum)
 
         ip_file = self.getPropertyValue(INST_PAR_PROP)
         if len(ip_file) > 0:
@@ -371,37 +389,72 @@ class LoadVesuvio(LoadEmptyVesuvio):
         if self._sumspectra:
             self._sum_all_spectra()
 
-        ms.DeleteWorkspace(Workspace=SUMMED_WS)
         self._store_results()
+        self._cleanup_raw()
 
 #----------------------------------------------------------------------------------------
 
-    def _load_single_run_spec_and_mon(self, all_spectra, run_str):
-        # check if the monitor spectra are already in the spectra list
+    def _load_single_foil_state(self, all_spectra):
+
+        # Check if the monitor spectra are already in the spectra list
+
         filtered_spectra = sorted([i for i in all_spectra if i <= self._mon_spectra[-1]])
         if filtered_spectra == self._mon_spectra and self._load_monitors:
             # Load monitors in workspace if defined by user
             self._load_monitors = False
+            all_spec_inc_mon = all_spectra
             logger.warning("LoadMonitors is true while monitor spectra are defined in the spectra list.")
             logger.warning("Monitors have been loaded into the data workspace not separately.")
-        if not self._load_monitors:
-            ms.LoadRaw(Filename=run_str, OutputWorkspace=SUMMED_WS, SpectrumList=all_spectra,
-                       EnableLogging=_LOGGING_)
         else:
+            # Create list of spectra with monitors
             all_spec_inc_mon = self._mon_spectra
             all_spec_inc_mon.extend(all_spectra)
-            ms.LoadRaw(Filename=run_str, OutputWorkspace=SUMMED_WS, SpectrumList=all_spec_inc_mon,
+
+
+
+
+        isis = config.getFacility('ISIS')
+        inst_prefix = isis.instrument('VESUVIO').shortName()
+
+        runs = self._get_runs()
+
+        for index, run in enumerate(runs):
+            run_str = inst_prefix + str(run)
+            self._raise_error_period_scatter(run_str, self._back_scattering)
+
+            # Sum runs
+            if index == 0:
+                out_name, out_mon = SUMMED_WS, SUMMED_WS + '_monitors'
+            else:
+                out_name, out_mon = SUMMED_WS + 'tmp', SUMMED_WS + 'tmp_monitors'
+
+            ms.LoadRaw(Filename=run_str, OutputWorkspace=out_name, SpectrumList=all_spec_inc_mon,
                        LoadMonitors='Separate', EnableLogging=_LOGGING_)
-            monitor_group = mtd[SUMMED_WS +'_monitors']
-            mon_out_name = self.getPropertyValue(WKSP_PROP) + "_monitors"
-            clone = self.createChildAlgorithm("CloneWorkspace", False)
-            clone.setProperty("InputWorkspace", monitor_group.getItem(0))
-            clone.setProperty("OutputWorkspace", mon_out_name)
-            clone.execute()
-            self._load_monitors_workspace = clone.getProperty("OutputWorkspace").value
-            self._load_monitors_workspace = self._sum_monitors_in_group(monitor_group,
-                                                                        self._load_monitors_workspace)
-            ms.DeleteWorkspace(Workspace=monitor_group)
+
+            if index > 0:
+                ms.Plus(LHSWorkspace=SUMMED_WS,
+                        RHSWorkspace=out_name,
+                        OutputWorkspace=SUMMED_WS,
+                        EnableLogging=_LOGGING_)
+                ms.Plus(LHSWorkspace=SUMMED_WS + '_monitors',
+                        RHSWorkspace=out_mon,
+                        OutputWorkspace=SUMMED_WS + '_monitors',
+                        EnableLogging=_LOGGING_)
+
+                ms.DeleteWorkspace(out_name, EnableLogging=_LOGGING_)
+                ms.DeleteWorkspace(out_mon, EnableLogging=_LOGGING_)
+
+            if self._load_monitors:
+                monitor_group = mtd[SUMMED_WS + '_monitors']
+                mon_out_name = self.getPropertyValue(WKSP_PROP) + "_monitors"
+                clone = self.createChildAlgorithm("CloneWorkspace", False)
+                clone.setProperty("InputWorkspace", monitor_group.getItem(0))
+                clone.setProperty("OutputWorkspace", mon_out_name)
+                clone.execute()
+                self._load_monitors_workspace = clone.getProperty("OutputWorkspace").value
+                self._load_monitors_workspace = self._sum_monitors_in_group(monitor_group,
+                                                                            self._load_monitors_workspace)
+            self._raw_monitors = mtd[SUMMED_WS + '_monitors']
 
 #----------------------------------------------------------------------------------------
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -327,7 +327,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
             inst_prefix = isis.instrument("VESUVIO").shortName()
 
             try:
-                run_str = inst_prefix + runs[0]
+                run_str = inst_prefix + runs[0] +'.raw'
             except ValueError:
                 run_str = runs[0]
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -585,16 +585,15 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 ms.DeleteWorkspace(out_mon, EnableLogging=_LOGGING_)
 
         # Check to see if extra data needs to be loaded to normalise in data
-        if "Difference" in self._diff_opt:
-            x_max = self._tof_max
-            if self._foil_out_norm_end > self._tof_max:
-                x_max = self._foil_out_norm_end
-                self._crop_required = True
+        x_max = self._tof_max
+        if self._foil_out_norm_end > self._tof_max:
+            x_max = self._foil_out_norm_end
+            self._crop_required = True
 
-            ms.CropWorkspace(Inputworkspace= SUMMED_WS,
-                             OutputWorkspace=SUMMED_WS,
-                             XMax=x_max,
-                             EnableLogging=_LOGGING_)
+        ms.CropWorkspace(Inputworkspace= SUMMED_WS,
+                         OutputWorkspace=SUMMED_WS,
+                         XMax=x_max,
+                         EnableLogging=_LOGGING_)
 
         summed_data, summed_mon = mtd[SUMMED_WS], mtd[SUMMED_WS + '_monitors']
 
@@ -608,8 +607,8 @@ class LoadVesuvio(LoadEmptyVesuvio):
             self._load_monitors_workspace = clone.getProperty("OutputWorkspace").value
             self._load_monitors_workspace = self._sum_monitors_in_group(summed_mon,
                                                                         self._load_monitors_workspace)
-        if "Difference" in self._diff_opt:
-            self._load_diff_mode_parameters(summed_data)
+
+        self._load_diff_mode_parameters(summed_data)
         return summed_data, summed_mon
 
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -317,7 +317,8 @@ class LoadVesuvio(LoadEmptyVesuvio):
         all_spectra = [item for sublist in self._spectra for item in sublist]
 
         self._set_spectra_type(all_spectra[0])
-        self._load_single_foil_state(all_spectra)
+        self._setup_raw(all_spectra)
+        self._create_foil_workspaces()
 
         raw_group = mtd[SUMMED_WS]
         self._nperiods = raw_group.size()
@@ -350,37 +351,18 @@ class LoadVesuvio(LoadEmptyVesuvio):
             np.sqrt(dataE, dataE)
             foil_out.setX(ws_index, x_values)
 
-            # Create monitor workspace for normalisation
-            first_mon_ws = self._raw_monitors[0]
-            nmonitor_bins = first_mon_ws.blocksize()
-            nhists = first_ws.getNumberHistograms()
-            data_kwargs = {'NVectors': nhists, 'XLength': nmonitor_bins, 'YLength': nmonitor_bins}
-            mon_out = WorkspaceFactory.create(first_mon_ws, **data_kwargs)
-
-            mon_raw_t = self._raw_monitors[0].readX(0)
-            delay = mon_raw_t[2] - mon_raw_t[1]
-            # The original EVS loader, raw.for/rawb.for, does this. Done here to match results
-            mon_raw_t = mon_raw_t - delay
-            self.mon_pt_times = mon_raw_t[1:]
-
-
             if self._nperiods == 6 and self._spectra_type == FORWARD:
                 mon_periods = (5, 6)
-                raw_grp_indices = foil_map.get_indices(spectrum_no, mon_periods)
-
-            outY = mon_out.dataY(ws_index)
+            else:
+                mon_periods = foil_out_periods
+            raw_grp_indices = foil_map.get_indices(spectrum_no, mon_periods)
+            outY = self.mon_out.dataY(ws_index)
             for grp_index in raw_grp_indices:
                 raw_ws = self._raw_monitors[grp_index]
                 outY += raw_ws.readY(self._mon_index)
 
-            # Normalise by monitor
-            indices_in_range = np.where((self.mon_pt_times >= self._mon_norm_start) & (self.mon_pt_times < self._mon_norm_end))
-            mon_values = mon_out.readY(ws_index)
-            mon_values_sum = np.sum(mon_values[indices_in_range])
-            foil_state = foil_out.dataY(ws_index)
-            foil_state *= (self._mon_scale/mon_values_sum)
-            err = foil_out.dataE(ws_index)
-            err *= (self._mon_scale/mon_values_sum)
+            self._ws_index = ws_index
+            self._normalise_by_monitor()
 
         ip_file = self.getPropertyValue(INST_PAR_PROP)
         if len(ip_file) > 0:
@@ -389,72 +371,37 @@ class LoadVesuvio(LoadEmptyVesuvio):
         if self._sumspectra:
             self._sum_all_spectra()
 
+        ms.DeleteWorkspace(Workspace=SUMMED_WS)
         self._store_results()
-        self._cleanup_raw()
 
 #----------------------------------------------------------------------------------------
 
-    def _load_single_foil_state(self, all_spectra):
-
-        # Check if the monitor spectra are already in the spectra list
-
+    def _load_single_run_spec_and_mon(self, all_spectra, run_str):
+        # check if the monitor spectra are already in the spectra list
         filtered_spectra = sorted([i for i in all_spectra if i <= self._mon_spectra[-1]])
         if filtered_spectra == self._mon_spectra and self._load_monitors:
             # Load monitors in workspace if defined by user
             self._load_monitors = False
-            all_spec_inc_mon = all_spectra
             logger.warning("LoadMonitors is true while monitor spectra are defined in the spectra list.")
             logger.warning("Monitors have been loaded into the data workspace not separately.")
+        if not self._load_monitors:
+            ms.LoadRaw(Filename=run_str, OutputWorkspace=SUMMED_WS, SpectrumList=all_spectra,
+                       EnableLogging=_LOGGING_)
         else:
-            # Create list of spectra with monitors
             all_spec_inc_mon = self._mon_spectra
             all_spec_inc_mon.extend(all_spectra)
-
-
-
-
-        isis = config.getFacility('ISIS')
-        inst_prefix = isis.instrument('VESUVIO').shortName()
-
-        runs = self._get_runs()
-
-        for index, run in enumerate(runs):
-            run_str = inst_prefix + str(run)
-            self._raise_error_period_scatter(run_str, self._back_scattering)
-
-            # Sum runs
-            if index == 0:
-                out_name, out_mon = SUMMED_WS, SUMMED_WS + '_monitors'
-            else:
-                out_name, out_mon = SUMMED_WS + 'tmp', SUMMED_WS + 'tmp_monitors'
-
-            ms.LoadRaw(Filename=run_str, OutputWorkspace=out_name, SpectrumList=all_spec_inc_mon,
+            ms.LoadRaw(Filename=run_str, OutputWorkspace=SUMMED_WS, SpectrumList=all_spec_inc_mon,
                        LoadMonitors='Separate', EnableLogging=_LOGGING_)
-
-            if index > 0:
-                ms.Plus(LHSWorkspace=SUMMED_WS,
-                        RHSWorkspace=out_name,
-                        OutputWorkspace=SUMMED_WS,
-                        EnableLogging=_LOGGING_)
-                ms.Plus(LHSWorkspace=SUMMED_WS + '_monitors',
-                        RHSWorkspace=out_mon,
-                        OutputWorkspace=SUMMED_WS + '_monitors',
-                        EnableLogging=_LOGGING_)
-
-                ms.DeleteWorkspace(out_name, EnableLogging=_LOGGING_)
-                ms.DeleteWorkspace(out_mon, EnableLogging=_LOGGING_)
-
-            if self._load_monitors:
-                monitor_group = mtd[SUMMED_WS + '_monitors']
-                mon_out_name = self.getPropertyValue(WKSP_PROP) + "_monitors"
-                clone = self.createChildAlgorithm("CloneWorkspace", False)
-                clone.setProperty("InputWorkspace", monitor_group.getItem(0))
-                clone.setProperty("OutputWorkspace", mon_out_name)
-                clone.execute()
-                self._load_monitors_workspace = clone.getProperty("OutputWorkspace").value
-                self._load_monitors_workspace = self._sum_monitors_in_group(monitor_group,
-                                                                            self._load_monitors_workspace)
-            self._raw_monitors = mtd[SUMMED_WS + '_monitors']
+            monitor_group = mtd[SUMMED_WS +'_monitors']
+            mon_out_name = self.getPropertyValue(WKSP_PROP) + "_monitors"
+            clone = self.createChildAlgorithm("CloneWorkspace", False)
+            clone.setProperty("InputWorkspace", monitor_group.getItem(0))
+            clone.setProperty("OutputWorkspace", mon_out_name)
+            clone.execute()
+            self._load_monitors_workspace = clone.getProperty("OutputWorkspace").value
+            self._load_monitors_workspace = self._sum_monitors_in_group(monitor_group,
+                                                                        self._load_monitors_workspace)
+            ms.DeleteWorkspace(Workspace=monitor_group)
 
 #----------------------------------------------------------------------------------------
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -1,6 +1,3 @@
-#pylint: disable=no-init, unused-variable, too-many-lines
-# we need to disable unused_variable because ws.dataY(n) returns a reference  to the underlying c++ object
-# that can be modified inplace
 from __future__ import (absolute_import, division, print_function)
 from mantid.kernel import *
 from mantid.api import *
@@ -33,8 +30,6 @@ FORWARD = 1
 
 # Child Algorithm logging
 _LOGGING_ = False
-
-#pylint: disable=too-many-instance-attributes
 
 
 class LoadVesuvio(LoadEmptyVesuvio):
@@ -346,7 +341,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
             elif self._diff_opt == "FoilInOut":
                 raw_grp_indices = list(range(0, self._nperiods))
             else:
-                raise RuntimeError("Unknown single foil mode: %s." % (self._diff_opt))
+                raise RuntimeError("Unknown single foil mode: %s." % self._diff_opt)
 
             dataY = foil_out.dataY(ws_index)
             dataE = foil_out.dataE(ws_index)
@@ -455,7 +450,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         def to_range_tuple(str_range):
             """Return a list of 2 floats giving the lower,upper range"""
             elements = str_range.split("-")
-            return (float(elements[0]),float(elements[1]))
+            return float(elements[0]), float(elements[1])
 
         self._back_mon_norm = to_range_tuple(self.backward_monitor_norm)
         self._back_period_sum1 = to_range_tuple(self.backward_period_sum1)
@@ -625,7 +620,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         Sums together all the monitors for one run
         @param monitor_group    :: All the monitor workspaces for a single run
         @param output_ws        :: The workspace that will contain the summed monitor data
-        @return                 :: The workspace contianing the summed monitor data
+        @return                 :: The workspace containing the summed monitor data
         """
 
         for mon_index in range(1, monitor_group.getNumberOfEntries()):
@@ -682,16 +677,14 @@ class LoadVesuvio(LoadEmptyVesuvio):
 #----------------------------------------------------------------------------------------
 
     def _is_back_scattering(self, spectrum_no):
-        return spectrum_no >= self._backward_spectra_list[0] and \
-            spectrum_no <= self._backward_spectra_list[-1]
+        return self._backward_spectra_list[0] <= spectrum_no <= self._backward_spectra_list[-1]
 
-#----------------------------------------------------------------------------------------
+    #----------------------------------------------------------------------------------------
 
     def _is_fwd_scattering(self, spectrum_no):
-        return spectrum_no >= self._forward_spectra_list[0] and \
-            spectrum_no <= self._forward_spectra_list[-1]
+        return self._forward_spectra_list[0] <= spectrum_no <= self._forward_spectra_list[-1]
 
-#----------------------------------------------------------------------------------------
+    #----------------------------------------------------------------------------------------
 
     def _integrate_periods(self):
         """
@@ -818,7 +811,6 @@ class LoadVesuvio(LoadEmptyVesuvio):
 
 #----------------------------------------------------------------------------------------
 
-    #pylint: disable=too-many-arguments
     def _sum_foils(self, foil_ws, mon_ws, sum_index, foil_periods, mon_periods=None):
         """
         Sums the counts from the given foil periods in the raw data group
@@ -1045,7 +1037,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         self.setProperty(WKSP_PROP, self.foil_out)
         # Add OutputWorkspace property for Monitors
         if self._load_monitors:
-            # Check property is not being re-decalred
+            # Check property is not being re-declared
             if not self.existsProperty(WKSP_PROP_LOAD_MON):
                 mon_out_name = self.getPropertyValue(WKSP_PROP) + '_monitors'
                 self.declareProperty(WorkspaceProperty(WKSP_PROP_LOAD_MON, mon_out_name, Direction.Output),
@@ -1074,7 +1066,7 @@ class SpectraToFoilPeriodMap(object):
     one_to_one          :: Only used in back scattering where there is a single
                            static foil
     odd_even/even_odd   :: Only used in forward scatter models when the foil
-                           is/isn't infront of each detector. First bank 135-142
+                           is/isn't in front of each detector. First bank 135-142
                            is odd_even, second (143-150) is even_odd and so on.
     """
 
@@ -1147,10 +1139,10 @@ class SpectraToFoilPeriodMap(object):
 
         if spectrum_no < 135:
             foil_periods = [1,2,3]
-        elif (spectrum_no >= 135 and spectrum_no <= 142) or \
-             (spectrum_no >= 151 and spectrum_no <= 158) or \
-             (spectrum_no >= 167 and spectrum_no <= 174) or \
-             (spectrum_no >= 183 and spectrum_no <= 190):
+        elif (135 <= spectrum_no <= 142) or \
+             (151 <= spectrum_no <= 158) or \
+             (167 <= spectrum_no <= 174) or \
+             (183 <= spectrum_no <= 190):
             foil_periods = [2,4,6] if foil_out else [1,3,5]
         else:
             foil_periods = [1,3,5] if foil_out else [2,4,6]
@@ -1163,7 +1155,7 @@ class SpectraToFoilPeriodMap(object):
         Returns a tuple of indices that can be used to access the Workspace within
         a WorkspaceGroup that corresponds to the foil state numbers given
         @param spectrum_no :: A spectrum number (1->nspectra)
-        @param foil_state_no :: A number between 1 & 6(inclusive) that defines which foil
+        @param foil_state_numbers :: A number between 1 & 6(inclusive) that defines which foil
                                 state is required
         @returns A tuple of indices in a WorkspaceGroup that gives the associated Workspace
         """
@@ -1189,10 +1181,10 @@ class SpectraToFoilPeriodMap(object):
         # For the back scattering banks or foil states > 6 then there is a 1:1 map
         if foil_state_no > 6 or spectrum_no < 135:
             foil_periods = self._one_to_one
-        elif (spectrum_no >= 135 and spectrum_no <= 142) or \
-             (spectrum_no >= 151 and spectrum_no <= 158) or \
-             (spectrum_no >= 167 and spectrum_no <= 174) or \
-             (spectrum_no >= 183 and spectrum_no <= 190):
+        elif (135 <= spectrum_no <= 142) or \
+             (151 <= spectrum_no <= 158) or \
+             (167 <= spectrum_no <= 174) or \
+             (183 <= spectrum_no <= 190):
              # For each alternating forward scattering bank :: foil_in = 1,3,5, foil out = 2,4,6
             foil_periods = self._odd_even
         else:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/VesuvioDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/VesuvioDiffractionReduction.py
@@ -101,16 +101,12 @@ class VesuvioDiffractionReduction(DataProcessorAlgorithm):
 
         # Split up runs as LoadVesuvio sums multiple runs
         input_files = self._data_files
-
         for run in input_files:
-            if "-" in run:
-                lower, upper = run.split("-")
-                # Range goes lower to up-1 but we want to include the last number
-                self._data_files = list(range(int(lower), int(upper) + 1))
-            elif "," in run:
-                self._data_files = run.split(",")
-            else:
-                self._data_files = [str(run)]
+            try:
+                number_generator = IntArrayProperty('array_generator', run)
+                self._data_files = number_generator.value.tolist()
+            except RuntimeError:
+                raise RuntimeError("Could not generate run numbers from this input: " + run)
 
         self._workspace_names, self._chopped_data = load_files(self._data_files,
                                                                ipf_filename=self._ipf_filename,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/VesuvioDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/VesuvioDiffractionReduction.py
@@ -1,4 +1,3 @@
-#pylint: disable=no-init, too-many-instance-attributes
 from __future__ import (absolute_import, division, print_function)
 from mantid.simpleapi import *
 from mantid.api import *
@@ -9,7 +8,6 @@ import os
 
 
 class VesuvioDiffractionReduction(DataProcessorAlgorithm):
-
     _workspace_names = None
     _chopped_data = None
     _output_ws = None
@@ -94,10 +92,25 @@ class VesuvioDiffractionReduction(DataProcessorAlgorithm):
         load_opts = dict()
         load_opts['Mode'] = 'FoilOut'
         load_opts['InstrumentParFile'] = self._par_filename
+        # Load monitors as True so monitors will not be loaded separately in LoadVesuvio
+        load_opts['LoadMonitors'] = True
 
         prog_reporter = Progress(self, start=0.0, end=1.0, nreports=1)
 
         prog_reporter.report("Loading Files")
+
+        # Split up runs as LoadVesuvio sums multiple runs
+        input_files = self._data_files
+
+        for run in input_files:
+            if "-" in run:
+                lower, upper = run.split("-")
+                # Range goes lower to up-1 but we want to include the last number
+                self._data_files = list(range(int(lower), int(upper) + 1))
+            elif "," in run:
+                self._data_files = run.split(",")
+            else:
+                self._data_files = [str(run)]
 
         self._workspace_names, self._chopped_data = load_files(self._data_files,
                                                                ipf_filename=self._ipf_filename,
@@ -195,7 +208,7 @@ class VesuvioDiffractionReduction(DataProcessorAlgorithm):
         self._ipf_filename = self._instrument_name + '_diffraction_' + self._mode + '_Parameters.xml'
         if not os.path.exists(self._ipf_filename):
             self._ipf_filename = os.path.join(config['instrumentDefinition.directory'], self._ipf_filename)
-        logger.information('IPF filename is: %s' % (self._ipf_filename))
+        logger.information('IPF filename is: %s' % self._ipf_filename)
 
         # Only enable sum files if we actually have more than one file
         sum_files = self.getProperty('SumFiles').value

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioDiffractionReductionTest.py
@@ -13,7 +13,7 @@ class VesuvioDiffractionReductionTest(unittest.TestCase):
         Sanity test to ensure the most basic reduction actually completes.
         """
 
-        wks = VesuvioDiffractionReduction(InputFiles=['EVS15289.raw'],
+        wks = VesuvioDiffractionReduction(InputFiles=['15289'],
                                       InstrumentParFIle='IP0005.dat')
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
@@ -30,7 +30,7 @@ class VesuvioDiffractionReductionTest(unittest.TestCase):
         Test setting individual grouping, one spectrum per detector.
         """
 
-        wks = VesuvioDiffractionReduction(InputFiles=['EVS15289.raw'],
+        wks = VesuvioDiffractionReduction(InputFiles=['15289'],
                                       GroupingPolicy='Individual',
                                       InstrumentParFIle='IP0005.dat')
 

--- a/docs/source/algorithms/VesuvioDiffractionReduction-v1.rst
+++ b/docs/source/algorithms/VesuvioDiffractionReduction-v1.rst
@@ -27,7 +27,7 @@ Usage
 
 .. testcode:: ExVesuvioDiffractionReductionSimple
 
-    VesuvioDiffractionReduction(InputFiles='EVS15289.raw',
+    VesuvioDiffractionReduction(InputFiles='15289',
                             OutputWorkspace='DiffractionReductions',
                             InstrumentParFile='IP0005.dat')
 

--- a/docs/source/release/v3.9.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.9.0/indirect_inelastic.rst
@@ -54,6 +54,10 @@ Transmission
 - :ref:`IsoRotDiff <func-IsoRotDiff>` models isotropic rotational diffusion of a particle
   tethered to the origin at a constant distance.
 
+Vesuvio
+#######
+
+- Run numbers can now be input as a range in :ref:`LoadVesuvio <algm-LoadVesuvio>` and :ref:`VesuvioDiffractionReduction <algm-VesuvioDiffractionReduction>`
 
 Improvements
 ------------

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -35,7 +35,7 @@ def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files=False, lo
         # The filename without path and extension will be the workspace name
         ws_name = os.path.splitext(os.path.basename(str(filename)))[0]
         logger.debug('Loading file %s as workspace %s' % (filename, ws_name))
-        print(filename)
+
         if 'VESUVIO' in ipf_filename:
             evs_filename = os.path.basename(str(filename)).replace('EVS', '')
             LoadVesuvio(Filename=evs_filename,

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -1,4 +1,3 @@
-#pylint: disable=invalid-name,too-many-branches,too-many-arguments,deprecated-module,no-name-in-module,too-many-locals
 from __future__ import (absolute_import, division, print_function)
 from mantid.api import WorkspaceGroup, AlgorithmManager
 from mantid import mtd, logger, config
@@ -34,11 +33,11 @@ def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files=False, lo
 
     for filename in data_files:
         # The filename without path and extension will be the workspace name
-        ws_name = os.path.splitext(os.path.basename(filename))[0]
+        ws_name = os.path.splitext(os.path.basename(str(filename)))[0]
         logger.debug('Loading file %s as workspace %s' % (filename, ws_name))
-
+        print(filename)
         if 'VESUVIO' in ipf_filename:
-            evs_filename = os.path.basename(filename).replace('EVS', '')
+            evs_filename = os.path.basename(str(filename)).replace('EVS', '')
             LoadVesuvio(Filename=evs_filename,
                         OutputWorkspace=ws_name,
                         SpectrumList='1-198',


### PR DESCRIPTION
LoadVesuvio and VesuvioDiffractionReduction have been modified to allow a range of run numbers to be input for `FoilOut`, `FoilIn` and `FoilInOut` modes. The runs are summed and result normalised. 

**To test:**

The InstrumentParFile can be found at: 
`\\olympic\babylon5\Public\Louise McCann\IP_2015_06_Chimney_header.par`

Ensure that the Data Archive Service can be accessed.
Run LoadVesuvio with the following parameters:

- Filename =  23893-23912
- SpectrumList = 3-134
- Mode =  `FoilOut`, `FoilIn` and `FoilInOut`
- InstrumentParFile = Previously mentioned file available from babylon5 - If you can't find the file in file browser, ensure the file browser is searching for .par files. It defaults to looking for .dat files.
- OutputWorkspace = outWs

Fixes #17891.

[Release Notes](https://github.com/mantidproject/mantid/blob/079e7ca5536cdb31087048e9b62a204eceae2587/docs/source/release/v3.9.0/indirect_inelastic.rst)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

