### PR TITLE
Sort dict before creating message, can't assume order with python3

### DIFF
--- a/scripts/SANS/sans/state/state_functions.py
+++ b/scripts/SANS/sans/state/state_functions.py
@@ -157,7 +157,7 @@ def validation_message(error_message, instruction, variables):
     @return: a formatted validation message string.
     """
     message = ""
-    for key, value in variables.items():
+    for key, value in sorted(variables.items()):
         message += "{0}: {1}\n".format(key, value)
     message += instruction
     return {error_message: message}


### PR DESCRIPTION
One test (PythonSANS_state_functions_test) is still failing sometimes because it assumes that `dict` is ordered. 
```
1654: ======================================================================
1654: FAIL: test_that_produces_correct_validation_message (__main__.StateFunctionsTest)
1654: ----------------------------------------------------------------------
1654: Traceback (most recent call last):
1654:   File "/home/builder/jenkins-linode/workspace/master_clean-ubuntu-python3/scripts/test/SANS/state/state_functions_test.py", line 114, in test_that_produces_correct_validation_message
1654:     self.assertTrue(val_message[error_message] == expected_text)
1654: AssertionError: False is not true
```

**To test:**
 * Compile with python 3 and run the tests multiple times to check it passes.

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
