### PR TITLE
Fix calling Load with None returns bad error

### DIFF
--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -37,7 +37,7 @@ from . import apiVersion, __gui__
 from .kernel._aliases import *
 from .api._aliases import *
 
-#------------------------ Specialized function calls --------------------------
+# ------------------------ Specialized function calls --------------------------
 # List of specialized algorithms
 __SPECIALIZED_FUNCTIONS__ = ["Load", "StartLiveData", "CutMD", "RenameWorkspace"]
 # List of specialized algorithms
@@ -101,7 +101,8 @@ def _create_generic_signature(algm_object):
     arg_str = ','.join(arg_list)
     # Calling help(...) will put a * in front of the first parameter name,
     # so we use \b to delete it
-    return ("\b%s" % arg_str, "\b\bVersion=%d" % algm_object.version())
+    return "\b%s" % arg_str, "\b\bVersion=%d" % algm_object.version()
+
 
 def Load(*args, **kwargs):
     """
@@ -139,6 +140,12 @@ def Load(*args, **kwargs):
       Load('INSTR00001000.nxs',OutputWorkspace='run_ws')
     """
     filename, = _get_mandatory_args('Load', ["Filename"], *args, **kwargs)
+    if not filename:
+        # If we try to set property with a None type we get a unhelpful error about allocators
+        # so check up front here
+        raise ValueError("Problem with supplied Filename. The value given was a 'None' "
+                         "type and cannot be used. Please ensure the Filename is set"
+                         " to the path of the file.")
 
     # Create and execute
     (_startProgress, _endProgress, kwargs) = extract_progress_kwargs(kwargs)

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -863,31 +863,25 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
                 raise RuntimeError('Internal error. Unknown property type encountered. "%s" '
                                    'on algorithm "%s" is not understood by '
                                    'Python. Please contact development team' % (name, algm_obj.name()))
-    # For reference this ensures multiple returns works eg
-    # foo, bar = myFunc(...)
-    # In the case foo and bar mean we have 2 on LHS and myFunc should return 2 member vars
+    nvals = len(retvals)
+    nlhs = lhs[0]
 
-    number_of_returned_values = len(retvals)
-    number_of_vars_lhs_of_func = lhs[0]
+    if nlhs == 0:
+        return None
 
-    if number_of_returned_values != number_of_vars_lhs_of_func:
-        if number_of_vars_lhs_of_func == 0:
+    if nvals != nlhs:
+        if nlhs == 1:
             pass  # This is fine as we do not need to unpack
         else:
             # There is a discrepancy in the number whilst unpacking variables
             # Let's not have the more cryptic unpacking error raised
             raise RuntimeError("%s is trying to return %d output(s) but you have provided %d variable(s). "
-                               "These numbers must match." % (func_name, number_of_returned_values, number_of_vars_lhs_of_func))
-
-    if number_of_returned_values == 0:
-        # Nothing was returned so return None type
-        return None
+                               "These numbers must match." % (func_name, nvals, nlhs))
 
     # Unpack and return
     ret_type = namedtuple(func_name + "_returns", retvals.keys())
     ret_value = ret_type(**retvals)
-    # If we have only one variable on LHS unpack for the caller. Otherwise forward the original return.
-    return ret_value[0] if number_of_returned_values == 1 else ret_value
+    return ret_value[0] if nvals == 1 else ret_value
 
 
 def _set_logging_option(algm_obj, kwargs):

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -866,22 +866,21 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
     nvals = len(retvals)
     nlhs = lhs[0]
 
-    if nlhs == 0:
-        return None
-
-    if nvals != nlhs:
-        if nlhs == 1:
-            pass  # This is fine as we do not need to unpack
+    # If we have more than one value but not the same number of values throw
+    if 1 < nlhs != nvals:
+        # There is a discrepancy in the number are unpacking variables
+        # Let's not have the more cryptic unpacking error raised
+        raise RuntimeError("%s is trying to return %d output(s) but you have provided %d variable(s). "
+                           "These numbers must match." % (func_name, nvals, nlhs))
+    if nvals > 0:
+        ret_type = namedtuple(func_name+"_returns", retvals.keys())
+        ret_value = ret_type(**retvals)
+        if nvals == 1:
+            return ret_value[0]
         else:
-            # There is a discrepancy in the number whilst unpacking variables
-            # Let's not have the more cryptic unpacking error raised
-            raise RuntimeError("%s is trying to return %d output(s) but you have provided %d variable(s). "
-                               "These numbers must match." % (func_name, nvals, nlhs))
-
-    # Unpack and return
-    ret_type = namedtuple(func_name + "_returns", retvals.keys())
-    ret_value = ret_type(**retvals)
-    return ret_value[0] if nvals == 1 else ret_value
+            return ret_value
+    else:
+        return None
 
 
 def _set_logging_option(algm_obj, kwargs):

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -866,21 +866,22 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
     nvals = len(retvals)
     nlhs = lhs[0]
 
-    # If we have more than one value but not the same number of values throw
-    if 1 < nlhs != nvals:
-        # There is a discrepancy in the number are unpacking variables
-        # Let's not have the more cryptic unpacking error raised
-        raise RuntimeError("%s is trying to return %d output(s) but you have provided %d variable(s). "
-                           "These numbers must match." % (func_name, nvals, nlhs))
-    if nvals > 0:
-        ret_type = namedtuple(func_name+"_returns", retvals.keys())
-        ret_value = ret_type(**retvals)
-        if nvals == 1:
-            return ret_value[0]
-        else:
-            return ret_value
-    else:
+    if nlhs == 0:
         return None
+
+    if nvals != nlhs:
+        if nlhs == 1:
+            pass  # This is fine as we do not need to unpack
+        else:
+            # There is a discrepancy in the number whilst unpacking variables
+            # Let's not have the more cryptic unpacking error raised
+            raise RuntimeError("%s is trying to return %d output(s) but you have provided %d variable(s). "
+                               "These numbers must match." % (func_name, nvals, nlhs))
+
+    # Unpack and return
+    ret_type = namedtuple(func_name + "_returns", retvals.keys())
+    ret_value = ret_type(**retvals)
+    return ret_value[0] if nvals == 1 else ret_value
 
 
 def _set_logging_option(algm_obj, kwargs):

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -863,19 +863,25 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
                 raise RuntimeError('Internal error. Unknown property type encountered. "%s" '
                                    'on algorithm "%s" is not understood by '
                                    'Python. Please contact development team' % (name, algm_obj.name()))
