### PR TITLE
Apply remaining fixes from clang-tidy modernize-use-nullptr.

### DIFF
--- a/Vates/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
@@ -25,8 +25,8 @@ private:
 class DLLExport ColorScaleLockGuard {
 public:
   ColorScaleLockGuard(ColorScaleLock *lock) {
-    if (lock == NULL || lock->isLocked()) {
-      m_lock = NULL;
+    if (!lock || lock->isLocked()) {
+      m_lock = nullptr;
     } else {
       m_lock = lock;
       m_lock->lock();
@@ -34,7 +34,7 @@ public:
   }
 
   ~ColorScaleLockGuard() {
-    if (m_lock != NULL) {
+    if (m_lock) {
       m_lock->unlock();
     }
   }

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetFactory.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetFactory.h
@@ -166,7 +166,7 @@ protected:
   boost::shared_ptr<IMDWorkspaceType>
   doInitialize(Mantid::API::Workspace_sptr workspace,
                bool bExactMatch = true) const {
-    if (workspace == NULL) {
+    if (!workspace) {
       std::string message = this->getFactoryTypeName() +
                             " initialize cannot operate on a null workspace";
       throw std::invalid_argument(message);

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToScaledDataSet.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetToScaledDataSet.h
@@ -46,7 +46,8 @@ public:
                        vtkPointSet *inputData, vtkInformation *info);
   /// Apply the scaling and add metadata
   vtkPointSet *execute(double xScale, double yScale, double zScale,
-                       vtkPointSet *inputData, vtkPointSet *outputData = NULL);
+                       vtkPointSet *inputData,
+                       vtkPointSet *outputData = nullptr);
 
 private:
   vtkDataSetToScaledDataSet &operator=(const vtkDataSetToScaledDataSet &other);

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
@@ -217,7 +217,7 @@ template <class Scalar> void vtkMDHWSignalArray<Scalar>::Squeeze() {
 template <class Scalar>
 vtkArrayIterator *vtkMDHWSignalArray<Scalar>::NewIterator() {
   vtkErrorMacro(<< "Not implemented.");
-  return NULL;
+  return nullptr;
 }
 
 //------------------------------------------------------------------------------

--- a/Vates/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h
+++ b/Vates/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h
@@ -48,7 +48,7 @@ public:
    * Default constructor.
    * @param parent the parent widget of the mode control widget
    */
-  ModeControlWidget(QWidget *parent = 0);
+  ModeControlWidget(QWidget *parent = nullptr);
   /// Default destructor.
   ~ModeControlWidget() override;
 

--- a/Vates/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.h
+++ b/Vates/VatesSimpleGui/QtWidgets/inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.h
@@ -42,7 +42,7 @@ class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_QTWIDGETS RotationPointDialog
 
 public:
   /// Default constructor.
-  RotationPointDialog(QWidget *parent = 0);
+  RotationPointDialog(QWidget *parent = nullptr);
   /// Default destructor.
   ~RotationPointDialog() override;
 

--- a/Vates/VatesSimpleGui/StandAloneExec/inc/VsgMainWindow.h
+++ b/Vates/VatesSimpleGui/StandAloneExec/inc/VsgMainWindow.h
@@ -49,7 +49,7 @@ public:
    * Default constructor.
    * @param parent the parent widget for the main window
    */
-  VsgMainWindow(QWidget *parent = 0);
+  VsgMainWindow(QWidget *parent = nullptr);
   /// Default destructor.
   ~VsgMainWindow() override;
 

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.h
@@ -41,7 +41,7 @@ class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS ColorMapEditorPanel
   Q_OBJECT
 public:
   /// Default constructor.
-  ColorMapEditorPanel(QWidget *parent = 0);
+  ColorMapEditorPanel(QWidget *parent = nullptr);
   /// Default destructor.
   ~ColorMapEditorPanel() override;
   /// Connect the panel to ParaView

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h
@@ -52,7 +52,7 @@ class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS ColorSelectionWidget
 
 public:
   /// Default constructor.
-  ColorSelectionWidget(QWidget *parent = 0);
+  ColorSelectionWidget(QWidget *parent = nullptr);
   /// Default destructor.
   ~ColorSelectionWidget() override {}
 

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MultisliceView.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MultisliceView.h
@@ -55,8 +55,8 @@ public:
    * @param rebinnedSourcesManager Pointer to a RebinnedSourcesManager
    * @param createRenderProxy :: Whether to create a render proxy for this view
    */
-  MultiSliceView(QWidget *parent = 0,
-                 RebinnedSourcesManager *rebinnedSourcesManager = 0,
+  MultiSliceView(QWidget *parent = nullptr,
+                 RebinnedSourcesManager *rebinnedSourcesManager = nullptr,
                  bool createRenderProxy = true);
   /// Default constructor.
   ~MultiSliceView() override;

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTabWidget.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTabWidget.h
@@ -20,7 +20,7 @@ namespace SimpleGui {
 class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS PeakCustomTabWidget
     : public QTabWidget {
 public:
-  PeakCustomTabWidget(QWidget *parent = 0) { setParent(parent); }
+  PeakCustomTabWidget(QWidget *parent = nullptr) { setParent(parent); }
 
   // Overridden method from QTabWidget
   QTabBar *tabBar() { return QTabWidget::tabBar(); }
@@ -31,7 +31,8 @@ class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS PeaksTabWidget
   Q_OBJECT
 public:
   PeaksTabWidget(std::vector<Mantid::API::IPeaksWorkspace_sptr> ws,
-                 const std::string &coordinateSystem, QWidget *parent = 0);
+                 const std::string &coordinateSystem,
+                 QWidget *parent = nullptr);
   ~PeaksTabWidget() override;
   void setupMvc(std::map<std::string, std::vector<bool>> visiblePeaks);
   void addNewPeaksWorkspace(Mantid::API::IPeaksWorkspace_sptr peaksWorkspace,

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
@@ -26,7 +26,7 @@ class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS PeaksTableControllerVsi
   Q_OBJECT
 public:
   PeaksTableControllerVsi(boost::shared_ptr<CameraManager> cameraManager,
-                          QWidget *parent = 0);
+                          QWidget *parent = nullptr);
   ~PeaksTableControllerVsi() override;
   std::vector<bool> getViewablePeaks();
   bool hasPeaks();

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksWidget.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/PeaksWidget.h
@@ -18,7 +18,7 @@ class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS PeaksWidget
   Q_OBJECT
 public:
   PeaksWidget(Mantid::API::IPeaksWorkspace_sptr ws,
-              const std::string &coordinateSystem, QWidget *parent = 0);
+              const std::string &coordinateSystem, QWidget *parent = nullptr);
   void setupMvc(std::vector<bool> visiblePeaks);
   void updateModel(std::vector<bool> visiblePeaks);
 signals:

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h
@@ -61,7 +61,7 @@ class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS RebinnedSourcesManager
       MantidQt::API::WorkspaceObserver {
   Q_OBJECT
 public:
-  RebinnedSourcesManager(QWidget *parent = 0);
+  RebinnedSourcesManager(QWidget *parent = nullptr);
 
   ~RebinnedSourcesManager() override;
 

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/SplatterPlotView.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/SplatterPlotView.h
@@ -65,9 +65,10 @@ public:
    * @param rebinnedSourcesManager Pointer to a RebinnedSourcesManager
    * @param createRenderProxy :: Whether to create a render proxy for this view
    */
-  explicit SplatterPlotView(QWidget *parent = 0,
-                            RebinnedSourcesManager *rebinnedSourcesManager = 0,
-                            bool createRenderProxy = true);
+  explicit SplatterPlotView(
+      QWidget *parent = nullptr,
+      RebinnedSourcesManager *rebinnedSourcesManager = nullptr,
+      bool createRenderProxy = true);
   /// Default destructor
   ~SplatterPlotView() override;
 

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
@@ -53,8 +53,8 @@ class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS StandardView
 
 public:
   /// Default constructor.
-  StandardView(QWidget *parent = 0,
-               RebinnedSourcesManager *rebinnedSourcesManager = 0,
+  StandardView(QWidget *parent = nullptr,
+               RebinnedSourcesManager *rebinnedSourcesManager = nullptr,
                bool createRenderProxy = true);
   /// Default destructor.
   ~StandardView() override;

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.h
@@ -56,8 +56,8 @@ public:
    * @param rebinnedSourcesManager Pointer to a RebinnedSourcesManager
    * @param createRenderProxy :: Whether to create a render proxy for this view
    */
-  ThreeSliceView(QWidget *parent = 0,
-                 RebinnedSourcesManager *rebinnedSourcesManager = 0,
+  ThreeSliceView(QWidget *parent = nullptr,
+                 RebinnedSourcesManager *rebinnedSourcesManager = nullptr,
                  bool createRenderProxy = true);
   /// Default destructor.
   ~ThreeSliceView() override;

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
@@ -42,7 +42,7 @@ class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS TimeControlWidget
 
 public:
   /// Default constructor.
-  TimeControlWidget(QWidget *parent = 0);
+  TimeControlWidget(QWidget *parent = nullptr);
   /// Default destructor.
   ~TimeControlWidget() override;
 

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
@@ -58,8 +58,8 @@ class EXPORT_OPT_MANTIDVATES_SIMPLEGUI_VIEWWIDGETS ViewBase : public QWidget {
   Q_OBJECT
 public:
   /// Default constructor.
-  ViewBase(QWidget *parent = 0,
-           RebinnedSourcesManager *rebinnedSourcesManager = 0);
+  ViewBase(QWidget *parent = nullptr,
+           RebinnedSourcesManager *rebinnedSourcesManager = nullptr);
 
   /// Default destructor.
   ~ViewBase() override {}

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h
@@ -16,7 +16,8 @@ public:
   typedef QObject Superclass;
 
 public:
-  VsiApplyBehaviour(Mantid::VATES::ColorScaleLock *lock, QObject *parent = 0);
+  VsiApplyBehaviour(Mantid::VATES::ColorScaleLock *lock,
+                    QObject *parent = nullptr);
   ~VsiApplyBehaviour() override{};
 
   /// Register/unregister pqPropertiesPanel instances to monitor.

--- a/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
@@ -552,7 +552,7 @@ void RebinnedSourcesManager::copySafe(vtkSMProxy *dest, vtkSMProxy *source) {
       }
 
       if (destValue) {
-        Q_ASSERT(srcValue != NULL);
+        Q_ASSERT(srcValue != nullptr);
         copySafe(destValue, srcValue);
         destPP->SetProxy(0, destValue);
       }

--- a/Vates/VatesSimpleGui/ViewWidgets/src/VatesParaViewApplication.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/VatesParaViewApplication.cpp
@@ -48,7 +48,7 @@ VatesParaViewApplication::VatesParaViewApplication()
         "set this variable.");
   }
 
-  Q_ASSERT(pqApplicationCore::instance() == NULL);
+  Q_ASSERT(pqApplicationCore::instance() == nullptr);
 
   // Provide ParaView's application core with a path to the running executable
   int argc = 1;


### PR DESCRIPTION
Description of work.

This applies all remaining changes from clang-tidy's moderize-use-nullptr to the Vates subdirectory.

**To test:**

<!-- Instructions for testing. -->

This is a minor change. If the builds pass, :squirrel:.

This is a followup to #18289.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
