### PR TITLE
Indirect>Corrections, Indirect>Analysis :: forbid group workspaces

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>803</width>
-    <height>643</height>
+    <height>689</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -53,6 +53,9 @@
         <property name="showLoad" stdset="0">
          <bool>false</bool>
         </property>
+        <property name="ShowGroups" stdset="0">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item row="0" column="0">
@@ -89,6 +92,9 @@
          </stringlist>
         </property>
         <property name="showLoad" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="ShowGroups" stdset="0">
          <bool>false</bool>
         </property>
        </widget>
@@ -151,7 +157,16 @@
         </property>
         <widget class="QWidget" name="pgAbsCorFlatPlate">
          <layout class="QGridLayout" name="loFlatPlate">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item row="1" column="3">
@@ -280,7 +295,16 @@
         </widget>
         <widget class="QWidget" name="pgAbsCorAnnulus">
          <layout class="QGridLayout" name="loAnnulus">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item row="1" column="0">
@@ -399,7 +423,16 @@
         </widget>
         <widget class="QWidget" name="pgAbsCorCylinder">
          <layout class="QGridLayout" name="loCylinder">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item row="0" column="3">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
@@ -46,6 +46,9 @@
         <property name="showLoad" stdset="0">
          <bool>false</bool>
         </property>
+        <property name="ShowGroups" stdset="0">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
      </layout>
@@ -179,6 +182,9 @@
          </stringlist>
         </property>
         <property name="showLoad" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="ShowGroups" stdset="0">
          <bool>false</bool>
         </property>
        </widget>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalculatePaalmanPings.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalculatePaalmanPings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>661</width>
-    <height>462</height>
+    <height>507</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,6 +49,9 @@
         <property name="showLoad" stdset="0">
          <bool>false</bool>
         </property>
+        <property name="ShowGroups" stdset="0">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item row="1" column="0">
@@ -82,6 +85,9 @@
          </stringlist>
         </property>
         <property name="showLoad" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="ShowGroups" stdset="0">
          <bool>false</bool>
         </property>
        </widget>
@@ -145,7 +151,16 @@
         </property>
         <widget class="QWidget" name="pgFlatPlate">
          <layout class="QGridLayout" name="gridLayout_2">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item row="0" column="2">
@@ -238,7 +253,16 @@
         </widget>
         <widget class="QWidget" name="pgCylinder">
          <layout class="QGridLayout" name="gridLayout_4">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item row="5" column="3">
@@ -345,7 +369,16 @@
         </widget>
         <widget class="QWidget" name="pgAnnulus">
          <layout class="QGridLayout" name="gridLayout_5">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item row="5" column="3">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>420</width>
+    <width>433</width>
     <height>420</height>
    </rect>
   </property>
@@ -72,6 +72,9 @@
         <property name="showLoad" stdset="0">
          <bool>false</bool>
         </property>
+        <property name="ShowGroups" stdset="0">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item row="1" column="1">
@@ -98,6 +101,9 @@
          </stringlist>
         </property>
         <property name="showLoad" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="ShowGroups" stdset="0">
          <bool>false</bool>
         </property>
        </widget>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>617</width>
-    <height>284</height>
+    <width>704</width>
+    <height>335</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -74,6 +74,9 @@
         <property name="showLoad" stdset="0">
          <bool>false</bool>
         </property>
+        <property name="ShowGroups" stdset="0">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item row="1" column="1" colspan="2">
@@ -102,6 +105,9 @@
          </stringlist>
         </property>
         <property name="showLoad" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="ShowGroups" stdset="0">
          <bool>false</bool>
         </property>
        </widget>
@@ -153,19 +159,19 @@
              </item>
              <item>
               <property name="text">
-                <string>ElasticDiffSphere</string>
+               <string>ElasticDiffSphere</string>
               </property>
              </item>
              <item>
               <property name="text">
-                <string>ElasticDiffRotDiscreteCircle</string>
+               <string>ElasticDiffRotDiscreteCircle</string>
               </property>
              </item>
-              <item>
-                <property name="text">
-                  <string>StretchedExpFT</string>
-                </property>
-              </item>
+             <item>
+              <property name="text">
+               <string>StretchedExpFT</string>
+              </property>
+             </item>
             </widget>
            </item>
           </layout>
