### PR TITLE
Fix angle definition in MayersSampleCorrection

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
@@ -57,6 +57,8 @@ public:
     double sigmaAbs;  ///< Absorption cross-section at 2200m/s (barns)
     double cylRadius; ///< Radius of cylinder (m)
     double cylHeight; ///< Height of cylinder (m)
+    size_t msNEvents; ///< Number of second-order scatters per run
+    size_t msNRuns;   ///< Number of runs to average ms correction over
   };
 
   /// Constructor

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
@@ -51,7 +51,7 @@ public:
     double l1;        ///< Nominal distance from source to sample (m)
     double l2;        ///< Nominal distance from sample to detector (m)
     double twoTheta;  ///< Scattering angle of the detector (radians)
-    double phi;       ///< Azimuth angle of the detector (radians)
+    double azimuth;   ///< Azimuth angle of the detector (radians)
     double rho;       ///< Number density of scatters (angstroms^-3)
     double sigmaSc;   ///< Total scattering cross-section (barns)
     double sigmaAbs;  ///< Absorption cross-section at 2200m/s (barns)

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
@@ -25,8 +25,6 @@ size_t N_MUR_PTS = 21;
 size_t N_RAD = 29;
 /// Number of theta points for cylindrical integration
 size_t N_THETA = 29;
-/// Number of second order event points
-size_t N_SECOND = 10000;
 /// Order of polynomial used to fit generated points
 size_t N_POLY_ORDER = 4;
 /// 2pi
