### PR TITLE
Fix locale issue in PeakColumn::read()

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
@@ -80,6 +80,7 @@ private:
   typedef boost::variant<double, int, std::string, Kernel::V3D> CacheValueType;
   ///
   mutable std::list<CacheValueType> m_oldRows;
+  void setPeakHKLOrRunNumber(const size_t index, const double val);
 };
 
 } // namespace Mantid

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
@@ -80,6 +80,7 @@ private:
   typedef boost::variant<double, int, std::string, Kernel::V3D> CacheValueType;
   ///
   mutable std::list<CacheValueType> m_oldRows;
+  /// Sets the correct value in the referenced peak.
   void setPeakHKLOrRunNumber(const size_t index, const double val);
 };
 

--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -191,8 +191,7 @@ void PeakColumn::read(const size_t index, std::istream &in) {
   double val;
   try {
     in >> val;
-  }
-  catch (std::exception &e) {
+  } catch (std::exception &e) {
     g_log.error() << "Could not convert input to a number.\n";
     return;
   }

--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -192,7 +192,7 @@ void PeakColumn::read(const size_t index, std::istream &in) {
   try {
     in >> val;
   } catch (std::exception &e) {
-    g_log.error() << "Could not convert input to a number.\n";
+    g_log.error() << "Could not convert input to a number. " << e.what() << '\n';
     return;
   }
 

--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -192,7 +192,8 @@ void PeakColumn::read(const size_t index, std::istream &in) {
   try {
     in >> val;
   } catch (std::exception &e) {
-    g_log.error() << "Could not convert input to a number. " << e.what() << '\n';
+    g_log.error() << "Could not convert input to a number. " << e.what()
+                  << '\n';
     return;
   }
 

--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -165,36 +165,18 @@ void PeakColumn::print(size_t index, std::ostream &s) const {
  */
 void PeakColumn::read(size_t index, const std::string &text) {
   // Don't modify read-only ones
-  if (this->getReadOnly())
+  if (this->getReadOnly() || index >= m_peaks.size())
     return;
-
-  // Avoid going out of bounds
-  if (size_t(index) >= m_peaks.size())
-    return;
-
-  // Reference to the peak in the workspace
-  Peak &peak = m_peaks[index];
 
   // Convert to a double
   double val = 0;
   int success = Strings::convert(text, val);
-  int ival = static_cast<int>(val);
 
   if (success == 0) {
     g_log.error() << "Could not convert string '" << text << "' to a number.\n";
     return;
   }
-
-  if (m_name == "h")
-    peak.setH(val);
-  else if (m_name == "k")
-    peak.setK(val);
-  else if (m_name == "l")
-    peak.setL(val);
-  else if (m_name == "RunNumber")
-    peak.setRunNumber(ival);
-  else
-    throw std::runtime_error("Unexpected column " + m_name + " being set.");
+  setPeakHKLOrRunNumber(index, val);
 }
 
 /** Read in from stream and convert to a number in the PeaksWorkspace
@@ -203,9 +185,19 @@ void PeakColumn::read(size_t index, const std::string &text) {
  * @param in :: input stream
  */
 void PeakColumn::read(const size_t index, std::istream &in) {
-  std::string s;
-  in >> s;
-  read(index, s);
+  if (this->getReadOnly() || index >= m_peaks.size())
+    return;
+
+  double val;
+  try {
+    in >> val;
+  }
+  catch (std::exception &e) {
+    g_log.error() << "Could not convert input to a number.\n";
+    return;
+  }
+
+  setPeakHKLOrRunNumber(index, val);
 }
 
 //-------------------------------------------------------------------------------------
@@ -330,6 +322,20 @@ double PeakColumn::toDouble(size_t /*index*/) const {
 void PeakColumn::fromDouble(size_t /*index*/, double /*value*/) {
   throw std::runtime_error("fromDouble() not implemented, PeakColumn is has no "
                            "general write access");
+}
+
+void PeakColumn::setPeakHKLOrRunNumber(const size_t index, const double val) {
+  Peak &peak = m_peaks[index];
+  if (m_name == "h")
+    peak.setH(val);
+  else if (m_name == "k")
+    peak.setK(val);
+  else if (m_name == "l")
+    peak.setL(val);
+  else if (m_name == "RunNumber")
+    peak.setRunNumber(static_cast<int>(val));
+  else
+    throw std::runtime_error("Unexpected column " + m_name + " being set.");
 }
 
 } // namespace Mantid

--- a/Framework/DataObjects/test/PeakColumnTest.h
+++ b/Framework/DataObjects/test/PeakColumnTest.h
@@ -120,7 +120,7 @@ public:
   void test_read_locale_awerness() {
     const std::vector<std::string> columnNames{"h", "k", "l", "RunNumber"};
     const std::vector<double> columnValues{-2.0, 5.0, 12.0, 143290.0};
-    const TestingNumpunctFacet numpunct;
+    TestingNumpunctFacet numpunct;
     const std::locale testLocale(std::locale::classic(), &numpunct);
     for (size_t i = 0; i < columnNames.size(); ++i) {
       PeakColumn pc(m_peaks, columnNames[i]);

--- a/Framework/DataObjects/test/PeakColumnTest.h
+++ b/Framework/DataObjects/test/PeakColumnTest.h
@@ -157,16 +157,11 @@ private:
   public:
     /// Informs locales not to delete this facet.
     TestingNumpunctFacet() : std::numpunct<char>(1) {}
+
   private:
-    char_type do_decimal_point() const override {
-      return '%';
-    }
-    char_type do_thousands_sep() const override {
-      return '@';
-    }
-    string_type do_grouping() const override {
-      return "\03";
-    }
+    char_type do_decimal_point() const override { return '%'; }
+    char_type do_thousands_sep() const override { return '@'; }
+    string_type do_grouping() const override { return "\03"; }
   };
 
   Mantid::Geometry::Instrument_sptr m_inst;

--- a/Framework/DataObjects/test/PeakColumnTest.h
+++ b/Framework/DataObjects/test/PeakColumnTest.h
@@ -117,20 +117,45 @@ public:
     TS_ASSERT(readOnly);
   }
 
-  void test_read_hkl() {
-    PeakColumn pc(m_peaks, "h");
-    TestingNumpunctFacet numpunct;
-    std::locale testLocale(std::locale::classic(), &numpunct);
-    std::istringstream in("-3%0");
-    in.imbue(testLocale);
-    pc.read(0, in);
-    std::cout << in.str() << '\n';
-    TS_ASSERT_EQUALS(m_peaks[0].getH(), -3.0)
+  void test_read_locale_awerness() {
+    const std::vector<std::string> columnNames{"h", "k", "l", "RunNumber"};
+    const std::vector<double> columnValues{-2.0, 5.0, 12.0, 143290.0};
+    const TestingNumpunctFacet numpunct;
+    const std::locale testLocale(std::locale::classic(), &numpunct);
+    for (size_t i = 0; i < columnNames.size(); ++i) {
+      PeakColumn pc(m_peaks, columnNames[i]);
+      // Use a fake punctuation facet for numeric formatting.
+      std::ostringstream out;
+      out.imbue(testLocale);
+      // Force some decimals to the numbers.
+      out << std::fixed;
+      out << std::setprecision(2);
+      out << columnValues[i];
+      std::istringstream in(out.str());
+      in.imbue(testLocale);
+      pc.read(0, in);
+      switch (i) {
+      case 0:
+        TS_ASSERT_EQUALS(m_peaks[0].getH(), columnValues[i])
+        break;
+      case 1:
+        TS_ASSERT_EQUALS(m_peaks[0].getK(), columnValues[i])
+        break;
+      case 2:
+        TS_ASSERT_EQUALS(m_peaks[0].getL(), columnValues[i])
+        break;
+      case 3:
+        TS_ASSERT_EQUALS(m_peaks[0].getRunNumber(), columnValues[i])
+        break;
+      }
+    }
   }
 
 private:
+  /// A locale facet mocking non-english numerical punctuation.
   class TestingNumpunctFacet : public std::numpunct<char> {
   public:
+    /// Informs locales not to delete this facet.
     TestingNumpunctFacet() : std::numpunct<char>(1) {}
   private:
     char_type do_decimal_point() const override {


### PR DESCRIPTION
This PR fixes the regressions introduced in PR #18315 with regards to the `PeakColumn` class. The `read(const size_t index, std::istream &)` method was erroneously delegating the reading directly to the `read(size_t, std::string &)` method which in turn did not take into account the locale in which the input string was written.

**To test:**

1. Load the 'Peaks5637.integrate' file from Mantid's unit test data using the `LoadIsawPeaks` algorithm.
2. Show the data.
3. Without these changes, a lot of errors may appear in the Mantid log (this depends on your locale settings!). The errors could be something like `Could not convert string'15,629' to a number for the RunNumber`.

Fixes #18366 

*Does not need to be in the release notes as this fixes a regression introduced in another PR which is already in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
