### PR TITLE
parallel, cross platform MinAndMax function for the VSI

### DIFF
--- a/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
@@ -97,11 +97,9 @@ struct MinAndMax {
   void operator()(const tbb::blocked_range<int> &r) {
     for (int id = r.begin(); id != r.end(); ++id) {
       if (m_isCellVisible(id)) {
-        {
-          double s = m_cellScalars->GetComponent(id, 0);
-          m_minimum = std::min(m_minimum, s);
-          m_maximum = std::max(m_maximum, s);
-        }
+        double s = m_cellScalars->GetComponent(id, 0);
+        m_minimum = std::min(m_minimum, s);
+        m_maximum = std::max(m_maximum, s);
       }
     }
   }

--- a/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
@@ -2,7 +2,6 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidGeometry/MDGeometry/MDGeometryXMLBuilder.h"
-#include "MantidKernel/MultiThreaded.h"
 #include "MantidVatesAPI/FactoryChains.h"
 #include "MantidVatesAPI/MDLoadingView.h"
 #include "MantidVatesAPI/MetaDataExtractorUtils.h"

--- a/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
@@ -156,9 +156,9 @@ MDHWInMemoryLoadingPresenter::execute(vtkDataSetFactory *factory,
   // Until this is addressed in VTK, we are better of doing the calculation
   // ourselves.
   // 600x600x600 vtkStructuredGrid, every other cell blank
-  // structuredGrid->GetScalarRange(range) : 2.36625s
-  // structuredGrid->GetCellData()->GetScalars()->GetRange(range) : 1.01453s
-  // ComputeScalarRange(structuredGrid,range): 0.086104s
+  // structuredGrid->GetScalarRange(range) : 2.267s
+  // structuredGrid->GetCellData()->GetScalars()->GetRange(range) : 1.023s
+  // ComputeScalarRange(structuredGrid,range): 0.075s
   double range[2];
   if (auto structuredGrid = vtkStructuredGrid::SafeDownCast(visualDataSet)) {
     ComputeScalarRange(structuredGrid, range);


### PR DESCRIPTION
Description of work.

This uses `tbb::parallel_reduce` instead of OpenMP to find the min and max of an array in parallel. Unlike the earlier solution, this will also work in OS X and Windows builds. 

**To test:**

<!-- Instructions for testing. -->

Load a MDHistoWorkspace and view it in the VSI.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
