### PR TITLE
cleanup files after test_execOrphanedFile

### DIFF
--- a/Framework/DataHandling/test/DownloadInstrumentTest.h
+++ b/Framework/DataHandling/test/DownloadInstrumentTest.h
@@ -145,9 +145,6 @@ public:
 
     Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(
         testDirectories);
-
-    auto test =
-        Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
   }
 
   void tearDown() override {

--- a/Framework/DataHandling/test/DownloadInstrumentTest.h
+++ b/Framework/DataHandling/test/DownloadInstrumentTest.h
@@ -117,14 +117,6 @@ public:
     cleanupDiretory(localInstDir);
   }
 
-  void test_execTwoTimesInARow() {
-    std::string localInstDir =
-        Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories()[0];
-    cleanupDiretory(localInstDir);
-
-    cleanupDiretory(localInstDir);
-  }
-
   void test_execOrphanedFile() {
     std::string localInstDir =
         Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories()[0];
@@ -147,6 +139,7 @@ public:
                orphanedFile.exists() == false);
 
     deleteFile(orphanedFilePath.toString());
+    cleanupDiretory(localInstDir);
   }
 
   int runDownloadInstrument() {

--- a/Framework/DataHandling/test/DownloadInstrumentTest.h
+++ b/Framework/DataHandling/test/DownloadInstrumentTest.h
@@ -100,19 +100,15 @@ public:
   }
   static void destroySuite(DownloadInstrumentTest *suite) { delete suite; }
 
