### PR TITLE
fix SNAP calibration bug

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/CalibrateRectangularDetectors.py
+++ b/Framework/PythonInterface/plugins/algorithms/CalibrateRectangularDetectors.py
@@ -375,14 +375,14 @@ class CalibrateRectangularDetectors(PythonAlgorithm):
         if wksp is None:
             return None
         MaskDetectors(Workspace=wksp, MaskedWorkspace=str(wksp)+"mask")
-        wksp = AlignDetectors(InputWorkspace=wksp, OutputWorkspace=wksp.name(),
+        wksp = AlignDetectors(InputWorkspace=wksp, OutputWorkspace=wksp,
                               CalibrationWorkspace=str(wksp)+"cal")
         # Diffraction focusing using new calibration file with offsets
         if self._diffractionfocus:
-            wksp = DiffractionFocussing(InputWorkspace=wksp, OutputWorkspace=wksp.name(),
+            wksp = DiffractionFocussing(InputWorkspace=wksp, OutputWorkspace=wksp,
                                         GroupingWorkspace=str(wksp)+"group")
 
-        wksp = Rebin(InputWorkspace=wksp, OutputWorkspace=wksp.name(), Params=self._binning)
+        wksp = Rebin(InputWorkspace=wksp, OutputWorkspace=wksp, Params=self._binning)
         return wksp
 
     def _initCCpars(self):

--- a/Testing/SystemTests/tests/analysis/CalibrateRectangularDetector_Test.py
+++ b/Testing/SystemTests/tests/analysis/CalibrateRectangularDetector_Test.py
@@ -36,7 +36,7 @@ class PG3Calibration(stresstesting.MantidStressTest):
 
         # run the actual code
         output = CalibrateRectangularDetectors(OutputDirectory = savedir, SaveAs = 'calibration', FilterBadPulses = True,
-                                               GroupDetectorsBy = 'All', DiffractionFocusWorkspace = False,
+                                               GroupDetectorsBy = 'All', DiffractionFocusWorkspace = True,
                                                Binning = '0.5, -0.0004, 2.5',
                                                MaxOffset=0.01, PeakPositions = '.6866,.7283,.8185,.8920,1.0758,1.2615,2.0599',
                                                CrossCorrelation = False, RunNumber = 'PG3_2538')


### PR DESCRIPTION
Description of work.
Calibration for SNAP is running again.  wksp.name() was used in the focusing and for some reason this stopped working in python algorithm.  Bug: I am trying to run it with two run numbers – on mantidplotnightly:
 
36249 on peak 2.03 and
36267 on peak 2.36
 
And it always crashes with the error:
 
MaskDetectors successful, Duration 1.57 seconds
Error in execution of algorithm CalibrateRectangularDetectors:
'str' object has no attribute 'name'
  at line 510 in '/opt/mantidnightly/plugins/python/algorithms/CalibrateRectangularDetectors.py'
  caused by line 378 in '/opt/mantidnightly/plugins/python/algorithms/CalibrateRectangularDetectors.py' 

**To test:**
![image003](https://cloud.githubusercontent.com/assets/1108354/23853194/d79f14fe-07c1-11e7-8d91-9da1b6abf32e.jpg)


Fixes #19121

<!-- RELEASE NOTES

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.

