### PR TITLE
Change python3 to use get_instructions in funcinspect.py

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/funcinspect.py
+++ b/Framework/PythonInterface/mantid/kernel/funcinspect.py
@@ -100,13 +100,18 @@ def decompile(code_object):
         variables = code_object.co_cellvars + code_object.co_freevars
         n = len(code)
         i = 0
+        e = 0
         while i < n:
             i_offset = i
             i_opcode = ord(code[i])
             i = i + 1
             if i_opcode >= opcode.HAVE_ARGUMENT:
-                i_argument = ord(code[i]) + (ord(code[i+1]) << (4*2))
+                i_argument = ord(code[i]) + (ord(code[i+1]) << (4*2)) + e
                 i = i + 2
+                if i_opcode == opcode.EXTENDED_ARG:
+                    e = i_argument << 16
+                else:
+                    e = 0
                 if i_opcode in opcode.hasconst:
                     i_arg_value = repr(code_object.co_consts[i_argument])
                 elif i_opcode in opcode.hasname:

--- a/Framework/PythonInterface/mantid/kernel/funcinspect.py
+++ b/Framework/PythonInterface/mantid/kernel/funcinspect.py
@@ -11,8 +11,8 @@ from __future__ import (absolute_import, division,
 import opcode
 import inspect
 import sys
-
-PY36 = sys.version_info >= (3, 6)
+import dis
+from six import PY3
 
 #-------------------------------------------------------------------------------
 def replace_signature(func, varnames):
@@ -60,19 +60,6 @@ def customise_func(func, name, signature, docstring):
     return func
 
 #-------------------------------------------------------------------------------
-
-if sys.version_info[0] >= 3:
-  def opcode_from_bytecode(bc):
-      """Return the opcode from the given single bytecode
-      """
-      return bc
-else:
-  def opcode_from_bytecode(bc):
-      """Return the opcode from the given single bytecode str
-      """
-      return ord(bc)
-
-#-------------------------------------------------------------------------------
 def decompile(code_object):
     """
     Taken from
@@ -93,7 +80,7 @@ def decompile(code_object):
 
     Outputs:
     =========     =====================================================================
-    instructions  a list of offsets, op_codes, names, arguments, argument_type,
+    instructions  a list of offsets, op_codes, names, arguments,
                   argument_value which can be deconstructed to find out various things
                   about a function call.
 
@@ -103,49 +90,41 @@ def decompile(code_object):
     i = f.f_lasti  # index of the last attempted instruction in byte code
     ins = decompile(f.f_code)
     """
-    code = code_object.co_code
-    variables = code_object.co_cellvars + code_object.co_freevars
     instructions = []
-    n = len(code)
-    i = 0
 
-    while i < n:
-        i_offset = i
-        i_opcode = opcode_from_bytecode(code[i])
-        i = i + 1
-        if i_opcode >= opcode.HAVE_ARGUMENT:
-            if PY36: # from 3.6 bytecode is now 16-bit not 8-bit
-                i_argument = code[i]
-                i = i + 1
-            else:
-                i_argument = opcode_from_bytecode(code[i]) + (opcode_from_bytecode(code[i+1]) << (4*2))
+    if PY3:
+        for ins in dis.get_instructions(code_object):
+            instructions.append( (ins.offset, ins.opcode, ins.opname, ins.arg, ins.argval) )
+    else:
+        code = code_object.co_code
+        variables = code_object.co_cellvars + code_object.co_freevars
+        n = len(code)
+        i = 0
+        while i < n:
+            i_offset = i
+            i_opcode = ord(code[i])
+            i = i + 1
+            if i_opcode >= opcode.HAVE_ARGUMENT:
+                i_argument = ord(code[i]) + (ord(code[i+1]) << (4*2))
                 i = i + 2
-            if i_opcode in opcode.hasconst:
-                i_arg_value = repr(code_object.co_consts[i_argument])
-                i_arg_type = 'CONSTANT'
-            elif i_opcode in opcode.hasname:
-                i_arg_value = code_object.co_names[i_argument]
-                i_arg_type = 'GLOBAL VARIABLE'
-            elif i_opcode in opcode.hasjrel:
-                i_arg_value = repr(i + i_argument)
-                i_arg_type = 'RELATIVE JUMP'
-            elif i_opcode in opcode.haslocal:
-                i_arg_value = code_object.co_varnames[i_argument]
-                i_arg_type = 'LOCAL VARIABLE'
-            elif i_opcode in opcode.hascompare:
-                i_arg_value = opcode.cmp_op[i_argument]
-                i_arg_type = 'COMPARE OPERATOR'
-            elif i_opcode in opcode.hasfree:
-                i_arg_value = variables[i_argument]
-                i_arg_type = 'FREE VARIABLE'
+                if i_opcode in opcode.hasconst:
+                    i_arg_value = repr(code_object.co_consts[i_argument])
+                elif i_opcode in opcode.hasname:
+                    i_arg_value = code_object.co_names[i_argument]
+                elif i_opcode in opcode.hasjrel:
+                    i_arg_value = repr(i + i_argument)
+                elif i_opcode in opcode.haslocal:
+                    i_arg_value = code_object.co_varnames[i_argument]
+                elif i_opcode in opcode.hascompare:
+                    i_arg_value = opcode.cmp_op[i_argument]
+                elif i_opcode in opcode.hasfree:
+                    i_arg_value = variables[i_argument]
+                else:
+                    i_arg_value = i_argument
             else:
-                i_arg_value = i_argument
-                i_arg_type = 'OTHER'
-        else:
-            i_argument = None
-            i_arg_value = None
-            i_arg_type = None
-        instructions.append( (i_offset, i_opcode, opcode.opname[i_opcode], i_argument, i_arg_type, i_arg_value) )
+                i_argument = None
+                i_arg_value = None
+            instructions.append( (i_offset, i_opcode, opcode.opname[i_opcode], i_argument, i_arg_value) )
     return instructions
 
 #-------------------------------------------------------------------------------
@@ -190,13 +169,13 @@ def process_frame(frame):
     start_offset = 0
 
     for index, instruction in enumerate(ins_stack):
-        (offset, op, name, argument, argtype, argvalue) = instruction
+        (offset, op, name, argument, argvalue) = instruction
         if name in __operator_names:
             call_function_locs[start_offset] = (start_index, index)
             start_index = index
             start_offset = offset
 
-    (offset, op, name, argument, argtype, argvalue) = ins_stack[-1]
+    (offset, op, name, argument, argvalue) = ins_stack[-1]
     # Append the index of the last entry to form the last boundary
     call_function_locs[start_offset] = (start_index, len(ins_stack)-1)
 
@@ -215,14 +194,14 @@ def process_frame(frame):
     output_var_names = []
     max_returns = []
     last_func_offset = call_function_locs[last_i][0]
-    (offset, op, name, argument, argtype, argvalue) = ins_stack[last_func_offset + 1]
+    (offset, op, name, argument, argvalue) = ins_stack[last_func_offset + 1]
     if name == 'POP_TOP':  # no return values
         pass
     if name == 'STORE_FAST' or name == 'STORE_NAME': # one return value
         output_var_names.append(argvalue)
     if name == 'UNPACK_SEQUENCE': # Many Return Values, One equal sign
         for index in range(argvalue):
-            (offset_, op_, name_, argument_, argtype_, argvalue_) = ins_stack[last_func_offset + 2 +index]
+            (offset_, op_, name_, argument_, argvalue_) = ins_stack[last_func_offset + 2 +index]
             output_var_names.append(argvalue_)
     max_returns = len(output_var_names)
     if name == 'DUP_TOP': # Many Return Values, Many equal signs
@@ -234,13 +213,13 @@ def process_frame(frame):
         count = 0
         max_returns = 0 # Must count the max_returns ourselves in this case
         while count < len(ins_stack[call_function_locs[i][0]:call_function_locs[i][1]]):
-            (offset_, op_, name_, argument_, argtype_, argvalue_) = ins[call_function_locs[i][0]+count]
+            (offset_, op_, name_, argument_, argvalue_) = ins[call_function_locs[i][0]+count]
             if name_ == 'UNPACK_SEQUENCE': # Many Return Values, One equal sign
                 hold = []
                 if argvalue_ > max_returns:
                     max_returns = argvalue_
                 for index in range(argvalue_):
-                    (_offset_, _op_, _name_, _argument_, _argtype_, _argvalue_) = ins[call_function_locs[i][0] + count+1+index]
+                    (_offset_, _op_, _name_, _argument_, _argvalue_) = ins[call_function_locs[i][0] + count+1+index]
                     hold.append(_argvalue_)
                 count = count + argvalue_
                 output_var_names.append(hold)


### PR DESCRIPTION
It seems that the changes in #18400 were not enough and we may care about the `EXTENDED_ARG` in a few cases. The following test still failed, which I initially thought was for a different reason.

```
480: ======================================================================
480: FAIL: test_complex_binary_ops_do_not_leave_temporary_workspaces_behind (__main__.MatrixWorkspaceTest)
480: ----------------------------------------------------------------------
480: Traceback (most recent call last):
480:   File "/home/rwp/mantid/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py", line 320, in test_complex_binary_ops_do_not_leave_temporary_workspaces_behind
480:     self.assertTrue('w1' in ads)
480: AssertionError: False is not true
```

```
483: ======================================================================
483: FAIL: test_comparisons_and_boolean_operations (__main__.MDHistoWorkspaceTest)
483: ----------------------------------------------------------------------
483: Traceback (most recent call last):
483:   File "/home/rwp/mantid/Framework/PythonInterface/test/python/mantid/api/MDHistoWorkspaceTest.py", line 146, in test_comparisons_and_boolean_operations
483:     self.assertEqual( E.name(), 'E')
483: AssertionError: '__python_op_tmp0' != 'E'
483: - __python_op_tmp0
483: + E
```

```
498: ======================================================================
498: FAIL: test_complex_binary_operations_with_group_do_not_leave_temporary_workspaces_in_ADS (__main__.WorkspaceGroupTest)
498: ----------------------------------------------------------------------
498: Traceback (most recent call last):
498:   File "/home/rwp/mantid/Framework/PythonInterface/test/python/mantid/api/WorkspaceGroupTest.py", line 79, in test_complex_binary_operations_with_group_do_not_leave_temporary_workspaces_in_ADS
498:     self.assertTrue('w1' in mtd)
498: AssertionError: False is not true
```

Even though dis.get_instructions is only 3.4+ I don't think there will ever be a need to support python 3.3

I removed i_arg_type as it doesn't appear to be used anywhere and dis.get_instructions doesn't provide an equivalent.

**To test:** Same again 😃 
 - [ ] @quantumsteve can you check that this also fixes these tests OSX with python 3.6
 - [x] @martyngigg can you have a look at the code since I'm guessing you're the one most familiar with `functinspect.py`

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
