### PR TITLE
Fix call to SaveOpenGenieAscii in Engg Presenter

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -6,9 +6,9 @@
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidQtCustomInterfaces/DllConfig.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionCalibration.h"
+#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionParam.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h"
-#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionParam.h"
 
 #include <boost/scoped_ptr.hpp>
 
@@ -263,8 +263,8 @@ private:
   void saveGSS(std::string inputWorkspace, std::string bank, std::string runNo);
   void saveFocusedXYE(std::string inputWorkspace, std::string bank,
                       std::string runNo);
-  void saveOpenGenie(std::string inputWorkspace, std::string specNums,
-                     std::string bank, std::string runNo);
+  void saveOpenGenie(std::string inputWorkspace, std::string bank,
+                     std::string runNo);
 
   // generates the required file name of the output files
   std::string outFileNameFactory(std::string inputWorkspace, std::string runNo,

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1,3 +1,4 @@
+#include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/ITableWorkspace.h"
@@ -7,7 +8,6 @@
 #include "MantidKernel/StringTokenizer.h"
 #include "MantidQtAPI/PythonRunner.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresWorker.h"
-#include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h"
 
 #include <algorithm>
@@ -267,7 +267,8 @@ void EnggDiffractionPresenter::grabCalibParms(const std::string &fname) {
             g_log.warning()
                 << "Error when trying to extract parameters from this line:  "
                 << line << ". This calibration file may not load correctly. "
-                           "Error details: " << rexc.what() << '\n';
+                           "Error details: "
+                << rexc.what() << '\n';
           }
         } else {
           g_log.warning() << "Could not parse correctly a parameters "
@@ -986,7 +987,8 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
         << "The calibration calculations failed. One of the "
            "algorithms did not execute correctly. See log messages for "
            "further details. Error: " +
-               std::string(rexc.what()) << '\n';
+               std::string(rexc.what())
+        << '\n';
   } catch (std::invalid_argument &) {
     g_log.error()
         << "The calibration calculations failed. Some input properties "
@@ -1533,7 +1535,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
   g_lastValidRun = runNo;
 
   g_log.notice() << "Generating new focusing workspace(s) and file(s) into "
-                    "this directory: " << dir << '\n';
+                    "this directory: "
+                 << dir << '\n';
 
   // TODO: this is almost 100% common with doNewCalibrate() - refactor
   EnggDiffCalibSettings cs = m_view->currentCalibSettings();
@@ -1578,7 +1581,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
         loadDetectorGroupingCSV(dgFile, bankIDs, specs);
       } catch (std::runtime_error &re) {
         g_log.error() << "Error loading detector grouping file: " + dgFile +
-                             ". Detailed error: " + re.what() << '\n';
+                             ". Detailed error: " + re.what()
+                      << '\n';
         bankIDs.clear();
         specs.clear();
       }
@@ -1594,8 +1598,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
         fpath.append(effectiveFilenames[idx]).toString();
     g_log.notice() << "Generating new focused file (bank " +
                           boost::lexical_cast<std::string>(bankIDs[idx]) +
-                          ") for run " + runNo +
-                          " into: " << effectiveFilenames[idx] << '\n';
+                          ") for run " + runNo + " into: "
+                   << effectiveFilenames[idx] << '\n';
     try {
       m_focusFinishedOK = false;
       doFocusing(cs, fullFilename, runNo, bankIDs[idx], specs[idx], dgFile);
@@ -1604,12 +1608,13 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
       g_log.error() << "The focusing calculations failed. One of the algorithms"
                        "did not execute correctly. See log messages for "
                        "further details. Error: " +
-                           std::string(rexc.what()) << '\n';
+                           std::string(rexc.what())
+                    << '\n';
     } catch (std::invalid_argument &ia) {
       g_log.error() << "The focusing failed. Some input properties "
                        "were not valid. "
-                       "See log messages for details. Error: " << ia.what()
-                    << '\n';
+                       "See log messages for details. Error: "
+                    << ia.what() << '\n';
     }
   }
 
