### PR TITLE
Fix a crash when right-clicking on workspace information

### DIFF
--- a/MantidQt/MantidWidgets/src/WorkspacePresenter/QWorkspaceDockView.cpp
+++ b/MantidQt/MantidWidgets/src/WorkspacePresenter/QWorkspaceDockView.cpp
@@ -1279,6 +1279,9 @@ void QWorkspaceDockView::popupContextMenu() {
     } else if (boost::dynamic_pointer_cast<const Mantid::API::ITableWorkspace>(
                    ws)) {
       addTableWorkspaceMenuItems(menu);
+    } else {
+      // None of the above? -> not a workspace
+      return;
     }
     addClearMenuItems(menu, selectedWsName);
 


### PR DESCRIPTION
**To test:**

- Load a dataset
- Expand the workspace to see run information
- Right-click on any of the entries (run title, instrument, etc).
- Mantid should not crash

Fixes #18797.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
