### PR TITLE
Fix AbinsLoadCRYSTALTest for python 3 and numpy <=1.9

### DIFF
--- a/scripts/test/AbinsLoadCRYSTALTest.py
+++ b/scripts/test/AbinsLoadCRYSTALTest.py
@@ -93,7 +93,7 @@ class AbinsLoadCRYSTALTest(unittest.TestCase):
         with open(AbinsTestHelpers.find_file(filename + "_data.txt")) as data_file:
             correct_data = json.loads(data_file.read().replace("\n", " "))
 
-        array = np.loadtxt(AbinsTestHelpers.find_file(filename + "_atomic_displacements_data.txt"), dtype=complex)
+        array = np.genfromtxt(AbinsTestHelpers.find_file(filename + "_atomic_displacements_data.txt"), dtype=complex)
         array.reshape(shape)
         k = len(correct_data["datasets"]["k_points_data"]["weights"])
         atoms = len(correct_data["datasets"]["atoms_data"])


### PR DESCRIPTION
numpy.loadtxt (`<=1.9`) fails to load complex values so use numpy.genfromtxt as alternative

This fixes the [failing AbinsLoadCRYSTALTest](http://builds.mantidproject.org/job/master_clean-ubuntu-python3/256/consoleFull) when using python 3 on Ubuntu 14.04, which uses numpy `1.8.2`

See the numpy issue at numpy/numpy#5655

**To test:**
 * Trust me I tested this on Ubuntu 14.04 with python 3, as long as it doesn't break anything it should be good.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
