### PR TITLE
Use system provided FindEigen3

### DIFF
--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -8,8 +8,7 @@ option(USE_SYSTEM_EIGEN "Use the system installed Eigen - v${eigen_version}?" OF
 
 if(USE_SYSTEM_EIGEN)
   message(STATUS "Using system Eigen")
-  find_package(Eigen3 ${eigen_version} EXACT REQUIRED
-               PATH_SUFFIXES eigen3 eigen )
+  find_package(Eigen3 ${eigen_version} REQUIRED)
 else()
   message(STATUS "Using Eigen in ExternalProject")
 

--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -8,7 +8,7 @@ option(USE_SYSTEM_EIGEN "Use the system installed Eigen - v${eigen_version}?" OF
 
 if(USE_SYSTEM_EIGEN)
   message(STATUS "Using system Eigen")
-  find_package(Eigen3 ${eigen_version} REQUIRED)
+  find_package(Eigen3 3.2 REQUIRED)
 else()
   message(STATUS "Using Eigen in ExternalProject")
 


### PR DESCRIPTION
Dropping the extra arguments from `find_package` causes cmake to use the system provided one. This still doesn't work with ubuntu, but that appears to be a problem with how that package was created. It does fix system eigen3 on fedora.

Also note that the eigen3 version is now a minimum rather than exact match.

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
