### PR TITLE
Fix indexing errors in NumPy 1.12 for failing systemtests

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/GenerateGroupingSNSInelastic.py
+++ b/Framework/PythonInterface/plugins/algorithms/GenerateGroupingSNSInelastic.py
@@ -69,16 +69,16 @@ class GenerateGroupingSNSInelastic(mantid.api.PythonAlgorithm):
 
         spectra = numpy.arange(numdet).reshape(-1,8,128)
 
-        banks = numdet/8/128
+        banks = numdet//8//128
 
         f = open(filename,'w')
 
         f.write('<?xml version="1.0" encoding="UTF-8" ?>\n<detector-grouping instrument="'+instrument+'">\n')
 
         groupnum = 0
-        for i in numpy.arange(banks):
-            for j in numpy.arange(8/pixelsx)*pixelsx:
-                for k in numpy.arange(128/pixelsy)*pixelsy:
+        for i in range(banks):
+            for j in range(0,8,pixelsx):
+                for k in range(0,128,pixelsy):
 
                     groupname = str(groupnum)
                     ids = spectra[i, j:j+pixelsx, k:k+pixelsy].reshape(-1)

--- a/scripts/Calibration/tube_calib.py
+++ b/scripts/Calibration/tube_calib.py
@@ -127,8 +127,8 @@ def fitGaussian(fitPar, index, ws, outputWs):
 
     RIGHTLIMIT = len(all_values)
 
-    min_index = max(centre-margin,0)
-    max_index = min(centre+margin, RIGHTLIMIT)
+    min_index = max(centre-int(margin),0)
+    max_index = min(centre+int(margin), RIGHTLIMIT)
     values = all_values[min_index:max_index]
 
     # find the peak position

--- a/scripts/reduction/instruments/reflectometer/wks_utility.py
+++ b/scripts/reduction/instruments/reflectometer/wks_utility.py
@@ -1677,7 +1677,7 @@ def getDistances(ws_event_data):
             dPS_array[y, x] = sample.getDistance(detector)
 
     # Distance sample->center of detector
-    dSD = dPS_array[256./2.,304./2.]
+    dSD = dPS_array[256//2,304//2]
     # Distance source->center of detector
     dMD = dSD + dSM
 


### PR DESCRIPTION
In 1.12 numpy changed some DeprecationWarnings to errors related to indexing, see https://docs.scipy.org/doc/numpy/release.html#deprecationwarning-to-error

These systemtests are failing with NumPy 1.12:
HYSPECReductionTest.HYSPECReductionTest
ISIS_WISHCalibration.WISHCalibrationTest
REFLReduction.REFLReduction
REFLWithBackground.REFLWithBackground

**To test:**
Code review should be sufficient, I don't expect anyone else to be using NumPy 1.12 currently


*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
