### PR TITLE
Prevent the zoom being cleared on the instrument view after updating detectors

### DIFF
--- a/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
@@ -316,11 +316,15 @@ void ProjectionSurface::updateView(bool picking) {
 }
 
 void ProjectionSurface::updateDetectors() {
+  // updating detectors should not reset the view rect
+  // cache the value here are reapply after updating the detectors
+  auto viewRectCache = m_viewRect;
   clear();
   this->init();
   // if integration range in the instrument actor has changed
   // update visiblity of peak markers
   setPeakVisibility();
+  m_viewRect = viewRectCache;
 }
 
 /// Send a redraw request to the surface owner

--- a/docs/source/release/v3.9.0/ui.rst
+++ b/docs/source/release/v3.9.0/ui.rst
@@ -58,8 +58,9 @@ Bugs Resolved
 - The "Plot Surface from Group" and "Plot Contour from Group" options have been fixed and now work for both histogram and point data. Note that all workspaces in the group must have the same X data.
 - Fixed a bug where enabling auto rebinning in the slice viewer and zooming would not rebin the workspace if it was a histogram workspace.
 - Legend placement has been fixed in the "tiled plot"/``plotSubplots`` option, and these graphs now use Mantid's default plot style options.
- - Fix a bug where saving a tiled plot saved to a project file would be reloaded with different size plots.
- - Fixed a bug where minimised windows would not stay minimised after being serialised to a Mantid project
+- Fix a bug where saving a tiled plot saved to a project file would be reloaded with different size plots.
+- Fixed a bug where minimised windows would not stay minimised after being serialised to a Mantid project.
+- Fixed a bug where changing the integration range of the instrument view would clear the applied zooming.
 
 SliceViewer Improvements
 ------------------------


### PR DESCRIPTION
Currently any zooming applied to the view will be cleared when the user, for example, changes the x integration range. This can be annoying for users who trying to alter the range to enhance what they've zoomed in to look at.

**To test:**
 - Open the instrument view
 - Zoom in on something
 - Change the x axis range (min/max at the bottom of the screen). 
 - Notice that the zoom is not reset with the fix applied.

Fixes #18250 .

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.