### PR TITLE
H5Utils::readStringVector new method

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/H5Util.h
@@ -113,6 +113,9 @@ MANTID_DATAHANDLING_DLL std::string readString(H5::Group &group,
 
 MANTID_DATAHANDLING_DLL std::string readString(H5::DataSet &dataset);
 
+MANTID_DATAHANDLING_DLL std::vector<std::string>
+readStringVector(H5::Group &, const std::string &);
+
 template <typename LocationType>
 std::string readAttributeAsString(LocationType &dataset,
                                   const std::string &attributeName);

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -245,8 +245,7 @@ std::vector<std::string> readStringVector(Group &group,
   DataSpace dataspace = dataset.getSpace();
   DataType datatype = dataset.getDataType();
 
-  int ndims = dataspace.getSimpleExtentDims(dims, NULL);
-  UNUSED_ARG(ndims);
+  dataspace.getSimpleExtentDims(dims, NULL);
 
   rdata = new char *[dims[0]];
   dataset.read(rdata, datatype);

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -229,6 +229,38 @@ std::string readString(H5::DataSet &dataset) {
   return value;
 }
 
+/**
+ * Returns 1D vector of variable length strings
+ * @param group :: H5::Group already opened
+ * @param name :: name of the dataset in the group (rank must be 1)
+ * @return :: vector of strings
+ */
+std::vector<std::string> readStringVector(Group &group,
+                                          const std::string &name) {
+  hsize_t dims[1];
+  char **rdata;
+  std::vector<std::string> result;
+
+  DataSet dataset = group.openDataSet(name);
+  DataSpace dataspace = dataset.getSpace();
+  DataType datatype = dataset.getDataType();
+
+  int ndims = dataspace.getSimpleExtentDims(dims, NULL);
+  UNUSED_ARG(ndims);
+
+  rdata = new char *[dims[0]];
+  dataset.read(rdata, datatype);
+
+  for (size_t i = 0; i < dims[0]; ++i)
+    result.emplace_back(std::string(rdata[i]));
+
+  dataset.vlenReclaim(rdata, datatype, dataspace);
+  dataset.close();
+  delete[] rdata;
+
+  return result;
+}
+
 template <typename LocationType>
 std::string readAttributeAsString(LocationType &location,
                                   const std::string &attributeName) {

--- a/Framework/DataHandling/test/H5UtilTest.h
+++ b/Framework/DataHandling/test/H5UtilTest.h
@@ -186,6 +186,7 @@ public:
     StrType datatype(0, H5T_VARIABLE);
     DataSet dataset = group.createDataSet(dataname, datatype, dataspace);
     dataset.write(wdata, datatype);
+    dataset.close();
     group.close();
     file.close();
 

--- a/Framework/DataHandling/test/H5UtilTest.h
+++ b/Framework/DataHandling/test/H5UtilTest.h
@@ -172,6 +172,43 @@ public:
     removeFile(FILENAME);
   }
 
+  void test_string_vector() {
+    std::vector<std::string> readout;
+    const std::string filename = "test_string_vec.h5";
+    const std::string dataname = "test_str_vec";
+    const hsize_t dims[1] = {5};
+    const char *wdata[5] = {"Lets", "see", "how", "it", "goes"};
+
+    // write a test file
+    H5File file(filename, H5F_ACC_TRUNC);
+    Group group = file.createGroup("entry");
+    DataSpace dataspace(1, dims);
+    StrType datatype(0, H5T_VARIABLE);
+    DataSet dataset = group.createDataSet(dataname, datatype, dataspace);
+    dataset.write(wdata, datatype);
+    group.close();
+    file.close();
+
+    // check it exists
+    TS_ASSERT(Poco::File(filename).exists());
+
+    // open and read the vector
+    H5File file_read(filename, H5F_ACC_RDONLY);
+    Group group_read = file_read.openGroup("entry");
+
+    readout = H5Util::readStringVector(group_read, dataname);
+
+    for (size_t i = 0; i < readout.size(); ++i) {
+      TS_ASSERT_EQUALS(readout[i], std::string(wdata[i]));
+    }
+
+    group_read.close();
+    file_read.close();
+
+    // remove the file
+    removeFile(filename);
+  }
+
 private:
   void do_assert_simple_string_data_set(
       const std::string &filename, const std::string &groupName,


### PR DESCRIPTION
This PR implements a new method in H5Utils to read arrays of variable length strings using the HDF5 C++ API.

**To test:**

<!-- Instructions for testing. -->

Code review & test pass.

Fixes #19051 .

*Internal change, does not need to be in the release notes.*
<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.