### PR TITLE
Fix bug in gd_prtn_chrg for chunked data

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/NormaliseByCurrent.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/NormaliseByCurrent.h
@@ -71,8 +71,8 @@ private:
   void init() override;
   void exec() override;
   // Extract the charge value from the logs.
-  double
-  extractCharge(boost::shared_ptr<Mantid::API::MatrixWorkspace> inputWS) const;
+  double extractCharge(boost::shared_ptr<Mantid::API::MatrixWorkspace> inputWS,
+                       const bool integratePCharge) const;
 };
 
 } // namespace Algorithm

--- a/Framework/Algorithms/src/NormaliseByCurrent.cpp
+++ b/Framework/Algorithms/src/NormaliseByCurrent.cpp
@@ -34,7 +34,8 @@ void NormaliseByCurrent::init() {
  * single period or multi-period data.
  *
  * @param inputWS :: The input workspace to extract the log details from.
- *
+ * @param integratePCharge :: recalculate the integrated proton charge if true
+
  * @throws Exception::NotFoundError, std::domain_error or
  * std::runtime_error if the charge value(s) are not set in the
  * workspace logs or if the values are invalid (0)

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -706,6 +706,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             self.log().warning('[SPECIAL DB] Normalize current to workspace %s' % sample_ws_name)
             # temp_ws = self.get_workspace(sample_ws_name)
             if not (is_event_workspace(sample_ws_name) and get_workspace(sample_ws_name).getNumberEvents() == 0):
+                mtd[str(sample_ws_name)].run().integrateProtonCharge()
                 api.NormaliseByCurrent(InputWorkspace=sample_ws_name,
                                        OutputWorkspace=sample_ws_name)
                 get_workspace(sample_ws_name).getRun()['gsas_monitor'] = 1
@@ -771,6 +772,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         # ENDFOR (processing each)
 
         if self._normalisebycurrent is True:
+            mtd[str(sumRun)].run().integrateProtonCharge()
             api.NormaliseByCurrent(InputWorkspace=sumRun,
                                    OutputWorkspace=sumRun)
             get_workspace(sumRun).getRun()['gsas_monitor'] = 1
@@ -944,6 +946,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                                    Tolerance=self.COMPRESS_TOL_TOF) # 100ns
             try:
                 if normalisebycurrent is True:
+                    mtd[str(output_wksp_list[split_index])].run().integrateProtonCharge()
                     api.NormaliseByCurrent(InputWorkspace=output_wksp_list[split_index],
                                            OutputWorkspace=output_wksp_list[split_index])
                     get_workspace(output_wksp_list[split_index]).getRun()['gsas_monitor'] = 1

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -706,9 +706,9 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             self.log().warning('[SPECIAL DB] Normalize current to workspace %s' % sample_ws_name)
             # temp_ws = self.get_workspace(sample_ws_name)
             if not (is_event_workspace(sample_ws_name) and get_workspace(sample_ws_name).getNumberEvents() == 0):
-                mtd[str(sample_ws_name)].run().integrateProtonCharge()
                 api.NormaliseByCurrent(InputWorkspace=sample_ws_name,
-                                       OutputWorkspace=sample_ws_name)
+                                       OutputWorkspace=sample_ws_name,
+                                       RecalculatePCharge=True)
                 get_workspace(sample_ws_name).getRun()['gsas_monitor'] = 1
             # END-IF
         # ENDI-IF
@@ -772,9 +772,9 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         # ENDFOR (processing each)
 
         if self._normalisebycurrent is True:
-            mtd[str(sumRun)].run().integrateProtonCharge()
             api.NormaliseByCurrent(InputWorkspace=sumRun,
-                                   OutputWorkspace=sumRun)
+                                   OutputWorkspace=sumRun,
+                                   RecalculatePCharge=True)
             get_workspace(sumRun).getRun()['gsas_monitor'] = 1
 
         return sumRun
@@ -946,9 +946,9 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                                    Tolerance=self.COMPRESS_TOL_TOF) # 100ns
             try:
                 if normalisebycurrent is True:
-                    mtd[str(output_wksp_list[split_index])].run().integrateProtonCharge()
                     api.NormaliseByCurrent(InputWorkspace=output_wksp_list[split_index],
-                                           OutputWorkspace=output_wksp_list[split_index])
+                                           OutputWorkspace=output_wksp_list[split_index],
+                                           RecalculatePCharge=True)
                     get_workspace(output_wksp_list[split_index]).getRun()['gsas_monitor'] = 1
             except RuntimeError as e:
                 self.log().warning(str(e))


### PR DESCRIPTION
There was a bug in the `gd_prtn_chrg` if the data was processed with chunking. Adding a call to `wksp.run().integrateProtonCharge()` before `NormaliseByCurrent` fixes the issue since it forces the workspace to re-integrate the proton charge based on the logs.

**To test:**

Process a dataset with chunking.

*There is no associated issue*

This does not have release notes because it the patch release needs to be setup and hasn't been yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
