### PR TITLE
Store monitor flags in Beamline::DetectorInfo

### DIFF
--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -52,7 +52,7 @@ size_t DetectorInfo::size() const { return m_detectorIDs.size(); }
 
 /// Returns true if the detector is a monitor.
 bool DetectorInfo::isMonitor(const size_t index) const {
-  return getDetector(index).isMonitor();
+  return m_instrument->isMonitor(index);
 }
 
 /// Returns true if the detector is a masked.

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -52,10 +52,10 @@ size_t DetectorInfo::size() const { return m_detectorIDs.size(); }
 
 /// Returns true if the detector is a monitor.
 bool DetectorInfo::isMonitor(const size_t index) const {
-  return m_instrument->isMonitorViaIndex(index);
+  return m_detectorInfo.isMonitor(index);
 }
 
-/// Returns true if the detector is a masked.
+/// Returns true if the detector is masked.
 bool DetectorInfo::isMasked(const size_t index) const {
   return m_detectorInfo.isMasked(index);
 }

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -52,7 +52,7 @@ size_t DetectorInfo::size() const { return m_detectorIDs.size(); }
 
 /// Returns true if the detector is a monitor.
 bool DetectorInfo::isMonitor(const size_t index) const {
-  return m_instrument->isMonitor(index);
+  return m_instrument->isMonitorViaIndex(index);
 }
 
 /// Returns true if the detector is a masked.

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -166,7 +166,11 @@ makeDetectorInfo(const Instrument &oldInstr, const Instrument &newInstr) {
   } else {
     // If there is no DetectorInfo in the instrument we create a default one.
     const auto numDets = oldInstr.getNumberDetectors();
-    return Kernel::make_unique<Beamline::DetectorInfo>(numDets);
+    std::vector<size_t> monitors;
+    for (size_t i = 0; i < numDets; ++i)
+      if (newInstr.isMonitorViaIndex(i))
+        monitors.push_back(i);
+    return Kernel::make_unique<Beamline::DetectorInfo>(numDets, monitors);
   }
 }
 }

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -166,6 +166,14 @@ makeDetectorInfo(const Instrument &oldInstr, const Instrument &newInstr) {
   } else {
     // If there is no DetectorInfo in the instrument we create a default one.
     const auto numDets = oldInstr.getNumberDetectors();
+    // Currently monitors flags are stored in the detector cache of the base
+    // instrument. The copy being made here is strictly speaking duplicating
+    // that data, but with future refactoring this will no longer be the case.
+    // Note that monitors will not change after creating a workspace.
+    // Instrument::markAsMonitor works only for the base instrument and it is
+    // not possible to obtain a non-const reference to the base instrument in a
+    // workspace. Thus we do not need to worry about the two copies of monitor
+    // flags running out of sync.
     std::vector<size_t> monitors;
     for (size_t i = 0; i < numDets; ++i)
       if (newInstr.isMonitorViaIndex(i))

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/MultiDomainFunction.h"
 #include "MantidAPI/IFunctionWithLocation.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Instrument/Component.h"
@@ -955,22 +956,18 @@ void IFunction::convertValue(std::vector<double> &values,
           << "Ignore convertion.";
       return;
     }
-    double l1 = instrument->getSource()->getDistance(*sample);
-    Geometry::IDetector_const_sptr det = ws->getDetector(wsIndex);
-    double l2(-1.0), twoTheta(0.0);
-    if (!det->isMonitor()) {
-      l2 = det->getDistance(*sample);
-      twoTheta = ws->detectorTwoTheta(*det);
-    } else // If this is a monitor then make l1+l2 = source-detector distance
-           // and twoTheta=0
-    {
-      l2 = det->getDistance(*(instrument->getSource()));
-      l2 = l2 - l1;
-      twoTheta = 0.0;
-    }
+    const auto &spectrumInfo = ws->spectrumInfo();
+    double l1 = spectrumInfo.l1();
+    // If this is a monitor then l1+l2 = source-detector distance and twoTheta=0
+    double l2 = spectrumInfo.l2(wsIndex);
+    double twoTheta(0.0);
+    if (!spectrumInfo.isMonitor(wsIndex))
+      twoTheta = spectrumInfo.twoTheta(wsIndex);
     int emode = static_cast<int>(ws->getEMode());
     double efixed(0.0);
     try {
+      boost::shared_ptr<const Geometry::IDetector> det(
+          &spectrumInfo.detector(wsIndex), NoDeleting());
       efixed = ws->getEFixed(det);
     } catch (std::exception &) {
       // assume elastic

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -29,7 +29,10 @@ SpectrumInfo::~SpectrumInfo() = default;
 
 /// Returns true if the detector(s) associated with the spectrum are monitors.
 bool SpectrumInfo::isMonitor(const size_t index) const {
-  return getDetector(index).isMonitor();
+  for (const auto detIndex : getDetectorIndices(index))
+    if (!m_detectorInfo.isMonitor(detIndex))
+      return false;
+  return true;
 }
 
 /// Returns true if the detector(s) associated with the spectrum are masked.

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -57,13 +57,17 @@ namespace Beamline {
 class MANTID_BEAMLINE_DLL DetectorInfo {
 public:
   DetectorInfo(const size_t numberOfDetectors);
+  DetectorInfo(const size_t numberOfDetectors,
+               const std::vector<size_t> &monitorIndices);
 
   size_t size() const;
 
+  bool isMonitor(const size_t index) const;
   bool isMasked(const size_t index) const;
   void setMasked(const size_t index, bool masked);
 
 private:
+  Kernel::cow_ptr<std::vector<bool>> m_isMonitor;
   Kernel::cow_ptr<std::vector<bool>> m_isMasked;
 };
 

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -17,7 +17,11 @@ DetectorInfo::DetectorInfo(const size_t numberOfDetectors,
 
 /// Returns the size of the DetectorInfo, i.e., the number of detectors in the
 /// instrument.
-size_t DetectorInfo::size() const { return m_isMasked->size(); }
+size_t DetectorInfo::size() const {
+  if (!m_isMasked)
+    return 0;
+  return m_isMasked->size();
+}
 
 /// Returns true if the detector is a monitor.
 bool DetectorInfo::isMonitor(const size_t index) const {

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -12,7 +12,7 @@ DetectorInfo::DetectorInfo(const size_t numberOfDetectors,
                            const std::vector<size_t> &monitorIndices)
     : DetectorInfo(numberOfDetectors) {
   for (const auto i : monitorIndices)
-    m_isMonitor.access()[i] = true;
+    m_isMonitor.access().at(i) = true;
 }
 
 /// Returns the size of the DetectorInfo, i.e., the number of detectors in the

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -5,13 +5,26 @@ namespace Mantid {
 namespace Beamline {
 
 DetectorInfo::DetectorInfo(const size_t numberOfDetectors)
-    : m_isMasked(Kernel::make_cow<std::vector<bool>>(numberOfDetectors)) {}
+    : m_isMonitor(Kernel::make_cow<std::vector<bool>>(numberOfDetectors)),
+      m_isMasked(Kernel::make_cow<std::vector<bool>>(numberOfDetectors)) {}
+
+DetectorInfo::DetectorInfo(const size_t numberOfDetectors,
+                           const std::vector<size_t> &monitorIndices)
+    : DetectorInfo(numberOfDetectors) {
+  for (const auto i : monitorIndices)
+    m_isMonitor.access()[i] = true;
+}
 
 /// Returns the size of the DetectorInfo, i.e., the number of detectors in the
 /// instrument.
 size_t DetectorInfo::size() const { return m_isMasked->size(); }
 
-/// Returns true if the detector is a masked.
+/// Returns true if the detector is a monitor.
+bool DetectorInfo::isMonitor(const size_t index) const {
+  return (*m_isMonitor)[index];
+}
+
+/// Returns true if the detector is masked.
 bool DetectorInfo::isMasked(const size_t index) const {
   return (*m_isMasked)[index];
 }

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -24,6 +24,18 @@ public:
     TS_ASSERT_EQUALS(detInfo->size(), 1);
   }
 
+  void test_constructor_with_monitors() {
+    std::unique_ptr<DetectorInfo> info;
+    std::vector<size_t> mons{0, 2};
+    TS_ASSERT_THROWS_NOTHING(info = Kernel::make_unique<DetectorInfo>(3, mons));
+    TS_ASSERT_EQUALS(info->size(), 3);
+    TS_ASSERT_THROWS_NOTHING(DetectorInfo(3, {}));
+    TS_ASSERT_THROWS_NOTHING(DetectorInfo(3, {0}));
+    TS_ASSERT_THROWS_NOTHING(DetectorInfo(3, {0, 1, 2}));
+    TS_ASSERT_THROWS_NOTHING(DetectorInfo(3, {0, 0, 0}));
+    TS_ASSERT_THROWS(DetectorInfo(3, {3}), std::out_of_range);
+  }
+
   void test_copy() {
     const DetectorInfo source(7);
     const auto copy(source);
@@ -50,6 +62,29 @@ public:
     assignee = std::move(source);
     TS_ASSERT_EQUALS(assignee.size(), 7);
     // TODO once DetectorInfo has moveable fields, check that they are cleared.
+  }
+
+  void test_no_monitors() {
+    DetectorInfo info(3);
+    TS_ASSERT(!info.isMonitor(0));
+    TS_ASSERT(!info.isMonitor(1));
+    TS_ASSERT(!info.isMonitor(2));
+  }
+
+  void test_monitors() {
+    std::vector<size_t> monitors{0, 2};
+    DetectorInfo info(3, monitors);
+    TS_ASSERT(info.isMonitor(0));
+    TS_ASSERT(!info.isMonitor(1));
+    TS_ASSERT(info.isMonitor(2));
+  }
+
+  void test_duplicate_monitors_ignored() {
+    std::vector<size_t> monitors{0, 0, 2, 2};
+    DetectorInfo info(3, monitors);
+    TS_ASSERT(info.isMonitor(0));
+    TS_ASSERT(!info.isMonitor(1));
+    TS_ASSERT(info.isMonitor(2));
   }
 
   void test_masking() {

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -46,7 +46,7 @@ public:
     DetectorInfo source(7);
     const auto moved(std::move(source));
     TS_ASSERT_EQUALS(moved.size(), 7);
-    // TODO once DetectorInfo has moveable fields, check that they are cleared.
+    TS_ASSERT_EQUALS(source.size(), 0);
   }
 
   void test_assign() {
@@ -61,7 +61,7 @@ public:
     DetectorInfo assignee(1);
     assignee = std::move(source);
     TS_ASSERT_EQUALS(assignee.size(), 7);
-    // TODO once DetectorInfo has moveable fields, check that they are cleared.
+    TS_ASSERT_EQUALS(source.size(), 0);
   }
 
   void test_no_monitors() {

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -557,7 +557,7 @@ public:
     TS_ASSERT_EQUALS(inst->getValidFromDate(),
                      std::string("2011-Jul-20 17:02:48.437294000"));
     TS_ASSERT_EQUALS(inst->getNumberDetectors(), 20483);
-    TS_ASSERT_EQUALS(inst->baseInstrument()->numMonitors(), 3);
+    TS_ASSERT_EQUALS(inst->baseInstrument()->getMonitors().size(), 3);
     auto params = inst->getParameterMap();
     TS_ASSERT_EQUALS(params->size(), 49);
     TS_ASSERT_EQUALS(params->getString(inst.get(), "deltaE-mode"), "direct");
@@ -580,7 +580,7 @@ public:
                                              // file
     TS_ASSERT_EQUALS(inst->getName(), "CNCS");
     TS_ASSERT_EQUALS(inst->getNumberDetectors(), 51203);
-    TS_ASSERT_EQUALS(inst->baseInstrument()->numMonitors(), 3);
+    TS_ASSERT_EQUALS(inst->baseInstrument()->getMonitors().size(), 3);
 
     // check that CNCS_Parameters.xml has been loaded
     auto params = inst->getParameterMap();

--- a/Framework/DataObjects/src/ReflectometryTransform.cpp
+++ b/Framework/DataObjects/src/ReflectometryTransform.cpp
@@ -1,6 +1,7 @@
 #include "MantidDataObjects/ReflectometryTransform.h"
 
 #include "MantidAPI/BinEdgeAxis.h"
+#include "MantidAPI/DetectorInfo.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/SpectrumDetectorMapping.h"
 #include "MantidAPI/SpectrumInfo.h"
@@ -218,29 +219,20 @@ DetectorAngularCache initAngularCaches(const MatrixWorkspace *const workspace) {
   std::vector<double> detectorHeights(nhist);
 
   auto inst = workspace->getInstrument();
-  const auto samplePos = inst->getSample()->getPos();
   const V3D upDirVec = inst->getReferenceFrame()->vecPointingUp();
 
-  for (size_t i = 0; i < nhist; ++i) // signed for OpenMP
-  {
-    IDetector_const_sptr det;
-    try {
-      det = workspace->getDetector(i);
-    } catch (Exception::NotFoundError &) {
-      // Catch if no detector. Next line tests whether this happened - test
-      // placed
-      // outside here because Mac Intel compiler doesn't like 'continue' in a
-      // catch
-      // in an openmp block.
-    }
-    // If no detector found, skip onto the next spectrum
-    if (!det || det->isMonitor()) {
+  const auto &spectrumInfo = workspace->spectrumInfo();
+  const auto &detectorInfo = workspace->detectorInfo();
+  for (size_t i = 0; i < nhist; ++i) {
+    if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i)) {
+      // If no detector found, skip onto the next spectrum
       thetas[i] = -1.0; // Indicates a detector to skip
       thetaWidths[i] = -1.0;
       continue;
     }
+
     // We have to convert theta from radians to degrees
-    const double theta = workspace->detectorSignedTwoTheta(*det) * rad2deg;
+    const double theta = spectrumInfo.signedTwoTheta(i) * rad2deg;
     thetas[i] = theta;
     /**
      * Determine width from shape geometry. A group is assumed to contain
@@ -248,17 +240,15 @@ DetectorAngularCache initAngularCaches(const MatrixWorkspace *const workspace) {
      * The shape is retrieved and rotated to match the rotation of the detector.
      * The angular width is computed using the l2 distance from the sample
      */
-    if (auto group = boost::dynamic_pointer_cast<const DetectorGroup>(det)) {
-      // assume they all have same shape and same r,theta
-      auto dets = group->getDetectors();
-      det = dets[0];
-    }
-    const auto pos = det->getPos() - samplePos;
-    double l2(0.0), t(0.0), p(0.0);
-    pos.getSpherical(l2, t, p);
+    // If the spectrum is based on a group of detectors assume they all have
+    // same shape and same r,theta
+    // DetectorGroup::getID gives ID of first detector.
+    size_t detIndex = detectorInfo.indexOf(spectrumInfo.detector(i).getID());
+    double l2 = detectorInfo.l2(detIndex);
     // Get the shape
     auto shape =
-        det->shape(); // Defined in its own reference frame with centre at 0,0,0
+        detectorInfo.detector(detIndex)
+            .shape(); // Defined in its own reference frame with centre at 0,0,0
     BoundingBox bbox = shape->getBoundingBox();
     auto maxPoint(bbox.maxPoint());
     auto minPoint(bbox.minPoint());

--- a/Framework/Geometry/inc/MantidGeometry/IDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/IDetector.h
@@ -100,9 +100,6 @@ public:
   /// Gives the phi of this detector offset from y=0 by offset.
   virtual double getPhiOffset(const double &offset) const = 0;
 
-  /// Indicates whether this is a monitor detector
-  virtual bool isMonitor() const = 0;
-
   /// returns the geometry of detectors, meaningful for groups, rectangular for
   /// single; returns the centre of a detector
   virtual det_topology getTopology(Kernel::V3D &center) const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <map>
+#include <tuple>
 #include <vector>
 
 namespace Mantid {
@@ -251,7 +252,7 @@ public:
   /// @return Full if all detectors are rect., Partial if some, None if none
   ContainsState containsRectDetectors() const;
 
-  bool isMonitor(const size_t index) const;
+  bool isMonitorViaIndex(const size_t index) const;
 
   bool hasDetectorInfo() const;
   const Beamline::DetectorInfo &detectorInfo() const;
@@ -270,8 +271,9 @@ private:
   void appendPlottable(const CompAssembly &ca,
                        std::vector<IObjComponent_const_sptr> &lst) const;
 
-  /// Map which holds detector-IDs and pointers to detector components
-  std::vector<std::pair<detid_t, IDetector_const_sptr>> m_detectorCache;
+  /// Map which holds detector-IDs and pointers to detector components, and
+  /// monitor flags.
+  std::vector<std::tuple<detid_t, IDetector_const_sptr, bool>> m_detectorCache;
 
   /// Purpose to hold copy of source component. For now assumed to be just one
   /// component

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -251,6 +251,8 @@ public:
   /// @return Full if all detectors are rect., Partial if some, None if none
   ContainsState containsRectDetectors() const;
 
+  bool isMonitor(const size_t index) const;
+
   bool hasDetectorInfo() const;
   const Beamline::DetectorInfo &detectorInfo() const;
   void

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -143,8 +143,6 @@ public:
 
   /// Returns a list containing the detector ids of monitors
   std::vector<detid_t> getMonitors() const;
-  /// Returns the number of monitors
-  size_t numMonitors() const;
 
   /// Get the bounding box for this component and store it in the given argument
   void getBoundingBox(BoundingBox &assemblyBox) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -124,7 +124,7 @@ public:
   /// child comp.)
   /// to be a monitor and also add it to _detectorCache for possible later
   /// retrieval
-  void markAsMonitor(IDetector *);
+  void markAsMonitor(const IDetector *);
 
   /// Remove a detector from the instrument
   void removeDetector(IDetector *);
@@ -300,9 +300,6 @@ private:
   /// specified
   /// by the user in radian (not degrees)
   std::map<std::string, std::string> m_logfileUnit;
-
-  /// a vector holding detector ids of monitor s
-  std::vector<detid_t> m_monitorCache;
 
   /// Stores the default type of the instrument view: 3D or one of the
   /// "unwrapped"

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
@@ -11,6 +11,7 @@
 
 namespace Mantid {
 namespace Geometry {
+class Instrument;
 
 /**
  * This class represents a detector - i.e. a single pixel in an instrument.
@@ -71,7 +72,6 @@ public:
   double getPhiOffset(const double &offset) const override;
   bool isMonitor() const override;
   // end IDetector methods
-  void markAsMonitor(const bool flag = true);
   /** returns the detector's topology, namely, the meaning of the detector's
      angular measurements.
       It is different in cartesian and cylindrical (surrounding the beam)
@@ -87,7 +87,12 @@ public:
   size_t index() const override;
   void setIndex(const size_t index) override;
 
+  // Temporary workaround for refactor: Instrument needs markAsMonitor
+  friend class Instrument;
+
 private:
+  void markAsMonitor(const bool flag = true);
+
   /// Linear index of the detector in the instrument
   size_t m_index{static_cast<size_t>(-1)};
   /// The detector id

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
@@ -70,7 +70,6 @@ public:
                            const Kernel::V3D &instrumentUp) const override;
   double getPhi() const override;
   double getPhiOffset(const double &offset) const override;
-  bool isMonitor() const override;
   // end IDetector methods
   /** returns the detector's topology, namely, the meaning of the detector's
      angular measurements.
@@ -87,18 +86,11 @@ public:
   size_t index() const override;
   void setIndex(const size_t index) override;
 
-  // Temporary workaround for refactor: Instrument needs markAsMonitor
-  friend class Instrument;
-
 private:
-  void markAsMonitor(const bool flag = true);
-
   /// Linear index of the detector in the instrument
   size_t m_index{static_cast<size_t>(-1)};
   /// The detector id
   const detid_t m_id;
-  /// Flags if this is a monitor
-  bool m_isMonitor;
 
 protected:
   /// Constructor for parametrized version

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
@@ -1,9 +1,6 @@
 #ifndef MANTID_GEOMETRY_DETECTORGROUP_H_
 #define MANTID_GEOMETRY_DETECTORGROUP_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument/Component.h"
 #include "MantidGeometry/Instrument/ObjComponent.h"
@@ -67,7 +64,6 @@ public:
   double getPhiOffset(const double &offset) const override;
   double solidAngle(const Kernel::V3D &observer) const override;
   bool isParametrized() const override;
-  bool isMonitor() const override;
   bool isValid(const Kernel::V3D &point) const override;
   bool isOnSide(const Kernel::V3D &point) const override;
   /// Try to find a point that lies within (or on) the object

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -789,18 +789,6 @@ std::vector<detid_t> Instrument::getMonitors() const {
 }
 
 /**
- * Returns the number of monitors attached to this instrument
- * @returns The number of monitors within the instrument
- */
-size_t Instrument::numMonitors() const {
-  if (m_map) {
-    return static_cast<const Instrument *>(m_base)->m_monitorCache.size();
-  } else {
-    return m_monitorCache.size();
-  }
-}
-
-/**
  * Get the bounding box for this instrument. It is simply the sum of the
  * bounding boxes of its children excluding the source
  * @param assemblyBox :: [Out] The resulting bounding box is stored here.

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1299,6 +1299,14 @@ Instrument::ContainsState Instrument::containsRectDetectors() const {
 
 } // containsRectDetectors
 
+/// Temporary helper for refactoring. Argument is index, *not* ID!
+bool Instrument::isMonitor(const size_t index) const {
+  if (m_map)
+    return m_instr->m_detectorCache[index].second->isMonitor();
+  else
+    return m_detectorCache[index].second->isMonitor();
+}
+
 /// Only for use by ExperimentInfo. Returns returns true if this instrument
 /// contains a DetectorInfo.
 bool Instrument::hasDetectorInfo() const {

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -189,13 +189,15 @@ void Instrument::getDetectors(detid2det_map &out_map) const {
     const auto &in_dets = m_instr->m_detectorCache;
     // And turn them into parametrized versions
     for (const auto &in_det : in_dets) {
-      out_map.emplace(in_det.first, ParComponentFactory::createDetector(
-                                        in_det.second.get(), m_map));
+      out_map.emplace(std::get<0>(in_det),
+                      ParComponentFactory::createDetector(
+                          std::get<1>(in_det).get(), m_map));
     }
   } else {
     // You can just return the detector cache directly.
     out_map.clear();
-    out_map.insert(m_detectorCache.begin(), m_detectorCache.end());
+    for (const auto &in_det : m_detectorCache)
+      out_map.emplace(std::get<0>(in_det), std::get<1>(in_det));
   }
 }
 
@@ -206,13 +208,13 @@ std::vector<detid_t> Instrument::getDetectorIDs(bool skipMonitors) const {
   if (m_map) {
     const auto &in_dets = m_instr->m_detectorCache;
     for (const auto &in_det : in_dets)
-      if (!skipMonitors || !in_det.second->isMonitor())
-        out.push_back(in_det.first);
+      if (!skipMonitors || !std::get<2>(in_det))
+        out.push_back(std::get<0>(in_det));
   } else {
     const auto &in_dets = m_detectorCache;
     for (const auto &in_det : in_dets)
-      if (!skipMonitors || !in_det.second->isMonitor())
-        out.push_back(in_det.first);
+      if (!skipMonitors || !std::get<2>(in_det))
+        out.push_back(std::get<0>(in_det));
   }
   return out;
 }
@@ -233,12 +235,12 @@ std::size_t Instrument::getNumberDetectors(bool skipMonitors) const {
     if (m_map) {
       const auto &in_dets = m_instr->m_detectorCache;
       for (const auto &in_det : in_dets)
-        if (in_det.second->isMonitor())
+        if (std::get<2>(in_det))
           monitors += 1;
     } else {
       const auto &in_dets = m_detectorCache;
       for (const auto &in_det : in_dets)
-        if (in_det.second->isMonitor())
+        if (std::get<2>(in_det))
           monitors += 1;
     }
     return (numDetIDs - monitors);
@@ -259,8 +261,8 @@ void Instrument::getMinMaxDetectorIDs(detid_t &min, detid_t &max) const {
     throw std::runtime_error(
         "No detectors on this instrument. Can't find min/max ids");
   // Maps are sorted by key. So it is easy to find
-  min = in_dets->begin()->first;
-  max = in_dets->rbegin()->first;
+  min = std::get<0>(*in_dets->begin());
+  max = std::get<0>(*in_dets->rbegin());
 }
 
 //------------------------------------------------------------------------------------------
@@ -449,22 +451,22 @@ Instrument::getAllComponentsWithName(const std::string &cname) const {
 }
 
 namespace {
-// Helpers for accessing m_detectorCache, which is a vector of pairs used as a
-// map. Lookup is by first element in a pair. Templated to support const and
+// Helpers for accessing m_detectorCache, which is a vector of tuples used as a
+// map. Lookup is by first element in a tuple. Templated to support const and
 // non-const.
 template <class T>
 auto lower_bound(T &map, const detid_t key) -> decltype(map.begin()) {
   return std::lower_bound(
       map.begin(), map.end(),
-      std::make_pair(key, IDetector_const_sptr(nullptr)),
+      std::make_tuple(key, IDetector_const_sptr(nullptr), false),
       [](const typename T::value_type &a, const typename T::value_type &b)
-          -> bool { return a.first < b.first; });
+          -> bool { return std::get<0>(a) < std::get<0>(b); });
 }
 
 template <class T>
 auto find(T &map, const detid_t key) -> decltype(map.begin()) {
   auto it = lower_bound(map, key);
-  if ((it != map.end()) && (it->first == key))
+  if ((it != map.end()) && (std::get<0>(*it) == key))
     return it;
   return map.end();
 }
@@ -489,7 +491,7 @@ IDetector_const_sptr Instrument::getDetector(const detid_t &detector_id) const {
     throw Kernel::Exception::NotFoundError(
         "Instrument: Detector with ID " + readInt.str() + " not found.", "");
   }
-  IDetector_const_sptr baseDet = it->second;
+  IDetector_const_sptr baseDet = std::get<1>(*it);
 
   if (!m_map)
     return baseDet;
@@ -511,19 +513,15 @@ const IDetector *Instrument::getBaseDetector(const detid_t &detector_id) const {
   if (it == m_instr->m_detectorCache.end()) {
     return nullptr;
   }
-  return it->second.get();
+  return std::get<1>(*it).get();
 }
 
 bool Instrument::isMonitor(const detid_t &detector_id) const {
-  // Find the (base) detector object in the map.
-  auto it = find(m_instr->m_detectorCache, detector_id);
-  if (it == m_instr->m_detectorCache.end())
+  const auto &baseInstr = m_map ? *m_instr : *this;
+  const auto it = find(baseInstr.m_detectorCache, detector_id);
+  if (it == baseInstr.m_detectorCache.end())
     return false;
-  // This is the detector
-  const Detector *det = dynamic_cast<const Detector *>(it->second.get());
-  if (det == nullptr)
-    return false;
-  return det->isMonitor();
+  return std::get<2>(*it);
 }
 
 bool Instrument::isMonitor(const std::set<detid_t> &detector_ids) const {
@@ -689,8 +687,9 @@ void Instrument::markAsDetector(const IDetector *det) {
   auto it = lower_bound(m_detectorCache, det->getID());
   // Silently ignore detector IDs that are already marked as detectors, even if
   // the actual detector is different.
-  if ((it == m_detectorCache.end()) || (it->first != det->getID())) {
-    m_detectorCache.emplace(it, det->getID(), det_sptr);
+  if ((it == m_detectorCache.end()) || (std::get<0>(*it) != det->getID())) {
+    bool isMonitor = false;
+    m_detectorCache.emplace(it, det->getID(), det_sptr, isMonitor);
   }
 }
 
@@ -703,7 +702,8 @@ void Instrument::markAsDetectorIncomplete(const IDetector *det) {
 
   // Create a (non-deleting) shared pointer to it
   IDetector_const_sptr det_sptr = IDetector_const_sptr(det, NoDeleting());
-  m_detectorCache.emplace_back(det->getID(), det_sptr);
+  bool isMonitor = false;
+  m_detectorCache.emplace_back(det->getID(), det_sptr, isMonitor);
 }
 
 /// Sorts the detector cache. Called after all detectors have been marked via
@@ -714,14 +714,14 @@ void Instrument::markAsDetectorFinalize() {
   // in this final sort by using stable_sort and removing duplicates. This will
   // effectively favor the first detector with a certain ID that was added.
   std::stable_sort(m_detectorCache.begin(), m_detectorCache.end(),
-                   [](const std::pair<detid_t, IDetector_const_sptr> &a,
-                      const std::pair<detid_t, IDetector_const_sptr> &b)
-                       -> bool { return a.first < b.first; });
+                   [](const std::tuple<detid_t, IDetector_const_sptr, bool> &a,
+                      const std::tuple<detid_t, IDetector_const_sptr, bool> &b)
+                       -> bool { return std::get<0>(a) < std::get<0>(b); });
   m_detectorCache.erase(
       std::unique(m_detectorCache.begin(), m_detectorCache.end(),
-                  [](const std::pair<detid_t, IDetector_const_sptr> &a,
-                     const std::pair<detid_t, IDetector_const_sptr> &b)
-                      -> bool { return a.first == b.first; }),
+                  [](const std::tuple<detid_t, IDetector_const_sptr, bool> &a,
+                     const std::tuple<detid_t, IDetector_const_sptr, bool> &b)
+                      -> bool { return std::get<0>(a) == std::get<0>(b); }),
       m_detectorCache.end());
 }
 
@@ -742,14 +742,9 @@ void Instrument::markAsMonitor(IDetector *det) {
   markAsDetector(det);
 
   // mark detector as a monitor
-  Detector *d = dynamic_cast<Detector *>(det);
-  if (d) {
-    d->markAsMonitor();
-    m_monitorCache.push_back(det->getID());
-  } else {
-    throw std::invalid_argument(
-        "The IDetector pointer does not point to a Detector object");
-  }
+  auto it = find(m_detectorCache, det->getID());
+  std::get<2>(*it) = true;
+  m_monitorCache.push_back(det->getID());
 }
 
 /** Removes a detector from the instrument and from the detector cache.
@@ -764,13 +759,13 @@ void Instrument::removeDetector(IDetector *det) {
   const detid_t id = det->getID();
   // Remove the detector from the detector cache
   const auto it = find(m_detectorCache, id);
-  m_detectorCache.erase(it);
   // Also need to remove from monitor cache if appropriate
-  if (det->isMonitor()) {
-    auto it = std::find(m_monitorCache.begin(), m_monitorCache.end(), id);
-    if (it != m_monitorCache.end())
-      m_monitorCache.erase(it);
+  if (std::get<2>(*it)) {
+    auto it2 = std::find(m_monitorCache.begin(), m_monitorCache.end(), id);
+    if (it2 != m_monitorCache.end())
+      m_monitorCache.erase(it2);
   }
+  m_detectorCache.erase(it);
 
   // Remove it from the parent assembly (and thus the instrument). Evilness
   // required here unfortunately.
@@ -1098,7 +1093,7 @@ void Instrument::saveNexus(::NeXus::File *file,
     auto detmons = getDetectors(detmonIDs);
     std::vector<detid_t> monitorIDs;
     for (size_t i = 0; i < detmonIDs.size(); i++) {
-      if (detmons[i]->isMonitor())
+      if (isMonitorViaIndex(i))
         monitorIDs.push_back(detmonIDs[i]);
     }
 
@@ -1260,7 +1255,7 @@ Instrument::ContainsState Instrument::containsRectDetectors() const {
     // Skip monitors
     IDetector_const_sptr detector =
         boost::dynamic_pointer_cast<const IDetector>(comp);
-    if (detector && detector->isMonitor())
+    if (detector && isMonitor(detector->getID()))
       continue;
 
     // skip choppers HACK!
@@ -1300,11 +1295,11 @@ Instrument::ContainsState Instrument::containsRectDetectors() const {
 } // containsRectDetectors
 
 /// Temporary helper for refactoring. Argument is index, *not* ID!
-bool Instrument::isMonitor(const size_t index) const {
+bool Instrument::isMonitorViaIndex(const size_t index) const {
   if (m_map)
-    return m_instr->m_detectorCache[index].second->isMonitor();
+    return std::get<2>(m_instr->m_detectorCache[index]);
   else
-    return m_detectorCache[index].second->isMonitor();
+    return std::get<2>(m_detectorCache[index]);
 }
 
 /// Only for use by ExperimentInfo. Returns returns true if this instrument

--- a/Framework/Geometry/src/Instrument/Detector.cpp
+++ b/Framework/Geometry/src/Instrument/Detector.cpp
@@ -17,7 +17,7 @@ using Kernel::Quat;
  * @param map: pointer to the ParameterMap
  * */
 Detector::Detector(const Detector *base, const ParameterMap *map)
-    : ObjComponent(base, map), m_id(base->m_id), m_isMonitor(false) {}
+    : ObjComponent(base, map), m_id(base->m_id) {}
 
 /** Constructor
  *  @param name :: The name of the component
@@ -25,7 +25,7 @@ Detector::Detector(const Detector *base, const ParameterMap *map)
  *  @param parent :: The parent component
  */
 Detector::Detector(const std::string &name, int id, IComponent *parent)
-    : IDetector(), ObjComponent(name, parent), m_id(id), m_isMonitor(false) {}
+    : IDetector(), ObjComponent(name, parent), m_id(id) {}
 
 /** Constructor
  *  @param name :: The name of the component
@@ -36,8 +36,7 @@ Detector::Detector(const std::string &name, int id, IComponent *parent)
  */
 Detector::Detector(const std::string &name, int id,
                    boost::shared_ptr<Object> shape, IComponent *parent)
-    : IDetector(), ObjComponent(name, shape, parent), m_id(id),
-      m_isMonitor(false) {}
+    : IDetector(), ObjComponent(name, shape, parent), m_id(id) {}
 
 /** Gets the detector id
  *  @returns the detector id
@@ -121,25 +120,6 @@ det_topology Detector::getTopology(V3D &center) const {
   center = this->getPos();
   return rect;
 }
-
-/// Is the detector a monitor?
-///@return true if it is a monitor
-bool Detector::isMonitor() const {
-  if (m_map) {
-    const Detector *d = dynamic_cast<const Detector *>(m_base);
-    if (d) {
-      return d->isMonitor();
-    }
-  }
-
-  return m_isMonitor;
-}
-
-/** Sets the flag for whether this detector object is a monitor
- *  @param flag :: True to mark the detector a monitor (default), false
- * otherwise
- */
-void Detector::markAsMonitor(const bool flag) { m_isMonitor = flag; }
 
 /// Helper for legacy access mode. Returns a reference to the ParameterMap.
 const ParameterMap &Detector::parameterMap() const { return *m_map; }

--- a/Framework/Geometry/src/Instrument/DetectorGroup.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorGroup.cpp
@@ -212,22 +212,6 @@ bool DetectorGroup::isParametrized() const {
   return false;
 }
 
-/** Indicates whether this is a monitor.
-*  Will return false if even one member of the group is not flagged as a monitor
-*  @return is detector group a monitor
-*/
-bool DetectorGroup::isMonitor() const {
-  // Would you ever want to group monitors?
-  // For now, treat as NOT a monitor if even one isn't
-  bool isMonitor = true;
-  DetCollection::const_iterator it;
-  for (it = m_detectors.begin(); it != m_detectors.end(); ++it) {
-    if (!(*it).second->isMonitor())
-      isMonitor = false;
-  }
-  return isMonitor;
-}
-
 /** isValid() is true if the point is inside any of the detectors, i.e. one of
 * the
 *  detectors has isValid() == true

--- a/Framework/Geometry/src/Objects/InstrumentRayTracer.cpp
+++ b/Framework/Geometry/src/Objects/InstrumentRayTracer.cpp
@@ -98,7 +98,7 @@ IDetector_const_sptr InstrumentRayTracer::getDetectorResult() const {
     IDetector_const_sptr det =
         boost::dynamic_pointer_cast<const IDetector>(component);
     if (det) {
-      if (!det->isMonitor()) {
+      if (!m_instrument->isMonitor(det->getID())) {
         return det;
       }
     } // (is a detector)

--- a/Framework/Geometry/test/DetectorGroupTest.h
+++ b/Framework/Geometry/test/DetectorGroupTest.h
@@ -81,13 +81,6 @@ public:
     TS_ASSERT_DELTA(m_detGroup->getDistance(m_origin), 4.24614987, 1e-08);
   }
 
-  void testIsMonitor() {
-    boost::shared_ptr<DetectorGroup> monitorGroup =
-        ComponentCreationHelper::createGroupOfTwoMonitors();
-    TS_ASSERT(!m_detGroup->isMonitor());
-    TS_ASSERT(monitorGroup->isMonitor());
-  }
-
   void testBoundingBox() {}
 
   void testAddDetector() {

--- a/Framework/Geometry/test/DetectorTest.h
+++ b/Framework/Geometry/test/DetectorTest.h
@@ -18,7 +18,6 @@ public:
     TS_ASSERT_EQUALS(det.getName(), "det1");
     TS_ASSERT(!det.getParent());
     TS_ASSERT_EQUALS(det.getID(), 0);
-    TS_ASSERT(!det.isMonitor());
     TS_ASSERT(!det.isParametrized());
   }
   void testDetTopology() {
@@ -34,7 +33,6 @@ public:
     TS_ASSERT_EQUALS(det.getName(), "det1");
     TS_ASSERT(det.getParent());
     TS_ASSERT_EQUALS(det.getID(), 0);
-    TS_ASSERT(!det.isMonitor());
   }
 
   void testId() {

--- a/Framework/Geometry/test/DetectorTest.h
+++ b/Framework/Geometry/test/DetectorTest.h
@@ -48,15 +48,6 @@ public:
     TS_ASSERT_EQUALS(det.type(), "DetectorComponent");
   }
 
-  void testMonitor() {
-    Detector det("det", 0, 0);
-    TS_ASSERT(!det.isMonitor());
-    TS_ASSERT_THROWS_NOTHING(det.markAsMonitor());
-    TS_ASSERT(det.isMonitor());
-    TS_ASSERT_THROWS_NOTHING(det.markAsMonitor(false));
-    TS_ASSERT(!det.isMonitor());
-  }
-
   void testGetNumberParameter() {
     Detector det("det", 0, 0);
     TS_ASSERT_EQUALS(det.getNumberParameter("testparam").size(), 0);

--- a/Framework/Geometry/test/InstrumentTest.h
+++ b/Framework/Geometry/test/InstrumentTest.h
@@ -240,11 +240,6 @@ public:
                      ndets - 1); // skipMonitors
   }
 
-  void testNumMonitors() {
-    TS_ASSERT_EQUALS(instrument.numMonitors(), 1);
-    TS_ASSERT_EQUALS(Instrument().numMonitors(), 0);
-  }
-
   void testDetector() {
     TS_ASSERT_THROWS(instrument.getDetector(0), Exception::NotFoundError);
     TS_ASSERT_EQUALS(instrument.getDetector(1).get(), det);

--- a/Framework/Geometry/test/ParDetectorTest.h
+++ b/Framework/Geometry/test/ParDetectorTest.h
@@ -66,19 +66,6 @@ public:
     TS_ASSERT_THROWS(pmap->addBool(&det, "masked", true), std::runtime_error);
   }
 
-  void testMonitor() {
-    Detector det("det", 0, 0);
-
-    ParameterMap_sptr pmap(new ParameterMap());
-    boost::shared_ptr<Detector> pdet(det.cloneParameterized(pmap.get()));
-
-    TS_ASSERT(!pdet->isMonitor());
-    TS_ASSERT_THROWS_NOTHING(det.markAsMonitor());
-    TS_ASSERT(pdet->isMonitor());
-    TS_ASSERT_THROWS_NOTHING(det.markAsMonitor(false));
-    TS_ASSERT(!pdet->isMonitor());
-  }
-
   void testGetNumberParameter() {
     Detector det("det", 0, 0);
 

--- a/Framework/Geometry/test/ParDetectorTest.h
+++ b/Framework/Geometry/test/ParDetectorTest.h
@@ -19,7 +19,6 @@ public:
     TS_ASSERT_EQUALS(pdet->getName(), "det1");
     TS_ASSERT(!pdet->getParent());
     TS_ASSERT_EQUALS(pdet->getID(), 0);
-    TS_ASSERT(!pdet->isMonitor());
   }
 
   void testNameParentConstructor() {
@@ -32,7 +31,6 @@ public:
     TS_ASSERT_EQUALS(pdet->getName(), "det1");
     TS_ASSERT(pdet->getParent());
     TS_ASSERT_EQUALS(pdet->getID(), 0);
-    TS_ASSERT(!pdet->isMonitor());
   }
 
   void testId() {

--- a/Framework/Geometry/test/ParInstrumentTest.h
+++ b/Framework/Geometry/test/ParInstrumentTest.h
@@ -88,9 +88,9 @@ public:
                      instrument->getComponentByID(id3)->getName());
   }
 
-  void test_numMonitors() {
+  void test_getMonitors() {
     Instrument pinstrument(instrument, pmap);
-    TS_ASSERT_EQUALS(pinstrument.numMonitors(), 1)
+    TS_ASSERT_EQUALS(pinstrument.getMonitors().size(), 1)
   }
 
 private:

--- a/Framework/Geometry/test/ParInstrumentTest.h
+++ b/Framework/Geometry/test/ParInstrumentTest.h
@@ -52,6 +52,14 @@ public:
                      std::invalid_argument);
   }
 
+  void test_getMonitors() {
+    // testDetector injects a pointer into `instrument` that is deleted later.
+    // Instrument::getMonitors will then cause a segmentation fault, so this
+    // test must run before we have invalid pointers.
+    Instrument pinstrument(instrument, pmap);
+    TS_ASSERT_EQUALS(pinstrument.getMonitors().size(), 1)
+  }
+
   void testDetector() {
     Instrument pinstrument(instrument, pmap);
     TS_ASSERT_THROWS(pinstrument.getDetector(0), Exception::NotFoundError);
@@ -86,11 +94,6 @@ public:
     ComponentID id3 = det3->getComponentID();
     TS_ASSERT_EQUALS(det3->getName(),
                      instrument->getComponentByID(id3)->getName());
-  }
-
-  void test_getMonitors() {
-    Instrument pinstrument(instrument, pmap);
-    TS_ASSERT_EQUALS(pinstrument.getMonitors().size(), 1)
   }
 
 private:

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -5,6 +5,7 @@
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/Run.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidKernel/EnabledWhenProperty.h"
 
 #include "MantidKernel/ArrayProperty.h"
@@ -307,18 +308,15 @@ void ConvertToMD::copyMetaData(API::IMDEventWorkspace_sptr &mdEventWS) const {
   // found detector which is not a monitor to get proper bin boundaries.
   size_t spectra_index(0);
   bool dector_found(false);
+  const auto &spectrumInfo = m_InWS2D->spectrumInfo();
   for (size_t i = 0; i < m_InWS2D->getNumberHistograms(); ++i) {
-    try {
-      auto det = m_InWS2D->getDetector(i);
-      if (!det->isMonitor()) {
-        spectra_index = i;
-        dector_found = true;
-        g_log.debug() << "Using spectra N " << i << " as the source of the bin "
-                                                    "boundaries for the "
-                                                    "resolution corrections \n";
-        break;
-      }
-    } catch (...) {
+    if (spectrumInfo.hasDetectors(i) && spectrumInfo.isMonitor(i)) {
+      spectra_index = i;
+      dector_found = true;
+      g_log.debug() << "Using spectra N " << i
+                    << " as the source of the bin "
+                       "boundaries for the resolution corrections \n";
+      break;
     }
   }
   if (!dector_found)

--- a/Framework/MDAlgorithms/test/ConvertToMDComponentsTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDComponentsTest.h
@@ -321,31 +321,10 @@ public:
     auto inputWS = boost::dynamic_pointer_cast<API::MatrixWorkspace>(
         API::AnalysisDataService::Instance().retrieve(wsName));
     const size_t nRows = inputWS->getNumberHistograms();
-
-    // build detectors ID list to mask
-    std::vector<detid_t> detectorList;
-    detectorList.reserve(nRows);
-    std::vector<size_t> indexLis;
-    indexLis.reserve(nRows);
-    for (size_t i = 0; i < nRows; i++) {
-      // get detector or detector group which corresponds to the spectra i
-      Geometry::IDetector_const_sptr spDet;
-      try {
-        spDet = inputWS->getDetector(i);
-      } catch (Kernel::Exception::NotFoundError &) {
-        continue;
-      }
-
-      // Check that we aren't dealing with monitor...
-      if (spDet->isMonitor())
-        continue;
-
-      indexLis.push_back(i);
-      // detectorList.push_back(spDet->getID());
-    }
-
     auto &spectrumInfo = inputWS->mutableSpectrumInfo();
-    for (const auto i : indexLis) {
+    for (size_t i = 0; i < nRows; i++) {
+      if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i))
+        continue;
       inputWS->getSpectrum(i).clearData();
       spectrumInfo.setMasked(i, true);
     }

--- a/Framework/MDAlgorithms/test/PreprocessDetectorsToMDTest.h
+++ b/Framework/MDAlgorithms/test/PreprocessDetectorsToMDTest.h
@@ -236,34 +236,15 @@ public:
         API::AnalysisDataService::Instance().retrieve("testMatrWS"));
     const size_t nRows = inputWS->getNumberHistograms();
 
-    // build detectors ID list to mask
-    std::vector<detid_t> detectorList;
-    detectorList.reserve(nRows);
-    std::vector<size_t> indexLis;
-    indexLis.reserve(nRows);
-    for (size_t i = 0; i < nRows; i++) {
-      // get detector or detector group which corresponds to the spectra i
-      Geometry::IDetector_const_sptr spDet;
-      try {
-        spDet = inputWS->getDetector(i);
-      } catch (Kernel::Exception::NotFoundError &) {
-        continue;
-      }
-
-      // Check that we aren't dealing with monitor...
-      if (spDet->isMonitor())
-        continue;
-
-      indexLis.push_back(i);
-      // detectorList.push_back(spDet->getID());
-    }
-
     // Now mask all detectors in the workspace
     auto &spectrumInfo = inputWS->mutableSpectrumInfo();
-    for (const auto i : indexLis) {
+    for (size_t i = 0; i < nRows; i++) {
+      if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i))
+        continue;
       inputWS->getSpectrum(i).clearData();
       spectrumInfo.setMasked(i, true);
     }
+
     // let's retrieve masks now
 
     TS_ASSERT_THROWS_NOTHING(pAlg->execute());

--- a/Framework/PythonInterface/mantid/api/src/Exports/DetectorInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/DetectorInfo.cpp
@@ -12,6 +12,8 @@ void export_DetectorInfo() {
       .def("size", &DetectorInfo::size, (arg("self")),
            "Returns the size of the DetectorInfo, i.e., the number of "
            "detectors in the instrument.")
+      .def("isMonitor", &DetectorInfo::isMonitor, (arg("self"), arg("index")),
+           "Returns True if the detector is a monitor.")
       .def("isMasked", &DetectorInfo::isMasked, (arg("self"), arg("index")),
            "Returns True if the detector is masked.");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -6,6 +6,9 @@ using namespace boost::python;
 
 void export_SpectrumInfo() {
   class_<SpectrumInfo, boost::noncopyable>("SpectrumInfo", no_init)
+      .def("isMonitor", &SpectrumInfo::isMonitor, (arg("self"), arg("index")),
+           "Returns true if the detector(s) associated with the spectrum are "
+           "monitors.")
       .def("isMasked", &SpectrumInfo::isMasked, (arg("self"), arg("index")),
            "Returns true if the detector(s) associated with the spectrum are "
            "masked.")

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Detector.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Detector.cpp
@@ -15,6 +15,14 @@ bool isMaskedDeprecated(const Detector &self) {
   const auto &detInfo = self.parameterMap().detectorInfo();
   return detInfo.isMasked(self.index());
 }
+
+bool isMonitorDeprecated(const Detector &self) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "'Detector::isMonitor' is deprecated, "
+             "use 'DetectorInfo::isMonitor' instead.");
+  const auto &detInfo = self.parameterMap().detectorInfo();
+  return detInfo.isMonitor(self.index());
+}
 }
 
 /**
@@ -26,5 +34,7 @@ void export_Detector() {
       "Detector", no_init)
       .def("isMasked", &isMaskedDeprecated, arg("self"),
            "Returns the value of the masked flag. True means ignore this "
-           "detector");
+           "detector")
+      .def("isMonitor", &isMonitorDeprecated, arg("self"),
+           "Returns True if the detector is marked as a monitor in the IDF");
 }

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp
@@ -20,6 +20,19 @@ bool isMaskedDeprecated(const DetectorGroup &self) {
   }
   return masked;
 }
+
+bool isMonitorDeprecated(const DetectorGroup &self) {
+  PyErr_Warn(PyExc_DeprecationWarning, "'DetectorGroup::isMonitor' is "
+                                       "deprecated, use "
+                                       "'SpectrumInfo::isMonitor' instead.");
+  const auto &dets = self.getDetectors();
+  for (const auto &det : dets) {
+    const auto &detInfo = det->parameterMap().detectorInfo();
+    if (!detInfo.isMonitor(det->index()))
+      return false;
+  }
+  return true;
+}
 }
 
 void export_DetectorGroup() {
@@ -28,6 +41,8 @@ void export_DetectorGroup() {
       .def("isMasked", &isMaskedDeprecated, arg("self"),
            "Returns the value of the masked flag. True means ignore this "
            "detector")
+      .def("isMonitor", &isMonitorDeprecated, arg("self"),
+           "Returns True if the detector is marked as a monitor in the IDF")
       .def("getDetectorIDs", &DetectorGroup::getDetectorIDs, arg("self"),
            "Returns the list of detector IDs within this group")
       .def("getNameSeparator", &DetectorGroup::getNameSeparator, arg("self"),

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/IDetector.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/IDetector.cpp
@@ -15,8 +15,6 @@ void export_IDetector() {
   class_<IDetector, bases<IObjComponent>, boost::noncopyable>("IDetector",
                                                               no_init)
       .def("getID", &IDetector::getID, arg("self"), "Returns the detector ID")
-      .def("isMonitor", &IDetector::isMonitor, arg("self"),
-           "Returns True if the detector is marked as a monitor in the IDF")
       .def("solidAngle", &IDetector::solidAngle, (arg("self"), arg("observer")),
            "Return the solid angle in steradians between this "
            "detector and an observer")

--- a/Framework/PythonInterface/plugins/algorithms/ExtractMonitors.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExtractMonitors.py
@@ -56,9 +56,10 @@ class ExtractMonitors(DataProcessorAlgorithm):
 
         monitors = []
         detectors = []
+        spectrumInfo = in_ws.spectrumInfo()
         for i in range(in_ws.getNumberHistograms()):
             try:
-                monitors.append(i) if in_ws.getDetector(i).isMonitor() else detectors.append(i)
+                monitors.append(i) if spectrumInfo.isMonitor(i) else detectors.append(i)
             except RuntimeError:
                 self.log().warning("Missing detector at " + str(i))
 

--- a/Framework/PythonInterface/plugins/algorithms/GenerateGroupingSNSInelastic.py
+++ b/Framework/PythonInterface/plugins/algorithms/GenerateGroupingSNSInelastic.py
@@ -56,7 +56,8 @@ class GenerateGroupingSNSInelastic(mantid.api.PythonAlgorithm):
         __w = mantid.simpleapi.LoadEmptyInstrument(Filename=IDF)
 
         i=0
-        while __w.getDetector(i).isMonitor():
+        spectrumInfo = __w.spectrumInfo()
+        while spectrumInfo.isMonitor(i):
             i += 1
         #i is the index of the first true detector
         #now, crop the workspace of the monitors

--- a/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
@@ -66,9 +66,10 @@ class MaskAngle(mantid.api.PythonAlgorithm):
         numspec = ws.getNumberHistograms()
         source=ws.getInstrument().getSource().getPos()
         sample=ws.getInstrument().getSample().getPos()
+        spectrumInfo = ws.spectrumInfo()
         for i in range(numspec):
-            det=ws.getDetector(i)
-            if not det.isMonitor():
+            if not spectrumInfo.isMonitor(i):
+                det = ws.getDetector(i)
                 tt=numpy.degrees(det.getTwoTheta(sample,sample-source))
                 if tt>= ttmin and tt<= ttmax:
                     detlist.append(det.getID())

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectTransmissionMonitor.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectTransmissionMonitor.py
@@ -96,8 +96,9 @@ class IndirectTransmissionMonitor(PythonAlgorithm):
 
         except IndexError:
             # If that fails just get the first spectrum which is a detector
+            spectrumInfo = workspace.spectrumInfo()
             for spec_idx in range(workspace.getNumberHistograms()):
-                if not workspace.getDetector(spec_idx).isMonitor():
+                if not spectrumInfo.isMonitor(spec_idx):
                     detector_1_idx = spec_idx
                     logger.information('Got index of first detector in workspace: %d' % (detector_1_idx))
                     break

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSDarkRunBackgroundCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSDarkRunBackgroundCorrection.py
@@ -294,9 +294,10 @@ class DarkRunMonitorAndDetectorRemover(object):
         # pylint: disable=bare-except
         try:
             num_histograms = dark_run.getNumberHistograms()
+            spectrumInfo = dark_run.spectrumInfo()
             for index in range(0, num_histograms):
-                det = dark_run.getDetector(index)
-                if det.isMonitor():
+                if spectrumInfo.isMonitor(index):
+                    det = dark_run.getDetector(index)
                     det_id_list.append(det.getID())
                     monitor_list.append(index)
         except:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
@@ -15,15 +15,13 @@ def _count_monitors(raw_file):
 
     raw_file = mtd[raw_file]
     num_hist = raw_file.getNumberHistograms()
-    detector = raw_file.getDetector(0)
     mon_count = 1
 
-    if detector.isMonitor():
+    spectrumInfo = raw_file.spectrumInfo()
+    if spectrumInfo.isMonitor(0):
         # Monitors are at the start
         for i in range(1, num_hist):
-            detector = raw_file.getDetector(i)
-
-            if detector.isMonitor():
+            if spectrumInfo.isMonitor(i):
                 mon_count += 1
             else:
                 break
@@ -31,16 +29,12 @@ def _count_monitors(raw_file):
         return mon_count, True
     else:
         # Monitors are at the end
-        detector = raw_file.getDetector(num_hist)
-
-        if not detector.isMonitor():
+        if not spectrumInfo.isMonitor(num_hist):
             #if it's not, we don't have any monitors!
             return 0, True
 
         for i in range(num_hist, 0, -1):
-            detector = raw_file.getDetector(i)
-
-            if detector.isMonitor():
+            if spectrumInfo.isMonitor(i):
                 mon_count += 1
             else:
                 break

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ExtractMonitorsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ExtractMonitorsTest.py
@@ -83,11 +83,13 @@ class ExtractMonitorsTest(unittest.TestCase):
         self.assertEquals(monitors.getNumberHistograms(), 3)
         self.assertEquals(detectors.getMonitorWorkspace().name(), "mon")
 
+        spectrumInfo = monitors.spectrumInfo()
         for i in range(monitors.getNumberHistograms()):
-            self.assertTrue(monitors.getDetector(i).isMonitor())
+            self.assertTrue(spectrumInfo.isMonitor(i))
 
+        spectrumInfo = detectors.spectrumInfo()
         for i in range(detectors.getNumberHistograms()):
-            self.assertFalse(detectors.getDetector(i).isMonitor())
+            self.assertFalse(spectrumInfo.isMonitor(i))
 
 if __name__=="__main__":
     unittest.main()

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ComponentCreationHelper.h
@@ -123,10 +123,7 @@ boost::shared_ptr<Mantid::Geometry::DetectorGroup>
 createRingOfCylindricalDetectors(const double R_min = 4.5,
                                  const double R_max = 5,
                                  const double z000000000000000 = 4);
-/**
- * Create a group of two monitors
- */
-boost::shared_ptr<Mantid::Geometry::DetectorGroup> createGroupOfTwoMonitors();
+
 /** create instrument with cylindrical detectors located in specific angular
  * positions */
 Mantid::Geometry::Instrument_sptr

--- a/Framework/TestHelpers/src/ComponentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/ComponentCreationHelper.cpp
@@ -243,25 +243,6 @@ createRingOfCylindricalDetectors(const double R_min, const double R_max,
   return boost::make_shared<DetectorGroup>(groupMembers);
 }
 
-//----------------------------------------------------------------------------------------------
-/**
- * Create a group of two monitors
- */
-boost::shared_ptr<DetectorGroup> createGroupOfTwoMonitors() {
-  const int ndets(2);
-  std::vector<boost::shared_ptr<const IDetector>> groupMembers(ndets);
-  for (int i = 0; i < ndets; ++i) {
-    std::ostringstream os;
-    os << "m" << i;
-    auto det = boost::make_shared<Detector>(os.str(), i + 1, nullptr);
-    det->setPos(static_cast<double>(i + 1), 2.0, 2.0);
-    det->markAsMonitor();
-    groupMembers[i] = det;
-  }
-  return boost::make_shared<DetectorGroup>(groupMembers);
-}
-
-//----------------------------------------------------------------------------------------------
 Instrument_sptr createTestInstrumentCylindrical(
     int num_banks, const Mantid::Kernel::V3D &sourcePos,
     const Mantid::Kernel::V3D &samplePos, const double cylRadius,

--- a/MantidQt/MantidWidgets/src/InstrumentView/PanelsSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/PanelsSurface.cpp
@@ -5,6 +5,8 @@
 #include "MantidQtMantidWidgets/InstrumentView/RectangularDetectorActor.h"
 #include "MantidQtMantidWidgets/InstrumentView/StructuredDetectorActor.h"
 
+#include "MantidAPI/DetectorInfo.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/Instrument/ObjCompAssembly.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/Tolerance.h"
@@ -426,6 +428,7 @@ void PanelsSurface::addCompAssembly(ComponentID bankId) {
   Mantid::Kernel::V3D pos0;
   bool normalFound = false;
   QList<ComponentID> detectors;
+  const auto &detectorInfo = m_instrActor->getWorkspace()->detectorInfo();
   for (size_t i = 0; i < nelem; ++i) {
     auto elem = assembly->getChild((int)i);
     Mantid::Geometry::IDetector_const_sptr det =
@@ -433,9 +436,10 @@ void PanelsSurface::addCompAssembly(ComponentID bankId) {
     if (!det) {
       return;
     }
-    if (det->isMonitor())
+    size_t detIndex = detectorInfo.indexOf(det->getID());
+    if (detectorInfo.isMonitor(detIndex))
       continue;
-    Mantid::Kernel::V3D pos = det->getPos();
+    Mantid::Kernel::V3D pos = detectorInfo.position(detIndex);
     if (i == 0) {
       pos0 = pos;
     } else if (i == 1) {

--- a/MantidQt/MantidWidgets/src/InstrumentView/RotationSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/RotationSurface.cpp
@@ -1,5 +1,7 @@
 #include "MantidQtMantidWidgets/InstrumentView/RotationSurface.h"
 #include "MantidKernel/Logger.h"
+#include "MantidAPI/DetectorInfo.h"
+#include "MantidAPI/MatrixWorkspace.h"
 
 #include <QCursor>
 #include <QMessageBox>
@@ -76,6 +78,8 @@ void RotationSurface::init() {
   m_u_min = -DBL_MAX;
   m_u_max = DBL_MAX;
 
+  const auto &detectorInfo = m_instrActor->getWorkspace()->detectorInfo();
+
   // Set if one of the threads in the following loop
   // throws an exception
   bool exceptionThrown = false;
@@ -99,7 +103,10 @@ void RotationSurface::init() {
                                   Mantid::Kernel::Exception::NotFoundError &) {
                               }
 
-                              if (!det || det->isMonitor() || (id < 0)) {
+                              if (!det ||
+                                  detectorInfo.isMonitor(
+                                      detectorInfo.indexOf(id)) ||
+                                  (id < 0)) {
                                 // Not a detector or a monitor
                                 // Make some blank, empty thing that won't draw
                                 m_unwrappedDetectors[i] = UnwrappedDetector();

--- a/MantidQt/SpectrumViewer/inc/MantidQtSpectrumViewer/MatrixWSDataSource.h
+++ b/MantidQt/SpectrumViewer/inc/MantidQtSpectrumViewer/MatrixWSDataSource.h
@@ -14,6 +14,9 @@ namespace Geometry {
 class IComponent;
 class Instrument;
 }
+namespace API {
+class SpectrumInfo;
+}
 }
 
 namespace MantidQt {
@@ -97,6 +100,7 @@ private:
   boost::shared_ptr<const Mantid::Geometry::Instrument> m_instrument;
   boost::shared_ptr<const Mantid::Geometry::IComponent> m_source;
   boost::shared_ptr<const Mantid::Geometry::IComponent> m_sample;
+  const Mantid::API::SpectrumInfo &m_spectrumInfo;
 };
 
 typedef boost::shared_ptr<MatrixWSDataSource> MatrixWSDataSource_sptr;

--- a/MantidQt/SpectrumViewer/src/MatrixWSDataSource.cpp
+++ b/MantidQt/SpectrumViewer/src/MatrixWSDataSource.cpp
@@ -21,6 +21,7 @@
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidAPI/Run.h"
+#include "MantidAPI/SpectrumInfo.h"
 
 using namespace Mantid;
 using namespace Kernel;
@@ -41,7 +42,7 @@ namespace SpectrumView {
  */
 MatrixWSDataSource::MatrixWSDataSource(MatrixWorkspace_const_sptr matWs)
     : SpectrumDataSource(0.0, 1.0, 0.0, 1.0, 0, 0), m_matWs(matWs),
-      m_emodeHandler(NULL) {
+      m_emodeHandler(NULL), m_spectrumInfo(m_matWs->spectrumInfo()) {
   m_totalXMin = matWs->getXMin();
   m_totalXMax = matWs->getXMax();
 
@@ -267,23 +268,18 @@ std::vector<std::string> MatrixWSDataSource::getInfoList(double x, double y) {
       return list;
     }
 
-    auto det = m_matWs->getDetector(row);
-    if (det == 0) {
+    if (!m_spectrumInfo.hasDetectors(row)) {
       g_log.debug() << "No DETECTOR for row " << row << " in MatrixWorkspace\n";
       return list;
     }
 
-    double l1 = m_source->getDistance(*m_sample);
-    double l2 = 0.0;
-    double two_theta = 0.0;
-    double azi = 0.0;
-    if (det->isMonitor()) {
-      l2 = det->getDistance(*m_source);
-      l2 = l2 - l1;
-    } else {
-      l2 = det->getDistance(*m_sample);
-      two_theta = m_matWs->detectorTwoTheta(*det);
-      azi = det->getPhi();
+    double l1 = m_spectrumInfo.l1();
+    double l2 = m_spectrumInfo.l2(row);
+    double two_theta = m_spectrumInfo.twoTheta(row);
+    double azi = m_spectrumInfo.detector(row).getPhi();
+    if (m_spectrumInfo.isMonitor(row)) {
+      two_theta = 0.0;
+      azi = 0.0;
     }
     SVUtils::PushNameValue("L2", 8, 4, l2, list);
     SVUtils::PushNameValue("TwoTheta", 8, 2, two_theta * rad2deg, list);
@@ -331,17 +327,18 @@ std::vector<std::string> MatrixWSDataSource::getInfoList(double x, double y) {
     // Finally, try getting indirect geometry information from the detector
     // object
     if (efixed == 0) {
-      if (!(det->isMonitor() && det->hasParameter("Efixed"))) {
+      const auto &det = m_spectrumInfo.detector(row);
+      if (!(m_spectrumInfo.isMonitor(row) && det.hasParameter("Efixed"))) {
         try {
           const ParameterMap &pmap = m_matWs->constInstrumentParameters();
-          Parameter_sptr par = pmap.getRecursive(det.get(), "Efixed");
+          Parameter_sptr par = pmap.getRecursive(&det, "Efixed");
           if (par) {
             efixed = par->value<double>();
             emode = 2;
           }
         } catch (std::runtime_error &) {
           g_log.debug() << "Failed to get Efixed from detector ID: "
-                        << det->getID() << " in MatrixWSDataSource\n";
+                        << det.getID() << " in MatrixWSDataSource\n";
           efixed = 0;
         }
       }


### PR DESCRIPTION
`Beamline::DetectorInfo` now also stores monitor flags. The flags are no longer part of `Geometry::IDetector`. This is part of the Instrument-2.0 transition.
For the time being the flags are however also stored in the detector cache of the base instrument. This seemed to be the only reasonable way to support current code in Geometry and in particular to deal with the incremental initialization of `Geometry::Instrument` (adding detectors one by one), which would be very inefficient to obtain with `Beamline::DetectorInfo`.

**To test:**

Code review.
There should be no changes that affect loading and saving files, but to be on the safe side checking forward and backward compatibility would be a plus.

Fixes #18372.
Fixes #18373.
Fixes #18375.

Internal change, no release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
