### PR TITLE
Group 13 Python 3 compatible (PyChop)

### DIFF
--- a/scripts/PyChop/Chop.py
+++ b/scripts/PyChop/Chop.py
@@ -17,6 +17,7 @@ technical reports:
     http://www.neutronresearch.com/parch/1993/01/199301013280.pdf
 """
 
+from __future__ import division
 import numpy as np
 
 # ------------------------------------------------------------------------------------------------- #
@@ -141,7 +142,7 @@ def flux_norm(ch_mod):
     ! Returns an empirically determined flux normalisation factor for different ISIS moderators
     """
     phi0 = {'A':1., 'AP':2.8, 'H2':1.8, 'CH4':2.6}
-    if ch_mod not in phi0.keys():
+    if ch_mod not in list(phi0.keys()):
         raise ValueError('Moderator %s is not supported in PyChop' % (ch_mod))
     return phi0[ch_mod]
 

--- a/scripts/PyChop/Chop.py
+++ b/scripts/PyChop/Chop.py
@@ -17,7 +17,7 @@ technical reports:
     http://www.neutronresearch.com/parch/1993/01/199301013280.pdf
 """
 
-from __future__ import division
+from __future__ import (absolute_import, division, print_function)
 import numpy as np
 
 # ------------------------------------------------------------------------------------------------- #
@@ -142,7 +142,7 @@ def flux_norm(ch_mod):
     ! Returns an empirically determined flux normalisation factor for different ISIS moderators
     """
     phi0 = {'A':1., 'AP':2.8, 'H2':1.8, 'CH4':2.6}
-    if ch_mod not in list(phi0.keys()):
+    if ch_mod not in phi0.keys():
         raise ValueError('Moderator %s is not supported in PyChop' % (ch_mod))
     return phi0[ch_mod]
 

--- a/scripts/PyChop/ISISDisk.py
+++ b/scripts/PyChop/ISISDisk.py
@@ -6,6 +6,7 @@ Contains the ISISDisk class which calculates resolution and flux for ISIS Disk c
 spectrometer (LET) - using the functions in MulpyRep and additional tables of instrument parameters
 """
 
+from __future__ import absolute_import, division
 import numpy as np
 from . import MulpyRep
 from .ISISFermi import ISISFermi
@@ -130,14 +131,14 @@ class ISISDisk:
                         raise ValueError('Frequency must be a 1-, 2- or 5-element list/array')
                 else:
                     self.freq = [frequency/4., 10., frequency/2., frequency/2., frequency]
-            if 'Chopper2Phase' in kwargs.keys():
+            if 'Chopper2Phase' in list(kwargs.keys()):
                 self.Chop2Phase = kwargs['Chopper2Phase']
         elif 'MERLIN' in self.instname:
             if hasattr(frequency, "__len__"):
                 self.freq = [50., frequency[0]]
             else:
                 self.freq = [50., frequency]
-            if 'Chopper2Phase' in kwargs.keys():
+            if 'Chopper2Phase' in list(kwargs.keys()):
                 self.Chop2Phase = kwargs['Chopper2Phase']
         else:
             raise RuntimeError('Instrument name has not been set')
@@ -178,7 +179,7 @@ class ISISDisk:
             ie_list = np.where(np.abs(np.array(Eis)-Ei) == np.min(np.abs(np.array(Eis)-Ei)))[0]
             Et = np.linspace(0.05, 0.95*Ei, 19, endpoint=True) if (Etrans is None) else Etrans
         else:
-            ie_list = range(len(Eis))
+            ie_list = list(range(len(Eis)))
             # This is the relative energy transfer
             Et = np.linspace(0.05, 0.95, 19, endpoint=True) if (Etrans is None) else Etrans
         res_list = []

--- a/scripts/PyChop/ISISDisk.py
+++ b/scripts/PyChop/ISISDisk.py
@@ -6,7 +6,7 @@ Contains the ISISDisk class which calculates resolution and flux for ISIS Disk c
 spectrometer (LET) - using the functions in MulpyRep and additional tables of instrument parameters
 """
 
-from __future__ import absolute_import, division
+from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from . import MulpyRep
 from .ISISFermi import ISISFermi
@@ -131,14 +131,14 @@ class ISISDisk:
                         raise ValueError('Frequency must be a 1-, 2- or 5-element list/array')
                 else:
                     self.freq = [frequency/4., 10., frequency/2., frequency/2., frequency]
