### PR TITLE
Update buildscript for python3

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -185,6 +185,11 @@ if [[ "$BUILDPKG" == true ]]; then
       PACKAGE_SUFFIX="unstable"
     fi
 
+    # Add '-python3' to package name and install path
+    if [[ ${JOB_NAME} == *python3* ]]; then
+	PACKAGE_SUFFIX=${PACKAGE_SUFFIX}-python3
+    fi
+
     # Only unsuffixed release builds create envvars scripts
     if [[ ${JOB_NAME} == *release* && -z "$PACKAGE_SUFFIX" ]]; then
       PACKAGINGVARS="${PACKAGINGVARS} -DENVVARS_ON_INSTALL=True -DCPACK_SET_DESTDIR=ON"
@@ -259,9 +264,9 @@ rm -f $userprops
 $SCL_ON_RHEL6 "ctest -j$BUILD_THREADS --schedule-random --output-on-failure"
 
 ###############################################################################
-# Run the documentation tests on Ubuntu when doing a pull request build.
+# Run the documentation tests on Ubuntu when doing a pull request build but not for python 3.
 ###############################################################################
-if [[ ${ON_UBUNTU} == true ]] && [[ ${PRBUILD} == true ]]; then
+if [[ ${ON_UBUNTU} == true ]] && [[ ${PRBUILD} == true ]] && [[ ! ${JOB_NAME} == *python3* ]]; then
   # Remove doctrees directory so it forces a full reparse. It seems that
   # without this newly added doctests are not executed
   if [ -d $BUILD_DIR/docs/doctrees ]; then


### PR DESCRIPTION
When building a python3 job this adds `-python3` to the package_suffix which is then used to set the package_name and install_prefix thereby having unique named packages and allowing parallel installs of python 2 and 3 versions of Mantid on Ubuntu. This should also work with fedora rpms.

This also disables running docs-test for pull requests when using python 3 which is needed for when we add a python3 build to pull requests.

**To test:**
 * Code review
 * You can test the `buildscript` by running and comparing the output of running via `sh -x buildscript` after setting different environment variables, _e.g._ `export NODE_LABELS=ubuntu` and `export JOB_NAME=pull_requests-ubuntu`/`export JOB_NAME=pull_requests-ubuntu-python3` 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
