### PR TITLE
DPDFReduction: calibrate with white-beam vanadium

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -21,12 +21,10 @@ class DPDFreduction(api.PythonAlgorithm):
     _runs = None
     _vanfile = None
     _ecruns = None
-    _ebins_str = None
-    _qbins_str = None
+    _ebins = None
+    _qbins = None
     _snorm = None
     _clean = None
-    _qbins = None
-    _ebins = None
 
     def category(self):
         return "Inelastic\\Reduction"

--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -263,10 +263,10 @@ class DPDFreduction(api.PythonAlgorithm):
         group_file_os_handle, group_file_name = mkstemp(suffix='.xml')
         group_file_handle = os.fdopen(group_file_os_handle, 'w')
         sapi.GenerateGroupingPowder(InputWorkspace=wn_reduced, AngleStep=dtheta,
-                                   GroupingFilename=group_file_name)
+                                    GroupingFilename=group_file_name)
         group_file_handle.close()
         sapi.GroupDetectors(InputWorkspace=wn_reduced, MapFile=group_file_name,
-                           OutputWorkspace=wn_ste)
+                            OutputWorkspace=wn_ste)
         # Group detectors according to theta angle for the emtpy can run
         if self._ecruns:
             sapi.GroupDetectors(InputWorkspace=wn_ec_reduced, MapFile=group_file_name,

--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -148,7 +148,6 @@ class DPDFreduction(PythonAlgorithm):
         wn_ec_reduced = prefix + 'ec_reduced'  # empty can data after DGSReduction
         wn_ec_ste = prefix + 'ec_S_theta_E'  # empty can data after grouping by theta angle
 
-
         datasearch = config["datasearch.searcharchive"]
         if datasearch != "On":
             config["datasearch.searcharchive"] = "On"

--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -3,9 +3,9 @@ from __future__ import (absolute_import, division, print_function)
 import os
 import numpy
 import re
-import mantid.simpleapi as api
-from mantid.api import *
-from mantid.kernel import *
+import mantid.simpleapi as sapi
+import mantid.api as api
+import mantid.kernel as kapi
 from mantid import config
 from tempfile import mkstemp
 
@@ -15,7 +15,7 @@ ENERGY_TO_WAVEVECTOR = 2.072
 #pylint: disable=too-many-instance-attributes
 
 
-class DPDFreduction(PythonAlgorithm):
+class DPDFreduction(api.PythonAlgorithm):
     channelgroup = None
 
     _runs = None
@@ -43,8 +43,8 @@ class DPDFreduction(PythonAlgorithm):
         titleInputOptions = "Input"
         self.declareProperty('RunNumbers', '', 'Sample run numbers')
         self.setPropertyGroup("RunNumbers", titleInputOptions)
-        self.declareProperty(FileProperty(name='Vanadium', defaultValue='',
-                                          action=FileAction.OptionalLoad, extensions=['.nxs']),
+        self.declareProperty(api.FileProperty(name='Vanadium', defaultValue='',
+                                              action=api.FileAction.OptionalLoad, extensions=['.nxs']),
                              'Preprocessed white-beam vanadium file.')
         self.setPropertyGroup("Vanadium", titleInputOptions)
         self.declareProperty('EmptyCanRunNumbers', '', 'Empty can run numbers')
@@ -52,25 +52,25 @@ class DPDFreduction(PythonAlgorithm):
 
         # Configuration parameters
         titleConfigurationOptions = "Configuration"
-        self.declareProperty('EnergyBins', '1.5',
-                             'Energy transfer binning scheme (in meV)',
-                             direction=Direction.Input)
+        e_validator = kapi.FloatArrayLengthValidator(1,3)
+        self.declareProperty(kapi.FloatArrayProperty('EnergyBins', [1.5,] ,validator=e_validator),
+                             'Energy transfer binning scheme (in meV)')
         self.setPropertyGroup("EnergyBins", titleConfigurationOptions)
-        self.declareProperty('MomentumTransferBins', '',
-                             'Momentum transfer binning scheme (in inverse Angstroms)',
-                             direction=Direction.Input)
+        q_validator = kapi.FloatArrayLengthValidator(0, 3)
+        self.declareProperty(kapi.FloatArrayProperty('MomentumTransferBins', list(), validator=q_validator),
+                             'Momentum transfer binning scheme (in inverse Angstroms)')
         self.setPropertyGroup("MomentumTransferBins", titleConfigurationOptions)
         self.declareProperty('NormalizeSlices', False,
-                             'Do we normalize each slice?', direction=Direction.Input)
+                             'Do we normalize each slice?', direction=kapi.Direction.Input)
         self.setPropertyGroup("NormalizeSlices", titleConfigurationOptions)
 
         # Ouptut parameters
         titleOuptutOptions = "Output"
         self.declareProperty('CleanWorkspaces', True,
-                             'Do we clean intermediate steps?', direction=Direction.Input)
+                             'Do we clean intermediate steps?', direction=kapi.Direction.Input)
         self.setPropertyGroup("CleanWorkspaces", titleOuptutOptions)
