### PR TITLE
Cleanup result workspaces from Fit in FindEPP

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/FindEPP.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindEPP.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function)
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, ITableWorkspaceProperty
 from mantid.kernel import Direction
-from mantid.simpleapi import Fit, CreateEmptyTableWorkspace
+from mantid.simpleapi import CreateEmptyTableWorkspace, DeleteWorkspace, Fit
 import numpy as np
 
 
@@ -92,11 +92,11 @@ class FindEPP(PythonAlgorithm):
         startX = tryCentre - 3.0*fwhm
         endX   = tryCentre + 3.0*fwhm
 
+        tempOutputPrefix = "__EPPfit_" + str(self.workspace) + "_" + str(index)
         # pylint: disable=assignment-from-none
         # result = fitStatus, chiSq, covarianceTable, paramTable
         result = Fit(InputWorkspace=self.workspace, WorkspaceIndex=index, StartX = startX, EndX=endX,
-                     Output='EPPfit', Function=fitFun, CreateOutput=True, OutputParametersOnly=True)
-
+                     Output=tempOutputPrefix, Function=fitFun, CreateOutput=True, OutputParametersOnly=True)
         return result
 
     def PyExec(self):
@@ -129,10 +129,9 @@ class FindEPP(PythonAlgorithm):
                     name = row["Name"]
                     nextrow[name] = row["Value"]
                     nextrow[name+"Error"] = row["Error"]
-
-            # self.log().debug("Next row= " + str(nextrow))
+                DeleteWorkspace(result.OutputParameters)
+                DeleteWorkspace(result.OutputNormalisedCovarianceMatrix)
             outws.addRow(nextrow)
-
         self.setProperty("OutputWorkspace", outws)
         return
 

--- a/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
@@ -274,14 +274,6 @@ class MatchPeaks(PythonAlgorithm):
         # Clean-up unused TableWorkspaces in try-catch
         # Direct deletion causes problems when running in parallel for too many workspaces
         try:
-            DeleteWorkspace('EPPfit_Parameters')
-        except ValueError:
-            logger.debug('Fit parameters workspace already deleted')
-        try:
-            DeleteWorkspace('EPPfit_NormalisedCovarianceMatrix')
-        except ValueError:
-            logger.debug('Fit covariance matrix already deleted')
-        try:
             DeleteWorkspace(fit_table)
         except ValueError:
             logger.debug('Fit table already deleted')

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindEPPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindEPPTest.py
@@ -1,12 +1,11 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
+import mantid
 from mantid.simpleapi import DeleteWorkspace, CreateSampleWorkspace, CloneWorkspace, GroupWorkspaces
-from testhelpers import run_algorithm
-from mantid.api import AnalysisDataService, WorkspaceGroup
+from mantid.api import AnalysisDataService, WorkspaceGroup, mtd
 import numpy as np
-
-
+from testhelpers import run_algorithm
 
 
 class FindEPPTest(unittest.TestCase):
@@ -101,6 +100,16 @@ class FindEPPTest(unittest.TestCase):
 
         run_algorithm("DeleteWorkspace", Workspace=wsoutput)
         run_algorithm("DeleteWorkspace", Workspace=ws_narrow)
+
+    def testFitOutputWorkspacesAreDeleted(self):
+        OutputWorkspaceName = "outputws1"
+        alg_test = run_algorithm("FindEPP", InputWorkspace=self._input_ws, OutputWorkspace=OutputWorkspaceName)
+        wsoutput = AnalysisDataService.retrieve(OutputWorkspaceName)
+        DeleteWorkspace(wsoutput)
+        oldOption = mantid.config['MantidOptions.InvisibleWorkspaces']
+        mantid.config['MantidOptions.InvisibleWorkspaces'] = '1'
+        self.assertEqual(mtd.size(), 1) # Only self._input_ws exists.
+        mantid.config['MantidOptions.InvisibleWorkspaces'] = oldOption
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -23,9 +23,10 @@ New
 Improved
 ########
 
-- :ref`RawFileInfo <algm-RawFileInfo-v1>` now provides sample information.
-- :ref`SetInstrumentParameter <algm-SetInstrumentParameter-v1>` now supports also boolean parameters, and better validates the inputs.
+- :ref:`RawFileInfo <algm-RawFileInfo-v1>` now provides sample information.
+- :ref:`SetInstrumentParameter <algm-SetInstrumentParameter-v1>` now supports also boolean parameters, and better validates the inputs.
 - Two new properties were added to :ref:`algm-Integration`: *RangeLowerList* and *RangeUpperList* can be used to give histogram-specific integration ranges.
+- :ref:`algm-FindEPP` does not output the two extra workspaces from the :ref:`algm-Fit` anymore.
 
 Bug Fixes
 #########


### PR DESCRIPTION
This PR changes [`FindEPP`](http://docs.mantidproject.org/nightly/algorithms/FindEPP-v1.html)  so that the output workspaces of the [`Fit`](http://docs.mantidproject.org/nightly/algorithms/Fit-v1.html) algorithm get deleted.

**To test:**

<!-- Instructions for testing. -->

1. Make sure that hidden workspaces are shown:
```python
mantid.config['MantidOptions.InvisibleWorkspaces'] = '1'
```
2. The following script should create only two workspaces: `ws` and `epps`.
```python
import numpy

ws = CreateSampleWorkspace(
    Function='Flat background',
    NumBanks=1,
    BankPixelWidth=1,
)

for i in range(ws.getNumberHistograms()):
    xs = ws.readX(i)
    ys = ws.dataY(i)
    for j in range(len(ys)):
        x = xs[j]
        ys[j] = 2000.0 * numpy.exp(-(5000 - x)**2/108800.0)

epps = FindEPP(ws)
```

Fixes #19125.


*Release notes have been updated accordingly.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
