### PR TITLE
Enable Mantid to support HFIR HB3A 512 x 512 detector

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h
@@ -96,10 +96,12 @@ private:
   /// Create output MatrixWorkspace
   API::MatrixWorkspace_sptr
   createMatrixWorkspaceVersion2(const std::vector<SpiceXMLNode> &vecxmlnode,
-                        	const std::string &detnodename,
-                        	const bool &loadinstrument);
+                                const std::string &detnodename,
+                                const bool &loadinstrument);
 
-  API::MatrixWorkspace_sptr parseDetectorNode(const std::string &detvaluestr,  bool loadinstrument, double& max_counts);
+  API::MatrixWorkspace_sptr parseDetectorNode(const std::string &detvaluestr,
+                                              bool loadinstrument,
+                                              double &max_counts);
 
   /// Set up sample logs from table workspace loaded where SPICE data file is
   /// loaded

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h
@@ -93,6 +93,14 @@ private:
                         const std::string &detnodename,
                         const bool &loadinstrument);
 
+  /// Create output MatrixWorkspace
+  API::MatrixWorkspace_sptr
+  createMatrixWorkspaceVersion2(const std::vector<SpiceXMLNode> &vecxmlnode,
+                        	const std::string &detnodename,
+                        	const bool &loadinstrument);
+
+  API::MatrixWorkspace_sptr parseDetectorNode(const std::string &detvaluestr,  bool loadinstrument, double& max_counts);
+
   /// Set up sample logs from table workspace loaded where SPICE data file is
   /// loaded
   void setupSampleLogFromSpiceTable(API::MatrixWorkspace_sptr matrixws,

--- a/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
+++ b/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
@@ -584,22 +584,24 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspace(
                       << " (int) value = " << ivalue << "\n";
       } else {
         std::string str_value(nodevalue);
-        if (nodename.compare("start_time") == 0)
-        {
+        if (nodename.compare("start_time") == 0) {
           // replace 2015-01-17 13:36:45 by
-          g_log.notice() << "FIXME ! : Original start time: " << nodevalue << "  vs. Mantid time format: " << "2016-07-23T06:55:21.502270666"
+          g_log.notice() << "FIXME ! : Original start time: " << nodevalue
+                         << "  vs. Mantid time format: "
+                         << "2016-07-23T06:55:21.502270666"
                          << "\n";
           str_value = nodevalue;
           str_value.replace(10, 1, "T");
           g_log.notice() << "Replaced string = " << str_value << "\n";
           // str_value = "2016-07-23T06:55:21.502270666";
           /*
-           * Original start time: 2015-01-17 13:36:45  vs. Mantid time format: 2016-07-23T06:55:21.502270666
+           * Original start time: 2015-01-17 13:36:45  vs. Mantid time format:
+           *2016-07-23T06:55:21.502270666
            *
            */
         }
         outws->mutableRun().addProperty(
-             new PropertyWithValue<std::string>(nodename, str_value));
+            new PropertyWithValue<std::string>(nodename, str_value));
         // g_log.debug() << "Log name / xml node : " << xmlnode.getName()
         //               << " (string) value = " << nodevalue << "\n";
       }
@@ -860,9 +862,13 @@ void LoadSpiceXML2DDet::setupSampleLogFromSpiceTable(
                     << "\n";
 
   // set up run start
-  // matrixws->mutableRun().addProperty(new PropertyWithValue<std::string>("run_start", "2016-07-23T06:55:21.502270666"));
-  // matrixws->mutableRun().addProperty(new PropertyWithValue<std::string>("start_time", "2016-07-23T06:55:21.502270666"));
-   
+  // matrixws->mutableRun().addProperty(new
+  // PropertyWithValue<std::string>("run_start",
+  // "2016-07-23T06:55:21.502270666"));
+  // matrixws->mutableRun().addProperty(new
+  // PropertyWithValue<std::string>("start_time",
+  // "2016-07-23T06:55:21.502270666"));
+
   //
   //
 }

--- a/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
+++ b/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
@@ -583,10 +583,10 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspace(
         g_log.debug() << "Log name / xml node : " << xmlnode.getName()
                       << " (int) value = " << ivalue << "\n";
       } else {
-        outws->mutableRun().addProperty(
-            new PropertyWithValue<std::string>(nodename, nodevalue));
-        g_log.debug() << "Log name / xml node : " << xmlnode.getName()
-                      << " (string) value = " << nodevalue << "\n";
+        // outws->mutableRun().addProperty(
+        //     new PropertyWithValue<std::string>(nodename, nodevalue));
+        // g_log.debug() << "Log name / xml node : " << xmlnode.getName()
+        //               << " (string) value = " << nodevalue << "\n";
       }
     }
   }
