### PR TITLE
Respect BUILD_PACKAGE variable if specified by Jenkins

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -41,9 +41,7 @@ fi
 # BUILD_PACKAGE can be provided as a job parameter on the pull requests
 # except RHEL7 as we always need to it to do the system tests
 if [[ ${JOB_NAME} == *pull_requests* ]]; then
-    if [[ ${BUILD_PACKAGE} == "no" ]]; then
-	BUILDPKG=false
-    fi
+  BUILDPKG=${BUILD_PACKAGE}
 fi
 
 ###############################################################################

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -40,7 +40,7 @@ fi
 
 # BUILD_PACKAGE can be provided as a job parameter on the pull requests
 # except RHEL7 as we always need to it to do the system tests
-if [[ ${JOB_NAME} == *pull_requests* ]]; then
+if [[ ${JOB_NAME} == *pull_requests* ]] && [[ -n ${BUILD_PACKAGE} ]]; then
   BUILDPKG=${BUILD_PACKAGE}
 fi
 

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -38,6 +38,14 @@ else
   BUILD_CONFIG="Release"
 fi
 
+# BUILD_PACKAGE can be provided as a job parameter on the pull requests
+# except RHEL7 as we always need to it to do the system tests
+if [[ ${JOB_NAME} == *pull_requests* ]]; then
+    if [[ ${BUILD_PACKAGE} == "no" ]]; then
+	BUILDPKG=false
+    fi
+fi
+
 ###############################################################################
 # Setup the build directory
 # For a clean build the entire thing is removed to guarantee it is clean. All
@@ -273,4 +281,4 @@ fi
 ###############################################################################
 if [[ "${ON_RHEL7}" == true ]] && [[ ${JOB_NAME} == *pull_requests* ]]; then
   $SCRIPT_DIR/systemtests
-	fi
+fi


### PR DESCRIPTION
Description of work.

The Linux/macOS buildscript now checks if the `BUILD_PACKAGE` variable is defined. Most PR builds don't need packages and on some slaves the archiving can take substantially longer than the build. 

**To test:**

Review the script and check the builds to see if the packaging (on all but RHEL7) was skipped.

No issue number

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
