### PR TITLE
MantidPlot: Fix Window resizing when second is closed

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -8988,7 +8988,11 @@ void ApplicationWindow::activateWindow(MdiSubWindow *w,
   FloatingWindow *fw = w->getFloatingWindow();
   if (fw) {
     if (activateOuterWindow) {
-      w->setNormal();
+      if (fw->isMaximized()) {
+        w->setMaximized();
+      } else {
+        w->setNormal();
+      }
     }
   } else {
     QMainWindow::activateWindow();

--- a/docs/source/release/v3.9.0/ui.rst
+++ b/docs/source/release/v3.9.0/ui.rst
@@ -91,6 +91,7 @@ Bugs Resolved
 - Fixed a bug where changing the integration range of the instrument view would clear the applied zooming.
 - Fixed a bug where the threshold filter in the VSI SplatterPlot view only returned an empty dataset.
 - Fixed a bug where plotting a column of TableWorkspace in the GUI did not work if decimal separator was not a dot.
+- Fixed a bug where closing a second plot window would cause a newly activated window to be resized.
 
 
 VSI Improvements


### PR DESCRIPTION
Description of work

Checks for maximised status of newly activated windows before changing their state.

**To test:**

Review the code and try the testing instructions in the original issue.

Fixes #18739.

[RELEASE NOTES](https://github.com/mantidproject/mantid/commit/1050de3e1ae2db019c898644e972177cad141f5c)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
