### PR TITLE
Revert expose SpectrumInfo to Python / remove added dangerous method from SpectrumInfo

### DIFF
--- a/Framework/API/inc/MantidAPI/SpectrumInfo.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfo.h
@@ -84,7 +84,6 @@ public:
   double twoTheta(const size_t index) const;
   double signedTwoTheta(const size_t index) const;
   Kernel::V3D position(const size_t index) const;
-  double phi(const size_t index) const;
   bool hasDetectors(const size_t index) const;
   bool hasUniqueDetector(const size_t index) const;
 

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -132,14 +132,6 @@ Kernel::V3D SpectrumInfo::position(const size_t index) const {
   return newPos / static_cast<double>(dets.size());
 }
 
-/// Returns the phi angle (in radians) for the spectrum with given index
-double SpectrumInfo::phi(const size_t index) const {
-  if (isMonitor(index))
-    throw std::logic_error("phi is not defined for monitors.");
-  Kernel::V3D pos = position(index);
-  return std::atan2(pos[1], pos[0]);
-}
-
 /// Returns true if the spectrum is associated with detectors in the instrument.
 bool SpectrumInfo::hasDetectors(const size_t index) const {
   // Workspaces can contain invalid detector IDs. Those IDs will be silently

--- a/Framework/API/test/SpectrumInfoTest.h
+++ b/Framework/API/test/SpectrumInfoTest.h
@@ -163,16 +163,6 @@ public:
     TS_ASSERT_THROWS(spectrumInfo.twoTheta(4), std::logic_error);
   }
 
-  void test_phi() {
-    const auto &spectrumInfo = m_workspace.spectrumInfo();
-    TS_ASSERT_DELTA(spectrumInfo.phi(0), -1.570796, 1e-6);
-    TS_ASSERT_DELTA(spectrumInfo.phi(1), 0.0, 1e-6);
-    TS_ASSERT_DELTA(spectrumInfo.phi(2), 1.570796, 1e-6);
-    // Monitors
-    TS_ASSERT_THROWS(spectrumInfo.phi(3), std::logic_error);
-    TS_ASSERT_THROWS(spectrumInfo.phi(4), std::logic_error);
-  }
-
   void test_twoTheta_grouped() {
     const auto &spectrumInfo = m_workspace.spectrumInfo();
     // Note that updating detector IDs like this is a trick that should not be

--- a/Framework/PythonInterface/mantid/api/src/Exports/DetectorInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/DetectorInfo.cpp
@@ -5,6 +5,10 @@ using Mantid::API::DetectorInfo;
 using namespace boost::python;
 
 void export_DetectorInfo() {
+  // WARNING DetectorInfo is work in progress and not ready for exposing more of
+  // its functionality to Python, and should not yet be used in user scripts. DO
+  // NOT ADD EXPORTS TO OTHER METHODS without contacting the team working on
+  // Instrument-2.0.
   class_<DetectorInfo, boost::noncopyable>("DetectorInfo", no_init)
       .def("__len__", &DetectorInfo::size, (arg("self")),
            "Returns the size of the DetectorInfo, i.e., the number of "

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -5,6 +5,10 @@ using Mantid::API::SpectrumInfo;
 using namespace boost::python;
 
 void export_SpectrumInfo() {
+  // WARNING SpectrumInfo is work in progress and not ready for exposing more of
+  // its functionality to Python, and should not yet be used in user scripts. DO
+  // NOT ADD EXPORTS TO OTHER METHODS without contacting the team working on
+  // Instrument-2.0.
   class_<SpectrumInfo, boost::noncopyable>("SpectrumInfo", no_init)
       .def("isMonitor", &SpectrumInfo::isMonitor, (arg("self"), arg("index")),
            "Returns true if the detector(s) associated with the spectrum are "

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -14,15 +14,5 @@ void export_SpectrumInfo() {
            "masked.")
       .def("hasDetectors", &SpectrumInfo::hasDetectors, (arg("self")),
            "Returns true if the spectrum is associated with detectors in the "
-           "instrument.")
-      .def("position", &SpectrumInfo::position, (arg("self"), arg("index")),
-           "Returns the position of the detector(s) associated with the "
-           "spectrum.")
-      .def("l2", &SpectrumInfo::l2, (arg("self"), arg("index")),
-           "Returns the distance from the sample of the detector(s) "
-           "associated with the spectrum.")
-      .def("phi", &SpectrumInfo::phi, (arg("self"), arg("index")),
-           "Returns phi angle of the detector(s) associated with the spectrum.")
-      .def("twoTheta", &SpectrumInfo::twoTheta, (arg("self"), arg("index")),
-           "Returns twoTheta of the detector(s) associated with the spectrum.");
+           "instrument.");
 }

--- a/Framework/PythonInterface/test/python/mantid/api/SpectrumInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SpectrumInfoTest.py
@@ -21,15 +21,5 @@ class SpectrumInfoTest(unittest.TestCase):
         info = self._ws.spectrumInfo()
         self.assertEquals(info.isMasked(1), False)
 
-    def test_geometry(self):
-        info = self._ws.spectrumInfo()
-        self.assertAlmostEquals(info.l2(1), 5.0009999)
-        self.assertAlmostEquals(info.twoTheta(1), 0.01999733)
-        self.assertAlmostEquals(info.phi(1), 1.57079632)
-        p = info.position(1)
-        self.assertEquals(p.X(), 0.0)
-        self.assertEquals(p.Y(), 0.1)
-        self.assertEquals(p.Z(), 5.0)
-
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -66,7 +66,6 @@ Python
       3.0
       3.0
 
-- Exposed more `SpectrumInfo` functionality to Python.
 
 
 Python Algorithms


### PR DESCRIPTION
As just discussed in the TSC call, this reverts https://github.com/mantidproject/mantid/pull/18962 (see there for discussion), and adds a warning to the export files.

Description of work.

**To test:**

Code review.
No issue.
No release notes, the reverted P has been merged after the release.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
