### PR TITLE
Indirect Diffraction - OSIRIS diffonly interface crash

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -115,7 +115,7 @@ void IndirectDiffractionReduction::run() {
   if (instName == "OSIRIS") {
     if (mode == "diffonly") {
       if (!validateVanCal()) {
-        showInformationBox("Vaniduium and Calibration input is invalid.");
+        showInformationBox("Vanadium and Calibration input is invalid.");
         return;
       }
       runOSIRISdiffonlyReduction();
@@ -133,7 +133,6 @@ void IndirectDiffractionReduction::run() {
     }
     runGenericReduction(instName, mode);
   }
-
 }
 
 /**
@@ -365,7 +364,7 @@ void IndirectDiffractionReduction::runGenericReduction(QString instName,
                                     m_uiForm.spCanScale->value());
   }
 
-  // Add the pproperty for grouping policy if needed
+  // Add the property for grouping policy if needed
   if (m_uiForm.ckIndividualGrouping->isChecked())
     msgDiffReduction->setProperty("GroupingPolicy", "Individual");
 
@@ -471,7 +470,7 @@ void IndirectDiffractionReduction::runOSIRISdiffonlyReduction() {
  *
  * Optionally loads an IPF if a reflection was provided.
  *
- * @param instrumentName Name of an inelastic indiretc instrument (IRIS, OSIRIN,
+ * @param instrumentName Name of an inelastic indirect instrument (IRIS, OSIRIS,
  *TOSCA, VESUVIO)
  * @param reflection Reflection mode to load parameters for (diffspec or
  *diffonly)
@@ -646,7 +645,7 @@ void IndirectDiffractionReduction::saveSettings() {
 /**
  * Validates the rebinning fields and updates invalid markers.
  *
- * @returns True if reinning options are valid, flase otherwise
+ * @returns True if reining options are valid, false otherwise
  */
 bool IndirectDiffractionReduction::validateRebin() {
   QString rebStartTxt = m_uiForm.leRebinStart->text();
@@ -737,7 +736,7 @@ bool IndirectDiffractionReduction::validateCalOnly() {
 }
 
 /**
- * Disables and shows message on run button indicating that run files have benn
+ * Disables and shows message on run button indicating that run files have been
  * changed.
  */
 void IndirectDiffractionReduction::runFilesChanged() {

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -131,8 +131,9 @@ void IndirectDiffractionReduction::run() {
       showInformationBox("Rebinning parameters are incorrect.");
       return;
     }
+    runGenericReduction(instName, mode);
   }
-  runGenericReduction(instName, mode);
+
 }
 
 /**

--- a/docs/source/release/v3.10.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.10.0/indirect_inelastic.rst
@@ -26,4 +26,6 @@ Improvements
 Bugfixes
 --------
 
+- The *Diffraction* Interface no longer crashes when in OSIRIS diffonly mode
+
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.10%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
The OSIRIS diffonly mode of the Indirect>Diffraction interface was crashing because it was trying to run the general IRISIndirectDiffractionReduction on top of the specialised OSIRISDiffractionReduction. It should only run the OSIRIS algorithm.

**To test:**
Input Files:
[Diffraction.zip](https://github.com/mantidproject/mantid/files/774937/Diffraction.zip)

Interfaces>Indirect>Diffraction
Instrument:`OSIRIS`
Input: `89813-89817`
Calibration: In input files
Vanadium:`89757-89761`
Press `Run`

There should be 2 workspaces, one ending in `_dRange` and the the other in `tof`
There are copies of the input/vanadium files if no access to ISIS data archive


Fixes #18856.


_Release notes have been updated_

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
