### PR TITLE
Added an input property for temperature in ComputeCalibrationCoefVan

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
@@ -58,8 +58,9 @@ class ComputeCalibrationCoefVan(PythonAlgorithm):
                              defaultValue=Property.EMPTY_DBL,
                              validator=FloatBoundedValidator(lower=0.0),
                              direction=Direction.Input,
-                             doc=("Temperature during the experiment, in " +
-                                  "Kelvins."))
+                             doc=("Temperature during the experiment (in " +
+                                  "Kelvins) if the 'temperature' sample log " +
+                                  "is missing or needs to be overriden."))
         return
 
     def validateInputs(self):

--- a/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
@@ -58,7 +58,8 @@ class ComputeCalibrationCoefVan(PythonAlgorithm):
                              defaultValue=Property.EMPTY_DBL,
                              validator=FloatBoundedValidator(lower=0.0),
                              direction=Direction.Input,
-                             doc=("Temperature during the experiment."))
+                             doc=("Temperature during the experiment, in " +
+                                  "Kelvins."))
         return
 
     def validateInputs(self):

--- a/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
+++ b/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
@@ -21,11 +21,11 @@ Algorithm creates a workspace with  detector sensitivity correction coefficients
 
    :math:`J(y) = \int_0^1 x\cdot\mathrm{coth}\left(\frac{x}{2y}\right)\,\mathrm{d}x`
 
-   where :math:`y=T/T_m` is the ratio of the temperature during the experiment :math:`T` to the Debye temperature :math:`T_m = 389K`, :math:`m_V` is the Vanadium atomic mass (in kg) and :math:`\theta_i` is the polar angle of the i-th detector.
+   where :math:`y=T/T_m` is the ratio of the temperature during the experiment :math:`T` to the Debye temperature :math:`T_m = 389K`, :math:`m_V` is the Vanadium atomic mass (in kg) and :math:`\theta_i` is the polar angle of the i-th detector. By default, the temperature is read from the 'temperature' entry in the sample logs. If the entry is missing, or incorrect, the *Temperature* input property can be used instead.
 
 .. warning::
 
-    If the input *Temperature* is not specified or the sample log *temperature* is not present in the given Vanadium workspace, or is set to an invalid value, T=293K will be taken for the Debye-Waller factor calculation. The algorithm will produce a warning in this case.
+    If the input *Temperature* is not specified or the sample log 'temperature' is not present in the given Vanadium workspace, or is set to an invalid value, T=293K will be taken for the Debye-Waller factor calculation. The algorithm will produce a warning in this case.
 
 2. Load the peak centre and sigma from the *EPPTable*. These values are used to calculate sum :math:`S_i` as
 

--- a/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
+++ b/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
@@ -25,7 +25,7 @@ Algorithm creates a workspace with  detector sensitivity correction coefficients
 
 .. warning::
 
-    If sample log *temperature* is not present in the given Vanadium workspace or temperature is set to an invalid value, T=293K will be taken for the Debye-Waller factor calculation. Algorithm will produce warning in this case.
+    If the input *Temperature* is not specified or the sample log *temperature* is not present in the given Vanadium workspace, or is set to an invalid value, T=293K will be taken for the Debye-Waller factor calculation. The algorithm will produce a warning in this case.
 
 2. Load the peak centre and sigma from the *EPPTable*. These values are used to calculate sum :math:`S_i` as
 

--- a/docs/source/release/v3.9.0/direct_inelastic.rst
+++ b/docs/source/release/v3.9.0/direct_inelastic.rst
@@ -18,6 +18,8 @@ Improvements
 
 - Overly pessimistic error calculation in :ref:`ComputeCalibrationCoefVan <algm-ComputeCalibrationCoefVan>` have been fixed.
 
+- A new input property *Temperature* has been added to :ref:`ComputeCalibrationCoefVan <algm-ComputeCalibrationCoefVan>`.
+
 New features
 ------------
 


### PR DESCRIPTION
This PR adds a *Temperature* input property to [`ComputeCalibratonCoefVan`](http://docs.mantidproject.org/nightly/algorithms/ComputeCalibrationCoefVan-v1.html). The temperature is used in correcting the integrated Vanadium data for the Debye-Waller factor. If a 'temperature' sample log exists in the *InputWorkspace*, the value given by the input property will override it.

**To test:**

1. Load `<mantid-build-dir>/ExternalData/Testing/Data/UnitTest/TOFTOFTestdata.nxs'
2. Check that the 'temperature' entry exists in the sample logs.
3. Run [`FindEPP`](http://docs.mantidproject.org/nightly/algorithms/FindEPP-v1.html) on the workspace.
4. Run `ComputeCalibrationCoefVan` without specifying *Temperature*. The algorithm should use the value in the sample logs.
5. Run `ComputeCalibrationCoefVan` with different *Temperature* than what is in the sample logs.

Fixes #18429.

*Release notes were updated accordingly.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
