### PR TITLE
 Fix for SAScollimation in SaveCanSAS1D and LoadCanSAS1D 

### DIFF
--- a/Framework/DataHandling/src/LoadCanSAS1D.cpp
+++ b/Framework/DataHandling/src/LoadCanSAS1D.cpp
@@ -387,10 +387,9 @@ void LoadCanSAS1D::createSampleInformation(
   try {
     auto name = sasCollimationElement->getChildElement("name");
     check(name, "name");
-  } catch(Kernel::Exception::NotFoundError&) {
+  } catch (Kernel::Exception::NotFoundError &) {
     isInValidOldFormat = false;
   }
-
 
   if (isInValidOldFormat) {
     // Get the geometry information
@@ -416,33 +415,33 @@ void LoadCanSAS1D::createSampleInformation(
     }
 
   } else {
-      // Get aperture
-      auto aperture = sasCollimationElement->getChildElement("aperture");
-      if (aperture) {
-          // Get geometry element
-          auto geometry = aperture->getAttribute("name");
-          if (!geometry.empty()) {
-            auto geometryID = getGeometryID(Poco::XML::fromXMLString(geometry));
-            sample.setGeometryFlag(geometryID);
-          }
-
-          // Get size
-          auto size = aperture->getChildElement("size");
-
-          // Get the width information
-          auto widthElement = size->getChildElement("x");
-          if (widthElement) {
-            double width = std::stod(widthElement->innerText());
-            sample.setWidth(width);
-          }
-
-          // Get the height information
-          auto heightElement = size->getChildElement("y");
-          if (heightElement) {
-            double height = std::stod(heightElement->innerText());
-            sample.setHeight(height);
-          }
+    // Get aperture
+    auto aperture = sasCollimationElement->getChildElement("aperture");
+    if (aperture) {
+      // Get geometry element
+      auto geometry = aperture->getAttribute("name");
+      if (!geometry.empty()) {
+        auto geometryID = getGeometryID(Poco::XML::fromXMLString(geometry));
+        sample.setGeometryFlag(geometryID);
       }
+
+      // Get size
+      auto size = aperture->getChildElement("size");
+
+      // Get the width information
+      auto widthElement = size->getChildElement("x");
+      if (widthElement) {
+        double width = std::stod(widthElement->innerText());
+        sample.setWidth(width);
+      }
+
+      // Get the height information
+      auto heightElement = size->getChildElement("y");
+      if (heightElement) {
+        double height = std::stod(heightElement->innerText());
+        sample.setHeight(height);
+      }
+    }
   }
 }
 }