-        self.declareProperty(MatrixWorkspaceProperty('OutputWorkspace', 'S_Q_E_sliced',
-                                                     Direction.Output), "Output workspace")
+        self.declareProperty(api.MatrixWorkspaceProperty('OutputWorkspace', 'S_Q_E_sliced',
+                                                         kapi.Direction.Output), "Output workspace")
         self.setPropertyGroup("OutputWorkspace", titleOuptutOptions)
 
     def validateInputs(self):
@@ -97,31 +97,21 @@ class DPDFreduction(PythonAlgorithm):
             checkrunnumbers('EmptyCanRunNumbers')
         # check energy bins
         ebins = self.getPropertyValue('EnergyBins')
-        pattern = re.compile(r'^\s*\d+[\.\d+]*\s*$|' +
-                             r'^\s*\d+[\.\d+]*\s*,\s*\d+[\.\d+]*\s*,\s*\d+[\.\d+]*\s*$')
-        if not pattern.match(ebins):
-            issues['EnergyBins'] = 'Energy bins is a string containing ' + \
-                                   'either one number or a triad separated by commas'
+        if len(ebins) not in (1, 3):
+            issues['EnergyBins'] = 'Energy bins is a list of either one or three values'
         # check momentum transfer bins
         qbins = self.getPropertyValue('MomentumTransferBins')
-        if qbins and not pattern.match(qbins):
-            issues['MomentumTransferBins'] = 'Momentum transfer bins is a string ' + \
-                                             'containing either one number or a triad separated by commas'
+        if len(qbins) not in (0, 1, 3):
+            issues['MomentumTransferBins'] = 'Momentum transfer bins is a list of zero, one, or three values'
         return issues
 
     #pylint: disable=too-many-locals, too-many-branches
     def PyExec(self):
-        # Save current configuration
-        facility = config['default.facility']
-        instrument = config['default.instrument']
-        # Allows searching for ARCS run numbers
-        config['default.facility'] = 'SNS'
-        config['default.instrument'] = 'ARCS'
         self._runs = self.getProperty('RunNumbers').value
         self._vanfile = self.getProperty('Vanadium').value
         self._ecruns = self.getProperty('EmptyCanRunNumbers').value
-        self._ebins_str = self.getProperty('EnergyBins').value
-        self._qbins_str = self.getProperty('MomentumTransferBins').value
+        self._ebins = (self.getProperty('EnergyBins').value).tolist()
+        self._qbins = (self.getProperty('MomentumTransferBins').value).tolist()
         self._snorm = self.getProperty('NormalizeSlices').value
         self._clean = self.getProperty('CleanWorkspaces').value
         wn_sqes = self.getPropertyValue("OutputWorkspace")
@@ -148,17 +138,22 @@ class DPDFreduction(PythonAlgorithm):
         wn_ec_reduced = prefix + 'ec_reduced'  # empty can data after DGSReduction
         wn_ec_ste = prefix + 'ec_S_theta_E'  # empty can data after grouping by theta angle
 
