### PR TITLE
Two specific fixes for poor behaviour with .mantid files

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6090,8 +6090,7 @@ void ApplicationWindow::loadDataFileByName(QString fn) {
   } else if (fnInfo.suffix() == "mantid") {
     // We have a mantid project file, pass on to project loading
     open(fn);
-  }
-  else if (mantidUI) {
+  } else if (mantidUI) {
     // Run Load algorithm on file
     QHash<QString, QString> params;
     params["Filename"] = fn;

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6087,7 +6087,11 @@ void ApplicationWindow::loadDataFileByName(QString fn) {
   if (fnInfo.suffix() == "py") {
     // We have a python file, just load it into script window
     loadScript(fn, true);
-  } else if (mantidUI) {
+  } else if (fnInfo.suffix() == "mantid") {
+    // We have a mantid project file, pass on to project loading
+    open(fn);
+  }
+  else if (mantidUI) {
     // Run Load algorithm on file
     QHash<QString, QString> params;
     params["Filename"] = fn;

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -560,8 +560,7 @@ void MuonAnalysis::runSaveGroupButton() {
   QString prevPath =
       prevValues.value("dir", QString::fromStdString(
                                   ConfigService::Instance().getString(
-                                      "defaultsave.directory")))
-          .toString();
+                                      "defaultsave.directory"))).toString();
 
   QString filter;
   filter.append("Files (*.xml *.XML)");
@@ -600,8 +599,7 @@ void MuonAnalysis::runLoadGroupButton() {
   QString prevPath =
       prevValues.value("dir", QString::fromStdString(
                                   ConfigService::Instance().getString(
-                                      "defaultload.directory")))
-          .toString();
+                                      "defaultload.directory"))).toString();
 
   QString filter;
   filter.append("Files (*.xml *.XML)");

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -560,7 +560,8 @@ void MuonAnalysis::runSaveGroupButton() {
   QString prevPath =
       prevValues.value("dir", QString::fromStdString(
                                   ConfigService::Instance().getString(
-                                      "defaultsave.directory"))).toString();
+                                      "defaultsave.directory")))
+          .toString();
 
   QString filter;
   filter.append("Files (*.xml *.XML)");
@@ -599,7 +600,8 @@ void MuonAnalysis::runLoadGroupButton() {
   QString prevPath =
       prevValues.value("dir", QString::fromStdString(
                                   ConfigService::Instance().getString(
-                                      "defaultload.directory"))).toString();
+                                      "defaultload.directory")))
+          .toString();
 
   QString filter;
   filter.append("Files (*.xml *.XML)");
@@ -2208,20 +2210,20 @@ void MuonAnalysis::setAppendingRun(int inc) {
 void MuonAnalysis::changeRun(int amountToChange) {
   QString filePath("");
   QString currentFile = m_uiForm.mwRunFiles->getFirstFilename();
-  if ((currentFile.isEmpty()))
+  if ((currentFile.isEmpty())) {
     if (m_previousFilenames.isEmpty()) {
       // not a valid file, and no previous valid files
-      int ret =
-          QMessageBox::warning(this, tr("Muon Analysis"),
-                               tr("Unable to open the file.\n"
-                                  "and no previous valid files available."),
-                               QMessageBox::Ok, QMessageBox::Ok);
+      QMessageBox::warning(this, tr("Muon Analysis"),
+                           tr("Unable to open the file.\n"
+                              "and no previous valid files available."),
+                           QMessageBox::Ok, QMessageBox::Ok);
       allowLoading(true);
       return;
     } else {
       // blank box - use previous run
       currentFile = m_previousFilenames[0];
     }
+  }
 
   QString run("");
   int runSize(-1);

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -2209,18 +2209,17 @@ void MuonAnalysis::changeRun(int amountToChange) {
   QString filePath("");
   QString currentFile = m_uiForm.mwRunFiles->getFirstFilename();
   if ((currentFile.isEmpty()))
-    if (m_previousFilenames.isEmpty())
-    {
-      //not a valid file, and no previous valid files
-      int ret = QMessageBox::warning(this, tr("Muon Analysis"),
-        tr("Unable to open the file.\n"
-          "and no previous valid files available."),
-        QMessageBox::Ok,
-        QMessageBox::Ok);
+    if (m_previousFilenames.isEmpty()) {
+      // not a valid file, and no previous valid files
+      int ret =
+          QMessageBox::warning(this, tr("Muon Analysis"),
+                               tr("Unable to open the file.\n"
+                                  "and no previous valid files available."),
+                               QMessageBox::Ok, QMessageBox::Ok);
       allowLoading(true);
       return;
     } else {
-      //blank box - use previous run
+      // blank box - use previous run
       currentFile = m_previousFilenames[0];
     }
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -2209,7 +2209,20 @@ void MuonAnalysis::changeRun(int amountToChange) {
   QString filePath("");
   QString currentFile = m_uiForm.mwRunFiles->getFirstFilename();
   if ((currentFile.isEmpty()))
-    currentFile = m_previousFilenames[0];
+    if (m_previousFilenames.isEmpty())
+    {
+      //not a valid file, and no previous valid files
+      int ret = QMessageBox::warning(this, tr("Muon Analysis"),
+        tr("Unable to open the file.\n"
+          "and no previous valid files available."),
+        QMessageBox::Ok,
+        QMessageBox::Ok);
+      allowLoading(true);
+      return;
+    } else {
+      //blank box - use previous run
+      currentFile = m_previousFilenames[0];
+    }
 
   QString run("");
   int runSize(-1);


### PR DESCRIPTION
Two specific fixes of bad behaviour when entering .mantid files where they should not be used.

**To test:**

1. Use File->Open File to open a .mantid project file (not Open Project) - should now work
2.  Paste a project file into the file box of the Muon Analysis interface, then click one of the arrows - Should no longer crash

Fixes #18188

## RELEASE NOTES
Does not need to be in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