@@ -290,13 +296,13 @@
            </property>
           </spacer>
          </item>
-          <item>
-            <widget class="QPushButton" name="pbPlotPreview">
-              <property name="text">
-                <string>Plot Current Preview</string>
-              </property>
-            </widget>
-          </item>
+         <item>
+          <widget class="QPushButton" name="pbPlotPreview">
+           <property name="text">
+            <string>Plot Current Preview</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>
@@ -417,12 +423,12 @@
       </item>
       <item>
        <widget class="QPushButton" name="pbPlot">
-         <property name="text">
-           <string>Plot</string>
-         </property>
-         <property name="enabled">
-           <bool>false</bool>
-         </property>
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Plot</string>
+        </property>
        </widget>
       </item>
       <item>
@@ -440,11 +446,11 @@
       </item>
       <item>
        <widget class="QPushButton" name="pbSave">
-        <property name="text">
-          <string>Save</string>
-        </property>
         <property name="enabled">
-          <bool>false</bool>
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Save</string>
         </property>
        </widget>
       </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.ui
@@ -72,6 +72,9 @@
         <property name="showLoad" stdset="0">
          <bool>false</bool>
         </property>
+        <property name="ShowGroups" stdset="0">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item row="2" column="1" colspan="2">
@@ -100,6 +103,9 @@
          </stringlist>
         </property>
         <property name="showLoad" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="ShowGroups" stdset="0">
          <bool>false</bool>
         </property>
        </widget>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.ui
@@ -44,6 +44,9 @@
         <property name="showLoad" stdset="0">
          <bool>false</bool>
         </property>
+        <property name="ShowGroups" stdset="0">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
      </layout>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
@@ -44,6 +44,9 @@
          <string>_Result.nxs</string>
         </stringlist>
        </property>
+       <property name="ShowGroups" stdset="0">
+        <bool>false</bool>
+       </property>
       </widget>
      </item>
      <item row="1" column="3">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/MSDFit.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/MSDFit.ui
@@ -41,6 +41,9 @@
         <property name="showLoad" stdset="0">
          <bool>false</bool>
         </property>
+        <property name="ShowGroups" stdset="0">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
      </layout>

--- a/docs/source/interfaces/Indirect_Corrections.rst
+++ b/docs/source/interfaces/Indirect_Corrections.rst
@@ -14,6 +14,8 @@ Overview
 Provides correction routines for quasielastic, inelastic and diffraction
 reductions.
 
+These interfaces do not support GroupWorkspace as input.
+
 Action Buttons
 ~~~~~~~~~~~~~~
 

--- a/docs/source/interfaces/Indirect_DataAnalysis.rst
+++ b/docs/source/interfaces/Indirect_DataAnalysis.rst
@@ -21,6 +21,8 @@ Reduction interface or using :math:`S(Q, \omega)` files (*_sqw.nxs*) and
 workspaces (*_sqw*) created using either the Indirect Data Reduction interface or
 taken from a bespoke algorithm or auto reduction.
 
+These interfaces do not support GroupWorkspace as input.
+
 Action Buttons
 ~~~~~~~~~~~~~~
 

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -40,6 +40,11 @@ Scripting Window
 Documentation
 #############
 
+Custom Interfaces
+#################
+
+Indirect > Corrections and Indirect > Analysis interfaces have been configured to not to accept GroupWorkspace as input.
+
 Bugs Resolved
 -------------
 


### PR DESCRIPTION
This PR merely configures the workspace selectors in the above mentioned custom interfaces to not to accept GroupWorkspace as input. The algorithms behind are not supposed to operate over the groups. Because of mishandling, the selection of groups was causing mantid to crash as shown in the issue.

**To test:**

Pick this if you are familiar with those interfaces and have some relevant files/workspaces ready.

1. Make sure that they work as before if workspaces are given.
2. Repeat the steps in the issue, and make sure that it is not possible anymore to select the WorkspaceGroup.
3. Test also the other tabs similarly.

<!-- Instructions for testing. -->

Fixes #18792 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.