### PR TITLE
Remove uses of IDetector::isMasked from unit tests.

### DIFF
--- a/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
+++ b/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
@@ -2,6 +2,7 @@
 #define MANTID_API_MATRIXWORKSPACEMDITERATORTEST_H_
 
 #include "MantidAPI/MatrixWorkspaceMDIterator.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/Detector.h"
 #include "MantidTestHelpers/FakeObjects.h"
@@ -120,9 +121,9 @@ public:
   void test_get_is_masked() {
     boost::shared_ptr<MatrixWorkspace> ws = makeFakeWS();
     IMDIterator *it = ws->createIterator(NULL);
+    const auto &spectrumInfo = ws->spectrumInfo();
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
-      Mantid::Geometry::IDetector_const_sptr det = ws->getDetector(i);
-      TS_ASSERT_EQUALS(det->isMasked(), it->getIsMasked());
+      TS_ASSERT_EQUALS(spectrumInfo.isMasked(i), it->getIsMasked());
       it->next();
     }
     delete it;

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -249,17 +249,12 @@ public:
         makeWorkspaceWithDetectors(3, 1));
 
     // Initially un masked
+    const auto &spectrumInfo = workspace->spectrumInfo();
     for (int i = 0; i < numHist; ++i) {
       TS_ASSERT_EQUALS(workspace->readY(i)[0], 1.0);
       TS_ASSERT_EQUALS(workspace->readE(i)[0], 1.0);
-
-      IDetector_const_sptr det;
-      TS_ASSERT_THROWS_NOTHING(det = workspace->getDetector(i));
-      if (det) {
-        TS_ASSERT_EQUALS(det->isMasked(), false);
-      } else {
-        TS_FAIL("No detector defined");
-      }
+      TS_ASSERT(spectrumInfo.hasDetectors(i));
+      TS_ASSERT_EQUALS(spectrumInfo.isMasked(i), false);
     }
 
     // Mask a spectra
@@ -268,6 +263,7 @@ public:
     workspace->mutableSpectrumInfo().setMasked(1, true);
     workspace->mutableSpectrumInfo().setMasked(2, true);
 
+    const auto &spectrumInfo2 = workspace->spectrumInfo();
     for (int i = 0; i < numHist; ++i) {
       double expectedValue(0.0);
       bool expectedMasked(false);
@@ -279,14 +275,8 @@ public:
       }
       TS_ASSERT_EQUALS(workspace->readY(i)[0], expectedValue);
       TS_ASSERT_EQUALS(workspace->readE(i)[0], expectedValue);
-
-      IDetector_const_sptr det;
-      TS_ASSERT_THROWS_NOTHING(det = workspace->getDetector(i));
-      if (det) {
-        TS_ASSERT_EQUALS(det->isMasked(), expectedMasked);
-      } else {
-        TS_FAIL("No detector defined");
-      }
+      TS_ASSERT(spectrumInfo2.hasDetectors(i));
+      TS_ASSERT_EQUALS(spectrumInfo2.isMasked(i), expectedMasked);
     }
   }
 

--- a/Framework/Algorithms/test/AppendSpectraTest.h
+++ b/Framework/Algorithms/test/AppendSpectraTest.h
@@ -97,8 +97,8 @@ public:
                      in2->getAxis(1)->spectraNo(2));
 
     // Check masking
-    TS_ASSERT_EQUALS(output->getDetector(maskTop)->isMasked(), true);
-    TS_ASSERT_EQUALS(output->getDetector(10 + maskBottom)->isMasked(), true);
+    TS_ASSERT_EQUALS(output->spectrumInfo().isMasked(maskTop), true);
+    TS_ASSERT_EQUALS(output->spectrumInfo().isMasked(10 + maskBottom), true);
   }
 
   //----------------------------------------------------------------------------------------------

--- a/Framework/Algorithms/test/CalculateEfficiencyTest.h
+++ b/Framework/Algorithms/test/CalculateEfficiencyTest.h
@@ -3,6 +3,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAlgorithms/CalculateEfficiency.h"
 #include "MantidDataHandling/LoadSpice2D.h"
 #include "MantidDataHandling/MoveInstrumentComponent.h"
@@ -100,12 +101,9 @@ public:
                     0.4502, tolerance);
 
     // Check that pixels that were out of range were masked
