### PR TITLE
Basic Python exports for SpectrumInfo and DetectorInfo

### DIFF
--- a/Framework/PythonInterface/mantid/api/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/api/CMakeLists.txt
@@ -13,6 +13,7 @@ set ( EXPORT_FILES
   src/Exports/AlgorithmHistory.cpp
   src/Exports/CatalogManager.cpp
   src/Exports/CatalogSession.cpp
+  src/Exports/DetectorInfo.cpp
   src/Exports/DeprecatedAlgorithmChecker.cpp
   src/Exports/Algorithm.cpp
   src/Exports/DataProcessorAlgorithm.cpp
@@ -61,6 +62,7 @@ set ( EXPORT_FILES
   src/Exports/Sample.cpp
   src/Exports/ScriptRepository.cpp
   src/Exports/ScriptRepositoryFactory.cpp
+  src/Exports/SpectrumInfo.cpp
   src/Exports/Run.cpp
   src/Exports/WorkspaceFactory.cpp
   src/Exports/IFunction.cpp

--- a/Framework/PythonInterface/mantid/api/src/Exports/DetectorInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/DetectorInfo.cpp
@@ -6,6 +6,9 @@ using namespace boost::python;
 
 void export_DetectorInfo() {
   class_<DetectorInfo, boost::noncopyable>("DetectorInfo", no_init)
+      .def("__len__", &DetectorInfo::size, (arg("self")),
+           "Returns the size of the DetectorInfo, i.e., the number of "
+           "detectors in the instrument.")
       .def("size", &DetectorInfo::size, (arg("self")),
            "Returns the size of the DetectorInfo, i.e., the number of "
            "detectors in the instrument.")

--- a/Framework/PythonInterface/mantid/api/src/Exports/DetectorInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/DetectorInfo.cpp
@@ -1,0 +1,14 @@
+#include "MantidAPI/DetectorInfo.h"
+#include <boost/python/class.hpp>
+
+using Mantid::API::DetectorInfo;
+using namespace boost::python;
+
+void export_DetectorInfo() {
+  class_<DetectorInfo, boost::noncopyable>("DetectorInfo", no_init)
+      .def("size", &DetectorInfo::size, (arg("self")),
+           "Returns the size of the DetectorInfo, i.e., the number of "
+           "detectors in the instrument.")
+      .def("isMasked", &DetectorInfo::isMasked, (arg("self"), arg("index")),
+           "Returns True if the detector is masked.");
+}

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -1,4 +1,5 @@
 #include "MantidGeometry/IDTypes.h"
+#include "MantidAPI/DetectorInfo.h"
 #include "MantidAPI/ExperimentInfo.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
@@ -70,5 +71,9 @@ void export_ExperimentInfo() {
            args("self", "detId", "value"))
 
       .def("getEMode", &ExperimentInfo::getEMode, args("self"),
-           "Returns the energy mode.");
+           "Returns the energy mode.")
+
+      .def("detectorInfo", &ExperimentInfo::detectorInfo,
+           return_value_policy<reference_existing_object>(), args("self"),
+           "Return a const reference to the DetectorInfo object.");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -1,6 +1,7 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 
 #include "MantidPythonInterface/api/CloneMatrixWorkspace.h"
@@ -240,6 +241,10 @@ void export_MatrixWorkspace() {
            "Returns the current Y unit for the data (Y axis) in the workspace")
       .def("YUnitLabel", &MatrixWorkspace::YUnitLabel, arg("self"),
            "Returns the caption for the Y axis")
+
+      .def("spectrumInfo", &MatrixWorkspace::spectrumInfo,
+           return_value_policy<reference_existing_object>(), args("self"),
+           "Return a const reference to the SpectrumInfo object.")
 
       // Deprecated
       .def("getNumberBins", &getNumberBinsDeprecated, arg("self"),

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -8,5 +8,8 @@ void export_SpectrumInfo() {
   class_<SpectrumInfo, boost::noncopyable>("SpectrumInfo", no_init)
       .def("isMasked", &SpectrumInfo::isMasked, (arg("self"), arg("index")),
            "Returns true if the detector(s) associated with the spectrum are "
-           "masked.");
+           "masked.")
+      .def("hasDetectors", &SpectrumInfo::hasDetectors, (arg("self")),
+           "Returns true if the spectrum is associated with detectors in the "
+           "instrument.");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -1,0 +1,12 @@
+#include "MantidAPI/SpectrumInfo.h"
+#include <boost/python/class.hpp>
+
+using Mantid::API::SpectrumInfo;
+using namespace boost::python;
+
+void export_SpectrumInfo() {
+  class_<SpectrumInfo, boost::noncopyable>("SpectrumInfo", no_init)
+      .def("isMasked", &SpectrumInfo::isMasked, (arg("self"), arg("index")),
+           "Returns true if the detector(s) associated with the spectrum are "
+           "masked.");
+}

--- a/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
@@ -107,16 +107,15 @@ class ComputeCalibrationCoefVan(PythonAlgorithm):
         dataX = self.vanaws.readX(0)
         coefY = np.zeros(nhist)
         coefE = np.zeros(nhist)
-        instrument = self.vanaws.getInstrument()
         detID_offset = self.get_detID_offset()
         peak_centre = eppws.column('PeakCentre')
         sigma = eppws.column('Sigma')
 
+        specInfo = self.vanaws.spectrumInfo()
         for idx in range(nhist):
             prog_reporter.report("Setting %dth spectrum" % idx)
             dataY = self.vanaws.readY(idx)
-            det = instrument.getDetector(idx + detID_offset)
-            if np.max(dataY) == 0 or det.isMasked():
+            if np.max(dataY) == 0 or specInfo.isMasked(idx):
                 coefY[idx] = 0.
                 coefE[idx] = 0.
             else:

--- a/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
@@ -107,7 +107,6 @@ class ComputeCalibrationCoefVan(PythonAlgorithm):
         dataX = self.vanaws.readX(0)
         coefY = np.zeros(nhist)
         coefE = np.zeros(nhist)
-        detID_offset = self.get_detID_offset()
         peak_centre = eppws.column('PeakCentre')
         sigma = eppws.column('Sigma')
 

--- a/Framework/PythonInterface/plugins/algorithms/DNSComputeDetEffCorrCoefs.py
+++ b/Framework/PythonInterface/plugins/algorithms/DNSComputeDetEffCorrCoefs.py
@@ -168,11 +168,9 @@ class DNSComputeDetEffCorrCoefs(PythonAlgorithm):
         returns number of not masked detectors
         """
         num = 0
-        instrument = workspace.getInstrument()
-        offset = workspace.getSpectrum(0).getDetectorIDs()[0]
+        spectrumInfo = workspace.spectrumInfo()
         for idx in range(workspace.getNumberHistograms()):
-            det = instrument.getDetector(idx + offset)        # for DNS first det ID=1
-            if not det.isMasked():
+            if not spectrumInfo.isMasked(idx):
                 num += 1
         return num
 

--- a/Framework/PythonInterface/plugins/algorithms/ExportSpectraMask.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExportSpectraMask.py
@@ -33,6 +33,7 @@ def export_masks(ws,fileName='',returnMasksOnly=False):
 
     no_detectors = 0
     masks = []
+    specInfo = pws.spectrumInfo()
     for i in range(nhist):
         # set provisional spectra ID
         ms = i+1
@@ -46,14 +47,13 @@ def export_masks(ws,fileName='',returnMasksOnly=False):
             masks.append(ms)
             continue
         try:
-            det = pws.getDetector(i)
+            if specInfo.isMasked(i):
+                masks.append(ms)
 #pylint: disable=W0703
         except Exception:
             no_detectors = no_detectors +1
             masks.append(ms)
             continue
-        if det.isMasked():
-            masks.append(ms)
 
     filename=''
     if len(fileName)==0 :

--- a/Framework/PythonInterface/plugins/algorithms/MaskWorkspaceToCalFile.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskWorkspaceToCalFile.py
@@ -8,14 +8,14 @@ from mantid.simpleapi import *
 
 
 class QueryFlag(object):
-    def isMasked(self, detector, dummy_yValue):
-        return detector.isMasked()
+    def isMasked(self, specInfo, index, dummy_yValue):
+        return specInfo.isMasked(index)
 
 #pylint: disable=too-few-public-methods
 
 
 class QueryValue(object):
-    def isMasked(self, dummy_detector, yValue):
+    def isMasked(self, dummy_specInfo, dummy_index, yValue):
         return yValue == 1
 
 
@@ -64,11 +64,12 @@ class MaskWorkspaceToCalFile(PythonAlgorithm):
         calFile.write('# '+instrumentName+' detector file\n')
         calFile.write('# Format: number      UDET       offset       select    group\n')
         #save the grouping
+        specInfo = inputWorkspace.spectrumInfo()
         for i in range(inputWorkspace.getNumberHistograms()):
             try:
                 det = inputWorkspace.getDetector(i)
                 y_value = inputWorkspace.readY(i)[0]
-                if mask_query.isMasked(det, y_value): #check if masked
+                if mask_query.isMasked(specInfo, i, y_value): #check if masked
                     group = masking_flag
                 else:
                     group = not_masking_flag

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSPatchSensitivity.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSPatchSensitivity.py
@@ -97,15 +97,17 @@ class SANSPatchSensitivity(PythonAlgorithm):
         # Array that will be fit
         id_to_fit =[]
 
+        patchDetInfo = patch_ws.detectorInfo()
+        inputDetInfo = in_ws.detectorInfo()
         for pixel_idx in range(tube_in_input_ws.nelements()):
             pixel_in_input_ws = tube_in_input_ws[pixel_idx]
             # ID will be the same in both WS
             detector_id = pixel_in_input_ws.getID()
-            pixel_in_patch_ws  = patch_ws.getInstrument().getDetector(detector_id)
+            detector_idx = detector_id - 1 # See note on hack below
 
-            if pixel_in_patch_ws.isMasked():
+            if patchDetInfo.isMasked(detector_idx):
                 id_to_fit.append(detector_id)
-            elif not pixel_in_input_ws.isMasked():
+            elif not inputDetInfo.isMasked(detector_idx):
                 id_to_calculate_fit.append(detector_id)
                 y_to_calculate_fit.append(in_ws.readY(detector_id).sum())
                 e_to_calculate_fit.append(in_ws.readE(detector_id).sum())

--- a/Framework/PythonInterface/test/python/mantid/api/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/api/CMakeLists.txt
@@ -14,6 +14,7 @@ set ( TEST_PY_FILES
   CompositeFunctionTest.py
   DataProcessorAlgorithmTest.py
   DeprecatedAlgorithmCheckerTest.py
+  DetectorInfoTest.py
   ExperimentInfoTest.py
   FilePropertyTest.py
   FileFinderTest.py
@@ -42,6 +43,7 @@ set ( TEST_PY_FILES
   RunPythonScriptTest.py
   RunTest.py
   SampleTest.py
+  SpectrumInfoTest.py
   WorkspaceFactoryTest.py
   WorkspaceTest.py
   WorkspaceGroupTest.py

--- a/Framework/PythonInterface/test/python/mantid/api/DetectorInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/DetectorInfoTest.py
@@ -1,0 +1,29 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+from testhelpers import WorkspaceCreationHelper
+
+class DetectorInfoTest(unittest.TestCase):
+
+    _ws = None
+
+    def setUp(self):
+        if self.__class__._ws is None:
+            self.__class__._ws = WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(2, 1, False) # no monitors
+            self.__class__._ws.getSpectrum(0).clearDetectorIDs()
+
+    def test_len(self):
+        info = self._ws.detectorInfo()
+        self.assertEquals(len(info), 2)
+
+    def test_size(self):
+        info = self._ws.detectorInfo()
+        self.assertEquals(info.size(), 2)
+
+    def test_isMasked(self):
+        info = self._ws.detectorInfo()
+        self.assertEquals(info.isMasked(0), False)
+        self.assertEquals(info.isMasked(1), False)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/api/ExperimentInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ExperimentInfoTest.py
@@ -38,6 +38,11 @@ class ExperimentInfoTest(unittest.TestCase):
         emode = self._expt_ws.getEMode()
         self.assertEquals(emode, 0)
 
+    def test_detectorInfo(self):
+        detInfo = self._expt_ws.detectorInfo()
+        # No instrument in test workspace, so size is 0.
+        self.assertEquals(detInfo.size(), 0)
+
 #    def test_set_and_get_efixed(self):
 #      ws = WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(1, 5, False, False)
 #        ws.setEFixed(1, pi)

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -68,7 +68,6 @@ class MatrixWorkspaceTest(unittest.TestCase):
         det = self._test_ws.getDetector(0)
         self.assertTrue(isinstance(det, Detector))
         self.assertEquals(det.getID(), 1)
-        self.assertFalse(det.isMasked())
         self.assertAlmostEqual(math.pi, det.getTwoTheta(V3D(0,0,11), V3D(0,0,1)))
 
     def test_spectrum_retrieval(self):

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -385,6 +385,11 @@ class MatrixWorkspaceTest(unittest.TestCase):
             pass
         self.assertTrue(allFine)
 
+    def test_spectrumInfo(self):
+        specInfo = self._test_ws.spectrumInfo()
+        self.assertEquals(specInfo.isMasked(0), False)
+        self.assertEquals(specInfo.isMasked(1), False)
+
 if __name__ == '__main__':
     unittest.main()
     #Testing particular test from Mantid

--- a/Framework/PythonInterface/test/python/mantid/api/SpectrumInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SpectrumInfoTest.py
@@ -1,0 +1,25 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+from testhelpers import WorkspaceCreationHelper
+
+class SpectrumInfoTest(unittest.TestCase):
+
+    _ws = None
+
+    def setUp(self):
+        if self.__class__._ws is None:
+            self.__class__._ws = WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(2, 1, False) # no monitors
+            self.__class__._ws.getSpectrum(0).clearDetectorIDs()
+
+    def test_hasDetectors(self):
+        info = self._ws.spectrumInfo()
+        self.assertEquals(info.hasDetectors(0), False)
+        self.assertEquals(info.hasDetectors(1), True)
+
+    def test_isMasked(self):
+        info = self._ws.spectrumInfo()
+        self.assertEquals(info.isMasked(1), False)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskAngleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskAngleTest.py
@@ -12,11 +12,12 @@ class MaskAngleTest(unittest.TestCase):
         w=WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(30,5,False,False)
         AnalysisDataService.add('w',w)
         masklist = MaskAngle(w,10,20)
-        for i in arange(w.getNumberHistograms())+1:
-            if (i<10) or (i>19):
-                self.assertTrue(not w.getInstrument().getDetector(int(i)).isMasked())
+        detInfo = w.detectorInfo()
+        for i in arange(w.getNumberHistograms()):
+            if (i<9) or (i>18):
+                self.assertFalse(detInfo.isMasked(int(i)))
             else:
-                self.assertTrue(w.getInstrument().getDetector(int(i)).isMasked())
+                self.assertTrue(detInfo.isMasked(int(i)))
         DeleteWorkspace(w)
         self.assertTrue(array_equal(masklist,arange(10)+10))
 
@@ -30,11 +31,12 @@ class MaskAngleTest(unittest.TestCase):
         MaskAngle(group, 10, 20)
 
         for w in group:
-            for i in arange(w.getNumberHistograms())+1:
-                if(i<10) or (i>19):
-                    self.assertTrue(not w.getInstrument().getDetector(int(i)).isMasked())
+            detInfo = w.detectorInfo()
+            for i in arange(w.getNumberHistograms()):
+                if(i<9) or (i>18):
+                    self.assertFalse(detInfo.isMasked(int(i)))
                 else:
-                    self.assertTrue(w.getInstrument().getDetector(int(i)).isMasked())
+                    self.assertTrue(detInfo.isMasked(int(i)))
 
         DeleteWorkspace(group)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
@@ -51,16 +51,17 @@ class MaskBTPTest(unittest.TestCase):
         self.assertTrue(array_equal(m3,concatenate((b5t3,b5t3+1024,b5t3+2048))))
         #check whether some pixels are masked when they should
         w=mtd['CNCSMaskBTP']
-        self.assertTrue(w.getInstrument().getDetector(29696).isMasked()) #pixel1
-        self.assertTrue(w.getInstrument().getDetector(29697).isMasked()) #pixel2
-        self.assertTrue(w.getInstrument().getDetector(29698).isMasked()) #pixel3
-        self.assertTrue(not w.getInstrument().getDetector(29699).isMasked()) #pixel4
-        self.assertTrue(w.getInstrument().getDetector(29700).isMasked()) #pixel5
+        detInfo = w.detectorInfo()
+        self.assertTrue(detInfo.isMasked(29699)) #pixel1 (detID 29696)
+        self.assertTrue(detInfo.isMasked(29700)) #pixel2 (detID 29697)
+        self.assertTrue(detInfo.isMasked(29701)) #pixel3 (detID 29698)
+        self.assertFalse(detInfo.isMasked(29702)) #pixel4 (detID 29699)
+        self.assertTrue(detInfo.isMasked(29703)) #pixel5 (detID 29700)
 
-        self.assertTrue(w.getInstrument().getDetector(1020).isMasked()) #bank 1
-        self.assertTrue(not w.getInstrument().getDetector(3068).isMasked()) #bank3, tube 8
+        self.assertTrue(detInfo.isMasked(1023)) #bank1 (detID 1020)
+        self.assertFalse(detInfo.isMasked(3071)) #bank3, tube 8 (detID 3068)
 
-        self.assertTrue(w.getInstrument().getDetector(4400).isMasked()) #bank5, tube 3
+        self.assertTrue(detInfo.isMasked(4403)) #bank5, tube 3 (detID 4400)
         DeleteWorkspace(w)
 
 if __name__ == '__main__':

--- a/Testing/SystemTests/tests/analysis/DirectInelasticDiagnostic.py
+++ b/Testing/SystemTests/tests/analysis/DirectInelasticDiagnostic.py
@@ -49,8 +49,9 @@ class DirectInelasticDiagnostic(MantidStressTest):
         # Save the masked spectra nmubers to a simple ASCII file for comparison
         self.saved_diag_file = os.path.join(ms.config['defaultsave.directory'], 'CurrentDirectInelasticDiag.txt')
         handle = file(self.saved_diag_file, 'w')
+        spectrumInfo = sample_ws.spectrumInfo()
         for index in range(sample_ws.getNumberHistograms()):
-            if sample_ws.getDetector(index).isMasked():
+            if spectrumInfo.isMasked(index):
                 spec_no = sample_ws.getSpectrum(index).getSpectrumNo()
                 handle.write(str(spec_no) + '\n')
         handle.close()

--- a/Testing/SystemTests/tests/analysis/DirectInelasticDiagnostic2.py
+++ b/Testing/SystemTests/tests/analysis/DirectInelasticDiagnostic2.py
@@ -71,8 +71,9 @@ class DirectInelasticDiagnostic2(MantidStressTest):
         self.saved_diag_file = os.path.join(config['defaultsave.directory'],
                                             'CurrentDirectInelasticDiag2.txt')
         handle = file(self.saved_diag_file, 'w')
+        spectrumInfo = sample.spectrumInfo()
         for index in range(sample.getNumberHistograms()):
-            if sample.getDetector(index).isMasked():
+            if spectrumInfo.isMasked(index):
                 spec_no = sample.getSpectrum(index).getSpectrumNo()
                 handle.write(str(spec_no) + '\n')
         handle.close()

--- a/Testing/SystemTests/tests/analysis/POLDILoadRunsTest.py
+++ b/Testing/SystemTests/tests/analysis/POLDILoadRunsTest.py
@@ -139,8 +139,8 @@ class POLDILoadRunsTest(stresstesting.MantidStressTest):
                       OutputWorkspace='twoWorkspacesMerged')
 
         wsMerged = AnalysisDataService.retrieve("twoWorkspacesMerged_data_6904")
-        self.assertEquals(len([True for x in range(wsMerged.getNumberHistograms()) if wsMerged.getDetector(
-            x).isMasked()]), 36)
+        specInfoMerged = wsMerged.spectrumInfo()
+        self.assertEquals(len([True for x in range(wsMerged.getNumberHistograms()) if specInfoMerged.isMasked(x)]), 36)
 
         self.clearAnalysisDataService()
 
@@ -150,8 +150,8 @@ class POLDILoadRunsTest(stresstesting.MantidStressTest):
                       OutputWorkspace='twoWorkspacesMerged')
 
         wsMerged = AnalysisDataService.retrieve("twoWorkspacesMerged_data_6904")
-        self.assertEquals(len([True for x in range(wsMerged.getNumberHistograms()) if wsMerged.getDetector(
-            x).isMasked()]), 49)
+        specInfoMerged = wsMerged.spectrumInfo()
+        self.assertEquals(len([True for x in range(wsMerged.getNumberHistograms()) if specInfoMerged.isMasked(x)]), 49)
 
         self.clearAnalysisDataService()
 
@@ -160,8 +160,8 @@ class POLDILoadRunsTest(stresstesting.MantidStressTest):
                       OutputWorkspace='twoWorkspacesMerged')
 
         wsMerged = AnalysisDataService.retrieve("twoWorkspacesMerged_data_6904")
-        self.assertEquals(len([True for x in range(wsMerged.getNumberHistograms()) if wsMerged.getDetector(
-            x).isMasked()]), 12)
+        specInfoMerged = wsMerged.spectrumInfo()
+        self.assertEquals( len([True for x in range(wsMerged.getNumberHistograms()) if specInfoMerged.isMasked(x)]), 12)
 
         self.clearAnalysisDataService()
 

--- a/Testing/SystemTests/tests/analysis/WishMasking.py
+++ b/Testing/SystemTests/tests/analysis/WishMasking.py
@@ -62,8 +62,8 @@ class WishMasking(stresstesting.MantidStressTest):
         masking_edge = 9
 
                 # Test the 'isMasked' property on the detectors of the original workspace
-        self.assertTrue( ws.getDetector(masking_edge).isMasked() )
-        self.assertTrue( not ws.getDetector(masking_edge + 1).isMasked() )
+        self.assertTrue( ws.spectrumInfo().isMasked(masking_edge) )
+        self.assertTrue( not ws.spectrumInfo().isMasked(masking_edge + 1) )
 
                 # Extract a masking workspace
         ExtractMask( InputWorkspace=ws, OutputWorkspace='masking_wish_workspace' )
@@ -74,8 +74,8 @@ class WishMasking(stresstesting.MantidStressTest):
                 # Test the 'isMasked' property on the detectors of the masked workspace
                 # The following tests have been added even though they are broken because extracted workspaces currently do not preserve the
                 # Masking flags (buty they SHOULD!). Hopefully the broken functionality will be fixed and I can enable them.
-                #self.assertTrue( mask_ws.getDetector(masking_edge).isMasked() )
-                #self.assertTrue( not mask_ws.getDetector(masking_edge + 1).isMasked() )
+                #self.assertTrue( mask_ws.spectrumInfo().isMasked(masking_edge) )
+                #self.assertTrue( not mask_ws.spectrumInfo().isMasked(masking_edge + 1) )
 
                 # Save masking
         mask_file = 'wish_masking_system_test_mask_file_temp.xml'
@@ -101,7 +101,7 @@ class WishMasking(stresstesting.MantidStressTest):
 
                 # Testing that the isMasking is the same on both sides of the masking boundary.
         # If things were working properly the following would not pass!
-        self.assertTrue( mask_ws.getDetector(masking_edge).isMasked() == mask_ws.getDetector(masking_edge + 1).isMasked() )
+        self.assertTrue( mask_ws.spectrumInfo().isMasked(masking_edge) == mask_ws.spectrumInfo().isMasked(masking_edge + 1) )
                 ## END CHARACTERISATION TESTS
 
                 #Test creation with normal masking

--- a/scripts/Examples/SolidAngle_Example.py
+++ b/scripts/Examples/SolidAngle_Example.py
@@ -28,9 +28,9 @@ phi = detector.getPhi()
 
 print 'R = ' + str(r) + ', TwoTheta = ' + str(twoTheta)+ ', Phi = ' + str(phi)
 
-# Check if the detector is masked out and calculate the result if not
+# Check if the spectrum is masked out and calculate the result if not
 solidAngle = 0.0
-if not detector.isMasked():
+if not rawData.spectrumInfo().isMasked(0):
     sAngle = detector.solidAngle(samplePos)
 
 print "The solid angle of the spectrum located at index " + str(wsIndex) + " is: " + str(sAngle) + " steradians"

--- a/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -1415,13 +1415,11 @@ class DirectEnergyConversion(object):
         signal = []
         error = []
         izerc = 0
+        data_specInfo = data_ws.spectrumInfo()
         for i in range(nhist):
-            try:
-                det = data_ws.getDetector(i)
-#pylint: disable=broad-except
-            except Exception:
+            if not data_specInfo.hasDetectors(i):
                 continue
-            if det.isMasked():
+            if data_specInfo.isMasked(i):
                 continue
             sig = data_ws.readY(i)[0]
             err = data_ws.readE(i)[0]

--- a/scripts/Inelastic/Direct/diagnostics.py
+++ b/scripts/Inelastic/Direct/diagnostics.py
@@ -454,13 +454,11 @@ def get_failed_spectra_list(diag_workspace):
         diag_workspace = mtd[diag_workspace]
 
     failed_spectra = []
+    spectrumInfo = diag_workspace.spectrumInfo()
     for i in range(diag_workspace.getNumberHistograms()):
-        try:
-            det = diag_workspace.getDetector(i)
-        except RuntimeError:
-            continue
-        if det.isMasked():
-            failed_spectra.append(diag_workspace.getSpectrum(i).getSpectrumNo())
+        if spectrumInfo.hasDetectors(i):
+            if spectrumInfo.isMasked(i):
+                failed_spectra.append(diag_workspace.getSpectrum(i).getSpectrumNo())
 
     return failed_spectra
 

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -869,7 +869,7 @@ def get_masked_det_ids(ws):
             # which is a big speed increase for SANS2D.
             break
         if spectrumInfo.isMasked(ws_index):
-            yield det.getID()
+            yield ws.getDetector(ws_index).getID()
 
 
 def create_zero_error_free_workspace(input_workspace_name, output_workspace_name):

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -862,14 +862,13 @@ def get_masked_det_ids(ws):
 
     @returns a list of IDs for masked detectors
     """
+    spectrumInfo = ws.spectrumInfo()
     for ws_index in range(ws.getNumberHistograms()):
-        try:
-            det = ws.getDetector(ws_index)
-        except RuntimeError:
+        if not spectrumInfo.hasDetectors(ws_index):
             # Skip the rest after finding the first spectra with no detectors,
             # which is a big speed increase for SANS2D.
             break
-        if det.isMasked():
+        if spectrumInfo.isMasked(ws_index):
             yield det.getID()
 
 


### PR DESCRIPTION
This adds basic Python exports for `SpectrumInfo` and `DetectorInfo`. The goal is to replace access to `IDetector::isMasked` and other methods that will be removed with Instrument-2.0.

See also #18317, which will provide way to keep legacy access possible in a transition period, to avoid/postpone breaking user scripts.

**To test:**

<!-- Instructions for testing. -->

Code review.

Fixes #18303.

I think this should not yet be part of the release notes since the functionality is very incomplete.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
