### PR TITLE
Make vtkMDHWSignalArray accessible from multiple threads.

### DIFF
--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
@@ -260,7 +260,7 @@ template <class Scalar> void vtkMDHWSignalArray<Scalar>::ClearLookup() {
 //------------------------------------------------------------------------------
 template <class Scalar>
 double *vtkMDHWSignalArray<Scalar>::GetTuple(vtkIdType i) {
-  this->GetTuple(i, m_temporaryTuple);
+  m_temporaryTuple[0] = this->GetValue(i);
   return &m_temporaryTuple[0];
 }
 
@@ -318,7 +318,7 @@ Scalar vtkMDHWSignalArray<Scalar>::GetValue(vtkIdType idx) const {
 //------------------------------------------------------------------------------
 template <class Scalar>
 Scalar &vtkMDHWSignalArray<Scalar>::GetValueReference(vtkIdType idx) {
-  this->GetTypedTuple(idx, m_temporaryTuple);
+  m_temporaryTuple[0] = this->GetValue(idx);
   return m_temporaryTuple[0];
 }
 

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
@@ -118,7 +118,7 @@ private:
 
   std::size_t m_offset;
   VisualNormalization m_normalization;
-  Mantid::DataObjects::MDHistoWorkspace *m_ws;
+  DataObjects::MDHistoWorkspace *m_ws;
   Scalar m_temporaryTuple[1];
 };
 
@@ -251,36 +251,14 @@ template <class Scalar> void vtkMDHWSignalArray<Scalar>::ClearLookup() {
 //------------------------------------------------------------------------------
 template <class Scalar>
 double *vtkMDHWSignalArray<Scalar>::GetTuple(vtkIdType i) {
-  auto pos = m_offset + i;
-  switch (m_normalization) {
-  case API::NoNormalization:
-    m_temporaryTuple[0] = m_ws->getSignalAt(pos);
-    break;
-  case API::VolumeNormalization:
-    m_temporaryTuple[0] = m_ws->getSignalAt(pos) * m_ws->getInverseVolume();
-    break;
-  case API::NumEventsNormalization:
-    m_temporaryTuple[0] = m_ws->getSignalAt(pos) / m_ws->getNumEventsAt(pos);
-    break;
-  }
+  this->GetTuple(i, m_temporaryTuple);
   return &m_temporaryTuple[0];
 }
 
 //------------------------------------------------------------------------------
 template <class Scalar>
 void vtkMDHWSignalArray<Scalar>::GetTuple(vtkIdType i, double *tuple) {
-  auto pos = m_offset + i;
-  switch (m_normalization) {
-  case NoNormalization:
-    tuple[0] = m_ws->getSignalAt(pos);
-    break;
-  case VolumeNormalization:
-    tuple[0] = m_ws->getSignalAt(pos) * m_ws->getInverseVolume();
-    break;
-  case NumEventsNormalization:
-    tuple[0] = m_ws->getSignalAt(pos) / m_ws->getNumEventsAt(pos);
-    break;
-  }
+  tuple[0] = this->GetValue(i);
 }
 
 //------------------------------------------------------------------------------
@@ -329,18 +307,7 @@ Scalar vtkMDHWSignalArray<Scalar>::GetValue(vtkIdType idx) const {
 //------------------------------------------------------------------------------
 template <class Scalar>
 Scalar &vtkMDHWSignalArray<Scalar>::GetValueReference(vtkIdType idx) {
-  auto pos = m_offset + idx;
-  switch (m_normalization) {
-  case NoNormalization:
-    m_temporaryTuple[0] = m_ws->getSignalAt(pos);
-    break;
-  case VolumeNormalization:
-    m_temporaryTuple[0] = m_ws->getSignalAt(pos) * m_ws->getInverseVolume();
-    break;
-  case NumEventsNormalization:
-    m_temporaryTuple[0] = m_ws->getSignalAt(pos) / m_ws->getNumEventsAt(pos);
-    break;
-  }
+  this->GetTypedTuple(idx, m_temporaryTuple);
   return m_temporaryTuple[0];
 }
 
@@ -348,18 +315,7 @@ Scalar &vtkMDHWSignalArray<Scalar>::GetValueReference(vtkIdType idx) {
 template <class Scalar>
 void vtkMDHWSignalArray<Scalar>::GetTypedTuple(vtkIdType tupleId,
                                                Scalar *tuple) const {
-  auto pos = m_offset + tupleId;
-  switch (m_normalization) {
-  case NoNormalization:
-    tuple[0] = m_ws->getSignalAt(pos);
-    break;
-  case VolumeNormalization:
-    tuple[0] = m_ws->getSignalAt(pos) * m_ws->getInverseVolume();
-    break;
-  case NumEventsNormalization:
-    tuple[0] = m_ws->getSignalAt(pos) / m_ws->getNumEventsAt(pos);
-    break;
-  }
+  tuple[0] = this->GetValue(tupleId);
 }
 
 //------------------------------------------------------------------------------

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
@@ -312,6 +312,8 @@ Scalar vtkMDHWSignalArray<Scalar>::GetValue(vtkIdType idx) const {
   case API::NumEventsNormalization:
     return m_ws->getSignalAt(pos) / m_ws->getNumEventsAt(pos);
   }
+  // Should not reach here
+  return std::numeric_limits<signal_t>::quiet_NaN();
 }
 //------------------------------------------------------------------------------
 template <class Scalar>

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -122,8 +122,7 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
   vtkNew<vtkMDHWSignalArray<double>> signal;
 
   signal->SetName(vtkDataSetFactory::ScalarName.c_str());
-  signal->InitializeArray(m_workspace.get(), m_normalizationOption, offset,
-                          imageSize);
+  signal->InitializeArray(m_workspace.get(), m_normalizationOption, offset);
   visualDataSet->GetCellData()->SetScalars(signal.GetPointer());
 
   // update progress after a 1% change

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -1,8 +1,6 @@
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidKernel/CPUTimer.h"
 #include "MantidDataObjects/MDHistoWorkspace.h"
-#include "MantidDataObjects/MDHistoWorkspaceIterator.h"
-
 #include "MantidVatesAPI/vtkMDHWSignalArray.h"
 #include "MantidVatesAPI/Common.h"
 #include "MantidVatesAPI/Normalization.h"
@@ -121,14 +119,11 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
     offset = timestep * indexMultiplier[2];
   }
 
-  std::unique_ptr<MDHistoWorkspaceIterator> iterator(
-      dynamic_cast<MDHistoWorkspaceIterator *>(createIteratorWithNormalization(
-          m_normalizationOption, m_workspace.get())));
-
   vtkNew<vtkMDHWSignalArray<double>> signal;
 
   signal->SetName(vtkDataSetFactory::ScalarName.c_str());
-  signal->InitializeArray(std::move(iterator), offset, imageSize);
+  signal->InitializeArray(m_workspace.get(), m_normalizationOption, offset,
+                          imageSize);
   visualDataSet->GetCellData()->SetScalars(signal.GetPointer());
 
   // update progress after a 1% change

--- a/Vates/VatesAPI/test/vtkMDHWSignalArrayTest.h
+++ b/Vates/VatesAPI/test/vtkMDHWSignalArrayTest.h
@@ -34,9 +34,8 @@ public:
     const int nBinsY = static_cast<int>(ws_sptr->getYDimension()->getNBins());
     const int nBinsZ = static_cast<int>(ws_sptr->getZDimension()->getNBins());
     const int imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
-
     signal->InitializeArray(ws_sptr.get(), Mantid::VATES::NoNormalization,
-                            offset, imageSize);
+                            offset);
 
     for (auto index = 0; index < imageSize; ++index) {
       double output1[1];
@@ -80,8 +79,7 @@ public:
             createIteratorWithNormalization(
                 Mantid::VATES::NumEventsNormalization, ws_sptr.get())));
     signal->InitializeArray(ws_sptr.get(),
-                            Mantid::VATES::NumEventsNormalization, offset,
-                            imageSize);
+                            Mantid::VATES::NumEventsNormalization, offset);
 
     vtkNew<vtkIdList> ptIds;
 
