### PR TITLE
Fix AlignComponents doctest for RHEL7

### DIFF
--- a/docs/source/algorithms/AlignComponents-v1.rst
+++ b/docs/source/algorithms/AlignComponents-v1.rst
@@ -58,7 +58,7 @@ components are aligned.
 Usage
 -----
 
-**Example - Align the X and Z position of bank26 in POWGEN:**
+**Example - Align the Y and Z position of bank26 in POWGEN:**
 
 .. testcode:: position
 
@@ -74,19 +74,20 @@ Usage
       AlignComponents(CalibrationTable="PG3_cal",
               Workspace=ws,
 	      MaskWorkspace="PG3_mask",
-	      Xposition=True, ZPosition=True,
+	      Yposition=True, ZPosition=True,
               ComponentList=component)
       ws=mtd['ws']
-      print "Final position is",ws.getInstrument().getComponentByName(component).getPos()
+      final_pos = ws.getInstrument().getComponentByName(component).getPos()
+      print "Final position is [{:.2f}.{:.2f},{:.2f}]".format(final_pos[0],final_pos[1],final_pos[2])
 
 Output:
 
 .. testoutput:: position
 
     Start position is [1.54436,0.863271,-1.9297]
-    Final position is [1.50591,0.863271,-1.92734]
+    Final position is [1.54.0.85,-1.95]
 
-**Example - Align the Y rotation of bank26 and bank46 in POWGEN:**
+**Example - Align the Y rotation of bank25 and bank46 in POWGEN:**
 
 .. testcode:: rotation
 
@@ -97,10 +98,10 @@ Output:
 	    MakeMaskWorkspace=True,
 	    WorkspaceName="PG3")
       ws = LoadEmptyInstrument(Filename="POWGEN_Definition_2015-08-01.xml")
-      components="bank26,bank46"
-      bank26Rot = ws.getInstrument().getComponentByName("bank26").getRotation().getEulerAngles()
+      components="bank25,bank46"
+      bank25Rot = ws.getInstrument().getComponentByName("bank25").getRotation().getEulerAngles()
       bank46Rot = ws.getInstrument().getComponentByName("bank46").getRotation().getEulerAngles()
-      print "Start bank26 rotation is [{:.3f}.{:.3f},{:.3f}]".format(bank26Rot[0], bank26Rot[1], bank26Rot[2])
+      print "Start bank25 rotation is [{:.3f}.{:.3f},{:.3f}]".format(bank25Rot[0], bank25Rot[1], bank25Rot[2])
       print "Start bank46 rotation is [{:.3f}.{:.3f},{:.3f}]".format(bank46Rot[0], bank46Rot[1], bank46Rot[2])
       AlignComponents(CalibrationTable="PG3_cal",
 	      Workspace=ws,
@@ -109,19 +110,19 @@ Output:
               AlphaRotation=True,
 	      ComponentList=components)
       ws=mtd['ws']
-      bank26Rot = ws.getInstrument().getComponentByName("bank26").getRotation().getEulerAngles()
+      bank25Rot = ws.getInstrument().getComponentByName("bank25").getRotation().getEulerAngles()
       bank46Rot = ws.getInstrument().getComponentByName("bank46").getRotation().getEulerAngles()
-      print "Final bank26 rotation is [{:.3f}.{:.3f},{:.3f}]".format(bank26Rot[0], bank26Rot[1], bank26Rot[2])
-      print "Final bank46 rotation is [{:.3f}.{:.3f},{:.3f}]".format(bank46Rot[0], bank46Rot[1], bank46Rot[2])
+      print "Final bank25 rotation is [{:.3f}.{:.3f},{:.3f}]".format(bank25Rot[0], bank25Rot[1], bank25Rot[2])
+      print "Final bank46 rotation is [{:.2f}.{:.3f},{:.3f}]".format(bank46Rot[0], bank46Rot[1], bank46Rot[2])
 
 Output:
 
 .. testoutput:: rotation
 
-      Start bank26 rotation is [-24.061.0.120,18.016]
+      Start bank25 rotation is [-24.089.0.179,9.030]
       Start bank46 rotation is [-41.092.0.061,17.795]
-      Final bank26 rotation is [-25.226.0.120,18.016]
-      Final bank46 rotation is [-37.397.0.061,17.795]
+      Final bank25 rotation is [-24.089.0.179,9.030]
+      Final bank46 rotation is [-37.40.0.061,17.795]
 
 **Example - Align sample position in POWGEN:**
 
@@ -143,14 +144,14 @@ Output:
             MaskWorkspace="PG3_mask",
             FitSamplePosition=True,
 	    Zposition=True)
-      print "Final sample position is {:.5f}".format(mtd['ws'].getInstrument().getSample().getPos().getZ())
+      print "Final sample position is {:.3f}".format(mtd['ws'].getInstrument().getSample().getPos().getZ())
 
 Output:
 
 .. testoutput:: sample
 
       Start sample position is 0.0
-      Final sample position is 0.02826
+      Final sample position is 0.028
 
 .. categories::
 


### PR DESCRIPTION
The AlignComponents doctest fails on RHEL7 as seen https://github.com/mantidproject/mantid/pull/18860#issuecomment-280259752

It should now pass on Ubuntu 16.04 and RHEL7 and everything in between.

**To test:**
Check that the AlignComponents doctest now passes on RHEL7


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
