### PR TITLE
HistogramData rollout: algorithms EnggDiffFittingPresenter.cpp to MuonAnalysisHelperTest.h

### DIFF
--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -1212,10 +1212,10 @@ std::string EnggDiffFittingPresenter::functionStrFactory(
       "name=LinearBackground,A0=" + boost::lexical_cast<std::string>(A0) +
       ",A1=" + boost::lexical_cast<std::string>(A1) +
       ";name=BackToBackExponential,I=" + boost::lexical_cast<std::string>(I) +
-      ",A=" + boost::lexical_cast<std::string>(A) +
-      ",B=" + boost::lexical_cast<std::string>(B) +
-      ",X0=" + boost::lexical_cast<std::string>(X0) +
-      ",S=" + boost::lexical_cast<std::string>(S);
+      ",A=" + boost::lexical_cast<std::string>(A) + ",B=" +
+      boost::lexical_cast<std::string>(B) + ",X0=" +
+      boost::lexical_cast<std::string>(X0) + ",S=" +
+      boost::lexical_cast<std::string>(S);
 
   return functionStr;
 }
@@ -1354,8 +1354,7 @@ void EnggDiffFittingPresenter::runEvaluateFunctionAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm EvaluateFunction, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 
@@ -1372,8 +1371,7 @@ void EnggDiffFittingPresenter::runCropWorkspaceAlg(std::string workspaceName) {
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm CropWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 
@@ -1390,8 +1388,7 @@ void EnggDiffFittingPresenter::runAppendSpectraAlg(std::string workspace1Name,
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm AppendWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 
@@ -1408,8 +1405,7 @@ void EnggDiffFittingPresenter::runRebinToWorkspaceAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm RebinToWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 
@@ -1452,8 +1448,8 @@ void EnggDiffFittingPresenter::getDifcTzero(MatrixWorkspace_const_sptr wks,
     g_log.warning()
         << "Could not retrieve the DIFC, DIFA, TZERO values from the workspace "
         << wks->getName() << ". Using default, which is not adjusted for this "
-                             "workspace/run: DIFA: "
-        << difa << ", DIFC: " << difc << ", TZERO: " << tzero
+                             "workspace/run: DIFA: " << difa
+        << ", DIFC: " << difc << ", TZERO: " << tzero
         << ". Error details: " << rexc.what() << '\n';
   }
 }
@@ -1498,8 +1494,8 @@ void EnggDiffFittingPresenter::runAlignDetectorsAlg(std::string workspaceName) {
     row << detID << difc << difa << tzero;
   } catch (std::runtime_error &rexc) {
     g_log.error() << "Failed to prepare calibration table input to convert "
-                     "units with the algorithm "
-                  << algName << ". Error details: " << rexc.what() << '\n';
+                     "units with the algorithm " << algName
+                  << ". Error details: " << rexc.what() << '\n';
     return;
   }
 
@@ -1548,11 +1544,9 @@ void EnggDiffFittingPresenter::runConvertUnitsAlg(std::string workspaceName) {
     ConvertUnits->execute();
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm ConvertUnits to convert "
-                     "workspace to "
-                  << targetUnit
+                     "workspace to " << targetUnit
                   << ", Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 
@@ -1570,8 +1564,7 @@ void EnggDiffFittingPresenter::runCloneWorkspaceAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm CreateWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -10,8 +10,8 @@
 #include "MantidQtCustomInterfaces/Muon/ALCHelper.h"
 
 #include <boost/lexical_cast.hpp>
-#include <fstream>
 #include <cctype>
+#include <fstream>
 
 #include <Poco/DirectoryIterator.h>
 #include <Poco/File.h>
@@ -1212,10 +1212,10 @@ std::string EnggDiffFittingPresenter::functionStrFactory(
       "name=LinearBackground,A0=" + boost::lexical_cast<std::string>(A0) +
       ",A1=" + boost::lexical_cast<std::string>(A1) +
       ";name=BackToBackExponential,I=" + boost::lexical_cast<std::string>(I) +
-      ",A=" + boost::lexical_cast<std::string>(A) + ",B=" +
-      boost::lexical_cast<std::string>(B) + ",X0=" +
-      boost::lexical_cast<std::string>(X0) + ",S=" +
-      boost::lexical_cast<std::string>(S);
+      ",A=" + boost::lexical_cast<std::string>(A) +
+      ",B=" + boost::lexical_cast<std::string>(B) +
+      ",X0=" + boost::lexical_cast<std::string>(X0) +
+      ",S=" + boost::lexical_cast<std::string>(S);
 
   return functionStr;
 }
@@ -1354,7 +1354,8 @@ void EnggDiffFittingPresenter::runEvaluateFunctionAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm EvaluateFunction, "
                      "Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1371,7 +1372,8 @@ void EnggDiffFittingPresenter::runCropWorkspaceAlg(std::string workspaceName) {
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm CropWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1388,7 +1390,8 @@ void EnggDiffFittingPresenter::runAppendSpectraAlg(std::string workspace1Name,
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm AppendWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1405,7 +1408,8 @@ void EnggDiffFittingPresenter::runRebinToWorkspaceAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm RebinToWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1448,8 +1452,8 @@ void EnggDiffFittingPresenter::getDifcTzero(MatrixWorkspace_const_sptr wks,
     g_log.warning()
         << "Could not retrieve the DIFC, DIFA, TZERO values from the workspace "
         << wks->getName() << ". Using default, which is not adjusted for this "
-                             "workspace/run: DIFA: " << difa
-        << ", DIFC: " << difc << ", TZERO: " << tzero
+                             "workspace/run: DIFA: "
+        << difa << ", DIFC: " << difc << ", TZERO: " << tzero
         << ". Error details: " << rexc.what() << '\n';
   }
 }
@@ -1494,8 +1498,8 @@ void EnggDiffFittingPresenter::runAlignDetectorsAlg(std::string workspaceName) {
     row << detID << difc << difa << tzero;
   } catch (std::runtime_error &rexc) {
     g_log.error() << "Failed to prepare calibration table input to convert "
-                     "units with the algorithm " << algName
-                  << ". Error details: " << rexc.what() << '\n';
+                     "units with the algorithm "
+                  << algName << ". Error details: " << rexc.what() << '\n';
     return;
   }
 
@@ -1544,9 +1548,11 @@ void EnggDiffFittingPresenter::runConvertUnitsAlg(std::string workspaceName) {
     ConvertUnits->execute();
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm ConvertUnits to convert "
-                     "workspace to " << targetUnit
+                     "workspace to "
+                  << targetUnit
                   << ", Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1564,7 +1570,8 @@ void EnggDiffFittingPresenter::runCloneWorkspaceAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm CreateWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1573,8 +1580,8 @@ void EnggDiffFittingPresenter::setDataToClonedWS(std::string &current_WS,
   AnalysisDataServiceImpl &ADS = Mantid::API::AnalysisDataService::Instance();
   auto currentPeakWS = ADS.retrieveWS<MatrixWorkspace>(current_WS);
   auto currentClonedWS = ADS.retrieveWS<MatrixWorkspace>(cloned_WS);
-  currentClonedWS->dataY(0) = currentPeakWS->readY(0);
-  currentClonedWS->dataE(0) = currentPeakWS->readE(0);
+  currentClonedWS->mutableY(0) = currentPeakWS->y(0);
+  currentClonedWS->mutableE(0) = currentPeakWS->e(0);
 }
 
 void EnggDiffFittingPresenter::setBankItems(

--- a/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
@@ -1028,19 +1028,15 @@ bool MantidEVWorker::showUB(const std::string &peaks_ws_name) {
 
     g_log.notice() << '\n';
     g_log.notice() << "Mantid UB = \n";
-    sprintf(logInfo,
-            std::string(" %12.8f %12.8f %12.8f\n %12.8f %12.8f "
-                        "%12.8f\n %12.8f %12.8f %12.8f\n")
-                .c_str(),
+    sprintf(logInfo, std::string(" %12.8f %12.8f %12.8f\n %12.8f %12.8f "
+                                 "%12.8f\n %12.8f %12.8f %12.8f\n").c_str(),
             UB[0][0], UB[0][1], UB[0][2], UB[1][0], UB[1][1], UB[1][2],
             UB[2][0], UB[2][1], UB[2][2]);
     g_log.notice(std::string(logInfo));
 
     g_log.notice() << "ISAW UB = \n";
-    sprintf(logInfo,
-            std::string(" %12.8f %12.8f %12.8f\n %12.8f %12.8f "
-                        "%12.8f\n %12.8f %12.8f %12.8f\n")
-                .c_str(),
+    sprintf(logInfo, std::string(" %12.8f %12.8f %12.8f\n %12.8f %12.8f "
+                                 "%12.8f\n %12.8f %12.8f %12.8f\n").c_str(),
             UB[2][0], UB[0][0], UB[1][0], UB[2][1], UB[0][1], UB[1][1],
             UB[2][2], UB[0][2], UB[1][2]);
     g_log.notice(std::string(logInfo));

--- a/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
@@ -1,20 +1,20 @@
 #include <iostream>
 #include <sstream>
 
-#include "MantidQtCustomInterfaces/MantidEVWorker.h"
-#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/AlgorithmManager.h"
-#include "MantidAPI/Workspace.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IEventWorkspace.h"
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
+#include "MantidAPI/Workspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/Crystal/IPeak.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/Logger.h"
+#include "MantidQtCustomInterfaces/MantidEVWorker.h"
 #include <exception>
 
 namespace MantidQt {
@@ -296,7 +296,7 @@ bool MantidEVWorker::findPeaks(const std::string &ev_ws_name,
         int_alg->execute();
         Mantid::API::MatrixWorkspace_sptr int_ws =
             ADS.retrieveWS<MatrixWorkspace>(ev_ws_name + "_integrated_monitor");
-        monitor_count = int_ws->readY(0)[0];
+        monitor_count = int_ws->y(0)[0];
         std::cout << "Beam monitor counts used for scaling = " << monitor_count
                   << "\n";
       } else {
@@ -1028,15 +1028,19 @@ bool MantidEVWorker::showUB(const std::string &peaks_ws_name) {
 
     g_log.notice() << '\n';
     g_log.notice() << "Mantid UB = \n";
-    sprintf(logInfo, std::string(" %12.8f %12.8f %12.8f\n %12.8f %12.8f "
-                                 "%12.8f\n %12.8f %12.8f %12.8f\n").c_str(),
+    sprintf(logInfo,
+            std::string(" %12.8f %12.8f %12.8f\n %12.8f %12.8f "
+                        "%12.8f\n %12.8f %12.8f %12.8f\n")
+                .c_str(),
             UB[0][0], UB[0][1], UB[0][2], UB[1][0], UB[1][1], UB[1][2],
             UB[2][0], UB[2][1], UB[2][2]);
     g_log.notice(std::string(logInfo));
 
     g_log.notice() << "ISAW UB = \n";
-    sprintf(logInfo, std::string(" %12.8f %12.8f %12.8f\n %12.8f %12.8f "
-                                 "%12.8f\n %12.8f %12.8f %12.8f\n").c_str(),
+    sprintf(logInfo,
+            std::string(" %12.8f %12.8f %12.8f\n %12.8f %12.8f "
+                        "%12.8f\n %12.8f %12.8f %12.8f\n")
+                .c_str(),
             UB[2][0], UB[0][0], UB[1][0], UB[2][1], UB[0][1], UB[1][1],
             UB[2][2], UB[0][2], UB[1][2]);
     g_log.notice(std::string(logInfo));

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
@@ -1,13 +1,13 @@
 #include "MantidQtCustomInterfaces/MultiDatasetFit/MDFDataController.h"
-#include "MantidQtCustomInterfaces/MultiDatasetFit/MultiDatasetFit.h"
 #include "MantidQtCustomInterfaces/MultiDatasetFit/MDFAddWorkspaceDialog.h"
+#include "MantidQtCustomInterfaces/MultiDatasetFit/MultiDatasetFit.h"
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 
-#include <QTableWidget>
 #include <QMessageBox>
+#include <QTableWidget>
 
 namespace {
 // columns in the data table
@@ -109,11 +109,11 @@ void DataController::addWorkspaceSpectrum(
   flags ^= Qt::ItemIsEditable;
   cell->setFlags(flags);
 
-  const double startX = ws.readX(wsIndex).front();
+  const auto startX = ws.x(wsIndex).front();
   cell = new QTableWidgetItem(makeNumber(startX));
   m_dataTable->setItem(row, startXColumn, cell);
 
-  const double endX = ws.readX(wsIndex).back();
+  const auto endX = ws.x(wsIndex).back();
   cell = new QTableWidgetItem(makeNumber(endX));
   m_dataTable->setItem(row, endXColumn, cell);
 }

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
@@ -93,15 +93,9 @@ void DatasetPlotData::setData(const Mantid::API::MatrixWorkspace *ws,
                               int wsIndex,
                               const Mantid::API::MatrixWorkspace *outputWS) {
   bool haveFitCurves = outputWS && outputWS->getNumberHistograms() >= 3;
-  std::vector<double> xValues = ws->readX(wsIndex);
-  if (ws->isHistogramData()) {
-    auto xend = xValues.end() - 1;
-    for (auto x = xValues.begin(); x != xend; ++x) {
-      *x = (*x + *(x + 1)) / 2;
-    }
-    xValues.pop_back();
-  }
-  m_dataCurve->setData(xValues.data(), ws->readY(wsIndex).data(),
+  auto &xValues = ws->points(wsIndex);
+
+  m_dataCurve->setData(xValues.rawData().data(), ws->y(wsIndex).rawData().data(),
                        static_cast<int>(xValues.size()));
 
   if (m_dataErrorCurve) {
@@ -109,23 +103,23 @@ void DatasetPlotData::setData(const Mantid::API::MatrixWorkspace *ws,
     delete m_dataErrorCurve;
   }
   m_dataErrorCurve =
-      new MantidQt::MantidWidgets::ErrorCurve(m_dataCurve, ws->readE(wsIndex));
+      new MantidQt::MantidWidgets::ErrorCurve(m_dataCurve, ws->e(wsIndex).rawData());
 
   if (haveFitCurves) {
     auto xBegin = std::lower_bound(xValues.begin(), xValues.end(),
-                                   outputWS->readX(1).front());
+                                   outputWS->x(1).front());
     if (xBegin == xValues.end())
       return;
     int i0 = static_cast<int>(std::distance(xValues.begin(), xBegin));
-    int n = static_cast<int>(outputWS->readY(1).size());
+    int n = static_cast<int>(outputWS->y(1).size());
     if (i0 + n > static_cast<int>(xValues.size()))
       return;
     m_calcCurve = new QwtPlotCurve("calc");
-    m_calcCurve->setData(xValues.data() + i0, outputWS->readY(1).data(), n);
+    m_calcCurve->setData(xValues.rawData().data() + i0, outputWS->y(1).rawData().data(), n);
     QPen penCalc("red");
     m_calcCurve->setPen(penCalc);
     m_diffCurve = new QwtPlotCurve("diff");
-    m_diffCurve->setData(xValues.data() + i0, outputWS->readY(2).data(), n);
+    m_diffCurve->setData(xValues.rawData().data() + i0, outputWS->y(2).rawData().data(), n);
     QPen penDiff("green");
     m_diffCurve->setPen(penDiff);
   }

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
@@ -95,15 +95,16 @@ void DatasetPlotData::setData(const Mantid::API::MatrixWorkspace *ws,
   bool haveFitCurves = outputWS && outputWS->getNumberHistograms() >= 3;
   auto &xValues = ws->points(wsIndex);
 
-  m_dataCurve->setData(xValues.rawData().data(), ws->y(wsIndex).rawData().data(),
+  m_dataCurve->setData(xValues.rawData().data(),
+                       ws->y(wsIndex).rawData().data(),
                        static_cast<int>(xValues.size()));
 
   if (m_dataErrorCurve) {
     m_dataErrorCurve->detach();
     delete m_dataErrorCurve;
   }
-  m_dataErrorCurve =
-      new MantidQt::MantidWidgets::ErrorCurve(m_dataCurve, ws->e(wsIndex).rawData());
+  m_dataErrorCurve = new MantidQt::MantidWidgets::ErrorCurve(
+      m_dataCurve, ws->e(wsIndex).rawData());
 
   if (haveFitCurves) {
     auto xBegin = std::lower_bound(xValues.begin(), xValues.end(),
@@ -115,11 +116,13 @@ void DatasetPlotData::setData(const Mantid::API::MatrixWorkspace *ws,
     if (i0 + n > static_cast<int>(xValues.size()))
       return;
     m_calcCurve = new QwtPlotCurve("calc");
-    m_calcCurve->setData(xValues.rawData().data() + i0, outputWS->y(1).rawData().data(), n);
+    m_calcCurve->setData(xValues.rawData().data() + i0,
+                         outputWS->y(1).rawData().data(), n);
     QPen penCalc("red");
     m_calcCurve->setPen(penCalc);
     m_diffCurve = new QwtPlotCurve("diff");
-    m_diffCurve->setData(xValues.rawData().data() + i0, outputWS->y(2).rawData().data(), n);
+    m_diffCurve->setData(xValues.rawData().data() + i0,
+                         outputWS->y(2).rawData().data(), n);
     QPen penDiff("green");
     m_diffCurve->setPen(penDiff);
   }

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
@@ -93,7 +93,7 @@ void DatasetPlotData::setData(const Mantid::API::MatrixWorkspace *ws,
                               int wsIndex,
                               const Mantid::API::MatrixWorkspace *outputWS) {
   bool haveFitCurves = outputWS && outputWS->getNumberHistograms() >= 3;
-  auto &xValues = ws->points(wsIndex);
+  auto xValues = ws->points(wsIndex);
 
   m_dataCurve->setData(xValues.rawData().data(),
                        ws->y(wsIndex).rawData().data(),

--- a/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -4,10 +4,10 @@
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FunctionFactory.h"
-#include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/TextAxis.h"
 #include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/TableRow.h"
+#include "MantidAPI/TextAxis.h"
 #include "MantidAPI/WorkspaceFactory.h"
 
 #include "Poco/ActiveResult.h"
@@ -86,7 +86,7 @@ void ALCBaselineModellingModel::disableUnwantedPoints(
   // disable list
   for (size_t i = 0; i < ws->blocksize(); ++i) {
     for (auto it = sections.begin(); it != sections.end(); ++it) {
-      if (ws->dataX(0)[i] >= it->first && ws->dataX(0)[i] <= it->second) {
+      if (ws->x(0)[i] >= it->first && ws->x(0)[i] <= it->second) {
         toDisable[i] = false;
         break; // No need to check other sections
       }
@@ -103,7 +103,7 @@ void ALCBaselineModellingModel::disableUnwantedPoints(
   // Disable chosen points
   for (size_t i = 0; i < ws->blocksize(); ++i) {
     if (toDisable[i]) {
-      ws->dataE(0)[i] = DISABLED_ERR;
+      ws->mutableE(0)[i] = DISABLED_ERR;
     }
   }
 }
@@ -117,7 +117,7 @@ void ALCBaselineModellingModel::enableDisabledPoints(
     MatrixWorkspace_sptr destWs, MatrixWorkspace_const_sptr sourceWs) {
   // Unwanted points were disabled by setting their errors to very high values.
   // We recover here the original errors stored in sourceWs
-  destWs->dataE(0) = sourceWs->readE(0);
+  destWs->mutableE(0) = sourceWs->e(0);
 }
 
 /**
@@ -126,7 +126,7 @@ void ALCBaselineModellingModel::enableDisabledPoints(
  */
 void ALCBaselineModellingModel::setErrorsAfterFit(MatrixWorkspace_sptr data) {
 
-  data->dataE(2) = data->readE(0);
+  data->mutableE(2) = data->e(0);
 }
 
 MatrixWorkspace_sptr ALCBaselineModellingModel::exportWorkspace() {

--- a/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingPresenter.cpp
@@ -176,9 +176,9 @@ void ALCBaselineModellingPresenter::updateCorrectedCurve() {
 
 void ALCBaselineModellingPresenter::updateBaselineCurve() {
   if (IFunction_const_sptr fittedFunc = m_model->fittedFunction()) {
-    const std::vector<double> &xValues = m_model->data()->readX(0);
+    auto &xValues = m_model->data()->x(0);
     m_view->setBaselineCurve(
-        *(ALCHelper::curveDataFromFunction(fittedFunc, xValues)));
+        *(ALCHelper::curveDataFromFunction(fittedFunc, xValues.rawData())));
   } else {
     m_view->setBaselineCurve(*(ALCHelper::emptyCurveData()));
   }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
@@ -13,9 +13,9 @@
 #include "MantidKernel/StringTokenizer.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 
-#include <QLineEdit>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QLineEdit>
 #include <QSpinBox>
 
 #include <boost/lexical_cast.hpp>
@@ -162,7 +162,7 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   double counts(0.0);
   for (size_t i = 0; i < runWs->getNumberHistograms(); ++i) {
     for (size_t j = 0; j < runWs->blocksize(); ++j) {
-      counts += runWs->dataY(i)[j];
+      counts += runWs->y(i)[j];
     }
   }
   // output this number to three decimal places
@@ -496,15 +496,15 @@ Workspace_sptr sumWorkspaces(const std::vector<Workspace_sptr> &workspaces) {
   };
 
   // Comparison function for doubles
-  auto numericalCompare =
-      [](const std::string &first, const std::string &second) {
-        try {
-          return boost::lexical_cast<double>(first) <
-                 boost::lexical_cast<double>(second);
-        } catch (boost::bad_lexical_cast & /*e*/) {
-          return false;
-        }
-      };
+  auto numericalCompare = [](const std::string &first,
+                             const std::string &second) {
+    try {
+      return boost::lexical_cast<double>(first) <
+             boost::lexical_cast<double>(second);
+    } catch (boost::bad_lexical_cast & /*e*/) {
+      return false;
+    }
+  };
 
   // Range of log values
   auto runNumRange = findLogRange(workspaces, "run_number", numericalCompare);

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
@@ -496,15 +496,15 @@ Workspace_sptr sumWorkspaces(const std::vector<Workspace_sptr> &workspaces) {
   };
 
   // Comparison function for doubles
-  auto numericalCompare = [](const std::string &first,
-                             const std::string &second) {
-    try {
-      return boost::lexical_cast<double>(first) <
-             boost::lexical_cast<double>(second);
-    } catch (boost::bad_lexical_cast & /*e*/) {
-      return false;
-    }
-  };
+  auto numericalCompare =
+      [](const std::string &first, const std::string &second) {
+        try {
+          return boost::lexical_cast<double>(first) <
+                 boost::lexical_cast<double>(second);
+        } catch (boost::bad_lexical_cast & /*e*/) {
+          return false;
+        }
+      };
 
   // Range of log values
   auto runNumRange = findLogRange(workspaces, "run_number", numericalCompare);

--- a/MantidQt/CustomInterfaces/src/SANSPlotSpecial.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSPlotSpecial.cpp
@@ -1,14 +1,14 @@
 #include "MantidQtCustomInterfaces/SANSPlotSpecial.h"
 
-#include "MantidKernel/PhysicalConstants.h"
 #include "MantidAPI/AlgorithmManager.h"
-#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/IFunction.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/PhysicalConstants.h"
 
 #include "MantidQtMantidWidgets/RangeSelector.h"
 
-#include <QLineEdit>
 #include "qwt_plot_curve.h"
+#include <QLineEdit>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -481,10 +481,10 @@ QwtPlotCurve *SANSPlotSpecial::plotMiniplot(
   curve = new QwtPlotCurve();
 
   using Mantid::MantidVec;
-  const MantidVec &dataX = workspace->readX(workspaceIndex);
-  const MantidVec &dataY = workspace->readY(workspaceIndex);
+  auto &dataX = workspace->x(workspaceIndex);
+  auto &dataY = workspace->y(workspaceIndex);
 
-  curve->setData(&dataX[0], &dataY[0],
+  curve->setData(dataX.rawData().data(), dataY.rawData().data(),
                  static_cast<int>(workspace->blocksize()));
   curve->attach(m_uiForm.plotWindow);
 

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -848,8 +848,7 @@ bool SANSRunWindow::loadUserFile() {
   QString errors =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().user_settings.execute(i."
-                              "ReductionSingleton()))")
-          .trimmed();
+                              "ReductionSingleton()))").trimmed();
   // create a string list with a string for each line
   const QStringList allOutput = errors.split("\n");
   errors.clear();
@@ -875,9 +874,8 @@ bool SANSRunWindow::loadUserFile() {
       runReduceScriptFunction("print(i.ReductionSingleton().mask.min_radius)")
           .toDouble();
   m_uiForm.rad_min->setText(QString::number(dbl_param * unit_conv));
-  dbl_param =
-      runReduceScriptFunction("print(i.ReductionSingleton().mask.max_radius)")
-          .toDouble();
+  dbl_param = runReduceScriptFunction(
+                  "print(i.ReductionSingleton().mask.max_radius)").toDouble();
   m_uiForm.rad_max->setText(QString::number(dbl_param * unit_conv));
   // EventsTime
   m_uiForm.l_events_binning->setText(
@@ -887,12 +885,10 @@ bool SANSRunWindow::loadUserFile() {
       "print(i.ReductionSingleton().to_wavelen.wav_low)"));
   m_uiForm.wav_max->setText(
       runReduceScriptFunction(
-          "print(i.ReductionSingleton().to_wavelen.wav_high)")
-          .trimmed());
+          "print(i.ReductionSingleton().to_wavelen.wav_high)").trimmed());
   const QString wav_step =
       runReduceScriptFunction(
-          "print(i.ReductionSingleton().to_wavelen.wav_step)")
-          .trimmed();
+          "print(i.ReductionSingleton().to_wavelen.wav_step)").trimmed();
   setLimitStepParameter("wavelength", wav_step, m_uiForm.wav_dw,
                         m_uiForm.wav_dw_opt);
   // Q
@@ -924,24 +920,20 @@ bool SANSRunWindow::loadUserFile() {
   m_uiForm.frontDetRescale->setText(
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().instrument.getDetector('"
-                              "FRONT').rescaleAndShift.scale)")
-          .trimmed());
+                              "FRONT').rescaleAndShift.scale)").trimmed());
   m_uiForm.frontDetShift->setText(
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().instrument.getDetector('"
-                              "FRONT').rescaleAndShift.shift)")
-          .trimmed());
+                              "FRONT').rescaleAndShift.shift)").trimmed());
 
   QString fitScale =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().instrument.getDetector('"
-                              "FRONT').rescaleAndShift.fitScale)")
-          .trimmed();
+                              "FRONT').rescaleAndShift.fitScale)").trimmed();
   QString fitShift =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().instrument.getDetector('"
-                              "FRONT').rescaleAndShift.fitShift)")
-          .trimmed();
+                              "FRONT').rescaleAndShift.fitShift)").trimmed();
 
   if (fitScale == "True")
     m_uiForm.frontDetRescaleCB->setChecked(true);
@@ -963,13 +955,11 @@ bool SANSRunWindow::loadUserFile() {
     m_uiForm.frontDetQmin->setText(
         runReduceScriptFunction("print("
                                 "i.ReductionSingleton().instrument.getDetector("
-                                "'FRONT').rescaleAndShift.qMin)")
-            .trimmed());
+                                "'FRONT').rescaleAndShift.qMin)").trimmed());
     m_uiForm.frontDetQmax->setText(
         runReduceScriptFunction("print("
                                 "i.ReductionSingleton().instrument.getDetector("
-                                "'FRONT').rescaleAndShift.qMax)")
-            .trimmed());
+                                "'FRONT').rescaleAndShift.qMax)").trimmed());
   } else
     m_uiForm.frontDetQrangeOnOff->setChecked(false);
 
@@ -1019,15 +1009,15 @@ bool SANSRunWindow::loadUserFile() {
       m_uiForm.enableFrontFlood_ck->checkState() == Qt::Checked);
 
   // Scale factor
-  dbl_param = runReduceScriptFunction(
-                  "print(i.ReductionSingleton()._corr_and_scale.rescale)")
-                  .toDouble();
+  dbl_param =
+      runReduceScriptFunction(
+          "print(i.ReductionSingleton()._corr_and_scale.rescale)").toDouble();
   m_uiForm.scale_factor->setText(QString::number(dbl_param / 100.));
 
   // Sample offset if one has been specified
-  dbl_param = runReduceScriptFunction(
-                  "print(i.ReductionSingleton().instrument.SAMPLE_Z_CORR)")
-                  .toDouble();
+  dbl_param =
+      runReduceScriptFunction(
+          "print(i.ReductionSingleton().instrument.SAMPLE_Z_CORR)").toDouble();
   m_uiForm.smpl_offset->setText(QString::number(dbl_param * unit_conv));
 
   // Centre coordinates
@@ -1063,9 +1053,9 @@ bool SANSRunWindow::loadUserFile() {
                   .toDouble();
   m_uiForm.front_beam_y->setText(QString::number(dbl_param * 1000.0));
   // Gravity switch
-  QString param = runReduceScriptFunction(
-                      "print(i.ReductionSingleton().to_Q.get_gravity())")
-                      .trimmed();
+  QString param =
+      runReduceScriptFunction(
+          "print(i.ReductionSingleton().to_Q.get_gravity())").trimmed();
   if (param == "True") {
     m_uiForm.gravity_check->setChecked(true);
   } else {
@@ -1075,16 +1065,14 @@ bool SANSRunWindow::loadUserFile() {
   // Read the extra length for the gravity correction
   const double extraLengthParam =
       runReduceScriptFunction(
-          "print(i.ReductionSingleton().to_Q.get_extra_length())")
-          .toDouble();
+          "print(i.ReductionSingleton().to_Q.get_extra_length())").toDouble();
   m_uiForm.gravity_extra_length_line_edit->setText(
       QString::number(extraLengthParam));
 
   ////Detector bank: support REAR, FRONT, HAB, BOTH, MERGED, MERGE options
   QString detName =
       runReduceScriptFunction(
-          "print(i.ReductionSingleton().instrument.det_selection)")
-          .trimmed();
+          "print(i.ReductionSingleton().instrument.det_selection)").trimmed();
 
   if (detName == "REAR" || detName == "MAIN") {
     m_uiForm.detbank_sel->setCurrentIndex(0);
@@ -1978,11 +1966,9 @@ void SANSRunWindow::saveFileBrowse() {
   prevValues.beginGroup("CustomInterfaces/SANSRunWindow/SaveOutput");
   // use their previous directory first and go to their default if that fails
   QString prevPath =
-      prevValues
-          .value("dir",
-                 QString::fromStdString(ConfigService::Instance().getString(
-                     "defaultsave.directory")))
-          .toString();
+      prevValues.value("dir", QString::fromStdString(
+                                  ConfigService::Instance().getString(
+                                      "defaultsave.directory"))).toString();
 
   const QString filter = ";;AllFiles (*)";
 
@@ -2329,8 +2315,8 @@ QString SANSRunWindow::readUserFileGUIChanges(const States type) {
   }
   // Set the Front detector Rescale and Shift
   QString fdArguments = "scale=" + m_uiForm.frontDetRescale->text().trimmed() +
-                        "," +
-                        "shift=" + m_uiForm.frontDetShift->text().trimmed();
+                        "," + "shift=" +
+                        m_uiForm.frontDetShift->text().trimmed();
   if (m_uiForm.frontDetRescaleCB->isChecked())
     fdArguments += ", fitScale=True";
   if (m_uiForm.frontDetShiftCB->isChecked())
@@ -2825,9 +2811,9 @@ void SANSRunWindow::handleRunFindCentre() {
   py_code +=
       "from centre_finder import FindDirectionEnum as FindDirectionEnum \n";
   // Find centre function
-  py_code += "i.FindBeamCentre(rlow=" + m_uiForm.beam_rmin->text() +
-             ",rupp=" + m_uiForm.beam_rmax->text() +
-             ",MaxIter=" + m_uiForm.beam_iter->text() + ",";
+  py_code += "i.FindBeamCentre(rlow=" + m_uiForm.beam_rmin->text() + ",rupp=" +
+             m_uiForm.beam_rmax->text() + ",MaxIter=" +
+             m_uiForm.beam_iter->text() + ",";
 
   if (m_uiForm.beamstart_box->currentIndex() == 0) {
     py_code += "xstart = None, ystart = None";
@@ -2902,8 +2888,7 @@ void SANSRunWindow::handleRunFindCentre() {
   QString errors =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().user_settings.execute(i."
-                              "ReductionSingleton()))")
-          .trimmed();
+                              "ReductionSingleton()))").trimmed();
 
   g_centreFinderLog.notice() << result.toStdString() << "\n";
 
@@ -2966,9 +2951,8 @@ void SANSRunWindow::handleDefSaveClick() {
       auto geometryID = m_uiForm.sample_geomid->currentText();
       // Remove the first three characters, since they are unwanted
       auto geometryName = geometryID.mid(3);
-      saveCommand += ", Geometry='" + geometryName +
-                     "', SampleHeight=" + sampleHeight +
-                     ", SampleWidth=" + sampleWidth +
+      saveCommand += ", Geometry='" + geometryName + "', SampleHeight=" +
+                     sampleHeight + ", SampleWidth=" + sampleWidth +
                      ", SampleThickness=" + sampleThickness;
       saveCommand += ")\n";
     } else if ((*alg) == "SaveNXcanSAS") {
@@ -3125,8 +3109,7 @@ void SANSRunWindow::handleInstrumentChange() {
       "print(i.ReductionSingleton().instrument.cur_detector().name())");
   QString detectorSelection =
       runReduceScriptFunction(
-          "print(i.ReductionSingleton().instrument.det_selection)")
-          .trimmed();
+          "print(i.ReductionSingleton().instrument.det_selection)").trimmed();
   int ind = m_uiForm.detbank_sel->findText(detect);
   // We set the detector selection only if nothing is set yet.
   // Previously, we didn't handle merged and both at this point
@@ -3834,8 +3817,7 @@ void SANSRunWindow::loadTransmissionSettings() {
   QString transMin =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().transmission_calculator."
-                              "lambdaMin('SAMPLE'))")
-          .trimmed();
+                              "lambdaMin('SAMPLE'))").trimmed();
   if (transMin == "None") {
     m_uiForm.transFit_ck->setChecked(false);
   } else {
@@ -3844,15 +3826,13 @@ void SANSRunWindow::loadTransmissionSettings() {
     m_uiForm.trans_max->setText(
         runReduceScriptFunction("print("
                                 "i.ReductionSingleton().transmission_"
-                                "calculator.lambdaMax('SAMPLE'))")
-            .trimmed());
+                                "calculator.lambdaMax('SAMPLE'))").trimmed());
   }
 
   QString text =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().transmission_calculator."
-                              "fitMethod('SAMPLE'))")
-          .trimmed();
+                              "fitMethod('SAMPLE'))").trimmed();
   int index = m_uiForm.trans_opt->findText(text, Qt::MatchFixedString);
   if (index >= 0) {
     m_uiForm.trans_opt->setCurrentIndex(index);
@@ -3864,8 +3844,7 @@ void SANSRunWindow::loadTransmissionSettings() {
 
   transMin = runReduceScriptFunction("print("
                                      "i.ReductionSingleton().transmission_"
-                                     "calculator.lambdaMin('CAN'))")
-                 .trimmed();
+                                     "calculator.lambdaMin('CAN'))").trimmed();
   if (transMin == "None") {
     m_uiForm.transFit_ck_can->setChecked(false);
   } else {
@@ -3874,13 +3853,11 @@ void SANSRunWindow::loadTransmissionSettings() {
     m_uiForm.trans_max_can->setText(
         runReduceScriptFunction("print("
                                 "i.ReductionSingleton().transmission_"
-                                "calculator.lambdaMax('CAN'))")
-            .trimmed());
+                                "calculator.lambdaMax('CAN'))").trimmed());
   }
   text = runReduceScriptFunction("print("
                                  "i.ReductionSingleton().transmission_"
-                                 "calculator.fitMethod('CAN'))")
-             .trimmed();
+                                 "calculator.fitMethod('CAN'))").trimmed();
   index = m_uiForm.trans_opt_can->findText(text, Qt::MatchFixedString);
   if (index >= 0) {
     m_uiForm.trans_opt_can->setCurrentIndex(index);
@@ -4385,18 +4362,18 @@ void SANSRunWindow::writeTransmissionSettingsToPythonScript(
     auto roi = m_uiForm.trans_roi_files_line_edit->text();
     if (m_uiForm.trans_roi_files_checkbox->isChecked() && !roi.isEmpty()) {
       roi = "'" + roi.simplified() + "'";
-      roi = runPythonCode(
-          "\nprint(i.ConvertToPythonStringList(to_convert=" + roi + "))",
-          false);
+      roi = runPythonCode("\nprint(i.ConvertToPythonStringList(to_convert=" +
+                              roi + "))",
+                          false);
       pythonCode += "i.SetTransmissionROI(trans_roi_files=" + roi + ")\n";
     }
     // Handle Mask
     auto mask = m_uiForm.trans_masking_line_edit->text();
     if (!mask.isEmpty()) {
       mask = "'" + mask.simplified() + "'";
-      mask = runPythonCode(
-          "\nprint(i.ConvertToPythonStringList(to_convert=" + mask + "))",
-          false);
+      mask = runPythonCode("\nprint(i.ConvertToPythonStringList(to_convert=" +
+                               mask + "))",
+                           false);
       pythonCode += "i.SetTransmissionMask(trans_mask_files=" + mask + ")\n";
     }
 
@@ -4597,9 +4574,9 @@ void SANSRunWindow::setBeamFinderDetails() {
   auto instrumentName = m_uiForm.inst_opt->currentText();
 
   // Set the labels according to the instrument
-  auto requiresAngle = runReduceScriptFunction(
-                           "print(i.is_current_workspace_an_angle_workspace())")
-                           .simplified();
+  auto requiresAngle =
+      runReduceScriptFunction(
+          "print(i.is_current_workspace_an_angle_workspace())").simplified();
   QString labelPosition;
   if (requiresAngle == m_constants.getPythonTrueKeyword()) {
     labelPosition = "Current ( " + QString(QChar(0x03B2)) + " , y ) [";
@@ -4974,9 +4951,9 @@ SANSRunWindow::retrieveBackgroundCorrectionSetting(bool isTime, bool isMon) {
 
   auto createPythonScript = [](bool isTime, bool isMon, QString component) {
     return "i.get_background_correction(is_time = " +
-           convertBoolToPythonBoolString(isTime) +
-           ", is_mon=" + convertBoolToPythonBoolString(isMon) +
-           ", component='" + component + "')";
+           convertBoolToPythonBoolString(isTime) + ", is_mon=" +
+           convertBoolToPythonBoolString(isMon) + ", component='" + component +
+           "')";
   };
 
   for (auto &command : commandMap) {

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -1,26 +1,26 @@
 #include "MantidQtCustomInterfaces/SANSRunWindow.h"
 
-#include "MantidKernel/ConfigService.h"
-#include "MantidKernel/FacilityInfo.h"
-#include "MantidKernel/PropertyWithValue.h"
-#include "MantidKernel/Exception.h"
-#include "MantidKernel/PropertyManagerDataService.h"
-#include "MantidKernel/Logger.h"
-#include "MantidKernel/V3D.h"
-#include "MantidGeometry/IComponent.h"
-#include "MantidGeometry/Instrument.h"
-#include "MantidGeometry/IDetector.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/DetectorInfo.h"
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidAPI/IEventWorkspace.h"
+#include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidGeometry/IComponent.h"
+#include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/Exception.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidKernel/Logger.h"
+#include "MantidKernel/PropertyManagerDataService.h"
+#include "MantidKernel/PropertyWithValue.h"
+#include "MantidKernel/V3D.h"
 
-#include "MantidQtAPI/MantidDesktopServices.h"
 #include "MantidQtAPI/ManageUserDirectories.h"
+#include "MantidQtAPI/MantidDesktopServices.h"
 #include "MantidQtCustomInterfaces/SANSAddFiles.h"
 #include "MantidQtCustomInterfaces/SANSBackgroundCorrectionSettings.h"
 #include "MantidQtCustomInterfaces/SANSEventSlicing.h"
@@ -31,11 +31,11 @@
 #include <QTextStream>
 #include <QUrl>
 
-#include <Poco/StringTokenizer.h>
 #include <Poco/Message.h>
+#include <Poco/StringTokenizer.h>
 
-#include <boost/lexical_cast.hpp>
 #include <boost/foreach.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/tuple/tuple.hpp>
 
 #include <cmath>
@@ -848,7 +848,8 @@ bool SANSRunWindow::loadUserFile() {
   QString errors =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().user_settings.execute(i."
-                              "ReductionSingleton()))").trimmed();
+                              "ReductionSingleton()))")
+          .trimmed();
   // create a string list with a string for each line
   const QStringList allOutput = errors.split("\n");
   errors.clear();
@@ -874,8 +875,9 @@ bool SANSRunWindow::loadUserFile() {
       runReduceScriptFunction("print(i.ReductionSingleton().mask.min_radius)")
           .toDouble();
   m_uiForm.rad_min->setText(QString::number(dbl_param * unit_conv));
-  dbl_param = runReduceScriptFunction(
-                  "print(i.ReductionSingleton().mask.max_radius)").toDouble();
+  dbl_param =
+      runReduceScriptFunction("print(i.ReductionSingleton().mask.max_radius)")
+          .toDouble();
   m_uiForm.rad_max->setText(QString::number(dbl_param * unit_conv));
   // EventsTime
   m_uiForm.l_events_binning->setText(
@@ -885,10 +887,12 @@ bool SANSRunWindow::loadUserFile() {
       "print(i.ReductionSingleton().to_wavelen.wav_low)"));
   m_uiForm.wav_max->setText(
       runReduceScriptFunction(
-          "print(i.ReductionSingleton().to_wavelen.wav_high)").trimmed());
+          "print(i.ReductionSingleton().to_wavelen.wav_high)")
+          .trimmed());
   const QString wav_step =
       runReduceScriptFunction(
-          "print(i.ReductionSingleton().to_wavelen.wav_step)").trimmed();
+          "print(i.ReductionSingleton().to_wavelen.wav_step)")
+          .trimmed();
   setLimitStepParameter("wavelength", wav_step, m_uiForm.wav_dw,
                         m_uiForm.wav_dw_opt);
   // Q
@@ -920,20 +924,24 @@ bool SANSRunWindow::loadUserFile() {
   m_uiForm.frontDetRescale->setText(
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().instrument.getDetector('"
-                              "FRONT').rescaleAndShift.scale)").trimmed());
+                              "FRONT').rescaleAndShift.scale)")
+          .trimmed());
   m_uiForm.frontDetShift->setText(
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().instrument.getDetector('"
-                              "FRONT').rescaleAndShift.shift)").trimmed());
+                              "FRONT').rescaleAndShift.shift)")
+          .trimmed());
 
   QString fitScale =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().instrument.getDetector('"
-                              "FRONT').rescaleAndShift.fitScale)").trimmed();
+                              "FRONT').rescaleAndShift.fitScale)")
+          .trimmed();
   QString fitShift =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().instrument.getDetector('"
-                              "FRONT').rescaleAndShift.fitShift)").trimmed();
+                              "FRONT').rescaleAndShift.fitShift)")
+          .trimmed();
 
   if (fitScale == "True")
     m_uiForm.frontDetRescaleCB->setChecked(true);
@@ -955,11 +963,13 @@ bool SANSRunWindow::loadUserFile() {
     m_uiForm.frontDetQmin->setText(
         runReduceScriptFunction("print("
                                 "i.ReductionSingleton().instrument.getDetector("
-                                "'FRONT').rescaleAndShift.qMin)").trimmed());
+                                "'FRONT').rescaleAndShift.qMin)")
+            .trimmed());
     m_uiForm.frontDetQmax->setText(
         runReduceScriptFunction("print("
                                 "i.ReductionSingleton().instrument.getDetector("
-                                "'FRONT').rescaleAndShift.qMax)").trimmed());
+                                "'FRONT').rescaleAndShift.qMax)")
+            .trimmed());
   } else
     m_uiForm.frontDetQrangeOnOff->setChecked(false);
 
@@ -1009,15 +1019,15 @@ bool SANSRunWindow::loadUserFile() {
       m_uiForm.enableFrontFlood_ck->checkState() == Qt::Checked);
 
   // Scale factor
-  dbl_param =
-      runReduceScriptFunction(
-          "print(i.ReductionSingleton()._corr_and_scale.rescale)").toDouble();
+  dbl_param = runReduceScriptFunction(
+                  "print(i.ReductionSingleton()._corr_and_scale.rescale)")
+                  .toDouble();
   m_uiForm.scale_factor->setText(QString::number(dbl_param / 100.));
 
   // Sample offset if one has been specified
-  dbl_param =
-      runReduceScriptFunction(
-          "print(i.ReductionSingleton().instrument.SAMPLE_Z_CORR)").toDouble();
+  dbl_param = runReduceScriptFunction(
+                  "print(i.ReductionSingleton().instrument.SAMPLE_Z_CORR)")
+                  .toDouble();
   m_uiForm.smpl_offset->setText(QString::number(dbl_param * unit_conv));
 
   // Centre coordinates
@@ -1053,9 +1063,9 @@ bool SANSRunWindow::loadUserFile() {
                   .toDouble();
   m_uiForm.front_beam_y->setText(QString::number(dbl_param * 1000.0));
   // Gravity switch
-  QString param =
-      runReduceScriptFunction(
-          "print(i.ReductionSingleton().to_Q.get_gravity())").trimmed();
+  QString param = runReduceScriptFunction(
+                      "print(i.ReductionSingleton().to_Q.get_gravity())")
+                      .trimmed();
   if (param == "True") {
     m_uiForm.gravity_check->setChecked(true);
   } else {
@@ -1065,14 +1075,16 @@ bool SANSRunWindow::loadUserFile() {
   // Read the extra length for the gravity correction
   const double extraLengthParam =
       runReduceScriptFunction(
-          "print(i.ReductionSingleton().to_Q.get_extra_length())").toDouble();
+          "print(i.ReductionSingleton().to_Q.get_extra_length())")
+          .toDouble();
   m_uiForm.gravity_extra_length_line_edit->setText(
       QString::number(extraLengthParam));
 
   ////Detector bank: support REAR, FRONT, HAB, BOTH, MERGED, MERGE options
   QString detName =
       runReduceScriptFunction(
-          "print(i.ReductionSingleton().instrument.det_selection)").trimmed();
+          "print(i.ReductionSingleton().instrument.det_selection)")
+          .trimmed();
 
   if (detName == "REAR" || detName == "MAIN") {
     m_uiForm.detbank_sel->setCurrentIndex(0);
@@ -1966,9 +1978,11 @@ void SANSRunWindow::saveFileBrowse() {
   prevValues.beginGroup("CustomInterfaces/SANSRunWindow/SaveOutput");
   // use their previous directory first and go to their default if that fails
   QString prevPath =
-      prevValues.value("dir", QString::fromStdString(
-                                  ConfigService::Instance().getString(
-                                      "defaultsave.directory"))).toString();
+      prevValues
+          .value("dir",
+                 QString::fromStdString(ConfigService::Instance().getString(
+                     "defaultsave.directory")))
+          .toString();
 
   const QString filter = ";;AllFiles (*)";
 
@@ -2093,11 +2107,9 @@ bool SANSRunWindow::handleLoadButtonClick() {
   Mantid::API::MatrixWorkspace_sptr sample_workspace =
       boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(baseWS);
 
-  if (sample_workspace && (!sample_workspace->readX(0).empty())) {
-    m_uiForm.tof_min->setText(
-        QString::number(sample_workspace->readX(0).front()));
-    m_uiForm.tof_max->setText(
-        QString::number(sample_workspace->readX(0).back()));
+  if (sample_workspace && (!sample_workspace->x(0).empty())) {
+    m_uiForm.tof_min->setText(QString::number(sample_workspace->x(0).front()));
+    m_uiForm.tof_max->setText(QString::number(sample_workspace->x(0).back()));
   }
 
   // Set the geometry if the sample has been changed
@@ -2317,8 +2329,8 @@ QString SANSRunWindow::readUserFileGUIChanges(const States type) {
   }
   // Set the Front detector Rescale and Shift
   QString fdArguments = "scale=" + m_uiForm.frontDetRescale->text().trimmed() +
-                        "," + "shift=" +
-                        m_uiForm.frontDetShift->text().trimmed();
+                        "," +
+                        "shift=" + m_uiForm.frontDetShift->text().trimmed();
   if (m_uiForm.frontDetRescaleCB->isChecked())
     fdArguments += ", fitScale=True";
   if (m_uiForm.frontDetShiftCB->isChecked())
@@ -2813,9 +2825,9 @@ void SANSRunWindow::handleRunFindCentre() {
   py_code +=
       "from centre_finder import FindDirectionEnum as FindDirectionEnum \n";
   // Find centre function
-  py_code += "i.FindBeamCentre(rlow=" + m_uiForm.beam_rmin->text() + ",rupp=" +
-             m_uiForm.beam_rmax->text() + ",MaxIter=" +
-             m_uiForm.beam_iter->text() + ",";
+  py_code += "i.FindBeamCentre(rlow=" + m_uiForm.beam_rmin->text() +
+             ",rupp=" + m_uiForm.beam_rmax->text() +
+             ",MaxIter=" + m_uiForm.beam_iter->text() + ",";
 
   if (m_uiForm.beamstart_box->currentIndex() == 0) {
     py_code += "xstart = None, ystart = None";
@@ -2890,7 +2902,8 @@ void SANSRunWindow::handleRunFindCentre() {
   QString errors =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().user_settings.execute(i."
-                              "ReductionSingleton()))").trimmed();
+                              "ReductionSingleton()))")
+          .trimmed();
 
   g_centreFinderLog.notice() << result.toStdString() << "\n";
 
@@ -2953,8 +2966,9 @@ void SANSRunWindow::handleDefSaveClick() {
       auto geometryID = m_uiForm.sample_geomid->currentText();
       // Remove the first three characters, since they are unwanted
       auto geometryName = geometryID.mid(3);
-      saveCommand += ", Geometry='" + geometryName + "', SampleHeight=" +
-                     sampleHeight + ", SampleWidth=" + sampleWidth +
+      saveCommand += ", Geometry='" + geometryName +
+                     "', SampleHeight=" + sampleHeight +
+                     ", SampleWidth=" + sampleWidth +
                      ", SampleThickness=" + sampleThickness;
       saveCommand += ")\n";
     } else if ((*alg) == "SaveNXcanSAS") {
@@ -3111,7 +3125,8 @@ void SANSRunWindow::handleInstrumentChange() {
       "print(i.ReductionSingleton().instrument.cur_detector().name())");
   QString detectorSelection =
       runReduceScriptFunction(
-          "print(i.ReductionSingleton().instrument.det_selection)").trimmed();
+          "print(i.ReductionSingleton().instrument.det_selection)")
+          .trimmed();
   int ind = m_uiForm.detbank_sel->findText(detect);
   // We set the detector selection only if nothing is set yet.
   // Previously, we didn't handle merged and both at this point
@@ -3819,7 +3834,8 @@ void SANSRunWindow::loadTransmissionSettings() {
   QString transMin =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().transmission_calculator."
-                              "lambdaMin('SAMPLE'))").trimmed();
+                              "lambdaMin('SAMPLE'))")
+          .trimmed();
   if (transMin == "None") {
     m_uiForm.transFit_ck->setChecked(false);
   } else {
@@ -3828,13 +3844,15 @@ void SANSRunWindow::loadTransmissionSettings() {
     m_uiForm.trans_max->setText(
         runReduceScriptFunction("print("
                                 "i.ReductionSingleton().transmission_"
-                                "calculator.lambdaMax('SAMPLE'))").trimmed());
+                                "calculator.lambdaMax('SAMPLE'))")
+            .trimmed());
   }
 
   QString text =
       runReduceScriptFunction("print("
                               "i.ReductionSingleton().transmission_calculator."
-                              "fitMethod('SAMPLE'))").trimmed();
+                              "fitMethod('SAMPLE'))")
+          .trimmed();
   int index = m_uiForm.trans_opt->findText(text, Qt::MatchFixedString);
   if (index >= 0) {
     m_uiForm.trans_opt->setCurrentIndex(index);
@@ -3846,7 +3864,8 @@ void SANSRunWindow::loadTransmissionSettings() {
 
   transMin = runReduceScriptFunction("print("
                                      "i.ReductionSingleton().transmission_"
-                                     "calculator.lambdaMin('CAN'))").trimmed();
+                                     "calculator.lambdaMin('CAN'))")
+                 .trimmed();
   if (transMin == "None") {
     m_uiForm.transFit_ck_can->setChecked(false);
   } else {
@@ -3855,11 +3874,13 @@ void SANSRunWindow::loadTransmissionSettings() {
     m_uiForm.trans_max_can->setText(
         runReduceScriptFunction("print("
                                 "i.ReductionSingleton().transmission_"
-                                "calculator.lambdaMax('CAN'))").trimmed());
+                                "calculator.lambdaMax('CAN'))")
+            .trimmed());
   }
   text = runReduceScriptFunction("print("
                                  "i.ReductionSingleton().transmission_"
-                                 "calculator.fitMethod('CAN'))").trimmed();
+                                 "calculator.fitMethod('CAN'))")
+             .trimmed();
   index = m_uiForm.trans_opt_can->findText(text, Qt::MatchFixedString);
   if (index >= 0) {
     m_uiForm.trans_opt_can->setCurrentIndex(index);
@@ -4364,18 +4385,18 @@ void SANSRunWindow::writeTransmissionSettingsToPythonScript(
     auto roi = m_uiForm.trans_roi_files_line_edit->text();
     if (m_uiForm.trans_roi_files_checkbox->isChecked() && !roi.isEmpty()) {
       roi = "'" + roi.simplified() + "'";
-      roi = runPythonCode("\nprint(i.ConvertToPythonStringList(to_convert=" +
-                              roi + "))",
-                          false);
+      roi = runPythonCode(
+          "\nprint(i.ConvertToPythonStringList(to_convert=" + roi + "))",
+          false);
       pythonCode += "i.SetTransmissionROI(trans_roi_files=" + roi + ")\n";
     }
     // Handle Mask
     auto mask = m_uiForm.trans_masking_line_edit->text();
     if (!mask.isEmpty()) {
       mask = "'" + mask.simplified() + "'";
-      mask = runPythonCode("\nprint(i.ConvertToPythonStringList(to_convert=" +
-                               mask + "))",
-                           false);
+      mask = runPythonCode(
+          "\nprint(i.ConvertToPythonStringList(to_convert=" + mask + "))",
+          false);
       pythonCode += "i.SetTransmissionMask(trans_mask_files=" + mask + ")\n";
     }
 
@@ -4576,9 +4597,9 @@ void SANSRunWindow::setBeamFinderDetails() {
   auto instrumentName = m_uiForm.inst_opt->currentText();
 
   // Set the labels according to the instrument
-  auto requiresAngle =
-      runReduceScriptFunction(
-          "print(i.is_current_workspace_an_angle_workspace())").simplified();
+  auto requiresAngle = runReduceScriptFunction(
+                           "print(i.is_current_workspace_an_angle_workspace())")
+                           .simplified();
   QString labelPosition;
   if (requiresAngle == m_constants.getPythonTrueKeyword()) {
     labelPosition = "Current ( " + QString(QChar(0x03B2)) + " , y ) [";
@@ -4953,9 +4974,9 @@ SANSRunWindow::retrieveBackgroundCorrectionSetting(bool isTime, bool isMon) {
 
   auto createPythonScript = [](bool isTime, bool isMon, QString component) {
     return "i.get_background_correction(is_time = " +
-           convertBoolToPythonBoolString(isTime) + ", is_mon=" +
-           convertBoolToPythonBoolString(isMon) + ", component='" + component +
-           "')";
+           convertBoolToPythonBoolString(isTime) +
+           ", is_mon=" + convertBoolToPythonBoolString(isMon) +
+           ", component='" + component + "')";
   };
 
   for (auto &command : commandMap) {

--- a/MantidQt/CustomInterfaces/src/SampleTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/SampleTransmission.cpp
@@ -184,8 +184,7 @@ void SampleTransmission::algorithmComplete(bool error) {
   m_uiForm.twResults->addTopLevelItem(transmissionItem);
   transmissionItem->setExpanded(true);
 
-  auto &transmissionData = ws->y(0);
-  Statistics stats = getStatistics(transmissionData.rawData());
+  Statistics stats = getStatistics(ws->y(0).rawData());
 
   QMap<QString, double> transmissionStats;
   transmissionStats["Min"] = stats.minimum;

--- a/MantidQt/CustomInterfaces/src/SampleTransmission.cpp
+++ b/MantidQt/CustomInterfaces/src/SampleTransmission.cpp
@@ -173,7 +173,7 @@ void SampleTransmission::algorithmComplete(bool error) {
           "CalculatedSampleTransmission");
 
   // Fill the output table
-  double scattering = ws->dataY(1)[0];
+  double scattering = ws->y(1)[0];
   QTreeWidgetItem *scatteringItem = new QTreeWidgetItem();
   scatteringItem->setText(0, "Scattering");
   scatteringItem->setText(1, QString::number(scattering));
@@ -184,8 +184,8 @@ void SampleTransmission::algorithmComplete(bool error) {
   m_uiForm.twResults->addTopLevelItem(transmissionItem);
   transmissionItem->setExpanded(true);
 
-  std::vector<double> transmissionData = ws->dataY(0);
-  Statistics stats = getStatistics(transmissionData);
+  auto &transmissionData = ws->y(0);
+  Statistics stats = getStatistics(transmissionData.rawData());
 
   QMap<QString, double> transmissionStats;
   transmissionStats["Min"] = stats.minimum;

--- a/MantidQt/CustomInterfaces/src/Tomography/ImggFormatsConvertViewQtWidget.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/ImggFormatsConvertViewQtWidget.cpp
@@ -14,8 +14,8 @@ using namespace MantidQt::CustomInterfaces;
 #include <QMessageBox>
 #include <QSettings>
 
-#include <iostream>
 #include <QImage>
+#include <iostream>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -231,7 +231,7 @@ void ImggFormatsConvertViewQtWidget::writeImg(
   const double scaleFactor = std::numeric_limits<unsigned short int>::max() /
                              std::numeric_limits<unsigned char>::max();
   for (int yi = 0; yi < static_cast<int>(width); ++yi) {
-    const auto &row = inWks->readY(yi);
+    const auto &row = inWks->y(yi);
     for (int xi = 0; xi < static_cast<int>(width); ++xi) {
       int scaled = static_cast<int>(row[xi] / scaleFactor);
       // Images not from IMAT, just crop. This needs much improvement when
@@ -282,9 +282,8 @@ ImggFormatsConvertViewQtWidget::loadImg(const std::string &inputName,
   const double scaleFactor = std::numeric_limits<unsigned char>::max();
   for (int yi = 0; yi < static_cast<int>(width); ++yi) {
     auto &row = imgWks->getSpectrum(yi);
-    auto &dataY = row.dataY();
-    auto &dataX = row.dataX();
-    std::fill(dataX.begin(), dataX.end(), static_cast<double>(yi));
+    auto &dataY = row.mutableY();
+    row.mutableX() = static_cast<double>(yi);
     for (int xi = 0; xi < static_cast<int>(width); ++xi) {
       QRgb vRgb = img.pixel(xi, yi);
       dataY[xi] = scaleFactor * qGray(vRgb);

--- a/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -8,6 +8,7 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidTestHelpers/HistogramDataTestHelper.h"
 
 #include "MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h"
 
@@ -15,6 +16,9 @@
 
 using namespace Mantid::API;
 using namespace MantidQt::CustomInterfaces;
+using Mantid::HistogramData::Points;
+using Mantid::HistogramData::Counts;
+using Mantid::HistogramData::CountStandardDeviations;
 
 class ALCBaselineModellingModelTest : public CxxTest::TestSuite {
   ALCBaselineModellingModel *m_model;
@@ -38,13 +42,10 @@ public:
   void tearDown() override { delete m_model; }
 
   void test_setData() {
-    std::vector<double> y = {100, 1, 2, 100, 100, 3, 4, 5, 100};
-    std::vector<double> x = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-
-    MatrixWorkspace_sptr data = WorkspaceFactory::Instance().create(
-        "Workspace2D", 1, y.size(), y.size());
-    data->dataY(0) = y;
-    data->dataX(0) = x;
+    MatrixWorkspace_sptr data =
+        WorkspaceFactory::Instance().create("Workspace2D", 1, 9, 9);
+    data->setHistogram(0, Points{1, 2, 3, 4, 5, 6, 7, 8, 9},
+                       Counts{100, 1, 2, 100, 100, 3, 4, 5, 100});
 
     QSignalSpy spy(m_model, SIGNAL(dataChanged()));
 
@@ -54,21 +55,18 @@ public:
 
     MatrixWorkspace_const_sptr modelData = m_model->data();
 
-    TS_ASSERT_EQUALS(modelData->readX(0), data->readX(0));
-    TS_ASSERT_EQUALS(modelData->readY(0), data->readY(0));
-    TS_ASSERT_EQUALS(modelData->readE(0), data->readE(0));
+    TS_ASSERT_EQUALS(modelData->x(0), data->x(0));
+    TS_ASSERT_EQUALS(modelData->y(0), data->y(0));
+    TS_ASSERT_EQUALS(modelData->e(0), data->e(0));
   }
 
   void test_fit() {
-    std::vector<double> e = {10.0, 1.0, 1.41, 10.0, 10.0, 1.73, 2.0, 2.5, 10.0};
-    std::vector<double> y = {100, 1, 2, 100, 100, 3, 4, 5, 100};
-    std::vector<double> x = {1, 2, 3, 4, 5, 6, 7, 8, 9};
-
-    MatrixWorkspace_sptr data = WorkspaceFactory::Instance().create(
-        "Workspace2D", 1, y.size(), y.size());
-    data->dataE(0) = e;
-    data->dataY(0) = y;
-    data->dataX(0) = x;
+    MatrixWorkspace_sptr data =
+        WorkspaceFactory::Instance().create("Workspace2D", 1, 9, 9);
+    data->setHistogram(0, Points{1, 2, 3, 4, 5, 6, 7, 8, 9},
+                       Counts{100, 1, 2, 100, 100, 3, 4, 5, 100},
+                       CountStandardDeviations{10.0, 1.0, 1.41, 10.0, 10.0,
+                                               1.73, 2.0, 2.5, 10.0});
 
     m_model->setData(data);
 
@@ -98,12 +96,12 @@ public:
       TS_ASSERT_EQUALS(corrected->getNumberHistograms(), 1);
       TS_ASSERT_EQUALS(corrected->blocksize(), 9);
 
-      TS_ASSERT_DELTA(corrected->readY(0)[0], 97.86021, 1E-5);
-      TS_ASSERT_DELTA(corrected->readY(0)[2], -0.13979, 1E-5);
-      TS_ASSERT_DELTA(corrected->readY(0)[5], 0.86021, 1E-5);
-      TS_ASSERT_DELTA(corrected->readY(0)[8], 97.86021, 1E-5);
+      TS_ASSERT_DELTA(corrected->y(0)[0], 97.86021, 1E-5);
+      TS_ASSERT_DELTA(corrected->y(0)[2], -0.13979, 1E-5);
+      TS_ASSERT_DELTA(corrected->y(0)[5], 0.86021, 1E-5);
+      TS_ASSERT_DELTA(corrected->y(0)[8], 97.86021, 1E-5);
 
-      TS_ASSERT_EQUALS(corrected->readE(0), data->readE(0));
+      TS_ASSERT_EQUALS(corrected->e(0), data->e(0));
     }
 
     ITableWorkspace_sptr parameters = m_model->parameterTable();

--- a/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/WarningSuppressions.h"
 
 #include "MantidQtCustomInterfaces/Muon/ALCBaselineModellingPresenter.h"
@@ -18,6 +19,10 @@ using namespace Mantid::API;
 using namespace MantidQt::CustomInterfaces;
 using namespace testing;
 using boost::scoped_ptr;
+using Mantid::HistogramData::Points;
+using Mantid::HistogramData::Counts;
+using Mantid::HistogramData::CountStandardDeviations;
+using Mantid::HistogramData::LinearGenerator;
 
 GCC_DIAG_OFF_SUGGEST_OVERRIDE
 
@@ -133,11 +138,9 @@ public:
     MatrixWorkspace_sptr ws =
         WorkspaceFactory::Instance().create("Workspace2D", 1, size, size);
 
-    for (size_t i = 0; i < size; ++i) {
-      ws->dataX(0)[i] = static_cast<double>(i + 1);
-      ws->dataY(0)[i] = ws->dataX(0)[i] + deltaY;
-      ws->dataE(0)[i] = 1;
-    }
+    ws->setHistogram(0, Points(size, LinearGenerator(1, 1)),
+                     Counts(size, LinearGenerator(1 + deltaY, 1)),
+                     CountStandardDeviations(size, 1));
 
     return ws;
   }

--- a/MantidQt/CustomInterfaces/test/ALCPeakFittingModelTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCPeakFittingModelTest.h
@@ -3,11 +3,11 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
-#include "MantidAPI/FunctionFactory.h"
-#include "MantidAPI/FrameworkManager.h"
-#include "MantidAPI/ITableWorkspace.h"
 
 #include "MantidQtCustomInterfaces/Muon/ALCPeakFittingModel.h"
 
@@ -15,6 +15,9 @@
 
 using namespace Mantid::API;
 using namespace MantidQt::CustomInterfaces;
+using Mantid::HistogramData::Points;
+using Mantid::HistogramData::Counts;
+using Mantid::HistogramData::CountStandardDeviations;
 
 class ALCPeakFittingModelTest : public CxxTest::TestSuite {
   ALCPeakFittingModel *m_model;
@@ -48,13 +51,13 @@ public:
   }
 
   void test_fit() {
-    std::vector<double> x = {1.00, 2.00, 3.00, 4.00, 5.00, 6.00, 7.00, 8.00};
-    std::vector<double> y = {0.00, 0.01, 0.02, 0.37, 1.00, 0.37, 0.01, 0.00};
+    MatrixWorkspace_sptr data =
+        WorkspaceFactory::Instance().create("Workspace2D", 1, 8, 8);
 
-    MatrixWorkspace_sptr data = WorkspaceFactory::Instance().create(
-        "Workspace2D", 1, y.size(), y.size());
-    data->dataY(0) = y;
-    data->dataX(0) = x;
+    data->setHistogram(0,
+                       Points{1.00, 2.00, 3.00, 4.00, 5.00, 6.00, 7.00, 8.00},
+                       Counts{0.00, 0.01, 0.02, 0.37, 1.00, 0.37, 0.01, 0.00},
+                       CountStandardDeviations(8, 0));
 
     m_model->setData(data);
 

--- a/MantidQt/CustomInterfaces/test/MuonAnalysisDataLoaderTest.h
+++ b/MantidQt/CustomInterfaces/test/MuonAnalysisDataLoaderTest.h
@@ -1,9 +1,9 @@
 #ifndef MANTIDQT_CUSTOMINTERFACES_MUONANALYSISDATALOADERTEST_H_
 #define MANTIDQT_CUSTOMINTERFACES_MUONANALYSISDATALOADERTEST_H_
 
-#include <cxxtest/TestSuite.h>
-#include <Poco/Path.h>
 #include <Poco/File.h>
+#include <Poco/Path.h>
+#include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/AlgorithmManager.h"
@@ -196,7 +196,7 @@ public:
       // Check that each period has number of spectra = number of groups
       TS_ASSERT_EQUALS(matrixWS->getNumberHistograms(), grouping.groups.size());
       // Check that each period has been corrected for dead time
-      TS_ASSERT_DELTA(matrixWS->getSpectrum(0).dataY().at(0),
+      TS_ASSERT_DELTA(matrixWS->getSpectrum(0).y()[0],
                       i == 0 ? 84.1692 : 16.0749, 0.0001);
     }
   }
@@ -263,7 +263,7 @@ public:
     const auto outputWS =
         boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(analysed);
     TS_ASSERT(outputWS);
-    const auto &data = outputWS->dataY(0);
+    const auto &data = outputWS->y(0);
     TS_ASSERT_EQUALS(data.size(), 617);
     for (size_t i = 0; i < expectedOutput.size(); i++) {
       TS_ASSERT_DELTA(data[i], expectedOutput[i], 1e-6);

--- a/MantidQt/CustomInterfaces/test/MuonAnalysisHelperTest.h
+++ b/MantidQt/CustomInterfaces/test/MuonAnalysisHelperTest.h
@@ -3,7 +3,6 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidQtCustomInterfaces/Muon/MuonAnalysisHelper.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -14,6 +13,7 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidQtCustomInterfaces/Muon/MuonAnalysisHelper.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 using namespace MantidQt::CustomInterfaces::MuonAnalysisHelper;
@@ -154,9 +154,9 @@ public:
     TS_ASSERT_EQUALS(result->getNumberHistograms(), 1);
     TS_ASSERT_EQUALS(result->blocksize(), 3);
 
-    TS_ASSERT_EQUALS(result->readY(0)[0], 6);
-    TS_ASSERT_EQUALS(result->readY(0)[1], 6);
-    TS_ASSERT_EQUALS(result->readY(0)[2], 6);
+    TS_ASSERT_EQUALS(result->y(0)[0], 6);
+    TS_ASSERT_EQUALS(result->y(0)[1], 6);
+    TS_ASSERT_EQUALS(result->y(0)[2], 6);
 
     TS_ASSERT_EQUALS(result->run().getProperty("run_number")->value(),
                      "15189-91");
@@ -166,8 +166,8 @@ public:
                      end.toSimpleString());
 
     // Original workspaces shouldn't be touched
-    TS_ASSERT_EQUALS(ws1->readY(0)[0], 2);
-    TS_ASSERT_EQUALS(ws3->readY(0)[2], 2);
+    TS_ASSERT_EQUALS(ws1->y(0)[0], 2);
+    TS_ASSERT_EQUALS(ws3->y(0)[2], 2);
   }
 
   void test_findConsecutiveRuns() {


### PR DESCRIPTION


## Description of work.
This PR is part of refactoring effort to use the new interface of the HistogramData module.
See https://github.com/mantidproject/mantid/issues/17641 for details.

The following algorithms were refactored to use HistogramData:
MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
MantidQt/CustomInterfaces/src/SampleTransmission.cpp
MantidQt/CustomInterfaces/src/SANSPlotSpecial.cpp
MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
MantidQt/CustomInterfaces/src/Tomography/ImageROIViewQtWidget.cpp
MantidQt/CustomInterfaces/src/Tomography/ImggFormatsConvertViewQtWidget.cpp
MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceViewQtGUI.cpp
MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
MantidQt/CustomInterfaces/test/ALCPeakFittingModelTest.h
MantidQt/CustomInterfaces/test/MuonAnalysisDataLoaderTest.h
MantidQt/CustomInterfaces/test/MuonAnalysisHelperTest.h

## To test.

Code review.

<Add any manual testing not covered by unit tests, especially GUIs>

Fixes <your issue>.
Internal change, no release notes (potential performance improvements will be added to release notes as part of the umbrella issue).