### PR TITLE
Show/hide group workspaces in WorkspaceSelector and DataSelector widgets

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataSelector.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataSelector.h
@@ -81,6 +81,7 @@ class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS DataSelector
                  setWorkspaceTypes)
   Q_PROPERTY(bool ShowHidden READ showHiddenWorkspaces WRITE
                  showHiddenWorkspaces)
+  Q_PROPERTY(bool ShowGroups READ showWorkspaceGroups WRITE showWorkspaceGroups)
   Q_PROPERTY(QString Algorithm READ getValidatingAlgorithm WRITE
                  setValidatingAlgorithm)
 
@@ -362,6 +363,24 @@ public:
    */
   void showHiddenWorkspaces(bool show) {
     m_uiForm.wsWorkspaceInput->showHiddenWorkspaces(show);
+  }
+
+  /**
+   * Gets if the workspace selector shows group workspaces
+   *
+   * @return Boolean flag if group workspaces are shown
+   */
+  bool showWorkspaceGroups() const {
+    return m_uiForm.wsWorkspaceInput->showWorkspaceGroups();
+  }
+
+  /**
+   * Sets if the workspace selector shows workspace groups
+   *
+   * @param show :: Boolean flag if group workspaces are shown
+   */
+  void showWorkspaceGroups(bool show) {
+    m_uiForm.wsWorkspaceInput->showWorkspaceGroups(show);
   }
 
   /**

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/WorkspaceSelector.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/WorkspaceSelector.h
@@ -66,6 +66,7 @@ class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS WorkspaceSelector : public QComboBox {
                  setWorkspaceTypes)
   Q_PROPERTY(bool ShowHidden READ showHiddenWorkspaces WRITE
                  showHiddenWorkspaces)
+  Q_PROPERTY(bool ShowGroups READ showWorkspaceGroups WRITE showWorkspaceGroups)
   Q_PROPERTY(bool Optional READ isOptional WRITE setOptional)
   Q_PROPERTY(QStringList Suffix READ getSuffixes WRITE setSuffixes)
   Q_PROPERTY(QString Algorithm READ getValidatingAlgorithm WRITE
@@ -82,6 +83,8 @@ public:
   void setWorkspaceTypes(const QStringList &types);
   bool showHiddenWorkspaces() const;
   void showHiddenWorkspaces(bool show);
+  bool showWorkspaceGroups() const;
+  void showWorkspaceGroups(bool show);
   bool isOptional() const;
   void setOptional(bool optional);
   QStringList getSuffixes() const;
@@ -131,7 +134,9 @@ private:
   /// A list of workspace types that should be shown in the ComboBox
   QStringList m_workspaceTypes;
   /// Whether to show "hidden" workspaces
-  bool m_showHidden;
+  bool m_showHidden;  
+  // show/hide workspace groups
+  bool m_showGroups;
   bool m_optional; ///< Whether to add an extra empty entry to the combobox
   // suffix
   QStringList m_suffix;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/WorkspaceSelector.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/WorkspaceSelector.h
@@ -134,7 +134,7 @@ private:
   /// A list of workspace types that should be shown in the ComboBox
   QStringList m_workspaceTypes;
   /// Whether to show "hidden" workspaces
-  bool m_showHidden;  
+  bool m_showHidden;
   // show/hide workspace groups
   bool m_showGroups;
   bool m_optional; ///< Whether to add an extra empty entry to the combobox

--- a/MantidQt/MantidWidgets/src/WorkspaceSelector.cpp
+++ b/MantidQt/MantidWidgets/src/WorkspaceSelector.cpp
@@ -248,8 +248,10 @@ bool WorkspaceSelector::checkEligibility(
   } else if (!hasValidSuffix(name)) {
     return false;
   } else if (!m_showGroups) {
-    auto group = boost::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(object);
-    if (group!=nullptr) return false;
+    auto group =
+        boost::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(object);
+    if (group != nullptr)
+      return false;
   }
 
   return true;

--- a/MantidQt/MantidWidgets/src/WorkspaceSelector.cpp
+++ b/MantidQt/MantidWidgets/src/WorkspaceSelector.cpp
@@ -10,6 +10,7 @@
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 
 #include <QDropEvent>
 #include <QMimeData>
@@ -30,8 +31,9 @@ WorkspaceSelector::WorkspaceSelector(QWidget *parent, bool init)
       m_clearObserver(*this, &WorkspaceSelector::handleClearEvent),
       m_renameObserver(*this, &WorkspaceSelector::handleRenameEvent),
       m_replaceObserver(*this, &WorkspaceSelector::handleReplaceEvent),
-      m_init(init), m_workspaceTypes(), m_showHidden(false), m_optional(false),
-      m_suffix(), m_algName(), m_algPropName(), m_algorithm() {
+      m_init(init), m_workspaceTypes(), m_showHidden(false), m_showGroups(true),
+      m_optional(false), m_suffix(), m_algName(), m_algPropName(),
+      m_algorithm() {
   setEditable(false);
   if (init) {
     Mantid::API::AnalysisDataServiceImpl &ads =
@@ -84,6 +86,17 @@ bool WorkspaceSelector::showHiddenWorkspaces() const { return m_showHidden; }
 void WorkspaceSelector::showHiddenWorkspaces(bool show) {
   if (show != m_showHidden) {
     m_showHidden = show;
+    if (m_init) {
+      refresh();
+    }
+  }
+}
+
+bool WorkspaceSelector::showWorkspaceGroups() const { return m_showGroups; }
+
+void WorkspaceSelector::showWorkspaceGroups(bool show) {
+  if (show != m_showGroups) {
+    m_showGroups = show;
     if (m_init) {
       refresh();
     }
@@ -234,6 +247,9 @@ bool WorkspaceSelector::checkEligibility(
     return false;
   } else if (!hasValidSuffix(name)) {
     return false;
+  } else if (!m_showGroups) {
+    auto group = boost::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(object);
+    if (group!=nullptr) return false;
   }
 
   return true;


### PR DESCRIPTION
This PR adds a new property to WorkspaceSelector (and DataSelector) GUI widgets to show or hide the group workspaces. By default, the groups will be shown, as before.

**To test:**

<!-- Instructions for testing. -->

1. Load/create some workspaces and workspace groups.
2. Open some custom interface, where there is one of the above mentioned widgets (e.g. Indirect -> Reduction -> Transmission tab is a good candidate, since there are no other restrictions on workspaces)
3. Check that all the workspaces and groups that you created can be selected.
4. Go to corresponding .ui file (e.g. IndirectTransmission.ui) with QtDesigner, find the widget element, and add a boolean dynamic property `ShowGroups` with a value of `False`.
5. Rebuild, and repeat steps 1 and 2, now the group workspaces should not be in the list.

Fixes #18238 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

Does not need to be in the release notes, nor in documentation.
It is a GUI change, so no automated test is available.

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.