### PR TITLE
Remove incorrect comparison with INT_MAX

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1679,17 +1679,6 @@ std::map<std::string, std::string> LoadNexusProcessed::validateInputs() {
     errorList["SpectrumMax"] = "SpectrumMax must be larger than SpectrumMin";
   }
 
-  // Next check that SpecMax is less than maximum int
-  if (specMax > INT_MAX) {
-    errorList["SpectrumMax"] =
-        "SpectrumMax must be less than " + to_string(INT_MAX);
-  }
-
-  if (specMin > INT_MAX) {
-    errorList["SpectrumMin"] =
-        "SpectrumMin must be less than " + to_string(INT_MAX);
-  }
-
   // Finished testing return any errors
   return errorList;
 }


### PR DESCRIPTION
Description of work.
This PR removes an incorrect comparison with INT_MAX - if the value is greater than the maximum value it will overflow therefore it cannot be greater so the check is useless. 

**To test:**
Ensure builds pass

Fixes N/A

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
