### PR TITLE
HistogramData rollout: algorithms <NexusFileIO to PoldiSpectrumConstantBackground>

### DIFF
--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -1,7 +1,7 @@
 // NexusFileIO
 // @author Ronald Fowler
-#include <vector>
 #include <sstream>
+#include <vector>
 
 #ifdef _WIN32
 #include <io.h>
@@ -9,18 +9,18 @@
 // Maximum base file name size on modern windows systems is 260 characters
 #define NAME_MAX 260
 #endif /* _WIN32 */
-#include "MantidGeometry/Instrument.h"
-#include "MantidKernel/TimeSeriesProperty.h"
-#include "MantidNexus/NexusFileIO.h"
-#include "MantidDataObjects/Workspace2D.h"
-#include "MantidKernel/UnitFactory.h"
-#include "MantidKernel/ArrayProperty.h"
 #include "MantidAPI/NumericAxis.h"
-#include "MantidKernel/Unit.h"
-#include "MantidKernel/VectorHelper.h"
-#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidDataObjects/RebinnedOutput.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidKernel/Unit.h"
+#include "MantidKernel/UnitFactory.h"
+#include "MantidKernel/VectorHelper.h"
+#include "MantidNexus/NexusFileIO.h"
 
 #include <Poco/File.h>
 #include <Poco/Path.h>
