### PR TITLE
Fix incorrect usage of std::move in WS Creation Helper

### DIFF
--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -112,9 +112,8 @@ Workspace2D_sptr create1DWorkspaceRand(int size, bool isHisto) {
   Counts counts(size, randFunc);
   CountStandardDeviations errorVals(size, randFunc);
 
-  auto generatedHisto = createHisto(isHisto, counts, errorVals);
   auto retVal = boost::make_shared<Workspace2D>();
-  retVal->initialize(1, std::move(generatedHisto));
+  retVal->initialize(1, createHisto(isHisto, counts, errorVals));
   return retVal;
 }
 
@@ -122,10 +121,9 @@ Workspace2D_sptr create1DWorkspaceConstant(int size, double value, double error,
                                            bool isHisto) {
   Counts yVals(size, value);
   CountStandardDeviations errVals(size, error);
-  auto generatedHisto = createHisto(isHisto, yVals, errVals);
 
   auto retVal = boost::make_shared<Workspace2D>();
-  retVal->initialize(1, std::move(generatedHisto));
+  retVal->initialize(1, createHisto(isHisto, yVals, errVals));
   return retVal;
 }
 
@@ -144,9 +142,8 @@ Workspace2D_sptr create1DWorkspaceFib(int size, bool isHisto) {
   Counts yVals(size, FibSeries<double>());
   CountStandardDeviations errVals(size);
 
-  auto generatedHisto = createHisto(isHisto, yVals, errVals);
   auto retVal = boost::make_shared<Workspace2D>();
-  retVal->initialize(1, std::move(generatedHisto));
+  retVal->initialize(1, createHisto(isHisto, yVals, errVals));
   return retVal;
 }
 


### PR DESCRIPTION
Description of work.
This PR fixes the incorrect usages of `std::move` [introduced](http://builds.mantidproject.org/view/Static%20Analysis/job/clang_tidy_framework/84/warnings14Result/category.749444337/) in the changes as part of #18724 

**To test:**
Ensure builds pass
Code review

Fixes: N/A

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