@@ -843,6 +843,13 @@ void LoadSpiceXML2DDet::setupSampleLogFromSpiceTable(
     g_log.warning() << "Pt. " << ptnumber
                     << " is not found.  Log is not loaded to output workspace."
                     << "\n";
+
+  // set up run start
+  matrixws->mutableRun().addProperty(new PropertyWithValue<std::string>("run_start", "2016-07-23T06:55:21.502270666"));
+  matrixws->mutableRun().addProperty(new PropertyWithValue<std::string>("start_time", "2016-07-23T06:55:21.502270666"));
+   
+  //
+  //
 }
 
 /** Get wavelength if the instrument is HB3A

--- a/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
+++ b/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
@@ -670,16 +670,20 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspaceVersion2(
 
   // Add the property to output workspace
   // TODO:FIXME - need to find out how to add run_start!!!
-  for (std::map<std::string, std::string>::iterator miter = str_log_map.begin(); miter != str_log_map.end(); ++miter){
-    outws->mutableRun().addProperty(new PropertyWithValue<std::string>(miter->first, miter->second));
+  for (std::map<std::string, std::string>::iterator miter = str_log_map.begin();
+       miter != str_log_map.end(); ++miter) {
+    outws->mutableRun().addProperty(
+        new PropertyWithValue<std::string>(miter->first, miter->second));
   }
-  for (std::map<std::string, int>::iterator miter = int_log_map.begin(); miter != int_log_map.end(); ++miter)
-  {
-    outws->mutableRun().addProperty(new PropertyWithValue<int>(miter->first, miter->second));
+  for (std::map<std::string, int>::iterator miter = int_log_map.begin();
+       miter != int_log_map.end(); ++miter) {
+    outws->mutableRun().addProperty(
+        new PropertyWithValue<int>(miter->first, miter->second));
   }
-  for (std::map<std::string, double>::iterator miter = dbl_log_map.begin(); miter != dbl_log_map.end(); ++miter)
-  {
-    outws->mutableRun().addProperty(new PropertyWithValue<double>(miter->first, miter->second));
+  for (std::map<std::string, double>::iterator miter = dbl_log_map.begin();
+       miter != dbl_log_map.end(); ++miter) {
+    outws->mutableRun().addProperty(
+        new PropertyWithValue<double>(miter->first, miter->second));
   }
 
   // Raise exception if no detector node is found

--- a/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
+++ b/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
@@ -227,19 +227,16 @@ void LoadSpiceXML2DDet::processInputs() {
   m_detXMLFileName = getPropertyValue("Filename");
   m_detXMLNodeName = getPropertyValue("DetectorLogName");
   std::vector<size_t> vec_pixelgeom = getProperty("DetectorGeometry");
-  if (vec_pixelgeom.size() == 2)
-  {
+  if (vec_pixelgeom.size() == 2) {
     m_numPixelX = vec_pixelgeom[0];
     m_numPixelY = vec_pixelgeom[1];
-  }
-  else if (vec_pixelgeom.size() == 0)
-  {
+  } else if (vec_pixelgeom.size() == 0) {
     m_numPixelX = 0;
     m_numPixelY = 0;
-  }
-  else
-  {
-    throw std::runtime_error("Input pixels geometry is not correct in format. It either has 2 integers or left empty to get determined automatically.");
+  } else {
+    throw std::runtime_error("Input pixels geometry is not correct in format. "
+                             "It either has 2 integers or left empty to get "
+                             "determined automatically.");
   }
 
   m_loadInstrument = getProperty("LoadInstrument");
@@ -327,12 +324,12 @@ void LoadSpiceXML2DDet::exec() {
 
   // Create output workspace
   MatrixWorkspace_sptr outws;
-  if ( m_numPixelX * m_numPixelY > 0)
-  	outws = createMatrixWorkspace(vec_xmlnode, m_numPixelX, m_numPixelY,
-  	                              m_detXMLNodeName, m_loadInstrument);
+  if (m_numPixelX * m_numPixelY > 0)
+    outws = createMatrixWorkspace(vec_xmlnode, m_numPixelX, m_numPixelY,
+                                  m_detXMLNodeName, m_loadInstrument);
   else
-  	outws = createMatrixWorkspaceVersion2(vec_xmlnode, m_detXMLNodeName, m_loadInstrument);
-
+    outws = createMatrixWorkspaceVersion2(vec_xmlnode, m_detXMLNodeName,
+                                          m_loadInstrument);
 
   // Set up log for loading instrument
   bool can_set_instrument = setupSampleLogs(outws);
@@ -482,7 +479,6 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspace(
                                             numpixelx));
   }
 
-
   // Go through all XML nodes to process
   size_t numxmlnodes = vecxmlnode.size();
   bool parsedDet = false;
@@ -608,7 +604,6 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspace(
   return outws;
 }
 
-
 /** create the output matrix workspace without knowledge of detector geometry
  *
  */
@@ -616,7 +611,9 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspaceVersion2(
     const std::vector<SpiceXMLNode> &vecxmlnode, const std::string &detnodename,
     const bool &loadinstrument) {
 
-  // TODO FIXME - NOW : change the order to parse Detector-node and create output workspace such that the detector geometry can be figured out from the XML file's detector-Node
+  // TODO FIXME - NOW : change the order to parse Detector-node and create
+  // output workspace such that the detector geometry can be figured out from
+  // the XML file's detector-Node
 
   // Create matrix workspace
   MatrixWorkspace_sptr outws;
@@ -653,20 +650,20 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspaceVersion2(
         //     new PropertyWithValue<double>(nodename, dvalue));
         // g_log.debug() << "Log name / xml node : " << xmlnode.getName()
         //               << " (double) value = " << dvalue << "\n";
-	dbl_log_map.emplace(nodename, dvalue);
+        dbl_log_map.emplace(nodename, dvalue);
       } else if (xmlnode.isInteger()) {
         int ivalue = atoi(nodevalue.c_str());
         // outws->mutableRun().addProperty(
         //     new PropertyWithValue<int>(nodename, ivalue));
         // g_log.debug() << "Log name / xml node : " << xmlnode.getName()
         //               << " (int) value = " << ivalue << "\n";
-	int_log_map.emplace(nodename, ivalue);
+        int_log_map.emplace(nodename, ivalue);
       } else {
         // outws->mutableRun().addProperty(
         //     new PropertyWithValue<std::string>(nodename, nodevalue));
         // g_log.debug() << "Log name / xml node : " << xmlnode.getName()
         //               << " (string) value = " << nodevalue << "\n";
-	str_log_map.emplace(nodename, nodevalue);
+        str_log_map.emplace(nodename, nodevalue);
       }
     }
   }
