### PR TITLE
Add eFixed methods to DetectorInfo and SpectrumInfo

### DIFF
--- a/Framework/API/inc/MantidAPI/DetectorInfo.h
+++ b/Framework/API/inc/MantidAPI/DetectorInfo.h
@@ -70,6 +70,7 @@ public:
   double signedTwoTheta(const size_t index) const;
   Kernel::V3D position(const size_t index) const;
   Kernel::Quat rotation(const size_t index) const;
+  double eFixed(const size_t index) const;
 
   void setPosition(const size_t index, const Kernel::V3D &position);
   void setRotation(const size_t index, const Kernel::Quat &rotation);

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -110,12 +110,12 @@ public:
   virtual int getRunNumber() const;
   /// Returns the emode for this run
   virtual Kernel::DeltaEMode::Type getEMode() const;
-  /// Easy access to the efixed value for this run & detector ID
-  virtual double getEFixed(const detid_t detID) const;
   /// Easy access to the efixed value for this run & optional detector
   virtual double
   getEFixed(const Geometry::IDetector_const_sptr
-                detector = Geometry::IDetector_const_sptr()) const;
+            detector = Geometry::IDetector_const_sptr()) const;
+  /// Easy access to the efixed value for this run & detector ID
+  virtual double getEFixed(const detid_t detID) const;
   /// Set the efixed value for a given detector ID
   virtual void setEFixed(const detid_t detID, const double value);
 

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -113,7 +113,7 @@ public:
   /// Easy access to the efixed value for this run & optional detector
   virtual double
   getEFixed(const Geometry::IDetector_const_sptr
-            detector = Geometry::IDetector_const_sptr()) const;
+                detector = Geometry::IDetector_const_sptr()) const;
   /// Easy access to the efixed value for this run & detector ID
   virtual double getEFixed(const detid_t detID) const;
   /// Set the efixed value for a given detector ID

--- a/Framework/API/inc/MantidAPI/SpectrumInfo.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfo.h
@@ -69,6 +69,7 @@ public:
   double twoTheta(const size_t index) const;
   double signedTwoTheta(const size_t index) const;
   Kernel::V3D position(const size_t index) const;