-            if 'Chopper2Phase' in list(kwargs.keys()):
+            if 'Chopper2Phase' in kwargs.keys():
                 self.Chop2Phase = kwargs['Chopper2Phase']
         elif 'MERLIN' in self.instname:
             if hasattr(frequency, "__len__"):
                 self.freq = [50., frequency[0]]
             else:
                 self.freq = [50., frequency]
-            if 'Chopper2Phase' in list(kwargs.keys()):
+            if 'Chopper2Phase' in kwargs.keys():
                 self.Chop2Phase = kwargs['Chopper2Phase']
         else:
             raise RuntimeError('Instrument name has not been set')
@@ -179,7 +179,7 @@ class ISISDisk:
             ie_list = np.where(np.abs(np.array(Eis)-Ei) == np.min(np.abs(np.array(Eis)-Ei)))[0]
             Et = np.linspace(0.05, 0.95*Ei, 19, endpoint=True) if (Etrans is None) else Etrans
         else:
-            ie_list = list(range(len(Eis)))
+            ie_list = range(len(Eis))
             # This is the relative energy transfer
             Et = np.linspace(0.05, 0.95, 19, endpoint=True) if (Etrans is None) else Etrans
         res_list = []
@@ -202,9 +202,9 @@ class ISISDisk:
         chop_width = np.array(chop_width) * (self.samp_det + self.chop_samp + lastChopDist) / lastChopDist
         mod_width = np.array(mod_width) * (self.chop_samp + self.samp_det) / lastChopDist
         if len(ie_list) == 1:
-            chop_width = chop_width[ie_list]
-            mod_width = mod_width[ie_list]
-            res_el = res_el[int(ie_list)]
+            chop_width = chop_width[ie_list[0]]
+            mod_width = mod_width[ie_list[0]]
+            res_el = res_el[ie_list[0]]
         return Eis, res_list, res_el, percent, ie_list, chop_width, mod_width
 
     def getElasticResolution(self, Ei_in=None, frequency=None):

--- a/scripts/PyChop/ISISFermi.py
+++ b/scripts/PyChop/ISISFermi.py
@@ -138,9 +138,9 @@ class ISISFermi:
         mychop = ISISFermi('Mari', 'G', 300)
         mychop.setFrequency(250)
         """
-        if 'Chopper2Phase' in list(kwargs.keys()):
+        if 'Chopper2Phase' in kwargs.keys():
             diskchopper_phase = kwargs['Chopper2Phase']
-        elif 'diskchopper_phase' in list(kwargs.keys()):
+        elif 'diskchopper_phase' in kwargs.keys():
             diskchopper_phase = kwargs['diskchopper_phase']
         else:
             diskchopper_phase = None

--- a/scripts/PyChop/ISISFermi.py
+++ b/scripts/PyChop/ISISFermi.py
@@ -7,6 +7,7 @@ Contains the ISISFermi class which calculates the resolution and flux for ISIS F
 spectrometers (MAPS, MARI, MERLIN) - using the functions in Chop.py and addition lookup tables.
 """
 
+from __future__ import absolute_import, division
 import numpy as np
 from . import Chop
 from scipy.interpolate import interp1d
@@ -96,7 +97,7 @@ class ISISFermi:
         Chopper type and frequency must also be given
         """
         instname = instname.upper()
-        if instname not in self.__Instruments.keys():
+        if instname not in list(self.__Instruments.keys()):
             raise ValueError('Instrument %s not recognised' % (instname))
         self.instname = instname
         if choppername:
@@ -113,7 +114,7 @@ class ISISFermi:
         """
         choppername = choppername.upper()
         self.freq = freq
-        if choppername not in self.__chopperParameters[self.instname].keys():
+        if choppername not in list(self.__chopperParameters[self.instname].keys()):
             raise ValueError('Chopper %s of %s not recognised' % (choppername, self.instname))
         self.choppername = choppername
         self.freq = freq[0] if np.shape(freq) else freq
@@ -137,9 +138,9 @@ class ISISFermi:
         mychop = ISISFermi('Mari', 'G', 300)
         mychop.setFrequency(250)
         """
-        if 'Chopper2Phase' in kwargs.keys():
+        if 'Chopper2Phase' in list(kwargs.keys()):
             diskchopper_phase = kwargs['Chopper2Phase']
-        elif 'diskchopper_phase' in kwargs.keys():
+        elif 'diskchopper_phase' in list(kwargs.keys()):
             diskchopper_phase = kwargs['diskchopper_phase']
         else:
             diskchopper_phase = None

--- a/scripts/PyChop/ISISFermi.py
+++ b/scripts/PyChop/ISISFermi.py
@@ -7,7 +7,7 @@ Contains the ISISFermi class which calculates the resolution and flux for ISIS F
 spectrometers (MAPS, MARI, MERLIN) - using the functions in Chop.py and addition lookup tables.
 """
 