-    nvals = len(retvals)
-    nlhs = lhs[0]
+
+    # If there is a snippet of code as follows
+    # foo, bar, baz = simpleAPI.myFunc(...)
+    # The number of values on LHS is 3 (foo, bar baz) and the number of
+    # returned values is the number of values myFunc(...) returns
+    number_of_returned_values = len(retvals)
+    number_of_values_on_lhs = lhs[0]
 
     # If we have more than one value but not the same number of values throw
-    if 1 < nlhs != nvals:
+    if number_of_values_on_lhs > 1 and number_of_returned_values != number_of_values_on_lhs:
         # There is a discrepancy in the number are unpacking variables
         # Let's not have the more cryptic unpacking error raised
         raise RuntimeError("%s is trying to return %d output(s) but you have provided %d variable(s). "
-                           "These numbers must match." % (func_name, nvals, nlhs))
-    if nvals > 0:
+                           "These numbers must match." % (func_name,
+                                                          number_of_returned_values, number_of_values_on_lhs))
+    if number_of_returned_values > 0:
         ret_type = namedtuple(func_name+"_returns", retvals.keys())
         ret_value = ret_type(**retvals)
-        if nvals == 1:
+        if number_of_returned_values == 1:
             return ret_value[0]
         else:
             return ret_value

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -24,6 +24,7 @@ from __future__ import (absolute_import, division,
 
 from six import iteritems
 from collections import OrderedDict, namedtuple
+import os
 
 from . import api as _api
 from . import kernel as _kernel

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -863,25 +863,31 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
                 raise RuntimeError('Internal error. Unknown property type encountered. "%s" '
                                    'on algorithm "%s" is not understood by '
                                    'Python. Please contact development team' % (name, algm_obj.name()))
-    nvals = len(retvals)
-    nlhs = lhs[0]
+    # For reference this ensures multiple returns works eg
+    # foo, bar = myFunc(...)
+    # In the case foo and bar mean we have 2 on LHS and myFunc should return 2 member vars
 
-    if nlhs == 0:
-        return None
+    number_of_returned_values = len(retvals)
+    number_of_vars_lhs_of_func = lhs[0]
 
-    if nvals != nlhs:
-        if nlhs == 1:
+    if number_of_returned_values != number_of_vars_lhs_of_func:
+        if number_of_vars_lhs_of_func == 0:
             pass  # This is fine as we do not need to unpack
         else:
             # There is a discrepancy in the number whilst unpacking variables
             # Let's not have the more cryptic unpacking error raised
             raise RuntimeError("%s is trying to return %d output(s) but you have provided %d variable(s). "
-                               "These numbers must match." % (func_name, nvals, nlhs))
+                               "These numbers must match." % (func_name, number_of_returned_values, number_of_vars_lhs_of_func))
+
+    if number_of_returned_values == 0:
+        # Nothing was returned so return None type
+        return None
 
     # Unpack and return
     ret_type = namedtuple(func_name + "_returns", retvals.keys())
     ret_value = ret_type(**retvals)
-    return ret_value[0] if nvals == 1 else ret_value
+    # If we have only one variable on LHS unpack for the caller. Otherwise forward the original return.
+    return ret_value[0] if number_of_returned_values == 1 else ret_value
 
 
 def _set_logging_option(algm_obj, kwargs):

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -32,7 +32,7 @@ from .kernel.funcinspect import replace_signature as _replace_signature
 from .kernel.funcinspect import customise_func as _customise_func
 
 # This is a simple API so give access to the aliases by default as well
-from . import __gui__
+from . import apiVersion, __gui__
 from .kernel._aliases import *
 from .api._aliases import *
 

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -22,7 +22,6 @@
 from __future__ import (absolute_import, division,
                         print_function)
 
-import os
 from six import iteritems
 from collections import OrderedDict, namedtuple
 
@@ -33,7 +32,7 @@ from .kernel.funcinspect import replace_signature as _replace_signature
 from .kernel.funcinspect import customise_func as _customise_func
 
 # This is a simple API so give access to the aliases by default as well
-from . import apiVersion, __gui__
+from . import __gui__
 from .kernel._aliases import *
 from .api._aliases import *
 
@@ -41,9 +40,10 @@ from .api._aliases import *
 # List of specialized algorithms
 __SPECIALIZED_FUNCTIONS__ = ["Load", "StartLiveData", "CutMD", "RenameWorkspace"]
 # List of specialized algorithms
-__MDCOORD_FUNCTIONS__ = ["PeakIntensityVsRadius", "CentroidPeaksMD","IntegratePeaksMD"]
+__MDCOORD_FUNCTIONS__ = ["PeakIntensityVsRadius", "CentroidPeaksMD", "IntegratePeaksMD"]
 # The "magic" keyword to enable/disable logging
 __LOGGING_KEYWORD__ = "EnableLogging"
+
 
 def specialization_exists(name):
     """
@@ -54,6 +54,7 @@ def specialization_exists(name):
     """
     return name in __SPECIALIZED_FUNCTIONS__
 
+
 def extract_progress_kwargs(kwargs):
     """
     Returns tuple(startProgress, endProgress, kwargs) with the special
@@ -61,11 +62,12 @@ def extract_progress_kwargs(kwargs):
     specified, None will be returned in their place.
     """
     start = kwargs.get('startProgress')
-    end   = kwargs.get('endProgress')
+    end = kwargs.get('endProgress')
     for item in ('startProgress', 'endProgress'):
         if item in kwargs:
             del kwargs[item]
-    return (start, end, kwargs)
+    return start, end, kwargs
+
 
 def _create_generic_signature(algm_object):
     """
@@ -86,7 +88,7 @@ def _create_generic_signature(algm_object):
     for p in algm_object.mandatoryProperties():
         prop = algm_object.getProperty(p)
         # Mandatory parameters are those for which the default value is not valid
-        if isinstance(prop.isValid,str):
+        if isinstance(prop.isValid, str):
             valid_str = prop.isValid
         else:
             valid_str = prop.isValid()
@@ -153,7 +155,7 @@ def Load(*args, **kwargs):
                                     endProgress=_endProgress)
     _set_logging_option(algm, kwargs)
     try:
-        algm.setProperty('Filename', filename) # Must be set first
+        algm.setProperty('Filename', filename)  # Must be set first
     except ValueError as ve:
         raise ValueError('Problem when setting Filename. This is the detailed error '
                          'description: ' + str(ve) + '\nIf the file has been found '
@@ -185,9 +187,10 @@ def Load(*args, **kwargs):
 
     # If a WorkspaceGroup was loaded then there will be a set of properties that have an underscore in the name
     # and users will simply expect the groups to be returned NOT the groups + workspaces.
-    return _gather_returns('Load', lhs, algm, ignore_regex=['LoaderName','LoaderVersion','.*_.*'])
+    return _gather_returns('Load', lhs, algm, ignore_regex=['LoaderName', 'LoaderVersion', '.*_.*'])
 
 ######################################################################
+
 
 def LoadDialog(*args, **kwargs):
     """Popup a dialog for the Load algorithm. More help on the Load function
