### PR TITLE
Fixed fitting range in muon

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
@@ -457,6 +457,9 @@ private:
   /// conversion from QString to int
   void getFullCode(int originalSize, QString &run);
 
+  /// Sets the fitting ranges
+  void setFittingRanges(double xmin, double xmax);
+
   /// Setup the signals for updating
   void connectAutoUpdate();
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -2384,20 +2384,20 @@ void MuonAnalysis::changeTab(int newTabIndex) {
     // to it
     connect(m_uiForm.fitBrowser, SIGNAL(workspaceNameChanged(const QString &)),
             this, SLOT(selectMultiPeak(const QString &)), Qt::QueuedConnection);
- 
-if (xmin == 0.0 && xmax == 0.0) {
+
+    if (xmin == 0.0 && xmax == 0.0) {
       // A previous fitting range of [0,0] means this is the first time the
       // user goes to "Data Analysis" tab
       // We have to initialise the fitting range
       m_dataSelector->setStartTime(
-        m_uiForm.timeAxisStartAtInput->text().toDouble());
+          m_uiForm.timeAxisStartAtInput->text().toDouble());
       m_dataSelector->setEndTime(
-        m_uiForm.timeAxisFinishAtInput->text().toDouble());
+          m_uiForm.timeAxisFinishAtInput->text().toDouble());
       m_uiForm.fitBrowser->setStartX(
-        m_uiForm.timeAxisStartAtInput->text().toDouble());
+          m_uiForm.timeAxisStartAtInput->text().toDouble());
       m_uiForm.fitBrowser->setEndX(
-        m_uiForm.timeAxisFinishAtInput->text().toDouble());
-      
+          m_uiForm.timeAxisFinishAtInput->text().toDouble());
+
     }
     // or set it to the previous values provided by the user:
     else {
@@ -2406,10 +2406,9 @@ if (xmin == 0.0 && xmax == 0.0) {
       m_dataSelector->setEndTime(xmax);
       m_uiForm.fitBrowser->setStartX(xmin);
       m_uiForm.fitBrowser->setEndX(xmax);
-}
+    }
 
-
-} else if (newTab == m_uiForm.ResultsTable) {
+  } else if (newTab == m_uiForm.ResultsTable) {
     m_resultTableTab->refresh();
   }
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -554,11 +554,9 @@ void MuonAnalysis::runSaveGroupButton() {
   // Get value for "dir". If the setting doesn't exist then use
   // the the path in "defaultsave.directory"
   QString prevPath =
-      prevValues
-          .value("dir",
-                 QString::fromStdString(ConfigService::Instance().getString(
-                     "defaultsave.directory")))
-          .toString();
+      prevValues.value("dir", QString::fromStdString(
+                                  ConfigService::Instance().getString(
+                                      "defaultsave.directory"))).toString();
 
   QString filter;
   filter.append("Files (*.xml *.XML)");
@@ -595,11 +593,9 @@ void MuonAnalysis::runLoadGroupButton() {
   // Get value for "dir". If the setting doesn't exist then use
   // the the path in "defaultsave.directory"
   QString prevPath =
-      prevValues
-          .value("dir",
-                 QString::fromStdString(ConfigService::Instance().getString(
-                     "defaultload.directory")))
-          .toString();
+      prevValues.value("dir", QString::fromStdString(
+                                  ConfigService::Instance().getString(
+                                      "defaultload.directory"))).toString();
 
   QString filter;
   filter.append("Files (*.xml *.XML)");
@@ -1718,9 +1714,9 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   safeWSName.replace("'", "\'");
   pyS.replace("%WSNAME%", safeWSName);
   pyS.replace("%PREV%", m_currentDataName);
-  pyS.replace("%USEPREV%",
-              policy == MuonAnalysisOptionTab::PreviousWindow ? "True"
-                                                              : "False");
+  pyS.replace("%USEPREV%", policy == MuonAnalysisOptionTab::PreviousWindow
+                               ? "True"
+                               : "False");
   pyS.replace("%ERRORS%", params["ShowErrors"]);
   pyS.replace("%CONNECT%", params["ConnectType"]);
   pyS.replace("%LOGSCALE%", logScale ? "True" : "False");

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -2370,24 +2370,6 @@ void MuonAnalysis::changeTab(int newTabIndex) {
         ConfigService::Instance().getString(PEAK_RADIUS_CONFIG);
     ConfigService::Instance().setString(PEAK_RADIUS_CONFIG, "99");
 
-    // setFitPropertyBrowser() above changes the fitting range, so we have to
-    // either initialise it to the correct values:
-    if (xmin == 0.0 && xmax == 0.0) {
-      // A previous fitting range of [0,0] means this is the first time the
-      // user goes to "Data Analysis" tab
-      // We have to initialise the fitting range
-      m_dataSelector->setStartTime(
-          m_uiForm.timeAxisStartAtInput->text().toDouble());
-      m_dataSelector->setEndTime(
-          m_uiForm.timeAxisFinishAtInput->text().toDouble());
-    }
-    // or set it to the previous values provided by the user:
-    else {
-      // A previous fitting range already exists, so we use it
-      m_dataSelector->setStartTime(xmin);
-      m_dataSelector->setEndTime(xmax);
-    }
-
     // If a workspace is selected:
     // - Show connected plot and attach PP tool to it (if has been assigned)
     // - Set input of data selector to selected workspace
@@ -2402,7 +2384,32 @@ void MuonAnalysis::changeTab(int newTabIndex) {
     // to it
     connect(m_uiForm.fitBrowser, SIGNAL(workspaceNameChanged(const QString &)),
             this, SLOT(selectMultiPeak(const QString &)), Qt::QueuedConnection);
-  } else if (newTab == m_uiForm.ResultsTable) {
+ 
+if (xmin == 0.0 && xmax == 0.0) {
+      // A previous fitting range of [0,0] means this is the first time the
+      // user goes to "Data Analysis" tab
+      // We have to initialise the fitting range
+      m_dataSelector->setStartTime(
+        m_uiForm.timeAxisStartAtInput->text().toDouble());
+      m_dataSelector->setEndTime(
+        m_uiForm.timeAxisFinishAtInput->text().toDouble());
+      m_uiForm.fitBrowser->setStartX(
+        m_uiForm.timeAxisStartAtInput->text().toDouble());
+      m_uiForm.fitBrowser->setEndX(
+        m_uiForm.timeAxisFinishAtInput->text().toDouble());
+      
+    }
+    // or set it to the previous values provided by the user:
+    else {
+      // A previous fitting range already exists, so we use it
+      m_dataSelector->setStartTime(xmin);
+      m_dataSelector->setEndTime(xmax);
+      m_uiForm.fitBrowser->setStartX(xmin);
+      m_uiForm.fitBrowser->setEndX(xmax);
+}
+
+
+} else if (newTab == m_uiForm.ResultsTable) {
     m_resultTableTab->refresh();
   }
 


### PR DESCRIPTION
Fixed the default fitting range in the muon analysis interface. 



<!-- Instructions for testing. -->
To test:
In the muon analysis interface the default fitting range should match the start and finish values in the settings tab (with Time axis set to "Start at First Good Data"). 

This addresses one of the issues from https://github.com/mantidproject/mantid/issues/18195
<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