+        # Save current configuration
+        facility = config['default.facility']
+        instrument = config['default.instrument']
         datasearch = config["datasearch.searcharchive"]
-        if datasearch != "On":
-            config["datasearch.searcharchive"] = "On"
+        # Allows searching for ARCS run numbers
+        config['default.facility'] = 'SNS'
+        config['default.instrument'] = 'ARCS'
+        config["datasearch.searcharchive"] = "On"
 
         try:
             # Load the vanadium file, assumed to be preprocessed, meaning that
             # for every detector all events within a particular wide wavelength
             # range have been rebinned into a single histogram
-            api.Load(Filename=self._vanfile, OutputWorkspace=wn_van)
+            self._load(self._vanfile, wn_van)
             # Check for white-beam vanadium, true if the vertical chopper is absent (vChTrans==2)
-            if mtd[wn_van].run().getProperty('vChTrans').value[0] != 2:
+            if api.mtd[wn_van].run().getProperty('vChTrans').value[0] != 2:
                 raise ValueError("White-vanadium is required")
 
             # Load several event files into a single workspace. The nominal incident
@@ -177,13 +172,13 @@ class DPDFreduction(PythonAlgorithm):
 
         # Obtain incident energy as the mean of the nominal Ei values.
         # There is one nominal value for each run number.
-        ws_data = api.mtd[wn_data]
+        ws_data = sapi.mtd[wn_data]
         Ei = ws_data.getRun()['EnergyRequest'].getStatistics().mean
         Ei_std = ws_data.getRun()['EnergyRequest'].getStatistics().standard_deviation
 
         # Verify empty can runs were obtained at similar energy
         if self._ecruns:
