### PR TITLE
New widget for Waterfall & Tiled plots

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MantidWSIndexDialog.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MantidWSIndexDialog.h
@@ -6,6 +6,7 @@
 //----------------------------------
 #include "MantidQtMantidWidgets/WidgetDllOption.h"
 #include <QCheckBox>
+#include <QComboBox>
 #include <QDialog>
 #include <QLabel>
 #include <QLineEdit>
@@ -323,7 +324,8 @@ private:
   QLineEditWithErrorMark *m_wsField, *m_spectraField;
   QVBoxLayout *m_outer, *m_wsBox, *m_spectraBox;
   QHBoxLayout *m_optionsBox;
-  QCheckBox *m_waterfallOpt, *m_tiledOpt;
+  // QCheckBox *m_waterfallOpt, *m_tiledOpt;
+  QComboBox *m_plotOptions;
 
   /// A list of names of workspaces which are to be plotted.
   QList<QString> m_wsNames;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MantidWSIndexDialog.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MantidWSIndexDialog.h
@@ -324,7 +324,6 @@ private:
   QLineEditWithErrorMark *m_wsField, *m_spectraField;
   QVBoxLayout *m_outer, *m_wsBox, *m_spectraBox;
   QHBoxLayout *m_optionsBox;
-  // QCheckBox *m_waterfallOpt, *m_tiledOpt;
   QComboBox *m_plotOptions;
 
   /// A list of names of workspaces which are to be plotted.

