### PR TITLE
Fix SpecularReflectionPositionCorrect2 crash when invalid detector or sample name is entered

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionPositionCorrect2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionPositionCorrect2.h
@@ -42,6 +42,7 @@ public:
   const std::string category() const override;
 
 private:
+  std::map<std::string, std::string> validateInputs() override;
   void init() override;
   void exec() override;
 };

--- a/Framework/Algorithms/src/SpecularReflectionPositionCorrect2.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionPositionCorrect2.cpp
@@ -73,6 +73,29 @@ void SpecularReflectionPositionCorrect2::init() {
       "An output workspace.");
 }
 
+/** Validate inputs
+*/
+std::map<std::string, std::string>
+SpecularReflectionPositionCorrect2::validateInputs() {
+
+  std::map<std::string, std::string> results;
+
+  MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
+  auto inst = inputWS->getInstrument();
+
+  // Detector
+  const std::string detectorName = getProperty("DetectorComponentName");
+  if (!inst->getComponentByName(detectorName))
+    results["DetectorComponentName"] = "Detector component not found.";
+
+  // Sample
+  const std::string sampleName = getProperty("SampleComponentName");
+  if (!inst->getComponentByName(sampleName))
+    results["SampleComponentName"] = "Sample component not found.";
+
+  return results;
+}
+
 //----------------------------------------------------------------------------------------------
 /** Execute the algorithm.
 */

--- a/Framework/Algorithms/test/SpecularReflectionPositionCorrect2Test.h
+++ b/Framework/Algorithms/test/SpecularReflectionPositionCorrect2Test.h
@@ -77,6 +77,29 @@ public:
     TS_ASSERT_THROWS_ANYTHING(alg.execute());
   }
 
+  void test_detector_component_is_valid() {
+    SpecularReflectionPositionCorrect2 alg;
+    alg.initialize();
+    alg.setChild(true);
+    alg.setProperty("InputWorkspace", m_interWS);
+    alg.setProperty("DetectorComponentName", "invalid-detector-name");
+    alg.setProperty("TwoTheta", 1.4);
+    alg.setPropertyValue("OutputWorkspace", "test_out");
+    TS_ASSERT_THROWS_ANYTHING(alg.execute());
+  }
+
+  void test_sample_component_is_valid() {
+    SpecularReflectionPositionCorrect2 alg;
+    alg.initialize();
+    alg.setChild(true);
+    alg.setProperty("InputWorkspace", m_interWS);
+    alg.setProperty("DetectorComponentName", "point-detector");
+    alg.setProperty("SampleComponentName", "invalid-sample-name");
+    alg.setProperty("TwoTheta", 1.4);
+    alg.setPropertyValue("OutputWorkspace", "test_out");
+    TS_ASSERT_THROWS_ANYTHING(alg.execute());
+  }
+
   void test_correct_point_detector() {
     SpecularReflectionPositionCorrect2 alg;
     alg.initialize();

--- a/docs/source/release/v3.10.0/reflectometry.rst
+++ b/docs/source/release/v3.10.0/reflectometry.rst
@@ -5,6 +5,12 @@ Reflectometry Changes
 .. contents:: Table of Contents
    :local:
 
+Algorithms
+----------
+
+* :ref:`algm-SpecularReflectionPositionCorrect2 <algm-SpecularReflectionPositionCorrect2> - fixed a bug where entering
+  an invalid detector or sample name would cause a segmentation fault.
+
 ConvertToReflectometryQ
 -----------------------
 


### PR DESCRIPTION
This fixes a bug where a segmentation fault occurs if an invalid `DetectorComponentName` or `SampleComponentName` is supplied to the algorithm. It will now give an error when this is done instead.

**To test:**

- Code review.
- Unit tests have been added to check for invalid detector/sample names, ensure they pass.
- To manually check, run the following two scripts which should throw an error respectively for invalid detector and sample names, rather than a segmentation fault:
```
inter = Load(Filename='INTER13460')
inter_new = SpecularReflectionPositionCorrect(inter, TwoTheta = 2*0.49, DetectorComponentName='invalid-detector-name')
```
```
inter = Load(Filename='INTER13460')
inter_new = SpecularReflectionPositionCorrect(inter, TwoTheta = 2*0.49, DetectorComponentName='point-detector', SampleComponentName='invalid-sample-name')
```

Fixes #18905.

*Release notes have been updated.*

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