@@ -214,16 +217,21 @@ def LoadDialog(*args, **kwargs):
     arguments['Filename'] = filename
     arguments['OutputWorkspace'] = wkspace
     arguments.update(kwargs)
-    if 'Enable' not in arguments: arguments['Enable']=''
-    if 'Disable' not in arguments: arguments['Disable']=''
-    if 'Message' not in arguments: arguments['Message']=''
+
+    if 'Enable' not in arguments:
+        arguments['Enable'] = ''
+    if 'Disable' not in arguments:
+        arguments['Disable'] = ''
+    if 'Message' not in arguments:
+        arguments['Message'] = ''
 
     algm = _create_algorithm_object('Load')
-    set_properties_dialog(algm,**arguments)
+    set_properties_dialog(algm, **arguments)
     algm.execute()
     return algm
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+
 
 def StartLiveData(*args, **kwargs):
     """
@@ -250,7 +258,7 @@ def StartLiveData(*args, **kwargs):
                                     endProgress=_endProgress)
     _set_logging_option(algm, kwargs)
     try:
-        algm.setProperty('Instrument', instrument) # Must be set first
+        algm.setProperty('Instrument', instrument)  # Must be set first
     except ValueError as ve:
         raise ValueError('Problem when setting Instrument. This is the detailed error '
                          'description: ' + str(ve))
@@ -275,7 +283,8 @@ def StartLiveData(*args, **kwargs):
     # Check for any properties that aren't known and warn they will not be used
     for key in list(final_keywords.keys()):
         if key not in algm:
-            logger.warning("You've passed a property (%s) to StartLiveData() that doesn't apply to this Instrument." % key)
+            logger.warning("You've passed a property (%s) to StartLiveData() "
+                           "that doesn't apply to this Instrument." % key)
             del final_keywords[key]
 
     set_properties(algm, **final_keywords)
@@ -283,7 +292,8 @@ def StartLiveData(*args, **kwargs):
 
     return _gather_returns("StartLiveData", lhs, algm)
 
-#---------------------------- Fit ---------------------------------------------
+# ---------------------------- Fit ---------------------------------------------
+
 
 def fitting_algorithm(f):
     """
@@ -292,7 +302,7 @@ def fitting_algorithm(f):
     function 'wrapper' defined below.
     """
     def wrapper(*args, **kwargs):
-        Function, InputWorkspace = _get_mandatory_args(function_name, ["Function", "InputWorkspace"], *args, **kwargs)
+        function, input_workspace = _get_mandatory_args(function_name, ["Function", "InputWorkspace"], *args, **kwargs)
         # Remove from keywords so it is not set twice
         if "Function" in kwargs:
             del kwargs['Function']
@@ -300,17 +310,18 @@ def fitting_algorithm(f):
             del kwargs['InputWorkspace']
 
         # Check for behaviour consistent with old API
-        if type(Function) == str and Function in _api.AnalysisDataService:
-            raise ValueError("Fit API has changed. The function must now come first in the argument list and the workspace second.")
+        if type(function) == str and function in _api.AnalysisDataService:
+            raise ValueError("Fit API has changed. The function must now come "
+                             "first in the argument list and the workspace second.")
         # Create and execute
         algm = _create_algorithm_object(function_name)
         _set_logging_option(algm, kwargs)
         if 'EvaluationType' in kwargs:
             algm.setProperty('EvaluationType', kwargs['EvaluationType'])
             del kwargs['EvaluationType']
-        algm.setProperty('Function', Function) # Must be set first
-        if InputWorkspace is not None:
-            algm.setProperty('InputWorkspace', InputWorkspace)
+        algm.setProperty('Function', function)  # Must be set first
+        if input_workspace is not None:
+            algm.setProperty('InputWorkspace', input_workspace)
         else:
             del algm['InputWorkspace']
 
@@ -324,20 +335,22 @@ def fitting_algorithm(f):
         # Check for any properties that aren't known and warn they will not be used
         for key in list(kwargs.keys()):
             if key not in algm:
-                logger.warning("You've passed a property (%s) to %s() that doesn't apply to any of the input workspaces." % (key,function_name))
+                logger.warning("You've passed a property (%s) to %s() that doesn't"
+                               " apply to any of the input workspaces." % (key, function_name))
                 del kwargs[key]
         set_properties(algm, **kwargs)
         algm.execute()
 
         return _gather_returns(function_name, lhs, algm)
-    #end
+    # end
     function_name = f.__name__
     signature = ("\bFunction, InputWorkspace", "**kwargs")
     fwrapper = _customise_func(wrapper, function_name, signature,
-                                  f.__doc__)
-    if not function_name in __SPECIALIZED_FUNCTIONS__:
+                               f.__doc__)
+    if function_name not in __SPECIALIZED_FUNCTIONS__:
         __SPECIALIZED_FUNCTIONS__.append(function_name)
     return fwrapper
+
 
 # Use a python decorator (defined above) to generate the code for this function.
 @fitting_algorithm
@@ -357,6 +370,7 @@ def Fit(*args, **kwargs):
     """
     return None
 
+
 # Use a python decorator (defined above) to generate the code for this function.
 @fitting_algorithm
 def CalculateChiSquared(*args, **kwargs):
@@ -371,6 +385,7 @@ def CalculateChiSquared(*args, **kwargs):
     """
     return None
 
+
 # Use a python decorator (defined above) to generate the code for this function.
 @fitting_algorithm
 def EvaluateFunction(*args, **kwargs):
@@ -383,6 +398,7 @@ def EvaluateFunction(*args, **kwargs):
           StartX='0.05',EndX='1.0',Output="Z1")
     """
     return None
