### PR TITLE
Fixes for custom matplotlib backend for v>=1.5

### DIFF
--- a/MantidPlot/pymantidplot/mpl/backend_mtdqt4agg.py
+++ b/MantidPlot/pymantidplot/mpl/backend_mtdqt4agg.py
@@ -116,7 +116,7 @@ if MPL_HAVE_GIVEN_FIG_METHOD:
         """
         Create a new figure manager instance for the given figure.
         """
-        canvas = FigureCanvasQT(figure)
+        canvas = FigureCanvasQTAgg(figure)
         manager = ThreadAwareFigureManagerQT(canvas, num)
         return manager
 

--- a/MantidPlot/pymantidplot/mpl/backend_mtdqt4agg.py
+++ b/MantidPlot/pymantidplot/mpl/backend_mtdqt4agg.py
@@ -91,7 +91,7 @@ class ThreadAwareFigureManagerQT(FigureManagerQT):
     is invoked on the main Qt thread"""
 
     def __init__(self, canvas, num):
-        super(ThreadAwareFigureManagerQT, self).__init__(canvas, num)
+        FigureManagerQT.__init__(self, canvas, num)
         self._destroy_orig = self.destroy
         self.destroy = QAppThreadCall(self._destroy_orig)
 

--- a/MantidPlot/pymantidplot/mpl/backend_mtdqt4agg.py
+++ b/MantidPlot/pymantidplot/mpl/backend_mtdqt4agg.py
@@ -17,9 +17,9 @@ except ImportError:
     # whereas older has qt4_compat with no QtWidgets
     from matplotlib.backends.qt4_compat import QtCore
     from matplotlib.backends.qt4_compat import QtGui as QtWidgets
-
 # Import everything from the *real* matplotlib backend
 from matplotlib.backends.backend_qt4agg import *
+import six
 
 # Remove the implementations of new_figure_manager_*. We replace them below
 del new_figure_manager
@@ -64,7 +64,7 @@ class QAppThreadCall(QtCore.QObject):
             QtCore.QMetaObject.invokeMethod(self, "on_call",
                                             QtCore.Qt.BlockingQueuedConnection)
             if self._exc_info is not None:
-                raise self._exc_info[1], None, self._exc_info[2]
+                six.reraise(*self._exc_info)
             return self._result
 
     @QtCore.pyqtSlot()
@@ -76,8 +76,6 @@ class QAppThreadCall(QtCore.QObject):
             self._result = \
                 self.callee(*self._args, **self._kwargs)
         except Exception as exc: #pylint: disable=broad-except
-            # Store exception info to get better traceback when rethrown
-            # http://nedbatchelder.com/blog/200711/rethrowing_exceptions_in_python.html
             import sys
             self._exc_info = sys.exc_info()
 

--- a/MantidPlot/test/MantidPlotMatplotlibTest.py
+++ b/MantidPlot/test/MantidPlotMatplotlibTest.py
@@ -7,7 +7,6 @@ import mantidplottests
 from mantidplottests import *
 import time
 import numpy as np
-from distutils.version import LooseVersion
 from PyQt4 import QtCore
 
 try:
@@ -21,20 +20,19 @@ except ImportError:
 
 class MantidPlotMatplotlibTest(unittest.TestCase):
 
-    def tearDown(self):
-        if LooseVersion(mpl.__version__) >= '1.5.0':
-             plt.close('all')
-        else:
-            # Old versions of matplotlib.pyplot.close work without this
-            # in a normal script session but fail here. The workaround
-            # is to ensure this happens on the same thread too.
-            gui_cmd(plt.close, 'all')
+    def setUp(self):
+        # A deliberate pause so that the tests wait a small
+        # moment for MantidPlot to initialize properly
+        # It seems to stop the occasional lockup
+        time.sleep(0.2)
 
     def test_1d_plot(self):
         x, y = np.arange(1.0,10.0), np.arange(1.0,10.)
         ax = plt.plot(x,y)
         self.assertTrue(ax is not None)
         plt.show()
+        time.sleep(0.2)
+        plt.close()
 
     def test_image_plot(self):
         delta = 0.025
@@ -48,6 +46,8 @@ class MantidPlotMatplotlibTest(unittest.TestCase):
                         origin='lower', extent=[-3, 3, -3, 3],
                         vmax=abs(Z).max(), vmin=-abs(Z).max())
         plt.show()
+        time.sleep(0.2)
+        plt.close()
 
 # Run the unit tests
 if HAVE_MPL:


### PR DESCRIPTION
Description of work.

Updated matplotlib backend for v>=1.5 and hopefully fixed intermittent test failures. 

**To test:**

Find some [`matplotlib` examples](http://matplotlib.org/1.5.1/examples/index.html) and run them in the script window in MantidPlot. It should not crash.

Fixes #18047 

*Does not need to be in the release notes - internal fix*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
