### PR TITLE
Fix CPython bytecode changes in Python 3.6

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/funcinspect.py
+++ b/Framework/PythonInterface/mantid/kernel/funcinspect.py
@@ -12,6 +12,8 @@ import opcode
 import inspect
 import sys
 
+PY36 = sys.version_info >= (3, 6)
+
 #-------------------------------------------------------------------------------
 def replace_signature(func, varnames):
     """
@@ -106,17 +108,18 @@ def decompile(code_object):
     instructions = []
     n = len(code)
     i = 0
+
     while i < n:
         i_offset = i
         i_opcode = opcode_from_bytecode(code[i])
         i = i + 1
         if i_opcode >= opcode.HAVE_ARGUMENT:
-            if sys.version_info < (3, 6): # from 3.6 bytecode is now 16-bit not 8-bit
+            if PY36: # from 3.6 bytecode is now 16-bit not 8-bit
+                i_argument = code[i]
+                i = i + 1
+            else:
                 i_argument = opcode_from_bytecode(code[i]) + (opcode_from_bytecode(code[i+1]) << (4*2))
                 i = i + 2
-            else:
-                i_argument = opcode_from_bytecode(code[i])
-                i = i + 1
             if i_opcode in opcode.hasconst:
                 i_arg_value = repr(code_object.co_consts[i_argument])
                 i_arg_type = 'CONSTANT'

--- a/Framework/PythonInterface/mantid/kernel/funcinspect.py
+++ b/Framework/PythonInterface/mantid/kernel/funcinspect.py
@@ -106,18 +106,17 @@ def decompile(code_object):
     instructions = []
     n = len(code)
     i = 0
-    e = 0
     while i < n:
         i_offset = i
         i_opcode = opcode_from_bytecode(code[i])
         i = i + 1
         if i_opcode >= opcode.HAVE_ARGUMENT:
-            i_argument = opcode_from_bytecode(code[i]) + (opcode_from_bytecode(code[i+1]) << (4*2)) + e
-            i = i + 2
-            if i_opcode == opcode.EXTENDED_ARG:
-                e = iarg << 16
+            if sys.version_info < (3, 6): # from 3.6 bytecode is now 16-bit not 8-bit
+                i_argument = opcode_from_bytecode(code[i]) + (opcode_from_bytecode(code[i+1]) << (4*2))
+                i = i + 2
             else:
-                e = 0
+                i_argument = opcode_from_bytecode(code[i])
+                i = i + 1
             if i_opcode in opcode.hasconst:
                 i_arg_value = repr(code_object.co_consts[i_argument])
                 i_arg_type = 'CONSTANT'
@@ -161,7 +160,8 @@ __operator_names = set(['CALL_FUNCTION', 'CALL_FUNCTION_VAR', 'CALL_FUNCTION_KW'
                         'INPLACE_TRUE_DIVIDE','INPLACE_FLOOR_DIVIDE',
                         'INPLACE_MODULO', 'INPLACE_ADD', 'INPLACE_SUBTRACT',
                         'INPLACE_LSHIFT','INPLACE_RSHIFT','INPLACE_AND', 'INPLACE_XOR',
-                        'INPLACE_OR', 'COMPARE_OP'])
+                        'INPLACE_OR', 'COMPARE_OP',
+                        'CALL_FUNCTION_EX'])
 #--------------------------------------------------------------------------------------
 
 def process_frame(frame):


### PR DESCRIPTION
From Python 3.6 the Python interpreter now uses a 16-bit wordcode instead of 8-bit bytecode. Also some new function call opcodes have been added. See https://docs.python.org/3.6/whatsnew/3.6.html#cpython-bytecode-changes

I also removed the variable `e` since `iarg` is not defined therefore `e` must never change.

Refs #18358

**To test:**
 - [x] @quantumsteve can you check that this also fixes OSX with python 3.6
 - [x] @martyngigg can you have a look at the code since I'm guessing you're the one most familiar with `functinspect.py`




*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
