### PR TITLE
Remove SortXAxis dependence of ADS

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SortXAxis.py
+++ b/Framework/PythonInterface/plugins/algorithms/SortXAxis.py
@@ -1,6 +1,5 @@
 #pylint: disable=no-init,invalid-name
 from __future__ import (absolute_import, division, print_function)
-import mantid.simpleapi as api
 
 from mantid.api import *
 from mantid.kernel import *

--- a/Framework/PythonInterface/plugins/algorithms/SortXAxis.py
+++ b/Framework/PythonInterface/plugins/algorithms/SortXAxis.py
@@ -29,7 +29,12 @@ class SortXAxis(PythonAlgorithm):
         output_ws = self.getPropertyValue('OutputWorkspace')
 
         num_specs = input_ws.getNumberHistograms()
-        api.CloneWorkspace(InputWorkspace=input_ws, OutputWorkspace=output_ws)
+
+        clone_alg = self.createChildAlgorithm("CloneWorkspace", enableLogging=False)
+        clone_alg.setProperty("InputWorkspace", input_ws)
+        clone_alg.setProperty("OutputWorkspace", output_ws)
+        clone_alg.execute()
+        output_ws = clone_alg.getProperty("OutputWorkspace").value
 
         for i in range(0, num_specs):
             x_data = input_ws.readX(i)
@@ -46,9 +51,9 @@ class SortXAxis(PythonAlgorithm):
             y_ordered = y_data[indexes]
             e_ordered = e_data[indexes]
 
-            mtd[output_ws].setX(i, x_ordered)
-            mtd[output_ws].setY(i, y_ordered)
-            mtd[output_ws].setE(i, e_ordered)
+            output_ws.setX(i, x_ordered)
+            output_ws.setY(i, y_ordered)
+            output_ws.setE(i, e_ordered)
 
         self.setProperty('OutputWorkspace', output_ws)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -246,7 +246,7 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
                 self._elt_workspace = sort_alg.getProperty("OutputWorkspace").value
             else:
                 clone_alg = self.createChildAlgorithm("CloneWorkspace", enableLogging=False)
-                clone_alg.setProperty("InputWorkspace", sort_alg.getProperty("OutputWorkspace").value)
+                clone_alg.setProperty("InputWorkspace", self.getProperty("OutputELF").value)
                 clone_alg.setProperty("OutputWorkspace", self._elt_workspace)
                 clone_alg.execute()
                 self._elt_workspace = clone_alg.getProperty("OutputWorkspace").value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -246,7 +246,7 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
                 self._elt_workspace = sort_alg.getProperty("OutputWorkspace").value
             else:
                 clone_alg = self.createChildAlgorithm("CloneWorkspace", enableLogging=False)
-                clone_alg.setProperty("InputWorkspace", self._elf_workspace)
+                clone_alg.setProperty("InputWorkspace", sort_alg.getProperty("OutputWorkspace").value)
                 clone_alg.setProperty("OutputWorkspace", self._elt_workspace)
                 clone_alg.execute()
                 self._elt_workspace = clone_alg.getProperty("OutputWorkspace").value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -216,7 +216,6 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
 
         progress.report('Creating ELF workspaces')
         transpose_alg = self.createChildAlgorithm("Transpose", enableLogging=False)
-        transpose_alg.setAlwaysStoreInADS(True)
         sort_alg = self.createChildAlgorithm("SortXAxis", enableLogging=False)
         # Process the ELF workspace
         if self._elf_workspace != '':
@@ -225,7 +224,7 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
             transpose_alg.setProperty("OutputWorkspace", self._elf_workspace)
             transpose_alg.execute()
 
-            sort_alg.setProperty("InputWorkspace", self._elf_workspace)
+            sort_alg.setProperty("InputWorkspace", transpose_alg.getProperty("OutputWorkspace").value)
             sort_alg.setProperty("OutputWorkspace", self._elf_workspace)
             sort_alg.execute()
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SortXAxisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SortXAxisTest.py
@@ -109,7 +109,33 @@ class SortXAxisTest(unittest.TestCase):
         DeleteWorkspace(unsortedws)
         DeleteWorkspace(sortedws)
 
-
+    def test_sort_x_works_child(self):
+        # Create unsorted workspace
+        parent = AlgorithmManager.createUnmanaged('Load')
+        create_ws_alg = parent.createChildAlgorithm("CreateWorkspace")
+        dataX = [4, 3, 2, 1]
+        dataY = [1, 2, 3]
+        dataE = [1, 2, 3]
+        create_ws_alg.setProperty("DataX", dataX)
+        create_ws_alg.setProperty("DataY", dataY)
+        create_ws_alg.setProperty("DataE", dataE)
+        create_ws_alg.setProperty("UnitX",'TOF')
+        create_ws_alg.setProperty("Distribution", False)
+        create_ws_alg.execute()
+        # Run the algorithm
+        sort_alg = parent.createChildAlgorithm("SortXAxis")
+        sort_alg.setProperty("InputWorkspace", create_ws_alg.getProperty("OutputWorkspace").value)
+        sort_alg.execute()
+        # Check the resulting data values. Sorting operation should have resulted in no changes
+        sortedws = sort_alg.getProperty("OutputWorkspace").value
+        sortedX = sortedws.readX(0)
+        sortedY = sortedws.readY(0)
+        sortedE = sortedws.readE(0)
+        self.assertEqual(sorted(dataX), sortedX.tolist())
+        dataY.reverse()
+        dataE.reverse()
+        self.assertEqual(dataY, sortedY.tolist())
+        self.assertEqual(dataE, sortedE.tolist())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
SortXAxis has been refactored to call CloneWorkspaces as a child algorithm to remove the error caused if the input workspace didn't exist in the ADS. 

**To test:**

[InputFiles.zip](https://github.com/mantidproject/mantid/files/754983/InputFiles.zip)
Load files from input folder
```Python
GroupWorkspaces(InputWorkspaces='osiris120225_graphite002_red,osiris120226_graphite002_red,osiris120227_graphite002_red', 
    OutputWorkspace='Elwin_Input')
ElasticWindowMultiple(InputWorkspaces='Elwin_Input', 
    IntegrationRangeStart=-0.0245,
    IntegrationRangeEnd=0.0245, 
    SampleEnvironmentLogName='Field', 
    OutputInQ='osiris120225-120227_graphite002_red_elwin_eq', 
    OutputInQSquared='osiris120225-120227_graphite002_red_elwin_eq2', 
    OutputELF='osiris120225-120227_graphite002_red_elwin_elf')
```

Fixes #18543 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
