### PR TITLE
Fix coverity warning in PDLoadCharacterizations

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/PDLoadCharacterizations.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/PDLoadCharacterizations.h
@@ -36,6 +36,7 @@ namespace DataHandling {
 */
 class DLLExport PDLoadCharacterizations : public API::Algorithm {
 public:
+  PDLoadCharacterizations();
   const std::string name() const override;
   int version() const override;
   const std::string category() const override;

--- a/Framework/DataHandling/inc/MantidDataHandling/PDLoadCharacterizations.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/PDLoadCharacterizations.h
@@ -36,7 +36,6 @@ namespace DataHandling {
 */
 class DLLExport PDLoadCharacterizations : public API::Algorithm {
 public:
-  PDLoadCharacterizations();
   const std::string name() const override;
   int version() const override;
   const std::string category() const override;
@@ -56,8 +55,6 @@ private:
   void readVersion1(const std::string &filename,
                     API::ITableWorkspace_sptr &wksp);
   void readExpIni(const std::string &filename, API::ITableWorkspace_sptr &wksp);
-  bool hasExtras;
-  std::vector<std::string> canColumnNames;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -87,9 +87,6 @@ extra_columns(const std::vector<std::string> &filenames) {
 }
 }
 
-PDLoadCharacterizations::PDLoadCharacterizations()
-    : hasExtras(false), canColumnNames() {}
-
 //----------------------------------------------------------------------------------------------
 /// Algorithm's name for identification. @see Algorithm::name
 const std::string PDLoadCharacterizations::name() const {
@@ -148,14 +145,8 @@ void PDLoadCharacterizations::init() {
 /** Execute the algorithm.
  */
 void PDLoadCharacterizations::exec() {
-  this->hasExtras = false;
   auto filenames = this->getFilenames();
-
-  for (const auto filename : filenames) { // REMOVE
-    std::cout << filename << std::endl;   // REMOVE
-  }                                       // REMOVE
-
-  this->canColumnNames = extra_columns(filenames);
+  const std::vector<std::string> canColumnNames = extra_columns(filenames);
 
   // setup the default table workspace for the characterization runs
   ITableWorkspace_sptr wksp = WorkspaceFactory::Instance().createTable();
@@ -173,7 +164,7 @@ void PDLoadCharacterizations::exec() {
   wksp->addColumn("double", "tof_max");
   wksp->addColumn("double", "wavelength_min");
   wksp->addColumn("double", "wavelength_max");
-  for (const auto name : this->canColumnNames) {
+  for (const auto name : canColumnNames) {
     wksp->addColumn("str", name); // all will be strings
   }
 
@@ -320,6 +311,8 @@ void PDLoadCharacterizations::readCharInfo(std::ifstream &file,
   if (file.eof())
     return;
 
+  const size_t num_of_columns = wksp->columnCount();
+
   // parse the file
   for (std::string line = Strings::getLine(file); !file.eof();
        line = Strings::getLine(file)) {
@@ -354,9 +347,11 @@ void PDLoadCharacterizations::readCharInfo(std::ifstream &file,
     row << boost::lexical_cast<double>(splitted[9]);  // tof_max
     row << boost::lexical_cast<double>(splitted[10]); // wavelength_min
     row << boost::lexical_cast<double>(splitted[11]); // wavelength_max
+
     // pad all extras with empty string
-    for (const auto name : this->canColumnNames)
+    for (size_t i = 14; i < num_of_columns; ++i) {
       row << "0";
+    }
   }
 }
 

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -348,7 +348,8 @@ void PDLoadCharacterizations::readCharInfo(std::ifstream &file,
     row << boost::lexical_cast<double>(splitted[10]); // wavelength_min
     row << boost::lexical_cast<double>(splitted[11]); // wavelength_max
 
-    // pad all extras with empty string
+    // pad all extras with empty string - the 14 required columns have
+    // already been added to the row
     for (size_t i = 14; i < num_of_columns; ++i) {
       row << "0";
     }

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -87,6 +87,9 @@ extra_columns(const std::vector<std::string> &filenames) {
 }
 }
 
+PDLoadCharacterizations::PDLoadCharacterizations()
+    : hasExtras(false), canColumnNames() {}
+
 //----------------------------------------------------------------------------------------------
 /// Algorithm's name for identification. @see Algorithm::name
 const std::string PDLoadCharacterizations::name() const {

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -164,7 +164,7 @@ void PDLoadCharacterizations::exec() {
   wksp->addColumn("double", "tof_max");
   wksp->addColumn("double", "wavelength_min");
   wksp->addColumn("double", "wavelength_max");
-  for (const auto name : canColumnNames) {
+  for (const auto &name : canColumnNames) {
     wksp->addColumn("str", name); // all will be strings
   }
 


### PR DESCRIPTION
This adds a constructor so default values for member variables can be set.

**To test:**

Just review the code

Fixes coverity issue 1366006.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

