### PR TITLE
Fix bug in reflectometry GUI

### DIFF
--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -1042,7 +1042,8 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
                     alg = AlgorithmManager.create("ReflectometryReductionOneAuto")
                     alg.initialize()
                     alg.setProperty("InputWorkspace", ws[i])
-                    alg.setProperty("FirstTransmissionRun", group_trans_ws)
+                    if group_trans_ws:
+                        alg.setProperty("FirstTransmissionRun", group_trans_ws)
                     if angle is not None:
                         alg.setProperty("ThetaIn", angle)
                     alg.setProperty("OutputWorkspaceBinned", runno+'_IvsQ_binned_'+str(i+1))
@@ -1074,7 +1075,8 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
                 alg = AlgorithmManager.create("ReflectometryReductionOneAuto")
                 alg.initialize()
                 alg.setProperty("InputWorkspace", ws)
-                alg.setProperty("FirstTransmissionRun", transmission_ws)
+                if transmission_ws:
+                    alg.setProperty("FirstTransmissionRun", transmission_ws)
                 if angle is not None:
                     alg.setProperty("ThetaIn", angle)
                 alg.setProperty("OutputWorkspaceBinned", runno+'_IvsQ_binned')

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -1067,7 +1067,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
                     wlamGroup.append(wlam)
                     thetaGroup.append(th)
 
-                wqBinned = GroupWorkspaces(InputWorkspaces=wqGroup, OutputWorkspace=runno+'_IvsQ_binned')
+                wqBinned = GroupWorkspaces(InputWorkspaces=wqGroupBinned, OutputWorkspace=runno+'_IvsQ_binned')
                 wq = GroupWorkspaces(InputWorkspaces=wqGroup, OutputWorkspace=runno+'_IvsQ')
                 wlam = GroupWorkspaces(InputWorkspaces=wlamGroup, OutputWorkspace=runno+'_IvsLam')
                 th = thetaGroup[0]


### PR DESCRIPTION
Fixes a bug when no transmission runs provided.

**To test:**

- Open the old reflectometry GUI
- Select `INTER` and enter run `13460`, hit process. The run should be reduced and workspaces `13460_IvsQ`, `13460_IvsLam` and `TOF` (this one should be a group with a single entry) should be created in the ADS.
- Reduce a multi-period dataset: select `POLREF`, enter run `18564` and hit `Process`, no errors should be shown and the run should be reduced.
- As an extra check, compare results to the new interface.

Fixes #16925.

No need to update release notes, this issue was reported by a developer and picked by squish test.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
