### PR TITLE
Disable nonOrthogonal sliceviewer button when orthogonal ws

### DIFF
--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -1713,9 +1713,8 @@ void SliceViewer::checkForHKLDimension() {
       const auto useNonOrthogonal = isHKL;
       switchQWTRaster(useNonOrthogonal);
     }
-    emit setNonOrthogonalbtn(); // true lets button decide what to enable
-                                // depending on workspace/axes etc
   }
+  emit setNonOrthogonalbtn();
 }
 //==============================================================================
 //================================ PYTHON METHODS ==============================


### PR DESCRIPTION
fixes #18515

**To test:**
try opening different files in sliceviewer. Only those with HKL axes should have the nonorthogonal button available


#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
