### PR TITLE
Fix an issue with first monitor in Reflectometry algorithms

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryWorkflowBase2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryWorkflowBase2.h
@@ -66,6 +66,10 @@ protected:
   Mantid::API::MatrixWorkspace_sptr
   makeMonitorWS(Mantid::API::MatrixWorkspace_sptr inputWS,
                 bool integratedMonitors);
+  // Rebin detectors to monitors
+  Mantid::API::MatrixWorkspace_sptr
+  rebinDetectorsToMonitors(Mantid::API::MatrixWorkspace_sptr detectorWS,
+                           Mantid::API::MatrixWorkspace_sptr monitorWS);
   // Read monitor properties from instrument
   void
   populateMonitorProperties(Mantid::API::IAlgorithm_sptr alg,

--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -103,13 +103,11 @@ CreateTransmissionWorkspace2::validateInputs() {
 void CreateTransmissionWorkspace2::exec() {
 
   MatrixWorkspace_sptr firstTransWS = getProperty("FirstTransmissionRun");
-  firstTransWS = convertToWavelength(firstTransWS);
   firstTransWS = normalizeDetectorsByMonitors(firstTransWS);
   firstTransWS = cropWavelength(firstTransWS);
 
   MatrixWorkspace_sptr secondTransWS = getProperty("SecondTransmissionRun");
   if (secondTransWS) {
-    secondTransWS = convertToWavelength(secondTransWS);
     secondTransWS = normalizeDetectorsByMonitors(secondTransWS);
     secondTransWS = cropWavelength(secondTransWS);
 
@@ -164,6 +162,8 @@ MatrixWorkspace_sptr CreateTransmissionWorkspace2::normalizeDetectorsByMonitors(
       !(intMinProperty->isDefault() || intMaxProperty->isDefault());
 
   auto monitorWS = makeMonitorWS(IvsLam, integratedMonitors);
+  if (!integratedMonitors)
+	  detectorWS = rebinDetectorsToMonitors(detectorWS, monitorWS);
 
   return divide(detectorWS, monitorWS);
 }

--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -163,7 +163,7 @@ MatrixWorkspace_sptr CreateTransmissionWorkspace2::normalizeDetectorsByMonitors(
 
   auto monitorWS = makeMonitorWS(IvsLam, integratedMonitors);
   if (!integratedMonitors)
-	  detectorWS = rebinDetectorsToMonitors(detectorWS, monitorWS);
+    detectorWS = rebinDetectorsToMonitors(detectorWS, monitorWS);
 
   return divide(detectorWS, monitorWS);
 }

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -163,15 +163,13 @@ void ReflectometryReductionOne2::exec() {
   } else {
     // xUnitID == "TOF"
 
-    IvsLam = convertToWavelength(runWS);
-
     // Detector workspace
-    auto detectorWS = makeDetectorWS(IvsLam);
+    auto detectorWS = makeDetectorWS(runWS);
 
     // Normalization by direct beam (optional)
     Property *directBeamProperty = getProperty("RegionOfDirectBeam");
     if (!directBeamProperty->isDefault()) {
-      const auto directBeam = makeDirectBeamWS(IvsLam);
+      const auto directBeam = makeDirectBeamWS(runWS);
       detectorWS = divide(detectorWS, directBeam);
     }
 
@@ -186,7 +184,9 @@ void ReflectometryReductionOne2::exec() {
         !backgroundMaxProperty->isDefault()) {
       const bool integratedMonitors =
           getProperty("NormalizeByIntegratedMonitors");
-      const auto monitorWS = makeMonitorWS(IvsLam, integratedMonitors);
+      const auto monitorWS = makeMonitorWS(runWS, integratedMonitors);
+      if (!integratedMonitors)
+        detectorWS = rebinDetectorsToMonitors(detectorWS, monitorWS);
       IvsLam = divide(detectorWS, monitorWS);
     } else {
       IvsLam = detectorWS;
@@ -211,11 +211,11 @@ void ReflectometryReductionOne2::exec() {
   setProperty("OutputWorkspace", IvsQ);
 }
 
-/** Creates a direct beam workspace from an input workspace in wavelength. This
+/** Creates a direct beam workspace in wavelength from an input workspace in TOF. This
 * method should only be called if RegionOfDirectBeam is provided.
 *
-* @param inputWS :: the input workspace in wavelength
-* @return :: the monitor workspace
+* @param inputWS :: the input workspace in TOF
+* @return :: the direct beam workspace in wavelength
 */
 MatrixWorkspace_sptr
 ReflectometryReductionOne2::makeDirectBeamWS(MatrixWorkspace_sptr inputWS) {
@@ -233,6 +233,8 @@ ReflectometryReductionOne2::makeDirectBeamWS(MatrixWorkspace_sptr inputWS) {
   groupDirectBeamAlg->execute();
   MatrixWorkspace_sptr directBeamWS =
       groupDirectBeamAlg->getProperty("OutputWorkspace");
+
+  directBeamWS = convertToWavelength(directBeamWS);
 
   return directBeamWS;
 }

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -211,8 +211,8 @@ void ReflectometryReductionOne2::exec() {
   setProperty("OutputWorkspace", IvsQ);
 }
 
-/** Creates a direct beam workspace in wavelength from an input workspace in TOF. This
-* method should only be called if RegionOfDirectBeam is provided.
+/** Creates a direct beam workspace in wavelength from an input workspace in
+* TOF. This method should only be called if RegionOfDirectBeam is provided.
 *
 * @param inputWS :: the input workspace in TOF
 * @return :: the direct beam workspace in wavelength

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -317,10 +317,10 @@ ReflectometryWorkflowBase2::cropWavelength(MatrixWorkspace_sptr inputWS) {
   return outputWS;
 }
 
-/** Process an input workspace according to specified processing commands to get
-* a detector workspace.
-* @param inputWS :: the input workspace in wavelength
-* @return :: the detector workspace
+/** Process an input workspace in TOF according to specified processing commands to get
+* a detector workspace in wavelength.
+* @param inputWS :: the input workspace in TOF
+* @return :: the detector workspace in wavelength
 */
 MatrixWorkspace_sptr
 ReflectometryWorkflowBase2::makeDetectorWS(MatrixWorkspace_sptr inputWS) {
@@ -334,16 +334,19 @@ ReflectometryWorkflowBase2::makeDetectorWS(MatrixWorkspace_sptr inputWS) {
   groupAlg->execute();
   MatrixWorkspace_sptr detectorWS = groupAlg->getProperty("OutputWorkspace");
 
+  detectorWS = convertToWavelength(detectorWS);
+
   return detectorWS;
 }
 
-/** Creates a monitor workspace. This method should only be called if
-* IOMonitorIndex has been specified and MonitorBackgroundWavelengthMin and
-* MonitorBackgroundWavelengthMax have been given.
-* @param inputWS :: the input workspace in wavelength
+/** Creates a monitor workspace in wavelength from an input workspace in TOF.
+* This method should only be called if IOMonitorIndex has been specified and
+* MonitorBackgroundWavelengthMin and MonitorBackgroundWavelengthMax have been
+* given.
+* @param inputWS :: the input workspace in TOF
 * @param integratedMonitors :: boolean to indicate if monitors should be
 * integrated
-* @return :: the monitor workspace
+* @return :: the monitor workspace in wavelength
 */
 MatrixWorkspace_sptr
 ReflectometryWorkflowBase2::makeMonitorWS(MatrixWorkspace_sptr inputWS,
@@ -359,6 +362,8 @@ ReflectometryWorkflowBase2::makeMonitorWS(MatrixWorkspace_sptr inputWS,
   cropWorkspaceAlg->execute();
   MatrixWorkspace_sptr monitorWS =
       cropWorkspaceAlg->getProperty("OutputWorkspace");
+
+  monitorWS = convertToWavelength(monitorWS);
 
   // Flat background correction
   const double backgroundMin = getProperty("MonitorBackgroundWavelengthMin");
@@ -397,6 +402,25 @@ ReflectometryWorkflowBase2::makeMonitorWS(MatrixWorkspace_sptr inputWS,
       integrationAlg->getProperty("OutputWorkspace");
 
   return integratedMonitor;
+}
+
+/** Rebin a detector workspace in wavelength to a given monitor workspace in
+* wavelength.
+* @param detectorWS :: the detector workspace in wavelength
+* @param monitorWS :: the monitor workspace in wavelength
+* @return :: the rebinned detector workspace
+*/
+MatrixWorkspace_sptr ReflectometryWorkflowBase2::rebinDetectorsToMonitors(
+    MatrixWorkspace_sptr detectorWS, MatrixWorkspace_sptr monitorWS) {
+
+  auto rebin = createChildAlgorithm("RebinToWorkspace");
+  rebin->initialize();
+  rebin->setProperty("WorkspaceToRebin", detectorWS);
+  rebin->setProperty("WorkspaceToMatch", monitorWS);
+  rebin->execute();
+  MatrixWorkspace_sptr rebinnedWS = rebin->getProperty("OutputWorkspace");
+
+  return rebinnedWS;
 }
 
 /** Set monitor properties

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -317,8 +317,8 @@ ReflectometryWorkflowBase2::cropWavelength(MatrixWorkspace_sptr inputWS) {
   return outputWS;
 }
 
-/** Process an input workspace in TOF according to specified processing commands to get
-* a detector workspace in wavelength.
+/** Process an input workspace in TOF according to specified processing commands
+* to get a detector workspace in wavelength.
 * @param inputWS :: the input workspace in TOF
 * @return :: the detector workspace in wavelength
 */

--- a/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
+++ b/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
@@ -160,11 +160,11 @@ public:
     TS_ASSERT(outLam);
     TS_ASSERT_EQUALS("Wavelength", outLam->getAxis(0)->unit()->unitID());
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     TS_ASSERT(outLam->x(0)[0] >= 1.5);
     TS_ASSERT(outLam->x(0)[7] <= 15.0);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 3.1530, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 3.1530, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 2.0000, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 2.0000, 0.0001);
   }
 
   void test_one_run_processing_instructions() {
@@ -183,12 +183,12 @@ public:
     TS_ASSERT(outLam);
     TS_ASSERT_EQUALS("Wavelength", outLam->getAxis(0)->unit()->unitID());
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     TS_ASSERT(outLam->x(0)[0] >= 1.5);
     TS_ASSERT(outLam->x(0)[7] <= 15.0);
-    // Y counts, should be 3.1530 * 2
-    TS_ASSERT_DELTA(outLam->y(0)[0], 6.3060, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 6.3060, 0.0001);
+    // Y counts, should be 2.0000 * 2
+    TS_ASSERT_DELTA(outLam->y(0)[0], 4.0000, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 4.0000, 0.0001);
   }
 
   void test_one_run_monitor_normalization() {
@@ -256,12 +256,12 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspace");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 10);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 16);
     TS_ASSERT(outLam->x(0)[0] >= 0.0);
     TS_ASSERT(outLam->x(0)[7] <= 15.0);
-    // Expected values are 0.3124 = 3.15301 (detectors) / (1.26139*8) (monitors)
-    TS_ASSERT_DELTA(outLam->y(0)[0], 0.3124, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 0.3124, 0.0001);
+    // Expected values are 0.1981 = 2.0000 (detectors) / (1.26139*8) (monitors)
+    TS_ASSERT_DELTA(outLam->y(0)[0], 0.1981, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 0.1981, 0.0001);
   }
 
   void test_two_transmission_runs() {
@@ -279,11 +279,11 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspace");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     TS_ASSERT(outLam->x(0)[0] >= 1.5);
     TS_ASSERT(outLam->x(0)[7] <= 15.0);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 3.1530, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 3.1530, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 2.0000, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 2.0000, 0.0001);
   }
 
   void test_two_transmission_runs_stitch_params() {
@@ -302,13 +302,13 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspace");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 113);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 126);
     TS_ASSERT(outLam->x(0)[0] >= 1.5);
     TS_ASSERT(outLam->x(0)[7] <= 15.0);
-    TS_ASSERT_DELTA(outLam->x(0)[0], 2.8257, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[1], 2.9257, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[2], 3.0257, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 3.1257, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 1.7924, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[1], 1.8924, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[2], 1.9924, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 2.0924, 0.0001);
   }
 };
 

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -62,11 +62,11 @@ public:
 
     TS_ASSERT(outLam);
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     TS_ASSERT(outLam->x(0)[0] >= 1.5);
     TS_ASSERT(outLam->x(0)[7] <= 15.0);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 3.1530, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 3.1530, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 2.0000, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 2.0000, 0.0001);
   }
 
   void test_IvsLam_processing_instructions_1to2() {
@@ -89,12 +89,12 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     TS_ASSERT(outLam->x(0)[0] >= 1.5);
     TS_ASSERT(outLam->x(0)[7] <= 15.0);
-    // Y counts, should be 3.1530 * 2
-    TS_ASSERT_DELTA(outLam->y(0)[0], 6.3060, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 6.3060, 0.0001);
+    // Y counts, should be 2.0000 * 2
+    TS_ASSERT_DELTA(outLam->y(0)[0], 4.0000, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 4.0000, 0.0001);
   }
 
   void test_IvsLam_processing_instructions_1to3() {
@@ -117,12 +117,12 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     TS_ASSERT(outLam->x(0)[0] >= 1.5);
     TS_ASSERT(outLam->x(0)[7] <= 15.0);
-    // Y counts, should be 3.1530 * 3
-    TS_ASSERT_DELTA(outLam->y(0)[0], 9.4590, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 9.4590, 0.0001);
+    // Y counts, should be 2.0000 * 3
+    TS_ASSERT_DELTA(outLam->y(0)[0], 6.0000, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 6.0000, 0.0001);
   }
 
   void test_bad_processing_instructions() {
@@ -162,7 +162,7 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     // Y counts, should be 0.5 = 1 (from detector ws) / 2 (from direct beam)
     TS_ASSERT_DELTA(outLam->y(0)[0], 0.5, 0.0001);
   }
@@ -208,14 +208,14 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     TS_ASSERT(outLam->x(0)[0] >= 1.5);
     TS_ASSERT(outLam->x(0)[7] <= 15.0);
     // No monitors considered because MonitorBackgroundWavelengthMin
     // and MonitorBackgroundWavelengthMax were not set
-    // Y counts must be 3.1530
-    TS_ASSERT_DELTA(outLam->y(0)[0], 3.1530, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 3.1530, 0.0001);
+    // Y counts must be 2.0000
+    TS_ASSERT_DELTA(outLam->y(0)[0], 2.0000, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 2.0000, 0.0001);
   }
 
   void test_IvsLam_monitor_normalization() {
@@ -299,12 +299,12 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 10);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 16);
     TS_ASSERT(outLam->x(0)[0] >= 0.0);
     TS_ASSERT(outLam->x(0)[7] <= 15.0);
-    // Expected values are 0.3124 = 3.15301 (detectors) / (1.26139*8) (monitors)
-    TS_ASSERT_DELTA(outLam->y(0)[0], 0.3124, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 0.3124, 0.0001);
+    // Expected values are 0.1981 = 2.0000 (detectors) / (1.26139*8) (monitors)
+    TS_ASSERT_DELTA(outLam->y(0)[0], 0.1981, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 0.1981, 0.0001);
   }
 
   void test_transmission_correction_run() {
@@ -324,7 +324,7 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     // Expected values are 1 = m_wavelength / m_wavelength
     TS_ASSERT_DELTA(outLam->y(0)[0], 1.0000, 0.0001);
     TS_ASSERT_DELTA(outLam->y(0)[7], 1.0000, 0.0001);
@@ -351,7 +351,7 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     // Expected values are 1 = m_wavelength / m_wavelength
     TS_ASSERT_DELTA(outLam->y(0)[0], 1.0000, 0.0001);
     TS_ASSERT_DELTA(outLam->y(0)[7], 1.0000, 0.0001);
@@ -376,10 +376,9 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
-    // Expected values are 29.0459 and 58.4912
-    TS_ASSERT_DELTA(outLam->y(0)[0], 22.4437, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 60.3415, 0.0001);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 12.5113, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 23.4290, 0.0001);
   }
 
   void test_polynomial_correction() {
@@ -400,9 +399,9 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 8);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 0.4262, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 0.0334, 0.0001);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 0.6093, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 0.0514, 0.0001);
   }
 
   void test_IvsQ() {
@@ -420,10 +419,10 @@ public:
     MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
 
     TS_ASSERT_EQUALS(outQ->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outQ->blocksize(), 8);
+    TS_ASSERT_EQUALS(outQ->blocksize(), 14);
     // X range in outQ
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.3403, 0.0001);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 1.1345, 0.0001);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.3353, 0.0001);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.5962, 0.0001);
   }
 };
 

