### PR TITLE
Fix building qthelp and html docs using python 3

### DIFF
--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -190,4 +190,4 @@ epub_uid = "Mantid Reference: " + version
 # Place in a separate file for clarity
 builder_options_file = "@CMAKE_CURRENT_SOURCE_DIR@/conf-@BUILDER@.py"
 if os.path.exists(builder_options_file):
-    execfile(builder_options_file)
+    exec(compile(open(builder_options_file).read(), builder_options_file, 'exec'))

--- a/docs/sphinxext/mantiddoc/directives/algorithm.py
+++ b/docs/sphinxext/mantiddoc/directives/algorithm.py
@@ -1,6 +1,8 @@
+from __future__ import (absolute_import, division, print_function)
 from mantiddoc.directives.base import AlgorithmBaseDirective #pylint: disable=unused-import
 import os
 import re
+from six import iteritems
 
 REDIRECT_TEMPLATE = "redirect.html"
 
@@ -102,7 +104,7 @@ class AlgorithmDirective(AlgorithmBaseDirective):
 
         try:
             picture = algorithm_screenshot(self.algorithm_name(), screenshots_dir, version=self.algorithm_version())
-        except RuntimeError, exc:
+        except RuntimeError as exc:
             env = self.state.document.settings.env
             env.warn(env.docname, "Unable to generate screenshot for '%s' - %s" % (self.algorithm_name(), str(exc)))
             picture = None
@@ -211,7 +213,7 @@ def html_collect_pages(dummy_app):
     template = REDIRECT_TEMPLATE
     all_algs = AlgorithmFactory.getRegisteredAlgorithms(True)
 
-    for name, versions in all_algs.iteritems():
+    for name, versions in iteritems(all_algs):
         redirect_pagename = "algorithms/%s" % name
         versions.sort()
         highest_version = versions[-1]

