### PR TITLE
Log when loading project starts/stops

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -9577,7 +9577,6 @@ void ApplicationWindow::newProject(const bool doNotSave) {
   folders->blockSignals(false);
 
   // Reset everything else
-  resultsLog->clear();
   setWindowTitle(tr("MantidPlot - untitled")); // Mantid
   projectname = "untitled";
 

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -14371,7 +14371,6 @@ bool ApplicationWindow::changeFolder(Folder *newFolder, bool force) {
 
   d_current_folder = newFolder;
 
-  resultsLog->clear();
   resultsLog->appendInformation(currentFolder()->logInfo());
 
   lv->clear();

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -13,6 +13,7 @@
 #include "Mantid/MantidUI.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidKernel/Logger.h"
 #include "MantidKernel/MantidVersion.h"
 #include "MantidQtAPI/PlotAxis.h"
 #include "MantidQtAPI/VatesViewerInterface.h"
@@ -24,6 +25,12 @@
 
 using namespace Mantid::API;
 using namespace MantidQt::API;
+using Mantid::Kernel::Logger;
+
+namespace {
+/// static logger
+Logger g_log("ProjectSerialiser");
+}
 
 // This C function is defined in the third party C lib minigzip.c
 extern "C" {
@@ -69,6 +76,9 @@ void ProjectSerialiser::load(std::string lines, const int fileVersion,
   // folder
   // This is a legacy edgecase because folders are written
   // <folder>\tsettings\tgo\there
+  g_log.notice() << "Reading Mantid Project: "
+                 << window->projectname.toStdString() << "\n";
+
   if (!isTopLevel && lines.size() > 0) {
     std::vector<std::string> lineVec;
     boost::split(lineVec, lines, boost::is_any_of("\n"));
@@ -105,6 +115,9 @@ void ProjectSerialiser::load(std::string lines, const int fileVersion,
     window->d_current_folder = window->projectFolder();
   else
     window->d_current_folder = parent;
+
+  g_log.notice() << "Finished Loading Project: "
+                 << window->projectname.toStdString() << "\n";
 }
 
 /**


### PR DESCRIPTION
The user should be informed when loading starts/stops. Users already have a visual cue as to when serialisation has finished saving with the work in #17969. 

**To test:**
 - Apply changes and open any mantid project
 - The log should show when loading starts and stops. Something like this:

![screen shot 2017-01-03 at 14 01 19](https://cloud.githubusercontent.com/assets/2487781/21609953/207f5f98-d1bd-11e6-8bdc-d73d438a59bb.png)

Fixes #17970.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
