### PR TITLE
Add Start to visual-studio.bat to stop it staying open

### DIFF
--- a/buildconfig/windows/visual-studio.bat
+++ b/buildconfig/windows/visual-studio.bat
@@ -7,4 +7,4 @@
 call %~dp0buildenv.bat
 
 :: Start IDE
-"%VS140COMNTOOLS%\..\IDE\devenv.exe" Mantid.sln
+start "" "%VS140COMNTOOLS%\..\IDE\devenv.exe" Mantid.sln


### PR DESCRIPTION
Description of work.
This is a small change to the `visual-studio.bat` script. It starts Visual Studio without waiting for it to return meaning the command prompt closes straight away. 
This will stop developers having a collection of command prompts at the end of a day.

**To test:**
This has been tested against Windows 10 so ideally the tester should have Windows 7. 
- Delete the old `visual-studio.bat` from your build folder to ensure its regenerated.
- Run CMake (just Generate without changing anything)
- Run `visual-studio.bat` the IDE should open and run as expected (e.g. build correctly) and the command window should automatically close

Fixes: No associated issue

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

