### PR TITLE
Avoid extra allocations in Strings::getLine.

### DIFF
--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -59,8 +59,9 @@ extra_columns(const std::vector<std::string> &filenames) {
     throw Exception::FileError("Unable to open file", filenames[F_INDEX_V1]);
   }
 
-  for (std::string line = Strings::getLine(file); !file.eof();
-       line = Strings::getLine(file)) {
+  std::string line;
+  for (Strings::getLine(file, line); !file.eof();
+       Strings::getLine(file, line)) {
     boost::smatch result;
     // all instances of table headers
     if (boost::regex_search(line, result, V1_TABLE_REG_EXP)) {
@@ -268,8 +269,9 @@ void PDLoadCharacterizations::readFocusInfo(std::ifstream &file) {
   std::vector<double> polar;
 
   // parse the file
-  for (std::string line = Strings::getLine(file); !file.eof();
-       line = Strings::getLine(file)) {
+  std::string line;
+  for (Strings::getLine(file, line); !file.eof();
+       Strings::getLine(file, line)) {
     line = Strings::strip(line);
     // skip empty lines and "comments"
     if (line.empty())
@@ -318,10 +320,10 @@ void PDLoadCharacterizations::readCharInfo(std::ifstream &file,
     return;
 
   // parse the file
-  for (std::string line = Strings::getLine(file); !file.eof();
-       line = Strings::getLine(file)) {
+  std::string line;
+  for (Strings::getLine(file, line); !file.eof();
+       Strings::getLine(file, line)) {
     line = Strings::strip(line);
-
     // skip empty lines and "comments"
     if (line.empty())
       continue;
@@ -453,9 +455,8 @@ void PDLoadCharacterizations::readVersion1(const std::string &filename,
 
   // store the names of the columns in order
   std::vector<std::string> columnNames;
-
-  for (std::string line = Strings::getLine(file); !file.eof();
-       line = Strings::getLine(file)) {
+  for (Strings::getLine(file, line); !file.eof();
+       Strings::getLine(file, line)) {
     if (line.empty())
       continue;
     if (line.substr(0, 1) == "#")
@@ -539,8 +540,9 @@ void PDLoadCharacterizations::readExpIni(const std::string &filename,
   }
 
   // parse the file
-  for (std::string line = Strings::getLine(file); !file.eof();
-       line = Strings::getLine(file)) {
+  std::string line;
+  for (Strings::getLine(file, line); !file.eof();
+       Strings::getLine(file, line)) {
     line = Strings::strip(line);
     // skip empty lines and "comments"
     if (line.empty())

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -59,7 +59,7 @@ extra_columns(const std::vector<std::string> &filenames) {
     throw Exception::FileError("Unable to open file", filenames[F_INDEX_V1]);
   }
 
-  for (std::string line = Strings::getLine(file, line); !file.eof();
+  for (std::string line = Strings::getLine(file); !file.eof();
        Strings::getLine(file, line)) {
     boost::smatch result;
     // all instances of table headers

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -59,8 +59,7 @@ extra_columns(const std::vector<std::string> &filenames) {
     throw Exception::FileError("Unable to open file", filenames[F_INDEX_V1]);
   }
 
-  std::string line;
-  for (Strings::getLine(file, line); !file.eof();
+  for (std::string line = Strings::getLine(file, line); !file.eof();
        Strings::getLine(file, line)) {
     boost::smatch result;
     // all instances of table headers
@@ -269,8 +268,7 @@ void PDLoadCharacterizations::readFocusInfo(std::ifstream &file) {
   std::vector<double> polar;
 
   // parse the file
-  std::string line;
-  for (Strings::getLine(file, line); !file.eof();
+  for (std::string line = Strings::getLine(file); !file.eof();
        Strings::getLine(file, line)) {
     line = Strings::strip(line);
     // skip empty lines and "comments"
@@ -320,8 +318,7 @@ void PDLoadCharacterizations::readCharInfo(std::ifstream &file,
     return;
 
   // parse the file
-  std::string line;
-  for (Strings::getLine(file, line); !file.eof();
+  for (std::string line = Strings::getLine(file); !file.eof();
        Strings::getLine(file, line)) {
     line = Strings::strip(line);
     // skip empty lines and "comments"
@@ -540,8 +537,7 @@ void PDLoadCharacterizations::readExpIni(const std::string &filename,
   }
 
   // parse the file
-  std::string line;
-  for (Strings::getLine(file, line); !file.eof();
+  for (std::string line = Strings::getLine(file); !file.eof();
        Strings::getLine(file, line)) {
     line = Strings::strip(line);
     // skip empty lines and "comments"

--- a/Framework/Kernel/inc/MantidKernel/Strings.h
+++ b/Framework/Kernel/inc/MantidKernel/Strings.h
@@ -101,7 +101,11 @@ MANTID_KERNEL_DLL int isEmpty(const std::string &A);
 /// Determines if a string starts with a #
 MANTID_KERNEL_DLL bool skipLine(const std::string &line);
 /// Get a line and strip comments
-MANTID_KERNEL_DLL std::string getLine(std::istream &fh, const int spc = 256);
+/// Use only for a single call
+MANTID_KERNEL_DLL std::string getLine(std::istream &fh);
+/// Get a line and strip comments
+/// Use within a loop
+MANTID_KERNEL_DLL void getLine(std::istream &fh, std::string &Line);
 /// Peek at a line without extracting it from the stream
 MANTID_KERNEL_DLL std::string peekLine(std::istream &fh);
 /// get a part of a long line

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -275,26 +275,31 @@ std::string removeSpace(const std::string &CLine) {
 
 //------------------------------------------------------------------------------------------------
 /**
+  *  Reads a line from the stream of max length spc.
+  *  Trailing comments are removed. (with # or ! character)
+  *  @param fh :: already open file handle
+  *  @return String read.
+  */
+std::string getLine(std::istream &fh) {
+  std::string line;
+  getLine(fh, line);
+  return line;
+}
+
+//------------------------------------------------------------------------------------------------
+/**
  *  Reads a line from the stream of max length spc.
  *  Trailing comments are removed. (with # or ! character)
  *  @param fh :: already open file handle
- *  @param spc :: max number of characters to read
- *  @return String read.
+ *  @param Line :: string read
  */
-std::string getLine(std::istream &fh, const int spc) {
-  auto ss = new char[spc + 1];
-  std::string Line;
-  if (fh.good()) {
-    fh.getline(ss, spc, '\n');
-    ss[spc] = 0; // incase line failed to read completely
-    Line = ss;
+void getLine(std::istream &fh, std::string &Line) {
+  if (std::getline(fh, Line, '\n')) {
     // remove trailing comments
-    std::string::size_type pos = Line.find_first_of("#!");
+    auto pos = Line.find_first_of("#!");
     if (pos != std::string::npos)
       Line.erase(pos);
   }
-  delete[] ss;
-  return Line;
 }
 
 /**

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -294,7 +294,7 @@ std::string getLine(std::istream &fh) {
  *  @param Line :: string read
  */
 void getLine(std::istream &fh, std::string &Line) {
-  if (std::getline(fh, Line, '\n')) {
+  if (std::getline(fh, Line)) {
     // remove trailing comments
     auto pos = Line.find_first_of("#!");
     if (pos != std::string::npos)

--- a/Framework/Kernel/test/StringsTest.h
+++ b/Framework/Kernel/test/StringsTest.h
@@ -419,17 +419,22 @@ public:
   }
 
   void test_toString_vector_of_ints() {
-    std::vector<int> sortedInts;
-    sortedInts.push_back(1);
-    sortedInts.push_back(2);
-    sortedInts.push_back(3);
-    sortedInts.push_back(5);
-    sortedInts.push_back(6);
-    sortedInts.push_back(8);
-
+    std::vector<int> sortedInts{1, 2, 3, 5, 6, 8};
     auto result = toString(sortedInts);
-
     TS_ASSERT_EQUALS(std::string("1-3,5-6,8"), result);
+  }
+
+  void test_getLine() {
+    std::istringstream text("blah blah\nfoo bar#comment\n");
+    std::string line = getLine(text);
+    TSM_ASSERT_EQUALS("Strings::getLine failed to read the first line.", line,
+                      "blah blah");
+    getLine(text, line);
+    TSM_ASSERT_EQUALS("Strings::getLine failed to remove comment.", line,
+                      "foo bar");
+    getLine(text, line);
+    TSM_ASSERT_EQUALS("Strings::getLine didn't return empty string after eof.",
+                      line, "");
   }
 };
 


### PR DESCRIPTION
Description of work.

This updates `Strings::getLine(std::istream &)` to using `std::getline` and avoid allocating an additional array of `char`. It also includes an additional function `Strings::getLine(std::istream &, std::string &)` which reuses the string buffer and minimizes additional allocations.

**To test:**

<!-- Instructions for testing. -->

The additional `Kernel::Strings` unit test should catch most issues. `PDLoadCharacterizations` uses the function several times.

There is no GitHub issue associated with this pull request

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
