### PR TITLE
Fix uninitialized variable in ISpectrum.

### DIFF
--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -260,7 +260,8 @@ private:
 
   void updateExperimentInfo() const;
   ExperimentInfo *m_experimentInfo{nullptr};
-  size_t m_index;
+  // The default value is meaningless. This will always be set before use.
+  size_t m_index{0};
 
   /// The spectrum number of this spectrum
   specnum_t m_specNo{0};


### PR DESCRIPTION
This should fix a coverity warning about an uninitialized variable.

**To test:**

<!-- Instructions for testing. -->

Code review.
No issue, no release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
