### PR TITLE
Disable broken documentation test

### DIFF
--- a/docs/source/algorithms/ConvertCWSDMDtoHKL-v1.rst
+++ b/docs/source/algorithms/ConvertCWSDMDtoHKL-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-This algorithms is to convert an MDEventWorkspace in Q-sample coordinate 
+This algorithms is to convert an MDEventWorkspace in Q-sample coordinate
 to HKL coordindate for a reactor-based four-circle single crystal diffractometer.
 Meanwhile, the algorithm is able to export the MDEvents to file.
 
@@ -26,20 +26,20 @@ Inputs
 
 **InputWorkspace** is an MDEventWorkspace ???.
 
-**PeakWorkspace** is an optional input as in many cases especially after calculating UB matrix, ... 
+**PeakWorkspace** is an optional input as in many cases especially after calculating UB matrix, ...
 
-**UBMatrix** is ???. 
+**UBMatrix** is ???.
 
 
 Outputs
 #######
 
-The output is an MDEventWorkspace that... .. 
+The output is an MDEventWorkspace that... ..
 
 MDEvent
 +++++++
 
-Each MDEvent in output MDEventWorkspace contain 
+Each MDEvent in output MDEventWorkspace contain
 * *H*
 * *K*
 * *L*
@@ -58,50 +58,53 @@ Usage
 
 **Example - Convert detector counts of an HB3A's measurement to HKL.**
 
-.. testcode:: ExConvertHB3AToHKL
+.. .. testcode:: ExConvertHB3AToHKL
+.. code-block:: python
 
   # Create input table workspaces for experiment information and virtual instrument parameters
-  CollectHB3AExperimentInfo(ExperimentNumber='406', ScanList='298', PtLists='-1,22', 
+  CollectHB3AExperimentInfo(ExperimentNumber='406', ScanList='298', PtLists='-1,22',
       DataDirectory='',
       GenerateVirtualInstrument=False,
       OutputWorkspace='ExpInfoTable', DetectorTableWorkspace='VirtualInstrumentTable')
 
   # Convert to MDWorkspace
-  ConvertCWSDExpToMomentum(InputWorkspace='ExpInfoTable', CreateVirtualInstrument=False, 
+  ConvertCWSDExpToMomentum(InputWorkspace='ExpInfoTable', CreateVirtualInstrument=False,
       OutputWorkspace='QSampleMD',
       Directory='')
-      
-  ConvertCWSDMDtoHKL(InputWorkspace='QSampleMD', 
+
+  ConvertCWSDMDtoHKL(InputWorkspace='QSampleMD',
                 UBMatrix='0.13329061, 0.07152342, -0.04215966, 0.01084569, -0.1620849, 0.0007607, -0.14018499, -0.07841385, -0.04002737',
                 OutputWorkspace='HKLMD')
-              
-  
+
+
   # Examine
   mdws = mtd['QSampleMD']
   print 'Output MDEventWorkspace has %d events.'%(mdws.getNEvents())
-  
+
   hklws = mtd['HKLMD']
   print 'H: range from %.5f to %.5f.' % (hklws.getXDimension().getMinimum(), hklws.getXDimension().getMaximum())
   print 'K: range from %.5f to %.5f.' % (hklws.getYDimension().getMinimum(), hklws.getYDimension().getMaximum())
   print 'L: range from %.5f to %.5f.' % (hklws.getZDimension().getMinimum(), hklws.getZDimension().getMaximum())
 
-.. testcleanup::  ExConvertHB3AToHKL
+..
+   .. testcleanup::  ExConvertHB3AToHKL
 
-  DeleteWorkspace(Workspace='QSampleMD')
-  DeleteWorkspace(Workspace='ExpInfoTable')
-  DeleteWorkspace(Workspace='VirtualInstrumentTable')
-  DeleteWorkspace(Workspace='HKLMD')
-  DeleteWorkspace(Workspace='HB3A_exp0406_scan0298')
-  DeleteWorkspace(Workspace='spicematrixws')
+     DeleteWorkspace(Workspace='QSampleMD')
+     DeleteWorkspace(Workspace='ExpInfoTable')
+     DeleteWorkspace(Workspace='VirtualInstrumentTable')
+     DeleteWorkspace(Workspace='HKLMD')
+     DeleteWorkspace(Workspace='HB3A_exp0406_scan0298')
+     DeleteWorkspace(Workspace='spicematrixws')
 
-Output:
+..
+   Output:
 
-.. testoutput:: ExConvertHB3AToHKL
+   .. testoutput:: ExConvertHB3AToHKL
 
-  Output MDEventWorkspace has 1631 events.
-  H: range from -0.26509 to 0.22324.
-  K: range from -0.33148 to 0.45354.
-  L: range from 4.92654 to 7.17077.
+     Output MDEventWorkspace has 1631 events.
+     H: range from -0.26509 to 0.22324.
+     K: range from -0.33148 to 0.45354.
+     L: range from 4.92654 to 7.17077.
 
 .. categories::
 


### PR DESCRIPTION
Disables the `ConvertCWSDMDtoHKL` doc test that slipped on the `master` in a broken state. As it is on `master` it will now affect all future PR builds.

This is a quick resolution. #18277 has been opened the properly address the issue.

**To test:**

Check Ubuntu build passes

No issue

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

