### PR TITLE
Fix an issue in `TimeSeriesProperty`

### DIFF
--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -176,6 +176,9 @@ operator==(const TimeSeriesProperty<TYPE> &right) const {
   { // so vectors can go out of scope
     std::vector<DateAndTime> lhsTimes = this->timesAsVector();
     std::vector<DateAndTime> rhsTimes = right.timesAsVector();
+    if (lhsTimes.size() != rhsTimes.size()) {
+      return false;
+    }
     if (!std::equal(lhsTimes.begin(), lhsTimes.end(), rhsTimes.begin())) {
       return false;
     }

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -175,20 +175,15 @@ operator==(const TimeSeriesProperty<TYPE> &right) const {
 
   if (this->realSize() != right.realSize()) {
     return false;
-  }
-
-  { // so vectors can go out of scope
-    std::vector<DateAndTime> lhsTimes = this->timesAsVector();
-    std::vector<DateAndTime> rhsTimes = right.timesAsVector();
+  } else {
+    const std::vector<DateAndTime> lhsTimes = this->timesAsVector();
+    const std::vector<DateAndTime> rhsTimes = right.timesAsVector();
     if (!std::equal(lhsTimes.begin(), lhsTimes.end(), rhsTimes.begin())) {
       return false;
     }
-  }
 
-  {
-    // so vectors can go out of scope
-    std::vector<TYPE> lhsValues = this->valuesAsVector();
-    std::vector<TYPE> rhsValues = right.valuesAsVector();
+    const std::vector<TYPE> lhsValues = this->valuesAsVector();
+    const std::vector<TYPE> rhsValues = right.valuesAsVector();
     if (!std::equal(lhsValues.begin(), lhsValues.end(), rhsValues.begin())) {
       return false;
     }

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -173,12 +173,13 @@ operator==(const TimeSeriesProperty<TYPE> &right) const {
     return false;
   }
 
+  if (this->realSize() != right.realSize()) {
+    return false;
+  }
+
   { // so vectors can go out of scope
     std::vector<DateAndTime> lhsTimes = this->timesAsVector();
     std::vector<DateAndTime> rhsTimes = right.timesAsVector();
-    if (lhsTimes.size() != rhsTimes.size()) {
-      return false;
-    }
     if (!std::equal(lhsTimes.begin(), lhsTimes.end(), rhsTimes.begin())) {
       return false;
     }

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -271,6 +271,39 @@ public:
     delete log;
   }
 
+  void test_ComparisonOperator() {
+    // Setup two logs and two filters so that logs have different sizes but are
+    // the same size after applying the filter
+
+    TimeSeriesProperty<int> *log1 = new TimeSeriesProperty<int>("count_rate");
+    log1->addValue("2016-03-17T00:00:00", 1);
+    log1->addValue("2016-03-17T00:30:00", 2);
+    log1->addValue("2016-03-17T01:00:00", 3);
+    log1->addValue("2016-03-17T01:30:00", 4);
+    log1->addValue("2016-03-17T02:00:00", 5);
+    TimeSeriesProperty<bool> *filter1 = new TimeSeriesProperty<bool>("filter");
+    filter1->addValue("2016-Mar-17T00:00:00", 1);
+    filter1->addValue("2016-Mar-17T01:00:00", 0);
+    log1->filterWith(filter1);
+
+    TimeSeriesProperty<int> *log2 = new TimeSeriesProperty<int>("count_rate");
+    log2->addValue("2016-03-17T03:00:00", 1);
+    log2->addValue("2016-03-17T04:00:00", 2);
+    log2->addValue("2016-03-17T05:00:00", 3);
+    log2->addValue("2016-03-17T06:00:0", 4);
+    TimeSeriesProperty<bool> *filter2 = new TimeSeriesProperty<bool>("filter");
+    filter2->addValue("2016-Mar-17T03:00:00", 1);
+    filter2->addValue("2016-Mar-17T05:00:00", 0);
+    log2->filterWith(filter2);
+
+    TS_ASSERT_THROWS_NOTHING(*log1 == *log2);
+
+    delete log1;
+    delete log2;
+    delete filter1;
+    delete filter2;
+  }
+
   //----------------------------------------------------------------------------
   void test_filterByTime() {
     TimeSeriesProperty<int> *log = createIntegerTSP(6);

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -296,7 +296,7 @@ public:
     filter2->addValue("2016-Mar-17T05:00:00", 0);
     log2->filterWith(filter2);
 
-    TS_ASSERT_THROWS_NOTHING(*log1 == *log2);
+    TS_ASSERT(!(*log1 == *log2));
 
     delete log1;
     delete log2;


### PR DESCRIPTION
Description of work.

**To test:**

- This has to be tested on Windows, debug mode.
- Run the script in the issue description, Mantid shouldn't crash.
- Make sure that the new unit test fails without this fix.
- I could have added a similar check for the property values before [this](https://github.com/mantidproject/mantid/blob/291847a5e65364b6933fcf325f91d15932b99f4c/Framework/Kernel/src/TimeSeriesProperty.cpp#L191) line, but I think it is unnecessary. Make sure you agree with me.

Fixes #18944.

No need to mention this in the release notes, as the bug only happens on Windows in debug mode.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
