### PR TITLE
Fix VSI progress bar

### DIFF
--- a/Vates/ParaviewPlugins/ParaViewFilters/SplatterPlot/vtkSplatterPlot.cxx
+++ b/Vates/ParaviewPlugins/ParaViewFilters/SplatterPlot/vtkSplatterPlot.cxx
@@ -177,8 +177,8 @@ void vtkSplatterPlot::PrintSelf(ostream& os, vtkIndent indent)
  */
 void vtkSplatterPlot::updateAlgorithmProgress(double progress, const std::string& message)
 {
-  this->SetProgress(progress);
   this->SetProgressText(message.c_str());
+  this->UpdateProgress(progress);
 }
 
 /**

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
@@ -126,7 +126,8 @@ int vtkMDHWNexusReader::RequestData(
   try {
     auto workspaceProvider = Mantid::Kernel::make_unique<
         ADSWorkspaceProvider<Mantid::API::IMDWorkspace>>();
-    m_presenter->makeNonOrthogonal(output, std::move(workspaceProvider));
+    m_presenter->makeNonOrthogonal(output, std::move(workspaceProvider),
+                                   &drawingProgressAction);
   } catch (std::invalid_argument &e) {
     std::string error = e.what();
     vtkDebugMacro(<< "Workspace does not have correct information to "

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
@@ -316,7 +316,7 @@ Setter for the algorithm progress.
 void vtkMDEWSource::updateAlgorithmProgress(double progress, const std::string& message)
 {
   this->SetProgressText(message.c_str());
-  this->SetProgress(progress);
+  this->UpdateProgress(progress);
 }
 
 /*

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
@@ -210,7 +210,8 @@ int vtkMDEWSource::RequestData(vtkInformation *, vtkInformationVector **, vtkInf
     try
     {
       auto workspaceProvider = Mantid::Kernel::make_unique<ADSWorkspaceProvider<Mantid::API::IMDWorkspace>>();
-      m_presenter->makeNonOrthogonal(output, std::move(workspaceProvider));
+      m_presenter->makeNonOrthogonal(output, std::move(workspaceProvider),
+                                     &drawingProgressUpdate);
     }
     catch (std::invalid_argument &e)
     {

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
@@ -181,7 +181,8 @@ int vtkMDHWSource::RequestData(vtkInformation *, vtkInformationVector **, vtkInf
     try
     {
       auto workspaceProvider = Mantid::Kernel::make_unique<ADSWorkspaceProvider<Mantid::API::IMDWorkspace>>();
-      m_presenter->makeNonOrthogonal(output, std::move(workspaceProvider));
+      m_presenter->makeNonOrthogonal(output, std::move(workspaceProvider),
+                                     &drawingProgressUpdate);
     }
     catch (std::invalid_argument &e)
     {

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
@@ -291,8 +291,8 @@ Setter for the algorithm progress.
 */
 void vtkMDHWSource::updateAlgorithmProgress(double progress, const std::string& message)
 {
-  this->SetProgress(progress);
   this->SetProgressText(message.c_str());
+  this->UpdateProgress(progress);
 }
 
 /*

--- a/Vates/VatesAPI/inc/MantidVatesAPI/MDLoadingPresenter.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/MDLoadingPresenter.h
@@ -57,7 +57,8 @@ public:
   virtual void setDefaultCOBandBoundaries(vtkDataSet *visualDataSet);
   virtual void makeNonOrthogonal(
       vtkDataSet *visualDataSet,
-      std::unique_ptr<Mantid::VATES::WorkspaceProvider> workspaceProvider);
+      std::unique_ptr<Mantid::VATES::WorkspaceProvider> workspaceProvider,
+      ProgressAction *progress);
   virtual bool canReadFile() const = 0;
   virtual const std::string &getGeometryXML() const = 0;
   virtual ~MDLoadingPresenter() {}

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToNonOrthogonalDataSet.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToNonOrthogonalDataSet.h
@@ -1,13 +1,14 @@
 #ifndef MANTID_VATES_VTKDATASETTONONORTHOGONALDATASET_H_
 #define MANTID_VATES_VTKDATASETTONONORTHOGONALDATASET_H_
 
-#include "MantidVatesAPI/WorkspaceProvider.h"
+#include "MantidGeometry/MDGeometry/MDTypes.h"
+#include "MantidKernel/Matrix.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
 #include "MantidKernel/System.h"
-#include "MantidKernel/cow_ptr.h"
-#include "MantidKernel/Matrix.h"
 #include "MantidKernel/V3D.h"
-#include "MantidGeometry/MDGeometry/MDTypes.h"
+#include "MantidKernel/cow_ptr.h"
+#include "MantidVatesAPI/ProgressAction.h"
+#include "MantidVatesAPI/WorkspaceProvider.h"
 
 #include <string>
 #include <array>
@@ -58,7 +59,7 @@ public:
       vtkDataSet *dataset, std::string name,
       std::unique_ptr<Mantid::VATES::WorkspaceProvider> workspaceProvider);
   /// Class execution method
-  void execute();
+  void execute(ProgressAction *progress = nullptr);
   /// Destructor
   virtual ~vtkDataSetToNonOrthogonalDataSet();
 

--- a/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
@@ -68,7 +68,7 @@ bool MDHWInMemoryLoadingPresenter::canReadFile() const {
 namespace {
 class CellVisibility {
 public:
-  CellVisibility(vtkStructuredGrid *structuredGrid)
+  explicit CellVisibility(vtkStructuredGrid *structuredGrid)
       : MASKED_CELL_VALUE(vtkDataSetAttributes::HIDDENCELL |
                           vtkDataSetAttributes::REFINEDCELL),
         InputCellGhostArray(

--- a/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
@@ -1,15 +1,19 @@
 #include "MantidVatesAPI/MDHWInMemoryLoadingPresenter.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
+#include "MantidGeometry/MDGeometry/MDGeometryXMLBuilder.h"
+#include "MantidKernel/MultiThreaded.h"
+#include "MantidVatesAPI/FactoryChains.h"
 #include "MantidVatesAPI/MDLoadingView.h"
 #include "MantidVatesAPI/MetaDataExtractorUtils.h"
-#include "MantidVatesAPI/FactoryChains.h"
 #include "MantidVatesAPI/ProgressAction.h"
-#include "MantidVatesAPI/vtkDataSetFactory.h"
 #include "MantidVatesAPI/WorkspaceProvider.h"
-#include "MantidGeometry/MDGeometry/MDGeometryXMLBuilder.h"
+#include "MantidVatesAPI/vtkDataSetFactory.h"
 #include <qwt_double_interval.h>
-#include <vtkUnstructuredGrid.h>
+
+#include "vtkStructuredGrid.h"
+#include "vtkUnsignedCharArray.h"
+#include "vtkUnstructuredGrid.h"
 
 namespace Mantid {
 namespace VATES {
@@ -61,6 +65,43 @@ bool MDHWInMemoryLoadingPresenter::canReadFile() const {
   return bCanReadIt;
 }
 
+namespace {
+class CellVisibility {
+public:
+  CellVisibility(vtkStructuredGrid *structuredGrid)
+      : MASKED_CELL_VALUE(vtkDataSetAttributes::HIDDENCELL |
+                          vtkDataSetAttributes::REFINEDCELL),
+        InputCellGhostArray(
+            structuredGrid->GetCellGhostArray()->GetPointer(0)) {}
+  bool operator()(vtkIdType id) const {
+    return !(this->InputCellGhostArray[id] & this->MASKED_CELL_VALUE);
+  }
+
+private:
+  const unsigned char MASKED_CELL_VALUE;
+  const unsigned char *InputCellGhostArray;
+};
+
+void ComputeScalarRange(vtkStructuredGrid *grid, double *cellRange) {
+  CellVisibility isCellVisible(grid);
+  vtkDataArray *cellScalars = grid->GetCellData()->GetScalars();
+  double minvalue = VTK_DOUBLE_MAX;
+  double maxvalue = VTK_DOUBLE_MIN;
+  int num = boost::numeric_cast<int>(grid->GetNumberOfCells());
+#if defined(_OPENMP) && _OPENMP >= 200805
+  PRAGMA_OMP(parallel for reduction(min : minvalue) reduction(max : maxvalue))
+#endif
+  for (int id = 0; id < num; id++) {
+    if (isCellVisible(id)) {
+      double s = cellScalars->GetComponent(id, 0);
+      minvalue = std::min(minvalue, s);
+      maxvalue = std::max(maxvalue, s);
+    }
+  }
+  cellRange[0] = minvalue;
+  cellRange[1] = maxvalue;
+}
+}
 /*
 Executes the underlying algorithm to create the MVP model.
 @param factory : visualisation factory to use.
@@ -87,20 +128,32 @@ MDHWInMemoryLoadingPresenter::execute(vtkDataSetFactory *factory,
       drawingProgressUpdate); // HACK: progressUpdate should be
                               // argument for drawing!
 
-  /*extractMetaData needs to be re-run here because the first execution of this
-    from ::executeLoadMetadata will not have ensured that all dimensions
-    have proper range extents set.
-  */
-
   // Update the meta data min and max values with the values of the visual data
   // set. This is necessary since we want the full data range of the visual
   // data set and not of the actual underlying data set.