-    TS_ASSERT(
-        !ws2d_out->getDetector(5 + SANSInstrumentCreationHelper::nMonitors)
-             ->isMasked())
-    TS_ASSERT(
-        !ws2d_out->getDetector(1 + SANSInstrumentCreationHelper::nMonitors)
-             ->isMasked())
+    const auto &oSpecInfo = ws2d_out->spectrumInfo();
+    TS_ASSERT(!oSpecInfo.isMasked(5 + SANSInstrumentCreationHelper::nMonitors));
+    TS_ASSERT(!oSpecInfo.isMasked(1 + SANSInstrumentCreationHelper::nMonitors));
 
     // Repeat the calculation by excluding high/low pixels
 
@@ -145,11 +143,9 @@ public:
                     0.5002, tolerance);
 
     // Check that pixels that were out of range were masked
-    TS_ASSERT(ws2d_out->getDetector(5 + SANSInstrumentCreationHelper::nMonitors)
-                  ->isMasked())
-    TS_ASSERT(
-        !ws2d_out->getDetector(1 + SANSInstrumentCreationHelper::nMonitors)
-             ->isMasked())
+    const auto &oSpecInfo2 = ws2d_out->spectrumInfo();
+    TS_ASSERT(oSpecInfo2.isMasked(5 + SANSInstrumentCreationHelper::nMonitors));
+    TS_ASSERT(!oSpecInfo2.isMasked(1 + SANSInstrumentCreationHelper::nMonitors));
 
     Mantid::API::AnalysisDataService::Instance().remove(inputWS);
     Mantid::API::AnalysisDataService::Instance().remove(outputWS);
@@ -232,9 +228,10 @@ public:
     TS_ASSERT_DELTA(ws2d_out->e(6 + nmon)[0], 0.105261, tolerance);
 
     // Check that pixels that were out of range were masked
-    TS_ASSERT(ws2d_out->getDetector(1826)->isMasked())
-    TS_ASSERT(ws2d_out->getDetector(2014)->isMasked())
-    TS_ASSERT(ws2d_out->getDetector(2015)->isMasked())
+    const auto &oSpecInfo = ws2d_out->spectrumInfo();
+    TS_ASSERT(oSpecInfo.isMasked(1826));
+    TS_ASSERT(oSpecInfo.isMasked(2014));
+    TS_ASSERT(oSpecInfo.isMasked(2015));
 
     Mantid::API::AnalysisDataService::Instance().remove(inputWS);
     Mantid::API::AnalysisDataService::Instance().remove(outputWS);

--- a/Framework/Algorithms/test/CalculateEfficiencyTest.h
+++ b/Framework/Algorithms/test/CalculateEfficiencyTest.h
@@ -145,7 +145,8 @@ public:
     // Check that pixels that were out of range were masked
     const auto &oSpecInfo2 = ws2d_out->spectrumInfo();
     TS_ASSERT(oSpecInfo2.isMasked(5 + SANSInstrumentCreationHelper::nMonitors));
-    TS_ASSERT(!oSpecInfo2.isMasked(1 + SANSInstrumentCreationHelper::nMonitors));
+    TS_ASSERT(
+        !oSpecInfo2.isMasked(1 + SANSInstrumentCreationHelper::nMonitors));
 
     Mantid::API::AnalysisDataService::Instance().remove(inputWS);
     Mantid::API::AnalysisDataService::Instance().remove(outputWS);

--- a/Framework/Algorithms/test/ConjoinWorkspacesTest.h
+++ b/Framework/Algorithms/test/ConjoinWorkspacesTest.h
@@ -115,8 +115,9 @@ public:
                      in2->getAxis(1)->spectraNo(2));
 
     // Check masking
