### PR TITLE
 Improve Q1D documentation

### DIFF
--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -80,16 +80,16 @@ void Q1D2::init() {
   declareProperty("RadiusCut", 0.0, mustBePositive,
                   "To increase resolution some wavelengths are excluded within "
                   "this distance from the beam center (mm). Note that RadiusCut\n"
-                  " and WaveCut both need to be larger than 0 to have an effect \n"
-                  "on the effective cutoff. See the algorithm description for\n"
-                  " a more detailed description of the cutoff.");
+                  " and WaveCut both need to be larger than 0 to affect \n"
+                  "the effective cutoff. See the algorithm description for\n"
+                  " a detailed explanation of the cutoff.");
 
   declareProperty("WaveCut", 0.0, mustBePositive,
 		  "To increase resolution by starting to remove some wavelengths below this"
 		  " threshold (angstrom).  Note that WaveCut\n"
-		  " and RadiusCut both need to be larger than 0 to have an effect \n"
+		  " and RadiusCut both need to be larger than 0 to affect \n"
 		  "on the effective cutoff. See the algorithm description for\n"
-		  " a more detailed description of the cutoff.");
+		  " a detailed explanation of the cutoff.");
 
   declareProperty("OutputParts", false,
                   "Set to true to output two additional workspaces which will "

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -77,19 +77,21 @@ void Q1D2::init() {
   auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
   mustBePositive->setLower(0.0);
 
-  declareProperty("RadiusCut", 0.0, mustBePositive,
-                  "To increase resolution some wavelengths are excluded within "
-                  "this distance from the beam center (mm). Note that RadiusCut\n"
-                  " and WaveCut both need to be larger than 0 to affect \n"
-                  "the effective cutoff. See the algorithm description for\n"
-                  " a detailed explanation of the cutoff.");
+  declareProperty(
+      "RadiusCut", 0.0, mustBePositive,
+      "To increase resolution some wavelengths are excluded within "
+      "this distance from the beam center (mm). Note that RadiusCut\n"
+      " and WaveCut both need to be larger than 0 to affect \n"
+      "the effective cutoff. See the algorithm description for\n"
+      " a detailed explanation of the cutoff.");
 
-  declareProperty("WaveCut", 0.0, mustBePositive,
-		  "To increase resolution by starting to remove some wavelengths below this"
-		  " threshold (angstrom).  Note that WaveCut\n"
-		  " and RadiusCut both need to be larger than 0 to affect \n"
-		  "on the effective cutoff. See the algorithm description for\n"
-		  " a detailed explanation of the cutoff.");
+  declareProperty(
+      "WaveCut", 0.0, mustBePositive,
+      "To increase resolution by starting to remove some wavelengths below this"
+      " threshold (angstrom).  Note that WaveCut\n"
+      " and RadiusCut both need to be larger than 0 to affect \n"
+      "on the effective cutoff. See the algorithm description for\n"
+      " a detailed explanation of the cutoff.");
 
   declareProperty("OutputParts", false,
                   "Set to true to output two additional workspaces which will "

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -76,14 +76,21 @@ void Q1D2::init() {
                   Direction::Input);
   auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
   mustBePositive->setLower(0.0);
+
   declareProperty("RadiusCut", 0.0, mustBePositive,
                   "To increase resolution some wavelengths are excluded within "
-                  "this distance from\n"
-                  "the beam center (mm)");
-  declareProperty(
-      "WaveCut", 0.0, mustBePositive,
-      "To increase resolution by starting to remove some wavelengths below this"
-      "freshold (angstrom)");
+                  "this distance from the beam center (mm). Note that RadiusCut\n"
+                  " and WaveCut both need to be larger than 0 to have an effect \n"
+                  "on the effective cutoff. See the algorithm description for\n"
+                  " a more detailed description of the cutoff.");
+
+  declareProperty("WaveCut", 0.0, mustBePositive,
+		  "To increase resolution by starting to remove some wavelengths below this"
+		  " threshold (angstrom).  Note that WaveCut\n"
+		  " and RadiusCut both need to be larger than 0 to have an effect \n"
+		  "on the effective cutoff. See the algorithm description for\n"
+		  " a more detailed description of the cutoff.");
+
   declareProperty("OutputParts", false,
                   "Set to true to output two additional workspaces which will "
                   "have the names OutputWorkspace_sumOfCounts "

--- a/docs/source/algorithms/Q1D-v2.rst
+++ b/docs/source/algorithms/Q1D-v2.rst
@@ -139,7 +139,7 @@ From the equation it is possible to see that for pixels in
 substituting :math:`WaveCut = W_{low}` we have that :math:`R = 0` and
 hence all detectors contribute at wavelengths above :math:`WaveCut`.
 
-*Practically, it is more likely to be necessary to implement
+Practically, it is more likely to be necessary to implement
 :math:`RadiusCut` and :math:`WaveCut` in situations where the scattering
 near to the beamstop is weak and 'contaminated' by short wavelength
 scatter. This might arise, for example, when running at long
@@ -147,7 +147,7 @@ sample-detector distances, or at short sample-detector distances with
 large diameter beams, or where the sample generates Bragg peaks at
 low-Q. The best recourse is to check the wavelength overlap. If it is
 not too bad it may be possible to improve the data presentation simply
-by altering :math:`Q{min}` and the binning scheme.*
+by altering :math:`Q{min}` and the binning scheme.
 
 Examples
 ######################


### PR DESCRIPTION
This is a minor modification of the Q1D algorithm description. It should point out that the algorithm input WaveCut and RadiusCut are only taking effect if both of them are larger than 0. The main point is though to encourage users to read the section regarding cutoffs in the actual algorithm description.

**To test:**

Ensure that the documentation change makes sense to you.


Fixes #18864


 #### Release notes
Minor change. No release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
