### PR TITLE
Fix logic in base directory check for macOS

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -301,7 +301,7 @@ void ConfigServiceImpl::setBaseDirectory() {
     // code crash.
     m_strBaseDir = Poco::Environment::get("MANTIDPATH") + "/";
     f = Poco::File(m_strBaseDir + m_properties_file_name);
-    if (!f.exists())
+    if (f.exists())
       return;
   }
 


### PR DESCRIPTION
Description of work.

Fixes `if` to return early if tested file path exists in ConfigService when searching for `Mantid.properties`.

The OSX system tests are currently failing on `master` because of the error: http://builds.mantidproject.org/job/master_systemtests-osx/

**To test:**

* Build a package on macOS and install it
* Run `/Applications/MantidPlot.app/Contents/MacOS/mantidpython --classic`
* `import mantid` should succeed now

No issue

*Does not need to be in the release notes. A regression introduced in #18680.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
