### PR TITLE
Export SpectraAxis class to Python

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -1,5 +1,6 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/BinEdgeAxis.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/TextAxis.h"
@@ -125,6 +126,28 @@ void export_Axis() {
 }
 
 // --------------------------------------------------------------------------------------------
+// SpectraAxis
+// --------------------------------------------------------------------------------------------
+/**
+* Creates a SpectraAxis referencing a given workspace
+* @param ws A pointer to the parent workspace
+* @return pointer to the axis object
+*/
+Axis *createSpectraAxis(const MatrixWorkspace *const ws) {
+  return new SpectraAxis(ws);
+}
+
+void export_SpectraAxis() {
+  /// Exported so that Boost.Python can give back a SpectraAxis class when an
+  /// Axis* is returned
+  class_<SpectraAxis, bases<Axis>, boost::noncopyable>("SpectraAxis", no_init)
+      .def("create", &createSpectraAxis, arg("workspace"),
+           return_internal_reference<>(),
+           "Creates a new SpectraAxis referencing the given workspace")
+      .staticmethod("create");
+}
+
+// --------------------------------------------------------------------------------------------
 // NumericAxis
 // --------------------------------------------------------------------------------------------
 /**
@@ -132,9 +155,7 @@ void export_Axis() {
 * @param length The length of the new axis
 * @return pointer to the axis object
 */
-Axis *createNumericAxis(int length) {
-  return new Mantid::API::NumericAxis(length);
-}
+Axis *createNumericAxis(int length) { return new NumericAxis(length); }
 
 void export_NumericAxis() {
   /// Exported so that Boost.Python can give back a NumericAxis class when an
@@ -155,9 +176,7 @@ void export_NumericAxis() {
 * @param length The length of the new axis
 * @return pointer to the axis object
 */
-Axis *createBinEdgeAxis(int length) {
-  return new Mantid::API::BinEdgeAxis(length);
-}
+Axis *createBinEdgeAxis(int length) { return new BinEdgeAxis(length); }
 
 void export_BinEdgeAxis() {
   /// Exported so that Boost.Python can give back a BinEdgeAxis class when an
@@ -179,7 +198,7 @@ void export_BinEdgeAxis() {
 * @param length The length of the new axis
 * @return pointer to the axis object
 */
-Axis *createTextAxis(int length) { return new Mantid::API::TextAxis(length); }
+Axis *createTextAxis(int length) { return new TextAxis(length); }
 
 void export_TextAxis() {
   class_<TextAxis, bases<Axis>, boost::noncopyable>("TextAxis", no_init)

--- a/Framework/PythonInterface/test/python/mantid/api/AxisTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/AxisTest.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest
 from testhelpers import run_algorithm
-from mantid.api import NumericAxis, TextAxis, mtd
+from mantid.api import NumericAxis, SpectraAxis, TextAxis, mtd
 import numpy as np
 
 class AxisTest(unittest.TestCase):
@@ -17,8 +17,9 @@ class AxisTest(unittest.TestCase):
                     self.__class__._test_ws = alg.getProperty("OutputWorkspace").value
 
     def test_constructor_methods_return_the_correct_type(self):
-        self.assertTrue(isinstance(NumericAxis.create(2),NumericAxis))
-        self.assertTrue(isinstance(TextAxis.create(2),TextAxis))
+        self.assertTrue(isinstance(NumericAxis.create(2), NumericAxis))
+        self.assertTrue(isinstance(SpectraAxis.create(self._test_ws), SpectraAxis))
+        self.assertTrue(isinstance(TextAxis.create(2), TextAxis))
 
     def test_axis_meta_data(self):
         yAxis = self._test_ws.getAxis(1)

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -84,6 +84,13 @@ Python
       3.0
       3.0
 
+- A `SpectraAxis` object can now be created from Python, in a similar way to the other Axis types:
+
+  .. code-block:: python
+  
+     ws1 = CreateSampleWorkspace()
+     # Create a new axis reference
+     s_axis = SpectraAxis.create(ws1)
 
 
 Python Algorithms


### PR DESCRIPTION
Description of work.

Add `SpectraAxis` exports to Python layer along with a unit test

**To test:**

The following script demonstrates a possible usage of this:

```python
# Create a workspace with a numeric axis
ws = CreateWorkspace(DataX=[1,2,3,4,5,6,7,8,9,10], DataY=[1,2,3,4,5,6,7,8,9,10], UnitX='TOF',VerticalAxisUnit='MomentumTransfer',VerticalAxisValues=[0.25,0.5], NSpec=2)
# Replace axis 1 with spectrum axis. Spectrum numbering will be controlled by the values in each ISpectrum Object
ws.replaceAxis(1, SpectraAxis.create(ws))
ax1 = ws.getAxis(1)
print ax1.getValue(0)
print ax1.getValue(1)

# Update the spectrum numbers on the workspace to check the axis updates
ws.getSpectrum(0).setSpectrumNo(10)
ws.getSpectrum(1).setSpectrumNo(11)

print ax1.getValue(0)
print ax1.getValue(1)
```

Fixes #19180 

[RELEASE NOTES](/mantidproject/mantid/commit/c77834f47731992f331c9d520babdf707c451ce8)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
