### PR TITLE
Fix doc test for ConvertCWMDToHKL.

### DIFF
--- a/docs/source/algorithms/ConvertCWSDMDtoHKL-v1.rst
+++ b/docs/source/algorithms/ConvertCWSDMDtoHKL-v1.rst
@@ -79,12 +79,14 @@ Usage
 
   # Examine
   mdws = mtd['QSampleMD']
-  print 'Output MDEventWorkspace has %d events.'%(mdws.getNEvents())
-
   hklws = mtd['HKLMD']
-  print 'H: range from %.5f to %.5f.' % (hklws.getXDimension().getMinimum(), hklws.getXDimension().getMaximum())
-  print 'K: range from %.5f to %.5f.' % (hklws.getYDimension().getMinimum(), hklws.getYDimension().getMaximum())
-  print 'L: range from %.5f to %.5f.' % (hklws.getZDimension().getMinimum(), hklws.getZDimension().getMaximum())
+  print 'Output QSample and HKL workspaces have %d and %d events.'%(mdws.getNEvents(), hklws.getNEvents())
+
+  BinMD(InputWorkspace='HKLMD', AlignedDim0='H,-0.3,0.3,60', AlignedDim1='K,-0.4,0.5,90', AlignedDim2='L,4,8,10', OutputWorkspace='BinndHKL')
+  histws = mtd['BinndHKL']
+  events_array = histws.getNumEventsArray()
+  print 'events[22, 53, 5] = %.1f' % events_array[22, 53, 5]
+  print 'events[30, 40, 5] = %.1f' % events_array[30, 40, 5]
 
 ..
    .. testcleanup::  ExConvertHB3AToHKL
@@ -101,10 +103,9 @@ Usage
 
    .. testoutput:: ExConvertHB3AToHKL
 
-     Output MDEventWorkspace has 1631 events.
-     H: range from -0.26509 to 0.22324.
-     K: range from -0.33148 to 0.45354.
-     L: range from 4.92654 to 7.17077.
+     Output QSample and HKL workspaces have 1631 and 1631 events.
+     events[22, 53, 5] = 19.0
+     events[30, 40, 5] = 38.0
 
 .. categories::
 

--- a/docs/source/algorithms/ConvertCWSDMDtoHKL-v1.rst
+++ b/docs/source/algorithms/ConvertCWSDMDtoHKL-v1.rst
@@ -58,8 +58,7 @@ Usage
 
 **Example - Convert detector counts of an HB3A's measurement to HKL.**
 
-.. .. testcode:: ExConvertHB3AToHKL
-.. code-block:: python
+.. testcode:: ExConvertHB3AToHKL
 
   # Create input table workspaces for experiment information and virtual instrument parameters
   CollectHB3AExperimentInfo(ExperimentNumber='406', ScanList='298', PtLists='-1,22',
@@ -88,24 +87,23 @@ Usage
   print 'events[22, 53, 5] = %.1f' % events_array[22, 53, 5]
   print 'events[30, 40, 5] = %.1f' % events_array[30, 40, 5]
 
-..
-   .. testcleanup::  ExConvertHB3AToHKL
+.. testcleanup::  ExConvertHB3AToHKL
 
-     DeleteWorkspace(Workspace='QSampleMD')
-     DeleteWorkspace(Workspace='ExpInfoTable')
-     DeleteWorkspace(Workspace='VirtualInstrumentTable')
-     DeleteWorkspace(Workspace='HKLMD')
-     DeleteWorkspace(Workspace='HB3A_exp0406_scan0298')
-     DeleteWorkspace(Workspace='spicematrixws')
+  DeleteWorkspace(Workspace='QSampleMD')
+  DeleteWorkspace(Workspace='ExpInfoTable')
+  DeleteWorkspace(Workspace='VirtualInstrumentTable')
+  DeleteWorkspace(Workspace='HKLMD')
+  DeleteWorkspace(Workspace='HB3A_exp0406_scan0298')
+  DeleteWorkspace(Workspace='spicematrixws')
 
-..
-   Output:
 
-   .. testoutput:: ExConvertHB3AToHKL
+Output:
 
-     Output QSample and HKL workspaces have 1631 and 1631 events.
-     events[22, 53, 5] = 19.0
-     events[30, 40, 5] = 38.0
+.. testoutput:: ExConvertHB3AToHKL
+
+  Output QSample and HKL workspaces have 1631 and 1631 events.
+  events[22, 53, 5] = 19.0
+  events[30, 40, 5] = 38.0
 
 .. categories::
 


### PR DESCRIPTION
Fix the failed doc test of ConvertCWMDToHKL on some specific build server.

**To test:**

Previously the doc test passed by build server, Ubuntu+Document Test.  But it failed on a local 16.04LTS desktop.  The current test result comes from the local 16.06LTS desktop.  If it passes the documentation test on the " Ubuntu+Document Test" server, then the issue should be resolved.

Fixes #18277.

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

