### PR TITLE
SNAPReduce OutputWorkspace name unique

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
@@ -436,7 +436,7 @@ class SNAPReduce(DataProcessorAlgorithm):
                 if norm == "Extracted from Data":
                     DeleteWorkspace(Workspace='%s_%s_normalizer' % (new_Tag, r)) # was 'peak_clip_WS'
 
-            propertyName = 'OutputWorkspace'
+            propertyName = 'OutputWorkspace_'+str(outputWksp)
             self.declareProperty(WorkspaceProperty(
                 propertyName, outputWksp, Direction.Output))
             self.setProperty(propertyName, outputWksp)


### PR DESCRIPTION
Antonio emailed a bug report:

When using SNAPReduce to process many runs we’re getting an error pasted below. It seems that the algorithm is not cleaning up properly before heading over to the next run, as the first pass seems to work.

Error message:
```python
Error in execution of algorithm SNAPReduce:
Property with given name already exists search object OUTPUTWORKSPACE
  at line 441 in '/opt/mantidnightly/plugins/python/algorithms/SNAPReduce.py'
```

The issue was the in registering the output workspaces as properties (so they get history), the property name was not unique.

**To test:**

Use `SNAPReduce` with multiple runs and see that it successfully finishes.

*There is no associated issue*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
