### PR TITLE
Fix slow rendering of Peaks Table in Splatterplot view

### DIFF
--- a/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
@@ -472,9 +472,9 @@ void SplatterPlotView::createPeaksFilter() {
     vtkSMPropertyHelper(dataRepresentation->getProxy(), "Representation")
         .Set(g_defaultRepresentation);
     vtkSMPropertyHelper(dataRepresentation->getProxy(), "GaussianRadius")
-        .Set(g_defaultOpacity);
-    vtkSMPropertyHelper(dataRepresentation->getProxy(), "Opacity")
         .Set(g_defaultRadius);
+    vtkSMPropertyHelper(dataRepresentation->getProxy(), "Opacity")
+        .Set(g_defaultOpacity);
     dataRepresentation->getProxy()->UpdateVTKObjects();
 
     if (!this->isPeaksWorkspace(this->origSrc)) {


### PR DESCRIPTION
The cause of the slow rendering were too large and too translucent spheres. The default values for the two properties were swapped.

No issue number and no release notes

**To test:**

1. Load the elliptical data sets into the splatter plot view of the VSI
2. Open the peaks table
   * Confirm that the speed when selecting a peak from the table is acceptable (response < 0.5s)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