-from __future__ import absolute_import, division
+from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from . import Chop
 from scipy.interpolate import interp1d
@@ -97,7 +97,7 @@ class ISISFermi:
         Chopper type and frequency must also be given
         """
         instname = instname.upper()
-        if instname not in list(self.__Instruments.keys()):
+        if instname not in self.__Instruments.keys():
             raise ValueError('Instrument %s not recognised' % (instname))
         self.instname = instname
         if choppername:
@@ -114,7 +114,7 @@ class ISISFermi:
         """
         choppername = choppername.upper()
         self.freq = freq
-        if choppername not in list(self.__chopperParameters[self.instname].keys()):
+        if choppername not in self.__chopperParameters[self.instname].keys():
             raise ValueError('Chopper %s of %s not recognised' % (choppername, self.instname))
         self.choppername = choppername
         self.freq = freq[0] if np.shape(freq) else freq

--- a/scripts/PyChop/MulpyRep.py
+++ b/scripts/PyChop/MulpyRep.py
@@ -6,7 +6,7 @@ Contains a class to calculate the possible reps, resolution and flux for a direc
 spectrometer. Python implementation by D J Voneshen based on the original Matlab program of R I Bewley.
 """
 
-from __future__ import division
+from __future__ import (absolute_import, division, print_function)
 import numpy as np
 import copy
 

--- a/scripts/PyChop/MulpyRep.py
+++ b/scripts/PyChop/MulpyRep.py
@@ -6,6 +6,7 @@ Contains a class to calculate the possible reps, resolution and flux for a direc
 spectrometer. Python implementation by D J Voneshen based on the original Matlab program of R I Bewley.
 """
 
+from __future__ import division
 import numpy as np
 import copy
 

--- a/scripts/PyChop/PyChop2.py
+++ b/scripts/PyChop/PyChop2.py
@@ -34,7 +34,7 @@ class PyChop2:
 
     def __init__(self, instname, *args):
         instname = instname.upper()
-        if instname not in list(self.__Classes.keys()):
+        if instname not in self.__Classes.keys():
             raise ValueError('Instrument %s not recognised' % (instname))
         self.object = self.__Classes[instname](instname, *args)
         self.instname = instname
@@ -43,7 +43,7 @@ class PyChop2:
         """
         ! Returns a list of currently implemented instruments
         """
-        return list(self.__Classes.keys())
+        return self.__Classes.keys()
 
     def setInstrument(self, *args):
         """
@@ -131,7 +131,7 @@ class PyChop2:
         """
         Private method to obtain multi-rep information
         """
-        if self.instname not in list(self.__MultiRepClasses.keys()):
+        if self.instname not in self.__MultiRepClasses.keys():
             raise ValueError('Instrument %s does not support multirep mode')
         if self.__MultiRepClasses[self.instname] == self.__Classes[self.instname]:
             obj = self.object
@@ -202,7 +202,7 @@ class PyChop2:
             if not isinstance(args[0], str):
                 raise ValueError('The first argument must be the instrument name')
             instname = args[0].upper()
-        elif 'inst' in list(kwargs.keys()):
+        elif 'inst' in kwargs.keys():
             instname = kwargs['inst'].upper()
         else:
             raise RuntimeError('You must specify the instrument name')
@@ -213,7 +213,7 @@ class PyChop2:
             lna = (len(argname) if len(args) > len(argname) else len(args))
             for ind in range(1, lna):
                 argdict[argname[ind]] = args[ind]
-            for ind in list(kwargs.keys()):
+            for ind in kwargs.keys():
                 if ind in argname:
                     argdict[ind] = kwargs[ind]
             for ind in range(1, 4):
@@ -222,7 +222,7 @@ class PyChop2:
             obj.setChopper(argdict['chtyp'], argdict['freq'])
             obj.setEi(argdict['ei'])
         else:
-            if 'variant' in list(kwargs.keys()):
+            if 'variant' in kwargs.keys():
                 argdict['variant'] = kwargs['variant']
             if len(args) > 1 and isinstance(args[1], str):
                 argname = ['inst', 'variant', 'freq', 'ei', 'etrans']
@@ -231,14 +231,14 @@ class PyChop2:
             lna = (len(argname) if len(args) > len(argname) else len(args))
             for ind in range(1, lna):
                 argdict[argname[ind]] = args[ind]
-            for ind in list(kwargs.keys()):
+            for ind in kwargs.keys():
                 if ind in argname:
                     argdict[ind] = kwargs[ind]
-            if 'variant' in list(argdict.keys()):
+            if 'variant' in argdict.keys():
                 obj.setChopper(argdict['variant'])
-            if 'freq' not in list(argdict.keys()) or 'ei' not in list(argdict.keys()):
+            if 'freq' not in argdict.keys() or 'ei' not in argdict.keys():
                 raise RuntimeError('The chopper frequency and focused incident energy must be specified')
             obj.setFrequency(argdict['freq'])
             obj.setEi(argdict['ei'])
-        etrans = argdict['etrans'] if 'etrans' in list(argdict.keys()) else 0.
+        etrans = argdict['etrans'] if 'etrans' in argdict.keys() else 0.
         return obj.getResolution(etrans), obj.getFlux()

--- a/scripts/PyChop/PyChop2.py
+++ b/scripts/PyChop/PyChop2.py
@@ -5,6 +5,7 @@ This module contains the PyChop2 class which allows calculation of the resolutio
 direct geometry time-of-flight inelastic neutron spectrometers.
 """
 