-  double *range = visualDataSet->GetScalarRange();
-  if (range) {
-    this->m_metadataJsonManager->setMinValue(range[0]);
-    this->m_metadataJsonManager->setMaxValue(range[1]);
+
+  // vtkStructuredGrid::GetScalarRange(...) is slow and single-threaded.
+  // Until this is addressed in VTK, we are better of doing the calculation
+  // ourselves.
+  // 600x600x600 vtkStructuredGrid, every other cell blank
+  // structuredGrid->GetScalarRange(range) : 2.36625s
+  // structuredGrid->GetCellData()->GetScalars()->GetRange(range) : 1.01453s
+  // ComputeScalarRange(structuredGrid,range): 0.086104s
+  double range[2];
+  if (auto structuredGrid = vtkStructuredGrid::SafeDownCast(visualDataSet)) {
+    ComputeScalarRange(structuredGrid, range);
+  } else {
+    // should never happen
+    visualDataSet->GetScalarRange(range);
   }
 
+  this->m_metadataJsonManager->setMinValue(range[0]);
+  this->m_metadataJsonManager->setMaxValue(range[1]);
+
+  /*extractMetaData needs to be re-run here because the first execution of this
+   from ::executeLoadMetadata will not have ensured that all dimensions
+   have proper range extents set.
+  */
   this->extractMetadata(*m_cachedVisualHistoWs);
 
   // Transposed workpace is temporary, outside the ADS, and does not have a

--- a/Vates/VatesAPI/src/MDLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDLoadingPresenter.cpp
@@ -41,11 +41,12 @@ void MDLoadingPresenter::setDefaultCOBandBoundaries(vtkDataSet *visualDataSet) {
  */
 void MDLoadingPresenter::makeNonOrthogonal(
     vtkDataSet *visualDataSet,
-    std::unique_ptr<Mantid::VATES::WorkspaceProvider> workspaceProvider) {
+    std::unique_ptr<Mantid::VATES::WorkspaceProvider> workspaceProvider,
+    ProgressAction *progress) {
   std::string wsName = vtkDataSetToWsName::exec(visualDataSet);
   vtkDataSetToNonOrthogonalDataSet converter(visualDataSet, wsName,
                                              std::move(workspaceProvider));
-  converter.execute();
+  converter.execute(progress);
 }
 }
 }

