### PR TITLE
Fix zeropadding for IMAT in Facilities.XML

### DIFF
--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -78,6 +78,7 @@
 
   <instrument name="IMAT">
     <technique>Neutron Imaging</technique>
+    <zeropadding size="8"/>
     <livedata>
       <connection name="histo" address="NDXIMAT:6789" listener="ISISHistoDataListener" />
     </livedata>


### PR DESCRIPTION
A quick change that fixes being able to load IMAT workspaces through the data archive.

No related issue.