### PR TITLE
Update buildscript.bat

### DIFF
--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -11,14 +11,8 @@ setlocal enableextensions enabledelayedexpansion
 :: All nodes currently have PARAVIEW_DIR=5.2.0 and PARAVIEW_NEXT_DIR=5.3.0-RC1
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 call cmake.exe --version
-set VS_VERSION=14
-
-:: While we transition between VS 2012 & 2015 we need to be able to clean the build directory
-:: if the previous build was not with the same compiler. Find grep for later
-for /f "delims=" %%I in ('where git') do @set GIT_EXE_DIR=%%~dpI
-set GIT_ROOT_DIR=%GIT_EXE_DIR:~0,-4%
-set GREP_EXE=%GIT_ROOT_DIR%bin\grep.exe
 echo %sha1%
+set VS_VERSION=14
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Environment setup
@@ -74,17 +68,6 @@ if not "%JOB_NAME%" == "%JOB_NAME:debug=%" (
 ::                            the links helps keep it fresh
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 set BUILD_DIR=%WORKSPACE%\build
-
-if EXIST %BUILD_DIR%\CMakeCache.txt (
-  call "%GREP_EXE%" CMAKE_LINKER:FILEPATH %BUILD_DIR%\CMakeCache.txt > compiler_version.log
-  call "%GREP_EXE%" %VS_VERSION% compiler_version.log
-  if ERRORLEVEL 1 (
-    set CLEANBUILD=yes
-    echo Previous build used a different compiler. Performing a clean build
-  ) else (
-    echo Previous build used the same compiler. No need to clean
-  )
-)
 
 if "!CLEANBUILD!" == "yes" (
   rmdir /S /Q %BUILD_DIR%


### PR DESCRIPTION
Remove check for old compilers that is no longer required. It is also not a robust check as it relies on git always being in the same place.

**To test:**

Windows builds should pass and **not** be a clean build.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
