### PR TITLE
Fix CPACK_DEBIAN_PACKAGE_DEPENDS for python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,12 @@ if ( ENABLE_CPACK )
             list ( APPEND DEPENDS_LIST ", libhdf5-cpp-11,libnexus0v5 (>= 4.3),libjsoncpp1,libqscintilla2-12v5, libmuparser2v5,libqwtplot3d-qt4-0v5,libgsl2,liboce-foundation10,liboce-modeling10")
             list (REMOVE_ITEM DEPENDS_LIST "libjsoncpp0 (>=0.7.0)," "libqscintilla2-11," "libmuparser2," "libnexus0 (>= 4.3)," "libqwtplot3d-qt4-0," "libgsl0ldbl," "liboce-foundation8,liboce-modeling8,")
         endif()
+        # Change DEPENDS_LIST for python 3
+        if ( PYTHON_VERSION_MAJOR EQUAL 3 )
+          list (REMOVE_ITEM DEPENDS_LIST "python-nxs (>= 4.3)," "python-pycifrw (>= 4.2.1),")
+          string ( REPLACE "python-" "python3-" DEPENDS_LIST ${DEPENDS_LIST} )
+          string ( REPLACE "python3-qt4" "python3-pyqt4" DEPENDS_LIST ${DEPENDS_LIST} )
+        endif ()
         # parse list to string required for deb package
         string ( REPLACE ";" "" CPACK_DEBIAN_PACKAGE_DEPENDS ${DEPENDS_LIST} )
       endif()


### PR DESCRIPTION
Currently there isn't python 3 packages for `python-nxs` and `python-pycifrw` so they are just removed. And `python-qt4` is called `python3-pyqt4` in python3.

**To test:**
On Ubuntu run `cmake -DPYTHON_EXECUTABLE=/usr/bin/python2 -DENABLE_CPACK=ON ..` and `cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -DENABLE_CPACK=ON ..` and compare the `CPACK_DEBIAN_PACKAGE_DEPENDS` in `CPackConfig.cmake`. Build the package for python 3 and check that it installs.

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
