### PR TITLE
Ensure MantidPlot runs with python's builtin range command by default

### DIFF
--- a/MantidPlot/mantidplotrc.py
+++ b/MantidPlot/mantidplotrc.py
@@ -22,6 +22,12 @@ if __name__ == '__main__':
     # Import MantidPlot python commands
     import mantidplot
     from mantidplot import *
+    try:
+        # The MantidPlot namespace is not ready for the python3-style range function
+        # so we ensure we revert back to the current built-in version
+        del range
+    except NameError:
+        pass
 
     # Make Mantid available
     import mantid

--- a/MantidPlot/test/MantidPlot1DPlotTest.py
+++ b/MantidPlot/test/MantidPlot1DPlotTest.py
@@ -52,6 +52,10 @@ class MantidPlot1DPlotTest(unittest.TestCase):
         g = plotSpectrum("fake", [0, 1])
         self.g = g
 
+    def test_plotSpectrum_range_command(self):
+        g = plotSpectrum("fake", range(0, 2))
+        self.g = g
+
     def test_Customized1DPlot(self):
         g = plotSpectrum("fake", 0, error_bars=True)
         l = g.activeLayer()
@@ -110,4 +114,3 @@ class MantidPlot1DPlotTest(unittest.TestCase):
 
 # Run the unit tests
 mantidplottests.runTests(MantidPlot1DPlotTest)
-


### PR DESCRIPTION
Description of work.

Deletes `six.moves.range` that was imported into the `MantidPlot` global namespace and so reverts back to python's built-in `range` command.

*This was a regression introduced since v3.8.0.*

**To test:**

The following breaks in nightly but should succeed after these changes:

```python
w = CreateSampleWorkspace()
plotSpectrum(w, range(5))
```

Fixes #18746

*Does not need to be in the release notes*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
