### PR TITLE
Add time index for DetectorInfo methods -> scanning support

### DIFF
--- a/Framework/API/inc/MantidAPI/DetectorInfo.h
+++ b/Framework/API/inc/MantidAPI/DetectorInfo.h
@@ -76,18 +76,30 @@ public:
   size_t size() const;
 
   bool isMonitor(const size_t index) const;
+  bool isMonitor(const std::pair<size_t, size_t> index) const;
   bool isMasked(const size_t index) const;
+  bool isMasked(const std::pair<size_t, size_t> index) const;
   double l2(const size_t index) const;
+  double l2(const std::pair<size_t, size_t> index) const;
   double twoTheta(const size_t index) const;
+  double twoTheta(const std::pair<size_t, size_t> index) const;
   double signedTwoTheta(const size_t index) const;
+  double signedTwoTheta(const std::pair<size_t, size_t> index) const;
   Kernel::V3D position(const size_t index) const;
+  Kernel::V3D position(const std::pair<size_t, size_t> index) const;
   Kernel::Quat rotation(const size_t index) const;
+  Kernel::Quat rotation(const std::pair<size_t, size_t> index) const;
 
   void setMasked(const size_t index, bool masked);
+  void setMasked(const std::pair<size_t, size_t> index, bool masked);
   void clearMaskFlags();
 
   void setPosition(const size_t index, const Kernel::V3D &position);
+  void setPosition(const std::pair<size_t, size_t> index,
+                   const Kernel::V3D &position);
   void setRotation(const size_t index, const Kernel::Quat &rotation);
+  void setRotation(const std::pair<size_t, size_t> index,
+                   const Kernel::Quat &rotation);
 
   void setPosition(const Geometry::IComponent &comp, const Kernel::V3D &pos);
   void setRotation(const Geometry::IComponent &comp, const Kernel::Quat &rot);

--- a/Framework/API/inc/MantidAPI/DetectorInfo.h
+++ b/Framework/API/inc/MantidAPI/DetectorInfo.h
@@ -122,7 +122,7 @@ public:
   std::pair<Kernel::DateAndTime, Kernel::DateAndTime>
   scanInterval(const std::pair<size_t, size_t> &index) const;
   void setScanInterval(
-      const std::pair<size_t, size_t> &index,
+      const size_t index,
       const std::pair<Kernel::DateAndTime, Kernel::DateAndTime> &interval);
 
   void merge(const DetectorInfo &other);

--- a/Framework/API/inc/MantidAPI/DetectorInfo.h
+++ b/Framework/API/inc/MantidAPI/DetectorInfo.h
@@ -77,29 +77,29 @@ public:
   size_t size() const;
 
   bool isMonitor(const size_t index) const;
-  bool isMonitor(const std::pair<size_t, size_t> index) const;
+  bool isMonitor(const std::pair<size_t, size_t> &index) const;
   bool isMasked(const size_t index) const;
-  bool isMasked(const std::pair<size_t, size_t> index) const;
+  bool isMasked(const std::pair<size_t, size_t> &index) const;
   double l2(const size_t index) const;
-  double l2(const std::pair<size_t, size_t> index) const;
+  double l2(const std::pair<size_t, size_t> &index) const;
   double twoTheta(const size_t index) const;
-  double twoTheta(const std::pair<size_t, size_t> index) const;
+  double twoTheta(const std::pair<size_t, size_t> &index) const;
   double signedTwoTheta(const size_t index) const;
-  double signedTwoTheta(const std::pair<size_t, size_t> index) const;
+  double signedTwoTheta(const std::pair<size_t, size_t> &index) const;
   Kernel::V3D position(const size_t index) const;
-  Kernel::V3D position(const std::pair<size_t, size_t> index) const;
+  Kernel::V3D position(const std::pair<size_t, size_t> &index) const;
   Kernel::Quat rotation(const size_t index) const;
-  Kernel::Quat rotation(const std::pair<size_t, size_t> index) const;
+  Kernel::Quat rotation(const std::pair<size_t, size_t> &index) const;
 
   void setMasked(const size_t index, bool masked);
-  void setMasked(const std::pair<size_t, size_t> index, bool masked);
+  void setMasked(const std::pair<size_t, size_t> &index, bool masked);
   void clearMaskFlags();
 
   void setPosition(const size_t index, const Kernel::V3D &position);
