### PR TITLE
Reflectometry interface (polref): Show error message when user switches strategies before run transfer

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflRunsTabPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflRunsTabPresenter.h
@@ -98,6 +98,8 @@ protected:
   void pushCommands();
 
 private:
+  std::string m_currentTransferMethod;
+
   static const std::string LegacyTransferMethod;
   static const std::string MeasureTransferMethod;
 

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflRunsTabPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflRunsTabPresenter.cpp
@@ -59,7 +59,7 @@ ReflRunsTabPresenter::ReflRunsTabPresenter(
   methods.insert(LegacyTransferMethod);
   methods.insert(MeasureTransferMethod);
   m_view->setTransferMethods(methods);
-  
+
   // Set current transfer method
   m_currentTransferMethod = m_view->getTransferMethod();
 
@@ -222,13 +222,13 @@ void ReflRunsTabPresenter::transfer() {
         "Error: Please select at least one run to transfer.",
         "No runs selected");
     return;
-  }
-  else if (m_currentTransferMethod != m_view->getTransferMethod()) {
+  } else if (m_currentTransferMethod != m_view->getTransferMethod()) {
     m_mainPresenter->giveUserCritical(
         "Error: Method selected for transferring runs (" +
-        m_view->getTransferMethod() +
-        ") must match the method used for searching runs (" +
-        m_currentTransferMethod + ").", "Transfer method mismatch");
+            m_view->getTransferMethod() +
+            ") must match the method used for searching runs (" +
+            m_currentTransferMethod + ").",
+        "Transfer method mismatch");
     return;
   }
 

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflRunsTabPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflRunsTabPresenter.cpp
@@ -59,6 +59,9 @@ ReflRunsTabPresenter::ReflRunsTabPresenter(
   methods.insert(LegacyTransferMethod);
   methods.insert(MeasureTransferMethod);
   m_view->setTransferMethods(methods);
+  
+  // Set current transfer method
+  m_currentTransferMethod = m_view->getTransferMethod();
 
   // Set up the instrument selectors
   std::vector<std::string> instruments;
@@ -197,6 +200,7 @@ void ReflRunsTabPresenter::search() {
 void ReflRunsTabPresenter::populateSearch(IAlgorithm_sptr searchAlg) {
   if (searchAlg->isExecuted()) {
     ITableWorkspace_sptr results = searchAlg->getProperty("OutputWorkspace");
+    m_currentTransferMethod = m_view->getTransferMethod();
     m_searchModel = ReflSearchModel_sptr(new ReflSearchModel(
         *getTransferStrategy(), results, m_view->getSearchInstrument()));
     m_view->showSearch(m_searchModel);
@@ -211,8 +215,17 @@ void ReflRunsTabPresenter::transfer() {
   SearchResultMap runs;
   auto selectedRows = m_view->getSelectedSearchRows();
 
-  // Do not begin transfer if nothing is selected
-  if (selectedRows.size() == 0) {
+  // Do not begin transfer if nothing is selected or if the transfer method does
+  // not match the one used for populating search
+  if (selectedRows.size() == 0)
+    return;
+
+  if (m_currentTransferMethod != m_view->getTransferMethod()) {
+    m_mainPresenter->giveUserCritical(
+        "Error: Method selected for transferring runs (" +
+        m_view->getTransferMethod() +
+        ") must match the method used for searching runs (" +
+        m_currentTransferMethod + ").", "Transfer method mismatch");
     return;
   }
 
@@ -284,9 +297,8 @@ void ReflRunsTabPresenter::transfer() {
 */
 std::unique_ptr<ReflTransferStrategy>
 ReflRunsTabPresenter::getTransferStrategy() {
-  const std::string currentMethod = m_view->getTransferMethod();
   std::unique_ptr<ReflTransferStrategy> rtnStrategy;
-  if (currentMethod == MeasureTransferMethod) {
+  if (m_currentTransferMethod == MeasureTransferMethod) {
 
     // We need catalog info overrides from the user-based config service
     std::unique_ptr<CatalogConfigService> catConfigService(
@@ -306,12 +318,12 @@ ReflRunsTabPresenter::getTransferStrategy() {
     rtnStrategy = Mantid::Kernel::make_unique<ReflMeasureTransferStrategy>(
         std::move(catInfo), std::move(source));
     return rtnStrategy;
-  } else if (currentMethod == LegacyTransferMethod) {
+  } else if (m_currentTransferMethod == LegacyTransferMethod) {
     rtnStrategy = make_unique<ReflLegacyTransferStrategy>();
     return rtnStrategy;
   } else {
     throw std::runtime_error("Unknown tranfer method selected: " +
-                             currentMethod);
+                             m_currentTransferMethod);
   }
 }
 

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflRunsTabPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflRunsTabPresenter.cpp
@@ -217,10 +217,13 @@ void ReflRunsTabPresenter::transfer() {
 
   // Do not begin transfer if nothing is selected or if the transfer method does
   // not match the one used for populating search
-  if (selectedRows.size() == 0)
+  if (selectedRows.size() == 0) {
+    m_mainPresenter->giveUserCritical(
+        "Error: Please select at least one run to transfer.",
+        "No runs selected");
     return;
-
-  if (m_currentTransferMethod != m_view->getTransferMethod()) {
+  }
+  else if (m_currentTransferMethod != m_view->getTransferMethod()) {
     m_mainPresenter->giveUserCritical(
         "Error: Method selected for transferring runs (" +
         m_view->getTransferMethod() +

--- a/docs/source/release/v3.9.0/reflectometry.rst
+++ b/docs/source/release/v3.9.0/reflectometry.rst
@@ -22,6 +22,7 @@ ISIS Reflectometry (Polref)
 - When runs are transferred to the processing table groups are now labeled according to run title.
 - Column :literal:`dQ/Q` is used as the rebin parameter to stitch workspaces.
 - Documentation regarding the interface has been updated accordingly.
+- Error messages are displayed if the user either attempts to transfer zero runs or transfer runs with a different strategy to the one they used to search for runs with. 
 
 ISIS Reflectometry
 ##################


### PR DESCRIPTION
An issue that was found was that if the user could search for runs using one strategy (e.g. Description), but switch to another strategy and attempt to transfer runs using it. This should be prevented from happening, so this PR has an error message display if this is attempted. In addition, an error message now displays if no runs are selected before trying to transfer.

**To test:**

- Open the interface from Interfaces->Reflectometry->ISIS Reflectometry (Polref).
- Select `POLREF` in the instrument combo box. Select `Description` strategy.
- Enter `1520249` and use your user ID and password to log in to the catalog. The table on the left will be populated with some runs.
- Change to `Measurement` strategy (without searching again).
- Select any of the runs and click on Transfer - an error message should appear warning that the strategy used for searching for runs does not match the one used for transferring them.
- Test that searching with `Measurement` and transferring with `Description` produces a similar result..
- Test that an error message is shown if Transfer is clicked without selecting any runs.

<!-- Instructions for testing. -->

Fixes #18163 .

*Release notes have been updated*

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
