### PR TITLE
Spelling correction in the instrument view pick tab

### DIFF
--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
@@ -550,7 +550,7 @@ void InstrumentWidgetMaskTab::setProperties() {
   m_userEditing = false;
 
   // bounding rect property
-  QtProperty *boundingRectGroup = m_groupManager->addProperty("Bounging Rect");
+  QtProperty *boundingRectGroup = m_groupManager->addProperty("Bounding Rect");
   m_browser->addProperty(boundingRectGroup);
   m_left = addDoubleProperty("left");
   m_top = addDoubleProperty("top");


### PR DESCRIPTION
"Bounging rect" - corrected to be "bounding"?

![image](https://cloud.githubusercontent.com/assets/1017173/23062988/31a9667c-f500-11e6-96dd-a46b0b6d7355.png)


**To test:**

1. Go to Draw tab and draw a rectangle
1. The entry in the table should now say "Bounding rect"
bounging


Fixes #15902.

### RELEASE NOTES

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