--- a/Framework/Algorithms/test/ReflectometryReductionOneAuto2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneAuto2Test.h
@@ -465,13 +465,13 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outQ->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outQ->blocksize(), 8);
+    TS_ASSERT_EQUALS(outQ->blocksize(), 14);
     // X range in outLam
-    TS_ASSERT_DELTA(outLam->x(0)[0], 2.8257, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 12.7158, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 1.7924, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 8.0658, 0.0001);
     // X range in outQ
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.3403, 0.0001);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 1.1345, 0.0001);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.3353, 0.0001);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.5962, 0.0001);
   }
 };
 

--- a/docs/source/algorithms/CreateTransmissionWorkspace-v2.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspace-v2.rst
@@ -80,10 +80,10 @@ Output:
 .. testoutput:: ExCreateTransWSSimple
 
     The first four transWS Y values are:
-    0.0255
-    0.0759
-    0.1324
-    0.1424
+    0.0052
+    0.0065
+    0.0088
+    0.0123
 
 **Example - Create a transmission run from two runs**
 
@@ -114,10 +114,10 @@ Output:
 .. testoutput:: ExCreateTransWSTwo
 
     The first four transWS Y values are:
-    0.0572
-    0.0575
-    0.0585
-    0.0585
+    0.0563
+    0.0561
+    0.0570
+    0.0578
 
 .. categories::
 

