### PR TITLE
slice viewer thickness

### DIFF
--- a/MantidPlot/pymantidplot/proxies.py
+++ b/MantidPlot/pymantidplot/proxies.py
@@ -734,11 +734,12 @@ class SliceViewerWindowProxy(QtProxyObject):
         # Set the width.
         if not width is None:
             liner.setThickness(width)
+            liner.setPlanarWidth(width*0.5)
         else:
-            liner.setPlanarWidth(planar_width)
+            liner.setPlanarWidth(planar_width*0.5)
             if not thicknesses is None:
                 for d in xrange(len(thicknesses)):
-                    liner.setThickness(d, thicknesses[i])
+                    liner.setThickness(d, thicknesses[d])
         # Bins
         liner.setNumBins(num_bins)
         liner.apply()

--- a/MantidPlot/test/MantidPlotSliceViewerTest.py
+++ b/MantidPlot/test/MantidPlotSliceViewerTest.py
@@ -136,7 +136,10 @@ class MantidPlotSliceViewerTest(unittest.TestCase):
         # Length of 10 with 200 bins = 0.05 width
         self.assertAlmostEqual(liner.getBinWidth(), 0.05, 3)
         # Width was set
-        self.assertAlmostEqual(liner.getPlanarWidth(), 0.88, 3)
+        # TODO: The new behavior for constructor is center+/-(width/2)
+        # but setPlanarWidth and getPlanarWidth still have old behavior.
+        # This will be fixed in a later mantid release.
+        self.assertAlmostEqual(liner.getPlanarWidth(), 0.44, 3)
         # Now turn it off
         svw.toggleLineMode(False)
         self.assertFalse( liner.isVisible(), "LineViewer was hidden")

--- a/MantidQt/Python/mantidqt.sip
+++ b/MantidQt/Python/mantidqt.sip
@@ -395,7 +395,7 @@ void LineViewer::setThickness(int dim, double width)
     Set the thickness to integrate in a particular dimension.
 
     Integration is performed perpendicular to the XY plane,
-    from -thickness below to +thickness above the center.
+    from -0.5 * thickness below to +0.5 * thickness above the center.
 
     Use setPlanarWidth() to set the width along the XY plane.
 
@@ -415,7 +415,7 @@ void LineViewer::setThickness(const QString & dim, double width)
     Set the thickness to integrate in a particular dimension.
 
     Integration is performed perpendicular to the XY plane,
-    from -thickness below to +thickness above the center.
+    from -0.5 * thickness below to +0.5 * thickness above the center.
 
     Use setPlanarWidth() to set the width along the XY plane.
 

--- a/MantidQt/SliceViewer/src/LineViewer.cpp
+++ b/MantidQt/SliceViewer/src/LineViewer.cpp
@@ -245,7 +245,7 @@ void LineViewer::updateStartEnd() {
     m_endText[d]->setText(QString::number(m_end[d]));
     m_thicknessText[d]->setText(QString::number(m_thickness[d]));
   }
-  ui.textPlaneWidth->setText(QString::number(m_planeWidth));
+  ui.textPlaneWidth->setText(QString::number(m_planeWidth * 2.));
 
   // Now show the width
   this->updateBinWidth();
@@ -299,7 +299,7 @@ void LineViewer::readTextboxes() {
     allOk = allOk && ok;
   }
   // Now the planar width
-  double tempPlaneWidth = ui.textPlaneWidth->text().toDouble(&ok);
+  double tempPlaneWidth = ui.textPlaneWidth->text().toDouble(&ok) * 0.5;
   allOk = allOk && ok;
 
   // Only continue if all values typed were valid numbers.
@@ -513,8 +513,8 @@ LineViewer::applyMDWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
       // Set the basis vector with the width *2 and 1 bin
       alg->setPropertyValue("BasisVector" + dim,
                             dim + ",units," + basis.toString(","));
-      OutputExtents.push_back(-m_thickness[d]);
-      OutputExtents.push_back(+m_thickness[d]);
+      OutputExtents.push_back(-0.5 * m_thickness[d]);
+      OutputExtents.push_back(+0.5 * m_thickness[d]);
       OutputBins.push_back(1);
 
       propNum++;
@@ -950,7 +950,7 @@ void LineViewer::setThickness(double width) {
 /** Set the thickness to integrate in a particular dimension.
  *
  * Integration is performed perpendicular to the XY plane,
- * from -thickness below to +thickness above the center.
+ * from -0.5 * thickness below to +0.5 * thickness above the center.
  *
  * Use setPlanarWidth() to set the width along the XY plane.
  *
@@ -971,7 +971,7 @@ void LineViewer::setThickness(int dim, double width) {
 /** Set the thickness to integrate in a particular dimension.
  *
  * Integration is performed perpendicular to the XY plane,
- * from -thickness below to +thickness above the center.
+ * from -0.5 * thickness below to +0.5 * thickness above the center.
  *
  * Use setPlanarWidth() to set the width along the XY plane.
  *

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -2257,8 +2257,8 @@ void SliceViewer::rebinParamsChanged() {
     int numBins = 1;
     if (widget->getShownDim() < 0) {
       // Slice point. So integrate with a thickness
-      min = widget->getSlicePoint() - widget->getThickness();
-      max = widget->getSlicePoint() + widget->getThickness();
+      min = widget->getSlicePoint() - 0.5 * widget->getThickness();
+      max = widget->getSlicePoint() + 0.5 * widget->getThickness();
       // From min to max, with only 1 bin
     } else {
       // Shown dimension. Use the currently visible range.

--- a/docs/source/release/v3.9.0/ui.rst
+++ b/docs/source/release/v3.9.0/ui.rst
@@ -63,7 +63,7 @@ SliceViewer Improvements
 ------------------------
 
 - Added the ability to view data using non orthogonal axes. View can be toggled on or off. When non orthogonal view is toggled the peak viewer and line viewer tools are disabled.
-- Setting the thickess now means that the slicing happens between `-0.5*thicness+center` and `+0.5*thicness+center`, instead of `-thicness+center` and `+thicness+center`.
+- Setting the thickess now means that the slicing happens between `-0.5*thicness+center` and `+0.5*thicness+center`, instead of `-thicness+center` and `+thicness+center`. For the LineViewer, the python `setPlanarWidth` and `getPlanarWidth` are still having the old behavior, but the constructoir is fixed.
 
 .. figure:: ../../images/SliceViewerNonOrthogonal.png
    :class: screenshot

--- a/docs/source/release/v3.9.0/ui.rst
+++ b/docs/source/release/v3.9.0/ui.rst
@@ -63,6 +63,7 @@ SliceViewer Improvements
 ------------------------
 
 - Added the ability to view data using non orthogonal axes. View can be toggled on or off. When non orthogonal view is toggled the peak viewer and line viewer tools are disabled.
+- Setting the thickess now means that the slicing happens between `-0.5*thicness+center` and `+0.5*thicness+center`, instead of `-thicness+center` and `+thicness+center`.
 
 .. figure:: ../../images/SliceViewerNonOrthogonal.png
    :class: screenshot


### PR DESCRIPTION
The meaning of SliceViewer thickness is now `center+-(thickness/2)` instead of `center+-thickness`

**To test:**
Load an MDE file, show it in slice viewer. Rebin it using the GUI, and check if the thickness of the MDHisto is what you expect. Do the similar for the lineViewer

Fixes #17956 .

**Note:** I will open a new ticket to fix all python problems. The constructor works as expected, but setting  and getting the thickness in plane is still the old behaviour. Wiki pages on sliceviewer will need to be changed

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
