### PR TITLE
Reflectometry interface (Polref): Fix to have 'Get Defaults' wrap polarization constant values in quote marks

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsTabPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsTabPresenter.h
@@ -65,6 +65,7 @@ private:
   void createStitchHints();
   void getExpDefaults();
   void getInstDefaults();
+  void quoteWrap(std::string &str) const;
   IAlgorithm_sptr createReductionAlg();
   Instrument_const_sptr createEmptyInstrument(std::string instName);
   std::string getTransmissionRuns() const;

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsTabPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsTabPresenter.cpp
@@ -1,10 +1,10 @@
 #include "MantidQtCustomInterfaces/Reflectometry/ReflSettingsTabPresenter.h"
-#include "MantidQtCustomInterfaces/Reflectometry/IReflMainWindowPresenter.h"
-#include "MantidQtCustomInterfaces/Reflectometry/IReflSettingsTabView.h"
-#include "MantidQtMantidWidgets/AlgorithmHintStrategy.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtCustomInterfaces/Reflectometry/IReflMainWindowPresenter.h"
+#include "MantidQtCustomInterfaces/Reflectometry/IReflSettingsTabView.h"
+#include "MantidQtMantidWidgets/AlgorithmHintStrategy.h"
 
 #include <boost/algorithm/string.hpp>
 
