### PR TITLE
Muon fitting with different groups

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -3023,6 +3023,9 @@ void MuonAnalysis::multiFitCheckboxChanged(int state) {
                                                 ? Muon::MultiFitState::Enabled
                                                 : Muon::MultiFitState::Disabled;
   m_fitFunctionPresenter->setMultiFitState(multiFitState);
+  if (multiFitState==Muon::MultiFitState::Disabled) {
+	  m_dataSelector->clearChosenGroups();
+  }
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -3023,8 +3023,8 @@ void MuonAnalysis::multiFitCheckboxChanged(int state) {
                                                 ? Muon::MultiFitState::Enabled
                                                 : Muon::MultiFitState::Disabled;
   m_fitFunctionPresenter->setMultiFitState(multiFitState);
-  if (multiFitState==Muon::MultiFitState::Disabled) {
-	  m_dataSelector->clearChosenGroups();
+  if (multiFitState == Muon::MultiFitState::Disabled) {
+    m_dataSelector->clearChosenGroups();
   }
 }
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -398,7 +398,7 @@ void MuonAnalysis::plotSelectedItem() {
 void MuonAnalysis::plotItem(ItemType itemType, int tableRow,
                             PlotType plotType) {
   m_updating = true;
-
+  m_dataSelector->clearChosenGroups();
   AnalysisDataServiceImpl &ads = AnalysisDataService::Instance();
 
   try {

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -175,7 +175,7 @@ void MuonAnalysisFitDataPresenter::handleDataPropertiesChanged() {
  * @param overwrite :: [input] Whether overwrite is on or off in interface
  */
 void MuonAnalysisFitDataPresenter::handleSelectedDataChanged(bool overwrite) {
-  const auto names = generateWorkspaceNames(overwrite);
+  const auto names = generateWorkspaceNames(overwrite);// might be this
   if (!names.empty()) {
     createWorkspacesToFit(names);
     updateWorkspaceNames(names);
@@ -487,6 +487,7 @@ void MuonAnalysisFitDataPresenter::handleFitFinished(
     const QString &status) const {
   Q_UNUSED(status);
   // If fitting was simultaneous, transform the results.
+  bool tmp = isSimultaneousFit();
   if (isSimultaneousFit()) {
     const auto label = m_dataSelector->getSimultaneousFitLabel();
     const auto groupName =
@@ -744,6 +745,8 @@ void MuonAnalysisFitDataPresenter::checkAndUpdateFitLabel(bool sequentialFit) {
  * @returns :: True for simultaneous fit, else false
  */
 bool MuonAnalysisFitDataPresenter::isSimultaneousFit() const {
+	int j = m_dataSelector->getChosenGroups().size();
+	int k = m_dataSelector->getPeriodSelections().size();
   if (m_dataSelector->getFitType() ==
       IMuonFitDataSelector::FitType::Simultaneous) {
     return true;
@@ -813,6 +816,7 @@ void MuonAnalysisFitDataPresenter::setUpDataSelector(
  * @returns :: True if multiple runs selected
  */
 bool MuonAnalysisFitDataPresenter::isMultipleRuns() const {
+	auto tmp = m_dataSelector->getRuns().toStdString();
   return m_dataSelector->getRuns().contains(QRegExp("-|,"));
 }
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -175,7 +175,7 @@ void MuonAnalysisFitDataPresenter::handleDataPropertiesChanged() {
  * @param overwrite :: [input] Whether overwrite is on or off in interface
  */
 void MuonAnalysisFitDataPresenter::handleSelectedDataChanged(bool overwrite) {
-  const auto names = generateWorkspaceNames(overwrite);// might be this
+  const auto names = generateWorkspaceNames(overwrite);
   if (!names.empty()) {
     createWorkspacesToFit(names);
     updateWorkspaceNames(names);
@@ -487,7 +487,6 @@ void MuonAnalysisFitDataPresenter::handleFitFinished(
     const QString &status) const {
   Q_UNUSED(status);
   // If fitting was simultaneous, transform the results.
-  bool tmp = isSimultaneousFit();
   if (isSimultaneousFit()) {
     const auto label = m_dataSelector->getSimultaneousFitLabel();
     const auto groupName =
@@ -745,8 +744,6 @@ void MuonAnalysisFitDataPresenter::checkAndUpdateFitLabel(bool sequentialFit) {
  * @returns :: True for simultaneous fit, else false
  */
 bool MuonAnalysisFitDataPresenter::isSimultaneousFit() const {
-	int j = m_dataSelector->getChosenGroups().size();
-	int k = m_dataSelector->getPeriodSelections().size();
   if (m_dataSelector->getFitType() ==
       IMuonFitDataSelector::FitType::Simultaneous) {
     return true;
@@ -816,7 +813,6 @@ void MuonAnalysisFitDataPresenter::setUpDataSelector(
  * @returns :: True if multiple runs selected
  */
 bool MuonAnalysisFitDataPresenter::isMultipleRuns() const {
-	auto tmp = m_dataSelector->getRuns().toStdString();
   return m_dataSelector->getRuns().contains(QRegExp("-|,"));
 }
 
@@ -851,7 +847,7 @@ void MuonAnalysisFitDataPresenter::updateFitLabelFromRuns() {
       label.find_first_not_of("0123456789-,") == std::string::npos;
   if (isDefault) {
     // replace with current run string
-    const auto &runString = m_dataSelector->getRuns();
+	const auto &runString = m_dataSelector->getRuns();
     m_dataSelector->setSimultaneousFitLabel(runString);
     m_fitModel->setSimultaneousLabel(runString.toStdString());
   }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -847,7 +847,7 @@ void MuonAnalysisFitDataPresenter::updateFitLabelFromRuns() {
       label.find_first_not_of("0123456789-,") == std::string::npos;
   if (isDefault) {
     // replace with current run string
-	const auto &runString = m_dataSelector->getRuns();
+    const auto &runString = m_dataSelector->getRuns();
     m_dataSelector->setSimultaneousFitLabel(runString);
     m_fitModel->setSimultaneousLabel(runString.toStdString());
   }

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitDataSelector.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitDataSelector.h
@@ -62,6 +62,7 @@ public:
   QStringList getChosenGroups() const override;
   /// Set chosen group
   void setChosenGroup(const QString &group) override;
+  /// Clear list of selected groups
   void clearChosenGroups() const;
   /// Get selected periods
   QStringList getPeriodSelections() const override;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitDataSelector.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitDataSelector.h
@@ -62,6 +62,7 @@ public:
   QStringList getChosenGroups() const override;
   /// Set chosen group
   void setChosenGroup(const QString &group) override;
+  void clearChosenGroups() const;
   /// Get selected periods
   QStringList getPeriodSelections() const override;
   /// Set selected period

--- a/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
@@ -380,15 +380,26 @@ QStringList MuonFitDataSelector::getChosenGroups() const {
   }
   return chosen;
 }
-
+/**
+* Returns a list of the selected groups (checked boxes)
+* @returns :: list of selected groups
+*/
+void MuonFitDataSelector::clearChosenGroups() const {
+	for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
+		++iter) {
+		iter.value()->setChecked(false);
+	}
+}
 /**
  * Set the chosen group ticked and all others off
  * Used when switching from Home tab to Data Analysis tab
  * @param group :: [input] Name of group to select
  */
 void MuonFitDataSelector::setChosenGroup(const QString &group) {
+	auto tmp = group.toStdString();
   for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
        ++iter) {
+
     if (iter.key() == group) {
       iter.value()->setChecked(true);
     }
@@ -628,6 +639,7 @@ QString MuonFitDataSelector::getSimultaneousFitLabel() const {
  * @param label :: [input] Text to set as label
  */
 void MuonFitDataSelector::setSimultaneousFitLabel(const QString &label) {
+	auto tmp = label;
   m_ui.txtSimFitLabel->setText(label);
 }
 

--- a/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
@@ -381,8 +381,7 @@ QStringList MuonFitDataSelector::getChosenGroups() const {
   return chosen;
 }
 /**
-* Returns a list of the selected groups (checked boxes)
-* @returns :: list of selected groups
+* Clears the list of selected groups (unchecks boxes)
 */
 void MuonFitDataSelector::clearChosenGroups() const {
 	for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
@@ -396,10 +395,8 @@ void MuonFitDataSelector::clearChosenGroups() const {
  * @param group :: [input] Name of group to select
  */
 void MuonFitDataSelector::setChosenGroup(const QString &group) {
-	auto tmp = group.toStdString();
   for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
        ++iter) {
-
     if (iter.key() == group) {
       iter.value()->setChecked(true);
     }
@@ -639,7 +636,6 @@ QString MuonFitDataSelector::getSimultaneousFitLabel() const {
  * @param label :: [input] Text to set as label
  */
 void MuonFitDataSelector::setSimultaneousFitLabel(const QString &label) {
-	auto tmp = label;
   m_ui.txtSimFitLabel->setText(label);
 }
 

--- a/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitDataSelector.cpp
@@ -384,10 +384,10 @@ QStringList MuonFitDataSelector::getChosenGroups() const {
 * Clears the list of selected groups (unchecks boxes)
 */
 void MuonFitDataSelector::clearChosenGroups() const {
-	for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
-		++iter) {
-		iter.value()->setChecked(false);
-	}
+  for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
+       ++iter) {
+    iter.value()->setChecked(false);
+  }
 }
 /**
  * Set the chosen group ticked and all others off


### PR DESCRIPTION
In muon analysis only the selected group will be fitted to (unless simultaneous fitting is selected). 

**To test:**

<!-- Instructions for testing. -->
1. Open Muon Analysis in the master branch and load some MUSR data. Make sure that in the settings tab "Enable Multiple fitting" is ticked. Then in the data analysis tab fit to multiple groups (e.g. fwd and bkwd). Make a note of the fitting results. (Step 2 should fail on master). 

2. Open Muon Analysis from this branch and load some MUSR data. Make sure that in the settings tab "Enable Multiple fitting" is not ticked. Got to the data analysis tab and fit a function. Then return to the Home tab and change the group /group pair (e.g. fwd to top). Then go back into the data analysis tab and try to fit the data (originally Mantid threw an error at this point). The fit should be completed. 

3. Open Muon Analysis from this branch and load some MUSR data. Make sure that in the settings tab "Enable Multiple fitting" is ticked. Use the same data, function(s) and groups as step 1. The results should be the same. 

Fixes #19104 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
