### PR TITLE
Remove sleep function from SANS unit tests

### DIFF
--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -1323,8 +1323,6 @@ class TestCorrectingCummulativeSampleLogs(unittest.TestCase):
         out_ws_name = 'out_ws'
         time_shift = 0
         log_names = ['good_uah_log', 'good_frames', 'new_series']
-        import time
-        time.sleep(10)
         start_time_1 = "2010-01-01T00:00:00"
         proton_charge_1 = 10.2
         lhs = provide_event_ws_with_entries(names[0],start_time_1, extra_time_shift = 0.0,
@@ -1513,8 +1511,6 @@ class TestBenchRotDetection(unittest.TestCase):
 
     def test_workspace_without_bench_raises(self):
         # Arrange
-        import time
-        time.sleep(10)
         ws = self._get_sample_workspace(has_bench_rot=False)
         # Act + Assert
         expected_raise = True
@@ -1523,8 +1519,6 @@ class TestBenchRotDetection(unittest.TestCase):
 
     def test_workspace_without_bench_but_no_log_dict_does_not_raise(self):
         # Arrange
-        import time
-        time.sleep(10)
         ws = self._get_sample_workspace(has_bench_rot=False)
         # Act + Assert
         expected_raise = False


### PR DESCRIPTION
Removed `time.sleep` from SANS unit tests.

**To test:**

Tests need to pass. 
Check that the only items which were removed are calls to `time.sleep`

Fixes #18966.

No release notes requiered.
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
