### PR TITLE
Add configuration dependent instrument path

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -297,6 +297,8 @@ private:
   /// Empty the list of facilities, deleting the FacilityInfo objects in the
   /// process
   void clearFacilities();
+  /// Determine the name of the facilities file to use
+  std::string getFacilityFilename(const std::string &fName);
   /// Verifies the directory exists and add it to the back of the directory list
   /// if valid
   bool addDirectoryifExists(const std::string &directoryName,

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1627,7 +1627,8 @@ const std::string ConfigServiceImpl::getVTPFileDirectory() {
   return directoryName;
 }
 /**
- * Fills the internal cache of instrument definition directories
+ * Fills the internal cache of instrument definition directories and creates
+ * The %appdata%/mantidproject/mantid or $home/.mantid directory.
  *
  * This will normally contain from Index 0
  * - The download directory (win %appdata%/mantidproject/mantid/instrument)
@@ -1638,21 +1639,21 @@ const std::string ConfigServiceImpl::getVTPFileDirectory() {
 void ConfigServiceImpl::cacheInstrumentPaths() {
   m_InstrumentDirs.clear();
 
+  Poco::Path path(getAppDataDir());
+  path.makeDirectory(); // making this directory is a necessary side effect
+  path.pushDirectory("instrument");
+
   // only use downloaded instruments if configured to download
   const std::string updateInstrStr =
       this->getString("UpdateInstrumentDefinitions.OnStartup");
   if (updateInstrStr.compare("1") == 0 || updateInstrStr.compare("on") == 0 ||
       updateInstrStr.compare("On") == 0) {
-    Poco::Path path(getAppDataDir());
-    path.makeDirectory();
-    path.pushDirectory("instrument");
-    std::string appdatadir = path.toString();
+    const std::string appdatadir = path.toString();
     addDirectoryifExists(appdatadir, m_InstrumentDirs);
   }
 
 #ifndef _WIN32
-  std::string etcdatadir = "/etc/mantid/instrument";
-  addDirectoryifExists(etcdatadir, m_InstrumentDirs);
+  addDirectoryifExists("/etc/mantid/instrument", m_InstrumentDirs);
 #endif
 
   // Determine the search directory for XML instrument definition files (IDFs)

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1637,11 +1637,18 @@ const std::string ConfigServiceImpl::getVTPFileDirectory() {
  */
 void ConfigServiceImpl::cacheInstrumentPaths() {
   m_InstrumentDirs.clear();
-  Poco::Path path(getAppDataDir());
-  path.makeDirectory();
-  path.pushDirectory("instrument");
-  std::string appdatadir = path.toString();
-  addDirectoryifExists(appdatadir, m_InstrumentDirs);
+
+  // only use downloaded instruments if configured to download
+  const std::string updateInstrStr =
+      this->getString("UpdateInstrumentDefinitions.OnStartup");
+  if (updateInstrStr.compare("1") == 0 || updateInstrStr.compare("on") == 0 ||
+      updateInstrStr.compare("On") == 0) {
+    Poco::Path path(getAppDataDir());
+    path.makeDirectory();
+    path.pushDirectory("instrument");
+    std::string appdatadir = path.toString();
+    addDirectoryifExists(appdatadir, m_InstrumentDirs);
+  }
 
 #ifndef _WIN32
   std::string etcdatadir = "/etc/mantid/instrument";


### PR DESCRIPTION
There was a bug in mantid related to loading `Facilities.xml` from the instrument download directory when instrument download was turned off. 

To reproduce (these are linux instructions):

1. Copy the [`Facilities.xml` from v3.8.0](https://github.com/mantidproject/mantid/blob/v3.8.0/instrument/Facilities.xml) into you instrument download directory `$HOME/.mantid/instrument/Facilities.xml`
2. Start `mantidpython`, `import mantid` then `print config.getInstrument('NOMAD').liveListener()` which will (incorrectly) be an empty string
3. Merge this branch
4. Do step 2 again, but see that the correct value of `SNSLiveEventDataListener` comes through

*There is no associated issue*

*Does not need to be in the release notes* because it is a bugfix to something that got in towards the end of the release cycle that wasn't seen by users.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
