### PR TITLE
Reflectometry interface (Polref): Fix to have 'Get Defaults' wrap polarization constant values in quote marks

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsPresenter.h
@@ -1,10 +1,10 @@
 #ifndef MANTID_CUSTOMINTERFACES_REFLSETTINGSPRESENTER_H
 #define MANTID_CUSTOMINTERFACES_REFLSETTINGSPRESENTER_H
 
-#include "MantidQtCustomInterfaces/DllConfig.h"
-#include "MantidQtCustomInterfaces/Reflectometry/IReflSettingsPresenter.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidGeometry/Instrument_fwd.h"
+#include "MantidQtCustomInterfaces/DllConfig.h"
+#include "MantidQtCustomInterfaces/Reflectometry/IReflSettingsPresenter.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -59,7 +59,7 @@ private:
   void createStitchHints();
   void getExpDefaults();
   void getInstDefaults();
-  void quoteWrap(std::string &str) const;
+  void wrapWithQuotes(std::string &str) const;
   Mantid::API::IAlgorithm_sptr createReductionAlg();
   Mantid::Geometry::Instrument_const_sptr
   createEmptyInstrument(const std::string &instName);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsPresenter.h
@@ -59,6 +59,7 @@ private:
   void createStitchHints();
   void getExpDefaults();
   void getInstDefaults();
+  void quoteWrap(std::string &str) const;
   Mantid::API::IAlgorithm_sptr createReductionAlg();
   Mantid::Geometry::Instrument_const_sptr
   createEmptyInstrument(const std::string &instName);

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsPresenter.cpp
@@ -1,12 +1,12 @@
 #include "MantidQtCustomInterfaces/Reflectometry/ReflSettingsPresenter.h"