--- a/docs/source/algorithms/CreateTransmissionWorkspace-v2.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspace-v2.rst
@@ -24,19 +24,25 @@ output workspace is generated with X-units of wavelength in angstroms.
 
 The diagram above illustrates the main steps in the algorithm. Below is a more
 detailed diagram describing how transmission workspaces are converted to units
-of wavelength and normalized by monitors. First, the input workspace is converted
-to wavelength and :literal:`ProcessingInstructions` are used to extract
-the detectors of interest. If :literal:`I0MonitorIndex`, :literal:`MonitorBackgroundWavelengthMin`
-and :literal:`MonitorBackgroundWavelengthMax` are provided, the monitor will be
-extracted from the input workspace and its background will be subtracted according
-to :literal:`MonitorBackgroundWavelengthMin` and :literal:`MonitorBackgroundWavelengthMax`.
-If :literal:`MonitorIntegrationWavelengthMin` and :literal:`MonitorIntegrationWavelengthMax`
-are provided, monitors will be integrated according to that range. Finally, the
-detector workspace will be normalized by the monitor workspace, and the resulting workspace
-will be cropped according to :literal:`WavelengthMin` and :literal:`WavelengthMax`.
-Note that monitor normalization is optional and only happens when all :literal:`I0MonitorIndex`,
-:literal:`MonitorBackgroundWavelengthMin` and :literal:`MonitorBackgroundWavelengthMax` are
-provided.
+of wavelength and normalized by monitors. First, detectors and monitors are
+extracted from the input workspace using :ref:`algm-GroupDetectors` and
+:ref:`algm-CropWorkspace` respectively, using ``ProcessingInstructions`` in the
+first case and ``I0MonitorIndex`` in the second case. Then, each of the resulting
+workspaces is converted to wavelength (note that ``AlignBins`` is set to ``True``
+for this), detectors are normalized by monitors, and the resulting workspace is
+cropped in wavelength according to ``WavelengthMin`` and ``WavelengthMax``, which
+are both mandatory parameters. Note that the normalization by monitors is optional,
+and only takes place if :literal:`I0MonitorIndex`, :literal:`MonitorBackgroundWavelengthMin`
+and :literal:`MonitorBackgroundWavelengthMax` are provided. In this case, the monitor
+of interest will be extracted from the input workspace, converted to wavelength, and its
+background will be subtracted according to :literal:`MonitorBackgroundWavelengthMin`
+and :literal:`MonitorBackgroundWavelengthMax`. If :literal:`MonitorIntegrationWavelengthMin`
+and :literal:`MonitorIntegrationWavelengthMax` are provided, monitors will be integrated
+according to that range. If monitors are not integrated, there is an addition step in which
+detectors will be rebinned to monitors using :ref:`algm-RebinToWorkspace`, to ensure that
+the normalization can be performed. Below is a summary of the main steps in the algorithm.
+For the sake of clarity, all possible steps are illustrated, even if some of them are
+optional.
 
 .. diagram:: CreateTransmissionWorkspace_ConvertToWavelength-v2_wkflw.dot
 

