### PR TITLE
Fix number of iterations/bins in SaveGSSTestPerformance

### DIFF
--- a/Framework/DataHandling/test/SaveGSSTest.h
+++ b/Framework/DataHandling/test/SaveGSSTest.h
@@ -23,11 +23,11 @@ namespace {
 //----------------------------------------------------------------------------------------------
 /** Generate a matrix workspace for writing to gsas file
 */
-API::MatrixWorkspace_sptr generateTestMatrixWorkspace() {
+API::MatrixWorkspace_sptr generateTestMatrixWorkspace(int nbins = 100) {
   // Create workspace
   MatrixWorkspace_sptr dataws = boost::dynamic_pointer_cast<MatrixWorkspace>(
       WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(
-          2, 100, false, false, true, "TestFake"));
+          2, nbins, false, false, true, "TestFake"));
   dataws->getAxis(0)->setUnit("TOF");
 
   // Set data with logarithm bin
@@ -370,7 +370,7 @@ class SaveGSSTestPerformance : public CxxTest::TestSuite {
 public:
   void setUp() override {
     // Create a workspace for writing out
-    MatrixWorkspace_sptr dataws = generateTestMatrixWorkspace();
+    MatrixWorkspace_sptr dataws = generateTestMatrixWorkspace(20000);
     AnalysisDataService::Instance().addOrReplace(wsName, dataws);
 
     for (int i = 0; i < numberOfIterations; ++i) {


### PR DESCRIPTION
I accidentally decreased the number of bins saved to file in `SaveGSSTest`, which caused a massive increase in performance (see [here](http://builds.mantidproject.org/job/master_performancetests2/Master_branch_performance_tests/DataHandlingTest.SaveGSSTestPerformance.testSaveGSSPerformance.htm)). This PR is to change it back to the previous value.

**To test:**

Check that the total number of bins saved to file (iterations * bins) in the performance test is the same as before.

Fixes #19061 .

No need to mention this in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
