### PR TITLE
Fix display normalization for MDNorm... ouputs

### DIFF
--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -118,8 +118,10 @@ void MDNormDirectSC::exec() {
   cacheInputs();
   auto outputWS = binInputWS();
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
+  outputWS->setDisplayNormalization(Mantid::API::NoNormalization);
   setProperty<Workspace_sptr>("OutputWorkspace", outputWS);
   createNormalizationWS(*outputWS);
+  m_normWS->setDisplayNormalization(Mantid::API::NoNormalization);
   setProperty("OutputNormalizationWorkspace", m_normWS);
 
   // Check for other dimensions if we could measure anything in the original

--- a/Framework/MDAlgorithms/src/MDNormSCD.cpp
+++ b/Framework/MDAlgorithms/src/MDNormSCD.cpp
@@ -113,8 +113,10 @@ void MDNormSCD::exec() {
   cacheInputs();
   auto outputWS = binInputWS();
   convention = Kernel::ConfigService::Instance().getString("Q.convention");
+  outputWS->setDisplayNormalization(Mantid::API::NoNormalization);
   setProperty<Workspace_sptr>("OutputWorkspace", outputWS);
   createNormalizationWS(*outputWS);
+  m_normWS->setDisplayNormalization(Mantid::API::NoNormalization);
   setProperty("OutputNormalizationWorkspace", m_normWS);
 
   // Check for other dimensions if we could measure anything in the original

--- a/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
@@ -262,7 +262,7 @@ void export_IMDHistoWorkspace() {
            &IMDHistoWorkspace::setDisplayNormalization,
            (arg("self"), arg("normalization")),
            "Sets the visual normalization of"
-           " the workspace.")   ;
+           " the workspace.");
 
   //-------------------------------------------------------------------------------------------------
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
@@ -256,7 +256,13 @@ void export_IMDHistoWorkspace() {
       .def("getCenter", &IMDHistoWorkspace::getCenter,
            (arg("self"), arg("linear_index")),
            return_value_policy<return_by_value>(),
-           "Return the position of the center of a bin at a given position");
+           "Return the position of the center of a bin at a given position")
+
+      .def("setDisplayNormalization",
+           &IMDHistoWorkspace::setDisplayNormalization,
+           (arg("self"), arg("normalization")),
+           "Sets the visual normalization of"
+           " the workspace.")   ;
 
   //-------------------------------------------------------------------------------------------------
 

--- a/docs/source/release/v3.9.0/framework.rst
+++ b/docs/source/release/v3.9.0/framework.rst
@@ -48,6 +48,8 @@ New
 Improved
 ########
 
+- The output and normalization MDHistoWorkspaces from :ref:`MDNormSCD <algm-MDNormSCD>` and :ref:`MDNormDirectSC <algm-MDNormDirectSC>` have the 'displayNormalization' set to 'NoNormalization'. For older outputs, the `setDisplayNormalization` function is now exposed to python.
+
 Python
 ------
 


### PR DESCRIPTION
The display normalization for the output of MDNorm... algorithms should be `NoNormalization`. 

**To test:**

Someone familiar with diffuse scattering on single crystal instruments should produce workspaces using `MDNormSCD`. When shown in `SliceViewer`, older versions of Mantid will use `Volume` normalization. It should now be `No` normalization. Also, if you load an older version of such workspace, one can now change the normalization for an `MDHistoWorkspace` using the `setDisplayNormalization` function.

```
md=LoadMD(filename)
print md.displayNormalization()
md.setDisplayNormalization(mantid.api.MDNormalization.NoNormalization)
print md.displayNormalization()
```

Fixes #18136.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
