### PR TITLE
Remove gtest's min cmake requirement

### DIFF
--- a/buildconfig/CMake/googletest_static.patch
+++ b/buildconfig/CMake/googletest_static.patch
@@ -1,8 +1,19 @@
+:100644 100644 8d2b552... 0000000... M	CMakeLists.txt
 :100644 100644 beb259a... 0000000... M	googlemock/CMakeLists.txt
 :100644 100644 621d0f0... 0000000... M	googletest/CMakeLists.txt
 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8d2b552..5c0d122 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,3 @@
+-cmake_minimum_required(VERSION 2.6.2)
+-
+ project( googletest-distribution )
+ 
+ enable_testing()
 diff --git a/googlemock/CMakeLists.txt b/googlemock/CMakeLists.txt
-index beb259a..d38128a 100644
+index beb259a..6f0cb3b 100644
 --- a/googlemock/CMakeLists.txt
 +++ b/googlemock/CMakeLists.txt
 @@ -7,7 +7,7 @@
@@ -14,7 +25,15 @@ index beb259a..d38128a 100644
  
  option(gmock_build_tests "Build all of Google Mock's own tests." OFF)
  
-@@ -103,10 +103,10 @@ endif()
+@@ -38,7 +38,6 @@ endif()
+ # ${gmock_BINARY_DIR}.
+ # Language "C" is required for find_package(Threads).
+ project(gmock CXX C)
+-cmake_minimum_required(VERSION 2.6.2)
+ 
+ if (COMMAND set_up_hermetic_build)
+   set_up_hermetic_build()
+@@ -103,10 +102,10 @@ endif()
  ########################################################################
  #
  # Install rules
@@ -30,7 +49,7 @@ index beb259a..d38128a 100644
  ########################################################################
  #
 diff --git a/googletest/CMakeLists.txt b/googletest/CMakeLists.txt
-index 621d0f0..6181e5c 100644
+index 621d0f0..c77f9ef 100644
 --- a/googletest/CMakeLists.txt
 +++ b/googletest/CMakeLists.txt
 @@ -7,7 +7,7 @@
@@ -42,7 +61,15 @@ index 621d0f0..6181e5c 100644
  
  # When other libraries are using a shared version of runtime libraries,
  # Google Test also has to use one.
-@@ -102,10 +102,10 @@ endif()
+@@ -45,7 +45,6 @@ endif()
+ # ${gtest_BINARY_DIR}.
+ # Language "C" is required for find_package(Threads).
+ project(gtest CXX C)
+-cmake_minimum_required(VERSION 2.6.2)
+ 
+ if (COMMAND set_up_hermetic_build)
+   set_up_hermetic_build()
+@@ -102,10 +101,10 @@ endif()
  ########################################################################
  #
  # Install rules


### PR DESCRIPTION
Remove a warning from `cmake` about `CMP0063`.

**To test:**

Look at a build go through and see that the warning is gone.

*There is no associated issue.*

*Does not need to be in the release notes* because it only is seen by developers.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
