### PR TITLE
Fix two issues with absolute rotations in RotateInstrumentComponent (via ComponentHelper::rotateComponent)

### DIFF
--- a/Framework/Geometry/src/Instrument/ComponentHelper.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentHelper.cpp
@@ -78,7 +78,7 @@ void rotateComponent(const IComponent &comp, ParameterMap &pmap,
     // Find the corresponding relative position
     auto parent = comp.getParent();
     if (parent) {
-      Quat rot0 = parent->getRelativeRot();
+      Quat rot0 = parent->getRotation();
       rot0.inverse();
       newRot = rot * rot0;
     }

--- a/Framework/Geometry/src/Instrument/ComponentHelper.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentHelper.cpp
@@ -80,7 +80,7 @@ void rotateComponent(const IComponent &comp, ParameterMap &pmap,
     if (parent) {
       Quat rot0 = parent->getRotation();
       rot0.inverse();
-      newRot = rot * rot0;
+      newRot = rot0 * rot;
     }
   } else if (rotType == Relative) {
     const Quat &Rot0 = comp.getRelativeRot();

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -15,6 +15,10 @@ New
 Improved
 ########
 
+Bug Fixes
+#########
+
+- Fixed two issues with absolute rotations that affected :ref:`RotateInstrumentComponent <algm-RotateInstrumentComponent>`. Previously, setting the absolute rotation of a component to ``R`` would result in its rotation being ``parent-rotation * R * inverse(relative-parent-rotation)``.
 
 Deprecated
 ##########


### PR DESCRIPTION
See issues.

**To test:**

Code review, and check if the following gives the expected result (in comparison to the old rotation computation, which did not):

For testing the first issue:

```python
LoadEmptyInstrument(InstrumentName='MAR', OutputWorkspace='ws')
RotateInstrumentComponent(Workspace='ws', ComponentName='wide angle bank', Z=1, Angle=-20, RelativeRotation=False)
RotateInstrumentComponent(Workspace='ws', ComponentName='W1-1', Z=1, Angle=60, RelativeRotation=False)
RotateInstrumentComponent(Workspace='ws', DetectorID=1101, Z=1, Angle=90, RelativeRotation=False)
```

For testing the second issue (need non-planar rotations, the second issue is not visible in the previous example):

```python
LoadEmptyInstrument(InstrumentName='MAR', OutputWorkspace='ws')
RotateInstrumentComponent(Workspace='ws', ComponentName='wide angle bank', Y=1, Angle=90)
RotateInstrumentComponent(Workspace='ws', ComponentName='W1-1', Z=1, Angle=90, RelativeRotation=False)
```

Fixes #18750.
Fixes #18811.

Release notes have been updated. This change affects the behavior of `RotateInstrumentComponent` when absolute rotations are enabled.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