@@ -304,7 +304,7 @@ int NexusFileIO::writeNexusProcessedData2D(
   const size_t nHist = localworkspace->getNumberHistograms();
   if (nHist < 1)
     return (2);
-  const size_t nSpectBins = localworkspace->readY(0).size();
+  const size_t nSpectBins = localworkspace->y(0).size();
   const size_t nSpect = spec.size();
   int dims_array[2] = {static_cast<int>(nSpect), static_cast<int>(nSpectBins)};
 
@@ -348,7 +348,7 @@ int NexusFileIO::writeNexusProcessedData2D(
     NXopendata(fileID, name.c_str());
     for (size_t i = 0; i < nSpect; i++) {
       int s = spec[i];
-      NXputslab(fileID, localworkspace->readY(s).data(), start, asize);
+      NXputslab(fileID, localworkspace->y(s).rawData().data(), start, asize);
       start[0]++;
     }
     if (m_progress != nullptr)
@@ -375,7 +375,7 @@ int NexusFileIO::writeNexusProcessedData2D(
     start[0] = 0;
     for (size_t i = 0; i < nSpect; i++) {
       int s = spec[i];
-      NXputslab(fileID, localworkspace->readE(s).data(), start, asize);
+      NXputslab(fileID, localworkspace->e(s).rawData().data(), start, asize);
       start[0]++;
     }
 
@@ -422,20 +422,20 @@ int NexusFileIO::writeNexusProcessedData2D(
 
   // write X data, as single array or all values if "ragged"
   if (uniformSpectra) {
-    dims_array[0] = static_cast<int>(localworkspace->readX(0).size());
+    dims_array[0] = static_cast<int>(localworkspace->x(0).size());
     NXmakedata(fileID, "axis1", NX_FLOAT64, 1, dims_array);
     NXopendata(fileID, "axis1");
-    NXputdata(fileID, localworkspace->readX(0).data());
+    NXputdata(fileID, localworkspace->x(0).rawData().data());
 
   } else {
     dims_array[0] = static_cast<int>(nSpect);
-    dims_array[1] = static_cast<int>(localworkspace->readX(0).size());
+    dims_array[1] = static_cast<int>(localworkspace->x(0).size());
     NXmakedata(fileID, "axis1", NX_FLOAT64, 2, dims_array);
     NXopendata(fileID, "axis1");
     start[0] = 0;
     asize[1] = dims_array[1];
     for (size_t i = 0; i < nSpect; i++) {
-      NXputslab(fileID, localworkspace->readX(i).data(), start, asize);
+      NXputslab(fileID, localworkspace->x(i).rawData().data(), start, asize);
       start[0]++;
     }
   }

--- a/Framework/SINQ/inc/MantidSINQ/PoldiPeakSearch.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiPeakSearch.h
@@ -3,16 +3,16 @@
 
 #include "MantidSINQ/DllConfig.h"
 
+#include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/V2D.h"
-#include "MantidAPI/Algorithm.h"
 
 #include "MantidDataObjects/Workspace2D.h"
 
-#include "MantidSINQ/PoldiUtilities/UncertainValue.h"
 #include "MantidSINQ/PoldiUtilities/PoldiPeak.h"
 #include "MantidSINQ/PoldiUtilities/PoldiPeakCollection.h"
+#include "MantidSINQ/PoldiUtilities/UncertainValue.h"
 
 namespace Mantid {
 namespace Poldi {
@@ -60,7 +60,7 @@ public:
   const std::string category() const override { return "SINQ\\Poldi"; }
 
 protected:
-  MantidVec getNeighborSums(MantidVec correlationCounts) const;
+  MantidVec getNeighborSums(const MantidVec &correlationCounts) const;
 
   std::list<MantidVec::const_iterator>
   findPeaks(MantidVec::const_iterator begin, MantidVec::const_iterator end);

--- a/Framework/SINQ/inc/MantidSINQ/PoldiPeakSearch.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiPeakSearch.h
@@ -15,6 +15,9 @@
 #include "MantidSINQ/PoldiUtilities/UncertainValue.h"
 
 namespace Mantid {
+namespace HistogramData {
+class HistogramY;
+}
 namespace Poldi {
 /** PoldiPeakSearch :
 
@@ -60,7 +63,8 @@ public:
   const std::string category() const override { return "SINQ\\Poldi"; }
 
 protected:
-  MantidVec getNeighborSums(const MantidVec &correlationCounts) const;
+  MantidVec
+  getNeighborSums(const HistogramData::HistogramY &correlationCounts) const;
 
   std::list<MantidVec::const_iterator>
   findPeaks(MantidVec::const_iterator begin, MantidVec::const_iterator end);

--- a/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -7,7 +7,6 @@
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
 #include "MantidKernel/ArrayProperty.h"
-#include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/Utils.h"
 
 #include <boost/algorithm/string.hpp>
@@ -24,6 +23,9 @@ using namespace Mantid::Geometry;
 using namespace Mantid;
 using namespace Mantid::DataObjects;
 using namespace ::NeXus;
+using Mantid::HistogramData::BinEdges;
+using Mantid::HistogramData::Points;
+using Mantid::HistogramData::Counts;
 
 // A reference to the logger is provided by the base class, it is called g_log.
 // It is used to print out information, warning and error messages
@@ -165,19 +167,17 @@ void LoadFlexiNexus::load2DWorkspace(NeXus::File *fin) {
   // x can be bin edges or points, depending on branching above
   auto x = Kernel::make_cow<HistogramData::HistogramX>(xData);
   for (int wsIndex = 0; wsIndex < nSpectra; wsIndex++) {
-    Mantid::MantidVec &Y = ws->dataY(wsIndex);
-    for (int j = 0; j < spectraLength; j++) {
-      Y[j] = data[spectraLength * wsIndex + j];
-    }
-    // Create and fill another vector for the errors, containing sqrt(count)
-    Mantid::MantidVec &E = ws->dataE(wsIndex);
-    std::transform(Y.begin(), Y.end(), E.begin(), dblSqrt);
-    ws->setX(wsIndex, x);
-    // Xtof		ws->getAxis(1)->spectraNo(i)= i;
-    ws->getSpectrum(wsIndex)
-        .setSpectrumNo(static_cast<specnum_t>(yData[wsIndex]));
-    ws->getSpectrum(wsIndex)
-        .setDetectorID(static_cast<detid_t>(yData[wsIndex]));
+    auto beg = data.begin() + spectraLength * wsIndex;
+    auto end = beg + spectraLength;
+    if (spectraLength == xData.size())
+      ws->setHistogram(wsIndex, Points(x), Counts(beg, end));
+    else
+      ws->setHistogram(wsIndex, BinEdges(x), Counts(beg, end));
+
+    ws->getSpectrum(wsIndex).setSpectrumNo(
+        static_cast<specnum_t>(yData[wsIndex]));
+    ws->getSpectrum(wsIndex).setDetectorID(
+        static_cast<detid_t>(yData[wsIndex]));
   }
 
   ws->setYUnit("Counts");

--- a/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -169,15 +169,15 @@ void LoadFlexiNexus::load2DWorkspace(NeXus::File *fin) {
   for (int wsIndex = 0; wsIndex < nSpectra; wsIndex++) {
     auto beg = data.begin() + spectraLength * wsIndex;
     auto end = beg + spectraLength;
-    if (spectraLength == xData.size())
+    if (static_cast<size_t>(spectraLength) == xData.size())
       ws->setHistogram(wsIndex, Points(x), Counts(beg, end));
     else
       ws->setHistogram(wsIndex, BinEdges(x), Counts(beg, end));
 
-    ws->getSpectrum(wsIndex)
-        .setSpectrumNo(static_cast<specnum_t>(yData[wsIndex]));
-    ws->getSpectrum(wsIndex)
-        .setDetectorID(static_cast<detid_t>(yData[wsIndex]));
+    ws->getSpectrum(wsIndex).setSpectrumNo(
+        static_cast<specnum_t>(yData[wsIndex]));
+    ws->getSpectrum(wsIndex).setDetectorID(
+        static_cast<detid_t>(yData[wsIndex]));
   }
 
   ws->setYUnit("Counts");

--- a/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -174,10 +174,10 @@ void LoadFlexiNexus::load2DWorkspace(NeXus::File *fin) {
     else
       ws->setHistogram(wsIndex, BinEdges(x), Counts(beg, end));
 
-    ws->getSpectrum(wsIndex).setSpectrumNo(
-        static_cast<specnum_t>(yData[wsIndex]));
-    ws->getSpectrum(wsIndex).setDetectorID(
-        static_cast<detid_t>(yData[wsIndex]));
+    ws->getSpectrum(wsIndex)
+        .setSpectrumNo(static_cast<specnum_t>(yData[wsIndex]));
+    ws->getSpectrum(wsIndex)
+        .setDetectorID(static_cast<detid_t>(yData[wsIndex]));
   }
 
   ws->setYUnit("Counts");

--- a/Framework/SINQ/src/MDHistoToWorkspace2D.cpp
+++ b/Framework/SINQ/src/MDHistoToWorkspace2D.cpp
@@ -83,13 +83,13 @@ void MDHistoToWorkspace2D::recurseData(IMDHistoWorkspace_sptr inWS,
                                        size_t currentDim, coord_t *pos) {
   boost::shared_ptr<const IMDDimension> dim = inWS->getDimension(currentDim);
   if (currentDim == m_rank - 1) {
-    MantidVec &Y = outWS->dataY(m_currentSpectra);
+    auto &Y = outWS->mutableY(m_currentSpectra);
     for (unsigned int j = 0; j < dim->getNBins(); j++) {
       pos[currentDim] = dim->getX(j);
       Y[j] = inWS->getSignalAtCoord(
           pos, static_cast<Mantid::API::MDNormalization>(0));
     }
-    MantidVec &E = outWS->dataE(m_currentSpectra);
+    auto &E = outWS->mutableE(m_currentSpectra);
     // MSVC compiler can't figure out the correct overload with out the function
     // cast on sqrt
     std::transform(Y.begin(), Y.end(), E.begin(),
@@ -115,15 +115,14 @@ void MDHistoToWorkspace2D::checkW2D(
     Mantid::DataObjects::Workspace2D_sptr outWS) {
   size_t nSpectra = outWS->getNumberHistograms();
   size_t length = outWS->blocksize();
-  MantidVec x, y, e;
 
   g_log.information() << "W2D has " << nSpectra << " histograms of length "
                       << length;
   for (size_t i = 0; i < nSpectra; i++) {
     auto &spec = outWS->getSpectrum(i);
-    x = spec.dataX();
-    y = spec.dataY();
-    e = spec.dataE();
+    auto &x = spec.x();
+    auto &y = spec.y();
+    auto &e = spec.e();
     if (x.size() != length) {
       g_log.information() << "Spectrum " << i << " x-size mismatch, is "
                           << x.size() << " should be " << length << "\n";

--- a/Framework/SINQ/src/PoldiAnalyseResiduals.cpp
+++ b/Framework/SINQ/src/PoldiAnalyseResiduals.cpp
@@ -1,9 +1,9 @@
 #include "MantidSINQ/PoldiAnalyseResiduals.h"
-#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidAPI/WorkspaceFactory.h"
-#include "MantidSINQ/PoldiUtilities/PoldiResidualCorrelationCore.h"
+#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidSINQ/PoldiUtilities/PoldiDeadWireDecorator.h"
+#include "MantidSINQ/PoldiUtilities/PoldiResidualCorrelationCore.h"
 
 #include <numeric>
 
@@ -42,12 +42,12 @@ const std::string PoldiAnalyseResiduals::summary() const {
 double PoldiAnalyseResiduals::sumCounts(
     const DataObjects::Workspace2D_sptr &workspace,
     const std::vector<int> &workspaceIndices) const {
-  return std::accumulate(
-      workspaceIndices.begin(), workspaceIndices.end(), 0.0,
-      [&workspace](double sum, int workspaceIndex) {
-        const MantidVec &counts = workspace->readY(workspaceIndex);
-        return sum + std::accumulate(counts.begin(), counts.end(), 0.0);
-      });
+  return std::accumulate(workspaceIndices.begin(), workspaceIndices.end(), 0.0,
+                         [&workspace](double sum, int workspaceIndex) {
+                           auto &counts = workspace->y(workspaceIndex);
+                           return sum + std::accumulate(counts.cbegin(),
+                                                        counts.cend(), 0.0);
+                         });
 }
 
 /// Counts the number of values in each spectrum specified by the list of
@@ -55,12 +55,12 @@ double PoldiAnalyseResiduals::sumCounts(
 size_t PoldiAnalyseResiduals::numberOfPoints(
     const DataObjects::Workspace2D_sptr &workspace,
     const std::vector<int> &workspaceIndices) const {
-  return std::accumulate(
-      workspaceIndices.begin(), workspaceIndices.end(), size_t{0},
-      [&workspace](size_t sum, int workspaceIndex) {
-        const MantidVec &counts = workspace->readY(workspaceIndex);
-        return sum + counts.size();
-      });
+  return std::accumulate(workspaceIndices.begin(), workspaceIndices.end(),
+                         size_t{0},
+                         [&workspace](size_t sum, int workspaceIndex) {
+                           auto &counts = workspace->y(workspaceIndex);
+                           return sum + counts.size();
+                         });
 }
 
 /// Adds the specified value to all spectra specified by the given workspace
@@ -69,10 +69,7 @@ void PoldiAnalyseResiduals::addValue(
     DataObjects::Workspace2D_sptr &workspace, double value,
     const std::vector<int> &workspaceIndices) const {
   for (auto workspaceIndex : workspaceIndices) {
-    MantidVec &counts = workspace->dataY(workspaceIndex);
-    for (double &count : counts) {
-      count += value;
-    }
+    workspace->mutableY(workspaceIndex) += value;
   }
 }
 
@@ -182,13 +179,11 @@ bool PoldiAnalyseResiduals::iterationLimitReached(int iterations) {
 /// total number of counts
 double PoldiAnalyseResiduals::relativeCountChange(
     const DataObjects::Workspace2D_sptr &sum, double totalMeasuredCounts) {
-  const MantidVec &corrCounts = sum->readY(0);
-  double csum = 0.0;
-  for (double corrCount : corrCounts) {
-    csum += fabs(corrCount);
-  }
-
-  return csum / totalMeasuredCounts * 100.0;
+  auto &corrCounts = sum->y(0);
+  return std::accumulate(
+             corrCounts.cbegin(), corrCounts.cend(), 0.0,
+             [](double sum, double val) { return sum += fabs(val); }) /
+         totalMeasuredCounts * 100.0;
 }
 
 void PoldiAnalyseResiduals::exec() {

--- a/Framework/SINQ/src/PoldiFitPeaks2D.cpp
+++ b/Framework/SINQ/src/PoldiFitPeaks2D.cpp
@@ -10,20 +10,20 @@
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
-#include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
 #include "MantidGeometry/Crystal/UnitCell.h"
 #include "MantidKernel/ListValidator.h"
 
 #include "MantidSINQ/PoldiUtilities/IPoldiFunction1D.h"
 #include "MantidSINQ/PoldiUtilities/Poldi2DFunction.h"
-#include "MantidSINQ/PoldiUtilities/PoldiInstrumentAdapter.h"
-#include "MantidSINQ/PoldiUtilities/PoldiDeadWireDecorator.h"
 #include "MantidSINQ/PoldiUtilities/PoldiDGrid.h"
+#include "MantidSINQ/PoldiUtilities/PoldiDeadWireDecorator.h"
+#include "MantidSINQ/PoldiUtilities/PoldiInstrumentAdapter.h"
+#include "MantidSINQ/PoldiUtilities/PoldiPeakCollection.h"
 #include "MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h"
 #include "MantidSINQ/PoldiUtilities/PoldiSpectrumLinearBackground.h"
 #include "MantidSINQ/PoldiUtilities/PoldiSpectrumPawleyFunction.h"
-#include "MantidSINQ/PoldiUtilities/PoldiPeakCollection.h"
 
 #include "boost/make_shared.hpp"
 
@@ -886,8 +886,8 @@ PoldiFitPeaks2D::getQSpectrum(const FunctionDomain1D &domain,
   MatrixWorkspace_sptr ws1D = WorkspaceFactory::Instance().create(
       "Workspace2D", 1, domain.size(), values.size());
 
-  MantidVec &xData = ws1D->dataX(0);
-  MantidVec &yData = ws1D->dataY(0);
+  auto &xData = ws1D->mutableX(0);
+  auto &yData = ws1D->mutableY(0);
   size_t offset = values.size() - 1;
   for (size_t i = 0; i < values.size(); ++i) {
     xData[offset - i] = Conversions::dToQ(domain[i]);
@@ -1137,7 +1137,7 @@ void PoldiFitPeaks2D::setDeltaTFromWorkspace(
     throw std::invalid_argument("MatrixWorkspace does not contain any data.");
   }
 
-  MantidVec xData = matrixWorkspace->readX(0);
+  auto &xData = matrixWorkspace->x(0);
 
   if (xData.size() < 2) {
     throw std::invalid_argument(
@@ -1146,7 +1146,7 @@ void PoldiFitPeaks2D::setDeltaTFromWorkspace(
 
   // difference between first and second x-value is assumed to be the bin
   // width.
-  setDeltaT(matrixWorkspace->readX(0)[1] - matrixWorkspace->readX(0)[0]);
+  setDeltaT(matrixWorkspace->x(0)[1] - matrixWorkspace->x(0)[0]);
 }
 
 /**

--- a/Framework/SINQ/src/PoldiPeakSearch.cpp
+++ b/Framework/SINQ/src/PoldiPeakSearch.cpp
@@ -32,6 +32,7 @@ DECLARE_ALGORITHM(PoldiPeakSearch)
 using namespace Kernel;
 using namespace API;
 using namespace DataObjects;
+using HistogramData::HistogramY;
 
 PoldiPeakSearch::PoldiPeakSearch()
     : API::Algorithm(), m_minimumDistance(0), m_doubleMinimumDistance(0),
@@ -48,7 +49,7 @@ PoldiPeakSearch::PoldiPeakSearch()
   * @return Vector with sum of neighboring correlation counts.
   */
 MantidVec
-PoldiPeakSearch::getNeighborSums(const MantidVec &correlationCounts) const {
+PoldiPeakSearch::getNeighborSums(const HistogramY &correlationCounts) const {
   /* Since the first and last element in a list don't have two neighbors, they
    *are excluded from the calculation
    * and the result vector's size is reduced by two. Also, the algorithm does
@@ -589,7 +590,7 @@ void PoldiPeakSearch::exec() {
                       << summedNeighborCounts.size() << " data points.\n";
 
   std::list<MantidVec::const_iterator> peakPositionsSummed =
-      findPeaks(summedNeighborCounts.begin(), summedNeighborCounts.end());
+      findPeaks(summedNeighborCounts.cbegin(), summedNeighborCounts.cend());
   g_log.information() << "   Peaks detected in summed spectrum: "
                       << peakPositionsSummed.size() << '\n';
 
@@ -611,7 +612,7 @@ void PoldiPeakSearch::exec() {
    * along with the Q-values.
    */
   std::vector<PoldiPeak_sptr> peakCoordinates =
-      getPeaks(correlatedCounts.begin(), correlatedCounts.end(),
+      getPeaks(correlatedCounts.cbegin(), correlatedCounts.cend(),
                peakPositionsCorrelation, correlationQValues.rawData(), xUnit);
   g_log.information()
       << "   Extracted peak positions in Q and intensity guesses.\n";

--- a/Framework/SINQ/src/PoldiPeakSearch.cpp
+++ b/Framework/SINQ/src/PoldiPeakSearch.cpp
@@ -1,20 +1,20 @@
 #include "MantidSINQ/PoldiPeakSearch.h"
 
 #include "MantidAPI/Axis.h"
-#include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAPI/WorkspaceProperty.h"
 #include "MantidKernel/BoundedValidator.h"
-#include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/UnitConversion.h"
+#include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/V2D.h"
 
-#include "MantidDataObjects/Workspace2D.h"
-#include "MantidDataObjects/TableWorkspace.h"
 #include "MantidAPI/TableRow.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
 
 #include "boost/bind.hpp"
-#include <list>
 #include <algorithm>
+#include <list>
 #include <numeric>
 #include <queue>
 
@@ -47,7 +47,8 @@ PoldiPeakSearch::PoldiPeakSearch()
   * @param correlationCounts :: Vector with correlation counts.
   * @return Vector with sum of neighboring correlation counts.
   */
-MantidVec PoldiPeakSearch::getNeighborSums(MantidVec correlationCounts) const {
+MantidVec
+PoldiPeakSearch::getNeighborSums(const MantidVec &correlationCounts) const {
   /* Since the first and last element in a list don't have two neighbors, they
    *are excluded from the calculation
    * and the result vector's size is reduced by two. Also, the algorithm does
@@ -556,8 +557,8 @@ void PoldiPeakSearch::exec() {
   g_log.information() << "PoldiPeakSearch:\n";
 
   Workspace2D_sptr correlationWorkspace = getProperty("InputWorkspace");
-  MantidVec correlationQValues = correlationWorkspace->readX(0);
-  MantidVec correlatedCounts = correlationWorkspace->readY(0);
+  auto &correlationQValues = correlationWorkspace->x(0);
+  auto &correlatedCounts = correlationWorkspace->y(0);
   g_log.information() << "   Auto-correlation data read.\n";
 
   Unit_sptr xUnit = correlationWorkspace->getAxis(0)->unit();
@@ -583,7 +584,7 @@ void PoldiPeakSearch::exec() {
 
   g_log.information() << "   Parameters set.\n";
 
-  MantidVec summedNeighborCounts = getNeighborSums(correlatedCounts);
+  MantidVec summedNeighborCounts = getNeighborSums(correlatedCounts.rawData());
   g_log.information() << "   Neighboring counts summed, contains "
                       << summedNeighborCounts.size() << " data points.\n";
 
@@ -611,12 +612,12 @@ void PoldiPeakSearch::exec() {
    */
   std::vector<PoldiPeak_sptr> peakCoordinates =
       getPeaks(correlatedCounts.begin(), correlatedCounts.end(),
-               peakPositionsCorrelation, correlationQValues, xUnit);
+               peakPositionsCorrelation, correlationQValues.rawData(), xUnit);
   g_log.information()
       << "   Extracted peak positions in Q and intensity guesses.\n";
 
-  UncertainValue backgroundWithSigma =
-      getBackgroundWithSigma(peakPositionsCorrelation, correlatedCounts);
+  UncertainValue backgroundWithSigma = getBackgroundWithSigma(
+      peakPositionsCorrelation, correlatedCounts.rawData());
   g_log.information() << "   Calculated average background and deviation: "
                       << UncertainValueIO::toString(backgroundWithSigma)
                       << '\n';

--- a/Framework/SINQ/src/PoldiTruncateData.cpp
+++ b/Framework/SINQ/src/PoldiTruncateData.cpp
@@ -1,5 +1,5 @@
-#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidSINQ/PoldiTruncateData.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidSINQ/PoldiUtilities/PoldiInstrumentAdapter.h"
 
 namespace Mantid {
@@ -68,7 +68,7 @@ void PoldiTruncateData::setTimeBinWidthFromWorkspace(
         "Workspace does not contain any data. Aborting.");
   }
 
-  const MantidVec &xData = workspace->readX(0);
+  auto &xData = workspace->x(0);
 
   if (xData.size() < 2) {
     throw std::invalid_argument(

--- a/Framework/SINQ/src/PoldiTruncateData.cpp
+++ b/Framework/SINQ/src/PoldiTruncateData.cpp
@@ -68,7 +68,7 @@ void PoldiTruncateData::setTimeBinWidthFromWorkspace(
         "Workspace does not contain any data. Aborting.");
   }
 
-  auto &xData = workspace->x(0);
+  const auto &xData = workspace->x(0);
 
   if (xData.size() < 2) {
     throw std::invalid_argument(

--- a/Framework/SINQ/src/PoldiUtilities/PoldiAutoCorrelationCore.cpp
+++ b/Framework/SINQ/src/PoldiUtilities/PoldiAutoCorrelationCore.cpp
@@ -1,16 +1,16 @@
 #include "MantidSINQ/PoldiUtilities/PoldiAutoCorrelationCore.h"
 
-#include <utility>
-#include <numeric>
-#include <algorithm>
-#include "boost/bind.hpp"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/MultiThreaded.h"
+#include "boost/bind.hpp"
+#include <algorithm>
+#include <numeric>
+#include <utility>
 
-#include "MantidSINQ/PoldiUtilities/PoldiDGrid.h"
 #include "MantidSINQ/PoldiUtilities/PoldiConversions.h"
+#include "MantidSINQ/PoldiUtilities/PoldiDGrid.h"
 #include "MantidSINQ/PoldiUtilities/UncertainValue.h"
 
 #include "MantidSINQ/PoldiUtilities/UncertainValueIO.h"
@@ -85,7 +85,7 @@ DataObjects::Workspace2D_sptr PoldiAutoCorrelationCore::finalizeCalculation(
 
   outputWorkspace->getAxis(0)->setUnit("MomentumTransfer");
 
-  outputWorkspace->dataY(0) = correctedCorrelatedIntensities;
+  outputWorkspace->mutableY(0) = correctedCorrelatedIntensities;
 
   outputWorkspace->setPoints(0, qValues);
 
@@ -118,7 +118,7 @@ DataObjects::Workspace2D_sptr PoldiAutoCorrelationCore::calculate(
      *  - d-resolution deltaD, which results directly from deltaT
      *  - number of time bins for each copper cycle
      */
-    std::vector<double> timeData = m_countData->readX(0);
+    auto &timeData = m_countData->x(0);
 
     m_logger.information() << "  Setting time data...\n";
     m_deltaT = timeData[1] - timeData[0];
@@ -624,7 +624,7 @@ std::vector<double> PoldiAutoCorrelationCore::getTofsFor1Angstrom(
   * @return Counts at position.
   */
 double PoldiAutoCorrelationCore::getCounts(int x, int y) const {
-  return m_countData->readY(x)[y];
+  return m_countData->y(x)[y];
 }
 
 /** Returns normalized counts for correlation method at given position - these
@@ -635,7 +635,7 @@ double PoldiAutoCorrelationCore::getCounts(int x, int y) const {
   * @return Normalized counts at position.
   */
 double PoldiAutoCorrelationCore::getNormCounts(int x, int y) const {
-  return std::max(1.0, m_normCountData->readY(x)[y]);
+  return std::max(1.0, m_normCountData->y(x)[y]);
 }
 
 /** Returns detector element index for given index

--- a/Framework/SINQ/src/PoldiUtilities/PoldiAutoCorrelationCore.cpp
+++ b/Framework/SINQ/src/PoldiUtilities/PoldiAutoCorrelationCore.cpp
@@ -118,7 +118,7 @@ DataObjects::Workspace2D_sptr PoldiAutoCorrelationCore::calculate(
      *  - d-resolution deltaD, which results directly from deltaT
      *  - number of time bins for each copper cycle
      */
-    auto &timeData = m_countData->x(0);
+    const auto &timeData = m_countData->x(0);
 
     m_logger.information() << "  Setting time data...\n";
     m_deltaT = timeData[1] - timeData[0];

--- a/Framework/SINQ/src/PoldiUtilities/PoldiResidualCorrelationCore.cpp
+++ b/Framework/SINQ/src/PoldiUtilities/PoldiResidualCorrelationCore.cpp
@@ -20,7 +20,7 @@ void PoldiResidualCorrelationCore::setWeight(double newWeight) {
 
 /// Returns norm counts (with an added weight).
 double PoldiResidualCorrelationCore::getNormCounts(int x, int y) const {
-  return fabs(m_normCountData->readY(x)[y]) + m_weight;
+  return fabs(m_normCountData->y(x)[y]) + m_weight;
 }
 
 /// Calculates a scaled and weighted average signal/noise value from the
@@ -186,7 +186,7 @@ DataObjects::Workspace2D_sptr PoldiResidualCorrelationCore::finalizeCalculation(
 /// Adds the supplied value to each data point.
 void PoldiResidualCorrelationCore::addToCountData(int x, int y,
                                                   double newCounts) const {
-  m_countData->dataY(x)[y] += newCounts;
+  m_countData->mutableY(x)[y] += newCounts;
 }
 
 } // namespace Poldi

--- a/Framework/SINQ/src/PoldiUtilities/PoldiSpectrumConstantBackground.cpp
+++ b/Framework/SINQ/src/PoldiUtilities/PoldiSpectrumConstantBackground.cpp
@@ -38,7 +38,7 @@ void PoldiSpectrumConstantBackground::setWorkspace(
       boost::dynamic_pointer_cast<const MatrixWorkspace>(ws);
 
   if (matrixWs && matrixWs->getNumberHistograms() > 0) {
-    m_timeBinCount = matrixWs->readX(0).size();
+    m_timeBinCount = matrixWs->x(0).size();
   }
 }
 

--- a/Framework/SINQ/test/LoadFlexiNexusTest.h
+++ b/Framework/SINQ/test/LoadFlexiNexusTest.h
@@ -1,14 +1,15 @@
 #ifndef __LOADFLEXINEXUSTEST
 #define __LOADFLEXINEXUSTEST
 
-#include <cxxtest/TestSuite.h>
-#include "MantidSINQ/LoadFlexiNexus.h"
 #include "MantidAPI/AnalysisDataService.h"
-#include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/Run.h"
+#include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidKernel/Property.h"
 #include "MantidKernel/cow_ptr.h"
+#include "MantidSINQ/LoadFlexiNexus.h"
+#include <cxxtest/TestSuite.h>
+#include <numeric>
 
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
@@ -95,12 +96,9 @@ public:
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputSpace);
     TS_ASSERT_EQUALS(data->getNumberHistograms(), 1);
-    MantidVec &X = data->dataX(0);
-    MantidVec &Y = data->dataY(0);
-    double dSum = .0;
-    for (size_t i = 0; i < Y.size(); i++) {
-      dSum += Y[i];
-    }
+    auto &X = data->x(0);
+    auto &Y = data->y(0);
+    double dSum = std::accumulate(Y.cbegin(), Y.cend(), 0.);
     TS_ASSERT_EQUALS(dSum, 198812);
 
     // test X

--- a/Framework/SINQ/test/LoadFlexiNexusTest.h
+++ b/Framework/SINQ/test/LoadFlexiNexusTest.h
@@ -96,8 +96,8 @@ public:
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputSpace);
     TS_ASSERT_EQUALS(data->getNumberHistograms(), 1);
-    auto &X = data->x(0);
-    auto &Y = data->y(0);
+    const auto &X = data->x(0);
+    const auto &Y = data->y(0);
     double dSum = std::accumulate(Y.cbegin(), Y.cend(), 0.);
     TS_ASSERT_EQUALS(dSum, 198812);
 

--- a/Framework/SINQ/test/MDHistoToWorkspace2DTest.h
+++ b/Framework/SINQ/test/MDHistoToWorkspace2DTest.h
@@ -10,6 +10,7 @@
 #include "MantidKernel/Property.h"
 #include "MantidKernel/cow_ptr.h"
 #include "MantidDataObjects/MDHistoWorkspace.h"
+#include <numeric>
 
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
@@ -45,12 +46,9 @@ public:
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputSpace);
     TS_ASSERT_EQUALS(data->getNumberHistograms(), 12000);
-    MantidVec &X = data->dataX(0);
-    MantidVec &Y = data->dataY(0);
-    double dSum = .0;
-    for (size_t i = 0; i < Y.size(); i++) {
-      dSum += Y[i];
-    }
+    auto &X = data->x(0);
+    auto &Y = data->y(0);
+	double dSum = std::accumulate(Y.cbegin(), Y.cend(), 0.);
     TS_ASSERT_EQUALS(dSum, 200);
 
     // test X

--- a/Framework/SINQ/test/MDHistoToWorkspace2DTest.h
+++ b/Framework/SINQ/test/MDHistoToWorkspace2DTest.h
@@ -48,7 +48,7 @@ public:
     TS_ASSERT_EQUALS(data->getNumberHistograms(), 12000);
     auto &X = data->x(0);
     auto &Y = data->y(0);
-	double dSum = std::accumulate(Y.cbegin(), Y.cend(), 0.);
+    double dSum = std::accumulate(Y.cbegin(), Y.cend(), 0.);
     TS_ASSERT_EQUALS(dSum, 200);
 
     // test X

--- a/Framework/SINQ/test/MDHistoToWorkspace2DTest.h
+++ b/Framework/SINQ/test/MDHistoToWorkspace2DTest.h
@@ -46,8 +46,8 @@ public:
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputSpace);
     TS_ASSERT_EQUALS(data->getNumberHistograms(), 12000);
-    auto &X = data->x(0);
-    auto &Y = data->y(0);
+    const auto &X = data->x(0);
+    const auto &Y = data->y(0);
     double dSum = std::accumulate(Y.cbegin(), Y.cend(), 0.);
     TS_ASSERT_EQUALS(dSum, 200);
 

--- a/Framework/SINQ/test/PoldiAnalyseResidualsTest.h
+++ b/Framework/SINQ/test/PoldiAnalyseResidualsTest.h
@@ -3,9 +3,9 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidSINQ/PoldiAnalyseResiduals.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
-#include "MantidAPI/FrameworkManager.h"
 
 using namespace Mantid::Poldi;
 using namespace Mantid::API;
@@ -64,10 +64,10 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         alg.addValue(testWorkspace, 3.0, std::vector<int>(1, 0)));
 
-    TS_ASSERT_EQUALS(testWorkspace->readY(0)[0], 3.0);
-    TS_ASSERT_EQUALS(testWorkspace->readY(0)[1], 3.0);
-    TS_ASSERT_EQUALS(testWorkspace->readY(1)[0], 4.0);
-    TS_ASSERT_EQUALS(testWorkspace->readY(1)[1], 4.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(0)[0], 3.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(0)[1], 3.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(1)[0], 4.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(1)[1], 4.0);
 
     TS_ASSERT_THROWS_ANYTHING(
         alg.addValue(testWorkspace, 3.0, std::vector<int>(1, 3)));
@@ -85,18 +85,18 @@ public:
         alg.calculateResidualWorkspace(measured, calculated));
     Workspace2D_sptr residuals =
         alg.calculateResidualWorkspace(measured, calculated);
-    TS_ASSERT_EQUALS(residuals->readY(0)[0], -3.0);
-    TS_ASSERT_EQUALS(residuals->readY(0)[1], -3.0);
-    TS_ASSERT_EQUALS(residuals->readY(1)[0], -3.0);
-    TS_ASSERT_EQUALS(residuals->readY(1)[1], -3.0);
+    TS_ASSERT_EQUALS(residuals->y(0)[0], -3.0);
+    TS_ASSERT_EQUALS(residuals->y(0)[1], -3.0);
+    TS_ASSERT_EQUALS(residuals->y(1)[0], -3.0);
+    TS_ASSERT_EQUALS(residuals->y(1)[1], -3.0);
 
     TS_ASSERT_THROWS_NOTHING(
         alg.calculateResidualWorkspace(calculated, measured));
     residuals = alg.calculateResidualWorkspace(calculated, measured);
-    TS_ASSERT_EQUALS(residuals->readY(0)[0], 3.0);
-    TS_ASSERT_EQUALS(residuals->readY(0)[1], 3.0);
-    TS_ASSERT_EQUALS(residuals->readY(1)[0], 3.0);
-    TS_ASSERT_EQUALS(residuals->readY(1)[1], 3.0);
+    TS_ASSERT_EQUALS(residuals->y(0)[0], 3.0);
+    TS_ASSERT_EQUALS(residuals->y(0)[1], 3.0);
+    TS_ASSERT_EQUALS(residuals->y(1)[0], 3.0);
+    TS_ASSERT_EQUALS(residuals->y(1)[1], 3.0);
   }
 
   void testNormalizeResiduals() {
@@ -108,12 +108,12 @@ public:
         alg.normalizeResiduals(testWorkspace, std::vector<int>(1, 1)));
 
     // nothing happens here
-    TS_ASSERT_EQUALS(testWorkspace->readY(0)[0], 2.0);
-    TS_ASSERT_EQUALS(testWorkspace->readY(0)[1], 2.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(0)[0], 2.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(0)[1], 2.0);
 
     // but here, because 1 is a valid workspace index
-    TS_ASSERT_EQUALS(testWorkspace->readY(1)[0], 0.0);
-    TS_ASSERT_EQUALS(testWorkspace->readY(1)[1], 0.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(1)[0], 0.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(1)[1], 0.0);
   }
 
   void testRelativeCountChange() {
@@ -138,10 +138,10 @@ public:
 
     Workspace2D_sptr sum = alg.addWorkspaces(lhs, rhs);
 
-    TS_ASSERT_EQUALS(sum->readY(0)[0], 0.0);
-    TS_ASSERT_EQUALS(sum->readY(0)[1], 0.0);
-    TS_ASSERT_EQUALS(sum->readY(1)[0], 2.0);
-    TS_ASSERT_EQUALS(sum->readY(1)[1], 2.0);
+    TS_ASSERT_EQUALS(sum->y(0)[0], 0.0);
+    TS_ASSERT_EQUALS(sum->y(0)[1], 0.0);
+    TS_ASSERT_EQUALS(sum->y(1)[0], 2.0);
+    TS_ASSERT_EQUALS(sum->y(1)[1], 2.0);
   }
 
   void testRelativeChangeIsLargerThanLimit() {

--- a/Framework/SINQ/test/PoldiAutoCorrelationCoreTest.h
+++ b/Framework/SINQ/test/PoldiAutoCorrelationCoreTest.h
@@ -7,15 +7,15 @@
 
 #include "MantidSINQ/PoldiUtilities/PoldiAutoCorrelationCore.h"
 
-#include "MantidSINQ/PoldiUtilities/PoldiAbstractDetector.h"
 #include "MantidSINQ/PoldiUtilities/PoldiAbstractChopper.h"
-#include "MantidSINQ/PoldiUtilities/PoldiDeadWireDecorator.h"
+#include "MantidSINQ/PoldiUtilities/PoldiAbstractDetector.h"
 #include "MantidSINQ/PoldiUtilities/PoldiDGrid.h"
+#include "MantidSINQ/PoldiUtilities/PoldiDeadWireDecorator.h"
 
 #include "MantidDataObjects/TableWorkspace.h"
 
-#include "MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h"
 
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
@@ -323,14 +323,14 @@ public:
 
     TS_ASSERT_EQUALS(output->getNumberHistograms(), 1);
 
-    const MantidVec &qValues = output->readX(0);
+    auto &qValues = output->x(0);
     // qvalues should be reversed.
     TS_ASSERT_EQUALS(qValues[0], Conversions::dToQ(dValues[3]));
     TS_ASSERT_EQUALS(qValues[1], Conversions::dToQ(dValues[2]));
     TS_ASSERT_EQUALS(qValues[2], Conversions::dToQ(dValues[1]));
     TS_ASSERT_EQUALS(qValues[3], Conversions::dToQ(dValues[0]));
 
-    const MantidVec &outputIntensities = output->readY(0);
+    auto &outputIntensities = output->y(0);
     // intensities are not reversed, they should be reversed already.
     TS_ASSERT_EQUALS(outputIntensities[0], intensities[0]);
     TS_ASSERT_EQUALS(outputIntensities[1], intensities[1]);

--- a/Framework/SINQ/test/PoldiAutoCorrelationCoreTest.h
+++ b/Framework/SINQ/test/PoldiAutoCorrelationCoreTest.h
@@ -323,14 +323,14 @@ public:
 
     TS_ASSERT_EQUALS(output->getNumberHistograms(), 1);
 
-    auto &qValues = output->x(0);
+    const auto &qValues = output->x(0);
     // qvalues should be reversed.
     TS_ASSERT_EQUALS(qValues[0], Conversions::dToQ(dValues[3]));
     TS_ASSERT_EQUALS(qValues[1], Conversions::dToQ(dValues[2]));
     TS_ASSERT_EQUALS(qValues[2], Conversions::dToQ(dValues[1]));
     TS_ASSERT_EQUALS(qValues[3], Conversions::dToQ(dValues[0]));
 
-    auto &outputIntensities = output->y(0);
+    const auto &outputIntensities = output->y(0);
     // intensities are not reversed, they should be reversed already.
     TS_ASSERT_EQUALS(outputIntensities[0], intensities[0]);
     TS_ASSERT_EQUALS(outputIntensities[1], intensities[1]);

--- a/Framework/SINQ/test/PoldiFitPeaks2DTest.h
+++ b/Framework/SINQ/test/PoldiFitPeaks2DTest.h
@@ -8,16 +8,17 @@
 
 #include "MantidKernel/Matrix.h"
 
+#include "MantidHistogramData/LinearGenerator.h"
 #include "MantidSINQ/PoldiFitPeaks2D.h"
 #include "MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h"
 #include "MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
-#include <numeric>
 
 using namespace Mantid::Poldi;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using namespace Mantid::Kernel;
+using Mantid::HistogramData::LinearGenerator;
 
 class PoldiFitPeaks2DTest : public CxxTest::TestSuite {
 public:
@@ -61,8 +62,7 @@ public:
 
   void testSetDeltaTFromWorkspace() {
     MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspace(1, 10);
-    auto &X = ws->mutableX(0);
-    std::iota(X.begin(), X.end(), 0);
+    ws->setBinEdges(0, LinearGenerator(0, 1));
     TestablePoldiFitPeaks2D spectrumCalculator;
     spectrumCalculator.setDeltaTFromWorkspace(ws);
     TS_ASSERT_EQUALS(spectrumCalculator.m_deltaT, 1.0);

--- a/Framework/SINQ/test/PoldiFitPeaks2DTest.h
+++ b/Framework/SINQ/test/PoldiFitPeaks2DTest.h
@@ -18,6 +18,7 @@ using namespace Mantid::Poldi;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using namespace Mantid::Kernel;
+using Mantid::HistogramData::BinEdges;
 using Mantid::HistogramData::LinearGenerator;
 
 class PoldiFitPeaks2DTest : public CxxTest::TestSuite {
@@ -62,7 +63,7 @@ public:
 
   void testSetDeltaTFromWorkspace() {
     MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspace(1, 10);
-    ws->setBinEdges(0, LinearGenerator(0, 1));
+    ws->setBinEdges(0, BinEdges(ws->x(0).size(), LinearGenerator(0, 1)));
     TestablePoldiFitPeaks2D spectrumCalculator;
     spectrumCalculator.setDeltaTFromWorkspace(ws);
     TS_ASSERT_EQUALS(spectrumCalculator.m_deltaT, 1.0);

--- a/Framework/SINQ/test/PoldiFitPeaks2DTest.h
+++ b/Framework/SINQ/test/PoldiFitPeaks2DTest.h
@@ -3,15 +3,16 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/FrameworkManager.h"
 
 #include "MantidKernel/Matrix.h"
 
 #include "MantidSINQ/PoldiFitPeaks2D.h"
-#include "MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h"
 #include "MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h"
+#include "MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include <numeric>
 
 using namespace Mantid::Poldi;
 using namespace Mantid::API;
@@ -60,10 +61,8 @@ public:
 
   void testSetDeltaTFromWorkspace() {
     MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspace(1, 10);
-    for (size_t i = 0; i <= 10; ++i) {
-      ws->dataX(0)[i] = static_cast<double>(i);
-    }
-
+    auto &X = ws->mutableX(0);
+    std::iota(X.begin(), X.end(), 0);
     TestablePoldiFitPeaks2D spectrumCalculator;
     spectrumCalculator.setDeltaTFromWorkspace(ws);
     TS_ASSERT_EQUALS(spectrumCalculator.m_deltaT, 1.0);

--- a/Framework/SINQ/test/PoldiResidualCorrelationCoreTest.h
+++ b/Framework/SINQ/test/PoldiResidualCorrelationCoreTest.h
@@ -5,8 +5,8 @@
 
 #include "MantidSINQ/PoldiUtilities/PoldiResidualCorrelationCore.h"
 
-#include "MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 using namespace Mantid::Poldi;
@@ -40,7 +40,7 @@ public:
     // test data with all 0s except (0, 0) - it's -1.0
     Mantid::DataObjects::Workspace2D_sptr testWorkspace =
         WorkspaceCreationHelper::create2DWorkspaceWhereYIsWorkspaceIndex(2, 2);
-    testWorkspace->dataY(0)[0] = -1.0;
+    testWorkspace->mutableY(0)[0] = -1.0;
 
     core.setNormCountData(testWorkspace);
 
@@ -66,11 +66,11 @@ public:
         WorkspaceCreationHelper::create2DWorkspaceWhereYIsWorkspaceIndex(2, 2);
     core.setCountData(testWorkspace);
 
-    TS_ASSERT_EQUALS(testWorkspace->dataY(0)[0], 0.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(0)[0], 0.0);
     core.addToCountData(0, 0, 23.0);
-    TS_ASSERT_EQUALS(testWorkspace->dataY(0)[0], 23.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(0)[0], 23.0);
     core.addToCountData(0, 0, 23.0);
-    TS_ASSERT_EQUALS(testWorkspace->dataY(0)[0], 46.0);
+    TS_ASSERT_EQUALS(testWorkspace->y(0)[0], 46.0);
   }
 
   void testCalculateCorrelationBackground() {
@@ -108,10 +108,10 @@ public:
     // subtracted from all counts.
     core.correctCountData();
 
-    TS_ASSERT_EQUALS(testWorkspace->readY(0)[0], -0.5);
-    TS_ASSERT_EQUALS(testWorkspace->readY(0)[1], -0.5);
-    TS_ASSERT_EQUALS(testWorkspace->readY(1)[0], 0.5);
-    TS_ASSERT_EQUALS(testWorkspace->readY(1)[1], 0.5);
+    TS_ASSERT_EQUALS(testWorkspace->y(0)[0], -0.5);
+    TS_ASSERT_EQUALS(testWorkspace->y(0)[1], -0.5);
+    TS_ASSERT_EQUALS(testWorkspace->y(1)[0], 0.5);
+    TS_ASSERT_EQUALS(testWorkspace->y(1)[1], 0.5);
   }
 
   void testCalculateAverage() {

--- a/Framework/SINQ/test/PoldiSpectrumConstantBackgroundTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumConstantBackgroundTest.h
@@ -42,7 +42,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(function->setWorkspace(ws));
     function->setParameter(0, 10.0);
 
-    FunctionDomain1DVector domain(ws->readX(0));
+    FunctionDomain1DVector domain(ws->x(0).rawData());
     FunctionValues values(domain);
 
     function->function(domain, values);

--- a/Framework/SINQ/test/PoldiTruncateDataTest.h
+++ b/Framework/SINQ/test/PoldiTruncateDataTest.h
@@ -8,13 +8,16 @@
 #include "MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
-#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidHistogramData/LinearGenerator.h"
 
 using namespace Mantid::Poldi;
 using namespace Mantid::API;
 
 using ::testing::Return;
+using Mantid::HistogramData::Points;
+using Mantid::HistogramData::LinearGenerator;
 
 class PoldiTruncateDataTest : public CxxTest::TestSuite {
 public:
@@ -174,7 +177,7 @@ public:
     // number of histograms does not change
     TS_ASSERT_EQUALS(cropped->getNumberHistograms(), 1);
 
-    const std::vector<double> &xData = cropped->readX(0);
+    auto &xData = cropped->x(0);
 
     TS_ASSERT_EQUALS(xData.size(), 500);
 
@@ -204,7 +207,7 @@ public:
     // number of histograms does not change
     TS_ASSERT_EQUALS(cropped->getNumberHistograms(), 1);
 
-    const std::vector<double> &xData = cropped->readX(0);
+    auto &xData = cropped->x(0);
 
     TS_ASSERT_EQUALS(xData.size(), 100);
 
@@ -223,7 +226,7 @@ public:
 
     MatrixWorkspace_sptr below = truncate.getWorkspaceBelowX(workspace, 1497.0);
 
-    const std::vector<double> &x = below->readX(0);
+    auto &x = below->x(0);
 
     TS_ASSERT_EQUALS(x.size(), 500);
     TS_ASSERT_EQUALS(x.front(), 0.0);
@@ -236,7 +239,7 @@ public:
 
     MatrixWorkspace_sptr above = truncate.getWorkspaceAboveX(workspace, 1500.0);
 
-    const std::vector<double> &x = above->readX(0);
+    auto &x = above->x(0);
 
     TS_ASSERT_EQUALS(x.size(), 100);
     TS_ASSERT_EQUALS(x.front(), 1500.0);
@@ -252,8 +255,8 @@ public:
     TS_ASSERT_EQUALS(summed->getNumberHistograms(), 1);
 
     // since all y-values are 2.0, the sum should be 10 * 2.0
-    TS_ASSERT_EQUALS(summed->readY(0).front(), 20.0);
-    TS_ASSERT_EQUALS(summed->readY(0).back(), 20.0);
+    TS_ASSERT_EQUALS(summed->y(0).front(), 20.0);
+    TS_ASSERT_EQUALS(summed->y(0).back(), 20.0);
   }
 
   void testGetCropAlgorithmForWorkspace() {
@@ -287,18 +290,13 @@ private:
   MatrixWorkspace_sptr getProperWorkspaceWithXValues(size_t histograms,
                                                      size_t binCount,
                                                      double spacing) {
-    std::vector<double> xValues(binCount);
-    for (size_t i = 0; i < binCount; ++i) {
-      xValues[i] = static_cast<double>(i) * spacing;
-    }
+    Points xValues(binCount, LinearGenerator(0, spacing));
 
     MatrixWorkspace_sptr workspace =
         WorkspaceCreationHelper::create2DWorkspace123(histograms, binCount);
 
-    for (size_t i = 0; i < histograms; ++i) {
-      std::vector<double> &xData = workspace->dataX(i);
-      xData.assign(xValues.begin(), xValues.end());
-    }
+    for (size_t i = 0; i < histograms; ++i)
+      workspace->setPoints(i, xValues);
 
     return workspace;
   }

--- a/Framework/SINQ/test/PoldiTruncateDataTest.h
+++ b/Framework/SINQ/test/PoldiTruncateDataTest.h
@@ -177,7 +177,7 @@ public:
     // number of histograms does not change
     TS_ASSERT_EQUALS(cropped->getNumberHistograms(), 1);
 
-    auto &xData = cropped->x(0);
+    const auto &xData = cropped->x(0);
 
     TS_ASSERT_EQUALS(xData.size(), 500);
 
@@ -207,7 +207,7 @@ public:
     // number of histograms does not change
     TS_ASSERT_EQUALS(cropped->getNumberHistograms(), 1);
 
-    auto &xData = cropped->x(0);
+    const auto &xData = cropped->x(0);
 
     TS_ASSERT_EQUALS(xData.size(), 100);
 
@@ -226,7 +226,7 @@ public:
 
     MatrixWorkspace_sptr below = truncate.getWorkspaceBelowX(workspace, 1497.0);
 
-    auto &x = below->x(0);
+    const auto &x = below->x(0);
 
     TS_ASSERT_EQUALS(x.size(), 500);
     TS_ASSERT_EQUALS(x.front(), 0.0);
@@ -239,7 +239,7 @@ public:
 
     MatrixWorkspace_sptr above = truncate.getWorkspaceAboveX(workspace, 1500.0);
 
-    auto &x = above->x(0);
+    const auto &x = above->x(0);
 
     TS_ASSERT_EQUALS(x.size(), 100);
     TS_ASSERT_EQUALS(x.front(), 1500.0);


### PR DESCRIPTION

## Description of work.
This PR is part of refactoring effort to use the new interface of the HistogramData module.
See https://github.com/mantidproject/mantid/issues/17641 for details.

The following algorithms were refactored to use HistogramData:

Framework/Nexus/src/NexusFileIO.cpp
Framework/SINQ/src/LoadFlexiNexus.cpp
Framework/SINQ/src/MDHistoToWorkspace2D.cpp
Framework/SINQ/src/PoldiAnalyseResiduals.cpp
Framework/SINQ/src/PoldiFitPeaks2D.cpp
Framework/SINQ/src/PoldiPeakSearch.cpp
Framework/SINQ/src/PoldiTruncateData.cpp
Framework/SINQ/src/PoldiUtilities/PoldiAutoCorrelationCore.cpp
Framework/SINQ/src/PoldiUtilities/PoldiResidualCorrelationCore.cpp
Framework/SINQ/src/PoldiUtilities/PoldiSpectrumConstantBackground.cpp

## To test.

Code review.

<Add any manual testing not covered by unit tests, especially GUIs>

Fixes <your issue>.
Internal change, no release notes (potential performance improvements will be added to release notes as part of the umbrella issue).
