### PR TITLE
Show column descriptions in Reflectometry GUI

### DIFF
--- a/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorTwoLevelTreeModel.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorTwoLevelTreeModel.cpp
@@ -91,6 +91,9 @@ QVariant QDataProcessorTwoLevelTreeModel::headerData(
   if (orientation == Qt::Horizontal && role == Qt::DisplayRole)
     return QString::fromStdString(m_whitelist.colNameFromColIndex(section));
 
+  if (orientation == Qt::Horizontal && role == Qt::WhatsThisRole)
+    return QString::fromStdString(m_whitelist.description(section));
+
   return QVariant();
 }
 

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/QDataProcessorTwoLevelTreeModelTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/QDataProcessorTwoLevelTreeModelTest.h
@@ -126,6 +126,10 @@ public:
                      "Column1");
     TS_ASSERT_EQUALS(model.headerData(1, Qt::Horizontal, Qt::DisplayRole),
                      "Column2");
+    TS_ASSERT_EQUALS(model.headerData(0, Qt::Horizontal, Qt::WhatsThisRole),
+                     "Description1");
+    TS_ASSERT_EQUALS(model.headerData(1, Qt::Horizontal, Qt::WhatsThisRole),
+                     "Description2");
   }
 
   void testConstructorFourRowTable() {

--- a/docs/source/release/v3.10.0/reflectometry.rst
+++ b/docs/source/release/v3.10.0/reflectometry.rst
@@ -32,6 +32,8 @@ ISIS Reflectometry
   - Ctrl+V pastes the contents of the clipboard into the selected row(s). If no rows are selected, new ones are added at the end.
   - Ctrl+X copies the selected row(s) to the clipboard and deletes them.
 
+- A brief description about the columns in the table can be now accessed by using the *What's this* tool (last tool in the toolbar) and clicking on the column headers.
+
 ISIS Reflectometry (Old)
 ########################
 


### PR DESCRIPTION
Users should be able to see a brief column description in the Reflectometry GUI.

**To test:**

- Open `Interfaces` > `Reflectometry` > `ISIS Reflectometry`.
- Click on the `What's this` button on the toolbar (last icon showing a cursor and a question mark).
- Click on one of the column headers, for instance `Q min`, you should be able to see a brief description.
- This should work for all the columns in the table.

Fixes #19187.

Release notes: https://github.com/mantidproject/mantid/commit/d64ae9a4280b8c1407d6603cc8fc364552e4edaa

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
