### PR TITLE
Added check for if nonorthogonal axes should be displayed

### DIFF
--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -2954,7 +2954,7 @@ void SliceViewer::switchAxis() {
   if (m_canSwitchScales) { // cannot be called when sliceviewer first
                            // initialised because axis is inaccurate
     auto isHKL = API::isHKLDimensions(m_ws, m_dimX, m_dimY);
-    if (isHKL) {
+    if (isHKL && ui.btnNonOrthogonalToggle->isChecked()) {
       applyNonOrthogonalAxisScaleDraw();
     } else {
       applyOrthogonalAxisScaleDraw();


### PR DESCRIPTION
Fixes https://github.com/mantidproject/mantid/issues/18832

To test, open a workspace with HKL axes. Change the dimensions shown and ensure the axes remain consistent. Switch back and forth between nonorthogonal and orthogonal modes and also check this.

