### PR TITLE
Improve error checking for CrossCorrelate algorithm

### DIFF
--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -135,6 +135,9 @@ void CrossCorrelate::exec() {
   // Create a 2DWorkspace that will hold the result
   const int nY = static_cast<int>(refY.size());
   const int npoints = 2 * nY - 3;
+  if (npoints < 1)
+    throw std::runtime_error("Range is not valid");
+
   MatrixWorkspace_sptr out =
       WorkspaceFactory::Instance().create(inputWS, nspecs, npoints, npoints);
 

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -77,7 +77,7 @@ void CrossCorrelate::exec() {
   auto minIt = std::find_if(referenceX.cbegin(), referenceX.cend(),
                             std::bind2nd(std::greater<double>(), xmin));
   if (minIt == referenceX.cend())
-    throw std::runtime_error("No daWorkspaceIndexMaxta above XMin");
+    throw std::runtime_error("No data above XMin");
   auto maxIt = std::find_if(minIt, referenceX.cend(),
                             std::bind2nd(std::greater<double>(), xmax));
   if (minIt == maxIt)


### PR DESCRIPTION
This PR adds a check to make sure the output vector length is valid before attempting to create the vector.

**To test:**

The following script should result in a `Range is not valid` error.

```python
ws = CreateSampleWorkspace(BankPixelWidth=1, XUnit='dSpacing', XMax=5, BinWidth=0.5)
ws = ScaleX(InputWorkspace='ws', Factor=0.5, Operation='Add', IndexMin=1, IndexMax=1)
OutputWorkspace = CrossCorrelate(InputWorkspace='ws', WorkspaceIndexMax=1, XMin=2, XMax=3)
```

Fixes #18384 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
