### PR TITLE
Error when save to ascii2 with no x errors present and x errors are requested 

### DIFF
--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -159,6 +159,10 @@ void SaveAscii2::exec() {
 
   // Check whether we need to write the fourth column
   m_writeDX = getProperty("WriteXError");
+  if(!m_ws->hasDx(0) && m_writeDX)
+  {
+	throw std::runtime_error("x data errors have been requested but do not exist.");
+  }
   const std::string choice = getPropertyValue("Separator");
   const std::string custom = getPropertyValue("CustomSeparator");
   // If the custom separator property is not empty, then we use that under any

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -159,9 +159,9 @@ void SaveAscii2::exec() {
 
   // Check whether we need to write the fourth column
   m_writeDX = getProperty("WriteXError");
-  if(!m_ws->hasDx(0) && m_writeDX)
-  {
-	throw std::runtime_error("x data errors have been requested but do not exist.");
+  if (!m_ws->hasDx(0) && m_writeDX) {
+    throw std::runtime_error(
+        "x data errors have been requested but do not exist.");
   }
   const std::string choice = getPropertyValue("Separator");
   const std::string custom = getPropertyValue("CustomSeparator");

--- a/Framework/DataHandling/test/SaveAscii2Test.h
+++ b/Framework/DataHandling/test/SaveAscii2Test.h
@@ -91,48 +91,29 @@ public:
     AnalysisDataService::Instance().remove(m_name);
   }
 
-  void testExec_DXNoData() {
-   
- Mantid::DataObjects::Workspace2D_sptr wsToSave =
+void testExec_DXNoData() {
+    Mantid::DataObjects::Workspace2D_sptr wsToSave =
         boost::dynamic_pointer_cast<Mantid::DataObjects::Workspace2D>(
             WorkspaceFactory::Instance().create("Workspace2D", 2, 3, 3));
     for (int i = 0; i < 2; i++) {
       std::vector<double> &X = wsToSave->dataX(i);
       std::vector<double> &Y = wsToSave->dataY(i);
       std::vector<double> &E = wsToSave->dataE(i);
-      wsToSave->setPointStandardDeviations(i, 3);
-      auto &DX = wsToSave->mutableDx(i);
       for (int j = 0; j < 3; j++) {
         X[j] = 1.5 * j / 0.9;
         Y[j] = (i + 1) * (2. + 4. * X[j]);
         E[j] = 1.;
-        DX[j] = i + 1;
       }
     }
-
     AnalysisDataService::Instance().add(m_name, wsToSave);
-
     SaveAscii2 save;
     std::string filename = initSaveAscii2(save);
     TS_ASSERT_THROWS_NOTHING(save.setPropertyValue("WriteXError", "1"));
-    TS_ASSERT_THROWS_NOTHING(save.execute());
-
-
-
-/*
-    SaveAscii2 save;
-    std::string filename = initSaveAscii2(save);
-   // TS_ASSERT_THROWS_ANYTHING(save.setPropertyValue("WriteXError", "1"));
-   // TS_ASSERT_THROWS_NOTHING(save.setPropertyValue("WriteXError", "1"));
-   // TS_ASSERT_THROWS_NOTHING(save.execute());
-   // TS_ASSERT_THROWS_ANYTHING(save.execute());
-  
-    Poco::File(filename).remove();
+    TS_ASSERT_THROWS_ANYTHING(save.execute());
     AnalysisDataService::Instance().remove(m_name);
-*/
 }
-
-  void testExec_DX() {
+  
+void testExec_DX() {
     Mantid::DataObjects::Workspace2D_sptr wsToSave =
         boost::dynamic_pointer_cast<Mantid::DataObjects::Workspace2D>(
             WorkspaceFactory::Instance().create("Workspace2D", 2, 3, 3));

--- a/Framework/DataHandling/test/SaveAscii2Test.h
+++ b/Framework/DataHandling/test/SaveAscii2Test.h
@@ -91,6 +91,47 @@ public:
     AnalysisDataService::Instance().remove(m_name);
   }
 
+  void testExec_DXNoData() {
+   
+ Mantid::DataObjects::Workspace2D_sptr wsToSave =
+        boost::dynamic_pointer_cast<Mantid::DataObjects::Workspace2D>(
+            WorkspaceFactory::Instance().create("Workspace2D", 2, 3, 3));
+    for (int i = 0; i < 2; i++) {
+      std::vector<double> &X = wsToSave->dataX(i);
+      std::vector<double> &Y = wsToSave->dataY(i);
+      std::vector<double> &E = wsToSave->dataE(i);
+      wsToSave->setPointStandardDeviations(i, 3);
+      auto &DX = wsToSave->mutableDx(i);
+      for (int j = 0; j < 3; j++) {
+        X[j] = 1.5 * j / 0.9;
+        Y[j] = (i + 1) * (2. + 4. * X[j]);
+        E[j] = 1.;
+        DX[j] = i + 1;
+      }
+    }
+
+    AnalysisDataService::Instance().add(m_name, wsToSave);
+
+    SaveAscii2 save;
+    std::string filename = initSaveAscii2(save);
+    TS_ASSERT_THROWS_NOTHING(save.setPropertyValue("WriteXError", "1"));
+    TS_ASSERT_THROWS_NOTHING(save.execute());
+
+
+
+/*
+    SaveAscii2 save;
+    std::string filename = initSaveAscii2(save);
+   // TS_ASSERT_THROWS_ANYTHING(save.setPropertyValue("WriteXError", "1"));
+   // TS_ASSERT_THROWS_NOTHING(save.setPropertyValue("WriteXError", "1"));
+   // TS_ASSERT_THROWS_NOTHING(save.execute());
+   // TS_ASSERT_THROWS_ANYTHING(save.execute());
+  
+    Poco::File(filename).remove();
+    AnalysisDataService::Instance().remove(m_name);
+*/
+}
+
   void testExec_DX() {
     Mantid::DataObjects::Workspace2D_sptr wsToSave =
         boost::dynamic_pointer_cast<Mantid::DataObjects::Workspace2D>(

--- a/Framework/DataHandling/test/SaveAscii2Test.h
+++ b/Framework/DataHandling/test/SaveAscii2Test.h
@@ -91,7 +91,7 @@ public:
     AnalysisDataService::Instance().remove(m_name);
   }
 
-void testExec_DXNoData() {
+  void testExec_DXNoData() {
     Mantid::DataObjects::Workspace2D_sptr wsToSave =
         boost::dynamic_pointer_cast<Mantid::DataObjects::Workspace2D>(
             WorkspaceFactory::Instance().create("Workspace2D", 2, 3, 3));
@@ -111,9 +111,9 @@ void testExec_DXNoData() {
     TS_ASSERT_THROWS_NOTHING(save.setPropertyValue("WriteXError", "1"));
     TS_ASSERT_THROWS_ANYTHING(save.execute());
     AnalysisDataService::Instance().remove(m_name);
-}
-  
-void testExec_DX() {
+  }
+
+  void testExec_DX() {
     Mantid::DataObjects::Workspace2D_sptr wsToSave =
         boost::dynamic_pointer_cast<Mantid::DataObjects::Workspace2D>(
             WorkspaceFactory::Instance().create("Workspace2D", 2, 3, 3));


### PR DESCRIPTION
Description of work.
This fixes 
This fixes https://github.com/mantidproject/mantid/issues/18565. 

Mantid was crashing if a workspace was loaded, which did not include any x errors and the user then selected save to ascii with the xerrors option selected. This fix now produces a runtime error and a unit test has been added to check for this bug. 

<!-- Instructions for testing. -->
To test load a workspace with no xerrors. Then save to ascii with the xerror option selected. It should give an error. 

Check that the system test works. 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
