### PR TITLE
Refactor SaveMDWorkspaceToVTK

### DIFF
--- a/Vates/VatesAPI/inc/MantidVatesAPI/SaveMDWorkspaceToVTKImpl.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/SaveMDWorkspaceToVTKImpl.h
@@ -50,7 +50,7 @@ public:
   void saveMDWorkspace(const Mantid::API::IMDWorkspace_sptr &workspace,
                        const std::string &filename,
                        VisualNormalization normalization, int recursionDepth,
-                       const std::string &compressorType) const;
+                       const std::string &compressorType);
 
   const static std::string structuredGridExtension;
   const static std::string unstructuredGridExtension;
@@ -60,6 +60,7 @@ public:
   VisualNormalization
   translateStringToVisualNormalization(const std::string &normalization) const;
   bool is3DWorkspace(const Mantid::API::IMDWorkspace &workspace) const;
+  void progressFunction(vtkObject *caller, unsigned long, void *);
 
 private:
   mutable API::Progress m_progress;
@@ -68,7 +69,7 @@ private:
   bool is4DWorkspace(const Mantid::API::IMDWorkspace &workspace) const;
   int writeDataSetToVTKFile(vtkXMLWriter *writer, vtkDataSet *dataSet,
                             const std::string &filename,
-                            vtkXMLWriter::CompressorType compressor) const;
+                            vtkXMLWriter::CompressorType compressor);
   double selectTimeSliceValue(const Mantid::API::IMDWorkspace &workspace) const;
   std::string getFullFilename(std::string filename,
                               bool isHistoWorkspace) const;

--- a/Vates/VatesAPI/src/SaveMDWorkspaceToVTKImpl.cpp
+++ b/Vates/VatesAPI/src/SaveMDWorkspaceToVTKImpl.cpp
@@ -15,7 +15,7 @@
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/make_unique.h"
 
-#include "vtkCallbackCommand.h"
+#include "vtkCommand.h"
 #include "vtkFloatArray.h"
 #include "vtkNew.h"
 #include "vtkSmartPointer.h"
@@ -77,7 +77,7 @@ SaveMDWorkspaceToVTKImpl::SaveMDWorkspaceToVTKImpl(SaveMDWorkspaceToVTK *parent)
 void SaveMDWorkspaceToVTKImpl::saveMDWorkspace(
     const Mantid::API::IMDWorkspace_sptr &workspace,
     const std::string &filename, VisualNormalization normalization,
-    int recursionDepth, const std::string &compressorType) const {
+    int recursionDepth, const std::string &compressorType) {
   auto isHistoWorkspace =
       boost::dynamic_pointer_cast<Mantid::API::IMDHistoWorkspace>(workspace) !=
       nullptr;
@@ -194,19 +194,18 @@ SaveMDWorkspaceToVTKImpl::getPresenter(bool isHistoWorkspace,
   return presenter;
 }
 
-void ProgressFunction(vtkObject *caller, long unsigned int vtkNotUsed(eventId),
-                      void *clientData, void *vtkNotUsed(callData)) {
-  vtkXMLWriter *testFilter = dynamic_cast<vtkXMLWriter *>(caller);
+void SaveMDWorkspaceToVTKImpl::progressFunction(vtkObject *caller,
+                                                long unsigned, void *) {
+  vtkAlgorithm *testFilter = vtkAlgorithm::SafeDownCast(caller);
   if (!testFilter)
     return;
   const char *progressText = testFilter->GetProgressText();
+
+  int progress = boost::math::iround(testFilter->GetProgress() * 100.0);
   if (progressText) {
-    reinterpret_cast<Kernel::ProgressBase *>(clientData)
-        ->report(boost::math::iround(testFilter->GetProgress() * 100.0),
-                 progressText);
+    this->m_progress.report(progress, progressText);
   } else {
-    reinterpret_cast<Kernel::ProgressBase *>(clientData)
-        ->report(boost::math::iround(testFilter->GetProgress() * 100.0));
+    this->m_progress.report(progress);
   }
 }
 
@@ -220,11 +219,9 @@ void ProgressFunction(vtkObject *caller, long unsigned int vtkNotUsed(eventId),
  */
 int SaveMDWorkspaceToVTKImpl::writeDataSetToVTKFile(
     vtkXMLWriter *writer, vtkDataSet *dataSet, const std::string &filename,
-    vtkXMLWriter::CompressorType compressor) const {
-  vtkNew<vtkCallbackCommand> progressCallback;
-  progressCallback->SetCallback(ProgressFunction);
-  writer->AddObserver(vtkCommand::ProgressEvent, progressCallback.GetPointer());
-  progressCallback->SetClientData(&m_progress);
+    vtkXMLWriter::CompressorType compressor) {
+  writer->AddObserver(vtkCommand::ProgressEvent, this,
+                      &SaveMDWorkspaceToVTKImpl::progressFunction);
   writer->SetFileName(filename.c_str());
   writer->SetInputData(dataSet);
   writer->SetCompressorType(compressor);

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
@@ -6,7 +6,6 @@
 #include "MantidQtAPI/MdSettings.h"
 #include "MantidQtAPI/VatesViewerInterface.h"
 #include "MantidQtAPI/WorkspaceObserver.h"
-#include "MantidVatesSimpleGuiViewWidgets/BackgroundRgbProvider.h"
 #include "MantidVatesSimpleGuiViewWidgets/RebinAlgorithmDialogProvider.h"
 #include "MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"

--- a/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -22,7 +22,6 @@
 #include "MantidQtAPI/TSVSerialiser.h"
 #include "MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h"
 #include "MantidVatesSimpleGuiQtWidgets/RotationPointDialog.h"
-#include "MantidVatesSimpleGuiViewWidgets/BackgroundRgbProvider.h"
 #include "MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.h"
 #include "MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h"
 #include "MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h"


### PR DESCRIPTION
This uses an alternate form of `vtkObject::AddObserver` that eliminates a reinterpret_cast. Functionality should not change.

I also removed two unnecessary headers.

Description of work.

**To test:**

<!-- Instructions for testing. -->

Load a large MDWorkspace in Mantid and export it using the `SaveMDWorkspaceToVTK` algorithm. Verify that the progress bar is updated.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