-            ws_ec_data = api.mtd[wn_ec_data]
+            ws_ec_data = sapi.mtd[wn_ec_data]
             ec_Ei = ws_ec_data.getRun()['EnergyRequest'].getStatistics().mean
             if abs(Ei - ec_Ei) > Ei_std:
                 raise RuntimeError('Empty can runs were obtained at a significant' +
@@ -192,9 +187,8 @@ class DPDFreduction(PythonAlgorithm):
         # Obtain energy range. If user did not supply a triad
         # [Estart, Ewidth, Eend] but only Ewidth, then estimate
         # Estart and End from the nominal energies
-        self._ebins = [float(x) for x in re.compile(r'\d+[\.\d+]*').findall(self._ebins_str)]
         if len(self._ebins) == 1:
-            ws_data = api.mtd[wn_data]
+            ws_data = sapi.mtd[wn_data]
             Ei = ws_data.getRun()['EnergyRequest'].getStatistics().mean
             self._ebins.insert(0, -0.5 * Ei)  # prepend
             self._ebins.append(0.95 * Ei)  # append
@@ -214,30 +208,29 @@ class DPDFreduction(PythonAlgorithm):
         # The output workspace is S(detector-id,E)
         factor = 0.1  # use a finer energy bin than the one passed (self._ebins[1])
         Erange = '{0},{1},{2}'.format(self._ebins[0], factor * self._ebins[1], self._ebins[2])
-        Ei_calc, T0 = api.GetEiT0atSNS(MonitorWorkspace=wn_data_mon, IncidentEnergyGuess=Ei)
-        api.MaskDetectors(Workspace=wn_data, MaskedWorkspace=wn_van)  # Use vanadium mask
-        api.DgsReduction(SampleInputWorkspace=wn_data,
-                         SampleInputMonitorWorkspace=wn_data_mon,
-                         IncidentEnergyGuess=Ei_calc,
-                         UseIncidentEnergyGuess=1,
-                         TimeZeroGuess=T0,
-                         EnergyTransferRange=Erange,
-                         IncidentBeamNormalisation='ByCurrent',
-                         OutputWorkspace=wn_reduced)
+        Ei_calc, T0 = sapi.GetEiT0atSNS(MonitorWorkspace=wn_data_mon, IncidentEnergyGuess=Ei)
+        sapi.MaskDetectors(Workspace=wn_data, MaskedWorkspace=wn_van)  # Use vanadium mask
+        sapi.DgsReduction(SampleInputWorkspace=wn_data,
+                          SampleInputMonitorWorkspace=wn_data_mon,
+                          IncidentEnergyGuess=Ei_calc,
+                          UseIncidentEnergyGuess=1,
+                          TimeZeroGuess=T0,
+                          EnergyTransferRange=Erange,
+                          IncidentBeamNormalisation='ByCurrent',
+                          OutputWorkspace=wn_reduced)
 
         if self._ecruns:
-            api.MaskDetectors(Workspace=wn_ec_data, MaskedWorkspace=wn_van)
-            api.DgsReduction(SampleInputWorkspace=wn_ec_data,
-                             SampleInputMonitorWorkspace=wn_ec_data_mon,
-                             IncidentEnergyGuess=Ei_calc,
-                             UseIncidentEnergyGuess=1,
-                             TimeZeroGuess=T0,
-                             EnergyTransferRange=Erange,
-                             IncidentBeamNormalisation='ByCurrent',
-                             OutputWorkspace=wn_ec_reduced)
+            sapi.MaskDetectors(Workspace=wn_ec_data, MaskedWorkspace=wn_van)
+            sapi.DgsReduction(SampleInputWorkspace=wn_ec_data,
+                              SampleInputMonitorWorkspace=wn_ec_data_mon,
+                              IncidentEnergyGuess=Ei_calc,
+                              UseIncidentEnergyGuess=1,
+                              TimeZeroGuess=T0,
+                              EnergyTransferRange=Erange,
+                              IncidentBeamNormalisation='ByCurrent',
+                              OutputWorkspace=wn_ec_reduced)
 
         # Obtain maximum and minimum |Q| values, as well as dQ if none passed
-        self._qbins = [float(x) for x in re.compile(r'\d+[\.\d+]*').findall(self._qbins_str)]
         if len(self._qbins) < 3:
             if not self._qbins:
                 # insert dQ if empty qbins. The minimal momentum transfer
@@ -246,15 +239,15 @@ class DPDFreduction(PythonAlgorithm):
                 dE = self._ebins[1]
                 self._qbins.append(numpy.sqrt((Ei + dE) / ENERGY_TO_WAVEVECTOR) -
                                    numpy.sqrt(Ei / ENERGY_TO_WAVEVECTOR))
-            mins, maxs = api.ConvertToMDMinMaxLocal(wn_reduced, Qdimensions='|Q|',
-                                                    dEAnalysisMode='Direct')
+            mins, maxs = sapi.ConvertToMDMinMaxLocal(wn_reduced, Qdimensions='|Q|',
+                                                     dEAnalysisMode='Direct')
             self._qbins.insert(0, mins[0])  # prepend minimum Q
             self._qbins.append(maxs[0])  # append maximum Q
 
         # Delete sample and empty can event workspaces to free memory.
-        api.DeleteWorkspace(wn_data)
+        sapi.DeleteWorkspace(wn_data)
         if self._ecruns:
-            api.DeleteWorkspace(wn_ec_data)
+            sapi.DeleteWorkspace(wn_ec_data)
 
         # Convert to S(theta,E)
         ki = numpy.sqrt(Ei / ENERGY_TO_WAVEVECTOR)
@@ -269,27 +262,27 @@ class DPDFreduction(PythonAlgorithm):
         # Group detectors according to theta angle for the sample runs
         group_file_os_handle, group_file_name = mkstemp(suffix='.xml')
         group_file_handle = os.fdopen(group_file_os_handle, 'w')
-        api.GenerateGroupingPowder(InputWorkspace=wn_reduced, AngleStep=dtheta,
+        sapi.GenerateGroupingPowder(InputWorkspace=wn_reduced, AngleStep=dtheta,
                                    GroupingFilename=group_file_name)
         group_file_handle.close()
-        api.GroupDetectors(InputWorkspace=wn_reduced, MapFile=group_file_name,
+        sapi.GroupDetectors(InputWorkspace=wn_reduced, MapFile=group_file_name,
                            OutputWorkspace=wn_ste)
         # Group detectors according to theta angle for the emtpy can run
         if self._ecruns:
-            api.GroupDetectors(InputWorkspace=wn_ec_reduced, MapFile=group_file_name,
-                               OutputWorkspace=wn_ec_ste)
+            sapi.GroupDetectors(InputWorkspace=wn_ec_reduced, MapFile=group_file_name,
+                                OutputWorkspace=wn_ec_ste)
             # Subtract the empty can from the can+sample
-            api.Minus(LHSWorkspace=wn_ste, RHSWorkspace=wn_ec_ste, OutputWorkspace=wn_ste)
+            sapi.Minus(LHSWorkspace=wn_ste, RHSWorkspace=wn_ec_ste, OutputWorkspace=wn_ste)
 
         # Normalize by the vanadium intensity, but before that we need S(theta)
         # for the vanadium. Recall every detector has all energies into a single
         # bin, so we get S(theta) instead of S(theta,E)
-        api.GroupDetectors(InputWorkspace=wn_van, MapFile=group_file_name,
-                           OutputWorkspace=wn_van_st)
+        sapi.GroupDetectors(InputWorkspace=wn_van, MapFile=group_file_name,
+                            OutputWorkspace=wn_van_st)
         # Divide by vanadium. Make sure it is integrated in the energy domain
-        api.Integration(wn_van_st, OutputWorkspace=wn_van_st)
-        api.Divide(wn_ste, wn_van_st, OutputWorkspace=wn_sten)
-        api.ClearMaskFlag(Workspace=wn_sten)
+        sapi.Integration(wn_van_st, OutputWorkspace=wn_van_st)
+        sapi.Divide(wn_ste, wn_van_st, OutputWorkspace=wn_sten)
+        sapi.ClearMaskFlag(Workspace=wn_sten)
 
         # Temporary file generated by GenerateGroupingPowder to be removed
         os.remove(group_file_name)  # no need for this file
@@ -300,7 +293,7 @@ class DPDFreduction(PythonAlgorithm):
 
         # Linear interpolation for those theta values with no intensity
         # First, find minimum theta index with a non-zero histogram
-        ws_sten = api.mtd[wn_sten]
+        ws_sten = sapi.mtd[wn_sten]
         for i_theta in range(ws_sten.getNumberHistograms()):
             if ws_sten.dataY(i_theta).any():
                 min_i_theta = i_theta
@@ -312,8 +305,8 @@ class DPDFreduction(PythonAlgorithm):
                 break
         # Scan the region [min_i_theta, max_i_theta] and apply interpolation to
         # theta angles with no signal whatsoever, S(theta*, E)=0.0 for all energies
-        api.CloneWorkspace(InputWorkspace=ws_sten, OutputWorkspace=wn_steni)
-        ws_steni = api.mtd[wn_steni]
+        sapi.CloneWorkspace(InputWorkspace=ws_sten, OutputWorkspace=wn_steni)
+        ws_steni = sapi.mtd[wn_steni]
         i_theta = 1 + min_i_theta
         while i_theta < max_i_theta:
             if not ws_steni.dataY(i_theta).any():
@@ -334,8 +327,8 @@ class DPDFreduction(PythonAlgorithm):
             i_theta += 1
 
         # Convert S(theta,E) to S(Q,E), then rebin in |Q| and E to MD workspace
-        api.ConvertToMD(InputWorkspace=wn_steni, QDimensions='|Q|',
-                        dEAnalysisMode='Direct', OutputWorkspace=wn_sqe)
+        sapi.ConvertToMD(InputWorkspace=wn_steni, QDimensions='|Q|',
+                         dEAnalysisMode='Direct', OutputWorkspace=wn_sqe)
         Qmin = self._qbins[0]
         Qmax = self._qbins[-1]
         dQ = self._qbins[1]
@@ -344,22 +337,22 @@ class DPDFreduction(PythonAlgorithm):
         Ei_max = self._ebins[-1]
         dE = self._ebins[1]
         deltaErange = 'DeltaE,{0},{1},{2}'.format(Ei_min, Ei_max, int((Ei_max - Ei_min) / dE))
-        api.BinMD(InputWorkspace=wn_sqe, AxisAligned=1, AlignedDim0=Qrange,
-                  AlignedDim1=deltaErange, OutputWorkspace=wn_sqeb)
+        sapi.BinMD(InputWorkspace=wn_sqe, AxisAligned=1, AlignedDim0=Qrange,
+                   AlignedDim1=deltaErange, OutputWorkspace=wn_sqeb)
 
         # Slice the data by transforming to a Matrix2Dworkspace,
         # with deltaE along the vertical axis
-        api.ConvertMDHistoToMatrixWorkspace(InputWorkspace=wn_sqeb,
-                                            Normalization='NumEventsNormalization',
-                                            OutputWorkspace=wn_sqes)
+        sapi.ConvertMDHistoToMatrixWorkspace(InputWorkspace=wn_sqeb,
+                                             Normalization='NumEventsNormalization',
+                                             OutputWorkspace=wn_sqes)
 
         # Ensure correct units
-        api.mtd[wn_sqes].getAxis(0).setUnit("MomentumTransfer")
-        api.mtd[wn_sqes].getAxis(1).setUnit("DeltaE")
+        sapi.mtd[wn_sqes].getAxis(0).setUnit("MomentumTransfer")
+        sapi.mtd[wn_sqes].getAxis(1).setUnit("DeltaE")
 
         # Shift the energy axis, since the reported values should be the center
         # of the bins, instead of the minimum bin boundary
-        ws_sqes = api.mtd[wn_sqes]
+        ws_sqes = sapi.mtd[wn_sqes]
         Eaxis = ws_sqes.getAxis(1)
         e_shift = self._ebins[1] / 2.0
         for i in range(Eaxis.length()):
@@ -367,15 +360,15 @@ class DPDFreduction(PythonAlgorithm):
 
         # Normalize each slice, if requested
         if self._snorm:
-            api.Integration(InputWorkspace=wn_sqes, OutputWorkspace=wn_sqesn)
-            api.Divide(LHSWorkspace=wn_sqes, RHSWorkspace=wn_sqesn, OutputWorkspace=wn_sqes)
+            sapi.Integration(InputWorkspace=wn_sqes, OutputWorkspace=wn_sqesn)
+            sapi.Divide(LHSWorkspace=wn_sqes, RHSWorkspace=wn_sqesn, OutputWorkspace=wn_sqes)
 
         # Clean up workspaces from intermediate steps
         if self._clean:
             for name in (wn_van, wn_reduced, wn_ste, wn_van_st, wn_sten,
                          wn_steni, wn_sqe, wn_sqeb, wn_sqesn, 'PreprocessedDetectorsWS'):
-                if api.mtd.doesExist(name):
-                    api.DeleteWorkspace(name)
+                if sapi.mtd.doesExist(name):
+                    sapi.DeleteWorkspace(name)
 
         # Ouput some info as a Notice in the log
         ebins = ', '.join(['{0:.2f}'.format(x) for x in self._ebins])
@@ -385,9 +378,9 @@ class DPDFreduction(PythonAlgorithm):
                   '\nEnergy bins: ' + ebins + \
                   '\nQ bins: ' + qbins + \
                   '\nTheta bins: '+tbins
-        logger.notice(message)
+        kapi.logger.notice(message)
 
-        self.setProperty("OutputWorkspace", api.mtd[wn_sqes])
+        self.setProperty("OutputWorkspace", sapi.mtd[wn_sqes])
 
     def _load(self, run_numbers, data_name):
         """
@@ -400,21 +393,23 @@ class DPDFreduction(PythonAlgorithm):
         :return: None
         """
         # Find out the files for each run
-        load_algorithm = AlgorithmManager.createUnmanaged("Load")
+        load_algorithm = api.AlgorithmManager.createUnmanaged("Load")
         load_algorithm.initialize()
         load_algorithm.setPropertyValue('Filename', str(run_numbers))
         files = (load_algorithm.getProperty('Filename').value)[0]
         if not isinstance(files, list):
             # run_numbers represents one file only
-            api.Load(Filename=files, LoadMonitors=True, OutputWorkspace=data_name)
+            sapi.Load(Filename=files, LoadMonitors=True, OutputWorkspace=data_name)
         else:
-            api.Load(Filename=files[0], LoadMonitors=True, OutputWorkspace=data_name)
+            sapi.Load(Filename=files[0], LoadMonitors=True, OutputWorkspace=data_name)
             monitor_name = data_name + '_monitors'
             for file in files[1:]:
-                api.Load(Filename=file, LoadMonitors=True, OutputWorkspace=data_name+'_tmp')
-                api.Plus(LHSWorkspace=data_name, RHSWorkspace=data_name+'_tmp', OutputWorkspace=data_name)
-                api.Plus(LHSWorkspace=monitor_name, RHSWorkspace=data_name + '_tmp_monitors', OutputWorkspace=monitor_name)
-            api.DeleteWorkspace(data_name+'_tmp')
+                sapi.Load(Filename=file, LoadMonitors=True, OutputWorkspace=data_name+'_tmp')
+                sapi.Plus(LHSWorkspace=data_name, RHSWorkspace=data_name+'_tmp', OutputWorkspace=data_name)
+                sapi.Plus(LHSWorkspace=monitor_name, RHSWorkspace=data_name + '_tmp_monitors', OutputWorkspace=monitor_name)
+            sapi.DeleteWorkspace(data_name+'_tmp')
+        if sapi.mtd[data_name].getInstrument().getName() not in ('ARCS'):
+            raise NotImplementedError("This algorithm works only for ARCS instrument")
 
 # Register algorithm with Mantid.
-AlgorithmFactory.subscribe(DPDFreduction)
+api.AlgorithmFactory.subscribe(DPDFreduction)

--- a/docs/source/algorithms/DPDFreduction-v1.rst
+++ b/docs/source/algorithms/DPDFreduction-v1.rst
@@ -17,9 +17,9 @@ distribution function :math:`G(r,E)` can be obtained via the
 Detailed Parameters description
 ===============================
 
-- **Vanadium**: a preprocessed vanadium file, meaning that for every detector,
+- **Vanadium**: a preprocessed white-beam vanadium file, meaning that
   all events within a particular wide wavelength range have been rebinned
-  into a single histogram.
+  into a single histogram, this for every detector.
 
 - **EnergyBins**: user can input a triad :math:`[E_{min}, E_{bin}, E_{max}]`
   or only the energy binning :math:`E_{bin}`. If this is the case,


### PR DESCRIPTION
1. Checks vanadium is white-beam
2. Mask workspace before call to DGSReduction.
3. Passed properties to DGSReduction are those typically passed on to ARCS reduction.

**To test:**
Try to run the following script:
```
DPDFreduction(RunNumbers="88708-88711",
    Vanadium="/SNS/ARCS/IPTS-18468/shared/autoreduce/ARCS_88358_autoreduced.nxs",
    EmptyCanRunNumbers="88781",
    EnergyBins=1.5,
    MomentumTransferBins=0.1,
    OutputWorkspace="slices_QE")
```
You should be replied that the vanadium is not white-beam. Now run with a white-beam vanadium:

```
DPDFreduction(RunNumbers="88708-88711",
    Vanadium="/SNS/ARCS/shared/autoreduce/vanadium_files/van88344.nxs",
    EmptyCanRunNumbers="88781",
    EnergyBins=1.5,
    MomentumTransferBins=0.1,
    OutputWorkspace="slices_QE")
```

The reduction will produce workspace `slices_QE`.

Fixes #19086.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
