### PR TITLE
Fix resolution in reflectometry GUI and algorithm

### DIFF
--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
@@ -500,7 +500,7 @@ ReflectometryReductionOneAuto2::rebinAndScale(MatrixWorkspace_sptr inputWS,
 
     IAlgorithm_sptr calcRes = createChildAlgorithm("CalculateResolution");
     calcRes->setProperty("Workspace", inputWS);
-    calcRes->setProperty("TwoTheta", 2 * theta);
+    calcRes->setProperty("TwoTheta", theta);
     calcRes->execute();
 
     if (!calcRes->isExecuted()) {

--- a/Framework/Algorithms/test/ReflectometryReductionOneAuto2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneAuto2Test.h
@@ -464,9 +464,6 @@ public:
     MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
-    for (size_t i = 0; i < outQ->blocksize(); i++)
-      std::cout << outLam->x(0)[i] << "\n";
-
     TS_ASSERT_EQUALS(outQ->getNumberHistograms(), 1);
     TS_ASSERT_EQUALS(outQ->blocksize(), 8);
     // X range in outLam

--- a/docs/source/algorithms/ReflectometryReductionOneAuto-v2.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneAuto-v2.rst
@@ -141,8 +141,8 @@ Usage
     print "%.5f" % (IvsLam.readY(0)[176])
     print "%.5f" % (IvsQ_unbinned.readY(0)[106])
     print "%.5f" % (IvsQ_unbinned.readY(0)[107])
-    print "%.5f" % (IvsQ.readY(0)[106])
-    print "%.5f" % (IvsQ.readY(0)[107])
+    print "%.5f" % (IvsQ.readY(0)[13])
+    print "%.5f" % (IvsQ.readY(0)[14])
 
 Output:
 
@@ -152,8 +152,8 @@ Output:
     0.59735
     0.57476
     0.54633
-    0.00027
-    0.00027
+    0.50034
+    0.26112
 
 **Example - Basic reduction with a transmission run**
 
@@ -167,8 +167,8 @@ Output:
     print "%.5f" % (IvsLam.readY(0)[164])
     print "%.5f" % (IvsQ_unbinned.readY(0)[96])
     print "%.5f" % (IvsQ_unbinned.readY(0)[97])
-    print "%.5f" % (IvsQ.readY(0)[96])
-    print "%.5f" % (IvsQ.readY(0)[97])
+    print "%.5f" % (IvsQ.readY(0)[5])
+    print "%.5f" % (IvsQ.readY(0)[6])
 
 Output:
 
@@ -178,8 +178,8 @@ Output:
     0.36906
     1.05389
     1.02234
-    0.00074
-    0.00069
+    1.30087
+    1.32781
 
 **Example - Reduction overriding some default values**
 
@@ -192,8 +192,8 @@ Output:
     print "%.5f" % (IvsLam.readY(0)[176])
     print "%.5f" % (IvsQ_unbinned.readY(0)[106])
     print "%.5f" % (IvsQ_unbinned.readY(0)[107])
-    print "%.5f" % (IvsQ.readY(0)[106])
-    print "%.5f" % (IvsQ.readY(0)[107])
+    print "%.5f" % (IvsQ.readY(0)[5])
+    print "%.5f" % (IvsQ.readY(0)[6])
 
 Output:
 
@@ -203,8 +203,8 @@ Output:
     0.52599
     0.51160
     0.48843
-    0.00027
-    0.00027
+    0.51819
+    0.52754
 
 .. categories::
 


### PR DESCRIPTION
`CalculateResolution` has an input property `TwoTheta`, but in order to get the correct resolution, one has to input just theta.

**To test:**

- Needs to be tested by someone at ISIS
- Open Interfaces -> Reflectometry -> Reflectometry (polref) and set the instrument to `INTER`
- Expand the first group bly clicking on the black arrow.
- Enter run number `41493` and click on `Process`
- Column `dQ/Q` should be populated with value `0.0199...`

Fixes #18606.

*Does not need to be in the release notes, as the issue was introduced in this release*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
