### PR TITLE
Now that we have dropped RHEL6 this doc test can be reenabled.

### DIFF
--- a/docs/source/algorithms/AlignComponents-v1.rst
+++ b/docs/source/algorithms/AlignComponents-v1.rst
@@ -60,7 +60,7 @@ Usage
 
 **Example - Align the X and Z position of bank26 in POWGEN:**
 
-.. code-block:: python
+.. testcode:: position
 
       LoadCalFile(InstrumentName="PG3",
             CalFilename="PG3_golden.cal",
@@ -81,14 +81,14 @@ Usage
 
 Output:
 
-.. code-block:: none
+.. testoutput:: position
 
     Start position is [1.54436,0.863271,-1.9297]
     Final position is [1.50591,0.863271,-1.92734]
 
 **Example - Align the Y rotation of bank26 and bank46 in POWGEN:**
 
-.. code-block:: python
+.. testcode:: rotation
 
       LoadCalFile(InstrumentName="PG3",
 	    CalFilename="PG3_golden.cal",
@@ -116,7 +116,7 @@ Output:
 
 Output:
 
-.. code-block:: none
+.. testoutput:: rotation
 
       Start bank26 rotation is [-24.061.0.120,18.016]
       Start bank46 rotation is [-41.092.0.061,17.795]
@@ -125,7 +125,7 @@ Output:
 
 **Example - Align sample position in POWGEN:**
 
-.. code-block:: python
+.. testcode:: sample
 
       LoadCalFile(InstrumentName="PG3",
 	    CalFilename="PG3_golden.cal",
@@ -147,7 +147,7 @@ Output:
 
 Output:
 
-.. code-block:: none
+.. testoutput:: sample
 
       Start sample position is 0.0
       Final sample position is 0.02826


### PR DESCRIPTION
Fixes #15425

This test was originally disabled because `scipy.optimize.minimize` doesn't exist on the version of scipy on RHEL6

Check that this doctest now runs.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
