### PR TITLE
Refactor SplineBackground

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
@@ -7,6 +7,10 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/Workspace_fwd.h"
 
+#include <gsl/gsl_bspline.h>
+#include <gsl/gsl_multifit.h>
+#include <gsl/gsl_statistics.h>
+
 namespace Mantid {
 namespace CurveFitting {
 namespace Algorithms {
@@ -56,6 +60,26 @@ private:
   // Overridden Algorithm methods
   void init() override;
   void exec() override;
+
+  void addWsDataToSpline(const API::MatrixWorkspace *ws, const size_t specNum,
+                         int expectedNumBins);
+  void allocateBSplinePointers(int numBins, int ncoeffs);
+  void freeBSplinePointers();
+  size_t calculateNumBinsToProcess(const API::MatrixWorkspace *ws);
+  API::MatrixWorkspace_sptr saveSplineOutput(const API::MatrixWorkspace_sptr ws,
+                                             const size_t spec);
+  void setupSpline(double xMin, double xMax, int numBins, int ncoeff);
+
+  /// Struct holding various pointers required by GSL
+  struct bSplinePointers {
+	  gsl_bspline_workspace *bw;
+	  gsl_vector *B;
+	  gsl_vector *c, *w, *x, *y;
+	  gsl_matrix *Z, *cov;
+	  gsl_multifit_linear_workspace *mw;
+  };
+
+  bSplinePointers m_splinePointers{};
 };
 
 } // namespace Algorithms

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
@@ -72,11 +72,12 @@ private:
 
   /// Struct holding various pointers required by GSL
   struct bSplinePointers {
-	  gsl_bspline_workspace *bw;
-	  gsl_vector *B;
-	  gsl_vector *c, *w, *x, *y;
-	  gsl_matrix *Z, *cov;
-	  gsl_multifit_linear_workspace *mw;
+    gsl_bspline_workspace *splineToProcess;
+    gsl_vector *inputSplineWs;
+    gsl_vector *xData, *yData;
+    gsl_vector *coefficients, *binWeights;
+    gsl_matrix *fittedWs, *covariance;
+    gsl_multifit_linear_workspace *weightedLinearFitWs;
   };
 
   bSplinePointers m_splinePointers{};

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
@@ -68,6 +68,9 @@ private:
   /// Allocates various pointers used within GSL
   void allocateBSplinePointers(int numBins, int ncoeffs);
 
+  /// Calculates the bin weight using the error values in the WS
+  double calculateBinWeight(double errValue);
+
   /// Deallocates various pointers within GSL
   void freeBSplinePointers();
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
@@ -61,13 +61,25 @@ private:
   void init() override;
   void exec() override;
 
+  /// Adds data from the workspace to the GSL vectors for later processing
   void addWsDataToSpline(const API::MatrixWorkspace *ws, const size_t specNum,
                          int expectedNumBins);
+
+  /// Allocates various pointers used within GSL
   void allocateBSplinePointers(int numBins, int ncoeffs);
+
+  /// Deallocates various pointers within GSL
   void freeBSplinePointers();
+
+  /// Calculates the number on unmasked bins to process
   size_t calculateNumBinsToProcess(const API::MatrixWorkspace *ws);
+
+  /// Gets the values from the fitted GSL, and creates a clone of input
+  /// workspace with new values
   API::MatrixWorkspace_sptr saveSplineOutput(const API::MatrixWorkspace_sptr ws,
                                              const size_t spec);
+
+  /// Sets up the splines for later fitting
   void setupSpline(double xMin, double xMax, int numBins, int ncoeff);
 
   /// Struct holding various pointers required by GSL

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
@@ -87,12 +87,12 @@ private:
 
   /// Struct holding various pointers required by GSL
   struct bSplinePointers {
-    gsl_bspline_workspace *splineToProcess;
-    gsl_vector *inputSplineWs;
-    gsl_vector *xData, *yData;
-    gsl_vector *coefficients, *binWeights;
-    gsl_matrix *fittedWs, *covariance;
-    gsl_multifit_linear_workspace *weightedLinearFitWs;
+    gsl_bspline_workspace *splineToProcess{nullptr};
+    gsl_vector *inputSplineWs{nullptr};
+    gsl_vector *xData{nullptr}, *yData{nullptr};
+    gsl_vector *coefficients{nullptr}, *binWeights{nullptr};
+    gsl_matrix *fittedWs{nullptr}, *covariance{nullptr};
+    gsl_multifit_linear_workspace *weightedLinearFitWs{nullptr};
   };
 
   bSplinePointers m_splinePointers{};

--- a/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
@@ -108,7 +108,7 @@ SplineBackground::calculateNumBinsToProcess(const API::MatrixWorkspace *ws) {
 void SplineBackground::addWsDataToSpline(const API::MatrixWorkspace *ws,
                                          const size_t specNum,
                                          int expectedNumBins) {
-  const auto xInputVals = ws->x(specNum);
+  const auto xInputVals = ws->points(specNum);
   const auto yInputVals = ws->y(specNum);
   const auto eInputVals = ws->e(specNum);
   const bool hasMaskedBins = ws->hasMaskedBins(specNum);

--- a/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
@@ -115,9 +115,24 @@ void SplineBackground::addWsDataToSpline(const API::MatrixWorkspace *ws,
       continue;
     gsl_vector_set(m_splinePointers.xData, numUnmaskedBins, xInputVals[i]);
     gsl_vector_set(m_splinePointers.yData, numUnmaskedBins, yInputVals[i]);
-    gsl_vector_set(m_splinePointers.binWeights, numUnmaskedBins,
-                   eInputVals[i] > 0. ? 1. / (eInputVals[i] * eInputVals[i])
-                                      : 0.);
+
+    double eVal = eInputVals[i];
+    if (!std::isnormal(eVal)) {
+      if (eVal == 0) {
+        g_log.warning(
+            "Spline background found an error value of 0 on an unmasked"
+            " bin. This bin will have no weight during the fitting process");
+      } else {
+        // nan / inf
+        eVal = 0;
+        g_log.warning(
+            "Spline background found an error value of nan or inf on an"
+            " unmasked bin. This bin will have no weight during the fitting"
+            " process");
+      }
+    }
+
+    gsl_vector_set(m_splinePointers.binWeights, numUnmaskedBins, eVal);
 
     ++numUnmaskedBins;
   }

--- a/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
@@ -181,7 +181,7 @@ void SplineBackground::allocateBSplinePointers(int numBins, int ncoeffs) {
   * @return:: The bin weight to use within the GSL allocation
   */
 double SplineBackground::calculateBinWeight(double errValue) {
-  double outBinWeight = 0;
+  double outBinWeight = -1;
   if (errValue <= 0 || !std::isfinite(errValue)) {
     // Regardless of which warning we print we should
     // set the bin weight

--- a/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
@@ -2,10 +2,10 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidCurveFitting/Algorithms/SplineBackground.h"
-#include "MantidKernel/cow_ptr.h"
-#include "MantidKernel/BoundedValidator.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidKernel/cow_ptr.h"
+#include "MantidKernel/BoundedValidator.h"
 
 #include <gsl/gsl_bspline.h>
 #include <gsl/gsl_multifit.h>
@@ -39,142 +39,187 @@ void SplineBackground::init() {
  *
  */
 void SplineBackground::exec() {
-
   API::MatrixWorkspace_sptr inWS = getProperty("InputWorkspace");
-  int spec = getProperty("WorkspaceIndex");
+  const int ncoeffs = getProperty("NCoeff");
+  const int spec = getProperty("WorkspaceIndex");
 
+  // Check if the user specified a spectrum number its valid
   if (spec > static_cast<int>(inWS->getNumberHistograms()))
     throw std::out_of_range("WorkspaceIndex is out of range.");
 
-  const auto &yInputVals = inWS->y(spec);
-  const int ncoeffs = getProperty("NCoeff");
+  /* this is the data to be fitted */
+  const int numBins = static_cast<int>(calculateNumBinsToProcess(inWS.get()));
+
+  if (numBins < ncoeffs) {
+    throw std::out_of_range("Too many basis functions (NCoeff)");
+  }
+
+  allocateBSplinePointers(numBins, ncoeffs);
+  addWsDataToSpline(inWS.get(), spec, numBins);
+
+  const auto &xInputPoints = inWS->x(spec);
+  setupSpline(xInputPoints.front(), xInputPoints.back(), numBins, ncoeffs);
+
+  // Wrap this in its own block so we can alias the member variable
+  // to a shorter name for the duration of this call
+  {
+    // Have to pass a pointer so it can write chi ^ 2 even though we don't
+    // use this value
+    double chisq;
+    // Create temporary alias to reduce the size of the call
+    bSplinePointers &sp = m_splinePointers;
+    // do the fit
+    gsl_multifit_wlinear(sp.Z, sp.w, sp.y, sp.c, sp.cov, &chisq, sp.mw);
+  }
+
+  auto outWS = saveSplineOutput(inWS, spec);
+  freeBSplinePointers();
+  setProperty("OutputWorkspace", outWS);
+}
+
+size_t
+SplineBackground::calculateNumBinsToProcess(const API::MatrixWorkspace *ws) {
+  const int spec = getProperty("WorkspaceIndex");
+  const auto &yInputVals = ws->y(spec);
+  size_t ySize = yInputVals.size();
+
+  // Check and subtract masked bins from the count
+  bool isMasked = ws->hasMaskedBins(spec);
+  if (isMasked) {
+    ySize -= static_cast<int>(ws->maskedBins(spec).size());
+  }
+  return ySize;
+}
+
+void SplineBackground::addWsDataToSpline(const API::MatrixWorkspace *ws,
+                                         const size_t specNum,
+                                         int expectedNumBins) {
+  const auto xInputVals = ws->x(specNum);
+  const auto yInputVals = ws->y(specNum);
+  const auto eInputVals = ws->e(specNum);
+  const bool hasMaskedBins = ws->hasMaskedBins(specNum);
+
+  // Mark masked bins to skip them later
+  std::vector<bool> masked(yInputVals.size(), false);
+  if (hasMaskedBins) {
+    const auto maskedBinsMap = ws->maskedBins(specNum);
+    for (const auto &maskedBin : maskedBinsMap) {
+      masked[maskedBin.first] = true;
+    }
+  }
+
+  int numUnmaskedBins = 0;
+  for (size_t i = 0; i < yInputVals.size(); ++i) {
+    if (hasMaskedBins && masked[i])
+      continue;
+    gsl_vector_set(m_splinePointers.x, numUnmaskedBins, xInputVals[i]);
+    gsl_vector_set(m_splinePointers.y, numUnmaskedBins, yInputVals[i]);
+    gsl_vector_set(m_splinePointers.w, numUnmaskedBins,
+                   eInputVals[i] > 0. ? 1. / (eInputVals[i] * eInputVals[i])
+                                      : 0.);
+
+    ++numUnmaskedBins;
+  }
+
+  if (expectedNumBins != numUnmaskedBins) {
+    freeBSplinePointers();
+    throw std::runtime_error(
+        "Assertion failed: number of unmasked bins found was"
+        " not equal to the number that was calculated");
+  }
+}
+
+void SplineBackground::allocateBSplinePointers(int numBins, int ncoeffs) {
   const int k = 4; // order of the spline + 1 (cubic)
   const int nbreak = ncoeffs - (k - 2);
 
   if (nbreak <= 0)
     throw std::out_of_range("Too low NCoeff");
 
-  gsl_bspline_workspace *bw;
-  gsl_vector *B;
+  // Create an alias to tidy it up
+  bSplinePointers &sp = m_splinePointers;
+  // allocate a cubic bspline workspace (k = 4)
+  sp.bw = gsl_bspline_alloc(k, nbreak);
+  sp.B = gsl_vector_alloc(ncoeffs);
 
-  gsl_vector *c, *w, *x, *y;
-  gsl_matrix *Z, *cov;
-  gsl_multifit_linear_workspace *mw;
-  double chisq;
+  sp.x = gsl_vector_alloc(numBins);
+  sp.y = gsl_vector_alloc(numBins);
+  sp.Z = gsl_matrix_alloc(numBins, ncoeffs);
+  sp.c = gsl_vector_alloc(ncoeffs);
+  sp.w = gsl_vector_alloc(numBins);
+  sp.cov = gsl_matrix_alloc(ncoeffs, ncoeffs);
+  sp.mw = gsl_multifit_linear_alloc(numBins, ncoeffs);
+}
 
-  int n = static_cast<int>(yInputVals.size());
-  bool isMasked = inWS->hasMaskedBins(spec);
-  std::vector<int> masked(yInputVals.size());
-  if (isMasked) {
-    auto maskedBins = inWS->maskedBins(spec);
-    for (auto &maskedBin : maskedBins)
-      masked[maskedBin.first] = 1;
-    n -= static_cast<int>(inWS->maskedBins(spec).size());
-  }
+void SplineBackground::freeBSplinePointers() {
+  // Create an alias to tidy it up
+  bSplinePointers &sp = m_splinePointers;
 
-  if (n < ncoeffs) {
-    g_log.error("Too many basis functions (NCoeff)");
-    throw std::out_of_range("Too many basis functions (NCoeff)");
-  }
+  gsl_bspline_free(sp.bw);
+  sp.bw = nullptr;
+  gsl_vector_free(sp.B);
+  sp.B = nullptr;
+  gsl_vector_free(sp.x);
+  sp.x = nullptr;
+  gsl_vector_free(sp.y);
+  sp.y = nullptr;
+  gsl_matrix_free(sp.Z);
+  sp.Z = nullptr;
+  gsl_vector_free(sp.c);
+  sp.c = nullptr;
+  gsl_vector_free(sp.w);
+  sp.w = nullptr;
+  gsl_matrix_free(sp.cov);
+  sp.cov = nullptr;
+  gsl_multifit_linear_free(sp.mw);
+  sp.mw = nullptr;
+}
 
-  /* allocate a cubic bspline workspace (k = 4) */
-  bw = gsl_bspline_alloc(k, nbreak);
-  B = gsl_vector_alloc(ncoeffs);
-
-  x = gsl_vector_alloc(n);
-  y = gsl_vector_alloc(n);
-  Z = gsl_matrix_alloc(n, ncoeffs);
-  c = gsl_vector_alloc(ncoeffs);
-  w = gsl_vector_alloc(n);
-  cov = gsl_matrix_alloc(ncoeffs, ncoeffs);
-  mw = gsl_multifit_linear_alloc(n, ncoeffs);
-
-  /* this is the data to be fitted */
-  const auto &eInputVals = inWS->e(spec);
-  const auto &xInputPoints = inWS->points(spec);
-  int j = 0;
-  for (MantidVec::size_type i = 0; i < yInputVals.size(); ++i) {
-    if (isMasked && masked[i])
-      continue;
-    gsl_vector_set(x, j, xInputPoints[i]);
-    gsl_vector_set(y, j, yInputVals[i]);
-    gsl_vector_set(
-        w, j, eInputVals[i] > 0. ? 1. / (eInputVals[i] * eInputVals[i]) : 0.);
-
-    ++j;
-  }
-
-  if (n != j) {
-    gsl_bspline_free(bw);
-    gsl_vector_free(B);
-    gsl_vector_free(x);
-    gsl_vector_free(y);
-    gsl_matrix_free(Z);
-    gsl_vector_free(c);
-    gsl_vector_free(w);
-    gsl_matrix_free(cov);
-    gsl_multifit_linear_free(mw);
-
-    throw std::runtime_error("Assertion failed: n != j");
-  }
-
-  const auto &xInputVals = inWS->x(spec);
-
-  double xStart = xInputVals.front();
-  double xEnd = xInputVals.back();
-
-  /* use uniform breakpoints */
-  gsl_bspline_knots_uniform(xStart, xEnd, bw);
-
-  /* construct the fit matrix X */
-  for (int i = 0; i < n; ++i) {
-    double xi = gsl_vector_get(x, i);
-
-    /* compute B_j(xi) for all j */
-    gsl_bspline_eval(xi, B, bw);
-
-    /* fill in row i of X */
-    for (j = 0; j < ncoeffs; ++j) {
-      double Bj = gsl_vector_get(B, j);
-      gsl_matrix_set(Z, i, j, Bj);
-    }
-  }
-
-  /* do the fit */
-  gsl_multifit_wlinear(Z, w, y, c, cov, &chisq, mw);
-
+MatrixWorkspace_sptr
+SplineBackground::saveSplineOutput(const API::MatrixWorkspace_sptr ws,
+                                   const size_t spec) {
+  const auto &xInputVals = ws->x(spec);
+  const auto &yInputVals = ws->y(spec);
   /* output the smoothed curve */
   API::MatrixWorkspace_sptr outWS = WorkspaceFactory::Instance().create(
-      inWS, 1, xInputVals.size(), yInputVals.size());
-  {
-    outWS->getSpectrum(0)
-        .setSpectrumNo(inWS->getSpectrum(spec).getSpectrumNo());
-    double yi, yerr;
+      ws, 1, xInputVals.size(), yInputVals.size());
 
-    auto &yVals = outWS->mutableY(0);
-    auto &eVals = outWS->mutableE(0);
+  outWS->getSpectrum(0).setSpectrumNo(ws->getSpectrum(spec).getSpectrumNo());
 
-    for (MantidVec::size_type i = 0; i < yInputVals.size(); i++) {
-      double xi = xInputVals[i];
-      gsl_bspline_eval(xi, B, bw);
-      gsl_multifit_linear_est(B, c, cov, &yi, &yerr);
-      yVals[i] = yi;
-      eVals[i] = yerr;
-    }
-    outWS->setSharedX(0, inWS->sharedX(0));
+  double yi, yerr;
+  auto &yVals = outWS->mutableY(0);
+  auto &eVals = outWS->mutableE(0);
+
+  for (size_t i = 0; i < yInputVals.size(); i++) {
+    double xi = xInputVals[i];
+    gsl_bspline_eval(xi, m_splinePointers.B, m_splinePointers.bw);
+    gsl_multifit_linear_est(m_splinePointers.B, m_splinePointers.c,
+                            m_splinePointers.cov, &yi, &yerr);
+    yVals[i] = yi;
+    eVals[i] = yerr;
   }
+  outWS->setSharedX(0, ws->sharedX(0));
+  return outWS;
+}
 
-  gsl_bspline_free(bw);
-  gsl_vector_free(B);
-  gsl_vector_free(x);
-  gsl_vector_free(y);
-  gsl_matrix_free(Z);
-  gsl_vector_free(c);
-  gsl_vector_free(w);
-  gsl_matrix_free(cov);
-  gsl_multifit_linear_free(mw);
+void SplineBackground::setupSpline(double xMin, double xMax, int numBins,
+                                   int ncoeff) {
+  /* use uniform breakpoints */
+  gsl_bspline_knots_uniform(xMin, xMax, m_splinePointers.bw);
 
-  setProperty("OutputWorkspace", outWS);
+  /* construct the fit matrix X */
+  for (int i = 0; i < numBins; ++i) {
+    double xi = gsl_vector_get(m_splinePointers.x, i);
+
+    /* compute B_j(xi) for all j */
+    gsl_bspline_eval(xi, m_splinePointers.B, m_splinePointers.bw);
+
+    /* fill in row i of X */
+    for (int j = 0; j < ncoeff; ++j) {
+      double Bj = gsl_vector_get(m_splinePointers.B, j);
+      gsl_matrix_set(m_splinePointers.Z, i, j, Bj);
+    }
+  }
 }
 
 } // namespace Algorithms

--- a/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
@@ -57,8 +57,8 @@ void SplineBackground::exec() {
   allocateBSplinePointers(numBins, ncoeffs);
   addWsDataToSpline(inWS.get(), spec, numBins);
 
-  const auto &xInputPoints = inWS->x(spec);
-  setupSpline(xInputPoints.front(), xInputPoints.back(), numBins, ncoeffs);
+  const auto &xVals = inWS->x(spec);
+  setupSpline(xVals.front(), xVals.back(), numBins, ncoeffs);
 
   // Wrap this in its own block so we can alias the member variable
   // to a shorter name for the duration of this call
@@ -108,7 +108,7 @@ SplineBackground::calculateNumBinsToProcess(const API::MatrixWorkspace *ws) {
 void SplineBackground::addWsDataToSpline(const API::MatrixWorkspace *ws,
                                          const size_t specNum,
                                          int expectedNumBins) {
-  const auto xInputVals = ws->points(specNum);
+  const auto xPointData = ws->points(specNum);
   const auto yInputVals = ws->y(specNum);
   const auto eInputVals = ws->e(specNum);
   const bool hasMaskedBins = ws->hasMaskedBins(specNum);
@@ -126,7 +126,7 @@ void SplineBackground::addWsDataToSpline(const API::MatrixWorkspace *ws,
   for (size_t i = 0; i < yInputVals.size(); ++i) {
     if (hasMaskedBins && masked[i])
       continue;
-    gsl_vector_set(m_splinePointers.xData, numUnmaskedBins, xInputVals[i]);
+    gsl_vector_set(m_splinePointers.xData, numUnmaskedBins, xPointData[i]);
     gsl_vector_set(m_splinePointers.yData, numUnmaskedBins, yInputVals[i]);
     gsl_vector_set(m_splinePointers.binWeights, numUnmaskedBins,
                    calculateBinWeight(eInputVals[i]));

--- a/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
@@ -182,7 +182,7 @@ void SplineBackground::allocateBSplinePointers(int numBins, int ncoeffs) {
   */
 double SplineBackground::calculateBinWeight(double errValue) {
   double outBinWeight = 0;
-  if (errValue < 0 || !std::isnormal(errValue)) {
+  if (errValue <= 0 || !std::isfinite(errValue)) {
     // Regardless of which warning we print we should
     // set the bin weight
     outBinWeight = 0;

--- a/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineBackground.cpp
@@ -78,6 +78,11 @@ void SplineBackground::exec() {
   setProperty("OutputWorkspace", outWS);
 }
 
+/**
+ * Calculates the number of unmasked bins to process within spline background
+ *
+ * @param ws:: The input workspace to calculate the number of unmasked bins of
+*/
 size_t
 SplineBackground::calculateNumBinsToProcess(const API::MatrixWorkspace *ws) {
   const int spec = getProperty("WorkspaceIndex");
@@ -92,6 +97,14 @@ SplineBackground::calculateNumBinsToProcess(const API::MatrixWorkspace *ws) {
   return ySize;
 }
 
+/**
+ * Adds the data from the workspace into various GSL vectors
+ * for the spline later
+ *
+ * @param ws:: The workspace containing data to process
+ * @param specNum:: The spectrum number to process from the input WS
+ * @param expectedNumBins:: The expected number of unmasked bins to add
+ */
 void SplineBackground::addWsDataToSpline(const API::MatrixWorkspace *ws,
                                          const size_t specNum,
                                          int expectedNumBins) {
@@ -145,6 +158,13 @@ void SplineBackground::addWsDataToSpline(const API::MatrixWorkspace *ws,
   }
 }
 
+/**
+  * Allocates the various vectors and workspaces within the GSL
+  *
+  * @param numBins:: The number of unmasked bins in the input workspaces to
+  *process
+  * @param ncoeffs:: The user specified number of coefficients to process
+  */
 void SplineBackground::allocateBSplinePointers(int numBins, int ncoeffs) {
   const int k = 4; // order of the spline + 1 (cubic)
   const int nbreak = ncoeffs - (k - 2);
@@ -167,6 +187,9 @@ void SplineBackground::allocateBSplinePointers(int numBins, int ncoeffs) {
   sp.weightedLinearFitWs = gsl_multifit_linear_alloc(numBins, ncoeffs);
 }
 
+/**
+ * Frees various vectors and workspaces within the GSL
+ */
 void SplineBackground::freeBSplinePointers() {
   // Create an alias to tidy it up
   bSplinePointers &sp = m_splinePointers;
@@ -191,6 +214,15 @@ void SplineBackground::freeBSplinePointers() {
   sp.weightedLinearFitWs = nullptr;
 }
 
+/**
+ * Makes a clone of the input workspace and retrieves fitted values
+ * and stores them in the output workspace with the user specified name
+ *
+ * @param ws:: The input workspace to clone
+ * @param spec:: The user specified spectrum number in the input ws to process
+ *
+ * @return:: A shared pointer to the output workspace
+ */
 MatrixWorkspace_sptr
 SplineBackground::saveSplineOutput(const API::MatrixWorkspace_sptr ws,
                                    const size_t spec) {
@@ -220,6 +252,14 @@ SplineBackground::saveSplineOutput(const API::MatrixWorkspace_sptr ws,
   return outWS;
 }
 
+/**
+ * Sets up GSL with various parameters needed for subsequent fitting
+ *
+ * @param xMin:: The minimum x value in the input workspace
+ * @param xMax:: The maximum x value in the input workspace
+ * @param numBins:: The number of unmasked bins in the input workspace
+ * @param ncoeff:: The user specified coefficient to use
+ */
 void SplineBackground::setupSpline(double xMin, double xMax, int numBins,
                                    int ncoeff) {
   /* use uniform breakpoints */


### PR DESCRIPTION
Description of work.
Whilst debugging this issue in #18818 `SplineBackground` was refactored although there should be no difference in the results / operation. A warning was added if the error values are 0 / inf / nan as these bins will not contribute to the fit. Previously this was performed silently however this issue has not been ran into by users.


**To test:**

The test files are located here: 
[18817_SplineTestFiles.zip](https://github.com/mantidproject/mantid/files/770964/18817_SplineTestFiles.zip)

- Load `BeforeSplineGood.nxs` and `AfterSplineGood.nxs`
- Run SplineBackground on `BeforeSplineGood.nxs` with coefficient set to 100
- Compare the result to `AfterSplineGood.nxs` they should still match

- Code review

Fixes #18817.

Does not need to be in the release notes - these changes should have no visible effect. 

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
