### PR TITLE
Fixed Debye-Waller factor correction in ComputeCalibrationCoefVan

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
@@ -150,9 +150,9 @@ class ComputeCalibrationCoefVan(PythonAlgorithm):
                 fwhm = sigma[idx]*2.*np.sqrt(2.*np.log(2.))
                 idxmin = (np.fabs(dataX-peak_centre[idx]+3.*fwhm)).argmin()
                 idxmax = (np.fabs(dataX-peak_centre[idx]-3.*fwhm)).argmin()
-                coefY[idx] = dwf[idx]*sum(dataY[idxmin:idxmax+1])
-                coefE[idx] = dwf[idx]*np.sqrt(sum(
-                    np.square(dataE[idxmin:idxmax+1])))
+                coefY[idx] = sum(dataY[idxmin:idxmax+1])/dwf[idx]
+                coefE[idx] = np.sqrt(sum(
+                    np.square(dataE[idxmin:idxmax+1])))/dwf[idx]
 
         # create X array, X data are the same for all detectors, so
         coefX = np.zeros(nhist)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ComputeCalibrationCoefVanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ComputeCalibrationCoefVanTest.py
@@ -143,8 +143,8 @@ class ComputeCalibrationCoefVanTest(unittest.TestCase):
         Bcoef = 3.0*integral*1e+20*hbar*hbar/(2.0*mvan*k*389.0)
         dwf = np.exp(
             -1.0*Bcoef*(4.0*np.pi*np.sin(0.5*np.radians(15.0))/4.0)**2)
-        self.assertAlmostEqual(y_sum*dwf, wsoutput.readY(1)[0])
-        self.assertAlmostEqual(e_sum*dwf, wsoutput.readE(1)[0])
+        self.assertAlmostEqual(y_sum/dwf, wsoutput.readY(1)[0])
+        self.assertAlmostEqual(e_sum/dwf, wsoutput.readE(1)[0])
 
 
 if __name__ == "__main__":

--- a/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
+++ b/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
@@ -35,7 +35,7 @@ Algorithm creates a workspace with  detector sensitivity correction coefficients
 
 3. Finally, the correction coefficients :math:`K_i` are calculated as
 
-   :math:`K_i = D_i\times S_i`
+   :math:`K_i = \frac{S_i}{D_i}`
 
 Workspace containing these correction coefficients is created as an output and can be used as a RHS workspace in :ref:`algm-Divide` to apply correction to the LHS workspace.
 
@@ -78,13 +78,13 @@ Usage
     print 'Spectrum 4 of the input workspace is filled with: ', round(wsVana.readY(999)[0], 1)
     print 'Spectrum 4 of the corrected workspace is filled with: ', round(wsCorr.readY(999)[0], 5)
 
-Output:    
+Output:
 
 .. testoutput:: ExComputeCalibrationCoefVan
 
-    Spectrum 4 of the output workspace is filled with:  6596.0
+    Spectrum 4 of the output workspace is filled with:  6897.0
     Spectrum 4 of the input workspace is filled with:  1.0
-    Spectrum 4 of the corrected workspace is filled with:  0.00015
+    Spectrum 4 of the corrected workspace is filled with:  0.00014
 
 .. categories::
 

--- a/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
+++ b/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
@@ -13,7 +13,7 @@ Algorithm creates a workspace with  detector sensitivity correction coefficients
 
 1. Calculate the Debye-Waller factor according to Sears and Shelley *Acta Cryst. A* **47**, 441 (1991):
 
-   :math:`D_i = \exp\left(-B_i\cdot\frac{4\pi\sin\theta_i}{\lambda^2}\right)`
+   :math:`D_i = \exp\left[-B_i\cdot\left(\frac{4\pi\sin\theta_i}{\lambda}\right)^2\right]`
 
    :math:`B_i = \frac{3\hbar^2\cdot 10^{20}}{2m_VkT_m}\cdot J(y)`
 

--- a/docs/source/release/v3.9.0/direct_inelastic.rst
+++ b/docs/source/release/v3.9.0/direct_inelastic.rst
@@ -16,7 +16,7 @@ Improvements
 
 - :ref:`LoadILLTOF <algm-LoadILLTOF>` has been upgraded to version 2. The new version loads the TOF axis as defined by the 'time_of_flight' field in the NeXus file. Consequently, the *FilenameVanadium* and *WorkspaceVanadium* input properties were removed and no 'EPP' entry is added to the sample logs anymore.
 
-- Overly pessimistic error calculation in :ref:`ComputeCalibrationCoefVan <algm-ComputeCalibrationCoefVan>` have been fixed.
+- The Debye-Waller factor correction was applied incorrectly to the vanadium data in :ref:`ComputeCalibrationCoefVan <algm-ComputeCalibrationCoefVan>`. This, as well as too pessimistic error evaluation in the algorithm have been fixed.
 
 - A new input property *Temperature* has been added to :ref:`ComputeCalibrationCoefVan <algm-ComputeCalibrationCoefVan>`.
 


### PR DESCRIPTION
This PR fixes the Debye-Waller correction in [`ComputeCalibrationCoefVan`](http://docs.mantidproject.org/nightly/algorithms/ComputeCalibrationCoefVan-v1.html). The integrated vanadium should be *divided* be the DWF, not *multiplied* by it.

**To test:**

This is a simple change, so code review should be enough.

Fixes #18583.

*The fix has been mentioned in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
