### PR TITLE
Add reduction for osiris diffspec

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -125,6 +125,7 @@ void IndirectDiffractionReduction::run() {
             "Calibration and rebinning parameters are incorrect.");
         return;
       }
+      runGenericReduction(instName, mode);
     }
   } else {
     if (!validateRebin()) {


### PR DESCRIPTION
Added a reduction step for OSIRIS diffspec when `Run` is clicked

**To test:**

Interfaces>Indirect>Diffraction
Set instrument to OSIRIS, mode to diffspec
Input: `89813`
Calibration: `osiris_041_RES10.cal`
Inputs can be found in the unit tests `\Build\ExternalData\Testing\Data\UnitTest`

No need for vanadium


Fixes #19021 .

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
