### PR TITLE
Load nxspe old files

### DIFF
--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -317,7 +317,7 @@ void LoadNXSPE::exec() {
 
   // If an instrument name is defined, load instrument parameter file for Emode
   // NB. LoadParameterFile must be used on a workspace with an instrument
-  if (!instrument_name.empty()) {
+  if (!instrument_name.empty() && instrument_name != "NXSPE") {
     std::string IDF_filename =
         ExperimentInfo::getInstrumentFilename(instrument_name);
     std::string instrument_parfile =


### PR DESCRIPTION
Description of work.

**To test:**
With an old version of Mantid, `LoadNXSPE` will have the instrument name NXSPE. Load any NXSPE file, then save it with `SaveNXSPE` 
Then in the new version of mantid run
```
w=Load(filename)
print w.getInstrument().getName()
```
For SNS tester, you can find the already processed NXSPE file at /SNS/users/3y9/test.xnspe


Fixes #18689 .


*Does not need to be in the release notes.* Bug was introduced in this release


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