@@ -1638,8 +1643,8 @@ void EnggDiffractionPresenter::loadDetectorGroupingCSV(
     auto delimPos = line.find_first_of(delim);
     if (std::string::npos == delimPos) {
       throw std::runtime_error(
-          "In file '" + dgFile + "', wrong format in line: " +
-          boost::lexical_cast<std::string>(li) +
+          "In file '" + dgFile +
+          "', wrong format in line: " + boost::lexical_cast<std::string>(li) +
           " which does not contain any delimiters (comma, etc.)");
     }
 
@@ -1653,10 +1658,10 @@ void EnggDiffractionPresenter::loadDetectorGroupingCSV(
             boost::lexical_cast<std::string>(li) + ", the bank ID is empty!");
       }
       if (spec.empty()) {
-        throw std::runtime_error("In file '" + dgFile +
-                                 "', wrong format in line: " +
-                                 boost::lexical_cast<std::string>(li) +
-                                 ", the list of spectrum Nos is empty!");
+        throw std::runtime_error(
+            "In file '" + dgFile +
+            "', wrong format in line: " + boost::lexical_cast<std::string>(li) +
+            ", the list of spectrum Nos is empty!");
       }
 
       size_t bankID = boost::lexical_cast<size_t>(bstr);
@@ -1666,8 +1671,8 @@ void EnggDiffractionPresenter::loadDetectorGroupingCSV(
       throw std::runtime_error(
           "In file '" + dgFile +
           "', issue found when trying to interpret line: " +
-          boost::lexical_cast<std::string>(li) + ". Error description: " +
-          re.what());
+          boost::lexical_cast<std::string>(li) +
+          ". Error description: " + re.what());
     }
   }
 }
@@ -1706,7 +1711,8 @@ void EnggDiffractionPresenter::focusingFinished() {
     if (lastRun != lastValid) {
       g_log.warning()
           << "Focussing process has been stopped, last successful "
-             "run number: " << g_lastValidRun
+             "run number: "
+          << g_lastValidRun
           << " , total number of focus run that could not be processed: "
           << (lastRun - lastValid) << '\n';
       m_view->showStatus("Focusing stopped. Ready");
@@ -1870,8 +1876,9 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in calibration. ",
         "Could not run the algorithm EnggCalibrate succesfully for bank " +
-            boost::lexical_cast<std::string>(bank) + ". Error description: " +
-            re.what() + " Please check also the log messages for details.";
+            boost::lexical_cast<std::string>(bank) +
+            ". Error description: " + re.what() +
+            " Please check also the log messages for details.";
     throw;
   }
   g_log.notice() << "Produced focused workspace: " << outWSName << '\n';
@@ -1888,8 +1895,9 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in calibration. ",
         "Could not run the algorithm EnggCalibrate succesfully for bank " +
-            boost::lexical_cast<std::string>(bank) + ". Error description: " +
-            re.what() + " Please check also the log messages for details.";
+            boost::lexical_cast<std::string>(bank) +
+            ". Error description: " + re.what() +
+            " Please check also the log messages for details.";
     throw;
   }
   g_log.notice() << "Saved focused workspace as file: " << fullFilename << '\n';
