### PR TITLE
Indirect Diffraction Vanadium Run

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -1,4 +1,4 @@
-#pylint: disable=no-init,too-many-instance-attributes
+# pylint: disable=no-init,too-many-instance-attributes
 from __future__ import (absolute_import, division, print_function)
 
 import os
@@ -12,7 +12,6 @@ from mantid import config
 
 
 class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
-
     _workspace_names = None
     _cal_file = None
     _chopped_data = None
@@ -29,8 +28,9 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
     _rebin_string = None
     _ipf_filename = None
     _sum_files = None
+    _vanadium_ws = None
 
-#------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     def category(self):
         return 'Diffraction\\Reduction'
@@ -38,21 +38,24 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
     def summary(self):
         return 'Performs a diffraction reduction for a set of raw run files for an ISIS indirect spectrometer'
 
-#------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     def PyInit(self):
         self.declareProperty(StringArrayProperty(name='InputFiles'),
                              doc='Comma separated list of input files.')
 
         self.declareProperty(StringArrayProperty(name='ContainerFiles'),
-                             doc='Comma separated list of input files for the empty contianer runs.')
+                             doc='Comma separated list of input files for the empty container runs.')
 
         self.declareProperty('ContainerScaleFactor', 1.0,
                              doc='Factor by which to scale the container runs.')
 
         self.declareProperty(FileProperty('CalFile', '', action=FileAction.OptionalLoad),
-                             doc='Filename of the .cal file to use in the [[AlignDetectors]] and '+
-                             '[[DiffractionFocussing]] child algorithms.')
+                             doc='Filename of the .cal file to use in the [[AlignDetectors]] and ' +
+                                 '[[DiffractionFocussing]] child algorithms.')
+
+        self.declareProperty(StringArrayProperty(name='VanadiumFiles'),
+                             doc='Comma separated array of vanadium runs')
 
         self.declareProperty(name='SumFiles', defaultValue=False,
                              doc='Enabled to sum spectra from each input file.')
@@ -82,7 +85,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
                                                     direction=Direction.Output),
                              doc='Group name for the result workspaces.')
 
-#------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     def validateInputs(self):
         """
@@ -116,9 +119,16 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
                 logger.warning('type = ' + str(type(mode)))
                 issues['CalFile'] = 'Cal Files are currently only available for use in OSIRIS diffspec mode'
 
+        num_samples = len(input_files)
+        num_vanadium = len(self.getProperty('VanadiumFiles').value)
+        if num_samples != num_vanadium and num_vanadium != 0:
+            run_num_mismatch = 'You must input the same number of sample and vanadium runs'
+            issues['InputFiles'] = run_num_mismatch
+            issues['VanadiumFiles'] = run_num_mismatch
+
         return issues
 
-#------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     def PyExec(self):
         from IndirectReductionCommon import (get_multi_frame_rebin,
@@ -151,7 +161,17 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
         # Load container if run is given
         self._load_and_scale_container(self._container_scale_factor, load_opts)
 
-        for c_ws_name in self._workspace_names:
+        # Load vanadium runs if given
+        if self._vanadium_runs:
+            self._vanadium_ws, _ = load_files(self._vanadium_runs,
+                                              self._ipf_filename,
+                                              self._spectra_range[0],
+                                              self._spectra_range[1],
+                                              sum_files=self._sum_files,
+                                              load_logs=self._load_logs,
+                                              load_opts=load_opts)
+
+        for index, c_ws_name in enumerate(self._workspace_names):
             is_multi_frame = isinstance(mtd[c_ws_name], WorkspaceGroup)
 
             # Get list of workspaces
@@ -173,6 +193,12 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
                     Minus(LHSWorkspace=ws_name,
                           RHSWorkspace=self._container_workspace,
                           OutputWorkspace=ws_name)
+
+                if self._vanadium_ws is not None:
+                    Divide(LHSWorkspace=ws_name,
+                           RHSWorkspace=self._vanadium_ws[index],
+                           OutputWorkspace=ws_name,
+                           AllowDifferentNumberSpectra=True)
 
                 monitor_ws_name = ws_name + '_mon'
 
@@ -226,7 +252,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
 
         self.setProperty('OutputWorkspace', self._output_ws)
 
-#------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------
 
     def _setup(self):
         """
@@ -237,6 +263,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
         self._data_files = self.getProperty('InputFiles').value
         self._container_data_files = self.getProperty('ContainerFiles').value
         self._cal_file = self.getProperty('CalFile').value
+        self._vanadium_runs = self.getProperty('VanadiumFiles').value
         self._container_scale_factor = self.getProperty('ContainerScaleFactor').value
         self._load_logs = self.getProperty('LoadLogFiles').value
         self._instrument_name = self.getPropertyValue('Instrument')
@@ -252,11 +279,15 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
         if len(self._container_data_files) == 0:
             self._container_data_files = None
 
