### PR TITLE
Fix MS Corrections Producing nan/0 error values

### DIFF
--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
@@ -157,6 +157,12 @@ MayersSampleCorrectionStrategy::getCorrectedHisto() {
   auto &errOut = outputHistogram.mutableE();
 
   for (size_t i = 0; i < m_histoYSize; ++i) {
+    const double yin(m_histogram.y()[i]), ein(m_histogram.e()[i]);
+    if (yin == 0) {
+      // Detector with 0 signal received - skip this bin
+      continue;
+    }
+
     const double sigt = sigmaTotal(flightPath, m_tofVals[i]);
     const double rmu = muR(sigt);
     // Varies between [-1,+1]
@@ -168,7 +174,7 @@ MayersSampleCorrectionStrategy::getCorrectedHisto() {
       corrfact *= (1.0 - beta) / rns;
     }
     // apply correction
-    const double yin(m_histogram.y()[i]), ein(m_histogram.e()[i]);
+
     sigOut[i] = yin * corrfact;
     errOut[i] = sigOut[i] * ein / yin;
   }

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -33,6 +33,22 @@ public:
     TS_ASSERT_DELTA(0.00030887, absFactor, delta);
   }
 
+  void test_Correction_Skips_Zero_Counts() {
+	  Histogram histo(Points{ 2, LinearGenerator(0,1) } , Counts{2, LinearGenerator(0, 1)});
+	  MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
+	  const auto outHisto = mscat.getCorrectedHisto();
+
+	  const auto &yVals = outHisto.y();
+	  const auto &eVals = outHisto.e();
+
+	  TSM_ASSERT_EQUALS("Bin with 0 count was modified", yVals[0], 0);
+	  TSM_ASSERT_EQUALS("Err val for 0 count was modified", eVals[0], 0);
+	  
+	  const double delta = 1e-8;
+	  TS_ASSERT_DELTA(0.18741573, yVals[1], delta);
+	  TS_ASSERT_DELTA(0.18741573, eVals[1], delta);
+  }
+
   void
   test_Multiple_Scattering_With_Fixed_Mur_And_Absorption_Correction_Factor() {
     Histogram histo(Points{0, 1}, Counts{0, 1});

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -44,10 +44,6 @@ public:
 
     TSM_ASSERT_EQUALS("Bin with 0 count was modified", yVals[0], 0);
     TSM_ASSERT_EQUALS("Err val for 0 count was modified", eVals[0], 0);
-
-    const double delta = 1e-8;
-    TS_ASSERT_DELTA(0.18741573, yVals[1], delta);
-    TS_ASSERT_DELTA(0.18741573, eVals[1], delta);
   }
 
   void

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -34,19 +34,20 @@ public:
   }
 
   void test_Correction_Skips_Zero_Counts() {
-	  Histogram histo(Points{ 2, LinearGenerator(0,1) } , Counts{2, LinearGenerator(0, 1)});
-	  MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
-	  const auto outHisto = mscat.getCorrectedHisto();
+    Histogram histo(Points{2, LinearGenerator(0, 1)},
+                    Counts{2, LinearGenerator(0, 1)});
+    MayersSampleCorrectionStrategy mscat(createTestParameters(), histo);
+    const auto outHisto = mscat.getCorrectedHisto();
 
-	  const auto &yVals = outHisto.y();
-	  const auto &eVals = outHisto.e();
+    const auto &yVals = outHisto.y();
+    const auto &eVals = outHisto.e();
 
-	  TSM_ASSERT_EQUALS("Bin with 0 count was modified", yVals[0], 0);
-	  TSM_ASSERT_EQUALS("Err val for 0 count was modified", eVals[0], 0);
-	  
-	  const double delta = 1e-8;
-	  TS_ASSERT_DELTA(0.18741573, yVals[1], delta);
-	  TS_ASSERT_DELTA(0.18741573, eVals[1], delta);
+    TSM_ASSERT_EQUALS("Bin with 0 count was modified", yVals[0], 0);
+    TSM_ASSERT_EQUALS("Err val for 0 count was modified", eVals[0], 0);
+
+    const double delta = 1e-8;
+    TS_ASSERT_DELTA(0.18741573, yVals[1], delta);
+    TS_ASSERT_DELTA(0.18741573, eVals[1], delta);
   }
 
   void


### PR DESCRIPTION
Description of work.
This PR was originally #18815 but was split into two.

This PR fixes an issue with Mayers Sample correction. The algorithm previously ran on focused workspaces so none of the individual bins had a 0 signal. In the current algorithm we run the sample correction before focusing, this means individual detectors can have a 0 count. 
We now check for a 0 signal and attempt to skip it.

**To test:**
The files are located at `\\olympic\babylon5\Public\David Fairbrother\PR Files`:
- Load `BeforeMS.nxs` and `AfterMS.nxs`
- Apply Mayers Sample Correction
- Look at `AfterMS` workspace error values - towards the end of the workspace there will be nan or 0 values
- Look at corrected workspace, ensure in the same positions there is no nan or 0 values.

Fixes #18796 .

Does not need to be in the release notes. - This is a bugfix following the recent changes in MS corrections so users will not have experienced this issue. 


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
