### PR TITLE
Change group font in Reflectometry GUI (Polref)

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflRunsTabWidget.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflRunsTabWidget.ui
@@ -248,6 +248,12 @@
            </property>
            <item>
              <widget class="QToolBox" name="toolbox">
+               <property name="font">
+                 <font>
+                   <pointsize>11</pointsize>
+                   <bold>true</bold>
+                 </font>
+               </property>
              </widget>
            </item>
          </layout>


### PR DESCRIPTION
Description of work.

See issue for description of wanted changes - increases font size of `Group1/2` and makes them bold.

**To test:**

Simply open the interface from Interfaces->Reflectometry->ISIS Reflectometry (Polref) and ensure the changes are there.

<!-- Instructions for testing. -->

Fixes #18822.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
