### PR TITLE
Add missing parameter in function call

### DIFF
--- a/Framework/Algorithms/test/NormaliseByCurrentTest.h
+++ b/Framework/Algorithms/test/NormaliseByCurrentTest.h
@@ -455,30 +455,34 @@ public:
   }
 
   void test_execPerformance() {
-    doTest(execWSIn, execWSOut, 1.0, 0.5 * M_SQRT2, performance);
+    doTest(execWSIn, execWSOut, 1.0, 0.5 * M_SQRT2, false, performance);
   }
   void test_execInPlacePerformance() {
-    doTest(execInPlaceWSIn, execInPlaceWSIn, 1.0, 0.5 * M_SQRT2, performance);
+    doTest(execInPlaceWSIn, execInPlaceWSIn, 1.0, 0.5 * M_SQRT2, false,
+           performance);
   }
 
   void test_execEventPerformance() {
     EventWorkspace_const_sptr outputEvent;
-    outputEvent = boost::dynamic_pointer_cast<const EventWorkspace>(
-        doTest(execEventWSIn, execEventWSOut, 1.0, 0.5 * M_SQRT2, performance));
+    outputEvent = boost::dynamic_pointer_cast<const EventWorkspace>(doTest(
+        execEventWSIn, execEventWSOut, 1.0, 0.5 * M_SQRT2, false, performance));
   }
   void test_execEventInPlacePerformance() {
     EventWorkspace_const_sptr outputEvent;
     outputEvent = boost::dynamic_pointer_cast<const EventWorkspace>(
         doTest(execEventInPlaceWSIn, execEventInPlaceWSIn, 1.0, 0.5 * M_SQRT2,
-               performance));
+               false, performance));
   }
   void test_multiPeriodDataPerformance() {
 
     // Check that normalisation has used the protonChargeByPeriod data. i.e Yout
     // = Yin/2.0, Yout = Yin/4.0, ... for each period workspace.
-    doTest(multiPeriodWS1, "period1", 1.00, 1.500, performance); // 2/2, 3/2
-    doTest(multiPeriodWS2, "period2", 0.50, 0.750, performance); // 2/4, 3/4
-    doTest(multiPeriodWS3, "period3", 0.25, 0.375, performance); // 2/8, 3/8
+    doTest(multiPeriodWS1, "period1", 1.00, 1.500, false,
+           performance); // 2/2, 3/2
+    doTest(multiPeriodWS2, "period2", 0.50, 0.750, false,
+           performance); // 2/4, 3/4
+    doTest(multiPeriodWS3, "period3", 0.25, 0.375, false,
+           performance); // 2/8, 3/8
   }
 
 private:


### PR DESCRIPTION
Fixed the bug that @rosswhitfield identified as being introduced [here](https://github.com/mantidproject/mantid/pull/18891#issuecomment-280723089) to the `NormaliseByCurrent` performance test.

**To test:**

Try running it and see if `ctest -R NormaliseByCurrentTest` works.

This addresses the bug introduced in #18891 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
