### PR TITLE
Fix bug when saving table contents to a workspace

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorTwoLevelTreeManager.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorTwoLevelTreeManager.h
@@ -100,8 +100,6 @@ private:
   DataProcessorPresenter *m_presenter;
   /// The model
   boost::shared_ptr<QDataProcessorTwoLevelTreeModel> m_model;
-  /// The workspace the model is currently representing
-  Mantid::API::ITableWorkspace_sptr m_ws;
 
   /// Insert a row in the model
   void insertRow(int groupIndex, int rowIndex);

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/QDataProcessorTwoLevelTreeModel.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/QDataProcessorTwoLevelTreeModel.h
@@ -70,6 +70,8 @@ public:
   // Get the index for a given column, row and parent
   QModelIndex index(int row, int column,
                     const QModelIndex &parent = QModelIndex()) const override;
+  // Get the underlying data structure
+  Mantid::API::ITableWorkspace_sptr getTableWorkspace() const;
 
   // Get the parent
   QModelIndex parent(const QModelIndex &index) const override;

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorTwoLevelTreeModel.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorTwoLevelTreeModel.cpp
@@ -448,5 +448,15 @@ void QDataProcessorTwoLevelTreeModel::setupModelData(
   }
 }
 
+/** Return the underlying data structure, i.e. the table workspace this model is
+ * representing
+ *
+ * @return :: the underlying table workspace
+ */
+ITableWorkspace_sptr
+QDataProcessorTwoLevelTreeModel::getTableWorkspace() const {
+  return m_tWS;
+}
+
 } // namespace MantidWidgets
 } // namespace Mantid

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorTwoLevelTreeManagerTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorTwoLevelTreeManagerTest.h
@@ -331,7 +331,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(manager.newTable(whitelist));
     auto ws = manager.getTableWorkspace();
     TS_ASSERT_EQUALS(ws->rowCount(), 1);
-	TS_ASSERT_EQUALS(ws->columnCount(), whitelist.size() + 1);
+    TS_ASSERT_EQUALS(ws->columnCount(), whitelist.size() + 1);
     // But the row should be empty
     TS_ASSERT_EQUALS(ws->String(0, 0), std::string());
     TS_ASSERT_EQUALS(ws->String(0, 1), std::string());

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorTwoLevelTreeManagerTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorTwoLevelTreeManagerTest.h
@@ -329,7 +329,19 @@ public:
     TS_ASSERT_EQUALS(manager.getTableWorkspace()->rowCount(), 4);
 
     TS_ASSERT_THROWS_NOTHING(manager.newTable(whitelist));
-    TS_ASSERT_EQUALS(manager.getTableWorkspace()->rowCount(), 0);
+    auto ws = manager.getTableWorkspace();
+    TS_ASSERT_EQUALS(ws->rowCount(), 1);
+	TS_ASSERT_EQUALS(ws->columnCount(), whitelist.size() + 1);
+    // But the row should be empty
+    TS_ASSERT_EQUALS(ws->String(0, 0), std::string());
+    TS_ASSERT_EQUALS(ws->String(0, 1), std::string());
+    TS_ASSERT_EQUALS(ws->String(0, 2), std::string());
+    TS_ASSERT_EQUALS(ws->String(0, 3), std::string());
+    TS_ASSERT_EQUALS(ws->String(0, 4), std::string());
+    TS_ASSERT_EQUALS(ws->String(0, 5), std::string());
+    TS_ASSERT_EQUALS(ws->String(0, 6), std::string());
+    TS_ASSERT_EQUALS(ws->String(0, 7), std::string());
+    TS_ASSERT_EQUALS(ws->String(0, 8), std::string());
   }
 
   void test_transfer_fails_no_group() {
@@ -408,21 +420,21 @@ public:
     auto data = manager.selectedData(false);
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter));
 
-    TS_ASSERT_EQUALS(data.size(), 3);
-    std::vector<std::string> secondRow = {
+    TS_ASSERT_EQUALS(data.size(), 2);
+    std::vector<std::string> firstRow = {
         "12345", "0.5",  "20000", "0.1",
         "0.2",   "0.04", "5",     "CorrectDetectorPositions=1"};
-    std::vector<std::string> thirdRow = {
+    std::vector<std::string> secondRow = {
         "12346", "0.6",  "20001", "0.1",
         "0.2",   "0.04", "4",     "CorrectDetectorPositions=0"};
-    std::vector<std::string> fourthRow = {"12347", "0.7",  "20003", "0.3",
-                                          "0.4",   "0.01", "3",     ""};
-    std::vector<std::string> fifthRow = {"12348", "0.8",  "20004", "0.4",
-                                         "0.5",   "0.02", "2",     ""};
-    TS_ASSERT_EQUALS(data[1][0], secondRow);
-    TS_ASSERT_EQUALS(data[1][1], thirdRow);
-    TS_ASSERT_EQUALS(data[2][0], fourthRow);
-    TS_ASSERT_EQUALS(data[2][1], fifthRow);
+    std::vector<std::string> thirdRow = {"12347", "0.7",  "20003", "0.3",
+                                         "0.4",   "0.01", "3",     ""};
+    std::vector<std::string> fourthRow = {"12348", "0.8",  "20004", "0.4",
+                                          "0.5",   "0.02", "2",     ""};
+    TS_ASSERT_EQUALS(data[0][0], firstRow);
+    TS_ASSERT_EQUALS(data[0][1], secondRow);
+    TS_ASSERT_EQUALS(data[1][0], thirdRow);
+    TS_ASSERT_EQUALS(data[1][1], fourthRow);
   }
 
   void test_update() {

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -452,6 +452,11 @@ public:
     presenter.notify(DataProcessorPresenter::SaveAsFlag);
 
     TS_ASSERT(AnalysisDataService::Instance().doesExist("Workspace"));
+    ITableWorkspace_sptr ws =
+        AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(
+            "Workspace");
+    TS_ASSERT_EQUALS(ws->rowCount(), 4);
+    TS_ASSERT_EQUALS(ws->columnCount(), 9);
 
     AnalysisDataService::Instance().remove("TestWorkspace");
     AnalysisDataService::Instance().remove("Workspace");

--- a/docs/source/release/v3.10.0/reflectometry.rst
+++ b/docs/source/release/v3.10.0/reflectometry.rst
@@ -18,6 +18,8 @@ ISIS Reflectometry (Polref)
 ISIS Reflectometry
 ##################
 
+* Fix a bug where contents of the processing table where not saved to a table workspace.
+
 |
 
 `Full list of changes on github <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.10%22+is%3Amerged+label%3A%22Component%3A+Reflectometry%22>`__


### PR DESCRIPTION
Reflectometry (Polref) GUI does not save the contents of the processing table.

**To test:**

- Open the reflectometry (polref) interface.
- Save the table via `Reflectometry` -> `Save Table` (or `Reflectometry` -> `Save Table As`.
- Double click on the table workspace that has been created in the ADS. You should see a table with a single row (this row will be empty).
- Enter some numbers in the GUI and save the table again. The table in the ADS should be updated with the new values.
- Ensure that transfer functionality works exactly the same as before:
 - Transfer all runs for a specific investigation id.
 - Transfer a group of runs first, then another group of runs.

Fixes #18973.

Release notes were updated.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