@@ -107,17 +105,13 @@ public:
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 3, 4);
     vtkNew<vtkMDHWSignalArray<double>> signal;
     std::size_t offset = 0;
-    const int nBinsX = static_cast<int>(ws_sptr->getXDimension()->getNBins());
-    const int nBinsY = static_cast<int>(ws_sptr->getYDimension()->getNBins());
-    const int nBinsZ = static_cast<int>(ws_sptr->getZDimension()->getNBins());
-    const int imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
 
     ws_sptr->setMDMaskAt(0, true);
     ws_sptr->setMDMaskAt(7, true);
     ws_sptr->setMDMaskAt(42, true);
 
     signal->InitializeArray(ws_sptr.get(), Mantid::VATES::NoNormalization,
-                            offset, imageSize);
+                            offset);
 
     vtkNew<vtkIdList> idList1, idList2;
 
@@ -131,13 +125,8 @@ public:
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 3);
     vtkNew<vtkMDHWSignalArray<double>> signal;
     std::size_t offset = 0;
-    const int nBinsX = static_cast<int>(ws_sptr->getXDimension()->getNBins());
-    const int nBinsY = static_cast<int>(ws_sptr->getYDimension()->getNBins());
-    const int nBinsZ = static_cast<int>(ws_sptr->getZDimension()->getNBins());
-    const int imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
-
     signal->InitializeArray(ws_sptr.get(), Mantid::VATES::VolumeNormalization,
-                            offset, imageSize);
+                            offset);
 
     vtkNew<vtkDoubleArray> doubleArray;
     doubleArray->SetNumberOfComponents(1);
