### PR TITLE
Change muon default plot policy

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -5322,6 +5322,23 @@ void ApplicationWindow::readSettings() {
     g_log.warning() << tr(mess.toAscii()).toStdString() << "\n";
     settings.setValue("/DuplicationDialogShown", true);
   }
+
+
+  // Mantid Muon interface one time only change
+  settings.beginGroup("/CustomInterfaces");
+  settings.beginGroup("/MuonAnalysis");
+  if (!settings.contains("/UpdateForPlotPolicy1")) {
+    settings.setValue("/UpdateForPlotPolicy1", "true");
+    settings.beginGroup("/GeneralOptions");
+    if (settings.value("/newPlotPolicy", 0).toInt() == 0) {
+      settings.setValue("/newPlotPolicy", 1);
+      settings.setValue("/fitsToKeep", 0);
+    }
+    settings.endGroup();
+  }
+  settings.endGroup();
+  settings.endGroup();
+  // END Mantid Muon interface one time only change
 }
 
 void ApplicationWindow::saveSettings() {

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -5323,7 +5323,6 @@ void ApplicationWindow::readSettings() {
     settings.setValue("/DuplicationDialogShown", true);
   }
 
-
   // Mantid Muon interface one time only change
   settings.beginGroup("/CustomInterfaces");
   settings.beginGroup("/MuonAnalysis");

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
@@ -295,6 +295,8 @@ void WidgetAutoSaver::saveWidgetValue() {
     settings.setValue(senderName, w->isChecked());
   } else if (auto w = qobject_cast<QComboBox *>(sender)) {
     settings.setValue(senderName, w->currentIndex());
+  } else if (auto w = qobject_cast<QSpinBox *>(sender)) {
+    settings.setValue(senderName, w->value());
   }
   // ... add more as neccessary
 }
@@ -319,6 +321,8 @@ void WidgetAutoSaver::loadWidgetValue(QWidget *widget) {
     w->setChecked(value.toBool());
   } else if (auto w = qobject_cast<QComboBox *>(widget)) {
     w->setCurrentIndex(value.toInt());
+  } else if (auto w = qobject_cast<QSpinBox *>(widget)) {
+    w->setValue(value.toInt());
   }
   // ... add more as neccessary
 }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisOptionTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisOptionTab.cpp
@@ -66,10 +66,10 @@ void MuonAnalysisOptionTab::initLayout() {
 
   m_autoSaver.beginGroup("GeneralOptions");
   m_autoSaver.registerWidget(m_uiForm.plotCreation, "plotCreation", 0);
-  m_autoSaver.registerWidget(m_uiForm.newPlotPolicy, "newPlotPolicy", 0);
+  m_autoSaver.registerWidget(m_uiForm.newPlotPolicy, "newPlotPolicy", 1);
   m_autoSaver.registerWidget(m_uiForm.hideToolbars, "toolbars", true);
   m_autoSaver.registerWidget(m_uiForm.hideGraphs, "hiddenGraphs", true);
-  m_autoSaver.registerWidget(m_uiForm.spinBoxNPlotsToKeep, "fitsToKeep", 1);
+  m_autoSaver.registerWidget(m_uiForm.spinBoxNPlotsToKeep, "fitsToKeep", 0);
   m_autoSaver.registerWidget(m_uiForm.chkEnableMultiFit, "enableMultiFit",
                              false);
   m_autoSaver.endGroup();

--- a/docs/source/interfaces/Muon_Analysis.rst
+++ b/docs/source/interfaces/Muon_Analysis.rst
@@ -605,6 +605,12 @@ General
 |       |                             | - **Create new window**. When plotting a new run, it is             |
 |       |                             |   plotted in a new window each time.                                |
 |       |                             |                                                                     |
+|       |                             |   NOTE: This can can cause speed and stability problems once the    |
+|       |                             |   number of graphs managed by Mantidplot passes a few hundred       |
+|       |                             |   which can hapen if you run Mantid for a few days on an            |
+|       |                             |   experiment. For long term stability we suggest you select         |
+|       |                             |   **Use previous window**.                                          |
+|       |                             |                                                                     |
 +-------+-----------------------------+---------------------------------------------------------------------+
 | **3** | **Hide Toolbars**           | If enabled, opening the interface up hides the MantidPlot           |
 |       |                             | toolbars. This is useful on smaller screens.                        |

--- a/docs/source/release/v3.9.0/muon.rst
+++ b/docs/source/release/v3.9.0/muon.rst
@@ -21,6 +21,7 @@ Muon Analysis
 - The layout of the new fitting tab UI has been improved to give more space for the fitting function, and enable the relative space given to each section to be adjusted by the user.
 - Fixed a bug where stale plot guesses would be left on the graph in some situations.
 - Fixed a bug with load current run that meant it would be actually loading old data due to caching. Data from current run files is no longer cached behind the scenes.
+- The default Plot Policy has been changed to **Use Previous Window**.  This avoids the speed and stability issues that could occur with **Create New Window** once hundreds of graph windows had accumulated over several days of an experiement.
 
 Algorithms
 ----------


### PR DESCRIPTION
Changes the default plot policy for the Muon interface

**To test:**

1. Start Mantidplot
1. click the Interfaces->Muon->Muon analysis menu
1. Click the settings tab
1. Under General, the New Plot Policy should be "Use Previous Window" and Keep last Plots should be 0.
1. Change the values (keep last plots is only visible when  set to "use Previous window")
1. Close mantid, restart and check the values are saved between sessions


Fixes #18396.

### RELEASE NOTES
docs/source/release/Muon

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
