### PR TITLE
Improve input validation of MatchPeaks

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
@@ -122,21 +122,27 @@ class MatchPeaks(PythonAlgorithm):
 
         if input3:
             if not input2:
-                issues['InputWorkspace2'] = 'When input 3 is given, input 2 is also required.'
+                issues['InputWorkspace2'] = 'When InputWorkspace3 is given, InputWorkspace2 is also required.'
             else:
-                if mtd[input3].blocksize() != mtd[input2].blocksize():
+                if mtd[input3].isDistribution() and not mtd[input2].isDistribution():
+                    issues['InputWorkspace3'] = 'InputWorkspace2 and InputWorkspace3 must be either point data or ' \
+                                                'histogram data'
+                elif mtd[input3].blocksize() != mtd[input2].blocksize():
                     issues['InputWorkspace3'] = 'Incompatible same number of bins'
-                if mtd[input3].getNumberHistograms() != mtd[input2].getNumberHistograms():
+                elif mtd[input3].getNumberHistograms() != mtd[input2].getNumberHistograms():
                     issues['InputWorkspace3'] = 'Incompatible number of spectra'
-                if np.all(mtd[input3].extractX() - mtd[input2].extractX()):
+                elif np.any(mtd[input3].extractX() - mtd[input2].extractX()):
                     issues['InputWorkspace3'] = 'Incompatible x-values'
 
         if input2:
-            if mtd[input1].blocksize() != mtd[input2].blocksize():
+            if mtd[input1].isDistribution() and not mtd[inout2].isDistribution():
+                issues['InputWorkspace2'] = 'InputWorkspace2 and InputWorkspace3 must be either point data or ' \
+                                            'histogram data'
+            elif mtd[input1].blocksize() != mtd[input2].blocksize():
                 issues['InputWorkspace2'] = 'Incompatible same number of bins'
-            if mtd[input1].getNumberHistograms() != mtd[input2].getNumberHistograms():
+            elif mtd[input1].getNumberHistograms() != mtd[input2].getNumberHistograms():
                 issues['InputWorkspace2'] = 'Incompatible number of spectra'
-            if np.all(mtd[input1].extractX() - mtd[input2].extractX()):
+            elif np.any(mtd[input1].extractX() - mtd[input2].extractX()):
                 issues['InputWorkspace2'] = 'Incompatible x-values'
 
         return issues

--- a/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
@@ -128,7 +128,7 @@ class MatchPeaks(PythonAlgorithm):
                     issues['InputWorkspace3'] = 'InputWorkspace2 and InputWorkspace3 must be either point data or ' \
                                                 'histogram data'
                 elif mtd[input3].blocksize() != mtd[input2].blocksize():
-                    issues['InputWorkspace3'] = 'Incompatible same number of bins'
+                    issues['InputWorkspace3'] = 'Incompatible number of bins'
                 elif mtd[input3].getNumberHistograms() != mtd[input2].getNumberHistograms():
                     issues['InputWorkspace3'] = 'Incompatible number of spectra'
                 elif np.any(mtd[input3].extractX() - mtd[input2].extractX()):
@@ -139,7 +139,7 @@ class MatchPeaks(PythonAlgorithm):
                 issues['InputWorkspace2'] = 'InputWorkspace2 and InputWorkspace3 must be either point data or ' \
                                             'histogram data'
             elif mtd[input1].blocksize() != mtd[input2].blocksize():
-                issues['InputWorkspace2'] = 'Incompatible same number of bins'
+                issues['InputWorkspace2'] = 'Incompatible number of bins'
             elif mtd[input1].getNumberHistograms() != mtd[input2].getNumberHistograms():
                 issues['InputWorkspace2'] = 'Incompatible number of spectra'
             elif np.any(mtd[input1].extractX() - mtd[input2].extractX()):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MatchPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MatchPeaksTest.py
@@ -7,6 +7,7 @@ from mantid.simpleapi import *
 from mantid.api import *
 from testhelpers import run_algorithm
 
+
 class MatchPeaksTest(unittest.TestCase):
 
     _args = {}
@@ -100,7 +101,7 @@ class MatchPeaksTest(unittest.TestCase):
         if AnalysisDataService.doesExist('to_be_shifted'):
             DeleteWorkspace(self._ws_shift)
         if AnalysisDataService.doesExist('in_2'):
-            DeleteWorkspace(self._ws_in_2 )
+            DeleteWorkspace(self._ws_in_2)
         if AnalysisDataService.doesExist('output'):
             DeleteWorkspace(mtd['output'])
         if AnalysisDataService.doesExist('wrong_number_of_histograms'):
@@ -108,60 +109,41 @@ class MatchPeaksTest(unittest.TestCase):
         if AnalysisDataService.doesExist('wrong_number_of_bins'):
             DeleteWorkspace(self._in2)
 
-    def testValidatorInput(self):
+    def testValidateInputWorkspace(self):
         self._args['OutputWorkspace'] = 'output'