+        self._vanadium_ws = None
+        if len(self._vanadium_runs) == 0:
+            self._vanadium_runs = None
+
         # Get the IPF filename
         self._ipf_filename = self._instrument_name + '_diffraction_' + self._mode + '_Parameters.xml'
         if not os.path.exists(self._ipf_filename):
             self._ipf_filename = os.path.join(config['instrumentDefinition.directory'], self._ipf_filename)
-        logger.information('IPF filename is: %s' % (self._ipf_filename))
+        logger.information('IPF filename is: %s' % self._ipf_filename)
 
         # Only enable sum files if we actually have more than one file
         sum_files = self.getProperty('SumFiles').value
@@ -307,6 +338,6 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
                       Operation='Multiply')
 
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 AlgorithmFactory.subscribe(ISISIndirectDiffractionReduction)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -194,7 +194,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
                           RHSWorkspace=self._container_workspace,
                           OutputWorkspace=ws_name)
 
-                if self._vanadium_ws is not None:
+                if self._vanadium_ws:
                     Divide(LHSWorkspace=ws_name,
                            RHSWorkspace=self._vanadium_ws[index],
                            OutputWorkspace=ws_name,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectDiffractionReductionTest.py
@@ -193,6 +193,8 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
         red_ws = wks[0]
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')
         self.assertEqual(red_ws.getNumberHistograms(), 1)
+        self.assertEquals(round(red_ws.readY(0)[1], 7), 0.0215684)
+        self.assertEquals(round(red_ws.readY(0)[-1], 7), 0.0022809)
 
     # ------------------------------------------Failure cases------------------------------------------
     def test_reduction_with_cal_file_osiris_diffonly_fails(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectDiffractionReductionTest.py
@@ -175,6 +175,25 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')
         self.assertEqual(red_ws.getNumberHistograms(), 1)
 
+
+    def test_reduction_with_vandium_iris(self):
+        """
+        Test to ensure that reduction with normalisation by vanadium works
+        """
+        wks = ISISIndirectDiffractionReduction(InputFiles=['IRS26176.RAW'],
+                                               VanadiumFiles=['IRS26173.RAW'],
+                                               Instrument='IRIS',
+                                               Mode='diffspec',
+                                               SpectraRange=[105, 112])
+
+        self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
+        self.assertEqual(len(wks), 1)
+        self.assertEqual(wks.getNames()[0], 'iris26176_diffspec_red')
+
+        red_ws = wks[0]
+        self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')
+        self.assertEqual(red_ws.getNumberHistograms(), 1)
+
     # ------------------------------------------Failure cases------------------------------------------
     def test_reduction_with_cal_file_osiris_diffonly_fails(self):
         """

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDiffractionReduction.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDiffractionReduction.ui
@@ -279,11 +279,46 @@
           <property name="title">
            <string>Calibration</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_5">
-           <property name="margin">
-            <number>6</number>
-           </property>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <item row="1" column="0">
+            <widget class="MantidQt::API::MWRunFiles" name="rfVanFile_only" native="true">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>41</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="findRunFiles" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="label" stdset="0">
+              <string>Vanadium File</string>
+             </property>
+             <property name="multipleFiles" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="optional" stdset="0">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="0">
+            <widget class="QCheckBox" name="ckUseVanadium">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Use Vanadium File</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
             <widget class="QCheckBox" name="ckUseCalib">
              <property name="minimumSize">
               <size>
@@ -296,7 +331,7 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0" colspan="2">
+           <item row="3" column="0">
             <widget class="MantidQt::API::MWRunFiles" name="rfCalFile_only" native="true">
              <property name="enabled">
               <bool>false</bool>
@@ -325,6 +360,10 @@
             </widget>
            </item>
           </layout>
+          <zorder>ckUseCalib</zorder>
+          <zorder>rfCalFile_only</zorder>
+          <zorder>rfVanFile_only</zorder>
+          <zorder>ckUseVanadium</zorder>
          </widget>
         </item>
         <item>
@@ -534,11 +573,11 @@
          <property name="enabled">
           <bool>false</bool>
          </property>
-          <item>
-            <property name="text">
-              <string>Spectra</string>
-            </property>
-          </item>
+         <item>
+          <property name="text">
+           <string>Spectra</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item>
@@ -741,12 +780,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>90</x>
-     <y>174</y>
+     <x>106</x>
+     <y>193</y>
     </hint>
     <hint type="destinationlabel">
-     <x>371</x>
-     <y>174</y>
+     <x>483</x>
+     <y>193</y>
     </hint>
    </hints>
   </connection>
@@ -757,12 +796,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>54</x>
-     <y>168</y>
+     <x>70</x>
+     <y>193</y>
     </hint>
     <hint type="destinationlabel">
-     <x>55</x>
-     <y>184</y>
+     <x>71</x>
+     <y>217</y>
     </hint>
    </hints>
   </connection>
@@ -773,12 +812,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>39</x>
+     <y>316</y>
     </hint>
     <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
+     <x>39</x>
+     <y>325</y>
     </hint>
    </hints>
   </connection>
@@ -789,12 +828,28 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>141</x>
-     <y>194</y>
+     <x>157</x>
+     <y>217</y>
     </hint>
     <hint type="destinationlabel">
-     <x>199</x>
-     <y>194</y>
+     <x>325</x>
+     <y>219</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ckUseVanadium</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>rfVanFile_only</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>249</x>
+     <y>268</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>249</x>
+     <y>287</y>
     </hint>
    </hints>
   </connection>

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -340,7 +340,8 @@ void IndirectDiffractionReduction::runGenericReduction(QString instName,
     }
   }
   if (mode == "diffspec") {
-    const auto vanFile = m_uiForm.rfVanFile_only->getFilenames().join(",").toStdString();
+    const auto vanFile =
+        m_uiForm.rfVanFile_only->getFilenames().join(",").toStdString();
     msgDiffReduction->setProperty("VanadiumFiles", vanFile);
   }
   msgDiffReduction->setProperty("SumFiles", m_uiForm.ckSumFiles->isChecked());
@@ -549,11 +550,10 @@ void IndirectDiffractionReduction::instrumentSelected(
     m_uiForm.swVanadium->setCurrentIndex(0);
   else if (calibNeeded)
     m_uiForm.swVanadium->setCurrentIndex(1);
-  else if (reflectionName!="diffspec")
+  else if (reflectionName != "diffspec")
     m_uiForm.swVanadium->setCurrentIndex(2);
   else
     m_uiForm.swVanadium->setCurrentIndex(1);
-
 
   // Hide options that the current instrument config cannot process
 
@@ -562,8 +562,7 @@ void IndirectDiffractionReduction::instrumentSelected(
     m_uiForm.ckUseCalib->setEnabled(false);
     m_uiForm.ckUseCalib->setToolTip("IRIS does not support calibration files");
     m_uiForm.ckUseCalib->setChecked(false);
-  }
-  else {
+  } else {
     m_uiForm.ckUseCalib->setEnabled(true);
     m_uiForm.ckUseCalib->setToolTip("");
     m_uiForm.ckUseCalib->setChecked(true);

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -339,6 +339,10 @@ void IndirectDiffractionReduction::runGenericReduction(QString instName,
       msgDiffReduction->setProperty("CalFile", calFile);
     }
   }
+  if (mode == "diffspec") {
+    const auto vanFile = m_uiForm.rfVanFile_only->getFilenames().join(",").toStdString();
+    msgDiffReduction->setProperty("VanadiumFiles", vanFile);
+  }
   msgDiffReduction->setProperty("SumFiles", m_uiForm.ckSumFiles->isChecked());
   msgDiffReduction->setProperty("LoadLogFiles",
                                 m_uiForm.ckLoadLogs->isChecked());
@@ -545,10 +549,26 @@ void IndirectDiffractionReduction::instrumentSelected(
     m_uiForm.swVanadium->setCurrentIndex(0);
   else if (calibNeeded)
     m_uiForm.swVanadium->setCurrentIndex(1);
-  else
+  else if (reflectionName!="diffspec")
     m_uiForm.swVanadium->setCurrentIndex(2);
+  else
+    m_uiForm.swVanadium->setCurrentIndex(1);
+
 
   // Hide options that the current instrument config cannot process
+
+  // Disable calibration for IRIS
+  if (instrumentName == "IRIS") {
+    m_uiForm.ckUseCalib->setEnabled(false);
+    m_uiForm.ckUseCalib->setToolTip("IRIS does not support calibration files");
+    m_uiForm.ckUseCalib->setChecked(false);
+  }
+  else {
+    m_uiForm.ckUseCalib->setEnabled(true);
+    m_uiForm.ckUseCalib->setToolTip("");
+    m_uiForm.ckUseCalib->setChecked(true);
+  }
+
   if (instrumentName == "OSIRIS" && reflectionName == "diffonly") {
     // Disable individual grouping
     m_uiForm.ckIndividualGrouping->setToolTip(

--- a/docs/source/release/v3.9.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.9.0/indirect_inelastic.rst
@@ -60,6 +60,11 @@ Transmission
 
 - Option to calculate number density from mass density
 
+Diffraction
+###########
+
+- Add option for normalisation by vanadium to spectroscopy mode. Divides the sample by vanadium after container subtraction.
+
 Vesuvio
 #######
 


### PR DESCRIPTION
An option to normalise by a vanadium run has been added to Indirect Diffraction Reduction for the spectroscopy mode. The sample workspace is divided by the vanadium run and an option has been added to the Indirect>Diffraction interface.

**To test:**

Access to ISIS Data Analysis Service required.
Interfaces>Indirect>Diffraction
Instrument = IRIS
Mode = diffspec
Input run: `26181`
Vanadium: `26174`

Comparing without/with vanadium should look like:
![g](https://cloud.githubusercontent.com/assets/12883435/22589277/6b1d0a12-ea01-11e6-8461-87bc9d0ee952.png)
Where the red is with vanadium.


Fixes #18695.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