--- a/docs/source/algorithms/CreateTransmissionWorkspaceAuto-v2.rst
+++ b/docs/source/algorithms/CreateTransmissionWorkspaceAuto-v2.rst
@@ -58,10 +58,10 @@ Output:
 
 .. testoutput:: ExCreateTransWSAutoSimple
 
-    0.3671
-    0.3684
-    0.3640
-    0.3578
+    0.0564
+    0.0577
+    0.0582
+    0.0590
 
     
 **Example - Create a transmission run, overriding some default parameters**
@@ -72,19 +72,19 @@ Output:
     trans = Load(Filename='INTER00013463.nxs')
     transWS = CreateTransmissionWorkspaceAuto(FirstTransmissionRun=trans, MonitorBackgroundWavelengthMin=0.0, MonitorBackgroundWavelengthMax=1.0)
 
-    print "%.4f" % (transWS.readY(0)[26])
-    print "%.4f" % (transWS.readY(0)[27])
-    print "%.4f" % (transWS.readY(0)[28])
-    print "%.4f" % (transWS.readY(0)[29])
+    print "%.3f" % (transWS.readY(0)[26])
+    print "%.3f" % (transWS.readY(0)[27])
+    print "%.3f" % (transWS.readY(0)[28])
+    print "%.3f" % (transWS.readY(0)[29])
 
 Output:
 
 .. testoutput:: ExCreateTransWSAutoOverload
 
