### PR TITLE
 Fix for cross representation bug for peak workspaces in SliceViewer

### DIFF
--- a/MantidQt/SliceViewer/src/PeakView.cpp
+++ b/MantidQt/SliceViewer/src/PeakView.cpp
@@ -15,8 +15,8 @@ PeakView::PeakView(PeaksPresenter *const presenter, QwtPlot *plot,
                    PeakViewColor foregroundColor, PeakViewColor backgroundColor,
                    double largestEffectiveRadius)
     : PeakOverlayInteractive(presenter, plot, plotXIndex, plotYIndex, parent),
-      m_peaks(vecPeakRepresentation), m_cachedOccupancyIntoView(0),
-      m_cachedOccupancyInView(0), m_showBackground(false),
+      m_peaks(vecPeakRepresentation), m_cachedOccupancyIntoView(0.015),
+      m_cachedOccupancyInView(0.015), m_showBackground(false),
       m_foregroundColor(foregroundColor), m_backgroundColor(backgroundColor),
       m_largestEffectiveRadius(largestEffectiveRadius) {}
 
@@ -133,7 +133,7 @@ void PeakView::takeSettingsFrom(const PeakOverlayView *const source) {
   // cross-type peak
   this->showBackgroundRadius(source->isBackgroundShown());
 
-  // Pass on the information which only concerns the cross-type peak
+  // Pass on the information which only concerns the cross-type peak.
   this->changeOccupancyIntoView(source->getOccupancyIntoView());
   this->changeOccupancyInView(source->getOccupancyInView());
 }


### PR DESCRIPTION
Fixes #18415

## Summary
Previously the cross representation of a peaks workspace would turn to a dot in the SliceViewer, when a user was sorting a column in the peaks table. 

## To test:

#### Test for cross representation

1. Get a workspace with an associated shapeless peaks workspace
2. Open both in the SliceViewer
   * Confirm that the peaks are represented as crosses
3. Sort a column in the peaks table
   * Confirm that the peaks are still represented as crosses

#### Test for elliptical representation

1. Get a workspace with an associated elliptical peaks workspace
2. Open both in the SliceViewer
   * Confirm that the peaks are represented as ellipses
3. Sort a column in the peaks table
   * Confirm that the peaks are still represented as ellipses

If you don't have suitable test data, ask me about it and I can provide you with some.


*Does not need to be in the release notes.*
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
