### PR TITLE
Unit test fails with GSL2

### DIFF
--- a/Framework/CurveFitting/test/Functions/DiffRotDiscreteCircleTest.h
+++ b/Framework/CurveFitting/test/Functions/DiffRotDiscreteCircleTest.h
@@ -239,7 +239,7 @@ public:
         "(composite=Convolution,FixResolution=true,NumDeriv=true;name=Gaussian,"
         "Height=1,PeakCentre=0,Sigma=20,ties=(Height=1,PeakCentre=0,Sigma=20);("
         "name=DiffRotDiscreteCircle,N=3,NumDeriv=true,Q=0.5,Intensity=47.014,"
-        "Radius=1.567,Decay=7.567))";
+        "Radius=1.567,Decay=0.07567))";
 
     // Initialize the fit function in the Fit algorithm
     Algorithms::Fit fitalg;
@@ -258,7 +258,7 @@ public:
                      "name=Gaussian,Height=1,PeakCentre=0,Sigma=20,ties=("
                      "Height=1,PeakCentre=0,Sigma=20);(name="
                      "DiffRotDiscreteCircle,N=3,NumDeriv=true,Q=0.5,Intensity="
-                     "10.0,Radius=1.567,Decay=20.0))";
+                     "20.0,Radius=1.567,Decay=0.1))";
     fitalg.setProperty("Function", funtion_string);
     fitalg.setProperty("InputWorkspace", data_workspace);
     fitalg.setPropertyValue("WorkspaceIndex", "0");
@@ -296,10 +296,10 @@ public:
                     47.014 * 0.05); // allow for a small percent variation
     TS_ASSERT_DELTA(fitalg_structure_factor->getParameter("Radius"), 1.567,
                     1.567 * 0.05); // allow for a small percent variation
-    TS_ASSERT_DELTA(fitalg_structure_factor->getParameter("Decay"), 7.567,
+    TS_ASSERT_DELTA(fitalg_structure_factor->getParameter("Decay"), 0.07567,
                     7.567 * 0.05); // allow for a small percent variation
     // std::cout << "\nGOAL: Intensity = 47.014,  Radius = 1.567,  Decay =
-    // 7.567\n"; // only for debugging purposes
+    // 0.07567\n"; // only for debugging purposes
     // std::cout << "OPTIMIZED: Intensity = " <<
     // fitalg_structure_factor->getParameter("Intensity") << "  Radius = " <<
     // fitalg_structure_factor->getParameter("Radius") << "  Decay = " <<


### PR DESCRIPTION
Currently the three parameters that are tested, `Intensity`, `Radius` and `Decay`, are 100% correlated which makes fit unstable. I changed the parameters of the simulated data set such that the fit should become stable.

**To test:**

`CurveFittingTest_DiffRotDiscreteCircleTest` should pass on all systems and with any version of the GSL.


Fixes #17778.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