+  double eFixed(const size_t index) const;
   bool hasDetectors(const size_t index) const;
   bool hasUniqueDetector(const size_t index) const;
 

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -95,7 +95,8 @@ Kernel::Quat DetectorInfo::rotation(const size_t index) const {
 
 double DetectorInfo::eFixed(const size_t index) const {
   const auto &detector = getDetector(index);
-  auto eFixedVector = detector.getNumberParameter("Efixed");
+  auto eFixedVector =
+      detector.getNumberParameter(Geometry::ParameterMap::eFixed());
 
   double eFixed = 0.0;
 

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -93,6 +93,19 @@ Kernel::Quat DetectorInfo::rotation(const size_t index) const {
   return getDetector(index).getRotation();
 }
 
+double DetectorInfo::eFixed(const size_t index) const {
+  const auto &detector = getDetector(index);
+  auto eFixedVector = detector.getNumberParameter("Efixed");
+
+  double eFixed = 0.0;
+
+  if (!eFixedVector.empty()) {
+    eFixed = eFixedVector.front();
+  }
+
+  return eFixed;
+}
+
 /// Set the absolute position of the detector with given index.
 void DetectorInfo::setPosition(const size_t index,
                                const Kernel::V3D &position) {

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -638,29 +638,17 @@ ExperimentInfo::getEFixed(const Geometry::IDetector_const_sptr detector) const {
     if (!detector)
       throw std::runtime_error("ExperimentInfo::getEFixed - Indirect mode "
                                "efixed requested without a valid detector.");
-    Parameter_sptr par =
-        constInstrumentParameters().getRecursive(detector.get(), "Efixed");
-    if (par) {
-      return par->value<double>();
+    const auto detectorIndex = detectorInfo().indexOf(detector->getID());
+    double eFixed = detectorInfo().eFixed(detectorIndex);
+    if (eFixed != 0.0) {
+      return eFixed;
     } else {
-      std::vector<double> efixedVec = detector->getNumberParameter("Efixed");
-      if (efixedVec.empty()) {
-        int detid = detector->getID();
-        IDetector_const_sptr detectorSingle =
-            getInstrument()->getDetector(detid);
-        efixedVec = detectorSingle->getNumberParameter("Efixed");
-      }
-      if (!efixedVec.empty()) {
-        return efixedVec.at(0);
-      } else {
         std::ostringstream os;
         os << "ExperimentInfo::getEFixed - Indirect mode efixed requested but "
-              "detector has no Efixed parameter attached. ID="
-           << detector->getID();
+              "detector has no Efixed parameter attached. ID=" << detector->getID();
         throw std::runtime_error(os.str());
-      }
     }
-  } else {
+    } else {
     throw std::runtime_error("ExperimentInfo::getEFixed - EFixed requested for "
                              "elastic mode, don't know what to do!");
   }

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -605,27 +605,14 @@ Kernel::DeltaEMode::Type ExperimentInfo::getEMode() const {
 }
 
 /**
- * Easy access to the efixed value for this run & detector ID
+ * Easy access to the efixed value for this run and detector ID.
  * @param detID :: The detector ID to ask for the efixed mode (ignored in Direct
- * & Elastic mode). The
- * detector with ID matching that given is pulled from the instrument with this
- * method and it will
- * throw a Exception::NotFoundError if the ID is unknown.
+ * & Elastic mode). The detector with ID matching that given is pulled from the
+ * instrument with this method and it will throw a std::out_of_range error if
+ * the ID is unknown.
  * @return The current EFixed value
  */
 double ExperimentInfo::getEFixed(const detid_t detID) const {
-  IDetector_const_sptr det = getInstrument()->getDetector(detID);
-  return getEFixed(det);
-}
-
-/**
- * Easy access to the efixed value for this run & detector
- * @param detector :: The detector object to ask for the efixed mode. Only
- * required for Indirect mode
- * @return The current efixed value
- */
-double
-ExperimentInfo::getEFixed(const Geometry::IDetector_const_sptr detector) const {
   Kernel::DeltaEMode::Type emode = getEMode();
   if (emode == Kernel::DeltaEMode::Direct) {
     try {
@@ -635,23 +622,43 @@ ExperimentInfo::getEFixed(const Geometry::IDetector_const_sptr detector) const {
           "Experiment logs do not contain an Ei value. Have you run GetEi?");
     }
   } else if (emode == Kernel::DeltaEMode::Indirect) {
-    if (!detector)
-      throw std::runtime_error("ExperimentInfo::getEFixed - Indirect mode "
-                               "efixed requested without a valid detector.");
-    const auto detectorIndex = detectorInfo().indexOf(detector->getID());
+    const auto detectorIndex = detectorInfo().indexOf(detID);
     double eFixed = detectorInfo().eFixed(detectorIndex);
     if (eFixed != 0.0) {
       return eFixed;
     } else {
-        std::ostringstream os;
-        os << "ExperimentInfo::getEFixed - Indirect mode efixed requested but "
-              "detector has no Efixed parameter attached. ID=" << detector->getID();
-        throw std::runtime_error(os.str());
+      std::ostringstream os;
+      os << "ExperimentInfo::getEFixed - Indirect mode efixed requested but "
+            "detector has no Efixed parameter attached. ID=" << detID;
+      throw std::runtime_error(os.str());
     }
-    } else {
+  } else {
     throw std::runtime_error("ExperimentInfo::getEFixed - EFixed requested for "
                              "elastic mode, don't know what to do!");
   }
+}
+
+/**
+ * Easy access to the efixed value for this run and detector
+ * @param detector :: The detector object to ask for the efixed mode. Only
+ * required for Indirect mode, will throw a std::runtime_error if the detector
+ * is invalid. This can be null for direct or elastic modes.
+ * @return The current efixed value
+ */
+double
+ExperimentInfo::getEFixed(const Geometry::IDetector_const_sptr detector) const {
+  detid_t detectorID(0);
+
+  if (getEMode() == Kernel::DeltaEMode::Indirect) {
+    if (detector) {
+      detectorID = detector->getID();
+    } else {
+      throw std::runtime_error("ExperimentInfo::getEFixed - Indirect mode "
+                               "efixed requested without a valid detector.");
+    }
+  }
+
+  return getEFixed(detectorID);
 }
 
 void ExperimentInfo::setEFixed(const detid_t detID, const double value) {

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -113,7 +113,6 @@ double SpectrumInfo::eFixed(const size_t index) const {
   return eFixed / static_cast<double>(dets.size());
 }
 
-
 /// Returns true if the spectrum is associated with detectors in the instrument.
 bool SpectrumInfo::hasDetectors(const size_t index) const {
   // Workspaces can contain invalid detector IDs. Those IDs will be silently

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -101,6 +101,19 @@ Kernel::V3D SpectrumInfo::position(const size_t index) const {
   return newPos / static_cast<double>(dets.size());
 }
 
+/// Returns the eFixed value of the spectrum with given index.
+double SpectrumInfo::eFixed(const size_t index) const {
+  double eFixed(0);
+  const auto &dets = getDetectorVector(index);
+  for (const auto &det : dets) {
+    const auto &detIndex = m_detectorInfo.indexOf(det->getID());
+    m_detectorInfo.setCachedDetector(detIndex, det);
+    eFixed += m_detectorInfo.eFixed(detIndex);
+  }
+  return eFixed / static_cast<double>(dets.size());
+}
+
+
 /// Returns true if the spectrum is associated with detectors in the instrument.
 bool SpectrumInfo::hasDetectors(const size_t index) const {
   // Workspaces can contain invalid detector IDs. Those IDs will be silently

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -104,13 +104,22 @@ Kernel::V3D SpectrumInfo::position(const size_t index) const {
 /// Returns the eFixed value of the spectrum with given index.
 double SpectrumInfo::eFixed(const size_t index) const {
   double eFixed(0);
+  size_t validEFixedSize(0);
   const auto &dets = getDetectorVector(index);
+
   for (const auto &det : dets) {
     const auto &detIndex = m_detectorInfo.indexOf(det->getID());
     m_detectorInfo.setCachedDetector(detIndex, det);
-    eFixed += m_detectorInfo.eFixed(detIndex);
+    double detectorEFixed = m_detectorInfo.eFixed(detIndex);
+
+    if (detectorEFixed != 0.0) {
+      eFixed += detectorEFixed;
+      validEFixedSize++;
+    }
   }
-  return eFixed / static_cast<double>(dets.size());
+
+  return validEFixedSize > 1 ? eFixed / static_cast<double>(validEFixedSize)
+                             : eFixed;
 }
 
 /// Returns true if the spectrum is associated with detectors in the instrument.

--- a/Framework/API/test/DetectorInfoTest.h
+++ b/Framework/API/test/DetectorInfoTest.h
@@ -37,7 +37,7 @@ public:
         IDetector_const_sptr det = m_workspace.getDetector(i);
         pmap.addBool(det.get(), "masked", true);
       }
-      pmap.addDouble(m_workspace.getDetector(i).get(), "Efixed",
+      pmap.addDouble(m_workspace.getDetector(i).get(), ParameterMap::eFixed(),
                      static_cast<double>(i));
     }
 

--- a/Framework/API/test/DetectorInfoTest.h
+++ b/Framework/API/test/DetectorInfoTest.h
@@ -37,6 +37,8 @@ public:
         IDetector_const_sptr det = m_workspace.getDetector(i);
         pmap.addBool(det.get(), "masked", true);
       }
+      pmap.addDouble(m_workspace.getDetector(i).get(), "Efixed",
+                     static_cast<double>(i));
     }
 
     m_workspaceNoInstrument.init(numberOfHistograms, numberOfBins,
@@ -150,6 +152,15 @@ public:
     TS_ASSERT_EQUALS(detectorInfo.position(2), V3D(0.0, 0.1, 5.0));
     TS_ASSERT_EQUALS(detectorInfo.position(3), V3D(0.0, 0.0, -9.0));
     TS_ASSERT_EQUALS(detectorInfo.position(4), V3D(0.0, 0.0, -2.0));
+  }
+
+  void test_eFixed() {
+    const auto &detectorInfo = m_workspace.detectorInfo();
+    TS_ASSERT_EQUALS(detectorInfo.eFixed(0), 0.0);
+    TS_ASSERT_EQUALS(detectorInfo.eFixed(1), 1.0);
+    TS_ASSERT_EQUALS(detectorInfo.eFixed(2), 2.0);
+    TS_ASSERT_EQUALS(detectorInfo.eFixed(3), 3.0);
+    TS_ASSERT_EQUALS(detectorInfo.eFixed(4), 4.0);
   }
 
   void test_setPosition() {

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -357,7 +357,7 @@ public:
     ExperimentInfo_sptr exptInfo(new ExperimentInfo);
     addInstrumentWithIndirectEmodeParameter(exptInfo);
 
-    TS_ASSERT_THROWS(exptInfo->getEFixed(1), std::runtime_error&);
+    TS_ASSERT_THROWS(exptInfo->getEFixed(1), std::runtime_error &);
   }
 
   void test_correct_efixed_value_is_returned_for_direct_run() {

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -354,10 +354,10 @@ public:
   }
 
   void test_getEFixed_throws_exception_if_detID_does_not_exist() {
-    ExperimentInfo_sptr exptInfo = createTestInfoWithDirectEModeLog();
+    ExperimentInfo_sptr exptInfo(new ExperimentInfo);
+    addInstrumentWithIndirectEmodeParameter(exptInfo);
 
-    TS_ASSERT_THROWS(exptInfo->getEFixed(1),
-                     Mantid::Kernel::Exception::NotFoundError);
+    TS_ASSERT_THROWS(exptInfo->getEFixed(1), std::runtime_error&);
   }
 
   void test_correct_efixed_value_is_returned_for_direct_run() {

--- a/Framework/API/test/SpectrumInfoTest.h
+++ b/Framework/API/test/SpectrumInfoTest.h
@@ -252,17 +252,17 @@ public:
 
   void test_eFixed() {
     const auto &spectrumInfo = m_workspace.spectrumInfo();
-    TS_ASSERT_EQUALS(spectrumInfo.eFixed(0), 0.0);
-    TS_ASSERT_EQUALS(spectrumInfo.eFixed(1), 1.0);
-    TS_ASSERT_EQUALS(spectrumInfo.eFixed(2), 2.0);
-    TS_ASSERT_EQUALS(spectrumInfo.eFixed(3), 3.0);
-    TS_ASSERT_EQUALS(spectrumInfo.eFixed(4), 4.0);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(0), 1.0);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(1), 2.0);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(2), 3.0);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(3), 4.0);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(4), 5.0);
   }
 
   void test_grouped_eFixed() {
     const auto &spectrumInfo = m_grouped.spectrumInfo();
-    TS_ASSERT_EQUALS(spectrumInfo.eFixed(0), 1.5);
-    TS_ASSERT_EQUALS(spectrumInfo.eFixed(1), 0.5);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(0), 2.5);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(1), 1.5);
     // Other eFixed values are not sensible since the detectors include monitors
   }
 
