### PR TITLE
Fix missing slot warning in Muon Analysis

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
@@ -200,9 +200,12 @@ private slots:
   /// Checks if the plot for the workspace does exist.
   bool plotExists(const QString &wsName);
 
-  /// Enable PP tool for the plot of the given WS
+  /// Enable PP tool for the plot of the given WS and optional filepath
   void selectMultiPeak(const QString &wsName,
                        const boost::optional<QString> &filePath);
+
+  /// Enable PP tool for the plot of the given WS overload to take just a ws
+  void selectMultiPeak(const QString &wsName);
 
   /// Disable tools for all the graphs within MantidPlot
   void disableAllTools();

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1841,6 +1841,16 @@ void MuonAnalysis::selectMultiPeak(const QString &wsName,
 }
 
 /**
+ * Pass through to selectMultiPeak(wsName, filePath) where filePath is set
+ * to blank. Enables connection as a slot without Qt understanding
+ * boost::optional.
+ * @param wsName Name of the selected workspace
+ */
+void MuonAnalysis::selectMultiPeak(const QString &wsName) {
+  selectMultiPeak(wsName, boost::optional<QString>());
+}
+
+/**
  * Disable tools for all the graphs within MantidPlot.
  */
 void MuonAnalysis::disableAllTools() { runPythonCode("disableTools()"); }


### PR DESCRIPTION
Description of work.

Adds an overload to allow calls to `selectMultiPeak` with a single argument as expected by various `connect` calls in the code. This was broken in [2b2dd7ce43d3eb7ad0fbe650825e21ec96130473](https://github.com/mantidproject/mantid/commit/2b2dd7ce43d3eb7ad0fbe650825e21ec96130473) when the second argument was added.

**To test:**

* Select search data archive in "View->Preferences" 
* open Muon interface
* select `HIFI`
* enter `113041` in the load run box
* press the right arrow to load the next run
* switch to the "Data Analysis" tab
* select a workspace in the fit browser and the plot should update

In the current nightly the plot does not update because the signal fails to be connected.

No issue.

Does not need to be in the release notes as this regression was introduced in this development cycle and was not present in `v3.8`.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
