### PR TITLE
Fix errors from Rebin and Logger in VisionReduction.

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/VisionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VisionReduction.py
@@ -118,20 +118,20 @@ class VisionReduction(PythonAlgorithm):
             CalTab[j][0]=tab[i][2]
             CalTab[j][1]=tab[i][3]
 
-        logger.information('Loading inelastic banks from', NexusFile)
+        logger.information('Loading inelastic banks from {}'.format(NexusFile))
         bank_list = ["bank%d" % i for i in range(1, 15)]
         bank_property = ",".join(bank_list)
         LoadEventNexus(Filename=NexusFile, BankName=bank_property, OutputWorkspace='__IED_T', LoadMonitors='0')
         LoadInstrument(Workspace='__IED_T',Filename='/SNS/VIS/shared/autoreduce/VISION_Definition_no_efixed.xml',RewriteSpectraMap=True)
         MaskDetectors(Workspace='__IED_T', DetectorList=MaskPX)
 
-        logger.information("Title:", mtd['__IED_T'].getTitle())
-        logger.information("Proton charge:", mtd['__IED_T'].getRun().getProtonCharge())
+        logger.information('Title: {}'.format(mtd['__IED_T'].getTitle()))
+        logger.information('Proton charge: {}'.format(mtd['__IED_T'].getRun().getProtonCharge()))
         if "Temperature" in mtd['__IED_T'].getTitle():
-            logger.error("Error: Non-equilibrium runs will not be reduced")
+            logger.error('Error: Non-equilibrium runs will not be reduced')
             # sys.exit()
         if mtd['__IED_T'].getRun().getProtonCharge() < 5.0:
-            logger.error("Error: Proton charge is too low")
+            logger.error('Error: Proton charge is too low')
             # sys.exit()
 
         NormaliseByCurrent(InputWorkspace='__IED_T',OutputWorkspace='__IED_T')
@@ -153,7 +153,7 @@ class VisionReduction(PythonAlgorithm):
             Ef=CalTab[Pixel][0]
             mtd['__IED_L'].setEFixed(Pixel, Ef)
         ConvertUnits(InputWorkspace='__IED_L',OutputWorkspace='__IED_E',EMode='Indirect',Target='DeltaE')
-        Rebin(InputWorkspace='__IED_E',OutputWorkspace='__IED_E',Params=self.binE,PreserveEvents='0')
+        Rebin(InputWorkspace='__IED_E',OutputWorkspace='__IED_E',Params=self.binE,PreserveEvents='0',IgnoreBinErrors=True)
         CorrectKiKf(InputWorkspace='__IED_E',OutputWorkspace='__IED_E',EMode='Indirect')
 
         GroupDetectors(InputWorkspace='__IED_E',OutputWorkspace='__IED_E_Forward',DetectorList=self.ListPXF)

--- a/docs/source/release/v3.10.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.10.0/indirect_inelastic.rst
@@ -44,5 +44,6 @@ Bugfixes
 
 - The *Diffraction* Interface no longer crashes when in OSIRIS diffonly mode
 - *Abins*:  fix setting very small off-diagonal elements of b tensors
+- Fix errors from calling Rebin from VisionReduction.
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.10%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_


### PR DESCRIPTION
Description of work.

This fixes two errors being generated by `VisionReduction`. 

```
VisionReduction-[Error] Error in execution of algorithm VisionReduction:
VisionReduction-[Error] Python argument types in
VisionReduction-[Error]     Logger.information(Logger, str, str)
VisionReduction-[Error] did not match C++ signature:
VisionReduction-[Error]     information(Mantid::Kernel::Logger {lvalue} self, std::string message)
VisionReduction-[Error]   at line 121 in '/opt/Mantid/plugins/python/algorithms/VisionReduction.py'
```
This was fixed by changing logging calls to pass a single string. 

Rebin gives the error 'Negative or zero bin widths are not allowed'. Since we have pixels that are not calibrated/used, the spectra on those pixels are zero along y, and they do not have a meaningful x (all x values showing as -8.98847e+307). Setting `IgnoreBinErrors=True` appears to work.

**To test:**

<!-- Instructions for testing. -->

Run VisionReduction on one of the NeXus files in `/SNS/VIS`

There is no GitHub issue associated with with pull request.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
