### PR TITLE
ConvertToMD: Relax checks for CopyToMD mode

### DIFF
--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -72,6 +72,15 @@ void backtraceToStream(std::ostream &os) {
  */
 void terminateHandler() {
   std::cerr << "\n********* UNHANDLED EXCEPTION *********\n";
+  try {
+    std::rethrow_exception(std::current_exception());
+  } catch (const std::exception &exc) {
+    std::cerr << "  what(): " << exc.what() << "\n\n";
+  } catch (...) {
+    std::cerr << "  what(): Unknown exception type. No more information "
+                 "available\n\n";
+  }
+  std::cerr << "Backtrace:\n";
   backtraceToStream(std::cerr);
   exit(1);
 }

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -327,22 +327,24 @@ void ConvertToMD::copyMetaData(API::IMDEventWorkspace_sptr &mdEventWS) const {
 
   // found detector which is not a monitor to get proper bin boundaries.
   size_t spectra_index(0);
-  bool dector_found(false);
+  bool detector_found(false);
   const auto &spectrumInfo = m_InWS2D->spectrumInfo();
   for (size_t i = 0; i < m_InWS2D->getNumberHistograms(); ++i) {
     if (spectrumInfo.hasDetectors(i) && spectrumInfo.isMonitor(i)) {
       spectra_index = i;
-      dector_found = true;
+      detector_found = true;
       g_log.debug() << "Using spectra N " << i
                     << " as the source of the bin "
                        "boundaries for the resolution corrections \n";
       break;
     }
   }
-  if (!dector_found)
-    g_log.warning() << "No detectors in the workspace are associated with "
-                       "spectra. Using spectrum 0 trying to retrieve the bin "
-                       "boundaries \n";
+  if (!detector_found) {
+    g_log.information()
+        << "No spectra in the workspace have detectors associated "
+           "with them. Storing bin boundaries from first spectrum for"
+           "resolution calculation\n";
+  }
 
   // retrieve representative bin boundaries
   auto binBoundaries = m_InWS2D->x(spectra_index);
@@ -359,8 +361,8 @@ void ConvertToMD::copyMetaData(API::IMDEventWorkspace_sptr &mdEventWS) const {
 
       UnitsConversionHelper &unitConv = m_Convertor->getUnitConversionHelper();
       unitConv.updateConversion(spectra_index);
-      for (auto &binBoundarie : binBoundaries) {
-        binBoundarie = unitConv.convertUnits(binBoundarie);
+      for (auto &binBoundary : binBoundaries) {
+        binBoundary = unitConv.convertUnits(binBoundary);
       }
     }
     // sort bin boundaries in case if unit transformation have swapped them.

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -25,6 +25,7 @@
 #include "MantidGeometry/MDGeometry/MDHistoDimensionBuilder.h"
 
 #include "MantidMDAlgorithms/ConvToMDSelector.h"
+#include "MantidMDAlgorithms/MDTransfQ3D.h"
 #include "MantidMDAlgorithms/MDWSTransform.h"
 
 using namespace Mantid::API;
@@ -196,6 +197,25 @@ void ConvertToMD::exec() {
   // get the min and max values for the dimensions from the input properties
   std::vector<double> dimMin = getProperty("MinValues");
   std::vector<double> dimMax = getProperty("MaxValues");
+
+  // Sanity check some options
+  if (QModReq != MDTransfQ3D().transfID()) {
+    MDWSTransform transform;
+    const std::string autoSelect =
+        transform.getTargetFrames()[CnvrtToMD::AutoSelect];
+    if (QFrame != autoSelect) {
+      g_log.warning("Q3DFrames value ignored with QDimensions != " +
+                    MDTransfQ3D().transfID());
+      QFrame = autoSelect;
+    }
+    const std::string noScaling =
+        transform.getQScalings()[CnvrtToMD::NoScaling];
+    if (convertTo_ != noScaling) {
+      g_log.warning("QConversionScales value ignored with QDimensions !=" +
+                    MDTransfQ3D().transfID());
+      convertTo_ = noScaling;
+    }
+  }
 
   // Build the target ws description as function of the input & output ws and
   // the parameters, supplied to the algorithm

--- a/Framework/MDAlgorithms/src/MDWSTransform.cpp
+++ b/Framework/MDAlgorithms/src/MDWSTransform.cpp
@@ -120,11 +120,9 @@ std::vector<double>
 MDWSTransform::getTransfMatrix(MDWSDescription &TargWSDescription,
                                CnvrtToMD::TargetFrame FrameID,
                                CoordScaling &ScaleID) const {
-
   Kernel::Matrix<double> mat(3, 3, true);
 
   bool powderMode = TargWSDescription.isPowder();
-
   bool has_lattice(true);
   if (!TargWSDescription.hasLattice())
     has_lattice = false;
@@ -132,23 +130,18 @@ MDWSTransform::getTransfMatrix(MDWSDescription &TargWSDescription,
   if (!(powderMode || has_lattice)) {
     std::string inWsName = TargWSDescription.getWSName();
     // notice about 3D case without lattice
-    g_Log.notice()
+    g_Log.information()
         << "Can not obtain transformation matrix from the input workspace: "
         << inWsName << " as no oriented lattice has been defined. \n"
                        "Will use unit transformation matrix.\n";
   }
   // set the frame ID to the values, requested by properties
   CnvrtToMD::TargetFrame CoordFrameID(FrameID);
-  if (FrameID == AutoSelect || powderMode) // if this value is auto-select, find
-                                           // appropriate frame from workspace
-                                           // properties
+  if (FrameID == AutoSelect || powderMode) {
     CoordFrameID = findTargetFrame(TargWSDescription);
-  else // if not, and specific target frame requested, verify if everything is
-       // available on the workspace for this frame
-    checkTargetFrame(
-        TargWSDescription,
-        CoordFrameID); // throw, if the information is not available
-
+  } else {
+    checkTargetFrame(TargWSDescription, CoordFrameID);
+  }
   switch (CoordFrameID) {
   case (CnvrtToMD::LabFrame): {
     ScaleID = NoScaling;

--- a/Framework/MDAlgorithms/test/ConvertToMDTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDTest.h
@@ -125,6 +125,9 @@ public:
     pAlg->setPropertyValue("OutputWorkspace", "WS3DNoQ");
     pAlg->setPropertyValue("PreprocDetectorsWS", "");
     pAlg->setPropertyValue("QDimensions", "CopyToMD");
+    // Following 2 arguments should be ignored
+    pAlg->setPropertyValue("Q3DFrames", "HKL");
+    pAlg->setPropertyValue("QConversionScales", "HKL");
     pAlg->setPropertyValue("OtherDimensions", "phi,chi");
     //    TS_ASSERT_THROWS_NOTHING(pAlg->setPropertyValue("dEAnalysisMode",
     //    "NoDE"));

--- a/Framework/MDAlgorithms/test/ConvertToMDTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDTest.h
@@ -125,9 +125,13 @@ public:
     pAlg->setPropertyValue("OutputWorkspace", "WS3DNoQ");
     pAlg->setPropertyValue("PreprocDetectorsWS", "");
     pAlg->setPropertyValue("QDimensions", "CopyToMD");
-    // Following 2 arguments should be ignored
+    // Following 5 arguments should be ignored
     pAlg->setPropertyValue("Q3DFrames", "HKL");
     pAlg->setPropertyValue("QConversionScales", "HKL");
+    pAlg->setPropertyValue("UProj", "0,0,1");
+    pAlg->setPropertyValue("VProj", "1,0,0");
+    pAlg->setPropertyValue("WProj", "0,1,0");
+
     pAlg->setPropertyValue("OtherDimensions", "phi,chi");
     //    TS_ASSERT_THROWS_NOTHING(pAlg->setPropertyValue("dEAnalysisMode",
     //    "NoDE"));


### PR DESCRIPTION
Description of work.

Ignores `Q3DFrames` & `QConversionScales` arguments if the transform mode is not `Q3D`

**To test:**

The test file is part of the SystemTestData.

```
Load(Filename='ExternalData/Testing/SystemTests/tests/analysis/reference/MARIReduction.nxs', OutputWorkspace='MARIReduction')
SofQWNormalisedPolygon(InputWorkspace='MARIReduction', OutputWorkspace='SofQW', QAxisBinning='0.1,0.01,4.5', EMode='Direct')
ConvertToMD(InputWorkspace='SofQW', OutputWorkspace='sqw_md', Q3DFrames='HKL')
```

Before these changes the algorithm would stop and claim that a UB matrix is required. After these changes it should complete successfully.

Fixes #19136.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
