### PR TITLE
Fix wrong detector selection when loading high angle bank user files in ISIS SANS

### DIFF
--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -3521,8 +3521,28 @@ void SANSRunWindow::fillDetectNames(QComboBox *output) {
                              "to continue by selecting a valid instrument");
   }
 
-  output->setItemText(0, dets[1]);
-  output->setItemText(1, dets[3]);
+  // The setting of the detector here has been the cause of problems for (apparently years).
+  // The code assumes for the indices
+  // |     | LOQ                | SANS2D         | LARMOR                  |
+  // |-----|--------------------|----------------|-------------------------|
+  // |  0  | main-detector-bank | rear-detector  | DetectorBench           |
+  // |  1  | HAB                | front-detector | front-detector (unused) |
+  // |  2  | both               | both           | both                    |
+  // |  3  | merged             | merged         | merged                  |
+  // But the Python method above listDetectors will return the selected detector first,
+  // ie if HAB was selected on LOQ, then it would return ["HAB","main-detector-bank"]
+  // if main-detector-bank was selected on LOQ, then it would return ["main-detector-bank", "HAB"]
+  // which means we need to assign the names to the right slots.
+  QStringList detectorNames = {dets[1], dets[3]};
+  for (auto& name : detectorNames) {
+    if (name == "main-detector-bank" || name ==  "rear-detector" || name == "DetectorBench") {
+      output->setItemText(0, name);
+    }
+
+    if (name == "HAB" || name == "front-detector") {
+      output->setItemText(1, name);
+    }
+  }
 }
 /** Checks if the workspace is a group and returns the first member of group,
 * throws

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -3521,7 +3521,8 @@ void SANSRunWindow::fillDetectNames(QComboBox *output) {
                              "to continue by selecting a valid instrument");
   }
 
-  // The setting of the detector here has been the cause of problems for (apparently years).
+  // The setting of the detector here has been the cause of problems for
+  // (apparently years).
   // The code assumes for the indices
   // |     | LOQ                | SANS2D         | LARMOR                  |
   // |-----|--------------------|----------------|-------------------------|
@@ -3529,13 +3530,17 @@ void SANSRunWindow::fillDetectNames(QComboBox *output) {
   // |  1  | HAB                | front-detector | front-detector (unused) |
   // |  2  | both               | both           | both                    |
   // |  3  | merged             | merged         | merged                  |
-  // But the Python method above listDetectors will return the selected detector first,
-  // ie if HAB was selected on LOQ, then it would return ["HAB","main-detector-bank"]
-  // if main-detector-bank was selected on LOQ, then it would return ["main-detector-bank", "HAB"]
+  // But the Python method above listDetectors will return the selected detector
+  // first,
+  // ie if HAB was selected on LOQ, then it would return
+  // ["HAB","main-detector-bank"]
+  // if main-detector-bank was selected on LOQ, then it would return
+  // ["main-detector-bank", "HAB"]
   // which means we need to assign the names to the right slots.
   QStringList detectorNames = {dets[1], dets[3]};
-  for (auto& name : detectorNames) {
-    if (name == "main-detector-bank" || name ==  "rear-detector" || name == "DetectorBench") {
+  for (auto &name : detectorNames) {
+    if (name == "main-detector-bank" || name == "rear-detector" ||
+        name == "DetectorBench") {
       output->setItemText(0, name);
     }
 

--- a/docs/source/release/v3.10.0/sans.rst
+++ b/docs/source/release/v3.10.0/sans.rst
@@ -8,6 +8,7 @@ SANS Changes
 Bug Fixes
 ---------
 - Fixed wrong first spectrum number for LARMOR. The first non-monitor spectrum number is 11, but it had been set to 10.
+- Fixed inconsistent detector selection for high-angle-bank-type detectors.
 
 |
 


### PR DESCRIPTION
Fixes #18924.

The ISIS SANS GUI had some inconsistent behaviour regarding the detector selection. The code assumed an ordering of detector selection drop-down list of:

0. LAB
1. HAB
2. BOTH
3. MERGED

which was broken by the a Python method which returns [LAB, HAB] or [HAB, LAB] depending on the current detector selection. The code then associated the first entry of the Python-returned list with index 0 in the drop down list and so on. This is wrong and seems to have been there for years. We added a more explicit name check.


## To test:

We want to compare the output of this fix with the output of an installed Mantid3.9 version, so you will need that installed on your computer. 

#### LOQ

Please find the relevant data here: smb://olympic/babylon5/Scratch/Anton/DetectorSelection/LOQ
Make sure that the data is in your path.

###### Test `main-detector-bank`

1. Open the ISIS SANS GUI
2. Select LOQ as your instrument
3. Load the user file: USER_LOQ_165B_M3_XinXpress_4mm_Changer_MAIN.txt
4. Close the ISIS SANS GUI
5. Open the ISIS SANS GUI
  * Confirm that your specified user file has been loaded
6. Switch to the Reduction Settings tab 
   * Confirm that the selected detector reads `main-detector-bank`. 
   * Confirm that  `main-detector-bank` is the first entry in the drop down list.  
7. Switch back to the Run Numbers tab and add `LOQ99335` as the sample scatter run.
8. Press `Load Data` and once the file has loaded press `1D Reduce`
9. Perform the same reduction in MantidV3.9, ie load the user file, set the sample scatter value, load it and start the reduction
10. Compare the results of the reduction (`99335main_1D_2.2_10.0`). See images below(log-log-plot):

Mantid 3.9:
![image](https://cloud.githubusercontent.com/assets/8955784/23121861/f915f7ba-f759-11e6-9137-7322cfaed5a0.png)

With Fix:
![image](https://cloud.githubusercontent.com/assets/8955784/23122767/81441862-f75d-11e6-8283-79c0ea8dc0a2.png)


Verify that your output looks the same and that the results from Mantid with and without the fix are the same.
11. Close the ISIS SANS Reduction GUI


###### Test `HAB`

1. Open the ISIS SANS GUI
2. Select LOQ as your instrument
3. Load the user file: USER_LOQ_165B_M3_XinXpress_4mm_Changer_HAB.txt
4. Close the ISIS SANS GUI
5. Open the ISIS SANS GUI
   * Confirm that your specified user file has been loaded
6. Switch to the Reduction Settings tab 
   * Confirm that the selected detector reads `HAB`. 
   * Confirm that  `HAB` is the second entry in the drop down list.  
7. Switch back to the Run Numbers tab and add `LOQ99335` as the sample scatter run.
8. Press `Load Data` and once the file has loaded press `1D Reduce`
9. Perform the same reduction in MantidV3.9, ie load the user file, set the sample scatter value, load it and start the reduction, note that the output's name will be `99335main_1D_2.2_10.0` which is part of the issue in M3.9 (you would normally expect it to be `99335hab_1D_2.2_10.0`).
10. Compare the results of the reduction (`99335hab_1D_2.2_10.0`). See images below(log-log-plot):

Mantid 3.9:
![image](https://cloud.githubusercontent.com/assets/8955784/23122827/bf4483ae-f75d-11e6-964d-438992e8bdbc.png)


With Fix:
![image](https://cloud.githubusercontent.com/assets/8955784/23122759/7b2def0c-f75d-11e6-97af-d118387d5a25.png)


Verify that your output looks the same and that the results from Mantid with and without the fix are different, especially the q range is different. With the fix the q range is  0.1125  to  1.4  as specified by the line `L/Q .1125 1.4 0.0125/lin` in the user file.
11. Close the ISIS SANS Reduction GUI


#### SANS2D

Please find the relevant data here: smb://olympic/babylon5/Scratch/Anton/DetectorSelection/SANS2D
Make sure that the data is in your path.

###### Test `rear-detector`

1. Open the ISIS SANS GUI
2. Select SANS2DTUBES as your instrument
3. Load the user file: USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_REAR.txt
4. Close the ISIS SANS GUI
5. Open the ISIS SANS GUI
   * Confirm that your specified user file has been loaded
6. Switch to the Reduction Settings tab 
   * Confirm that the selected detector reads `rear-detector`. 
   * Confirm that  `rear-detector` is the first entry in the drop down list.  
7. Switch back to the Run Numbers tab and add `SANS2D00034484` as the sample scatter run.
8. Press `Load Data` and once the file has loaded press `1D Reduce`
9. Perform the same reduction in MantidV3.9, ie load the user file, set the sample scatter value, load it and start the reduction.
10. Compare the results of the reduction (`34484rear_1D_1.75_16.5`). See images below(log-log-plot):

Mantid 3.9:
![image](https://cloud.githubusercontent.com/assets/8955784/23123006/8eff2c2a-f75e-11e6-8dd2-14119fbf5923.png)


With Fix:
![image](https://cloud.githubusercontent.com/assets/8955784/23123170/41a95594-f75f-11e6-80ad-c73452a79de6.png)

Verify that your output looks the same and that the results from Mantid with and without the fix are the same.
11. Close the ISIS SANS Reduction GUI

###### Test `front-detector`

1. Open the ISIS SANS GUI
2. Select SANS2DTUBES as your instrument
3. Load the user file: USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_FRONT.txt
4. Close the ISIS SANS GUI
5. Open the ISIS SANS GUI
   * Confirm that your specified user file has been loaded
6. Switch to the Reduction Settings tab 
   * Confirm that the selected detector reads `front-detector`. 
   * Confirm that  front-detector` is the second entry in the drop down list.  
7. Switch back to the Run Numbers tab and add `SANS2D00034484` as the sample scatter run.
8. Press `Load Data` and once the file has loaded press `1D Reduce`
9. Perform the same reduction in MantidV3.9, ie load the user file, set the sample scatter value, load it and start the reduction (the name of the workspace will be `34484rear_1D_1.75_16.5` which is part of the problem)
10. Compare the results of the reduction (`34484front_1D_1.75_16.5`). See images below(log-log-plot):

Mantid 3.9:
![image](https://cloud.githubusercontent.com/assets/8955784/23123571/c74301a4-f760-11e6-9bca-9a932c64b290.png)


With Fix:
![image](https://cloud.githubusercontent.com/assets/8955784/23123487/7860afc8-f760-11e6-9c27-ce2f0aa0b298.png)


Verify that your output looks the same and that the result from Mantid with and without the fix is not the same. Note that the q range is not selected well here, since all I did was change `Det\Rear` to `Det\Front` in an existing user file, but I didn't change `L\Q`, hence the result does not make sense but it demonstrates the difference between M3.9 and the version with the fix.
11. Close the ISIS SANS Reduction GUI


#### LARMOR

Please find the relevant data here: smb://olympic/babylon5/Scratch/Anton/DetectorSelection/LARMOR
Make sure that the data is in your path.

LARMOR has only one detector, it should not have been affected by the bug previously, nevertheless 
we make sure that everything is ok at this point.

###### Test `DetectorBench`

1. Open the ISIS SANS GUI
2. Select LARMOR as your instrument
3. Load the user file: USER_Pappas_RB1569004_163C_3DMag_12x12_r12194.txt
4. Close the ISIS SANS GUI
5. Open the ISIS SANS GUI
   * Confirm that your specified user file has been loaded
6. Switch to the Reduction Settings tab 
    * Confirm that the selected detector reads `DetectorBench`. 
    * Confirm that  `DetectorBench` is the first entry in the drop down list.  
7. Switch back to the Run Numbers tab and add `LARMOR00012311` as the sample scatter run.
8. Press `Load Data` and once the file has loaded press `1D Reduce`
9. Perform the same reduction in MantidV3.9, ie load the user file, set the sample scatter value, load it and start the reduction
10. Compare the results of the reduction (`12311rear_1D_0.9_12.5`). See images below(log-log-plot):

Mantid 3.9:
![image](https://cloud.githubusercontent.com/assets/8955784/23123842/029d10b8-f762-11e6-830b-fa5d0f0672b2.png)


With Fix:
![image](https://cloud.githubusercontent.com/assets/8955784/23123944/6d7f5eb8-f762-11e6-8d71-1bf9275fcfea.png)



Verify that your output looks the same and that the results from Mantid with and without the fix are the same. Nothing should have changed here.
11. Close the ISIS SANS Reduction GUI


### Release Notes

Please see [here](https://github.com/mantidproject/mantid/pull/18926/commits/a0bba84f80c871fd89de09e8102f80451f5fb6e9)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