+
 
 def FitDialog(*args, **kwargs):
     """Popup a dialog for the Load algorithm. More help on the Load function
@@ -401,19 +417,23 @@ def FitDialog(*args, **kwargs):
     except RuntimeError:
         pass
     arguments.update(kwargs)
-    if 'Enable' not in arguments: arguments['Enable']=''
-    if 'Disable' not in arguments: arguments['Disable']=''
-    if 'Message' not in arguments: arguments['Message']=''
+    if 'Enable' not in arguments:
+        arguments['Enable'] = ''
+    if 'Disable' not in arguments:
+        arguments['Disable'] = ''
+    if 'Message' not in arguments:
+        arguments['Message'] = ''
 
     (_startProgress, _endProgress, kwargs) = extract_progress_kwargs(kwargs)
 
     algm = _create_algorithm_object('Fit', startProgress=_startProgress,
                                     endProgress=_endProgress)
-    set_properties_dialog(algm,**arguments)
+    set_properties_dialog(algm, **arguments)
     algm.execute()
     return algm
 
-#--------------------------------------------------- --------------------------
+# --------------------------------------------------- --------------------------
+
 
 def CutMD(*args, **kwargs):
     """
@@ -433,24 +453,25 @@ def CutMD(*args, **kwargs):
     if "InputWorkspace" in kwargs:
         del kwargs['InputWorkspace']
 
-    #Make sure we were given some output workspace names
+    # Make sure we were given some output workspace names
     lhs = _lhs_info()
     if lhs[0] == 0 and 'OutputWorkspace' not in kwargs:
         raise RuntimeError("Unable to set output workspace name. Please either assign the output of "
                            "CutMD to a variable or use the OutputWorkspace keyword.")
 
-    #Take what we were given
+    # Take what we were given
     if "OutputWorkspace" in kwargs:
         out_names = kwargs["OutputWorkspace"]
     else:
         out_names = list(lhs[1])
 
-    #Ensure the output names we were given are valid
+    # Ensure the output names we were given are valid
     if handling_multiple_workspaces:
         if not isinstance(out_names, list):
-            raise RuntimeError("Multiple OutputWorkspaces must be given as a list when processing multiple InputWorkspaces.")
+            raise RuntimeError("Multiple OutputWorkspaces must be given as a list when"
+                               " processing multiple InputWorkspaces.")
     else:
-        #We wrap in a list for our convenience. The user musn't pass us one though.
+        # We wrap in a list for our convenience. The user must not pass us one though.
         if not isinstance(out_names, list):
             out_names = [out_names]
         elif len(out_names) != 1:
@@ -464,8 +485,8 @@ def CutMD(*args, **kwargs):
         bins = kwargs["PBins"]
         del kwargs["PBins"]
         if isinstance(bins, tuple) or isinstance(bins, list):
-            for bin in range(len(bins)):
-                kwargs["P{0}Bin".format(bin+1)] = bins[bin]
+            for bin_index in range(len(bins)):
+                kwargs["P{0}Bin".format(bin_index+1)] = bins[bin_index]
 
     # Create and execute
     (_startProgress, _endProgress, kwargs) = extract_progress_kwargs(kwargs)
@@ -484,14 +505,14 @@ def CutMD(*args, **kwargs):
         ws = in_list[i]
 
         if isinstance(ws, _api.Workspace):
-            #It's a workspace, do nothing to it
+            # It's a workspace, do nothing to it
             to_process.append(ws)
         elif isinstance(ws, str):
             if ws in mtd:
-                #It's a name of something in the ads, just take it from the ads
+                # It's a name of something in the ads, just take it from the ads
                 to_process.append(_api.AnalysisDataService[ws])
             else:
-                #Let's try treating it as a filename
+                # Let's try treating it as a filename
                 load_alg = AlgorithmManager.create("Load")
                 load_alg.setLogging(True)
                 load_alg.setAlwaysStoreInADS(False)
@@ -505,27 +526,28 @@ def CutMD(*args, **kwargs):
         else:
             raise TypeError("Unexpected type: " + type(ws))
 
-    #Run the algorithm across the inputs and outputs
+    # Run the algorithm across the inputs and outputs
     for i in range(len(to_process)):
         set_properties(algm, **kwargs)
         algm.setProperty('InputWorkspace', to_process[i])
         algm.setProperty('OutputWorkspace', out_names[i])
         algm.execute()
 
-    #Get the workspace objects so we can return them
+    # Get the workspace objects so we can return them
     for i in range(len(out_names)):
         out_names[i] = _api.AnalysisDataService[out_names[i]]
 
-    #We should only return a list if we're handling multiple workspaces
+    # We should only return a list if we're handling multiple workspaces
     if handling_multiple_workspaces:
         return out_names
     else:
         return out_names[0]
-#enddef
+# enddef
 
 _replace_signature(CutMD, ("\bInputWorkspace", "**kwargs"))
 
-#--------------------- RenameWorkspace ------------- --------------------------
+
+# --------------------- RenameWorkspace ------------- --------------------------
 
 def RenameWorkspace(*args, **kwargs):
     """ Rename workspace with option to renaming monitors
@@ -533,23 +555,23 @@ def RenameWorkspace(*args, **kwargs):
     """
     arguments = {}
     lhs = _kernel.funcinspect.lhs_info()
-    if lhs[0]>0:
+    if lhs[0] > 0:
         if 'OutputWorkspace' not in kwargs:
             arguments['OutputWorkspace'] = lhs[1][0]
-            pos_arg = {0:"InputWorkspace",1:"RenameMonitors"}
+            pos_arg = {0: "InputWorkspace", 1: "RenameMonitors"}
         else:
-           pos_arg = {0:"InputWorkspace", 1:"OutputWorkspace", 2:"RenameMonitors"}
+            pos_arg = {0: "InputWorkspace", 1: "OutputWorkspace", 2: "RenameMonitors"}
     else:
-        pos_arg = {0:"InputWorkspace", 1:"OutputWorkspace", 2:"RenameMonitors"}
+        pos_arg = {0: "InputWorkspace", 1: "OutputWorkspace", 2: "RenameMonitors"}
 
     for ind, arg in enumerate(args):
         arguments[pos_arg[ind]] = arg
     for key, val in kwargs.items():
         arguments[key] = val
     if 'OutputWorkspace' not in arguments:
-        raise RuntimeError("Unable to set output workspace name."\
-              " Please either assign the output of "\
-              "RenameWorkspace to a variable or use the OutputWorkspace keyword.")
+        raise RuntimeError("Unable to set output workspace name."
+                           " Please either assign the output of "
+                           "RenameWorkspace to a variable or use the OutputWorkspace keyword.")
 
     # Create and execute
     (_startProgress, _endProgress, kwargs) = extract_progress_kwargs(kwargs)
@@ -562,11 +584,11 @@ def RenameWorkspace(*args, **kwargs):
     algm.execute()
 
     return _gather_returns("RenameWorkspace", lhs, algm)
-#enddef
-_replace_signature(RenameWorkspace,
-                  ("\bInputWorkspace,[OutputWorkspace],[True||False]", "**kwargs"))
+# enddef
+_replace_signature(RenameWorkspace, ("\bInputWorkspace,[OutputWorkspace],[True||False]", "**kwargs"))
 
-#--------------------------------------------------- --------------------------
+# --------------------------------------------------- --------------------------
+
 
 def _get_function_spec(func):
     """Get the python function signature for the given function object
@@ -584,7 +606,7 @@ def _get_function_spec(func):
         return ''
     # Algorithm functions have varargs set not args
     args = argspec[0]
-    if args != []:
+    if args:
         # For methods strip the self argument
         if hasattr(func, 'im_func'):
             args = args[1:]
@@ -610,7 +632,8 @@ def _get_function_spec(func):
                 defs.append(arg_token[1])
             else:
                 args.append(arg)
-        if len(defs) == 0: defs = None
+        if len(defs) == 0:
+            defs = None
     else:
         return ''
 
@@ -630,9 +653,10 @@ def _get_function_spec(func):
         calltip = '(' + calltip.rstrip(',') + ')'
     return calltip
 
-#--------------------------------------------------- --------------------------
+# --------------------------------------------------- --------------------------
 
-def _get_mandatory_args(func_name, required_args ,*args, **kwargs):
+
+def _get_mandatory_args(func_name, required_args, *args, **kwargs):
     """Given a list of required arguments, parse them
     from the given args & kwargs and raise an error if they
     are not provided
@@ -647,10 +671,10 @@ def _get_mandatory_args(func_name, required_args ,*args, **kwargs):
     :type dict.
     :returns: A tuple of provided mandatory arguments
     """
-    def get_argument_value(key, kwargs):
+    def get_argument_value(key, dict_containing_key):
         try:
-            value = kwargs[key]
-            return value
+            val = dict_containing_key[key]
+            return val
         except KeyError:
             raise RuntimeError('%s argument not supplied to %s function' % (str(key), func_name))
     nrequired = len(required_args)
@@ -675,6 +699,7 @@ def _get_mandatory_args(func_name, required_args ,*args, **kwargs):
                            % (func_name, reqd_as_str))
     return tuple(mandatory_args)
 
+
 def _check_mandatory_args(algorithm, _algm_object, error, *args, **kwargs):
     """When a runtime error of the form 'Some invalid Properties found'
     is thrown call this function to return more specific message to user in
@@ -689,21 +714,23 @@ def _check_mandatory_args(algorithm, _algm_object, error, *args, **kwargs):
     for p in props:
         prop = _algm_object.getProperty(p)
         # Mandatory properties are ones with invalid defaults
-        if isinstance(prop.isValid,str):
+        if isinstance(prop.isValid, str):
             valid_str = prop.isValid
         else:
             valid_str = prop.isValid()
         if len(valid_str) > 0 and p not in kwargs.keys():
             missing_arg_list.append(p)
     if len(missing_arg_list) != 0:
-        raise RuntimeError("%s argument(s) not supplied to %s" % (missing_arg_list,algorithm))
+        raise RuntimeError("%s argument(s) not supplied to %s" % (missing_arg_list, algorithm))
     # If the error was not caused by missing property the algorithm specific error should suffice
     else:
         raise RuntimeError(str(error))
 
-#------------------------ General simple function calls ----------------------
+# ------------------------ General simple function calls ----------------------
+
 
 def _is_workspace_property(prop):
+
     """
         Returns true if the property is a workspace property.
 
@@ -722,6 +749,7 @@ def _is_workspace_property(prop):
         # Doesn't look like a workspace property
         return False
 
+
 def _get_args_from_lhs(lhs, algm_obj):
     """
         Return the extra arguments that are to be passed to the algorithm
@@ -732,7 +760,8 @@ def _get_args_from_lhs(lhs, algm_obj):
         workspace property an entry is added to the returned dictionary
         that contains {PropertyName:lhs_name}.
 
-        :param lhs: A 2-tuple that contains the number of variables supplied on the lhs of the function call and the names of these variables
+        :param lhs: A 2-tuple that contains the number of variables supplied on the lhs of the
+        function call and the names of these variables
         :param algm_obj: An initialised algorithm object
         :returns: A dictionary mapping property names to the values extracted from the lhs variables
     """
@@ -740,7 +769,7 @@ def _get_args_from_lhs(lhs, algm_obj):
     ret_names = lhs[1]
     extra_args = {}
 
-    output_props = [ algm_obj.getProperty(p) for p in algm_obj.outputProperties() ]
+    output_props = [algm_obj.getProperty(p) for p in algm_obj.outputProperties()]
 
     nprops = len(output_props)
     nnames = len(ret_names)
@@ -749,8 +778,9 @@ def _get_args_from_lhs(lhs, algm_obj):
 
     for p in output_props:
         if _is_workspace_property(p):
-            if nnames > 0 and nprops > nnames:
-                extra_args[p.name] = ret_names[0] # match argument to property name
+            # Check nnames is greater than 0 and less than nprops
+            if 0 < nnames < nprops:
+                extra_args[p.name] = ret_names[0]  # match argument to property name
                 ret_names = ret_names[1:]
                 nnames -= 1
             elif nnames > 0:
@@ -759,6 +789,7 @@ def _get_args_from_lhs(lhs, algm_obj):
         name += 1
 
     return extra_args
+
 
 def _merge_keywords_with_lhs(keywords, lhs_args):
     """
@@ -774,6 +805,7 @@ def _merge_keywords_with_lhs(keywords, lhs_args):
     final_keywords.update(keywords)
     return final_keywords
 
