### PR TITLE
Ignore boxes where the normalized signal is zero.

### DIFF
--- a/Vates/VatesAPI/src/vtkMDHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHexFactory.cpp
@@ -117,7 +117,7 @@ void vtkMDHexFactory::doCreate(
       API::IMDNode *box = boxes[i];
       Mantid::signal_t signal_normalized = (box->*normFunction)();
 
-      if (std::isfinite(signal_normalized)) {
+      if (std::isnormal(signal_normalized)) {
         // Cache the signal and using of it
         signalCache[i] = static_cast<float>(signal_normalized);
         useBox[i] = true;


### PR DESCRIPTION
Description of work.

In Mantid 3.8 and earlier, boxes with a zero signal were ignored. This was accidentally changed while while removing the `thresholdRange` classes and is fixed here by replacing `std::isfinite` with `std::isnormal`. 

**To test:**

<!-- Instructions for testing. -->

Load a MDEventWorkspace in the VSI's Slice View and verify that boxes with zero events are not visible.

One should also apply this MR to VTK which makes cutting a vtkUnstructuredGrid thread-safe.
https://gitlab.kitware.com/vtk/vtk/merge_requests/2541

This fixes a regression from #18288.


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
