### PR TITLE
Fix sum file behaviour for vesuvio diffraction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -147,6 +147,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
         load_opts = dict()
         if self._instrument_name == 'VESUVIO':
             load_opts['Mode'] = 'FoilOut'
+            load_opts['LoadMonitors'] = True
 
         self._workspace_names, self._chopped_data = load_files(self._data_files,
                                                                self._ipf_filename,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/VesuvioDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/VesuvioDiffractionReduction.py
@@ -98,7 +98,6 @@ class VesuvioDiffractionReduction(DataProcessorAlgorithm):
         prog_reporter = Progress(self, start=0.0, end=1.0, nreports=1)
 
         prog_reporter.report("Loading Files")
-
         self._workspace_names, self._chopped_data = load_files(self._data_files,
                                                                ipf_filename=self._ipf_filename,
                                                                spec_min=self._spectra_range[0],
@@ -182,7 +181,6 @@ class VesuvioDiffractionReduction(DataProcessorAlgorithm):
         self._mode = 'diffspec'
 
         self._output_ws = self.getPropertyValue('OutputWorkspace')
-        self._data_files = self.getProperty('InputFiles').value
         self._par_filename = self.getPropertyValue('InstrumentParFile')
         self._spectra_range = self.getProperty('SpectraRange').value
         self._rebin_string = self.getPropertyValue('RebinParam')
@@ -197,17 +195,20 @@ class VesuvioDiffractionReduction(DataProcessorAlgorithm):
             self._ipf_filename = os.path.join(config['instrumentDefinition.directory'], self._ipf_filename)
         logger.information('IPF filename is: %s' % self._ipf_filename)
 
-        # Only enable sum files if we actually have more than one file
-        sum_files = self.getProperty('SumFiles').value
-        self._sum_files = False
-
-        if sum_files:
-            num_raw_files = len(self._data_files)
-            if num_raw_files > 1:
-                self._sum_files = True
-                logger.information('Summing files enabled (have %d files)' % num_raw_files)
-            else:
-                logger.information('SumFiles options is ignored when only one file is provided')
+        # Split up runs given as a range LoadVesuvio sums multiple runs on its own
+        self._sum_files = self.getProperty('SumFiles').value
+        user_input = self.getProperty('InputFiles').value
+        single_files = []
+        for run in user_input:
+            try:
+                number_generator = IntArrayProperty('array_generator', run)
+                single_files.extend(number_generator.value.tolist())
+            except RuntimeError as exc:
+                raise RuntimeError("Could not generate run numbers from '{0}': '{1}'".format(run, str(exc)))
+        # end
+        self._data_files = single_files
+        if self._sum_files and len(self._data_files) == 1:
+            logger.warning('Ignoring SumFiles=True as only one file has been provided')
 
 
 AlgorithmFactory.subscribe(VesuvioDiffractionReduction)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/VesuvioDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/VesuvioDiffractionReduction.py
@@ -92,21 +92,12 @@ class VesuvioDiffractionReduction(DataProcessorAlgorithm):
         load_opts = dict()
         load_opts['Mode'] = 'FoilOut'
         load_opts['InstrumentParFile'] = self._par_filename
-        # Load monitors as True so monitors will not be loaded separately in LoadVesuvio
+        # Tell LoadVesuvio to load the monitors and keep them in the output
         load_opts['LoadMonitors'] = True
 
         prog_reporter = Progress(self, start=0.0, end=1.0, nreports=1)
 
         prog_reporter.report("Loading Files")
-
-        # Split up runs as LoadVesuvio sums multiple runs
-        input_files = self._data_files
-        for run in input_files:
-            try:
-                number_generator = IntArrayProperty('array_generator', run)
-                self._data_files = number_generator.value.tolist()
-            except RuntimeError:
-                raise RuntimeError("Could not generate run numbers from this input: " + run)
 
         self._workspace_names, self._chopped_data = load_files(self._data_files,
                                                                ipf_filename=self._ipf_filename,
@@ -115,7 +106,7 @@ class VesuvioDiffractionReduction(DataProcessorAlgorithm):
                                                                sum_files=self._sum_files,
                                                                load_opts=load_opts)
 
-        prog_reporter.resetNumSteps(self._workspace_names.__len__(), 0.0, 1.0)
+        prog_reporter.resetNumSteps(len(self._workspace_names), 0.0, 1.0)
 
         for c_ws_name in self._workspace_names:
             is_multi_frame = isinstance(mtd[c_ws_name], WorkspaceGroup)


### PR DESCRIPTION
Description of work.

**To test:**

Requires access to the ISIS archive.

The following scripts provides a basis for testing. When `SumFiles=True` there should be a group output with a single reduced workspace. When `SumFiles=False` there should be a workspace per input run. 

```
VesuvioDiffractionReduction(InputFiles='15288,15289',
                        OutputWorkspace='DiffractionReductions',
                        SumFiles=True,
                        InstrumentParFile='IP0005.dat')
```


No issue number

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
