### PR TITLE
Blank instrument view with U correction

### DIFF
--- a/MantidQt/MantidWidgets/src/InstrumentView/RotationSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/RotationSurface.cpp
@@ -162,7 +162,7 @@ void RotationSurface::init() {
                             udet.u = applyUCorrection(udet.u);
                           }
                         }
-    updateViewRectForUCorrection();
+                        updateViewRectForUCorrection();
 }
 
 /** Update the view rect to account for the U correction

--- a/MantidQt/MantidWidgets/src/InstrumentView/RotationSurface.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/RotationSurface.cpp
@@ -162,6 +162,7 @@ void RotationSurface::init() {
                             udet.u = applyUCorrection(udet.u);
                           }
                         }
+    updateViewRectForUCorrection();
 }
 
 /** Update the view rect to account for the U correction


### PR DESCRIPTION
It appears the start up the instrument view doesn't draw the correct viewport unless a U correction is applied. This appears to have been missed in the original PR, probably because the U correction gets cached in the QSettings.

**To test:**
Follow the same instructions as in PR #18875.  

Fixes #18869 .

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
