### PR TITLE
Clear the search table when the instrument changes

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSearchModel.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSearchModel.h
@@ -57,6 +57,8 @@ public:
   Qt::ItemFlags flags(const QModelIndex &index) const override;
   /// maps each run number to why it was unusable in the process table
   std::vector<std::map<std::string, std::string>> m_errors;
+  /// clear the model
+  void clear();
 
 protected:
   // vector of the run numbers

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflRunsTabView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflRunsTabView.cpp
@@ -267,6 +267,9 @@ void QtReflRunsTabView::showSearchContextMenu(const QPoint &pos) {
  * @param index : The index of the combo box
  */
 void QtReflRunsTabView::instrumentChanged(int index) {
+  ui.textSearch->clear();
+  if (m_searchModel)
+    m_searchModel->clear();
   m_calculator->setCurrentInstrumentName(
       ui.comboSearchInstrument->itemText(index).toStdString());
   m_calculator->processInstrumentHasBeenChanged();

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflSearchModel.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflSearchModel.cpp
@@ -161,5 +161,20 @@ Qt::ItemFlags ReflSearchModel::flags(const QModelIndex &index) const {
   else
     return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
+
+/**
+Clear the model
+*/
+void ReflSearchModel::clear() {
+
+  beginResetModel();
+
+  m_runs.clear();
+  m_descriptions.clear();
+  m_locations.clear();
+
+  endResetModel();
+}
+
 } // namespace CustomInterfaces
 } // namespace Mantid


### PR DESCRIPTION
In the reflectometry GUI, when the selected instrument changes, the search table and investigation id should be cleared.

**To test:**

- Needs to be tested by someone at ISIS with access to the catalog.
- Open the new reflectometry GUI (Interfaces > Reflectometry > ISIS Reflectometry).
- Select instrument `POLREF`
- Enter investigation id `1520249` and enter your login details, the table in section `Search Runs` should be populated.
- Change the instrument, the search table and investigation id should ble cleared.

Fixes #19160.

*Does not need to be in the release notes, as it is a minor improvement that was not requested by scientists*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