@@ -235,11 +233,10 @@ MayersSampleCorrectionStrategy::calculateMS(const size_t irp, const double muR,
   seedRNG(irp);
 
   // Take an average over a number of sets of second scatters
-  const size_t nsets(10);
-  std::vector<double> deltas(nsets, 0.0);
-  for (size_t j = 0; j < nsets; ++j) {
+  std::vector<double> deltas(m_pars.msNRuns, 0.0);
+  for (size_t j = 0; j < m_pars.msNRuns; ++j) {
     double sum = 0.0;
-    for (size_t i = 0; i < N_SECOND; ++i) {
+    for (size_t i = 0; i < m_pars.msNEvents; ++i) {
       // Random (r,theta,z)
       const double r1 = pow(m_rng->nextValue(), radDistPower) * muR;
       const double r2 = pow(m_rng->nextValue(), radDistPower) * muR;

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
@@ -187,6 +187,7 @@ MayersSampleCorrectionStrategy::calculateSelfAttenuation(const double muR) {
   const double dyr = muR / to<double>(N_RAD - 1);
   const double dyth = TWOPI / to<double>(N_THETA - 1);
   const double muRSq = muR * muR;
+  const double cosaz = cos(m_pars.azimuth);
 
   // Store values at each point
   std::vector<double> yr(N_RAD), yth(N_THETA);
@@ -206,7 +207,7 @@ MayersSampleCorrectionStrategy::calculateSelfAttenuation(const double muR) {
       if (fact2 < 0.0)
         fact2 = 0.0;
       const double mul2 =
-          (sqrt(fact2) - r0 * cos(m_pars.twoTheta - theta)) / cos(m_pars.phi);
+          (sqrt(fact2) - r0 * cos(m_pars.twoTheta - theta)) / cosaz;
       yth[j] = exp(-mul1 - mul2);
     }
 
@@ -229,7 +230,8 @@ MayersSampleCorrectionStrategy::calculateMS(const size_t irp, const double muR,
   // Radial coordinate raised to power 1/3 to ensure uniform density of points
   // across circle following discussion with W.G.Marshall (ISIS)
   const double radDistPower = 1. / 3.;
-  double muH = muR * (m_pars.cylHeight / m_pars.cylRadius);
+  const double muH = muR * (m_pars.cylHeight / m_pars.cylRadius);
+  const double cosaz = cos(m_pars.azimuth);
   seedRNG(irp);
 
   // Take an average over a number of sets of second scatters
@@ -254,7 +256,7 @@ MayersSampleCorrectionStrategy::calculateMS(const size_t irp, const double muR,
         fact2 = 0.0;
       // Path out from final point
       const double mul2 =
-          (sqrt(fact2) - r2 * cos(m_pars.twoTheta - th2)) / cos(m_pars.phi);
+          (sqrt(fact2) - r2 * cos(m_pars.twoTheta - th2)) / cosaz;
       // Path between point 1 & 2
       const double mul12 =
           sqrt(pow(r1 * cos(th1) - r2 * cos(th2), 2) +
@@ -264,7 +266,7 @@ MayersSampleCorrectionStrategy::calculateMS(const size_t irp, const double muR,
       sum += exp(-(mul1 + mul2 + mul12)) / pow(mul12, 2);
     }
     const double beta =
-        pow(M_PI * muR * muR * muH, 2) * sum / to<double>(N_SECOND);
+        pow(M_PI * muR * muR * muH, 2) * sum / to<double>(m_pars.msNEvents);
     const double delta = 0.25 * beta / (M_PI * abs * muH);
     deltas[j] = delta;
   }

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -192,7 +192,7 @@ private:
     pars.l1 = 14.0;
     pars.l2 = 2.2;
     pars.twoTheta = 0.10821;
-    pars.phi = 0.0;
+    pars.azimuth = 0.0;
     pars.rho = 0.07261;
     pars.sigmaSc = 5.1;
     pars.sigmaAbs = 5.08;

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -8,6 +8,8 @@
 #include <algorithm>
 #include <cmath>
 
+#include <iomanip>
+
 using Mantid::Algorithms::MayersSampleCorrectionStrategy;
 using namespace Mantid::HistogramData;
 
@@ -50,8 +52,7 @@ public:
                     Counts(nypts, 2.0));
     MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
 
-    auto outHisto = mscat.getCorrectedHisto();
-
+    const auto outHisto = mscat.getCorrectedHisto();
     const auto &tof = outHisto.x();
     const auto &signal = outHisto.y();
     const auto &error = outHisto.e();
@@ -75,8 +76,7 @@ public:
                     Counts(nypts, 2.0));
     MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
 
-    auto outHisto = mscat.getCorrectedHisto();
-
+    const auto outHisto = mscat.getCorrectedHisto();
     const auto &tof = outHisto.x();
     const auto &signal = outHisto.y();
     const auto &error = outHisto.e();
@@ -95,7 +95,7 @@ public:
 
   void test_Corrects_For_Absorption_For_Histogram_Data() {
     const size_t nypts(100);
-    bool mscatOn(false);
+    const bool mscatOn(false);
     Histogram histo(BinEdges(nypts + 1, LinearGenerator(99.5, 1.0)),
                     Counts(nypts, 2.0));
     MayersSampleCorrectionStrategy mscat(createTestParameters(mscatOn), histo);
@@ -116,6 +116,60 @@ public:
 
     TS_ASSERT_DELTA(1.6574851, error.front(), delta);
     TS_ASSERT_DELTA(1.6609527, error.back(), delta);
+  }
+
+  void test_MutlipleScattering_NEvents_Parameter() {
+    const size_t nypts(100);
+    Histogram histo(BinEdges(nypts + 1, LinearGenerator(99.5, 1.0)),
+                    Counts(nypts, 2.0));
+    const bool mscatOn(true);
+    auto corrPars = createTestParameters(mscatOn);
+    corrPars.msNEvents = 1000;
+    MayersSampleCorrectionStrategy mscat(corrPars, histo);
+
+    const auto outHisto = mscat.getCorrectedHisto();
+    const auto tof = outHisto.x();
+    const auto signal = outHisto.y();
+    const auto error = outHisto.e();
+
+    // Check some values
+    // Check some values
+    const double delta(1e-06);
+    TS_ASSERT_DELTA(99.5, tof.front(), delta);
+    TS_ASSERT_DELTA(199.5, tof.back(), delta);
+
+    TS_ASSERT_DELTA(0.37553636, signal.front(), delta);
+    TS_ASSERT_DELTA(0.37554482, signal.back(), delta);
+
+    TS_ASSERT_DELTA(0.26554431, error.front(), delta);
+    TS_ASSERT_DELTA(0.26555029, error.back(), delta);
+  }
+
+  void test_MutlipleScattering_NRuns_Parameter() {
+    const size_t nypts(100);
+    Histogram histo(BinEdges(nypts + 1, LinearGenerator(99.5, 1.0)),
+                    Counts(nypts, 2.0));
+    const bool mscatOn(true);
+    auto corrPars = createTestParameters(mscatOn);
+    corrPars.msNRuns = 2;
+    MayersSampleCorrectionStrategy mscat(corrPars, histo);
+
+    const auto outHisto = mscat.getCorrectedHisto();
+    const auto tof = outHisto.x();
+    const auto signal = outHisto.y();
+    const auto error = outHisto.e();
+
+    // Check some values
+    // Check some values
+    const double delta(1e-06);
+    TS_ASSERT_DELTA(99.5, tof.front(), delta);
+    TS_ASSERT_DELTA(199.5, tof.back(), delta);
+
+    TS_ASSERT_DELTA(0.37376334, signal.front(), delta);
+    TS_ASSERT_DELTA(0.37123648, signal.back(), delta);
+
+    TS_ASSERT_DELTA(0.26429059, error.front(), delta);
+    TS_ASSERT_DELTA(0.26250383, error.back(), delta);
   }
 
   // ---------------------- Failure tests -----------------------------
@@ -144,6 +198,8 @@ private:
     pars.sigmaAbs = 5.08;
     pars.cylRadius = 0.0025;
     pars.cylHeight = 0.04;
+    pars.msNEvents = 10000;
+    pars.msNRuns = 10;
     return pars;
   }
 };

--- a/Framework/Algorithms/test/MayersSampleCorrectionTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionTest.h
@@ -41,11 +41,11 @@ public:
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(0.37497317, signal.front(), delta);
-    TS_ASSERT_DELTA(0.37629282, signal.back(), delta);
+    TS_ASSERT_DELTA(0.37666067, signal.front(), delta);
+    TS_ASSERT_DELTA(0.37553044, signal.back(), delta);
 
-    TS_ASSERT_DELTA(0.26514607, error.front(), delta);
-    TS_ASSERT_DELTA(0.2660792, error.back(), delta);
+    TS_ASSERT_DELTA(0.26633931, error.front(), delta);
+    TS_ASSERT_DELTA(0.26554012, error.back(), delta);
   }
 
   void test_Success_With_Just_Absorption_Correction() {
@@ -96,6 +96,8 @@ private:
     alg->initialize();
     alg->setProperty("InputWorkspace", inputWS);
     alg->setProperty("MultipleScattering", mscatOn);
+    alg->setProperty("MSEvents", 2000);
+    alg->setProperty("MSRuns", 5);
     alg->setPropertyValue("OutputWorkspace", "_unused_for_child");
     alg->execute();
     return alg;

--- a/docs/source/release/v3.9.0/framework.rst
+++ b/docs/source/release/v3.9.0/framework.rst
@@ -31,6 +31,7 @@ Improved
 - :ref:`SetSample <algm-SetSample>` now accepts an Angle argument for defining a rotated flat plate sample.
 - :ref:`SavePlot1D <algm-SavePlot1D>` now supports optional ``SpectraList`` for plotting
 - :ref:`MaskDetectors <algm-MaskDetectors>` has now a new option to mask detectors by instrument component name.
+- :ref:`MayersSampleCorrection <algm-MayersSampleCorrection>`: The calculation of the azimuth angle has been fixed. Previously it was set equal to the Mantid definition of phi but the old code defined it as the angle away from the scattering plane.
 
 Renamed
 #######


### PR DESCRIPTION
Fixes the azimuthal angle definition for the multiple scattering calculation in MayersSampleCorrection. Previously it was incorrectly defined as `det.getPhi` when translated from the fortran but the actual definition should be the angle away from the scattering plane. 

While this makes only a small numerical difference to the results it avoids an issue seen on POLARIS where the detectors at `phi=90 deg` (mantid) gave an infinite second path length as there is a `1/cos(phi)` dependence. Phi should be 45 deg above the scattering plane though so as to avoid `cos(90)=0`.

**To test:**

Run `MayersSampleCorrection` on an unfocussed POLARIS (ISIS) dataset and confirm that for all spectra >=55 there are no `inf` values. 

No issue number

[Release notes](/mantidproject/mantid/commit/ccd77803b721fd4423954b64d91192089138419b)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
