### PR TITLE
`SetInstrumentParameter` to support bool parameter

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SetInstrumentParameter.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SetInstrumentParameter.h
@@ -47,6 +47,7 @@ public:
 
   int version() const override;
   const std::string category() const override;
+  std::map<std::string, std::string> validateInputs() override;
 
 private:
   void init() override;

--- a/Framework/Algorithms/src/SetInstrumentParameter.cpp
+++ b/Framework/Algorithms/src/SetInstrumentParameter.cpp
@@ -189,7 +189,7 @@ void SetInstrumentParameter::addParameter(
   if (paramType == "String") {
     pmap.addString(cmptId, paramName, paramValue);
   } else if (paramType == "Number") {
-    int intVal;    
+    int intVal;
     if (Strings::convert(paramValue, intVal)) {
       pmap.addInt(cmptId, paramName, intVal);
     } else {

--- a/Framework/Algorithms/src/SetInstrumentParameter.cpp
+++ b/Framework/Algorithms/src/SetInstrumentParameter.cpp
@@ -8,6 +8,8 @@
 #include "MantidKernel/Strings.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 
+#include <boost/algorithm/string.hpp>
+
 namespace Mantid {
 namespace Algorithms {
 
@@ -52,12 +54,35 @@ void SetInstrumentParameter::init() {
                   boost::make_shared<MandatoryValidator<std::string>>(),
                   "The name that will identify the parameter");
 
-  std::vector<std::string> propOptions{"String", "Number"};
+  std::vector<std::string> propOptions{"String", "Number", "Bool"};
   declareProperty("ParameterType", "String",
                   boost::make_shared<StringListValidator>(propOptions),
                   "The type that the parameter value will be.");
 
   declareProperty("Value", "", "The content of the Parameter");
+}
+
+/// @copydoc Algorithm::validateInputs()
+std::map<std::string, std::string> SetInstrumentParameter::validateInputs() {
+  std::map<std::string, std::string> errors;
+  const std::set<std::string> allowedBoolValues{"1", "0", "true", "false"};
+  const std::string type = getPropertyValue("ParameterType");
+  std::string val = getPropertyValue("Value");
+
+  if (type == "Bool") {
+    boost::algorithm::to_lower(val);
+    if (allowedBoolValues.find(val) == allowedBoolValues.end()) {
+      errors["Value"] = "Invalid value for Bool type.";
+    }
+  } else if (type == "Number") {
+    int intVal;
+    double dblVal;
+    if (!Strings::convert(val, intVal) && !Strings::convert(val, dblVal)) {
+      errors["Value"] = "Invalid value for Number type.";
+    }
+  }
+
+  return errors;
 }
 
 //----------------------------------------------------------------------------------------------
@@ -164,22 +189,19 @@ void SetInstrumentParameter::addParameter(
   if (paramType == "String") {
     pmap.addString(cmptId, paramName, paramValue);
   } else if (paramType == "Number") {
-    bool valueIsInt(false);
     int intVal;
     double dblVal;
     if (Strings::convert(paramValue, intVal)) {
-      valueIsInt = true;
-    } else if (!Strings::convert(paramValue, dblVal)) {
-      throw std::invalid_argument("Error interpreting string '" + paramValue +
-                                  "' as a number.");
-    }
-
-    if (valueIsInt)
       pmap.addInt(cmptId, paramName, intVal);
-    else
+    } else {
+      Strings::convert(paramValue, dblVal);
       pmap.addDouble(cmptId, paramName, dblVal);
-  } else {
-    throw std::invalid_argument("Unknown Parameter Type " + paramType);
+    }
+  } else if (paramType == "Bool") {
+    std::string paramValueLower(paramValue);
+    boost::algorithm::to_lower(paramValueLower);
+    bool paramBoolValue = (paramValueLower == "true" || paramValue == "1");
+    pmap.addBool(cmptId, paramName, paramBoolValue);
   }
 }
 

--- a/Framework/Algorithms/src/SetInstrumentParameter.cpp
+++ b/Framework/Algorithms/src/SetInstrumentParameter.cpp
@@ -189,11 +189,11 @@ void SetInstrumentParameter::addParameter(
   if (paramType == "String") {
     pmap.addString(cmptId, paramName, paramValue);
   } else if (paramType == "Number") {
-    int intVal;
-    double dblVal;
+    int intVal;    
     if (Strings::convert(paramValue, intVal)) {
       pmap.addInt(cmptId, paramName, intVal);
     } else {
+      double dblVal;
       Strings::convert(paramValue, dblVal);
       pmap.addDouble(cmptId, paramName, dblVal);
     }

--- a/Framework/Algorithms/test/SetInstrumentParameterTest.h
+++ b/Framework/Algorithms/test/SetInstrumentParameterTest.h
@@ -150,6 +150,18 @@ public:
     TS_ASSERT_EQUALS(paramValue2, cmpt->getStringParameter(paramName)[0]);
   }
 
+  void test_bool() {
+    std::string paramName = "TestParam";
+    std::string paramType = "Bool";
+    std::string paramValue = "true";
+
+    MatrixWorkspace_sptr ws =
+        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(3, 3);
+
+    ExecuteAlgorithm(ws, "", "", paramName, paramValue, paramType);
+    TS_ASSERT(ws->getInstrument()->getBoolParameter(paramName)[0]);
+  }
+
   MatrixWorkspace_sptr
   ExecuteAlgorithm(MatrixWorkspace_sptr testWS, std::string cmptName,
                    std::string detList, std::string paramName,

--- a/Framework/Algorithms/test/SetInstrumentParameterTest.h
+++ b/Framework/Algorithms/test/SetInstrumentParameterTest.h
@@ -151,15 +151,20 @@ public:
   }
 
   void test_bool() {
-    std::string paramName = "TestParam";
-    std::string paramType = "Bool";
-    std::string paramValue = "true";
+    const std::string paramName = "TestParam";
+    const std::string paramType = "Bool";
+    const std::map<std::string, bool> paramValues = {
+        {"true", true},   {"TRUE", true},   {"True", true},   {"1", true},
+        {"false", false}, {"FALSE", false}, {"False", false}, {"0", false}};
 
     MatrixWorkspace_sptr ws =
         WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(3, 3);
 
-    ExecuteAlgorithm(ws, "", "", paramName, paramValue, paramType);
-    TS_ASSERT(ws->getInstrument()->getBoolParameter(paramName)[0]);
+    for (const auto &value : paramValues) {
+      ExecuteAlgorithm(ws, "", "", paramName, value.first, paramType);
+      TS_ASSERT(ws->getInstrument()->getBoolParameter(paramName)[0] ==
+                value.second);
+    }
   }
 
   MatrixWorkspace_sptr

--- a/Framework/Algorithms/test/SetInstrumentParameterTest.h
+++ b/Framework/Algorithms/test/SetInstrumentParameterTest.h
@@ -153,9 +153,14 @@ public:
   void test_bool() {
     const std::string paramName = "TestParam";
     const std::string paramType = "Bool";
-    const std::map<std::string, bool> paramValues = {
-        {"true", true},   {"TRUE", true},   {"True", true},   {"1", true},
-        {"false", false}, {"FALSE", false}, {"False", false}, {"0", false}};
+    const std::map<std::string, bool> paramValues = {{"true", true},
+                                                     {"TRUE", true},
+                                                     {"True", true},
+                                                     {"1", true},
+                                                     {"false", false},
+                                                     {"FALSE", false},
+                                                     {"False", false},
+                                                     {"0", false}};
 
     MatrixWorkspace_sptr ws =
         WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(3, 3);

--- a/docs/source/algorithms/SetInstrumentParameter-v1.rst
+++ b/docs/source/algorithms/SetInstrumentParameter-v1.rst
@@ -23,6 +23,12 @@ parameter is not specified it will be attached to the whole instrument.
 At present this algorithm only supports simple instrument parameters,
 NOT fitting parameters.
 
+Parameter Types
+---------------
+
+The algorithm supports three types of parameters; `Number` (integer or floating point), `String` and `Bool`.
+For `Bool` type, valid values are `1`, `0`, `true` or `false` (not case-sensitive).
+
 Usage
 -----
 

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -17,6 +17,7 @@ Improved
 ########
 
 - :ref`RawFileInfo <algm-RawFileInfo-v1>` now provides sample information.
+- :ref`SetInstrumentParameter <algm-SetInstrumentParameter-v1>` now supports also boolean parameters, and better validates the inputs.
 
 Bug Fixes
 #########


### PR DESCRIPTION
This PR adds the option to add a boolean instrument parameter.
Boolean validation is not too strict, i.e. `0, 1, true, false, True, False, TRUE, FALSE` are valid.
Also the number validation is put now in `validateInputs()`. 

**To test:**
Play around with this snippet. Try different values for boolean. Also try non-number value for number type parameter.
```
ws = CreateSampleWorkspace()
SetInstrumentParameter(ws,ParameterName="TestParam",ParameterType="Bool",Value="True")
print ws.getInstrument().getBoolParameter("TestParam")[0]
```

<!-- Instructions for testing. -->

Fixes #18965 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.