+from __future__ import absolute_import, division
 from .ISISFermi import ISISFermi
 from .ISISDisk import ISISDisk
 
@@ -33,7 +34,7 @@ class PyChop2:
 
     def __init__(self, instname, *args):
         instname = instname.upper()
-        if instname not in self.__Classes.keys():
+        if instname not in list(self.__Classes.keys()):
             raise ValueError('Instrument %s not recognised' % (instname))
         self.object = self.__Classes[instname](instname, *args)
         self.instname = instname
@@ -42,7 +43,7 @@ class PyChop2:
         """
         ! Returns a list of currently implemented instruments
         """
-        return self.__Classes.keys()
+        return list(self.__Classes.keys())
 
     def setInstrument(self, *args):
         """
@@ -130,7 +131,7 @@ class PyChop2:
         """
         Private method to obtain multi-rep information
         """
-        if self.instname not in self.__MultiRepClasses.keys():
+        if self.instname not in list(self.__MultiRepClasses.keys()):
             raise ValueError('Instrument %s does not support multirep mode')
         if self.__MultiRepClasses[self.instname] == self.__Classes[self.instname]:
             obj = self.object
@@ -201,7 +202,7 @@ class PyChop2:
             if not isinstance(args[0], str):
                 raise ValueError('The first argument must be the instrument name')
             instname = args[0].upper()
-        elif 'inst' in kwargs.keys():
+        elif 'inst' in list(kwargs.keys()):
             instname = kwargs['inst'].upper()
         else:
             raise RuntimeError('You must specify the instrument name')
@@ -212,7 +213,7 @@ class PyChop2:
             lna = (len(argname) if len(args) > len(argname) else len(args))
             for ind in range(1, lna):
                 argdict[argname[ind]] = args[ind]
-            for ind in kwargs.keys():
+            for ind in list(kwargs.keys()):
                 if ind in argname:
                     argdict[ind] = kwargs[ind]
             for ind in range(1, 4):
@@ -221,7 +222,7 @@ class PyChop2:
             obj.setChopper(argdict['chtyp'], argdict['freq'])
             obj.setEi(argdict['ei'])
         else:
-            if 'variant' in kwargs.keys():
+            if 'variant' in list(kwargs.keys()):
                 argdict['variant'] = kwargs['variant']
             if len(args) > 1 and isinstance(args[1], str):
                 argname = ['inst', 'variant', 'freq', 'ei', 'etrans']
@@ -230,14 +231,14 @@ class PyChop2:
             lna = (len(argname) if len(args) > len(argname) else len(args))
             for ind in range(1, lna):
                 argdict[argname[ind]] = args[ind]
-            for ind in kwargs.keys():
+            for ind in list(kwargs.keys()):
                 if ind in argname:
                     argdict[ind] = kwargs[ind]
-            if 'variant' in argdict.keys():
+            if 'variant' in list(argdict.keys()):
                 obj.setChopper(argdict['variant'])
-            if 'freq' not in argdict.keys() or 'ei' not in argdict.keys():
+            if 'freq' not in list(argdict.keys()) or 'ei' not in list(argdict.keys()):
                 raise RuntimeError('The chopper frequency and focused incident energy must be specified')
             obj.setFrequency(argdict['freq'])
             obj.setEi(argdict['ei'])
-        etrans = argdict['etrans'] if 'etrans' in argdict.keys() else 0.
+        etrans = argdict['etrans'] if 'etrans' in list(argdict.keys()) else 0.
         return obj.getResolution(etrans), obj.getFlux()

--- a/scripts/PyChop/PyChop2.py
+++ b/scripts/PyChop/PyChop2.py
@@ -5,7 +5,7 @@ This module contains the PyChop2 class which allows calculation of the resolutio
 direct geometry time-of-flight inelastic neutron spectrometers.
 """
 
