### PR TITLE
Option in BASISReduction to output the dynamic susceptibility

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -74,9 +74,6 @@ class BASISReduction(PythonAlgorithm):
         self._normWs = None
         self._normMonWs = None
 
-        # additional output
-
-
     def category(self):
         return "Inelastic\\Reduction"
 
@@ -159,8 +156,6 @@ class BASISReduction(PythonAlgorithm):
         self.declareProperty("OutputSusceptibility", False, direction=Direction.Input,
                              doc="Output dynamic susceptibility (Xqw)")
         self.setPropertyGroup("OutputSusceptibility", titleAddionalOutput)
-
-
 
     #pylint: disable=too-many-branches
     def PyExec(self):

--- a/docs/source/algorithms/BASISReduction-v1.rst
+++ b/docs/source/algorithms/BASISReduction-v1.rst
@@ -90,6 +90,14 @@ range given by **NormWavelengthRange** to obtain
 :math:`S_v(i)` and then divide :math:`S_s(\lambda, i)/S_v(i)=S'_s(\lambda, i)`. From this
 point on, the reduction process continues using :math:`S'_s` in place of :math:`S_s`.
 
+Dynamic Susceptibility
+======================
+
+If <i>OutputSusceptibility</i> is checked, one additional workspace and one Nexus file will be generated,
+both containing the dynamic susceptibility as a function of frequency, in units of GHz.
+The extension denoting this quantity in the workspace and file names is "Xqw"
+(the extension for the structure factor is "sqw").
+
 Usage
 -----
 

--- a/docs/source/release/v3.10.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.10.0/indirect_inelastic.rst
@@ -15,6 +15,7 @@ Algorithms
 - :ref:`FlatPlatePaalmanPingsCorrection <algm-FlatPlatePaalmanPingsCorrection>` and :ref:`CylinderPaalmanPingsCorrection <algm-CylinderPaalmanPingsCorrection>` algorithms are extended for `Efixed` mode, where the correction will be computed for a single wavelength point.
 - :ref:`LoadVesuvio <algm-LoadVesuvio>` can now load NeXus files as well as raw files
 - :ref:`BASISReduction311 <algm-BASISReduction311>` has been deprecated (2017-03-11). Use :ref:`BASISReduction <algm-BASISReduction>` instead.
+- :ref:`BASISReduction <algm-BASISReduction>` includes now an option to compute and save the dynamic susceptibility.
 
 Data Reduction
 ##############


### PR DESCRIPTION
To make users' life a bit easier, include an option to save-to-file the dynamics susceptibility.

**To test:**
Run the following reduction script:
```
# Outputs susceptibility in workspace BSS_66008_Xqw  
BASISReduction(RunNumbers="66008", ReflectionType="silicon111", EnergyBins=[-120,0.4,120], MomentumTransferBins=[0.3,0.2,1.9], OutputSusceptibility=1)

# Calculates susceptibility from the structure factor:
ApplyDetailedBalance(InputWorkspace="BSS_66008_sqw", OutputWorkspace="BSS_66008_other", Temperature="300")
ConvertUnits(InputWorkspace="BSS_66008_other",  OutputWorkspace="BSS_66008_other", Emode="Indirect", Target="DeltaE_inFrequency")

# Compare workspaces BSS_66008_Xqw and BSS_66008_other. They should be identical
```



Fixes #19070.

Updated [release notes](https://github.com/mantidproject/mantid/blob/17312f6ad76c137a270759654aa12cba32cada50/docs/source/release/v3.10.0/indirect_inelastic.rst#algorithms)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