--- a/MantidQt/MantidWidgets/src/MantidWSIndexDialog.cpp
+++ b/MantidQt/MantidWidgets/src/MantidWSIndexDialog.cpp
@@ -22,8 +22,8 @@ namespace MantidWidgets {
  * @param parent :: The owning dialog
  * @param flags :: Window flags that are passed the the QWidget constructor
  * @param wsNames :: the names of the workspaces to be plotted
- * @param showWaterfallOption :: If true the waterfall checkbox is created
- * @param showTiledOption :: If true the "Tiled" checkbox is created
+ * @param showWaterfallOption :: true if waterfall plot enabled
+ * @param showTiledOption :: true if tiled plot enabled
  */
 MantidWSIndexWidget::MantidWSIndexWidget(QWidget *parent, Qt::WFlags flags,
                                          QList<QString> wsNames,
@@ -31,9 +31,8 @@ MantidWSIndexWidget::MantidWSIndexWidget(QWidget *parent, Qt::WFlags flags,
                                          const bool showTiledOption)
     : QWidget(parent, flags), m_spectra(false),
       m_waterfall(showWaterfallOption), m_tiled(showTiledOption),
-      m_waterfallOpt(nullptr), m_tiledOpt(nullptr), m_wsNames(wsNames),
-      m_wsIndexIntervals(), m_spectraNumIntervals(), m_wsIndexChoice(),
-      m_spectraIdChoice() {
+      m_plotOptions(), m_wsNames(wsNames), m_wsIndexIntervals(),
+      m_spectraNumIntervals(), m_wsIndexChoice(), m_spectraIdChoice() {
   checkForSpectraAxes();
   // Generate the intervals allowed to be plotted by the user.
   generateWsIndexIntervals();
@@ -108,7 +107,8 @@ QMultiMap<QString, std::set<int>> MantidWSIndexWidget::getPlots() const {
  * @returns True if waterfall plot selected
  */
 bool MantidWSIndexWidget::isWaterfallPlotSelected() const {
-  return m_waterfallOpt ? m_waterfallOpt->isChecked() : false;
+  //return m_waterfallOpt ? m_waterfallOpt->isChecked() : false;
+  return(m_plotOptions->currentText() == "Waterfall Plot");
 }
 
 /**
@@ -116,7 +116,8 @@ bool MantidWSIndexWidget::isWaterfallPlotSelected() const {
  * @returns True if tiled plot selected
  */
 bool MantidWSIndexWidget::isTiledPlotSelected() const {
-  return m_tiledOpt ? m_tiledOpt->isChecked() : false;
+  //return m_tiledOpt ? m_tiledOpt->isChecked() : false;
+  return(m_plotOptions->currentText() == "Tiled Plot");
 }
 
 /**
@@ -243,14 +244,17 @@ void MantidWSIndexWidget::initSpectraBox() {
  */
 void MantidWSIndexWidget::initOptionsBoxes() {
   m_optionsBox = new QHBoxLayout;
-  if (m_waterfall) {
-    m_waterfallOpt = new QCheckBox("Waterfall Plot");
-    m_optionsBox->addWidget(m_waterfallOpt);
-  }
 
-  if (m_tiled) {
-    m_tiledOpt = new QCheckBox("Tiled Plot");
-    m_optionsBox->addWidget(m_tiledOpt);
+  if (m_waterfall || m_tiled) {
+    m_plotOptions = new QComboBox();
+    m_plotOptions->addItem(tr("1D Plot"));
+    if (m_waterfall) {
+      m_plotOptions->addItem(tr("Waterfall Plot"));
+    }
+    if (m_tiled) {
+      m_plotOptions->addItem(tr("Tiled Plot"));
+    }
+    m_optionsBox->addWidget(m_plotOptions);
   }
 
   m_outer->addItem(m_optionsBox);

--- a/MantidQt/MantidWidgets/src/MantidWSIndexDialog.cpp
+++ b/MantidQt/MantidWidgets/src/MantidWSIndexDialog.cpp
@@ -107,7 +107,6 @@ QMultiMap<QString, std::set<int>> MantidWSIndexWidget::getPlots() const {
  * @returns True if waterfall plot selected
  */
 bool MantidWSIndexWidget::isWaterfallPlotSelected() const {
-  //return m_waterfallOpt ? m_waterfallOpt->isChecked() : false;
   return(m_plotOptions->currentText() == "Waterfall Plot");
 }
 
@@ -116,7 +115,6 @@ bool MantidWSIndexWidget::isWaterfallPlotSelected() const {
  * @returns True if tiled plot selected
  */
 bool MantidWSIndexWidget::isTiledPlotSelected() const {
-  //return m_tiledOpt ? m_tiledOpt->isChecked() : false;
   return(m_plotOptions->currentText() == "Tiled Plot");
 }
 

--- a/MantidQt/MantidWidgets/src/MantidWSIndexDialog.cpp
+++ b/MantidQt/MantidWidgets/src/MantidWSIndexDialog.cpp
@@ -107,7 +107,7 @@ QMultiMap<QString, std::set<int>> MantidWSIndexWidget::getPlots() const {
  * @returns True if waterfall plot selected
  */
 bool MantidWSIndexWidget::isWaterfallPlotSelected() const {
-  return(m_plotOptions->currentText() == "Waterfall Plot");
+  return (m_plotOptions->currentText() == "Waterfall Plot");
 }
 
 /**
@@ -115,7 +115,7 @@ bool MantidWSIndexWidget::isWaterfallPlotSelected() const {
  * @returns True if tiled plot selected
  */
 bool MantidWSIndexWidget::isTiledPlotSelected() const {
-  return(m_plotOptions->currentText() == "Tiled Plot");
+  return (m_plotOptions->currentText() == "Tiled Plot");
 }
 
 /**


### PR DESCRIPTION
When plotting spectra, change selection of Waterfall and Tiled plots from two check boxes to one dropdown list (ComboBox). Note that previous situation if both tiled and waterfall were selected,  tiled is plotted without waterfall.

**To test:**

Load or create various workspaces with more than one spectrum including group workspaces, 

check the drop-down list of 1D-plot, Waterfall Plot & Tiled Plot is available if you plot spectra or plot spectra with errors.

Check that it works as expected

You may also check that the dialog box does not appear, if one plots a spectrum from a single spectrum workspace, even if its a group workspace. One can use CropWorkspace to create a single-spectrum workspace.

Fixes #18256 

<!-- RELEASE NOTES
*Does not need to be in the release notes.* part of work on #18159 
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
