### PR TITLE
Stitch1DMany not stitching when scaling LHS workspace

### DIFF
--- a/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -134,13 +134,6 @@ std::map<std::string, std::string> Stitch1DMany::validateInputs() {
   if (m_params.empty())
     errors["Params"] = "At least one parameter must be given.";
 
-  if (!m_scaleRHSWorkspace) {
-    // Flip these around for processing
-    std::reverse(m_inputWorkspaces.begin(), m_inputWorkspaces.end());
-    std::reverse(m_startOverlaps.begin(), m_startOverlaps.end());
-    std::reverse(m_endOverlaps.begin(), m_endOverlaps.end());
-  }
-
   m_scaleFactors.clear();
   m_outputWorkspace.reset();
 

--- a/Framework/Algorithms/test/Stitch1DManyTest.h
+++ b/Framework/Algorithms/test/Stitch1DManyTest.h
@@ -51,12 +51,12 @@ private:
 
     MatrixWorkspace_sptr ws =
         WorkspaceFactory::Instance().create("Workspace2D", 2, nbins + 1, nbins);
-    ws->dataX(0) = xData1;
-    ws->dataX(1) = xData2;
-    ws->dataY(0) = yData1;
-    ws->dataY(1) = yData2;
-    ws->dataE(0) = eData1;
-    ws->dataE(1) = eData2;
+    ws->mutableX(0) = xData1;
+    ws->mutableX(1) = xData2;
+    ws->mutableY(0) = yData1;
+    ws->mutableY(1) = yData2;
+    ws->mutableE(0) = eData1;
+    ws->mutableE(1) = eData2;
     ws->getAxis(0)->unit() = UnitFactory::Instance().create("Wavelength");
 
     return ws;
@@ -187,18 +187,18 @@ public:
     auto stitched = boost::dynamic_pointer_cast<MatrixWorkspace>(outws);
     TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(stitched->blocksize(), 17);
-    TS_ASSERT_DELTA(stitched->readY(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[9], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[16], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[0], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[9], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[16], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[9], 0.77919, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[16], 1.24316, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[0], 1.41421, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[9], 1.10982, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[16], 1.79063, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[9], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[16], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[9], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[16], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[9], 0.77919, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[16], 1.24316, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[0], 1.41421, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[9], 1.10982, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[16], 1.79063, 0.00001);
 
     // Test out sclae factors
     std::vector<double> scales = alg.getProperty("OutScaleFactors");
@@ -221,8 +221,8 @@ public:
     alg2.execute();
     MatrixWorkspace_sptr stitched2 = alg2.getProperty("OutputWorkspace");
     TS_ASSERT_EQUALS(stitched->readX(0), stitched2->readX(0));
-    TS_ASSERT_EQUALS(stitched->readY(0), stitched2->readY(0));
-    TS_ASSERT_EQUALS(stitched->readE(0), stitched2->readE(0));
+    TS_ASSERT_EQUALS(stitched->y(0).rawData(), stitched2->y(0).rawData());
+    TS_ASSERT_EQUALS(stitched->e(0).rawData(), stitched2->e(0).rawData());
 
     // Remove workspaces from ADS
     AnalysisDataService::Instance().remove("ws1");
@@ -256,25 +256,25 @@ public:
     TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(stitched->blocksize(), 25);
     // First spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[9], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[16], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[24], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[9], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[16], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[24], 1, 0.00001);
     // Second spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(1)[0], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[9], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[16], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[24], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[9], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[16], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[24], 2, 0.00001);
     // First spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[9], 0.77919, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[16], 0.90865, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[24], 1.33144, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[9], 0.77919, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[16], 0.90865, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[24], 1.33144, 0.00001);
     // Second spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(1)[0], 1.41421, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[9], 1.10982, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[16], 1.33430, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[24], 2.00079, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[0], 1.41421, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[9], 1.10982, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[16], 1.33430, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[24], 2.00079, 0.00001);
 
     // Test out sclae factors
     std::vector<double> scales = alg.getProperty("OutScaleFactors");
@@ -336,21 +336,21 @@ public:
     TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(stitched->blocksize(), 25);
     // First spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[10], 0.55000, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[18], 0.75000, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[10], 0.55000, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[18], 0.75000, 0.00001);
     // Second spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(1)[0], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[10], 1.05000, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[18], 1.25000, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[10], 1.05000, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[18], 1.25000, 0.00001);
     // First spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(0)[0], 1.00000, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[10], 0.52440, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[18], 0.61237, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[0], 1.00000, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[10], 0.52440, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[18], 0.61237, 0.00001);
     // Second spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(1)[0], 1.41421, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[10], 0.72457, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[18], 0.79057, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[0], 1.41421, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[10], 0.72457, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[18], 0.79057, 0.00001);
 
     // Test out sclae factors
     std::vector<double> scales = alg.getProperty("OutScaleFactors");
@@ -432,25 +432,25 @@ public:
     TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(stitched->blocksize(), 25);
     // First spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[9], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[16], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[24], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[9], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[16], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[24], 1, 0.00001);
     // Second spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(1)[0], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[9], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[16], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[24], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[9], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[16], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[24], 2, 0.00001);
     // First spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[9], 0.77919, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[16], 0.90865, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[24], 1.33144, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[9], 0.77919, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[16], 0.90865, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[24], 1.33144, 0.00001);
     // Second spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(1)[0], 1.41421, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[9], 1.10982, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[16], 1.33430, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[24], 2.00079, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[0], 1.41421, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[9], 1.10982, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[16], 1.33430, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[24], 2.00079, 0.00001);
 
     // Test out sclae factors
     std::vector<double> scales = alg.getProperty("OutScaleFactors");
@@ -507,42 +507,42 @@ public:
     TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(stitched->blocksize(), 17);
     // First spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[9], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[16], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[9], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[16], 1, 0.00001);
     // Second spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(1)[0], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[9], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[16], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[9], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[16], 2, 0.00001);
     // First spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[9], 0.77919, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[16], 1.24316, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[9], 0.77919, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[16], 1.24316, 0.00001);
     // Second spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(1)[0], 1.41421, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[9], 1.10982, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[16], 1.79063, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[0], 1.41421, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[9], 1.10982, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[16], 1.79063, 0.00001);
 
     // Second item in the output group
     stitched = boost::dynamic_pointer_cast<MatrixWorkspace>(group->getItem(1));
     TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(stitched->blocksize(), 17);
     // First spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(0)[0], 1.5, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[9], 1.5, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[16], 1.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[9], 1.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[16], 1.5, 0.00001);
     // Second spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(1)[0], 2.5, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[9], 2.5, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[16], 2.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[9], 2.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[16], 2.5, 0.00001);
     // First spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(0)[0], 1.22474, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[9], 0.95883, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[16], 1.54110, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[0], 1.22474, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[9], 0.95883, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[16], 1.54110, 0.00001);
     // Second spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(1)[0], 1.58114, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[9], 1.24263, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[16], 2.00959, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[0], 1.58114, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[9], 1.24263, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[16], 2.00959, 0.00001);
 
     // Test out sclae factors
     std::vector<double> scales = alg.getProperty("OutScaleFactors");
@@ -605,42 +605,42 @@ public:
     TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(stitched->blocksize(), 17);
     // First spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[9], 0.64705, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[16], 0.55000, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[9], 0.64705, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[16], 0.55000, 0.00001);
     // Second spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(1)[0], 2, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[9], 1.24752, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[16], 1.05000, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[9], 1.24752, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[16], 1.05000, 0.00001);
     // First spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(0)[0], 1, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[9], 0.46442, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[16], 0.52440, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[0], 1, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[9], 0.46442, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[16], 0.52440, 0.00001);
     // Second spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(1)[0], 1.41421, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[9], 0.64485, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[16], 0.72456, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[0], 1.41421, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[9], 0.64485, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[16], 0.72456, 0.00001);
 
     // Second item in the output group
     stitched = boost::dynamic_pointer_cast<MatrixWorkspace>(group->getItem(1));
     TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(stitched->blocksize(), 17);
     // First spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(0)[0], 1.5, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[9], 0.94736, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[16], 0.8, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[9], 0.94736, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[16], 0.8, 0.00001);
     // Second spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(1)[0], 2.5, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[9], 1.54762, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[16], 1.3, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[9], 1.54762, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[16], 1.3, 0.00001);
     // First spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(0)[0], 1.22474, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[9], 0.56195, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(0)[16], 0.63245, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[0], 1.22474, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[9], 0.56195, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[16], 0.63245, 0.00001);
     // Second spectrum, E values
-    TS_ASSERT_DELTA(stitched->readE(1)[0], 1.58114, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[9], 0.71824, 0.00001);
-    TS_ASSERT_DELTA(stitched->readE(1)[16], 0.80622, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[0], 1.58114, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[9], 0.71824, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[16], 0.80622, 0.00001);
 
     // Test out sclae factors
     std::vector<double> scales = alg.getProperty("OutScaleFactors");
@@ -678,13 +678,13 @@ public:
     TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
     TS_ASSERT_EQUALS(stitched->blocksize(), 25);
     // First spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(0)[0], 1.5, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[10], 1.5, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(0)[18], 1.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[10], 1.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[18], 1.5, 0.00001);
     // Second spectrum, Y values
-    TS_ASSERT_DELTA(stitched->readY(1)[0], 2.5, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[10], 2.5, 0.00001);
-    TS_ASSERT_DELTA(stitched->readY(1)[18], 2.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[10], 2.5, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[18], 2.5, 0.00001);
 
     // Test out sclae factors
     std::vector<double> scales = alg.getProperty("OutScaleFactors");


### PR DESCRIPTION
`Stitch1DMany` stitches two or more workspaces by recursively calling `Stitch1D`. By default, it scales the right-hand-side workspace by an appropriate factor, however, there's the option to stitch the left-hand-side workspace (`ScaleRHSWorkspace=False`). This option does not seem to be working unless the workspaces to stitch share the same X values (which is not normally the case). 

When scaling the right-hand-side workspace (default behaviour) the algorithm will take the first two workspaces and stitch them together using `Stitch1D`. The resulting workspace and the next workspace on the list will be then stitched together, and so on.

When scaling the left-hand-side workspace (i.e. when `ScaleRHSWorkspace=False`), the algorithm first reverses the order of the input workspaces (and some other input parameters). Then it applies `Stitch1D` to the first pair, then the resulting workspace is stitched with the next workspace in the list, and so on. The fact that we reverse the order of the input workspaces is making `Stitch1D` fail, as it is not able to calculate properly the integration ranges, overlap regions, etc. The problem is solved if we don't reverse the workspace list. I think we don't need to do this as the order in which pairs of workspaces are stitched should have no effect on the final result (i.e. if we have three workspaces, I think it doesn't matter if we stitch first the first two workspaces and then the result with the third workspace, or if we first stitch the last two workspaces and then the result with the first workspace).

**To test:**

1. Test that the order in which pairs of workspaces are stitched has no effect on the final result. To test this, I've run the following script:

```
x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
y = [1, 1, 2, 2, 1, 1, 1, 1, 1]
ws_1 = CreateWorkspace(x, y)

x = [9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
y = [3, 3, 3, 3, 3, 3, 3, 3, 3]
ws_2 = CreateWorkspace(x, y)

x = [17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
y = [4, 4, 5, 5, 5, 5, 5, 5, 5]
ws_3 = CreateWorkspace(x, y)

stitched_from_right_to_left, scale_factor_rtl_1 = Stitch1D(ws_2, ws_3, ScaleRHSWorkspace=False)
stitched_from_right_to_left, scale_factor_rtl_2 = Stitch1D(ws_1, stitched_from_right_to_left, ScaleRHSWorkspace=False)

stitched_from_left_to_right, scale_factor_ltr_1 = Stitch1D(ws_1, ws_2, ScaleRHSWorkspace=False)
stitched_from_left_to_right, scale_factor_ltr_2 = Stitch1D(stitched_from_left_to_right, ws_3, ScaleRHSWorkspace=False)

# 'stitched_from_right_to_left' and 'stitched_from_left_to_right' should match
```

2. Test the fix, i.e., test that `Stitch1DMany` is now able to stitch with `ScaleRHSWorkspace = False`: the script below should run successfully with no errors:

```
x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
y = [1, 1, 1, 1, 1, 1, 1, 1, 1]
ws_1 = CreateWorkspace(x, y)

x = [9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
y = [2, 2, 2, 2, 2, 2, 2, 2, 2]
ws_2 = CreateWorkspace(x, y)

# stitched_1 and stitched_2 should match
stitched_1, scale_factors = Stitch1D(ws_1, ws_2, Params='1', ScaleRHSWorkspace=False)
stitched_2, scale_factors = Stitch1DMany(InputWorkspaces='ws_1, ws_2',
                                       Params='1',
                                       ScaleRHSWorkspace=False)

# stitched_1 and stitched_2 should match
stitched_1, scale_factors = Stitch1D(ws_1, ws_2,
                                       Params='1',
                                       StartOverlap=9,
                                       EndOverlap=10,
                                       ScaleRHSWorkspace=False)
stitched_2, scale_factors = Stitch1DMany(InputWorkspaces='ws_1, ws_2',
                                       Params='1',
                                       StartOverlaps=[9],
                                       EndOverlaps=[10],
                                       ScaleRHSWorkspace=False)
```

Fixes #18158.

No need to mention this in the release notes, as this issue was reported by me.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
