### PR TITLE
Add '-python3' to the install prefix in mantidinstaller

### DIFF
--- a/Testing/SystemTests/scripts/mantidinstaller.py
+++ b/Testing/SystemTests/scripts/mantidinstaller.py
@@ -188,6 +188,9 @@ class LinuxInstaller(MantidInstaller):
         else:
             install_prefix += '/Mantid'
 
+        if 'python3' in package:
+            install_prefix += '-python3'
+
         self.mantidPlotPath = install_prefix + '/bin/MantidPlot'
         self.python_cmd = install_prefix + '/bin/mantidpython'
 


### PR DESCRIPTION
We have changed the directory into which the python 3 version of Mantid is installed and the systemtests no longer set the correct path. See #18582

The `master_systemtests-ubuntu-16.04-python3` failed because it now has the wrong path, see [here](http://builds.mantidproject.org/job/master_systemtests-ubuntu-16.04-python3/2/console).

**To test:**
Code review and make sure the RHEL7 systemtests still run and pass on this pull request.



*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
