### PR TITLE
Better masking tools for Instrument View

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
@@ -3,13 +3,18 @@
 
 #include "InstrumentWidgetTypes.h"
 #include "MantidGLWidget.h"
-#include <MantidQtMantidWidgets/WidgetDllOption.h>
+#include "UnwrappedSurface.h"
 
 #include "MantidAPI/AlgorithmObserver.h"
+#include "MantidAPI/IMaskWorkspace.h"
+#include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
+#include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/Workspace.h"
 #include "MantidQtAPI/GraphOptions.h"
 #include "MantidQtAPI/WorkspaceObserver.h"
+
+#include <MantidQtMantidWidgets/WidgetDllOption.h>
 #include <boost/shared_ptr.hpp>
 
 namespace Mantid {
@@ -288,7 +293,16 @@ private:
   void renameHandle(const std::string &oldName,
                     const std::string &newName) override;
   void clearADSHandle() override;
-
+  /// overlay a peaks workspace on the projection surface
+  void overlayPeaksWorkspace(Mantid::API::IPeaksWorkspace_sptr ws);
+  /// overlay a masked workspace on the projection surface
+  void overlayMaskedWorkspace(Mantid::API::IMaskWorkspace_sptr ws);
+  /// overlay a table workspace with shape parameters on the projection surface
+  void overlayShapesWorkspace(Mantid::API::ITableWorkspace_sptr);
+  /// get a workspace from the ADS
+  Mantid::API::Workspace_sptr getWorkspaceFromADS(const std::string &name);
+  /// get a handle to the unwrapped surface
+  boost::shared_ptr<UnwrappedSurface> getUnwrappedSurface();
   /// Load tabs on the widget form a project file
   void loadTabs(const std::string &lines) const;
   /// Save tabs on the widget to a string

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
@@ -152,6 +152,7 @@ signals:
   void requestSelectComponent(const QString &);
   void preDeletingHandle();
   void clearingHandle();
+  void maskedWorkspaceOverlayed();
 
 protected:
   /// Implements AlgorithmObserver's finish handler

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetMaskTab.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetMaskTab.h
@@ -95,6 +95,7 @@ protected slots:
   void storeBinMask();
   void storeMask();
   void clearMask();
+  void saveShapesToTable() const;
   void saveInvertedMaskToWorkspace();
   void saveInvertedMaskToFile();
   void saveMaskToWorkspace();
@@ -165,6 +166,7 @@ protected:
 
   QPushButton *m_applyToData;
   QPushButton *m_applyToView;
+  QPushButton *m_saveShapesToTable;
   QPushButton *m_clearAll;
   QPushButton *m_saveButton;
   bool m_maskBins;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetMaskTab.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetMaskTab.h
@@ -109,7 +109,7 @@ protected slots:
   void saveExcludeGroupToFile();
   void showSaveMenuTooltip(QAction *);
   void toggleMaskGroup();
-
+  void enableApplyButtons();
   void doubleChanged(QtProperty *);
 
 protected:
@@ -124,7 +124,6 @@ protected:
   void saveMaskingToCalFile(bool invertMask = false);
   void saveMaskingToTableWorkspace(bool invertMask = false);
   std::string generateMaskWorkspaceName(bool temp = false) const;
-  void enableApplyButtons();
   void setSelectActivity();
   Mode getMode() const;
   /// Get mask/group border color

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/ProjectionSurface.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/ProjectionSurface.h
@@ -227,6 +227,10 @@ public:
   void changeBorderColor(const QColor &color) {
     m_maskShapes.changeBorderColor(color);
   }
+  /// Save masks to a table workspace
+  void saveShapesToTableWorkspace();
+  /// Load masks from a table workspace
+  void loadShapesFromTableWorkspace(Mantid::API::ITableWorkspace_const_sptr ws);
 
   //-----------------------------------
   //    Peaks overlay methods

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/Shape2DCollection.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/Shape2DCollection.h
@@ -1,6 +1,8 @@
 #ifndef MANTIDPLOT_SHAPE2DCOLLECTION_H_
 #define MANTIDPLOT_SHAPE2DCOLLECTION_H_
 
+#include "MantidAPI/ITableWorkspace.h"
+
 #include "Shape2D.h"
 #include "RectF.h"
 
@@ -85,6 +87,10 @@ public:
 
   /// Change border color of all shapes.
   void changeBorderColor(const QColor &color);
+  /// Save shape collection to a Table workspace
+  void saveToTableWorkspace();
+  /// Load shape collectio from a Table workspace
+  void loadFromTableWorkspace(Mantid::API::ITableWorkspace_const_sptr ws);
   /// Load settings for the shape 2D collection from a project file
   virtual void loadFromProject(const std::string &lines);
   /// Save settings for the shape 2D collection to a project file

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
@@ -9,8 +9,8 @@
 #include "MantidQtMantidWidgets/InstrumentView/InstrumentWidgetTreeTab.h"
 
 #include "MantidAPI/Axis.h"
-#include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidAPI/IMaskWorkspace.h"
+#include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Workspace.h"
 #include "MantidKernel/Unit.h"
@@ -935,55 +935,30 @@ void InstrumentWidget::setColorMapAutoscaling(bool on) {
 */
 bool InstrumentWidget::overlay(const QString &wsName) {
   using namespace Mantid::API;
-  Workspace_sptr workspace;
-  bool success(false);
-  try {
-    workspace = AnalysisDataService::Instance().retrieve(wsName.toStdString());
-  } catch (std::runtime_error) {
-    QMessageBox::warning(this, "MantidPlot - Warning",
-                         "No workspace called '" + wsName + "' found. ");
-    return success;
-  }
+
+  auto workspace = getWorkspaceFromADS(wsName.toStdString());
 
   auto pws = boost::dynamic_pointer_cast<IPeaksWorkspace>(workspace);
   auto table = boost::dynamic_pointer_cast<ITableWorkspace>(workspace);
-  auto maskedWs = boost::dynamic_pointer_cast<IMaskWorkspace>(workspace);
+  auto mask = boost::dynamic_pointer_cast<IMaskWorkspace>(workspace);
 
-  if (!pws && !table && !maskedWs) {
+  if (!pws && !table && !mask) {
     QMessageBox::warning(this, "MantidPlot - Warning",
                          "Work space called '" + wsName +
                              "' is not suitable."
                              " Please select another workspace. ");
-    return success;
+    return false;
   }
 
-  auto surface = boost::dynamic_pointer_cast<UnwrappedSurface>(getSurface());
-  if (!surface) {
-    QMessageBox::warning(
-        this, "MantidPlot - Warning",
-        "Please change to an unwrapped view to see peak labels.");
-    return success;
+  if (pws) {
+    overlayPeaksWorkspace(pws);
+  } else if (table) {
+    overlayShapesWorkspace(table);
+  } else if (mask) {
+    overlayMaskedWorkspace(mask);
   }
 
-  if (pws && surface) {
-    surface->setPeaksWorkspace(pws);
-    updateInstrumentView();
-    success = true;
-  } else if (table && surface) {
-    surface->loadShapesFromTableWorkspace(table);
-    updateInstrumentView();
-    success = true;
-  } else if (maskedWs && surface) {
-    auto actor = getInstrumentActor();
-    actor->setMaskMatrixWorkspace(
-              boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
-                  maskedWs));
-    actor->updateColors();
-    updateInstrumentDetectors();
-    emit maskedWorkspaceOverlayed();
-  }
-
-  return success;
+  return true;
 }
 
 /**
@@ -1295,6 +1270,74 @@ void InstrumentWidget::renameHandle(const std::string &oldName,
 void InstrumentWidget::clearADSHandle() {
   emit clearingHandle();
   close();
+}
+
+/**
+ * Overlay a peaks workspace on the surface projection
+ * @param ws :: peaks workspace to overlay
+ */
+void InstrumentWidget::overlayPeaksWorkspace(IPeaksWorkspace_sptr ws) {
+  auto surface = getUnwrappedSurface();
+  surface->setPeaksWorkspace(ws);
+  updateInstrumentView();
+}
+
+/**
+ * Overlay a mask workspace on the surface projection
+ * @param ws :: mask workspace to overlay
+ */
+void InstrumentWidget::overlayMaskedWorkspace(IMaskWorkspace_sptr ws) {
+  auto actor = getInstrumentActor();
+  actor->setMaskMatrixWorkspace(
+      boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws));
+  actor->updateColors();
+  updateInstrumentDetectors();
+  emit maskedWorkspaceOverlayed();
+}
+
+/**
+ * Overlay a table workspace containing shape parameters
+ * @param ws :: a workspace of shape parameters to create
+ */
+void InstrumentWidget::overlayShapesWorkspace(ITableWorkspace_sptr ws) {
+  auto surface = getUnwrappedSurface();
+  surface->loadShapesFromTableWorkspace(ws);
+  updateInstrumentView();
+}
+
+/**
+ * Get a workspace from the ADS using its name
+ * @param name :: name of the workspace
+ * @return a handle to the workspace (null if not found)
+ */
+Workspace_sptr InstrumentWidget::getWorkspaceFromADS(const std::string &name) {
+  Workspace_sptr workspace;
+
+  try {
+    workspace = AnalysisDataService::Instance().retrieve(name);
+  } catch (std::runtime_error) {
+    QMessageBox::warning(this, "MantidPlot - Warning",
+                         "No workspace called '" +
+                             QString::fromStdString(name) + "' found. ");
+    return nullptr;
+  }
+
+  return workspace;
+}
+
+/**
+ * Get an unwrapped surface
+ * @return a handle to the unwrapped surface (or null if view was not found).
+ */
+boost::shared_ptr<UnwrappedSurface> InstrumentWidget::getUnwrappedSurface() {
+  auto surface = boost::dynamic_pointer_cast<UnwrappedSurface>(getSurface());
+  if (!surface) {
+    QMessageBox::warning(
+        this, "MantidPlot - Warning",
+        "Please change to an unwrapped view to see peak labels.");
+    return nullptr;
+  }
+  return surface;
 }
 
 int InstrumentWidget::getCurrentTab() const {

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
@@ -945,7 +945,8 @@ bool InstrumentWidget::overlay(const QString &wsName) {
   }
 
   auto pws = boost::dynamic_pointer_cast<IPeaksWorkspace>(workspace);
-  if (!pws) {
+  auto table = boost::dynamic_pointer_cast<ITableWorkspace>(workspace);
+  if (!pws && !table) {
     QMessageBox::warning(this, "MantidPlot - Warning",
                          "Work space called '" + wsName +
                              "' is not suitable."
@@ -965,7 +966,12 @@ bool InstrumentWidget::overlay(const QString &wsName) {
     surface->setPeaksWorkspace(pws);
     updateInstrumentView();
     success = true;
+  } else if (table && surface) {
+    surface->loadShapesFromTableWorkspace(table);
+    updateInstrumentView();
+    success = true;
   }
+
   return success;
 }
 

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
@@ -1301,8 +1301,10 @@ void InstrumentWidget::overlayMaskedWorkspace(IMaskWorkspace_sptr ws) {
  */
 void InstrumentWidget::overlayShapesWorkspace(ITableWorkspace_sptr ws) {
   auto surface = getUnwrappedSurface();
-  surface->loadShapesFromTableWorkspace(ws);
-  updateInstrumentView();
+  if (surface) {
+    surface->loadShapesFromTableWorkspace(ws);
+    updateInstrumentView();
+  }
 }
 
 /**
@@ -1334,7 +1336,7 @@ boost::shared_ptr<UnwrappedSurface> InstrumentWidget::getUnwrappedSurface() {
   if (!surface) {
     QMessageBox::warning(
         this, "MantidPlot - Warning",
-        "Please change to an unwrapped view to see peak labels.");
+        "Please change to an unwrapped view to overlay a workspace.");
     return nullptr;
   }
   return surface;

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
@@ -331,6 +331,9 @@ InstrumentWidgetMaskTab::InstrumentWidgetMaskTab(InstrumentWidget *instrWidget)
   buttons->addWidget(m_applyToData, 0, 0);
   box->setLayout(buttons);
   layout->addWidget(box);
+
+  connect(m_instrWidget, SIGNAL(maskedWorkspaceOverlayed()), this,
+          SLOT(enableApplyButtons()));
 }
 
 /**
@@ -1059,6 +1062,7 @@ void InstrumentWidgetMaskTab::enableApplyButtons() {
     m_applyToData->setEnabled(false);
     m_applyToView->setEnabled(false);
   }
+  m_saveShapesToTable->setEnabled(hasMaskShapes);
   m_saveButton->setEnabled(hasDetectorMask && (!enableBinMasking));
   m_clearAll->setEnabled(hasMask);
   setActivity();

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
@@ -200,6 +200,12 @@ InstrumentWidgetMaskTab::InstrumentWidgetMaskTab(InstrumentWidget *instrWidget)
   m_applyToView->setToolTip("Apply current mask to the view.");
   connect(m_applyToView, SIGNAL(clicked()), this, SLOT(applyMaskToView()));
 
+  m_saveShapesToTable = new QPushButton("Save Shapes to Table");
+  m_saveShapesToTable->setToolTip(
+      "Store the current Mask/ROI/Group shapes as a table");
+  connect(m_saveShapesToTable, SIGNAL(clicked()), this,
+          SLOT(saveShapesToTable()));
+
   m_clearAll = new QPushButton("Clear All");
   m_clearAll->setToolTip(
       "Clear all masking that have not been applied to the data.");
@@ -313,8 +319,9 @@ InstrumentWidgetMaskTab::InstrumentWidgetMaskTab(InstrumentWidget *instrWidget)
   QGroupBox *box = new QGroupBox("View");
   QGridLayout *buttons = new QGridLayout();
   buttons->addWidget(m_applyToView, 0, 0, 1, 2);
-  buttons->addWidget(m_saveButton, 1, 0);
-  buttons->addWidget(m_clearAll, 1, 1);
+  buttons->addWidget(m_saveShapesToTable, 1, 0, 1, 2);
+  buttons->addWidget(m_saveButton, 2, 0);
+  buttons->addWidget(m_clearAll, 2, 1);
 
   box->setLayout(buttons);
   layout->addWidget(box);
@@ -576,6 +583,13 @@ void InstrumentWidgetMaskTab::setProperties() {
   }
 
   shapeChanged();
+}
+
+/**
+ * Save shapes to a table workspace
+ */
+void InstrumentWidgetMaskTab::saveShapesToTable() const {
+  m_instrWidget->getSurface()->saveShapesToTableWorkspace();
 }
 
 void InstrumentWidgetMaskTab::doubleChanged(QtProperty *prop) {

--- a/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
@@ -594,6 +594,22 @@ void ProjectionSurface::startCreatingFreeShape(const QColor &borderColor,
 }
 
 /**
+ * Save shapes drawn on the view to a table workspace
+ */
+void ProjectionSurface::saveShapesToTableWorkspace() {
+  m_maskShapes.saveToTableWorkspace();
+}
+
+/**
+ * Load shapes from a table workspace on to the view.
+ * @param ws :: table workspace to load shapes from
+ */
+void ProjectionSurface::loadShapesFromTableWorkspace(
+    Mantid::API::ITableWorkspace_const_sptr ws) {
+  m_maskShapes.loadFromTableWorkspace(ws);
+}
+
+/**
 * Return a combined list of peak parkers from all overlays
 * @param detID :: The detector ID of interest
 */

--- a/docs/source/release/v3.9.0/ui.rst
+++ b/docs/source/release/v3.9.0/ui.rst
@@ -23,6 +23,8 @@ User Interface
 Instrument View
 ###############
  - New peak comparison tool on the pick tab. The user can select two peaks and information relating to their properties and the angles between them.
+ - Added the ability to drag and drog mask workspaces onto the instrument view. This will apply the store workspace to the view.
+ - Added the ability to store masking/ROI/grouping shapes to a table workspace which can be dragged & dropped back onto different instrument views 
 
 Plotting Improvements
 #####################


### PR DESCRIPTION
This adds some additional functionality to the instrument view.

**To test:**

 - Check that you can now overlay mask workspaces onto the projection surface by dragging and dropping the workspace (same as for a peaks workspace).
 - Check that you can use the new save shapes to table option to save the shapes that are drawn on the view to a table workspace. Dragging and dropping this workspace back onto the view should recreate the shapes on the view.
- Try this between different runs of the same instrument.
- Try this between different runs of a different instrument.

Fixes #18240 .

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.