@@ -1902,8 +1910,7 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
     try {
       saveFocusedXYE(outWSName, boost::lexical_cast<std::string>(bank), runNo);
       saveGSS(outWSName, boost::lexical_cast<std::string>(bank), runNo);
-      saveOpenGenie(outWSName, specNumsOpenGenie,
-                    boost::lexical_cast<std::string>(bank), runNo);
+      saveOpenGenie(outWSName, boost::lexical_cast<std::string>(bank), runNo);
     } catch (std::runtime_error &re) {
       g_log.error() << "Error saving focused data. ",
           "There was an error while saving focused data. "
@@ -1963,7 +1970,8 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "This is possibly because some of the settings are not "
                        "consistent. Please check the log messages for "
                        "details. Details: " +
-                           std::string(ia.what()) << '\n';
+                           std::string(ia.what())
+                    << '\n';
       throw;
     } catch (std::runtime_error &re) {
       g_log.error() << "Failed to calculate Vanadium corrections. "
@@ -1972,14 +1980,15 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "There was no obvious error in the input properties "
                        "but the algorithm failed. Please check the log "
                        "messages for details." +
-                           std::string(re.what()) << '\n';
+                           std::string(re.what())
+                    << '\n';
       throw;
     }
   } else {
     g_log.notice() << "Found precalculated Vanadium correction features for "
-                      "Vanadium run " << vanNo
-                   << ". Re-using these files: " << preIntegFilename << ", and "
-                   << preCurvesFilename << '\n';
+                      "Vanadium run "
+                   << vanNo << ". Re-using these files: " << preIntegFilename
+                   << ", and " << preCurvesFilename << '\n';
     try {
       loadVanadiumPrecalcWorkspaces(preIntegFilename, preCurvesFilename,
                                     vanIntegWS, vanCurvesWS, vanNo, specNos);
@@ -2105,10 +2114,10 @@ void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
   if (specNos != "") {
     if (specNos == northBank) {
       // when north bank is selected while cropped calib
-      saveOpenGenie(curvesWSName, specNosBank1, northBank, vanNo);
+      saveOpenGenie(curvesWSName, northBank, vanNo);
     } else if (specNos == southBank) {
       // when south bank is selected while cropped calib
-      saveOpenGenie(curvesWSName, specNosBank2, southBank, vanNo);
+      saveOpenGenie(curvesWSName, southBank, vanNo);
     } else {
 
       // when SpectrumNos are provided
@@ -2118,12 +2127,12 @@ void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
       if (CustomisedBankName.empty())
         CustomisedBankName = "cropped";
 
-      saveOpenGenie(curvesWSName, specNos, CustomisedBankName, vanNo);
+      saveOpenGenie(curvesWSName, CustomisedBankName, vanNo);
     }
   } else {
     // when full calibration is carried; saves both banks
-    saveOpenGenie(curvesWSName, specNosBank1, northBank, vanNo);
-    saveOpenGenie(curvesWSName, specNosBank2, southBank, vanNo);
+    saveOpenGenie(curvesWSName, northBank, vanNo);
+    saveOpenGenie(curvesWSName, southBank, vanNo);
   }
 }
 
@@ -2248,8 +2257,9 @@ void EnggDiffractionPresenter::doRebinningTime(const std::string &runNo,
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning with a regular bin width in time. "
                      "Coult not run the algorithm " +
-                         rebinName + " successfully. Error description: " +
-                         re.what() + ".\n";
+                         rebinName +
+                         " successfully. Error description: " + re.what() +
+                         ".\n";
     return;
   }
 
@@ -2351,8 +2361,9 @@ void EnggDiffractionPresenter::doRebinningPulses(const std::string &runNo,
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning by pulse times. "
                      "Coult not run the algorithm " +
-                         rebinName + " successfully. Error description: " +
-                         re.what() + ".\n";
+                         rebinName +
+                         " successfully. Error description: " + re.what() +
+                         ".\n";
     return;
   }
 
@@ -2575,12 +2586,10 @@ void EnggDiffractionPresenter::saveGSS(const std::string inputWorkspace,
 * OpenGenie format
 *
 * @param inputWorkspace title of the focused workspace
-* @param specNums number of spectrum to display
 * @param bank the number of the bank as a string
 * @param runNo the run number as a string
 */
 void EnggDiffractionPresenter::saveOpenGenie(const std::string inputWorkspace,
-                                             std::string specNums,
                                              std::string bank,
                                              std::string runNo) {
 
@@ -2613,7 +2622,7 @@ void EnggDiffractionPresenter::saveOpenGenie(const std::string inputWorkspace,
     alg->setProperty("InputWorkspace", inputWorkspace);
     std::string filename(saveDir.toString());
     alg->setPropertyValue("Filename", filename);
-    alg->setPropertyValue("SpecNumberField", specNums);
+    alg->setPropertyValue("OpenGenieFormat", "ENGIN-X Format");
     alg->execute();
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in saving OpenGenie format file. ",
@@ -2738,12 +2747,13 @@ std::string EnggDiffractionPresenter::DifcZeroWorkspaceFactory(
 
                            " if (i == 1):\n"
                            "  difc=" +
-      boost::lexical_cast<std::string>(difc[bank1]) + "\n" + "  tzero=" +
-      boost::lexical_cast<std::string>(tzero[bank1]) + "\n" + " else:\n"
+      boost::lexical_cast<std::string>(difc[bank1]) + "\n" +
+      "  tzero=" + boost::lexical_cast<std::string>(tzero[bank1]) + "\n" +
+      " else:\n"
 
-                                                              "  difc=" +
-      boost::lexical_cast<std::string>(difc[bank2]) + "\n" + "  tzero=" +
-      boost::lexical_cast<std::string>(tzero[bank2]) + "\n" +
+      "  difc=" +
+      boost::lexical_cast<std::string>(difc[bank2]) + "\n" +
+      "  tzero=" + boost::lexical_cast<std::string>(tzero[bank2]) + "\n" +
 
       " for irow in range(0, bank_ws.rowCount()):\n"
       "  xVal.append(bank_ws.cell(irow, 0))\n"
@@ -2875,8 +2885,8 @@ EnggDiffractionPresenter::outFilesUserDir(const std::string &addToDir) {
     }
   } catch (Poco::FileAccessDeniedException &e) {
     g_log.error() << "Error caused by file access/permission, path to user "
-                     "directory: " << dir.toString()
-                  << ". Error details: " << e.what() << '\n';
+                     "directory: "
+                  << dir.toString() << ". Error details: " << e.what() << '\n';
   } catch (std::runtime_error &re) {
     g_log.error() << "Error while finding/creating a user path: "
                   << dir.toString() << ". Error details: " << re.what() << '\n';
@@ -2907,8 +2917,8 @@ EnggDiffractionPresenter::outFilesGeneralDir(const std::string &addComponent) {
     }
   } catch (Poco::FileAccessDeniedException &e) {
     g_log.error() << "Error caused by file access/permission, path to "
-                     "general directory: " << dir.toString()
-                  << ". Error details: " << e.what() << '\n';
+                     "general directory: "
+                  << dir.toString() << ". Error details: " << e.what() << '\n';
   } catch (std::runtime_error &re) {
     g_log.error() << "Error while finding/creating a general path: "
                   << dir.toString() << ". Error details: " << re.what() << '\n';

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1824,28 +1824,17 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
   }
 
   std::string outWSName;
-  std::string specNumsOpenGenie;
   if (!dgFile.empty()) {
     // doing focus "texture"
     outWSName = "engggui_focusing_output_ws_texture_bank_" +
                 boost::lexical_cast<std::string>(bank);
-    specNumsOpenGenie = specNos;
   } else if (specNos.empty()) {
     // doing focus "normal" / by banks
     outWSName = "engggui_focusing_output_ws_bank_" +
                 boost::lexical_cast<std::string>(bank);
-
-    // specnum for opengenie according to bank number
-    if (boost::lexical_cast<std::string>(bank) == "1") {
-      specNumsOpenGenie = "1 - 1200";
-    } else if (boost::lexical_cast<std::string>(bank) == "2") {
-      specNumsOpenGenie = "1201 - 1400";
-    }
-
   } else {
     // doing focus "cropped"
     outWSName = "engggui_focusing_output_ws_cropped";
-    specNumsOpenGenie = specNos;
   }
   try {
     auto alg =
@@ -1869,7 +1858,7 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
 
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in calibration. ",
-        "Could not run the algorithm EnggCalibrate succesfully for bank " +
+        "Could not run the algorithm EnggCalibrate successfully for bank " +
             boost::lexical_cast<std::string>(bank) + ". Error description: " +
             re.what() + " Please check also the log messages for details.";
     throw;
@@ -1887,7 +1876,7 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
     alg->execute();
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in calibration. ",
-        "Could not run the algorithm EnggCalibrate succesfully for bank " +
+        "Could not run the algorithm EnggCalibrate successfully for bank " +
             boost::lexical_cast<std::string>(bank) + ". Error description: " +
             re.what() + " Please check also the log messages for details.";
     throw;
@@ -2096,8 +2085,6 @@ void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
   // algCurves->getProperty("OutputWorkspace");
   vanCurvesWS = ADS.retrieveWS<MatrixWorkspace>(curvesWSName);
 
-  const std::string specNosBank1 = "1-2000";
-  const std::string specNosBank2 = "1201-2400";
   const std::string northBank = "North";
   const std::string southBank = "South";
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -267,8 +267,7 @@ void EnggDiffractionPresenter::grabCalibParms(const std::string &fname) {
             g_log.warning()
                 << "Error when trying to extract parameters from this line:  "
                 << line << ". This calibration file may not load correctly. "
-                           "Error details: "
-                << rexc.what() << '\n';
+                           "Error details: " << rexc.what() << '\n';
           }
         } else {
           g_log.warning() << "Could not parse correctly a parameters "
@@ -987,8 +986,7 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
         << "The calibration calculations failed. One of the "
            "algorithms did not execute correctly. See log messages for "
            "further details. Error: " +
-               std::string(rexc.what())
-        << '\n';
+               std::string(rexc.what()) << '\n';
   } catch (std::invalid_argument &) {
     g_log.error()
         << "The calibration calculations failed. Some input properties "
@@ -1535,8 +1533,7 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
   g_lastValidRun = runNo;
 
   g_log.notice() << "Generating new focusing workspace(s) and file(s) into "
-                    "this directory: "
-                 << dir << '\n';
+                    "this directory: " << dir << '\n';
 
   // TODO: this is almost 100% common with doNewCalibrate() - refactor
   EnggDiffCalibSettings cs = m_view->currentCalibSettings();
@@ -1581,8 +1578,7 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
         loadDetectorGroupingCSV(dgFile, bankIDs, specs);
       } catch (std::runtime_error &re) {
         g_log.error() << "Error loading detector grouping file: " + dgFile +
-                             ". Detailed error: " + re.what()
-                      << '\n';
+                             ". Detailed error: " + re.what() << '\n';
         bankIDs.clear();
         specs.clear();
       }
@@ -1598,8 +1594,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
         fpath.append(effectiveFilenames[idx]).toString();
     g_log.notice() << "Generating new focused file (bank " +
                           boost::lexical_cast<std::string>(bankIDs[idx]) +
-                          ") for run " + runNo + " into: "
-                   << effectiveFilenames[idx] << '\n';
+                          ") for run " + runNo +
+                          " into: " << effectiveFilenames[idx] << '\n';
     try {
       m_focusFinishedOK = false;
       doFocusing(cs, fullFilename, runNo, bankIDs[idx], specs[idx], dgFile);
@@ -1608,13 +1604,12 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
       g_log.error() << "The focusing calculations failed. One of the algorithms"
                        "did not execute correctly. See log messages for "
                        "further details. Error: " +
-                           std::string(rexc.what())
-                    << '\n';
+                           std::string(rexc.what()) << '\n';
     } catch (std::invalid_argument &ia) {
       g_log.error() << "The focusing failed. Some input properties "
                        "were not valid. "
-                       "See log messages for details. Error: "
-                    << ia.what() << '\n';
+                       "See log messages for details. Error: " << ia.what()
+                    << '\n';
     }
   }
 
@@ -1643,8 +1638,8 @@ void EnggDiffractionPresenter::loadDetectorGroupingCSV(
     auto delimPos = line.find_first_of(delim);
     if (std::string::npos == delimPos) {
       throw std::runtime_error(
-          "In file '" + dgFile +
-          "', wrong format in line: " + boost::lexical_cast<std::string>(li) +
+          "In file '" + dgFile + "', wrong format in line: " +
+          boost::lexical_cast<std::string>(li) +
           " which does not contain any delimiters (comma, etc.)");
     }
 
@@ -1658,10 +1653,10 @@ void EnggDiffractionPresenter::loadDetectorGroupingCSV(
             boost::lexical_cast<std::string>(li) + ", the bank ID is empty!");
       }
       if (spec.empty()) {
-        throw std::runtime_error(
-            "In file '" + dgFile +
-            "', wrong format in line: " + boost::lexical_cast<std::string>(li) +
-            ", the list of spectrum Nos is empty!");
+        throw std::runtime_error("In file '" + dgFile +
+                                 "', wrong format in line: " +
+                                 boost::lexical_cast<std::string>(li) +
+                                 ", the list of spectrum Nos is empty!");
       }
 
       size_t bankID = boost::lexical_cast<size_t>(bstr);
@@ -1671,8 +1666,8 @@ void EnggDiffractionPresenter::loadDetectorGroupingCSV(
       throw std::runtime_error(
           "In file '" + dgFile +
           "', issue found when trying to interpret line: " +
-          boost::lexical_cast<std::string>(li) +
-          ". Error description: " + re.what());
+          boost::lexical_cast<std::string>(li) + ". Error description: " +
+          re.what());
     }
   }
 }
