### PR TITLE
Fix problem removing peaks workspaces with sliceviewer's peakviewer

### DIFF
--- a/MantidQt/SliceViewer/src/CompositePeaksPresenter.cpp
+++ b/MantidQt/SliceViewer/src/CompositePeaksPresenter.cpp
@@ -87,9 +87,9 @@ Clear all peaks
 */
 void CompositePeaksPresenter::clear() {
   if (!m_subjects.empty()) {
-	  for (auto i = 0; i < m_subjects.size(); i++) {
-		  m_subjects[i]->setShown(false);
-	}
+    for (auto i = 0; i < m_subjects.size(); i++) {
+      m_subjects[i]->setShown(false);
+    }
     m_subjects.clear();
     this->m_zoomablePlottingWidget->detach();
     PeakPalette<PeakViewColor> tempPeakViewColor;

--- a/MantidQt/SliceViewer/src/CompositePeaksPresenter.cpp
+++ b/MantidQt/SliceViewer/src/CompositePeaksPresenter.cpp
@@ -87,6 +87,9 @@ Clear all peaks
 */
 void CompositePeaksPresenter::clear() {
   if (!m_subjects.empty()) {
+	  for (auto i = 0; i < m_subjects.size(); i++) {
+		  m_subjects[i]->setShown(false);
+	}
     m_subjects.clear();
     this->m_zoomablePlottingWidget->detach();
     PeakPalette<PeakViewColor> tempPeakViewColor;

--- a/MantidQt/SliceViewer/src/CompositePeaksPresenter.cpp
+++ b/MantidQt/SliceViewer/src/CompositePeaksPresenter.cpp
@@ -86,9 +86,10 @@ bool CompositePeaksPresenter::isLabelOfFreeAxis(
 Clear all peaks
 */
 void CompositePeaksPresenter::clear() {
+
   if (!m_subjects.empty()) {
-    for (auto i = 0; i < m_subjects.size(); i++) {
-      m_subjects[i]->setShown(false);
+    for (auto &i : m_subjects) {
+      i->setShown(false);
     }
     m_subjects.clear();
     this->m_zoomablePlottingWidget->detach();

--- a/MantidQt/SliceViewer/src/PeaksViewer.cpp
+++ b/MantidQt/SliceViewer/src/PeaksViewer.cpp
@@ -493,7 +493,6 @@ void PeaksViewer::updatePeaksWorkspace(
 bool PeaksViewer::removePeaksWorkspace(
     boost::shared_ptr<const Mantid::API::IPeaksWorkspace> toRemove) {
   bool somethingToRemove = false;
-
   if (m_presenter) {
 
     QList<PeaksWorkspaceWidget *> children =
@@ -513,6 +512,7 @@ bool PeaksViewer::removePeaksWorkspace(
         break;
       }
     }
+	m_presenter->hideInPlot(toRemove, somethingToRemove);
     m_presenter->remove(toRemove);
   }
   return somethingToRemove;

--- a/MantidQt/SliceViewer/src/PeaksViewer.cpp
+++ b/MantidQt/SliceViewer/src/PeaksViewer.cpp
@@ -512,7 +512,7 @@ bool PeaksViewer::removePeaksWorkspace(
         break;
       }
     }
-	m_presenter->hideInPlot(toRemove, somethingToRemove);
+    m_presenter->hideInPlot(toRemove, somethingToRemove);
     m_presenter->remove(toRemove);
   }
   return somethingToRemove;


### PR DESCRIPTION
Set so peaks representations will be hidden when peak workspaces are removed. Additionally changed 'remove all' button (mentioned in ticket) so it removes all peak workspaces currently being viewed in the sliceviewer's peakviewer.

**To test:**
Go to \\olympic\Babylon5\Scratch\Lottie\18911_peakviewer for files to use. Open them in slice viewer, make sure the 'remove' and 'remove all' buttons work correctly and as you would expect. 


Fixes https://github.com/mantidproject/mantid/issues/18974

<!-- RELEASE NOTES
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
