### PR TITLE
MatchPeaks :: minor change in peak finding

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
@@ -286,14 +286,12 @@ class MatchPeaks(PythonAlgorithm):
         # Direct deletion causes problems when running in parallel for too many workspaces
 
         try:
-            if mtd['EPPfit_Parameters']:
-                DeleteWorkspace('EPPfit_Parameters')
+            DeleteWorkspace('EPPfit_Parameters')
         except ValueError:
             logger.debug('Fit parameters workspace already deleted')
 
         try:
-            if mtd['EPPfit_NormalisedCovarianceMatrix']:
-                DeleteWorkspace('EPPfit_NormalisedCovarianceMatrix')
+            DeleteWorkspace('EPPfit_NormalisedCovarianceMatrix')
         except ValueError:
             logger.debug('Fit covariance matrix already deleted')
 

--- a/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
@@ -147,7 +147,6 @@ class MatchPeaks(PythonAlgorithm):
         output_ws = CloneWorkspace(InputWorkspace=mtd[self._input_ws], OutputWorkspace=self._output_ws)
 
         size = mtd[self._input_ws].blocksize()
-
         mid_bin = int(size / 2)
 
         # Find peak positions in input workspace
@@ -208,7 +207,6 @@ class MatchPeaks(PythonAlgorithm):
             bin_range = CreateEmptyTableWorkspace(OutputWorkspace=self._output_bin_range)
             bin_range.addColumn(type="double", name='MinBin')
             bin_range.addColumn(type="double", name='MaxBin')
-
             bin_range.addRow({'MinBin': min_bin, 'MaxBin': max_bin})
             self.setProperty('BinRangeTable', bin_range)
 
@@ -233,30 +231,21 @@ class MatchPeaks(PythonAlgorithm):
 
         # Mid bin number
         mid_bin = int(mtd[self._input_ws].blocksize() / 2)
-
         # Initialisation
         peak_bin = np.ones(mtd[self._input_ws].getNumberHistograms()) * mid_bin
-
         # Bin range: difference between mid bin and peak bin should be in this range
         tolerance = int(mid_bin / 2)
-
         x_values = mtd[self._input_ws].readX(0)
 
         for i in range(mtd[self._input_ws].getNumberHistograms()):
-
             fit = fit_table.row(i)
-
             # Bin number, where Y has its maximum
             y_values = mtd[self._input_ws].readY(i)
-
             max_pos = np.argmax(y_values)
-
             peak_plus_error = abs(fit["PeakCentreError"]) + abs(fit["PeakCentre"])
 
             if peak_plus_error > x_values[0] and peak_plus_error < x_values[-1]:
-
                 peak_plus_error_bin = mtd[self._input_ws].binIndexOf(peak_plus_error)
-
                 if abs(peak_plus_error_bin - mid_bin) < tolerance and fit["FitStatus"] == 'success':
                     # fit succeeded, and fitted peak is within acceptance range, take it
                     peak_bin[i] = mtd[self._input_ws].binIndexOf(fit["PeakCentre"])
@@ -284,17 +273,14 @@ class MatchPeaks(PythonAlgorithm):
 
         # Clean-up unused TableWorkspaces in try-catch
         # Direct deletion causes problems when running in parallel for too many workspaces
-
         try:
             DeleteWorkspace('EPPfit_Parameters')
         except ValueError:
             logger.debug('Fit parameters workspace already deleted')
-
         try:
             DeleteWorkspace('EPPfit_NormalisedCovarianceMatrix')
         except ValueError:
             logger.debug('Fit covariance matrix already deleted')
-
         try:
             DeleteWorkspace(fit_table)
         except ValueError:


### PR DESCRIPTION
This PR slightly modifies the peak finding logic in `MatchPeaks` (used by `IndirectILLReductionQENS` in PR #18131 for peak alignment) to cope with some pathological cases if the peak is not so clear.

The logic should be as follows:
If the fitted peak (with it's error taken into account) is within the trusted region (not far from the central bin), it's position should be taken. Otherwise the position of the maximum should be taken if it is also inside the trusted region. If not, then the central bin is taken, meaning that no circular shift will actually be performed (since `to_shift = peak_bin - central_bin`)

**To test:**
Make sure the existing test passes.

<!-- Instructions for testing. -->

Fixes #18168 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
Does not need to be in the release notes, nor in documentation.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.