@@ -1711,8 +1706,7 @@ void EnggDiffractionPresenter::focusingFinished() {
     if (lastRun != lastValid) {
       g_log.warning()
           << "Focussing process has been stopped, last successful "
-             "run number: "
-          << g_lastValidRun
+             "run number: " << g_lastValidRun
           << " , total number of focus run that could not be processed: "
           << (lastRun - lastValid) << '\n';
       m_view->showStatus("Focusing stopped. Ready");
@@ -1876,9 +1870,8 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in calibration. ",
         "Could not run the algorithm EnggCalibrate succesfully for bank " +
-            boost::lexical_cast<std::string>(bank) +
-            ". Error description: " + re.what() +
-            " Please check also the log messages for details.";
+            boost::lexical_cast<std::string>(bank) + ". Error description: " +
+            re.what() + " Please check also the log messages for details.";
     throw;
   }
   g_log.notice() << "Produced focused workspace: " << outWSName << '\n';
@@ -1895,9 +1888,8 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in calibration. ",
         "Could not run the algorithm EnggCalibrate succesfully for bank " +
-            boost::lexical_cast<std::string>(bank) +
-            ". Error description: " + re.what() +
-            " Please check also the log messages for details.";
+            boost::lexical_cast<std::string>(bank) + ". Error description: " +
+            re.what() + " Please check also the log messages for details.";
     throw;
   }
   g_log.notice() << "Saved focused workspace as file: " << fullFilename << '\n';
