### PR TITLE
Set MantidPlot DPI awareness to unaware in Windows

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -637,7 +637,11 @@ set ( MOCCED_FILES ${MOCCED_FILES} ${CMAKE_CURRENT_BINARY_DIR}/qtcolorpicker.moc
 
 set ( SRC_FILES ${QTIPLOT_SRCS} ${MANTID_SRCS} ${SIP_SRC} )
 set ( INC_FILES ${QTIPLOT_HDRS} ${MANTID_HDRS} )
-set ( ALL_SRC ${SRC_FILES} ${MOCCED_FILES} )
+if ( WIN32 )
+  set ( MANIFEST_FILES MantidPlot.manifest )
+endif ()
+
+set ( ALL_SRC ${SRC_FILES} ${MOCCED_FILES} ${MANIFEST_FILES} )
 
 # Use a precompiled header where they are supported
 enable_precompiled_headers( src/PrecompiledHeader.h ALL_SRC )

--- a/MantidPlot/MantidPlot.manifest
+++ b/MantidPlot/MantidPlot.manifest
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0' xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level='asInvoker' uiAccess='false' />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <!-- 
+   MantidPlot embeds a Python interpreter which depends on MSVCRT90.dll.
+   Extension modules
+   can also depend on the same runtime but it exists in the SxS system folder.
+   Even though Python27.dll loads the runtime correctly there is an issue that extension
+   modules
+   using ctypes.cdll.LoadLibrary don't consult the SxS registry and fail to load
+   the correct
+   runtime library. See for example zmq.
+   For more information see https://bugs.python.org/issue24429 -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type='win32' name='Microsoft.VC90.CRT' version='9.0.21022.8' processorArchitecture='amd64' publicKeyToken='1fc8b3b9a1e18e3b' />
+    </dependentAssembly>
+  </dependency>
+  <!--
+    MantidPlot is not DPI aware and we need Windows to apply the user-defined scaling factor.
+    The documentation claims that dpi unaware is the default but without this setting
+    appears to be set to SystemAware when viewed with Process Explorer.
+    https://blogs.msdn.microsoft.com/chuckw/2013/09/10/manifest-madness/ -->
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>false</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/MantidPlot/src/main.cpp
+++ b/MantidPlot/src/main.cpp
@@ -153,22 +153,6 @@ only one class per file, with the exception of
 the indentation depth for him/herself.
 */
 
-#if defined(_MSC_VER)
-// MantidPlot embeds a Python interpreter which depends on MSVCRT90.dll.
-// Extension modules
-// can also depend on the same runtime but it exists in the SxS system folder.
-// Even though
-// Python27.dll loads the runtime correctly there is an issue that extension
-// modules
-// using ctypes.cdll.LoadLibrary don't consult the SxS registry and fail to load
-// the correct
-// runtime library. See for example zmq.
-// For more information see https://bugs.python.org/issue24429
-#pragma comment(                                                               \
-    linker,                                                                    \
-    "\"/manifestdependency:type='win32' name='Microsoft.VC90.CRT' version='9.0.21022.8' processorArchitecture='amd64' publicKeyToken='1fc8b3b9a1e18e3b'\"")
-#endif
-
 int main(int argc, char **argv) {
   // First, look for command-line arguments that we want to deal with before
   // launching anything

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -17,12 +17,15 @@ OS X
 User Interface
 --------------
 
+- MantidPlot now respects the system scaling on high-resolution displays. All icons and bitmaps will now be sized
+  appropriately rather than being too small to be usable (Windows only).
 
 Instrument View
 ###############
- - Fixed a bug preventing the some of the banks from being visible when using a U correction.
- - Fixed a bug where pressing delete would delete a workspace even when the dock was not focused.
- - Fixed a bug where the user would not be prompted before deleting workspaces even if confirmations were turned on.
+
+- Fixed a bug preventing the some of the banks from being visible when using a U correction.
+- Fixed a bug where pressing delete would delete a workspace even when the dock was not focused.
+- Fixed a bug where the user would not be prompted before deleting workspaces even if confirmations were turned on.
 
 Plotting Improvements
 #####################
@@ -31,7 +34,7 @@ Algorithm Toolbox
 #################
 
 - The Algorithm Progress bar has been improved to handle reporting the progress of multiple algorithms much better.  Now it will correctly show the progress of the most recently started algorithms, and correctly move onto the next most recent should  the first finish sooner.  In addition the "Details" button now shows whether Mantid is Idle or how many algorithms it is running.
-  
+
 .. figure:: ../../images/Progress_running.png
    :class: screenshot
    :width: 396px


### PR DESCRIPTION
Forces `dpiAware=False` within MantidPlot by using an explicit manifest file.

Setting this flag ensures that the system will scale MantidPlot icons and bitmaps by the amount selected by the user in the system preferences. 

**To test:**

This needs to be tested on Windows with a machine connected to a high-resolution display, e.g. 4K.

The icons in the MantidPlot toolbar should be very small prior to this change and after applying this fix and rebuilding then you should see the icons at a suitable size.

Another check is to use the Process Explorer tool to verify that the MantidPlot executable is DPI unaware as described [here](https://technet.microsoft.com/en-gb/library/dn528847.aspx#Anchor_0) 

Fixes #19078 

[Release notes](/mantidproject/mantid/commit/42aad0f74fd207930418ba4001fe4de96f31c1ab) have been updated.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