@@ -686,105 +683,106 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspaceVersion2(
 
 /**
  */
-API::MatrixWorkspace_sptr LoadSpiceXML2DDet::parseDetectorNode(const std::string &detvaluestr, bool loadinstrument,
-		double& max_counts){
-      // Split to lines
-      std::vector<std::string> vecLines;
-      boost::split(vecLines, detvaluestr, boost::algorithm::is_any_of("\n"));
-      g_log.debug() << "There are " << vecLines.size() << " lines"
-                    << "\n";
+API::MatrixWorkspace_sptr
+LoadSpiceXML2DDet::parseDetectorNode(const std::string &detvaluestr,
+                                     bool loadinstrument, double &max_counts) {
+  // Split to lines
+  std::vector<std::string> vecLines;
+  boost::split(vecLines, detvaluestr, boost::algorithm::is_any_of("\n"));
+  g_log.debug() << "There are " << vecLines.size() << " lines"
+                << "\n";
 
-      // determine the number of pixels at X direction (bear in mind that the XML file records data in column major)
-      size_t num_pixel_x = vecLines.size();
+  // determine the number of pixels at X direction (bear in mind that the XML
+  // file records data in column major)
+  size_t num_pixel_x = vecLines.size();
 
-      // read the first line to determine the number of pixels at X direction
-      std::vector<std::string> veccounts;
-      boost::split(veccounts, vecLines[0], boost::algorithm::is_any_of(" \t"));
-      size_t num_pixel_y = veccounts.size();
+  // read the first line to determine the number of pixels at X direction
+  std::vector<std::string> veccounts;
+  boost::split(veccounts, vecLines[0], boost::algorithm::is_any_of(" \t"));
+  size_t num_pixel_y = veccounts.size();
 
-      // create output workspace
-  	MatrixWorkspace_sptr outws;
+  // create output workspace
+  MatrixWorkspace_sptr outws;
 
-  	if (loadinstrument) {
-  	  size_t numspec = num_pixel_x * num_pixel_y;
-  	  outws = boost::dynamic_pointer_cast<MatrixWorkspace>(
-  	      WorkspaceFactory::Instance().create("Workspace2D", numspec, 2, 1));
-  	} else {
-  	  outws = boost::dynamic_pointer_cast<MatrixWorkspace>(
-  	      WorkspaceFactory::Instance().create("Workspace2D", num_pixel_y, num_pixel_x,
-  	                                          num_pixel_x));
-  	}
+  if (loadinstrument) {
+    size_t numspec = num_pixel_x * num_pixel_y;
+    outws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        WorkspaceFactory::Instance().create("Workspace2D", numspec, 2, 1));
+  } else {
+    outws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        WorkspaceFactory::Instance().create("Workspace2D", num_pixel_y,
+                                            num_pixel_x, num_pixel_x));
+  }
 
-      // XML file records data in the order of column-major
-      // FIXME - This may waste the previous result by parsing first line
-      size_t i_col = 0;
-      max_counts = 0;
-      for (size_t i = 0; i < vecLines.size(); ++i) {
-        std::string &line = vecLines[i];
+  // XML file records data in the order of column-major
+  // FIXME - This may waste the previous result by parsing first line
+  size_t i_col = 0;
+  max_counts = 0;
+  for (size_t i = 0; i < vecLines.size(); ++i) {
+    std::string &line = vecLines[i];
 
-        // Skip empty line
-        if (line.empty()) {
-          g_log.debug() << "\tFound empty Line at " << i << "\n";
-          continue;
-        }
+    // Skip empty line
+    if (line.empty()) {
+      g_log.debug() << "\tFound empty Line at " << i << "\n";
+      continue;
+    }
 
-        // Check whether it exceeds boundary
-        if (i_col == num_pixel_x) {
-          std::stringstream errss;
-          errss << "Number of non-empty rows (" << i_col + 1
-                << ") in detector data "
-                << "exceeds user defined geometry size " << num_pixel_x << ".";
-          throw std::runtime_error(errss.str());
-        }
+    // Check whether it exceeds boundary
+    if (i_col == num_pixel_x) {
+      std::stringstream errss;
+      errss << "Number of non-empty rows (" << i_col + 1
+            << ") in detector data "
+            << "exceeds user defined geometry size " << num_pixel_x << ".";
+      throw std::runtime_error(errss.str());
+    }
 
-        // Split line
-        std::vector<std::string> veccounts;
-        boost::split(veccounts, line, boost::algorithm::is_any_of(" \t"));
+    // Split line
+    std::vector<std::string> veccounts;
+    boost::split(veccounts, line, boost::algorithm::is_any_of(" \t"));
 
-        // check number of counts per column should not exceeds number of pixels
-        // in Y direction
-        if (veccounts.size() != num_pixel_y) {
-          std::stringstream errss;
-          errss << "Row " << i_col << " contains " << veccounts.size()
-                << " items other than " << num_pixel_y
-                << " counts specified by user.";
-          throw std::runtime_error(errss.str());
-        }
+    // check number of counts per column should not exceeds number of pixels
+    // in Y direction
+    if (veccounts.size() != num_pixel_y) {
+      std::stringstream errss;
+      errss << "Row " << i_col << " contains " << veccounts.size()
+            << " items other than " << num_pixel_y
+            << " counts specified by user.";
+      throw std::runtime_error(errss.str());
+    }
 
-        // scan per column
-        for (size_t j_row = 0; j_row < veccounts.size(); ++j_row) {
-          double counts = atof(veccounts[j_row].c_str());
-          size_t rowIndex, columnIndex;
+    // scan per column
+    for (size_t j_row = 0; j_row < veccounts.size(); ++j_row) {
+      double counts = atof(veccounts[j_row].c_str());
+      size_t rowIndex, columnIndex;
 
-          if (loadinstrument) {
-            // the detector ID and ws index are set up in column-major too!
-            rowIndex = i_col * num_pixel_x + j_row;
-            columnIndex = 0;
-          } else {
-            rowIndex = j_row;
-            columnIndex = i_col;
-          }
+      if (loadinstrument) {
+        // the detector ID and ws index are set up in column-major too!
+        rowIndex = i_col * num_pixel_x + j_row;
+        columnIndex = 0;
+      } else {
+        rowIndex = j_row;
+        columnIndex = i_col;
+      }
 
-          outws->mutableX(rowIndex)[columnIndex] =
-              static_cast<double>(columnIndex);
-          outws->mutableY(rowIndex)[columnIndex] = counts;
+      outws->mutableX(rowIndex)[columnIndex] = static_cast<double>(columnIndex);
+      outws->mutableY(rowIndex)[columnIndex] = counts;
 
-          if (counts > 0)
-            outws->mutableE(rowIndex)[columnIndex] = sqrt(counts);
-          else
-            outws->mutableE(rowIndex)[columnIndex] = 1.0;
+      if (counts > 0)
+        outws->mutableE(rowIndex)[columnIndex] = sqrt(counts);
+      else
+        outws->mutableE(rowIndex)[columnIndex] = 1.0;
 
-          // record max count
-          if (counts > max_counts) {
-            max_counts = counts;
-          }
-        }
+      // record max count
+      if (counts > max_counts) {
+        max_counts = counts;
+      }
+    }
 
-        // Update column index (i.e., column number)
-        i_col += 1;
-      } // END-FOR (i-vec line)
+    // Update column index (i.e., column number)
+    i_col += 1;
+  } // END-FOR (i-vec line)
 
-      return outws;
+  return outws;
 }
 
 /** Set up sample logs from table workspace loaded where SPICE data file is

--- a/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
+++ b/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
@@ -238,7 +238,8 @@ void LoadSpiceXML2DDet::processInputs() {
                              "It either has 2 integers or left empty to get "
                              "determined automatically.");
   }
-  g_log.debug() << "User input poixels numbers: " << m_numPixelX << ", " << m_numPixelY << "\n";
+  g_log.debug() << "User input poixels numbers: " << m_numPixelX << ", "
+                << m_numPixelY << "\n";
 
   m_loadInstrument = getProperty("LoadInstrument");
 
@@ -525,8 +526,8 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspace(
         // in Y direction
         if (veccounts.size() != numpixely) {
           std::stringstream errss;
-          errss << "[Version 1] Row " << i_col << " contains " << veccounts.size()
-                << " items other than " << numpixely
+          errss << "[Version 1] Row " << i_col << " contains "
+                << veccounts.size() << " items other than " << numpixely
                 << " counts specified by user.";
           throw std::runtime_error(errss.str());
         }
@@ -589,8 +590,8 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspace(
           // replace 2015-01-17 13:36:45 by  2015-01-17T13:36:45
           str_value = nodevalue;
           str_value.replace(10, 1, "T");
-          g_log.debug() << "Replace start_time " << nodevalue << " by Mantid time format "
-                        << str_value << "\n";
+          g_log.debug() << "Replace start_time " << nodevalue
+                        << " by Mantid time format " << str_value << "\n";
         }
         outws->mutableRun().addProperty(
             new PropertyWithValue<std::string>(nodename, str_value));
@@ -658,15 +659,14 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspaceVersion2(
           // replace 2015-01-17 13:36:45 by  2015-01-17T13:36:45
           std::string str_value(nodevalue);
           str_value.replace(10, 1, "T");
-          g_log.debug() << "Replace start_time " << nodevalue << " by Mantid time format "
-                        << str_value << "\n";
+          g_log.debug() << "Replace start_time " << nodevalue
+                        << " by Mantid time format " << str_value << "\n";
           str_log_map.emplace(nodename, str_value);
-        }
-        else
+        } else
           str_log_map.emplace(nodename, nodevalue);
       } // END-IF-ELSE (node value type)
-    } // END-IF-ELSE (detector-node or log node)
-  } // END-FOR (xml nodes)
+    }   // END-IF-ELSE (detector-node or log node)
+  }     // END-FOR (xml nodes)
 
   // Add the property to output workspace
   for (std::map<std::string, std::string>::iterator miter = str_log_map.begin();
@@ -713,12 +713,11 @@ LoadSpiceXML2DDet::parseDetectorNode(const std::string &detvaluestr,
   // file records data in column major)
   size_t num_empty_line = 0;
   size_t num_weird_line = 0;
-  for (size_t iline = 0; iline < vecLines.size(); ++iline)
-  {
+  for (size_t iline = 0; iline < vecLines.size(); ++iline) {
     if (vecLines[iline].size() == 0)
-      ++ num_empty_line;
+      ++num_empty_line;
     else if (vecLines[iline].size() < 100)
-      ++ num_weird_line;
+      ++num_weird_line;
   }
   size_t num_pixel_x = vecLines.size() - num_empty_line - num_weird_line;
   g_log.information() << "There are " << num_empty_line << " lines and "
@@ -727,9 +726,10 @@ LoadSpiceXML2DDet::parseDetectorNode(const std::string &detvaluestr,
   // read the first line to determine the number of pixels at X direction
   size_t first_regular_line = 0;
   if (vecLines[first_regular_line].size() < 100)
-    ++ first_regular_line;
+    ++first_regular_line;
   std::vector<std::string> veccounts;
-  boost::split(veccounts, vecLines[first_regular_line], boost::algorithm::is_any_of(" \t"));
+  boost::split(veccounts, vecLines[first_regular_line],
+               boost::algorithm::is_any_of(" \t"));
   size_t num_pixel_y = veccounts.size();
 
   // create output workspace

--- a/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
+++ b/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
@@ -583,8 +583,23 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspace(
         g_log.debug() << "Log name / xml node : " << xmlnode.getName()
                       << " (int) value = " << ivalue << "\n";
       } else {
-        // outws->mutableRun().addProperty(
-        //     new PropertyWithValue<std::string>(nodename, nodevalue));
+        std::string str_value(nodevalue);
+        if (nodename.compare("start_time") == 0)
+        {
+          // replace 2015-01-17 13:36:45 by
+          g_log.notice() << "FIXME ! : Original start time: " << nodevalue << "  vs. Mantid time format: " << "2016-07-23T06:55:21.502270666"
+                         << "\n";
+          str_value = nodevalue;
+          str_value.replace(10, 1, "T");
+          g_log.notice() << "Replaced string = " << str_value << "\n";
+          // str_value = "2016-07-23T06:55:21.502270666";
+          /*
+           * Original start time: 2015-01-17 13:36:45  vs. Mantid time format: 2016-07-23T06:55:21.502270666
+           *
+           */
+        }
+        outws->mutableRun().addProperty(
+             new PropertyWithValue<std::string>(nodename, str_value));
         // g_log.debug() << "Log name / xml node : " << xmlnode.getName()
         //               << " (string) value = " << nodevalue << "\n";
       }
