### PR TITLE
Peakviewer in sliceviewer makes incorrect assumptions regarding dimensions

### DIFF
--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ConcretePeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ConcretePeaksPresenter.h
@@ -85,9 +85,9 @@ private:
   EditMode m_editMode;
   /// Can we add to this peaks workspace
   bool m_hasAddPeaksMode;
-
+  bool m_initMappingTransform; // whether to use default transformation or not
   /// Configure peak transformations
-  bool configureMappingTransform();
+  bool configureMappingTransform(bool m_initMappingTransform = false);
   /// Hide all views
   void hideAll();
   /// Show all views

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ConcretePeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ConcretePeaksPresenter.h
@@ -85,7 +85,6 @@ private:
   EditMode m_editMode;
   /// Can we add to this peaks workspace
   bool m_hasAddPeaksMode;
-  bool m_initMappingTransform; // whether to use default transformation or not
   /// Configure peak transformations
   bool configureMappingTransform();
   /// Hide all views

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ConcretePeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ConcretePeaksPresenter.h
@@ -87,7 +87,7 @@ private:
   bool m_hasAddPeaksMode;
   bool m_initMappingTransform; // whether to use default transformation or not
   /// Configure peak transformations
-  bool configureMappingTransform(bool m_initMappingTransform = false);
+  bool configureMappingTransform();
   /// Hide all views
   void hideAll();
   /// Show all views