-    0.3638
-    0.3651
-    0.3607
-    0.3546
+    0.056
+    0.057
+    0.058
+    0.059
 
     
 **Example - Create a transmission run from two runs**
@@ -104,10 +104,10 @@ Output:
 
 .. testoutput:: ExCreateTransWSAutoTwo
 
-    0.0825
-    0.0860
-    0.0879
-    0.0879
+    0.0822
+    0.0847
+    0.0863
+    0.0869
 
 .. categories::
 

--- a/docs/source/algorithms/ReflectometryReductionOne-v2.rst
+++ b/docs/source/algorithms/ReflectometryReductionOne-v2.rst
@@ -137,20 +137,20 @@ Usage
                                             MonitorIntegrationWavelengthMin=4.0,
                                             MonitorIntegrationWavelengthMax=10.0)
 
-   print "%.4f" % (IvsLam.readY(0)[173])
-   print "%.4f" % (IvsLam.readY(0)[174])
-   print "%.4f" % (IvsQ.readY(0)[2])
-   print "%.4f" % (IvsQ.readY(0)[3])
+   print "%.4f" % (IvsLam.readY(0)[533])
+   print "%.4f" % (IvsLam.readY(0)[534])
+   print "%.4f" % (IvsQ.readY(0)[327])
+   print "%.4f" % (IvsQ.readY(0)[328])
 
 
 Output:
 
 .. testoutput:: ExReflRedOneSimple
 
