### PR TITLE
Add function to compare workspaces in Python

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/api.cpp.in
+++ b/Framework/PythonInterface/mantid/api/src/api.cpp.in
@@ -5,12 +5,15 @@
 #include <boost/python/def.hpp>
 #include <boost/python/module.hpp>
 #include <boost/python/docstring_options.hpp>
+#include <boost/python/args.hpp>
+
 
 // See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL API_ARRAY_API
 #include <numpy/arrayobject.h>
 
 #include "MantidAPI/AlgorithmFactory.h"
+#include "MantidAPI/Workspace.h"
 #include "MantidPythonInterface/api/Algorithms/RunPythonScript.h"
 
 namespace
@@ -27,6 +30,15 @@ namespace
   {
     Mantid::API::AlgorithmFactory::Instance().subscribe<Mantid::PythonInterface::RunPythonScript>();
   }
+
+  /**
+   * Checks if two workspace shared pointers point to the same workspace
+   */
+  bool isSameWorkspaceObject(Mantid::API::Workspace_sptr workspace1, 
+		             Mantid::API::Workspace_sptr workspace2) {
+    return workspace1 == workspace2;
+  }
+
 }
 
 // Forward declare
@@ -41,6 +53,11 @@ BOOST_PYTHON_MODULE(_api)
   
   // Internal function to declare C++ algorithms that are a part of this module
   boost::python::def("_declareCPPAlgorithms", &_declareCPPAlgorithms);
+
+  // Workspace address comparison
+  boost::python::def("isSameWorkspaceObject",
+		     &isSameWorkspaceObject, 
+		     boost::python::args("workspace1", "workspace2"));
 
   try {
 @EXPORT_FUNCTIONS@


### PR DESCRIPTION
Fix #19167

For workflow algorithms which can be defined in Python we somtimes want to check if the input workspace is the same as the output workspace (as is done sometimes on the `c++` side). A naive `ws1 is ws2` or `ws1 == ws2` does not produce the correct result since it only compares the Python wrapper and not the underlying workspace. Overloading `==` is not a good option since `==` implies a value comparison we want to actually know if the we are dealing with the same workspace and not with a clone. Overloading `is` is not possible, hence a free function seems to be the clearest option here.

### To Test

Run a the Python script below

```python
ws1 = CreateSampleWorkspace()
ws2 = CreateSampleWorkspace()
print("Expect to be the same, ie should be True and is: {}".format(isSameWorkspaceObject(ws1, ws1)))
print("Expect to be not the same, ie should be False and is: {}".format(isSameWorkspaceObject(ws1, ws2)))
# comment added to aid cut and paste
```
Play around and check if the comparisons make sense.


*Does not need to be in the release notes, since this is a developer facing change*



---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
