### PR TITLE
Handle invalid pixel IDs in LoadEventNexus

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
@@ -53,6 +53,8 @@ public:
   void run() override;
 
 private:
+  size_t getWorkspaceIndexFromPixelID(const detid_t pixID);
+
   /// Algorithm being run
   LoadEventNexus *alg;
   /// NXS path to bank

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -298,6 +298,15 @@ public:
         // ID. Setting this will abort the loading of the bank.
         m_loadError = true;
       }
+      // fixup the minimum pixel id in the case that it's lower than the lowest
+      // 'known' id. We test this by checking that when we add the offset we
+      // would not get a negative index into the vector. Note that m_min_id is
+      // a uint so we have to be cautious about adding it to an int which may be
+      // negative.
+      if (alg->pixelID_to_wi_offset < 0 &&
+          m_min_id < abs(alg->pixelID_to_wi_offset)) {
+        m_min_id = abs(alg->pixelID_to_wi_offset);
+      }
       // fixup the maximum pixel id in the case that it's higher than the
       // highest 'known' id
       if (m_max_id > static_cast<uint32_t>(alg->eventid_max))

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -303,9 +303,8 @@ public:
       // would not get a negative index into the vector. Note that m_min_id is
       // a uint so we have to be cautious about adding it to an int which may be
       // negative.
-      if (alg->pixelID_to_wi_offset < 0 &&
-          m_min_id < abs(alg->pixelID_to_wi_offset)) {
-        m_min_id = abs(alg->pixelID_to_wi_offset);
+      if (static_cast<int32_t>(m_min_id) + alg->pixelID_to_wi_offset < 0) {
+        m_min_id = static_cast<uint32_t>(abs(alg->pixelID_to_wi_offset));
       }
       // fixup the maximum pixel id in the case that it's higher than the
       // highest 'known' id

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -55,8 +55,8 @@ void ProcessBankData::run() { // override {
     const size_t numEventLists = outputWS.getNumberHistograms();
     for (detid_t pixID = m_min_id; pixID <= m_max_id; pixID++) {
       if (counts[pixID - m_min_id] > 0) {
+        size_t wi = getWorkspaceIndexFromPixelID(pixID);
         // Find the the workspace index corresponding to that pixel ID
-        size_t wi = pixelID_to_wi_vector[pixID + pixelID_to_wi_offset];
         // Allocate it
         if (wi < numEventLists) {
           outputWS.reserveEventListAt(wi, counts[pixID - m_min_id]);
@@ -202,7 +202,7 @@ void ProcessBankData::run() { // override {
     for (detid_t pixID = m_min_id; pixID <= m_max_id; pixID++) {
       if (usedDetIds[pixID - m_min_id]) {
         // Find the the workspace index corresponding to that pixel ID
-        size_t wi = pixelID_to_wi_vector[pixID + pixelID_to_wi_offset];
+        size_t wi = getWorkspaceIndexFromPixelID(pixID);
         auto &el = outputWS.getSpectrum(wi);
         if (compress)
           el.compressEvents(alg->compressTolerance, &el);
@@ -242,5 +242,19 @@ void ProcessBankData::run() { // override {
 #endif
 } // END-OF-RUN()
 
+// Get the workspace index for a given pixel ID. Throws if the pixel ID is
+// not in the expected range.
+size_t ProcessBankData::getWorkspaceIndexFromPixelID(const detid_t pixID) {
+  // Check that the vector index is not out of range
+  const detid_t offset_pixID = pixID + pixelID_to_wi_offset;
+  if (offset_pixID < 0 || offset_pixID >= pixelID_to_wi_vector.size()) {
+    std::stringstream msg;
+    msg << "Error finding workspace index; pixelID "
+      << pixID << " with offset " << pixelID_to_wi_offset
+      << " is out of range (length=" << pixelID_to_wi_vector.size() << ")";
+    throw std::runtime_error(msg.str());
+  }
+  return pixelID_to_wi_vector[offset_pixID];
+}
 } // namespace Mantid{
 } // namespace DataHandling{

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -247,7 +247,8 @@ void ProcessBankData::run() { // override {
 size_t ProcessBankData::getWorkspaceIndexFromPixelID(const detid_t pixID) {
   // Check that the vector index is not out of range
   const detid_t offset_pixID = pixID + pixelID_to_wi_offset;
-  if (offset_pixID < 0 || offset_pixID >= pixelID_to_wi_vector.size()) {
+  if (offset_pixID < 0 ||
+      offset_pixID >= static_cast<int32_t>(pixelID_to_wi_vector.size())) {
     std::stringstream msg;
     msg << "Error finding workspace index; pixelID " << pixID << " with offset "
         << pixelID_to_wi_offset

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -246,7 +246,7 @@ void ProcessBankData::run() { // override {
  * Get the workspace index for a given pixel ID. Throws if the pixel ID is
  * not in the expected range.
  *
- * @param The pixel ID to look up
+ * @param pixID :: The pixel ID to look up
  * @return The workspace index for this pixel
  */
 size_t ProcessBankData::getWorkspaceIndexFromPixelID(const detid_t pixID) {

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -249,9 +249,9 @@ size_t ProcessBankData::getWorkspaceIndexFromPixelID(const detid_t pixID) {
   const detid_t offset_pixID = pixID + pixelID_to_wi_offset;
   if (offset_pixID < 0 || offset_pixID >= pixelID_to_wi_vector.size()) {
     std::stringstream msg;
-    msg << "Error finding workspace index; pixelID "
-      << pixID << " with offset " << pixelID_to_wi_offset
-      << " is out of range (length=" << pixelID_to_wi_vector.size() << ")";
+    msg << "Error finding workspace index; pixelID " << pixID << " with offset "
+        << pixelID_to_wi_offset
+        << " is out of range (length=" << pixelID_to_wi_vector.size() << ")";
     throw std::runtime_error(msg.str());
   }
   return pixelID_to_wi_vector[offset_pixID];

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -242,8 +242,13 @@ void ProcessBankData::run() { // override {
 #endif
 } // END-OF-RUN()
 
-// Get the workspace index for a given pixel ID. Throws if the pixel ID is
-// not in the expected range.
+/**
+ * Get the workspace index for a given pixel ID. Throws if the pixel ID is
+ * not in the expected range.
+ *
+ * @param The pixel ID to look up
+ * @return The workspace index for this pixel
+ */
 size_t ProcessBankData::getWorkspaceIndexFromPixelID(const detid_t pixID) {
   // Check that the vector index is not out of range
   const detid_t offset_pixID = pixID + pixelID_to_wi_offset;


### PR DESCRIPTION
This fixes a debug assertion caused by invalid pixel IDs in an event file.

**To test:**

Run LoadEventNexusTest in Debug mode. Previously this caused a debug assertion. It should now be fixed.

Fixes #19103 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