-  void createDirectory(Poco::Path path)
-  {
+  void createDirectory(Poco::Path path) {
     Poco::File file(path);
-    if (file.createDirectory())
-    {
+    if (file.createDirectory()) {
       m_directoriesToRemove.push_back(file);
     }
   }
 
-  void removeDirectories()
-  {
-    for (auto directory : m_directoriesToRemove)
-    {
+  void removeDirectories() {
+    for (auto directory : m_directoriesToRemove) {
       try {
         directory.remove(true);
       } catch (Poco::FileException &fe) {
@@ -125,7 +121,7 @@ public:
   void setUp() override {
     const std::string TEST_SUFFIX = "TEMPORARY_unitTest";
     m_originalInstDir =
-      Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
+        Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
 
     // change the local download directory by adding a unittest subdirectory
     auto testDirectories = m_originalInstDir;
@@ -143,17 +139,20 @@ public:
       createDirectory(installInstrumentPath);
       testDirectories.back() = installInstrumentPath.toString();
     } catch (Poco::FileException &) {
-      std::cout << "Failed to change instrument directory continuing without, fine, just slower\n";
+      std::cout << "Failed to change instrument directory continuing without, "
+                   "fine, just slower\n";
     }
 
-    Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(testDirectories);
+    Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(
+        testDirectories);
 
     auto test =
-      Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
+        Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
   }
 
   void tearDown() override {
-    Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(m_originalInstDir);
+    Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(
+        m_originalInstDir);
     removeDirectories();
   }
 
@@ -163,7 +162,7 @@ public:
     TS_ASSERT(alg.isInitialized())
   }
 
-  // These tests create some files, but they entire directories are created and 
+  // These tests create some files, but they entire directories are created and
   // removed in setup and teardown
   void test_exec() {
     TSM_ASSERT_EQUALS("The expected number of files downloaded was wrong.",
@@ -179,14 +178,13 @@ public:
     std::ofstream file;
     file.open(orphanedFilePath.toString().c_str());
     file.close();
-    
+
     TSM_ASSERT_EQUALS("The expected number of files downloaded was wrong.",
                       runDownloadInstrument(), 2);
 
     Poco::File orphanedFile(orphanedFilePath);
     TSM_ASSERT("The orphaned file was not deleted",
                orphanedFile.exists() == false);
-
   }
 
   int runDownloadInstrument() {

--- a/Framework/DataHandling/test/DownloadInstrumentTest.h
+++ b/Framework/DataHandling/test/DownloadInstrumentTest.h
@@ -100,37 +100,86 @@ public:
   }
   static void destroySuite(DownloadInstrumentTest *suite) { delete suite; }
 
+  void createDirectory(Poco::Path path)
+  {
+    Poco::File file(path);
+    if (file.createDirectory())
+    {
+      m_directoriesToRemove.push_back(file);
+    }
+  }
+
+  void removeDirectories()
+  {
+    for (auto directory : m_directoriesToRemove)
+    {
+      try {
+        directory.remove(true);
+      } catch (Poco::FileException &fe) {
+        std::cout << fe.what() << std::endl;
+      }
+    }
+    m_directoriesToRemove.clear();
+  }
+
+  void setUp() override {
+    const std::string TEST_SUFFIX = "TEMPORARY_unitTest";
+    m_originalInstDir =
+      Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
+
+    // change the local download directory by adding a unittest subdirectory
+    auto testDirectories = m_originalInstDir;
+    Poco::Path localDownloadPath(m_originalInstDir[0]);
+    localDownloadPath.pushDirectory(TEST_SUFFIX);
+    m_localInstDir = localDownloadPath.toString();
+    createDirectory(localDownloadPath);
+    testDirectories[0] = m_localInstDir;
+
+    // also if you move the instrument directory to one with less files then it
+    // will run faster as it does not need to checksum as many files
+    try {
+      Poco::Path installInstrumentPath(testDirectories.back());
+      installInstrumentPath.pushDirectory(TEST_SUFFIX);
+      createDirectory(installInstrumentPath);
+      testDirectories.back() = installInstrumentPath.toString();
+    } catch (Poco::FileException &) {
+      std::cout << "Failed to change instrument directory continuing without, fine, just slower\n";
+    }
+
+    Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(testDirectories);
+
+    auto test =
+      Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
+  }
+
+  void tearDown() override {
+    Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(m_originalInstDir);
+    removeDirectories();
+  }
+
   void test_Init() {
     MockedDownloadInstrument alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
   }
 
+  // These tests create some files, but they entire directories are created and 
+  // removed in setup and teardown
   void test_exec() {
-    std::string localInstDir =
-        Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories()[0];
-    cleanupDiretory(localInstDir);
-
     TSM_ASSERT_EQUALS("The expected number of files downloaded was wrong.",
                       runDownloadInstrument(), 2);
-
-    cleanupDiretory(localInstDir);
   }
 
   void test_execOrphanedFile() {
-    std::string localInstDir =
-        Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories()[0];
-    cleanupDiretory(localInstDir);
-
     // add an orphaned file
-    Poco::Path orphanedFilePath(localInstDir);
+    Poco::Path orphanedFilePath(m_localInstDir);
     orphanedFilePath.makeDirectory();
     orphanedFilePath.setFileName("Orphaned_Should_not_be_here.xml");
 
     std::ofstream file;
     file.open(orphanedFilePath.toString().c_str());
     file.close();
-
+    
     TSM_ASSERT_EQUALS("The expected number of files downloaded was wrong.",
                       runDownloadInstrument(), 2);
 
@@ -138,8 +187,6 @@ public:
     TSM_ASSERT("The orphaned file was not deleted",
                orphanedFile.exists() == false);
 
-    deleteFile(orphanedFilePath.toString());
-    cleanupDiretory(localInstDir);
   }
 
   int runDownloadInstrument() {
@@ -155,23 +202,9 @@ public:
     return alg.getProperty("FileDownloadCount");
   }
 
-  void cleanupDiretory(std::string dir) {
-    Poco::Path path(dir);
-    path.makeDirectory();
-    deleteFile(path.setFileName("github.json").toString());
-    deleteFile(path.setFileName("NewFile.xml").toString());
-    deleteFile(path.setFileName("UpdatableFile.xml").toString());
-  }
-
-  bool deleteFile(std::string filePath) {
-    Poco::File file(filePath);
-    if (file.exists()) {
-      file.remove();
-      return true;
-    } else {
-      return false;
-    }
-  }
+  std::string m_localInstDir;
+  std::vector<std::string> m_originalInstDir;
+  std::vector<Poco::File> m_directoriesToRemove;
 };
 
 #endif /* MANTID_DATAHANDLING_DOWNLOADINSTRUMENTTEST_H_ */

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -208,7 +208,7 @@ public:
   /// Get the list of user search paths
   const std::vector<std::string> &getUserSearchDirs() const;
   /// Sets instrument directories
-  void setInstrumentDirectories(const std::vector<std::string>& directories);
+  void setInstrumentDirectories(const std::vector<std::string> &directories);
   /// Get instrument search directory
   const std::vector<std::string> &getInstrumentDirectories() const;
   /// Get instrument search directory

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -207,6 +207,8 @@ public:
   void appendDataSearchSubDir(const std::string &subdir);
   /// Get the list of user search paths
   const std::vector<std::string> &getUserSearchDirs() const;
+  /// Sets instrument directories
+  void setInstrumentDirectories(const std::vector<std::string>& directories);
   /// Get instrument search directory
   const std::vector<std::string> &getInstrumentDirectories() const;
   /// Get instrument search directory

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1622,6 +1622,15 @@ const std::vector<std::string> &ConfigServiceImpl::getUserSearchDirs() const {
 }
 
 /**
+* Sets the search directories for XML instrument definition files (IDFs)
+* @params directories An ordered list of paths for instrument searching
+*/
+void ConfigServiceImpl::setInstrumentDirectories(
+    const std::vector<std::string> &directories) {
+  m_InstrumentDirs = directories;
+}
+
+/**
  * Return the search directories for XML instrument definition files (IDFs)
  * @returns An ordered list of paths for instrument searching
  */

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1623,7 +1623,7 @@ const std::vector<std::string> &ConfigServiceImpl::getUserSearchDirs() const {
 
 /**
 * Sets the search directories for XML instrument definition files (IDFs)
-* @params directories An ordered list of paths for instrument searching
+* @param directories An ordered list of paths for instrument searching
 */
 void ConfigServiceImpl::setInstrumentDirectories(
     const std::vector<std::string> &directories) {

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -360,11 +360,12 @@ public:
 
   void TestSetInstrumentDirectory() {
 
-    auto originalDirectories = ConfigService::Instance().getInstrumentDirectories();
+    auto originalDirectories =
+        ConfigService::Instance().getInstrumentDirectories();
     std::vector<std::string> testDirectories;
     testDirectories.push_back("Test Directory 1");
     testDirectories.push_back("Test Directory 2");
-    ConfigService::Instance().setInstrumentDirectories(testDirectories); 
+    ConfigService::Instance().setInstrumentDirectories(testDirectories);
     auto readDirectories = ConfigService::Instance().getInstrumentDirectories();
     TS_ASSERT_EQUALS(readDirectories.size(), testDirectories.size());
     TS_ASSERT_EQUALS(readDirectories[0], testDirectories[0]);

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -358,6 +358,25 @@ public:
     }
   }
 
+  void TestSetInstrumentDirectory() {
+
+    auto originalDirectories = ConfigService::Instance().getInstrumentDirectories();
+    std::vector<std::string> testDirectories;
+    testDirectories.push_back("Test Directory 1");
+    testDirectories.push_back("Test Directory 2");
+    ConfigService::Instance().setInstrumentDirectories(testDirectories); 
+    auto readDirectories = ConfigService::Instance().getInstrumentDirectories();
+    TS_ASSERT_EQUALS(readDirectories.size(), testDirectories.size());
+    TS_ASSERT_EQUALS(readDirectories[0], testDirectories[0]);
+    TS_ASSERT_EQUALS(readDirectories[1], testDirectories[1]);
+
+    // Restore original settings
+    ConfigService::Instance().setInstrumentDirectories(originalDirectories);
+    readDirectories = ConfigService::Instance().getInstrumentDirectories();
+    TS_ASSERT_EQUALS(readDirectories.size(), originalDirectories.size());
+    TS_ASSERT_EQUALS(readDirectories[0], originalDirectories[0]);
+  }
+
   void TestCustomProperty() {
     std::string countString =
         ConfigService::Instance().getString("algorithms.retained");


### PR DESCRIPTION
A test was not cleaning up after itself

**To test:**

1. all unit tests should pass
1. run test with `ctest -C Debug -R DownloadInstrumentTest -V` (-C only needed on windows)
1. Check if you have a subdirectory of "TEMPORARY_unitTest"  or any of the following files in the download directory
   - github.json
   - NewFile.xml
   - UpdatableFile.xml
   - Orphaned_Should_not_be_here.xml


Download directory:
   - win `%appdata%\mantidproject\mantid\instrument`
   - others `$home/.mantid/instrument`

Fixes #18885.

### RELEASE NOTES

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
