### PR TITLE
ShiftLogTime bugfix

### DIFF
--- a/Framework/Algorithms/src/ShiftLogTime.cpp
+++ b/Framework/Algorithms/src/ShiftLogTime.cpp
@@ -84,7 +84,7 @@ void ShiftLogTime::exec() {
     times.erase(times.begin(), times.begin() + indexshift);
   } else // indexshift < 0
   { 
-    //indexshift<0, so -indexshift>0
+    // indexshift<0, so -indexshift>0
     values.erase(values.begin(), values.begin() - indexshift);
     times.erase(times.end() + indexshift, times.end());
   }

--- a/Framework/Algorithms/src/ShiftLogTime.cpp
+++ b/Framework/Algorithms/src/ShiftLogTime.cpp
@@ -83,8 +83,9 @@ void ShiftLogTime::exec() {
     values.erase(values.end() - indexshift, values.end());
     times.erase(times.begin(), times.begin() + indexshift);
   } else // indexshift < 0
-  {
-    values.erase(values.begin(), values.begin() - indexshift); #indexshift<0, so -indexshift>0
+  { 
+    //indexshift<0, so -indexshift>0
+    values.erase(values.begin(), values.begin() - indexshift);
     times.erase(times.end() + indexshift, times.end());
   }
 

--- a/Framework/Algorithms/src/ShiftLogTime.cpp
+++ b/Framework/Algorithms/src/ShiftLogTime.cpp
@@ -83,7 +83,7 @@ void ShiftLogTime::exec() {
     values.erase(values.end() - indexshift, values.end());
     times.erase(times.begin(), times.begin() + indexshift);
   } else // indexshift < 0
-  { 
+  {
     // indexshift<0, so -indexshift>0
     values.erase(values.begin(), values.begin() - indexshift);
     times.erase(times.end() + indexshift, times.end());

--- a/Framework/Algorithms/src/ShiftLogTime.cpp
+++ b/Framework/Algorithms/src/ShiftLogTime.cpp
@@ -84,8 +84,8 @@ void ShiftLogTime::exec() {
     times.erase(times.begin(), times.begin() + indexshift);
   } else // indexshift < 0
   {
-    values.erase(values.begin(), values.begin() + indexshift);
-    times.erase(times.end() - indexshift, times.end());
+    values.erase(values.begin(), values.begin() - indexshift); #indexshift<0, so -indexshift>0
+    times.erase(times.end() + indexshift, times.end());
   }
 
   // Create the new log

--- a/Framework/Algorithms/test/ShiftLogTimeTest.h
+++ b/Framework/Algorithms/test/ShiftLogTimeTest.h
@@ -30,9 +30,13 @@ public:
     start_str = "2011-07-14T12:00Z"; // Noon on Bastille day 2011.
   }
 
-  void testCopyHist() { this->verify("ShiftLogTime_in", "ShiftLogTime_out"); }
+  void testCopyHist() { this->verify("ShiftLogTime_in", "ShiftLogTime_out",5); }
 
-  void testInplace() { this->verify("ShiftLogTime", "ShiftLogTime"); }
+  void testInplace() { this->verify("ShiftLogTime", "ShiftLogTime",5); }
+
+  void testCopyHistNeg() { this->verify("ShiftLogTime_in", "ShiftLogTime_out",-5); }
+
+  void testInplaceNeg() { this->verify("ShiftLogTime", "ShiftLogTime",-5); }
 
 private:
   /// Name of the log to create/modify.
@@ -48,7 +52,7 @@ private:
    * @param in_name Name of the input workspace.
    * @param out_name Name of the output workspace.
    */
-  void verify(const std::string in_name, const std::string out_name) {
+  void verify(const std::string in_name, const std::string out_name, const int shift) {
     DateAndTime start(start_str);
 
     // create a workspace to mess with
@@ -76,7 +80,7 @@ private:
     alg.setPropertyValue("InputWorkspace", in_name);
     alg.setPropertyValue("OutputWorkspace", out_name);
     alg.setPropertyValue("LogName", logname);
-    alg.setPropertyValue("IndexShift", "5");
+    alg.setProperty("IndexShift", shift);
 
     // run the algorithm
     TS_ASSERT_THROWS_NOTHING(alg.execute());
@@ -90,9 +94,19 @@ private:
             outWorkspace->run().getLogData(logname));
     TS_ASSERT(newlog);
     TS_ASSERT(!newlog->units().empty());
-    TS_ASSERT_EQUALS(length - 5, newlog->size());
-    TS_ASSERT_EQUALS(start + 5., newlog->firstTime());
-    TS_ASSERT_EQUALS(0., newlog->firstValue());
+    TS_ASSERT_EQUALS(length - std::abs(shift), newlog->size());
+    if (shift>0) {
+      TS_ASSERT_EQUALS(start + static_cast<double>(shift), newlog->firstTime());
+      TS_ASSERT_EQUALS(0., newlog->firstValue());
+      TS_ASSERT_EQUALS(start+static_cast<double>(length-1),newlog->lastTime());
+      TS_ASSERT_EQUALS(static_cast<double>(shift-1), newlog->lastValue());
+    }
+    if (shift<0) {
+      TS_ASSERT_EQUALS(start, newlog->firstTime());
+      TS_ASSERT_EQUALS(static_cast<double>(-shift), newlog->firstValue());
+      TS_ASSERT_EQUALS(start+static_cast<double>(-shift-1),newlog->lastTime());
+      TS_ASSERT_EQUALS(9., newlog->lastValue());
+    }
 
     // cleanup
     AnalysisDataService::Instance().remove(in_name);

--- a/Framework/Algorithms/test/ShiftLogTimeTest.h
+++ b/Framework/Algorithms/test/ShiftLogTimeTest.h
@@ -30,13 +30,17 @@ public:
     start_str = "2011-07-14T12:00Z"; // Noon on Bastille day 2011.
   }
 
-  void testCopyHist() { this->verify("ShiftLogTime_in", "ShiftLogTime_out",5); }
+  void testCopyHist() {
+    this->verify("ShiftLogTime_in", "ShiftLogTime_out", 5);
+  }
 
-  void testInplace() { this->verify("ShiftLogTime", "ShiftLogTime",5); }
+  void testInplace() { this->verify("ShiftLogTime", "ShiftLogTime", 5); }
 
-  void testCopyHistNeg() { this->verify("ShiftLogTime_in", "ShiftLogTime_out",-5); }
+  void testCopyHistNeg() {
+    this->verify("ShiftLogTime_in", "ShiftLogTime_out", -5);
+  }
 
-  void testInplaceNeg() { this->verify("ShiftLogTime", "ShiftLogTime",-5); }
+  void testInplaceNeg() { this->verify("ShiftLogTime", "ShiftLogTime", -5); }
 
 private:
   /// Name of the log to create/modify.
@@ -52,7 +56,8 @@ private:
    * @param in_name Name of the input workspace.
    * @param out_name Name of the output workspace.
    */
-  void verify(const std::string in_name, const std::string out_name, const int shift) {
+  void verify(const std::string in_name, const std::string out_name,
+              const int shift) {
     DateAndTime start(start_str);
 
     // create a workspace to mess with
@@ -95,16 +100,18 @@ private:
     TS_ASSERT(newlog);
     TS_ASSERT(!newlog->units().empty());
     TS_ASSERT_EQUALS(length - std::abs(shift), newlog->size());
-    if (shift>0) {
+    if (shift > 0) {
       TS_ASSERT_EQUALS(start + static_cast<double>(shift), newlog->firstTime());
       TS_ASSERT_EQUALS(0., newlog->firstValue());
-      TS_ASSERT_EQUALS(start+static_cast<double>(length-1),newlog->lastTime());
-      TS_ASSERT_EQUALS(static_cast<double>(shift-1), newlog->lastValue());
+      TS_ASSERT_EQUALS(start + static_cast<double>(length - 1),
+                       newlog->lastTime());
+      TS_ASSERT_EQUALS(static_cast<double>(shift - 1), newlog->lastValue());
     }
-    if (shift<0) {
+    if (shift < 0) {
       TS_ASSERT_EQUALS(start, newlog->firstTime());
       TS_ASSERT_EQUALS(static_cast<double>(-shift), newlog->firstValue());
-      TS_ASSERT_EQUALS(start+static_cast<double>(-shift-1),newlog->lastTime());
+      TS_ASSERT_EQUALS(start + static_cast<double>(-shift - 1),
+                       newlog->lastTime());
       TS_ASSERT_EQUALS(9., newlog->lastValue());
     }
 

--- a/docs/source/release/v3.9.0/framework.rst
+++ b/docs/source/release/v3.9.0/framework.rst
@@ -60,6 +60,7 @@ Bug Fixes
 - If a run is aborted and restarted, the ``running`` log in the workspace will correctly reflect this. (``running`` will be false at all times before the abort.)
 - Fixed several issues with masked detectors and neighbour counts in the nearest-neighbour code used by a few algorithms.
 - Issues with :ref:`CalculateFlatBackground <algm-CalculateFlatBackground>` with  **Return Background** option returning fake values has been fixed.
+- :ref:`ShiftLogTime <algm-ShiftLogTime>` now correctly handles shift in the negative direction
 
 Deprecated
 ##########


### PR DESCRIPTION
The correct range is fixed for deleting with negative shifts.

**To test:**

Run the script in the original issue

Fixes #18603 


*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