@@ -397,7 +397,8 @@ private:
         IDetector_const_sptr det = ws.getDetector(i);
         pmap.addBool(det.get(), "masked", true);
       }
-      pmap.addDouble(ws.getDetector(i).get(), "Efixed", static_cast<double>(i));
+      pmap.addDouble(ws.getDetector(i).get(), ParameterMap::eFixed(),
+                     static_cast<double>(i + 1));
     }
     return ws;
   }

--- a/Framework/API/test/SpectrumInfoTest.h
+++ b/Framework/API/test/SpectrumInfoTest.h
@@ -250,6 +250,22 @@ public:
     detectorInfo.setPosition(1, oldPos);
   }
 
+  void test_eFixed() {
+    const auto &spectrumInfo = m_workspace.spectrumInfo();
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(0), 0.0);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(1), 1.0);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(2), 2.0);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(3), 3.0);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(4), 4.0);
+  }
+
+  void test_grouped_eFixed() {
+    const auto &spectrumInfo = m_grouped.spectrumInfo();
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(0), 1.5);
+    TS_ASSERT_EQUALS(spectrumInfo.eFixed(1), 0.5);
+    // Other eFixed values are not sensible since the detectors include monitors
+  }
+
   void test_hasDetectors() {
     const auto &spectrumInfo = m_workspace.spectrumInfo();
     TS_ASSERT(spectrumInfo.hasDetectors(0));
@@ -381,6 +397,7 @@ private:
         IDetector_const_sptr det = ws.getDetector(i);
         pmap.addBool(det.get(), "masked", true);
       }
