### PR TITLE
Remove MatrixWorkspace::maskWorkspaceIndex

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -100,6 +100,7 @@ set ( SRC_FILES
 	src/MultipleExperimentInfos.cpp
 	src/MultipleFileProperty.cpp
 	src/NearestNeighbourInfo.cpp
+	src/NearestNeighbours.cpp
 	src/NotebookBuilder.cpp
 	src/NotebookWriter.cpp
 	src/NullCoordTransform.cpp
@@ -285,6 +286,7 @@ set ( INC_FILES
 	inc/MantidAPI/MultipleExperimentInfos.h
 	inc/MantidAPI/MultipleFileProperty.h
 	inc/MantidAPI/NearestNeighbourInfo.h
+        inc/MantidAPI/NearestNeighbours.h
 	inc/MantidAPI/NotebookBuilder.h
 	inc/MantidAPI/NotebookWriter.h
 	inc/MantidAPI/NullCoordTransform.h
@@ -399,6 +401,7 @@ set ( TEST_FILES
 	MultipleExperimentInfosTest.h
 	MultipleFilePropertyTest.h
 	NearestNeighbourInfoTest.h
+	NearestNeighboursTest.h
 	NotebookBuilderTest.h
 	NotebookWriterTest.h
 	NumericAxisTest.h

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -424,9 +424,6 @@ public:
   bool isDistribution() const;
   void setDistribution(bool newValue);
 
-  /// Mask a given workspace index, setting the data and error values to zero
-  void maskWorkspaceIndex(const std::size_t index);
-
   // Methods to set and access masked bins
   void maskBin(const size_t &workspaceIndex, const size_t &binIndex,
                const double &weight = 1.0);

--- a/Framework/API/inc/MantidAPI/NearestNeighbourInfo.h
+++ b/Framework/API/inc/MantidAPI/NearestNeighbourInfo.h
@@ -2,7 +2,7 @@
 #define MANTID_API_NEARESTNEIGHBOURINFO_H_
 
 #include "MantidAPI/DllConfig.h"
-#include "MantidGeometry/Instrument/NearestNeighbours.h"
+#include "MantidAPI/NearestNeighbours.h"
 
 namespace Mantid {
 namespace API {
@@ -48,7 +48,7 @@ public:
 
 private:
   const MatrixWorkspace &m_workspace;
-  Geometry::NearestNeighbours m_nearestNeighbours;
+  NearestNeighbours m_nearestNeighbours;
 };
 
 } // namespace API

--- a/Framework/API/inc/MantidAPI/NearestNeighbourInfo.h
+++ b/Framework/API/inc/MantidAPI/NearestNeighbourInfo.h
@@ -3,11 +3,13 @@
 
 #include "MantidAPI/DllConfig.h"
 #include "MantidAPI/NearestNeighbours.h"
+#include <memory>
 
 namespace Mantid {
 namespace API {
 
 class MatrixWorkspace;
+class NearestNeighbours;
 
 /** NearestNeighbourInfo provides easy access to nearest-neighbour information
   for a workspace.
@@ -48,7 +50,7 @@ public:
 
 private:
   const MatrixWorkspace &m_workspace;
-  NearestNeighbours m_nearestNeighbours;
+  std::unique_ptr<NearestNeighbours> m_nearestNeighbours;
 };
 
 } // namespace API

--- a/Framework/API/inc/MantidAPI/NearestNeighbourInfo.h
+++ b/Framework/API/inc/MantidAPI/NearestNeighbourInfo.h
@@ -2,10 +2,16 @@
 #define MANTID_API_NEARESTNEIGHBOURINFO_H_
 
 #include "MantidAPI/DllConfig.h"
-#include "MantidAPI/NearestNeighbours.h"
+#include "MantidGeometry/IDTypes.h"
+#include "MantidKernel/V3D.h"
+
 #include <memory>
+#include <map>
 
 namespace Mantid {
+namespace Geometry {
+class IDetector;
+}
 namespace API {
 
 class MatrixWorkspace;
@@ -40,6 +46,7 @@ public:
   NearestNeighbourInfo(const MatrixWorkspace &workspace,
                        const bool ignoreMaskedDetectors,
                        const int nNeighbours = 8);
+  ~NearestNeighbourInfo();
 
   std::map<specnum_t, Kernel::V3D>
   getNeighbours(const Geometry::IDetector *comp,

--- a/Framework/API/inc/MantidAPI/NearestNeighbours.h
+++ b/Framework/API/inc/MantidAPI/NearestNeighbours.h
@@ -61,7 +61,7 @@ class SpectrumInfo;
 class MANTID_API_DLL NearestNeighbours {
 public:
   NearestNeighbours(int nNeighbours, const SpectrumInfo &spectrumInfo,
-                    const std::vector<specnum_t> spectrumNumbers,
+                    std::vector<specnum_t> spectrumNumbers,
                     bool ignoreMaskedDetectors = false);
 
   // Neighbouring spectra by radius

--- a/Framework/API/inc/MantidAPI/NearestNeighbours.h
+++ b/Framework/API/inc/MantidAPI/NearestNeighbours.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_GEOMETRY_INSTRUMENT_NEARESTNEIGHBOURS
 #define MANTID_GEOMETRY_INSTRUMENT_NEARESTNEIGHBOURS
 
-#include "MantidGeometry/DllConfig.h"
+#include "MantidAPI/DllConfig.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidKernel/V3D.h"
 // Boost graphing
@@ -13,9 +13,10 @@
 
 namespace Mantid {
 namespace Geometry {
-
 class Instrument;
 class IDetector;
+}
+namespace API {
 
 typedef std::unordered_map<specnum_t, std::set<detid_t>>
     ISpectrumDetectorMapping;
@@ -58,11 +59,11 @@ typedef std::unordered_map<specnum_t, std::set<detid_t>>
  *  File change history is stored at: <https://github.com/mantidproject/mantid>
  *  Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class MANTID_GEOMETRY_DLL NearestNeighbours {
+class MANTID_API_DLL NearestNeighbours {
 public:
   /// Constructor with an instrument and a spectra map and number of neighbours
   NearestNeighbours(int nNeighbours,
-                    boost::shared_ptr<const Instrument> instrument,
+                    boost::shared_ptr<const Geometry::Instrument> instrument,
                     const ISpectrumDetectorMapping &spectraMap,
                     bool ignoreMaskedDetectors = false);
 
@@ -75,12 +76,12 @@ public:
 
 protected:
   /// Get the spectra associated with all in the instrument
-  std::map<specnum_t, boost::shared_ptr<const IDetector>>
-  getSpectraDetectors(boost::shared_ptr<const Instrument> instrument,
+  std::map<specnum_t, boost::shared_ptr<const Geometry::IDetector>>
+  getSpectraDetectors(boost::shared_ptr<const Geometry::Instrument> instrument,
                       const ISpectrumDetectorMapping &spectraMap);
 
   /// A pointer the the instrument
-  boost::shared_ptr<const Instrument> m_instrument;
+  boost::shared_ptr<const Geometry::Instrument> m_instrument;
   /// A reference to the spectra map
   const ISpectrumDetectorMapping &m_spectraMap;
 
@@ -122,14 +123,7 @@ private:
   bool m_bIgnoreMaskedDetectors;
 };
 
-/// Typedef for shared pointer to the NearestNeighbours class
-typedef boost::shared_ptr<Mantid::Geometry::NearestNeighbours>
-    NearestNeighbours_sptr;
-/// Typedef for constant shared pointer to the NearestNeighbours class
-typedef boost::shared_ptr<const Mantid::Geometry::NearestNeighbours>
-    NearestNeighbours_const_sptr;
-
-} // namespace Geometry
+} // namespace API
 } // namespace Mantid
 
 #endif

--- a/Framework/API/inc/MantidAPI/NearestNeighbours.h
+++ b/Framework/API/inc/MantidAPI/NearestNeighbours.h
@@ -17,10 +17,7 @@ class Instrument;
 class IDetector;
 }
 namespace API {
-
-typedef std::unordered_map<specnum_t, std::set<detid_t>>
-    ISpectrumDetectorMapping;
-
+class SpectrumInfo;
 /**
  * This class is used to find the nearest neighbours of a detector in the
  * instrument geometry. This class can be queried through calls to the
@@ -61,10 +58,8 @@ typedef std::unordered_map<specnum_t, std::set<detid_t>>
  */
 class MANTID_API_DLL NearestNeighbours {
 public:
-  /// Constructor with an instrument and a spectra map and number of neighbours
-  NearestNeighbours(int nNeighbours,
-                    boost::shared_ptr<const Geometry::Instrument> instrument,
-                    const ISpectrumDetectorMapping &spectraMap,
+  NearestNeighbours(int nNeighbours, const SpectrumInfo &spectrumInfo,
+                    const std::vector<specnum_t> spectrumNumbers,
                     bool ignoreMaskedDetectors = false);
 
   // Neighbouring spectra by radius
@@ -75,17 +70,14 @@ public:
   std::map<specnum_t, Mantid::Kernel::V3D> neighbours(specnum_t spectrum) const;
 
 protected:
-  /// Get the spectra associated with all in the instrument
-  std::map<specnum_t, boost::shared_ptr<const Geometry::IDetector>>
-  getSpectraDetectors(boost::shared_ptr<const Geometry::Instrument> instrument,
-                      const ISpectrumDetectorMapping &spectraMap);
-
-  /// A pointer the the instrument
-  boost::shared_ptr<const Geometry::Instrument> m_instrument;
-  /// A reference to the spectra map
-  const ISpectrumDetectorMapping &m_spectraMap;
+  std::vector<size_t> getSpectraDetectors();
 
 private:
+  /// A reference to the SpectrumInfo
+  const SpectrumInfo &m_spectrumInfo;
+  /// Vector of spectrum numbers
+  const std::vector<specnum_t> m_spectrumNumbers;
+
   /// typedef for Graph object used to hold the calculated information
   typedef boost::adjacency_list<
       boost::vecS, boost::vecS, boost::directedS,

--- a/Framework/API/inc/MantidAPI/NearestNeighbours.h
+++ b/Framework/API/inc/MantidAPI/NearestNeighbours.h
@@ -19,6 +19,8 @@ class IDetector;
 namespace API {
 class SpectrumInfo;
 /**
+ * This class is not intended for direct use. Use NearestNeighbourInfo instead!
+ *
  * This class is used to find the nearest neighbours of a detector in the
  * instrument geometry. This class can be queried through calls to the
  * getNeighbours() function on a Detector object.

--- a/Framework/API/inc/MantidAPI/PrecompiledHeader.h
+++ b/Framework/API/inc/MantidAPI/PrecompiledHeader.h
@@ -14,7 +14,6 @@
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument.h"
-#include "MantidGeometry/Instrument/NearestNeighbours.h"
 
 // STL
 #include <vector>

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -896,35 +896,6 @@ bool MatrixWorkspace::isCommonBins() const {
   return m_isCommonBinsFlag;
 }
 
-/**
-* Mask a given workspace index, setting the data and error values to zero
-* @param index :: The index within the workspace to mask
-*/
-void MatrixWorkspace::maskWorkspaceIndex(const std::size_t index) {
-  if (index >= this->getNumberHistograms()) {
-    throw Kernel::Exception::IndexError(
-        index, this->getNumberHistograms(),
-        "MatrixWorkspace::maskWorkspaceIndex,index");
-  }
-
-  auto &spec = this->getSpectrum(index);
-
-  // Virtual method clears the spectrum as appropriate
-  spec.clearData();
-
-  const auto dets = spec.getDetectorIDs();
-  for (auto detId : dets) {
-    try {
-      if (const Geometry::Detector *det =
-              dynamic_cast<const Geometry::Detector *>(
-                  sptr_instrument->getDetector(detId).get())) {
-        m_parmap->addBool(det, "masked", true); // Thread-safe method
-      }
-    } catch (Kernel::Exception::NotFoundError &) {
-    }
-  }
-}
-
 /** Called by the algorithm MaskBins to mask a single bin for the first time,
 * algorithms that later propagate the
 *  the mask from an input to the output should call flagMasked() instead. Here

--- a/Framework/API/src/NearestNeighbourInfo.cpp
+++ b/Framework/API/src/NearestNeighbourInfo.cpp
@@ -1,6 +1,6 @@
 #include "MantidAPI/NearestNeighbourInfo.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/SpectrumDetectorMapping.h"
+#include "MantidKernel/make_unique.h"
 
 namespace Mantid {
 namespace API {
@@ -15,10 +15,15 @@ namespace API {
 NearestNeighbourInfo::NearestNeighbourInfo(const MatrixWorkspace &workspace,
                                            const bool ignoreMaskedDetectors,
                                            const int nNeighbours)
-    : m_workspace(workspace),
-      m_nearestNeighbours(nNeighbours, workspace.getInstrument(),
-                          SpectrumDetectorMapping(&workspace).getMapping(),
-                          ignoreMaskedDetectors) {}
+    : m_workspace(workspace) {
+  std::vector<specnum_t> spectrumNumbers;
+  for (size_t i = 0; i < m_workspace.getNumberHistograms(); ++i)
+    spectrumNumbers.push_back(m_workspace.getSpectrum(i).getSpectrumNo());
+
+  m_nearestNeighbours = Kernel::make_unique<NearestNeighbours>(
+      nNeighbours, workspace.spectrumInfo(), std::move(spectrumNumbers),
+      ignoreMaskedDetectors);
+}
 
 /** Queries the NearestNeighbours object for the selected detector.
 * NOTE! getNeighbours(spectrumNumber, radius) is MUCH faster.
@@ -39,7 +44,7 @@ NearestNeighbourInfo::getNeighbours(const Geometry::IDetector *comp,
                                            "detector",
                                            comp->getID());
   }
-  return m_nearestNeighbours.neighboursInRadius(spectra[0], radius);
+  return m_nearestNeighbours->neighboursInRadius(spectra[0], radius);
 }
 
 /** Queries the NearestNeighbours object for the selected spectrum number.
@@ -50,7 +55,7 @@ NearestNeighbourInfo::getNeighbours(const Geometry::IDetector *comp,
 */
 std::map<specnum_t, Kernel::V3D>
 NearestNeighbourInfo::getNeighbours(specnum_t spec, const double radius) const {
-  return m_nearestNeighbours.neighboursInRadius(spec, radius);
+  return m_nearestNeighbours->neighboursInRadius(spec, radius);
 }
 
 /** Queries the NearestNeighbours object for the selected spectrum number.
@@ -60,7 +65,7 @@ NearestNeighbourInfo::getNeighbours(specnum_t spec, const double radius) const {
 */
 std::map<specnum_t, Kernel::V3D>
 NearestNeighbourInfo::getNeighboursExact(specnum_t spec) const {
-  return m_nearestNeighbours.neighbours(spec);
+  return m_nearestNeighbours->neighbours(spec);
 }
 
 } // namespace API

--- a/Framework/API/src/NearestNeighbourInfo.cpp
+++ b/Framework/API/src/NearestNeighbourInfo.cpp
@@ -1,4 +1,5 @@
 #include "MantidAPI/NearestNeighbourInfo.h"
+#include "MantidAPI/NearestNeighbours.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/make_unique.h"
 
@@ -24,6 +25,9 @@ NearestNeighbourInfo::NearestNeighbourInfo(const MatrixWorkspace &workspace,
       nNeighbours, workspace.spectrumInfo(), std::move(spectrumNumbers),
       ignoreMaskedDetectors);
 }
+
+// Defined as default in source for forward declaration with std::unique_ptr.
+NearestNeighbourInfo::~NearestNeighbourInfo() = default;
 
 /** Queries the NearestNeighbours object for the selected detector.
 * NOTE! getNeighbours(spectrumNumber, radius) is MUCH faster.

--- a/Framework/API/src/NearestNeighbours.cpp
+++ b/Framework/API/src/NearestNeighbours.cpp
@@ -1,4 +1,4 @@
-#include "MantidGeometry/Instrument/NearestNeighbours.h"
+#include "MantidAPI/NearestNeighbours.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorGroup.h"
 #include "MantidGeometry/Objects/BoundingBox.h"
@@ -8,7 +8,8 @@
 #include "MantidKernel/Timer.h"
 
 namespace Mantid {
-namespace Geometry {
+using namespace Geometry;
+namespace API {
 using Mantid::detid_t;
 using Kernel::V3D;
 

--- a/Framework/API/src/NearestNeighbours.cpp
+++ b/Framework/API/src/NearestNeighbours.cpp
@@ -24,10 +24,12 @@ using Kernel::V3D;
  * @param ignoreMaskedDetectors :: flag indicating that masked detectors should
  * be ignored.
  */
-NearestNeighbours::NearestNeighbours(
-    int nNeighbours, const SpectrumInfo &spectrumInfo,
-    const std::vector<specnum_t> spectrumNumbers, bool ignoreMaskedDetectors)
-    : m_spectrumInfo(spectrumInfo), m_spectrumNumbers(spectrumNumbers),
+NearestNeighbours::NearestNeighbours(int nNeighbours,
+                                     const SpectrumInfo &spectrumInfo,
+                                     std::vector<specnum_t> spectrumNumbers,
+                                     bool ignoreMaskedDetectors)
+    : m_spectrumInfo(spectrumInfo),
+      m_spectrumNumbers(std::move(spectrumNumbers)),
       m_noNeighbours(nNeighbours), m_cutoff(-DBL_MAX), m_radius(0),
       m_bIgnoreMaskedDetectors(ignoreMaskedDetectors) {
   this->build(m_noNeighbours);

--- a/Framework/API/src/NearestNeighbours.cpp
+++ b/Framework/API/src/NearestNeighbours.cpp
@@ -170,7 +170,7 @@ void NearestNeighbours::build(const int noNeighbours) {
       V3D distance = neighbour - realPos;
       double separation = distance.norm();
       boost::add_edge(m_specToVertex[m_spectrumNumbers[idx]], // from
-                      pointNoToVertex[index],       // to
+                      pointNoToVertex[index],                 // to
                       distance, m_graph);
       if (separation > m_cutoff) {
         m_cutoff = separation;

--- a/Framework/API/src/NearestNeighbours.cpp
+++ b/Framework/API/src/NearestNeighbours.cpp
@@ -17,8 +17,10 @@ using Kernel::V3D;
 /**
  * Constructor
  * @param nNeighbours :: Number of neighbours to use
- * @param instrument :: A shared pointer to Instrument object
- * @param spectraMap :: A reference to the spectra-detector mapping
+ * @param spectrumInfo :: Reference to the SpectrumInfo of the underlying
+ * workspace
+ * @param spectrumNumbers :: Vector of spectrum numbers, defining the ordering
+ * of spectra
  * @param ignoreMaskedDetectors :: flag indicating that masked detectors should
  * be ignored.
  */

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -263,8 +263,10 @@ public:
     }
 
     // Mask a spectra
-    workspace->maskWorkspaceIndex(1);
-    workspace->maskWorkspaceIndex(2);
+    workspace->getSpectrum(1).clearData();
+    workspace->getSpectrum(2).clearData();
+    workspace->mutableSpectrumInfo().setMasked(1, true);
+    workspace->mutableSpectrumInfo().setMasked(2, true);
 
     for (int i = 0; i < numHist; ++i) {
       double expectedValue(0.0);
@@ -292,8 +294,10 @@ public:
     // Workspace has 3 spectra, each 1 in length
     const int numHist(3);
     auto workspace = makeWorkspaceWithDetectors(numHist, 1);
-    workspace->maskWorkspaceIndex(1);
-    workspace->maskWorkspaceIndex(2);
+    workspace->getSpectrum(1).clearData();
+    workspace->getSpectrum(2).clearData();
+    workspace->mutableSpectrumInfo().setMasked(1, true);
+    workspace->mutableSpectrumInfo().setMasked(2, true);
 
     const auto &spectrumInfo = workspace->spectrumInfo();
     for (int i = 0; i < numHist; ++i) {

--- a/Framework/API/test/NearestNeighbourInfoTest.h
+++ b/Framework/API/test/NearestNeighbourInfoTest.h
@@ -6,6 +6,7 @@
 #include "MantidTestHelpers/FakeObjects.h"
 #include "MantidTestHelpers/InstrumentCreationHelper.h"
 #include "MantidAPI/NearestNeighbourInfo.h"
+#include "MantidAPI/SpectrumInfo.h"
 
 using Mantid::API::NearestNeighbourInfo;
 
@@ -23,7 +24,8 @@ public:
     InstrumentCreationHelper::addFullInstrumentToWorkspace(workspace, false,
                                                            false, "");
     workspace.rebuildSpectraMapping();
-    workspace.maskWorkspaceIndex(0);
+    workspace.getSpectrum(0).clearData();
+    workspace.mutableSpectrumInfo().setMasked(0, true);
   }
 
   void test_construct() {

--- a/Framework/API/test/NearestNeighboursTest.h
+++ b/Framework/API/test/NearestNeighboursTest.h
@@ -1,10 +1,10 @@
 #ifndef MANTID_TEST_GEOMETRY_NEARESTNEIGHBOURS
 #define MANTID_TEST_GEOMETRY_NEARESTNEIGHBOURS
 
+#include "MantidAPI/NearestNeighbours.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Instrument.h"
-#include "MantidGeometry/Instrument/NearestNeighbours.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/Objects/BoundingBox.h"
@@ -14,6 +14,7 @@
 
 using namespace Mantid;
 using namespace Mantid::Geometry;
+using namespace Mantid::API;
 using Mantid::Kernel::V3D;
 
 /**
@@ -37,7 +38,7 @@ public:
 private:
   /// Helper type giving access to protected methods. Makes testing of NN
   /// internals possible.
-  class ExposedNearestNeighbours : public Mantid::Geometry::NearestNeighbours {
+  class ExposedNearestNeighbours : public Mantid::API::NearestNeighbours {
   public:
     ExposedNearestNeighbours(boost::shared_ptr<const Instrument> instrument,
                              const ISpectrumDetectorMapping &spectraMap,

--- a/Framework/API/test/NearestNeighboursTest.h
+++ b/Framework/API/test/NearestNeighboursTest.h
@@ -221,8 +221,10 @@ public:
         ComponentCreationHelper::createTestInstrumentCylindrical(2));
 
     // Create the NearestNeighbours object directly.
+    const auto &spectrumInfo = ws->spectrumInfo();
+    const auto spectrumNumbers = getSpectrumNumbers(*ws);
     for (size_t i = 0; i < 2000; i++) {
-      NearestNeighbours nn(8, ws->spectrumInfo(), getSpectrumNumbers(*ws));
+      NearestNeighbours nn(8, spectrumInfo, spectrumNumbers);
       nn.neighbours(1);
     }
   }

--- a/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
@@ -108,14 +108,11 @@ protected:
   checkSizeCompatibility(const API::MatrixWorkspace_const_sptr lhs,
                          const API::MatrixWorkspace_const_sptr rhs) const;
 
-  /// Checks if the spectra at the given index of either input workspace is
-  /// masked. If so then the output spectra has zeroed data
-  /// and is also masked. The function returns true if further processing is not
-  /// required on the spectra.
   virtual bool propagateSpectraMask(const API::SpectrumInfo &lhsSpectrumInfo,
                                     const API::SpectrumInfo &rhsSpectrumInfo,
                                     const int64_t index,
-                                    API::MatrixWorkspace &out);
+                                    API::MatrixWorkspace &out,
+                                    API::SpectrumInfo &outSpectrumInfo);
 
   /** Carries out the binary operation on a single spectrum, with another
    *spectrum as the right-hand operand.

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -437,6 +437,7 @@ std::string BinaryOperation::checkSizeCompatibility(
  * @param rhsSpectrumInfo :: The RHS spectrum info object
  * @param index :: The workspace index to check
  * @param out :: A pointer to the output workspace
+ * @param outSpectrumInfo :: The spectrum info object of `out`
  * @returns True if further processing is not required on the spectra, false if
  * the binary operation should be performed.
  */

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -696,8 +696,8 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
             continue;
         } else {
           // Check for masking except when mismatched sizes
-          if (!propagateSpectraMask(lhsSpectrumInfo, rhsSpectrumInfo, i,
-                                    *m_out, outSpectrumInfo))
+          if (!propagateSpectraMask(lhsSpectrumInfo, rhsSpectrumInfo, i, *m_out,
+                                    outSpectrumInfo))
             continue;
         }
         // Reach here? Do the division
@@ -729,8 +729,8 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
             continue;
         } else {
           // Check for masking except when mismatched sizes
-          if (!propagateSpectraMask(lhsSpectrumInfo, rhsSpectrumInfo, i,
-                                    *m_out, outSpectrumInfo))
+          if (!propagateSpectraMask(lhsSpectrumInfo, rhsSpectrumInfo, i, *m_out,
+                                    outSpectrumInfo))
             continue;
         }
 

--- a/Framework/Algorithms/src/CalculateEfficiency.cpp
+++ b/Framework/Algorithms/src/CalculateEfficiency.cpp
@@ -311,8 +311,11 @@ void CalculateEfficiency::maskComponent(MatrixWorkspace &ws,
       }
     }
     auto indexList = ws.getIndicesFromDetectorIDs(detectorList);
-    for (const auto &idx : indexList)
-      ws.maskWorkspaceIndex(idx);
+    auto &spectrumInfo = ws.mutableSpectrumInfo();
+    for (const auto &idx : indexList) {
+      ws.getSpectrum(idx).clearData();
+      spectrumInfo.setMasked(idx, true);
+    }
   } catch (std::exception &) {
     g_log.warning("Expecting the component " + componentName +
                   " to be a CompAssembly, e.g., a bank. Component not masked!");

--- a/Framework/Algorithms/src/ConvertAxisByFormula.cpp
+++ b/Framework/Algorithms/src/ConvertAxisByFormula.cpp
@@ -178,7 +178,7 @@ void ConvertAxisByFormula::exec() {
     if ((isRaggedBins) || (isGeometryRequired)) {
       // ragged bins or geometry used - we have to calculate for every spectra
       size_t numberOfSpectra_i = outputWs->getNumberHistograms();
-      const auto &spectrumInfo = outputWs->spectrumInfo();
+      auto &spectrumInfo = outputWs->mutableSpectrumInfo();
 
       size_t failedDetectorCount = 0;
       Progress prog(this, 0.6, 1.0, numberOfSpectra_i);
@@ -192,7 +192,8 @@ void ConvertAxisByFormula::exec() {
         // both handled the same way
         {
           // could not find the geometry info for this spectra
-          outputWs->maskWorkspaceIndex(i);
+          outputWs->getSpectrum(i).clearData();
+          spectrumInfo.setMasked(i, true);
           failedDetectorCount++;
         }
         prog.report();

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -543,7 +543,7 @@ ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUnit,
       boost::dynamic_pointer_cast<EventWorkspace>(outputWS);
   assert(static_cast<bool>(eventWS) == m_inputEvents); // Sanity check
 
-  const auto &outSpectrumInfo = outputWS->spectrumInfo();
+  auto &outSpectrumInfo = outputWS->mutableSpectrumInfo();
   // Loop over the histograms (detector spectra)
   for (int64_t i = 0; i < numberOfSpectra_i; ++i) {
     double efixed = efixedProp;
@@ -581,7 +581,9 @@ ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUnit,
       // detectors, this call is
       // the same as just zeroing out the data (calling clearData on the
       // spectrum)
-      outputWS->maskWorkspaceIndex(i);
+      outputWS->getSpectrum(i).clearData();
+      if (outSpectrumInfo.hasDetectors(i))
+        outSpectrumInfo.setMasked(i, true);
     }
 
     prog.report("Convert to " + m_outputUnit->unitID());

--- a/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
+++ b/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
@@ -7,6 +7,7 @@
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/IBackgroundFunction.h"
 #include "MantidAPI/TableRow.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventWorkspace.h"
@@ -475,6 +476,7 @@ void GetDetOffsetsMultiPeaks::calculateDetectorsOffsets() {
   // Fit all the spectra with a gaussian
   Progress prog(this, 0, 1.0, nspec);
 
+  auto &spectrumInfo = m_maskWS->mutableSpectrumInfo();
   // cppcheck-suppress syntaxError
     PRAGMA_OMP(parallel for schedule(dynamic, 1) )
     for (int wi = 0; wi < nspec; ++wi) {
@@ -509,7 +511,8 @@ void GetDetOffsetsMultiPeaks::calculateDetectorsOffsets() {
           const size_t workspaceIndex = mapEntry->second;
           if (offsetresult.mask > 0.9) {
             // Being masked
-            m_maskWS->maskWorkspaceIndex(workspaceIndex);
+            m_maskWS->getSpectrum(workspaceIndex).clearData();
+            spectrumInfo.setMasked(workspaceIndex, true);
             m_maskWS->mutableY(workspaceIndex)[0] = offsetresult.mask;
           } else {
             // Using the detector

--- a/Framework/Algorithms/src/GetDetectorOffsets.cpp
+++ b/Framework/Algorithms/src/GetDetectorOffsets.cpp
@@ -3,6 +3,7 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IPeakFunction.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/MaskWorkspace.h"
 #include "MantidDataObjects/OffsetsWorkspace.h"
@@ -108,6 +109,7 @@ void GetDetectorOffsets::exec() {
 
   // Fit all the spectra with a gaussian
   Progress prog(this, 0, 1.0, nspec);
+  auto &spectrumInfo = maskWS->mutableSpectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputW))
   for (int wi = 0; wi < nspec; ++wi) {
     PARALLEL_START_INTERUPT_REGION
@@ -134,7 +136,8 @@ void GetDetectorOffsets::exec() {
         const size_t workspaceIndex = mapEntry->second;
         if (mask == 1.) {
           // Being masked
-          maskWS->maskWorkspaceIndex(workspaceIndex);
+          maskWS->getSpectrum(workspaceIndex).clearData();
+          spectrumInfo.setMasked(workspaceIndex, true);
           maskWS->mutableY(workspaceIndex)[0] = mask;
         } else {
           // Using the detector

--- a/Framework/Algorithms/src/He3TubeEfficiency.cpp
+++ b/Framework/Algorithms/src/He3TubeEfficiency.cpp
@@ -2,6 +2,7 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/InstrumentValidator.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/EventWorkspace.h"
@@ -423,6 +424,7 @@ void He3TubeEfficiency::execEvent() {
       boost::dynamic_pointer_cast<DataObjects::EventWorkspace>(matrixOutputWS);
 
   std::size_t numHistograms = outputWS->getNumberHistograms();
+  auto &spectrumInfo = outputWS->mutableSpectrumInfo();
   this->progress = new API::Progress(this, 0.0, 1.0, numHistograms);
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int i = 0; i < static_cast<int>(numHistograms); ++i) {
@@ -440,7 +442,8 @@ void He3TubeEfficiency::execEvent() {
       // Parameters are bad so skip correction
       PARALLEL_CRITICAL(deteff_invalid) {
         this->spectraSkipped.push_back(outputWS->getAxis(1)->spectraNo(i));
-        outputWS->maskWorkspaceIndex(i);
+        outputWS->getSpectrum(i).clearData();
+        spectrumInfo.setMasked(i, true);
       }
     }
 

--- a/Framework/Algorithms/src/MedianDetectorTest.cpp
+++ b/Framework/Algorithms/src/MedianDetectorTest.cpp
@@ -247,7 +247,7 @@ int MedianDetectorTest::maskOutliers(
     checkForMask = ((instrument->getSource() != nullptr) &&
                     (instrument->getSample() != nullptr));
   }
-  const auto &spectrumInfo = countsWS->spectrumInfo();
+  auto &spectrumInfo = countsWS->mutableSpectrumInfo();
 
   for (size_t i = 0; i < indexmap.size(); ++i) {
     std::vector<size_t> &hists = indexmap[i];
@@ -263,11 +263,13 @@ int MedianDetectorTest::maskOutliers(
         }
       }
       if ((value < out_lo * median) && (value > 0.0)) {
-        countsWS->maskWorkspaceIndex(hists[j]);
+        countsWS->getSpectrum(hists[j]).clearData();
+        spectrumInfo.setMasked(hists[j], true);
         PARALLEL_ATOMIC
         ++numFailed;
       } else if (value > out_hi * median) {
-        countsWS->maskWorkspaceIndex(hists[j]);
+        countsWS->getSpectrum(hists[j]).clearData();
+        spectrumInfo.setMasked(hists[j], true);
         PARALLEL_ATOMIC
         ++numFailed;
       }

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -76,6 +76,7 @@ WorkspaceJoiners::execWS2D(API::MatrixWorkspace_const_sptr ws1,
   // For second loop we use the offset from the first
   const int64_t &nhist2 = ws2->getNumberHistograms();
   const auto &spectrumInfo = ws2->spectrumInfo();
+  auto &outSpectrumInfo = output->mutableSpectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*ws2, *output))
   for (int64_t j = 0; j < nhist2; ++j) {
     PARALLEL_START_INTERUPT_REGION
@@ -95,8 +96,10 @@ WorkspaceJoiners::execWS2D(API::MatrixWorkspace_const_sptr ws1,
       }
     }
     // Propagate spectrum masking
-    if (spectrumInfo.hasDetectors(j) && spectrumInfo.isMasked(j))
-      output->maskWorkspaceIndex(nhist1 + j);
+    if (spectrumInfo.hasDetectors(j) && spectrumInfo.isMasked(j)) {
+      output->getSpectrum(nhist1 + j).clearData();
+      outSpectrumInfo.setMasked(nhist1 + j, true);
+    }
 
     m_progress->report();
     PARALLEL_END_INTERUPT_REGION
@@ -137,6 +140,7 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
   // For second loop we use the offset from the first
   const int64_t &nhist2 = event_ws2->getNumberHistograms();
   const auto &spectrumInfo = event_ws2->spectrumInfo();
+  auto &outSpectrumInfo = output->mutableSpectrumInfo();
   for (int64_t j = 0; j < nhist2; ++j) {
     // This is the workspace index at which we assign in the output
     int64_t output_wi = j + nhist1;
@@ -144,8 +148,10 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
 
     // Propagate spectrum masking. First workspace will have been done by the
     // factory
-    if (spectrumInfo.hasDetectors(j) && spectrumInfo.isMasked(j))
-      output->maskWorkspaceIndex(output_wi);
+    if (spectrumInfo.hasDetectors(j) && spectrumInfo.isMasked(j)) {
+      output->getSpectrum(output_wi).clearData();
+      outSpectrumInfo.setMasked(output_wi, true);
+    }
 
     m_progress->report();
   }

--- a/Framework/Algorithms/test/AppendSpectraTest.h
+++ b/Framework/Algorithms/test/AppendSpectraTest.h
@@ -4,6 +4,7 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAlgorithms/AppendSpectra.h"
 #include "MantidDataHandling/LoadRaw3.h"
 #include "MantidKernel/TimeSeriesProperty.h"
@@ -66,8 +67,10 @@ public:
 
     // Mask a spectrum and check it is carried over
     const size_t maskTop(5), maskBottom(10);
-    in1->maskWorkspaceIndex(maskTop);
-    in2->maskWorkspaceIndex(maskBottom);
+    in1->getSpectrum(maskTop).clearData();
+    in2->getSpectrum(maskBottom).clearData();
+    in1->mutableSpectrumInfo().setMasked(maskTop, true);
+    in2->mutableSpectrumInfo().setMasked(maskBottom, true);
 
     // Now it should succeed
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace1", "top"));

--- a/Framework/Algorithms/test/ConjoinWorkspacesTest.h
+++ b/Framework/Algorithms/test/ConjoinWorkspacesTest.h
@@ -5,6 +5,7 @@
 
 #include "MantidAlgorithms/ConjoinWorkspaces.h"
 #include "MantidAPI/Axis.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceHistory.h"
 #include "MantidDataHandling/LoadRaw3.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
@@ -74,8 +75,10 @@ public:
 
     // Mask a spectrum and check it is carried over
     const size_t maskTop(5), maskBottom(10);
-    in1->maskWorkspaceIndex(maskTop);
-    in2->maskWorkspaceIndex(maskBottom);
+    in1->getSpectrum(maskTop).clearData();
+    in2->getSpectrum(maskBottom).clearData();
+    in1->mutableSpectrumInfo().setMasked(maskTop, true);
+    in2->mutableSpectrumInfo().setMasked(maskBottom, true);
 
     // Check it fails if properties haven't been set
     TS_ASSERT_THROWS(conj.execute(), std::runtime_error);

--- a/Framework/Algorithms/test/MedianDetectorTestTest.h
+++ b/Framework/Algorithms/test/MedianDetectorTestTest.h
@@ -9,10 +9,10 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataHandling/LoadInstrument.h"
-//#include "MantidDataHandling/LoadEmptyInstrument.h"
 #include <boost/shared_ptr.hpp>
 #include <boost/lexical_cast.hpp>
 #include <Poco/File.h>
@@ -232,7 +232,8 @@ public:
     m_2DWS->getAxis(0)->unit() = UnitFactory::Instance().create("TOF");
 
     // mask the detector
-    m_2DWS->maskWorkspaceIndex(THEMASKED);
+    m_2DWS->getSpectrum(THEMASKED).clearData();
+    m_2DWS->mutableSpectrumInfo().setMasked(THEMASKED, true);
   }
 
 private:

--- a/Framework/CurveFitting/src/Algorithms/ConvertToYSpace.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvertToYSpace.cpp
@@ -4,6 +4,7 @@
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidGeometry/Instrument.h"
@@ -196,6 +197,11 @@ void ConvertToYSpace::exec() {
   const int64_t nreports = nhist;
   auto progress = boost::make_shared<Progress>(this, 0.0, 1.0, nreports);
 
+  auto &spectrumInfo = m_outputWS->mutableSpectrumInfo();
+  SpectrumInfo *qSpectrumInfo{nullptr};
+  if (m_qOutputWS)
+    qSpectrumInfo = &m_qOutputWS->mutableSpectrumInfo();
+
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *m_outputWS))
   for (int64_t i = 0; i < nhist; ++i) {
     PARALLEL_START_INTERUPT_REGION
@@ -203,9 +209,12 @@ void ConvertToYSpace::exec() {
     if (!convert(i)) {
       g_log.warning("No detector defined for index=" + std::to_string(i) +
                     ". Zeroing spectrum.");
-      m_outputWS->maskWorkspaceIndex(i);
-      if (m_qOutputWS)
-        m_qOutputWS->maskWorkspaceIndex(i);
+      m_outputWS->getSpectrum(i).clearData();
+      spectrumInfo.setMasked(i, true);
+      if (m_qOutputWS) {
+        m_qOutputWS->getSpectrum(i).clearData();
+        qSpectrumInfo->setMasked(i, true);
+      }
     }
 
     PARALLEL_END_INTERUPT_REGION

--- a/Framework/DataHandling/src/LoadCalFile.cpp
+++ b/Framework/DataHandling/src/LoadCalFile.cpp
@@ -2,6 +2,7 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/Run.h"
 #include "MantidDataHandling/LoadCalFile.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
@@ -259,6 +260,9 @@ void LoadCalFile::readCalFile(const std::string &calFileName,
   int n, udet, select, group;
   double n_d, udet_d, offset, select_d, group_d;
 
+  SpectrumInfo *maskSpectrumInfo{nullptr};
+  if (maskWS)
+    maskSpectrumInfo = &maskWS->mutableSpectrumInfo();
   std::string str;
   while (getline(grFile, str)) {
     if (str.empty() || str[0] == '#')
@@ -309,7 +313,8 @@ void LoadCalFile::readCalFile(const std::string &calFileName,
 
         if (select <= 0) {
           // Not selected, then mask this detector
-          maskWS->maskWorkspaceIndex(wi);
+          maskWS->getSpectrum(wi).clearData();
+          maskSpectrumInfo->setMasked(wi, true);
           maskWS->mutableY(wi)[0] = 1.0;
         } else {
           // Selected, set the value to be 0

--- a/Framework/DataHandling/src/LoadVulcanCalFile.cpp
+++ b/Framework/DataHandling/src/LoadVulcanCalFile.cpp
@@ -2,6 +2,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/Run.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
@@ -288,9 +289,11 @@ void LoadVulcanCalFile::setupMaskWorkspace() {
 
   // Mask workspace index
   std::ostringstream msg;
+  auto &spectrumInfo = m_maskWS->mutableSpectrumInfo();
   for (size_t i = 0; i < m_maskWS->getNumberHistograms(); ++i) {
     if (m_maskWS->readY(i)[0] > 0.5) {
-      m_maskWS->maskWorkspaceIndex(i);
+      m_maskWS->getSpectrum(i).clearData();
+      spectrumInfo.setMasked(i, true);
       m_maskWS->dataY(i)[0] = 1.0;
       msg << "Spectrum " << i << " is masked. DataY = " << m_maskWS->readY(i)[0]
           << "\n";
@@ -628,6 +631,9 @@ void LoadVulcanCalFile::readCalFile(const std::string &calFileName,
   int n, udet, select, group;
   double n_d, udet_d, offset, select_d, group_d;
 
+  SpectrumInfo *maskSpectrumInfo{nullptr};
+  if (maskWS)
+    maskSpectrumInfo = &maskWS->mutableSpectrumInfo();
   std::string str;
   while (getline(grFile, str)) {
     if (str.empty() || str[0] == '#')
@@ -674,7 +680,8 @@ void LoadVulcanCalFile::readCalFile(const std::string &calFileName,
 
         if (select <= 0) {
           // Not selected, then mask this detector
-          maskWS->maskWorkspaceIndex(wi);
+          maskWS->getSpectrum(wi).clearData();
+          maskSpectrumInfo->setMasked(wi, true);
           maskWS->dataY(wi)[0] = 1.0;
         } else {
           // Selected, set the value to be 0

--- a/Framework/DataHandling/src/MaskDetectors.cpp
+++ b/Framework/DataHandling/src/MaskDetectors.cpp
@@ -4,6 +4,7 @@
 #include "MantidDataObjects/MaskWorkspace.h"
 
 #include "MantidAPI/DetectorInfo.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
@@ -209,10 +210,12 @@ void MaskDetectors::exec() {
   }
 
   // Get a reference to the spectra-detector map to get hold of detector ID's
+  auto &spectrumInfo = WS->mutableSpectrumInfo();
   double prog = 0.0;
-  std::vector<size_t>::const_iterator wit;
-  for (wit = indexList.begin(); wit != indexList.end(); ++wit) {
-    WS->maskWorkspaceIndex(*wit);
+  for (const auto i : indexList) {
+    WS->getSpectrum(i).clearData();
+    if (spectrumInfo.hasDetectors(i))
+      spectrumInfo.setMasked(i, true);
 
     // Progress
     prog += (1.0 / static_cast<int>(indexList.size()));

--- a/Framework/DataHandling/test/SaveCalFileTest.h
+++ b/Framework/DataHandling/test/SaveCalFileTest.h
@@ -6,6 +6,7 @@
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/OffsetsWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Timer.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
@@ -42,7 +43,8 @@ public:
     groupWS->setValue(3, 45);
     offsetsWS->setValue(1, 0.123);
     offsetsWS->setValue(2, 0.456);
-    maskWS->maskWorkspaceIndex(0);
+    maskWS->getSpectrum(0).clearData();
+    maskWS->mutableSpectrumInfo().setMasked(0, true);
 
     // Name of the output workspace.
     std::string outWSName("SaveCalFileTest_OutputWS");

--- a/Framework/DataHandling/test/SaveDiffCalTest.h
+++ b/Framework/DataHandling/test/SaveDiffCalTest.h
@@ -4,6 +4,7 @@
 #include <cxxtest/TestSuite.h>
 #include <Poco/File.h>
 
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidDataHandling/SaveDiffCal.h"
 #include "MantidDataObjects/MaskWorkspace.h"
@@ -50,7 +51,8 @@ public:
 
   MaskWorkspace_sptr createMasking(Instrument_sptr instr) {
     MaskWorkspace_sptr maskWS = boost::make_shared<MaskWorkspace>(instr);
-    maskWS->maskWorkspaceIndex(0);
+    maskWS->getSpectrum(0).clearData();
+    maskWS->mutableSpectrumInfo().setMasked(0, true);
     return maskWS;
   }
 

--- a/Framework/DataObjects/test/EventWorkspaceTest.h
+++ b/Framework/DataObjects/test/EventWorkspaceTest.h
@@ -17,6 +17,7 @@
 
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidAPI/Axis.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
@@ -169,7 +170,8 @@ public:
         WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument(
             1, 10, false /*dont clear the events*/);
     TS_ASSERT_EQUALS(ws->getSpectrum(2).getNumberEvents(), 200);
-    ws->maskWorkspaceIndex(2);
+    ws->getSpectrum(2).clearData();
+    ws->mutableSpectrumInfo().setMasked(2, true);
     TS_ASSERT_EQUALS(ws->getSpectrum(2).getNumberEvents(), 0);
   }
 

--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -53,7 +53,6 @@ set ( SRC_FILES
 	src/Instrument/Goniometer.cpp
 	src/Instrument/IDFObject.cpp
 	src/Instrument/InstrumentDefinitionParser.cpp
-	src/Instrument/NearestNeighbours.cpp
 	src/Instrument/ObjCompAssembly.cpp
 	src/Instrument/ObjComponent.cpp
 	src/Instrument/ParComponentFactory.cpp
@@ -206,7 +205,6 @@ set ( INC_FILES
 	inc/MantidGeometry/Instrument/Goniometer.h
 	inc/MantidGeometry/Instrument/IDFObject.h
 	inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
-	inc/MantidGeometry/Instrument/NearestNeighbours.h
 	inc/MantidGeometry/Instrument/ObjCompAssembly.h
 	inc/MantidGeometry/Instrument/ObjComponent.h
 	inc/MantidGeometry/Instrument/ParComponentFactory.h
@@ -350,7 +348,6 @@ set ( TEST_FILES
 	MathSupportTest.h
 	MatrixVectorPairParserTest.h
 	MatrixVectorPairTest.h
-	NearestNeighboursTest.h
 	NiggliCellTest.h
 	NullImplicitFunctionTest.h
 	ObjCompAssemblyTest.h

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/NearestNeighbours.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/NearestNeighbours.h
@@ -60,11 +60,6 @@ typedef std::unordered_map<specnum_t, std::set<detid_t>>
  */
 class MANTID_GEOMETRY_DLL NearestNeighbours {
 public:
-  /// Constructor with an instrument and a spectra map
-  NearestNeighbours(boost::shared_ptr<const Instrument> instrument,
-                    const ISpectrumDetectorMapping &spectraMap,
-                    bool ignoreMaskedDetectors = false);
-
   /// Constructor with an instrument and a spectra map and number of neighbours
   NearestNeighbours(int nNeighbours,
                     boost::shared_ptr<const Instrument> instrument,

--- a/Framework/Geometry/src/Instrument/NearestNeighbours.cpp
+++ b/Framework/Geometry/src/Instrument/NearestNeighbours.cpp
@@ -13,22 +13,6 @@ using Mantid::detid_t;
 using Kernel::V3D;
 
 /**
-*Constructor
-*@param instrument :: A shared pointer to Instrument object
-*@param spectraMap :: A reference to the spectra-detector mapping
-*@param ignoreMaskedDetectors :: flag indicating that masked detectors should be
-* ignored.
-*/
-NearestNeighbours::NearestNeighbours(
-    boost::shared_ptr<const Instrument> instrument,
-    const ISpectrumDetectorMapping &spectraMap, bool ignoreMaskedDetectors)
-    : m_instrument(instrument), m_spectraMap(spectraMap), m_noNeighbours(8),
-      m_cutoff(-DBL_MAX), m_radius(0),
-      m_bIgnoreMaskedDetectors(ignoreMaskedDetectors) {
-  this->build(m_noNeighbours);
-}
-
-/**
  * Constructor
  * @param nNeighbours :: Number of neighbours to use
  * @param instrument :: A shared pointer to Instrument object

--- a/Framework/Geometry/test/NearestNeighboursTest.h
+++ b/Framework/Geometry/test/NearestNeighboursTest.h
@@ -42,7 +42,7 @@ private:
     ExposedNearestNeighbours(boost::shared_ptr<const Instrument> instrument,
                              const ISpectrumDetectorMapping &spectraMap,
                              bool ignoreMasked = false)
-        : NearestNeighbours(instrument, spectraMap, ignoreMasked) {}
+        : NearestNeighbours(8, instrument, spectraMap, ignoreMasked) {}
 
     // Direct access to intermdiate spectra detectors
     std::map<specnum_t, IDetector_const_sptr> getSpectraDetectors() {
@@ -88,7 +88,7 @@ public:
     Instrument_sptr m_instrument(new Instrument(instrument, pmap));
 
     // Create the NearestNeighbours object directly.
-    NearestNeighbours nn(m_instrument, spectramap);
+    NearestNeighbours nn(8, m_instrument, spectramap);
 
     detid2det_map m_detectors;
     m_instrument->getDetectors(m_detectors);
@@ -153,7 +153,7 @@ public:
     Instrument_sptr m_instrument(new Instrument(instrument, pmap));
 
     // Create the NearestNeighbours object directly.
-    NearestNeighbours nn(m_instrument, spectramap);
+    NearestNeighbours nn(8, m_instrument, spectramap);
 
     // Correct # of detectors
     TS_ASSERT_EQUALS(m_instrument->getDetectorIDs().size(), 512);
@@ -235,26 +235,9 @@ public:
     Instrument_sptr m_instrument(new Instrument(instrument, pmap));
 
     // Create the NearestNeighbours object directly.
-    NearestNeighbours nn(m_instrument, spectramap);
+    NearestNeighbours nn(8, m_instrument, spectramap);
     for (size_t i = 0; i < 2000; i++) {
       nn.neighboursInRadius(1, 5.0);
-    }
-  }
-
-  void testUsingDefault() {
-    Instrument_sptr instrument = boost::dynamic_pointer_cast<Instrument>(
-        ComponentCreationHelper::createTestInstrumentCylindrical(2));
-    const ISpectrumDetectorMapping spectramap =
-        NearestNeighboursTest::buildSpectrumDetectorMapping(1, 18);
-    // Default parameter map.
-    ParameterMap_sptr pmap(new ParameterMap());
-    // Parameterized instrument
-    Instrument_sptr m_instrument(new Instrument(instrument, pmap));
-
-    // Create the NearestNeighbours object directly.
-    NearestNeighbours nn(m_instrument, spectramap);
-    for (size_t i = 0; i < 2000; i++) {
-      nn.neighboursInRadius(1, 0.0);
     }
   }
 

--- a/Framework/MDAlgorithms/test/ConvertToMDComponentsTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDComponentsTest.h
@@ -3,6 +3,7 @@
 // tests for different parts of ConvertToMD exec functions
 
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidMDAlgorithms/ConvertToMD.h"
 #include "MantidMDAlgorithms/MDWSTransform.h"
@@ -343,9 +344,10 @@ public:
       // detectorList.push_back(spDet->getID());
     }
 
-    std::vector<size_t>::const_iterator wit;
-    for (wit = indexLis.begin(); wit != indexLis.end(); ++wit) {
-      inputWS->maskWorkspaceIndex(*wit);
+    auto &spectrumInfo = inputWS->mutableSpectrumInfo();
+    for (const auto i : indexLis) {
+      inputWS->getSpectrum(i).clearData();
+      spectrumInfo.setMasked(i, true);
     }
   }
 };

--- a/Framework/MDAlgorithms/test/PreprocessDetectorsToMDTest.h
+++ b/Framework/MDAlgorithms/test/PreprocessDetectorsToMDTest.h
@@ -5,6 +5,7 @@
 #include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidMDAlgorithms/PreprocessDetectorsToMD.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidAPI/SpectrumInfo.h"
 
 using namespace Mantid;
 using namespace Mantid::MDAlgorithms;
@@ -258,9 +259,10 @@ public:
     }
 
     // Now mask all detectors in the workspace
-    std::vector<size_t>::const_iterator wit;
-    for (wit = indexLis.begin(); wit != indexLis.end(); ++wit) {
-      inputWS->maskWorkspaceIndex(*wit);
+    auto &spectrumInfo = inputWS->mutableSpectrumInfo();
+    for (const auto i : indexLis) {
+      inputWS->getSpectrum(i).clearData();
+      spectrumInfo.setMasked(i, true);
     }
     // let's retrieve masks now
 


### PR DESCRIPTION
This PR removes `MatrixWorkspace::maskWorkspaceIndex`.

For the Instrument-2.0 rollout, `MatrixWorkspace::maskWorkspaceIndex` would need to be refactored to set masking bits via `SpectrumInfo`. However, due to the COW mechanism of `ParameterMap` and the ensuing rebuilds of `SpectrumInfo` this cannot be implemented in a decent way (solutions would be to add locking (slow) or remove the COW mechanism (memory issues for MDWorkspaces)).

This could be done cleanly once Instrument-2.0 has progressed more (when the COW mechanism is no longer required and `SpectrumInfo` will not be rebuilt anymore). Until then, refactoring client code to do this manually appears to be the easiest solution. 

**To test:**

Code review.

Fixes #18201.

Internal change, no release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