-from __future__ import absolute_import, division
+from __future__ import (absolute_import, division, print_function)
 from .ISISFermi import ISISFermi
 from .ISISDisk import ISISDisk
 

--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -8,7 +8,7 @@
 This module contains a class to create a graphical user interface for PyChop.
 """
 
-from __future__ import absolute_import, division
+from __future__ import (absolute_import, division, print_function)
 import sys
 import re
 import numpy as np

--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -113,7 +113,7 @@ class PyChopGui(QtGui.QMainWindow):
         Sets the chopper frequency(ies), in Hz.
         """
         freq_gui = float(self.widgets['FrequencyCombo']['Combo'].currentText())
-        freq_in = kwargs['manual_freq'] if ('manual_freq' in list(kwargs.keys())) else freq_gui
+        freq_in = kwargs['manual_freq'] if ('manual_freq' in kwargs.keys()) else freq_gui
         if 'LET' in str(self.engine.instname):
             freqpr = float(self.widgets['PulseRemoverCombo']['Combo'].currentText())
             chop2phase = float(self.widgets['Chopper2Phase']['Edit'].text()) % 1e5
@@ -232,7 +232,7 @@ class PyChopGui(QtGui.QMainWindow):
         overplot = self.widgets['HoldCheck'].isChecked()
         if hasattr(freq, '__len__'):
             freq = freq[-1]
-        update = kwargs['update'] if 'update' in list(kwargs.keys()) else False
+        update = kwargs['update'] if 'update' in kwargs.keys() else False
         # Do not recalculate if all relevant parameters still the same.
         _, labels = self.flxaxes2.get_legend_handles_labels()
         searchStr = '([A-Z]+) "([A-z ]+)" ([0-9]+) Hz'

--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -8,6 +8,7 @@
 This module contains a class to create a graphical user interface for PyChop.
 """
 
+from __future__ import absolute_import, division
 import sys
 import re
 import numpy as np
@@ -112,7 +113,7 @@ class PyChopGui(QtGui.QMainWindow):
         Sets the chopper frequency(ies), in Hz.
         """
         freq_gui = float(self.widgets['FrequencyCombo']['Combo'].currentText())
-        freq_in = kwargs['manual_freq'] if ('manual_freq' in kwargs.keys()) else freq_gui
+        freq_in = kwargs['manual_freq'] if ('manual_freq' in list(kwargs.keys())) else freq_gui
         if 'LET' in str(self.engine.instname):
             freqpr = float(self.widgets['PulseRemoverCombo']['Combo'].currentText())
             chop2phase = float(self.widgets['Chopper2Phase']['Edit'].text()) % 1e5
@@ -231,7 +232,7 @@ class PyChopGui(QtGui.QMainWindow):
         overplot = self.widgets['HoldCheck'].isChecked()
         if hasattr(freq, '__len__'):
             freq = freq[-1]
-        update = kwargs['update'] if 'update' in kwargs.keys() else False
+        update = kwargs['update'] if 'update' in list(kwargs.keys()) else False
         # Do not recalculate if all relevant parameters still the same.
         _, labels = self.flxaxes2.get_legend_handles_labels()
         searchStr = '([A-Z]+) "([A-z ]+)" ([0-9]+) Hz'

--- a/scripts/PyChop/__init__.py
+++ b/scripts/PyChop/__init__.py
@@ -17,6 +17,7 @@ resolution, flux = PyChop2.calculate(inst='maps', chtyp='a', freq=500, ei=600, e
 PyChop2.showGUI()
 """
 
+from __future__ import absolute_import
 import warnings
 from .PyChop2 import PyChop2
 # If the system doesn't have matplotlib, don't import the GUI.

--- a/scripts/PyChop/__init__.py
+++ b/scripts/PyChop/__init__.py
@@ -17,7 +17,7 @@ resolution, flux = PyChop2.calculate(inst='maps', chtyp='a', freq=500, ei=600, e
 PyChop2.showGUI()
 """
 
-from __future__ import absolute_import
+from __future__ import (absolute_import, division, print_function)
 import warnings
 from .PyChop2 import PyChop2
 # If the system doesn't have matplotlib, don't import the GUI.


### PR DESCRIPTION
Changes PyChop code to make it compatible with Python2 and Python3 (mostly explicitly specifying `list`). This is group 13 of #18550

**To test:**

Check thay PyChop still works with Python 3.

Fixes #18901 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
