### PR TITLE
GetEiMonDet interface improvements

### DIFF
--- a/Framework/Algorithms/src/GetEiMonDet2.cpp
+++ b/Framework/Algorithms/src/GetEiMonDet2.cpp
@@ -292,6 +292,7 @@ double GetEiMonDet2::computeTOF(const double distance, const double detectorEPP,
     if (m_detectorWs->run().hasProperty(SampleLogs::PULSE_INTERVAL)) {
       pulseInterval = m_detectorWs->run().getPropertyAsSingleValue(
           SampleLogs::PULSE_INTERVAL);
+      pulseInterval *= 1e6; // To microseconds.
     }
   }
   const double pulseIntervalLimit = nominalTimeOfFlight - pulseInterval / 2;

--- a/Framework/Algorithms/src/GetEiMonDet2.cpp
+++ b/Framework/Algorithms/src/GetEiMonDet2.cpp
@@ -38,11 +38,11 @@ const static std::string FIT_STATUS_SUCCESS("success");
  */
 namespace IndexTypes {
 /// Tag for detector ids
-const static std::string DETECTOR_ID("DetectorID");
+const static std::string DETECTOR_ID("Detector ID");
 /// Tag for spectrum numbers
-const static std::string SPECTRUM_NUMBER("SpectrumNumber");
+const static std::string SPECTRUM_NUMBER("Spectrum Number");
 /// Tag for workspace indices
-const static std::string WORKSPACE_INDEX("WorkspaceIndex");
+const static std::string WORKSPACE_INDEX("Workspace Index");
 }
 
 /** A private namespace holding the property names of

--- a/Framework/Algorithms/src/GetEiMonDet2.cpp
+++ b/Framework/Algorithms/src/GetEiMonDet2.cpp
@@ -132,7 +132,8 @@ void GetEiMonDet2::init() {
   declareProperty(PropertyNames::MONITOR, EMPTY_INT(), mandatoryIntProperty,
                   "Monitor's detector id/spectrum number/workspace index.");
   declareProperty(PropertyNames::PULSE_INTERVAL, EMPTY_DBL(),
-                  "Interval between neutron pulses, in microseconds. Taken from the sample logs, if not specified.");
+                  "Interval between neutron pulses, in microseconds. Taken "
+                  "from the sample logs, if not specified.");
   declareProperty(
       PropertyNames::NOMINAL_ENERGY, EMPTY_DBL(), mustBePositive,
       "Incident energy guess. Taken from the sample logs, if not specified.");
@@ -289,7 +290,8 @@ double GetEiMonDet2::computeTOF(const double distance, const double detectorEPP,
   double pulseInterval = getProperty(PropertyNames::PULSE_INTERVAL);
   if (pulseInterval == EMPTY_DBL()) {
     if (m_detectorWs->run().hasProperty(SampleLogs::PULSE_INTERVAL)) {
-      pulseInterval = m_detectorWs->run().getPropertyAsSingleValue(SampleLogs::PULSE_INTERVAL);
+      pulseInterval = m_detectorWs->run().getPropertyAsSingleValue(
+          SampleLogs::PULSE_INTERVAL);
     }
   }
   const double pulseIntervalLimit = nominalTimeOfFlight - pulseInterval / 2;
@@ -311,8 +313,8 @@ double GetEiMonDet2::computeTOF(const double distance, const double detectorEPP,
     // Neutrons hit the detectors in a later frame.
     interruption_point();
     if (pulseInterval == EMPTY_DBL()) {
-          throw std::runtime_error(PropertyNames::PULSE_INTERVAL +
-                                   " not specified nor found in sample logs");
+      throw std::runtime_error(PropertyNames::PULSE_INTERVAL +
+                               " not specified nor found in sample logs");
     }
     ++delayFrameCount;
     timeOfFlight = delayFrameCount * pulseInterval - monitorEPP + detectorEPP;

--- a/Framework/Algorithms/test/GetEiMonDet2Test.h
+++ b/Framework/Algorithms/test/GetEiMonDet2Test.h
@@ -54,7 +54,7 @@ public:
     TS_ASSERT(algorithm.isInitialized())
   }
 
-  void testSuccessOnMinimumInput() {
+  void testSuccessOnMinimalInput() {
     const double realEi = 0.97 * EI;
     const auto peaks =
         peakCentres(100, realEi, std::numeric_limits<double>::max());
@@ -105,6 +105,7 @@ public:
     MatrixWorkspace_sptr detectorWs =
         spectrumExtraction.getProperty("OutputWorkspace");
     GetEiMonDet2 algorithm;
+    algorithm.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(algorithm.initialize())
     TS_ASSERT(algorithm.isInitialized())
     TS_ASSERT_THROWS_NOTHING(
@@ -129,6 +130,15 @@ public:
         realEi, 1e-6)
   }
 
+  void testSuccessOnPulseIntervalInProperties() {
+    runPulseIntervalInputsTest(PulseIntervalInputs::AS_PROPERTY);
+  }
+
+  void testSuccessOnPulseIntervalInSampleLogs() {
+    runPulseIntervalInputsTest(PulseIntervalInputs::AS_SAMLPE_LOG);
+  }
+
+
   void testFailureOnAllDetectorsMasked() {
     const double realEi = EI;
     const auto peaks =
@@ -144,7 +154,7 @@ public:
     maskDetectors.execute();
     GetEiMonDet2 algorithm;
     setupSimple(ws, eppTable, algorithm);
-    TS_ASSERT_THROWS_NOTHING(algorithm.execute())
+    TS_ASSERT_THROWS(algorithm.execute(), std::runtime_error)
     TS_ASSERT(!algorithm.isExecuted())
   }
 
@@ -163,7 +173,7 @@ public:
     maskDetectors.execute();
     GetEiMonDet2 algorithm;
     setupSimple(ws, eppTable, algorithm);
-    TS_ASSERT_THROWS_NOTHING(algorithm.execute())
+    TS_ASSERT_THROWS(algorithm.execute(), std::runtime_error)
     TS_ASSERT(!algorithm.isExecuted())
   }
 
@@ -178,7 +188,7 @@ public:
     auto ws = createWorkspace();
     GetEiMonDet2 algorithm;
     setupSimple(ws, eppTable, algorithm);
-    TS_ASSERT_THROWS_NOTHING(algorithm.execute())
+    TS_ASSERT_THROWS(algorithm.execute(), std::runtime_error)
     TS_ASSERT(!algorithm.isExecuted())
   }
 
@@ -192,7 +202,7 @@ public:
     auto ws = createWorkspace();
     GetEiMonDet2 algorithm;
     setupSimple(ws, eppTable, algorithm);
-    TS_ASSERT_THROWS_NOTHING(algorithm.execute())
+    TS_ASSERT_THROWS(algorithm.execute(), std::runtime_error)
     TS_ASSERT(!algorithm.isExecuted())
   }
 
@@ -204,6 +214,7 @@ public:
     auto eppTable = createEPPTable(peaks, successes);
     auto ws = createWorkspace();
     GetEiMonDet2 algorithm;
+    algorithm.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(algorithm.initialize())
     TS_ASSERT(algorithm.isInitialized())
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("DetectorWorkspace", ws))
@@ -211,7 +222,7 @@ public:
         algorithm.setProperty("DetectorEPPTable", eppTable))
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("Detectors", "1"))
     TS_ASSERT_THROWS_NOTHING(algorithm.setPropertyValue("Monitor", "1"))
-    TS_ASSERT_THROWS_NOTHING(algorithm.execute())
+    TS_ASSERT_THROWS(algorithm.execute(), std::runtime_error)
     TS_ASSERT(!algorithm.isExecuted())
   }
 
@@ -239,7 +250,7 @@ public:
     TS_ASSERT(!algorithm.isExecuted())
   }
 
-  void testFailuroOnNonexistentDetectorIndex() {
+  void testFailureOnNonexistentDetectorIndex() {
     const double realEi = EI;
     const auto peaks =
         peakCentres(100, realEi, std::numeric_limits<double>::max());
@@ -247,6 +258,7 @@ public:
     auto eppTable = createEPPTable(peaks, successes);
     auto ws = createWorkspace();
     GetEiMonDet2 algorithm;
+    algorithm.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(algorithm.initialize())
     TS_ASSERT(algorithm.isInitialized())
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("DetectorWorkspace", ws))
@@ -254,11 +266,11 @@ public:
         algorithm.setProperty("DetectorEPPTable", eppTable))
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("Detectors", "42"))
     TS_ASSERT_THROWS_NOTHING(algorithm.setPropertyValue("Monitor", "0"))
-    TS_ASSERT_THROWS_NOTHING(algorithm.execute())
+    TS_ASSERT_THROWS(algorithm.execute(), std::runtime_error)
     TS_ASSERT(!algorithm.isExecuted())
   }
 
-  void testFailuroOnNonexistentMonitorIndex() {
+  void testFailureOnNonexistentMonitorIndex() {
     const double realEi = EI;
     const auto peaks =
         peakCentres(100, realEi, std::numeric_limits<double>::max());
@@ -266,6 +278,7 @@ public:
     auto eppTable = createEPPTable(peaks, successes);
     auto ws = createWorkspace();
     GetEiMonDet2 algorithm;
+    algorithm.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(algorithm.initialize())
     TS_ASSERT(algorithm.isInitialized())
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("DetectorWorkspace", ws))
@@ -273,8 +286,12 @@ public:
         algorithm.setProperty("DetectorEPPTable", eppTable))
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("Detectors", "1"))
     TS_ASSERT_THROWS_NOTHING(algorithm.setPropertyValue("Monitor", "42"))
-    TS_ASSERT_THROWS_NOTHING(algorithm.execute())
+    TS_ASSERT_THROWS(algorithm.execute(), std::runtime_error)
     TS_ASSERT(!algorithm.isExecuted())
+  }
+
+  void testFailureOnPulseIntervalMissing() {
+    runPulseIntervalInputsTest(PulseIntervalInputs::NONE);
   }
 
 private:
@@ -337,6 +354,7 @@ private:
   // Mininum setup for GetEiMonDet2.
   void setupSimple(MatrixWorkspace_sptr ws, ITableWorkspace_sptr eppTable,
                    GetEiMonDet2 &algorithm) {
+    algorithm.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(algorithm.initialize())
     TS_ASSERT(algorithm.isInitialized())
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("DetectorWorkspace", ws))
@@ -344,6 +362,51 @@ private:
         algorithm.setProperty("DetectorEPPTable", eppTable))
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("Detectors", "1"))
     TS_ASSERT_THROWS_NOTHING(algorithm.setPropertyValue("Monitor", "0"))
+  }
+
+  enum class PulseIntervalInputs {
+    AS_PROPERTY,
+    AS_SAMLPE_LOG,
+    NONE
+  };
+
+  void runPulseIntervalInputsTest(const PulseIntervalInputs pulseIntervalInput) {
+    const double realEi = 1.18 * EI;
+    const double pulseInterval = std::floor(time_of_flight(velocity(EI)) / 2);
+    const double timeAtMonitor = 0.34 * pulseInterval;
+    auto peaks =
+        peakCentres(timeAtMonitor, realEi, pulseInterval);
+    std::vector<bool> successes(peaks.size(), true);
+    auto eppTable = createEPPTable(peaks, successes);
+    auto ws = createWorkspace();
+    if (pulseIntervalInput == PulseIntervalInputs::AS_SAMLPE_LOG) {
+      ws->mutableRun().addProperty("pulse_interval", pulseInterval);
+    }
+    GetEiMonDet2 algorithm;
+    algorithm.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(algorithm.initialize())
+    TS_ASSERT(algorithm.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(
+        algorithm.setProperty("DetectorWorkspace", ws));
+    TS_ASSERT_THROWS_NOTHING(
+        algorithm.setProperty("DetectorEPPTable", eppTable))
+    TS_ASSERT_THROWS_NOTHING(
+        algorithm.setProperty("IndexType", "Spectrum Number"))
+    TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("Detectors", "2"))
+    TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("Monitor", 1))
+    if (pulseIntervalInput == PulseIntervalInputs::AS_PROPERTY) {
+      TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("PulseInterval", pulseInterval));
+    }
+    if (pulseIntervalInput == PulseIntervalInputs::NONE) {
+      TS_ASSERT_THROWS(algorithm.execute(), std::runtime_error)
+      TS_ASSERT(!algorithm.isExecuted())
+    } else {
+      TS_ASSERT_THROWS_NOTHING(algorithm.execute())
+      TS_ASSERT(algorithm.isExecuted())
+      TS_ASSERT_DELTA(
+          static_cast<decltype(realEi)>(algorithm.getProperty("IncidentEnergy")),
+          realEi, 1e-6)
+    }
   }
 };
 

--- a/Framework/Algorithms/test/GetEiMonDet2Test.h
+++ b/Framework/Algorithms/test/GetEiMonDet2Test.h
@@ -112,7 +112,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         algorithm.setProperty("DetectorEPPTable", detectorEPPTable))
     TS_ASSERT_THROWS_NOTHING(
-        algorithm.setProperty("IndexType", "SpectrumNumber"))
+        algorithm.setProperty("IndexType", "Spectrum Number"))
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("Detectors", "2"))
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("NominalIncidentEnergy", EI))
     TS_ASSERT_THROWS_NOTHING(
@@ -230,7 +230,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         algorithm.setProperty("DetectorEPPTable", eppTable))
     TS_ASSERT_THROWS_NOTHING(
-        algorithm.setProperty("IndexType", "WorkspaceIndex"))
+        algorithm.setProperty("IndexType", "Workspace Index"))
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("Detectors", "1"))
     TS_ASSERT_THROWS_NOTHING(algorithm.setPropertyValue("Monitor", "-1"))
     const std::string exceptionMessage("Monitor cannot be negative.");

--- a/Framework/Algorithms/test/GetEiMonDet2Test.h
+++ b/Framework/Algorithms/test/GetEiMonDet2Test.h
@@ -138,7 +138,6 @@ public:
     runPulseIntervalInputsTest(PulseIntervalInputs::AS_SAMLPE_LOG);
   }
 
-
   void testFailureOnAllDetectorsMasked() {
     const double realEi = EI;
     const auto peaks =
@@ -364,18 +363,14 @@ private:
     TS_ASSERT_THROWS_NOTHING(algorithm.setPropertyValue("Monitor", "0"))
   }
 
-  enum class PulseIntervalInputs {
-    AS_PROPERTY,
-    AS_SAMLPE_LOG,
-    NONE
-  };
+  enum class PulseIntervalInputs { AS_PROPERTY, AS_SAMLPE_LOG, NONE };
 
-  void runPulseIntervalInputsTest(const PulseIntervalInputs pulseIntervalInput) {
+  void
+  runPulseIntervalInputsTest(const PulseIntervalInputs pulseIntervalInput) {
     const double realEi = 1.18 * EI;
     const double pulseInterval = std::floor(time_of_flight(velocity(EI)) / 2);
     const double timeAtMonitor = 0.34 * pulseInterval;
-    auto peaks =
-        peakCentres(timeAtMonitor, realEi, pulseInterval);
+    auto peaks = peakCentres(timeAtMonitor, realEi, pulseInterval);
     std::vector<bool> successes(peaks.size(), true);
     auto eppTable = createEPPTable(peaks, successes);
     auto ws = createWorkspace();
@@ -386,8 +381,7 @@ private:
     algorithm.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(algorithm.initialize())
     TS_ASSERT(algorithm.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(
-        algorithm.setProperty("DetectorWorkspace", ws));
+    TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("DetectorWorkspace", ws));
     TS_ASSERT_THROWS_NOTHING(
         algorithm.setProperty("DetectorEPPTable", eppTable))
     TS_ASSERT_THROWS_NOTHING(
@@ -395,7 +389,8 @@ private:
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("Detectors", "2"))
     TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("Monitor", 1))
     if (pulseIntervalInput == PulseIntervalInputs::AS_PROPERTY) {
-      TS_ASSERT_THROWS_NOTHING(algorithm.setProperty("PulseInterval", pulseInterval));
+      TS_ASSERT_THROWS_NOTHING(
+          algorithm.setProperty("PulseInterval", pulseInterval));
     }
     if (pulseIntervalInput == PulseIntervalInputs::NONE) {
       TS_ASSERT_THROWS(algorithm.execute(), std::runtime_error)
@@ -403,9 +398,9 @@ private:
     } else {
       TS_ASSERT_THROWS_NOTHING(algorithm.execute())
       TS_ASSERT(algorithm.isExecuted())
-      TS_ASSERT_DELTA(
-          static_cast<decltype(realEi)>(algorithm.getProperty("IncidentEnergy")),
-          realEi, 1e-6)
+      TS_ASSERT_DELTA(static_cast<decltype(realEi)>(
+                          algorithm.getProperty("IncidentEnergy")),
+                      realEi, 1e-6)
     }
   }
 };

--- a/Framework/Algorithms/test/GetEiMonDet2Test.h
+++ b/Framework/Algorithms/test/GetEiMonDet2Test.h
@@ -375,7 +375,7 @@ private:
     auto eppTable = createEPPTable(peaks, successes);
     auto ws = createWorkspace();
     if (pulseIntervalInput == PulseIntervalInputs::AS_SAMLPE_LOG) {
-      ws->mutableRun().addProperty("pulse_interval", pulseInterval);
+      ws->mutableRun().addProperty("pulse_interval", pulseInterval * 1e-6);
     }
     GetEiMonDet2 algorithm;
     algorithm.setRethrows(true);

--- a/docs/source/algorithms/GetEiMonDet-v2.rst
+++ b/docs/source/algorithms/GetEiMonDet-v2.rst
@@ -9,11 +9,11 @@
 Description
 -----------
 
-This algorithm calculates the incident energy from the time-of-flight between one monitor and some detectors. The time information is extracted from the PeakCentre columns of the EPP workspaces. The FitSuccess column in the EPP tables is used to single out detectors without good quality elastic peaks: only detectors with ``success`` in the column are accepted. Monitor-to-sample and sample-to-detector distances are loaded from the instrument definition. Both the time and the distance data is averaged over the specified detectors. 
+This algorithm calculates the incident energy from the time-of-flight between one monitor and some detectors. The time information is extracted from the 'PeakCentre' columns of the EPP workspaces. The 'FitSuccess' column in the EPP tables is used to single out detectors without good quality elastic peaks: only detectors with ``success`` in the column are accepted. Monitor-to-sample and sample-to-detector distances are loaded from the instrument definition. Both the time and the distance data is averaged over the specified detectors. 
 
 The EPP tables can be produced using the :ref:`algm-FindEPP` algorithm.
 
-If no MonitorWorkspace is specified, the monitor spectrum is expected to be in the detector workspace.
+If no *MonitorWorkspace* is specified, the monitor spectrum is expected to be in the detector workspace.
 
 Specifying the detectors and monitor
 ####################################
@@ -23,7 +23,7 @@ The drop-down menu is used to specify what the numbers in the *Detectors* and *M
 Neutrons detected in later frames
 #################################
 
-It is possible that a neutron pulse is detected at the detectors in a later frame than at the monitor. These cases can be identified if the time-of-flight from the monitor to the detectors is negative or if the calculated incident energy would end up being too large. In these cases, the value of  the *PulseInterval* field is added to the time-of-flight until the result is satisfactory.
+It is possible that a neutron pulse is detected at the detectors in a later frame than at the monitor. These cases can be identified if the time-of-flight from the monitor to the detectors is negative or if the calculated incident energy would end up being too large. In these cases, the value of  the *PulseInterval* field (in micro seconds) is added to the time-of-flight until the result is satisfactory. If *PulseInterval* is not given, the algorithm uses the 'pulse_interval' sample log (in seconds) instead.
 
 To identify when the incident energy is within acceptable bounds, the algorithm applies simple heuristics. Basically, the final energy has to be within 20% of the *NominalIncidentEnergy* or within the *PulseInterval* corrected time-of-flight :math:`\pm` *PulseInterval* / 2.
 


### PR DESCRIPTION
This pull request improves the GetEiMonDet algorithm in two ways: the pulse interval can be read from the sample logs, if needed, and the option strings in the *IndexType* property have spaces instead of CamelCase, bringing them closer to other Mantid algorithms.

**To test:**

Code review. The pulse interval sample log part should be covered by unit tests while the new *IndexType* options should work as-is.

Fixes #18121 #18122 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
