### PR TITLE
Fix VSI crash when treshold filter is being used in combination with rebin.

### DIFF
--- a/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
@@ -465,7 +465,8 @@ void RebinnedSourcesManager::rebuildPipeline(pqPipelineSource *source1,
           builder->createFilter("filters", "Threshold", endOfSource2Pipeline);
     } else {
       QString message = QString("The filter ") + QString(proxy1->GetXMLName()) +
-                        QString(" is not known. You need to add it to the list of filters in the RebinnedSourcesManager");
+                        QString(" is not known. You need to add it to the list "
+                                "of filters in the RebinnedSourcesManager");
       throw std::runtime_error(message.toStdString());
     }
 

--- a/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
@@ -460,6 +460,13 @@ void RebinnedSourcesManager::rebuildPipeline(pqPipelineSource *source1,
     } else if (QString(proxy1->GetXMLName()).contains("Cut")) {
       newPipelineElement =
           builder->createFilter("filters", "Cut", endOfSource2Pipeline);
+    } else if (QString(proxy1->GetXMLName()).contains("Threshold")) {
+      newPipelineElement =
+          builder->createFilter("filters", "Threshold", endOfSource2Pipeline);
+    } else {
+      QString message = QString("The filter ") + QString(proxy1->GetXMLName()) +
+                        QString(" is not known. You need to add it to the list of filters in the RebinnedSourcesManager");
+      throw std::runtime_error(message.toStdString());
     }
 
     newFilter = qobject_cast<pqPipelineFilter *>(newPipelineElement);


### PR DESCRIPTION
This issue was originally reported by Jon Taylor:
>The data is at https://www.dropbox.com/s/65b0cr6qw5c80at/SEQ_MDEW.nxs?dl=0 its 2.5GB

>I did the following 
load —>VSI —> rebin in 2 Q directions with 150 points integrating the 3rd Q to give a Qx,Qy,Energy transfer volume. 
This is worked ok

>I then used the threshold feature (which is really very useful) and that worked.

>Selecting the original data and rebin again crashed the app.

It turns out the data set does not matter, you can use a much smaller data set to test.

Rebinning in the VSI swaps the underlying source for a rebinned source. This means that the whole filter pipeline needs to be rebuilt on top of the new source, e.g oldSource->filter1->filter2 is then newSource->filter1->filter2. 

The newly added Threshold filter was not registered in the RebinnedSourcesManager. This PR adds the Threshold filter to the swap method of the sources manager.

No issue number and no release notes.

**To test:**

1. Take an MDEvent Workspace (can be small) and load it into the standard view
2. Add a threshold filter (you need to press apply to actually add it)
3. Rebin->BinMD and select AxisAligned which should give you some default settings. Press OK
   * Confirm that Mantid does not crash
4. Select Rebin->Remove Binning 
   * Confirm that Mantid does not crash

Please create more varied pipelines and use BinMD to perform binning and remove the binning later on. Ensure that Mantid does not crash.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
