### PR TITLE
scipy 0.18 dropped nanmean and nanmedian in favor of numpy

### DIFF
--- a/scripts/CompareFitMinimizers/post_processing.py
+++ b/scripts/CompareFitMinimizers/post_processing.py
@@ -20,7 +20,14 @@
 
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
-from scipy import stats  # older version of numpy does not support nanmean and nanmedian
+
+# older version of numpy does not support nanmean and nanmedian
+# and nanmean and nanmedian was removed in scipy 0.18 in favor of numpy
+# so try numpy first then scipy.stats
+try:
+    from numpy import nanmean, nanmedian
+except ImportError:
+    from scipy.stats import nanmean, nanmedian
 
 
 def calc_summary_table(minimizers, group_results):
@@ -60,8 +67,8 @@ def calc_summary_table(minimizers, group_results):
         norm_acc_rankings = accuracy_tbl / min_sum_err_sq[:, None]
         norm_runtime_rankings = time_tbl / min_runtime[:, None]
 
-        groups_norm_acc[group_idx, :] = stats.nanmedian(norm_acc_rankings, 0)
-        groups_norm_runtime[group_idx, :] = stats.nanmedian(norm_runtime_rankings, 0)
+        groups_norm_acc[group_idx, :] = nanmedian(norm_acc_rankings, 0)
+        groups_norm_runtime[group_idx, :] = nanmedian(norm_runtime_rankings, 0)
 
     return groups_norm_acc, groups_norm_runtime
 
@@ -103,14 +110,14 @@ def calc_norm_summary_tables(accuracy_tbl, time_tbl):
 
     summary_cells_acc = np.array([np.nanmin(norm_acc_rankings, 0),
                                   np.nanmax(norm_acc_rankings, 0),
-                                  stats.nanmean(norm_acc_rankings, 0),
-                                  stats.nanmedian(norm_acc_rankings, 0)
+                                  nanmean(norm_acc_rankings, 0),
+                                  nanmedian(norm_acc_rankings, 0)
                                   ])
 
     summary_cells_runtime = np.array([np.nanmin(norm_runtimes, 0),
                                       np.nanmax(norm_runtimes, 0),
-                                      stats.nanmean(norm_runtimes, 0),
-                                      stats.nanmedian(norm_runtimes, 0)
+                                      nanmean(norm_runtimes, 0),
+                                      nanmedian(norm_runtimes, 0)
                                       ])
 
     return norm_acc_rankings, norm_runtimes, summary_cells_acc, summary_cells_runtime

--- a/scripts/CompareFitMinimizers/results_output.py
+++ b/scripts/CompareFitMinimizers/results_output.py
@@ -25,8 +25,15 @@ formats such as RST and plain text.
 from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
-from scipy import stats  # older version of numpy does not support nanmean and nanmedian
 import post_processing as postproc
+
+# older version of numpy does not support nanmean and nanmedian
+# and nanmean and nanmedian was removed in scipy 0.18 in favor of numpy
+# so try numpy first then scipy.stats
+try:
+    from numpy import nanmean, nanmedian
+except ImportError:
+    from scipy.stats import nanmean, nanmedian
 
 # Some naming conventions for the output files
 BENCHMARK_VERSION_STR = 'v3.8'
@@ -448,8 +455,8 @@ def print_tables_simple_text(minimizers, results_per_test, accuracy_tbl, time_tb
     results_text += '---------------- Summary (accuracy): -------- \n'
     results_text += 'Best ranking: {0}\n'.format(np.nanmin(norm_acc_rankings, 0))
     results_text += 'Worst ranking: {0}\n'.format(np.nanmax(norm_acc_rankings, 0))
-    results_text += 'Mean: {0}\n'.format(stats.nanmean(norm_acc_rankings, 0))
-    results_text += 'Median: {0}\n'.format(stats.nanmedian(norm_acc_rankings, 0))
+    results_text += 'Mean: {0}\n'.format(nanmean(norm_acc_rankings, 0))
+    results_text += 'Median: {0}\n'.format(nanmedian(norm_acc_rankings, 0))
     results_text += '\n'
 
     print(results_text)
@@ -467,8 +474,8 @@ def print_tables_simple_text(minimizers, results_per_test, accuracy_tbl, time_tb
     time_text += '---------------- Summary (run time): -------- \n'
     time_text += 'Best ranking: {0}\n'.format(np.nanmin(norm_runtimes, 0))
     time_text += 'Worst ranking: {0}\n'.format(np.nanmax(norm_runtimes, 0))
-    time_text += 'Mean: {0}\n'.format(stats.nanmean(norm_runtimes, 0))
-    time_text += 'Median: {0}\n'.format(stats.nanmedian(norm_runtimes, 0))
+    time_text += 'Mean: {0}\n'.format(nanmean(norm_runtimes, 0))
+    time_text += 'Median: {0}\n'.format(nanmedian(norm_runtimes, 0))
     time_text += '\n'
 
     print(time_text)


### PR DESCRIPTION
scipy 0.18 dropped nanmean and nanmedian in favor of numpy, so try numpy first then scipy.stats

https://docs.scipy.org/doc/scipy-0.18.0/reference/release.0.18.0.html#scipy-stats

Fedora 25 has scipy `0.18` @peterfpeterson 

**To test:**
While using scipy `0.18` the FittingBenchmarks system should now pass. `./systemtest -R FittingBenchmarks`


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
