### PR TITLE
Bug in output from multi-domain fitting.

### DIFF
--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -206,9 +206,7 @@ std::string IFunction::asString() const {
   }
   // print the parameters
   for (size_t i = 0; i < nParams(); i++) {
-    if (!isFixed(i)) {
-      ostr << ',' << parameterName(i) << '=' << getParameter(i);
-    }
+    ostr << ',' << parameterName(i) << '=' << getParameter(i);
   }
 
   // collect non-default constraints

--- a/Framework/API/test/FunctionFactoryTest.h
+++ b/Framework/API/test/FunctionFactoryTest.h
@@ -433,9 +433,9 @@ public:
   void test_MultiDomainFunction_creation_moreComplex() {
     const std::string fnString =
         "composite=MultiDomainFunction,NumDeriv=true;(name=FunctionFactoryTest_"
-        "FunctA,a0=0,a1=0.5;name=FunctionFactoryTest_FunctB,b0=0.1,ties="
+        "FunctA,a0=0,a1=0.5;name=FunctionFactoryTest_FunctB,b0=0.1,b1=0.2,ties="
         "(b1=0.2),$domains=i);(name=FunctionFactoryTest_FunctA,a0=0,a1=0.5;"
-        "name=FunctionFactoryTest_FunctB,b0=0.1,$domains=i);ties=(f1.f1."
+        "name=FunctionFactoryTest_FunctB,b0=0.1,b1=0.2,$domains=i);ties=(f1.f1."
         "b1=f0.f1.b1)";
     IFunction_sptr fun;
     TS_ASSERT_THROWS_NOTHING(

--- a/Framework/API/test/ImmutableCompositeFunctionTest.h
+++ b/Framework/API/test/ImmutableCompositeFunctionTest.h
@@ -279,10 +279,9 @@ public:
     icf.addTies("b2=b1,a2=a1/5");
     icf.applyTies();
 
-    TS_ASSERT_EQUALS(
-        icf.asString(),
-        "name=ImmutableCompositeFunctionTest_"
-        "Function,NumDeriv=false,a1=11,b1=12,ties=(a2=a1/5,b2=b1)");
+    TS_ASSERT_EQUALS(icf.asString(), "name=ImmutableCompositeFunctionTest_"
+                                     "Function,NumDeriv=false,a1=11,b1=12,a2=2."
+                                     "2,b2=12,ties=(a2=a1/5,b2=b1)");
 
     auto fun = FunctionFactory::Instance().createInitialized(icf.asString());
     TS_ASSERT(fun);
@@ -309,7 +308,7 @@ public:
 
     TS_ASSERT_EQUALS(icf.asString(), "name=ImmutableCompositeFunctionTest_"
                                      "FunctionWithTies,NumDeriv=false,a1=1,b1="
-                                     "2");
+                                     "2,a2=0.25,b2=1");
 
     auto fun = FunctionFactory::Instance().createInitialized(icf.asString());
     TS_ASSERT(fun);

--- a/Framework/API/test/MultiDomainFunctionTest.h
+++ b/Framework/API/test/MultiDomainFunctionTest.h
@@ -441,14 +441,29 @@ public:
   }
 
   void test_string_representation() {
-    const std::string expected =
-        "composite=MultiDomainFunction,NumDeriv=true;"
-        "name=MultiDomainFunctionTest_Function,A=0,B=1,$domains=i;"
-        "name=MultiDomainFunctionTest_Function,B=2,$domains=i;"
-        "name=MultiDomainFunctionTest_Function,B=3,$domains=i;ties=(f1.A="
-        "f0.A,f2.A=f0.A)";
+    const std::string expected = "composite=MultiDomainFunction,NumDeriv=true;"
+                                 "name=MultiDomainFunctionTest_Function,A=0,B="
+                                 "1,$domains=i;name=MultiDomainFunctionTest_"
+                                 "Function,A=0,B=2,$domains=i;name="
+                                 "MultiDomainFunctionTest_Function,A=0,B=3,$"
+                                 "domains=i;ties=(f1.A=f0.A,f2.A=f0.A)";
     TS_ASSERT_EQUALS(multi.asString(), expected);
     TS_ASSERT_EQUALS(multi.asString(), multi.clone()->asString());
+  }
+
+  void test_equivalent_functions() {
+    std::string ini =
+        "composite=MultiDomainFunction;"
+        "name=MultiDomainFunctionTest_Function,A=1,B=2,$domains=i;"
+        "name=MultiDomainFunctionTest_Function,A=3,B=4,$domains=i;ties=(f1.A="
+        "f0.B)";
+    auto mfun = boost::dynamic_pointer_cast<CompositeFunction>(
+        FunctionFactory::Instance().createInitialized(ini));
+
+    auto eqFuns = mfun->createEquivalentFunctions();
+    TS_ASSERT_EQUALS(eqFuns.size(), 2);
+    TS_ASSERT_EQUALS(eqFuns[0]->asString(), "name=MultiDomainFunctionTest_Function,A=1,B=2");
+    TS_ASSERT_EQUALS(eqFuns[1]->asString(), "name=MultiDomainFunctionTest_Function,A=2,B=4");
   }
 
 private:

--- a/Framework/API/test/MultiDomainFunctionTest.h
+++ b/Framework/API/test/MultiDomainFunctionTest.h
@@ -462,8 +462,10 @@ public:
 
     auto eqFuns = mfun->createEquivalentFunctions();
     TS_ASSERT_EQUALS(eqFuns.size(), 2);
-    TS_ASSERT_EQUALS(eqFuns[0]->asString(), "name=MultiDomainFunctionTest_Function,A=1,B=2");
-    TS_ASSERT_EQUALS(eqFuns[1]->asString(), "name=MultiDomainFunctionTest_Function,A=2,B=4");
+    TS_ASSERT_EQUALS(eqFuns[0]->asString(),
+                     "name=MultiDomainFunctionTest_Function,A=1,B=2");
+    TS_ASSERT_EQUALS(eqFuns[1]->asString(),
+                     "name=MultiDomainFunctionTest_Function,A=2,B=4");
   }
 
 private:


### PR DESCRIPTION
Reverting recent changes to `IFunction::asString()` method that don't output values of tied or fixed parameters. Outputs from a multi-domain fit are calculated by copies of member functions of a `MultiDomainFunction`. Tied parameters were not set properly. 

**To test:**

Run the script from the issue description.

Fixes #19115.

*This probably needs to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
