### PR TITLE
Send error notifications for parent algorithms

### DIFF
--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1200,8 +1200,24 @@ bool Algorithm::doCallProcessGroups(Mantid::Kernel::DateAndTime &startTime) {
   startTime = Mantid::Kernel::DateAndTime::getCurrentTime();
   // Start a timer
   Timer timer;
-  // Call the concrete algorithm's processGroups method
-  const bool completed = processGroups();
+
+  bool completed = false;
+  try {
+    // Call the concrete algorithm's processGroups method
+    completed = processGroups();
+  } catch (std::exception &ex) {
+    // The child algorithm will already have logged the error etc.,
+    // but we also need to update flags in the parent algorithm and
+    // send an ErrorNotification (because the child isn't registered with the
+    // AlgorithmMonitor).
+    setExecuted(false);
+    m_runningAsync = false;
+    m_running = false;
+    notificationCenter().postNotification(
+        new ErrorNotification(this, ex.what()));
+    throw;
+  }
+
   // Check for a cancellation request in case the concrete algorithm doesn't
   interruption_point();
 

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1216,6 +1216,13 @@ bool Algorithm::doCallProcessGroups(Mantid::Kernel::DateAndTime &startTime) {
     notificationCenter().postNotification(
         new ErrorNotification(this, ex.what()));
     throw;
+  } catch (...) {
+    setExecuted(false);
+    m_runningAsync = false;
+    m_running = false;
+    notificationCenter().postNotification(new ErrorNotification(
+        this, "UNKNOWN Exception caught from processGroups"));
+    throw;
   }
 
   // Check for a cancellation request in case the concrete algorithm doesn't

--- a/Framework/API/test/AsynchronousTest.h
+++ b/Framework/API/test/AsynchronousTest.h
@@ -5,6 +5,7 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidTestHelpers/FakeObjects.h"
 #include <Poco/ActiveResult.h>
 #include <Poco/NObserver.h>
@@ -18,9 +19,9 @@ using namespace std;
 
 class AsyncAlgorithm : public Algorithm {
 public:
-  AsyncAlgorithm() : Algorithm(), throw_exception(false), result(0) {}
+  AsyncAlgorithm() : Algorithm(), result(0), throw_exception(false) {}
   AsyncAlgorithm(const bool throw_default)
-      : Algorithm(), throw_exception(throw_default), result(0) {}
+      : Algorithm(), result(0), throw_exception(throw_default) {}
   ~AsyncAlgorithm() override {}
   const std::string name() const override {
     return "AsyncAlgorithm";
@@ -34,7 +35,7 @@ public:
   const std::string summary() const override { return "Test summary"; }
 
   void init() override {
-    declareProperty(std::make_unique<WorkspaceProperty<>>(
+    declareProperty(Kernel::make_unique<WorkspaceProperty<>>(
         "InputWorkspace", "", Direction::Input, PropertyMode::Optional));
   }
 

--- a/Framework/API/test/AsynchronousTest.h
+++ b/Framework/API/test/AsynchronousTest.h
@@ -88,43 +88,6 @@ public:
         m_progressObserver(*this, &AsynchronousTest::handleProgress), count(0) {
   }
 
-  Poco::NObserver<AsynchronousTest, Mantid::API::Algorithm::StartedNotification>
-      m_startedObserver;
-  bool startedNotificationReseived;
-  void handleStarted(
-      const Poco::AutoPtr<Mantid::API::Algorithm::StartedNotification> &) {
-    startedNotificationReseived = true;
-  }
-
-  Poco::NObserver<AsynchronousTest,
-                  Mantid::API::Algorithm::FinishedNotification>
-      m_finishedObserver;
-  bool finishedNotificationReseived;
-  void handleFinished(
-      const Poco::AutoPtr<Mantid::API::Algorithm::FinishedNotification> &) {
-    finishedNotificationReseived = true;
-  }
-
-  Poco::NObserver<AsynchronousTest, Mantid::API::Algorithm::ErrorNotification>
-      m_errorObserver;
-  bool errorNotificationReseived;
-  std::string errorNotificationMessage;
-  void handleError(
-      const Poco::AutoPtr<Mantid::API::Algorithm::ErrorNotification> &pNf) {
-    errorNotificationReseived = true;
-    errorNotificationMessage = pNf->what;
-  }
-
-  Poco::NObserver<AsynchronousTest,
-                  Mantid::API::Algorithm::ProgressNotification>
-      m_progressObserver;
-  int count;
-  void handleProgress(
-      const Poco::AutoPtr<Mantid::API::Algorithm::ProgressNotification> &pNf) {
-    count++;
-    TS_ASSERT_LESS_THAN(pNf->progress, 1.000001)
-  }
-
   void testExecution() {
     AsyncAlgorithm alg;
     setupTest(alg);
@@ -204,6 +167,43 @@ public:
   }
 
 private:
+  Poco::NObserver<AsynchronousTest, Mantid::API::Algorithm::StartedNotification>
+      m_startedObserver;
+  bool startedNotificationReseived;
+  void handleStarted(
+      const Poco::AutoPtr<Mantid::API::Algorithm::StartedNotification> &) {
+    startedNotificationReseived = true;
+  }
+
+  Poco::NObserver<AsynchronousTest,
+                  Mantid::API::Algorithm::FinishedNotification>
+      m_finishedObserver;
+  bool finishedNotificationReseived;
+  void handleFinished(
+      const Poco::AutoPtr<Mantid::API::Algorithm::FinishedNotification> &) {
+    finishedNotificationReseived = true;
+  }
+
+  Poco::NObserver<AsynchronousTest, Mantid::API::Algorithm::ErrorNotification>
+      m_errorObserver;
+  bool errorNotificationReseived;
+  std::string errorNotificationMessage;
+  void handleError(
+      const Poco::AutoPtr<Mantid::API::Algorithm::ErrorNotification> &pNf) {
+    errorNotificationReseived = true;
+    errorNotificationMessage = pNf->what;
+  }
+
+  Poco::NObserver<AsynchronousTest,
+                  Mantid::API::Algorithm::ProgressNotification>
+      m_progressObserver;
+  int count;
+  void handleProgress(
+      const Poco::AutoPtr<Mantid::API::Algorithm::ProgressNotification> &pNf) {
+    count++;
+    TS_ASSERT_LESS_THAN(pNf->progress, 1.000001)
+  }
+
   WorkspaceGroup_sptr makeGroupWorkspace() {
     boost::shared_ptr<WorkspaceTester> ws0 =
         boost::make_shared<WorkspaceTester>();

--- a/Framework/API/test/AsynchronousTest.h
+++ b/Framework/API/test/AsynchronousTest.h
@@ -15,7 +15,9 @@ using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace std;
 
-#define NofLoops 10
+namespace {
+constexpr int NO_OF_LOOPS = 10;
+}
 
 class AsyncAlgorithm : public Algorithm {
 public:
@@ -41,13 +43,13 @@ public:
 
   void exec() override {
     Poco::Thread *thr = Poco::Thread::current();
-    for (int i = 0; i < NofLoops; i++) {
+    for (int i = 0; i < NO_OF_LOOPS; i++) {
       result = i;
       if (thr)
         thr->sleep(1);
-      progress(double(i) / NofLoops); // send progress notification
-      interruption_point();           // check for a termination request
-      if (throw_exception && i == NofLoops / 2)
+      progress(double(i) / NO_OF_LOOPS); // send progress notification
+      interruption_point();              // check for a termination request
+      if (throw_exception && i == NO_OF_LOOPS / 2)
         throw std::runtime_error("Exception thrown");
     }
   }
@@ -97,8 +99,8 @@ public:
     result.wait();
     generalChecks(alg, true, true, true, false);
     TS_ASSERT(result.available())
-    TS_ASSERT_EQUALS(count, NofLoops)
-    TS_ASSERT_EQUALS(alg.result, NofLoops - 1)
+    TS_ASSERT_EQUALS(count, NO_OF_LOOPS)
+    TS_ASSERT_EQUALS(alg.result, NO_OF_LOOPS - 1)
   }
 
   void testCancel() {
@@ -108,7 +110,7 @@ public:
     alg.cancel();
     result.wait();
     generalChecks(alg, false, true, false, true);
-    TS_ASSERT_LESS_THAN(alg.result, NofLoops - 1)
+    TS_ASSERT_LESS_THAN(alg.result, NO_OF_LOOPS - 1)
   }
 
   void testException() {
@@ -118,7 +120,7 @@ public:
     Poco::ActiveResult<bool> result = alg.executeAsync();
     result.wait();
     generalChecks(alg, false, true, false, true);
-    TS_ASSERT_LESS_THAN(alg.result, NofLoops - 1)
+    TS_ASSERT_LESS_THAN(alg.result, NO_OF_LOOPS - 1)
     TS_ASSERT_EQUALS(errorNotificationMessage, "Exception thrown")
   }
 
@@ -132,8 +134,8 @@ public:
     result.wait();
     generalChecks(alg, true, true, true, false);
     TS_ASSERT(result.available())
-    // There are 2 * NofLoops because there are two child workspaces
-    TS_ASSERT_EQUALS(count, NofLoops * 2)
+    // There are 2 * NO_OF_LOOPS because there are two child workspaces
+    TS_ASSERT_EQUALS(count, NO_OF_LOOPS * 2)
     // The parent algorithm is not executed directly, so the result remains 0
     TS_ASSERT_EQUALS(alg.result, 0)
   }


### PR DESCRIPTION
This PR fixes a problem where error notifications are not sent from a parent algorithm if one of its child algorithms throws an exception. This causes a problem where the algorithm monitor still thinks the algorithm is running and it cannot be cancelled from the Details dialog. MantidPlot also hangs when you try to close it because it is waiting for the algorithm to finish.

This PR also adds some additional tests to check that the correct notifications are received when running algorithms on workspace groups.

**To test:**

<!-- Instructions for testing. -->
Run the following script:
```
inWS=Load(Filename=r'POLREF00014882.NXS')
IvsQ, IvsQ_unbinned, IvsLam = ReflectometryReductionOneAuto(InputWorkspace=inWS)
```
MantidPlot should report a runtime error about theta being 0. Open the Details dialog - the algorithm should have finished and should not be shown in the Details dialog. You should be able to close MantidPlot without it hanging.

Fixes #18820 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
