### PR TITLE
Indirect ConvFit - PeakRadius parameter

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -314,6 +314,7 @@ void ConvFit::run() {
   cfs->setProperty("EndX", m_properties["EndX"]->valueText().toStdString());
   cfs->setProperty("SpecMin", specMin);
   cfs->setProperty("SpecMax", specMax);
+  cfs->setProperty("PeakRadius", 50);
   cfs->setProperty("Convolve", true);
   cfs->setProperty("Minimizer",
                    minimizerString("$outputname_$wsindex").toStdString());
@@ -1270,6 +1271,7 @@ void ConvFit::singleFit() {
   m_singleFitAlg->setProperty("CreateOutput", true);
   m_singleFitAlg->setProperty("OutputCompositeMembers", true);
   m_singleFitAlg->setProperty("ConvolveMembers", true);
+  m_singleFitAlg->setProperty("PeakRadius", 50);
   m_singleFitAlg->setProperty("MaxIterations", maxIterations);
   m_singleFitAlg->setProperty(
       "Minimizer", minimizerString(m_singleFitOutputName).toStdString());

--- a/docs/source/release/v3.10.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.10.0/indirect_inelastic.rst
@@ -17,10 +17,11 @@ Algorithms
 Data Analysis
 #############
 
-Conv Fit
-~~~~~~~~
+ConvFit
+~~~~~~~
 
 * All FABADA minimizer options are now accessible from the function browser.
+- Added peak radius parameter with value of 50
 
 Jump Fit
 ~~~~~~~~


### PR DESCRIPTION
The default PeakRadius for ConvolutionFitSequential is 0, for use in the IndirectConvfit interface it should be 50.

**To test:**

Code review

Fixes #18987 .

_Release Notes have been updated_

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