+      pmap.addDouble(ws.getDetector(i).get(), "Efixed", static_cast<double>(i));
     }
     return ws;
   }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -87,6 +87,7 @@ public:
   static const std::string &rotx();
   static const std::string &roty();
   static const std::string &rotz();
+  static const std::string &eFixed();
   static const std::string &pDouble(); // p prefix to avoid name clash
   static const std::string &pInt();
   static const std::string &pBool();

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -29,6 +29,8 @@ const std::string ROTX_PARAM_NAME = "rotx";
 const std::string ROTY_PARAM_NAME = "roty";
 const std::string ROTZ_PARAM_NAME = "rotz";
 
+const std::string EFIXED_PARAM_NAME = "Efixed";
+
 const std::string DOUBLE_PARAM_NAME = "double";
 const std::string INT_PARAM_NAME = "int";
 const std::string BOOL_PARAM_NAME = "bool";
@@ -69,6 +71,8 @@ const std::string &ParameterMap::roty() { return ROTY_PARAM_NAME; }
 const std::string &ParameterMap::rotz() { return ROTZ_PARAM_NAME; }
 
 // Other types
+const std::string &ParameterMap::eFixed() { return EFIXED_PARAM_NAME; }
+
 const std::string &ParameterMap::pDouble() { return DOUBLE_PARAM_NAME; }
 
 const std::string &ParameterMap::pInt() { return INT_PARAM_NAME; }
