### PR TITLE
Add missing synchronization in ParameterMap::setDetectorInfo.

### DIFF
--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1165,7 +1165,10 @@ const Beamline::DetectorInfo &ParameterMap::detectorInfo() const {
 /// Only for use by ExperimentInfo. Sets the pointer to the DetectorInfo.
 void ParameterMap::setDetectorInfo(
     boost::shared_ptr<const Beamline::DetectorInfo> detectorInfo) {
-  m_detectorInfo = std::move(detectorInfo);
+  if (detectorInfo != m_detectorInfo) {
+    PARALLEL_CRITICAL(ParameterMap_setDetectorInfo)
+    m_detectorInfo = std::move(detectorInfo);
+  }
 }
 
 } // Namespace Geometry


### PR DESCRIPTION
This fixes an issue with caching a pointer to `DetectorInfo` in `ParameterMap`. This is mainly used for providing legacy Python wrappers. This bug causes sporadic segfaults in `SCDCalibratePanelsTest`

**To test:**

Code review.

Fixes #18390.

No release notes, this bug was introduced very recently.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