@@ -305,7 +305,7 @@ void ReflSettingsTabPresenter::getExpDefaults() {
 
   auto cAp = inst->getStringParameter("cAp");
   if (!cAp.empty())
-    defaults[4] = "\"" + cAp[0] + "\""; 
+    defaults[4] = "\"" + cAp[0] + "\"";
 
   auto cPp = inst->getStringParameter("cPp");
   if (!cPp.empty())

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsTabPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsTabPresenter.cpp
@@ -131,23 +131,31 @@ std::string ReflSettingsTabPresenter::getReductionOptions() const {
 
   // Add CRho
   auto crho = m_view->getCRho();
-  if (!crho.empty())
+  if (!crho.empty()) {
+    quoteWrap(crho);
     options.push_back("CRho=" + crho);
+  }
 
   // Add CAlpha
   auto calpha = m_view->getCAlpha();
-  if (!calpha.empty())
+  if (!calpha.empty()) {
+    quoteWrap(calpha);
     options.push_back("CAlpha=" + calpha);
+  }
 
   // Add CAp
   auto cap = m_view->getCAp();
-  if (!cap.empty())
+  if (!cap.empty()) {
+    quoteWrap(cap);
     options.push_back("CAp=" + cap);
+  }
 
   // Add CPp
   auto cpp = m_view->getCPp();
-  if (!cpp.empty())
+  if (!cpp.empty()) {
+    quoteWrap(cpp);
     options.push_back("CPp=" + cpp);
+  }
 
   // Add direct beam
   auto dbnr = m_view->getDirectBeam();
@@ -219,6 +227,10 @@ std::string ReflSettingsTabPresenter::getReductionOptions() const {
   auto transRuns = this->getTransmissionRuns();
   if (!transRuns.empty())
     options.push_back(transRuns);
+
+  for (auto &x : options) {
+    std::cout << ">>> " << x << "\n";
+  }
 
   return boost::algorithm::join(options, ",");
 }
@@ -296,8 +308,9 @@ void ReflSettingsTabPresenter::getExpDefaults() {
   defaults[1] = alg->getPropertyValue("PolarizationAnalysis");
 
   auto cRho = inst->getStringParameter("crho");
-  if (!cRho.empty())
+  if (!cRho.empty()) {
     defaults[2] = "\"" + cRho[0] + "\"";
+  }
 
   auto cAlpha = inst->getStringParameter("calpha");
   if (!cAlpha.empty())
@@ -314,6 +327,16 @@ void ReflSettingsTabPresenter::getExpDefaults() {
   defaults[6] = alg->getPropertyValue("ScaleFactor");
 
   m_view->setExpDefaults(defaults);
+}
+
+/** Wraps string with quote marks if it does not already have them
+* @param str :: [input] The string to be wrapped
+*/
+void ReflSettingsTabPresenter::quoteWrap(std::string &str) const {
+  if (str.front() != '\"')
+    str = "\"" + str;
+  if (str.back() != '\"')
+    str = str + "\"";
 }
 
 /** Fills instrument settings with default values

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsTabPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsTabPresenter.cpp
@@ -297,19 +297,19 @@ void ReflSettingsTabPresenter::getExpDefaults() {
 
   auto cRho = inst->getStringParameter("crho");
   if (!cRho.empty())
-    defaults[2] = cRho[0];
+    defaults[2] = "\"" + cRho[0] + "\"";
 
   auto cAlpha = inst->getStringParameter("calpha");
   if (!cAlpha.empty())
-    defaults[3] = cAlpha[0];
+    defaults[3] = "\"" + cAlpha[0] + "\"";
 
   auto cAp = inst->getStringParameter("cAp");
   if (!cAp.empty())
-    defaults[4] = cAp[0];
+    defaults[4] = "\"" + cAp[0] + "\""; 
 
   auto cPp = inst->getStringParameter("cPp");
   if (!cPp.empty())
-    defaults[5] = cPp[0];
+    defaults[5] = "\"" + cPp[0] + "\"";
 
   defaults[6] = alg->getPropertyValue("ScaleFactor");
 

--- a/MantidQt/CustomInterfaces/test/ReflSettingsTabPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflSettingsTabPresenterTest.h
@@ -1,10 +1,10 @@
 #ifndef MANTID_CUSTOMINTERFACES_REFLSETTINGSTABPRESENTERTEST_H
 #define MANTID_CUSTOMINTERFACES_REFLSETTINGSTABPRESENTERTEST_H
 
+#include <boost/algorithm/string.hpp>
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <boost/algorithm/string.hpp>
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -101,12 +101,18 @@ public:
     EXPECT_CALL(mockView, getAnalysisMode())
         .Times(Exactly(1))
         .WillOnce(Return("MultiDetectorAnalysis"));
-    EXPECT_CALL(mockView, getCRho()).Times(Exactly(1)).WillOnce(Return("2.5"));
+    EXPECT_CALL(mockView, getCRho())
+        .Times(Exactly(1))
+        .WillOnce(Return("\"2.5,0.4,1.1\""));
     EXPECT_CALL(mockView, getCAlpha())
         .Times(Exactly(1))
-        .WillOnce(Return("0.6"));
-    EXPECT_CALL(mockView, getCAp()).Times(Exactly(1)).WillOnce(Return("100.0"));
-    EXPECT_CALL(mockView, getCPp()).Times(Exactly(1)).WillOnce(Return("0.54"));
+        .WillOnce(Return("\"0.6,0.9,1.2\""));
+    EXPECT_CALL(mockView, getCAp())
+        .Times(Exactly(1))
+        .WillOnce(Return("\"100.0,17.0,44.0\""));
+    EXPECT_CALL(mockView, getCPp())
+        .Times(Exactly(1))
+        .WillOnce(Return("\"0.54,0.33,1.81\""));
     EXPECT_CALL(mockView, getDirectBeam())
         .Times(Exactly(1))
         .WillOnce(Return("\"0,3\""));
@@ -154,10 +160,10 @@ public:
     std::vector<std::string> optionsVec;
     boost::split(optionsVec, options, split_q());
     TS_ASSERT_EQUALS(optionsVec[0], "AnalysisMode=MultiDetectorAnalysis");
-    TS_ASSERT_EQUALS(optionsVec[1], "CRho=2.5");
-    TS_ASSERT_EQUALS(optionsVec[2], "CAlpha=0.6");
-    TS_ASSERT_EQUALS(optionsVec[3], "CAp=100.0");
-    TS_ASSERT_EQUALS(optionsVec[4], "CPp=0.54");
+    TS_ASSERT_EQUALS(optionsVec[1], "CRho=\"2.5,0.4,1.1\"");
+    TS_ASSERT_EQUALS(optionsVec[2], "CAlpha=\"0.6,0.9,1.2\"");
+    TS_ASSERT_EQUALS(optionsVec[3], "CAp=\"100.0,17.0,44.0\"");
+    TS_ASSERT_EQUALS(optionsVec[4], "CPp=\"0.54,0.33,1.81\"");
     TS_ASSERT_EQUALS(optionsVec[5], "RegionOfDirectBeam=\"0,3\"");
     TS_ASSERT_EQUALS(optionsVec[6], "PolarizationAnalysis=PNR");
     TS_ASSERT_EQUALS(optionsVec[7], "NormalizeByIntegratedMonitors=True");
@@ -218,11 +224,13 @@ public:
     presenter.setInstrumentName("POLREF");
 
     std::vector<std::string> defaults = {
-        "PointDetectorAnalysis", "None",
-        "1.006831,-0.011467,0.002244,-0.000095",
-        "1.017526,-0.017183,0.003136,-0.000140",
-        "0.917940,0.038265,-0.006645,0.000282",
-        "0.972762,0.001828,-0.000261,0.0", "1"};
+        "PointDetectorAnalysis",
+        "None",
+        "\"1.006831,-0.011467,0.002244,-0.000095\"",
+        "\"1.017526,-0.017183,0.003136,-0.000140\"",
+        "\"0.917940,0.038265,-0.006645,0.000282\"",
+        "\"0.972762,0.001828,-0.000261,0.0\"",
+        "1"};
 
     EXPECT_CALL(mockView, setExpDefaults(defaults)).Times(1);
     presenter.notify(IReflSettingsTabPresenter::ExpDefaultsFlag);

--- a/MantidQt/CustomInterfaces/test/ReflSettingsTabPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflSettingsTabPresenterTest.h
@@ -224,13 +224,11 @@ public:
     presenter.setInstrumentName("POLREF");
 
     std::vector<std::string> defaults = {
-        "PointDetectorAnalysis",
-        "None",
+        "PointDetectorAnalysis", "None",
         "\"1.006831,-0.011467,0.002244,-0.000095\"",
         "\"1.017526,-0.017183,0.003136,-0.000140\"",
         "\"0.917940,0.038265,-0.006645,0.000282\"",
-        "\"0.972762,0.001828,-0.000261,0.0\"",
-        "1"};
+        "\"0.972762,0.001828,-0.000261,0.0\"", "1"};
 
     EXPECT_CALL(mockView, setExpDefaults(defaults)).Times(1);
     presenter.notify(IReflSettingsTabPresenter::ExpDefaultsFlag);


### PR DESCRIPTION
In the `Settings` tab, the polarization constants (`CRho`, `CAlpha`, `CAp`, `CPp`) are given as a string of comma-separated values. The original problem with the 'Get Defaults' button however was that it did not wrap these values with quote marks. Without re-inserting the quote marks, an attempt at data reduction would fail. This PR fixes this by adding the quote marks back in when 'Get Defaults' is clicked.

**To test:**

- Access the Reflectometry interface from from Interfaces->Reflectometry->ISIS Reflectometry (Polref).
- On the Runs tab, set Instrument to POLREF.
- On the Settings tab, for the Experiment Settings section, click the Get Defaults button.
- Parameters CRho, CAlpha, CAp, CPp should be filled with multiple values all enclosed with quote marks.

Fixes #18208.

*Does not need to be in the release notes.*

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
