### PR TITLE
Change group font in Reflectometry GUI (Polref)

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflEventTabWidget.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflEventTabWidget.ui
@@ -19,6 +19,12 @@
       </property>
       <item>
         <widget class="QToolBox" name="toolbox">
+          <property name="font">
+            <font>
+              <pointsize>11</pointsize>
+              <bold>true</bold>
+            </font>
+          </property>
         </widget>
       </item>
     </layout>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflEventWidget.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflEventWidget.ui
@@ -10,6 +10,12 @@
         <height>346</height>
       </rect>
     </property>
+    <property name="font">
+      <font>
+        <pointsize>8</pointsize>
+        <bold>false</bold>
+      </font>
+    </property>
     <property name="windowTitle">
       <string>Event Widget</string>
     </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsTabWidget.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsTabWidget.ui
@@ -19,6 +19,12 @@
       </property>
       <item>
         <widget class="QToolBox" name="toolbox">
+          <property name="font">
+            <font>
+              <pointsize>11</pointsize>
+              <bold>true</bold>
+            </font>
+          </property>
         </widget>
       </item>
     </layout>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsWidget.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSettingsWidget.ui
@@ -10,6 +10,12 @@
         <height>346</height>
       </rect>
     </property>
+    <property name="font">
+      <font>
+        <pointsize>8</pointsize>
+        <bold>false</bold>
+      </font>
+    </property>
     <property name="windowTitle">
       <string>Settings Tab</string>
     </property>


### PR DESCRIPTION
See #18822 for description - increases font size of Group1/2 and makes them bold. The previous PR (#18863) only made changes for the `Runs` tab, hence the new PR.

**To test:**

Open the interface from Interfaces->Reflectometry->ISIS Reflectometry (Polref) and ensure the changes are there for the `Runs`, `Event Handling` and `Settings` tabs.

Fixes #18822.

*Does not need to be in the release notes.*

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