@@ -157,13 +146,9 @@ public:
         MDEventsTestHelper::makeFakeMDHistoWorkspace(8.0, 3, 10, 5.0);
     vtkNew<vtkMDHWSignalArray<double>> signal;
     std::size_t offset = 0;
-    const int nBinsX = static_cast<int>(ws_sptr->getXDimension()->getNBins());
-    const int nBinsY = static_cast<int>(ws_sptr->getYDimension()->getNBins());
-    const int nBinsZ = static_cast<int>(ws_sptr->getZDimension()->getNBins());
-    const int imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
 
     signal->InitializeArray(ws_sptr.get(), Mantid::VATES::NoNormalization,
-                            offset, imageSize);
+                            offset);
     TS_ASSERT(signal->LookupValue(1.0) == 0);
     TS_ASSERT(signal->LookupTypedValue(1.0) == 0);
   }
@@ -173,13 +158,8 @@ public:
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 3);
     vtkNew<vtkMDHWSignalArray<double>> signal;
     std::size_t offset = 0;
-    const int nBinsX = static_cast<int>(ws_sptr->getXDimension()->getNBins());
-    const int nBinsY = static_cast<int>(ws_sptr->getYDimension()->getNBins());
-    const int nBinsZ = static_cast<int>(ws_sptr->getZDimension()->getNBins());
-    const int imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
-
     signal->InitializeArray(ws_sptr.get(), Mantid::VATES::NoNormalization,
-                            offset, imageSize);
+                            offset);
 
     vtkNew<vtkIdList> idList1, idList2;
     signal->LookupValue(0.0, idList1.GetPointer());
@@ -210,8 +190,7 @@ public:
     imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
 
     m_signal->InitializeArray(ws_sptr.get(),
-                              Mantid::VATES::NumEventsNormalization, offset,
-                              imageSize);
+                              Mantid::VATES::NumEventsNormalization, offset);
   }
 
   void tearDown() override {}

--- a/Vates/VatesAPI/test/vtkMDHWSignalArrayTest.h
+++ b/Vates/VatesAPI/test/vtkMDHWSignalArrayTest.h
@@ -35,11 +35,8 @@ public:
     const int nBinsZ = static_cast<int>(ws_sptr->getZDimension()->getNBins());
     const int imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
 
-    std::unique_ptr<MDHistoWorkspaceIterator> iterator(
-        dynamic_cast<MDHistoWorkspaceIterator *>(
-            createIteratorWithNormalization(Mantid::VATES::NoNormalization,
-                                            ws_sptr.get())));
-    signal->InitializeArray(std::move(iterator), offset, imageSize);
+    signal->InitializeArray(ws_sptr.get(), Mantid::VATES::NoNormalization,
+                            offset, imageSize);
 
     for (auto index = 0; index < imageSize; ++index) {
       double output1[1];
@@ -82,7 +79,9 @@ public:
         dynamic_cast<MDHistoWorkspaceIterator *>(
             createIteratorWithNormalization(
                 Mantid::VATES::NumEventsNormalization, ws_sptr.get())));
