### PR TITLE
Fix PythonScriptsTest_CrystalFieldTest for python 3

### DIFF
--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -2,6 +2,8 @@ from __future__ import (absolute_import, division, print_function)
 import numpy as np
 import re
 import warnings
+from six import string_types
+
 
 # RegEx pattern matching a composite function parameter name, eg f2.Sigma.
 FN_PATTERN = re.compile('f(\\d+)\\.(.+)')
@@ -786,7 +788,7 @@ class CrystalField(object):
             ws_index = args.pop(0)
 
         pptype = 'M(T)' if (typeid == 4) else 'M(H)'
-        self._typeid = self._str2id(typeid) if isinstance(typeid, basestring) else int(typeid)
+        self._typeid = self._str2id(typeid) if isinstance(typeid, string_types) else int(typeid)
 
         return self._getPhysProp(PhysicalProperties(pptype, *args, **kwargs), workspace, ws_index)
 
@@ -1045,7 +1047,7 @@ class CrystalField(object):
         alg = AlgorithmManager.createUnmanaged('EvaluateFunction')
         alg.initialize()
         alg.setChild(True)
-        alg.setProperty('Function', i if isinstance(i, basestring) else self.makeSpectrumFunction(i))
+        alg.setProperty('Function', i if isinstance(i, string_types) else self.makeSpectrumFunction(i))
         alg.setProperty("InputWorkspace", workspace)
         alg.setProperty('WorkspaceIndex', ws_index)
         alg.setProperty('OutputWorkspace', 'dummy')

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 import re
+from six import string_types
 
 parNamePattern = re.compile(r'([a-zA-Z][\w.]+)')
 
@@ -637,7 +638,7 @@ class PhysicalProperties(object):
         self._hdir = [0., 0., 1.]
         self._hmag = 1.
         self._physpropTemperature = 1.
-        self._typeid = self._str2id(typeid) if isinstance(typeid, basestring) else int(typeid)
+        self._typeid = self._str2id(typeid) if isinstance(typeid, string_types) else int(typeid)
         try:
             initialiser = getattr(self, 'init' + str(self._typeid))
         except AttributeError:
@@ -660,7 +661,7 @@ class PhysicalProperties(object):
     def _checkhdir(self, hdir):
         import numpy as np
         try:
-            if isinstance(hdir, basestring):
+            if isinstance(hdir, string_types):
                 if 'powder' in hdir.lower():
                     return 'powder'
                 else:
@@ -693,7 +694,7 @@ class PhysicalProperties(object):
     @Inverse.setter
     def Inverse(self, value):
         if (self._typeid == 2 or self._typeid == 4):
-            if isinstance(value, basestring):
+            if isinstance(value, string_types):
                 self._suscInverseFlag = value.lower() in ['true', 't', '1', 'yes', 'y']
             else:
                 self._suscInverseFlag = bool(value)  # In some cases will always be true...
@@ -733,7 +734,7 @@ class PhysicalProperties(object):
             raise ValueError('No environment arguments should be specified for heat capacity')
 
     def _parseargs(self, mapping, *args, **kwargs):
-        args = filter(None, list(args))
+        args = [_f for _f in list(args) if _f]
         # Handles special case of first argument being a unit type
         if len(args) > 0:
             try:


### PR DESCRIPTION
This was just merged in, see #18389

**To test:**
  * Compile with python3 and see that `PythonScriptsTest_CrystalFieldTest` now passes

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
