### PR TITLE
FileDialogHandlerTest fails with clang 3.9.1 on MacOS.

### DIFF
--- a/MantidQt/API/src/FileDialogHandler.cpp
+++ b/MantidQt/API/src/FileDialogHandler.cpp
@@ -19,7 +19,9 @@ QString getExtensionFromFilter(const QString &selectedFilter) {
   if (boost::regex_search(selectedFilter.toStdString(), result,
                           FILE_EXT_REG_EXP) &&
       result.size() == 2) {
-    auto extension = QString::fromStdString(result[1]);
+    //clang fails to cast result[1] to std::string.
+    std::string output = result[1];
+    auto extension = QString::fromStdString(output);
     if (extension.startsWith("*"))
       return extension.remove(0, 1);
     else

--- a/MantidQt/API/src/FileDialogHandler.cpp
+++ b/MantidQt/API/src/FileDialogHandler.cpp
@@ -19,7 +19,7 @@ QString getExtensionFromFilter(const QString &selectedFilter) {
   if (boost::regex_search(selectedFilter.toStdString(), result,
                           FILE_EXT_REG_EXP) &&
       result.size() == 2) {
-    //clang fails to cast result[1] to std::string.
+    // clang fails to cast result[1] to std::string.
     std::string output = result[1];
     auto extension = QString::fromStdString(output);
     if (extension.startsWith("*"))


### PR DESCRIPTION
Description of work.

This fixes a test failing on [master_clean-osx-10.10-openmp](http://builds.mantidproject.org/job/master_clean-osx-10.10-openmp). 

```
00:56:33 171/1746 Test #1597: MantidQtAPITest_FileDialogHandlerTest ........................***Failed    0.20 sec
00:56:33 Running 2 tests
00:56:33 In FileDialogHandlerTest::test_addExtension:
00:56:33 /Users/builder/jenkins-linode/workspace/master_clean-osx-10.10-openmp/MantidQt/API/test/FileDialogHandlerTest.h:16: Error: Expected (nexusResult.toStdString() == result1.toStdString()), found ("/tmp/testing.nxs" != "/tmp/testing\0\0\0\0\0")
00:56:33 /Users/builder/jenkins-linode/workspace/master_clean-osx-10.10-openmp/MantidQt/API/test/FileDialogHandlerTest.h:20: Error: Expected (nexusResult.toStdString() == result2.toStdString()), found ("/tmp/testing.nxs" != "/tmp/testing.\0\0\0\0\0")
00:56:33 .
00:56:33 Failed 1 of 2 tests
00:56:33 Success rate: 50%
00:56:33 
```

There appears to be an issue casting result[1] to a std::string, and explicitly generating temporary std::string fixes the test. I generated a self-contained repro and believe the error is in Qt4 because 1) the issue disappears in debug builds and 2) the issue disappears when building with Qt5.

**To test:**

<!-- Instructions for testing. -->

If the builds pass, :squirrel:.

There is no GitHub issue associated with this pull rquest.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
