### PR TITLE
Avoid synchronization issues with ParameterMap::setDetectorInfo.

### DIFF
--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -58,7 +58,9 @@ ExperimentInfo::ExperimentInfo()
     : m_moderatorModel(), m_choppers(), m_sample(new Sample()),
       m_run(new Run()), m_parmap(new ParameterMap()),
       sptr_instrument(new Instrument()),
-      m_detectorInfo(boost::make_shared<Beamline::DetectorInfo>(0)) {}
+      m_detectorInfo(boost::make_shared<Beamline::DetectorInfo>(0)) {
+  m_parmap->setDetectorInfo(m_detectorInfo);
+}
 
 /**
  * Constructs the object from a copy if the input. This leaves the new mutex
@@ -208,12 +210,13 @@ void ExperimentInfo::setInstrument(const Instrument_const_sptr &instr) {
   m_detectorInfoWrapper = nullptr;
   if (instr->isParametrized()) {
     sptr_instrument = instr->baseInstrument();
-    m_parmap = instr->getParameterMap();
+    m_parmap = boost::make_shared<ParameterMap>(*instr->getParameterMap());
   } else {
     sptr_instrument = instr;
     m_parmap = boost::make_shared<ParameterMap>();
   }
   m_detectorInfo = makeDetectorInfo(*sptr_instrument, *instr);
+  m_parmap->setDetectorInfo(m_detectorInfo);
   // Detector IDs that were previously dropped because they were not part of the
   // instrument may now suddenly be valid, so we have to reinitialize the
   // detector grouping. Also the index corresponding to specific IDs may have
@@ -404,6 +407,7 @@ void ExperimentInfo::replaceInstrumentParameters(
   m_spectrumInfoWrapper = nullptr;
   m_detectorInfoWrapper = nullptr;
   this->m_parmap.reset(new ParameterMap(pmap));
+  m_parmap->setDetectorInfo(m_detectorInfo);
 }
 
 /**
@@ -418,6 +422,7 @@ void ExperimentInfo::swapInstrumentParameters(Geometry::ParameterMap &pmap) {
   m_spectrumInfoWrapper = nullptr;
   m_detectorInfoWrapper = nullptr;
   this->m_parmap->swap(pmap);
+  m_parmap->setDetectorInfo(m_detectorInfo);
 }
 
 /**

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -72,11 +72,6 @@ MatrixWorkspace::MatrixWorkspace(const MatrixWorkspace &other)
   m_isCommonBinsFlag = other.m_isCommonBinsFlag;
   m_masks = other.m_masks;
   // TODO: Do we need to init m_monitorWorkspace?
-
-  // This call causes copying of m_parmap (ParameterMap). The constructor of
-  // ExperimentInfo just kept a shared_ptr to the same map as in other, which
-  // is not enough as soon as the maps in one of the workspaces it edited.
-  instrumentParameters();
 }
 
 /// Destructor

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -10,6 +10,7 @@
 #include "tbb/concurrent_unordered_map.h"
 
 #include <memory>
+#include <mutex>
 #include <vector>
 #include <typeinfo>
 
@@ -378,6 +379,7 @@ private:
   /// Pointer to the DetectorInfo object. NULL unless the instrument is
   /// associated with an ExperimentInfo object.
   boost::shared_ptr<const Beamline::DetectorInfo> m_detectorInfo{nullptr};
+  std::mutex m_detectorInfoMutex;
 };
 
 /// ParameterMap shared pointer typedef

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -10,7 +10,6 @@
 #include "tbb/concurrent_unordered_map.h"
 
 #include <memory>
-#include <mutex>
 #include <vector>
 #include <typeinfo>
 
@@ -379,7 +378,6 @@ private:
   /// Pointer to the DetectorInfo object. NULL unless the instrument is
   /// associated with an ExperimentInfo object.
   boost::shared_ptr<const Beamline::DetectorInfo> m_detectorInfo{nullptr};
-  std::mutex m_detectorInfoMutex;
 };
 
 /// ParameterMap shared pointer typedef

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1302,8 +1302,6 @@ const Beamline::DetectorInfo &Instrument::detectorInfo() const {
 /// Only for use by ExperimentInfo. Sets the pointer to the DetectorInfo.
 void Instrument::setDetectorInfo(
     boost::shared_ptr<const Beamline::DetectorInfo> detectorInfo) {
-  if (m_map_nonconst)
-    m_map_nonconst->setDetectorInfo(detectorInfo);
   m_detectorInfo = std::move(detectorInfo);
 }
 

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1166,8 +1166,10 @@ const Beamline::DetectorInfo &ParameterMap::detectorInfo() const {
 void ParameterMap::setDetectorInfo(
     boost::shared_ptr<const Beamline::DetectorInfo> detectorInfo) {
   if (detectorInfo != m_detectorInfo) {
-    PARALLEL_CRITICAL(ParameterMap_setDetectorInfo)
-    m_detectorInfo = std::move(detectorInfo);
+    std::lock_guard<std::mutex> lock(m_detectorInfoMutex);
+    if (detectorInfo != m_detectorInfo) {
+      m_detectorInfo = std::move(detectorInfo);
+    }
   }
 }
 

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1165,12 +1165,7 @@ const Beamline::DetectorInfo &ParameterMap::detectorInfo() const {
 /// Only for use by ExperimentInfo. Sets the pointer to the DetectorInfo.
 void ParameterMap::setDetectorInfo(
     boost::shared_ptr<const Beamline::DetectorInfo> detectorInfo) {
-  if (detectorInfo != m_detectorInfo) {
-    std::lock_guard<std::mutex> lock(m_detectorInfoMutex);
-    if (detectorInfo != m_detectorInfo) {
-      m_detectorInfo = std::move(detectorInfo);
-    }
-  }
+  m_detectorInfo = std::move(detectorInfo);
 }
 
 } // Namespace Geometry


### PR DESCRIPTION
After https://github.com/mantidproject/mantid/pull/18393 SCDCalibratePanels would still show sporadic segfaults, this is an attempt to fix this.

I now set the `DetectorInfo` in the `ParameterMap` just after creation, which avoids threading issues.

I have been running `SCDCalibratePanelsTest` in a loop for 5 hours now. It segfaulted twice, which is much less than previously. Also, previously I had observed two kinds of segfaults, now I see only one in relation to `tbb::concurrent_unordered_map`. I do not know if that is related to any changes with `DetectorInfo`, or if it exists independently.

In conclusion, this might not fix all issues, but it should be a significant improvement.

**To test:**

Code review

Fixes #18390.

No release notes, internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
