### PR TITLE
Make sub-algorithm of `ExtractMonitors` to child algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ExtractMonitors.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExtractMonitors.py
@@ -64,25 +64,35 @@ class ExtractMonitors(DataProcessorAlgorithm):
 
         if detector_ws_name:
             if detectors:
-                detector_ws = ExtractSpectra(InputWorkspace=in_ws,
-                                             WorkspaceIndexList=detectors)
+                extract_alg = self.createChildAlgorithm("ExtractSpectra")
+                extract_alg.setProperty("InputWorkspace", in_ws)
+                extract_alg.setProperty("WorkspaceIndexList", detectors)
+                extract_alg.execute()
+                detector_ws = extract_alg.getProperty("OutputWorkspace").value
             else:
                 self.log().error("No detectors found in input workspace. No detector output workspace created.")
 
         if monitor_ws_name:
             if monitors:
-                monitor_ws = ExtractSpectra(InputWorkspace=in_ws,
-                                            WorkspaceIndexList=monitors)
+                extract_alg = self.createChildAlgorithm("ExtractSpectra")
+                extract_alg.setProperty("InputWorkspace", in_ws)
+                extract_alg.setProperty("WorkspaceIndexList", monitors)
+                extract_alg.execute()
+                monitor_ws = extract_alg.getProperty("OutputWorkspace").value
             else:
                 self.log().error("No monitors found in input workspace. No monitor output workspace created.")
 
         if detector_ws_name and detectors:
             self.setProperty("DetectorWorkspace", detector_ws)
-            DeleteWorkspace(detector_ws)
+            delete_alg = self.createChildAlgorithm("DeleteWorkspace")
+            delete_alg.setProperty("Workspace", detector_ws)
+            delete_alg.execute()
 
         if monitor_ws_name and monitors:
             self.setProperty("MonitorWorkspace", monitor_ws)
-            DeleteWorkspace(monitor_ws)
+            delete_alg = self.createChildAlgorithm("DeleteWorkspace")
+            delete_alg.setProperty("Workspace", monitor_ws)
+            delete_alg.execute()
 
         if detector_ws_name and detectors and monitor_ws_name and monitors:
             detector_ws.setMonitorWorkspace(monitor_ws)

--- a/Framework/PythonInterface/plugins/algorithms/ExtractMonitors.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExtractMonitors.py
@@ -69,6 +69,7 @@ class ExtractMonitors(DataProcessorAlgorithm):
                 extract_alg.setProperty("WorkspaceIndexList", detectors)
                 extract_alg.execute()
                 detector_ws = extract_alg.getProperty("OutputWorkspace").value
+                self.setProperty("DetectorWorkspace", detector_ws)
             else:
                 self.log().error("No detectors found in input workspace. No detector output workspace created.")
 
@@ -79,20 +80,9 @@ class ExtractMonitors(DataProcessorAlgorithm):
                 extract_alg.setProperty("WorkspaceIndexList", monitors)
                 extract_alg.execute()
                 monitor_ws = extract_alg.getProperty("OutputWorkspace").value
+                self.setProperty("MonitorWorkspace", monitor_ws)
             else:
                 self.log().error("No monitors found in input workspace. No monitor output workspace created.")
-
-        if detector_ws_name and detectors:
-            self.setProperty("DetectorWorkspace", detector_ws)
-            delete_alg = self.createChildAlgorithm("DeleteWorkspace")
-            delete_alg.setProperty("Workspace", detector_ws)
-            delete_alg.execute()
-
-        if monitor_ws_name and monitors:
-            self.setProperty("MonitorWorkspace", monitor_ws)
-            delete_alg = self.createChildAlgorithm("DeleteWorkspace")
-            delete_alg.setProperty("Workspace", monitor_ws)
-            delete_alg.execute()
 
         if detector_ws_name and detectors and monitor_ws_name and monitors:
             detector_ws.setMonitorWorkspace(monitor_ws)


### PR DESCRIPTION
The `ExtractMonitors` algorithm is extremely useful to split workspaces.

Fixes #18257 

# To test:

## Ensure that the old doc test runs fine:
```python

ws = Load('ENGINX00213855.nxs')

ExtractMonitors(InputWorkspace = ws,
                DetectorWorkspace = 'Detectors',
                MonitorWorkspace = 'Monitors')

detector_ws = mtd['Detectors']
monitor_ws = mtd['Monitors']

# Detector histograms
print("Number of spectra in input workspace: {0}").format(ws.getNumberHistograms())
# Detector histograms (spectra missing detectors generate warnings)
print("Number of spectra in detector workspace: {0}").format(detector_ws.getNumberHistograms())
# Monitor histograms
print("Number of spectra in monitor workspace: {0}").format(monitor_ws.getNumberHistograms())
# Check if the first spectrum in the detector workspace is a monitor
print("Detector workspace isMonitor for spectrum 0: {0}").format(detector_ws.getDetector(0).isMonitor())
# Check if the first spectrum in the monitor workspace is a monitor
print("Monitor workspace isMonitor for spectrum 0: {0}").format(monitor_ws.getDetector(0).isMonitor())
# See the monitor workspace is set
print("Name of monitor workspace: {0}").format(detector_ws.getMonitorWorkspace().name())

```

## Ensure that running the old doc test in an ADS-free mode runs fine

1. Delete all workspaces from the ADS
2. Run the script below
3. Confirm that the output is the same as for the test above
4. Confirm that there are no workspaces in the ADS

```python
load_alg = AlgorithmManager.createUnmanaged("Load")
load_alg.initialize()
load_alg.setChild(True)
load_alg.setProperty("Filename", 'ENGINX00213855.nxs')
load_alg.setProperty("OutputWorkspace", "test")
load_alg.execute()
ws = load_alg.getProperty("OutputWorkspace").value


extract_alg = AlgorithmManager.createUnmanaged("ExtractMonitors")
extract_alg.initialize()
extract_alg.setChild(True)
extract_alg.setProperty("InputWorkspace", ws)
extract_alg.setProperty("DetectorWorkspace", 'Detectors')
extract_alg.setProperty("MonitorWorkspace", 'Monitors')
extract_alg.execute()
detector_ws = extract_alg.getProperty("DetectorWorkspace").value
monitor_ws = extract_alg.getProperty("MonitorWorkspace").value


# Detector histograms
print("Number of spectra in input workspace: {0}").format(ws.getNumberHistograms())
# Detector histograms (spectra missing detectors generate warnings)
print("Number of spectra in detector workspace: {0}").format(detector_ws.getNumberHistograms())
# Monitor histograms
print("Number of spectra in monitor workspace: {0}").format(monitor_ws.getNumberHistograms())
# Check if the first spectrum in the detector workspace is a monitor
print("Detector workspace isMonitor for spectrum 0: {0}").format(detector_ws.getDetector(0).isMonitor())
# Check if the first spectrum in the monitor workspace is a monitor
print("Monitor workspace isMonitor for spectrum 0: {0}").format(monitor_ws.getDetector(0).isMonitor())
# See the monitor workspace is set
print("Name of monitor workspace: {0}").format(detector_ws.getMonitorWorkspace().name())
```




# Release notes

Small change -- no release note entry
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