--- a/Vates/VatesAPI/src/MDLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDLoadingPresenter.cpp
@@ -38,6 +38,7 @@ void MDLoadingPresenter::setDefaultCOBandBoundaries(vtkDataSet *visualDataSet) {
  * @param visualDataSet: the vtk visual data set to which the transformation
  * will be applied
  * @param workspaceProvider: the provider of the underlying workspace
+ * @param optional progress reporting.
  */
 void MDLoadingPresenter::makeNonOrthogonal(
     vtkDataSet *visualDataSet,

--- a/Vates/VatesAPI/src/MDLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDLoadingPresenter.cpp
@@ -38,7 +38,7 @@ void MDLoadingPresenter::setDefaultCOBandBoundaries(vtkDataSet *visualDataSet) {
  * @param visualDataSet: the vtk visual data set to which the transformation
  * will be applied
  * @param workspaceProvider: the provider of the underlying workspace
- * @param optional progress reporting.
+ * @param progress: optional progress reporting.
  */
 void MDLoadingPresenter::makeNonOrthogonal(
     vtkDataSet *visualDataSet,

--- a/Vates/VatesAPI/src/PresenterUtilities.cpp
+++ b/Vates/VatesAPI/src/PresenterUtilities.cpp
@@ -56,7 +56,8 @@ void applyCOBMatrixSettingsToVtkDataSet(
     Mantid::VATES::MDLoadingPresenter *presenter, vtkDataSet *dataSet,
     std::unique_ptr<Mantid::VATES::WorkspaceProvider> workspaceProvider) {
   try {
-    presenter->makeNonOrthogonal(dataSet, std::move(workspaceProvider));
+    presenter->makeNonOrthogonal(dataSet, std::move(workspaceProvider),
+                                 nullptr);
   } catch (std::invalid_argument &e) {
     std::string error = e.what();
     g_log_presenter_utilities.warning()

--- a/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
@@ -223,7 +223,8 @@ void vtkDataSetToNonOrthogonalDataSet::execute(ProgressAction *progress) {
 
   vtkIdType progressIncrement = points->GetNumberOfValues() / 25;
 
-  double progressFactor = 0.25 / points->GetNumberOfValues();
+  double progressFactor =
+      0.25 / static_cast<double>(points->GetNumberOfValues());
 
   for (float *it = points->GetPointer(0); it < end; std::advance(it, 3)) {
     if (progress) {

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -135,7 +135,7 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
   vtkIdType progressIncrement = imageSize / 50;
   for (vtkIdType index = 0; index < imageSize; ++index) {
     if (index % progressIncrement == 0)
-      progressUpdate.eventRaised(double(index) * progressFactor);
+      progressUpdate.eventRaised(static_cast<double>(index) * progressFactor);
     double signalScalar = signal->GetValue(index);
     bool maskValue = (!std::isfinite(signalScalar) ||
                       !m_thresholdRange->inRange(signalScalar));

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -171,7 +171,7 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
   }
   float *it = pointsarray->WritePointer(0, nPointsX * nPointsY * nPointsZ * 3);
   // Array with the point IDs (only set where needed)
-  progressFactor = 0.5 / static_cast<double>(nPointsZ);
+  progressFactor = 0.25 / static_cast<double>(nPointsZ);
   double progressOffset = 0.5;
   for (int z = 0; z < nPointsZ; z++) {
     // Report progress updates for the last 50%

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -131,8 +131,10 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
   signal->InitializeArray(std::move(iterator), offset, imageSize);
   visualDataSet->GetCellData()->SetScalars(signal.GetPointer());
 
+  vtkIdType progressIncrement = imageSize/100;
   for (vtkIdType index = 0; index < imageSize; ++index) {
-    progressUpdate.eventRaised(double(index) * progressFactor);
+    if ( index % progressIncrement == 0)
+      progressUpdate.eventRaised(double(index) * progressFactor);
     double signalScalar = signal->GetValue(index);
     bool maskValue = (!std::isfinite(signalScalar) ||
                       !m_thresholdRange->inRange(signalScalar));

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -134,7 +134,7 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
   // update progress after a 1% change
   vtkIdType progressIncrement = imageSize / 50;
   for (vtkIdType index = 0; index < imageSize; ++index) {
-    if ( index % progressIncrement == 0)
+    if (index % progressIncrement == 0)
       progressUpdate.eventRaised(double(index) * progressFactor);
     double signalScalar = signal->GetValue(index);
     bool maskValue = (!std::isfinite(signalScalar) ||

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -114,7 +114,7 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
   visualDataSet->SetDimensions(nBinsX + 1, nBinsY + 1, nBinsZ + 1);
 
   // Array with true where the voxel should be shown
-  double progressFactor = 0.5 / double(imageSize);
+  double progressFactor = 0.5 / static_cast<double>(imageSize);
 
   std::size_t offset = 0;
   if (nDims == 4) {
@@ -131,7 +131,8 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
   signal->InitializeArray(std::move(iterator), offset, imageSize);
   visualDataSet->GetCellData()->SetScalars(signal.GetPointer());
 
-  vtkIdType progressIncrement = imageSize/100;
+  // update progress after a 1% change
+  vtkIdType progressIncrement = imageSize / 50;
   for (vtkIdType index = 0; index < imageSize; ++index) {
     if ( index % progressIncrement == 0)
       progressUpdate.eventRaised(double(index) * progressFactor);

--- a/Vates/VatesAPI/test/MDHWNexusLoadingPresenterTest.h
+++ b/Vates/VatesAPI/test/MDHWNexusLoadingPresenterTest.h
@@ -181,7 +181,8 @@ public:
     try {
       auto workspaceProvider = Mantid::Kernel::make_unique<
           ADSWorkspaceProvider<Mantid::API::IMDWorkspace>>();
-      presenter.makeNonOrthogonal(product, std::move(workspaceProvider));
+      presenter.makeNonOrthogonal(product, std::move(workspaceProvider),
+                                  &mockDrawingProgressAction);
     } catch (...) {
       // Add the standard change of basis matrix and set the boundaries
       presenter.setDefaultCOBandBoundaries(product);

--- a/Vates/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
+++ b/Vates/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
@@ -17,6 +17,7 @@
 #include "MantidKernel/MDUnit.h"
 
 #include "MantidVatesAPI/vtkRectilinearGrid_Silent.h"
+#include "MockObjects.h"
 #include <vtkDataArray.h>
 #include <vtkFieldData.h>
 #include <vtkFloatArray.h>

--- a/Vates/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
+++ b/Vates/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
@@ -33,6 +33,7 @@ using namespace Mantid::VATES;
 
 class vtkDataSetToNonOrthogonalDataSetTest : public CxxTest::TestSuite {
 private:
+  MockProgressAction progress;
   std::string
   createMantidWorkspace(bool nonUnityTransform, bool wrongCoords = false,
                         bool forgetUB = false, bool forgetWmat = false,
@@ -269,16 +270,6 @@ public:
     vtkDataSetToNonOrthogonalDataSet converter(ds, wsName,
                                                std::move(workspaceProvider));
     TS_ASSERT_THROWS_NOTHING(converter.execute());
-  }
-
-  void testStaticUseForSimpleDataSet() {
-    std::string wsName = createMantidWorkspace(false);
-    vtkSmartPointer<vtkUnstructuredGrid> ds;
-    ds.TakeReference(createSingleVoxelPoints());
-    auto workspaceProvider = Mantid::Kernel::make_unique<
-        ADSWorkspaceProvider<Mantid::API::IMDWorkspace>>();
-    TS_ASSERT_THROWS_NOTHING(vtkDataSetToNonOrthogonalDataSet::exec(
-        ds, wsName, std::move(workspaceProvider)));
   }
 
   void testNonUnitySimpleDataset() {

--- a/Vates/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
+++ b/Vates/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
@@ -17,7 +17,6 @@
 #include "MantidKernel/MDUnit.h"
 
 #include "MantidVatesAPI/vtkRectilinearGrid_Silent.h"
-#include "MockObjects.h"
 #include <vtkDataArray.h>
 #include <vtkFieldData.h>
 #include <vtkFloatArray.h>
@@ -34,7 +33,6 @@ using namespace Mantid::VATES;
 
 class vtkDataSetToNonOrthogonalDataSetTest : public CxxTest::TestSuite {
 private:
-  MockProgressAction progress;
   std::string
   createMantidWorkspace(bool nonUnityTransform, bool wrongCoords = false,
                         bool forgetUB = false, bool forgetWmat = false,

--- a/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -212,7 +212,7 @@ void StandardView::render() {
     drep->getProxy()->UpdateVTKObjects();
   }
 
-  this->resetDisplay();
+  //this->resetDisplay();
   emit this->triggerAccept();
 }
 

--- a/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -205,15 +205,11 @@ void StandardView::render() {
   if (!this->isPeaksWorkspace(this->origSrc)) {
     vtkSMPVRepresentationProxy::SetScalarColoring(
         drep->getProxy(), "signal", vtkDataObject::FIELD_ASSOCIATION_CELLS);
-    // drep->getProxy()->UpdateVTKObjects();
-    // vtkSMPVRepresentationProxy::RescaleTransferFunctionToDataRange(drep->getProxy(),
-    //                                                               "signal",
-    //                                                               vtkDataObject::FIELD_ASSOCIATION_CELLS);
     drep->getProxy()->UpdateVTKObjects();
   }
 
-  //this->resetDisplay();
   emit this->triggerAccept();
+  this->resetDisplay();
 }
 
 void StandardView::onCutButtonClicked() {

--- a/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
@@ -315,7 +315,7 @@ pqPipelineSource *ViewBase::setPluginSource(QString pluginName, QString wsName,
 
   // Update the source so that it retrieves the data from the Mantid workspace
   src->getProxy()->UpdateVTKObjects();        // Updates all the proxies
-  src->updatePipeline();                      // Updates the pipeline
+  //src->updatePipeline();                      // Updates the pipeline
   src->setModifiedState(pqProxy::UNMODIFIED); // Just to that the UI state looks
                                               // consistent with the apply
 

--- a/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
@@ -315,7 +315,7 @@ pqPipelineSource *ViewBase::setPluginSource(QString pluginName, QString wsName,
 
   // Update the source so that it retrieves the data from the Mantid workspace
   src->getProxy()->UpdateVTKObjects();        // Updates all the proxies
-  //src->updatePipeline();                      // Updates the pipeline
+  src->updatePipeline();                      // Updates the pipeline
   src->setModifiedState(pqProxy::UNMODIFIED); // Just to that the UI state looks
                                               // consistent with the apply
 

--- a/docs/source/release/v3.9.0/ui.rst
+++ b/docs/source/release/v3.9.0/ui.rst
@@ -74,4 +74,5 @@ changes on GitHub
 VSI Improvements
 ----------------
 
-ParaView updated to v5.2.0
+- ParaView updated to v5.2.0
+- The sources and views more reliably show progress in the VSI status bar. 


### PR DESCRIPTION
Description of work.

This updates sources and views so that the VSI progress bar is active and regularly updated. 

[This patch](https://gitlab.kitware.com/paraview/paraview/merge_requests/1211) connects the vtkDataSetSurfaceFilter to the progress bar. It has been installed on the RHEL 7 build servers.

**To test:**

<!-- Instructions for testing. -->

Open a MDHistoWorkspace in the VSI and check that the progress bar is updating and displays "Drawing..." and "vtkGeometryRepresentationWithFaces".

There is no GitHub issue associated with this pull request.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
