### PR TITLE
Fix building with clang on Linux

### DIFF
--- a/Framework/Kernel/src/ArrayBoundedValidator.cpp
+++ b/Framework/Kernel/src/ArrayBoundedValidator.cpp
@@ -139,7 +139,7 @@ template <typename TYPE> void ArrayBoundedValidator<TYPE>::clearUpper() {
 template class ArrayBoundedValidator<double>;
 template class ArrayBoundedValidator<int32_t>;
 template class ArrayBoundedValidator<int64_t>;
-#if defined(_WIN32) || defined(__clang__)
+#if defined(_WIN32) || defined(__clang__) && defined(__APPLE__)
 template class ArrayBoundedValidator<long>;
 #endif
 

--- a/Framework/Kernel/src/ArrayLengthValidator.cpp
+++ b/Framework/Kernel/src/ArrayLengthValidator.cpp
@@ -188,7 +188,7 @@ template class ArrayLengthValidator<double>;
 template class ArrayLengthValidator<int32_t>;
 template class ArrayLengthValidator<int64_t>;
 template class ArrayLengthValidator<std::string>;
-#if defined(_WIN32) || defined(__clang__)
+#if defined(_WIN32) || defined(__clang__) && defined(__APPLE__)
 template class ArrayLengthValidator<long>;
 #endif
 } // namespace Mantid

--- a/Framework/Kernel/src/ArrayProperty.cpp
+++ b/Framework/Kernel/src/ArrayProperty.cpp
@@ -116,7 +116,7 @@ template class DLLExport ArrayProperty<std::vector<float>>;
 template class DLLExport ArrayProperty<std::vector<double>>;
 template class DLLExport ArrayProperty<std::vector<std::string>>;
 
-#if defined(_WIN32) || defined(__clang__)
+#if defined(_WIN32) || defined(__clang__) && defined(__APPLE__)
 template class DLLExport ArrayProperty<long>;
 template class DLLExport ArrayProperty<unsigned long>;
 template class DLLExport ArrayProperty<std::vector<long>>;

--- a/Framework/Kernel/src/MandatoryValidator.cpp
+++ b/Framework/Kernel/src/MandatoryValidator.cpp
@@ -42,7 +42,7 @@ template <> DLLExport bool checkIsEmpty(const long &value) {
   // 32 bit for Windows and Clang, 64 bit for GCC
   return (value == Mantid::EMPTY_LONG());
 }
-#if defined(_WIN32) || defined(__clang__)
+#if defined(_WIN32) || defined(__clang__) && defined(__APPLE__)
 /**
  * Specialization of checkIsEmpty for 64 bit intiger
  * @param value :: A int64_t value

--- a/Framework/Kernel/src/PropertyWithValue.cpp
+++ b/Framework/Kernel/src/PropertyWithValue.cpp
@@ -49,7 +49,7 @@ template class MANTID_KERNEL_DLL
     PropertyWithValue<boost::shared_ptr<IValidator>>;
 template class MANTID_KERNEL_DLL
     PropertyWithValue<boost::shared_ptr<PropertyManager>>;
-#if defined(_WIN32) || defined(__clang__)
+#if defined(_WIN32) || defined(__clang__) && defined(__APPLE__)
 template class MANTID_KERNEL_DLL PropertyWithValue<long>;
 template class MANTID_KERNEL_DLL PropertyWithValue<unsigned long>;
 template class MANTID_KERNEL_DLL PropertyWithValue<std::vector<long>>;


### PR DESCRIPTION
You can't assume `__clang__` only includes OSX, Mantid can also be built on Linux using clang

Currently you get these type of errors when building on Linux with clang:
```
../../Framework/Kernel/src/ArrayBoundedValidator.cpp:143:16: error: duplicate explicit instantiation of 'ArrayBoundedValidator<long>'
template class ArrayBoundedValidator<long>;
               ^
../../Framework/Kernel/src/ArrayBoundedValidator.cpp:141:16: note: previous explicit instantiation is here
template class ArrayBoundedValidator<int64_t>;
               ^
```

This changes the check for the `long` template to be `__clang__` and `__APPLE__`

**To test:**
 * If this doesn't break any of the other builds it should be good
 * If you are really motivated you can build Mantid with clang on Linux or just trust me that it now works


Does not need to be in the release notes.


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
