### PR TITLE
Store masking information in class DetectorInfo

### DIFF
--- a/Framework/API/inc/MantidAPI/SpectrumInfo.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfo.h
@@ -91,6 +91,7 @@ private:
   const Geometry::IDetector &getDetector(const size_t index) const;
   std::vector<boost::shared_ptr<const Geometry::IDetector>>
   getDetectorVector(const size_t index) const;
+  std::vector<size_t> getDetectorIndices(const size_t index) const;
 
   const ExperimentInfo &m_experimentInfo;
   DetectorInfo *m_mutableDetectorInfo{nullptr};

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -57,7 +57,7 @@ bool DetectorInfo::isMonitor(const size_t index) const {
 
 /// Returns true if the detector is a masked.
 bool DetectorInfo::isMasked(const size_t index) const {
-  return getDetector(index).isMasked();
+  return m_detectorInfo.isMasked(index);
 }
 
 /** Returns L2 (distance from sample to spectrum).
@@ -113,16 +113,17 @@ Kernel::Quat DetectorInfo::rotation(const size_t index) const {
 
 /// Set the mask flag of the detector with given index. Not thread safe.
 void DetectorInfo::setMasked(const size_t index, bool masked) {
-  // Note that masking via the ParameterMap is actually thread safe, but it will
-  // not be with upcoming internal changes.
-  m_pmap->addBool(&getDetector(index), "masked", masked);
+  m_detectorInfo.setMasked(index, masked);
 }
 
 /** Sets all mask flags to false (unmasked). Not thread safe.
  *
  * This method was introduced to help with refactoring and may be removed in the
  *future. */
-void DetectorInfo::clearMaskFlags() { m_pmap->clearParametersByName("masked"); }
+void DetectorInfo::clearMaskFlags() {
+  for (size_t i = 0; i < size(); ++i)
+    m_detectorInfo.setMasked(i, false);
+}
 
 /// Set the absolute position of the detector with given index. Not thread safe.
 void DetectorInfo::setPosition(const size_t index,

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1324,8 +1324,7 @@ void ExperimentInfo::populateWithParameter(
     if (!det)
       throw std::runtime_error(
           "Found masking for a non-detector component. This is not possible");
-    m_detectorInfo->setMasked(m_detectorInfoWrapper->indexOf(det->getID()),
-                              paramValue);
+    m_detectorInfo->setMasked(detectorInfo().indexOf(det->getID()), paramValue);
   } else if (name.compare("x") == 0 || name.compare("y") == 0 ||
              name.compare("z") == 0) {
     paramMap.addPositionCoordinate(paramInfo.m_component, name, paramValue);

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -9,6 +9,8 @@
 
 #include "MantidGeometry/Instrument/InstrumentDefinitionParser.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidGeometry/Instrument/Detector.h"
+#include "MantidGeometry/Instrument/ParameterFactory.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
 #include "MantidGeometry/Instrument/XMLInstrumentParameter.h"
@@ -24,6 +26,7 @@
 #include "MantidKernel/make_unique.h"
 
 #include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/regex.hpp>
 
@@ -1275,7 +1278,23 @@ void ExperimentInfo::readParameterMap(const std::string &parameterStr) {
     int size = static_cast<int>(tokens.count());
     for (int i = 4; i < size; i++)
       paramValue += ";" + tokens[4];
-    pmap.add(tokens[1], comp, tokens[2], paramValue);
+
+    if (tokens[2].compare("masked") == 0) {
+      // Do not add masking to ParameterMap, it is stored in DetectorInfo
+      const auto det = dynamic_cast<const Detector *const>(comp);
+      if (!det)
+        throw std::runtime_error(
+            "Found masking for a non-detector component. This is not possible");
+      const auto &type = tokens[1];
+      const std::string name = "dummy";
+      auto param = ParameterFactory::create(type, name);
+      param->fromString(paramValue);
+      bool value = param->value<bool>();
+      m_detectorInfo->setMasked(m_detectorInfoWrapper->indexOf(det->getID()),
+                                value);
+    } else {
+      pmap.add(tokens[1], comp, tokens[2], paramValue);
+    }
   }
 }
 
@@ -1300,8 +1319,16 @@ void ExperimentInfo::populateWithParameter(
     pDescription = &paramInfo.m_description;
 
   // Some names are special. Values should be convertible to double
-  if (name.compare("x") == 0 || name.compare("y") == 0 ||
-      name.compare("z") == 0) {
+  if (name.compare("masked") == 0) {
+    // Do not add masking to ParameterMap, it is stored in DetectorInfo
+    const auto det = dynamic_cast<const Detector *const>(paramInfo.m_component);
+    if (!det)
+      throw std::runtime_error(
+          "Found masking for a non-detector component. This is not possible");
+    m_detectorInfo->setMasked(m_detectorInfoWrapper->indexOf(det->getID()),
+                              paramValue);
+  } else if (name.compare("x") == 0 || name.compare("y") == 0 ||
+             name.compare("z") == 0) {
     paramMap.addPositionCoordinate(paramInfo.m_component, name, paramValue);
   } else if (name.compare("rot") == 0 || name.compare("rotx") == 0 ||
              name.compare("roty") == 0 || name.compare("rotz") == 0) {

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1290,8 +1290,7 @@ void ExperimentInfo::readParameterMap(const std::string &parameterStr) {
       auto param = ParameterFactory::create(type, name);
       param->fromString(paramValue);
       bool value = param->value<bool>();
-      m_detectorInfo->setMasked(m_detectorInfoWrapper->indexOf(det->getID()),
-                                value);
+      m_detectorInfo->setMasked(detectorInfo().indexOf(det->getID()), value);
     } else {
       pmap.add(tokens[1], comp, tokens[2], paramValue);
     }

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -754,7 +754,7 @@ MatrixWorkspace::getDetector(const size_t workspaceIndex) const {
   }
   // Else need to construct a DetectorGroup and return that
   auto dets_ptr = localInstrument->getDetectors(dets);
-  return boost::make_shared<Geometry::DetectorGroup>(dets_ptr, false);
+  return boost::make_shared<Geometry::DetectorGroup>(dets_ptr);
 }
 
 /** Returns the signed 2Theta scattering angle for a detector

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -34,7 +34,10 @@ bool SpectrumInfo::isMonitor(const size_t index) const {
 
 /// Returns true if the detector(s) associated with the spectrum are masked.
 bool SpectrumInfo::isMasked(const size_t index) const {
-  return getDetector(index).isMasked();
+  bool masked = true;
+  for (const auto detIndex : getDetectorIndices(index))
+    masked &= m_detectorInfo.isMasked(detIndex);
+  return masked;
 }
 
 /** Returns L2 (distance from sample to spectrum).
@@ -139,11 +142,8 @@ bool SpectrumInfo::hasUniqueDetector(const size_t index) const {
  *
  * Currently this simply sets the mask flags for the underlying detectors. */
 void SpectrumInfo::setMasked(const size_t index, bool masked) {
-  for (const auto &det : getDetectorVector(index)) {
-    const auto detIndex = m_detectorInfo.indexOf(det->getID());
-    m_detectorInfo.setCachedDetector(detIndex, det);
+  for (const auto detIndex : getDetectorIndices(index))
     m_mutableDetectorInfo->setMasked(detIndex, masked);
-  }
 }
 
 /// Return a const reference to the detector or detector group of the spectrum
@@ -218,6 +218,22 @@ SpectrumInfo::getDetectorVector(const size_t index) const {
     size_t thread = static_cast<size_t>(PARALLEL_THREAD_NUMBER);
     return {m_lastDetector[thread]};
   }
+}
+
+std::vector<size_t> SpectrumInfo::getDetectorIndices(const size_t index) const {
+  std::vector<size_t> detIndices;
+  const auto &validDetectorIDs = m_detectorInfo.detectorIDs();
+  for (const auto &id : m_experimentInfo.detectorIDsInGroup(index)) {
+    const auto &it = std::lower_bound(validDetectorIDs.cbegin(),
+                                      validDetectorIDs.cend(), id);
+    if (it != validDetectorIDs.cend() && *it == id) {
+      detIndices.push_back(m_detectorInfo.indexOf(id));
+    }
+  }
+  if (detIndices.empty())
+    throw Kernel::Exception::NotFoundError(
+        "SpectrumInfo: No detectors for this workspace index.", "");
+  return detIndices;
 }
 
 } // namespace API

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -201,7 +201,7 @@ const Geometry::IDetector &SpectrumInfo::getDetector(const size_t index) const {
       }
     }
     m_lastDetector[thread] =
-        boost::make_shared<Geometry::DetectorGroup>(det_ptrs, false);
+        boost::make_shared<Geometry::DetectorGroup>(det_ptrs);
   }
 
   return *m_lastDetector[thread];