@@ -1970,8 +1962,7 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "This is possibly because some of the settings are not "
                        "consistent. Please check the log messages for "
                        "details. Details: " +
-                           std::string(ia.what())
-                    << '\n';
+                           std::string(ia.what()) << '\n';
       throw;
     } catch (std::runtime_error &re) {
       g_log.error() << "Failed to calculate Vanadium corrections. "
@@ -1980,15 +1971,14 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "There was no obvious error in the input properties "
                        "but the algorithm failed. Please check the log "
                        "messages for details." +
-                           std::string(re.what())
-                    << '\n';
+                           std::string(re.what()) << '\n';
       throw;
     }
   } else {
     g_log.notice() << "Found precalculated Vanadium correction features for "
-                      "Vanadium run "
-                   << vanNo << ". Re-using these files: " << preIntegFilename
-                   << ", and " << preCurvesFilename << '\n';
+                      "Vanadium run " << vanNo
+                   << ". Re-using these files: " << preIntegFilename << ", and "
+                   << preCurvesFilename << '\n';
     try {
       loadVanadiumPrecalcWorkspaces(preIntegFilename, preCurvesFilename,
                                     vanIntegWS, vanCurvesWS, vanNo, specNos);
@@ -2257,9 +2247,8 @@ void EnggDiffractionPresenter::doRebinningTime(const std::string &runNo,
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning with a regular bin width in time. "
                      "Coult not run the algorithm " +
-                         rebinName +
-                         " successfully. Error description: " + re.what() +
-                         ".\n";
+                         rebinName + " successfully. Error description: " +
+                         re.what() + ".\n";
     return;
   }
 
@@ -2361,9 +2350,8 @@ void EnggDiffractionPresenter::doRebinningPulses(const std::string &runNo,
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning by pulse times. "
                      "Coult not run the algorithm " +
-                         rebinName +
-                         " successfully. Error description: " + re.what() +
-                         ".\n";
+                         rebinName + " successfully. Error description: " +
+                         re.what() + ".\n";
     return;
   }
 
@@ -2747,13 +2735,12 @@ std::string EnggDiffractionPresenter::DifcZeroWorkspaceFactory(
 
                            " if (i == 1):\n"
                            "  difc=" +
-      boost::lexical_cast<std::string>(difc[bank1]) + "\n" +
-      "  tzero=" + boost::lexical_cast<std::string>(tzero[bank1]) + "\n" +
-      " else:\n"
+      boost::lexical_cast<std::string>(difc[bank1]) + "\n" + "  tzero=" +
+      boost::lexical_cast<std::string>(tzero[bank1]) + "\n" + " else:\n"
 
-      "  difc=" +
-      boost::lexical_cast<std::string>(difc[bank2]) + "\n" +
-      "  tzero=" + boost::lexical_cast<std::string>(tzero[bank2]) + "\n" +
+                                                              "  difc=" +
+      boost::lexical_cast<std::string>(difc[bank2]) + "\n" + "  tzero=" +
+      boost::lexical_cast<std::string>(tzero[bank2]) + "\n" +
 
       " for irow in range(0, bank_ws.rowCount()):\n"
       "  xVal.append(bank_ws.cell(irow, 0))\n"
@@ -2885,8 +2872,8 @@ EnggDiffractionPresenter::outFilesUserDir(const std::string &addToDir) {
     }
   } catch (Poco::FileAccessDeniedException &e) {
     g_log.error() << "Error caused by file access/permission, path to user "
-                     "directory: "
-                  << dir.toString() << ". Error details: " << e.what() << '\n';
+                     "directory: " << dir.toString()
+                  << ". Error details: " << e.what() << '\n';
   } catch (std::runtime_error &re) {
     g_log.error() << "Error while finding/creating a user path: "
                   << dir.toString() << ". Error details: " << re.what() << '\n';
@@ -2917,8 +2904,8 @@ EnggDiffractionPresenter::outFilesGeneralDir(const std::string &addComponent) {
     }
   } catch (Poco::FileAccessDeniedException &e) {
     g_log.error() << "Error caused by file access/permission, path to "
-                     "general directory: "
-                  << dir.toString() << ". Error details: " << e.what() << '\n';
+                     "general directory: " << dir.toString()
+                  << ". Error details: " << e.what() << '\n';
   } catch (std::runtime_error &re) {
     g_log.error() << "Error while finding/creating a general path: "
                   << dir.toString() << ". Error details: " << re.what() << '\n';


### PR DESCRIPTION
Description of work.
This PR follows the call to SaveOpenGenieAscii as we removed a mandatory field during refactoring.

**To test:**

*I highly recommend you build in release as it cuts the calibration/focus runtime from 10-15 minutes to a few.*

Using files from `\\olympic\babylon5\Public\David Fairbrother\ENGINX\`

- Open the Engineering Diffraction interface
- Go to the calibration tab
- Set the vanadium to ENGINX236516 from above folder
- Set the calibration sample to ENGINX241391 from above folder
- Run calibration
- Go to focus tab
- Use ENGINX241391 again and run focus
- Ensure there are no errors in the log about OpenGenie failing to save. 

Fixes #18563 .

*Does not need to be in the release notes. Should have been done as part of the refactoring and got missed*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
