### PR TITLE
Fix malformed fit benchmarking summary tables 

### DIFF
--- a/scripts/CompareFitMinimizers/results_output.py
+++ b/scripts/CompareFitMinimizers/results_output.py
@@ -277,6 +277,7 @@ def calc_cell_len_rst_table(columns_txt, items_link, cells, color_scale=None):
     @param items_link :: the links from rst table cells to other pages/sections of pages
     @param cells :: the values of the results
     @param color_scale :: whether a color_scale is used or not
+    @returns :: the length of the longest cell in a table
     """
 
     # The length of the longest header (minimizer name)
@@ -424,6 +425,12 @@ def format_cell_value_rst(value, width=None, color_scale=None, items_link=None):
     """
     Build the content string for a table cell, adding style/color tags
     if required.
+
+    @param value :: the value of the result
+    @param width :: the width of the longest table cell
+    @param color_scale :: the colour scale used
+    @param items_link :: the links from rst table cells to other pages/sections of pages
+    @returns :: the (formatted) contents of a cell
 
     """
     if not color_scale:

--- a/scripts/CompareFitMinimizers/results_output.py
+++ b/scripts/CompareFitMinimizers/results_output.py
@@ -288,7 +288,9 @@ def calc_cell_len_rst_table(columns_txt, items_link, cells, color_scale=None):
     # One space on each end of a cell
     padding = 2
     # Set cell length equal to the length of: the longest combination of value, test name, and colour (plus padding)
-    cell_len = len(format_cell_value_rst(float(max_value), 0, color_scale, max_item).strip()) + padding
+    cell_len = len(format_cell_value_rst(value=float(max_value),
+                                         color_scale=color_scale,
+                                         items_link=max_item).strip()) + padding
     # If the header is longer than any cell's contents, i.e. is a group results table, use that length instead
     if cell_len < max_header:
         cell_len = max_header
@@ -418,7 +420,7 @@ def build_items_links(comparison_type, comparison_dim, using_errors):
     return items_link
 
 
-def format_cell_value_rst(value, width, color_scale=None, items_link=None):
+def format_cell_value_rst(value, width=None, color_scale=None, items_link=None):
     """
     Build the content string for a table cell, adding style/color tags
     if required.
@@ -426,9 +428,9 @@ def format_cell_value_rst(value, width, color_scale=None, items_link=None):
     """
     if not color_scale:
         if not items_link:
-            value_text = ' {0:.4g}'.format(value).ljust(width, ' ')
+            value_text = ' {0:.4g}'.format(value)
         else:
-            value_text = ' :ref:`{0:.4g} <{1}>`'.format(value, items_link).ljust(width, ' ')
+            value_text = ' :ref:`{0:.4g} <{1}>`'.format(value, items_link)
     else:
         color = ''
         for color_descr in color_scale:
@@ -437,7 +439,10 @@ def format_cell_value_rst(value, width, color_scale=None, items_link=None):
                 break
         if not color:
             color = color_scale[-1][1]
-        value_text = " :{0}:`{1:.4g}`".format(color, value).ljust(width, ' ')
+        value_text = " :{0}:`{1:.4g}`".format(color, value)
+
+    if width:
+        value_text.ljust(width, ' ')
 
     return value_text
 

--- a/scripts/CompareFitMinimizers/results_output.py
+++ b/scripts/CompareFitMinimizers/results_output.py
@@ -274,7 +274,7 @@ def calc_cell_len_rst_table(columns_txt, items_link, cells, color_scale=None):
     Calculate ascii character width needed for an RST table, using the length of the longest table cell.
 
     @param columns_txt :: list of the contents of the column headers
-    @param items_link :: the test names used for summary tables
+    @param items_link :: the links from rst table cells to other pages/sections of pages
     @param cells :: the values of the results
     @param color_scale :: whether a color_scale is used or not
     """

--- a/scripts/CompareFitMinimizers/results_output.py
+++ b/scripts/CompareFitMinimizers/results_output.py
@@ -271,7 +271,7 @@ def display_name_for_minimizers(names):
 
 def calc_cell_len_rst_table(columns_txt, items_link, cells, color_scale=None):
     """
-    Calculate what width in ascii characters we need for an RST table.
+    Calculate ascii character width needed for an RST table, using the length of the longest table cell.
 
     @param columns_txt :: list of the contents of the column headers
     @param items_link :: the test names used for summary tables

--- a/scripts/CompareFitMinimizers/results_output.py
+++ b/scripts/CompareFitMinimizers/results_output.py
@@ -280,7 +280,7 @@ def calc_cell_len_rst_table(columns_txt, items_link, cells, color_scale=None):
     """
 
     # The length of the longest header (minimizer name)
-    max_header = len(max(col for col in columns_txt))
+    max_header = len(max((col for col in columns_txt), key=len))
     # The value of the longest (once formatted) value in the table
     max_value = max(("%.4g" % cell for cell in np.nditer(cells)), key=len)
     # The length of the longest link reference (angular bracket content present in summary tables)

--- a/scripts/CompareFitMinimizers/results_output.py
+++ b/scripts/CompareFitMinimizers/results_output.py
@@ -441,8 +441,8 @@ def format_cell_value_rst(value, width=None, color_scale=None, items_link=None):
             color = color_scale[-1][1]
         value_text = " :{0}:`{1:.4g}`".format(color, value)
 
-    if width:
-        value_text.ljust(width, ' ')
+    if width is not None:
+        value_text = value_text.ljust(width, ' ')
 
     return value_text
 

--- a/scripts/CompareFitMinimizers/results_output.py
+++ b/scripts/CompareFitMinimizers/results_output.py
@@ -137,12 +137,12 @@ def save_table_to_file(table_data, errors, group_name, metric_type, file_extensi
     """
     Saves a group results table or overall results table to a given file type.
 
-    :param table_data: the results table
-    :param errors: whether to use observational errors
-    :param group_name: name of this group of problems (example 'NIST "lower difficulty"', or
+    @param table_data :: the results table
+    @param errors :: whether to use observational errors
+    @param group_name :: name of this group of problems (example 'NIST "lower difficulty"', or
                          'Neutron data')
-    :param metric_type: the test type of the table data (e.g. runtime, accuracy)
-    :param file_extension: the file type extension (e.g. html)
+    @param metric_type :: the test type of the table data (e.g. runtime, accuracy)
+    @param file_extension :: the file type extension (e.g. html)
     """
     file_name = ('comparison_{weighted}_{version}_{metric_type}_{group_name}.'
                  .format(weighted=weighted_suffix_string(errors),


### PR DESCRIPTION
Summary tables were previously being outputted as malformed due to the (maximum) cell length in `calc_cell_len_rst_table` not being long enough. This fix changes `calc_cell_len_rst_table` logic to calculate a cell length based on the longest length of any one cell in the table.

**To test:**

Run all minimizers against all sets of problems and ensure that both summary and group tables are outputting correctly formatted HTML files.

Fixes #18993 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
