### PR TITLE
Fixed Qt selection in ROI tab, and removed repeatedly showing success/warning/error messages

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Tomography/ImageROIPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Tomography/ImageROIPresenter.h
@@ -74,6 +74,9 @@ protected:
   void processBrowseImage();
   void processBrowseStack();
   void processNewStack(bool singleImage);
+  void processLoadSingleImage();
+  void processLoadStackOfImages();
+  void setupAlgorithmRunnerAfterLoad();
   void processChangeImageType();
   void processChangeRotation();
   void processPlayStartStop();

--- a/MantidQt/CustomInterfaces/src/Tomography/EnergyBandsViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/EnergyBandsViewQtGUI.cpp
@@ -132,6 +132,8 @@ void TomographyIfaceViewQtGUI::browseAggScriptClicked() {
 void TomographyIfaceViewQtGUI::runAggregateBands(
     Mantid::API::IAlgorithm_sptr alg) {
 
+  // reset any previous connections
+  m_aggAlgRunner.get()->disconnect();
   connect(m_aggAlgRunner.get(), SIGNAL(batchComplete(bool)), this,
           SLOT(finishedAggBands(bool)), Qt::QueuedConnection);
 

--- a/MantidQt/CustomInterfaces/src/Tomography/ImageROIViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/ImageROIViewQtWidget.cpp
@@ -481,6 +481,9 @@ void ImageROIViewQtWidget::refreshROIetAl() {
   if (!pp)
     return;
 
+  m_ui.label_img->setMaximumWidth(static_cast<int>(m_imgWidth));
+  m_ui.label_img->setMaximumHeight(static_cast<int>(m_imgHeight));
+
   QPixmap toDisplay(*m_basePixmap.get());
   QPainter painter(&toDisplay);
 

--- a/docs/source/release/v3.9.0/imaging.rst
+++ b/docs/source/release/v3.9.0/imaging.rst
@@ -12,7 +12,6 @@ Tomographic reconstruction graphical user interface
 
 Bug Fixes
 ---------
-- The external interpreter and scripts paths are no longer ignored and are now correctly appended when running a local reconstruction
 - Selecting the Center of Rotation, Area for Normalsation and Region of Interest will now always follow the exact position of the mouse
 - Multiple success/warning/error messages will no longer be shown after an operation. 
 

--- a/docs/source/release/v3.9.0/imaging.rst
+++ b/docs/source/release/v3.9.0/imaging.rst
@@ -1,0 +1,21 @@
+=====================
+Imaging Changes
+=====================
+
+.. contents:: Table of Contents
+   :local:
+
+Tomographic reconstruction graphical user interface
+###################################################
+
+- Running local reconstructions is now possible
+
+Bug Fixes
+---------
+- The external interpreter and scripts paths are no longer ignored and are now correctly appended when running a local reconstruction
+- Selecting the Center of Rotation, Area for Normalsation and Region of Interest will now always follow the exact position of the mouse
+- Multiple success/warning/error messages will no longer be shown after an operation. 
+
+|
+
+`Full list of changes on github <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.9%22+is%3Amerged+label%3A%22Component%3A+Imaging%22>`__


### PR DESCRIPTION
Description of work.

- A little bit of refactoring in the ROI presenter
- Repeatedly loading a corrupt image should always show _only_ 1 warning/error message
- Aggregating images should now show only 1 success/error messages
- Select Centre of Rotation (COR)/Area for Normalisation/Region of Interest (ROI) should now *always* be accurate independent of the size of the window or the image position

**To test:**

- Try repeatedly loading corrupt images (could just be a file with nonsense information and extension `.fits`)
- Try aggregating a few times
- Load an image and select the COR, it should always be placed on the Mouse position
- Load an image and select the area for normalisation, ROI, the areas should always be accurate to the mouse position.

<!-- Instructions for testing. -->

Fixes #17942 
Fixes #18082

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

Release Notes
----------------
[In `imaging.rst`](https://github.com/mantidproject/mantid/pull/18113/files#diff-e678fb82fbdc92d52b938c69b0858a2e)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

