### PR TITLE
Fix an issue when populating values in the Reflectometry table

### DIFF
--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -675,8 +675,13 @@ GenericDataProcessorPresenter::reduceRow(const std::vector<std::string> &data) {
             alg->getPropertyValue(m_whitelist.algPropFromColIndex(i));
 
         if (m_options["Round"].toBool()) {
-          propValue = propValue.substr(
-              0, propValue.find(".") + m_options["RoundPrecision"].toInt() + 1);
+          std::string exp = (propValue.find("e") != std::string::npos)
+                                ? propValue.substr(propValue.find("e"))
+                                : "";
+          propValue =
+              propValue.substr(0, propValue.find(".") +
+                                      m_options["RoundPrecision"].toInt() + 1) +
+              exp;
         }
 
         newData[i] = propValue;


### PR DESCRIPTION
Fixes a bug in the Reflectometry GUI, where results in scientific notation were not populated correctly (the exponential was missing).

**To test:**

- Open Interfaces > Reflectometry > ISIS Reflectometry (Polref)
- Enter run `13460` like this:

![inter-run](https://cloud.githubusercontent.com/assets/8956985/23505453/b3702d2c-ff3b-11e6-8011-41e28dcdbd77.png)

- In menu `Reflectometry`, select `Options`, in tab `Rounding` tick the checkbox and select a number of decimal places.
- Hit `Process`, `Q min` and `Q max` should be populated with `1.388...e-06` and `1.562...e-05`.

Fixes #19030.

Release notes: I don't think this needs to be mentioned in the release notes, the bug was found by me and I don't think scientists are aware of it.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
