### PR TITLE
Deprecate algorihtm BASISReduction311

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction311.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction311.py
@@ -7,6 +7,7 @@ from mantid.kernel import *
 from mantid import config
 import os
 
+DEPRECATION_NOTICE = "BASISReduction311 is deprecated (on 2017-03-11). Use BASISReduction instead."
 DEFAULT_BINS = [-740, 1.6, 740]
 DEFAULT_QBINS = [0.4, 0.2, 3.8]
 DEFAULT_WRANGE = [6.24, 6.30]
@@ -48,7 +49,7 @@ class BASISReduction311(PythonAlgorithm):
         return "BASISReduction311"
 
     def summary(self):
-        return "THIS ALGORITHM IS DEPRECATED (2017-03-11). USE BASISReduction instead"
+        return DEPRECATION_NOTICE
 
     def PyInit(self):
         self._short_inst = "BSS"
@@ -80,7 +81,7 @@ class BASISReduction311(PythonAlgorithm):
                              "Switch for grouping detectors")
 
     def PyExec(self):
-        self.log().error('THIS ALGORITHM IS DEPRECATED (2017-03-11). USE BASISReduction instead')
+        self.log().error(DEPRECATION_NOTICE)
         config['default.facility'] = "SNS"
         config['default.instrument'] = self._long_inst
         self._doIndiv = self.getProperty("DoIndividual").value

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction311.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction311.py
@@ -48,7 +48,7 @@ class BASISReduction311(PythonAlgorithm):
         return "BASISReduction311"
 
     def summary(self):
-        return "Multiple-file BASIS reduction for the 311 reflection."
+        return "THIS ALGORITHM IS DEPRECATED (2017-03-11). USE BASISReduction instead"
 
     def PyInit(self):
         self._short_inst = "BSS"
@@ -80,6 +80,7 @@ class BASISReduction311(PythonAlgorithm):
                              "Switch for grouping detectors")
 
     def PyExec(self):
+        self.log().error('THIS ALGORITHM IS DEPRECATED (2017-03-11). USE BASISReduction instead')
         config['default.facility'] = "SNS"
         config['default.instrument'] = self._long_inst
         self._doIndiv = self.getProperty("DoIndividual").value

--- a/docs/source/release/v3.10.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.10.0/indirect_inelastic.rst
@@ -12,7 +12,8 @@ Algorithms
 ##########
 
 - A new input property *RebinCanToSample* was added to :ref:`ApplyPaalmanPingsCorrection <algm-ApplyPaalmanPingsCorrection>` which enables or disables the rebinning of the empty container workspace.
-- :ref:`LoadVesuvio <algm-LoadVesuvio> can now load NeXus files as well as raw files
+- :ref:`LoadVesuvio <algm-LoadVesuvio>` can now load NeXus files as well as raw files
+- :ref:`BASISReduction311 <algm-BASISReduction311>` has been deprecated (2017-03-11). Use :ref:`BASISReduction <algm-BASISReduction>` instead.
 
 Data Reduction
 ##############


### PR DESCRIPTION
Python algorithms cannot inherit from class `DeprecatedAlgorihtm` because it is not exported. I included a warning in the Algorithm summary and one error in the log upon execution.

**To test:**
- Open BASISReduction311. The summary should contain the deprecation notice.
- Run the algorithm
`BASISReduction311(RunNumbers="65534", EnergyBins=[-740,1.6,740], MomentumTransferBins=[0.4,0.2,3.8])`
and check the deprecation notice is posted in the log widget.

<!-- Instructions for testing. -->

Fixes #19046.

[Updated release notes](https://github.com/mantidproject/mantid/blob/78a817e5c16abe3d02c3556383798fd9c6a9f50b/docs/source/release/v3.10.0/indirect_inelastic.rst#algorithms)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
