### PR TITLE
ILLIndirectReductionQENS system test skipped fix

### DIFF
--- a/Testing/SystemTests/tests/analysis/ILLIndirectReductionQENS.py
+++ b/Testing/SystemTests/tests/analysis/ILLIndirectReductionQENS.py
@@ -1,8 +1,8 @@
 import stresstesting
 from mantid.simpleapi import *
 from mantid import config
-from testhelpers import run_algorithm
-
+import unittest
+from testhelpers import *
 
 class ILLIndirectReductionQENSTest(stresstesting.MantidStressTest):
 

--- a/Testing/SystemTests/tests/analysis/ILLIndirectReductionQENS.py
+++ b/Testing/SystemTests/tests/analysis/ILLIndirectReductionQENS.py
@@ -2,6 +2,7 @@ import stresstesting
 from mantid.simpleapi import *
 from mantid import config
 
+
 class ILLIndirectReductionQENSTest(stresstesting.MantidStressTest):
 
     # cache default instrument and datadirs

--- a/Testing/SystemTests/tests/analysis/ILLIndirectReductionQENS.py
+++ b/Testing/SystemTests/tests/analysis/ILLIndirectReductionQENS.py
@@ -1,8 +1,6 @@
 import stresstesting
 from mantid.simpleapi import *
 from mantid import config
-import unittest
-from testhelpers import *
 
 class ILLIndirectReductionQENSTest(stresstesting.MantidStressTest):
 
@@ -40,33 +38,25 @@ class ILLIndirectReductionQENSTest(stresstesting.MantidStressTest):
                 'UnmirrorOption' : 0,
                 'OutputWorkspace' : 'zero'}
 
-        alg_test = run_algorithm('IndirectILLReductionQENS', **args)
-
-        self.assertTrue(alg_test.isExecuted(), "IndirectILLReductionQENS not executed for unmirror 0")
+        IndirectILLReductionQENS(**args)
 
         args['UnmirrorOption'] = 1
 
         args['OutputWorkspace'] = 'both'
 
-        alg_test = run_algorithm('IndirectILLReductionQENS', **args)
-
-        self.assertTrue(alg_test.isExecuted(), "IndirectILLReductionQENS not executed for unmirror 1")
+        IndirectILLReductionQENS(**args)
 
         args['UnmirrorOption'] = 2
 
         args['OutputWorkspace'] = 'left'
 
-        alg_test = run_algorithm('IndirectILLReductionQENS', **args)
-
-        self.assertTrue(alg_test.isExecuted(), "IndirectILLReductionQENS not executed for unmirror 2")
+        IndirectILLReductionQENS(**args)
 
         args['UnmirrorOption'] = 3
 
         args['OutputWorkspace'] = 'right'
 
-        alg_test = run_algorithm('IndirectILLReductionQENS', **args)
-
-        self.assertTrue(alg_test.isExecuted(), "IndirectILLReductionQENS not executed for unmirror 3")
+        IndirectILLReductionQENS(**args)
 
         summed = Plus(mtd['left_red'].getItem(0),mtd['right_red'].getItem(0))
 
@@ -88,9 +78,7 @@ class ILLIndirectReductionQENSTest(stresstesting.MantidStressTest):
                 'UnmirrorOption': 4,
                 'OutputWorkspace': 'vana4'}
 
-        alg_test = run_algorithm('IndirectILLReductionQENS', **args)
-
-        self.assertTrue(alg_test.isExecuted(), "IndirectILLReductionQENS not executed for unmirror 4")
+        IndirectILLReductionQENS(**args)
 
         args['AlignmentRun'] = '136553.nxs'
 
@@ -98,9 +86,7 @@ class ILLIndirectReductionQENSTest(stresstesting.MantidStressTest):
 
         args['OutputWorkspace'] = 'vana5'
 
-        alg_test = run_algorithm('IndirectILLReductionQENS', **args)
-
-        self.assertTrue(alg_test.isExecuted(), "IndirectILLReductionQENS not executed for unmirror 5")
+        IndirectILLReductionQENS(**args)
 
         result = CompareWorkspaces('vana4_red', 'vana5_red')
 
@@ -113,9 +99,7 @@ class ILLIndirectReductionQENSTest(stresstesting.MantidStressTest):
                 'UnmirrorOption': 6,
                 'OutputWorkspace': 'vana6'}
 
-        alg_test = run_algorithm('IndirectILLReductionQENS', **args)
-
-        self.assertTrue(alg_test.isExecuted(), "IndirectILLReductionQENS not executed for unmirror 6")
+        IndirectILLReductionQENS(**args)
 
         args['AlignmentRun'] = '136553.nxs'
 
@@ -123,9 +107,7 @@ class ILLIndirectReductionQENSTest(stresstesting.MantidStressTest):
 
         args['OutputWorkspace'] = 'vana7'
 
-        alg_test = run_algorithm('IndirectILLReductionQENS', **args)
-
-        self.assertTrue(alg_test.isExecuted(), "IndirectILLReductionQENS not executed for unmirror 7")
+        IndirectILLReductionQENS(**args)
 
         result = CompareWorkspaces('vana6_red','vana7_red')
 


### PR DESCRIPTION
ILLIndirectReductionQENS system test has been constantly skipped on build servers, since it was added. Locally it run fine. An error from the logs suggested that the `testhelpers` was wrongly imported. Not sure if that was the reason (since it was running fine locally), anyway it was modified to not to use the helper, but call the testee algorithm directly.

**To test:**

Make sure this test both runs and passes both locally and on jenkins.

<!-- Instructions for testing. -->

Fixes #18595 .

Does not need to be in the release notes.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.