+
 def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
     """Gather the return values and ensure they are in the
        correct order as defined by the output properties and
@@ -781,16 +813,20 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
        value it is returned on its own
 
        :param func_name: The name of the calling function.
-       :param lhs: A 2-tuple that contains the number of variables supplied on the lhs of the function call and the names of these variables.
+       :param lhs: A 2-tuple that contains the number of variables supplied on the
+       lhs of the function call and the names of these variables.
        :param algm_obj: An executed algorithm object.
-       :param ignore_regex: A list of strings containing regex expressions to match against property names that will be ignored & not returned.
+       :param ignore_regex: A list of strings containing regex expressions to match
+       against property names that will be ignored & not returned.
     """
-    if ignore_regex is None: ignore_regex = []
+    if ignore_regex is None:
+        ignore_regex = []
 
     import re
-    def ignore_property(name, ignore_regex):
-        for regex in ignore_regex:
-            if regex.match(name) is not None:
+
+    def ignore_property(name_to_check, regex_to_ignore):
+        for regex in regex_to_ignore:
+            if regex.match(name_to_check) is not None:
                 return True
         # Matched nothing
         return False
@@ -813,35 +849,38 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=None):
         if _is_workspace_property(prop):
             value_str = prop.valueAsStr
             try:
-                retvals[name]=_api.AnalysisDataService[value_str]
+                retvals[name] = _api.AnalysisDataService[value_str]
             except KeyError:
                 if not prop.isOptional():
