### PR TITLE
Fix misc-suspicious-string-compare warning.

### DIFF
--- a/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
+++ b/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
@@ -655,6 +655,10 @@ int SaveToSNSHistogramNexus::WriteAttributes(int is_definition) {
   NXname attrName;
   void *attrBuffer;
 
+  std::array<const char *, 6> attrs = {{"NeXus_version", "XML_version",
+                                        "HDF_version", "HDF5_Version",
+                                        "file_name", "file_time"}};
+
   do {
 #ifdef NEXUS43
     status = NXgetnextattr(inId, attrName, &attrLen, &attrType);
@@ -669,10 +673,10 @@ int SaveToSNSHistogramNexus::WriteAttributes(int is_definition) {
         return NX_ERROR;
       attrLen = dims[0];
 #endif
-      if (strcmp(attrName, "NeXus_version") &&
-          strcmp(attrName, "XML_version") && strcmp(attrName, "HDF_version") &&
-          strcmp(attrName, "HDF5_Version") && strcmp(attrName, "file_name") &&
-          strcmp(attrName, "file_time")) {
+      if (std::none_of(attrs.cbegin(), attrs.cend(),
+                       [attrName](const char *name) {
+                         return strcmp(attrName, name) == 0;
+                       })) {
         attrLen++; /* Add space for string termination */
         if (NXmalloc(&attrBuffer, 1, &attrLen, attrType) != NX_OK)
           return NX_ERROR;

--- a/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
+++ b/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
@@ -674,7 +674,7 @@ int SaveToSNSHistogramNexus::WriteAttributes(int is_definition) {
       attrLen = dims[0];
 #endif
       if (std::none_of(attrs.cbegin(), attrs.cend(),
-                       [attrName](const char *name) {
+                       [&attrName](const char *name) {
                          return strcmp(attrName, name) == 0;
                        })) {
         attrLen++; /* Add space for string termination */


### PR DESCRIPTION
Description of work.

clang-tidy complains that the `function 'strcmp' is called without explicitly comparing result`. While the original logic appears correct, `std::none_of` is clearer and suppresses this warning.

**To test:**

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
