### PR TITLE
Fix crash in MonitorDlg

### DIFF
--- a/MantidPlot/src/Mantid/AlgorithmMonitor.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmMonitor.cpp
@@ -206,6 +206,9 @@ void MonitorDlg::update() {
        itr != iend; ++itr) {
     IAlgorithm_sptr alg =
         Mantid::API::AlgorithmManager::Instance().getAlgorithm(*itr);
+    if (!alg) {
+      continue;
+    }
     // m_algorithms << alg;
     QStringList iList;
     iList << QString::fromStdString(alg->name());


### PR DESCRIPTION
This PR avoids a potential crash when clicking the Details button to open the monitor dialog. It does not solve the root cause of the problem (an algorithm pointer being null) but stops mantid crashing if a null pointer is found.

**To test:**

<!-- Instructions for testing. -->
The crash is intermittent and is not easily reproducible. The problem has been seen frequently by offspec users and we have managed to reproduce it under the debugger on their machine. They are testing a dev version with the same fix as this PR and so far have not seen the crash again.

Fixes #18951 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
