### PR TITLE
Fix finding Mantid .properties file on OSX

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -121,6 +121,8 @@ public:
     std::string m_prev;  ///< The previous value for the property
   };
 
+  /// Setup the base directory
+  void setBaseDirectory();
   /// Reset to "factory" settings. Removes current user properties
   void reset();
   /// Wipe out the current configuration and load a new one


### PR DESCRIPTION
This adds another path to check on OSX for the .properties file.

**To test:**

 - Code review.
 - Check OSX builds pass.
 - Run the following commands and check it runs successfully with these changes:

```
cd build/docs
../bin/MantidPlot.app/Contents/MacOS/MantidPlot -xq runsphinx_qthelp.py
```

Fixes #18676 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