-#include "MantidQtCustomInterfaces/Reflectometry/IReflSettingsTabPresenter.h"
-#include "MantidQtCustomInterfaces/Reflectometry/IReflSettingsView.h"
-#include "MantidQtMantidWidgets/AlgorithmHintStrategy.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidQtCustomInterfaces/Reflectometry/IReflSettingsTabPresenter.h"
+#include "MantidQtCustomInterfaces/Reflectometry/IReflSettingsView.h"
+#include "MantidQtMantidWidgets/AlgorithmHintStrategy.h"
 #include <boost/algorithm/string.hpp>
 
 namespace MantidQt {
@@ -127,28 +127,28 @@ std::string ReflSettingsPresenter::getReductionOptions() const {
   // Add CRho
   auto crho = m_view->getCRho();
   if (!crho.empty()) {
-    quoteWrap(crho);
+    wrapWithQuotes(crho);
     options.push_back("CRho=" + crho);
   }
 
   // Add CAlpha
   auto calpha = m_view->getCAlpha();
   if (!calpha.empty()) {
-    quoteWrap(calpha);
+    wrapWithQuotes(calpha);
     options.push_back("CAlpha=" + calpha);
   }
 
   // Add CAp
   auto cap = m_view->getCAp();
   if (!cap.empty()) {
-    quoteWrap(cap);
+    wrapWithQuotes(cap);
     options.push_back("CAp=" + cap);
   }
 
   // Add CPp
   auto cpp = m_view->getCPp();
   if (!cpp.empty()) {
-    quoteWrap(cpp);
+    wrapWithQuotes(cpp);
     options.push_back("CPp=" + cpp);
   }
 
@@ -300,19 +300,19 @@ void ReflSettingsPresenter::getExpDefaults() {
 
   auto cRho = inst->getStringParameter("crho");
   if (!cRho.empty())
-    defaults[2] = "\"" + cRho[0] + "\"";
+    defaults[2] = cRho[0];
 
   auto cAlpha = inst->getStringParameter("calpha");
   if (!cAlpha.empty())
-    defaults[3] = "\"" + cAlpha[0] + "\"";
+    defaults[3] = cAlpha[0];
 
   auto cAp = inst->getStringParameter("cAp");
   if (!cAp.empty())
-    defaults[4] = "\"" + cAp[0] + "\"";
+    defaults[4] = cAp[0];
 
   auto cPp = inst->getStringParameter("cPp");
   if (!cPp.empty())
-    defaults[5] = "\"" + cPp[0] + "\"";
+    defaults[5] = cPp[0];
 
   defaults[6] = alg->getPropertyValue("ScaleFactor");
 
@@ -322,7 +322,7 @@ void ReflSettingsPresenter::getExpDefaults() {
 /** Wraps string with quote marks if it does not already have them
 * @param str :: [input] The string to be wrapped
 */
-void ReflSettingsPresenter::quoteWrap(std::string &str) const {
+void ReflSettingsPresenter::wrapWithQuotes(std::string &str) const {
   if (str.front() != '\"')
     str = "\"" + str;
   if (str.back() != '\"')

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsPresenter.cpp
@@ -126,23 +126,31 @@ std::string ReflSettingsPresenter::getReductionOptions() const {
 
   // Add CRho
   auto crho = m_view->getCRho();
-  if (!crho.empty())
+  if (!crho.empty()) {
+    quoteWrap(crho);
     options.push_back("CRho=" + crho);
+  }
 
   // Add CAlpha
   auto calpha = m_view->getCAlpha();
-  if (!calpha.empty())
+  if (!calpha.empty()) {
+    quoteWrap(calpha);
     options.push_back("CAlpha=" + calpha);
+  }
 
   // Add CAp
   auto cap = m_view->getCAp();
-  if (!cap.empty())
+  if (!cap.empty()) {
+    quoteWrap(cap);
     options.push_back("CAp=" + cap);
+  }
 
   // Add CPp
   auto cpp = m_view->getCPp();
-  if (!cpp.empty())
+  if (!cpp.empty()) {
+    quoteWrap(cpp);
     options.push_back("CPp=" + cpp);
+  }
 
   // Add direct beam
   auto dbnr = m_view->getDirectBeam();
@@ -292,23 +300,33 @@ void ReflSettingsPresenter::getExpDefaults() {
 
   auto cRho = inst->getStringParameter("crho");
   if (!cRho.empty())
-    defaults[2] = cRho[0];
+    defaults[2] = "\"" + cRho[0] + "\"";
 
   auto cAlpha = inst->getStringParameter("calpha");
   if (!cAlpha.empty())
-    defaults[3] = cAlpha[0];
+    defaults[3] = "\"" + cAlpha[0] + "\"";
 
   auto cAp = inst->getStringParameter("cAp");
   if (!cAp.empty())
-    defaults[4] = cAp[0];
+    defaults[4] = "\"" + cAp[0] + "\"";
 
   auto cPp = inst->getStringParameter("cPp");
   if (!cPp.empty())
-    defaults[5] = cPp[0];
+    defaults[5] = "\"" + cPp[0] + "\"";
 
   defaults[6] = alg->getPropertyValue("ScaleFactor");
 
   m_view->setExpDefaults(defaults);
+}
+
+/** Wraps string with quote marks if it does not already have them
+* @param str :: [input] The string to be wrapped
+*/
+void ReflSettingsPresenter::quoteWrap(std::string &str) const {
+  if (str.front() != '\"')
+    str = "\"" + str;
+  if (str.back() != '\"')
+    str = str + "\"";
 }
 
 /** Fills instrument settings with default values

--- a/MantidQt/CustomInterfaces/test/ReflSettingsPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflSettingsPresenterTest.h
@@ -99,12 +99,18 @@ public:
     EXPECT_CALL(mockView, getAnalysisMode())
         .Times(Exactly(1))
         .WillOnce(Return("MultiDetectorAnalysis"));
-    EXPECT_CALL(mockView, getCRho()).Times(Exactly(1)).WillOnce(Return("2.5"));
+    EXPECT_CALL(mockView, getCRho())
+        .Times(Exactly(1))
+        .WillOnce(Return("\"2.5,0.4,1.1\""));
     EXPECT_CALL(mockView, getCAlpha())
         .Times(Exactly(1))
-        .WillOnce(Return("0.6"));
-    EXPECT_CALL(mockView, getCAp()).Times(Exactly(1)).WillOnce(Return("100.0"));
-    EXPECT_CALL(mockView, getCPp()).Times(Exactly(1)).WillOnce(Return("0.54"));
+        .WillOnce(Return("\"0.6,0.9,1.2\""));
+    EXPECT_CALL(mockView, getCAp())
+        .Times(Exactly(1))
+        .WillOnce(Return("\"100.0,17.0,44.0\""));
+    EXPECT_CALL(mockView, getCPp())
+        .Times(Exactly(1))
+        .WillOnce(Return("\"0.54,0.33,1.81\""));
     EXPECT_CALL(mockView, getDirectBeam())
         .Times(Exactly(1))
         .WillOnce(Return("\"0,3\""));
@@ -152,10 +158,10 @@ public:
     std::vector<std::string> optionsVec;
     boost::split(optionsVec, options, split_q());
     TS_ASSERT_EQUALS(optionsVec[0], "AnalysisMode=MultiDetectorAnalysis");
-    TS_ASSERT_EQUALS(optionsVec[1], "CRho=2.5");
-    TS_ASSERT_EQUALS(optionsVec[2], "CAlpha=0.6");
-    TS_ASSERT_EQUALS(optionsVec[3], "CAp=100.0");
-    TS_ASSERT_EQUALS(optionsVec[4], "CPp=0.54");
+    TS_ASSERT_EQUALS(optionsVec[1], "CRho=\"2.5,0.4,1.1\"");
+    TS_ASSERT_EQUALS(optionsVec[2], "CAlpha=\"0.6,0.9,1.2\"");
+    TS_ASSERT_EQUALS(optionsVec[3], "CAp=\"100.0,17.0,44.0\"");
+    TS_ASSERT_EQUALS(optionsVec[4], "CPp=\"0.54,0.33,1.81\"");
     TS_ASSERT_EQUALS(optionsVec[5], "RegionOfDirectBeam=\"0,3\"");
     TS_ASSERT_EQUALS(optionsVec[6], "PolarizationAnalysis=PNR");
     TS_ASSERT_EQUALS(optionsVec[7], "NormalizeByIntegratedMonitors=True");
@@ -214,10 +220,10 @@ public:
 
     std::vector<std::string> defaults = {
         "PointDetectorAnalysis", "None",
-        "1.006831,-0.011467,0.002244,-0.000095",
-        "1.017526,-0.017183,0.003136,-0.000140",
-        "0.917940,0.038265,-0.006645,0.000282",
-        "0.972762,0.001828,-0.000261,0.0", "1"};
+        "\"1.006831,-0.011467,0.002244,-0.000095\"",
+        "\"1.017526,-0.017183,0.003136,-0.000140\"",
+        "\"0.917940,0.038265,-0.006645,0.000282\"",
+        "\"0.972762,0.001828,-0.000261,0.0\"", "1"};
 
     EXPECT_CALL(mockView, setExpDefaults(defaults)).Times(1);
     presenter.notify(IReflSettingsPresenter::ExpDefaultsFlag);

--- a/MantidQt/CustomInterfaces/test/ReflSettingsPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflSettingsPresenterTest.h
@@ -101,16 +101,16 @@ public:
         .WillOnce(Return("MultiDetectorAnalysis"));
     EXPECT_CALL(mockView, getCRho())
         .Times(Exactly(1))
-        .WillOnce(Return("\"2.5,0.4,1.1\""));
+        .WillOnce(Return("2.5,0.4,1.1"));
     EXPECT_CALL(mockView, getCAlpha())
         .Times(Exactly(1))
-        .WillOnce(Return("\"0.6,0.9,1.2\""));
+        .WillOnce(Return("0.6,0.9,1.2"));
     EXPECT_CALL(mockView, getCAp())
         .Times(Exactly(1))
-        .WillOnce(Return("\"100.0,17.0,44.0\""));
+        .WillOnce(Return("100.0,17.0,44.0"));
     EXPECT_CALL(mockView, getCPp())
         .Times(Exactly(1))
-        .WillOnce(Return("\"0.54,0.33,1.81\""));
+        .WillOnce(Return("0.54,0.33,1.81"));
     EXPECT_CALL(mockView, getDirectBeam())
         .Times(Exactly(1))
         .WillOnce(Return("\"0,3\""));
@@ -219,11 +219,13 @@ public:
     presenter.setInstrumentName("POLREF");
 
     std::vector<std::string> defaults = {
-        "PointDetectorAnalysis", "None",
-        "\"1.006831,-0.011467,0.002244,-0.000095\"",
-        "\"1.017526,-0.017183,0.003136,-0.000140\"",
-        "\"0.917940,0.038265,-0.006645,0.000282\"",
-        "\"0.972762,0.001828,-0.000261,0.0\"", "1"};
+        "PointDetectorAnalysis",
+        "None",
+        "1.006831,-0.011467,0.002244,-0.000095",
+        "1.017526,-0.017183,0.003136,-0.000140",
+        "0.917940,0.038265,-0.006645,0.000282",
+        "0.972762,0.001828,-0.000261,0.0",
+        "1"};
 
     EXPECT_CALL(mockView, setExpDefaults(defaults)).Times(1);
     presenter.notify(IReflSettingsPresenter::ExpDefaultsFlag);

--- a/MantidQt/CustomInterfaces/test/ReflSettingsPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflSettingsPresenterTest.h
@@ -219,13 +219,11 @@ public:
     presenter.setInstrumentName("POLREF");
 
     std::vector<std::string> defaults = {
-        "PointDetectorAnalysis",
-        "None",
+        "PointDetectorAnalysis", "None",
         "1.006831,-0.011467,0.002244,-0.000095",
         "1.017526,-0.017183,0.003136,-0.000140",
         "0.917940,0.038265,-0.006645,0.000282",
-        "0.972762,0.001828,-0.000261,0.0",
-        "1"};
+        "0.972762,0.001828,-0.000261,0.0", "1"};
 
     EXPECT_CALL(mockView, setExpDefaults(defaults)).Times(1);
     presenter.notify(IReflSettingsPresenter::ExpDefaultsFlag);


### PR DESCRIPTION
(This is essentially a merge conflict fix for PR https://github.com/mantidproject/mantid/pull/18211)

In the Settings tab, the polarization constants (CRho, CAlpha, CAp, CPp) are given as a string of comma-separated values. The original problem with the 'Get Defaults' button however was that it did not wrap these values with quote marks. Without re-inserting the quote marks, an attempt at data reduction would fail. This PR fixes this by adding the quote marks back in when 'Get Defaults' is clicked.

Edit: Quote marks are now added when the interface retrieves the values from the view, rather than added in the view itself.

To test:

- Access the Reflectometry interface from from Interfaces->Reflectometry->ISIS Reflectometry (Polref).
- On the Runs tab, set Instrument to POLREF.
- On the Settings tab, for the Experiment Settings section, click the Get Defaults button.
- Parameters CRho, CAlpha, CAp, CPp should be filled with multiple values. 
- Processing runs should not throw an error.

Fixes #18208.

*Does not need to be in the release notes.*

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