-        # Test if incompatible workspaces will fail
-        if sys.version_info >= (2, 7):
-            with self.assertRaises(RuntimeError):
-                self._args['InputWorkspace'] = self._in1
-                run_algorithm('MatchPeaks', **self._args)
+        self.assertTrue(sys.version_info >= (2, 7))
+        with self.assertRaises(RuntimeError) as contextManager:
+            self._args['InputWorkspace'] = self._in1
+            run1 = run_algorithm('MatchPeaks', **self._args)
+            self.assertTrue(run1.isExecuted())
+        self.assertEqual('Some invalid Properties found', str(contextManager.exception))
+        with self.assertRaises(RuntimeError) as contextManager:
+            self._args['InputWorkspace'] = self._in2
+            run2 = run_algorithm('MatchPeaks', **self._args)
+            self.assertTrue(run2.isExecuted())
+        self.assertEqual('Some invalid Properties found', str(contextManager.exception))
 
-                self._args['InputWorkspace'] = self._in2
-                run_algorithm('MatchPeaks', **self._args)
-        else:
-            incompatible = False
-            try:
-                self._args['InputWorkspace'] = self._in1
-                run_algorithm('MatchPeaks', **self._args)
-
-                self._args['InputWorkspace'] = self._in2
-                run_algorithm('MatchPeaks', **self._args)
-            except RuntimeError:
-                incompatible = True
-            self.assertTrue(incompatible, "Workspaces are incompatible")
-
-        # Test if compatible workspaces will be accepted (size, X-values, E-values)
-        self._args['InputWorkspace'] = self._ws_shift
-        alg_test = run_algorithm('MatchPeaks', **self._args)
-        self.assertTrue(alg_test.isExecuted())
-
-    def testValidatorInput2(self):
+    def testValidateInputWorkspace2(self):
         self._args['InputWorkspace'] = self._ws_shift
         self._args['OutputWorkspace'] = 'output'
-        # Test if incompatible workspaces will fail
-        if sys.version_info >= (2, 7):
-            with self.assertRaises(RuntimeError):
-                self._args['InputWorkspace2'] = self._in1
-                run_algorithm('MatchPeaks', **self._args)
+        self.assertTrue(sys.version_info >= (2, 7))
+        with self.assertRaises(RuntimeError) as contextManager:
+            self._args['InputWorkspace2'] = self._in1
+            run_algorithm('MatchPeaks', **self._args)
+        self.assertEqual('Some invalid Properties found', str(contextManager.exception))
+        with self.assertRaises(RuntimeError) as contextManager:
+            self._args['InputWorkspace2'] = self._in2
+            run_algorithm('MatchPeaks', **self._args)
+        self.assertEqual('Some invalid Properties found', str(contextManager.exception))
 
-                self._args['InputWorkspace2'] = self._in2
-                run_algorithm('MatchPeaks', **self._args)
-        else:
-            incompatible = False
-            try:
-                self._args['InputWorkspace2'] = self._in1
-                run_algorithm('MatchPeaks', **self._args)
-
-                self._args['InputWorkspace2'] = self._in2
-                run_algorithm('MatchPeaks', **self._args)
-            except RuntimeError:
-                incompatible = True
-            self.assertTrue(incompatible, "Workspaces are incompatible")
-
-        # Test if compatible workspaces will be accepted (size, X-values, E-values)
-        self._args['InputWorkspace2'] = self._ws_in_2
-        alg_test = run_algorithm('MatchPeaks', **self._args)
-        self.assertTrue(alg_test.isExecuted())
+    def testValidateInputWorkspace3(self):
+        self._args['InputWorkspace'] = self._ws_shift
+        self._args['InputWorkspace3'] = self._ws_in_3
+        self._args['OutputWorkspace'] = 'output'
+        self.assertTrue(sys.version_info >= (2, 7))
+        with self.assertRaises(RuntimeError) as contextManager:
+            run_algorithm('MatchPeaks', **self._args)
+        self.assertEqual('Some invalid Properties found', str(contextManager.exception))
 
     def testMatchCenter(self):
         # Input workspace should match its center


### PR DESCRIPTION
Input validation improved (compability of workspaces):
- histogram workspaces or point data
- if elif structure for appropriate messages
- `np.all` replaced by `np.any` for checking incompatible x values
- unit test for input validation of `InputWorkspace3`
- unit tests explicitely check for runtime error `Some invalid Properties found`

**To test:**
Run `MatchPeaks` with the two input workspaces

```Python
CreateSampleWorkspace(OutputWorkspace='ws1', XMax=4, BinWidth=1)
CreateSampleWorkspace(OutputWorkspace='ws2', XMin=0.2, XMax=4.2, BinWidth=1)
```
The invalid property marked should be `Incompatible x-values`

Fixes #19044 .

Behavior of `MatchPeaks` not changed.

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