-   0.0014
-   0.0014
-   0.0001
-   0.0001
+   0.0003
+   0.0003
+   0.0003
+   0.0003
 
 
 **Example - Reduce a run and normalize by transmission workspace**
@@ -173,8 +173,8 @@ Output:
 					    FirstTransmissionRun=trans1,
 					    SecondTransmissionRun=trans2)
 
-   print "%.4f" % (IvsLam.readY(0)[170])
-   print "%.4f" % (IvsLam.readY(0)[171])
+   print "%.4f" % (IvsLam.readY(0)[480])
+   print "%.4f" % (IvsLam.readY(0)[481])
    print "%.4f" % (IvsQ.readY(0)[107])
    print "%.4f" % (IvsQ.readY(0)[108])
 
@@ -183,10 +183,10 @@ Output:
 
 .. testoutput:: ExReflRedOneTrans
 
-   0.4897
-   0.5468
-   0.6144
-   0.5943
+   0.4588
+   0.4655
+   0.7336
+   1.0156
 
 .. categories::
 

--- a/docs/source/algorithms/ReflectometryReductionOne-v2.rst
+++ b/docs/source/algorithms/ReflectometryReductionOne-v2.rst
@@ -38,20 +38,23 @@ Conversion to Wavelength
 First, the algorithm checks the X units of
 the input workspace. If the input workspace is already in wavelength, normalization by
 monitors and direct beam are not performed, as it is considered that the input run was
-already reduced using this algorithm. If the input workspace is in TOF, it will be
-converted to wavelength (note that :literal:`AlignBins` will be set to :literal:`True` for this in 
-:ref:`algm-ConvertUnits`) and the detectors
-of interest, specified via :literal:`ProcessingInstructions`, will be grouped together using
-:ref:`algm-GroupDetectors`. **Optionally**, the algorithm will perform direct beam
-normalization (if :literal:`RegionOfDirectBeam` is specified) dividing the detectors of
-interest by the direct beam, and monitor normalization (if :literal:`I0MonitorIndex` and
-:literal:`MonitorBackgroundWavelengthMin` and :literal:`MonitorBackgroundWavelengthMax` are all specified),
-in which case the detectors of interest will be divided by monitors. Detectors can be normalized
-by integrated monitors by setting :literal:`NormalizeByIntegratedMonitors` to true, in which case
-:literal:`MonitorIntegrationWavelengthMin` and :literal:`MonitorIntegrationWavelengthMax` will
-be used as the integration range. Finally, the resulting workspace will be cropped according to
-:literal:`WavelengthMin` and :literal:`WavelengthMax`, which are both mandatory properties.
-A summary of the steps is shown in the workflow diagram below.
+already reduced using this algorithm. If the input workspace is in TOF, monitors, detectors of
+interest and region of direct beam are extracted by running :ref:`algm-GroupDetectors` with
+``ProcessingInstructions`` as input, :ref:`algm-GroupDetectors` with ``RegionOfDirectBeam`` as input,
+and :ref:`algm-CropWorkspace` with ``I0MonitorIndex`` as input respectively, and each of
+the resulting workspaces is converted to wavelength (note that :literal:`AlignBins` is set
+to :literal:`True` in all the three cases). Note that the normalization by a direct beam
+is optional, and only happens if ``RegionOfDirectBeam`` is provided. In the same way,
+monitor normalization is also optional, and only takes place if ``I0MonitorIndex``,
+``MonitorBackgroundWavelengthMin`` and ``MonitorBackgroundWavelengthMax`` are all
+specified. Detectors can be normalized by integrated monitors by setting
+:literal:`NormalizeByIntegratedMonitors` to true, in which case
+:literal:`MonitorIntegrationWavelengthMin` and :literal:`MonitorIntegrationWavelengthMax` are
+used as the integration range. If monitors are not integrated, detectors are rebinned to
+monitors using :ref:`algm-RebinToWorkspace` so that the normalization by monitors can take place.
+Finally, the resulting workspace is cropped in wavelength according to :literal:`WavelengthMin`
+and :literal:`WavelengthMax`, which are both mandatory properties. A summary of the steps
+is shown in the workflow diagram below. For the sake of clarity, all possible steps are illustrated, even if some of them are optional.
 
 .. diagram:: ReflectometryReductionOne_ConvertToWavelength-v2_wkflw.dot
 

