### PR TITLE
Extend RawFileInfo to provide sample information

### DIFF
--- a/Framework/DataHandling/src/RawFileInfo.cpp
+++ b/Framework/DataHandling/src/RawFileInfo.cpp
@@ -93,6 +93,10 @@ void RawFileInfo::init() {
                   "If this is true, the parameters from the RPB struct are "
                   "placed into a TableWorkspace called Raw_RPB",
                   Direction::Input);
+  declareProperty("GetSampleParameters", false,
+                  "If this is true, the parameters from the SPB struct are "
+                  "placed into a TableWorkspace called Raw_SPB. ",
+                  Direction::Input);
   declareProperty("RunTitle", std::string(""),
                   "The run title from the HDR struct", Direction::Output);
   declareProperty("RunHeader", std::string(""), "The run header",
@@ -176,6 +180,7 @@ void RawFileInfo::exec() {
     run_table->addColumn("str", "r_endtime");  // format HH-MM-SS
     run_table->addColumn("int", "r_prop");     // RB (proposal) number
 
+
     API::TableRow t = run_table->appendRow();
     t << isis_raw.rpb.r_dur << isis_raw.rpb.r_durunits
       << isis_raw.rpb.r_dur_freq << isis_raw.rpb.r_dmp
@@ -189,6 +194,68 @@ void RawFileInfo::exec() {
       << std::string(isis_raw.rpb.r_endtime, 8) << isis_raw.rpb.r_prop;
 
     setProperty("RunParameterTable", run_table);
+  }
+
+  bool getSampleParameters = getProperty("GetSampleParameters");
+  if (getSampleParameters) {
+      declareProperty(make_unique<WorkspaceProperty<API::ITableWorkspace>>(
+                          "SampleParameterTable", "Raw_SPB", Direction::Output),
+                      "The name of the TableWorkspace in which to store the list "
+                      "of sample parameters");
+
+      API::ITableWorkspace_sptr sample_table =
+          WorkspaceFactory::Instance().createTable("TableWorkspace");
+      sample_table->addColumn("int", "e_posn");        //< sample changer position
+      sample_table->addColumn("int", "e_type");        //< sample type (1=sample+can,2=empty can)
+      sample_table->addColumn("int","e_geom");         //< sample geometry
+      sample_table->addColumn("double", "e_thick");    //< sample thickness normal to sample (mm)
+      sample_table->addColumn("double", "e_height");   //< sample height (mm)
+      sample_table->addColumn("double","e_width");     //< sample width (mm)
+      sample_table->addColumn("double", "e_omega");    //< omega sample angle (degrees)
+      sample_table->addColumn("double", "e_chi");      //< chi sample angle (degrees)
+      sample_table->addColumn("double","e_phi");       //< phi sample angle (degrees)
+      sample_table->addColumn("double", "e_scatt");    //< scattering geometry (1=trans, 2 =reflect)
+      sample_table->addColumn("double", "e_xscatt");   //< sample coherent scattering cross section (barn)
+      sample_table->addColumn("double","samp_cs_inc"); //< sample incoherent cross section
+      sample_table->addColumn("double", "samp_cs_abs");//< sample absorption cross section
+      sample_table->addColumn("double", "e_dens");     //< sample number density (atoms.A-3)
+      sample_table->addColumn("double","e_canthick");  //< can wall thickness (mm)
+      sample_table->addColumn("double", "e_canxsect"); //< can coherent scattering cross section (barn)
+      sample_table->addColumn("double", "can_cs_inc"); //< dunno
+      sample_table->addColumn("double","can_cs_abs");  //< dunno
+      sample_table->addColumn("double", "can_nd");     //< can number density (atoms.A-3)
+      sample_table->addColumn("str", "e_name");        //< sample name of chemical formula
+      sample_table->addColumn("int","e_equip");        //< dunno
+      sample_table->addColumn("int","e_eqname");       //< dunno
+
+      const int nameLength = static_cast<int>(strlen(isis_raw.spb.e_name));
+      std::string name(isis_raw.spb.e_name, nameLength);
+
+      API::TableRow t = sample_table->appendRow();
+      t << isis_raw.spb.e_posn
+        << isis_raw.spb.e_type
+        << isis_raw.spb.e_geom
+        << static_cast<double>(isis_raw.spb.e_thick)
+        << static_cast<double>(isis_raw.spb.e_height)
+        << static_cast<double>(isis_raw.spb.e_width)
+        << static_cast<double>(isis_raw.spb.e_omega)
+        << static_cast<double>(isis_raw.spb.e_chi)
+        << static_cast<double>(isis_raw.spb.e_phi)
+        << static_cast<double>(isis_raw.spb.e_scatt)
+        << static_cast<double>(isis_raw.spb.e_xscatt)
+        << static_cast<double>(isis_raw.spb.samp_cs_inc)
+        << static_cast<double>(isis_raw.spb.samp_cs_abs)
+        << static_cast<double>(isis_raw.spb.e_dens)
+        << static_cast<double>(isis_raw.spb.e_canthick)
+        << static_cast<double>(isis_raw.spb.e_canxsect)
+        << static_cast<double>(isis_raw.spb.can_cs_inc)
+        << static_cast<double>(isis_raw.spb.can_cs_abs)
+        << static_cast<double>(isis_raw.spb.can_nd)
+        << name
+        << isis_raw.spb.e_equip
+        << isis_raw.spb.e_eqname;
+
+      setProperty("SampleParameterTable", sample_table);
   }
 
   // This is not going to be a slow algorithm

--- a/Framework/DataHandling/src/RawFileInfo.cpp
+++ b/Framework/DataHandling/src/RawFileInfo.cpp
@@ -180,7 +180,6 @@ void RawFileInfo::exec() {
     run_table->addColumn("str", "r_endtime");  // format HH-MM-SS
     run_table->addColumn("int", "r_prop");     // RB (proposal) number
 
-
     API::TableRow t = run_table->appendRow();
     t << isis_raw.rpb.r_dur << isis_raw.rpb.r_durunits
       << isis_raw.rpb.r_dur_freq << isis_raw.rpb.r_dmp
@@ -198,64 +197,73 @@ void RawFileInfo::exec() {
 
   bool getSampleParameters = getProperty("GetSampleParameters");
   if (getSampleParameters) {
-      declareProperty(make_unique<WorkspaceProperty<API::ITableWorkspace>>(
-                          "SampleParameterTable", "Raw_SPB", Direction::Output),
-                      "The name of the TableWorkspace in which to store the list "
-                      "of sample parameters");
+    declareProperty(make_unique<WorkspaceProperty<API::ITableWorkspace>>(
+                        "SampleParameterTable", "Raw_SPB", Direction::Output),
+                    "The name of the TableWorkspace in which to store the list "
+                    "of sample parameters");
 
-      API::ITableWorkspace_sptr sample_table =
-          WorkspaceFactory::Instance().createTable("TableWorkspace");
-      sample_table->addColumn("int", "e_posn");        //< sample changer position
-      sample_table->addColumn("int", "e_type");        //< sample type (1=sample+can,2=empty can)
-      sample_table->addColumn("int","e_geom");         //< sample geometry
-      sample_table->addColumn("double", "e_thick");    //< sample thickness normal to sample (mm)
-      sample_table->addColumn("double", "e_height");   //< sample height (mm)
-      sample_table->addColumn("double","e_width");     //< sample width (mm)
-      sample_table->addColumn("double", "e_omega");    //< omega sample angle (degrees)
-      sample_table->addColumn("double", "e_chi");      //< chi sample angle (degrees)
-      sample_table->addColumn("double","e_phi");       //< phi sample angle (degrees)
-      sample_table->addColumn("double", "e_scatt");    //< scattering geometry (1=trans, 2 =reflect)
-      sample_table->addColumn("double", "e_xscatt");   //< sample coherent scattering cross section (barn)
-      sample_table->addColumn("double","samp_cs_inc"); //< sample incoherent cross section
-      sample_table->addColumn("double", "samp_cs_abs");//< sample absorption cross section
-      sample_table->addColumn("double", "e_dens");     //< sample number density (atoms.A-3)
-      sample_table->addColumn("double","e_canthick");  //< can wall thickness (mm)
-      sample_table->addColumn("double", "e_canxsect"); //< can coherent scattering cross section (barn)
-      sample_table->addColumn("double", "can_cs_inc"); //< dunno
-      sample_table->addColumn("double","can_cs_abs");  //< dunno
-      sample_table->addColumn("double", "can_nd");     //< can number density (atoms.A-3)
-      sample_table->addColumn("str", "e_name");        //< sample name of chemical formula
-      sample_table->addColumn("int","e_equip");        //< dunno
-      sample_table->addColumn("int","e_eqname");       //< dunno
+    API::ITableWorkspace_sptr sample_table =
+        WorkspaceFactory::Instance().createTable("TableWorkspace");
+    sample_table->addColumn("int", "e_posn"); //< sample changer position
+    sample_table->addColumn(
+        "int", "e_type"); //< sample type (1=sample+can,2=empty can)
+    sample_table->addColumn("int", "e_geom"); //< sample geometry
+    sample_table->addColumn(
+        "double", "e_thick"); //< sample thickness normal to sample (mm)
+    sample_table->addColumn("double", "e_height"); //< sample height (mm)
+    sample_table->addColumn("double", "e_width");  //< sample width (mm)
+    sample_table->addColumn("double",
+                            "e_omega");         //< omega sample angle (degrees)
+    sample_table->addColumn("double", "e_chi"); //< chi sample angle (degrees)
+    sample_table->addColumn("double", "e_phi"); //< phi sample angle (degrees)
+    sample_table->addColumn(
+        "double", "e_scatt"); //< scattering geometry (1=trans, 2 =reflect)
+    sample_table->addColumn(
+        "double",
+        "e_xscatt"); //< sample coherent scattering cross section (barn)
+    sample_table->addColumn("double",
+                            "samp_cs_inc"); //< sample incoherent cross section
+    sample_table->addColumn("double",
+                            "samp_cs_abs"); //< sample absorption cross section
+    sample_table->addColumn("double",
+                            "e_dens"); //< sample number density (atoms.A-3)
+    sample_table->addColumn("double", "e_canthick"); //< can wall thickness (mm)
+    sample_table->addColumn(
+        "double",
+        "e_canxsect"); //< can coherent scattering cross section (barn)
+    sample_table->addColumn("double", "can_cs_inc"); //< dunno
+    sample_table->addColumn("double", "can_cs_abs"); //< dunno
+    sample_table->addColumn("double",
+                            "can_nd"); //< can number density (atoms.A-3)
+    sample_table->addColumn("str",
+                            "e_name"); //< sample name of chemical formula
+    sample_table->addColumn("int", "e_equip");  //< dunno
+    sample_table->addColumn("int", "e_eqname"); //< dunno
 
-      const int nameLength = static_cast<int>(strlen(isis_raw.spb.e_name));
-      std::string name(isis_raw.spb.e_name, nameLength);
+    const auto nameLength = static_cast<int>(strlen(isis_raw.spb.e_name));
+    std::string name(isis_raw.spb.e_name, nameLength);
 
-      API::TableRow t = sample_table->appendRow();
-      t << isis_raw.spb.e_posn
-        << isis_raw.spb.e_type
-        << isis_raw.spb.e_geom
-        << static_cast<double>(isis_raw.spb.e_thick)
-        << static_cast<double>(isis_raw.spb.e_height)
-        << static_cast<double>(isis_raw.spb.e_width)
-        << static_cast<double>(isis_raw.spb.e_omega)
-        << static_cast<double>(isis_raw.spb.e_chi)
-        << static_cast<double>(isis_raw.spb.e_phi)
-        << static_cast<double>(isis_raw.spb.e_scatt)
-        << static_cast<double>(isis_raw.spb.e_xscatt)
-        << static_cast<double>(isis_raw.spb.samp_cs_inc)
-        << static_cast<double>(isis_raw.spb.samp_cs_abs)
-        << static_cast<double>(isis_raw.spb.e_dens)
-        << static_cast<double>(isis_raw.spb.e_canthick)
-        << static_cast<double>(isis_raw.spb.e_canxsect)
-        << static_cast<double>(isis_raw.spb.can_cs_inc)
-        << static_cast<double>(isis_raw.spb.can_cs_abs)
-        << static_cast<double>(isis_raw.spb.can_nd)
-        << name
-        << isis_raw.spb.e_equip
-        << isis_raw.spb.e_eqname;
+    API::TableRow t = sample_table->appendRow();
+    t << isis_raw.spb.e_posn << isis_raw.spb.e_type << isis_raw.spb.e_geom
+      << static_cast<double>(isis_raw.spb.e_thick)
+      << static_cast<double>(isis_raw.spb.e_height)
+      << static_cast<double>(isis_raw.spb.e_width)
+      << static_cast<double>(isis_raw.spb.e_omega)
+      << static_cast<double>(isis_raw.spb.e_chi)
+      << static_cast<double>(isis_raw.spb.e_phi)
+      << static_cast<double>(isis_raw.spb.e_scatt)
+      << static_cast<double>(isis_raw.spb.e_xscatt)
+      << static_cast<double>(isis_raw.spb.samp_cs_inc)
+      << static_cast<double>(isis_raw.spb.samp_cs_abs)
+      << static_cast<double>(isis_raw.spb.e_dens)
+      << static_cast<double>(isis_raw.spb.e_canthick)
+      << static_cast<double>(isis_raw.spb.e_canxsect)
+      << static_cast<double>(isis_raw.spb.can_cs_inc)
+      << static_cast<double>(isis_raw.spb.can_cs_abs)
+      << static_cast<double>(isis_raw.spb.can_nd) << name
+      << isis_raw.spb.e_equip << isis_raw.spb.e_eqname;
 
-      setProperty("SampleParameterTable", sample_table);
+    setProperty("SampleParameterTable", sample_table);
   }
 
   // This is not going to be a slow algorithm

--- a/Framework/DataHandling/test/RawFileInfoTest.h
+++ b/Framework/DataHandling/test/RawFileInfoTest.h
@@ -109,15 +109,15 @@ private:
 
       // Sample thickness
       double e_thick = sample_table->getRef<double>("e_thick", 0);
-      TS_ASSERT_EQUALS(e_thick, 1);
+      TS_ASSERT_EQUALS(e_thick, 2.);
 
       // Sample height
       double e_height = sample_table->getRef<double>("e_height", 0);
-      TS_ASSERT_EQUALS(e_height, 1);
+      TS_ASSERT_EQUALS(e_height, 8.);
 
       // Sample width
       double e_width = sample_table->getRef<double>("e_width", 0);
-      TS_ASSERT_EQUALS(e_width, 1);
+      TS_ASSERT_EQUALS(e_width, 8.);
 
       // Tidy up
       Mantid::API::AnalysisDataService::Instance().remove("Raw_SPB");

--- a/Framework/DataHandling/test/RawFileInfoTest.h
+++ b/Framework/DataHandling/test/RawFileInfoTest.h
@@ -21,11 +21,11 @@ public:
 
   void testGetRunParameters() { runTest(true); }
 
-  void testGetSampleParameters() {runTest(false, true); }
+  void testGetSampleParameters() { runTest(false, true); }
 
 private:
   // Check the parameters are correct
-  void runTest(bool tableToExist, bool getSampleParameters=false) {
+  void runTest(bool tableToExist, bool getSampleParameters = false) {
     RawFileInfo alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT_EQUALS(alg.isInitialized(), true);
@@ -91,7 +91,8 @@ private:
     }
 
     if (getSampleParameters) {
-      Mantid::API::Workspace_sptr workspace = Mantid::API::AnalysisDataService::Instance().retrieve("Raw_SPB");
+      Mantid::API::Workspace_sptr workspace =
+          Mantid::API::AnalysisDataService::Instance().retrieve("Raw_SPB");
       TS_ASSERT(workspace.get());
 
       Mantid::API::ITableWorkspace_sptr sample_table =

--- a/Framework/DataHandling/test/RawFileInfoTest.h
+++ b/Framework/DataHandling/test/RawFileInfoTest.h
@@ -21,9 +21,11 @@ public:
 
   void testGetRunParameters() { runTest(true); }
 
+  void testGetSampleParameters() {runTest(false, true); }
+
 private:
   // Check the parameters are correct
-  void runTest(bool tableToExist) {
+  void runTest(bool tableToExist, bool getSampleParameters=false) {
     RawFileInfo alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT_EQUALS(alg.isInitialized(), true);
@@ -32,6 +34,10 @@ private:
     alg.setPropertyValue("Filename", m_filetotest);
     if (tableToExist) {
       alg.setPropertyValue("GetRunParameters", "1");
+    }
+
+    if (getSampleParameters) {
+      alg.setPropertyValue("GetSampleParameters", "1");
     }
 
     TS_ASSERT_THROWS_NOTHING(alg.execute());
@@ -82,6 +88,10 @@ private:
 
       // Tidy up
       Mantid::API::AnalysisDataService::Instance().remove("Raw_RPB");
+    }
+
+    if (getSampleParameters) {
+      Mantid::API::Workspace_sptr workspace = Mantid::API::AnalysisDataService::Instance().retrieve("Raw_SPB");
     }
   }
 

--- a/Framework/DataHandling/test/RawFileInfoTest.h
+++ b/Framework/DataHandling/test/RawFileInfoTest.h
@@ -92,6 +92,34 @@ private:
 
     if (getSampleParameters) {
       Mantid::API::Workspace_sptr workspace = Mantid::API::AnalysisDataService::Instance().retrieve("Raw_SPB");
+      TS_ASSERT(workspace.get());
+
+      Mantid::API::ITableWorkspace_sptr sample_table =
+          boost::dynamic_pointer_cast<Mantid::API::ITableWorkspace>(workspace);
+      TS_ASSERT(sample_table.get());
+
+      // Sample type
+      int e_type = sample_table->getRef<int>("e_type", 0);
+      TS_ASSERT_EQUALS(e_type, 1);
+
+      // Sample geometry
+      int e_geom = sample_table->getRef<int>("e_geom", 0);
+      TS_ASSERT_EQUALS(e_geom, 3);
+
+      // Sample thickness
+      double e_thick = sample_table->getRef<double>("e_thick", 0);
+      TS_ASSERT_EQUALS(e_thick, 1);
+
+      // Sample height
+      double e_height = sample_table->getRef<double>("e_height", 0);
+      TS_ASSERT_EQUALS(e_height, 1);
+
+      // Sample width
+      double e_width = sample_table->getRef<double>("e_width", 0);
+      TS_ASSERT_EQUALS(e_width, 1);
+
+      // Tidy up
+      Mantid::API::AnalysisDataService::Instance().remove("Raw_SPB");
     }
   }
 

--- a/docs/source/algorithms/RawFileInfo-v1.rst
+++ b/docs/source/algorithms/RawFileInfo-v1.rst
@@ -13,7 +13,10 @@ Extracts run parameters from the :ref:`RAW <Raw File>` file given as an
 input property. If the ``GetRunParameters`` argument is ``True`` then a
 `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__ is created that contains a 
 column for each value of the ``RPB_STRUCT``, i.e. column names such as ``r_dur``, ``r_goodfrm``
-etc. This is Mantid's version of the ``Get`` routine in `Open Genie <http://www.opengenie.org/>`__.
+etc. If the ``GetSampleParameters`` argument is ``True`` then a 
+`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__ is created that contains a 
+column for each value of the ``SPB_STRUCT``, i.e. column names such as ``e_geom``, ``e_width``, etc.
+This is Mantid's version of the ``Get`` routine in `Open Genie <http://www.opengenie.org/>`__.
 
 .. categories::
 

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -14,7 +14,7 @@ New
 
 Improved
 ########
-
+- :ref`RawFileInfo <algm-RawFileInfo-v1>` now provides sample information.
 
 Deprecated
 ##########


### PR DESCRIPTION
This PR allows the user to retrieve sample information from a raw file object. The sample information is provided as a table workspace. This is consistent with the way that run information is exposed.

Fixes #18930.

### For Testing:

1. Open Mantid
2. Select `RawFileInfo`
3. Enable `GetRunParameters`
4. Set the file to `SANS2D00000989.raw`
5. Press `Run`
   * Confirm that a table workspace with the name `Raw_RBP` was created. This is how the behaviour used to be
6. Enable `GetSampleParameters`
7. Press `Run`
   * Confirm that a table workspace with the name `Raw_SBP` was created. This is new. 
   * Confirm that  `e_geom` is 1, `e_width`is 8, `e_thick` is 1, `e_height` is 8. Note that `e_name` has no entry for this particular workspace.


### Release notes:

See [here](https://github.com/mantidproject/mantid/pull/18932/commits/63bc56085c26641828351b72097932014dacc030)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
