### PR TITLE
Fix toctree warnings in MuonAnalysis Testing documentation

### DIFF
--- a/docs/source/interfaces/MuonAnalysis_test_guides/index.rst
+++ b/docs/source/interfaces/MuonAnalysis_test_guides/index.rst
@@ -1,21 +1,19 @@
-.. Interfaces master file
+.. Muon Analysis Test Guides master file
    It contains a hidden root toctree directive so that Sphinx
    has an internal index of all of the pages and doesn't
    produce a plethora of warnings about most documents not being in
    a toctree.
    See http://sphinx-doc.org/tutorial.html#defining-document-structure
 
-.. _interfaces contents:
+.. _MuonAnalysis_test_guides contents:
 
-============
- Interfaces
-============
+=========================
+Muon Analysis Test Guides
+=========================
 
 .. toctree::
-   :hidden:
    :glob:
    :maxdepth: 1
 
    *
-   MuonAnalysis_test_guides/index
 


### PR DESCRIPTION
Remove some toctree warnings arising from a new folder in the documentation

**To test:**

Check that the documentation builds OK, without any warnings connected the MuonAnalysis
and the documentation for testing the MuonAnalysis interface is good.

Fixes #18154.

<!-- RELEASE NOTES
*Does not need to be in the release notes.*
-->


I've done so in a manner similar to the concepts/calibration folder

Signed-off-by: Karl Palmen <karl.palmen@stfc.ac.uk>