### PR TITLE
SCDCalibrate l1 bug

### DIFF
--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -139,17 +139,17 @@ bool SCDCalibratePanels::edgePixel(const PeaksWorkspace &ws,
 void SCDCalibratePanels::exec() {
   PeaksWorkspace_sptr peaksWs = getProperty("PeakWorkspace");
   // We must sort the peaks
-  std::vector<std::pair<std::string, bool> > criteria{ { "BankName", true } };
+  std::vector<std::pair<std::string, bool>> criteria{{"BankName", true}};
   peaksWs->sort(criteria);
   // Remove peaks on edge
   int edge = this->getProperty("EdgePixels");
   if (edge > 0) {
     std::vector<Peak> &peaks = peaksWs->getPeaks();
-    auto it = std::remove_if(peaks.begin(), peaks.end(),
-                             [&peaksWs, edge, this](const Peak &pk) {
-      return this->edgePixel(*peaksWs, pk.getBankName(), pk.getCol(),
-                             pk.getRow(), edge);
-    });
+    auto it = std::remove_if(
+        peaks.begin(), peaks.end(), [&peaksWs, edge, this](const Peak &pk) {
+          return this->edgePixel(*peaksWs, pk.getBankName(), pk.getCol(),
+                                 pk.getRow(), edge);
+        });
     peaks.erase(it, peaks.end());
   }
   findU(peaksWs);
@@ -223,8 +223,7 @@ void SCDCalibratePanels::exec() {
     IAlgorithm_sptr fit_alg;
     try {
       fit_alg = createChildAlgorithm("Fit", -1, -1, false);
-    }
-    catch (Exception::NotFoundError &) {
+    } catch (Exception::NotFoundError &) {
       g_log.error("Can't locate Fit algorithm");
       throw;
     }
@@ -263,8 +262,7 @@ void SCDCalibratePanels::exec() {
       IAlgorithm_sptr fit2_alg;
       try {
         fit2_alg = createChildAlgorithm("Fit", -1, -1, false);
-      }
-      catch (Exception::NotFoundError &) {
+      } catch (Exception::NotFoundError &) {
         g_log.error("Can't locate Fit algorithm");
         throw;
       }
@@ -406,8 +404,7 @@ void SCDCalibratePanels::exec() {
           RowY[icount] = theoretical.getRow();
           TofX[icount] = peak.getTOF();
           TofY[icount] = theoretical.getTOF();
-        }
-        catch (...) {
+        } catch (...) {
           // g_log.debug() << "Problem only in printing peaks\n";
         }
         icount++;
@@ -465,8 +462,7 @@ void SCDCalibratePanels::findL1(int nPeaks,
   IAlgorithm_sptr fitL1_alg;
   try {
     fitL1_alg = createChildAlgorithm("Fit", -1, -1, false);
-  }
-  catch (Exception::NotFoundError &) {
+  } catch (Exception::NotFoundError &) {
     g_log.error("Can't locate Fit algorithm");
     throw;
   }
@@ -501,8 +497,7 @@ void SCDCalibratePanels::findU(DataObjects::PeaksWorkspace_sptr peaksWs) {
   IAlgorithm_sptr ub_alg;
   try {
     ub_alg = createChildAlgorithm("CalculateUMatrix", -1, -1, false);
-  }
-  catch (Exception::NotFoundError &) {
+  } catch (Exception::NotFoundError &) {
     g_log.error("Can't locate CalculateUMatrix algorithm");
     throw;
   }
@@ -796,11 +791,11 @@ void SCDCalibratePanels::saveIsawDetCal(
 }
 
 void SCDCalibratePanels::init() {
-  declareProperty(Kernel::make_unique<WorkspaceProperty<PeaksWorkspace> >(
+  declareProperty(Kernel::make_unique<WorkspaceProperty<PeaksWorkspace>>(
                       "PeakWorkspace", "", Kernel::Direction::InOut),
                   "Workspace of Indexed Peaks");
 
-  auto mustBePositive = boost::make_shared<BoundedValidator<double> >();
+  auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
   mustBePositive->setLower(0.0);
 
   declareProperty("a", EMPTY_DBL(), mustBePositive,
@@ -830,7 +825,7 @@ void SCDCalibratePanels::init() {
                   "Remove peaks that are at pixels this close to edge. ");
 
   // ---------- outputs
-  const std::vector<std::string> detcalExts{ ".DetCal", ".Det_Cal" };
+  const std::vector<std::string> detcalExts{".DetCal", ".Det_Cal"};
   declareProperty(
       Kernel::make_unique<FileProperty>("DetCalFilename", "SCDCalibrate.DetCal",
                                         FileProperty::Save, detcalExts),

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -139,17 +139,17 @@ bool SCDCalibratePanels::edgePixel(const PeaksWorkspace &ws,
 void SCDCalibratePanels::exec() {
   PeaksWorkspace_sptr peaksWs = getProperty("PeakWorkspace");
   // We must sort the peaks
-  std::vector<std::pair<std::string, bool>> criteria{{"BankName", true}};
+  std::vector<std::pair<std::string, bool> > criteria{ { "BankName", true } };
   peaksWs->sort(criteria);
   // Remove peaks on edge
   int edge = this->getProperty("EdgePixels");
   if (edge > 0) {
     std::vector<Peak> &peaks = peaksWs->getPeaks();
-    auto it = std::remove_if(
-        peaks.begin(), peaks.end(), [&peaksWs, edge, this](const Peak &pk) {
-          return this->edgePixel(*peaksWs, pk.getBankName(), pk.getCol(),
-                                 pk.getRow(), edge);
-        });
+    auto it = std::remove_if(peaks.begin(), peaks.end(),
+                             [&peaksWs, edge, this](const Peak &pk) {
+      return this->edgePixel(*peaksWs, pk.getBankName(), pk.getCol(),
+                             pk.getRow(), edge);
+    });
     peaks.erase(it, peaks.end());
   }
   findU(peaksWs);
@@ -223,7 +223,8 @@ void SCDCalibratePanels::exec() {
     IAlgorithm_sptr fit_alg;
     try {
       fit_alg = createChildAlgorithm("Fit", -1, -1, false);
-    } catch (Exception::NotFoundError &) {
+    }
+    catch (Exception::NotFoundError &) {
       g_log.error("Can't locate Fit algorithm");
       throw;
     }
@@ -262,7 +263,8 @@ void SCDCalibratePanels::exec() {
       IAlgorithm_sptr fit2_alg;
       try {
         fit2_alg = createChildAlgorithm("Fit", -1, -1, false);
-      } catch (Exception::NotFoundError &) {
+      }
+      catch (Exception::NotFoundError &) {
         g_log.error("Can't locate Fit algorithm");
         throw;
       }
@@ -306,10 +308,11 @@ void SCDCalibratePanels::exec() {
                              parameter_workspaces.end());
 
   // Try again to optimize L1
-  if (changeL1)
+  if (changeL1) {
     findL1(nPeaks, peaksWs);
-  parameter_workspaces.push_back("params_L1");
-  fit_workspaces.push_back("fit_L1");
+    parameter_workspaces.push_back("params_L1");
+    fit_workspaces.push_back("fit_L1");
+  }
   std::sort(parameter_workspaces.begin(), parameter_workspaces.end());
   std::sort(fit_workspaces.begin(), fit_workspaces.end());
 
@@ -403,7 +406,8 @@ void SCDCalibratePanels::exec() {
           RowY[icount] = theoretical.getRow();
           TofX[icount] = peak.getTOF();
           TofY[icount] = theoretical.getTOF();
-        } catch (...) {
+        }
+        catch (...) {
           // g_log.debug() << "Problem only in printing peaks\n";
         }
         icount++;
@@ -461,7 +465,8 @@ void SCDCalibratePanels::findL1(int nPeaks,
   IAlgorithm_sptr fitL1_alg;
   try {
     fitL1_alg = createChildAlgorithm("Fit", -1, -1, false);
-  } catch (Exception::NotFoundError &) {
+  }
+  catch (Exception::NotFoundError &) {
     g_log.error("Can't locate Fit algorithm");
     throw;
   }
@@ -496,7 +501,8 @@ void SCDCalibratePanels::findU(DataObjects::PeaksWorkspace_sptr peaksWs) {
   IAlgorithm_sptr ub_alg;
   try {
     ub_alg = createChildAlgorithm("CalculateUMatrix", -1, -1, false);
-  } catch (Exception::NotFoundError &) {
+  }
+  catch (Exception::NotFoundError &) {
     g_log.error("Can't locate CalculateUMatrix algorithm");
     throw;
   }
@@ -790,11 +796,11 @@ void SCDCalibratePanels::saveIsawDetCal(
 }
 
 void SCDCalibratePanels::init() {
-  declareProperty(Kernel::make_unique<WorkspaceProperty<PeaksWorkspace>>(
+  declareProperty(Kernel::make_unique<WorkspaceProperty<PeaksWorkspace> >(
                       "PeakWorkspace", "", Kernel::Direction::InOut),
                   "Workspace of Indexed Peaks");
 
-  auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
+  auto mustBePositive = boost::make_shared<BoundedValidator<double> >();
   mustBePositive->setLower(0.0);
 
   declareProperty("a", EMPTY_DBL(), mustBePositive,
@@ -824,7 +830,7 @@ void SCDCalibratePanels::init() {
                   "Remove peaks that are at pixels this close to edge. ");
 
   // ---------- outputs
-  const std::vector<std::string> detcalExts{".DetCal", ".Det_Cal"};
+  const std::vector<std::string> detcalExts{ ".DetCal", ".Det_Cal" };
   declareProperty(
       Kernel::make_unique<FileProperty>("DetCalFilename", "SCDCalibrate.DetCal",
                                         FileProperty::Save, detcalExts),


### PR DESCRIPTION
Description of work.
SCDCalibratePanels now works with ChangeL1=False when workspaces are grouped at end.  Found this error when working with instrument scientist testing mantidplotnightly.

**To test:**
```python
LoadIsawPeaks(Filename='Si2mm_Cubic_F.integrate', OutputWorkspace='peaks_ws')
SCDCalibratePanels(PeakWorkspace='peaks_ws', a=5.431, b=5.431, c=5.431, alpha=90, beta=90, gamma=90, DetCalFilename='SCDCalibrate.DetCal',ChangeL1=False)
```
https://www.dropbox.com/s/5eidrhs9ehnfkge/Si2mm_Cubic_F.integrate?dl=0

Fixes #18683


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