@@ -80,6 +84,7 @@ const std::string &ParameterMap::pString() { return STRING_PARAM_NAME; }
 const std::string &ParameterMap::pV3D() { return V3D_PARAM_NAME; }
 
 const std::string &ParameterMap::pQuat() { return QUAT_PARAM_NAME; }
+
 
 /**
  * Compares the values in this object with that given for inequality

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -85,7 +85,6 @@ const std::string &ParameterMap::pV3D() { return V3D_PARAM_NAME; }
 
 const std::string &ParameterMap::pQuat() { return QUAT_PARAM_NAME; }
 
-
 /**
  * Compares the values in this object with that given for inequality
  * The order of the values in the map is not important.


### PR DESCRIPTION
`DetectorInfo` and `SpectrumInfo` now have their own `eFixed` methods for getting the value from detectors.

`ExperimentInfo` has been updated to include this. When performing the refactoring for #17743 then either the methods in `ExperimentInfo`, `DetectorInfo` or `SpectrumInfo` should be used for getting the eFixed parameter.

**To test:**

Code review. Are the methods added here adequate for the refactoring, and does it make sense for `SpectrumInfo` to have the eFixed method?

`eFixed` returns 0 when the parameter does not exist from `DetectorInfo`, and averages any detectors with eFixed in `SpectrumInfo`, or returns 0. Does this make sense, or should the eFixed methods return a bool to say if an eFixed exists?

Fixes #18081.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
