### PR TITLE
Bad double checked locking in ExperimentInfo::detectorInfo().

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -220,8 +220,7 @@ private:
   mutable std::recursive_mutex m_mutex;
 
   boost::shared_ptr<Beamline::DetectorInfo> m_detectorInfo;
-  mutable std::unique_ptr<DetectorInfo> m_detectorInfoWrapper;
-  mutable std::mutex m_detectorInfoMutex;
+  std::unique_ptr<DetectorInfo> m_detectorInfoWrapper;
 
   mutable std::unique_ptr<Beamline::SpectrumInfo> m_spectrumInfo;
   mutable std::unique_ptr<SpectrumInfo> m_spectrumInfoWrapper;


### PR DESCRIPTION
Locking in this way without memory fences is broken. We fix this by simply avoiding it.

Note that `ExperimentInfo::spectrumInfo()` suffers from the same problem. It will be dealt with in another pull request, since it will be easier to deal with once some unrelated work on Instrument-2.0 is finished.

**To test:**

Code review.

No issue, not release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
