### PR TITLE
Add a new download location for external data at ISIS

### DIFF
--- a/buildconfig/CMake/MantidExternalData.cmake
+++ b/buildconfig/CMake/MantidExternalData.cmake
@@ -37,6 +37,9 @@ list(APPEND ExternalData_URL_TEMPLATES
 list(APPEND ExternalData_URL_TEMPLATES
      "file:///Users/builder/MantidExternalData-readonly/%(algo)/%(hash)" )
 list(APPEND ExternalData_URL_TEMPLATES
+     "http://mantidweb.nd.rl.ac.uk/externaldata/isis-readonly/%(algo)/%(hash)" )
+# This should always be last as it's the main read/write cache
+list(APPEND ExternalData_URL_TEMPLATES
      "http://198.74.56.37/ftp/external-data/%(algo)/%(hash)" )
 
 # Increase network timeout defaults to avoid our slow server connection but don't override what a user provides


### PR DESCRIPTION
NOTE: It makes most sense to test this at ISIS

Description of work.

Added a new read-only external data mirror located at ISIS.

**To test:**

* find one of the larger test files in your local data cache (default location is `$HOME/MantidExternalData` on Linux or `C:\MantidExternalData` on Windows, I used file `61cb32d79599a3d1919d5e7e134f67e5`.
* delete this file
* checkout these changes and rerun cmake
* build the `SystemTestData` target and the downloading should be significantly faster at ISIS

No issue number.

*Internal change: Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