-    signal->InitializeArray(std::move(iterator), offset, imageSize);
+    signal->InitializeArray(ws_sptr.get(),
+                            Mantid::VATES::NumEventsNormalization, offset,
+                            imageSize);
 
     vtkNew<vtkIdList> ptIds;
 
@@ -117,11 +116,8 @@ public:
     ws_sptr->setMDMaskAt(7, true);
     ws_sptr->setMDMaskAt(42, true);
 
-    std::unique_ptr<MDHistoWorkspaceIterator> iterator(
-        dynamic_cast<MDHistoWorkspaceIterator *>(
-            createIteratorWithNormalization(Mantid::VATES::NoNormalization,
-                                            ws_sptr.get())));
-    signal->InitializeArray(std::move(iterator), offset, imageSize);
+    signal->InitializeArray(ws_sptr.get(), Mantid::VATES::NoNormalization,
+                            offset, imageSize);
 
     vtkNew<vtkIdList> idList1, idList2;
 
@@ -140,11 +136,8 @@ public:
     const int nBinsZ = static_cast<int>(ws_sptr->getZDimension()->getNBins());
     const int imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
 
-    std::unique_ptr<MDHistoWorkspaceIterator> iterator(
-        dynamic_cast<MDHistoWorkspaceIterator *>(
-            createIteratorWithNormalization(Mantid::VATES::VolumeNormalization,
-                                            ws_sptr.get())));
-    signal->InitializeArray(std::move(iterator), offset, imageSize);
+    signal->InitializeArray(ws_sptr.get(), Mantid::VATES::VolumeNormalization,
+                            offset, imageSize);
 
     vtkNew<vtkDoubleArray> doubleArray;
     doubleArray->SetNumberOfComponents(1);
@@ -169,11 +162,8 @@ public:
     const int nBinsZ = static_cast<int>(ws_sptr->getZDimension()->getNBins());
     const int imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
 
-    std::unique_ptr<MDHistoWorkspaceIterator> iterator(
-        dynamic_cast<MDHistoWorkspaceIterator *>(
-            createIteratorWithNormalization(Mantid::VATES::NoNormalization,
-                                            ws_sptr.get())));
-    signal->InitializeArray(std::move(iterator), offset, imageSize);
+    signal->InitializeArray(ws_sptr.get(), Mantid::VATES::NoNormalization,
+                            offset, imageSize);
     TS_ASSERT(signal->LookupValue(1.0) == 0);
     TS_ASSERT(signal->LookupTypedValue(1.0) == 0);
   }
@@ -188,11 +178,8 @@ public:
     const int nBinsZ = static_cast<int>(ws_sptr->getZDimension()->getNBins());
     const int imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
 
-    std::unique_ptr<MDHistoWorkspaceIterator> iterator(
-        dynamic_cast<MDHistoWorkspaceIterator *>(
-            createIteratorWithNormalization(Mantid::VATES::NoNormalization,
-                                            ws_sptr.get())));
-    signal->InitializeArray(std::move(iterator), offset, imageSize);
+    signal->InitializeArray(ws_sptr.get(), Mantid::VATES::NoNormalization,
+                            offset, imageSize);
 
     vtkNew<vtkIdList> idList1, idList2;
     signal->LookupValue(0.0, idList1.GetPointer());
@@ -222,11 +209,9 @@ public:
     const int nBinsZ = static_cast<int>(ws_sptr->getZDimension()->getNBins());
     imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
 
-    std::unique_ptr<MDHistoWorkspaceIterator> iterator(
-        dynamic_cast<MDHistoWorkspaceIterator *>(
-            createIteratorWithNormalization(
-                Mantid::VATES::NumEventsNormalization, ws_sptr.get())));
-    m_signal->InitializeArray(std::move(iterator), offset, imageSize);
+    m_signal->InitializeArray(ws_sptr.get(),
+                              Mantid::VATES::NumEventsNormalization, offset,
+                              imageSize);
   }
 
   void tearDown() override {}


### PR DESCRIPTION
Description of work.

This modifies `vtkMDHWSignalArray` to retrieve values from the `MDHistoWorkspace` directly instead of using the the (not threadsafe) `MDHistoWorkspaceIterator`. This, along with PR #18288 will make it possible to perform [this loop](https://github.com/mantidproject/mantid/blob/793647337b1460588c05824536bc8588ebff70b0/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp#L136) in parallel.

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

