### PR TITLE
Make sure we deal with negative Qz

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -419,7 +419,7 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
         theta = (dangle - dangle0) * math.pi / 180.0 / 2.0 + ((direct_beam_pix - ref_pix) * pixel_width) / (2.0 * det_distance)
         if theta < 0:
             logger.warning("The calculated scattering angle is negative: taking absolute value")
-            theta = -theta
+            theta = abs(theta)
         angle_offset = self.getProperty("AngleOffset").value
         return theta + angle_offset
 

--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -417,7 +417,9 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
 
         #theta = (dangle - dangle0) * math.pi / 360.0
         theta = (dangle - dangle0) * math.pi / 180.0 / 2.0 + ((direct_beam_pix - ref_pix) * pixel_width) / (2.0 * det_distance)
-
+        if theta < 0:
+            logger.warning("The calculated scattering angle is negative: taking absolute value")
+            theta = -theta
         angle_offset = self.getProperty("AngleOffset").value
         return theta + angle_offset
 


### PR DESCRIPTION
REFM can take data where the defined Qz would be negative.
Treat all scattering angles as positive angles and return the reflectivity as a function of the absolute value of Qz.

**To test:**
- Make sure the tests pass
- Review code

There is no Github issue for this PR. All the info is here.

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
