### PR TITLE
Fix SCD Interface bug

### DIFF
--- a/MantidQt/CustomInterfaces/src/MantidEV.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEV.cpp
@@ -1076,7 +1076,7 @@ void MantidEV::integratePeaks_slot() {
   bool ellipsoid_integrate = m_uiForm.EllipsoidIntegration_rbtn->isChecked();
   bool use_cylinder_integration = m_uiForm.Cylinder_ckbx->isChecked();
 
-  if (sphere_integrate || use_cylinder_integration) {
+  if (sphere_integrate) {
     double peak_radius = 0.20;
     double inner_radius = 0.20;
     double outer_radius = 0.25;


### PR DESCRIPTION
Description of work.

**To test:**

Open SCD Event Data Reduction Interface
In "Load Event Data" input "TOPAZ_3132"
Apply on tabs Select Data, Find Peaks, and Find UB.
In Integrate tab:
Check "Integrate with cylinder" and select Apply
Then check Ellipsoidal Integration and select Apply.
Make sure you see IntegrateEllipsoids successful in Results Log.

Fixes #19177 

Does not need to be in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
