### PR TITLE
Algorithms return namedtuple

### DIFF
--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -529,10 +529,9 @@ void FilterEvents::createOutputWorkspaces() {
     if (add2output) {
       // Generate output property name
       std::stringstream propertynamess;
-      if (wsgroup == -1){
+      if (wsgroup == -1) {
         propertynamess << "OutputWorkspace_unfiltered";
-      }
-      else{
+      } else {
         propertynamess << "OutputWorkspace_" << wsgroup;
       }
 

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -529,7 +529,12 @@ void FilterEvents::createOutputWorkspaces() {
     if (add2output) {
       // Generate output property name
       std::stringstream propertynamess;
-      propertynamess << "OutputWorkspace_" << wsgroup;
+      if (wsgroup == -1){
+        propertynamess << "OutputWorkspace_unfiltered";
+      }
+      else{
+        propertynamess << "OutputWorkspace_" << wsgroup;
+      }
 
       // Inserted this pair to map
       m_wsNames.push_back(wsname.str());

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -567,8 +567,12 @@ def _get_function_spec(func):
     :param func: A Python function object
     """
     import inspect
+    import six
     try:
-        argspec = inspect.getargspec(func)
+        if six.PY3:
+            argspec = inspect.getfullargspec(func)
+        else:
+            argspec = inspect.getargspec(func)
     except TypeError:
         return ''
     # Algorithm functions have varargs set not args

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -24,6 +24,7 @@ from __future__ import (absolute_import, division,
 
 import os
 from six import iteritems
+from collections import OrderedDict, namedtuple
 
 from . import api as _api
 from . import kernel as _kernel
@@ -789,7 +790,7 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
     for index, expr in enumerate(ignore_regex):
         ignore_regex[index] = re.compile(expr)
 
-    retvals = []
+    retvals = OrderedDict()
     for name in algm_obj.outputProperties():
         if ignore_property(name, ignore_regex):
             continue
@@ -801,14 +802,14 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
         if _is_workspace_property(prop):
             value_str = prop.valueAsStr
             try:
-                retvals.append(_api.AnalysisDataService[value_str])
+                retvals[name]=_api.AnalysisDataService[value_str]
             except KeyError:
                 if not prop.isOptional():
                     raise RuntimeError("Internal error. Output workspace property '%s' on algorithm '%s' has not been stored correctly."
                                        "Please contact development team." % (name,  algm_obj.name()))
         else:
             if hasattr(prop, 'value'):
-                retvals.append(prop.value)
+                retvals[name]=prop.value
             else:
                 raise RuntimeError('Internal error. Unknown property type encountered. "%s" on algorithm "%s" is not understood by '
                        'Python. Please contact development team' % (name, algm_obj.name()))
@@ -821,10 +822,13 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
         # Let's not have the more cryptic unpacking error raised
         raise RuntimeError("%s is trying to return %d output(s) but you have provided %d variable(s). "
                            "These numbers must match." % (func_name, nvals, nlhs))
-    if nvals > 1:
-        return tuple(retvals) # Create a tuple
-    elif nvals == 1:
-        return retvals[0]
+    if nvals > 0:
+        ret_type=namedtuple(func_name+"_returns",retvals.keys())
+        ret_value=ret_type(**retvals)
+        if nvals==1:
+            return ret_value[0]
+        else:
+            return ret_value
     else:
         return None
 

--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -173,7 +173,7 @@ IgnoreBinErrors(Input) *boolean*       Ignore errors related to zero/negative bi
         self.assertTrue( wsname in mtd )
         self.assertTrue( wsname_box in mtd )
         
-        self.assertTrue( type(query) == tuple )
+        self.assertTrue( isinstance(query, tuple) )
         self.assertEquals( 2, len(query) )
         
         self.assertTrue( isinstance(query[0], ITableWorkspace) )

--- a/Framework/WorkflowAlgorithms/src/RefReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/RefReduction.cpp
@@ -356,12 +356,12 @@ MatrixWorkspace_sptr RefReduction::processData(const std::string polarization) {
     std::string wsName = prefix + polarization;
     Poco::replaceInPlace(wsName, "entry", "");
     declareProperty(Kernel::make_unique<WorkspaceProperty<>>(
-        "OutputWorkspace_" + polarization, wsName, Direction::Output));
-    setProperty("OutputWorkspace_" + polarization, outputWS);
+        "OutputWorkspace_" + polarizationTranslation, wsName, Direction::Output));
+    setProperty("OutputWorkspace_" + polarizationTranslation, outputWS);
     declareProperty(Kernel::make_unique<WorkspaceProperty<>>(
-        "OutputWorkspace2D_" + polarization, "2D_" + wsName,
+        "OutputWorkspace2D_" + polarizationTranslation, "2D_" + wsName,
         Direction::Output));
-    setProperty("OutputWorkspace2D_" + polarization, output2DWS);
+    setProperty("OutputWorkspace2D_" + polarizationTranslation, output2DWS);
   }
   m_output_message += "Reflectivity calculation completed\n";
   return outputWS;

--- a/Framework/WorkflowAlgorithms/src/RefReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/RefReduction.cpp
@@ -310,7 +310,8 @@ MatrixWorkspace_sptr RefReduction::processData(const std::string polarization) {
   refAlg1->executeAsChildAlg();
   MatrixWorkspace_sptr outputWS2 = refAlg1->getProperty("OutputWorkspace");
   std::string polarizationTranslation(polarization);
-  std::replace(polarizationTranslation.begin(),polarizationTranslation.end(),'-','_');
+  std::replace(polarizationTranslation.begin(), polarizationTranslation.end(),
+               '-', '_');
   declareProperty(Kernel::make_unique<WorkspaceProperty<>>(
       "OutputWorkspace_jc_" + polarizationTranslation, "Lambda_" + polarization,
       Direction::Output));

--- a/Framework/WorkflowAlgorithms/src/RefReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/RefReduction.cpp
@@ -356,7 +356,8 @@ MatrixWorkspace_sptr RefReduction::processData(const std::string polarization) {
     std::string wsName = prefix + polarization;
     Poco::replaceInPlace(wsName, "entry", "");
     declareProperty(Kernel::make_unique<WorkspaceProperty<>>(
-        "OutputWorkspace_" + polarizationTranslation, wsName, Direction::Output));
+        "OutputWorkspace_" + polarizationTranslation, wsName,
+        Direction::Output));
     setProperty("OutputWorkspace_" + polarizationTranslation, outputWS);
     declareProperty(Kernel::make_unique<WorkspaceProperty<>>(
         "OutputWorkspace2D_" + polarizationTranslation, "2D_" + wsName,

--- a/Framework/WorkflowAlgorithms/src/RefReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/RefReduction.cpp
@@ -14,6 +14,7 @@
 #include "Poco/File.h"
 #include "Poco/NumberFormatter.h"
 #include "Poco/String.h"
+#include <algorithm>
 
 namespace Mantid {
 namespace WorkflowAlgorithms {
@@ -308,10 +309,12 @@ MatrixWorkspace_sptr RefReduction::processData(const std::string polarization) {
   refAlg1->setProperty("ScatteringAngle", theta);
   refAlg1->executeAsChildAlg();
   MatrixWorkspace_sptr outputWS2 = refAlg1->getProperty("OutputWorkspace");
+  std::string polarizationTranslation(polarization);
+  std::replace(polarizationTranslation.begin(),polarizationTranslation.end(),'-','_');
   declareProperty(Kernel::make_unique<WorkspaceProperty<>>(
-      "OutputWorkspace_jc_" + polarization, "Lambda_" + polarization,
+      "OutputWorkspace_jc_" + polarizationTranslation, "Lambda_" + polarization,
       Direction::Output));
-  setProperty("OutputWorkspace_jc_" + polarization, outputWS2);
+  setProperty("OutputWorkspace_jc_" + polarizationTranslation, outputWS2);
 
   // Conversion to Q
   IAlgorithm_sptr refAlg = createChildAlgorithm("RefRoi", 0.90, 0.95);

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -34,6 +34,26 @@ Improved
 Python
 ------
 
+- For multiple output parameters, python algorithms now return a `namedtuple` instead of a tuple. Old scripts should still work,
+  but one can now do
+
+  .. code-block:: python
+
+      results = GetEi(w)
+      print(results)
+      print(results.IncidentEnergy)
+      print(results[0])
+
+  This will yield:
+
+  .. code-block:: python
+
+      GetEi_returns(IncidentEnergy=3.0, FirstMonitorPeak=0.0, FirstMonitorIndex=0, Tzero=61.77080180287334)
+      3.0
+      3.0
+
+
+
 Python Algorithms
 #################
 


### PR DESCRIPTION
Algorithms now return named tuples instead of tuples.

**To test:**
1. All unit tests and system tests should pass. The only difference is that if you have more than one output property, and you store those in a `result`, the type of `result` is not a tuple. But `isinstance(result,tuple)` returns `True`
2. Run something like this
```
w=Load('CNCS_7860')
dgs1=DgsReduction(SampleInputWorkspace=w,SampleInputMonitorWorkspace=w)
dgs2,params=DgsReduction(SampleInputWorkspace=w,SampleInputMonitorWorkspace=w)
result=GetEi(w)
print(result)
print(result[0])
print(result.IncidentEnergy)
```

This would yield
```
GetEi_returns(IncidentEnergy=3.0, FirstMonitorPeak=0.0, FirstMonitorIndex=0, Tzero=61.77080180287334)
3.0
3.0
```
In addition, you should have 3 workspaces, named `w`,`dgs1`, and `dgs2`

Fixes #18791.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