-    TS_ASSERT_EQUALS(output->getDetector(maskTop)->isMasked(), true);
-    TS_ASSERT_EQUALS(output->getDetector(10 + maskBottom)->isMasked(), true);
+    const auto &spectrumInfo = output->spectrumInfo();
+    TS_ASSERT_EQUALS(spectrumInfo.isMasked(maskTop), true);
+    TS_ASSERT_EQUALS(spectrumInfo.isMasked(10 + maskBottom), true);
 
     // Check that 2nd input workspace no longer exists
     TS_ASSERT_THROWS(AnalysisDataService::Instance().retrieve("bottom"),

--- a/Framework/Algorithms/test/ExtractMaskToTableTest.h
+++ b/Framework/Algorithms/test/ExtractMaskToTableTest.h
@@ -7,6 +7,7 @@
 #include "MantidAlgorithms/ExtractMask.h"
 #include "MantidAlgorithms/SumNeighbours.h"
 #include "MantidAlgorithms/MaskDetectorsIf.h"
+#include "MantidAPI/DetectorInfo.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidDataObjects/Workspace2D.h"
@@ -375,12 +376,11 @@ public:
       cout << "Workspace masked."
            << "\n";
 
-    Instrument_const_sptr instrument = inputws->getInstrument();
-    for (size_t i = 0; i < instrument->getDetectorIDs().size(); ++i) {
-      if (instrument->getDetector(instrument->getDetectorIDs()[i])->isMasked())
-        cout << "Detector : " << instrument->getDetectorIDs()[i]
-             << " is masked."
-             << "\n";
+    const auto &detectorInfo = inputws->detectorInfo();
+    for (size_t i = 0; i < detectorInfo.size(); ++i) {
+      if (detectorInfo.isMasked(i))
+        cout << "Detector : " << detectorInfo.detectorIDs()[i]
+             << " is masked.\n";
     }
 
     /*

--- a/Framework/Algorithms/test/GetDetOffsetsMultiPeaksTest.h
+++ b/Framework/Algorithms/test/GetDetOffsetsMultiPeaksTest.h
@@ -5,6 +5,7 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
+#include "MantidAPI/DetectorInfo.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidDataObjects/OffsetsWorkspace.h"
@@ -88,7 +89,7 @@ public:
             maskWS));
     if (!mask)
       return;
-    TS_ASSERT(!mask->getInstrument()->getDetector(1)->isMasked());
+    TS_ASSERT(!mask->detectorInfo().isMasked(0));
   }
 
   //----------------------------------------------------------------------------------------------
@@ -143,7 +144,7 @@ public:
             maskWS));
     if (!mask)
       return;
-    TS_ASSERT(!mask->getInstrument()->getDetector(1)->isMasked());
+    TS_ASSERT(!mask->detectorInfo().isMasked(0));
   }
 
   //----------------------------------------------------------------------------------------------
@@ -214,7 +215,7 @@ public:
             maskWS));
     if (!mask)
       return;
-    TS_ASSERT(!mask->getInstrument()->getDetector(1)->isMasked());
+    TS_ASSERT(!mask->detectorInfo().isMasked(0));
   }
 
   //----------------------------------------------------------------------------------------------
@@ -285,7 +286,7 @@ public:
             maskWS));
     if (!mask)
       return;
-    TS_ASSERT(!mask->getInstrument()->getDetector(1)->isMasked());
+    TS_ASSERT(!mask->detectorInfo().isMasked(0));
   }
 
   //----------------------------------------------------------------------------------------------
@@ -355,7 +356,7 @@ public:
             maskWS));
     if (!mask)
       return;
-    TS_ASSERT(!mask->getInstrument()->getDetector(1)->isMasked());
+    TS_ASSERT(!mask->detectorInfo().isMasked(0));
   }
 
   //----------------------------------------------------------------------------------------------
@@ -416,7 +417,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         mask = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             maskWS));
-    TS_ASSERT(mask->getInstrument()->getDetector(1)->isMasked());
+    TS_ASSERT(mask->detectorInfo().isMasked(0));
 
     return;
   }

--- a/Framework/Algorithms/test/GetDetectorOffsetsTest.h
+++ b/Framework/Algorithms/test/GetDetectorOffsetsTest.h
@@ -9,6 +9,7 @@
 #include <cxxtest/TestSuite.h>
 #include "MantidDataObjects/OffsetsWorkspace.h"
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/DetectorInfo.h"
 #include "MantidAPI/FrameworkManager.h"
 
 using namespace Mantid::API;
@@ -85,7 +86,7 @@ public:
             maskWS));
     if (!mask)
       return;
-    TS_ASSERT(!mask->getInstrument()->getDetector(1)->isMasked());
+    TS_ASSERT(!mask->detectorInfo().isMasked(0));
   }
 
   void testExecWithGroup() {
@@ -136,7 +137,7 @@ public:
             maskWS));
     if (!mask)
       return;
-    TS_ASSERT(!mask->getInstrument()->getDetector(1)->isMasked());
+    TS_ASSERT(!mask->detectorInfo().isMasked(0));
   }
 
   void testExecAbsolute() {
@@ -191,7 +192,7 @@ public:
             maskWS));
     if (!mask)
       return;
-    TS_ASSERT(!mask->getInstrument()->getDetector(1)->isMasked());
+    TS_ASSERT(!mask->detectorInfo().isMasked(0));
   }
 
 private:

--- a/Framework/Algorithms/test/IntegrateByComponentTest.h
+++ b/Framework/Algorithms/test/IntegrateByComponentTest.h
@@ -4,6 +4,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/DetectorInfo.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAlgorithms/IntegrateByComponent.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
@@ -224,11 +225,12 @@ public:
     TS_ASSERT(result);
     if (!result)
       return;
+    const auto &spectrumInfo = result->spectrumInfo();
     for (size_t i = 0; i < result->getNumberHistograms() / 4; i++) {
       TS_ASSERT_DELTA(result->readY(4 * i + 1)[0], 8 * i + 4, 1e-10);
       TS_ASSERT_DELTA(result->readY(4 * i + 2)[0], 8 * i + 4, 1e-10);
       TS_ASSERT_DELTA(result->readY(4 * i + 3)[0], 8 * i + 4, 1e-10);
-      TS_ASSERT(result->getDetector(4 * i)->isMasked());
+      TS_ASSERT(spectrumInfo.isMasked(4 * i));
     }
 
     // Remove workspace from the data service.

--- a/Framework/Algorithms/test/MultiplyDivideTest.in.h
+++ b/Framework/Algorithms/test/MultiplyDivideTest.in.h
@@ -11,6 +11,7 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidDataObjects/EventWorkspaceHelpers.h"
@@ -956,18 +957,17 @@ public:
     MatrixWorkspace_sptr output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("work_in1");
     TS_ASSERT(output);
 
+    const auto &spectrumInfo = output->spectrumInfo();
     for( int i = 0; i < nHist; ++i )
     {
-      IDetector_const_sptr det = output->getDetector(i);
-      TS_ASSERT(det);
-      if( !det ) TS_FAIL("No detector found");
+      TS_ASSERT(spectrumInfo.hasDetectors(i));
       if( masking.count(i) == 0 )
       {
-        TS_ASSERT_EQUALS(det->isMasked(), false);
+        TS_ASSERT_EQUALS(spectrumInfo.isMasked(i), false);
       }
       else
       {
-        TS_ASSERT_EQUALS(det->isMasked(), true);
+        TS_ASSERT_EQUALS(spectrumInfo.isMasked(i), true);
         double yValue = output->readY(i)[0];
         TS_ASSERT_EQUALS(yValue, yValue );
         TS_ASSERT( !std::isinf(yValue) );

--- a/Framework/CurveFitting/test/Algorithms/SeqDomainSpectrumCreatorTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SeqDomainSpectrumCreatorTest.h
@@ -17,6 +17,7 @@
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/SpectrumInfo.h"
 
 #include "MantidTestHelpers/HistogramDataTestHelper.h"
 
@@ -245,9 +246,10 @@ public:
       const auto &y = outputWsMatrix->y(i);
 
       TS_ASSERT_EQUALS(x, matrixWs->x(i));
+      const auto &spectrumInfo = outputWsMatrix->spectrumInfo();
       for (size_t j = 0; j < x.size(); ++j) {
         // If detector is not masked, there should be values, otherwise 0.
-        if (!outputWsMatrix->getDetector(i)->isMasked()) {
+        if (!spectrumInfo.isMasked(i)) {
           TS_ASSERT_EQUALS(y[j], static_cast<double>(i) + slope * x[j]);
         } else {
           TS_ASSERT_EQUALS(y[j], 0.0);


### PR DESCRIPTION
Remove uses of the older masking interface and use `SpectrumInfo` or `DetectorInfo` instead.

**To test:**

Code review.

Fixes #18301.

Internal change, no release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

