### PR TITLE
Deal with DetectorInfo when using ExperimentInfo::replaceInstrumentParameters

### DIFF
--- a/Framework/API/inc/MantidAPI/DetectorInfo.h
+++ b/Framework/API/inc/MantidAPI/DetectorInfo.h
@@ -13,6 +13,9 @@
 
 namespace Mantid {
 using detid_t = int32_t;
+namespace Beamline {
+class DetectorInfo;
+}
 namespace Geometry {
 class IComponent;
 class IDetector;
@@ -60,8 +63,11 @@ class SpectrumInfo;
 */
 class MANTID_API_DLL DetectorInfo {
 public:
-  DetectorInfo(boost::shared_ptr<const Geometry::Instrument> instrument,
+  DetectorInfo(Beamline::DetectorInfo &detectorInfo,
+               boost::shared_ptr<const Geometry::Instrument> instrument,
                Geometry::ParameterMap *pmap = nullptr);
+
+  DetectorInfo &operator=(const DetectorInfo &rhs);
 
   size_t size() const;
 
@@ -113,6 +119,9 @@ private:
   void doCacheSource() const;
   void doCacheSample() const;
   void cacheL1() const;
+
+  /// Reference to the actual DetectorInfo object (non-wrapping part).
+  Beamline::DetectorInfo &m_detectorInfo;
 
   Geometry::ParameterMap *m_pmap;
   boost::shared_ptr<const Geometry::Instrument> m_instrument;

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -16,6 +16,9 @@ namespace Mantid {
 namespace Kernel {
 class Property;
 }
+namespace Beamline {
+class DetectorInfo;
+}
 namespace Geometry {
 class ParameterMap;
 class XMLInstrumentParameter;
@@ -205,7 +208,8 @@ private:
   /// Mutex to protect against cow_ptr copying
   mutable std::recursive_mutex m_mutex;
 
-  mutable std::unique_ptr<DetectorInfo> m_detectorInfo;
+  std::unique_ptr<Beamline::DetectorInfo> m_detectorInfo;
+  mutable std::unique_ptr<DetectorInfo> m_detectorInfoWrapper;
   mutable std::mutex m_detectorInfoMutex;
 };
 

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -208,7 +208,7 @@ private:
   /// Mutex to protect against cow_ptr copying
   mutable std::recursive_mutex m_mutex;
 
-  std::unique_ptr<Beamline::DetectorInfo> m_detectorInfo;
+  boost::shared_ptr<Beamline::DetectorInfo> m_detectorInfo;
   mutable std::unique_ptr<DetectorInfo> m_detectorInfoWrapper;
   mutable std::mutex m_detectorInfoMutex;
 };

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -70,9 +70,7 @@ public:
   // Add parameters to the instrument parameter map
   virtual void populateInstrumentParameters();
 
-  /// Replaces current parameter map with copy of given map
   virtual void replaceInstrumentParameters(const Geometry::ParameterMap &pmap);
-  /// exchange contents of current parameter map with contents of other map)
   virtual void swapInstrumentParameters(Geometry::ParameterMap &pmap);
 
   /// Cache a lookup of grouped detIDs to member IDs

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -340,6 +340,8 @@ void ExperimentInfo::populateInstrumentParameters() {
 
 /**
  * Replaces current parameter map with a copy of the given map
+ * Careful: Parameters that are stored in DetectorInfo are not automatically
+ * handled.
  * @ pmap const reference to parameter map whose copy replaces the current
  * parameter map
  */
@@ -352,6 +354,8 @@ void ExperimentInfo::replaceInstrumentParameters(
 
 /**
  * exchanges contents of current parameter map with contents of other map)
+ * Careful: Parameters that are stored in DetectorInfo are not automatically
+ * handled.
  * @ pmap reference to parameter map which would exchange its contents with
  * current map
  */

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -918,7 +918,7 @@ const DetectorInfo &ExperimentInfo::detectorInfo() const {
     std::lock_guard<std::mutex> lock{m_detectorInfoMutex};
     if (!m_detectorInfoWrapper)
       m_detectorInfoWrapper =
-          Kernel::make_unique<DetectorInfo>(getInstrument());
+          Kernel::make_unique<DetectorInfo>(*m_detectorInfo, getInstrument());
   }
   return *m_detectorInfoWrapper;
 }
@@ -941,7 +941,7 @@ DetectorInfo &ExperimentInfo::mutableDetectorInfo() {
   // reference count to the ParameterMap. This has do be done *after* getting
   // the ParameterMap.
   m_detectorInfoWrapper =
-      Kernel::make_unique<DetectorInfo>(getInstrument(), pmap);
+      Kernel::make_unique<DetectorInfo>(*m_detectorInfo, getInstrument(), pmap);
   return *m_detectorInfoWrapper;
 }
 

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -155,8 +155,8 @@ void ExperimentInfo::setInstrument(const Instrument_const_sptr &instr) {
     m_parmap = boost::make_shared<ParameterMap>();
   }
   const auto numDets = sptr_instrument->getNumberDetectors();
-  if (sptr_instrument->hasDetectorInfo()) {
-    const auto &detInfo = sptr_instrument->detectorInfo();
+  if (instr->hasDetectorInfo()) {
+    const auto &detInfo = instr->detectorInfo();
     if (numDets != detInfo.size())
       throw std::runtime_error("ExperimentInfo::setInstrument: size mismatch "
                                "between DetectorInfo and number of detectors "

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -79,8 +79,7 @@ void ExperimentInfo::copyExperimentInfoFrom(const ExperimentInfo *other) {
   for (const auto &chopper : other->m_choppers) {
     m_choppers.push_back(chopper->clone());
   }
-  m_detectorInfo =
-      Kernel::make_unique<Beamline::DetectorInfo>(*other->m_detectorInfo);
+  *m_detectorInfo = *other->m_detectorInfo;
 }
 
 /** Clone this ExperimentInfo class into a new one
@@ -164,6 +163,7 @@ void ExperimentInfo::setInstrument(const Instrument_const_sptr &instr) {
                                "in instrument");
     *m_detectorInfo = *detInfo;
   } else {
+    // If there is no DetectorInfo in the instrument we create a default one.
     m_detectorInfo = Kernel::make_unique<Beamline::DetectorInfo>(numDets);
   }
 }

--- a/Framework/API/test/DetectorInfoTest.h
+++ b/Framework/API/test/DetectorInfoTest.h
@@ -310,6 +310,22 @@ public:
     TS_ASSERT_EQUALS(ids, sorted_ids);
   }
 
+  void test_assignment() {
+    auto ws1 = makeWorkspace(2);
+    auto ws2 = makeWorkspace(2);
+    TS_ASSERT_THROWS_NOTHING(ws2->mutableDetectorInfo() = ws1->detectorInfo());
+    // TODO Beamline::DetectorInfo is currently not containing data, so there is
+    // nothing we can check here. Once the class is getting populated add more
+    // checks here.
+  }
+
+  void test_assignment_mismatch() {
+    auto ws1 = makeWorkspace(1);
+    auto ws2 = makeWorkspace(2);
+    TS_ASSERT_THROWS(ws2->mutableDetectorInfo() = ws1->detectorInfo(),
+                     std::runtime_error);
+  }
+
 private:
   WorkspaceTester m_workspace;
   WorkspaceTester m_workspaceNoInstrument;

--- a/Framework/API/test/DetectorInfoTest.h
+++ b/Framework/API/test/DetectorInfoTest.h
@@ -318,13 +318,16 @@ private:
     auto ws = Kernel::make_unique<WorkspaceTester>();
     ws->initialize(numSpectra, 1, 1);
     auto inst = boost::make_shared<Instrument>("TestInstrument");
-    ws->setInstrument(inst);
-    auto &pmap = ws->instrumentParameters();
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
       auto det = new Detector("pixel", static_cast<detid_t>(i), inst.get());
       inst->add(det);
       inst->markAsDetector(det);
+    }
+    ws->setInstrument(inst);
+    auto &pmap = ws->instrumentParameters();
+    for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
       ws->getSpectrum(i).addDetectorID(static_cast<detid_t>(i));
+      const auto &det = ws->getDetector(i);
       if (i % 2 == 0)
         pmap.addBool(det->getComponentID(), "masked", true);
     }

--- a/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
+++ b/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
@@ -32,7 +32,6 @@ public:
       }
     }
     Instrument_sptr inst(new Instrument("TestInstrument"));
-    ws->setInstrument(inst);
     // We get a 1:1 map by default so the detector ID should match the spectrum
     // number
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
@@ -43,6 +42,7 @@ public:
       inst->markAsDetector(det);
       ws->getSpectrum(i).addDetectorID(static_cast<detid_t>(i));
     }
+    ws->setInstrument(inst);
     ws->replaceAxis(1, ax1);
 
     return ws;

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -51,7 +51,6 @@ boost::shared_ptr<MatrixWorkspace> makeWorkspaceWithDetectors(size_t numSpectra,
   ws2->initialize(numSpectra, numBins, numBins);
 
   auto inst = boost::make_shared<Instrument>("TestInstrument");
-  ws2->setInstrument(inst);
   // We get a 1:1 map by default so the detector ID should match the spectrum
   // number
   for (size_t i = 0; i < ws2->getNumberHistograms(); ++i) {
@@ -61,6 +60,7 @@ boost::shared_ptr<MatrixWorkspace> makeWorkspaceWithDetectors(size_t numSpectra,
     inst->markAsDetector(det);
     ws2->getSpectrum(i).addDetectorID(static_cast<detid_t>(i));
   }
+  ws2->setInstrument(inst);
   return ws2;
 }
 
@@ -579,7 +579,6 @@ public:
     // the detector ID
     // is stored in at least 3 places
     auto inst = boost::make_shared<Instrument>("TestInstrument");
-    ws->setInstrument(inst);
     // We get a 1:1 map by default so the detector ID should match the spectrum
     // number
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
@@ -594,6 +593,7 @@ public:
       inst->markAsDetector(det);
       ws->getSpectrum(i).addDetectorID(detid);
     }
+    ws->setInstrument(inst);
     ws->getSpectrum(66).clearDetectorIDs();
 
     TS_ASSERT_THROWS_NOTHING(

--- a/Framework/API/test/SpectrumInfoTest.h
+++ b/Framework/API/test/SpectrumInfoTest.h
@@ -426,13 +426,13 @@ private:
     auto ws = Kernel::make_unique<WorkspaceTester>();
     ws->initialize(numSpectra, 1, 1);
     auto inst = boost::make_shared<Instrument>("TestInstrument");
-    ws->setInstrument(inst);
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
       auto det = new Detector("pixel", static_cast<detid_t>(i), inst.get());
       inst->add(det);
       inst->markAsDetector(det);
       ws->getSpectrum(i).addDetectorID(static_cast<detid_t>(i));
     }
+    ws->setInstrument(inst);
     auto &detectorInfo = ws->mutableDetectorInfo();
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i)
       if (i % 2 == 0)

--- a/Framework/Algorithms/src/CopyInstrumentParameters.cpp
+++ b/Framework/Algorithms/src/CopyInstrumentParameters.cpp
@@ -96,7 +96,12 @@ void CopyInstrumentParameters::exec() {
     // changed parameters
     m_receivingWorkspace->swapInstrumentParameters(targMap);
 
-    // Deal with parameters that are stored in Beamline::DetectorInfo
+    // Deal with parameters that are stored in DetectorInfo. Note that this
+    // mimics what the above code is doing when copying the ParameterMap, even
+    // if it may not make sense. That is, we do a matching purely based on
+    // detector IDs, but completely ignore whether these belong to different
+    // instruments or different incompatible versions of the same instrument.
+    // This algorithm should probably enforce stricter compatiblity checks.
     const auto &givingDetInfo = m_givingWorkspace->detectorInfo();
     auto &receivingDetInfo = m_receivingWorkspace->mutableDetectorInfo();
     try {
@@ -112,9 +117,9 @@ void CopyInstrumentParameters::exec() {
         if (std::find(givingDetIDs.begin(), givingDetIDs.end(), detID) !=
             givingDetIDs.end()) {
           // const auto givingIndex = givingDetInfo.indexOf(detID);
-          // Copy values for all fields in Beamline::DetectorInfo
+          // Copy values for all fields in DetectorInfo
         } else {
-          // Set default values for all fields in Beamline::DetectorInfo
+          // Set default values for all fields in DetectorInfo
         }
       }
     }

--- a/Framework/Algorithms/src/EditInstrumentGeometry.cpp
+++ b/Framework/Algorithms/src/EditInstrumentGeometry.cpp
@@ -299,9 +299,6 @@ void EditInstrumentGeometry::exec() {
   instrument->markAsSource(source);
   source->setPos(0.0, 0.0, -1.0 * l1);
 
-  // Add the new instrument
-  workspace->setInstrument(instrument);
-
   // Add/copy detector information
   for (size_t i = 0; i < workspace->getNumberHistograms(); i++) {
     // Create a new detector.
@@ -335,6 +332,9 @@ void EditInstrumentGeometry::exec() {
     instrument->markAsDetector(detector);
 
   } // ENDFOR workspace index
+
+  // Add the new instrument
+  workspace->setInstrument(instrument);
 }
 
 } // namespace Mantid

--- a/Framework/Algorithms/test/CalculateFlatBackgroundTest.h
+++ b/Framework/Algorithms/test/CalculateFlatBackgroundTest.h
@@ -680,7 +680,6 @@ private:
         new Geometry::Instrument("testInst"));
     // testInst->setReferenceFrame(boost::shared_ptr<Geometry::ReferenceFrame>(new
     // Geometry::ReferenceFrame(Geometry::PointingAlong::Y,Geometry::X,Geometry::Left,"")));
-    WS->setInstrument(testInst);
 
     const double pixelRadius(0.05);
     Geometry::Object_sptr pixelShape =
@@ -700,6 +699,7 @@ private:
       testInst->markAsMonitor(physicalPixel);
       WS->getSpectrum(i).addDetectorID(physicalPixel->getID());
     }
+    WS->setInstrument(testInst);
   }
 
   /// Creates a  workspace with a single special value in each spectrum.

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -532,7 +532,6 @@ public:
     ws->getAxis(0)->unit() = UnitFactory::Instance().create("TOF");
 
     Instrument_sptr testInst(new Instrument);
-    ws->setInstrument(testInst);
     // Make it look like MARI (though not bin boundaries are different to the
     // real MARI file used before)
     // Define a source and sample position
@@ -552,6 +551,7 @@ public:
     physicalPixel->setPos(-0.34732, -3.28797, -2.29022);
     testInst->add(physicalPixel);
     testInst->markAsDetector(physicalPixel);
+    ws->setInstrument(testInst);
     ws->getSpectrum(0).addDetectorID(physicalPixel->getID());
 
     ConvertUnits conv;

--- a/Framework/Algorithms/test/DetectorEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/DetectorEfficiencyCorTest.h
@@ -137,20 +137,23 @@ private:
         ShapeFactory().createShape(xmlShape, addTypeTag);
 
     boost::shared_ptr<Instrument> instrument = boost::make_shared<Instrument>();
+    const int ndets(2);
+    std::vector<Detector *> detectors;
+    for (int i = 0; i < ndets; ++i) {
+      Detector *detector = new Detector("det", i + 1, shape, NULL);
+      detector->setPos(i * 0.2, i * 0.2, 5);
+      instrument->markAsDetector(detector);
+      detectors.push_back(detector);
+    }
     space2D->setInstrument(instrument);
     ObjComponent *sample = new ObjComponent("sample", shape, NULL);
     sample->setPos(0, 0, 0);
     instrument->markAsSamplePos(sample);
 
     ParameterMap &pmap = space2D->instrumentParameters();
-    // Detector info
-    const int ndets(2);
-    for (int i = 0; i < ndets; ++i) {
-      Detector *detector = new Detector("det", i + 1, shape, NULL);
-      detector->setPos(i * 0.2, i * 0.2, 5);
+    for (const auto detector : detectors) {
       pmap.add("double", detector, "TubePressure", 10.0);
       pmap.add("double", detector, "TubeThickness", 0.0008);
-      instrument->markAsDetector(detector);
     }
     return space2D;
   }

--- a/Framework/Algorithms/test/FindDeadDetectorsTest.h
+++ b/Framework/Algorithms/test/FindDeadDetectorsTest.h
@@ -41,7 +41,6 @@ public:
         WorkspaceCreationHelper::create2DWorkspaceBinned(sizey, sizex, -1, 3.0);
 
     Instrument_sptr instr(new Instrument);
-    work_in->setInstrument(instr);
 
     // yVeryDead is a detector that never responds and produces no counts
     Counts yVeryDead(sizex, 0);
@@ -78,6 +77,7 @@ public:
       instr->markAsDetector(det);
       work_in->getSpectrum(i).setDetectorID(i);
     }
+    work_in->setInstrument(instr);
 
     FindDeadDetectors alg;
 

--- a/Framework/Algorithms/test/FindDetectorsOutsideLimitsTest.h
+++ b/Framework/Algorithms/test/FindDetectorsOutsideLimitsTest.h
@@ -41,7 +41,6 @@ public:
         WorkspaceCreationHelper::create2DWorkspaceBinned(sizey, sizex, -1, 3.0);
 
     Instrument_sptr instr(new Instrument);
-    work_in->setInstrument(instr);
 
     // yVeryDead is a detector with low counts
     Counts yVeryDead(sizex, 0.1);
@@ -78,6 +77,7 @@ public:
       instr->markAsDetector(det);
       work_in->getSpectrum(i).setDetectorID(i);
     }
+    work_in->setInstrument(instr);
 
     FindDetectorsOutsideLimits alg;
 

--- a/Framework/Algorithms/test/HRPDSlabCanAbsorptionTest.h
+++ b/Framework/Algorithms/test/HRPDSlabCanAbsorptionTest.h
@@ -37,7 +37,6 @@ public:
 
     boost::shared_ptr<Instrument> testInst =
         boost::make_shared<Instrument>("testInst");
-    testWS->setInstrument(testInst);
 
     // Define a source and sample position
     // Define a source component
@@ -68,6 +67,8 @@ public:
     det3->setPos(V3D(1.98194, 0.0990971, 3.19728));
     testInst->add(det3);
     testInst->markAsDetector(det3);
+
+    testWS->setInstrument(testInst);
 
     TS_ASSERT_THROWS_NOTHING(
         atten.setProperty<MatrixWorkspace_sptr>("InputWorkspace", testWS));

--- a/Framework/Algorithms/test/NormaliseToMonitorTest.h
+++ b/Framework/Algorithms/test/NormaliseToMonitorTest.h
@@ -42,7 +42,6 @@ void setUpWorkspace(int histograms = 3, int bins = 10) {
   input->getSpectrum(1).setSpectrumNo(1);
   input->getSpectrum(2).setSpectrumNo(2);
   boost::shared_ptr<Instrument> instr = boost::make_shared<Instrument>();
-  input->setInstrument(instr);
   Mantid::Geometry::Detector *mon =
       new Mantid::Geometry::Detector("monitor", 0, NULL);
   instr->add(mon);
@@ -51,6 +50,7 @@ void setUpWorkspace(int histograms = 3, int bins = 10) {
       new Mantid::Geometry::Detector("NOTmonitor", 1, NULL);
   instr->add(det);
   instr->markAsDetector(det);
+  input->setInstrument(instr);
 
   AnalysisDataService::Instance().addOrReplace("normMon", input);
 

--- a/Framework/Algorithms/test/WorkspaceGroupTest.h
+++ b/Framework/Algorithms/test/WorkspaceGroupTest.h
@@ -181,8 +181,6 @@ public:
     Workspace2D_sptr work_in2 =
         WorkspaceCreationHelper::create2DWorkspace154(nHist, nBins, 1);
     Instrument_sptr instr(new Instrument);
-    work_in1->setInstrument(instr);
-    work_in2->setInstrument(instr);
 
     // set some dead detectors
     Counts yDead(nBins, 0);
@@ -198,6 +196,8 @@ public:
       instr->add(det);
       instr->markAsDetector(det);
     }
+    work_in1->setInstrument(instr);
+    work_in2->setInstrument(instr);
 
     for (int i = 0; i < nBins; i++) {
       if (i % 2 == 0) {

--- a/Framework/Beamline/CMakeLists.txt
+++ b/Framework/Beamline/CMakeLists.txt
@@ -1,0 +1,47 @@
+set ( SRC_FILES
+	src/DetectorInfo.cpp
+)
+
+set ( INC_FILES
+	inc/MantidBeamline/DetectorInfo.h
+)
+
+set ( TEST_FILES
+	DetectorInfoTest.h
+)
+
+if (COVERALLS)
+  foreach( loop_var ${SRC_FILES} ${INC_FILES})
+    set_property(GLOBAL APPEND PROPERTY COVERAGE_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/${loop_var}")
+  endforeach(loop_var)
+endif()
+
+if(UNITY_BUILD)
+  include(UnityBuild)
+  enable_unity_build(Beamline SRC_FILES SRC_UNITY_IGNORE_FILES 10)
+endif(UNITY_BUILD)
+
+# Add the target for this directory
+add_library ( Beamline ${SRC_FILES} ${INC_FILES} )
+# Set the name of the generated library
+set_target_properties ( Beamline PROPERTIES OUTPUT_NAME MantidBeamline
+  COMPILE_DEFINITIONS IN_MANTID_BEAMLINE )
+
+if (OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties ( Beamline PROPERTIES INSTALL_RPATH "@loader_path/../MacOS")
+endif ()
+
+# Add to the 'Framework' group in VS
+set_property ( TARGET Beamline PROPERTY FOLDER "MantidFramework" )
+
+target_link_libraries ( Beamline LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} 
+                        ${GSL_LIBRARIES} ${MANTIDLIBS} )
+
+# Add the unit tests directory
+add_subdirectory ( test )
+
+###########################################################################
+# Installation settings
+###########################################################################
+
+install ( TARGETS Beamline ${SYSTEM_PACKAGE_TARGET} DESTINATION ${LIB_DIR} )

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -3,7 +3,6 @@
 
 #include "MantidBeamline/DllConfig.h"
 
-
 namespace Mantid {
 namespace Beamline {
 
@@ -31,7 +30,14 @@ namespace Beamline {
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 class MANTID_BEAMLINE_DLL DetectorInfo {
-public:};
+public:
+  DetectorInfo(const size_t numberOfDetectors);
+
+  size_t size() const;
+
+private:
+  size_t m_size;
+};
 
 } // namespace Beamline
 } // namespace Mantid

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -1,0 +1,39 @@
+#ifndef MANTID_BEAMLINE_DETECTORINFO_H_
+#define MANTID_BEAMLINE_DETECTORINFO_H_
+
+#include "MantidBeamline/DllConfig.h"
+
+
+namespace Mantid {
+namespace Beamline {
+
+/** DetectorInfo : TODO: DESCRIPTION
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_BEAMLINE_DLL DetectorInfo {
+public:};
+
+} // namespace Beamline
+} // namespace Mantid
+
+#endif /* MANTID_BEAMLINE_DETECTORINFO_H_ */

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -6,7 +6,31 @@
 namespace Mantid {
 namespace Beamline {
 
-/** DetectorInfo : TODO: DESCRIPTION
+/** Beamline::DetectorInfo provides easy access to commonly used parameters of
+  individual detectors (pixels) in a beamline, such as mask and monitor flags,
+  positions, L2, and 2-theta.
+
+  Currently only a limited subset of functionality is implemented in
+  Beamline::DetectorInfo. The remainder is available in API::DetectorInfo which
+  acts as a wrapper around the old instrument implementation. API::DetectorInfo
+  will be removed once all functionality has been moved to
+  Beamline::DetectorInfo. For the time being, API::DetectorInfo will forward
+  calls to Beamline::DetectorInfo when applicable.
+
+  The reason for having both DetectorInfo classes in parallel is:
+  - We need to be able to move around the DetectorInfo object including data it
+    contains such as a vector of mask flags. This is relevant for the interface
+    of ExperimentInfo, when replacing the ParameterMap or when setting a new
+    instrument.
+  - API::DetectorInfo contains a caching mechanism and is frequently flushed
+    upon modification of the instrument and is thus hard to handle outside the
+    context of its owning workspace.
+  Splitting DetectorInfo into two classes seemed to be the safest and easiest
+  solution to this.
+
+
+  @author Simon Heybrock
+  @date 2016
 
   Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source

--- a/Framework/Beamline/inc/MantidBeamline/DllConfig.h
+++ b/Framework/Beamline/inc/MantidBeamline/DllConfig.h
@@ -1,0 +1,37 @@
+#ifndef MANTID_BEAMLINE_DLLCONFIG_H_
+#define MANTID_BEAMLINE_DLLCONFIG_H_
+
+/*
+  This file contains the DLLExport/DLLImport linkage configuration for the
+  Beamline library
+
+  Copyright &copy; 2016 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+#include "MantidKernel/System.h"
+
+#ifdef IN_MANTID_BEAMLINE
+#define MANTID_BEAMLINE_DLL DLLExport
+#else
+#define MANTID_BEAMLINE_DLL DLLImport
+#endif // IN_MANTID_BEAMLINE
+
+#endif // MANTID_BEAMLINE_DLLCONFIG_H_

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -3,5 +3,10 @@
 namespace Mantid {
 namespace Beamline {
 
+DetectorInfo::DetectorInfo(const size_t numberOfDetectors)
+    : m_size(numberOfDetectors) {}
+
+size_t DetectorInfo::size() const { return m_size; }
+
 } // namespace Beamline
 } // namespace Mantid

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -1,0 +1,7 @@
+#include "MantidBeamline/DetectorInfo.h"
+
+namespace Mantid {
+namespace Beamline {
+
+} // namespace Beamline
+} // namespace Mantid

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -6,6 +6,8 @@ namespace Beamline {
 DetectorInfo::DetectorInfo(const size_t numberOfDetectors)
     : m_size(numberOfDetectors) {}
 
+/// Returns the size of the DetectorInfo, i.e., the number of detectors in the
+/// instrument.
 size_t DetectorInfo::size() const { return m_size; }
 
 } // namespace Beamline

--- a/Framework/Beamline/test/CMakeLists.txt
+++ b/Framework/Beamline/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+if ( CXXTEST_FOUND )
+  include_directories ( SYSTEM ${CXXTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR} ${GTEST_INCLUDE_DIR} ../../TestHelpers/inc)
+
+  cxxtest_add_test ( BeamlineTest ${TEST_FILES} ${GMOCK_TEST_FILES})
+  target_link_libraries( BeamlineTest LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
+    Beamline
+    ${Boost_LIBRARIES}
+    ${GTEST_LIBRARIES} )
+  
+  add_dependencies ( FrameworkTests BeamlineTest )
+  # Add to the 'FrameworkTests' group in VS
+  set_property ( TARGET BeamlineTest PROPERTY FOLDER "UnitTests" )
+endif ()

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -1,0 +1,27 @@
+#ifndef MANTID_BEAMLINE_DETECTORINFOTEST_H_
+#define MANTID_BEAMLINE_DETECTORINFOTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidBeamline/DetectorInfo.h"
+
+using Mantid::Beamline::DetectorInfo;
+
+class DetectorInfoTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static DetectorInfoTest *createSuite() { return new DetectorInfoTest(); }
+  static void destroySuite( DetectorInfoTest *suite ) { delete suite; }
+
+
+  void test_Something()
+  {
+    TS_FAIL( "You forgot to write a test!");
+  }
+
+
+};
+
+
+#endif /* MANTID_BEAMLINE_DETECTORINFOTEST_H_ */

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -4,24 +4,53 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidBeamline/DetectorInfo.h"
+#include "MantidKernel/make_unique.h"
 
-using Mantid::Beamline::DetectorInfo;
+using namespace Mantid;
+using Beamline::DetectorInfo;
 
 class DetectorInfoTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
   static DetectorInfoTest *createSuite() { return new DetectorInfoTest(); }
-  static void destroySuite( DetectorInfoTest *suite ) { delete suite; }
+  static void destroySuite(DetectorInfoTest *suite) { delete suite; }
 
-
-  void test_Something()
-  {
-    TS_FAIL( "You forgot to write a test!");
+  void test_constructor() {
+    std::unique_ptr<DetectorInfo> detInfo;
+    TS_ASSERT_THROWS_NOTHING(detInfo = Kernel::make_unique<DetectorInfo>(0));
+    TS_ASSERT_EQUALS(detInfo->size(), 0);
+    TS_ASSERT_THROWS_NOTHING(detInfo = Kernel::make_unique<DetectorInfo>(1));
+    TS_ASSERT_EQUALS(detInfo->size(), 1);
   }
 
+  void test_copy() {
+    const DetectorInfo source(7);
+    const auto copy(source);
+    TS_ASSERT_EQUALS(copy.size(), 7);
+  }
 
+  void test_move() {
+    DetectorInfo source(7);
+    const auto moved(std::move(source));
+    TS_ASSERT_EQUALS(moved.size(), 7);
+    // TODO once DetectorInfo has moveable fields, check that they are cleared.
+  }
+
+  void test_assign() {
+    const DetectorInfo source(7);
+    DetectorInfo assignee(1);
+    assignee = source;
+    TS_ASSERT_EQUALS(assignee.size(), 7);
+  }
+
+  void test_move_assign() {
+    DetectorInfo source(7);
+    DetectorInfo assignee(1);
+    assignee = std::move(source);
+    TS_ASSERT_EQUALS(assignee.size(), 7);
+    // TODO once DetectorInfo has moveable fields, check that they are cleared.
+  }
 };
-
 
 #endif /* MANTID_BEAMLINE_DETECTORINFOTEST_H_ */

--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -70,9 +70,13 @@ add_subdirectory (Kernel)
 include_directories (HistogramData/inc)
 add_subdirectory (HistogramData)
 
+include_directories (Beamline/inc)
+add_subdirectory (Beamline)
+
 # HistogramData has header-only dependency on Kernel, so Kernel comes after.
 set ( MANTIDLIBS ${MANTIDLIBS} HistogramData )
 set ( MANTIDLIBS ${MANTIDLIBS} Kernel )
+set ( MANTIDLIBS ${MANTIDLIBS} Beamline )
 
 include_directories (Geometry/inc)
 # muParser needed by Geometry and subsequent packages
@@ -134,7 +138,7 @@ add_subdirectory (ScriptRepository)
 # Add a custom target to build all of the Framework
 ###########################################################################
 
-set ( FRAMEWORK_LIBS Kernel HistogramData Geometry API DataObjects
+set ( FRAMEWORK_LIBS Kernel HistogramData Beamline Geometry API DataObjects
                      PythonKernelModule PythonGeometryModule PythonAPIModule
                      PythonDataObjectsModule
                      DataHandling Nexus Algorithms CurveFitting ICat

--- a/Framework/DataHandling/src/LoadGSS.cpp
+++ b/Framework/DataHandling/src/LoadGSS.cpp
@@ -509,7 +509,6 @@ void LoadGSS::createInstrumentGeometry(
   // Create a new instrument and set its name
   Geometry::Instrument_sptr instrument(
       new Geometry::Instrument(instrumentname));
-  workspace->setInstrument(instrument);
 
   // Add dummy source and samplepos to instrument
   Geometry::ObjComponent *samplepos =
@@ -557,6 +556,7 @@ void LoadGSS::createInstrumentGeometry(
     instrument->markAsDetector(detector);
 
   } // ENDFOR (i: spectrum)
+  workspace->setInstrument(instrument);
 }
 
 } // namespace

--- a/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
@@ -67,7 +67,6 @@ void LoadInstrumentFromRaw::exec() {
 
   // Create a new Instrument with the right name and add it to the workspace
   Geometry::Instrument_sptr instrument(new Instrument(iraw.i_inst));
-  localWorkspace->setInstrument(instrument);
 
   // Add dummy source and samplepos to instrument
   // The L2 and 2-theta values from Raw file assumed to be relative to sample
@@ -146,6 +145,7 @@ void LoadInstrumentFromRaw::exec() {
     prog += (0.5 / numDetector);
     progress(prog);
   }
+  localWorkspace->setInstrument(instrument);
 
   std::vector<detid_t> monitorList = instrument->getMonitors();
   setProperty("MonitorList", monitorList);

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -265,7 +265,6 @@ void LoadNXSPE::exec() {
   // generate instrument
   Geometry::Instrument_sptr instrument(new Geometry::Instrument(
       instrument_name.empty() ? "NXSPE" : instrument_name));
-  outputWS->setInstrument(instrument);
 
   Geometry::ObjComponent *source = new Geometry::ObjComponent("source");
   source->setPos(0.0, 0.0, -10.);
@@ -294,6 +293,7 @@ void LoadNXSPE::exec() {
     instrument->add(det);
     instrument->markAsDetector(det);
   }
+  outputWS->setInstrument(instrument);
 
   std::vector<double>::iterator itdata = data.begin(), iterror = error.begin(),
                                 itdataend, iterrorend;

--- a/Framework/DataHandling/src/LoadQKK.cpp
+++ b/Framework/DataHandling/src/LoadQKK.cpp
@@ -132,7 +132,6 @@ void LoadQKK::exec() {
   std::string instrumentname = "QUOKKA";
   Geometry::Instrument_sptr instrument(
       new Geometry::Instrument(instrumentname));
-  outputWorkspace->setInstrument(instrument);
 
   // Add dummy source and samplepos to instrument
 
@@ -209,6 +208,8 @@ void LoadQKK::exec() {
     }
   // Position the detector so the z axis goes through its centre
   bank->setPos(-width / 2, -height / 2, 0);
+
+  outputWorkspace->setInstrument(instrument);
 
   // Set the workspace title
   outputWorkspace->setTitle(entry.getString("experiment/title"));

--- a/Framework/DataHandling/test/LoadDetectorInfoTest.h
+++ b/Framework/DataHandling/test/LoadDetectorInfoTest.h
@@ -225,7 +225,6 @@ void makeTestWorkspace(const int ndets, const int nbins,
   }
 
   Instrument_sptr instr(new Instrument);
-  space2D->setInstrument(instr);
   ObjComponent *samplePos = new ObjComponent("sample-pos", instr.get());
   instr->markAsSamplePos(samplePos);
 
@@ -235,6 +234,7 @@ void makeTestWorkspace(const int ndets, const int nbins,
     Detector *d = new Detector(os.str(), i, 0);
     instr->markAsDetector(d);
   }
+  space2D->setInstrument(instr);
 
   // Register the workspace in the data service
   AnalysisDataService::Instance().add(ads_name, space2D);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -1,9 +1,6 @@
 #ifndef MANTID_GEOMETRY_INSTRUMENT_H_
 #define MANTID_GEOMETRY_INSTRUMENT_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Instrument_fwd.h"
 #include "MantidGeometry/IDetector.h"
@@ -19,11 +16,11 @@ namespace Mantid {
 /// Typedef of a map from detector ID to detector shared pointer.
 typedef std::map<detid_t, Geometry::IDetector_const_sptr> detid2det_map;
 
+namespace Beamline {
+class DetectorInfo;
+}
 namespace Geometry {
 
-//------------------------------------------------------------------
-// Forward declarations
-//------------------------------------------------------------------
 class XMLInstrumentParameter;
 class ParameterMap;
 class ReferenceFrame;
@@ -251,6 +248,9 @@ public:
   /// @return Full if all detectors are rect., Partial if some, None if none
   ContainsState containsRectDetectors() const;
 
+  const Beamline::DetectorInfo *detectorInfo() const;
+  void setDetectorInfo(const Beamline::DetectorInfo *detectorInfo);
+
 private:
   /// Save information about a set of detectors to Nexus
   void saveDetectorSetInfoToNexus(::NeXus::File *file,
@@ -327,6 +327,10 @@ private:
 
   /// Pointer to the reference frame object.
   boost::shared_ptr<ReferenceFrame> m_referenceFrame;
+
+  /// Pointer to the DetectorInfo object. NULL unless the instrument is
+  /// associated with an ExperimentInfo object.
+  const Beamline::DetectorInfo *m_detectorInfo{nullptr};
 };
 
 } // namespace Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -248,8 +248,10 @@ public:
   /// @return Full if all detectors are rect., Partial if some, None if none
   ContainsState containsRectDetectors() const;
 
-  const Beamline::DetectorInfo *detectorInfo() const;
-  void setDetectorInfo(const Beamline::DetectorInfo *detectorInfo);
+  bool hasDetectorInfo() const;
+  const Beamline::DetectorInfo &detectorInfo() const;
+  void
+  setDetectorInfo(boost::shared_ptr<const Beamline::DetectorInfo> detectorInfo);
 
 private:
   /// Save information about a set of detectors to Nexus
@@ -330,7 +332,7 @@ private:
 
   /// Pointer to the DetectorInfo object. NULL unless the instrument is
   /// associated with an ExperimentInfo object.
-  const Beamline::DetectorInfo *m_detectorInfo{nullptr};
+  boost::shared_ptr<const Beamline::DetectorInfo> m_detectorInfo{nullptr};
 };
 
 } // namespace Geometry

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1245,7 +1245,7 @@ bool Instrument::hasDetectorInfo() const {
 /// Only for use by ExperimentInfo. Returns a reference to the DetectorInfo.
 const Beamline::DetectorInfo &Instrument::detectorInfo() const {
   if (!hasDetectorInfo())
-    throw std::runtime_error("CAnnot return reference to NULL DetectorInfo");
+    throw std::runtime_error("Cannot return reference to NULL DetectorInfo");
   return *m_detectorInfo;
 }
 

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1237,14 +1237,22 @@ Instrument::ContainsState Instrument::containsRectDetectors() const {
 
 } // containsRectDetectors
 
-/// Only for use by ExperimentInfo. Returns the pointer to the DetectorInfo.
-const Beamline::DetectorInfo *Instrument::detectorInfo() const {
-  return m_detectorInfo;
+/// Only for use by ExperimentInfo. Returns returns true if this instrument
+/// contains a DetectorInfo.
+bool Instrument::hasDetectorInfo() const {
+  return static_cast<bool>(m_detectorInfo);
+}
+/// Only for use by ExperimentInfo. Returns a reference to the DetectorInfo.
+const Beamline::DetectorInfo &Instrument::detectorInfo() const {
+  if (!hasDetectorInfo())
+    throw std::runtime_error("CAnnot return reference to NULL DetectorInfo");
+  return *m_detectorInfo;
 }
 
 /// Only for use by ExperimentInfo. Sets the pointer to the DetectorInfo.
-void Instrument::setDetectorInfo(const Beamline::DetectorInfo *detectorInfo) {
-  m_detectorInfo = detectorInfo;
+void Instrument::setDetectorInfo(
+    boost::shared_ptr<const Beamline::DetectorInfo> detectorInfo) {
+  m_detectorInfo = std::move(detectorInfo);
 }
 
 } // namespace Geometry

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -46,7 +46,8 @@ Instrument::Instrument(const boost::shared_ptr<const Instrument> instr,
       m_sampleCache(instr->m_sampleCache), m_defaultView(instr->m_defaultView),
       m_defaultViewAxis(instr->m_defaultViewAxis), m_instr(instr),
       m_map_nonconst(map), m_ValidFrom(instr->m_ValidFrom),
-      m_ValidTo(instr->m_ValidTo), m_referenceFrame(new ReferenceFrame) {}
+      m_ValidTo(instr->m_ValidTo), m_referenceFrame(new ReferenceFrame),
+      m_detectorInfo(instr->m_detectorInfo) {}
 
 /** Copy constructor
  *  This method was added to deal with having distinct neutronic and physical
@@ -62,7 +63,8 @@ Instrument::Instrument(const Instrument &instr)
       m_defaultViewAxis(instr.m_defaultViewAxis), m_instr(),
       m_map_nonconst(), /* Should not be parameterized */
       m_ValidFrom(instr.m_ValidFrom), m_ValidTo(instr.m_ValidTo),
-      m_referenceFrame(instr.m_referenceFrame) {
+      m_referenceFrame(instr.m_referenceFrame),
+      m_detectorInfo(instr.m_detectorInfo) {
   // Now we need to fill the detector, source and sample caches with pointers
   // into the new instrument
   std::vector<IComponent_const_sptr> children;
@@ -1234,6 +1236,16 @@ Instrument::ContainsState Instrument::containsRectDetectors() const {
     return Instrument::ContainsState::None;
 
 } // containsRectDetectors
+
+/// Only for use by ExperimentInfo. Returns the pointer to the DetectorInfo.
+const Beamline::DetectorInfo *Instrument::detectorInfo() const {
+  return m_detectorInfo;
+}
+
+/// Only for use by ExperimentInfo. Sets the pointer to the DetectorInfo.
+void Instrument::setDetectorInfo(const Beamline::DetectorInfo *detectorInfo) {
+  m_detectorInfo = detectorInfo;
+}
 
 } // namespace Geometry
 } // Namespace Mantid

--- a/Framework/MDAlgorithms/test/ConvertToMDMinMaxGlobalTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDMinMaxGlobalTest.h
@@ -221,9 +221,8 @@ private:
     }
 
     if (Ef > 0) {
-      Mantid::Geometry::ParameterMap pmap(ws->instrumentParameters());
+      auto &pmap = ws->instrumentParameters();
       pmap.addDouble(physicalPixel, "Efixed", Ef);
-      ws->replaceInstrumentParameters(pmap);
     }
     Mantid::Geometry::OrientedLattice latt(2, 3, 4, 90, 90, 90);
     ws->mutableSample().setOrientedLattice(&latt);

--- a/Framework/MDAlgorithms/test/ConvertToMDMinMaxGlobalTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDMinMaxGlobalTest.h
@@ -192,7 +192,6 @@ private:
 
     Mantid::Geometry::Instrument_sptr testInst(
         new Mantid::Geometry::Instrument);
-    ws->setInstrument(testInst);
     // Define a source and sample position
     // Define a source component
     Mantid::Geometry::ObjComponent *source = new Mantid::Geometry::ObjComponent(
@@ -212,6 +211,7 @@ private:
     physicalPixel->setPos(0.5, 0, 5.0);
     testInst->add(physicalPixel);
     testInst->markAsDetector(physicalPixel);
+    ws->setInstrument(testInst);
 
     ws->getSpectrum(0).addDetectorID(physicalPixel->getID());
 

--- a/Framework/MDAlgorithms/test/ConvertToMDMinMaxLocalTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDMinMaxLocalTest.h
@@ -240,11 +240,6 @@ private:
           new Mantid::Kernel::PropertyWithValue<double>("Ei", Ei));
     }
 
-    if (Ef > 0) {
-      Mantid::Geometry::ParameterMap pmap(ws->instrumentParameters());
-      pmap.addDouble(physicalPixel, "Efixed", Ef);
-      ws->replaceInstrumentParameters(pmap);
-    }
     Mantid::Geometry::OrientedLattice latt(2, 3, 4, 90, 90, 90);
     ws->mutableSample().setOrientedLattice(&latt);
 

--- a/Framework/MDAlgorithms/test/ConvertToMDMinMaxLocalTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDMinMaxLocalTest.h
@@ -212,7 +212,6 @@ private:
 
     Mantid::Geometry::Instrument_sptr testInst(
         new Mantid::Geometry::Instrument);
-    ws->setInstrument(testInst);
     // Define a source and sample position
     // Define a source component
     Mantid::Geometry::ObjComponent *source = new Mantid::Geometry::ObjComponent(
@@ -232,6 +231,7 @@ private:
     physicalPixel->setPos(0.5, 0, 5.0);
     testInst->add(physicalPixel);
     testInst->markAsDetector(physicalPixel);
+    ws->setInstrument(testInst);
 
     ws->getSpectrum(0).addDetectorID(physicalPixel->getID());
 

--- a/Framework/TestHelpers/src/InstrumentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/InstrumentCreationHelper.cpp
@@ -18,7 +18,6 @@ void addFullInstrumentToWorkspace(MatrixWorkspace &workspace,
   auto instrument = boost::make_shared<Instrument>(instrumentName);
   instrument->setReferenceFrame(
       boost::make_shared<ReferenceFrame>(Y, Z, Right, ""));
-  workspace.setInstrument(instrument);
 
   const double pixelRadius(0.05);
   Object_sptr pixelShape = ComponentCreationHelper::createCappedCylinder(
@@ -87,5 +86,6 @@ void addFullInstrumentToWorkspace(MatrixWorkspace &workspace,
   Component *chop_pos = new Component("chopper-position",
                                       Kernel::V3D(0, 0, -10), instrument.get());
   instrument->add(chop_pos);
+  workspace.setInstrument(instrument);
 }
 }

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -506,8 +506,6 @@ void createInstrumentForWorkspaceWithDistances(
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 
-  workspace->setInstrument(instrument);
-
   for (int i = 0; i < static_cast<int>(detectorPositions.size()); ++i) {
     std::stringstream buffer;
     buffer << "detector_" << i;
@@ -520,6 +518,7 @@ void createInstrumentForWorkspaceWithDistances(
     workspace->getSpectrum(i).clearDetectorIDs();
     workspace->getSpectrum(i).addDetectorID(det->getID());
   }
+  workspace->setInstrument(instrument);
 }
 
 //================================================================================================================


### PR DESCRIPTION
Soon masking and position information will be moved from `ParameterMap` into `DetectorInfo`. Code that handles `ParameterMap` objects must thus also include `DetectorInfo`.

Basically this is only `CopyInstrumentParameters`.

**To test:**

Code review. Note that this PR is based on https://github.com/mantidproject/mantid/pull/18276, but github is showing all changes.

Fixes #18263.

Internal change, no release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
