### PR TITLE
Require Python mock as a developer dependency

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -10,7 +10,7 @@ if( MSVC )
   include ( ExternalProject )
   set( EXTERNAL_ROOT ${PROJECT_SOURCE_DIR}/external )
   set( THIRD_PARTY_GIT_URL "https://github.com/mantidproject/thirdparty-msvc2015.git" )
-  set ( THIRD_PARTY_GIT_SHA1 d3d733e772a57b18b663f3b79439a068bb00a71c )
+  set ( THIRD_PARTY_GIT_SHA1 4691e740fa2050f4fd0b44628eac445906bb2978 )
   set ( THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty )
   # Generates a script to do the clone/update in tmp
   set ( _project_name ThirdParty )

--- a/buildconfig/dev-packages/deb/mantid-developer/ns-control
+++ b/buildconfig/dev-packages/deb/mantid-developer/ns-control
@@ -3,7 +3,7 @@ Priority: optional
 Standards-Version: 3.9.2
 
 Package: mantid-developer
-Version: 1.2.9
+Version: 1.3.0
 Maintainer: Mantid Project <mantid-tech@mantidproject.org>
 Priority: optional
 Architecture: all
@@ -12,7 +12,7 @@ Depends: git, g++, clang-format-3.6, cmake-qt-gui(>=3.5), ninja-build, libtbb-de
   libpocoodbc31-dbg, libpocosqlite31-dbg, libpocoutil31-dbg, libpocoxml31-dbg, libpocozip31-dbg, libnexus0-dev,
   libhdf5-dev, libhdf4-dev, libgsl0-dev, liboce-visualization-dev, libmuparser-dev, libssl-dev, libjsoncpp-dev(>=0.7.0),
   libpython-dev, python-numpy, python-scipy, python-qt4-dev, python-qt4-dbg, python-sphinx, python-dateutil,
-  python-sphinx-bootstrap-theme, python-matplotlib, python-h5py, python-yaml, ipython-qtconsole (>=1.2.0),
+  python-sphinx-bootstrap-theme, python-matplotlib, python-h5py, python-yaml, python-mock, ipython-qtconsole (>=1.2.0),
   qt4-default, qt4-qmake, qt4-dev-tools, libqtwebkit-dev, libqwt5-qt4-dev, libqwtplot3d-qt4-dev, libqscintilla2-dev,
   texlive, texlive-latex-extra, dvipng, graphviz, doxygen
 Description: Installs all packages required for a Mantid developer

--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -5,7 +5,7 @@
 %endif
 
 Name:           mantid-developer
-Version:        1.20
+Version:        1.21
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -56,6 +56,7 @@ Requires: python-pip
 Requires: python-sphinx
 Requires: python-sphinx-theme-bootstrap
 Requires: PyYAML
+Requires: python2-mock
 Requires: qscintilla-devel
 Requires: qt-devel >= 4.6
 %if 0%{?el6}
@@ -102,6 +103,7 @@ Requires: python3-h5py
 Requires: python3-ipython-gui
 Requires: python3-matplotlib
 Requires: python3-PyYAML
+Requires: python3-mock
 Requires: boost-python3-devel
 %endif
 
@@ -127,6 +129,9 @@ required for Mantid development.
 %files
 
 %changelog
+* Wed Dec 21 2016 Martyn Gigg <martyn.gigg@stfc.ac.uk>
+- Require python-mock & python3-mock on fedora
+
 * Fri Nov 18 2016 Martyn Gigg <martyn.gigg@stfc.ac.uk>
 - Require PyYAML
 


### PR DESCRIPTION
Description of work.

Bring in Python mock package as a developer dependency.

**To test:**

On Windows check you can `import mock` in Python.

The other OSs will need to have the packages installed.

*No issue*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