--- a/docs/source/algorithms/ReflectometryReductionOneAuto-v2.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneAuto-v2.rst
@@ -148,12 +148,12 @@ Output:
 
 .. testoutput:: ExReflRedOneAutoSimple
 
-    0.56682
-    0.59735
-    0.57476
-    0.54633
-    0.50034
-    0.26112
+    0.00324
+    0.00331
+    3.19458
+    1.00769
+    0.50160
+    0.26028
 
 **Example - Basic reduction with a transmission run**
 
@@ -174,12 +174,12 @@ Output:
 
 .. testoutput:: ExReflRedOneAutoTrans
 
-    0.36906
-    0.36906
-    1.05389
-    1.02234
-    1.30087
-    1.32781
+    0.00230
+    0.00230
+    1.17014
+    0.89341
+    1.45989
+    1.41389
 
 **Example - Reduction overriding some default values**
 
@@ -199,12 +199,12 @@ Output:
 
 .. testoutput:: ExReflRedOneAutoOverload
 
-    0.50401
-    0.52599
-    0.51160
-    0.48843
-    0.51819
-    0.52754
+    0.00322
+    0.00329
+    0.64231
+    0.41456
+    0.51028
+    0.52242
 
 .. categories::
 

--- a/docs/source/diagrams/CreateTransmissionWorkspace_ConvertToWavelength-v2_wkflw.dot
+++ b/docs/source/diagrams/CreateTransmissionWorkspace_ConvertToWavelength-v2_wkflw.dot
@@ -7,7 +7,7 @@ $global_style
 subgraph params {
  $param_style
   inputWS             [label="TransmissionRun"]
-  procCommands        [label="ProcessingCommands"]
+  procCommands        [label="ProcessingInstructions"]
   wavMin              [label="WavelengthMin", group=gwav]
   wavMax              [label="WavelengthMax", group=gwav]
   monitorIndex        [label="I0MonitorIndex"]
@@ -23,8 +23,9 @@ subgraph decisions {
 
 subgraph algorithms {
  $algorithm_style
-  convertWav    [label="ConvertUnits\n(AlignBins = True)", group=g1]
-  groupDet      [label="GroupDetectors"]
+  convertDet    [label="ConvertUnits\n(AlignBins = True)", group=g1]
+  convertMon    [label="ConvertUnits\n(AlignBins = True)", group=g11]
+  groupDet      [label="GroupDetectors", group=g1]
   cropMonWS     [label="CropWorkspace", group=g11]
   calcFlatBg    [label="CalculateFlatBackground", group=g11]
   intMon        [label="Integration", group=g11]
@@ -38,25 +39,26 @@ subgraph processes {
 
 subgraph values {
  $value_style
-  valWav        [label="I(&lambda;)", group=g1]
   valWavOut     [label="I(&lambda;)", group=g1]
 }
 
-inputWS             -> convertWav
-convertWav          -> valWav
-valWav              -> groupDet       [label="Detectors"]
-procCommands        -> groupDet
+inputWS             -> groupDet			[label="Detectors"]
+procCommands		-> groupDet
 
-valWav              -> cropMonWS      [label="Monitors"]
-monitorIndex        -> cropMonWS
-cropMonWS           -> calcFlatBg
+inputWS				-> cropMonWS		[label="Montitors"]
+monitorIndex		-> cropMonWS
+
+groupDet			-> convertDet
+cropMonWS			-> convertMon
+
+convertMon          -> calcFlatBg
 monBackWavMin       -> calcFlatBg
 monBackWavMax       -> calcFlatBg
 calcFlatBg          -> intMon
 monIntWavMin        -> intMon
 monIntWavMax        -> intMon
 
-groupDet            -> divideDetMon
+convertDet          -> divideDetMon
 intMon              -> divideDetMon
 wavMin              -> cropWav
 divideDetMon        -> cropWav
@@ -71,4 +73,5 @@ monBackWavMax -> monIntWavMax [style=invis]
 {rank=same; monIntWavMin; monIntWavMax}
 {rank=same; monBackWavMin; monBackWavMax}
 {rank=same; groupDet; cropMonWS}
+{rank=same; convertDet; convertMon}
 }

--- a/docs/source/diagrams/ReflectometryReductionOne_ConvertToWavelength-v2_wkflw.dot
+++ b/docs/source/diagrams/ReflectometryReductionOne_ConvertToWavelength-v2_wkflw.dot
@@ -1,4 +1,5 @@
 digraph ReflectometryReductionOne {
+splines=line
 label = "\n"
 rankdir = TB;
  $global_style
@@ -7,7 +8,7 @@ subgraph params {
  $param_style
   inputWS             [label="InputWorkspace"]
   outputWS            [label="OutputWorkspaceWavelength"]
-  procCommands        [label="ProcessingCommands"]
+  procCommands        [label="ProcessingInstructions"]
   wavMin              [label="WavelengthMin", group=gwav]
   wavMax              [label="WavelengthMax", group=gwav]
   monitorIndex        [label="I0MonitorIndex"]
@@ -24,7 +25,9 @@ subgraph decisions {
 
 subgraph algorithms {
  $algorithm_style
-  convertWav    [label="ConvertUnits\n(AlignBins = True)"]
+  convertDet    [label="ConvertUnits\n(AlignBins = True)"]
+  convertDB     [label="ConvertUnits\n(AlignBins = True)"]
+  convertMon    [label="ConvertUnits\n(AlignBins = True)", group=g11]
   groupDet      [label="GroupDetectors"]
   cropMonWS     [label="CropWorkspace", group=g11]
   calcFlatBg    [label="CalculateFlatBackground", group=g11]
@@ -41,22 +44,25 @@ subgraph processes {
 
 subgraph values {
  $value_style
-  valWav        [label="I(&lambda;)"]
 }
 
-inputWS             -> convertWav
-convertWav          -> valWav
-valWav              -> groupDet       [label="Detectors"]
-procCommands        -> groupDet
+inputWS				-> groupDet			[label="Detectors"]
+inputWS				-> groupDetRDB		[label="Direct Beam"]
+inputWS				-> cropMonWS		[label="Monitors"]
 
-valWav              -> groupDetRDB    [label="Direct Beam"]
-regionOfDirectBeam  -> groupDetRDB
-groupDetRDB         -> divideDetRDB
-groupDet            -> divideDetRDB
+procCommands		-> groupDet
+groupDet			-> convertDet
 
-valWav              -> cropMonWS      [label="Monitors"]
-monitorIndex        -> cropMonWS
-cropMonWS           -> calcFlatBg
+regionOfDirectBeam	-> groupDetRDB
+groupDetRDB			-> convertDB
+
+monitorIndex		-> cropMonWS
+cropMonWS			-> convertMon
+
+convertDet			-> divideDetRDB
+convertDB			-> divideDetRDB
+
+convertMon          -> calcFlatBg
 monBackWavMin       -> calcFlatBg
 monBackWavMax       -> calcFlatBg
 calcFlatBg          -> intMon
@@ -70,6 +76,8 @@ divideDetMon        -> cropWav
 wavMax              -> cropWav
 cropWav             -> outputWS
 
+{rank=same; groupDet; groupDetRDB; cropMonWS}
+{rank=same; convertDet; convertDB; convertMon}
 {rank=same; monIntWavMin; monIntWavMax}
 {rank=same; divideDetRDB; intMon}
 {rank=same; monBackWavMin; monBackWavMax}


### PR DESCRIPTION
In `ReflectometryReductionOne` and `CreateTransmissionWorkspace` (both new version and old version), the first `ConvertUnits` is run with `AlignBins=True`. Scientists have realized this is a problem as the first monitor is distorting the data. The alternative approach is:

- Extract monitors of interest, given by `I0MonitorIndex`, from the input workspace, and convert to wavelength
- Extract the detectors of interest, given by `ProcessingInstructions`, from the input workspace and convert to wavelength (`AlignBins` can be now set to `True`).
- Divide detectors by monitors, rebinning detectors to monitors if necessary, i.e., if monitors have not been integrated.

**To test:**

<!-- Instructions for testing. -->

Agreed with scientists that the above is the correct workflow. Check that code follows the description above. Check changes to documentation and workflow diagrams.

Fixes #18610.

Release notes:  I'll update release notes in https://github.com/mantidproject/mantid/issues/18580


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
