### PR TITLE
Peak comparison tool updates

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
@@ -88,6 +88,7 @@ public:
   std::string getWorkspaceNameStdString() const;
   void renameWorkspace(const std::string &workspace);
   SurfaceType getSurfaceType() const { return m_surfaceType; }
+  Mantid::Kernel::V3D getSurfaceAxis(const int surfaceType) const;
   /// Get pointer to the projection surface
   boost::shared_ptr<ProjectionSurface> getSurface() const;
   /// True if the GL instrument display is currently on

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -86,6 +86,7 @@ public:
   bool addToDisplayContextMenu(QMenu &) const override;
   void selectTool(const ToolType tool);
   boost::shared_ptr<ProjectionSurface> getSurface() const;
+  const InstrumentWidget* getInstrumentWidget() const;
   /// Load settings for the pick tab from a project file
   virtual void loadFromProject(const std::string &lines) override;
   /// Save settings for the pick tab to a project file

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -105,8 +105,8 @@ private slots:
   void removeCurve(const QString &);
   void singleComponentTouched(size_t pickID);
   void singleComponentPicked(size_t pickID);
-  void comparePeaks(const std::pair<Mantid::Geometry::IPeak *,
-                                    Mantid::Geometry::IPeak *> &peaks);
+  void comparePeaks(const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                                    std::vector<Mantid::Geometry::IPeak *>> &peaks);
   void updateSelectionInfoDisplay();
   void shapeCreated();
   void updatePlotMultipleDetectors();
@@ -185,8 +185,9 @@ public:
                           InstrumentActor *instrActor, QTextEdit *infoDisplay);
 public slots:
   void displayInfo(size_t pickID);
-  void displayComparePeaksInfo(
-      std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> peaks);
+  void displayComparePeaksInfo(const std::pair<
+                               std::vector<Mantid::Geometry::IPeak *>,
+                               std::vector<Mantid::Geometry::IPeak *>>& peaks);
   void clear();
 
 private:
@@ -194,7 +195,7 @@ private:
   QString displayNonDetectorInfo(Mantid::Geometry::ComponentID compID);
   QString displayPeakInfo(Mantid::Geometry::IPeak *peak);
   QString displayPeakAngles(
-      std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> peaks);
+      const std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> &peaks);
   QString getParameterInfo(Mantid::Geometry::IComponent_const_sptr comp);
   QString getPeakOverlayInfo();
 

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -86,7 +86,7 @@ public:
   bool addToDisplayContextMenu(QMenu &) const override;
   void selectTool(const ToolType tool);
   boost::shared_ptr<ProjectionSurface> getSurface() const;
-  const InstrumentWidget* getInstrumentWidget() const;
+  const InstrumentWidget *getInstrumentWidget() const;
   /// Load settings for the pick tab from a project file
   virtual void loadFromProject(const std::string &lines) override;
   /// Save settings for the pick tab to a project file

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -105,8 +105,9 @@ private slots:
   void removeCurve(const QString &);
   void singleComponentTouched(size_t pickID);
   void singleComponentPicked(size_t pickID);
-  void comparePeaks(const std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                                    std::vector<Mantid::Geometry::IPeak *>> &peaks);
+  void
+  comparePeaks(const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                               std::vector<Mantid::Geometry::IPeak *>> &peaks);
   void updateSelectionInfoDisplay();
   void shapeCreated();
   void updatePlotMultipleDetectors();
@@ -185,17 +186,17 @@ public:
                           InstrumentActor *instrActor, QTextEdit *infoDisplay);
 public slots:
   void displayInfo(size_t pickID);
-  void displayComparePeaksInfo(const std::pair<
-                               std::vector<Mantid::Geometry::IPeak *>,
-                               std::vector<Mantid::Geometry::IPeak *>>& peaks);
+  void displayComparePeaksInfo(
+      const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                      std::vector<Mantid::Geometry::IPeak *>> &peaks);
   void clear();
 
 private:
   QString displayDetectorInfo(Mantid::detid_t detid);
   QString displayNonDetectorInfo(Mantid::Geometry::ComponentID compID);
   QString displayPeakInfo(Mantid::Geometry::IPeak *peak);
