### PR TITLE
Fix debug assertion when running tests in Windows debug mode

### DIFF
--- a/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -161,7 +161,7 @@ void ExtractSpectra::execHistogram() {
         outputWorkspace->setSharedDx(
             j,
             make_cow<HistogramData::HistogramDx>(
-                oldDx.begin() + m_minX, oldDx.begin() + m_maxX - m_histogram));
+                oldDx.begin() + m_minX, oldDx.begin() + (m_maxX - m_histogram)));
       }
     } else {
       // Safe to just copy whole vector 'cos can't be cropping in X if not
@@ -328,7 +328,7 @@ void ExtractSpectra::execEvent() {
       if (hasDx) {
         auto &oldDx = m_inputWorkspace->dx(i);
         outEL.setPointStandardDeviations(oldDx.begin() + m_minX,
-                                         oldDx.begin() + m_maxX - m_histogram);
+                                         oldDx.begin() + (m_maxX - m_histogram));
       }
     }
 

--- a/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -159,9 +159,9 @@ void ExtractSpectra::execHistogram() {
       if (hasDx) {
         auto &oldDx = m_inputWorkspace->dx(i);
         outputWorkspace->setSharedDx(
-            j,
-            make_cow<HistogramData::HistogramDx>(
-                oldDx.begin() + m_minX, oldDx.begin() + (m_maxX - m_histogram)));
+            j, make_cow<HistogramData::HistogramDx>(
+                   oldDx.begin() + m_minX,
+                   oldDx.begin() + (m_maxX - m_histogram)));
       }
     } else {
       // Safe to just copy whole vector 'cos can't be cropping in X if not
@@ -327,8 +327,8 @@ void ExtractSpectra::execEvent() {
       // X is already set in workspace creation, just set Dx if necessary.
       if (hasDx) {
         auto &oldDx = m_inputWorkspace->dx(i);
-        outEL.setPointStandardDeviations(oldDx.begin() + m_minX,
-                                         oldDx.begin() + (m_maxX - m_histogram));
+        outEL.setPointStandardDeviations(
+            oldDx.begin() + m_minX, oldDx.begin() + (m_maxX - m_histogram));
       }
     }
 


### PR DESCRIPTION
Description of work

The MSVC standard library has quite strict checks in debug mode. Running the unit tests produced a
debug assertion for an iterator out of bounds error in `ExtractSpectraTest`. This fixes the code to avoid
that problem.

Note that the code was actually correct but this avoids it looking as if something is wrong.

**To test:**

Code review should suffice.

No issue number.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
