### PR TITLE
Fix *IsoRotDiff doc-tests for scipy 1.18

### DIFF
--- a/docs/source/fitfunctions/ElasticIsoRotDiff.rst
+++ b/docs/source/fitfunctions/ElasticIsoRotDiff.rst
@@ -56,11 +56,7 @@ following model:
 .. testcode:: ExampleElasticIsoRotDiff
 
     import numpy as np
-    import scipy
-    if int(scipy.__version__.split('.')[1]) < 18:
-        from scipy.special import sph_jn as jn
-    else:
-        from scipy.special import spherical_jn as jn
+    from scipy.special import sph_jn
     """Generate resolution function with the following properties:
     1. Normal distribution along the energy axis, same for all Q-values
     2. FWHM = 0.005 meV
@@ -94,7 +90,7 @@ following model:
         noise = dataY*np.random.random(nE)*0.1 # noise is up to 10% of the elastic signal
         background = np.random.random()+np.random.random()*dataX  # linear background
         background = (0.01*H*max(dataY)) * (background/max(np.abs(background))) # up to 1% of H
-        j0 = jn(0,Q*R)[0][0]
+        j0 = sph_jn(0,Q*R)[0][0]
         qdataY=np.append(qdataY, H*j0**2*(dataY+noise) + background)
     # Create data workspace
     data=CreateWorkspace(np.tile(dataX,nQ), qdataY, NSpec=nQ, UnitX="deltaE",

--- a/docs/source/fitfunctions/InelasticIsoRotDiff.rst
+++ b/docs/source/fitfunctions/InelasticIsoRotDiff.rst
@@ -60,11 +60,7 @@ and the overal intensity of the signal with a fit to the following model:
 .. testcode:: ExampleInelasticIsoRotDiff
 
     import numpy as np
-    import scipy
-    if int(scipy.__version__.split('.')[1]) < 18:
-        from scipy.special import sph_jn as jn
-    else:
-        from scipy.special import spherical_jn as jn
+    from scipy.special import sph_jn
     """Generate resolution function with the following properties:
     1. Gaussian in Energy
     2. Dynamic range = [-0.1, 0.1] meV with spacing 0.0004 meV
@@ -91,7 +87,7 @@ and the overal intensity of the signal with a fit to the following model:
     for Q in Qs:
         centre=dE*np.random.random()  # some shift along the energy axis
         dataY=np.zeros(nE)  # holds the inelastic signal for this Q-value
-        js=jn(N,Q*R)[0]  # spherical bessel functions from L=0 to L=N
+        js=sph_jn(N,Q*R)[0]  # spherical bessel functions from L=0 to L=N
         for L in range(1,N+1):
             HWHM = L*(L+1)*hbar/tau; aL=(2*L+1)*js[L]**2
             dataY += H*aL/np.pi * HWHM/(HWHM**2+(dataX-centre)**2)  # add component

--- a/docs/source/fitfunctions/IsoRotDiff.rst
+++ b/docs/source/fitfunctions/IsoRotDiff.rst
@@ -59,11 +59,7 @@ and the overal intensity of the signal with a fit to the following model:
 .. testcode:: ExampleIsoRotDiff
 
     import numpy as np
-    import scipy
-    if int(scipy.__version__.split('.')[1]) < 18:
-        from scipy.special import sph_jn as jn
-    else:
-        from scipy.special import spherical_jn as jn
+    from scipy.special import sph_jn
     """Generate resolution function with the following properties:
     1. Gaussian in Energy
     2. Dynamic range = [-0.1, 0.1] meV with spacing 0.0004 meV
@@ -94,7 +90,7 @@ and the overal intensity of the signal with a fit to the following model:
     for Q in Qs:
         centre=0  # some shift along the energy axis
         dataY=np.zeros(nE)
-        js=jn(N,Q*R)[0]  # spherical bessel functions from L=0 to L=N
+        js=sph_jn(N,Q*R)[0]  # spherical bessel functions from L=0 to L=N
         for L in range(1,N+1):
             HWHM = L*(L+1)*hbar/tau
             aL = (2*L+1)*js[L]**2


### PR DESCRIPTION
spherical_jn has a different signature to sph_jn so is not a drop-in replacement

Switch to using deprecated function sph_jn for scipy 1.18. This will need to be fixed properly when the function is remove from scipy, until then this will work.

**To test:**
* While using scipy 1.18 check that the `*IsoRotDiff` doc-tests now pass, `mantidpython --classic docs/runsphinx_doctest.py -R ".*IsoRotDiff"`

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