--- a/Framework/API/test/DetectorInfoTest.h
+++ b/Framework/API/test/DetectorInfoTest.h
@@ -32,11 +32,10 @@ public:
         m_workspace, includeMonitors, startYNegative, instrumentName);
 
     std::set<int64_t> toMask{0, 3};
-    ParameterMap &pmap = m_workspace.instrumentParameters();
+    auto &detInfo = m_workspace.mutableDetectorInfo();
     for (size_t i = 0; i < m_workspace.getNumberHistograms(); ++i) {
       if (toMask.find(i) != toMask.end()) {
-        IDetector_const_sptr det = m_workspace.getDetector(i);
-        pmap.addBool(det.get(), "masked", true);
+        detInfo.setMasked(i, true);
       }
     }
 
@@ -340,12 +339,11 @@ private:
       inst->markAsDetector(det);
     }
     ws->setInstrument(inst);
-    auto &pmap = ws->instrumentParameters();
+    auto &detInfo = ws->mutableDetectorInfo();
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
       ws->getSpectrum(i).addDetectorID(static_cast<detid_t>(i));
-      const auto &det = ws->getDetector(i);
       if (i % 2 == 0)
-        pmap.addBool(det->getComponentID(), "masked", true);
+        detInfo.setMasked(i, true);
     }
     return std::move(ws);
   }

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -756,6 +756,19 @@ public:
     TS_ASSERT(target.detectorInfo().isMasked(0));
   }
 
+  void test_getInstrument_setInstrument_copy_on_write_not_broken() {
+    auto inst = ComponentCreationHelper::createTestInstrumentCylindrical(1);
+    ExperimentInfo source;
+    ExperimentInfo target;
+    source.setInstrument(inst);
+    target.setInstrument(inst);
+
+    TS_ASSERT(!target.detectorInfo().isMasked(0));
+    target.setInstrument(source.getInstrument());
+    source.mutableDetectorInfo().setMasked(0, true);
+    TS_ASSERT(!target.detectorInfo().isMasked(0));
+  }
+
 private:
   void addInstrumentWithParameter(ExperimentInfo &expt, const std::string &name,
                                   const std::string &value) {

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -1,6 +1,7 @@
 #ifndef MANTID_API_EXPERIMENTINFOTEST_H_
 #define MANTID_API_EXPERIMENTINFOTEST_H_
 
+#include "MantidAPI/DetectorInfo.h"
 #include "MantidAPI/ExperimentInfo.h"
 #include "MantidAPI/ChopperModel.h"
 #include "MantidAPI/ModeratorModel.h"
@@ -740,6 +741,19 @@ public:
     TS_ASSERT_THROWS_NOTHING(eiCastNonConst = (ExperimentInfo_sptr)val);
     TS_ASSERT(eiCastNonConst != NULL);
     TS_ASSERT_EQUALS(eiCastConst, eiCastNonConst);
+  }
+
+  void test_getInstrument_setInstrument_copies_masking() {
+    auto inst = ComponentCreationHelper::createTestInstrumentCylindrical(1);
+    ExperimentInfo source;
+    ExperimentInfo target;
+    source.setInstrument(inst);
+    target.setInstrument(inst);
+
+    source.mutableDetectorInfo().setMasked(0, true);
+    TS_ASSERT(!target.detectorInfo().isMasked(0));
+    target.setInstrument(source.getInstrument());
+    TS_ASSERT(target.detectorInfo().isMasked(0));
   }
 
 private:

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -3,6 +3,7 @@
 #include "MantidAlgorithms/Qhelper.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/CommonBinsValidator.h"
