### PR TITLE
Fix VS2017 compilation errors

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/FortranVector.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FortranVector.h
@@ -38,9 +38,8 @@ template <class VectorClass> class FortranVector : public VectorClass {
   int m_base;
   /// Typedef the types returned by the base class's operators []. They aren't
   /// necessarily the same as the stored type (double or complex).
-  using ElementConstType = decltype(
-	  std::declval<const VectorClass>()[0]);
-  using ElementRefType = decltype(std::declval<VectorClass>()[0]) ;
+  using ElementConstType = decltype(std::declval<const VectorClass>()[0]);
+  using ElementRefType = decltype(std::declval<VectorClass>()[0]);
 
 public:
   /// Constructor

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FortranVector.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FortranVector.h
@@ -38,9 +38,9 @@ template <class VectorClass> class FortranVector : public VectorClass {
   int m_base;
   /// Typedef the types returned by the base class's operators []. They aren't
   /// necessarily the same as the stored type (double or complex).
-  typedef decltype(
-      std::declval<const VectorClass>().operator[](0)) ElementConstType;
-  typedef decltype(std::declval<VectorClass>().operator[](0)) ElementRefType;
+  using ElementConstType = decltype(
+	  std::declval<const VectorClass>()[0]);
+  using ElementRefType = decltype(std::declval<VectorClass>()[0]) ;
 
 public:
   /// Constructor

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -48,7 +48,7 @@ public:
 // MSVC 2015 won't build with noexcept.
 // error C2610: 'Mantid::DataObjects::Peak::Peak(Mantid::DataObjects::Peak &&)
 // noexcept': is not a special member function which can be defaulted
-#if defined(_MSC_VER) && _MSC_VER <= 1900
+#if defined(_MSC_VER) && _MSC_VER <= 1910
   Peak(Peak &&);
   Peak &operator=(Peak &&);
 #elif defined(__GNUC__) && (__GNUC__ == 5)

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -58,8 +58,8 @@ public:
 #elif((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
   // The noexcept default deceleration was fixed in GCC 4.9.0
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53903
-  Peak(Peak &&) noexcept;
-  Peak &operator=(Peak &&) noexcept;
+  Peak(Peak &&) = default;
+  Peak &operator=(Peak &&) = default;
 #else
   Peak(Peak &&) noexcept = default;
   Peak &operator=(Peak &&) noexcept = default;

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -45,18 +45,19 @@ public:
 
   /// Copy constructor
   Peak(const Peak &other);
-// MSVC 2015 won't build with noexcept.
-// error C2610: 'Mantid::DataObjects::Peak::Peak(Mantid::DataObjects::Peak &&)
-// noexcept': is not a special member function which can be defaulted
+
+// MSVC 2015/17 can build with noexcept = default however
+// intellisense still incorrectly reports this as an error despite compiling. 
+// https://connect.microsoft.com/VisualStudio/feedback/details/1795240/visual-c-2015-default-move-constructor-and-noexcept-keyword-bug
+// For that reason we still use the supplied default which should be noexcept
+// once the above is fixed we can remove this workaround
+
 #if defined(_MSC_VER) && _MSC_VER <= 1910
-  Peak(Peak &&);
-  Peak &operator=(Peak &&);
-#elif defined(__GNUC__) && (__GNUC__ == 5)
+  Peak(Peak &&) = default;
+  Peak &operator=(Peak &&) = default;
+#else
   Peak(Peak &&) noexcept = default;
   Peak &operator=(Peak &&) noexcept = default;
-#else
-  Peak(Peak &&) noexcept;
-  Peak &operator=(Peak &&) noexcept;
 #endif
 
   // Construct a peak from a reference to the interface

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -47,7 +47,7 @@ public:
   Peak(const Peak &other);
 
 // MSVC 2015/17 can build with noexcept = default however
-// intellisense still incorrectly reports this as an error despite compiling. 
+// intellisense still incorrectly reports this as an error despite compiling.
 // https://connect.microsoft.com/VisualStudio/feedback/details/1795240/visual-c-2015-default-move-constructor-and-noexcept-keyword-bug
 // For that reason we still use the supplied default which should be noexcept
 // once the above is fixed we can remove this workaround

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -55,7 +55,7 @@ public:
 #if defined(_MSC_VER) && _MSC_VER <= 1910
   Peak(Peak &&) = default;
   Peak &operator=(Peak &&) = default;
-#elif ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
+#elif((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
   // The noexcept default deceleration was fixed in GCC 4.9.0
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53903
   Peak(Peak &&) noexcept;

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -56,7 +56,8 @@ public:
   Peak(Peak &&) = default;
   Peak &operator=(Peak &&) = default;
 #elif((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
-  // The noexcept default deceleration was fixed in GCC 4.9.0
+  // The noexcept default declaration was fixed in GCC 4.9.0
+  // so for versions 4.8.x and below use default only
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53903
   Peak(Peak &&) = default;
   Peak &operator=(Peak &&) = default;

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -55,6 +55,11 @@ public:
 #if defined(_MSC_VER) && _MSC_VER <= 1910
   Peak(Peak &&) = default;
   Peak &operator=(Peak &&) = default;
+#elif(__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
+  // The noexcept default deceleration was fixed in GCC 4.9.0
+  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53903
+  Peak(Peak &&) noexcept;
+  Peak &operator=(Peak &&) noexcept;
 #else
   Peak(Peak &&) noexcept = default;
   Peak &operator=(Peak &&) noexcept = default;

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -55,7 +55,7 @@ public:
 #if defined(_MSC_VER) && _MSC_VER <= 1910
   Peak(Peak &&) = default;
   Peak &operator=(Peak &&) = default;
-#elif(__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
+#elif ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
   // The noexcept default deceleration was fixed in GCC 4.9.0
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53903
   Peak(Peak &&) noexcept;

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -233,15 +233,6 @@ Peak::Peak(const Geometry::IPeak &ipeak)
   }
 }
 
-#if defined(_MSC_VER) && _MSC_VER <= 1910
-Peak::Peak(Peak &&) = default;
-Peak &Peak::operator=(Peak &&) = default;
-#elif defined(__GNUC__) && (__GNUC__ == 5)
-// already defined in the header
-#else
-Peak::Peak(Peak &&) noexcept = default;
-Peak &Peak::operator=(Peak &&) noexcept = default;
-#endif
 //----------------------------------------------------------------------------------------------
 /** Set the incident wavelength of the neutron. Calculates the energy from this.
  * Assumes elastic scattering.

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -233,7 +233,7 @@ Peak::Peak(const Geometry::IPeak &ipeak)
   }
 }
 
-#if defined(_MSC_VER) && _MSC_VER <= 1900
+#if defined(_MSC_VER) && _MSC_VER <= 1910
 Peak::Peak(Peak &&) = default;
 Peak &Peak::operator=(Peak &&) = default;
 #elif defined(__GNUC__) && (__GNUC__ == 5)


### PR DESCRIPTION
Description of work.
This PR fixes various compilation errors using MSVC on our end. 

It does **not** allow us to compile with VC2017 yet:

-----
We require Boost 1.64 (beta starts 22nd March) which (AFAIK) will be the first version to support the compiler properly. We currently fail in 2017 to compile due to the *one definition rule* being violated with `boost::get_pointer` in `PythonKernelModule` and `PythonAPIModule`

-----

**To test:**
Ensure builds pass.

Fixes N/A

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