--- a/MantidQt/SliceViewer/src/ConcretePeaksPresenter.cpp
+++ b/MantidQt/SliceViewer/src/ConcretePeaksPresenter.cpp
@@ -188,7 +188,6 @@ void ConcretePeaksPresenter::initialize() {
   produceViews();
   changeShownDim(); // in case dimensions shown are not those expected by
                     // default transformation
-
 }
 
 /**
@@ -271,10 +270,10 @@ bool ConcretePeaksPresenter::changeShownDim() {
 bool ConcretePeaksPresenter::configureMappingTransform() {
   bool transformSucceeded = false;
   try {
-      std::string xLabel = m_viewFactory->getPlotXLabel();
-      std::string yLabel = m_viewFactory->getPlotYLabel();
-      auto temp = m_transformFactory->createTransform(xLabel, yLabel);
-      m_transform = temp;
+    std::string xLabel = m_viewFactory->getPlotXLabel();
+    std::string yLabel = m_viewFactory->getPlotYLabel();
+    auto temp = m_transformFactory->createTransform(xLabel, yLabel);
+    m_transform = temp;
     showAll();
     transformSucceeded = true;
   } catch (Mantid::Geometry::PeakTransformException &) {

--- a/MantidQt/SliceViewer/src/ConcretePeaksPresenter.cpp
+++ b/MantidQt/SliceViewer/src/ConcretePeaksPresenter.cpp
@@ -184,10 +184,12 @@ void ConcretePeaksPresenter::reInitialize(IPeaksWorkspace_sptr peaksWS) {
  * @brief initialize inner components. Produces the views.
  */
 void ConcretePeaksPresenter::initialize() {
-
-  const bool transformSucceeded =
-      this->configureMappingTransform(m_initMappingTransform);
-
+	bool transformSucceeded = true;
+	if (!m_initMappingTransform) {
+		transformSucceeded = false;
+		transformSucceeded =
+			this->configureMappingTransform();
+	}
   // Make and register each peak widget.
   produceViews();
   changeShownDim(); // in case dimensions shown are not those expected by
@@ -274,20 +276,13 @@ bool ConcretePeaksPresenter::changeShownDim() {
  changes the chosen dimensions to plot.
  @return True if the mapping has succeeded.
  */
-bool ConcretePeaksPresenter::configureMappingTransform(
-    bool m_initMappingTransform) {
+bool ConcretePeaksPresenter::configureMappingTransform() {
   bool transformSucceeded = false;
   try {
-    if (m_initMappingTransform) {
-      auto temp = m_transformFactory->createDefaultTransform();
-      m_transform = temp;
-      m_initMappingTransform = false;
-    } else {
       std::string xLabel = m_viewFactory->getPlotXLabel();
       std::string yLabel = m_viewFactory->getPlotYLabel();
       auto temp = m_transformFactory->createTransform(xLabel, yLabel);
       m_transform = temp;
-    }
     showAll();
     transformSucceeded = true;
   } catch (Mantid::Geometry::PeakTransformException &) {

--- a/MantidQt/SliceViewer/src/ConcretePeaksPresenter.cpp
+++ b/MantidQt/SliceViewer/src/ConcretePeaksPresenter.cpp
@@ -159,7 +159,7 @@ ConcretePeaksPresenter::ConcretePeaksPresenter(
           canAddPeaksTo(peaksWS.get(), m_transform->getCoordinateSystem())) {
   // Check that the workspaces appear to be compatible. Log if otherwise.
   checkWorkspaceCompatibilities(mdWS);
-
+  m_initMappingTransform = true;
   this->initialize();
 }
 
@@ -184,11 +184,14 @@ void ConcretePeaksPresenter::reInitialize(IPeaksWorkspace_sptr peaksWS) {
  * @brief initialize inner components. Produces the views.
  */
 void ConcretePeaksPresenter::initialize() {
-  const bool transformSucceeded = this->configureMappingTransform();
+
+  const bool transformSucceeded =
+      this->configureMappingTransform(m_initMappingTransform);
 
   // Make and register each peak widget.
   produceViews();
-
+  changeShownDim(); // in case dimensions shown are not those expected by
+                    // default transformation
   if (!transformSucceeded) {
     hideAll();
   }
@@ -271,13 +274,20 @@ bool ConcretePeaksPresenter::changeShownDim() {
  changes the chosen dimensions to plot.
  @return True if the mapping has succeeded.
  */
-bool ConcretePeaksPresenter::configureMappingTransform() {
+bool ConcretePeaksPresenter::configureMappingTransform(
+    bool m_initMappingTransform) {
   bool transformSucceeded = false;
   try {
-    std::string xLabel = m_viewFactory->getPlotXLabel();
-    std::string yLabel = m_viewFactory->getPlotYLabel();
-    auto temp = m_transformFactory->createTransform(xLabel, yLabel);
-    m_transform = temp;
+    if (m_initMappingTransform) {
+      auto temp = m_transformFactory->createDefaultTransform();
+      m_transform = temp;
+      m_initMappingTransform = false;
+    } else {
+      std::string xLabel = m_viewFactory->getPlotXLabel();
+      std::string yLabel = m_viewFactory->getPlotYLabel();
+      auto temp = m_transformFactory->createTransform(xLabel, yLabel);
+      m_transform = temp;
+    }
     showAll();
     transformSucceeded = true;
   } catch (Mantid::Geometry::PeakTransformException &) {

--- a/MantidQt/SliceViewer/src/ConcretePeaksPresenter.cpp
+++ b/MantidQt/SliceViewer/src/ConcretePeaksPresenter.cpp
@@ -159,7 +159,6 @@ ConcretePeaksPresenter::ConcretePeaksPresenter(
           canAddPeaksTo(peaksWS.get(), m_transform->getCoordinateSystem())) {
   // Check that the workspaces appear to be compatible. Log if otherwise.
   checkWorkspaceCompatibilities(mdWS);
-  m_initMappingTransform = true;
   this->initialize();
 }
 
@@ -184,19 +183,12 @@ void ConcretePeaksPresenter::reInitialize(IPeaksWorkspace_sptr peaksWS) {
  * @brief initialize inner components. Produces the views.
  */
 void ConcretePeaksPresenter::initialize() {
-	bool transformSucceeded = true;
-	if (!m_initMappingTransform) {
-		transformSucceeded = false;
-		transformSucceeded =
-			this->configureMappingTransform();
-	}
+
   // Make and register each peak widget.
   produceViews();
   changeShownDim(); // in case dimensions shown are not those expected by
                     // default transformation
-  if (!transformSucceeded) {
-    hideAll();
-  }
+
 }
 
 /**

--- a/MantidQt/SliceViewer/test/ConcretePeaksPresenterTest.h
+++ b/MantidQt/SliceViewer/test/ConcretePeaksPresenterTest.h
@@ -558,7 +558,7 @@ public:
     auto pMockView = new NiceMock<MockPeakOverlayView>;
     auto mockView = boost::shared_ptr<NiceMock<MockPeakOverlayView>>(pMockView);
     EXPECT_CALL(*pMockView, showView())
-        .Times(1); // Expect that the view will be forced to SHOW.
+        .Times(2); // Expect that the view will be forced to SHOW.
     EXPECT_CALL(*pMockView, hideView())
         .Times(1); // Expect that the view will be forced to HIDE.
     EXPECT_CALL(*pMockView, updateView())


### PR DESCRIPTION
Fixes #18911 

To test go to \\olympic\Babylon5\Scratch\Lottie\18911_peakviewer
load SEQ_11499_md_enp.nxs and MDEvent_ellipPeaks_new.nxs in the sliceviewer, and test with the peak files testPeak.nxs and ellipPeaks_new.nxs.
When changing dimensions, or enabling the peakviewer whilst viewing 'unexpected' dimensions (eg H is Y and K is X axis), the peak representations should stay accurate.

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
