### PR TITLE
New unit to represent DeltaE in the frequency domain

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConvertUnits.h
@@ -22,8 +22,8 @@ namespace Algorithms {
    </LI>
     </UL>
 
-    Optional properties required for certain units (DeltaE &
-   DeltaE_inWavenumber):
+    Optional properties required for certain units (DeltaE,
+   DeltaE_inWavenumber, DeltaE_inFrequency):
     <UL>
     <LI> Emode  - The energy mode (0=elastic, 1=direct geometry, 2=indirect
    geometry) </LI>

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -602,11 +602,11 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputSpace));
-    TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(), "DeltaE_inFrequency");
+    TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(),
+                     "DeltaE_inFrequency");
     TS_ASSERT_EQUALS(output->blocksize(), 1669);
     // Check EMode has been set
     TS_ASSERT_EQUALS(Mantid::Kernel::DeltaEMode::Direct, output->getEMode());
-
 
     AnalysisDataService::Instance().remove(outputSpace);
   }

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -590,6 +590,24 @@ public:
     // Check EMode has been set
     TS_ASSERT_EQUALS(Mantid::Kernel::DeltaEMode::Indirect, output->getEMode());
 
+    ConvertUnits conv3;
+    conv3.initialize();
+    conv3.setProperty("InputWorkspace", ws);
+    conv3.setPropertyValue("OutputWorkspace", outputSpace);
+    conv3.setPropertyValue("Target", "DeltaE_inFrequency");
+    conv3.setPropertyValue("Emode", "Direct");
+    conv3.setPropertyValue("Efixed", "12.95");
+    conv3.execute();
+
+    TS_ASSERT_THROWS_NOTHING(
+        output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            outputSpace));
+    TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(), "DeltaE_inFrequency");
+    TS_ASSERT_EQUALS(output->blocksize(), 1669);
+    // Check EMode has been set
+    TS_ASSERT_EQUALS(Mantid::Kernel::DeltaEMode::Direct, output->getEMode());
+
+
     AnalysisDataService::Instance().remove(outputSpace);
   }
 

--- a/Framework/Kernel/inc/MantidKernel/PhysicalConstants.h
+++ b/Framework/Kernel/inc/MantidKernel/PhysicalConstants.h
@@ -70,6 +70,10 @@ static constexpr double meV = 1.602176487e-22;
  * <http://physics.nist.gov/cuu/Constants> on 02/04/2008. */
 static constexpr double meVtoWavenumber = 8.06554465;
 
+/** 1 meV in frequency (GHz). Division of energy by Plank's constant. Taken from
+ * <http://physics.nist.gov/cuu/Constants> on 03/11/2017. */
+static constexpr double meVtoFrequency = 0.2417989262;
+
 /** 1 meV in Kelvin. Taken from <http://physics.nist.gov/cuu/Constants> on
  * 09/09/2011. */
 static constexpr double meVtoKelvin = 11.604519;

--- a/Framework/Kernel/inc/MantidKernel/Unit.h
+++ b/Framework/Kernel/inc/MantidKernel/Unit.h
@@ -497,6 +497,22 @@ public:
 };
 
 //=================================================================================================