@@ -845,8 +860,8 @@ void LoadSpiceXML2DDet::setupSampleLogFromSpiceTable(
                     << "\n";
 
   // set up run start
-  matrixws->mutableRun().addProperty(new PropertyWithValue<std::string>("run_start", "2016-07-23T06:55:21.502270666"));
-  matrixws->mutableRun().addProperty(new PropertyWithValue<std::string>("start_time", "2016-07-23T06:55:21.502270666"));
+  // matrixws->mutableRun().addProperty(new PropertyWithValue<std::string>("run_start", "2016-07-23T06:55:21.502270666"));
+  // matrixws->mutableRun().addProperty(new PropertyWithValue<std::string>("start_time", "2016-07-23T06:55:21.502270666"));
    
   //
   //

--- a/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
+++ b/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
@@ -668,6 +668,20 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspaceVersion2(
     }
   }
 
+  // Add the property to output workspace
+  // TODO:FIXME - need to find out how to add run_start!!!
+  for (std::map<std::string, std::string>::iterator miter = str_log_map.begin(); miter != str_log_map.end(); ++miter){
+    outws->mutableRun().addProperty(new PropertyWithValue<std::string>(miter->first, miter->second));
+  }
+  for (std::map<std::string, int>::iterator miter = int_log_map.begin(); miter != int_log_map.end(); ++miter)
+  {
+    outws->mutableRun().addProperty(new PropertyWithValue<int>(miter->first, miter->second));
+  }
+  for (std::map<std::string, double>::iterator miter = dbl_log_map.begin(); miter != dbl_log_map.end(); ++miter)
+  {
+    outws->mutableRun().addProperty(new PropertyWithValue<double>(miter->first, miter->second));
+  }
+
   // Raise exception if no detector node is found
   if (!parsedDet) {
     std::stringstream errss;

--- a/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
+++ b/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
@@ -50,7 +50,7 @@ public:
    *   sample logs: including run_start, monitor, omega, chi, phi and 2theta
    * @brief Load data without instrument
    */
-  void test_LoadDataNoInstrument() {
+  void Passed_test_LoadDataNoInstrument() {
     LoadSpiceXML2DDet loader;
     loader.initialize();
 
@@ -161,6 +161,11 @@ public:
         AnalysisDataService::Instance().retrieve("Exp0335_S0038"));
     TS_ASSERT(outws);
     TS_ASSERT_EQUALS(outws->getNumberHistograms(), 256 * 256);
+
+    for (auto property : outws->run().getProperties())
+    {
+      std::cout << property->name() << ": " << property->value() << "\n";
+    }
 
     // test signal value on various pixels
     // pixel at (256, 1): column 1
@@ -283,7 +288,7 @@ public:
    *    (a) at center pixel, 2-theta = 42.797
    * @brief Load data and instrument with sample log value
    */
-  void test_loadDataUsingSampleLogValue() {
+  void Xtest_loadDataUsingSampleLogValue() {
     // initialize the algorithm
     LoadSpiceXML2DDet loader;
     loader.initialize();
@@ -374,7 +379,7 @@ public:
    * Testing include
    * 1. 2theta = 15 degree: scattering angle of all 4 corners should be same;
    */
-  void test_loadHB3ACalibratedDetDistance() {
+  void Xtest_loadHB3ACalibratedDetDistance() {
     // Test 2theta at 15 degree with sample-detector distance shift
     LoadSpiceXML2DDet loader;
     loader.initialize();
@@ -469,7 +474,7 @@ public:
    *  3. Check the symmetry of the peak positions
    * @brief Load data and instrument with sample log value
    */
-  void test_loadDataShiftDetectorCenter() {
+  void Xtest_loadDataShiftDetectorCenter() {
     // initialize the algorithm
     LoadSpiceXML2DDet loader;
     loader.initialize();

--- a/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
+++ b/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
@@ -162,8 +162,7 @@ public:
     TS_ASSERT(outws);
     TS_ASSERT_EQUALS(outws->getNumberHistograms(), 256 * 256);
 
-    for (auto property : outws->run().getProperties())
-    {
+    for (auto property : outws->run().getProperties()) {
       std::cout << property->name() << ": " << property->value() << "\n";
     }
 

--- a/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
+++ b/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
@@ -584,14 +584,16 @@ public:
   }
 
   //----------------------------------------------------------------------------------------------
-  /** Test with loading instrument without Spice scan Table and WITHOUT user-specified detector
+  /** Test with loading instrument without Spice scan Table and WITHOUT
+   * user-specified detector
    * geometry, while the 2theta value is from sample
    *    sample log
    *  Testing includes:
    *  1. Load the instrument without Spice Table;
    *  2. Check the positions of detectors.
    *    (a) at center pixel, 2-theta = 42.797
-   * This should have the same result as unti test "test_loadDataUsingSampleLogValue"
+   * This should have the same result as unti test
+   * "test_loadDataUsingSampleLogValue"
    * @brief Load data and instrument with sample log value
    */
   void test_loadDataWithoutSpecifyingDetectorGeometry() {

--- a/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
+++ b/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
@@ -50,7 +50,7 @@ public:
    *   sample logs: including run_start, monitor, omega, chi, phi and 2theta
    * @brief Load data without instrument
    */
-  void Passed_test_LoadDataNoInstrument() {
+  void test_LoadDataNoInstrument() {
     LoadSpiceXML2DDet loader;
     loader.initialize();
 
@@ -119,7 +119,7 @@ public:
     // check start_time and end_time
     TS_ASSERT(outws->run().hasProperty("start_time"));
     std::string start_time = outws->run().getProperty("start_time")->value();
-    TS_ASSERT_EQUALS(start_time, "2015-01-17 13:36:45");
+    TS_ASSERT_EQUALS(start_time, "2015-01-17T13:36:45");
 
     // Clean
     AnalysisDataService::Instance().remove("Exp0335_S0038");
@@ -287,7 +287,7 @@ public:
    *    (a) at center pixel, 2-theta = 42.797
    * @brief Load data and instrument with sample log value
    */
-  void Xtest_loadDataUsingSampleLogValue() {
+  void test_loadDataUsingSampleLogValue() {
     // initialize the algorithm
     LoadSpiceXML2DDet loader;
     loader.initialize();
@@ -378,7 +378,7 @@ public:
    * Testing include
    * 1. 2theta = 15 degree: scattering angle of all 4 corners should be same;
    */
-  void Xtest_loadHB3ACalibratedDetDistance() {
+  void test_loadHB3ACalibratedDetDistance() {
     // Test 2theta at 15 degree with sample-detector distance shift
     LoadSpiceXML2DDet loader;
     loader.initialize();
@@ -473,7 +473,7 @@ public:
    *  3. Check the symmetry of the peak positions
    * @brief Load data and instrument with sample log value
    */
-  void Xtest_loadDataShiftDetectorCenter() {
+  void test_loadDataShiftDetectorCenter() {
     // initialize the algorithm
     LoadSpiceXML2DDet loader;
     loader.initialize();
@@ -583,6 +583,101 @@ public:
     AnalysisDataService::Instance().remove("Exp0335_S0038C");
   }
 
+  //----------------------------------------------------------------------------------------------
+  /** Test with loading instrument without Spice scan Table and WITHOUT user-specified detector
+   * geometry, while the 2theta value is from sample
+   *    sample log
+   *  Testing includes:
+   *  1. Load the instrument without Spice Table;
+   *  2. Check the positions of detectors.
+   *    (a) at center pixel, 2-theta = 42.797
+   * This should have the same result as unti test "test_loadDataUsingSampleLogValue"
+   * @brief Load data and instrument with sample log value
+   */
+  void test_loadDataWithoutSpecifyingDetectorGeometry() {
+    // initialize the algorithm
+    LoadSpiceXML2DDet loader;
+    loader.initialize();
+
+    // set up properties
+    const std::string filename("HB3A_exp355_scan0001_0522.xml");
+    TS_ASSERT_THROWS_NOTHING(loader.setProperty("Filename", filename));
+    TS_ASSERT_THROWS_NOTHING(
+        loader.setProperty("OutputWorkspace", "Exp0335_S0038F"));
+    std::vector<size_t> geometryvec;
+    geometryvec.push_back(0);
+    geometryvec.push_back(0);
+    loader.setProperty("DetectorGeometry", geometryvec);
+    loader.setProperty("LoadInstrument", true);
+    loader.setProperty("ShiftedDetectorDistance", 0.);
+
+    loader.execute();
+    TS_ASSERT(loader.isExecuted());
+
+    // Get data
+    MatrixWorkspace_sptr outws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("Exp0335_S0038F"));
+    TS_ASSERT(outws);
+    TS_ASSERT_EQUALS(outws->getNumberHistograms(), 256 * 256);
+
+    // Value
+    // test signal value on various pixels
+    // pixel at (256, 1): column 1
+    TS_ASSERT_DELTA(outws->readY(255)[0], 1.0, 0.0001);
+    // pixel at (254, 256): colun 256
+    TS_ASSERT_DELTA(outws->readY(255 * 256 + 138)[0], 2.0, 0.00001);
+
+    // Instrument
+    TS_ASSERT(outws->getInstrument());
+
+    // get 2theta from workspace
+    double twotheta_raw =
+        atof(outws->run().getProperty("_2theta")->value().c_str());
+
+    Kernel::Property *raw_property = outws->run().getProperty("2theta");
+    Kernel::TimeSeriesProperty<double> *twotheta_property =
+        dynamic_cast<Kernel::TimeSeriesProperty<double> *>(raw_property);
+    TS_ASSERT(twotheta_property);
+    double twotheta_log = twotheta_property->valuesAsVector()[0];
+    // 2-theta = 42.797
+
+    TS_ASSERT_EQUALS(twotheta_raw, twotheta_log);
+
+    // check the center of the detector
+    const auto &spectrumInfo = outws->spectrumInfo();
+
+    // check the center position
+    size_t center_row = 115 - 1;
+    size_t center_col = 128 - 1;
+    size_t center_ws_index = 256 * center_col + center_row;
+    const auto center_det_pos = spectrumInfo.position(center_ws_index);
+    TS_ASSERT_DELTA(center_det_pos.Y(), 0., 0.00000001);
+    double sample_center_distance = spectrumInfo.l2(center_ws_index);
+    // TS_ASSERT_DELTA(center_det_pos.X(), )
+    TS_ASSERT_DELTA(sample_center_distance, 0.3750, 0.0000001);
+    double sample_center_angle = spectrumInfo.twoTheta(center_ws_index);
+    TS_ASSERT_DELTA(sample_center_angle * 180. / M_PI, twotheta_log, 0.0001);
+
+    size_t ll_ws_index = 0;
+    const auto ll_det_pos = spectrumInfo.position(ll_ws_index);
+    double ll_sample_r = spectrumInfo.l2(ll_ws_index);
+    TS_ASSERT_DELTA(ll_sample_r, 0.37597, 0.001);
+
+    size_t lu_ws_index = 255; // row = 255, col = 1
+    const auto lu_det_pos = spectrumInfo.position(lu_ws_index);
+    double lu_sample_r = spectrumInfo.l2(lu_ws_index);
+    TS_ASSERT_DELTA(lu_sample_r, 0.37689, 0.001);
+
+    TS_ASSERT_DELTA(ll_det_pos.X(), lu_det_pos.X(), 0.000001);
+    TS_ASSERT(ll_det_pos.Y() + lu_det_pos.Y() > 0);
+
+    TS_ASSERT(ll_det_pos.X() > center_det_pos.X());
+
+    // Clean
+    AnalysisDataService::Instance().remove("Exp0335_S0038F");
+  }
+
+  //----------------------------------------------------------------------------------------------
   /** Create SPICE scan table workspace
    * @brief createSpiceScanTable
    * @return

--- a/Framework/MDAlgorithms/src/ConvertCWSDExpToMomentum.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWSDExpToMomentum.cpp
@@ -40,6 +40,11 @@ void ConvertCWSDExpToMomentum::init() {
       "Name of table workspace for data file names in the experiment.");
 
   declareProperty(
+      make_unique<FileProperty>("InstrumentFilename", "",
+                                FileProperty::OptionalLoad, ".xml"));
+ 
+
+  declareProperty(
       "DetectorSampleDistanceShift", 0.0,
       "Amount of shift in sample-detector distance from 0.3750 meter.");
 
@@ -617,6 +622,13 @@ ConvertCWSDExpToMomentum::loadSpiceData(const std::string &filename,
     loader->setProperty("ShiftedDetectorDistance", m_detSampleDistanceShift);
     loader->setProperty("DetectorCenterXShift", m_detXShift);
     loader->setProperty("DetectorCenterYShift", m_detYShift);
+
+    // TODO/FIXME - This is not a nice solution for detector geometry
+    std::string idffile = getPropertyValue("InstrumentFilename");
+    if (idffile.size() > 0){
+      loader->setProperty("InstrumentFilename", idffile);
+      loader->setProperty("DetectorGeometry", "512, 512");
+    }
 
     double wavelength = getProperty("UserDefinedWavelength");
 

--- a/Framework/MDAlgorithms/src/ConvertCWSDExpToMomentum.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWSDExpToMomentum.cpp
@@ -39,10 +39,8 @@ void ConvertCWSDExpToMomentum::init() {
                                                       Direction::Input),
       "Name of table workspace for data file names in the experiment.");
 
-  declareProperty(
-      make_unique<FileProperty>("InstrumentFilename", "",
-                                FileProperty::OptionalLoad, ".xml"));
- 
+  declareProperty(make_unique<FileProperty>(
+      "InstrumentFilename", "", FileProperty::OptionalLoad, ".xml"));
 
   declareProperty(
       "DetectorSampleDistanceShift", 0.0,
@@ -625,7 +623,7 @@ ConvertCWSDExpToMomentum::loadSpiceData(const std::string &filename,
 
     // TODO/FIXME - This is not a nice solution for detector geometry
     std::string idffile = getPropertyValue("InstrumentFilename");
-    if (idffile.size() > 0){
+    if (idffile.size() > 0) {
       loader->setProperty("InstrumentFilename", idffile);
       loader->setProperty("DetectorGeometry", "512, 512");
     }

--- a/docs/source/release/v3.10.0/diffraction.rst
+++ b/docs/source/release/v3.10.0/diffraction.rst
@@ -11,7 +11,10 @@ Crystal Improvements
 Engineering Diffraction
 -----------------------
 
-|
+Single Crystal Diffraction
+--------------------------
+
+- A new HB3A's instrument definition file, for its 512 x 512 detector, is add to Mantid.
 
 Full list of `diffraction <https://github.com/mantidproject/mantid/issues?q=is%3Aclosed+milestone%3A%22Release+3.10%22+label%3A%22Component%3A+Diffraction%22>`_
 and

--- a/instrument/HB3A_Definition.xml
+++ b/instrument/HB3A_Definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2015-05-18 10:35:21.877396" name="HB3A" valid-from="2015-05-18 10:35:21" valid-to="2017-02-11 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2015-05-18 10:35:21.877396" name="HB3A" valid-from="2010-05-18 10:35:21" valid-to="2017-02-11 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Wenduo Zhou-->
   <!--SOURCE-->
   <component type="moderator">

--- a/instrument/HB3A_Definition_2017-02-12.xml
+++ b/instrument/HB3A_Definition_2017-02-12.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2015-05-18 10:35:21.877396" name="HB3A" valid-from="2015-05-18 10:35:21" valid-to="2017-02-11 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2015-05-18 10:35:21.877396" name="HB3A" valid-from="2017-02-12 10:35:21" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Wenduo Zhou-->
   <!--SOURCE-->
   <component type="moderator">
@@ -40,14 +40,14 @@
 		  </location>
 	  </component>
   </type>
-  <type is="rectangular_detector" name="panel" type="pixel" xpixels="256" xstart="0.0252015625" xstep="-0.0001984375" ypixels="256" ystart="-0.022621875" ystep="0.0001984375">
+  <type is="rectangular_detector" name="panel" type="pixel" xpixels="512" xstart="0.0564140625" xstep="-0.0002265625" ypixels="512" ystart="-0.0355703125" ystep="0.0002265625">
  </type>
   <type is="detector" name="pixel">
     <cuboid id="pixel-shape">
-      <left-front-bottom-point x="-9.921875e-05" y="-9.921875e-05" z="0.0"/>
-      <left-front-top-point x="-9.921875e-05" y="9.921875e-05" z="0.0"/>
-      <left-back-bottom-point x="-9.921875e-05" y="-9.921875e-05" z="-0.0001"/>
-      <right-front-bottom-point x="9.921875e-05" y="-9.921875e-05" z="0.0"/>
+      <left-front-bottom-point x="-0.00011328125" y="-0.00011328125" z="0.0"/>
+      <left-front-top-point x="-0.00011328125" y="0.00011328125" z="0.0"/>
+      <left-back-bottom-point x="-0.00011328125" y="-0.00011328125" z="-0.0001"/>
+      <right-front-bottom-point x="0.00011328125" y="-0.00011328125" z="0.0"/>
     </cuboid>
     <algebra val="pixel-shape"/>
   </type>

--- a/instrument/HB3A_Definition_2017-02-12.xml
+++ b/instrument/HB3A_Definition_2017-02-12.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2015-05-18 10:35:21.877396" name="HB3A" valid-from="2017-02-12 10:35:21" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2017-02-18 10:35:21.877396" name="HB3A" valid-from="2017-02-12 10:35:21" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Wenduo Zhou-->
   <!--SOURCE-->
   <component type="moderator">
@@ -12,7 +12,7 @@
   </component>
   <type is="SamplePos" name="sample-position"/>
   <!--PANEL-->
-  <component idfillbyfirst="x" idstart="1" idstepbyrow="256" type="arm">
+  <component idfillbyfirst="x" idstart="1" idstepbyrow="512" type="arm">
     <location name="bank1">
       <parameter name="r-position">
 	      <logfile eq="1.0*value+0.3750" id="diffr"/>

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
@@ -10,6 +10,7 @@
 ################################################################################
 import csv
 import random
+import os
 
 from fourcircle_utility import *
 from peakprocesshelper import PeakProcessRecord
@@ -1474,8 +1475,10 @@ class CWSCDReductionControl(object):
 
         # load SPICE Pt.  detector file
         pt_ws_name = get_raw_data_workspace_name(exp_no, scan_no, pt_no)
-        new_idf_name = '/home/wzz/Projects/HB3A/NewDetector/HB3A_ND_Definition.xml'
-        # new_idf_name = '/SNS/users/wzz/Projects/HB3A/HB3A_ND_Definition.xml'
+        # new_idf_name = '/home/wzz/Projects/HB3A/NewDetector/HB3A_ND_Definition.xml'
+        new_idf_name = '/SNS/users/wzz/Projects/HB3A/HB3A_ND_Definition.xml'
+        if os.path.exists(new_idf_name) is False:
+            raise RuntimeError('Instrument file {0} cannot be found!'.format(new_idf_name))
         try:
             mantidsimple.LoadSpiceXML2DDet(Filename=xml_file_name,
                                            OutputWorkspace=pt_ws_name,
@@ -1719,8 +1722,10 @@ class CWSCDReductionControl(object):
                     alg_args['UserDefinedWavelength'] = self._userWavelengthDict[exp_no]
 
                 # TODO/FIXME/NOW - Should get a flexible way to define IDF or no IDF
-                new_idf_name = '/home/wzz/Projects/HB3A/NewDetector/HB3A_ND_Definition.xml'
-                # new_idf_name = '/SNS/users/wzz/Projects/HB3A/HB3A_ND_Definition.xml'
+                # new_idf_name = '/home/wzz/Projects/HB3A/NewDetector/HB3A_ND_Definition.xml'
+                new_idf_name = '/SNS/users/wzz/Projects/HB3A/HB3A_ND_Definition.xml'
+                if os.path.exists(new_idf_name) is False:
+                    raise RuntimeError('Instrument file {0} cannot be found!'.format(new_idf_name))
                 alg_args['InstrumentFilename'] = new_idf_name
 
                 # call:

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
@@ -1473,12 +1473,14 @@ class CWSCDReductionControl(object):
 
         # load SPICE Pt.  detector file
         pt_ws_name = get_raw_data_workspace_name(exp_no, scan_no, pt_no)
+        new_idf_name = '/home/wzz/Projects/HB3A/NewDetector/HB3A_ND_Definition.xml'
+        # new_idf_name = '/SNS/users/wzz/Projects/HB3A/HB3A_ND_Definition.xml'
         try:
             mantidsimple.LoadSpiceXML2DDet(Filename=xml_file_name,
                                            OutputWorkspace=pt_ws_name,
                                            # FIXME - Need UI input
                                            DetectorGeometry='512,512',
-                                           InstrumentFilename='/SNS/users/wzz/Projects/HB3A/HB3A_ND_Definition.xml',
+                                           InstrumentFilename=new_idf_name,
                                            SpiceTableWorkspace=spice_table_name,
                                            PtNumber=pt_no)
         except RuntimeError as run_err:
@@ -1695,6 +1697,11 @@ class CWSCDReductionControl(object):
                 # set up the user-defined wave length
                 if exp_no in self._userWavelengthDict:
                     alg_args['UserDefinedWavelength'] = self._userWavelengthDict[exp_no]
+
+                # TODO/FIXME/NOW - Should get a flexible way to define IDF or no IDF
+                new_idf_name = '/home/wzz/Projects/HB3A/NewDetector/HB3A_ND_Definition.xml'
+                # new_idf_name = '/SNS/users/wzz/Projects/HB3A/HB3A_ND_Definition.xml'
+                alg_args['InstrumentFilename'] = new_idf_name
 
                 # call:
                 mantidsimple.ConvertCWSDExpToMomentum(**alg_args)

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
@@ -749,6 +749,7 @@ class CWSCDReductionControl(object):
         raw_ws = self.get_raw_data_workspace(exp_no, scan_no, pt_no)
         if raw_ws is None:
             return False, 'Raw data for Exp %d Scan %d Pt %d is not loaded.' % (exp_no, scan_no, pt_no)
+        print '[DB...BAT] Raw workspace size: ', raw_ws.getNumberHistograms()
 
         # Convert to numpy array
         array2d = numpy.ndarray(shape=(DET_X_SIZE, DET_Y_SIZE), dtype='float')

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
@@ -1488,7 +1488,7 @@ class CWSCDReductionControl(object):
             return False, str(run_err)
 
         # Add data storage
-        assert AnalysisDataService.doesExist(pt_ws_name)
+        assert AnalysisDataService.doesExist(pt_ws_name), 'blabla'
         raw_matrix_ws = AnalysisDataService.retrieve(pt_ws_name)
         self._add_raw_workspace(exp_no, scan_no, pt_no, raw_matrix_ws)
 
@@ -1513,12 +1513,31 @@ class CWSCDReductionControl(object):
         assert isinstance(merged_ws_name, str), 'Target MDWorkspace name for merged scans %s (%s) must ' \
                                                 'be a string.' % (str(merged_ws_name), type(merged_ws_name))
 
+
         # get the workspace
         ws_name_list = ''
         for i_ws, ws_name in enumerate(scan_md_ws_list):
+            # build the input MDWorkspace list
             if i_ws != 0:
                 ws_name_list += ', '
             ws_name_list += ws_name
+        
+            # rebin the MDEventWorkspace to make all MDEventWorkspace have same MDGrid
+            md_ws = AnalysisDataService.retrieve(ws_name)
+            frame = md_ws.getDimension(0).getMDFrame().name()
+            
+            if frame == 'HKL':
+                mantidsimple.SliceMD(InputWorkspace=ws_name,
+                                     AlignedDim0='H,-10,10,1',
+                                     AlignedDim1='K,-10,10,1',
+                                     AlignedDim2='L,-10,10,1',
+                                     OutputWorkspace=ws_name)
+            else:
+                mantidsimple.SliceMD(InputWorkspace=ws_name,
+                                     AlignedDim0='Q_sample_x,-10,10,1',
+                                     AlignedDim1='Q_sample_y,-10,10,1',
+                                     AlignedDim2='Q_sample_z,-10,10,1',
+                                     OutputWorkspace=ws_name)
         # END-FOR
 
         # merge

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
@@ -1516,7 +1516,6 @@ class CWSCDReductionControl(object):
         assert isinstance(merged_ws_name, str), 'Target MDWorkspace name for merged scans %s (%s) must ' \
                                                 'be a string.' % (str(merged_ws_name), type(merged_ws_name))
 
-
         # get the workspace
         ws_name_list = ''
         for i_ws, ws_name in enumerate(scan_md_ws_list):
@@ -1524,11 +1523,11 @@ class CWSCDReductionControl(object):
             if i_ws != 0:
                 ws_name_list += ', '
             ws_name_list += ws_name
-        
+
             # rebin the MDEventWorkspace to make all MDEventWorkspace have same MDGrid
             md_ws = AnalysisDataService.retrieve(ws_name)
             frame = md_ws.getDimension(0).getMDFrame().name()
-            
+
             if frame == 'HKL':
                 mantidsimple.SliceMD(InputWorkspace=ws_name,
                                      AlignedDim0='H,-10,10,1',

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleControl.py
@@ -24,8 +24,9 @@ from mantid.kernel import V3D
 
 DebugMode = True
 
-DET_X_SIZE = 256
-DET_Y_SIZE = 256
+# TODO - changed without configuration
+DET_X_SIZE = 512
+DET_Y_SIZE = 512
 
 MAX_SCAN_NUMBER = 100000
 
@@ -1475,7 +1476,9 @@ class CWSCDReductionControl(object):
         try:
             mantidsimple.LoadSpiceXML2DDet(Filename=xml_file_name,
                                            OutputWorkspace=pt_ws_name,
-                                           DetectorGeometry='256,256',
+                                           # FIXME - Need UI input
+                                           DetectorGeometry='512,512',
+                                           InstrumentFilename='/SNS/users/wzz/Projects/HB3A/HB3A_ND_Definition.xml',
                                            SpiceTableWorkspace=spice_table_name,
                                            PtNumber=pt_no)
         except RuntimeError as run_err:

--- a/scripts/HFIR_4Circle_Reduction/reduce4circleGUI.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleGUI.py
@@ -3417,7 +3417,8 @@ class MainWindow(QtGui.QMainWindow):
         raw_det_data = self._myControl.get_raw_detector_counts(exp_no, scan_no, pt_no)
         # raw_det_data = numpy.rot90(raw_det_data, 1)
         self.ui.graphicsView_detector2dPlot.clear_canvas()
-        self.ui.graphicsView_detector2dPlot.add_plot_2d(raw_det_data, x_min=0, x_max=256, y_min=0, y_max=256,
+        # TODO/FIXME - changed to 512 from 256 as prototype.  Should be via configuration
+        self.ui.graphicsView_detector2dPlot.add_plot_2d(raw_det_data, x_min=0, x_max=512, y_min=0, y_max=512,
                                                         hold_prev_image=False)
         status, roi = self._myControl.get_region_of_interest(exp_no, scan_number=None)
         if status:


### PR DESCRIPTION
Description of work.

* Generated a new HB3A's IDF for its new 512 x 512 detector;
* Modified the beginning and expiration time of the original IDF of HB3A;
* Modified LoadSpiceXML2DDet such that it was able to load the instrument without user's specifying detector geometry.  A unit test was implemented for this feature.

**To test:**

<!-- Instructions for testing. -->

1. Launch Mantidplot and then interface "HFIR 4Circle Reduction";
2. Test with Exp 566. You can choose arbitrary scans such as  1931-1941. 
3. Choose one or two scans to add peak.
4. Set up UB matrix by reading from SPICE file.
5. Index the peaks with UB matrix to check whether the results are consistent with SPICE.


Fixes #18896 .

*Does not need to be in the release notes.*
The new feature. will be described in release notes in the next PR associated with HB3A.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
