### PR TITLE
Fix MantidPlot1D test on Python 3

### DIFF
--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -10,31 +10,36 @@ try:
 except ImportError:
     raise ImportError('The "mantidplot" module can only be used from within MantidPlot.')
 
+# -------------------------- WARNING!!!!!! -------------------------------
+# Be careful about adding/changing imports here. This whole module gets imported into the MantidPlot
+# namespace wholesale. This means that names that we don't want there should be hidden with the _ prefix.
+# User scripts may be accidentally dependent on these names without knowing about it and we shouldn't
+# break those.
 import pymantidplot.proxies as proxies
 from pymantidplot.proxies import threadsafe_call, new_proxy, getWorkspaceNames
 
 from PyQt4 import QtCore, QtGui
-from PyQt4.QtCore import Qt
-import collections
+from PyQt4.QtCore import Qt # noqa
+import collections as _collections
 import os
 import time
 import mantid.api
 import mantidqtpython
-from mantidqtpython import GraphOptions
+from mantidqtpython import GraphOptions # noqa
 # historical names in MantidPlot
 from mantidqtpython import MantidQt as _MantidQt
 from six.moves import range
-InstrumentViewMaskTab = _MantidQt.MantidWidgets.InstrumentWidgetMaskTab
-InstrumentViewPickTab = _MantidQt.MantidWidgets.InstrumentWidgetPickTab
 
-# Import into the global namespace qti classes that:
 #   (a) don't need a proxy & (b) can be constructed from python or (c) have enumerations within them
-from _qti import (PlotSymbol, ImageSymbol, ArrowMarker, ImageMarker, InstrumentView)
+from _qti import (PlotSymbol, ImageSymbol, ArrowMarker, ImageMarker, InstrumentView) # noqa
 
 # Make the ApplicationWindow instance accessible from the mantidplot namespace
-from _qti import app
+from _qti import app # noqa
 
-
+# Aliases
+# Import into the global namespace qti classes that:
+InstrumentViewMaskTab = _MantidQt.MantidWidgets.InstrumentWidgetMaskTab
+InstrumentViewPickTab = _MantidQt.MantidWidgets.InstrumentWidgetPickTab
 # Alias threadsafe_call so users have a more understandable name
 gui_cmd = threadsafe_call
 
@@ -208,7 +213,7 @@ def newTiledWindow(name=None, sources = None, ncols = None):
     if ncols is None:
         ncols = proxy.columnCount()
 
-    if not sources is None:
+    if sources is not None:
         row = 0
         col = 0
         for source in sources:
@@ -261,7 +266,7 @@ def plotSpectrum(source, indices, distribution = mantidqtpython.MantidQt.Distrib
                                  " number of spectra in this workspace - 1 (%d)" % (name, idx, max_spec))
 
     # Unwrap the window object, if any specified