+/// Energy transfer in units of frequency (GHz)
+class MANTID_KERNEL_DLL DeltaE_inFrequency : public DeltaE {
+public:
+  const std::string unitID() const override; ///< "DeltaE_inFrequency"
+  const std::string caption() const override { return "Energy transfer"; }
+  const UnitLabel label() const override;
+
+  void init() override;
+  Unit *clone() const override;
+  double conversionTOFMin() const override;
+  double conversionTOFMax() const override;
+  /// Constructor
+  DeltaE_inFrequency();
+};
+
+//=================================================================================================
 /// Momentum in Angstrom^-1
 class MANTID_KERNEL_DLL Momentum : public Unit {
 public:

--- a/Framework/Kernel/inc/MantidKernel/UnitLabelTypes.h
+++ b/Framework/Kernel/inc/MantidKernel/UnitLabelTypes.h
@@ -50,6 +50,8 @@ public:
   static const UnitLabel InverseAngstromSq;
   /// MilliElectronVolts
   static const UnitLabel MilliElectronVolts;
+  /// GHz
+  static const UnitLabel GHz;
   /// Metre
   static const UnitLabel Metre;
   /// Nanometre

--- a/Framework/Kernel/src/Unit.cpp
+++ b/Framework/Kernel/src/Unit.cpp
@@ -862,7 +862,8 @@ double DeltaE_inWavenumber::conversionTOFMax() const {
 /* Energy Transfer in units of frequency
  * =====================================================================================================
  *
- * This is identical to Energy Transfer in meV, with one division by Plank's constant, or multiplication
+ * This is identical to Energy Transfer in meV, with one division by Plank's
+ *constant, or multiplication
  * by factor PhysicalConstants::meVtoFrequency
  */
 DECLARE_UNIT(DeltaE_inFrequency)
@@ -880,7 +881,7 @@ Unit *DeltaE_inFrequency::clone() const {
 }
 
 DeltaE_inFrequency::DeltaE_inFrequency() : DeltaE() {
-  addConversion("DeltaE", 1.0/PhysicalConstants::meVtoFrequency, 1.);
+  addConversion("DeltaE", 1.0 / PhysicalConstants::meVtoFrequency, 1.);
 }
 
 double DeltaE_inFrequency::conversionTOFMin() const {

--- a/Framework/Kernel/src/Unit.cpp
+++ b/Framework/Kernel/src/Unit.cpp
@@ -714,6 +714,7 @@ DeltaE::DeltaE()
     : Unit(), factorTo(DBL_MIN), factorFrom(DBL_MIN), t_other(DBL_MIN),
       t_otherFrom(DBL_MIN), unitScaling(DBL_MIN) {
   addConversion("DeltaE_inWavenumber", PhysicalConstants::meVtoWavenumber, 1.);
+  addConversion("DeltaE_inFrequency", PhysicalConstants::meVtoFrequency, 1.);
 }
 
 void DeltaE::init() {
@@ -854,6 +855,39 @@ double DeltaE_inWavenumber::conversionTOFMin() const {
 }
 
 double DeltaE_inWavenumber::conversionTOFMax() const {
+  return DeltaE::conversionTOFMax();
+}
+
+// =====================================================================================================
+/* Energy Transfer in units of frequency
+ * =====================================================================================================
+ *
+ * This is identical to Energy Transfer in meV, with one division by Plank's constant, or multiplication
+ * by factor PhysicalConstants::meVtoFrequency
+ */
+DECLARE_UNIT(DeltaE_inFrequency)
+
+const UnitLabel DeltaE_inFrequency::label() const { return Symbol::GHz; }
+
+void DeltaE_inFrequency::init() {
+  DeltaE::init();
+  // Change the unit scaling factor
+  unitScaling = PhysicalConstants::meVtoFrequency;
+}
+
+Unit *DeltaE_inFrequency::clone() const {
+  return new DeltaE_inFrequency(*this);
+}
+
+DeltaE_inFrequency::DeltaE_inFrequency() : DeltaE() {
+  addConversion("DeltaE", 1.0/PhysicalConstants::meVtoFrequency, 1.);
+}
+
+double DeltaE_inFrequency::conversionTOFMin() const {
+  return DeltaE::conversionTOFMin();
+}
+
+double DeltaE_inFrequency::conversionTOFMax() const {
   return DeltaE::conversionTOFMax();
 }
 

--- a/Framework/Kernel/src/UnitLabelTypes.cpp
+++ b/Framework/Kernel/src/UnitLabelTypes.cpp
@@ -22,7 +22,7 @@ const UnitLabel Symbol::InverseAngstromSq("Angstrom^-2", L"\u212b\u207b\u00b2",
 /// MilliElectronVolts
 const UnitLabel Symbol::MilliElectronVolts("meV");
 /// GHz
-  const UnitLabel Symbol::GHz("GHz");
+const UnitLabel Symbol::GHz("GHz");
 /// Metre
 const UnitLabel Symbol::Metre("m");
 /// Nanometre

--- a/Framework/Kernel/src/UnitLabelTypes.cpp
+++ b/Framework/Kernel/src/UnitLabelTypes.cpp
@@ -21,6 +21,8 @@ const UnitLabel Symbol::InverseAngstromSq("Angstrom^-2", L"\u212b\u207b\u00b2",
                                           "\\AA^{-2}");
 /// MilliElectronVolts
 const UnitLabel Symbol::MilliElectronVolts("meV");
+/// GHz
+  const UnitLabel Symbol::GHz("GHz");
 /// Metre
 const UnitLabel Symbol::Metre("m");
 /// Nanometre

--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -943,7 +943,9 @@ public:
   // Energy transfer in frequency tests
   //----------------------------------------------------------------------
 
-  void testDeltaEf_unitID() { TS_ASSERT_EQUALS(dEf.unitID(), "DeltaE_inFrequency") }
+  void testDeltaEf_unitID() {
+    TS_ASSERT_EQUALS(dEf.unitID(), "DeltaE_inFrequency")
+  }
 
   void testDeltaEf_caption() {
     TS_ASSERT_EQUALS(dE.caption(), "Energy transfer")
@@ -961,7 +963,8 @@ public:
   }
 
   void testDeltaEf_toTOF() {
-    std::vector<double> x(1, 0.26597881882), y(1, 1.0);  //1.1meV = h*0.26597881882Ghz
+    std::vector<double> x(1, 0.26597881882),
+        y(1, 1.0); // 1.1meV = h*0.26597881882Ghz
     std::vector<double> yy = y;
     TS_ASSERT_THROWS_NOTHING(dEf.toTOF(x, y, 1.5, 2.5, 0.0, 1, 4.0, 0.0))
     TS_ASSERT_DELTA(x[0], 5071.066, 0.001)

--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -229,6 +229,9 @@ public:
     unit = DeltaE_inWavenumber().clone();
     TS_ASSERT(dynamic_cast<DeltaE_inWavenumber *>(unit));
     delete unit;
+    unit = DeltaE_inFrequency().clone();
+    TS_ASSERT(dynamic_cast<DeltaE_inFrequency *>(unit));
+    delete unit;
     unit = Momentum().clone();
     TS_ASSERT(dynamic_cast<Momentum *>(unit));
     delete unit;
@@ -937,6 +940,103 @@ public:
   }
 
   //----------------------------------------------------------------------
+  // Energy transfer in frequency tests
+  //----------------------------------------------------------------------
+
+  void testDeltaEf_unitID() { TS_ASSERT_EQUALS(dEf.unitID(), "DeltaE_inFrequency") }
+
+  void testDeltaEf_caption() {
+    TS_ASSERT_EQUALS(dE.caption(), "Energy transfer")
+  }
+
+  void testDeltaEf_label() {
+    TS_ASSERT_EQUALS(dEf.label().ascii(), "GHz")
+    TS_ASSERT_EQUALS(dEf.label().utf8(), L"GHz")
+  }
+
+  void testDeltaEf_cast() {
+    Unit *u = NULL;
+    TS_ASSERT_THROWS_NOTHING(u = dynamic_cast<Unit *>(&dEf));
+    TS_ASSERT_EQUALS(u->unitID(), "DeltaE_inFrequency");
+  }
+
+  void testDeltaEf_toTOF() {
+    std::vector<double> x(1, 0.26597881882), y(1, 1.0);  //1.1meV = h*0.26597881882Ghz
+    std::vector<double> yy = y;
+    TS_ASSERT_THROWS_NOTHING(dEf.toTOF(x, y, 1.5, 2.5, 0.0, 1, 4.0, 0.0))
+    TS_ASSERT_DELTA(x[0], 5071.066, 0.001)
+    TS_ASSERT(yy == y)
+
+    x[0] = 0.26597881882;
+    TS_ASSERT_THROWS_NOTHING(dEf.toTOF(x, y, 1.5, 2.5, 0.0, 2, 4.0, 0.0))
+    TS_ASSERT_DELTA(x[0], 4376.406, 0.001)
+    TS_ASSERT(yy == y)
+
+    // emode = 0
+    TS_ASSERT_THROWS(dEf.toTOF(x, y, 1.5, 2.5, 0.0, 0, 4.0, 0.0),
+                     std::invalid_argument)
+  }
+
+  void testDeltaEf_fromTOF() {
+    std::vector<double> x(1, 2001.0), y(1, 1.0);
+    std::vector<double> yy = y;
+    TS_ASSERT_THROWS_NOTHING(dEf.fromTOF(x, y, 1.5, 2.5, 0.0, 1, 4.0, 0.0))
+    TS_ASSERT_DELTA(x[0], -95.4064, 0.0001)
+    TS_ASSERT(yy == y)
+
+    x[0] = 3001.0;
+    TS_ASSERT_THROWS_NOTHING(dEf.fromTOF(x, y, 1.5, 2.5, 0.0, 2, 4.0, 0.0))
+    TS_ASSERT_DELTA(x[0], 137.7866, 0.0001)
+    TS_ASSERT(yy == y)
+
+    // emode = 0
+    TS_ASSERT_THROWS(dEf.fromTOF(x, y, 1.5, 2.5, 0.0, 0, 4.0, 0.0),
+                     std::invalid_argument)
+  }
+
+  void testDE_fRange() {
+    std::vector<double> sample, rezult;
+    // Direct
+    dEf.initialize(2001.0, 1.0, 1.5, 1, 10., 0.0);
+
+    std::string err_mess =
+        convert_units_check_range(dEf, sample, rezult, DBL_EPSILON);
+    TSM_ASSERT(" ERROR:" + err_mess, err_mess.size() == 0);
+
+    TSM_ASSERT_DELTA(
+        "Direct energy transfer limits Failed for conversion t_min: ",
+        sample[0], rezult[0], 10 * FLT_EPSILON);
+    TSM_ASSERT_DELTA(
+        "Direct energy transfer limits Failed for conversion t_max: ",
+        sample[1] / rezult[1], 1., 0.05);
+    TSM_ASSERT_DELTA(
+        "Direct energy transfer limits Failed for conversion e_min: ",
+        sample[2], rezult[2], 10 * FLT_EPSILON);
+    TSM_ASSERT_DELTA(
+        "Direct energy transfer limits Failed for conversion e_max: ",
+        sample[3], rezult[3], 10 * FLT_EPSILON);
+
+    // Indirect
+    dEf.initialize(2001.0, 1.0, 1.5, 2, 10., 0.0);
+
+    err_mess = convert_units_check_range(dEf, sample, rezult);
+    TSM_ASSERT(" ERROR:" + err_mess, err_mess.size() == 0);
+
+    TSM_ASSERT_DELTA(
+        "Indirect energy transfer limits Failed for conversion t_min: ",
+        sample[0], rezult[0], 10 * FLT_EPSILON);
+    TSM_ASSERT_DELTA(
+        "Indirect energy transfer limits Failed for conversion t_max: ",
+        sample[1] / rezult[1], 1., 0.05);
+    TSM_ASSERT_DELTA(
+        "Indirect energy transfer limits Failed for conversion e_min: ",
+        sample[2], rezult[2], 10 * FLT_EPSILON);
+    TSM_ASSERT_DELTA(
+        "Indirect energy transfer limits Failed for conversion e_max: ",
+        sample[3], rezult[3], 10 * FLT_EPSILON);
+  }
+
+  //----------------------------------------------------------------------
   // Momentum tests
   //----------------------------------------------------------------------
 
@@ -1235,6 +1335,7 @@ private:
   Units::QSquared q2;
   Units::DeltaE dE;
   Units::DeltaE_inWavenumber dEk;
+  Units::DeltaE_inFrequency dEf;
   Units::Momentum k_i;
   Units::SpinEchoLength delta;
   Units::SpinEchoTime tau;

--- a/Framework/MDAlgorithms/test/UnitsConversionHelperTest.h
+++ b/Framework/MDAlgorithms/test/UnitsConversionHelperTest.h
@@ -4,6 +4,7 @@
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidKernel/PhysicalConstants.h"
 #include "MantidMDAlgorithms/MDWSDescription.h"
 #include "MantidMDAlgorithms/UnitsConversionHelper.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
@@ -89,6 +90,43 @@ public:
     TS_ASSERT_EQUALS(-100000, range.first);
     TS_ASSERT_EQUALS(0, range.second);
   }
+
+  void testConvertFastFromInelasticWStoFrequency() {
+    UnitsConversionHelper Conv;
+    MDWSDescription WSD;
+
+    // ws description currently needs min/max to be set properly
+    std::vector<double> min(2, -10), max(2, 10);
+    WSD.setMinMax(min, max);
+
+    WSD.buildFromMatrixWS(ws2D, "|Q|", "Direct");
+    WSD.m_PreprDetTable = detLoc;
+
+    TS_ASSERT_THROWS_NOTHING(Conv.initialize(WSD, "DeltaE_inFrequency"));
+
+    const auto &X = ws2D->readX(0);
+    size_t n_bins = X.size() - 1;
+    for (size_t i = 0; i < n_bins; i++) {
+      TS_ASSERT_DELTA(X[i]*Mantid::PhysicalConstants::meVtoFrequency, Conv.convertUnits(X[i]), 1.e-4);
+    }
+
+    auto range = Conv.getConversionRange(0, 10);
+    TS_ASSERT_EQUALS(0, range.first);
+    TS_ASSERT_EQUALS(3, range.second);
+
+    range = Conv.getConversionRange(-10, 3);
+    TS_ASSERT_EQUALS(-10, range.first);
+    TS_ASSERT_EQUALS(3, range.second);
+
+    range = Conv.getConversionRange(-100000, 2);
+    TS_ASSERT_EQUALS(-100000, range.first);
+    TS_ASSERT_EQUALS(2, range.second);
+
+    range = Conv.getConversionRange(0, -100000);
+    TS_ASSERT_EQUALS(-100000, range.first);
+    TS_ASSERT_EQUALS(0, range.second);
+  }
+
   void testConvertToTofInelasticWS() {
     UnitsConversionHelper Conv;
     MDWSDescription WSD;

--- a/Framework/MDAlgorithms/test/UnitsConversionHelperTest.h
+++ b/Framework/MDAlgorithms/test/UnitsConversionHelperTest.h
@@ -107,7 +107,8 @@ public:
     const auto &X = ws2D->readX(0);
     size_t n_bins = X.size() - 1;
     for (size_t i = 0; i < n_bins; i++) {
-      TS_ASSERT_DELTA(X[i]*Mantid::PhysicalConstants::meVtoFrequency, Conv.convertUnits(X[i]), 1.e-4);
+      TS_ASSERT_DELTA(X[i] * Mantid::PhysicalConstants::meVtoFrequency,
+                      Conv.convertUnits(X[i]), 1.e-4);
     }
 
     auto range = Conv.getConversionRange(0, 10);

--- a/Framework/PythonInterface/test/python/mantid/kernel/UnitFactoryTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/UnitFactoryTest.py
@@ -24,7 +24,8 @@ class UnitFactoryTest(unittest.TestCase):
         # but allow for others to be added
         core_units = ['Empty', 'Label', 'TOF', 'Wavelength','Energy',
                       'Energy_inWavenumber', 'dSpacing', 'MomentumTransfer',
-                      'QSquared', 'DeltaE', 'DeltaE_inWavenumber', 'Momentum']
+                      'QSquared', 'DeltaE', 'DeltaE_inWavenumber',
+                      'DeltaE_inFrequency', 'Momentum']
         self.assertTrue(len(core_units) <= len(known_units))
 
         for unit in core_units:

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -5,6 +5,11 @@ Framework Changes
 .. contents:: Table of Contents
    :local:
 
+API
+---
+
+- Frequency unit (GHz) included as an option to represent energy transfer.
+
 Algorithms
 ----------
 


### PR DESCRIPTION
Added a new unit, `DeltaE_inFrequency`, which is nothing but `DeltaE/h` with `h` Planck's constant. The units of  `DeltaE_inFrequency` are GHz.

**To test:**
Run the following script:

```
import numpy as np
from scipy.signal import gaussian
y=gaussian(100, 20)
x=np.arange(-50,50)+0.5
sqe = CreateWorkspace(x, y, NSpec=1, UnitX="DeltaE")
ConvertUnits(InputWorkspace="sqe", OutputWorkspace="sqf", Emode="Indirect", Target="DeltaE_inFrequency")
```

Plot `sqf` and check the X-axis label is GHz. Also, the X-axis values of sqf are those of `sqe` multiplied by factor 0.2417989262. You can check that too.

Fixes #19057.

[release notes](https://github.com/mantidproject/mantid/blob/46ecbcf06aa5b28640d8afa26271a9cbd2f21a2d/docs/source/release/v3.10.0/framework.rst#api)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
