### PR TITLE
Add 2D merge option back in

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSStitch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSStitch.py
@@ -178,7 +178,7 @@ class SANSStitch(DataProcessorAlgorithm):
 
         if ws.getNumberHistograms() != 1:
             # Strip zeros is only possible on 1D workspaces
-            return
+            return ws
 
         y_vals = ws.readY(0)
         length = len(y_vals)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -81,6 +81,7 @@ set ( TEST_PY_FILES
   OSIRISDiffractionReductionTest.py
   ResNorm2Test.py
   RetrieveRunInfoTest.py
+  SANSStitchTest.py
   SANSFitShiftScaleTest.py
   SANSWideAngleCorrectionTest.py
   SaveNexusPDTest.py

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -4446,7 +4446,8 @@ bool SANSRunWindow::areSettingsValid(States type) {
   // We currently do not allow a 2D reduction with a merged flag and fitting
   // because we can only fit 1D functions
   auto isMergedReduction = m_uiForm.detbank_sel->currentIndex() == 3;
-  auto hasFitEnabled = m_uiForm.frontDetShiftCB->isChecked() || m_uiForm.frontDetRescaleCB->isChecked();
+  auto hasFitEnabled = m_uiForm.frontDetShiftCB->isChecked() ||
+                       m_uiForm.frontDetRescaleCB->isChecked();
   if (type == States::TwoD && isMergedReduction && hasFitEnabled) {
     isValid = false;
     message +=

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -4443,13 +4443,16 @@ bool SANSRunWindow::areSettingsValid(States type) {
   QString message;
   // ------------ GUI INPUT CHECKS ------------
 
-  // We currently do not allow a 2D reduction with a merged flag
+  // We currently do not allow a 2D reduction with a merged flag and fitting
+  // because we can only fit 1D functions
   auto isMergedReduction = m_uiForm.detbank_sel->currentIndex() == 3;
-  if (type == States::TwoD && isMergedReduction) {
+  auto hasFitEnabled = m_uiForm.frontDetShiftCB->isChecked() || m_uiForm.frontDetRescaleCB->isChecked();
+  if (type == States::TwoD && isMergedReduction && hasFitEnabled) {
     isValid = false;
     message +=
-        "A merged Detector Bank selection is currently not supported for 2D "
-        "reductions.\n";
+        "A merged reduction with fitting is currently not supported for 2D "
+        "reductions. You can run a merged reduction wihthout fitting enabled"
+        " for 2D reductions.\n";
   }
 
   // R_MAX -- can be only >0 or -1


### PR DESCRIPTION
The option to merge 2D reductions was taken out by accident a while back. We revive it here.

Fixes #18331 

**To test:**

Please find the test data here: smb://olympic/babylon5/Scratch/Anton/LoqData

1. Open the ISIS SANS GUI
2. Select the LOQ instrument
3. Load the user file: USER_LOQ_161G_Hedstrom_8mm_Magnet-MERGED.txt
4. Set   LOQ97072.nxs as the sample scatter input
5. Press Load Data
6. Press 2D Reduce
  * Confirm that a warning pops up saying that the 2D reduction cannot be done in merged-mode and with fitting enabled
7. Go to the Reduction Settings tab
8. Disable the Fit checkboxs for the Front detector
9. Go back to the Run Numbers tab
10. Press 2D Reduce
  * Confirm that the reduction is executed without errors.


No release notes required

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
