### PR TITLE
Add support for NeXus files in LoadVesuvio

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -448,7 +448,6 @@ class LoadVesuvio(LoadEmptyVesuvio):
         if self._load_common_called:
             return
 
-        isis = config.getFacility("ISIS")
         empty_vesuvio_ws = self._load_empty_evs()
         empty_vesuvio = empty_vesuvio_ws.getInstrument()
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -402,7 +402,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         if self._sumspectra:
             self._sum_all_spectra()
 
-        ms.DeleteWorkspace(Workspace=SUMMED_WS)
+        ms.DeleteWorkspace(Workspace=SUMMED_WS, EnableLogging=_LOGGING_)
         self._store_results()
         self._cleanup_raw()
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -158,9 +158,10 @@ class LoadVesuvio(LoadEmptyVesuvio):
         issues = {}
 
         # Validate run number ranges
-        run_str = self.getProperty(RUN_PROP).value
+        user_input = self.getProperty(RUN_PROP).value
+        run_str = os.path.basename(user_input)
         # String could be a full file path
-        if "-" in os.path.basename(run_str):
+        if "-" in run_str:
             lower, upper = run_str.split("-")
             issues = self._validate_range_formatting(lower, upper, RUN_PROP, issues)
 
@@ -685,17 +686,19 @@ class LoadVesuvio(LoadEmptyVesuvio):
         """
         Returns the runs as a list of strings
         """
-        run_str = self.getProperty(RUN_PROP).value
+        # String could be a full file path
+        user_input = self.getProperty(RUN_PROP).value
+        run_str = os.path.basename(user_input)
         # Load is not doing the right thing when summing. The numbers don't look correct
         if "-" in run_str:
             lower, upper = run_str.split("-")
             # Range goes lower to up-1 but we want to include the last number
             runs = list(range(int(lower), int(upper)+1))
-
         elif "," in run_str:
             runs = run_str.split(",")
         else:
-            runs = [run_str]
+            # Leave it as it is
+            runs = [user_input]
 
         return runs
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -7,6 +7,7 @@ from LoadEmptyVesuvio import LoadEmptyVesuvio
 
 import copy
 import numpy as np
+import os
 import re
 import six
 
@@ -158,7 +159,8 @@ class LoadVesuvio(LoadEmptyVesuvio):
 
         # Validate run number ranges
         run_str = self.getProperty(RUN_PROP).value
-        if "-" in run_str:
+        # String could be a full file path
+        if "-" in os.path.basename(run_str):
             lower, upper = run_str.split("-")
             issues = self._validate_range_formatting(lower, upper, RUN_PROP, issues)
 

--- a/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -1,7 +1,7 @@
 #pylint: disable=invalid-name,no-init,too-many-public-methods,too-many-arguments
 import stresstesting
 
-from mantid.api import MatrixWorkspace, mtd
+from mantid.api import FileFinder, MatrixWorkspace, mtd
 import mantid.simpleapi as ms
 
 import math
@@ -45,6 +45,25 @@ class VesuvioTests(unittest.TestCase):
         self.assertTrue(mtd.doesExist(self.ws_name))
 
     #================== Success cases ================================
+
+    def test_filename_accepts_full_filepath(self):
+        diff_mode = "FoilOut"
+        rawfile = FileFinder.getFullPath("EVS14188.raw")
+        self._run_load(rawfile, "3", diff_mode)
+        self.assertTrue(mtd.doesExist('evs_raw'))
+        self.assertEquals(mtd['evs_raw'].getNumberHistograms(), 1)
+
+    def test_filename_accepts_filename_no_path(self):
+        diff_mode = "FoilOut"
+        self._run_load("EVS14188.raw", "3", diff_mode)
+        self.assertTrue(mtd.doesExist('evs_raw'))
+        self.assertEquals(mtd['evs_raw'].getNumberHistograms(), 1)
+
+    def test_filename_accepts_run_and_ext(self):
+        diff_mode = "FoilOut"
+        self._run_load("14188.raw", "3", diff_mode)
+        self.assertTrue(mtd.doesExist('evs_raw'))
+        self.assertEquals(mtd['evs_raw'].getNumberHistograms(), 1)
 
     def test_load_with_back_scattering_spectra_produces_correct_workspace_using_double_difference(self):
         diff_mode = "DoubleDifference"

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -92,7 +92,9 @@ except NameError:
 # Run this after each test group has executed
 doctest_global_cleanup = """
 from mantid.api import FrameworkManager
+from mantid.kernel import ConfigService
 FrameworkManager.Instance().clear()
+ConfigService.Instance().reset()
 """
 
 # -- Options for pngmath --------------------------------------------------

--- a/docs/source/release/v3.10.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.10.0/indirect_inelastic.rst
@@ -12,6 +12,7 @@ Algorithms
 ##########
 
 - A new input property *RebinCanToSample* was added to :ref:`ApplyPaalmanPingsCorrection <algm-ApplyPaalmanPingsCorrection>` which enables or disables the rebinning of the empty container workspace.
+- :ref:`LoadVesuvio <algm-LoadVesuvio> can now load NeXus files as well as raw files
 
 Data Analysis
 #############

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -37,8 +37,8 @@ def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files=False, lo
         logger.debug('Loading file %s as workspace %s' % (filename, ws_name))
 
         if 'VESUVIO' in ipf_filename:
-            evs_filename = os.path.basename(str(filename)).replace('EVS', '')
-            LoadVesuvio(Filename=evs_filename,
+            # Load all spectra. They are cropped later
+            LoadVesuvio(Filename=filename,
                         OutputWorkspace=ws_name,
                         SpectrumList='1-198',
                         **load_opts)

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -38,7 +38,7 @@ def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files=False, lo
 
         if 'VESUVIO' in ipf_filename:
             # Load all spectra. They are cropped later
-            LoadVesuvio(Filename=filename,
+            LoadVesuvio(Filename=str(filename),
                         OutputWorkspace=ws_name,
                         SpectrumList='1-198',
                         **load_opts)


### PR DESCRIPTION
Description of work.

Uses `Load` in `LoadVesuvio` so that it can use either `.raw` or `.nxs` files. 

**To test:**

This will need to be tested at ISIS with access to the data archive.

Run `25999` uses the new long naming convention and is a standard 6-period file - this should now load with `LoadVesuvio`.

Also check older files still load, i.e ones prefixed `EVS`

Fixes #18843 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
