### PR TITLE
Indirect ConvFit - Unable to plot results

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -327,7 +327,7 @@ void ConvFit::plotClicked() {
         // Plot results for both Lorentzians if "Two Lorentzians"
         if (m_uiForm.cbFitType->currentIndex() == 2) {
           IndirectTab::plotSpectrum(QString::fromStdString(resultWs->getName()),
-            specNumber + 2, specNumber + 2);
+                                    specNumber + 2, specNumber + 2);
         }
       }
     }
@@ -1548,7 +1548,7 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
   if (functionName.compare("Two Lorentzians") == 0) {
     currentFitFunction = "Lorentzian";
     IFunction_sptr func = FunctionFactory::Instance().createFunction(
-      currentFitFunction.toStdString());
+        currentFitFunction.toStdString());
     for (size_t i = 0; i < func->nParams(); i++) {
       parameters << QString::fromStdString(func->parameterName(i));
     }

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -324,6 +324,11 @@ void ConvFit::plotClicked() {
         const auto specNumber = m_uiForm.cbPlotType->currentIndex();
         IndirectTab::plotSpectrum(QString::fromStdString(resultWs->getName()),
                                   specNumber, specNumber);
+        // Plot results for both Lorentzians if "Two Lorentzians"
+        if (m_uiForm.cbFitType->currentIndex() == 2) {
+          IndirectTab::plotSpectrum(QString::fromStdString(resultWs->getName()),
+            specNumber + 2, specNumber + 2);
+        }
       }
     }
   } else {

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1540,17 +1540,16 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
     }
   }
   // Add another Lorentzian function parameter for two Lorentzian fit
-  if (functionName.compare("Two Lorentzian") == 0) {
+  if (functionName.compare("Two Lorentzians") == 0) {
     currentFitFunction = "Lorentzian";
-  }
-  if (functionName.compare("Zero Lorentzians") == 0) {
-    parameters.append("Zero");
-  } else {
     IFunction_sptr func = FunctionFactory::Instance().createFunction(
-        currentFitFunction.toStdString());
+      currentFitFunction.toStdString());
     for (size_t i = 0; i < func->nParams(); i++) {
       parameters << QString::fromStdString(func->parameterName(i));
     }
+  }
+  if (functionName.compare("Zero Lorentzians") == 0) {
+    parameters.append("Zero");
   }
   return parameters;
 }

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -265,11 +265,11 @@ void IndirectTab::plotSpectrum(const QStringList &workspaceNames, int specStart,
 
   pyInput += "plotSpectrum(['";
   pyInput += workspaceNames.join("','");
-  pyInput += "'], range(";
+  pyInput += "'], list(range(";
   pyInput += QString::number(specStart);
   pyInput += ",";
   pyInput += QString::number(specEnd + 1);
-  pyInput += "), error_bars = True)\n";
+  pyInput += ")), error_bars = True)\n";
 
   m_pythonRunner.runPythonCode(pyInput);
 }

--- a/docs/source/release/v3.9.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.9.0/indirect_inelastic.rst
@@ -19,17 +19,13 @@ Data Reduction
 ##############
 
 - Q-values in :ref:`BASISReduction <algm-BASISReduction>` output are now point data so that their values display correctly when plotted
+- When plotting *ConvFit* results "Two Lorentzians" will produce plots for both lorentzians
 
 Data Analysis
 #############
 
 - :ref:`TeixeiraWaterSQE <func-TeixeiraWaterSQE>` models translation of water-like molecules (jump diffusion).
 - :ref:`GetQsInQENSData <algm-GetQsInQENSData>` Extracts or computes Q values from a MatrixWorkspace.
-
-Improvements
-------------
-
-- When plotting from interfaces the plots now display error bars as standard
 
 Corrections
 ###########
@@ -60,11 +56,13 @@ Improvements
 
 - Data saved in an ASCII format using the *EnergyTransfer* interface can be re-loaded into Mantid
 - TOSCA instrument definition file has been updated
+- When plotting from interfaces the plots now display error bars as standard
 
 Bugfixes
 --------
 
 - Clicking 'Save' without creating a res file in *ISISCalibration* no longer causes an error
+- Fixed issue when trying to plot multiple spectra
 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.9%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
The IndirectTab call to plotSpectrum has been updated for python 3. Also corrected issue that was causing each parameter to show up twice in `Plot Options`.

**To test:**

Interfaces > Indirect > Data Analysis > ConvFit

Sample: `\\olympic\babylon5\Public\Louise McCann\DataAnalysis\ConvFit\irs26176_graphite002_red`
Res:` \\olympic\babylon5\Public\Louise McCann\DataAnalysis\ConvFit\irs26173_graphite002_res`

Select `Two Lorentzians` as the Fit Type
Ensure the parameters for both Lorentzian functions are present and can be edited.
Ensure that clicking `Plot` and `Plot Current Preview` produce the expected plot. Note that`Two Lorentzians` should produce 2 graphs for Amplitude/FWHM (one for each lorentzian)
Also test with other `Fit Type` and ensure correct plots are produced.

Fixes #18202.

[Release Notes](https://github.com/mantidproject/mantid/blob/cbccfeb68ab64499c8824f8e73c2b3a475491867/docs/source/release/v3.9.0/indirect_inelastic.rst)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
