### PR TITLE
Remove partial copy-on-write mechanism of ParameterMap in ExperimentInfo

### DIFF
--- a/Framework/API/inc/MantidAPI/SpectrumInfo.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfo.h
@@ -67,9 +67,8 @@ class ExperimentInfo;
 class MANTID_API_DLL SpectrumInfo {
 public:
   SpectrumInfo(const Beamline::SpectrumInfo &spectrumInfo,
-               const ExperimentInfo &experimentInfo);
-  SpectrumInfo(const Beamline::SpectrumInfo &spectrumInfo,
-               ExperimentInfo &experimentInfo);
+               const ExperimentInfo &experimentInfo,
+               DetectorInfo &detectorInfo);
   ~SpectrumInfo();
 
   size_t size() const;
@@ -110,8 +109,7 @@ private:
   std::vector<size_t> getDetectorIndices(const size_t index) const;
 
   const ExperimentInfo &m_experimentInfo;
-  DetectorInfo *m_mutableDetectorInfo{nullptr};
-  const DetectorInfo &m_detectorInfo;
+  DetectorInfo &m_detectorInfo;
   const Beamline::SpectrumInfo &m_spectrumInfo;
   mutable std::vector<boost::shared_ptr<const Geometry::IDetector>>
       m_lastDetector;

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -14,18 +14,11 @@ namespace Mantid {
 namespace API {
 
 SpectrumInfo::SpectrumInfo(const Beamline::SpectrumInfo &spectrumInfo,
-                           const ExperimentInfo &experimentInfo)
+                           const ExperimentInfo &experimentInfo,
+                           DetectorInfo &detectorInfo)
     : m_experimentInfo(experimentInfo),
-      m_detectorInfo(experimentInfo.detectorInfo()),
+      m_detectorInfo(detectorInfo),
       m_spectrumInfo(spectrumInfo), m_lastDetector(PARALLEL_GET_MAX_THREADS),
-      m_lastIndex(PARALLEL_GET_MAX_THREADS, -1) {}
-
-SpectrumInfo::SpectrumInfo(const Beamline::SpectrumInfo &spectrumInfo,
-                           ExperimentInfo &experimentInfo)
-    : m_experimentInfo(experimentInfo),
-      m_mutableDetectorInfo(&experimentInfo.mutableDetectorInfo()),
-      m_detectorInfo(*m_mutableDetectorInfo), m_spectrumInfo(spectrumInfo),
-      m_lastDetector(PARALLEL_GET_MAX_THREADS),
       m_lastIndex(PARALLEL_GET_MAX_THREADS, -1) {}
 
 // Defined as default in source for forward declaration with std::unique_ptr.
@@ -159,7 +152,7 @@ bool SpectrumInfo::hasUniqueDetector(const size_t index) const {
  * Currently this simply sets the mask flags for the underlying detectors. */
 void SpectrumInfo::setMasked(const size_t index, bool masked) {
   for (const auto detIndex : getDetectorIndices(index))
-    m_mutableDetectorInfo->setMasked(detIndex, masked);
+    m_detectorInfo.setMasked(detIndex, masked);
 }
 
 /// Return a const reference to the detector or detector group of the spectrum

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -16,8 +16,7 @@ namespace API {
 SpectrumInfo::SpectrumInfo(const Beamline::SpectrumInfo &spectrumInfo,
                            const ExperimentInfo &experimentInfo,
                            DetectorInfo &detectorInfo)
-    : m_experimentInfo(experimentInfo),
-      m_detectorInfo(detectorInfo),
+    : m_experimentInfo(experimentInfo), m_detectorInfo(detectorInfo),
       m_spectrumInfo(spectrumInfo), m_lastDetector(PARALLEL_GET_MAX_THREADS),
       m_lastIndex(PARALLEL_GET_MAX_THREADS, -1) {}
 

--- a/Framework/API/test/SpectrumInfoTest.h
+++ b/Framework/API/test/SpectrumInfoTest.h
@@ -53,7 +53,9 @@ public:
 
   void test_constructor() {
     Beamline::SpectrumInfo specInfo(3);
-    TS_ASSERT_THROWS_NOTHING(SpectrumInfo(specInfo, *makeWorkspace(3)));
+    auto ws = makeWorkspace(3);
+    TS_ASSERT_THROWS_NOTHING(
+        SpectrumInfo(specInfo, *ws, ws->mutableDetectorInfo()));
   }
 
   void test_sourcePosition() {

--- a/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
+++ b/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
@@ -186,8 +186,10 @@ double DiffractionEventCalibrateDetectors::intensity(
   const MantidVec &yValues = outputW->readY(0);
   auto it = std::max_element(yValues.begin(), yValues.end());
   double peakHeight = *it;
-  if (peakHeight == 0)
+  if (peakHeight == 0) {
+    movedetector(-x, -y, -z, -rotx, -roty, -rotz, detname, inputW);
     return -0.000;
+  }
   double peakLoc = outputW->readX(0)[it - yValues.begin()];
 
   IAlgorithm_sptr fit_alg;

--- a/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
+++ b/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
@@ -186,10 +186,8 @@ double DiffractionEventCalibrateDetectors::intensity(
   const MantidVec &yValues = outputW->readY(0);
   auto it = std::max_element(yValues.begin(), yValues.end());
   double peakHeight = *it;
-  if (peakHeight == 0) {
-    movedetector(-x, -y, -z, -rotx, -roty, -rotz, detname, inputW);
+  if (peakHeight == 0)
     return -0.000;
-  }
   double peakLoc = outputW->readX(0)[it - yValues.begin()];
 
   IAlgorithm_sptr fit_alg;
@@ -291,7 +289,12 @@ void DiffractionEventCalibrateDetectors::exec() {
   const std::string rb_params = getProperty("Params");
 
   // Get some stuff from the input workspace
-  Instrument_const_sptr inst = inputW->getInstrument();
+  // We make a copy of the instrument since we will be moving detectors in
+  // `inputW` but want to access original positions (etc.) via `detList` below.
+  const auto &baseInstr = inputW->getInstrument()->baseInstrument();
+  auto pmap = boost::make_shared<ParameterMap>(
+      *inputW->getInstrument()->getParameterMap());
+  Instrument_const_sptr inst = boost::make_shared<Instrument>(baseInstr, pmap);
 
   // Build a list of Rectangular Detectors
   std::vector<boost::shared_ptr<RectangularDetector>> detList;


### PR DESCRIPTION
`ExperimentInfo::instrumentParameters()` has a copy-on-write mechanism: It copies the `ParameterMap` if the reference to it is not unique.

There are several reasons for non-unique references:

1. Client code has obtained a `shared_ptr<Instrument>` or a `shared_ptr<IDetector>` from the workspaces. `ExperimentInfo::instrumentParameters()` will then trigger a copy. This implies the following behavior:

  ```cpp
  const auto det = ws.getInstrument()->getDetector(42);
  MoveInstrumentComponent(ws, 42, oldPos + offset); // not actual code
  ws.getInstrument()->getDetector(42)->getPos(); // oldPos + offset
  det->getPos(); // oldPos
  ```

  This is probably unexpected, and there is little to no use of this functionality in Mantid.

2. Several workspaces sharing the same `ParameterMap`. This was possible until recently, except for `MatrixWorkspace`, which explicitly triggered a copy in its constructor. After a [recent change](https://github.com/mantidproject/mantid/pull/18831) a copy is always made, so this is not possible anymore.

3. `DetectorInfo` holds a reference to the `ParameterMap` (directly or indirectly). Conceptually this is similar to item (1.), so this sharing does not require a copy.


In conclusion, since we have https://github.com/mantidproject/mantid/pull/18831, it should be possible to remove the COW mechanism, if we fix potential code that relies on the functionality described in (1.).

Important benefits:

- Calling `ExperimentInfo::instrumentParameters()` will no longer invalidate references to `SpectrumInfo` or `DetectorInfo`. Several developers working on the rollout during the maintenance period suffered from issues due to this unfortunate behavior.
- `DetectorInfo` will be flushed much less frequently, and thus the moderately costly rebuilds can be avoided.
- Can remove some very complex code in the getters for mutable `SpectrumInfo` and `DetectorInfo` in `ExperimentInfo`.

**To test:**

Code review.

Fixes #19001.

Internal change, no release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
