### PR TITLE
Bug fix for default values of prompt peak correction for LOQ

### DIFF
--- a/docs/source/release/v3.10.0/sans.rst
+++ b/docs/source/release/v3.10.0/sans.rst
@@ -12,5 +12,6 @@ Bug Fixes
 - Fixed LOQ Batch mode bug where geometry information was not saved out when using SaveCanSAS1D.
 - Fixed LOQ Batch mode bug where custom user file without a .txt ending was not being picked up.
 - Fixed Batch mode bug where the output name suffix was hardcoded to SANS2D. It now takes the individual instruments into account.
+- Fixed LOQ bug where prompt peak was not set correctly for monitor normalisation.
 
 `Full list of changes on github <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.10%22+is%3Amerged+label%3A%22Component%3A+SANS%22>`__

--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -1937,6 +1937,8 @@ class NormalizeToMonitor(ReductionStep):
         self.output_wksp = None
 
     def execute(self, reducer, workspace):
+        self.set_prompt_parameter_if_not_set(reducer)
+
         normalization_spectrum = self._normalization_spectrum
         if normalization_spectrum is None:
             # the -1 converts from spectrum number to spectrum index
@@ -1979,6 +1981,18 @@ class NormalizeToMonitor(ReductionStep):
         else:
             r_alg = 'Rebin'
         reducer.to_wavelen.execute(reducer, self.output_wksp, bin_alg=r_alg)
+
+    def set_prompt_parameter_if_not_set(self, reducer):
+        """
+        This method sets default prompt peak values in case the user has not provided some. Currently
+        we only use default values for LOQ.
+        """
+        is_prompt_peak_not_set = reducer.transmission_calculator.removePromptPeakMin is None and\
+                                 reducer.transmission_calculator.removePromptPeakMax is None
+        if is_prompt_peak_not_set:
+            if reducer.instrument.name() == "LOQ":
+                reducer.transmission_calculator.removePromptPeakMin = 19000.0 # Units of micro-seconds
+                reducer.transmission_calculator.removePromptPeakMax = 20500.0 # Units of micro-seconds
 
 
 class TransmissionCalc(ReductionStep):

--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -1987,12 +1987,11 @@ class NormalizeToMonitor(ReductionStep):
         This method sets default prompt peak values in case the user has not provided some. Currently
         we only use default values for LOQ.
         """
-        is_prompt_peak_not_set = reducer.transmission_calculator.removePromptPeakMin is None and\
-                                 reducer.transmission_calculator.removePromptPeakMax is None
-        if is_prompt_peak_not_set:
+        if (reducer.transmission_calculator.removePromptPeakMin is None and
+           reducer.transmission_calculator.removePromptPeakMax is None):
             if reducer.instrument.name() == "LOQ":
-                reducer.transmission_calculator.removePromptPeakMin = 19000.0 # Units of micro-seconds
-                reducer.transmission_calculator.removePromptPeakMax = 20500.0 # Units of micro-seconds
+                reducer.transmission_calculator.removePromptPeakMin = 19000.0  # Units of micro-seconds
+                reducer.transmission_calculator.removePromptPeakMax = 20500.0  # Units of micro-seconds
 
 
 class TransmissionCalc(ReductionStep):


### PR DESCRIPTION
Fixes #19138

The prompt peak correction was not performed correctly for LOQ. This makes sure that the default values for the monitor normalization for LOQ are set up correctly. This is a regression from M3.8

**To test:**

Testing this is a bit involved. You will require the test files from here:smb://olympic/babylon5/Scratch/Anton/LOQ_Prompt_Peak_Fix
Note that this folder also contains a Windows installer which you can use for testing.

We will be running a test script for this version, for 3.9.1. and for 3.8. Since you can easily install several versions of Mantid next to each other on Windows, that might be a good platform to test this PR.

1. Run the following script in each version. Make sure that the test data is in the Mantid path:
```python
import ISISCommandInterface as i_old
import SANSBatchMode as i_old_batch
i_old.Clean()
MASKFILE = FileFinder.getFullPath('MASKLOQ_MAN_133E_Hornqvist_6mm_Furnace_MERGED.txt')
BATCHFILE = FileFinder.getFullPath('reduce_fe35cr_500c_merged_2.csv')
i_old.LOQ()
i_old.MaskFile(MASKFILE)
i_old_batch.BatchReduce(BATCHFILE, format='.nxs', saveAlgs={"SaveCanSAS1D": ".xml"}, combineDet="merged")
```
2. M3.9.1 and the version with the fix will output a workspace wit the name `80523_merged_hab`, the equivalient workspace on M3.8 is called `80523_merged_front`. Save the workspaces to file for each version

3. Load the three files into any version and plot the workspaces against each other.
  Confirm that the workspace from  3.8 and the fixed version overlap. Confirm that the workspace from 3.9.1 is off.

The output should look like this

![image](https://cloud.githubusercontent.com/assets/8955784/23939805/40b92134-095a-11e7-99ab-f944a7705990.png)

![image](https://cloud.githubusercontent.com/assets/8955784/23939757/103b2444-095a-11e7-820c-a7228044b229.png)

Note that the red and the black line overlap and therefore only the red is visible


##### Release notes

See [here](https://github.com/mantidproject/mantid/pull/19141/commits/0efa53ef1c6c4bf95c58db02dad3fd51016edd7f)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
