### PR TITLE
Reflectometry Interface (Polref): Allow setting values to be passed without enclosing quotes

### DIFF
--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflSettingsPresenter.cpp
@@ -106,8 +106,10 @@ std::string ReflSettingsPresenter::getTransmissionOptions() const {
 
   // Add detector limits
   auto procInst = m_view->getProcessingInstructions();
-  if (!procInst.empty())
+  if (!procInst.empty()) {
+    wrapWithQuotes(procInst);
     options.push_back("ProcessingInstructions=" + procInst);
+  }
 
   return boost::algorithm::join(options, ",");
 }
@@ -154,8 +156,10 @@ std::string ReflSettingsPresenter::getReductionOptions() const {
 
   // Add direct beam
   auto dbnr = m_view->getDirectBeam();
-  if (!dbnr.empty())
+  if (!dbnr.empty()) {
+    wrapWithQuotes(dbnr);
     options.push_back("RegionOfDirectBeam=" + dbnr);
+  }
 
   // Add polarisation corrections
   auto polCorr = m_view->getPolarisationCorrections();
@@ -215,8 +219,10 @@ std::string ReflSettingsPresenter::getReductionOptions() const {
 
   // Add detector limits
   auto procInst = m_view->getProcessingInstructions();
-  if (!procInst.empty())
+  if (!procInst.empty()) {
+    wrapWithQuotes(procInst);
     options.push_back("ProcessingInstructions=" + procInst);
+  }
 
   // Add transmission runs
   auto transRuns = this->getTransmissionRuns();

--- a/MantidQt/CustomInterfaces/test/ReflSettingsPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflSettingsPresenterTest.h
@@ -74,7 +74,7 @@ public:
         .WillOnce(Return("2"));
     EXPECT_CALL(mockView, getProcessingInstructions())
         .Times(Exactly(1))
-        .WillOnce(Return("\"3,4\""));
+        .WillOnce(Return("3,4"));
     auto options = presenter.getTransmissionOptions();
 
     std::vector<std::string> optionsVec;
@@ -113,7 +113,7 @@ public:
         .WillOnce(Return("0.54,0.33,1.81"));
     EXPECT_CALL(mockView, getDirectBeam())
         .Times(Exactly(1))
-        .WillOnce(Return("\"0,3\""));
+        .WillOnce(Return("0,3"));
     EXPECT_CALL(mockView, getPolarisationCorrections())
         .Times(Exactly(1))
         .WillOnce(Return("PNR"));
@@ -149,7 +149,7 @@ public:
         .WillOnce(Return("-0.02"));
     EXPECT_CALL(mockView, getProcessingInstructions())
         .Times(Exactly(1))
-        .WillOnce(Return("\"3,4\""));
+        .WillOnce(Return("3,4"));
     EXPECT_CALL(mockView, getTransmissionRuns())
         .Times(Exactly(1))
         .WillOnce(Return("INTER00013463,INTER00013464"));


### PR DESCRIPTION
This is relatively similar to PR #18253. This allows the 'Direct Beam' and 'Processing Instructions' settings values in the interface to be passed without enclosing them in quote marks.

**To test:**

- Open the ISIS Reflectometry (Polref) interface.
- Import INTER_NR_test2.tbl (can be obtain from sample datasets).
- Go to the 'Settings' tab and enter unquoted values into 'Processing Instructions' (e.g. `3, 4`).
- Select some runs in the 'Runs' tab and process - it should not throw an error regarding the format of the setting value (like `Invalid key value pair, '4'`),
- Do the same for 'Direct Beam' (set analysis mode to multidetector for this).

<!-- Instructions for testing. -->

Fixes #18399.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