-    if window != None:
+    if window is not None:
         window = window._getHeldObject()
 
     graph = proxies.Graph(threadsafe_call(_qti.app.mantidUI.plot1D,
@@ -358,7 +363,7 @@ def plot2D(source, style=DEFAULT_2D_STYLE, window=None):
         raise ValueError("No workspace names given to plot")
 
     # Unwrap the window object, if any specified
-    if window != None:
+    if window is not None:
         window = window._getHeldObject()
 
     handles = []
@@ -419,7 +424,7 @@ def plotMD(source, plot_axis=-2, normalization=DEFAULT_MD_NORMALIZATION, error_b
                     "Incorrect axis index given for workspace '%s': %d, should be < %d" % (name, plot_axis, max_axis))
 
     # Unwrap the window object, if any specified
-    if window != None:
+    if window is not None:
         window = window._getHeldObject()
 
     graph = proxies.Graph(threadsafe_call(_qti.app.mantidUI.plotMDList, workspace_names, plot_axis, normalization,
@@ -432,7 +437,6 @@ def fitBrowser():
     """
     Access the fit browser.
     """
-    import mantidqtpython
     return proxies.FitBrowserProxy(_qti.app.mantidUI.fitFunctionBrowser())
 
 
@@ -475,7 +479,7 @@ def plotBin(source, indices, error_bars=False, type=-1, window=None, clearWindow
                                  " number of bins in this workspace - 1 (%d)" % (name, idx, max_bin))
 
     # Unwrap the window object, if any specified
-    if window != None:
+    if window is not None:
         window = window._getHeldObject()
 
     graph = proxies.Graph(threadsafe_call(_qti.app.mantidUI.plot1D,
@@ -502,11 +506,11 @@ def stemPlot(source, index, power=None, startPoint=None, endPoint=None):
         A string representation of the stem plot
     """
     # Turn the optional arguments into the magic numbers that the C++ expects
-    if power == None:
+    if power is None:
         power = 1001
-    if startPoint == None:
+    if startPoint is None:
         startPoint = 0
-    if endPoint == None:
+    if endPoint is None:
         endPoint = -1
 
     if isinstance(source, proxies.QtProxyObject):
@@ -723,6 +727,7 @@ InstrumentWidgetPickTab = mantidqtpython.MantidQt.MantidWidgets.InstrumentWidget
 InstrumentWidgetMaskTab = mantidqtpython.MantidQt.MantidWidgets.InstrumentWidgetMaskTab
 InstrumentWidgetTreeTab = mantidqtpython.MantidQt.MantidWidgets.InstrumentWidgetTreeTab
 
+
 def getInstrumentView(name, tab=InstrumentWidget.RENDER):
     """Create an instrument view window based on the given workspace.
 
@@ -737,6 +742,7 @@ def getInstrumentView(name, tab=InstrumentWidget.RENDER):
     if name not in ads:
         raise ValueError("Workspace '%s' does not exist" % name)
     return new_proxy(proxies.InstrumentView, _qti.app.mantidUI.getInstrumentView, name, tab)
+
 
 def importMatrixWorkspace(name, firstIndex=None, lastIndex=None, showDialog=False, visible=False):
     """Create a MantidMatrix object from the named workspace.
@@ -796,7 +802,9 @@ def plotSlice(source, label="", xydim=None, slicepoint=None,
     Optional Keyword Args:
         label :: label for the window title
         xydim :: indexes or names of the dimensions to plot, as an (X,Y) list or tuple. See SliceViewer::setXYDim()
-        slicepoint :: list with the slice point in each dimension.  Must be the same length as the number of dimensions of the workspace. See SliceViewer::setSlicePoint()
+        slicepoint :: list with the slice point in each dimension.
+                      Must be the same length as the number of dimensions of the workspace.
+                      See SliceViewer::setSlicePoint()
         colormin :: value of the minimum color in the scale. See SliceViewer::setColorScaleMin()
         colormax :: value of the maximum color in the scale. See SliceViewer::setColorScaleMax()
         colorscalelog :: value of the maximum color in the scale. See SliceViewer::setColorScaleLog()
@@ -923,10 +931,9 @@ DistrFlag.DistrDefault = mantidqtpython.MantidQt.DistributionDefault
 DistrFlag.DistrTrue = mantidqtpython.MantidQt.DistributionTrue
 DistrFlag.DistrFalse = mantidqtpython.MantidQt.DistributionFalse
 
+
 # -----------------------------------------------------------------------------
 # --------------------------- "Private" functions -----------------------------
-# -----------------------------------------------------------------------------
-
 # -----------------------------------------------------------------------------
 def __doSliceViewer(wsname, label="", xydim=None, slicepoint=None,
                     colormin=None, colormax=None, colorscalelog=False,
@@ -953,14 +960,14 @@ def __doSliceViewer(wsname, label="", xydim=None, slicepoint=None,
 
     sv = threadsafe_call(svw.getSlicer)
     # --- X/Y Dimensions ---
-    if (not xydim is None):
+    if (xydim is not None):
         if len(xydim) != 2:
             raise Exception("You need to specify two values in the 'xydim' parameter")
         else:
             threadsafe_call(sv.setXYDim, xydim[0], xydim[1])
 
     # --- Slice point ---
-    if not slicepoint is None:
+    if slicepoint is not None:
         for d in range(len(slicepoint)):
             try:
                 val = float(slicepoint[d])
@@ -973,18 +980,20 @@ def __doSliceViewer(wsname, label="", xydim=None, slicepoint=None,
     threadsafe_call(sv.setNormalization, normalization)
 
     # --- Color scale ---
-    if (not colormin is None) and (not colormax is None):
+    if (colormin is not None) and (colormax is not None):
         threadsafe_call(sv.setColorScale, colormin, colormax, colorscalelog)
     else:
-        if (not colormin is None): threadsafe_call(sv.setColorScaleMin, colormin)
-        if (not colormax is None): threadsafe_call(sv.setColorScaleMax, colormax)
+        if colormin is not None:
+            threadsafe_call(sv.setColorScaleMin, colormin)
+        if colormax is not None:
+            threadsafe_call(sv.setColorScaleMax, colormax)
     try:
         threadsafe_call(sv.setColorScaleLog, colorscalelog)
     except:
         print("Log color scale not possible.")
 
     # --- XY limits ---
-    if not limits is None:
+    if limits is not None:
         threadsafe_call(sv.setXYLimits, limits[0], limits[1], limits[2], limits[3])
 
     return svw
@@ -995,7 +1004,7 @@ def get_screenshot_dir():
     or NONE if not set """
     expected_env_var = 'MANTID_SCREENSHOT_REPORT'
     dest = os.getenv(expected_env_var)
-    if not dest is None:
+    if dest is not None:
         # Create the report directory if needed
         if not os.path.exists(dest):
             os.mkdir(dest)
@@ -1086,7 +1095,7 @@ def screenshot(widget, filename, description, png_exists=False):
     :param png_exists: if True, then the 'filename' already exists. Don't grab a screenshot, but add to the report.
     """
     dest = get_screenshot_dir()
-    if not dest is None:
+    if dest is not None:
         report = os.path.join(dest, "index.html")
 
         if png_exists:
@@ -1148,7 +1157,7 @@ def __getWorkspaceIndices(source):
                 index_list.append(int(cleaned))
             except ValueError:
                 continue
-    elif isinstance(source, collections.Iterable):
+    elif isinstance(source, _collections.Iterable):
         index_list = list(source)
     elif isinstance(source, int):
         index_list = [source]
@@ -1236,7 +1245,7 @@ def __checkPlotSliceWorkspaces(ws_names):
 # Creates and shows the detector table
 def createDetectorTable(source):
     try:
-        import mantidqtpython
+        import mantidqtpython # noqa
     except:
         print("Could not find module mantidqtpython. Cannot open the detector table.")
         return
@@ -1248,7 +1257,7 @@ def createDetectorTable(source):
     else:
         return new_proxy(proxies.MDIWindow, _qti.app.mantidUI.createDetectorTable, workspace_names[0])
 
-# -----------------------------------------------------------------------------
+
 def plotSubplots(source, indices, distribution = mantidqtpython.MantidQt.DistributionDefault, error_bars=False, window=None):
     """Open a tiled plot.
 
@@ -1293,7 +1302,7 @@ def plotSubplots(source, indices, distribution = mantidqtpython.MantidQt.Distrib
                                  " number of spectra in this workspace - 1 (%d)" % (name, idx, max_spec))
 
     # Unwrap the window object, if any specified
-    if window != None:
+    if window is not None:
         window = window._getHeldObject()
 
     graph = proxies.Graph(threadsafe_call(_qti.app.mantidUI.plotSubplots,

--- a/MantidPlot/test/MantidPlot1DPlotTest.py
+++ b/MantidPlot/test/MantidPlot1DPlotTest.py
@@ -48,12 +48,49 @@ class MantidPlot1DPlotTest(unittest.TestCase):
         g = plotSpectrum(ws, 0, error_bars=True)
         self.g = g
 
-    def test_plotSpectrum_severalSpectra(self):
+    def test_plotSpectrum_single_integer(self):
+        g = plotSpectrum("fake", 1)
+        self._check_graph_contents(g, ["fake-sp-2"])
+        self.g = g
+
+    def test_plotSpectrum_single_str(self):
+        g = plotSpectrum("fake", "1")
+        self._check_graph_contents(g, ["fake-sp-2"])
+        self.g = g
+
+    def test_plotSpectrum_list_of_spectra(self):
         g = plotSpectrum("fake", [0, 1])
+        self._check_graph_contents(g, ["fake-sp-1", "fake-sp-2"])
+        self.g = g
+
+    def test_plotSpectrum_tuple_of_spectra(self):
+        g = plotSpectrum("fake", (0, 1))
+        self._check_graph_contents(g, ["fake-sp-1", "fake-sp-2"])
+        self.g = g
+
+    def test_plotSpectrum_comma_separated_list(self):
+        g = plotSpectrum("fake", "0, 1")
+        self._check_graph_contents(g, ["fake-sp-1", "fake-sp-2"])
+        self.g = g
+
+    def test_plotSpectrum_comma_separated_list_leading_comma(self):
+        g = plotSpectrum("fake", "0, 1,")
+        self._check_graph_contents(g, ["fake-sp-1", "fake-sp-2"])
+        self.g = g
+
+    def test_plotSpectrum_comma_separated_list_trailing_comma(self):
+        g = plotSpectrum("fake", "0, 1,")
+        self._check_graph_contents(g, ["fake-sp-1", "fake-sp-2"])
+        self.g = g
+
+    def test_plotSpectrum_comma_separated_list_empty_value(self):
+        g = plotSpectrum("fake", "0, ,1")
+        self._check_graph_contents(g, ["fake-sp-1", "fake-sp-2"])
         self.g = g
 
     def test_plotSpectrum_range_command(self):
         g = plotSpectrum("fake", range(0, 2))
+        self._check_graph_contents(g, ["fake-sp-1", "fake-sp-2"])
         self.g = g
 
     def test_Customized1DPlot(self):
@@ -111,6 +148,14 @@ class MantidPlot1DPlotTest(unittest.TestCase):
         g = plotBin("fake", (0,1))
         self.assertTrue(g is not None)
         self.g = g
+
+    # ---------------- Non-test methods ----------------
+    def _check_graph_contents(self, g, curve_titles):
+        layer = g.activeLayer()
+        self.assertEqual(len(curve_titles), layer.numCurves())
+        for i, title in enumerate(curve_titles):
+            self.assertEqual(title, layer.curveTitle(i))
+
 
 # Run the unit tests
 mantidplottests.runTests(MantidPlot1DPlotTest)

--- a/MantidPlot/test/MantidPlot1DPlotTest.py
+++ b/MantidPlot/test/MantidPlot1DPlotTest.py
@@ -3,7 +3,6 @@ Test of basic 1D plotting methods in MantidPlot
 """
 import mantidplottests
 from mantidplottests import *
-import time
 import numpy as np
 from PyQt4 import QtGui, QtCore
 
@@ -20,7 +19,10 @@ X = np.append(X1, X2)
 Y = np.append(Y1, Y2)
 E = np.sqrt(Y)
 
-CreateWorkspace(OutputWorkspace="fake", DataX=list(X), DataY=list(Y), DataE=list(E), NSpec=2, UnitX="TOF", YUnitLabel="Counts",  WorkspaceTitle="Faked data Workspace")
+CreateWorkspace(OutputWorkspace="fake", DataX=list(X), DataY=list(Y), DataE=list(E),
+                NSpec=2, UnitX="TOF", YUnitLabel="Counts",
+                WorkspaceTitle="Faked data Workspace")
+
 
 class MantidPlot1DPlotTest(unittest.TestCase):
 
@@ -30,13 +32,13 @@ class MantidPlot1DPlotTest(unittest.TestCase):
     def tearDown(self):
         """Clean up by closing the created window """
         if hasattr(self, "g") and self.g is not None:
-          self.g.confirmClose(False)
-          self.g.close()
+            self.g.confirmClose(False)
+            self.g.close()
         try:
-          self.t.confirmClose(False)
-          self.t.close()
+            self.t.confirmClose(False)
+            self.t.close()
         except AttributeError:
-          pass
+            pass
         QtCore.QCoreApplication.processEvents()
 
     def test_plotSpectrum_errorBars(self):
@@ -119,7 +121,9 @@ class MantidPlot1DPlotTest(unittest.TestCase):
         self.g = g
         l = g.activeLayer() # Plot columns 2, 3 and 4
         for i in range(0, l.numCurves()):
-            l.setCurveLineColor(i, 1 + i) # Curve color is defined as an integer value. Alternatively, the 2nd argument can be of type QtGui.QColor.
+            # Curve color is defined as an integer value. Alternatively, the
+            # 2nd argument can be of type QtGui.QColor.
+            l.setCurveLineColor(i, 1 + i)
             l.setCurveLineWidth(i, 0.5 + 2*i)
 
             l.setCurveLineStyle(1, QtCore.Qt.DotLine)


### PR DESCRIPTION
Description of work.

Fixes MantidPlot tests for Python 3. They were broken by a recent [fix for Python 2](9f00b00cefe12606183c0072409e1f8dadeca98e).

I have have also fixed some flake8 warnings in the files that I have touched. Let me know if you would prefer if I separated those into a separate PR.

**To test:**

Code review and check the MantidPlot tests work under Python 3.

No issue

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
