### PR TITLE
Fix indexing errors in NumPy 1.12

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AngularAutoCorrelationsTwoAxes.py
+++ b/Framework/PythonInterface/plugins/algorithms/AngularAutoCorrelationsTwoAxes.py
@@ -310,7 +310,7 @@ class AngularAutoCorrelationsTwoAxes(PythonAlgorithm):
 
     def fold_correlation(self,omega):
         # Folds an array with symmetrical values into half by averaging values around the centre
-        right_half=omega[int(len(omega))/2:]
+        right_half=omega[int(len(omega))//2:]
         left_half=omega[:int(np.ceil(len(omega)/2.0))][::-1]
 
         return (left_half+right_half)/2.0

--- a/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
@@ -19,18 +19,18 @@ def mask_ws(ws_to_mask, xstart, xend):
 
     if xstart > 0:
         logger.debug('Mask bins smaller than {0}'.format(xstart))
-        MaskBins(InputWorkspace=ws_to_mask, OutputWorkspace=ws_to_mask, XMin=x_values[0], XMax=x_values[xstart])
+        MaskBins(InputWorkspace=ws_to_mask, OutputWorkspace=ws_to_mask, XMin=x_values[0], XMax=x_values[int(xstart)])
     else:
         logger.debug('No masking due to x bin <= 0!: {0}'.format(xstart))
     if xend < len(x_values) - 1:
         logger.debug('Mask bins larger than {0}'.format(xend))
-        MaskBins(InputWorkspace=ws_to_mask, OutputWorkspace=ws_to_mask, XMin=x_values[xend + 1], XMax=x_values[-1])
+        MaskBins(InputWorkspace=ws_to_mask, OutputWorkspace=ws_to_mask, XMin=x_values[int(xend) + 1], XMax=x_values[-1])
     else:
         logger.debug('No masking due to x bin >= len(x_values) - 1!: {0}'.format(xend))
 
     if xstart > 0 and xend < len(x_values) - 1:
         logger.information('Bins out of range {0} {1} [Unit of X-axis] are masked'.format
-                           (x_values[xstart],x_values[xend + 1]))
+                           (x_values[int(xstart)],x_values[int(xend) + 1]))
 
 
 class MatchPeaks(PythonAlgorithm):

--- a/Framework/PythonInterface/plugins/algorithms/VelocityAutoCorrelations.py
+++ b/Framework/PythonInterface/plugins/algorithms/VelocityAutoCorrelations.py
@@ -308,7 +308,7 @@ class VelocityAutoCorrelations(PythonAlgorithm):
 
     def fold_correlation(self,w):
         # Folds an array with symmetrical values into half by averaging values around the centre
-        right_half=w[len(w)/2:]
+        right_half=w[len(w)//2:]
         left_half=w[:int(np.ceil(len(w)/2.0))][::-1]
 
         return (left_half+right_half)/2.0

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
@@ -172,11 +172,11 @@ class IndirectILLReductionQENS(PythonAlgorithm):
 
         if xstart > 0:
             self.log().debug('Mask bins smaller than {0}'.format(xstart))
-            MaskBins(InputWorkspace=ws, OutputWorkspace=ws, XMin=x_values[0], XMax=x_values[xstart])
+            MaskBins(InputWorkspace=ws, OutputWorkspace=ws, XMin=x_values[0], XMax=x_values[int(xstart)])
 
         if xend < len(x_values) - 1:
             self.log().debug('Mask bins larger than {0}'.format(xend))
-            MaskBins(InputWorkspace=ws, OutputWorkspace=ws, XMin=x_values[xend + 1], XMax=x_values[-1])
+            MaskBins(InputWorkspace=ws, OutputWorkspace=ws, XMin=x_values[int(xend) + 1], XMax=x_values[-1])
 
     def _filter_files(self, files, label):
         '''

--- a/Framework/PythonInterface/test/python/plugins/algorithms/BinWidthAtXTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/BinWidthAtXTest.py
@@ -28,7 +28,7 @@ class BinWidthAtXTest(unittest.TestCase):
         xs = self._make_boundaries(xBegin, binWidths)
         ys = numpy.zeros(len(xs) - 1)
         ws = CreateWorkspace(DataX=xs, DataY=ys)
-        i = len(binWidths) / 2
+        i = len(binWidths) // 2
         middleBinWidth = binWidths[i]
         middleBinX = xs[i] + 0.5 * middleBinWidth
         return ws, middleBinX, middleBinWidth

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MuscatSofQWTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MuscatSofQWTest.py
@@ -37,7 +37,7 @@ class MuscatSofQWTest(unittest.TestCase):
         x_data = sqw_ws.dataX(0)
         self.assertAlmostEqual(x_data[0], -0.5)
         self.assertAlmostEqual(x_data[-1], 0.5)
-        self.assertAlmostEqual(x_data[len(x_data)/2], 0.0)
+        self.assertAlmostEqual(x_data[len(x_data)//2], 0.0)
 
         self.assertEquals(sqw_ws.blocksize(), 200)
 
@@ -59,7 +59,7 @@ class MuscatSofQWTest(unittest.TestCase):
         x_data = sqw_ws.dataX(0)
         self.assertAlmostEqual(x_data[0], -1.0)
         self.assertAlmostEqual(x_data[-1], 1.0)
-        self.assertAlmostEqual(x_data[len(x_data)/2], 0.0)
+        self.assertAlmostEqual(x_data[len(x_data)//2], 0.0)
 
         self.assertEquals(sqw_ws.blocksize(), 400)
 
@@ -81,7 +81,7 @@ class MuscatSofQWTest(unittest.TestCase):
         x_data = sqw_ws.dataX(0)
         self.assertAlmostEqual(x_data[0], -0.5)
         self.assertAlmostEqual(x_data[-1], 0.5)
-        self.assertAlmostEqual(x_data[len(x_data)/2], 0.0)
+        self.assertAlmostEqual(x_data[len(x_data)//2], 0.0)
 
         self.assertEquals(sqw_ws.blocksize(), 10)
 

--- a/scripts/PyChop/ISISDisk.py
+++ b/scripts/PyChop/ISISDisk.py
@@ -203,7 +203,7 @@ class ISISDisk:
         if len(ie_list) == 1:
             chop_width = chop_width[ie_list]
             mod_width = mod_width[ie_list]
-            res_el = res_el[ie_list]
+            res_el = res_el[int(ie_list)]
         return Eis, res_list, res_el, percent, ie_list, chop_width, mod_width
 
     def getElasticResolution(self, Ei_in=None, frequency=None):


### PR DESCRIPTION
In 1.12 numpy changed some DeprecationWarnings to errors related to indexing, see https://docs.scipy.org/doc/numpy/release.html#deprecationwarning-to-error

This only fixes the errors where unit tests were failing, mostly using floats to index arrays, see http://builds.mantidproject.org/job/master_clean-archlinux/748/console

**To test:**
Code review should be sufficient, I don't expect anyone else to be using NumPy 1.12 currently



*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
