### PR TITLE
Improve export image for sliceviewer

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ColorBarWidget.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ColorBarWidget.h
@@ -49,7 +49,8 @@ public:
   enum CheckboxStrategy {
     ADD_AUTOSCALE_CURRENT_SLICE = 0,
     ADD_AUTOSCALE_ON_LOAD = 1,
-    ADD_AUTOSCALE_BOTH = 2
+    ADD_AUTOSCALE_BOTH = 2,
+    ADD_AUTOSCALE_NONE = 3
   };
 
   void updateColorMap();

--- a/MantidQt/MantidWidgets/src/ColorBarWidget.cpp
+++ b/MantidQt/MantidWidgets/src/ColorBarWidget.cpp
@@ -100,7 +100,7 @@ void ColorBarWidget::setRenderMode(bool rendering) {
 *	 ADD_AUTOSCALE_CURRENT_SLICE
 *	 ADD_AUTOSCALE_ON_LOAD
 *	 ADD_AUTOSCALE_BOTH
-*
+*	 ADD_AUTOSCALE_NONE
 * @param strategy :: select which checkboxes are shown
 */
 void ColorBarWidget::setCheckBoxMode(CheckboxStrategy strategy) {
@@ -125,6 +125,13 @@ void ColorBarWidget::setCheckBoxMode(CheckboxStrategy strategy) {
     ui.autoScale->setEnabled(true);
     ui.autoScaleForCurrentSlice->setVisible(true);
     ui.autoScaleForCurrentSlice->setEnabled(true);
+    break;
+
+  case ADD_AUTOSCALE_NONE: // for exporting images
+    ui.autoScale->setVisible(false);
+    ui.autoScale->setEnabled(false);
+    ui.autoScaleForCurrentSlice->setVisible(false);
+    ui.autoScaleForCurrentSlice->setEnabled(false);
     break;
   }
 }

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -1301,9 +1301,7 @@ QPixmap SliceViewer::getImage() {
   this->m_colorBar->setRenderMode(true);
   auto previousStyle = ui.frmPlot->styleSheet();
   ui.frmPlot->setStyleSheet("background-color: white;");
-  MantidQt::MantidWidgets::ColorBarWidget::CheckboxStrategy test =
-      MantidWidgets::ColorBarWidget::ADD_AUTOSCALE_NONE;
-  this->m_colorBar->setCheckBoxMode(test);
+  this->m_colorBar->setCheckBoxMode(MantidWidgets::ColorBarWidget::ADD_AUTOSCALE_NONE);
 
   // Grab it
   QCoreApplication::processEvents();

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -1299,6 +1299,11 @@ QPixmap SliceViewer::getImage() {
   // Hide the line overlay handles
   this->m_lineOverlay->setShowHandles(false);
   this->m_colorBar->setRenderMode(true);
+  auto previousStyle = ui.frmPlot->styleSheet();
+  ui.frmPlot->setStyleSheet("background-color: white;");
+  MantidQt::MantidWidgets::ColorBarWidget::CheckboxStrategy test =
+      MantidWidgets::ColorBarWidget::ADD_AUTOSCALE_NONE;
+  this->m_colorBar->setCheckBoxMode(test);
 
   // Grab it
   QCoreApplication::processEvents();
@@ -1309,7 +1314,9 @@ QPixmap SliceViewer::getImage() {
   this->m_lineOverlay->setShowHandles(true);
   this->m_colorBar->setRenderMode(false);
   this->setFastRender(oldFast);
-
+  this->m_colorBar->setCheckBoxMode(
+      MantidWidgets::ColorBarWidget::ADD_AUTOSCALE_BOTH);
+  ui.frmPlot->setStyleSheet(previousStyle);
   return pix;
 }
 

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -1301,7 +1301,8 @@ QPixmap SliceViewer::getImage() {
   this->m_colorBar->setRenderMode(true);
   auto previousStyle = ui.frmPlot->styleSheet();
   ui.frmPlot->setStyleSheet("background-color: white;");
-  this->m_colorBar->setCheckBoxMode(MantidWidgets::ColorBarWidget::ADD_AUTOSCALE_NONE);
+  this->m_colorBar->setCheckBoxMode(
+      MantidWidgets::ColorBarWidget::ADD_AUTOSCALE_NONE);
 
   // Grab it
   QCoreApplication::processEvents();


### PR DESCRIPTION
Description of work.

**To test:**

Open dataset in sliceviewer, and from the File button, test the output of 'Save to Image File' or 'Copy to Clipboard'. The resulting images should have a white background and no Autoscale checkboxes.

Fixes https://github.com/mantidproject/mantid/issues/18788

<!-- RELEASE NOTES
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
