### PR TITLE
Indirect Transmission :: add ILL IN16B to available instruments

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IndirectTransmission.py
+++ b/Framework/PythonInterface/plugins/algorithms/IndirectTransmission.py
@@ -35,7 +35,7 @@ class IndirectTransmission(PythonAlgorithm):
 
     def PyInit(self):
         self.declareProperty(name='Instrument', defaultValue='IRIS',
-                             validator=StringListValidator(['IRIS', 'OSIRIS', 'TOSCA', 'BASIS', 'VISION']),
+                             validator=StringListValidator(['IRIS', 'OSIRIS', 'TOSCA', 'BASIS', 'VISION', 'IN16B']),
                              doc='Instrument')
 
         self.declareProperty(name='Analyser', defaultValue='graphite',
@@ -43,7 +43,7 @@ class IndirectTransmission(PythonAlgorithm):
                              doc='Analyser')
 
         self.declareProperty(name='Reflection', defaultValue='002',
-                             validator=StringListValidator(['002', '004', '006', '111']),
+                             validator=StringListValidator(['002', '004', '006', '111', '311']),
                              doc='Reflection')
 
         self.declareProperty(name='ChemicalFormula', defaultValue='', validator=StringMandatoryValidator(),

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmissionCalc.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmissionCalc.ui
@@ -33,6 +33,7 @@
           <property name="techniques" stdset="0">
            <stringlist>
             <string>TOF Indirect Geometry Spectroscopy</string>
+            <string>Reactor Indirect Geometry Spectroscopy</string>
            </stringlist>
           </property>
           <property name="disabledInstruments" stdset="0">
@@ -57,9 +58,6 @@
         <string>Sample Details</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
-        <property name="margin">
-         <number>9</number>
-        </property>
         <item row="0" column="0">
          <widget class="QLabel" name="lbChemicalFormula">
           <property name="text">


### PR DESCRIPTION
This adds the ILL IN16B instrument to available instruments list of `IndirectTransmission` algorithm.

**To test:**

1. Set ILL/IN16B as facility/instrument.
2. Go to Interfaces -> Indirect -> Tools -> Transmission tab.
3. You should now be able to select IN16B, silicon, 111.
4. Set some chemical formula, (e.g. D2-O) and run.
5. It should run without errors, and produce some table of results on the right hand side.


<!-- Instructions for testing. -->

Fixes #18280 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

Does not need to be in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
