### PR TITLE
Change the way the extension is specified in SaveMDWorkspaceToVTK

### DIFF
--- a/Vates/VatesAPI/src/SaveMDWorkspaceToVTKImpl.cpp
+++ b/Vates/VatesAPI/src/SaveMDWorkspaceToVTKImpl.cpp
@@ -57,8 +57,8 @@ bool isNDWorkspace(const Mantid::API::IMDWorkspace &workspace,
 namespace Mantid {
 namespace VATES {
 
-const std::string SaveMDWorkspaceToVTKImpl::structuredGridExtension = "vts";
-const std::string SaveMDWorkspaceToVTKImpl::unstructuredGridExtension = "vtu";
+const std::string SaveMDWorkspaceToVTKImpl::structuredGridExtension = ".vts";
+const std::string SaveMDWorkspaceToVTKImpl::unstructuredGridExtension = ".vtu";
 
 SaveMDWorkspaceToVTKImpl::SaveMDWorkspaceToVTKImpl(SaveMDWorkspaceToVTK *parent)
     : m_progress(parent, 0.0, 1.0, 101) {
@@ -313,7 +313,6 @@ SaveMDWorkspaceToVTKImpl::getFullFilename(std::string filename,
   const auto extension =
       isHistoWorkspace ? structuredGridExtension : unstructuredGridExtension;
   if (!has_suffix(filename, extension)) {
-    filename += ".";
     filename += extension;
   }
   return filename;


### PR DESCRIPTION
This fixes setting the extension in the algorithm GUI, the `FileProperty` [here](https://github.com/mantidproject/mantid/blob/master/Vates/VatesAPI/src/SaveMDWorkspaceToVTK.cpp#L51-L54) expects a list of extensions with `.` at the start. Before this setting the filename to `filename` would results in the it changing to `filenamevts` and not `filename.vts`. This fixes that.

**To test:**
Start the `SaveMDWorkspaceToVTK` algorithm GUI. Select `Browse` and enter a `File name` without an extension. The extension should now be correctly append to the file name.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