--- a/Framework/DataHandling/src/LoadCanSAS1D.cpp
+++ b/Framework/DataHandling/src/LoadCanSAS1D.cpp
@@ -381,26 +381,68 @@ void LoadCanSAS1D::createSampleInformation(
       sasInstrumentElement->getChildElement("SAScollimation");
   check(sasCollimationElement, "<SAScollimation>");
 
-  // Get the geometry information
-  auto geometryElement = sasCollimationElement->getChildElement("name");
-  if (geometryElement) {
-    auto geometry = geometryElement->innerText();
-    auto geometryID = getGeometryID(geometry);
-    sample.setGeometryFlag(geometryID);
+  // Since we have shipped a sligthly invalid CanSAS1D format we need to
+  // make sure that we can read those files back in again
+  bool isInValidOldFormat = true;
+  try {
+    auto name = sasCollimationElement->getChildElement("name");
+    check(name, "name");
+  } catch(Kernel::Exception::NotFoundError&) {
+    isInValidOldFormat = false;
   }
 
-  // Get the thickness information
-  auto widthElement = sasCollimationElement->getChildElement("X");
-  if (widthElement) {
-    double width = std::stod(widthElement->innerText());
-    sample.setWidth(width);
-  }
 
-  // Get the thickness information
-  auto heightElement = sasCollimationElement->getChildElement("Y");
-  if (heightElement) {
-    double height = std::stod(heightElement->innerText());
-    sample.setHeight(height);
+  if (isInValidOldFormat) {
+    // Get the geometry information
+    auto geometryElement = sasCollimationElement->getChildElement("name");
+    if (geometryElement) {
+      auto geometry = geometryElement->innerText();
+      auto geometryID = getGeometryID(geometry);
+      sample.setGeometryFlag(geometryID);
+    }
+
+    // Get the width information
+    auto widthElement = sasCollimationElement->getChildElement("X");
+    if (widthElement) {
+      double width = std::stod(widthElement->innerText());
+      sample.setWidth(width);
+    }
+
+    // Get the height information
+    auto heightElement = sasCollimationElement->getChildElement("Y");
+    if (heightElement) {
+      double height = std::stod(heightElement->innerText());
+      sample.setHeight(height);
+    }
+
+  } else {
+      // Get aperture
+      auto aperture = sasCollimationElement->getChildElement("aperture");
+      if (aperture) {
+          // Get geometry element
+          auto geometry = aperture->getAttribute("name");
+          if (!geometry.empty()) {
+            auto geometryID = getGeometryID(Poco::XML::fromXMLString(geometry));
+            sample.setGeometryFlag(geometryID);
+          }
+
+          // Get size
+          auto size = aperture->getChildElement("size");
+
+          // Get the width information
+          auto widthElement = size->getChildElement("x");
+          if (widthElement) {
+            double width = std::stod(widthElement->innerText());
+            sample.setWidth(width);
+          }
+
+          // Get the height information
+          auto heightElement = size->getChildElement("y");
+          if (heightElement) {
+            double height = std::stod(heightElement->innerText());
+            sample.setHeight(height);
+          }
+      }
   }
 }
 }

--- a/Framework/DataHandling/src/SaveCanSAS1D.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D.cpp
@@ -638,10 +638,28 @@ void SaveCanSAS1D::createSASProcessElement(std::string &sasProcess) {
 }
 
 /** This method creates an XML element named "SASinstrument"
+ *
+ * The structure for required(r) parts of the SASinstrument and the parts
+ * we want to add is:
+ *
+ * SASinstrument
+ *   name(r)
+ *   SASsource(r)
+ *     radiation(r)
+ *   SAScollimation(r)
+ *     aperature[name]
+ *       size
+ *         x[units]
+ *         y[units]
+ *   SASdetector
+ *     name
+ *
 *  @param sasInstrument :: string for sasinstrument element in the xml
 */
 void SaveCanSAS1D::createSASInstrument(std::string &sasInstrument) {
   sasInstrument = "\n\t\t<SASinstrument>";
+
+  // Set name(r)
   std::string sasInstrName = "\n\t\t\t<name>";
   std::string instrname = m_workspace->getInstrument()->getName();
   // look for xml special characters and replace with entity refrence
@@ -650,10 +668,12 @@ void SaveCanSAS1D::createSASInstrument(std::string &sasInstrument) {
   sasInstrName += "</name>";
   sasInstrument += sasInstrName;
 
+  // Set SASsource(r)
   std::string sasSource;
   createSASSourceElement(sasSource);
   sasInstrument += sasSource;
 
+  // Set SAScollimation(r)
   // Add the collimation. We add the collimation information if
   // either the width of the height is different from 0
   double collimationHeight = getProperty("SampleHeight");
@@ -661,19 +681,27 @@ void SaveCanSAS1D::createSASInstrument(std::string &sasInstrument) {
   std::string sasCollimation = "\n\t\t\t<SAScollimation/>";
   if (collimationHeight > 0 || collimationWidth > 0) {
     sasCollimation = "\n\t\t\t<SAScollimation>";
-    // Geometry
+
+    // aperture with name
     std::string collimationGeometry = getProperty("Geometry");
-    sasCollimation += "\n\t\t\t\t<name>" + collimationGeometry + "</name>";
+    sasCollimation += "\n\t\t\t\t<aperture name=\"" + collimationGeometry + "\">";
+
+    // size
+    sasCollimation += "\n\t\t\t\t\t<size>";
+
     // Width
     sasCollimation +=
-        "\n\t\t\t\t<X unit=\"mm\">" + std::to_string(collimationWidth) + "</X>";
+        "\n\t\t\t\t\t\t<x unit=\"mm\">" + std::to_string(collimationWidth) + "</x>";
     // Height
-    sasCollimation += "\n\t\t\t\t<Y unit=\"mm\">" +
-                      std::to_string(collimationHeight) + "</Y>";
+    sasCollimation += "\n\t\t\t\t\t\t<y unit=\"mm\">" + std::to_string(collimationHeight) + "</y>";
+
+    sasCollimation += "\n\t\t\t\t\t</size>";
+    sasCollimation += "\n\t\t\t\t</aperture>";
     sasCollimation += "\n\t\t\t</SAScollimation>";
   }
   sasInstrument += sasCollimation;
 
+  // Set SASdetector
   std::string sasDet;
   createSASDetectorElement(sasDet);
   sasInstrument += sasDet;

--- a/Framework/DataHandling/src/SaveCanSAS1D.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D.cpp
@@ -684,16 +684,18 @@ void SaveCanSAS1D::createSASInstrument(std::string &sasInstrument) {
 
     // aperture with name
     std::string collimationGeometry = getProperty("Geometry");
-    sasCollimation += "\n\t\t\t\t<aperture name=\"" + collimationGeometry + "\">";
+    sasCollimation +=
+        "\n\t\t\t\t<aperture name=\"" + collimationGeometry + "\">";
 
     // size
     sasCollimation += "\n\t\t\t\t\t<size>";
 
     // Width
-    sasCollimation +=
-        "\n\t\t\t\t\t\t<x unit=\"mm\">" + std::to_string(collimationWidth) + "</x>";
+    sasCollimation += "\n\t\t\t\t\t\t<x unit=\"mm\">" +
+                      std::to_string(collimationWidth) + "</x>";
     // Height
-    sasCollimation += "\n\t\t\t\t\t\t<y unit=\"mm\">" + std::to_string(collimationHeight) + "</y>";
+    sasCollimation += "\n\t\t\t\t\t\t<y unit=\"mm\">" +
+                      std::to_string(collimationHeight) + "</y>";
 
     sasCollimation += "\n\t\t\t\t\t</size>";
     sasCollimation += "\n\t\t\t\t</aperture>";

--- a/Framework/DataHandling/test/SaveCanSAS1dTest2.h
+++ b/Framework/DataHandling/test/SaveCanSAS1dTest2.h
@@ -4,11 +4,15 @@
 
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/Sample.h"
 #include "MantidDataHandling/LoadRaw3.h"
 #include "MantidDataHandling/SaveCanSAS1D2.h"
-#include "MantidDataHandling/LoadCanSAS1D.h"
+#include "MantidDataHandling/LoadCanSAS1D2.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+
 #include <Poco/Path.h>
 #include <Poco/File.h>
 
@@ -31,7 +35,6 @@ public:
         m_workspace3("SaveCanSAS1dTest2_in3"), m_filename("./savecansas1d2.xml")
 
   {
-
     LoadRaw3 loader;
     if (!loader.isInitialized())
       loader.initialize();
@@ -280,7 +283,64 @@ public:
     TS_ASSERT_DELTA(ws2d->dataE(0).back(), 0, tolerance);
   }
 
+  void test_that_can_save_and_load_full_collimation_information() {
+    std::string geometry = "Disc";
+    double width = 1;
+    double height = 2;
+    int expectedGeometryFlag = 3;
+    double expectedWidth = 1;
+    double expectedHeight = 2;
+    do_test_collimation_settings(geometry, width, height,
+                                 expectedGeometryFlag, expectedWidth, expectedHeight);
+  }
+
+
 private:
+  void do_test_collimation_settings(const std::string& geometry, double width, double height,
+                                 int expectedGeometry, double expectedWidth, double expectedHeight) {
+    // Create sample workspace
+    auto wsIn = WorkspaceCreationHelper::create1DWorkspaceRand(3);
+    AnalysisDataService::Instance().addOrReplace("test_worksapce_can_sas_1d", wsIn);
+    // Save the workspace
+    SaveCanSAS1D2 savealg;
+    TS_ASSERT_THROWS_NOTHING(savealg.initialize());
+    TS_ASSERT(savealg.isInitialized());
+    savealg.setPropertyValue("InputWorkspace", "test_worksapce_can_sas_1d");
+    savealg.setPropertyValue("Filename", m_filename);
+    savealg.setPropertyValue("DetectorNames", "HAB");
+    savealg.setProperty("Geometry", geometry);
+    savealg.setProperty("SampleWidth", width);
+    savealg.setProperty("SampleHeight", height);
+
+    TS_ASSERT_THROWS_NOTHING(savealg.execute());
+    TS_ASSERT(savealg.isExecuted());
+
+    // retrieve the data that we saved to check it
+    LoadCanSAS1D lAlg;
+    TS_ASSERT_THROWS_NOTHING(lAlg.initialize());
+    TS_ASSERT(lAlg.isInitialized());
+    lAlg.setPropertyValue("OutputWorkspace", "test_worksapce_can_sas_1d_reloaded");
+    lAlg.setPropertyValue("Filename", m_filename);
+    TS_ASSERT_THROWS_NOTHING(lAlg.execute());
+    TS_ASSERT(lAlg.isExecuted());
+    Workspace_sptr ws = AnalysisDataService::Instance().retrieve("test_worksapce_can_sas_1d_reloaded");
+    Mantid::API::MatrixWorkspace_sptr loaded = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
+
+    // Check that elements are set correctly
+    TS_ASSERT(loaded->sample().getGeometryFlag() == expectedGeometry);
+    TS_ASSERT(loaded->sample().getWidth() == expectedWidth);
+    TS_ASSERT(loaded->sample().getHeight() == expectedHeight);
+
+    // Delete workspaces
+    std::string toDeleteList[2] = {"test_worksapce_can_sas_1d", "test_worksapce_can_sas_1d_reloaded"};
+    for (auto& toDelete: toDeleteList) {
+      if (AnalysisDataService::Instance().doesExist(toDelete)) {
+        AnalysisDataService::Instance().remove(toDelete);
+      }
+    }
+  }
+
+
   std::string m_workspace1, m_workspace2, m_workspace3, m_filename;
   std::string m_runNum;
   MatrixWorkspace_sptr ws;

--- a/Framework/DataHandling/test/SaveCanSAS1dTest2.h
+++ b/Framework/DataHandling/test/SaveCanSAS1dTest2.h
@@ -12,7 +12,6 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
-
 #include <Poco/Path.h>
 #include <Poco/File.h>
 
@@ -290,17 +289,19 @@ public:
     int expectedGeometryFlag = 3;
     double expectedWidth = 1;
     double expectedHeight = 2;
-    do_test_collimation_settings(geometry, width, height,
-                                 expectedGeometryFlag, expectedWidth, expectedHeight);
+    do_test_collimation_settings(geometry, width, height, expectedGeometryFlag,
+                                 expectedWidth, expectedHeight);
   }
 
-
 private:
-  void do_test_collimation_settings(const std::string& geometry, double width, double height,
-                                 int expectedGeometry, double expectedWidth, double expectedHeight) {
+  void do_test_collimation_settings(const std::string &geometry, double width,
+                                    double height, int expectedGeometry,
+                                    double expectedWidth,
+                                    double expectedHeight) {
     // Create sample workspace
     auto wsIn = WorkspaceCreationHelper::create1DWorkspaceRand(3);
-    AnalysisDataService::Instance().addOrReplace("test_worksapce_can_sas_1d", wsIn);
+    AnalysisDataService::Instance().addOrReplace("test_worksapce_can_sas_1d",
+                                                 wsIn);
     // Save the workspace
     SaveCanSAS1D2 savealg;
     TS_ASSERT_THROWS_NOTHING(savealg.initialize());
@@ -319,12 +320,15 @@ private:
     LoadCanSAS1D lAlg;
     TS_ASSERT_THROWS_NOTHING(lAlg.initialize());
     TS_ASSERT(lAlg.isInitialized());
-    lAlg.setPropertyValue("OutputWorkspace", "test_worksapce_can_sas_1d_reloaded");
+    lAlg.setPropertyValue("OutputWorkspace",
+                          "test_worksapce_can_sas_1d_reloaded");
     lAlg.setPropertyValue("Filename", m_filename);
     TS_ASSERT_THROWS_NOTHING(lAlg.execute());
     TS_ASSERT(lAlg.isExecuted());
-    Workspace_sptr ws = AnalysisDataService::Instance().retrieve("test_worksapce_can_sas_1d_reloaded");
-    Mantid::API::MatrixWorkspace_sptr loaded = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
+    Workspace_sptr ws = AnalysisDataService::Instance().retrieve(
+        "test_worksapce_can_sas_1d_reloaded");
+    Mantid::API::MatrixWorkspace_sptr loaded =
+        boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
 
     // Check that elements are set correctly
     TS_ASSERT(loaded->sample().getGeometryFlag() == expectedGeometry);
@@ -332,14 +336,14 @@ private:
     TS_ASSERT(loaded->sample().getHeight() == expectedHeight);
 
     // Delete workspaces
-    std::string toDeleteList[2] = {"test_worksapce_can_sas_1d", "test_worksapce_can_sas_1d_reloaded"};
-    for (auto& toDelete: toDeleteList) {
+    std::string toDeleteList[2] = {"test_worksapce_can_sas_1d",
+                                   "test_worksapce_can_sas_1d_reloaded"};
+    for (auto &toDelete : toDeleteList) {
       if (AnalysisDataService::Instance().doesExist(toDelete)) {
         AnalysisDataService::Instance().remove(toDelete);
       }
     }
   }
-
 
   std::string m_workspace1, m_workspace2, m_workspace3, m_filename;
   std::string m_runNum;

--- a/Framework/DataHandling/test/SaveCanSAS1dTest2.h
+++ b/Framework/DataHandling/test/SaveCanSAS1dTest2.h
@@ -300,13 +300,17 @@ private:
                                     double expectedHeight) {
     // Create sample workspace
     auto wsIn = WorkspaceCreationHelper::create1DWorkspaceRand(3);
+    auto axis = wsIn->getAxis(0);
+    axis->unit() = UnitFactory::Instance().create("MomentumTransfer");
+    axis->title() = "|Q|";
+
     AnalysisDataService::Instance().addOrReplace("test_worksapce_can_sas_1d",
                                                  wsIn);
     // Save the workspace
     SaveCanSAS1D2 savealg;
     TS_ASSERT_THROWS_NOTHING(savealg.initialize());
     TS_ASSERT(savealg.isInitialized());
-    savealg.setPropertyValue("InputWorkspace", "test_worksapce_can_sas_1d");
+    savealg.setProperty("InputWorkspace", wsIn);
     savealg.setPropertyValue("Filename", m_filename);
     savealg.setPropertyValue("DetectorNames", "HAB");
     savealg.setProperty("Geometry", geometry);

--- a/docs/source/release/v3.9.0/sans.rst
+++ b/docs/source/release/v3.9.0/sans.rst
@@ -22,6 +22,7 @@ Bug Fixes
 - Issue where Gui changes were not picked up for batch reductions was resolved.
 - Remove SaveNexusProcessed and SaveCSV as an option. Reorder options by dimensionality.
 - Fix for merged reduction with phi masking.
+- Fix SAScollimation issue in SaveCanSAS1D and LoadCanSAS1D.
 
 X uncertainties (delta-Q)
 -------------------------


### PR DESCRIPTION
This fixes an inconsistency of our CanSAS1D loaders and savers.
Fixes #18478

**To test:**

Run the python script below and confirm that the geometry information is on the workspace (3 is the geometry flag for a Disk)

```python
file_path = PATH_TO_SAVE_LOCATION/test_file.xml

# Save and load with full information
ws = CreateSampleWorkspace(OutputWorkspace='ws3', NumBanks=1, BankPixelWidth=1, XUnit='MomentumTransfer', XMax=10, BinWidth=3)
SaveCanSAS1D(InputWorkspace=ws, FIlename=file_path, Geometry="Disc", SampleHeight=1, SampleWidth=2)
ws_loaded = LoadCanSAS1D(Filename=file_path)
sample = ws_loaded.sample()


print "The geometry flag is {} and expected {}".format(sample.getGeometryFlag(), 3)
print "Height is {} and expected {}".format(sample.getHeight(), 1.0)
print "Width is {} and expected {}".format(sample.getWidth(), 2.0)

```



<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
