### PR TITLE
Fix vtkMDHWSignalArrayTestPerformance.

### DIFF
--- a/Vates/VatesAPI/test/vtkMDHWSignalArrayTest.h
+++ b/Vates/VatesAPI/test/vtkMDHWSignalArrayTest.h
@@ -213,18 +213,18 @@ public:
     imageSize = (nBinsX) * (nBinsY) * (nBinsZ);
     m_signal->InitializeArray(
         ws_sptr->getSignalArray(), ws_sptr->getNumEventsArray(),
-        ws_sptr->getInverseVolume(), SignalArrayNormalization::None, imageSize,
-        offset);
+        ws_sptr->getInverseVolume(), SignalArrayNormalization::Volume,
+        imageSize, offset);
   }
 
   void tearDown() override {}
 
   void testGetTupleValuePerformance() {
+    double expected = ws_sptr->getSignalNormalizedAt(0);
     for (auto index = 0; index < imageSize; ++index) {
       // test member function.
-      double output[1];
-      m_signal->GetTypedTuple(index, output);
-      TS_ASSERT_DELTA(0.25, output[0], 0.0001);
+      double output = m_signal->GetValue(index);
+      TS_ASSERT_DELTA(expected, output, 0.0001);
     }
   }
 };


### PR DESCRIPTION
Description of work.

This fixes `vtkMDHWSignalArrayTestPerformance`. It looks like PR #19159 accidentally changed the normalization from volume to none. This changes it back.

**To test:**

<!-- Instructions for testing. -->

Verify `vtkMDHWSignalArrayTestPerformance` runs without errors.

*There is no GitHub issue associated with this pull request.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
