### PR TITLE
Refactor loading of proton_charge_by_period log 

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
@@ -126,8 +126,7 @@ private:
   void loadSampleData(DataObjects::Workspace2D_sptr &,
                       Mantid::NeXus::NXEntry &entry);
   /// Load log data from the nexus file
-  void loadLogs(DataObjects::Workspace2D_sptr &ws,
-                Mantid::NeXus::NXEntry &entry);
+  void loadLogs(DataObjects::Workspace2D_sptr &ws);
   // Load a given period into the workspace
   void loadPeriodData(int64_t period, Mantid::NeXus::NXEntry &entry,
                       DataObjects::Workspace2D_sptr &local_workspace,

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -283,7 +283,7 @@ void LoadISISNexus2::exec() {
   // ticket #8697
   loadSampleData(local_workspace, entry);
   m_progress->report("Loading logs");
-  loadLogs(local_workspace, entry);
+  loadLogs(local_workspace);
 
   // Load first period outside loop
   m_progress->report("Loading data");
@@ -1117,10 +1117,8 @@ void LoadISISNexus2::loadSampleData(
 *   /raw_data_1/runlog group of the file. Call to this method must be done
 *   within /raw_data_1 group.
 *   @param ws :: The workspace to load the logs to.
-*   @param entry :: Nexus entry
 */
-void LoadISISNexus2::loadLogs(DataObjects::Workspace2D_sptr &ws,
-                              NXEntry &entry) {
+void LoadISISNexus2::loadLogs(DataObjects::Workspace2D_sptr &ws) {
   IAlgorithm_sptr alg = createChildAlgorithm("LoadNexusLogs", 0.0, 0.5);
   alg->setPropertyValue("Filename", this->getProperty("Filename"));
   alg->setProperty<MatrixWorkspace_sptr>("Workspace", ws);

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -1131,23 +1131,7 @@ void LoadISISNexus2::loadLogs(DataObjects::Workspace2D_sptr &ws,
                     << "data associated with this workspace\n";
     return;
   }
-  // For ISIS Nexus only, fabricate an additional log containing an array of
-  // proton charge information from the periods group.
-  try {
-    NXClass protonChargeClass = entry.openNXGroup("periods");
-    NXFloat periodsCharge = protonChargeClass.openNXFloat("proton_charge");
-    periodsCharge.load();
-    size_t nperiods = periodsCharge.dim0();
-    std::vector<double> chargesVector(nperiods);
-    std::copy(periodsCharge(), periodsCharge() + nperiods,
-              chargesVector.begin());
-    ArrayProperty<double> *protonLogData =
-        new ArrayProperty<double>("proton_charge_by_period", chargesVector);
-    ws->mutableRun().addProperty(protonLogData);
-  } catch (std::runtime_error &) {
-    this->g_log.debug("Cannot read periods information from the nexus file. "
-                      "This group may be absent.");
-  }
+
   // Populate the instrument parameters.
   ws->populateInstrumentParameters();
 

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -1,6 +1,7 @@
 #include "MantidDataHandling/LoadNexusLogs.h"
 #include <nexus/NeXusException.hpp>
 #include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidKernel/ArrayProperty.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/Run.h"
 #include <cctype>
@@ -366,6 +367,40 @@ void LoadNexusLogs::loadNPeriods(
   const std::string nPeriodsLabel = "nperiods";
   if (!run.hasProperty(nPeriodsLabel)) {
     run.addProperty(new PropertyWithValue<int>(nPeriodsLabel, value));
+  }
+
+  // For ISIS Nexus only, fabricate an additional log containing an array of
+  // proton charge information from the periods group.
+  try {
+    file.openGroup("periods", "IXperiods");
+
+    // Get the number of periods again
+    file.openData("number");
+    int numberOfPeriods = 0;
+    file.getData(&numberOfPeriods);
+    file.closeData();
+
+    // Get the proton charge vector
+    std::vector<double> protonChargeByPeriod(numberOfPeriods);
+    file.openData("proton_charge");
+    file.getDataCoerce(protonChargeByPeriod);
+    file.closeData();
+
+    // Add the proton charge vector
+    API::Run &run = workspace->mutableRun();
+    const std::string protonChargeByPeriodLabel = "proton_charge_by_period";
+    if (!run.hasProperty(protonChargeByPeriodLabel)) {
+      run.addProperty(new ArrayProperty<double>(protonChargeByPeriodLabel, protonChargeByPeriod));
+    }
+    file.closeGroup();
+  } catch (::NeXus::Exception &) {
+    this->g_log.debug("Cannot read periods information from the nexus file. "
+                      "This group may be absent.");
+    file.closeGroup();
+  } catch (std::runtime_error &) {
+    this->g_log.debug("Cannot read periods information from the nexus file. "
+                      "This group may be absent.");
+    file.closeGroup();
   }
 }
 

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -390,7 +390,8 @@ void LoadNexusLogs::loadNPeriods(
     API::Run &run = workspace->mutableRun();
     const std::string protonChargeByPeriodLabel = "proton_charge_by_period";
     if (!run.hasProperty(protonChargeByPeriodLabel)) {
-      run.addProperty(new ArrayProperty<double>(protonChargeByPeriodLabel, protonChargeByPeriod));
+      run.addProperty(new ArrayProperty<double>(protonChargeByPeriodLabel,
+                                                protonChargeByPeriod));
     }
     file.closeGroup();
   } catch (::NeXus::Exception &) {

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -532,6 +532,7 @@ void LoadNexusMonitors2::splitMutiPeriodHistrogramData(
                              Counts(inYBegin, inYBegin + yLength));
     }
     // add period logs
+    monLogCreator.addStatusLog(wsPeriod->mutableRun());
     monLogCreator.addPeriodLogs(static_cast<int>(i + 1),
                                 wsPeriod->mutableRun());
 

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -12,6 +12,7 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/PhysicalConstants.h"
 
+
 using namespace Mantid;
 using namespace Mantid::Geometry;
 using namespace Mantid::API;
@@ -168,6 +169,12 @@ public:
                                           periodValues.end());
     TSM_ASSERT_EQUALS("Should have 4 periods in total", 4,
                       uniquePeriods.size());
+
+    const bool hasProtonChargeByPeriod = run.hasProperty("run_title");
+    TSM_ASSERT("Should have extracted proton_charge_by_period log.", hasProtonChargeByPeriod);
+
+    std::vector<double> protonChargeByPeriod = run.getPropertyValueAsType<std::vector<double>>("proton_charge_by_period");
+    TSM_ASSERT_EQUALS("Should have four proton charge entries", 4, protonChargeByPeriod.size());
   }
 
   void test_extract_run_title_from_event_nexus() {

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -84,7 +84,8 @@ public:
     const API::Run &run = testWS->run();
     const std::vector<Property *> &logs = run.getLogData();
     TS_ASSERT_EQUALS(logs.size(),
-                     35); // 34 logs in file + 1 synthetic nperiods log
+                     36); // 34 logs in file + 1 synthetic nperiods log
+                          // + 1 proton_charge_by_period log
 
     TimeSeriesProperty<std::string> *slog =
         dynamic_cast<TimeSeriesProperty<std::string> *>(

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -12,7 +12,6 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/PhysicalConstants.h"
 
-
 using namespace Mantid;
 using namespace Mantid::Geometry;
 using namespace Mantid::API;
@@ -171,10 +170,14 @@ public:
                       uniquePeriods.size());
 
     const bool hasProtonChargeByPeriod = run.hasProperty("run_title");
-    TSM_ASSERT("Should have extracted proton_charge_by_period log.", hasProtonChargeByPeriod);
+    TSM_ASSERT("Should have extracted proton_charge_by_period log.",
+               hasProtonChargeByPeriod);
 
-    std::vector<double> protonChargeByPeriod = run.getPropertyValueAsType<std::vector<double>>("proton_charge_by_period");
-    TSM_ASSERT_EQUALS("Should have four proton charge entries", 4, protonChargeByPeriod.size());
+    std::vector<double> protonChargeByPeriod =
+        run.getPropertyValueAsType<std::vector<double>>(
+            "proton_charge_by_period");
+    TSM_ASSERT_EQUALS("Should have four proton charge entries", 4,
+                      protonChargeByPeriod.size());
   }
 
   void test_extract_run_title_from_event_nexus() {

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -170,10 +170,6 @@ public:
     TSM_ASSERT_EQUALS("Should have 4 periods in total", 4,
                       uniquePeriods.size());
 
-    const bool hasProtonChargeByPeriod = run.hasProperty("run_title");
-    TSM_ASSERT("Should have extracted proton_charge_by_period log.",
-               hasProtonChargeByPeriod);
-
     std::vector<double> protonChargeByPeriod =
         run.getPropertyValueAsType<std::vector<double>>(
             "proton_charge_by_period");

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -23,6 +23,8 @@ Bug Fixes
 
 - Fixed two issues with absolute rotations that affected :ref:`RotateInstrumentComponent <algm-RotateInstrumentComponent>`. Previously, setting the absolute rotation of a component to ``R`` would result in its rotation being ``parent-rotation * R * inverse(relative-parent-rotation)``.
 - :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` has been modified to allow `EventWorkspace` as input
+- Fixed an issue where the log `proton_charge_by_period` was not loaded for `LoadEventNexus <algm-LoadEventNexus>`.
+
 
 Deprecated
 ##########


### PR DESCRIPTION
Fixes #18981

The log property `proton_charge_by_period` was not loaded by `LoadEventNexus` since the loading was hardcoded in `LoadISISNexus`. We move it here to `LoadNexusLogs` in order to share the functionality between `LoadEventNexus` and `LoadISISNexus`

**To test:**


#### Loading multi-period event files

From the unit tests grab the file: `LARMOR00003368`
1. Load the data using `LoadEventNexus`
2. Check in the sample logs that there is an entry for `proton_charge_by_period` with four entries
3. Apply `NormaliseByCurrent` to it and confirm that there is no error
5. Delete the loaded files
6. Repeat steps 1 to 3 with `LoadISISNexus`

#### Loading multi-period histogram files

From the system tests grab the file: `SANS2D0005512.nxs`

Note that there seems to be a general bug with the sample logs for some of the entries. Mantid crashes. This behaviour was reproduced on M3.9 and a the issue can be found [here](https://github.com/mantidproject/mantid/issues/18990).

1. Load the data using the standard `Load` interface
2. Check in the sample logs of the child workspace 13 that there is an entry for `proton_charge_by_period` with 13 entries.
3. Apply `NormaliseByCurrent` to `SANS2D00005512_13` and confirm that there is no error

#### Loading standard event files

From the system test data grab `SANS2D00028797.nxs`

1. Load the data using the standard `Load` interface (this will select `LoadEventNexus`)
2. Check in the sample logs of the loaded workspace contains a `proton_charge_by_period` log with exactly one entry.
3. Apply `NormaliseByCurrent` to `SANS2D00028797` and confirm that there is no error
5. Delete the loaded files
6. Repeat steps 1 to 3 with `LoadISISNexus`

#### Loading standard histogram files

From the system test data grab `LARMOR00002260.nxs`

1. Load the data using the standard `Load` interface
2. Check in the sample logs of the loaded workspace contains a `proton_charge_by_period` log with exactly one entry.
3. Apply `NormaliseByCurrent` to `LARMOR00002260` and confirm that there is no error




### Release notes

See [here](https://github.com/mantidproject/mantid/pull/18985/commits/c2c4519b8bbbdc77995a29d7bd6c89773af19235)



---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