-                    raise RuntimeError("Internal error. Output workspace property '%s' on algorithm '%s' has not been stored correctly."
+                    raise RuntimeError("Internal error. Output workspace property '%s' on "
+                                       "algorithm '%s' has not been stored correctly."
                                        "Please contact development team." % (name,  algm_obj.name()))
         else:
             if hasattr(prop, 'value'):
-                retvals[name]=prop.value
+                retvals[name] = prop.value
             else:
-                raise RuntimeError('Internal error. Unknown property type encountered. "%s" on algorithm "%s" is not understood by '
-                       'Python. Please contact development team' % (name, algm_obj.name()))
-
-
+                raise RuntimeError('Internal error. Unknown property type encountered. "%s" '
+                                   'on algorithm "%s" is not understood by '
+                                   'Python. Please contact development team' % (name, algm_obj.name()))
     nvals = len(retvals)
     nlhs = lhs[0]
-    if nlhs > 1 and nvals != nlhs:
+
+    # If we have more than one value but not the same number of values throw
+    if 1 < nlhs != nvals:
         # There is a discrepancy in the number are unpacking variables
         # Let's not have the more cryptic unpacking error raised
         raise RuntimeError("%s is trying to return %d output(s) but you have provided %d variable(s). "
                            "These numbers must match." % (func_name, nvals, nlhs))
     if nvals > 0:
-        ret_type=namedtuple(func_name+"_returns",retvals.keys())
-        ret_value=ret_type(**retvals)
-        if nvals==1:
+        ret_type = namedtuple(func_name+"_returns", retvals.keys())
+        ret_value = ret_type(**retvals)
+        if nvals == 1:
             return ret_value[0]
         else:
             return ret_value
     else:
         return None
+
 
 def _set_logging_option(algm_obj, kwargs):
     """
@@ -849,32 +888,33 @@ def _set_logging_option(algm_obj, kwargs):
         algorithm logging accordingly and removes the value from the dictionary. If the keyword
         does not exist then it does nothing.
 
-        :param alg_object: An initialised algorithm object
+        :param algm_obj: An initialised algorithm object
         :param **kwargs: A dictionary of the keyword arguments passed to the simple function call
     """
     if __LOGGING_KEYWORD__ in kwargs:
         algm_obj.setLogging(kwargs[__LOGGING_KEYWORD__])
         del kwargs[__LOGGING_KEYWORD__]
 
+
 def set_properties(alg_object, *args, **kwargs):
     """
         Set all of the properties of the algorithm. There is no guarantee of
         the order the properties will be set
         :param alg_object: An initialised algorithm object
-        :param *args: Positional arguments
-        :param **kwargs: Keyword arguments
+        :param args: Positional arguments
+        :param kwargs: Keyword arguments
     """
-    def do_set_property(name, value):
-        if value is None:
+    def do_set_property(name, new_value):
+        if new_value is None:
             return
         # The correct parent/child relationship is not quite set up yet: #5157
         # ChildAlgorithms in Python are marked as children but their output is in the
-        # ADS meaning we cannot just set DataItem properties by value. At the moment
+        # ADS meaning we cannot just set DataItem properties by new_value. At the moment
         # they are just set with strings
-        if isinstance(value, _kernel.DataItem):
-            alg_object.setPropertyValue(key, value.name())
+        if isinstance(new_value, _kernel.DataItem):
+            alg_object.setPropertyValue(key, new_value.name())
         else:
-            alg_object.setProperty(key, value)
+            alg_object.setProperty(key, new_value)
     # end
     if len(args) > 0:
         mandatory_props = alg_object.mandatoryProperties()
@@ -896,7 +936,8 @@ def _create_algorithm_function(name, version, algm_object):
     """
         Create a function that will set up and execute an algorithm.
         The help that will be displayed is that of the most recent version.
-        :param algorithm: name of the algorithm
+        :param name: name of the algorithm
+        :param version: The version of the algorithm
         :param algm_object: the created algorithm object.
     """
     def algorithm_wrapper(*args, **kwargs):
@@ -947,7 +988,7 @@ def _create_algorithm_function(name, version, algm_object):
                 raise
 
         return _gather_returns(name, lhs, algm)
-    #enddef
+    # enddef
     # Insert definition in to global dict
     algm_wrapper = _customise_func(algorithm_wrapper, name,
                                    _create_generic_signature(algm_object),
@@ -956,11 +997,12 @@ def _create_algorithm_function(name, version, algm_object):
     # Register aliases
     for alias in algm_object.alias().strip().split(' '):
         alias = alias.strip()
-        if len(alias)>0:
+        if len(alias) > 0:
             globals()[alias] = algm_wrapper
-    #endfor
+    # endfor
     return algm_wrapper
-#-------------------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------------------
+
 
 def _create_algorithm_object(name, version=-1, startProgress=None, endProgress=None):
     """
@@ -974,13 +1016,13 @@ def _create_algorithm_object(name, version=-1, startProgress=None, endProgress=N
     import inspect
     parent = _find_parent_pythonalgorithm(inspect.currentframe())
     if parent is not None:
-        kwargs = {'version':version}
+        kwargs = {'version': version}
         if (startProgress is not None) and (endProgress is not None):
             kwargs['startProgress'] = float(startProgress)
             kwargs['endProgress'] = float(endProgress)
         alg = parent.createChildAlgorithm(name, **kwargs)
 
-        alg.setLogging(parent.isLogging()) # default is to log if parent is logging
+        alg.setLogging(parent.isLogging())  # default is to log if parent is logging
 
         # Historic: simpleapi functions always put stuff in the ADS
         #           If we change this we culd potentially break many users' algorithms
@@ -993,7 +1035,8 @@ def _create_algorithm_object(name, version=-1, startProgress=None, endProgress=N
     alg.setRethrows(True)
     return alg
 
-#-------------------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------------------
+
 
 def _find_parent_pythonalgorithm(frame):
     """
@@ -1008,8 +1051,8 @@ def _find_parent_pythonalgorithm(frame):
     fn_name = "PyExec"
 
     # Return the 'self' object of a given frame
-    def get_self(frame):
-        return frame.f_locals['self']
+    def get_self(frame_arg):
+        return frame_arg.f_locals['self']
 
     # Look recursively for the PyExec method in the stack
     if frame.f_code.co_name == fn_name:
@@ -1026,7 +1069,8 @@ def _find_parent_pythonalgorithm(frame):
     else:
         return None
 
-#-------------------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------------------
+
 
 def set_properties_dialog(algm_object, *args, **kwargs):
     """
@@ -1041,36 +1085,36 @@ def set_properties_dialog(algm_object, *args, **kwargs):
 
     # generic setup
     enabled_list = [s.lstrip(' ') for s in kwargs.get("Enable", "").split(',')]
-    del kwargs["Enable"] # no longer needed
+    del kwargs["Enable"]  # no longer needed
     disabled_list = [s.lstrip(' ') for s in kwargs.get("Disable", "").split(',')]
-    del kwargs["Disable"] # no longer needed
+    del kwargs["Disable"]  # no longer needed
     message = kwargs.get("Message", "")
     del kwargs["Message"]
     presets = '|'
 
-    #-------------------------------------------------------------------------------
-    def make_str(value):
-        """Make a string out of a value such that the Mantid properties can understand it
+    # -------------------------------------------------------------------------------
+    def make_str(value_to_use):
+        """Make a string out of a value_to_use such that the Mantid properties can understand it
         """
         import numpy
 
-        if isinstance(value, numpy.ndarray):
-            value = list(value) # Temp until more complete solution available (#2340)
-        if isinstance(value, list) or \
-           isinstance(value, _kernel.std_vector_dbl) or \
-           isinstance(value, _kernel.std_vector_int) or \
-           isinstance(value, _kernel.std_vector_long) or \
-           isinstance(value, _kernel.std_vector_size_t):
-            return str(value).lstrip('[').rstrip(']')
-        elif isinstance(value, tuple):
-            return str(value).lstrip('(').rstrip(')')
-        elif isinstance(value, bool):
-            if value:
+        if isinstance(value_to_use, numpy.ndarray):
+            value_to_use = list(value_to_use)  # Temp until more complete solution available (#2340)
+        if isinstance(value_to_use, list) or \
+           isinstance(value_to_use, _kernel.std_vector_dbl) or \
+           isinstance(value_to_use, _kernel.std_vector_int) or \
+           isinstance(value_to_use, _kernel.std_vector_long) or \
+           isinstance(value_to_use, _kernel.std_vector_size_t):
+            return str(value_to_use).lstrip('[').rstrip(']')
+        elif isinstance(value_to_use, tuple):
+            return str(value_to_use).lstrip('(').rstrip(')')
+        elif isinstance(value_to_use, bool):
+            if value_to_use:
                 return '1'
             else:
                 return '0'
         else:
-            return str(value)
+            return str(value_to_use)
     # Translate positional arguments and add them to the keyword list
     ordered_props = algm_object.orderedProperties()
     for index, value in enumerate(args):
@@ -1085,11 +1129,13 @@ def set_properties_dialog(algm_object, *args, **kwargs):
 
     # finally run the configured dialog
     import mantidplot
-    dialog_accepted =  mantidplot.createScriptInputDialog(algm_object.name(), presets, message, enabled_list, disabled_list)
+    dialog_accepted = mantidplot.createScriptInputDialog(algm_object.name(), presets, message,
+                                                         enabled_list, disabled_list)
     if not dialog_accepted:
         raise RuntimeError('Algorithm input cancelled')
 
-#----------------------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------------------
+
 
 def _create_algorithm_dialog(algorithm, version, _algm_object):
     """
@@ -1108,40 +1154,43 @@ def _create_algorithm_dialog(algorithm, version, _algm_object):
                 kwargs[item] = ""
 
         algm = _create_algorithm_object(algorithm, _version)
-        set_properties_dialog(algm, *args, **kwargs) # throws if input cancelled
+        set_properties_dialog(algm, *args, **kwargs)  # throws if input cancelled
         algm.execute()
         return algm
-    #enddef
+    # enddef
     arg_list = []
     for p in _algm_object.orderedProperties():
         arg_list.append("%s=None" % p)
     arg_str = ','.join(arg_list)
     signature = ("\b%s" % arg_str, "\b\bMessage=\"\", Enable=\"\", Disable=\"\", Version=%d" % version)
     algm_wrapper = _customise_func(algorithm_wrapper, "%sDialog" % algorithm,
-                                     signature, "\n\n%s dialog" % algorithm)
+                                   signature, "\n\n%s dialog" % algorithm)
 
     globals()["%sDialog" % algorithm] = algm_wrapper
     # Register aliases
     for alias in _algm_object.alias().strip().split(' '):
         alias = alias.strip()
-        if len(alias)>0:
+        if len(alias) > 0:
             globals()["%sDialog" % alias] = algm_wrapper
 
-#--------------------------------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------------------
+
 
 def _create_fake_function(name):
     """Create fake functions for the given name
     """
-    #------------------------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------------------------
     def fake_function(*args, **kwargs):
         raise RuntimeError("Mantid import error. The mock simple API functions have not been replaced!" +
-                           " This is an error in the core setup logic of the mantid module, please contact the development team.")
-    #------------------------------------------------------------------------------------------------
+                           " This is an error in the core setup logic of the mantid module, "
+                           "please contact the development team.")
+    # ------------------------------------------------------------------------------------------------
     fake_function.__name__ = name
-    _replace_signature(fake_function, ("",""))
+    _replace_signature(fake_function, ("", ""))
     globals()[name] = fake_function
 
-#------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------------------------------
+
 
 def _mockup(plugins):
     """
@@ -1159,28 +1208,30 @@ def _mockup(plugins):
         function definitions can overwrite the "fake" ones.
         :param plugins: A list of  modules that have been loaded
     """
-    #--------------------------------------------------------------------------------------------------------
-    def create_fake_function(name):
-        """Create fake functions for the given name
+    # --------------------------------------------------------------------------------------------------------
+    def create_fake_function(func_name):
+        """Create fake functions for the given func_name
         """
-        #------------------------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------------------------
         def fake_function(*args, **kwargs):
             raise RuntimeError("Mantid import error. The mock simple API functions have not been replaced!" +
-                               " This is an error in the core setup logic of the mantid module, please contact the development team.")
-        #------------------------------------------------------------------------------------------------
-        if "." in name:
-            name = name.rstrip('.py')
-        if specialization_exists(name):
+                               " This is an error in the core setup logic of the mantid module, "
+                               "please contact the development team.")
+        # ------------------------------------------------------------------------------------------------
+        if "." in func_name:
+            func_name = func_name.rstrip('.py')
+        if specialization_exists(func_name):
             return
-        fake_function.__name__ = name
-        globals()[name] = fake_function
-    #--------------------------------------------------------
+        fake_function.__name__ = func_name
+        globals()[func_name] = fake_function
+    # --------------------------------------------------------
+
     def create_fake_functions(alg_names):
         """Create fake functions for all of the listed names
         """
         for alg_name in alg_names:
             create_fake_function(alg_name)
-    #-------------------------------------
+    # -------------------------------------
 
     # Start with the loaded C++ algorithms
     from mantid.api import AlgorithmFactory
@@ -1194,7 +1245,8 @@ def _mockup(plugins):
         name = os.path.splitext(name)[0]
         create_fake_function(name)
 
-#------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------------------------------
+
 
 def _translate():
     """
@@ -1204,9 +1256,11 @@ def _translate():
     """
     from mantid.api import AlgorithmFactory, AlgorithmManager
 
-    new_functions = [] # Names of new functions added to the global namespace
-    new_methods = {} # Method names mapped to their algorithm names. Used to detect multiple copies of same method name
-                     # on different algorithms, which is an error
+    # Names of new functions added to the global namespace
+    new_functions = []
+    # Method names mapped to their algorithm names. Used to detect multiple copies of same method name
+    # on different algorithms, which is an error
+    new_methods = {}
 
     algs = AlgorithmFactory.getRegisteredAlgorithms(True)
     algorithm_mgr = AlgorithmManager
@@ -1229,7 +1283,8 @@ def _translate():
                 raise RuntimeError("simpleapi: Trying to attach '%s' as method to point to '%s' algorithm but "
                                    "it has already been attached to point to the '%s' algorithm.\n"
                                    "Does one inherit from the other? "
-                                   "Please check and update one of the algorithms accordingly." % (method_name,algm_object.name(),other_alg))
+                                   "Please check and update one of the algorithms accordingly."
+                                   % (method_name, algm_object.name(), other_alg))
             _attach_algorithm_func_as_method(method_name, algorithm_wrapper, algm_object)
             new_methods[method_name] = algm_object.name()
 