--- a/docs/sphinxext/mantiddoc/directives/categories.py
+++ b/docs/sphinxext/mantiddoc/directives/categories.py
@@ -6,9 +6,11 @@
     creates "index" pages that lists the contents of each category. The display of each
     "index" page is controlled by a jinja2 template.
 """
+from __future__ import (absolute_import, division, print_function)
 from mantiddoc.directives.base import AlgorithmBaseDirective, algorithm_name_and_version #pylint: disable=unused-import
 from sphinx.util.osutil import relative_uri
 import os
+from six import iteritems, itervalues
 
 CATEGORY_PAGE_TEMPLATE = "category.html"
 # relative to the directory containing the source file
@@ -319,7 +321,7 @@ def create_category_pages(app):
     template = CATEGORY_PAGE_TEMPLATE
 
     categories = env.categories
-    for name, category in categories.iteritems():
+    for name, category in iteritems(categories):
         context = {}
         # First write out the named page
         context["title"] = category.name
@@ -378,7 +380,7 @@ def purge_categories(app, env, docname):
         return
 
     deadref = PageRef(name, docname)
-    for category in categories.itervalues():
+    for category in itervalues(categories):
         pages = category.pages
         if deadref in pages:
             pages.remove(deadref)

--- a/docs/sphinxext/mantiddoc/directives/diagram.py
+++ b/docs/sphinxext/mantiddoc/directives/diagram.py
@@ -1,8 +1,10 @@
+from __future__ import (absolute_import, division, print_function)
 from mantiddoc.directives.base import BaseDirective #pylint: disable=unused-import
 from sphinx.locale import _ #pylint: disable=unused-import
 import os
 from string import Template
 import subprocess
+from six import PY3
 
 ######################
 #CONFIGURABLE OPTIONS#
@@ -86,6 +88,8 @@ class DiagramDirective(BaseDirective):
             raise RuntimeError("Cannot find dot-file: '" + diagram_name + "' in '" + os.path.join(env.srcdir,"diagrams"))
 
         out_src = Template(in_src).substitute(STYLE)
+        if PY3:
+            out_src = out_src.encode()
         gviz = subprocess.Popen([dot_executable,"-Tpng","-o",out_path], stdin=subprocess.PIPE)
         gviz.communicate(input=out_src)
         gviz.wait()

--- a/docs/sphinxext/mantiddoc/directives/properties.py
+++ b/docs/sphinxext/mantiddoc/directives/properties.py
@@ -1,7 +1,9 @@
 #pylint: disable=invalid-name,deprecated-module
+from __future__ import (absolute_import, division, print_function)
 from mantiddoc.directives.base import AlgorithmBaseDirective #pylint: disable=unused-import
 import re
 from string import punctuation
+from six.moves import range
 
 SUBSTITUTE_REF_RE = re.compile(r'\|(.+?)\|')
 
@@ -35,7 +37,7 @@ class PropertiesDirective(AlgorithmBaseDirective):
             # names for the table headers.
             header = ('Name', 'Default', 'Description')
 
-            for i in xrange(ifunc.numParams()):
+            for i in range(ifunc.numParams()):
                 properties.append((ifunc.parameterName(i),
                                    str(ifunc.getParameterValue(i)),
                                    ifunc.paramDescription(i)

--- a/docs/sphinxext/mantiddoc/directives/sourcelink.py
+++ b/docs/sphinxext/mantiddoc/directives/sourcelink.py
@@ -1,6 +1,8 @@
-from base import AlgorithmBaseDirective #pylint: disable=unused-import
+from __future__ import (absolute_import, division, print_function)
+from .base import AlgorithmBaseDirective #pylint: disable=unused-import
 import mantid
 import os
+from six import iteritems
 
 class SourceLinkError(Exception):
     def __init__(self, value):
@@ -175,7 +177,7 @@ class SourceLinkDirective(AlgorithmBaseDirective):
         valid_ext_list = []
 
         self.add_rst(self.make_header("Source"))
-        for extension, filepath in file_paths.iteritems():
+        for extension, filepath in iteritems(file_paths):
             if filepath is not None:
                 self.output_path_to_page(filepath,extension)
                 valid_ext_list.append(extension)
@@ -187,10 +189,10 @@ class SourceLinkDirective(AlgorithmBaseDirective):
             if len(valid_ext_list) == 0:
                 raise SourceLinkError("No file possibilities for " + file_name + " have been found\n" +
                                       "Please specify a better one using the :filename: opiton or use the " +
-                                      str(self.file_types.keys()) + " options\n" +
+                                      str(list(self.file_types.keys())) + " options\n" +
                                       "e.g. \n" +
                                       ".. sourcelink:\n" +
-                                      "      :" + self.file_types.keys()[0] + ": " + suggested_path + "\n "+
+                                      "      :" + list(self.file_types.keys())[0] + ": " + suggested_path + "\n "+
                                       "or \n" +
                                       ".. sourcelink:\n" +
                                       "      :filename: " + file_name)
@@ -200,10 +202,10 @@ class SourceLinkDirective(AlgorithmBaseDirective):
                     raise SourceLinkError("Only one of .h and .cpp found for " + file_name + "\n" +
                                           "valid files found for " + str(valid_ext_list) + "\n" +
                                           "Please specify the missing one using an " +
-                                          str(self.file_types.keys()) + " option\n" +
+                                          str(list(self.file_types.keys())) + " option\n" +
                                           "e.g. \n" +
                                           ".. sourcelink:\n" +
-                                          "      :" + self.file_types.keys()[0] + ": " + suggested_path)
+                                          "      :" + list(self.file_types.keys())[0] + ": " + suggested_path)
         return
 
     def output_path_to_page(self, filepath, extension):


### PR DESCRIPTION
Building qthelp is required for packaging and if we add python3 to pull requests this needs to build.

**To test:**
 * Build mantid with python 3
 * You should now be able to run `make docs-qthelp` and `make docs-html`
   * Check that the docs are built correctly
 * Make sure the python 2 docs still build

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