+#include "MantidAPI/DetectorInfo.h"
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/ISpectrum.h"
@@ -382,11 +383,17 @@ void Q1D2::calculateNormalization(
 void Q1D2::pixelWeight(API::MatrixWorkspace_const_sptr pixelAdj,
                        const size_t wsIndex, double &weight,
                        double &error) const {
-  const V3D samplePos = m_dataWS->getInstrument()->getSample()->getPos();
+  const auto &detectorInfo = m_dataWS->detectorInfo();
+  const V3D samplePos = detectorInfo.samplePosition();
 
-  if (m_doSolidAngle)
-    weight = m_dataWS->getDetector(wsIndex)->solidAngle(samplePos);
-  else
+  if (m_doSolidAngle) {
+    weight = 0.0;
+    for (const auto detID : m_dataWS->getSpectrum(wsIndex).getDetectorIDs()) {
+      const auto index = detectorInfo.indexOf(detID);
+      if (!detectorInfo.isMasked(index))
+        weight += detectorInfo.detector(index).solidAngle(samplePos);
+    }
+  } else
     weight = 1.0;
 
   if (weight < 1e-200) {

--- a/Framework/Algorithms/src/Qxy.cpp
+++ b/Framework/Algorithms/src/Qxy.cpp
@@ -122,6 +122,7 @@ void Qxy::exec() {
   Progress prog(this, 0.05, 1.0, numSpec);
 
   const auto &spectrumInfo = inputWorkspace->spectrumInfo();
+  const auto &detectorInfo = inputWorkspace->detectorInfo();
 
   // the samplePos is often not (0, 0, 0) because the instruments components are
   // moved to account for the beam centre
@@ -165,7 +166,12 @@ void Qxy::exec() {
 
     // the solid angle of the detector as seen by the sample is used for
     // normalisation later on
-    double angle = spectrumInfo.detector(i).solidAngle(samplePos);
+    double angle = 0.0;
+    for (const auto detID : inputWorkspace->getSpectrum(i).getDetectorIDs()) {
+      const auto index = detectorInfo.indexOf(detID);
+      if (!detectorInfo.isMasked(index))
+        angle += detectorInfo.detector(index).solidAngle(samplePos);
+    }
 
     // some bins are masked completely or partially, the following vector will
     // contain the fractions

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -64,7 +64,6 @@ public:
   void setMasked(const size_t index, bool masked);
 
 private:
-  size_t m_size;
   Kernel::cow_ptr<std::vector<bool>> m_isMasked;
 };
 

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -2,6 +2,7 @@
 #define MANTID_BEAMLINE_DETECTORINFO_H_
 
 #include "MantidBeamline/DllConfig.h"
+#include "MantidKernel/cow_ptr.h"
 
 namespace Mantid {
 namespace Beamline {
@@ -59,8 +60,12 @@ public:
 
   size_t size() const;
 
+  bool isMasked(const size_t index) const;
+  void setMasked(const size_t index, bool masked);
+
 private:
   size_t m_size;
+  Kernel::cow_ptr<std::vector<bool>> m_isMasked;
 };
 
 } // namespace Beamline

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -1,14 +1,26 @@
 #include "MantidBeamline/DetectorInfo.h"
+#include "MantidKernel/make_cow.h"
 
 namespace Mantid {
 namespace Beamline {
 
 DetectorInfo::DetectorInfo(const size_t numberOfDetectors)
-    : m_size(numberOfDetectors) {}
+    : m_size(numberOfDetectors),
+      m_isMasked(Kernel::make_cow<std::vector<bool>>(numberOfDetectors)) {}
 
 /// Returns the size of the DetectorInfo, i.e., the number of detectors in the
 /// instrument.
 size_t DetectorInfo::size() const { return m_size; }
+
+/// Returns true if the detector is a masked.
+bool DetectorInfo::isMasked(const size_t index) const {
+  return (*m_isMasked)[index];
+}
+
+/// Set the mask flag of the detector with given index. Not thread safe.
+void DetectorInfo::setMasked(const size_t index, bool masked) {
+  m_isMasked.access()[index] = masked;
+}
 
 } // namespace Beamline
 } // namespace Mantid

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -5,12 +5,11 @@ namespace Mantid {
 namespace Beamline {
 
 DetectorInfo::DetectorInfo(const size_t numberOfDetectors)
-    : m_size(numberOfDetectors),
-      m_isMasked(Kernel::make_cow<std::vector<bool>>(numberOfDetectors)) {}
+    : m_isMasked(Kernel::make_cow<std::vector<bool>>(numberOfDetectors)) {}
 
 /// Returns the size of the DetectorInfo, i.e., the number of detectors in the
 /// instrument.
-size_t DetectorInfo::size() const { return m_size; }
+size_t DetectorInfo::size() const { return m_isMasked->size(); }
 
 /// Returns true if the detector is a masked.
 bool DetectorInfo::isMasked(const size_t index) const {

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -51,6 +51,31 @@ public:
     TS_ASSERT_EQUALS(assignee.size(), 7);
     // TODO once DetectorInfo has moveable fields, check that they are cleared.
   }
+
+  void test_masking() {
+    DetectorInfo info(3);
+    TS_ASSERT(!info.isMasked(0));
+    TS_ASSERT(!info.isMasked(1));
+    TS_ASSERT(!info.isMasked(2));
+    info.setMasked(1, true);
+    TS_ASSERT(!info.isMasked(0));
+    TS_ASSERT(info.isMasked(1));
+    TS_ASSERT(!info.isMasked(2));
+    info.setMasked(1, false);
+    TS_ASSERT(!info.isMasked(0));
+    TS_ASSERT(!info.isMasked(1));
+    TS_ASSERT(!info.isMasked(2));
+  }
+
+  void test_masking_copy() {
+    DetectorInfo source(1);
+    source.setMasked(0, true);
+    DetectorInfo copy(source);
+    TS_ASSERT(copy.isMasked(0));
+    source.setMasked(0, false);
+    TS_ASSERT(!source.isMasked(0));
+    TS_ASSERT(copy.isMasked(0));
+  }
 };
 
 #endif /* MANTID_BEAMLINE_DETECTORINFOTEST_H_ */

--- a/Framework/Geometry/inc/MantidGeometry/IDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/IDetector.h
@@ -109,6 +109,13 @@ public:
   /// single; returns the centre of a detector
   virtual det_topology getTopology(Kernel::V3D &center) const = 0;
 
+  /// Helper for legacy access mode. Returns a reference to the ParameterMap.
+  virtual const ParameterMap &parameterMap() const = 0;
+  /// Helper for legacy access mode. Returns the index of the detector.
+  virtual size_t index() const = 0;
+  /// Helper for legacy access mode. Sets the index of the detector.
+  virtual void setIndex(const size_t index) = 0;
+
   /// (Empty) Constructor.
   /// prevent Warning C4436 and many failing unit tests on MSVC 2015.
   IDetector() {} // NOLINT

--- a/Framework/Geometry/inc/MantidGeometry/IDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/IDetector.h
@@ -100,8 +100,6 @@ public:
   /// Gives the phi of this detector offset from y=0 by offset.
   virtual double getPhiOffset(const double &offset) const = 0;
 
-  /// Indicates whether the detector has been masked
-  virtual bool isMasked() const = 0;
   /// Indicates whether this is a monitor detector
   virtual bool isMonitor() const = 0;
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <map>
+#include <vector>
 
 namespace Mantid {
 /// Typedef of a map from detector ID to detector shared pointer.
@@ -266,7 +267,7 @@ private:
                        std::vector<IObjComponent_const_sptr> &lst) const;
 
   /// Map which holds detector-IDs and pointers to detector components
-  std::map<detid_t, IDetector_const_sptr> m_detectorCache;
+  std::vector<std::pair<detid_t, IDetector_const_sptr>> m_detectorCache;
 
   /// Purpose to hold copy of source component. For now assumed to be just one
   /// component

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -116,6 +116,8 @@ public:
   /// child comp.)
   /// to be a Detector component by adding it to _detectorCache
   void markAsDetector(const IDetector *);
+  void markAsDetectorIncomplete(const IDetector *);
+  void markAsDetectorFinalize();
 
   /// mark a Component which has already been added to the Instrument (as a
   /// child comp.)

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
@@ -69,7 +69,6 @@ public:
                            const Kernel::V3D &instrumentUp) const override;
   double getPhi() const override;
   double getPhiOffset(const double &offset) const override;
-  bool isMasked() const override;
   bool isMonitor() const override;
   // end IDetector methods
   void markAsMonitor(const bool flag = true);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
@@ -84,7 +84,13 @@ public:
     return ObjComponent::getRelativePos();
   }
 
+  const ParameterMap &parameterMap() const override;
+  size_t index() const override;
+  void setIndex(const size_t index) override;
+
 private:
+  /// Linear index of the detector in the instrument
+  size_t m_index{static_cast<size_t>(-1)};
   /// The detector id
   const detid_t m_id;
   /// Flags if this is a monitor

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
@@ -47,10 +47,9 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 class MANTID_GEOMETRY_DLL DetectorGroup : public virtual IDetector {
 public:
   DetectorGroup();
-  DetectorGroup(const std::vector<IDetector_const_sptr> &dets,
-                bool warnAboutMasked = false);
+  DetectorGroup(const std::vector<IDetector_const_sptr> &dets);
 
-  void addDetector(IDetector_const_sptr det, bool &warn);
+  void addDetector(IDetector_const_sptr det);
 
   // IDetector methods
   IDetector *cloneParameterized(const ParameterMap *) const override {

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
@@ -67,7 +67,6 @@ public:
   double getPhiOffset(const double &offset) const override;
   double solidAngle(const Kernel::V3D &observer) const override;
   bool isParametrized() const override;
-  bool isMasked() const override;
   bool isMonitor() const override;
   bool isValid(const Kernel::V3D &point) const override;
   bool isOnSide(const Kernel::V3D &point) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
@@ -184,6 +184,10 @@ public:
     return const_cast<const DetectorGroup *>(this);
   }
 
+  const ParameterMap &parameterMap() const override;
+  size_t index() const override;
+  void setIndex(const size_t index) override;
+
 protected:
   /// The ID of this effective detector
   int m_id;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -199,6 +199,7 @@ public:
   void addQuat(const IComponent *comp, const std::string &name,
                const Kernel::Quat &value,
                const std::string *const pDescription = nullptr);
+  void forceUnsafeSetMasked(const IComponent *comp, bool value);
   //@}
 
   /// Does the named parameter exist for the given component and type

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -17,6 +17,9 @@ namespace Mantid {
 namespace Kernel {
 template <class KEYTYPE, class VALUETYPE> class Cache;
 }
+namespace Beamline {
+class DetectorInfo;
+}
 namespace Geometry {
 class BoundingBox;
 
@@ -340,6 +343,11 @@ public:
   pmap_it end() { return m_map.end(); }
   pmap_cit end() const { return m_map.end(); }
 
+  bool hasDetectorInfo() const;
+  const Beamline::DetectorInfo &detectorInfo() const;
+  void
+  setDetectorInfo(boost::shared_ptr<const Beamline::DetectorInfo> detectorInfo);
+
 private:
   boost::shared_ptr<Parameter> create(const std::string &className,
                                       const std::string &name) const;
@@ -366,6 +374,10 @@ private:
   /// internal cache map for cached bounding boxes
   std::unique_ptr<Kernel::Cache<const ComponentID, BoundingBox>>
       m_boundingBoxMap;
+
+  /// Pointer to the DetectorInfo object. NULL unless the instrument is
+  /// associated with an ExperimentInfo object.
+  boost::shared_ptr<const Beamline::DetectorInfo> m_detectorInfo{nullptr};
 };
 
 /// ParameterMap shared pointer typedef

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -690,7 +690,6 @@ void Instrument::markAsDetector(const IDetector *det) {
   // Silently ignore detector IDs that are already marked as detectors, even if
   // the actual detector is different.
   if ((it == m_detectorCache.end()) || (it->first != det->getID())) {
-    //printf("inserting %d\n", det->getID());
     m_detectorCache.emplace(it, det->getID(), det_sptr);
   }
 }
@@ -715,9 +714,9 @@ void Instrument::markAsDetectorFinalize() {
   // in this final sort by using stable_sort and removing duplicates. This will
   // effectively favor the first detector with a certain ID that was added.
   std::stable_sort(m_detectorCache.begin(), m_detectorCache.end(),
-            [](const std::pair<detid_t, IDetector_const_sptr> &a,
-               const std::pair<detid_t, IDetector_const_sptr> &b)
-                -> bool { return a.first < b.first; });
+                   [](const std::pair<detid_t, IDetector_const_sptr> &a,
+                      const std::pair<detid_t, IDetector_const_sptr> &b)
+                       -> bool { return a.first < b.first; });
   m_detectorCache.erase(
       std::unique(m_detectorCache.begin(), m_detectorCache.end(),
                   [](const std::pair<detid_t, IDetector_const_sptr> &a,

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -531,9 +531,8 @@ Instrument::getDetectorG(const std::set<detid_t> &det_ids) const {
   } else {
     boost::shared_ptr<DetectorGroup> det_group =
         boost::make_shared<DetectorGroup>();
-    bool warn(false);
     for (const auto detID : det_ids) {
-      det_group->addDetector(this->getDetector(detID), warn);
+      det_group->addDetector(this->getDetector(detID));
     }
     return det_group;
   }

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1023,7 +1023,7 @@ void Instrument::saveNexus(::NeXus::File *file,
       for (size_t i = 0; i < m_detectorInfo->size(); ++i) {
         if (m_detectorInfo->isMasked(i)) {
           const auto *det = getBaseDetector(detIDs.at(i));
-          params.addBool(det, std::string("masked"), true);
+          params.forceUnsafeSetMasked(det, true);
         }
       }
     }

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1022,8 +1022,8 @@ void Instrument::saveNexus(::NeXus::File *file,
       const auto &detIDs = getDetectorIDs();
       for (size_t i = 0; i < m_detectorInfo->size(); ++i) {
         if (m_detectorInfo->isMasked(i)) {
-          const auto &det = m_detectorCache.at(detIDs.at(i));
-          params.addBool(det.get(), std::string("masked"), true);
+          const auto *det = getBaseDetector(detIDs.at(i));
+          params.addBool(det, std::string("masked"), true);
         }
       }
     }

--- a/Framework/Geometry/src/Instrument/Detector.cpp
+++ b/Framework/Geometry/src/Instrument/Detector.cpp
@@ -122,20 +122,6 @@ det_topology Detector::getTopology(V3D &center) const {
   return rect;
 }
 
-/** Returns true if the detector is masked. Only Parametrized instruments
- * can have masked detectors.
- *  @return false
- */
-bool Detector::isMasked() const {
-  if (m_map) {
-    Parameter_sptr par = m_map->get(m_base, "masked");
-    if (par)
-      return par->value<bool>();
-  }
-  // If you get to here, instead of the Detector method, then it isn't masked
-  return false;
-}
-
 /// Is the detector a monitor?
 ///@return true if it is a monitor
 bool Detector::isMonitor() const {

--- a/Framework/Geometry/src/Instrument/Detector.cpp
+++ b/Framework/Geometry/src/Instrument/Detector.cpp
@@ -155,5 +155,14 @@ bool Detector::isMonitor() const {
  */
 void Detector::markAsMonitor(const bool flag) { m_isMonitor = flag; }
 
+/// Helper for legacy access mode. Returns a reference to the ParameterMap.
+const ParameterMap &Detector::parameterMap() const { return *m_map; }
+
+/// Helper for legacy access mode. Returns the index of the detector.
+size_t Detector::index() const { return m_index; }
+
+/// Helper for legacy access mode. Sets the index of the detector.
+void Detector::setIndex(const size_t index) { m_index = index; }
+
 } // Namespace Geometry
 } // Namespace Mantid

--- a/Framework/Geometry/src/Instrument/DetectorGroup.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorGroup.cpp
@@ -27,8 +27,7 @@ DetectorGroup::DetectorGroup()
 * generated if a one of the detectors in dets is masked.
 *  @throw std::invalid_argument If an empty vector is passed as argument
 */
-DetectorGroup::DetectorGroup(const std::vector<IDetector_const_sptr> &dets,
-                             bool warnAboutMasked)
+DetectorGroup::DetectorGroup(const std::vector<IDetector_const_sptr> &dets)
     : IDetector(), m_id(), m_detectors(), group_topology(undef) {
   if (dets.empty()) {
     g_log.error("Illegal attempt to create an empty DetectorGroup");
@@ -36,7 +35,7 @@ DetectorGroup::DetectorGroup(const std::vector<IDetector_const_sptr> &dets,
   }
   std::vector<IDetector_const_sptr>::const_iterator it;
   for (it = dets.begin(); it != dets.end(); ++it) {
-    addDetector(*it, warnAboutMasked);
+    addDetector(*it);
   }
 }
 
@@ -44,28 +43,16 @@ DetectorGroup::DetectorGroup(const std::vector<IDetector_const_sptr> &dets,
 *  @param det ::  A pointer to the detector to add
 *  @param warn :: Whether to issue warnings to the log
 */
-void DetectorGroup::addDetector(IDetector_const_sptr det, bool &warn) {
+void DetectorGroup::addDetector(IDetector_const_sptr det) {
   // the topology of the group become undefined and needs recalculation if new
   // detector has been added to the group
   group_topology = undef;
-  // Warn if adding a masked detector
-  if (warn && det->isMasked()) {
-    g_log.warning() << "Adding a detector (ID:" << det->getID()
-                    << ") that is flagged as masked.\n";
-    warn = false;
-  }
 
   // For now at least, the ID is the same as the first detector that is added
   if (m_detectors.empty())
     m_id = det->getID();
 
-  if ((!m_detectors.insert(DetCollection::value_type(det->getID(), det))
-            .second) &&
-      warn) {
-    g_log.warning() << "Detector with ID " << det->getID()
-                    << " is already in group.\n";
-    warn = false;
-  }
+  m_detectors.insert(DetCollection::value_type(det->getID(), det));
 }
 
 detid_t DetectorGroup::getID() const { return m_id; }

--- a/Framework/Geometry/src/Instrument/DetectorGroup.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorGroup.cpp
@@ -201,22 +201,6 @@ double DetectorGroup::solidAngle(const V3D &observer) const {
   return result;
 }
 
-/** Are ALL the detectors in this group masked?
- *  @return True if every one of the detectors in this group is masked, false
- * otherwise.
- */
-bool DetectorGroup::isMasked() const {
-  bool isMasked = true;
-  DetCollection::const_iterator it;
-  for (it = m_detectors.begin(); it != m_detectors.end(); ++it) {
-    if (!(*it).second->isMasked()) {
-      isMasked = false;
-      break;
-    }
-  }
-  return isMasked;
-}
-
 /** Return true if any detector in the group is parametrized.
  *
  */

--- a/Framework/Geometry/src/Instrument/DetectorGroup.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorGroup.cpp
@@ -476,5 +476,21 @@ const Kernel::Material DetectorGroup::material() const {
   return Kernel::Material();
 }
 
+/// Helper for legacy access mode. Always throws for DetectorGroup.
+const ParameterMap &DetectorGroup::parameterMap() const {
+  throw std::runtime_error("A DetectorGroup cannot have a ParameterMap");
+}
+
+/// Helper for legacy access mode. Always throws for DetectorGroup.
+size_t DetectorGroup::index() const {
+  throw std::runtime_error("A DetectorGroup cannot have an index");
+}
+
+/// Helper for legacy access mode. Always throws for DetectorGroup.
+void DetectorGroup::setIndex(const size_t index) {
+  UNUSED_ARG(index);
+  throw std::runtime_error("A DetectorGroup cannot have an index");
+}
+
 } // namespace Geometry
 } // namespace Mantid

--- a/Framework/Geometry/src/Instrument/DetectorGroup.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorGroup.cpp
@@ -23,8 +23,6 @@ DetectorGroup::DetectorGroup()
 /** Constructor that takes a list of detectors to add
 *  @param dets :: The vector of IDetector pointers that this virtual detector
 * will hold
-*  @param warnAboutMasked :: If true a log message at warning level will be
-* generated if a one of the detectors in dets is masked.
 *  @throw std::invalid_argument If an empty vector is passed as argument
 */
 DetectorGroup::DetectorGroup(const std::vector<IDetector_const_sptr> &dets)
@@ -41,7 +39,6 @@ DetectorGroup::DetectorGroup(const std::vector<IDetector_const_sptr> &dets)
 
 /** Add a detector to the collection
 *  @param det ::  A pointer to the detector to add
-*  @param warn :: Whether to issue warnings to the log
 */
 void DetectorGroup::addDetector(IDetector_const_sptr det) {
   // the topology of the group become undefined and needs recalculation if new

--- a/Framework/Geometry/src/Instrument/DetectorGroup.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorGroup.cpp
@@ -186,7 +186,6 @@ std::vector<IDetector_const_sptr> DetectorGroup::getDetectors() const {
 
 /** Gives the total solid angle subtended by a group of detectors by summing the
  *  contributions from the individual detectors.
- *  Any masked detector in the group is excluded from the sum.
  *  @param observer :: The point from which the detector is being viewed
  *  @return The solid angle in steradians
  *  @throw NullPointerException If geometrical form of any detector has not been
@@ -197,8 +196,7 @@ double DetectorGroup::solidAngle(const V3D &observer) const {
   DetCollection::const_iterator it;
   for (it = m_detectors.begin(); it != m_detectors.end(); ++it) {
     IDetector_const_sptr det = (*it).second;
-    if (!det->isMasked())
-      result += det->solidAngle(observer);
+    result += det->solidAngle(observer);
   }
   return result;
 }

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -455,6 +455,12 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *prog) {
   if (m_indirectPositions)
     createNeutronicInstrument();
 
+  // Instrument::markAsDetector is slow unless the detector IDs in the IDF are
+  // sorted. To circumvent this we use the 2-part interface,
+  // markAsDetectorIncomplete (which does not sort) and markAsDetectorFinalize
+  // (which does the final sorting).
+  m_instrument->markAsDetectorFinalize();
+
   // And give back what we created
   return m_instrument;
 }
@@ -1238,7 +1244,7 @@ void InstrumentDefinitionParser::createDetectorOrMonitor(
            pLocElem->getAttribute("mark-as").compare("monitor") == 0)) {
         m_instrument->markAsMonitor(detector);
       } else
-        m_instrument->markAsDetector(detector);
+        m_instrument->markAsDetectorIncomplete(detector);
     }
 
   } catch (Kernel::Exception::ExistsError &) {
@@ -1351,7 +1357,7 @@ void InstrumentDefinitionParser::createRectangularDetector(
           if (m_haveDefaultFacing)
             makeXYplaneFaceComponent(comp, m_defaultFacing);
           // Mark it as a detector (add to the instrument cache)
-          m_instrument->markAsDetector(detector.get());
+          m_instrument->markAsDetectorIncomplete(detector.get());
         }
       }
     }
@@ -1496,7 +1502,7 @@ void InstrumentDefinitionParser::createStructuredDetector(
           if (m_haveDefaultFacing)
             makeXYplaneFaceComponent(comp, m_defaultFacing);
           // Mark it as a detector (add to the instrument cache)
-          m_instrument->markAsDetector(detector.get());
+          m_instrument->markAsDetectorIncomplete(detector.get());
         }
       }
     }

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -71,7 +71,8 @@ ParameterMap::ParameterMap(const ParameterMap &other)
               *other.m_cacheRotMap)),
       m_boundingBoxMap(
           Kernel::make_unique<Kernel::Cache<const ComponentID, BoundingBox>>(
-              *other.m_boundingBoxMap)) {}
+              *other.m_boundingBoxMap)),
+      m_detectorInfo(other.m_detectorInfo) {}
 
 // Defined as default in source for forward declaration with std::unique_ptr.
 ParameterMap::~ParameterMap() = default;
@@ -1147,6 +1148,24 @@ boost::shared_ptr<Parameter>
 ParameterMap::create(const std::string &className,
                      const std::string &name) const {
   return ParameterFactory::create(className, name);
+}
+
+/// Only for use by ExperimentInfo. Returns returns true if this instrument
+/// contains a DetectorInfo.
+bool ParameterMap::hasDetectorInfo() const {
+  return static_cast<bool>(m_detectorInfo);
+}
+/// Only for use by ExperimentInfo. Returns a reference to the DetectorInfo.
+const Beamline::DetectorInfo &ParameterMap::detectorInfo() const {
+  if (!hasDetectorInfo())
+    throw std::runtime_error("Cannot return reference to NULL DetectorInfo");
+  return *m_detectorInfo;
+}
+
+/// Only for use by ExperimentInfo. Sets the pointer to the DetectorInfo.
+void ParameterMap::setDetectorInfo(
+    boost::shared_ptr<const Beamline::DetectorInfo> detectorInfo) {
+  m_detectorInfo = std::move(detectorInfo);
 }
 
 } // Namespace Geometry

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -40,6 +40,12 @@ const std::string QUAT_PARAM_NAME = "Quat";
 
 // static logger reference
 Kernel::Logger g_log("ParameterMap");
+
+void checkIsNotMaskingParameter(const std::string &name) {
+  if (name == std::string("masked"))
+    throw std::runtime_error("Masking data (\"masked\") cannot be stored in "
+                             "ParameterMap. Use DetectorInfo instead");
+}
 }
 //--------------------------------------------------------------------------
 // Public method
@@ -285,6 +291,7 @@ const std::string ParameterMap::diff(const ParameterMap &rhs,
  * @param name :: The name of the parameter
  */
 void ParameterMap::clearParametersByName(const std::string &name) {
+  checkIsNotMaskingParameter(name);
   // Key is component ID so have to search through whole lot
   for (auto itr = m_map.begin(); itr != m_map.end();) {
     if (itr->second->name() == name) {
@@ -305,6 +312,7 @@ void ParameterMap::clearParametersByName(const std::string &name) {
  */
 void ParameterMap::clearParametersByName(const std::string &name,
                                          const IComponent *comp) {
+  checkIsNotMaskingParameter(name);
   if (!m_map.empty()) {
     const ComponentID id = comp->getComponentID();
     auto itrs = m_map.equal_range(id);
@@ -355,6 +363,7 @@ void ParameterMap::add(const std::string &type, const IComponent *comp,
 void ParameterMap::add(const IComponent *comp,
                        const boost::shared_ptr<Parameter> &par,
                        const std::string *const pDescription) {
+  checkIsNotMaskingParameter(par->name());
   // can not add null pointer
   if (!par)
     return;
@@ -596,6 +605,33 @@ void ParameterMap::addBool(const IComponent *comp, const std::string &name,
   add(pBool(), comp, name, value, pDescription);
 }
 
+/** Force adding masking information. ONLY FOR INTERNAL USE by class Instrument.
+ *
+ * ParameterMap usually rejects "legacy style" masking information since it is
+ * now stored in DetectorInfo. However, for the purpose of writing files class
+ * Instrument needs to insert masking information. This method is only for
+ * internal use by class Instrument. ParameterMaps modified by this method are
+ * only for use as a temporary. */
+void ParameterMap::forceUnsafeSetMasked(const IComponent *comp, bool value) {
+  const std::string name("masked");
+  auto param = create(pBool(), name);
+  auto typedParam = boost::dynamic_pointer_cast<ParameterType<bool>>(param);
+  typedParam->setValue(value);
+
+// When using Clang & Linux, TBB 4.4 doesn't detect C++11 features.
+// https://software.intel.com/en-us/forums/intel-threading-building-blocks/topic/641658
+#if defined(__clang__) && !defined(__APPLE__)
+#define CLANG_ON_LINUX true
+#else
+#define CLANG_ON_LINUX false
+#endif
+#if TBB_VERSION_MAJOR >= 4 && TBB_VERSION_MINOR >= 4 && !CLANG_ON_LINUX
+  m_map.emplace(comp->getComponentID(), param);
+#else
+  m_map.insert(std::make_pair(comp->getComponentID(), param));
+#endif
+}
+
 /**
  * Adds a std::string value to the parameter map.
  * @param comp :: Component to which the new parameter is related
@@ -691,6 +727,7 @@ bool ParameterMap::contains(const IComponent *comp, const std::string &name,
  */
 bool ParameterMap::contains(const IComponent *comp, const char *name,
                             const char *type) const {
+  checkIsNotMaskingParameter(name);
   if (m_map.empty())
     return false;
   const ComponentID id = comp->getComponentID();
@@ -713,6 +750,7 @@ bool ParameterMap::contains(const IComponent *comp, const char *name,
  */
 bool ParameterMap::contains(const IComponent *comp,
                             const Parameter &parameter) const {
+  checkIsNotMaskingParameter(parameter.name());
   if (m_map.empty() || !comp)
     return false;
 
@@ -754,6 +792,7 @@ Parameter_sptr ParameterMap::get(const IComponent *comp,
 boost::shared_ptr<Parameter> ParameterMap::get(const IComponent *comp,
                                                const char *name,
                                                const char *type) const {
+  checkIsNotMaskingParameter(name);
   Parameter_sptr result;
   if (!comp)
     return result;
@@ -897,6 +936,7 @@ Parameter_sptr ParameterMap::getRecursive(const IComponent *comp,
 Parameter_sptr ParameterMap::getRecursive(const IComponent *comp,
                                           const char *name,
                                           const char *type) const {
+  checkIsNotMaskingParameter(name);
   Parameter_sptr result = this->get(comp->getComponentID(), name, type);
   if (result)
     return result;

--- a/Framework/Geometry/test/DetectorGroupTest.h
+++ b/Framework/Geometry/test/DetectorGroupTest.h
@@ -81,8 +81,6 @@ public:
     TS_ASSERT_DELTA(m_detGroup->getDistance(m_origin), 4.24614987, 1e-08);
   }
 
-  void testMasked() { TS_ASSERT(!m_detGroup->isMasked()); }
-
   void testIsMonitor() {
     boost::shared_ptr<DetectorGroup> monitorGroup =
         ComponentCreationHelper::createGroupOfTwoMonitors();
@@ -97,7 +95,6 @@ public:
         ComponentCreationHelper::createDetectorGroupWith5CylindricalDetectors();
     auto d = boost::make_shared<Detector>("d", 6, nullptr);
     d->setPos(6.0, 3.0, 2.0);
-    TS_ASSERT(!detg->isMasked());
     detg->addDetector(d);
     TS_ASSERT_EQUALS(detg->getID(), 1);
     TS_ASSERT_DELTA(detg->getPos()[0], 3.5, 1e-08);

--- a/Framework/Geometry/test/DetectorGroupTest.h
+++ b/Framework/Geometry/test/DetectorGroupTest.h
@@ -98,8 +98,7 @@ public:
     auto d = boost::make_shared<Detector>("d", 6, nullptr);
     d->setPos(6.0, 3.0, 2.0);
     TS_ASSERT(!detg->isMasked());
-    bool warn = true;
-    detg->addDetector(d, warn);
+    detg->addDetector(d);
     TS_ASSERT_EQUALS(detg->getID(), 1);
     TS_ASSERT_DELTA(detg->getPos()[0], 3.5, 1e-08);
     TS_ASSERT_DELTA(detg->getPos()[1], 2.16666667, 1e-08);
@@ -124,8 +123,7 @@ public:
     DetectorGroup cluster;
     Detector *det = new Detector("det", 0, 0);
     det->setPos(1, -1, 0);
-    bool warn = false;
-    cluster.addDetector(IDetector_const_sptr(det), warn);
+    cluster.addDetector(IDetector_const_sptr(det));
 
     V3D axis(1, 0, 0);
     V3D sample(0, 0, 0);

--- a/Framework/Geometry/test/DetectorTest.h
+++ b/Framework/Geometry/test/DetectorTest.h
@@ -18,7 +18,6 @@ public:
     TS_ASSERT_EQUALS(det.getName(), "det1");
     TS_ASSERT(!det.getParent());
     TS_ASSERT_EQUALS(det.getID(), 0);
-    TS_ASSERT(!det.isMasked());
     TS_ASSERT(!det.isMonitor());
     TS_ASSERT(!det.isParametrized());
   }
@@ -35,7 +34,6 @@ public:
     TS_ASSERT_EQUALS(det.getName(), "det1");
     TS_ASSERT(det.getParent());
     TS_ASSERT_EQUALS(det.getID(), 0);
-    TS_ASSERT(!det.isMasked());
     TS_ASSERT(!det.isMonitor());
   }
 
@@ -48,11 +46,6 @@ public:
   void testType() {
     Detector det("det", 0, 0);
     TS_ASSERT_EQUALS(det.type(), "DetectorComponent");
-  }
-
-  void testDead() {
-    Detector det("det", 0, 0);
-    TS_ASSERT(!det.isMasked());
   }
 
   void testMonitor() {

--- a/Framework/Geometry/test/ParDetectorTest.h
+++ b/Framework/Geometry/test/ParDetectorTest.h
@@ -19,7 +19,6 @@ public:
     TS_ASSERT_EQUALS(pdet->getName(), "det1");
     TS_ASSERT(!pdet->getParent());
     TS_ASSERT_EQUALS(pdet->getID(), 0);
-    TS_ASSERT(!pdet->isMasked());
     TS_ASSERT(!pdet->isMonitor());
   }
 
@@ -33,7 +32,6 @@ public:
     TS_ASSERT_EQUALS(pdet->getName(), "det1");
     TS_ASSERT(pdet->getParent());
     TS_ASSERT_EQUALS(pdet->getID(), 0);
-    TS_ASSERT(!pdet->isMasked());
     TS_ASSERT(!pdet->isMonitor());
   }
 
@@ -62,9 +60,10 @@ public:
     ParameterMap_sptr pmap(new ParameterMap());
     boost::shared_ptr<Detector> pdet(det.cloneParameterized(pmap.get()));
 
-    TS_ASSERT(!pdet->isMasked());
-    pmap->addBool(&det, "masked", true);
-    TS_ASSERT(pdet->isMasked());
+    // Reading and writing masking should throw: Masking is now stored in
+    // DetectorInfo and ParameterMap should reject it.
+    TS_ASSERT_THROWS(pdet->isMasked(), std::runtime_error);
+    TS_ASSERT_THROWS(pmap->addBool(&det, "masked", true), std::runtime_error);
   }
 
   void testMonitor() {

--- a/Framework/Geometry/test/ParDetectorTest.h
+++ b/Framework/Geometry/test/ParDetectorTest.h
@@ -62,7 +62,7 @@ public:
 
     // Reading and writing masking should throw: Masking is now stored in
     // DetectorInfo and ParameterMap should reject it.
-    TS_ASSERT_THROWS(pdet->isMasked(), std::runtime_error);
+    TS_ASSERT_THROWS(pmap->get(&det, "masked"), std::runtime_error);
     TS_ASSERT_THROWS(pmap->addBool(&det, "masked", true), std::runtime_error);
   }
 

--- a/Framework/PythonInterface/mantid/geometry/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/geometry/CMakeLists.txt
@@ -82,6 +82,7 @@ set_target_output_directory ( PythonGeometryModule ${OUTPUT_DIR} .pyd )
 target_link_libraries ( PythonGeometryModule LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
             PythonKernelModule
             Geometry
+            Beamline
             Kernel
             ${PYTHON_LIBRARIES}
             ${POCO_LIBRARIES}

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Detector.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Detector.cpp
@@ -1,4 +1,6 @@
 #include "MantidGeometry/Instrument/Detector.h"
+#include "MantidGeometry/Instrument/ParameterMap.h"
+#include "MantidBeamline/DetectorInfo.h"
 #include <boost/python/class.hpp>
 
 using Mantid::Geometry::Detector;
@@ -6,11 +8,23 @@ using Mantid::Geometry::IDetector;
 using Mantid::Geometry::ObjComponent;
 using namespace boost::python;
 
+namespace {
+bool isMaskedDeprecated(const Detector &self) {
+  PyErr_Warn(PyExc_DeprecationWarning, "'Detector::isMasked' is deprecated, "
+                                       "use 'DetectorInfo::isMasked' instead.");
+  const auto &detInfo = self.parameterMap().detectorInfo();
+  return detInfo.isMasked(self.index());
+}
+}
+
 /**
  * Enables boost.python to automatically "cast" an object up to the
  * appropriate Detector leaf type
  */
 void export_Detector() {
   class_<Detector, bases<IDetector, ObjComponent>, boost::noncopyable>(
-      "Detector", no_init);
+      "Detector", no_init)
+      .def("isMasked", &isMaskedDeprecated, arg("self"),
+           "Returns the value of the masked flag. True means ignore this "
+           "detector");
 }

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp
@@ -1,13 +1,33 @@
 #include "MantidGeometry/Instrument/DetectorGroup.h"
+#include "MantidGeometry/Instrument/ParameterMap.h"
+#include "MantidBeamline/DetectorInfo.h"
 #include <boost/python/class.hpp>
 
 using Mantid::Geometry::DetectorGroup;
 using Mantid::Geometry::IDetector;
 using namespace boost::python;
 
+namespace {
+bool isMaskedDeprecated(const DetectorGroup &self) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "'DetectorGroup::isMasked' is deprecated, "
+             "use 'SpectrumInfo::isMasked' instead.");
+  const auto &dets = self.getDetectors();
+  bool masked = true;
+  for (const auto &det : dets) {
+    const auto &detInfo = det->parameterMap().detectorInfo();
+    masked &= detInfo.isMasked(det->index());
+  }
+  return masked;
+}
+}
+
 void export_DetectorGroup() {
   class_<DetectorGroup, bases<IDetector>, boost::noncopyable>("DetectorGroup",
                                                               no_init)
+      .def("isMasked", &isMaskedDeprecated, arg("self"),
+           "Returns the value of the masked flag. True means ignore this "
+           "detector")
       .def("getDetectorIDs", &DetectorGroup::getDetectorIDs, arg("self"),
            "Returns the list of detector IDs within this group")
       .def("getNameSeparator", &DetectorGroup::getNameSeparator, arg("self"),

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/IDetector.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/IDetector.cpp
@@ -15,9 +15,6 @@ void export_IDetector() {
   class_<IDetector, bases<IObjComponent>, boost::noncopyable>("IDetector",
                                                               no_init)
       .def("getID", &IDetector::getID, arg("self"), "Returns the detector ID")
-      .def("isMasked", &IDetector::isMasked, arg("self"),
-           "Returns the value of the masked flag. True means ignore this "
-           "detector")
       .def("isMonitor", &IDetector::isMonitor, arg("self"),
            "Returns True if the detector is marked as a monitor in the IDF")
       .def("solidAngle", &IDetector::solidAngle, (arg("self"), arg("observer")),

--- a/Framework/TestHelpers/src/ComponentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/ComponentCreationHelper.cpp
@@ -174,7 +174,7 @@ createDetectorGroupWith5CylindricalDetectors() {
     groupMembers[i] = det;
   }
 
-  return boost::make_shared<DetectorGroup>(groupMembers, false);
+  return boost::make_shared<DetectorGroup>(groupMembers);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -197,7 +197,7 @@ createDetectorGroupWithNCylindricalDetectorsWithGaps(unsigned int nDet,
     groupMembers[i] = det;
   }
 
-  return boost::make_shared<DetectorGroup>(groupMembers, false);
+  return boost::make_shared<DetectorGroup>(groupMembers);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -240,7 +240,7 @@ createRingOfCylindricalDetectors(const double R_min, const double R_max,
       ic++;
     }
   }
-  return boost::make_shared<DetectorGroup>(groupMembers, false);
+  return boost::make_shared<DetectorGroup>(groupMembers);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -258,7 +258,7 @@ boost::shared_ptr<DetectorGroup> createGroupOfTwoMonitors() {
     det->markAsMonitor();
     groupMembers[i] = det;
   }
-  return boost::make_shared<DetectorGroup>(groupMembers, false);
+  return boost::make_shared<DetectorGroup>(groupMembers);
 }
 
 //----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR moves the storage location of mask flags for detectors from `ParameterMap` into `Beamline::DetectorInfo`. This is part of Instrument-2.0.

Masking data is intercepted when loading and added to `DetectorInfo` instead of `ParameterMap`. Masking data is injected into `ParameterMap` before saving. This ensures **backward and forward compatibility** for files (in particular processed Nexus).

For compatibility with legacy Python scripts a wrapper for `IDetector::isMasked` is provided. As a consequence docstests that are using this method are unchanged for now.


**To test:**

<!-- Instructions for testing. -->

- Thorough code review.
- Manually check backward and forward compatibility of Nexus files: Have two Mantid builds (this branch and maybe a released version such as v3.8), in each of them mask detectors in a workspace, save as Nexus, try to load the file in the respective other build. Check that masking is loaded and looks the same.

Fixes #18290.
Fixes #18228.
Fixes #18319.
Fixes #18325.
Fixes #18351.
Fixes #18317.
Fixes #18354.

With the Python wrappers this is an internal change, so does not need to be in the release notes. We might observe performance improvements in a few cases, if so, those can be added later.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
