### PR TITLE
SavePlot1D decrease margin size

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
@@ -150,12 +150,14 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
                 fig['layout']['yaxis%d' % (i+1)].update(title=ylabel)
                 if len(spectraNames) > 0:  # remove the used spectra names
                     spectraNames = spectraNames[len(traces):]
+            fig['layout'].update(margin={'l':40,'r':0,'t':0,'b':40})
         else:
             (traces, xlabel, ylabel) = self.toScatterAndLabels(self._wksp,
                                                                spectraNames)
 
             layout = go.Layout(yaxis={'title': ylabel},
-                               xaxis={'title': xlabel})
+                               xaxis={'title': xlabel},
+                               margin={'l':40,'r':0,'t':0,'b':40})
 
             fig = go.Figure(data=traces, layout=layout)
 


### PR DESCRIPTION
Decrease the margin size (from the default `80`) of the plotly plots to make better use of the space. This is particularly useful for the web monitor.

**To test:**
Try using SavePlot1D with output_type plotly to plot some things. Check that nothing gets cut off, axes, legend, _etc_.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
