### PR TITLE
Exclude scripts/test directory from packaging

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -177,13 +177,13 @@ if ( WIN32 ) # General windows environment
     install ( DIRECTORY ../scripts/ DESTINATION ${INBUNDLE}scripts PATTERN "*.pyc"
               EXCLUDE PATTERN ".svn" EXCLUDE PATTERN ".gitignore"
               EXCLUDE PATTERN "*.so" EXCLUDE PATTERN "*_win32.pyd" EXCLUDE PATTERN "CMakeLists.txt"
-              EXCLUDE PATTERN "test/*" EXCLUDE )
+              EXCLUDE PATTERN "test" EXCLUDE )
   else ()
     # Excludes so files & _win64 binaries
     install ( DIRECTORY ../scripts/ DESTINATION ${INBUNDLE}scripts PATTERN "*.pyc"
               EXCLUDE PATTERN ".svn" EXCLUDE PATTERN ".gitignore"
               EXCLUDE PATTERN "*.so" EXCLUDE PATTERN "*_win64.pyd" EXCLUDE PATTERN "CMakeLists.txt"
-              EXCLUDE PATTERN "test/*" EXCLUDE )
+              EXCLUDE PATTERN "test" EXCLUDE )
   endif ()
 
   # Also ship mingw libraries for Inelastic fortran code. We need to do a better job here and build things
@@ -194,7 +194,7 @@ else ()
   install ( DIRECTORY ../scripts/ DESTINATION ${INBUNDLE}scripts PATTERN "*.pyc"
             EXCLUDE PATTERN ".svn" EXCLUDE PATTERN ".gitignore"
             EXCLUDE PATTERN "*_win*.pyd" EXCLUDE PATTERN "*_lnx64.so" EXCLUDE PATTERN "CMakeLists.txt"
-            EXCLUDE PATTERN "test/*" EXCLUDE )
+            EXCLUDE PATTERN "test" EXCLUDE )
 endif ()
 
 # THIS MUST BE THE LAST SUB_DIRECTORY ADDED. See Properties/CMakeLists.txt.

--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -174,20 +174,27 @@ install ( DIRECTORY ../instrument/ DESTINATION ${INBUNDLE}instrument
 if ( WIN32 ) # General windows environment
   if ( CMAKE_SIZEOF_VOID_P EQUAL 8 ) # Recommended way of detecting 64- vs 32-bit build
     # Excludes .so files & _win32 binaries
-    install ( DIRECTORY ../scripts/ DESTINATION ${INBUNDLE}scripts PATTERN "*.pyc" EXCLUDE
-              PATTERN ".svn" EXCLUDE PATTERN "*.so" EXCLUDE PATTERN "*_win32.pyd" EXCLUDE PATTERN "CMakeLists.txt" EXCLUDE )
+    install ( DIRECTORY ../scripts/ DESTINATION ${INBUNDLE}scripts PATTERN "*.pyc"
+              EXCLUDE PATTERN ".svn" EXCLUDE PATTERN ".gitignore"
+              EXCLUDE PATTERN "*.so" EXCLUDE PATTERN "*_win32.pyd" EXCLUDE PATTERN "CMakeLists.txt"
+              EXCLUDE PATTERN "test/*" EXCLUDE )
   else ()
     # Excludes so files & _win64 binaries
-    install ( DIRECTORY ../scripts/ DESTINATION ${INBUNDLE}scripts PATTERN "*.pyc" EXCLUDE
-              PATTERN ".svn" EXCLUDE PATTERN "*.so" EXCLUDE PATTERN "*_win64.pyd" EXCLUDE PATTERN "CMakeLists.txt" EXCLUDE )
+    install ( DIRECTORY ../scripts/ DESTINATION ${INBUNDLE}scripts PATTERN "*.pyc"
+              EXCLUDE PATTERN ".svn" EXCLUDE PATTERN ".gitignore"
+              EXCLUDE PATTERN "*.so" EXCLUDE PATTERN "*_win64.pyd" EXCLUDE PATTERN "CMakeLists.txt"
+              EXCLUDE PATTERN "test/*" EXCLUDE )
   endif ()
-    # Also ship mingw libraries for Inelastic fortran code. We need to do a better job here and build things
-    file ( GLOB MINGW_DLLS "${THIRD_PARTY_DIR}/bin/mingw/*.dll" )
-    install ( FILES ${MINGW_DLLS} DESTINATION ${INBUNDLE}scripts/Inelastic )
-  else ()
+
+  # Also ship mingw libraries for Inelastic fortran code. We need to do a better job here and build things
+  file ( GLOB MINGW_DLLS "${THIRD_PARTY_DIR}/bin/mingw/*.dll" )
+  install ( FILES ${MINGW_DLLS} DESTINATION ${INBUNDLE}scripts/Inelastic )
+else ()
   # These don't work correctly and the linux ones are in no way general. They really need to be part of the build
-  install ( DIRECTORY ../scripts/ DESTINATION ${INBUNDLE}scripts PATTERN "*.pyc" EXCLUDE
-            PATTERN ".svn" EXCLUDE PATTERN "*_win*.pyd" EXCLUDE PATTERN "*_lnx64.so" EXCLUDE PATTERN "CMakeLists.txt" EXCLUDE )
+  install ( DIRECTORY ../scripts/ DESTINATION ${INBUNDLE}scripts PATTERN "*.pyc"
+            EXCLUDE PATTERN ".svn" EXCLUDE PATTERN ".gitignore"
+            EXCLUDE PATTERN "*_win*.pyd" EXCLUDE PATTERN "*_lnx64.so" EXCLUDE PATTERN "CMakeLists.txt"
+            EXCLUDE PATTERN "test/*" EXCLUDE )
 endif ()
 
 # THIS MUST BE THE LAST SUB_DIRECTORY ADDED. See Properties/CMakeLists.txt.


### PR DESCRIPTION
Packages are currently including `scripts/test` in them. This PR removes them.

**To test:**

Build the package (or download from a build server) and see that it doesn't contain `scripts/test` any more.

*There is no associated issue.*

*Does not need to be in the release notes* because it is just shrinking the package by removing tests that users shouldn't have anyhow.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
