### PR TITLE
Bugfix NOMAD generating NaNs in their x-axis

### DIFF
--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -135,17 +135,19 @@ string determineXMinMax(MatrixWorkspace_sptr inputWS, vector<double> &xmins,
     if (updateXMins || updateXMaxs) {
       const auto &xvalues = inputWS->x(i);
       if (updateXMins) {
-        if (std::isnan(xvalues.front())) {
+        const auto minimum = xvalues.front();
+        if (std::isnan(minimum) || minimum >= xmax_wksp) {
           xmins.push_back(xmin_wksp);
         } else {
-          xmins.push_back(xvalues.front());
+          xmins.push_back(minimum);
         }
       }
       if (updateXMaxs) {
-        if (std::isnan(xvalues.back())) {
+        const auto maximum = xvalues.back();
+        if (std::isnan(maximum) || maximum <= xmin_wksp) {
           xmaxs.push_back(xmax_wksp);
         } else {
-          xmaxs.push_back(xvalues.back());
+          xmaxs.push_back(maximum);
         }
       }
     }


### PR DESCRIPTION
There was a bug with some calibration files generating conversion factors that produced imaginary d-spacing. C++ represents this as a `qNaN`. This change just quietly changes the range used by `ResampleX` to get around it.

**To test:**

The script that exposed it is below and based on their autoreduction script (the plotting has been removed).

```python
import os
import sys
import shutil
sys.path.append("/opt/mantidnightly/bin")
from mantid.simpleapi import *
import mantid

########## user defined parameters
resamplex=-6000
vanradius=0.58
#wavelengthMin=0.1
#wavelengthMax=2.9
calFile="/SNS/NOM/IPTS-17697/shared/NOM_calibrate_d89318_2017_03_03.h5"#/SNS/NOM/shared/CALIBRATION/2016_2_1B_CAL/NOM_d81755_2016_10_19_furnace.h5"
charFile="/SNS/NOM/shared/CALIBRATION/2016_2_1B_CAL/NOM_char_2016_12_13-rietveld.txt"
expiniFileDefault="/SNS/NOM/IPTS-17697/shared/autoNOM/exp.ini"
# 0 means use the runs specified in the exp.ini
# -1 means turn off the correction
# specify files to be summed as a tuple or list
sampleBackRun=0
vanRun=0
vanBackRun=0
########## end of user defined parameters

eventFileAbs='/SNS/NOM/IPTS-17697/nexus/NOM_89452.nxs.h5' #sys.argv[1]
outputDir='/tmp' #sys.argv[2]
maxChunkSize=8.
#if len(sys.argv)>3:
#    maxChunkSize=float(sys.argv[3])

eventFile = os.path.split(eventFileAbs)[-1]
nexusDir = eventFileAbs.replace(eventFile, '')
cacheDir = "/tmp" # local disk to (hopefully) reduce issues
runNumber = eventFile.split('_')[1].split('.')[0]
configService = mantid.config
dataSearchPath = configService.getDataSearchDirs()
dataSearchPath.append(nexusDir)
configService.setDataSearchDirs(";".join(dataSearchPath))

# setup for MPI
if AlgorithmFactory.exists('GatherWorkspaces'):
     from mpi4py import MPI
     mpiRank = MPI.COMM_WORLD.Get_rank()
else:
     mpiRank = 0

# uncomment next line to delete cache files
#if mpiRank == 0: CleanFileCache(CacheDir=cacheDir, AgeInDays=0)

proposalDir = '/' + '/'.join(nexusDir.split('/')[1:4])
expiniFilename=os.path.join(proposalDir, 'shared', 'autoNOM', 'exp.ini')
if not os.path.exists(expiniFilename):
    expiniFilename=expiniFileDefault
print "Using", expiniFilename

# determine information for caching
wksp=LoadEventNexus(Filename=eventFileAbs, MetaDataOnly=True)
PDLoadCharacterizations(Filename=charFile,
                        ExpIniFilename=expiniFilename,
                        OutputWorkspace="characterizations")
PDDetermineCharacterizations(InputWorkspace=wksp,
                             Characterizations="characterizations",
                             BackRun=sampleBackRun,
                             NormRun=vanRun,
                             NormBackRun=vanBackRun)
DeleteWorkspace(str(wksp))
DeleteWorkspace("characterizations")
charPM = mantid.PropertyManagerDataService.retrieve('__pd_reduction_properties')

# get back the runs to use so they can be explicit in the generated python script
sampleBackRun = charPM['container'].value[0]
vanRun        = charPM['vanadium'].value[0]
vanBackRun    = charPM['vanadium_background'].value[0]

# work on container cache file
if sampleBackRun > 0:
    canWkspName="NOM_"+str(sampleBackRun)
    canProcessingProperties = ['container', 'd_min', 'd_max',
                               'tof_min', 'tof_max']
    canProcessingOtherProperties = ["ResampleX="+str(resamplex),
                                    "BackgroundSmoothParams="+str(''),
                                    "CalibrationFile="+calFile]

    (canCacheName, _) = CreateCacheFilename(Prefix=canWkspName, CacheDir=cacheDir,
                                            PropertyManager='__pd_reduction_properties',
                                            Properties=canProcessingProperties,
                                            OtherProperties=canProcessingOtherProperties)
    print "Container cache file:", canCacheName

    if os.path.exists(canCacheName):
        print "Loading container cache file '%s'" % canCacheName
        Load(Filename=canCacheName, OutputWorkspace=canWkspName)

# work on vanadium cache file
if vanRun > 0:
    vanWkspName="NOM_"+str(vanRun)
    vanProcessingProperties = ['vanadium', 'vanadium_background', 'd_min', 'd_max',
                               'tof_min', 'tof_max']
    vanProcessingOtherProperties = ["ResampleX="+str(resamplex),
                                    "VanadiumRadius="+str(vanradius),
                                    "CalibrationFile="+calFile]

    (vanCacheName, _) =  CreateCacheFilename(Prefix=vanWkspName, CacheDir=cacheDir,
                                             PropertyManager='__pd_reduction_properties',
                                             Properties=vanProcessingProperties,
                                             OtherProperties=vanProcessingOtherProperties)
    print "Vanadium cache file:", vanCacheName

    if os.path.exists(vanCacheName):
        print "Loading vanadium cache file '%s'" % vanCacheName
        Load(Filename=vanCacheName, OutputWorkspace=vanWkspName)

# process the run
SNSPowderReduction(Filename=eventFile,
                   MaxChunkSize=maxChunkSize, PreserveEvents=True,PushDataPositive='AddMinimum',
                   CalibrationFile=calFile,
                   CharacterizationRunsFile=charFile,
                   BackgroundNumber=str(sampleBackRun),
                   VanadiumNumber=str(vanRun),
                   VanadiumBackgroundNumber=str(vanBackRun),
                   ExpIniFilename=expiniFilename,
                   RemovePromptPulseWidth=50,
                   ResampleX=resamplex,
                   BinInDspace=True,
                   FilterBadPulses=25.,
                   SaveAs="gsas fullprof topas",
                   OutputDirectory=outputDir,
                   StripVanadiumPeaks=True,
                   VanadiumRadius=vanradius,
                   NormalizeByCurrent=True, FinalDataUnits="dSpacing")

# only write out thing on control job
if mpiRank == 0:
    # save out the container cache file
    if sampleBackRun > 0 and not os.path.exists(canCacheName):
        ConvertUnits(InputWorkspace=canWkspName, OutputWorkspace=canWkspName, Target="TOF")
        SaveNexusProcessed(InputWorkspace=canWkspName, Filename=canCacheName)

    # save out the vanadium cache file
    if vanRun > 0 and not os.path.exists(vanCacheName):
        ConvertUnits(InputWorkspace=vanWkspName, OutputWorkspace=vanWkspName, Target="TOF")
        SaveNexusProcessed(InputWorkspace=vanWkspName, Filename=vanCacheName)

    wksp_name = "NOM_"+runNumber

    # save the processing script
    GeneratePythonScript(InputWorkspace=wksp_name,
                     Filename=os.path.join(outputDir,wksp_name+'.py'))

    ConvertUnits(InputWorkspace=wksp_name, OutputWorkspace=wksp_name, Target="dSpacing")
```

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
