### PR TITLE
Make W3 warning level explicit

### DIFF
--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -22,13 +22,10 @@ add_definitions ( -DQ_COMPILER_INITIALIZER_LISTS )
 # Additional compiler flags
 ##########################################################################
 # /MP     - Compile .cpp files in parallel
-# /w34296 - Treat warning C4396, about comparison on unsigned and zero,
-#           as a level 3 warning
-# /w34389 - Treat warning C4389, about equality comparison on unsigned
-#           and signed, as a level 3 warning
+# /W3     - Warning Level 3 (This is also the default)
 # /Zc:wchar_t- - Do not treat wchar_t as a builtin type. Required for Qt to
 #           work with wstring
-set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /w34296 /w34389 /Zc:wchar_t-" )
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /W3 /Zc:wchar_t-" )
 
 # Set PCH heap limit, the default does not work when running msbuild from the commandline for some reason
 # Any other value lower or higher seems to work but not the default. It it is fine without this when compiling


### PR DESCRIPTION
For visual studio Make W3 warning level explicit and remove specfic warning handling

W3 is the default, and the specific handling only moved warnings to W3 level anyway, so this is a no change, just being more explicit.

**To test:**

Visual studio builds test and pass without errors or warnings


Fixes  #18597

### RELEASE NOTES

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
