### PR TITLE
Convert all supplied runs to a single list

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -95,6 +95,8 @@ def allEventWorkspaces(*args):
 
 
 def getBasename(filename):
+    if type(filename) == list:
+        filename = filename[0]
     name = os.path.split(filename)[-1]
     for extension in EXTENSIONS_NXS:
         name = name.replace(extension, '')
@@ -268,6 +270,11 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         self._outTypes = self.getProperty("SaveAs").value.lower()
 
         samRuns = self.getProperty("Filename").value
+        if type(samRuns[0]) == list:
+            linearizedRuns = []
+            for item in samRuns:
+                linearizedRuns.extend(item)
+            samRuns = linearizedRuns[:] # deep copy
         self._determineInstrument(samRuns[0])
 
         preserveEvents = self.getProperty("PreserveEvents").value
@@ -973,24 +980,22 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         # Determine characterization
         if mtd.doesExist("characterizations"):
             # get the correct row of the table if table workspace 'charactersizations' exists
-
-            #pylint: disable=unused-variable
-            charac = api.PDDetermineCharacterizations(InputWorkspace=wksp_name,
-                                                      Characterizations="characterizations",
-                                                      ReductionProperties="__snspowderreduction",
-                                                      BackRun=self.getProperty("BackgroundNumber").value,
-                                                      NormRun=self.getProperty("VanadiumNumber").value,
-                                                      NormBackRun=self.getProperty("VanadiumBackgroundNumber").value,
-                                                      FrequencyLogNames=self.getProperty("FrequencyLogNames").value,
-                                                      WaveLengthLogNames=self.getProperty("WaveLengthLogNames").value)
+            api.PDDetermineCharacterizations(InputWorkspace=wksp_name,
+                                             Characterizations="characterizations",
+                                             ReductionProperties="__snspowderreduction",
+                                             BackRun=self.getProperty("BackgroundNumber").value,
+                                             NormRun=self.getProperty("VanadiumNumber").value,
+                                             NormBackRun=self.getProperty("VanadiumBackgroundNumber").value,
+                                             FrequencyLogNames=self.getProperty("FrequencyLogNames").value,
+                                             WaveLengthLogNames=self.getProperty("WaveLengthLogNames").value)
         else:
-            charac = api.PDDetermineCharacterizations(InputWorkspace=wksp_name,
-                                                      ReductionProperties="__snspowderreduction",
-                                                      BackRun=self.getProperty("BackgroundNumber").value,
-                                                      NormRun=self.getProperty("VanadiumNumber").value,
-                                                      NormBackRun=self.getProperty("VanadiumBackgroundNumber").value,
-                                                      FrequencyLogNames=self.getProperty("FrequencyLogNames").value,
-                                                      WaveLengthLogNames=self.getProperty("WaveLengthLogNames").value)
+            api.PDDetermineCharacterizations(InputWorkspace=wksp_name,
+                                             ReductionProperties="__snspowderreduction",
+                                             BackRun=self.getProperty("BackgroundNumber").value,
+                                             NormRun=self.getProperty("VanadiumNumber").value,
+                                             NormBackRun=self.getProperty("VanadiumBackgroundNumber").value,
+                                             FrequencyLogNames=self.getProperty("FrequencyLogNames").value,
+                                             WaveLengthLogNames=self.getProperty("WaveLengthLogNames").value)
 
         # convert the result into a dict
         return PropertyManagerDataService.retrieve("__snspowderreduction")


### PR DESCRIPTION
There was a bug in the powder diffraction interface where users couldn't reduce a list of runs.

Also changed was deleting an unused variable that was always set to `None`.

**To test:**

Try the "Powder Diffraction Interface" with a list of runs.

*There was no associated issue*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