@@ -1239,7 +1294,8 @@ def _translate():
 
     return new_functions
 
-#-------------------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------------------
+
 
 def _attach_algorithm_func_as_method(method_name, algorithm_wrapper, algm_object):
     """
@@ -1253,13 +1309,14 @@ def _attach_algorithm_func_as_method(method_name, algorithm_wrapper, algm_object
     if input_prop == "":
         raise RuntimeError("simpleapi: '%s' has requested to be attached as a workspace method but "
                            "Algorithm::workspaceMethodInputProperty() has returned an empty string."
-                           "This method is required to map the calling object to the correct property." % algm_object.name())
+                           "This method is required to map the calling object to the correct property."
+                           % algm_object.name())
     if input_prop not in algm_object:
         raise RuntimeError("simpleapi: '%s' has requested to be attached as a workspace method but "
                            "Algorithm::workspaceMethodInputProperty() has returned a property name that "
                            "does not exist on the algorithm." % algm_object.name())
 
     _api._workspaceops.attach_func_as_method(method_name, algorithm_wrapper, input_prop,
-                                                  algm_object.workspaceMethodOn())
+                                             algm_object.workspaceMethodOn())
 
-#-------------------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------------------

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLEnergyTransfer.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
+import os
 import numpy as np
 from mantid.simpleapi import *  # noqa
 from mantid.kernel import *  # noqa

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionFWS.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionFWS.py
@@ -5,6 +5,7 @@ from mantid.simpleapi import *  # noqa
 from mantid.kernel import *  # noqa
 from mantid.api import *  # noqa
 from mantid import mtd
+import os
 import numpy as np
 import time
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
@@ -5,6 +5,7 @@ from mantid.kernel import *  # noqa
 from mantid.api import *  # noqa
 from mantid import mtd
 import numpy
+import os
 
 
 class IndirectILLReductionQENS(PythonAlgorithm):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MolDynTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MolDynTest.py
@@ -1,6 +1,7 @@
 #pylint: disable=too-many-public-methods,invalid-name
 from __future__ import (absolute_import, division, print_function)
 
+import os
 import unittest
 from mantid.simpleapi import *
 from mantid.api import *

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -11,6 +11,7 @@ from mantid.kernel import (DateAndTime, time_duration, FloatTimeSeriesProperty,
 import SANSUtility as su
 import re
 import random
+import os
 import numpy as np
 
 


### PR DESCRIPTION
Description of work.
This PR fixes an issue with `Load` being called in Python with `Filename=None` passed. Previously it would print a long error message describing the Python container. Now it prints a valid error saying that a `None` is not acceptable.

Additionally I tided `simpleapi` to fix the PEP8 white space issues (which should reduce the number of warnings in flake8) ~~and remove `import os` from the `simpleapi` which was unused into the various scripts which relied on this implicit import.~~ this was too much work so in the next maintenance cycle I'll open another PR to finish this properly. 

**To test:**
Ensure all builds pass
Run the following and check it gives a sane error message
`Load(Filename=None)`

Fixes #19190 .

*Does not need to be in the release notes. - Only noticed internally*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
