### PR TITLE
Fix load current run on Muon Analysis interface

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisDataLoader.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisDataLoader.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/Workspace_fwd.h"
 #include <QMap>
+#include <QRegExp>
 #include <QStringList>
 
 namespace MantidQt {
@@ -39,7 +40,7 @@ struct AnalysisOptions {
   std::string groupPairName; /// Name of group or pair to use
   const Mantid::API::Grouping grouping; /// Grouping to use
   PlotType plotType = {};               /// Type of analysis to perform
-  explicit AnalysisOptions(const Mantid::API::Grouping &g) : grouping(g){};
+  explicit AnalysisOptions(const Mantid::API::Grouping &g) : grouping(g) {}
 };
 } // namespace Muon
 
@@ -77,6 +78,7 @@ public:
                         const std::string &deadTimesFile = "");
   /// change list of supported instruments
   void setSupportedInstruments(const QStringList &instruments);
+
   /// load files
   Muon::LoadResult loadFiles(const QStringList &files) const;
   /// correct and group loaded data
@@ -106,6 +108,9 @@ private:
   /// Get instrument name from workspace
   std::string
   getInstrumentName(const Mantid::API::Workspace_sptr workspace) const;
+  /// Check if we should cache result of a load of the given files
+  bool shouldBeCached(const QStringList &filenames) const;
+
   /// Dead times type
   Muon::DeadTimesType m_deadTimesType;
   /// Dead times file
@@ -114,6 +119,8 @@ private:
   QStringList m_instruments;
   /// Cache of previously loaded data
   mutable std::map<std::string, Muon::LoadResult> m_loadedDataCache;
+  /// Regex blacklisting certain files from being cached
+  QRegExp m_cacheBlacklist;
 };
 
 } // namespace CustomInterfaces

--- a/docs/source/release/v3.9.0/muon.rst
+++ b/docs/source/release/v3.9.0/muon.rst
@@ -20,6 +20,7 @@ Muon Analysis
 - The "compatibility mode" option has been renamed "Enable multiple fitting", and defaults to off. The interface will therefore look the same as it did in Mantid 3.7 by default. To enable the new multi-fitting functionality, just tick the box on the settings tab.
 - The layout of the new fitting tab UI has been improved to give more space for the fitting function, and enable the relative space given to each section to be adjusted by the user.
 - Fixed a bug where stale plot guesses would be left on the graph in some situations.
+- Fixed a bug with load current run that meant it would be actually loading old data due to caching. Data from current run files is no longer cached behind the scenes.
 
 Algorithms
 ----------


### PR DESCRIPTION
Caching of the workspace for data coming from the current MUON runs has been disabled. The file names only have 5 variants to after a while no new data could be loaded. Caching is now disabled for files matching a given regex.

**To test:**

This must be tested at ISIS on a Windows machine.

* set your facility to ISIS and default instrument to one of the MUON instruments, say HIFI.
* set mantid to search the data archive
* go to "Interfaces->Muon->Muon Analysis"
* set the log level in the results log to information
* click "Load current run"
* the results log should **not** mention anything about caching the data
* type `103722` in the run box and tab away, it should load this file
* click the left and right arrow to first load `103721` then `103722` again. The second time for `103722` should have a caching message for that run
* click "Load current run" again and there should be know caching message again for that load.

Fixes #18116

[Release Notes](https://github.com/mantidproject/mantid/commit/e2ae197e671af628105bc5191aa34c673cde238e)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