-  QString displayPeakAngles(
-      const std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> &peaks);
+  QString displayPeakAngles(const std::pair<Mantid::Geometry::IPeak *,
+                                            Mantid::Geometry::IPeak *> &peaks);
   QString getParameterInfo(Mantid::Geometry::IComponent_const_sptr comp);
   QString getPeakOverlayInfo();
 

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/ProjectionSurface.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/ProjectionSurface.h
@@ -352,6 +352,8 @@ private:
   void drawMaskShapes(QPainter &painter) const;
   /// Draw the selection rectangle to the surface
   void drawSelectionRect(QPainter &painter) const;
+  /// Check if a peak is visible at a given point
+  bool peakVisibleAtPoint(const QPointF &point) const;
   /// Get the current input controller
   MantidQt::MantidWidgets::InputController *getController() const;
 

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/ProjectionSurface.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/ProjectionSurface.h
@@ -272,8 +272,8 @@ signals:
   // peaks
   void peaksWorkspaceAdded();
   void peaksWorkspaceDeleted();
-  void comparePeaks(
-      const std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> &);
+  void comparePeaks(const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+            std::vector<Mantid::Geometry::IPeak *>>&);
 
   // other
   void redrawRequired(); ///< request redrawing of self
@@ -339,8 +339,9 @@ protected:
   bool m_showPeakRelativeIntensity; ///< flag to show peak hkl labels
   mutable int m_peakShapesStyle; ///< index of a default PeakMarker2D style to
   std::pair<QPointF, QPointF> m_selectedMarkers;
-  std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *>
-      m_selectedPeaks;
+  std::pair<std::vector<Mantid::Geometry::IPeak *>,
+            std::vector<Mantid::Geometry::IPeak *>>
+  m_selectedPeaks;
   /// use with a new PeakOverlay.
 
 private:

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/ProjectionSurface.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/ProjectionSurface.h
@@ -273,7 +273,7 @@ signals:
   void peaksWorkspaceAdded();
   void peaksWorkspaceDeleted();
   void comparePeaks(const std::pair<std::vector<Mantid::Geometry::IPeak *>,
-            std::vector<Mantid::Geometry::IPeak *>>&);
+                                    std::vector<Mantid::Geometry::IPeak *>> &);
 
   // other
   void redrawRequired(); ///< request redrawing of self
@@ -340,8 +340,7 @@ protected:
   mutable int m_peakShapesStyle; ///< index of a default PeakMarker2D style to
   std::pair<QPointF, QPointF> m_selectedMarkers;
   std::pair<std::vector<Mantid::Geometry::IPeak *>,
-            std::vector<Mantid::Geometry::IPeak *>>
-  m_selectedPeaks;
+            std::vector<Mantid::Geometry::IPeak *>> m_selectedPeaks;
   /// use with a new PeakOverlay.
 
 private:

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/Shape2DCollection.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/Shape2DCollection.h
@@ -53,6 +53,7 @@ public:
   void keyPressEvent(QKeyEvent *);
 
   bool selectAtXY(int x, int y, bool edit = true);