-  void setPosition(const std::pair<size_t, size_t> index,
+  void setPosition(const std::pair<size_t, size_t> &index,
                    const Kernel::V3D &position);
   void setRotation(const size_t index, const Kernel::Quat &rotation);
-  void setRotation(const std::pair<size_t, size_t> index,
+  void setRotation(const std::pair<size_t, size_t> &index,
                    const Kernel::Quat &rotation);
 
   void setPosition(const Geometry::IComponent &comp, const Kernel::V3D &pos);
@@ -120,10 +120,10 @@ public:
 
   size_t scanCount(const size_t index) const;
   std::pair<Kernel::DateAndTime, Kernel::DateAndTime>
-  scanInterval(const std::pair<size_t, size_t> index) const;
-  void
-  setScanInterval(const std::pair<size_t, size_t> index,
-                  std::pair<Kernel::DateAndTime, Kernel::DateAndTime> interval);
+  scanInterval(const std::pair<size_t, size_t> &index) const;
+  void setScanInterval(
+      const std::pair<size_t, size_t> &index,
+      const std::pair<Kernel::DateAndTime, Kernel::DateAndTime> &interval);
 
   void merge(const DetectorInfo &other);
 

--- a/Framework/API/inc/MantidAPI/DetectorInfo.h
+++ b/Framework/API/inc/MantidAPI/DetectorInfo.h
@@ -2,6 +2,7 @@
 #define MANTID_API_DETECTORINFO_H_
 
 #include "MantidAPI/DllConfig.h"
+#include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/Quat.h"
 #include "MantidKernel/V3D.h"
 
@@ -116,6 +117,15 @@ public:
   /// Returns the index of the detector with the given detector ID.
   /// This will throw an out of range exception if the detector does not exist.
   size_t indexOf(const detid_t id) const { return m_detIDToIndex.at(id); }
+
+  size_t scanCount(const size_t index) const;
+  std::pair<Kernel::DateAndTime, Kernel::DateAndTime>
+  scanInterval(const std::pair<size_t, size_t> index) const;
+  void
+  setScanInterval(const std::pair<size_t, size_t> index,
+                  std::pair<Kernel::DateAndTime, Kernel::DateAndTime> interval);
+
+  void merge(const DetectorInfo &other);
 
   friend class SpectrumInfo;
 

--- a/Framework/API/inc/MantidAPI/SpectrumInfo.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfo.h
@@ -103,7 +103,7 @@ public:
 
 private:
   const Geometry::IDetector &getDetector(const size_t index) const;
-  std::vector<size_t> getDetectorIndices(const size_t index) const;
+  const SpectrumDefinition &getDetectorIndices(const size_t index) const;
 
   const ExperimentInfo &m_experimentInfo;
   DetectorInfo &m_detectorInfo;

--- a/Framework/API/inc/MantidAPI/SpectrumInfo.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfo.h
@@ -103,7 +103,8 @@ public:
 
 private:
   const Geometry::IDetector &getDetector(const size_t index) const;
-  const SpectrumDefinition &getDetectorIndices(const size_t index) const;
+  const SpectrumDefinition &
+  checkAndGetSpectrumDefinition(const size_t index) const;
 
   const ExperimentInfo &m_experimentInfo;
   DetectorInfo &m_detectorInfo;

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -279,6 +279,11 @@ void DetectorInfo::setPosition(const Geometry::IComponent &comp,
     const auto index = indexOf(det->getID());
     setPosition(index, pos);
   } else {
+    const auto &detIndices = getAssemblyDetectorIndices(comp);
+    if ((!detIndices.empty()) && m_detectorInfo.isScanning())
+      throw std::runtime_error("Cannot move parent component containing "
+                               "detectors since the beamline has "
+                               "time-dependent (moving) detectors.");
     // This will go badly wrong if the parameter map in the component is not
     // identical to ours, but there does not seem to be a way to check?
     const auto oldPos = comp.getPos();
@@ -288,7 +293,6 @@ void DetectorInfo::setPosition(const Geometry::IComponent &comp,
     // If comp is a detector cached positions stay valid. In all other cases
     // (higher level in instrument tree, or other leaf component such as sample
     // or source) we flush all cached positions.
-    const auto &detIndices = getAssemblyDetectorIndices(comp);
     if (detIndices.size() == 0 || detIndices.size() == size()) {
       // Update only if comp is not a bank (not detectors) or the full
       // instrument (all detectors). The should make this thread-safe for
@@ -321,6 +325,11 @@ void DetectorInfo::setRotation(const Geometry::IComponent &comp,
     const auto index = indexOf(det->getID());
     setRotation(index, rot);
   } else {
+    const auto &detIndices = getAssemblyDetectorIndices(comp);
+    if ((!detIndices.empty()) && m_detectorInfo.isScanning())
+      throw std::runtime_error("Cannot move parent component containing "
+                               "detectors since the beamline has "
+                               "time-dependent (moving) detectors.");
     // This will go badly wrong if the parameter map in the component is not
     // identical to ours, but there does not seem to be a way to check?
     const auto pos = toVector3d(comp.getPos());
@@ -333,7 +342,6 @@ void DetectorInfo::setRotation(const Geometry::IComponent &comp,
     // If comp is a detector cached positions and rotations stay valid. In all
     // other cases (higher level in instrument tree, or other leaf component
     // such as sample or source) we flush all cached positions and rotations.
-    const auto &detIndices = getAssemblyDetectorIndices(comp);
     if (detIndices.size() == 0 || detIndices.size() == size()) {
       // Update only if comp is not a bank (not detectors) or the full
       // instrument (all detectors). The should make this thread-safe for

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -388,6 +388,35 @@ const std::vector<detid_t> &DetectorInfo::detectorIDs() const {
   return m_detectorIDs;
 }
 
+/// Returns the scan count of the detector with given detector index.
+size_t DetectorInfo::scanCount(const size_t index) const {
+  return m_detectorInfo.scanCount(index);
+}
+
+/// Returns the scan interval of the detector with given index.
+std::pair<Kernel::DateAndTime, Kernel::DateAndTime>
+DetectorInfo::scanInterval(const std::pair<size_t, size_t> index) const {
+  const auto &interval = m_detectorInfo.scanInterval(index);
+  return {interval.first, interval.second};
+}
+
+/// Set the scan interval of the detector with given index.
+void DetectorInfo::setScanInterval(
+    const std::pair<size_t, size_t> index,
+    std::pair<Kernel::DateAndTime, Kernel::DateAndTime> interval) {
+  m_detectorInfo.setScanInterval(index, {interval.first.totalNanoseconds(),
+                                         interval.second.totalNanoseconds()});
+}
+
+/** Merges the contents of other into this.
+ *
+ * Scan intervals in both other and this must be set. Intervals must be
+ * identical or non-overlapping. If they are identical all other parameters (for
+ * that index) must match. */
+void DetectorInfo::merge(const DetectorInfo &other) {
+  m_detectorInfo.merge(other.m_detectorInfo);
+}
+
 const Geometry::IDetector &DetectorInfo::getDetector(const size_t index) const {
   size_t thread = static_cast<size_t>(PARALLEL_THREAD_NUMBER);
   if (m_lastIndex[thread] != index) {

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -401,16 +401,25 @@ size_t DetectorInfo::scanCount(const size_t index) const {
   return m_detectorInfo.scanCount(index);
 }
 
-/// Returns the scan interval of the detector with given index.
+/** Returns the scan interval of the detector with given index.
+ *
+ * The interval start and end values would typically correspond to nanoseconds
+ * since 1990, as in Kernel::DateAndTime. */
 std::pair<Kernel::DateAndTime, Kernel::DateAndTime>
 DetectorInfo::scanInterval(const std::pair<size_t, size_t> &index) const {
   const auto &interval = m_detectorInfo.scanInterval(index);
   return {interval.first, interval.second};
 }
 
-/// Set the scan interval of the detector with given index.
+/** Set the scan interval of the detector with given detector index.
+ *
+ * The interval start and end values would typically correspond to nanoseconds
+ * since 1990, as in Kernel::DateAndTime. Note that it is currently not possible
+ * to modify scan intervals for a DetectorInfo with time-dependent detectors,
+ * i.e., time intervals must be set with this method before merging individual
+ * scans. */
 void DetectorInfo::setScanInterval(
-    const std::pair<size_t, size_t> &index,
+    const size_t index,
     const std::pair<Kernel::DateAndTime, Kernel::DateAndTime> &interval) {
   m_detectorInfo.setScanInterval(index, {interval.first.totalNanoseconds(),
                                          interval.second.totalNanoseconds()});

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -71,7 +71,7 @@ bool DetectorInfo::isMonitor(const size_t index) const {
 }
 
 /// Returns true if the detector is a monitor.
-bool DetectorInfo::isMonitor(const std::pair<size_t, size_t> index) const {
+bool DetectorInfo::isMonitor(const std::pair<size_t, size_t> &index) const {
   return m_detectorInfo.isMonitor(index);
 }
 
@@ -81,7 +81,7 @@ bool DetectorInfo::isMasked(const size_t index) const {
 }
 
 /// Returns true if the detector is masked.
-bool DetectorInfo::isMasked(const std::pair<size_t, size_t> index) const {
+bool DetectorInfo::isMasked(const std::pair<size_t, size_t> &index) const {
   return m_detectorInfo.isMasked(index);
 }
 
@@ -102,7 +102,7 @@ double DetectorInfo::l2(const size_t index) const {
  * For monitors this is defined such that L1+L2 = source-detector distance,
  * i.e., for a monitor in the beamline between source and sample L2 is negative.
  */
-double DetectorInfo::l2(const std::pair<size_t, size_t> index) const {
+double DetectorInfo::l2(const std::pair<size_t, size_t> &index) const {
   if (!isMonitor(index))
     return position(index).distance(samplePosition());
   else
@@ -128,7 +128,7 @@ double DetectorInfo::twoTheta(const size_t index) const {
 }
 
 /// Returns 2 theta (scattering angle w.r.t. to beam direction).
-double DetectorInfo::twoTheta(const std::pair<size_t, size_t> index) const {
+double DetectorInfo::twoTheta(const std::pair<size_t, size_t> &index) const {
   if (isMonitor(index))
     throw std::logic_error(
         "Two theta (scattering angle) is not defined for monitors.");
@@ -175,7 +175,7 @@ double DetectorInfo::signedTwoTheta(const size_t index) const {
 
 /// Returns signed 2 theta (signed scattering angle w.r.t. to beam direction).
 double
-DetectorInfo::signedTwoTheta(const std::pair<size_t, size_t> index) const {
+DetectorInfo::signedTwoTheta(const std::pair<size_t, size_t> &index) const {
   if (isMonitor(index))
     throw std::logic_error(
         "Two theta (scattering angle) is not defined for monitors.");
@@ -209,7 +209,7 @@ Kernel::V3D DetectorInfo::position(const size_t index) const {
 
 /// Returns the position of the detector with given index.
 Kernel::V3D
-DetectorInfo::position(const std::pair<size_t, size_t> index) const {
+DetectorInfo::position(const std::pair<size_t, size_t> &index) const {
   return Kernel::toV3D(m_detectorInfo.position(index));
 }
 
@@ -220,7 +220,7 @@ Kernel::Quat DetectorInfo::rotation(const size_t index) const {
 
 /// Returns the rotation of the detector with given index.
 Kernel::Quat
-DetectorInfo::rotation(const std::pair<size_t, size_t> index) const {
+DetectorInfo::rotation(const std::pair<size_t, size_t> &index) const {
   return Kernel::toQuat(m_detectorInfo.rotation(index));
 }
 
@@ -230,7 +230,7 @@ void DetectorInfo::setMasked(const size_t index, bool masked) {
 }
 
 /// Set the mask flag of the detector with given index. Not thread safe.
-void DetectorInfo::setMasked(const std::pair<size_t, size_t> index,
+void DetectorInfo::setMasked(const std::pair<size_t, size_t> &index,
                              bool masked) {
   m_detectorInfo.setMasked(index, masked);
 }
@@ -251,7 +251,7 @@ void DetectorInfo::setPosition(const size_t index,
 }
 
 /// Set the absolute position of the detector with given index. Not thread safe.
-void DetectorInfo::setPosition(const std::pair<size_t, size_t> index,
+void DetectorInfo::setPosition(const std::pair<size_t, size_t> &index,
                                const Kernel::V3D &position) {
   m_detectorInfo.setPosition(index, Kernel::toVector3d(position));
 }
@@ -263,7 +263,7 @@ void DetectorInfo::setRotation(const size_t index,
 }
 
 /// Set the absolute rotation of the detector with given index. Not thread safe.
-void DetectorInfo::setRotation(const std::pair<size_t, size_t> index,
+void DetectorInfo::setRotation(const std::pair<size_t, size_t> &index,
                                const Kernel::Quat &rotation) {
   m_detectorInfo.setRotation(index, Kernel::toQuaterniond(rotation));
 }
@@ -403,15 +403,15 @@ size_t DetectorInfo::scanCount(const size_t index) const {
 
 /// Returns the scan interval of the detector with given index.
 std::pair<Kernel::DateAndTime, Kernel::DateAndTime>
-DetectorInfo::scanInterval(const std::pair<size_t, size_t> index) const {
+DetectorInfo::scanInterval(const std::pair<size_t, size_t> &index) const {
   const auto &interval = m_detectorInfo.scanInterval(index);
   return {interval.first, interval.second};
 }
 
 /// Set the scan interval of the detector with given index.
 void DetectorInfo::setScanInterval(
-    const std::pair<size_t, size_t> index,
-    std::pair<Kernel::DateAndTime, Kernel::DateAndTime> interval) {
+    const std::pair<size_t, size_t> &index,
+    const std::pair<Kernel::DateAndTime, Kernel::DateAndTime> &interval) {
   m_detectorInfo.setScanInterval(index, {interval.first.totalNanoseconds(),
                                          interval.second.totalNanoseconds()});
 }

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -174,14 +174,12 @@ const Geometry::IDetector &SpectrumInfo::getDetector(const size_t index) const {
   return *m_lastDetector[thread];
 }
 
-std::vector<size_t> SpectrumInfo::getDetectorIndices(const size_t index) const {
-  std::vector<size_t> detIndices;
-  for (const auto &def : spectrumDefinition(index))
-    detIndices.push_back(def.first);
-  if (detIndices.empty())
+const SpectrumDefinition &
+SpectrumInfo::getDetectorIndices(const size_t index) const {
+  if (spectrumDefinition(index).size() == 0)
     throw Kernel::Exception::NotFoundError(
         "SpectrumInfo: No detectors for this workspace index.", "");
-  return detIndices;
+  return spectrumDefinition(index);
 }
 
 } // namespace API

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -42,7 +42,7 @@ SpectrumInfo::sharedSpectrumDefinitions() const {
 
 /// Returns true if the detector(s) associated with the spectrum are monitors.
 bool SpectrumInfo::isMonitor(const size_t index) const {
-  for (const auto detIndex : getDetectorIndices(index))
+  for (const auto &detIndex : checkAndGetSpectrumDefinition(index))
     if (!m_detectorInfo.isMonitor(detIndex))
       return false;
   return true;
@@ -51,7 +51,7 @@ bool SpectrumInfo::isMonitor(const size_t index) const {
 /// Returns true if the detector(s) associated with the spectrum are masked.
 bool SpectrumInfo::isMasked(const size_t index) const {
   bool masked = true;
-  for (const auto detIndex : getDetectorIndices(index))
+  for (const auto &detIndex : checkAndGetSpectrumDefinition(index))
     masked &= m_detectorInfo.isMasked(detIndex);
   return masked;
 }
@@ -63,7 +63,7 @@ bool SpectrumInfo::isMasked(const size_t index) const {
  */
 double SpectrumInfo::l2(const size_t index) const {
   double l2{0.0};
-  for (const auto detIndex : getDetectorIndices(index))
+  for (const auto &detIndex : checkAndGetSpectrumDefinition(index))
     l2 += m_detectorInfo.l2(detIndex);
   return l2 / static_cast<double>(spectrumDefinition(index).size());
 }
@@ -75,7 +75,7 @@ double SpectrumInfo::l2(const size_t index) const {
  */
 double SpectrumInfo::twoTheta(const size_t index) const {
   double twoTheta{0.0};
-  for (const auto detIndex : getDetectorIndices(index))
+  for (const auto &detIndex : checkAndGetSpectrumDefinition(index))
     twoTheta += m_detectorInfo.twoTheta(detIndex);
   return twoTheta / static_cast<double>(spectrumDefinition(index).size());
 }
@@ -87,7 +87,7 @@ double SpectrumInfo::twoTheta(const size_t index) const {
  */
 double SpectrumInfo::signedTwoTheta(const size_t index) const {
   double signedTwoTheta{0.0};
-  for (const auto detIndex : getDetectorIndices(index))
+  for (const auto &detIndex : checkAndGetSpectrumDefinition(index))
     signedTwoTheta += m_detectorInfo.signedTwoTheta(detIndex);
   return signedTwoTheta / static_cast<double>(spectrumDefinition(index).size());
 }
@@ -95,7 +95,7 @@ double SpectrumInfo::signedTwoTheta(const size_t index) const {
 /// Returns the position of the spectrum with given index.
 Kernel::V3D SpectrumInfo::position(const size_t index) const {
   Kernel::V3D newPos;
-  for (const auto detIndex : getDetectorIndices(index))
+  for (const auto &detIndex : checkAndGetSpectrumDefinition(index))
     newPos += m_detectorInfo.position(detIndex);
   return newPos / static_cast<double>(spectrumDefinition(index).size());
 }
@@ -118,7 +118,7 @@ bool SpectrumInfo::hasUniqueDetector(const size_t index) const {
  *
  * Currently this simply sets the mask flags for the underlying detectors. */
 void SpectrumInfo::setMasked(const size_t index, bool masked) {
-  for (const auto detIndex : getDetectorIndices(index))
+  for (const auto &detIndex : checkAndGetSpectrumDefinition(index))
     m_detectorInfo.setMasked(detIndex, masked);
 }
 
@@ -175,7 +175,7 @@ const Geometry::IDetector &SpectrumInfo::getDetector(const size_t index) const {
 }
 
 const SpectrumDefinition &
-SpectrumInfo::getDetectorIndices(const size_t index) const {
+SpectrumInfo::checkAndGetSpectrumDefinition(const size_t index) const {
   if (spectrumDefinition(index).size() == 0)
     throw Kernel::Exception::NotFoundError(
         "SpectrumInfo: No detectors for this workspace index.", "");

--- a/Framework/API/test/MatrixWorkspaceTest.h
+++ b/Framework/API/test/MatrixWorkspaceTest.h
@@ -1430,8 +1430,8 @@ public:
     auto &detInfo2 = ws2->mutableDetectorInfo();
     detInfo1.setPosition(0, {1, 0, 0});
     detInfo2.setPosition(0, {2, 0, 0});
-    detInfo1.setScanInterval({0, 0}, {10, 20});
-    detInfo2.setScanInterval({0, 0}, {20, 30});
+    detInfo1.setScanInterval(0, {10, 20});
+    detInfo2.setScanInterval(0, {20, 30});
 
     // Merge
     auto merged = WorkspaceFactory::Instance().create(ws1, 2);

--- a/Framework/Algorithms/src/ConvertToConstantL2.cpp
+++ b/Framework/Algorithms/src/ConvertToConstantL2.cpp
@@ -116,7 +116,7 @@ void ConvertToConstantL2::exec() {
     V3D newPos;
     newPos.spherical(m_l2, theta, phi);
 
-    const size_t detIndex = inputSpecInfo.spectrumDefinition(i)[0].first;
+    const auto detIndex = inputSpecInfo.spectrumDefinition(i)[0];
     outputDetInfo.setPosition(detIndex, newPos);
 
     m_outputWS->mutableX(i) -= deltaTOF;

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -86,13 +86,31 @@ public:
   void setRotation(const std::pair<size_t, size_t> index,
                    const Eigen::Quaterniond &rotation);
 
+  size_t scanCount(const size_t index) const;
+  std::pair<int64_t, int64_t>
+  scanInterval(const std::pair<size_t, size_t> index) const;
+  void setScanInterval(const std::pair<size_t, size_t> index,
+                       std::pair<int64_t, int64_t> interval);
+
+  void merge(const DetectorInfo &other);
+
 private:
   size_t linearIndex(const std::pair<size_t, size_t> &index) const;
   void checkNoTimeDependence() const;
+  void initScanCounts();
+  void initScanIntervals();
+  void initIndices();
+
   Kernel::cow_ptr<std::vector<bool>> m_isMonitor{nullptr};
   Kernel::cow_ptr<std::vector<bool>> m_isMasked{nullptr};
   Kernel::cow_ptr<std::vector<Eigen::Vector3d>> m_positions{nullptr};
   Kernel::cow_ptr<std::vector<Eigen::Quaterniond>> m_rotations{nullptr};
+
+  Kernel::cow_ptr<std::vector<size_t>> m_scanCounts{nullptr};
+  Kernel::cow_ptr<std::vector<std::pair<int64_t, int64_t>>> m_scanIntervals{
+      nullptr};
+  Kernel::cow_ptr<std::vector<std::vector<size_t>>> m_indexMap{nullptr};
+  Kernel::cow_ptr<std::vector<std::pair<size_t, size_t>>> m_indices{nullptr};
 };
 
 /** Returns the position of the detector with given detector index.

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -71,27 +71,27 @@ public:
   bool isScanning() const;
 
   bool isMonitor(const size_t index) const;
-  bool isMonitor(const std::pair<size_t, size_t> index) const;
+  bool isMonitor(const std::pair<size_t, size_t> &index) const;
   bool isMasked(const size_t index) const;
-  bool isMasked(const std::pair<size_t, size_t> index) const;
+  bool isMasked(const std::pair<size_t, size_t> &index) const;
   void setMasked(const size_t index, bool masked);
-  void setMasked(const std::pair<size_t, size_t> index, bool masked);
+  void setMasked(const std::pair<size_t, size_t> &index, bool masked);
   Eigen::Vector3d position(const size_t index) const;
   Eigen::Vector3d position(const std::pair<size_t, size_t> index) const;
   Eigen::Quaterniond rotation(const size_t index) const;
   Eigen::Quaterniond rotation(const std::pair<size_t, size_t> index) const;
   void setPosition(const size_t index, const Eigen::Vector3d &position);
-  void setPosition(const std::pair<size_t, size_t> index,
+  void setPosition(const std::pair<size_t, size_t> &index,
                    const Eigen::Vector3d &position);
   void setRotation(const size_t index, const Eigen::Quaterniond &rotation);
-  void setRotation(const std::pair<size_t, size_t> index,
+  void setRotation(const std::pair<size_t, size_t> &index,
                    const Eigen::Quaterniond &rotation);
 
   size_t scanCount(const size_t index) const;
   std::pair<int64_t, int64_t>
-  scanInterval(const std::pair<size_t, size_t> index) const;
-  void setScanInterval(const std::pair<size_t, size_t> index,
-                       std::pair<int64_t, int64_t> interval);
+  scanInterval(const std::pair<size_t, size_t> &index) const;
+  void setScanInterval(const std::pair<size_t, size_t> &index,
+                       const std::pair<int64_t, int64_t> &interval);
 
   void merge(const DetectorInfo &other);
 

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -77,9 +77,9 @@ public:
   void setMasked(const size_t index, bool masked);
   void setMasked(const std::pair<size_t, size_t> &index, bool masked);
   Eigen::Vector3d position(const size_t index) const;
-  Eigen::Vector3d position(const std::pair<size_t, size_t> index) const;
+  Eigen::Vector3d position(const std::pair<size_t, size_t> &index) const;
   Eigen::Quaterniond rotation(const size_t index) const;
-  Eigen::Quaterniond rotation(const std::pair<size_t, size_t> index) const;
+  Eigen::Quaterniond rotation(const std::pair<size_t, size_t> &index) const;
   void setPosition(const size_t index, const Eigen::Vector3d &position);
   void setPosition(const std::pair<size_t, size_t> &index,
                    const Eigen::Vector3d &position);
@@ -90,7 +90,7 @@ public:
   size_t scanCount(const size_t index) const;
   std::pair<int64_t, int64_t>
   scanInterval(const std::pair<size_t, size_t> &index) const;
-  void setScanInterval(const std::pair<size_t, size_t> &index,
+  void setScanInterval(const size_t index,
                        const std::pair<int64_t, int64_t> &interval);
 
   void merge(const DetectorInfo &other);

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -68,6 +68,7 @@ public:
   bool isEquivalent(const DetectorInfo &other) const;
 
   size_t size() const;
+  bool isScanning() const;
 
   bool isMonitor(const size_t index) const;
   bool isMonitor(const std::pair<size_t, size_t> index) const;

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -101,6 +101,7 @@ private:
   void initScanCounts();
   void initScanIntervals();
   void initIndices();
+  std::vector<bool> buildMergeIndices(const DetectorInfo &other) const;
 
   Kernel::cow_ptr<std::vector<bool>> m_isMonitor{nullptr};
   Kernel::cow_ptr<std::vector<bool>> m_isMasked{nullptr};

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -87,31 +87,49 @@ public:
                    const Eigen::Quaterniond &rotation);
 
 private:
+  size_t linearIndex(const std::pair<size_t, size_t> &index) const;
+  void checkNoTimeDependence() const;
   Kernel::cow_ptr<std::vector<bool>> m_isMonitor{nullptr};
   Kernel::cow_ptr<std::vector<bool>> m_isMasked{nullptr};
   Kernel::cow_ptr<std::vector<Eigen::Vector3d>> m_positions{nullptr};
   Kernel::cow_ptr<std::vector<Eigen::Quaterniond>> m_rotations{nullptr};
 };
 
-/// Returns the position of the detector with given index.
+/** Returns the position of the detector with given detector index.
+ *
+ * Convenience method for beamlines with static (non-moving) detectors.
+ * Throws if there are time-dependent detectors. */
 inline Eigen::Vector3d DetectorInfo::position(const size_t index) const {
+  checkNoTimeDependence();
   return (*m_positions)[index];
 }
 
-/// Returns the rotation of the detector with given index.
+/** Returns the rotation of the detector with given detector index.
+ *
+ * Convenience method for beamlines with static (non-moving) detectors.
+ * Throws if there are time-dependent detectors. */
 inline Eigen::Quaterniond DetectorInfo::rotation(const size_t index) const {
+  checkNoTimeDependence();
   return (*m_rotations)[index];
 }
 
-/// Set the position of the detector with given index.
+/** Set the position of the detector with given detector index.
+ *
+ * Convenience method for beamlines with static (non-moving) detectors.
+ * Throws if there are time-dependent detectors. */
 inline void DetectorInfo::setPosition(const size_t index,
                                       const Eigen::Vector3d &position) {
+  checkNoTimeDependence();
   m_positions.access()[index] = position;
 }
 
-/// Set the rotation of the detector with given index.
+/** Set the rotation of the detector with given detector index.
+ *
+ * Convenience method for beamlines with static (non-moving) detectors.
+ * Throws if there are time-dependent detectors. */
 inline void DetectorInfo::setRotation(const size_t index,
                                       const Eigen::Quaterniond &rotation) {
+  checkNoTimeDependence();
   m_rotations.access()[index] = rotation.normalized();
 }
 

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -70,12 +70,21 @@ public:
   size_t size() const;
 
   bool isMonitor(const size_t index) const;
+  bool isMonitor(const std::pair<size_t, size_t> index) const;
   bool isMasked(const size_t index) const;
+  bool isMasked(const std::pair<size_t, size_t> index) const;
   void setMasked(const size_t index, bool masked);
+  void setMasked(const std::pair<size_t, size_t> index, bool masked);
   Eigen::Vector3d position(const size_t index) const;
+  Eigen::Vector3d position(const std::pair<size_t, size_t> index) const;
   Eigen::Quaterniond rotation(const size_t index) const;
+  Eigen::Quaterniond rotation(const std::pair<size_t, size_t> index) const;
   void setPosition(const size_t index, const Eigen::Vector3d &position);
+  void setPosition(const std::pair<size_t, size_t> index,
+                   const Eigen::Vector3d &position);
   void setRotation(const size_t index, const Eigen::Quaterniond &rotation);
+  void setRotation(const std::pair<size_t, size_t> index,
+                   const Eigen::Quaterniond &rotation);
 
 private:
   Kernel::cow_ptr<std::vector<bool>> m_isMonitor{nullptr};

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -179,7 +179,10 @@ size_t DetectorInfo::scanCount(const size_t index) const {
   return (*m_scanCounts)[index];
 }
 
-/// Returns the scan interval of the detector with given index.
+/** Returns the scan interval of the detector with given index.
+ *
+ * The interval start and end values would typically correspond to nanoseconds
+ * since 1990, as in Kernel::DateAndTime. */
 std::pair<int64_t, int64_t>
 DetectorInfo::scanInterval(const std::pair<size_t, size_t> index) const {
   if (!m_scanIntervals)
@@ -187,7 +190,10 @@ DetectorInfo::scanInterval(const std::pair<size_t, size_t> index) const {
   return (*m_scanIntervals)[linearIndex(index)];
 }
 
-/// Set the scan interval of the detector with given index.
+/* Set the scan interval of the detector with given index.
+ *
+ * The interval start and end values would typically correspond to nanoseconds
+ * since 1990, as in Kernel::DateAndTime. */
 void DetectorInfo::setScanInterval(const std::pair<size_t, size_t> index,
                                    std::pair<int64_t, int64_t> interval) {
   if (!m_scanIntervals)

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -195,7 +195,7 @@ void DetectorInfo::setScanInterval(const std::pair<size_t, size_t> index,
   // We forbid this since we (currently?) can not verify that the new interval
   // has no collisions with any of the other intervals for this detector.
   checkNoTimeDependence();
-  if (interval.first > interval.second)
+  if (interval.first >= interval.second)
     throw std::runtime_error(
         "DetectorInfo: cannot set scan interval with start > end");
   m_scanIntervals.access()[linearIndex(index)] = interval;
@@ -303,7 +303,7 @@ void DetectorInfo::initScanCounts() {
 void DetectorInfo::initScanIntervals() {
   checkNoTimeDependence();
   m_scanIntervals = Kernel::make_cow<std::vector<std::pair<int64_t, int64_t>>>(
-      size(), std::pair<int64_t, int64_t>{0, 0});
+      size(), std::pair<int64_t, int64_t>{0, 1});
 }
 
 void DetectorInfo::initIndices() {

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -39,6 +39,7 @@ DetectorInfo::DetectorInfo(std::vector<Eigen::Vector3d> positions,
 bool DetectorInfo::isEquivalent(const DetectorInfo &other) const {
   if (this == &other)
     return true;
+  // Same number of detectors
   if (size() != other.size())
     return false;
   if (size() == 0)
@@ -48,6 +49,17 @@ bool DetectorInfo::isEquivalent(const DetectorInfo &other) const {
     return false;
   if (!(m_isMasked == other.m_isMasked) && (*m_isMasked != *other.m_isMasked))
     return false;
+
+  // Scanning related fields. Not testing m_scanCounts and m_indexMap since
+  // those just are internally derived from m_indices.
+  if (m_scanIntervals && other.m_scanIntervals &&
+      !(m_scanIntervals == other.m_scanIntervals) &&
+      (*m_scanIntervals != *other.m_scanIntervals))
+    return false;
+  if (m_indices && other.m_indices && !(m_indices == other.m_indices) &&
+      (*m_indices != *other.m_indices))
+    return false;
+
   // Positions: Absolute difference matter, so comparison is not relative.
   // Changes below 1 nm = 1e-9 m are allowed.
   if (!(m_positions == other.m_positions) &&

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -190,7 +190,7 @@ DetectorInfo::scanInterval(const std::pair<size_t, size_t> &index) const {
   return (*m_scanIntervals)[linearIndex(index)];
 }
 
-/* Set the scan interval of the detector with given index.
+/** Set the scan interval of the detector with given index.
  *
  * The interval start and end values would typically correspond to nanoseconds
  * since 1990, as in Kernel::DateAndTime. */

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -86,19 +86,59 @@ size_t DetectorInfo::size() const {
   return m_isMasked->size();
 }
 
-/// Returns true if the detector is a monitor.
+/// Returns true if the detector with given index is a monitor.
 bool DetectorInfo::isMonitor(const size_t index) const {
   return (*m_isMonitor)[index];
 }
 
-/// Returns true if the detector is masked.
+/// Returns true if the detector with given index is a monitor.
+bool DetectorInfo::isMonitor(const std::pair<size_t, size_t> index) const {
+  return (*m_isMonitor)[index.first];
+}
+
+/// Returns true if the detector with given index is masked.
 bool DetectorInfo::isMasked(const size_t index) const {
   return (*m_isMasked)[index];
+}
+
+/// Returns true if the detector with given index is masked.
+bool DetectorInfo::isMasked(const std::pair<size_t, size_t> index) const {
+  return (*m_isMasked)[index.first];
 }
 
 /// Set the mask flag of the detector with given index. Not thread safe.
 void DetectorInfo::setMasked(const size_t index, bool masked) {
   m_isMasked.access()[index] = masked;
+}
+
+/// Set the mask flag of the detector with given index. Not thread safe.
+void DetectorInfo::setMasked(const std::pair<size_t, size_t> index,
+                             bool masked) {
+  m_isMasked.access()[index.first] = masked;
+}
+
+/// Returns the position of the detector with given index.
+Eigen::Vector3d
+DetectorInfo::position(const std::pair<size_t, size_t> index) const {
+  return (*m_positions)[index.first];
+}
+
+/// Returns the rotation of the detector with given index.
+Eigen::Quaterniond
+DetectorInfo::rotation(const std::pair<size_t, size_t> index) const {
+  return (*m_rotations)[index.first];
+}
+
+/// Set the position of the detector with given index.
+void DetectorInfo::setPosition(const std::pair<size_t, size_t> index,
+                               const Eigen::Vector3d &position) {
+  m_positions.access()[index.first] = position;
+}
+
+/// Set the rotation of the detector with given index.
+void DetectorInfo::setRotation(const std::pair<size_t, size_t> index,
+                               const Eigen::Quaterniond &rotation) {
+  m_rotations.access()[index.first] = rotation.normalized();
 }
 
 } // namespace Beamline

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -190,22 +190,22 @@ DetectorInfo::scanInterval(const std::pair<size_t, size_t> &index) const {
   return (*m_scanIntervals)[linearIndex(index)];
 }
 
-/** Set the scan interval of the detector with given index.
+/** Set the scan interval of the detector with given detector index.
  *
  * The interval start and end values would typically correspond to nanoseconds
- * since 1990, as in Kernel::DateAndTime. */
+ * since 1990, as in Kernel::DateAndTime. Note that it is currently not possible
+ * to modify scan intervals for a DetectorInfo with time-dependent detectors,
+ * i.e., time intervals must be set with this method before merging individual
+ * scans. */
 void DetectorInfo::setScanInterval(
-    const std::pair<size_t, size_t> &index,
-    const std::pair<int64_t, int64_t> &interval) {
+    const size_t index, const std::pair<int64_t, int64_t> &interval) {
+  checkNoTimeDependence();
   if (!m_scanIntervals)
     initScanIntervals();
-  // We forbid this since we (currently?) can not verify that the new interval
-  // has no collisions with any of the other intervals for this detector.
-  checkNoTimeDependence();
   if (interval.first >= interval.second)
     throw std::runtime_error(
         "DetectorInfo: cannot set scan interval with start > end");
-  m_scanIntervals.access()[linearIndex(index)] = interval;
+  m_scanIntervals.access()[index] = interval;
 }
 
 namespace {

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -239,12 +239,12 @@ void DetectorInfo::merge(const DetectorInfo &other) {
       const auto index2 = linearIndex({detIndex, timeIndex});
       const auto &interval2 = (*m_scanIntervals)[index2];
       if (interval1 == interval2) {
-        if ((*m_isMasked)[index1] != (*other.m_isMasked)[index2])
+        if ((*m_isMasked)[index2] != (*other.m_isMasked)[index1])
           failMerge("matching scan interval but mask flags differ");
-        if ((*m_positions)[index1] != (*other.m_positions)[index2])
+        if ((*m_positions)[index2] != (*other.m_positions)[index1])
           failMerge("matching scan interval but positions differ");
-        if ((*m_rotations)[index1].coeffs() !=
-            (*other.m_rotations)[index2].coeffs())
+        if ((*m_rotations)[index2].coeffs() !=
+            (*other.m_rotations)[index1].coeffs())
           failMerge("matching scan interval but rotations differ");
         merge[index1] = false;
       } else if ((interval1.first < interval2.second) &&

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -204,7 +204,7 @@ void DetectorInfo::setScanInterval(
     initScanIntervals();
   if (interval.first >= interval.second)
     throw std::runtime_error(
-        "DetectorInfo: cannot set scan interval with start > end");
+        "DetectorInfo: cannot set scan interval with start >= end");
   m_scanIntervals.access()[index] = interval;
 }
 

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -258,13 +258,15 @@ void DetectorInfo::merge(const DetectorInfo &other) {
     initScanCounts();
   if (!m_indexMap)
     initIndices();
+  // Temporary to accumulate scan counts (need original for index offset).
+  auto scanCounts(m_scanCounts);
   for (size_t index = 0; index < other.m_positions->size(); ++index) {
     if (!merge[index])
       continue;
     auto newIndex = getIndex(other.m_indices, index);
     const size_t detIndex = newIndex.first;
     newIndex.second += scanCount(detIndex);
-    m_scanCounts.access()[detIndex]++;
+    scanCounts.access()[detIndex]++;
     m_indexMap.access()[detIndex].push_back((*m_indices).size());
     m_indices.access().push_back(newIndex);
     m_isMasked.access().push_back((*other.m_isMasked)[index]);
@@ -272,6 +274,7 @@ void DetectorInfo::merge(const DetectorInfo &other) {
     m_rotations.access().push_back((*other.m_rotations)[index]);
     m_scanIntervals.access().push_back((*other.m_scanIntervals)[index]);
   }
+  m_scanCounts = std::move(scanCounts);
 }
 
 /// Returns the linear index for a pair of detector index and time index.

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -88,6 +88,9 @@ size_t DetectorInfo::size() const {
   return m_isMonitor->size();
 }
 
+/// Returns true if the beamline has scanning detectors.
+bool DetectorInfo::isScanning() const { return size() != m_positions->size(); }
+
 /// Returns true if the detector with given detector index is a monitor.
 bool DetectorInfo::isMonitor(const size_t index) const {
   // No check for time dependence since monitor flags are not time dependent.
@@ -272,7 +275,7 @@ size_t DetectorInfo::linearIndex(const std::pair<size_t, size_t> &index) const {
 
 /// Throws if this has time-dependent data.
 void DetectorInfo::checkNoTimeDependence() const {
-  if (size() != m_positions->size())
+  if (isScanning())
     throw std::runtime_error("DetectorInfo accessed without time index but the "
                              "beamline has time-dependent (moving) detectors.");
 }

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -225,7 +225,13 @@ getIndex(const Kernel::cow_ptr<std::vector<std::pair<size_t, size_t>>> &indices,
  *
  * Scan intervals in both other and this must be set. Intervals must be
  * identical or non-overlapping. If they are identical all other parameters (for
- * that index) must match. */
+ * that index) must match.
+ *
+ * Time indices in `this` are preserved. Time indices added from `other` are
+ * incremented by the scan count of that detector in `this`. The relative order
+ * of time indices added from `other` is preserved. If the interval for a time
+ * index in `other` is identical to a corresponding interval in `this`, it is
+ * ignored, i.e., no time index is added. */
 void DetectorInfo::merge(const DetectorInfo &other) {
   if (size() != other.size())
     failMerge("size mismatch");

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -113,7 +113,7 @@ bool DetectorInfo::isMonitor(const size_t index) const {
  *
  * The time component of the index is ignored since a detector is a monitor
  * either for *all* times or for *none*. */
-bool DetectorInfo::isMonitor(const std::pair<size_t, size_t> index) const {
+bool DetectorInfo::isMonitor(const std::pair<size_t, size_t> &index) const {
   // Monitors are not time dependent, ignore time component of index.
   return (*m_isMonitor)[index.first];
 }
@@ -128,7 +128,7 @@ bool DetectorInfo::isMasked(const size_t index) const {
 }
 
 /// Returns true if the detector with given index is masked.
-bool DetectorInfo::isMasked(const std::pair<size_t, size_t> index) const {
+bool DetectorInfo::isMasked(const std::pair<size_t, size_t> &index) const {
   return (*m_isMasked)[linearIndex(index)];
 }
 
@@ -143,31 +143,31 @@ void DetectorInfo::setMasked(const size_t index, bool masked) {
 }
 
 /// Set the mask flag of the detector with given index. Not thread safe.
-void DetectorInfo::setMasked(const std::pair<size_t, size_t> index,
+void DetectorInfo::setMasked(const std::pair<size_t, size_t> &index,
                              bool masked) {
   m_isMasked.access()[linearIndex(index)] = masked;
 }
 
 /// Returns the position of the detector with given index.
 Eigen::Vector3d
-DetectorInfo::position(const std::pair<size_t, size_t> index) const {
+DetectorInfo::position(const std::pair<size_t, size_t> &index) const {
   return (*m_positions)[linearIndex(index)];
 }
 
 /// Returns the rotation of the detector with given index.
 Eigen::Quaterniond
-DetectorInfo::rotation(const std::pair<size_t, size_t> index) const {
+DetectorInfo::rotation(const std::pair<size_t, size_t> &index) const {
   return (*m_rotations)[linearIndex(index)];
 }
 
 /// Set the position of the detector with given index.
-void DetectorInfo::setPosition(const std::pair<size_t, size_t> index,
+void DetectorInfo::setPosition(const std::pair<size_t, size_t> &index,
                                const Eigen::Vector3d &position) {
   m_positions.access()[linearIndex(index)] = position;
 }
 
 /// Set the rotation of the detector with given index.
-void DetectorInfo::setRotation(const std::pair<size_t, size_t> index,
+void DetectorInfo::setRotation(const std::pair<size_t, size_t> &index,
                                const Eigen::Quaterniond &rotation) {
   m_rotations.access()[linearIndex(index)] = rotation.normalized();
 }
@@ -184,7 +184,7 @@ size_t DetectorInfo::scanCount(const size_t index) const {
  * The interval start and end values would typically correspond to nanoseconds
  * since 1990, as in Kernel::DateAndTime. */
 std::pair<int64_t, int64_t>
-DetectorInfo::scanInterval(const std::pair<size_t, size_t> index) const {
+DetectorInfo::scanInterval(const std::pair<size_t, size_t> &index) const {
   if (!m_scanIntervals)
     return {0, 0};
   return (*m_scanIntervals)[linearIndex(index)];
@@ -194,8 +194,9 @@ DetectorInfo::scanInterval(const std::pair<size_t, size_t> index) const {
  *
  * The interval start and end values would typically correspond to nanoseconds
  * since 1990, as in Kernel::DateAndTime. */
-void DetectorInfo::setScanInterval(const std::pair<size_t, size_t> index,
-                                   std::pair<int64_t, int64_t> interval) {
+void DetectorInfo::setScanInterval(
+    const std::pair<size_t, size_t> &index,
+    const std::pair<int64_t, int64_t> &interval) {
   if (!m_scanIntervals)
     initScanIntervals();
   // We forbid this since we (currently?) can not verify that the new interval

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -404,6 +404,28 @@ public:
     TS_ASSERT_EQUALS(a.scanCount(1), 1);
   }
 
+  void test_merge_idempotent() {
+    DetectorInfo a(PosVec(2), RotVec(2), {1});
+    // Monitor at index 1, set up for identical interval
+    std::pair<int64_t, int64_t> monitorInterval(0, 2);
+    a.setScanInterval({1, 0}, monitorInterval);
+    a.setPosition(1, {0, 0, 0});
+    auto b(a);
+    Eigen::Vector3d pos1(1, 0, 0);
+    Eigen::Vector3d pos2(2, 0, 0);
+    a.setPosition(0, pos1);
+    b.setPosition(0, pos2);
+    std::pair<int64_t, int64_t> interval1(0, 1);
+    std::pair<int64_t, int64_t> interval2(1, 2);
+    a.setScanInterval({0, 0}, interval1);
+    b.setScanInterval({0, 0}, interval2);
+
+    TS_ASSERT_THROWS_NOTHING(a.merge(b));
+    auto a0(a);
+    TS_ASSERT_THROWS_NOTHING(a.merge(b));
+    TS_ASSERT(a.isEquivalent(a0));
+  }
+
   void test_merge_multiple() {
     DetectorInfo a(PosVec(2), RotVec(2), {1});
     // Monitor at index 1, set up for identical interval

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -268,23 +268,23 @@ public:
 
   void test_setScanInterval() {
     DetectorInfo info(PosVec(1), RotVec(1));
-    info.setScanInterval({0, 0}, {1, 2});
+    info.setScanInterval(0, {1, 2});
     TS_ASSERT_EQUALS(info.scanInterval({0, 0}),
                      (std::pair<int64_t, int64_t>(1, 2)));
   }
 
   void test_setScanInterval_failures() {
     DetectorInfo info(PosVec(1), RotVec(1));
-    TS_ASSERT_THROWS(info.setScanInterval({0, 0}, {1, 1}), std::runtime_error);
-    TS_ASSERT_THROWS(info.setScanInterval({0, 0}, {2, 1}), std::runtime_error);
+    TS_ASSERT_THROWS(info.setScanInterval(0, {1, 1}), std::runtime_error);
+    TS_ASSERT_THROWS(info.setScanInterval(0, {2, 1}), std::runtime_error);
   }
 
   void test_merge_fail_size() {
     DetectorInfo a(PosVec(1), RotVec(1));
     DetectorInfo b(PosVec(2), RotVec(2));
-    a.setScanInterval({0, 0}, {0, 1});
-    b.setScanInterval({0, 0}, {0, 1});
-    b.setScanInterval({1, 0}, {0, 1});
+    a.setScanInterval(0, {0, 1});
+    b.setScanInterval(0, {0, 1});
+    b.setScanInterval(1, {0, 1});
     TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
   }
 
@@ -293,25 +293,25 @@ public:
     DetectorInfo b(PosVec(1), RotVec(1));
     DetectorInfo c(PosVec(1), RotVec(1));
     TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
-    c.setScanInterval({0, 0}, {0, 1});
+    c.setScanInterval(0, {0, 1});
     TS_ASSERT_THROWS(a.merge(c), std::runtime_error);
-    a.setScanInterval({0, 0}, {0, 1});
+    a.setScanInterval(0, {0, 1});
     TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
   }
 
   void test_merge_fail_monitor_mismatch() {
     DetectorInfo a(PosVec(2), RotVec(2));
     DetectorInfo b(PosVec(2), RotVec(2), {1});
-    a.setScanInterval({0, 0}, {0, 1});
-    a.setScanInterval({1, 0}, {0, 1});
-    b.setScanInterval({0, 0}, {0, 1});
-    b.setScanInterval({1, 0}, {0, 1});
+    a.setScanInterval(0, {0, 1});
+    a.setScanInterval(1, {0, 1});
+    b.setScanInterval(0, {0, 1});
+    b.setScanInterval(1, {0, 1});
     TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
   }
 
   void test_merge_identical_interval_failures() {
     DetectorInfo a(PosVec(1), RotVec(1));
-    a.setScanInterval({0, 0}, {0, 1});
+    a.setScanInterval(0, {0, 1});
     Eigen::Vector3d pos1(1, 0, 0);
     Eigen::Vector3d pos2(2, 0, 0);
     Eigen::Quaterniond rot1(
@@ -345,7 +345,7 @@ public:
 
   void test_merge_identical_interval() {
     DetectorInfo a(PosVec(1), RotVec(1));
-    a.setScanInterval({0, 0}, {0, 1});
+    a.setScanInterval(0, {0, 1});
     const auto b(a);
     TS_ASSERT_THROWS_NOTHING(a.merge(b));
     TS_ASSERT(a.isEquivalent(b));
@@ -353,8 +353,8 @@ public:
 
   void test_merge_identical_interval_with_monitor() {
     DetectorInfo a(PosVec(2), RotVec(2), {1});
-    a.setScanInterval({0, 0}, {0, 1});
-    a.setScanInterval({1, 0}, {0, 1});
+    a.setScanInterval(0, {0, 1});
+    a.setScanInterval(1, {0, 1});
     const auto b(a);
     TS_ASSERT_THROWS_NOTHING(a.merge(b));
     TS_ASSERT(a.isEquivalent(b));
@@ -362,16 +362,16 @@ public:
 
   void test_merge_fail_partial_overlap() {
     DetectorInfo a(PosVec(2), RotVec(2));
-    a.setScanInterval({0, 0}, {0, 10});
-    a.setScanInterval({1, 0}, {0, 10});
+    a.setScanInterval(0, {0, 10});
+    a.setScanInterval(1, {0, 10});
     auto b(a);
     TS_ASSERT_THROWS_NOTHING(b.merge(a));
     b = a;
-    b.setScanInterval({1, 0}, {-1, 5});
+    b.setScanInterval(1, {-1, 5});
     TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
-    b.setScanInterval({1, 0}, {1, 5});
+    b.setScanInterval(1, {1, 5});
     TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
-    b.setScanInterval({1, 0}, {1, 11});
+    b.setScanInterval(1, {1, 11});
     TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
   }
 
@@ -379,7 +379,7 @@ public:
     DetectorInfo a(PosVec(2), RotVec(2), {1});
     // Monitor at index 1, set up for identical interval
     std::pair<int64_t, int64_t> monitorInterval(0, 2);
-    a.setScanInterval({1, 0}, monitorInterval);
+    a.setScanInterval(1, monitorInterval);
     auto b(a);
     Eigen::Vector3d pos1(1, 0, 0);
     Eigen::Vector3d pos2(2, 0, 0);
@@ -387,8 +387,8 @@ public:
     b.setPosition(0, pos2);
     std::pair<int64_t, int64_t> interval1(0, 1);
     std::pair<int64_t, int64_t> interval2(1, 2);
-    a.setScanInterval({0, 0}, interval1);
-    b.setScanInterval({0, 0}, interval2);
+    a.setScanInterval(0, interval1);
+    b.setScanInterval(0, interval2);
     TS_ASSERT_THROWS_NOTHING(a.merge(b));
     TS_ASSERT(a.isScanning());
     TS_ASSERT(!a.isEquivalent(b));
@@ -409,7 +409,7 @@ public:
     DetectorInfo a(PosVec(2), RotVec(2), {1});
     // Monitor at index 1, set up for identical interval
     std::pair<int64_t, int64_t> monitorInterval(0, 2);
-    a.setScanInterval({1, 0}, monitorInterval);
+    a.setScanInterval(1, monitorInterval);
     a.setPosition(1, {0, 0, 0});
     auto b(a);
     Eigen::Vector3d pos1(1, 0, 0);
@@ -418,8 +418,8 @@ public:
     b.setPosition(0, pos2);
     std::pair<int64_t, int64_t> interval1(0, 1);
     std::pair<int64_t, int64_t> interval2(1, 2);
-    a.setScanInterval({0, 0}, interval1);
-    b.setScanInterval({0, 0}, interval2);
+    a.setScanInterval(0, interval1);
+    b.setScanInterval(0, interval2);
 
     TS_ASSERT_THROWS_NOTHING(a.merge(b));
     auto a0(a);
@@ -431,7 +431,7 @@ public:
     DetectorInfo a(PosVec(2), RotVec(2), {1});
     // Monitor at index 1, set up for identical interval
     std::pair<int64_t, int64_t> monitorInterval(0, 3);
-    a.setScanInterval({1, 0}, monitorInterval);
+    a.setScanInterval(1, monitorInterval);
     auto b(a);
     auto c(a);
     Eigen::Vector3d pos1(1, 0, 0);
@@ -443,9 +443,9 @@ public:
     std::pair<int64_t, int64_t> interval1(0, 1);
     std::pair<int64_t, int64_t> interval2(1, 2);
     std::pair<int64_t, int64_t> interval3(2, 3);
-    a.setScanInterval({0, 0}, interval1);
-    b.setScanInterval({0, 0}, interval2);
-    c.setScanInterval({0, 0}, interval3);
+    a.setScanInterval(0, interval1);
+    b.setScanInterval(0, interval2);
+    c.setScanInterval(0, interval3);
     TS_ASSERT_THROWS_NOTHING(a.merge(b));
     TS_ASSERT_THROWS_NOTHING(a.merge(c));
     TS_ASSERT(a.isScanning());
@@ -479,9 +479,9 @@ public:
     std::pair<int64_t, int64_t> interval1(0, 1);
     std::pair<int64_t, int64_t> interval2(1, 2);
     std::pair<int64_t, int64_t> interval3(2, 3);
-    a1.setScanInterval({0, 0}, interval1);
-    b.setScanInterval({0, 0}, interval2);
-    c.setScanInterval({0, 0}, interval3);
+    a1.setScanInterval(0, interval1);
+    b.setScanInterval(0, interval2);
+    c.setScanInterval(0, interval3);
     auto a2(a1);
     TS_ASSERT_THROWS_NOTHING(a1.merge(b));
     TS_ASSERT_THROWS_NOTHING(a1.merge(c));

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -275,8 +275,14 @@ public:
 
   void test_setScanInterval_failures() {
     DetectorInfo info(PosVec(1), RotVec(1));
-    TS_ASSERT_THROWS(info.setScanInterval(0, {1, 1}), std::runtime_error);
-    TS_ASSERT_THROWS(info.setScanInterval(0, {2, 1}), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(
+        info.setScanInterval(0, {1, 1}), const std::runtime_error &e,
+        std::string(e.what()),
+        "DetectorInfo: cannot set scan interval with start >= end");
+    TS_ASSERT_THROWS_EQUALS(
+        info.setScanInterval(0, {2, 1}), const std::runtime_error &e,
+        std::string(e.what()),
+        "DetectorInfo: cannot set scan interval with start >= end");
   }
 
   void test_merge_fail_size() {
@@ -285,18 +291,26 @@ public:
     a.setScanInterval(0, {0, 1});
     b.setScanInterval(0, {0, 1});
     b.setScanInterval(1, {0, 1});
-    TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(a.merge(b), const std::runtime_error &e,
+                            std::string(e.what()),
+                            "Cannot merge DetectorInfo: size mismatch");
   }
 
   void test_merge_fail_no_intervals() {
     DetectorInfo a(PosVec(1), RotVec(1));
     DetectorInfo b(PosVec(1), RotVec(1));
     DetectorInfo c(PosVec(1), RotVec(1));
-    TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(
+        a.merge(b), const std::runtime_error &e, std::string(e.what()),
+        "Cannot merge DetectorInfo: scan intervals not defined");
     c.setScanInterval(0, {0, 1});
-    TS_ASSERT_THROWS(a.merge(c), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(
+        a.merge(c), const std::runtime_error &e, std::string(e.what()),
+        "Cannot merge DetectorInfo: scan intervals not defined");
     a.setScanInterval(0, {0, 1});
-    TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(
+        a.merge(b), const std::runtime_error &e, std::string(e.what()),
+        "Cannot merge DetectorInfo: scan intervals not defined");
   }
 
   void test_merge_fail_monitor_mismatch() {
@@ -306,7 +320,9 @@ public:
     a.setScanInterval(1, {0, 1});
     b.setScanInterval(0, {0, 1});
     b.setScanInterval(1, {0, 1});
-    TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(
+        a.merge(b), const std::runtime_error &e, std::string(e.what()),
+        "Cannot merge DetectorInfo: monitor flags mismatch");
   }
 
   void test_merge_identical_interval_failures() {
@@ -326,19 +342,28 @@ public:
 
     b = a;
     b.setMasked(0, false);
-    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(b.merge(a), const std::runtime_error &e,
+                            std::string(e.what()), "Cannot merge DetectorInfo: "
+                                                   "matching scan interval but "
+                                                   "mask flags differ");
     b.setMasked(0, true);
     TS_ASSERT_THROWS_NOTHING(b.merge(a));
 
     b = a;
     b.setPosition(0, pos2);
-    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(b.merge(a), const std::runtime_error &e,
+                            std::string(e.what()), "Cannot merge DetectorInfo: "
+                                                   "matching scan interval but "
+                                                   "positions differ");
     b.setPosition(0, pos1);
     TS_ASSERT_THROWS_NOTHING(b.merge(a));
 
     b = a;
     b.setRotation(0, rot2);
-    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(b.merge(a), const std::runtime_error &e,
+                            std::string(e.what()), "Cannot merge DetectorInfo: "
+                                                   "matching scan interval but "
+                                                   "rotations differ");
     b.setRotation(0, rot1);
     TS_ASSERT_THROWS_NOTHING(b.merge(a));
   }
@@ -368,11 +393,17 @@ public:
     TS_ASSERT_THROWS_NOTHING(b.merge(a));
     b = a;
     b.setScanInterval(1, {-1, 5});
-    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(
+        b.merge(a), const std::runtime_error &e, std::string(e.what()),
+        "Cannot merge DetectorInfo: scan intervals overlap but not identical");
     b.setScanInterval(1, {1, 5});
-    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(
+        b.merge(a), const std::runtime_error &e, std::string(e.what()),
+        "Cannot merge DetectorInfo: scan intervals overlap but not identical");
     b.setScanInterval(1, {1, 11});
-    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    TS_ASSERT_THROWS_EQUALS(
+        b.merge(a), const std::runtime_error &e, std::string(e.what()),
+        "Cannot merge DetectorInfo: scan intervals overlap but not identical");
   }
 
   void test_merge() {

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -405,6 +405,7 @@ public:
   }
 
   void test_merge_idempotent() {
+    // Test that A + B + B = A + B
     DetectorInfo a(PosVec(2), RotVec(2), {1});
     // Monitor at index 1, set up for identical interval
     std::pair<int64_t, int64_t> monitorInterval(0, 2);
@@ -464,8 +465,7 @@ public:
 
   void test_merge_multiple_associative() {
     // Test that (A + B) + C == A + (B + C)
-    // This is currently true given the implementation, but not a guarantee of
-    // the interface.
+    // This is implied by the ordering guaranteed by merge().
     DetectorInfo a1(PosVec(1), RotVec(1));
     a1.setRotation(0, Eigen::Quaterniond::Identity());
     auto b(a1);

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -273,6 +273,12 @@ public:
                      (std::pair<int64_t, int64_t>(1, 2)));
   }
 
+  void test_setScanInterval_failures() {
+    DetectorInfo info(PosVec(1), RotVec(1));
+    TS_ASSERT_THROWS(info.setScanInterval({0, 0}, {1, 1}), std::runtime_error);
+    TS_ASSERT_THROWS(info.setScanInterval({0, 0}, {2, 1}), std::runtime_error);
+  }
+
   void test_merge_fail_size() {
     DetectorInfo a(PosVec(1), RotVec(1));
     DetectorInfo b(PosVec(2), RotVec(2));

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -253,6 +253,211 @@ public:
     info.setRotation(0, rot);
     TS_ASSERT_EQUALS(info.rotation(0).coeffs(), rot.normalized().coeffs());
   }
+
+  void test_scanCount() {
+    DetectorInfo info(PosVec(1), RotVec(1));
+    TS_ASSERT_EQUALS(info.scanCount(0), 1);
+  }
+
+  void test_scanInterval() {
+    DetectorInfo info(PosVec(1), RotVec(1));
+    TS_ASSERT_EQUALS(info.scanInterval({0, 0}),
+                     (std::pair<int64_t, int64_t>(0, 0)));
+  }
+
+  void test_setScanInterval() {
+    DetectorInfo info(PosVec(1), RotVec(1));
+    info.setScanInterval({0, 0}, {1, 2});
+    TS_ASSERT_EQUALS(info.scanInterval({0, 0}),
+                     (std::pair<int64_t, int64_t>(1, 2)));
+  }
+
+  void test_merge_fail_size() {
+    DetectorInfo a(PosVec(1), RotVec(1));
+    DetectorInfo b(PosVec(2), RotVec(2));
+    a.setScanInterval({0, 0}, {0, 1});
+    b.setScanInterval({0, 0}, {0, 1});
+    b.setScanInterval({1, 0}, {0, 1});
+    TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
+  }
+
+  void test_merge_fail_no_intervals() {
+    DetectorInfo a(PosVec(1), RotVec(1));
+    DetectorInfo b(PosVec(1), RotVec(1));
+    DetectorInfo c(PosVec(1), RotVec(1));
+    TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
+    c.setScanInterval({0, 0}, {0, 1});
+    TS_ASSERT_THROWS(a.merge(c), std::runtime_error);
+    a.setScanInterval({0, 0}, {0, 1});
+    TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
+  }
+
+  void test_merge_fail_monitor_mismatch() {
+    DetectorInfo a(PosVec(2), RotVec(2));
+    DetectorInfo b(PosVec(2), RotVec(2), {1});
+    a.setScanInterval({0, 0}, {0, 1});
+    a.setScanInterval({1, 0}, {0, 1});
+    b.setScanInterval({0, 0}, {0, 1});
+    b.setScanInterval({1, 0}, {0, 1});
+    TS_ASSERT_THROWS(a.merge(b), std::runtime_error);
+  }
+
+  void test_merge_identical_interval_failures() {
+    DetectorInfo a(PosVec(1), RotVec(1));
+    a.setScanInterval({0, 0}, {0, 1});
+    Eigen::Vector3d pos1(1, 0, 0);
+    Eigen::Vector3d pos2(2, 0, 0);
+    Eigen::Quaterniond rot1(
+        Eigen::AngleAxisd(30.0, Eigen::Vector3d{1, 2, 3}.normalized()));
+    Eigen::Quaterniond rot2(
+        Eigen::AngleAxisd(31.0, Eigen::Vector3d{1, 2, 3}.normalized()));
+    a.setMasked(0, true);
+    a.setPosition(0, pos1);
+    a.setRotation(0, rot1);
+    auto b(a);
+    TS_ASSERT_THROWS_NOTHING(b.merge(a));
+
+    b = a;
+    b.setMasked(0, false);
+    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    b.setMasked(0, true);
+    TS_ASSERT_THROWS_NOTHING(b.merge(a));
+
+    b = a;
+    b.setPosition(0, pos2);
+    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    b.setPosition(0, pos1);
+    TS_ASSERT_THROWS_NOTHING(b.merge(a));
+
+    b = a;
+    b.setRotation(0, rot2);
+    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    b.setRotation(0, rot1);
+    TS_ASSERT_THROWS_NOTHING(b.merge(a));
+  }
+
+  void test_merge_identical_interval() {
+    DetectorInfo a(PosVec(1), RotVec(1));
+    a.setScanInterval({0, 0}, {0, 1});
+    const auto b(a);
+    TS_ASSERT_THROWS_NOTHING(a.merge(b));
+    TS_ASSERT(a.isEquivalent(b));
+  }
+
+  void test_merge_identical_interval_with_monitor() {
+    DetectorInfo a(PosVec(2), RotVec(2), {1});
+    a.setScanInterval({0, 0}, {0, 1});
+    a.setScanInterval({1, 0}, {0, 1});
+    const auto b(a);
+    TS_ASSERT_THROWS_NOTHING(a.merge(b));
+    TS_ASSERT(a.isEquivalent(b));
+  }
+
+  void test_merge_fail_partial_overlap() {
+    DetectorInfo a(PosVec(2), RotVec(2));
+    a.setScanInterval({0, 0}, {0, 10});
+    a.setScanInterval({1, 0}, {0, 10});
+    auto b(a);
+    TS_ASSERT_THROWS_NOTHING(b.merge(a));
+    b = a;
+    b.setScanInterval({1, 0}, {-1, 5});
+    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    b.setScanInterval({1, 0}, {1, 5});
+    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+    b.setScanInterval({1, 0}, {1, 11});
+    TS_ASSERT_THROWS(b.merge(a), std::runtime_error);
+  }
+
+  void test_merge() {
+    DetectorInfo a(PosVec(2), RotVec(2), {1});
+    // Monitor at index 1, set up for identical interval
+    std::pair<int64_t, int64_t> monitorInterval(0, 2);
+    a.setScanInterval({1, 0}, monitorInterval);
+    auto b(a);
+    Eigen::Vector3d pos1(1, 0, 0);
+    Eigen::Vector3d pos2(2, 0, 0);
+    a.setPosition(0, pos1);
+    b.setPosition(0, pos2);
+    std::pair<int64_t, int64_t> interval1(0, 1);
+    std::pair<int64_t, int64_t> interval2(1, 2);
+    a.setScanInterval({0, 0}, interval1);
+    b.setScanInterval({0, 0}, interval2);
+    TS_ASSERT_THROWS_NOTHING(a.merge(b));
+    TS_ASSERT(!a.isEquivalent(b));
+    TS_ASSERT_EQUALS(a.size(), 2);
+    TS_ASSERT_EQUALS(a.scanCount(0), 2);
+    // Note that the order is not guaranteed, currently these are just int the
+    // order in which the are merged.
+    TS_ASSERT_EQUALS(a.scanInterval({0, 0}), interval1);
+    TS_ASSERT_EQUALS(a.scanInterval({0, 1}), interval2);
+    TS_ASSERT_EQUALS(a.position({0, 0}), pos1);
+    TS_ASSERT_EQUALS(a.position({0, 1}), pos2);
+    // Monitor is not scanning
+    TS_ASSERT_EQUALS(a.scanCount(1), 1);
+  }
+
+  void test_merge_multiple() {
+    DetectorInfo a(PosVec(2), RotVec(2), {1});
+    // Monitor at index 1, set up for identical interval
+    std::pair<int64_t, int64_t> monitorInterval(0, 3);
+    a.setScanInterval({1, 0}, monitorInterval);
+    auto b(a);
+    auto c(a);
+    Eigen::Vector3d pos1(1, 0, 0);
+    Eigen::Vector3d pos2(2, 0, 0);
+    Eigen::Vector3d pos3(3, 0, 0);
+    a.setPosition(0, pos1);
+    b.setPosition(0, pos2);
+    c.setPosition(0, pos3);
+    std::pair<int64_t, int64_t> interval1(0, 1);
+    std::pair<int64_t, int64_t> interval2(1, 2);
+    std::pair<int64_t, int64_t> interval3(2, 3);
+    a.setScanInterval({0, 0}, interval1);
+    b.setScanInterval({0, 0}, interval2);
+    c.setScanInterval({0, 0}, interval3);
+    TS_ASSERT_THROWS_NOTHING(a.merge(b));
+    TS_ASSERT_THROWS_NOTHING(a.merge(c));
+    TS_ASSERT(!a.isEquivalent(b));
+    TS_ASSERT(!a.isEquivalent(c));
+    TS_ASSERT_EQUALS(a.size(), 2);
+    TS_ASSERT_EQUALS(a.scanCount(0), 3);
+    TS_ASSERT_EQUALS(a.scanInterval({0, 0}), interval1);
+    TS_ASSERT_EQUALS(a.scanInterval({0, 1}), interval2);
+    TS_ASSERT_EQUALS(a.scanInterval({0, 2}), interval3);
+    TS_ASSERT_EQUALS(a.position({0, 0}), pos1);
+    TS_ASSERT_EQUALS(a.position({0, 1}), pos2);
+    TS_ASSERT_EQUALS(a.position({0, 2}), pos3);
+    // Monitor is not scanning
+    TS_ASSERT_EQUALS(a.scanCount(1), 1);
+  }
+
+  void test_merge_multiple_associative() {
+    // Test that (A + B) + C == A + (B + C)
+    // This is currently true given the implementation, but not a guarentee of
+    // the interface.
+    DetectorInfo a1(PosVec(1), RotVec(1));
+    a1.setRotation(0, Eigen::Quaterniond::Identity());
+    auto b(a1);
+    auto c(a1);
+    Eigen::Vector3d pos1(1, 0, 0);
+    Eigen::Vector3d pos2(2, 0, 0);
+    Eigen::Vector3d pos3(3, 0, 0);
+    a1.setPosition(0, pos1);
+    b.setPosition(0, pos2);
+    c.setPosition(0, pos3);
+    std::pair<int64_t, int64_t> interval1(0, 1);
+    std::pair<int64_t, int64_t> interval2(1, 2);
+    std::pair<int64_t, int64_t> interval3(2, 3);
+    a1.setScanInterval({0, 0}, interval1);
+    b.setScanInterval({0, 0}, interval2);
+    c.setScanInterval({0, 0}, interval3);
+    auto a2(a1);
+    TS_ASSERT_THROWS_NOTHING(a1.merge(b));
+    TS_ASSERT_THROWS_NOTHING(a1.merge(c));
+    TS_ASSERT_THROWS_NOTHING(b.merge(c));
+    TS_ASSERT_THROWS_NOTHING(a2.merge(b));
+    TS_ASSERT(a1.isEquivalent(a2));
+  }
 };
 
 #endif /* MANTID_BEAMLINE_DETECTORINFOTEST_H_ */

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -464,7 +464,7 @@ public:
 
   void test_merge_multiple_associative() {
     // Test that (A + B) + C == A + (B + C)
-    // This is currently true given the implementation, but not a guarentee of
+    // This is currently true given the implementation, but not a guarantee of
     // the interface.
     DetectorInfo a1(PosVec(1), RotVec(1));
     a1.setRotation(0, Eigen::Quaterniond::Identity());

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -25,6 +25,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         detInfo = Kernel::make_unique<DetectorInfo>(PosVec(1), RotVec(1)));
     TS_ASSERT_EQUALS(detInfo->size(), 1);
+    TS_ASSERT(!detInfo->isScanning());
   }
 
   void test_constructor_with_monitors() {
@@ -383,6 +384,7 @@ public:
     a.setScanInterval({0, 0}, interval1);
     b.setScanInterval({0, 0}, interval2);
     TS_ASSERT_THROWS_NOTHING(a.merge(b));
+    TS_ASSERT(a.isScanning());
     TS_ASSERT(!a.isEquivalent(b));
     TS_ASSERT_EQUALS(a.size(), 2);
     TS_ASSERT_EQUALS(a.scanCount(0), 2);
@@ -417,6 +419,7 @@ public:
     c.setScanInterval({0, 0}, interval3);
     TS_ASSERT_THROWS_NOTHING(a.merge(b));
     TS_ASSERT_THROWS_NOTHING(a.merge(c));
+    TS_ASSERT(a.isScanning());
     TS_ASSERT(!a.isEquivalent(b));
     TS_ASSERT(!a.isEquivalent(c));
     TS_ASSERT_EQUALS(a.size(), 2);

--- a/Framework/PythonInterface/mantid/api/src/Exports/DetectorInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/DetectorInfo.cpp
@@ -9,6 +9,9 @@ void export_DetectorInfo() {
   // its functionality to Python, and should not yet be used in user scripts. DO
   // NOT ADD EXPORTS TO OTHER METHODS without contacting the team working on
   // Instrument-2.0.
+  bool (DetectorInfo::*isMonitor)(const size_t) const =
+      &DetectorInfo::isMonitor;
+  bool (DetectorInfo::*isMasked)(const size_t) const = &DetectorInfo::isMasked;
   class_<DetectorInfo, boost::noncopyable>("DetectorInfo", no_init)
       .def("__len__", &DetectorInfo::size, (arg("self")),
            "Returns the size of the DetectorInfo, i.e., the number of "
@@ -16,8 +19,8 @@ void export_DetectorInfo() {
       .def("size", &DetectorInfo::size, (arg("self")),
            "Returns the size of the DetectorInfo, i.e., the number of "
            "detectors in the instrument.")
-      .def("isMonitor", &DetectorInfo::isMonitor, (arg("self"), arg("index")),
+      .def("isMonitor", isMonitor, (arg("self"), arg("index")),
            "Returns True if the detector is a monitor.")
-      .def("isMasked", &DetectorInfo::isMasked, (arg("self"), arg("index")),
+      .def("isMasked", isMasked, (arg("self"), arg("index")),
            "Returns True if the detector is masked.");
 }


### PR DESCRIPTION
This PR adds an (optional) time index to methods of `DetectorInfo`. It can now be accessed with the complete index stored in `SpectrumDefinition` (obtained from `SpectrumInfo::spectrumDefinition()`). With this time index, we support scanning, with certain limitations:

- Scanning of detectors is support, but not of any higher-level method.
- Code that accesses the position or the rotation of an `IDetector` for a scanning workspace will fail. Currently this is `solidAngle`, `getBoundingBox`, and low level code such as ray tracing. Only access via `DetectorInfo` or `SpectrumInfo` is supported (position, rotation, L2, twoTheta).
- All scan positions will yield the same parameters obtained from the parameter map.

`DetectorInfo` will now do a more complex index translation, however, a mechanism that should ensure close to zero overhead for non-scanning cases was put in place.

**To test:**

Thorough code review.

Fixes #19016.

Internal change, no release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
