### PR TITLE
Use ccache if it is available

### DIFF
--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -6,6 +6,15 @@
 # project settings should be included in the relevant CMakeLists.txt file
 # for that project.
 
+option ( USE_CCACHE "Use ccache to cache object artifacts if available" ON )
+if ( USE_CCACHE )
+  find_program(CCACHE_FOUND ccache)
+  if(CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+  endif()
+endif()
+
 # Set our own compiler version flag from the cmake one and export it globally
 if ( CMAKE_COMPILER_IS_GNUCXX )
   set( GCC_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION} CACHE INTERNAL "")


### PR DESCRIPTION
Description of work.

Checks for presence of the ccache command and uses this for compilation if available. `ccache` caches the compiled object files so that subsequent clean rebuilds are many times faster.

**To test:**

This applies only to Linux/macOS.

* install `ccache`
* run a clean cmake configuration
* compile the `Kernel` library
* `clean` the build 
* recompile the kernel target and it will compile in a few seconds.

No issue number

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