+  bool selectAtXY(const QPointF &point, bool edit = true);
   void deselectAtXY(int x, int y);
   bool selectIn(const QRect &rect);
   void removeCurrentShape();

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
@@ -210,8 +210,8 @@ void InstrumentWidget::renameWorkspace(const std::string &workspace) {
  * @param surfaceType :: Surface type for this projection
  * @return a V3D for the axis being projected on
  */
-Mantid::Kernel::V3D InstrumentWidget::getSurfaceAxis(const int surfaceType) const
-{
+Mantid::Kernel::V3D
+InstrumentWidget::getSurfaceAxis(const int surfaceType) const {
   Mantid::Kernel::V3D axis;
 
   // define the axis

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
@@ -206,6 +206,30 @@ void InstrumentWidget::renameWorkspace(const std::string &workspace) {
 }
 
 /**
+ * Get the axis vector for the surface projection type.
+ * @param surfaceType :: Surface type for this projection
+ * @return a V3D for the axis being projected on
+ */
+Mantid::Kernel::V3D InstrumentWidget::getSurfaceAxis(const int surfaceType) const
+{
+  Mantid::Kernel::V3D axis;
+
+  // define the axis
+  if (surfaceType == SPHERICAL_Y || surfaceType == CYLINDRICAL_Y) {
+    axis = Mantid::Kernel::V3D(0, 1, 0);
+  } else if (surfaceType == SPHERICAL_Z || surfaceType == CYLINDRICAL_Z) {
+    axis = Mantid::Kernel::V3D(0, 0, 1);
+  } else if (surfaceType == SPHERICAL_X || surfaceType == CYLINDRICAL_X) {
+    axis = Mantid::Kernel::V3D(1, 0, 0);
+  } else // SIDE_BY_SIDE
+  {
+    axis = Mantid::Kernel::V3D(0, 0, 1);
+  }
+
+  return axis;
+}
+
+/**
 * Init the geometry and colour map outside constructor to prevent creating a
 * broken MdiSubwindow.
 * Must be called straight after constructor.
@@ -382,18 +406,7 @@ void InstrumentWidget::setSurfaceType(int type) {
         throw InstrumentHasNoSampleError();
       }
       Mantid::Kernel::V3D sample_pos = sample->getPos();
-      Mantid::Kernel::V3D axis;
-      // define the axis
-      if (surfaceType == SPHERICAL_Y || surfaceType == CYLINDRICAL_Y) {
-        axis = Mantid::Kernel::V3D(0, 1, 0);
-      } else if (surfaceType == SPHERICAL_Z || surfaceType == CYLINDRICAL_Z) {
-        axis = Mantid::Kernel::V3D(0, 0, 1);
-      } else if (surfaceType == SPHERICAL_X || surfaceType == CYLINDRICAL_X) {
-        axis = Mantid::Kernel::V3D(1, 0, 0);
-      } else // SIDE_BY_SIDE
-      {
-        axis = Mantid::Kernel::V3D(0, 0, 1);
-      }
+      auto axis = getSurfaceAxis(surfaceType);
 
       // create the surface
       if (surfaceType == FULL3D) {

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
@@ -544,12 +544,12 @@ void InstrumentWidgetPickTab::initSurface() {
   connect(surface, SIGNAL(singleComponentPicked(size_t)), this,
           SLOT(singleComponentPicked(size_t)));
   connect(
-      surface,
-      SIGNAL(comparePeaks(std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                                    std::vector<Mantid::Geometry::IPeak *>>)),
-      this,
-      SLOT(comparePeaks(std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                                  std::vector<Mantid::Geometry::IPeak *>>)));
+      surface, SIGNAL(comparePeaks(
+                   const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                                   std::vector<Mantid::Geometry::IPeak *>> &)),
+      this, SLOT(comparePeaks(
+                const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                                std::vector<Mantid::Geometry::IPeak *>> &)));
   connect(surface, SIGNAL(peaksWorkspaceAdded()), this,
           SLOT(updateSelectionInfoDisplay()));
   connect(surface, SIGNAL(peaksWorkspaceDeleted()), this,

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
@@ -931,36 +931,10 @@ QString ComponentInfoController::displayPeakAngles(
   auto peak1 = peaks.first;
   auto peak2 = peaks.second;
 
-  auto pos1 = peak1->getDetector()->getPos();
-  auto pos2 = peak2->getDetector()->getPos();
-
-  // get which way is "up". e.g. y unit vector if this is a cylindrical y
-  // projection
-  auto instWidget = m_tab->getInstrumentWidget();
-  auto surfaceType = instWidget->getSurfaceType();
-  auto axis = instWidget->getSurfaceAxis(surfaceType);
-
-  // get beam direction
-  auto instrument = peak1->getInstrument();
-  auto sample = instrument->getSample()->getPos();
-  auto source = instrument->getSource()->getPos();
-  auto L1 = (sample - source);
-  auto normal = axis.cross_prod(L1);
-
-  // always compute the angle from the right most peak
-  // relative to the coordinates of the sample
-  if (pos1.scalar_prod(normal) > pos2.scalar_prod(normal))
-    std::swap(pos1, pos2);
-
-  // compute the angle between -180 and +180
-  auto angle = pos2.angle(pos1);
-  auto refRight = axis.cross_prod(pos1);
-  angle = std::copysign(angle, pos2.scalar_prod(refRight));
+  auto pos1 = peak1->getQLabFrame();
+  auto pos2 = peak2->getQLabFrame();
+  auto angle = pos1.angle(pos2);
   angle *= double_constants::radian;
-
-  // correct the angle to the range to be 0 < theta < 360
-  if (angle < 0)
-    angle = 360 + angle;
 
   text << "Angle: " << angle << "\n";
 

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
@@ -545,11 +545,11 @@ void InstrumentWidgetPickTab::initSurface() {
           SLOT(singleComponentPicked(size_t)));
   connect(
       surface,
-      SIGNAL(comparePeaks(
-          std::pair<std::vector<Mantid::Geometry::IPeak *>, std::vector<Mantid::Geometry::IPeak *>>)),
+      SIGNAL(comparePeaks(std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                                    std::vector<Mantid::Geometry::IPeak *>>)),
       this,
-      SLOT(comparePeaks(
-          std::pair<std::vector<Mantid::Geometry::IPeak *>, std::vector<Mantid::Geometry::IPeak *>>)));
+      SLOT(comparePeaks(std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                                  std::vector<Mantid::Geometry::IPeak *>>)));
   connect(surface, SIGNAL(peaksWorkspaceAdded()), this,
           SLOT(updateSelectionInfoDisplay()));
   connect(surface, SIGNAL(peaksWorkspaceDeleted()), this,
@@ -681,8 +681,9 @@ void InstrumentWidgetPickTab::singleComponentPicked(size_t pickID) {
   m_plotController->updatePlot();
 }
 
-void InstrumentWidgetPickTab::comparePeaks(const std::pair<std::vector<
-    Mantid::Geometry::IPeak *>, std::vector<Mantid::Geometry::IPeak *>> &peaks) {
+void InstrumentWidgetPickTab::comparePeaks(
+    const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                    std::vector<Mantid::Geometry::IPeak *>> &peaks) {
   m_infoController->displayComparePeaksInfo(peaks);
 }
 
@@ -925,8 +926,8 @@ ComponentInfoController::displayPeakInfo(Mantid::Geometry::IPeak *peak) {
   return QString::fromStdString(text.str());
 }
 
-QString ComponentInfoController::displayPeakAngles(
-    const std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> &peaks) {
+QString ComponentInfoController::displayPeakAngles(const std::pair<
+    Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> &peaks) {
   std::stringstream text;
   auto peak1 = peaks.first;
   auto peak2 = peaks.second;
@@ -941,13 +942,14 @@ QString ComponentInfoController::displayPeakAngles(
   return QString::fromStdString(text.str());
 }
 
-void ComponentInfoController::displayComparePeaksInfo(const
-                                                      std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                                                      std::vector<Mantid::Geometry::IPeak *>> &peaks) {
+void ComponentInfoController::displayComparePeaksInfo(
+    const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                    std::vector<Mantid::Geometry::IPeak *>> &peaks) {
   std::stringstream text;
 
   text << "Comparison Information\n";
-  auto peaksFromDetectors = std::make_pair(peaks.first.front(), peaks.second.front());
+  auto peaksFromDetectors =
+      std::make_pair(peaks.first.front(), peaks.second.front());
   text << displayPeakAngles(peaksFromDetectors).toStdString();
 
   text << "-------------------------------\n";
@@ -961,7 +963,6 @@ void ComponentInfoController::displayComparePeaksInfo(const
     text << displayPeakInfo(peak).toStdString();
 
   text << "\n";
-
 
   m_selectionInfoDisplay->setText(QString::fromStdString(text.str()));
 }

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
@@ -546,10 +546,10 @@ void InstrumentWidgetPickTab::initSurface() {
   connect(
       surface,
       SIGNAL(comparePeaks(
-          std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *>)),
+          std::pair<std::vector<Mantid::Geometry::IPeak *>, std::vector<Mantid::Geometry::IPeak *>>)),
       this,
       SLOT(comparePeaks(
-          std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *>)));
+          std::pair<std::vector<Mantid::Geometry::IPeak *>, std::vector<Mantid::Geometry::IPeak *>>)));
   connect(surface, SIGNAL(peaksWorkspaceAdded()), this,
           SLOT(updateSelectionInfoDisplay()));
   connect(surface, SIGNAL(peaksWorkspaceDeleted()), this,
@@ -681,8 +681,8 @@ void InstrumentWidgetPickTab::singleComponentPicked(size_t pickID) {
   m_plotController->updatePlot();
 }
 
-void InstrumentWidgetPickTab::comparePeaks(const std::pair<
-    Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> &peaks) {
+void InstrumentWidgetPickTab::comparePeaks(const std::pair<std::vector<
+    Mantid::Geometry::IPeak *>, std::vector<Mantid::Geometry::IPeak *>> &peaks) {
   m_infoController->displayComparePeaksInfo(peaks);
 }
 
@@ -926,7 +926,7 @@ ComponentInfoController::displayPeakInfo(Mantid::Geometry::IPeak *peak) {
 }
 
 QString ComponentInfoController::displayPeakAngles(
-    std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> peaks) {
+    const std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> &peaks) {
   std::stringstream text;
   auto peak1 = peaks.first;
   auto peak2 = peaks.second;
@@ -967,19 +967,28 @@ QString ComponentInfoController::displayPeakAngles(
   return QString::fromStdString(text.str());
 }
 
-void ComponentInfoController::displayComparePeaksInfo(
-    std::pair<Mantid::Geometry::IPeak *, Mantid::Geometry::IPeak *> peaks) {
+void ComponentInfoController::displayComparePeaksInfo(const
+                                                      std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                                                      std::vector<Mantid::Geometry::IPeak *>> &peaks) {
   std::stringstream text;
-  auto peak1 = peaks.first;
-  auto peak2 = peaks.second;
 
-  text << "First Peak \n";
-  text << displayPeakInfo(peak1).toStdString();
+  text << "Comparison Information\n";
+  auto peaksFromDetectors = std::make_pair(peaks.first.front(), peaks.second.front());
+  text << displayPeakAngles(peaksFromDetectors).toStdString();
+
   text << "-------------------------------\n";
-  text << "Second Peak \n";
-  text << displayPeakInfo(peak2).toStdString();
+  text << "First Detector Peaks \n";
+  for (auto peak : peaks.first)
+    text << displayPeakInfo(peak).toStdString();
+
   text << "-------------------------------\n";
-  text << displayPeakAngles(peaks).toStdString();
+  text << "Second Detector Peaks \n";
+  for (auto peak : peaks.second)
+    text << displayPeakInfo(peak).toStdString();
+
+  text << "\n";
+
+
   m_selectionInfoDisplay->setText(QString::fromStdString(text.str()));
 }
 

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
@@ -931,14 +931,16 @@ QString ComponentInfoController::displayPeakAngles(
   auto pos2 = peak2->getDetector()->getPos();
 
   auto angle = pos1.angle(pos2) * double_constants::radian;
-  auto distance = pos1 - pos2;
+  auto distance = pos2 - pos1;
   auto dirAngles = distance.directionAngles();
+
+  auto x = dirAngles[0];
+  auto y = dirAngles[1];
 
   text << "Angle between: " << angle << "\n";
   text << "Direction angles: ";
-  text << " a: " << dirAngles[0];
-  text << " b: " << dirAngles[1];
-  text << " c: " << dirAngles[2];
+  text << " x: " << x;
+  text << " y: " << y;
   text << "\n";
 
   return QString::fromStdString(text.str());

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
@@ -931,8 +931,8 @@ QString ComponentInfoController::displayPeakAngles(
   auto peak1 = peaks.first;
   auto peak2 = peaks.second;
 
-  auto pos1 = peak1->getQLabFrame();
-  auto pos2 = peak2->getQLabFrame();
+  auto pos1 = peak1->getQSampleFrame();
+  auto pos2 = peak2->getQSampleFrame();
   auto angle = pos1.angle(pos2);
   angle *= double_constants::radian;
 

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
@@ -584,9 +584,8 @@ InstrumentWidgetPickTab::getSurface() const {
   return m_instrWidget->getSurface();
 }
 
-const InstrumentWidget *InstrumentWidgetPickTab::getInstrumentWidget() const
-{
- return m_instrWidget;
+const InstrumentWidget *InstrumentWidgetPickTab::getInstrumentWidget() const {
+  return m_instrWidget;
 }
 
 /**
@@ -960,7 +959,8 @@ QString ComponentInfoController::displayPeakAngles(
   angle *= double_constants::radian;
 
   // correct the angle to the range to be 0 < theta < 360
-  if(angle < 0) angle = 360 + angle;
+  if (angle < 0)
+    angle = 360 + angle;
 
   text << "Angle: " << angle << "\n";
 

--- a/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
@@ -526,7 +526,6 @@ void ProjectionSurface::drawPeakComparisonLine(QPainter &painter) const {
     windowRect.findTransform(transform, painter.viewport());
     auto p1 = transform.map(m_selectedMarkers.first);
     auto p2 = transform.map(m_selectedMarkers.second);
-
     painter.setPen(Qt::red);
     painter.drawLine(p1, p2);
   }
@@ -647,6 +646,10 @@ void ProjectionSurface::clearPeakOverlays() {
     m_peakShapesStyle = 0;
     emit peaksWorkspaceDeleted();
   }
+  m_selectedPeaks.first = nullptr;
+  m_selectedPeaks.second = nullptr;
+  m_selectedMarkers.first = QPointF();
+  m_selectedMarkers.second = QPointF();
 }
 
 /**
@@ -738,6 +741,20 @@ void ProjectionSurface::touchComponentAt(int x, int y) {
 void ProjectionSurface::erasePeaks(const QRect &rect) {
   foreach (PeakOverlay *po, m_peakShapes) {
     po->selectIn(rect);
+    auto peakMarkers = po->getSelectedPeakMarkers();
+
+    // clear selected peak markers
+    for (auto marker : peakMarkers) {
+      auto peak = po->getPeaksWorkspace()->getPeakPtr(marker->getRow());
+      if (m_selectedPeaks.first == peak ||
+          m_selectedPeaks.second == peak) {
+        m_selectedPeaks.first = nullptr;
+        m_selectedPeaks.second = nullptr;
+        m_selectedMarkers.first = QPointF();
+        m_selectedMarkers.second = QPointF();
+      }
+    }
+
     po->removeSelectedShapes();
   }
 }

--- a/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
@@ -744,7 +744,7 @@ void ProjectionSurface::erasePeaks(const QRect &rect) {
     auto peakMarkers = po->getSelectedPeakMarkers();
 
     // clear selected peak markers
-    for (auto marker : peakMarkers) {
+    for (const auto &marker : peakMarkers) {
       auto peak = po->getPeaksWorkspace()->getPeakPtr(marker->getRow());
       if (m_selectedPeaks.first.front() == peak ||
           m_selectedPeaks.second.front() == peak) {
@@ -767,13 +767,13 @@ void ProjectionSurface::comparePeaks(const QRect &rect) {
     po->selectIn(rect);
     const auto markers = po->getSelectedPeakMarkers();
 
-    // make the assumption that the first peak found in the recticule is the one
+    // make the assumption that the first peak found in the recticle is the one
     // we wanted.
     if (markers.length() > 0 && origin.isNull()) {
       origin = markers.first()->origin();
     }
 
-    for (auto marker : markers) {
+    for (const auto &marker : markers) {
       // only collect peaks in the same detector & with the same origin
       if (marker->origin() == origin) {
         auto peak = po->getPeaksWorkspace()->getPeakPtr(marker->getRow());

--- a/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
@@ -766,7 +766,7 @@ void ProjectionSurface::comparePeaks(const QRect &rect) {
   PeakMarker2D *marker = nullptr;
   Mantid::Geometry::IPeak *peak = nullptr;
   QPointF origin;
-  foreach (PeakOverlay *po, m_peakShapes) {
+  for(auto *po : m_peakShapes) {
     po->selectIn(rect);
     const auto markers = po->getSelectedPeakMarkers();
     if (markers.length() > 0) {

--- a/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
@@ -746,7 +746,8 @@ void ProjectionSurface::erasePeaks(const QRect &rect) {
     // clear selected peak markers
     for (auto marker : peakMarkers) {
       auto peak = po->getPeaksWorkspace()->getPeakPtr(marker->getRow());
-      if (m_selectedPeaks.first.front() == peak || m_selectedPeaks.second.front() == peak) {
+      if (m_selectedPeaks.first.front() == peak ||
+          m_selectedPeaks.second.front() == peak) {
         m_selectedPeaks.first.clear();
         m_selectedPeaks.second.clear();
         m_selectedMarkers.first = QPointF();
@@ -761,7 +762,7 @@ void ProjectionSurface::erasePeaks(const QRect &rect) {
 void ProjectionSurface::comparePeaks(const QRect &rect) {
   // Find the selected peak across all of the peak overlays.
   QPointF origin;
-  std::vector<Mantid::Geometry::IPeak*> peaks;
+  std::vector<Mantid::Geometry::IPeak *> peaks;
   for (auto *po : m_peakShapes) {
     po->selectIn(rect);
     const auto markers = po->getSelectedPeakMarkers();
@@ -789,8 +790,8 @@ void ProjectionSurface::comparePeaks(const QRect &rect) {
     // Two peaks have now been selected
     m_selectedPeaks.second = peaks;
     m_selectedMarkers.second = origin;
-  } else if (!m_selectedPeaks.first.empty()
-             && !m_selectedPeaks.second.empty()) {
+  } else if (!m_selectedPeaks.first.empty() &&
+             !m_selectedPeaks.second.empty()) {
     // Two peaks have already been selected. Clear the pair and store
     // the new peak as the first entry
     m_selectedPeaks.first = peaks;

--- a/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/ProjectionSurface.cpp
@@ -746,8 +746,7 @@ void ProjectionSurface::erasePeaks(const QRect &rect) {
     // clear selected peak markers
     for (auto marker : peakMarkers) {
       auto peak = po->getPeaksWorkspace()->getPeakPtr(marker->getRow());
-      if (m_selectedPeaks.first == peak ||
-          m_selectedPeaks.second == peak) {
+      if (m_selectedPeaks.first == peak || m_selectedPeaks.second == peak) {
         m_selectedPeaks.first = nullptr;
         m_selectedPeaks.second = nullptr;
         m_selectedMarkers.first = QPointF();
@@ -766,7 +765,7 @@ void ProjectionSurface::comparePeaks(const QRect &rect) {
   PeakMarker2D *marker = nullptr;
   Mantid::Geometry::IPeak *peak = nullptr;
   QPointF origin;
-  for(auto *po : m_peakShapes) {
+  for (auto *po : m_peakShapes) {
     po->selectIn(rect);
     const auto markers = po->getSelectedPeakMarkers();
     if (markers.length() > 0) {

--- a/MantidQt/MantidWidgets/src/InstrumentView/Shape2DCollection.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/Shape2DCollection.cpp
@@ -300,13 +300,20 @@ void Shape2DCollection::touchShapeOrControlPointAt(int x, int y) {
 * Select a shape which contains a point (x,y) of the screen.
 */
 bool Shape2DCollection::selectAtXY(int x, int y, bool edit) {
+  const auto point = m_transform.inverted().map(QPointF(x, y));
+  return selectAtXY(point, edit);
+}
+
+/**
+* Select a shape which contains a point (x, y) of the world.
+*/
+bool Shape2DCollection::selectAtXY(const QPointF &point, bool edit) {
   if (edit) {
     // if shape has to be edited (resized) it must be the only selection
     deselectAll();
   }
-  QPointF p = m_transform.inverted().map(QPointF(x, y));
   foreach (Shape2D *shape, m_shapes) {
-    bool picked = shape->selectAt(p);
+    bool picked = shape->selectAt(point);
     if (picked) {
       addToSelection(shape);
       return true;


### PR DESCRIPTION
Fixed two issues:
 - Swapped to calculating the angle between Q vectors
 - Fixed bug where line would be left after changing between tools or clearing/erasing peaks 

**To test:**

 - Load some single crystal data
 - Open the instrument view and choose some peaks
 - Select the peak comparison tool
 - Choose two peaks and check the following
    - the correct reciprocal angle between the two Q vectors is calculated
 - Clear the peaks.
    - the line between two peaks should be removed

Fixes #18043.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.