### PR TITLE
fix the release note link to the new relese notes location

### DIFF
--- a/Framework/Kernel/src/MantidVersion.cpp.in
+++ b/Framework/Kernel/src/MantidVersion.cpp.in
@@ -25,7 +25,9 @@ const char* MantidVersion::versionShort()
 
 std::string MantidVersion::releaseNotes()
 {
-  const std::string STEM = "http://www.mantidproject.org/Release_Notes_";
+  const std::string STEM = "http://docs.mantidproject.org/v";
+  const std::string MID = "/release/v";
+  const std::string END = "/index.html";
   // Cast here in those cases where patch number is of the form 20131022.1356.
   const unsigned int patchVersion = static_cast<unsigned int>(@VERSION_PATCH@);
 
@@ -34,11 +36,17 @@ std::string MantidVersion::releaseNotes()
   // we're currently in a dev version is to check if the patch version is larger than
   // some arbitrarily low value.
 
-  std::stringstream url;
-  url << STEM << @VERSION_MAJOR@ << "." << @VERSION_MINOR@;
+  std::stringstream versionLabel;
+  versionLabel << versionShort();
   
   if(( patchVersion < 100 ) && ( patchVersion != 0 ))
-    url << "." << patchVersion;
+    versionLabel << "." << patchVersion;
+  else
+    versionLabel << "." << "0";
+
+
+  std::stringstream url;
+  url << STEM << versionLabel.str() << MID << versionLabel.str() << END;
 
   return url.str();
 }


### PR DESCRIPTION
the title says it all, the link was still pointing to the old wiki location, updated it to the new docs location



**To test:**

1. start mantidplot
1. help->first time setup
1. click on release notes


Fixes #18760

### RELEASE NOTES

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
