### PR TITLE
Fix spelling of property value

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
@@ -197,7 +197,7 @@ class SNAPReduce(DataProcessorAlgorithm):
             if len(filename) <= 0:
                 issues[
                     "MaskingFilename"] = "Masking=\"%s\" requires a filename" % masking
-        elif masking == "MaskingWorkspace":
+        elif masking == "Masking Workspace":
             mask_workspace = self.getPropertyValue("MaskingWorkspace")
             if mask_workspace is None or len(mask_workspace) <= 0:
                 issues["MaskingWorkspace"] = "Must supply masking workspace"


### PR DESCRIPTION
A user discovered a bug when using a masking workspace rather than one of the other options. This is traced back to a spelling mistake (see diff).

```
Unexpected exception: Masking value "Masking Workspace" not supported
at line 205 in '/opt/mantidnightly/plugins/python/algorithms/SNAPReduce.py'
Continue working.
```

**To test:**

Just look at the diff.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

