### PR TITLE
SNSPowderReduction list error

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -850,7 +850,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
 
             # Do align and focus
             num_out_wksp = len(output_ws_name_list)
-            for split_index in xrange(num_out_wksp):
+            for split_index in range(num_out_wksp):
                 # Get workspace name
                 out_ws_name_chunk_split = output_ws_name_list[split_index]
                 # Align and focus

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -481,7 +481,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         return
 
     def _getLinearizedFilenames(self, propertyName):
-        runnumbers = self.getProperty("Filename").value
+        runnumbers = self.getProperty(propertyName).value
         linearizedRuns = []
         for item in runnumbers:
             if type(item) == list:

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -269,12 +269,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         self._outPrefix = self.getProperty("OutputFilePrefix").value.strip()
         self._outTypes = self.getProperty("SaveAs").value.lower()
 
-        samRuns = self.getProperty("Filename").value
-        if type(samRuns[0]) == list:
-            linearizedRuns = []
-            for item in samRuns:
-                linearizedRuns.extend(item)
-            samRuns = linearizedRuns[:] # deep copy
+        samRuns = self._getLinearizedFilenames("Filename")
         self._determineInstrument(samRuns[0])
 
         preserveEvents = self.getProperty("PreserveEvents").value
@@ -484,6 +479,16 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                 self.setProperty(propertyName, wksp)
 
         return
+
+    def _getLinearizedFilenames(self, propertyName):
+        runnumbers = self.getProperty("Filename").value
+        linearizedRuns = []
+        for item in runnumbers:
+            if type(item) == list:
+                linearizedRuns.extend(item)
+            else:
+                linearizedRuns.append(item)
+        return linearizedRuns
 
     def _determineInstrument(self, filename):
         name = getBasename(filename)

--- a/docs/source/release/v3.9.0/diffraction.rst
+++ b/docs/source/release/v3.9.0/diffraction.rst
@@ -35,7 +35,7 @@ Engineering Diffraction
 Powder Diffraction
 ------------------
 
-:ref:`algm-SNSPowderReduction` had an error in logic of subtracting the vanadium background. It was not being subtracted when ``PreserveEvents=True``.
+:ref:`algm-SNSPowderReduction` had an error in logic of subtracting the vanadium background. It was not being subtracted when ``PreserveEvents=True``. There is also a fix in reducing a series of runs from the powder diffraction gui.
 
 :ref:`algm-PDLoadCharacterizations` and
 :ref:`algm-PDDetermineCharacterizations` have been upgraded to support


### PR DESCRIPTION
Due to the interaction of the powder diffraction gui and `SNSPowderReduction` there was a bug in linearizing the list of files to process in the algorithm.

**To test:**

Run the script below before and after merging the branch.

```python
config['default.facility']="SNS"

SNSPowderReduction(
                       SaveAs = 'gsas and fullprof and topas',
                       FinalDataUnits = 'dSpacing',
                       Filename = '22029,22030,22041,22042,22845-22852',
                       Sum = '0',
                       BackgroundNumber = '-1',
                       Binning = '-0.0008000',
                       OutputDirectory = '/tmp',
                       BinInDspace = '0',
                       CalibrationFile = '/SNS/PG3/shared/CALIBRATION/2015_1_11A_CAL/PG3_PAC_JANIS_d21989_2015_01_25.cal',
                       CharacterizationRunsFile = '/SNS/PG3/shared/CALIBRATION/2015_1_11A_CAL/PG3_char_2015_01_27-HR.txt',
                       StripVanadiumPeaks = '1',
                       RemovePromptPulseWidth = '50.0',
                       FilterBadPulses = '10.0',
                       PushDataPositive = 'None',
                       PreserveEvents = '1',
                       ScaleData = '100.0')
```

*There  is no associated issue*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
