### PR TITLE
Fixed locale issues in Sample Transmission Calculator

### DIFF
--- a/MantidQt/CustomInterfaces/src/SampleTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/SampleTransmission.cpp
@@ -116,11 +116,11 @@ void SampleTransmission::calculate() {
   switch (wavelengthBinning) {
   // Single
   case 0: {
-    QStringList params;
-    params << m_uiForm.spSingleLow->text() << m_uiForm.spSingleWidth->text()
-           << m_uiForm.spSingleHigh->text();
-    QString binString = params.join(",");
-    transCalcAlg->setProperty("WavelengthRange", binString.toStdString());
+    // Convert values to binning params using the 'C' locale.
+    std::ostringstream binning;
+    binning.imbue(std::locale::classic());
+    binning << m_uiForm.spSingleLow->value() << ',' << m_uiForm.spSingleWidth->value() << ',' << m_uiForm.spSingleHigh->value();
+    transCalcAlg->setProperty("WavelengthRange", binning.str());
     break;
   }
 

--- a/MantidQt/CustomInterfaces/src/SampleTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/SampleTransmission.cpp
@@ -119,7 +119,9 @@ void SampleTransmission::calculate() {
     // Convert values to binning params using the 'C' locale.
     std::ostringstream binning;
     binning.imbue(std::locale::classic());
-    binning << m_uiForm.spSingleLow->value() << ',' << m_uiForm.spSingleWidth->value() << ',' << m_uiForm.spSingleHigh->value();
+    binning << m_uiForm.spSingleLow->value() << ','
+            << m_uiForm.spSingleWidth->value() << ','
+            << m_uiForm.spSingleHigh->value();
     transCalcAlg->setProperty("WavelengthRange", binning.str());
     break;
   }


### PR DESCRIPTION
This PR fixes the locale issues in the Input Wavelength Range number fields when Type is set to Single. On a locale which doesn't use dots for decimal separators, the text which was directly read from the fields wasn't accepted by the Rebin algorithm. Now, the field contents are converted to strings using the 'C' locale.

**To test:**
Change the system locale to something which uses commas as decimal separators. For example, French, German or Finnish should do the job. Open the Sample Transmission Calculator and make sure the Wavelength range doesn't give errors in Mantid log. 

Fixes #18546.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
