### PR TITLE
Use ParaView to calculate colormap min and max values

### DIFF
--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/PeaksFilter.xml
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/PeaksFilter.xml
@@ -33,8 +33,6 @@
         Set the radius type.
       </Documentation>
     </IntVectorProperty>
-    <DoubleVectorProperty name="MinValue" command="GetMinValue" information_only="1"/>
-    <DoubleVectorProperty name="MaxValue" command="GetMaxValue" information_only="1"/>
     <StringVectorProperty name="Instrument" command="GetInstrument" number_of_elements="1" information_only="1"/>
     </SourceProxy>
   </ProxyGroup>

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.cxx
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.cxx
@@ -23,8 +23,8 @@ vtkStandardNewMacro(vtkPeaksFilter)
 using namespace Mantid::VATES;
 
 vtkPeaksFilter::vtkPeaksFilter()
-    : m_radiusNoShape(0.5), m_minValue(0.1), m_maxValue(0.1),
-      m_coordinateSystem(0), m_radiusType(Mantid::Geometry::PeakShape::Radius),
+    : m_radiusNoShape(0.5), m_coordinateSystem(0),
+      m_radiusType(Mantid::Geometry::PeakShape::Radius),
       m_metadataJsonManager(new MetadataJsonManager()),
       m_vatesConfigurations(new VatesConfigurations()) {
   this->SetNumberOfInputPorts(1);
@@ -54,8 +54,6 @@ int vtkPeaksFilter::RequestData(vtkInformation*, vtkInformationVector **inputVec
     std::string jsonString = fieldDataToMetadata(fieldData, m_vatesConfigurations->getMetadataIdJson());
     m_metadataJsonManager->readInSerializedJson(jsonString);
 
-    m_minValue = m_metadataJsonManager->getMinValue();
-    m_maxValue = m_metadataJsonManager->getMaxValue();
     m_instrument = m_metadataJsonManager->getInstrument();
     m_coordinateSystem = m_metadataJsonManager->getSpecialCoordinates();
   }
@@ -91,9 +89,6 @@ int vtkPeaksFilter::RequestInformation(vtkInformation*, vtkInformationVector** i
 
     std::string jsonString = fieldDataToMetadata(fieldData, m_vatesConfigurations->getMetadataIdJson());
     m_metadataJsonManager->readInSerializedJson(jsonString);
-
-    m_minValue = m_metadataJsonManager->getMinValue();
-    m_maxValue = m_metadataJsonManager->getMaxValue();
     m_instrument = m_metadataJsonManager->getInstrument();
     m_coordinateSystem = m_metadataJsonManager->getSpecialCoordinates();
   }
@@ -172,26 +167,6 @@ vtkPeaksFilter::getPeaksWorkspaces(
     }
   }
   return peaksWorkspaces;
-}
-
-/**
- * Gets the minimum value of the data associated with the 
- * workspace.
- * @returns The minimum value of the workspace data.
- */
-double vtkPeaksFilter::GetMinValue()
-{
-  return m_minValue;
-}
-
-/**
- * Gets the maximum value of the data associated with the 
- * workspace.
- * @returns The maximum value of the workspace data.
- */
-double vtkPeaksFilter::GetMaxValue(){
-
-   return m_maxValue;
 }
 
 /**

--- a/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
+++ b/Vates/ParaviewPlugins/ParaViewFilters/PeaksFilter/vtkPeaksFilter.h
@@ -21,8 +21,6 @@ public:
   void SetRadiusNoShape(double radius);
   void SetRadiusType(int type);
   void updateAlgorithmProgress(double progress, const std::string &message);
-  double GetMinValue();
-  double GetMaxValue();
   const char *GetInstrument();
 
 protected:
@@ -37,8 +35,6 @@ private:
   std::vector<Mantid::API::IPeaksWorkspace_sptr>
   getPeaksWorkspaces(const Mantid::Kernel::StringTokenizer &workspaceNames);
   double m_radiusNoShape;
-  double m_minValue;
-  double m_maxValue;
   int m_coordinateSystem;
   Mantid::Geometry::PeakShape::RadiusType m_radiusType;
   std::string m_instrument;

--- a/Vates/ParaviewPlugins/ParaViewFilters/ScaleWorkspace/ScaleWorkspace.xml
+++ b/Vates/ParaviewPlugins/ParaViewFilters/ScaleWorkspace/ScaleWorkspace.xml
@@ -19,8 +19,6 @@
 	  <DoubleVectorProperty name="X Scaling Factor" command="SetXScaling" number_of_elements="1" default_values="1"/>
 	  <DoubleVectorProperty name="Y Scaling Factor" command="SetYScaling" number_of_elements="1" default_values="1"/>
 	  <DoubleVectorProperty name="Z Scaling Factor" command="SetZScaling" number_of_elements="1" default_values="1"/>
-    <DoubleVectorProperty name="MinValue"	command="GetMinValue" information_only="1"/>
-    <DoubleVectorProperty name="MaxValue" command="GetMaxValue" information_only="1"/>
     <StringVectorProperty name="Instrument" command="GetInstrument" number_of_elements="1" information_only="1"/>
     <IntVectorProperty name="SpecialCoordinates" command="GetSpecialCoordinates" number_of_elements="1" information_only="1" default_values="0">
 		<SimpleIntInformationHelper />

--- a/Vates/ParaviewPlugins/ParaViewFilters/ScaleWorkspace/vtkScaleWorkspace.cxx
+++ b/Vates/ParaviewPlugins/ParaViewFilters/ScaleWorkspace/vtkScaleWorkspace.cxx
@@ -22,8 +22,6 @@ vtkScaleWorkspace::vtkScaleWorkspace() :
   m_xScaling(1),
   m_yScaling(1),
   m_zScaling(1),
-  m_minValue(0.1),
-  m_maxValue(0.1),
   m_specialCoordinates(-1),
   m_metadataJsonManager(new MetadataJsonManager()),
   m_vatesConfigurations(new VatesConfigurations())
@@ -109,26 +107,6 @@ void vtkScaleWorkspace::SetZScaling(double zScaling)
 }
 
 /**
- * Gets the minimum value of the data associated with the 
- * workspace.
- * @returns The minimum value of the workspace data.
- */
-double vtkScaleWorkspace::GetMinValue()
-{
-  return m_minValue;
-}
-
-/**
- * Gets the maximum value of the data associated with the 
- * workspace.
- * @returns The maximum value of the workspace data.
- */
-double vtkScaleWorkspace::GetMaxValue()
-{
-   return m_maxValue;
-}
-
-/**
  * Gets the (first) instrument which is associated with the workspace.
  * @return The name of the instrument.
  */
@@ -155,8 +133,6 @@ void vtkScaleWorkspace::updateMetaData(vtkPointSet *inputDataSet) {
   std::string jsonString = fieldDataToMetadata(fieldData, m_vatesConfigurations->getMetadataIdJson());
   m_metadataJsonManager->readInSerializedJson(jsonString);
 
-  m_minValue = m_metadataJsonManager->getMinValue();
-  m_maxValue = m_metadataJsonManager->getMaxValue();
   m_instrument = m_metadataJsonManager->getInstrument();
   m_specialCoordinates = m_metadataJsonManager->getSpecialCoordinates();
 }

--- a/Vates/ParaviewPlugins/ParaViewFilters/ScaleWorkspace/vtkScaleWorkspace.h
+++ b/Vates/ParaviewPlugins/ParaViewFilters/ScaleWorkspace/vtkScaleWorkspace.h
@@ -15,8 +15,6 @@ public:
   void SetXScaling(double xScaling);
   void SetYScaling(double yScaling);
   void SetZScaling(double zScaling);
-  double GetMinValue();
-  double GetMaxValue();
   const char *GetInstrument();
   int GetSpecialCoordinates();
 
@@ -36,9 +34,6 @@ private:
   double m_xScaling;
   double m_yScaling;
   double m_zScaling;
-
-  double m_minValue;
-  double m_maxValue;
   std::string m_instrument;
   int m_specialCoordinates;
 

--- a/Vates/ParaviewPlugins/ParaViewFilters/SplatterPlot/SplatterPlot.xml
+++ b/Vates/ParaviewPlugins/ParaViewFilters/SplatterPlot/SplatterPlot.xml
@@ -32,28 +32,12 @@
             The set the viewing limit to the top percentile of the denses boxes.
          </Documentation>
       </DoubleVectorProperty>
-	  <DoubleVectorProperty 
-        name="MinValue"
-		command="GetMinValue"
-        information_only="1">
-        <Documentation>
-          Minimum value of the data set.
-        </Documentation>
-      </DoubleVectorProperty>
-	  <DoubleVectorProperty 
-        name="MaxValue"
-		command="GetMaxValue"
-        information_only="1">
-        <Documentation>
-          Maximum value of the data set.
-        </Documentation>
-      </DoubleVectorProperty>
-	  <StringVectorProperty
+      <StringVectorProperty
          name="Instrument"
          command="GetInstrument"
          number_of_elements="1"
          information_only="1">
-       </StringVectorProperty>
+      </StringVectorProperty>
     </SourceProxy>
   </ProxyGroup>
   <!-- End SplatterPlot -->

--- a/Vates/ParaviewPlugins/ParaViewFilters/SplatterPlot/vtkSplatterPlot.cxx
+++ b/Vates/ParaviewPlugins/ParaViewFilters/SplatterPlot/vtkSplatterPlot.cxx
@@ -180,44 +180,6 @@ void vtkSplatterPlot::updateAlgorithmProgress(double progress, const std::string
 }
 
 /**
- * Gets the minimum value of the data associated with the 
- * workspace.
- * @return The minimum value of the workspace data.
- */
-double vtkSplatterPlot::GetMinValue()
-{
-  if (nullptr == m_presenter) {
-    return 0.0;
-  }
-  try {
-    return m_presenter->getMinValue();
-  }
-  catch (std::runtime_error &)
-  {
-    return 0.0;
-  }
-}
-
-/**
- * Gets the maximum value of the data associated with the 
- * workspace.
- * @return The maximum value of the workspace data.
- */
-double vtkSplatterPlot::GetMaxValue()
-{
-  if (nullptr == m_presenter) {
-    return 0.0;
-  }
-  try {
-    return m_presenter->getMaxValue();
-  }
-  catch (std::runtime_error &)
-  {
-    return 0.0;
-  }
-}
-
-/**
  * Gets the (first) instrument which is associated with the workspace.
  * @return The name of the instrument.
  */

--- a/Vates/ParaviewPlugins/ParaViewFilters/SplatterPlot/vtkSplatterPlot.h
+++ b/Vates/ParaviewPlugins/ParaViewFilters/SplatterPlot/vtkSplatterPlot.h
@@ -21,10 +21,6 @@ public:
   void SetNumberOfPoints(int nPoints);
   void SetTopPercentile(double topPercentile);
   void updateAlgorithmProgress(double progress, const std::string &message);
-  /// Getter for the minimum value of the workspace data
-  double GetMinValue();
-  /// Getter for the maximum value of the workspace data
-  double GetMaxValue();
   /// Getter for the maximum value of the workspace data
   const char *GetInstrument();
 

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/MDEWSource.xml
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/MDEWSource.xml
@@ -68,28 +68,12 @@
         information_only="1"
         si_class="vtkSITimeLabelProperty">
       </StringVectorProperty>
-	         <DoubleVectorProperty 
-        name="MinValue"
-		command="GetMinValue"
+      <StringVectorProperty
+        name="Instrument"
+        command="GetInstrument"
+        number_of_elements="1"
         information_only="1">
-        <Documentation>
-          Minimum value of the data set.
-        </Documentation>
-      </DoubleVectorProperty>
-	  <DoubleVectorProperty 
-        name="MaxValue"
-		command="GetMaxValue"
-        information_only="1">
-        <Documentation>
-          Maximum value of the data set.
-        </Documentation>
-      </DoubleVectorProperty>
-	 <StringVectorProperty
-         name="Instrument"
-         command="GetInstrument"
-         number_of_elements="1"
-         information_only="1">
-       </StringVectorProperty>
+      </StringVectorProperty>
     </SourceProxy>
   </ProxyGroup>
   <!-- End MDEWSource -->

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
@@ -96,38 +96,6 @@ int vtkMDEWSource::GetSpecialCoordinates() {
 }
 
 /**
- * Gets the minimum value of the data associated with the
- * workspace.
- * @return The minimum value of the workspace data.
- */
-double vtkMDEWSource::GetMinValue() {
-  if (nullptr == m_presenter) {
-    return 0.0;
-  }
-  try {
-    return m_presenter->getMinValue();
-  } catch (std::runtime_error &) {
-    return 0;
-  }
-}
-
-/**
- * Gets the maximum value of the data associated with the
- * workspace.
- * @return The maximum value of the workspace data.
- */
-double vtkMDEWSource::GetMaxValue() {
-  if (nullptr == m_presenter) {
-    return 0.0;
-  }
-  try {
-    return m_presenter->getMaxValue();
-  } catch (std::runtime_error &) {
-    return 0;
-  }
-}
-
-/**
  * Gets the (first) instrument which is associated with the workspace.
  * @return The name of the instrument.
  */

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.h
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.h
@@ -70,10 +70,6 @@ public:
   const std::string &GetWorkspaceName();
   /// Getter for the workspace type
   std::string GetWorkspaceTypeName();
-  /// Getter for the minimum value of the workspace data.
-  double GetMinValue();
-  /// Getter for the maximum value of the workspace data.
-  double GetMaxValue();
   /// Getter for the instrument associated with the workspace data.
   std::string GetInstrument();
 

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/MDHWSource.xml
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/MDHWSource.xml
@@ -59,28 +59,12 @@
         information_only="1"
         si_class="vtkSITimeLabelProperty">
       </StringVectorProperty>
-       <DoubleVectorProperty 
-        name="MinValue"
-		command="GetMinValue"
+      <StringVectorProperty
+        name="Instrument"
+        command="GetInstrument"
+        number_of_elements="1"
         information_only="1">
-        <Documentation>
-          Minimum value of the data set.
-        </Documentation>
-      </DoubleVectorProperty>
-	  <DoubleVectorProperty 
-        name="MaxValue"
-		command="GetMaxValue"
-        information_only="1">
-        <Documentation>
-          Maximum value of the data set.
-        </Documentation>
-      </DoubleVectorProperty>
-	  <StringVectorProperty
-         name="Instrument"
-         command="GetInstrument"
-         number_of_elements="1"
-         information_only="1">
-       </StringVectorProperty>
+      </StringVectorProperty>
     </SourceProxy>
   </ProxyGroup>
   <!-- End MDHWSource -->

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
@@ -79,38 +79,6 @@ int vtkMDHWSource::GetSpecialCoordinates() {
 }
 
 /**
- * Gets the minimum value of the data associated with the 
- * workspace.
- * @return The minimum value of the workspace data.
- */
-double vtkMDHWSource::GetMinValue() {
-  if (nullptr == m_presenter) {
-    return 0.0;
-  }
-  try {
-    return m_presenter->getMinValue();
-  } catch (std::runtime_error &) {
-    return 0.0;
-  }
-}
-
-/**
- * Gets the maximum value of the data associated with the 
- * workspace.
- * @return The maximum value of the workspace data.
- */
-double vtkMDHWSource::GetMaxValue() {
-  if (nullptr == m_presenter) {
-    return 0.0;
-  }
-  try {
-    return m_presenter->getMaxValue();
-  } catch (std::runtime_error &) {
-    return 0.0;
-  }
-}
-
-/**
  * Gets the (first) instrument which is associated with the workspace.
  * @return The name of the instrument.
  */

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.h
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.h
@@ -69,10 +69,6 @@ public:
   const std::string &GetWorkspaceName();
   /// Getter for the workspace type
   std::string GetWorkspaceTypeName();
-  /// Getter for the minimum value of the workspace data
-  double GetMinValue();
-  /// Getter for the maximum value of the workspace data
-  double GetMaxValue();
   /// Getter for the maximum value of the workspace data
   std::string GetInstrument();
   /// Setter for the normalization

--- a/Vates/VatesAPI/inc/MantidVatesAPI/MDEWLoadingPresenter.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/MDEWLoadingPresenter.h
@@ -53,8 +53,6 @@ public:
   void setAxisLabels(vtkDataSet *visualDataSet) override;
   ~MDEWLoadingPresenter() override;
   const std::string &getInstrument() override;
-  double getMinValue() override;
-  double getMaxValue() override;
 
 protected:
   /*---------------------------------------------------------------------------

--- a/Vates/VatesAPI/inc/MantidVatesAPI/MDHWLoadingPresenter.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/MDHWLoadingPresenter.h
@@ -53,8 +53,6 @@ public:
   void setAxisLabels(vtkDataSet *visualDataSet) override;
   ~MDHWLoadingPresenter() override;
   const std::string &getInstrument() override;
-  double getMinValue() override;
-  double getMaxValue() override;
 
   /// Transpose a workspace to push integrated dimensions to the last
   static void

--- a/Vates/VatesAPI/inc/MantidVatesAPI/MDLoadingPresenter.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/MDLoadingPresenter.h
@@ -64,19 +64,6 @@ public:
   virtual ~MDLoadingPresenter() {}
   virtual std::string getWorkspaceTypeName() { return "NotSet"; }
   virtual int getSpecialCoordinates() { return Kernel::None; }
-
-  /**
-   * Gets the minimum value.
-   * @returns The minimum value of the dataset or 0.0
-   */
-  virtual double getMinValue() { return 0.0; };
-
-  /**
-   * Gets the maximum value.
-   * @returns The maximum value of the dataset or 0.0
-   */
-  virtual double getMaxValue() { return 0.0; };
-
   /**
    * Gets the instrument associated with the dataset.
    * @returns The instrument associated with the dataset.

--- a/Vates/VatesAPI/inc/MantidVatesAPI/MetaDataExtractorUtils.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/MetaDataExtractorUtils.h
@@ -43,29 +43,11 @@ public:
   ~MetaDataExtractorUtils();
 
   /**
-    * Get the minimum, maximum pair from the workspace
-    * @param workspace A pointer to the workspace
-    * @returns A pair of minimum and maximum values.
-    */
-  QwtDoubleInterval getMinAndMax(const Mantid::API::IMDWorkspace *workspace);
-
-  /**
     * Extracts the instrument from the workspace.
     * @param workspace A pointer to a workspace.
     * @returns The instrument.
     */
   std::string extractInstrument(const Mantid::API::IMDWorkspace *workspace);
-
-private:
-  /**
-  * Get the range of data values from an MD iterator
-  * @param it Iterator for a general MD workspace.
-  * @returns A maximum and minimum pair.
-  */
-  QwtDoubleInterval getRange(Mantid::API::IMDIterator *it);
-
-  double defaultMin;
-  double defaultMax;
 };
 }
 }

--- a/Vates/VatesAPI/inc/MantidVatesAPI/MetadataJsonManager.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/MetadataJsonManager.h
@@ -38,31 +38,17 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 class DLLExport MetadataJsonManager {
 public:
   MetadataJsonManager();
-
   ~MetadataJsonManager();
-
   std::string getSerializedJson();
-
   void readInSerializedJson(const std::string &serializedJson);
-
   void setInstrument(const std::string &instrument);
   std::string &getInstrument();
-
-  void setMinValue(double minValue);
-  double getMinValue();
-
-  void setMaxValue(double maxValue);
-  double getMaxValue();
-
   void setSpecialCoordinates(int specialCoordinates);
   int getSpecialCoordinates();
 
 private:
   Json::Value metadataContainer;
-
   std::string instrument;
-  double minValue;
-  double maxValue;
   int specialCoordinates;
 };
 }

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkSplatterPlotFactory.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkSplatterPlotFactory.h
@@ -82,12 +82,6 @@ public:
   /// Set the time value.
   void setTime(double timeStep);
 
-  /// Get the max value of the data set
-  virtual double getMinValue();
-
-  /// Get the min value of the data set
-  virtual double getMaxValue();
-
   /// Getter for the instrument
   virtual const std::string &getInstrument();
 
@@ -151,12 +145,6 @@ private:
 
   /// Time value.
   double m_time;
-
-  /// Min data value
-  mutable double m_minValue;
-
-  /// Max data value;
-  mutable double m_maxValue;
 
   /// Instrument
   mutable std::string m_instrument;

--- a/Vates/VatesAPI/src/MDEWInMemoryLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDEWInMemoryLoadingPresenter.cpp
@@ -83,16 +83,6 @@ MDEWInMemoryLoadingPresenter::execute(vtkDataSetFactory *factory,
     from ::executeLoadMetadata will not have ensured that all dimensions
     have proper range extents set.
   */
-
-  // Update the meta data min and max values with the values of the visual data
-  // set. This is necessary since we want the full data range of the visual
-  // data set and not of the actual underlying data set.
-  double *range = visualDataSet->GetScalarRange();
-  if (range) {
-    this->m_metadataJsonManager->setMinValue(range[0]);
-    this->m_metadataJsonManager->setMaxValue(range[1]);
-  }
-
   this->extractMetadata(*eventWs);
 
   this->appendMetadata(visualDataSet, eventWs->getName());
@@ -110,12 +100,6 @@ void MDEWInMemoryLoadingPresenter::executeLoadMetadata() {
       boost::dynamic_pointer_cast<Mantid::API::IMDEventWorkspace>(ws);
   m_wsTypeName = eventWs->id();
   m_specialCoords = eventWs->getSpecialCoordinateSystem();
-
-  // Set the minimum and maximum of the workspace data.
-  QwtDoubleInterval minMaxContainer =
-      m_metaDataExtractor->getMinAndMax(eventWs.get());
-  m_metadataJsonManager->setMinValue(minMaxContainer.minValue());
-  m_metadataJsonManager->setMaxValue(minMaxContainer.maxValue());
 
   // Set the instrument which is associated with the workspace.
   m_metadataJsonManager->setInstrument(

--- a/Vates/VatesAPI/src/MDEWLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDEWLoadingPresenter.cpp
@@ -236,21 +236,5 @@ std::string MDEWLoadingPresenter::getTimeStepLabel() const {
 const std::string &MDEWLoadingPresenter::getInstrument() {
   return m_metadataJsonManager->getInstrument();
 }
-
-/**
-* Getter for the minimum value;
-* @return The minimum value of the data set.
-*/
-double MDEWLoadingPresenter::getMinValue() {
-  return m_metadataJsonManager->getMinValue();
-}
-
-/**
- * Getter for the maximum value;
- * @return The maximum value of the data set.
- */
-double MDEWLoadingPresenter::getMaxValue() {
-  return m_metadataJsonManager->getMaxValue();
-}
 }
 }

--- a/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDHWInMemoryLoadingPresenter.cpp
@@ -64,63 +64,6 @@ bool MDHWInMemoryLoadingPresenter::canReadFile() const {
   return bCanReadIt;
 }
 
-namespace {
-class CellVisibility {
-public:
-  explicit CellVisibility(const unsigned char *array)
-      : MASKED_CELL_VALUE(vtkDataSetAttributes::HIDDENCELL |
-                          vtkDataSetAttributes::REFINEDCELL),
-        InputCellGhostArray(array) {}
-  bool operator()(vtkIdType id) const {
-    if (InputCellGhostArray)
-      return !(this->InputCellGhostArray[id] & this->MASKED_CELL_VALUE);
-    else
-      return true;
-  }
-
-private:
-  const unsigned char MASKED_CELL_VALUE;
-  const unsigned char *InputCellGhostArray;
-};
-
-struct MinAndMax {
-  double m_minimum = VTK_DOUBLE_MAX;
-  double m_maximum = VTK_DOUBLE_MIN;
-  vtkDataArray *m_cellScalars;
-  CellVisibility m_isCellVisible;
-  MinAndMax(vtkDataArray *cellScalars, const unsigned char *cellGhostArray)
-      : m_cellScalars(cellScalars), m_isCellVisible(cellGhostArray) {}
-  MinAndMax(MinAndMax &rhs, tbb::split)
-      : m_cellScalars(rhs.m_cellScalars), m_isCellVisible(rhs.m_isCellVisible) {
-  }
-  void operator()(const tbb::blocked_range<int> &r) {
-    for (int id = r.begin(); id != r.end(); ++id) {
-      if (m_isCellVisible(id)) {
-        double s = m_cellScalars->GetComponent(id, 0);
-        m_minimum = std::min(m_minimum, s);
-        m_maximum = std::max(m_maximum, s);
-      }
-    }
-  }
-  void join(MinAndMax &rhs) {
-    m_minimum = std::min(m_minimum, rhs.m_minimum);
-    m_maximum = std::max(m_maximum, rhs.m_maximum);
-  }
-};
-
-void ComputeScalarRange(vtkStructuredGrid *grid, double *cellRange) {
-  vtkDataArray *cellScalars = grid->GetCellData()->GetScalars();
-  auto cga = grid->GetCellGhostArray();
-  MinAndMax minandmax(cellScalars, cga ? cga->GetPointer(0) : nullptr);
-
-  int num = boost::numeric_cast<int>(grid->GetNumberOfCells());
-  tbb::parallel_reduce(tbb::blocked_range<int>(0, num), minandmax);
-
-  cellRange[0] = minandmax.m_minimum;
-  cellRange[1] = minandmax.m_maximum;
-}
-}
-
 /*
 Executes the underlying algorithm to create the MVP model.
 @param factory : visualisation factory to use.
@@ -146,28 +89,6 @@ MDHWInMemoryLoadingPresenter::execute(vtkDataSetFactory *factory,
       m_cachedVisualHistoWs,
       drawingProgressUpdate); // HACK: progressUpdate should be
                               // argument for drawing!
-
-  // Update the meta data min and max values with the values of the visual data
-  // set. This is necessary since we want the full data range of the visual
-  // data set and not of the actual underlying data set.
-
-  // vtkStructuredGrid::GetScalarRange(...) is slow and single-threaded.
-  // Until this is addressed in VTK, we are better of doing the calculation
-  // ourselves.
-  // 600x600x600 vtkStructuredGrid, every other cell blank
-  // structuredGrid->GetScalarRange(range) : 2.267s
-  // structuredGrid->GetCellData()->GetScalars()->GetRange(range) : 1.023s
-  // ComputeScalarRange(structuredGrid,range): 0.075s
-  double range[2];
-  if (auto structuredGrid = vtkStructuredGrid::SafeDownCast(visualDataSet)) {
-    ComputeScalarRange(structuredGrid, range);
-  } else {
-    // should never happen
-    visualDataSet->GetScalarRange(range);
-  }
-
-  this->m_metadataJsonManager->setMinValue(range[0]);
-  this->m_metadataJsonManager->setMaxValue(range[1]);
 
   /*extractMetaData needs to be re-run here because the first execution of this
    from ::executeLoadMetadata will not have ensured that all dimensions
@@ -199,12 +120,6 @@ void MDHWInMemoryLoadingPresenter::executeLoadMetadata() {
   m_specialCoords = histoWs->getSpecialCoordinateSystem();
 
   MDHWLoadingPresenter::transposeWs(histoWs, m_cachedVisualHistoWs);
-
-  // Set the minimum and maximum of the workspace data.
-  QwtDoubleInterval minMaxContainer =
-      m_metaDataExtractor->getMinAndMax(histoWs.get());
-  m_metadataJsonManager->setMinValue(minMaxContainer.minValue());
-  m_metadataJsonManager->setMaxValue(minMaxContainer.maxValue());
 
   // Set the instrument which is associated with the workspace.
   m_metadataJsonManager->setInstrument(

--- a/Vates/VatesAPI/src/MDHWLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDHWLoadingPresenter.cpp
@@ -300,21 +300,5 @@ std::string MDHWLoadingPresenter::getTimeStepLabel() const {
 const std::string &MDHWLoadingPresenter::getInstrument() {
   return m_metadataJsonManager->getInstrument();
 }
-
-/**
-  * Getter for the minimum value;
-  * @return The minimum value of the data set.
-  */
-double MDHWLoadingPresenter::getMinValue() {
-  return m_metadataJsonManager->getMinValue();
-}
-
-/**
- * Getter for the maximum value;
- * @return The maximum value of the data set.
- */
-double MDHWLoadingPresenter::getMaxValue() {
-  return m_metadataJsonManager->getMaxValue();
-}
 }
 }

--- a/Vates/VatesAPI/src/MetaDataExtractorUtils.cpp
+++ b/Vates/VatesAPI/src/MetaDataExtractorUtils.cpp
@@ -18,10 +18,9 @@ namespace {
 Kernel::Logger g_log("MetaDataExtractorUtils");
 }
 
-MetaDataExtractorUtils::MetaDataExtractorUtils()
-    : defaultMin(0.0), defaultMax(1.0) {}
+MetaDataExtractorUtils::MetaDataExtractorUtils() = default;
 
-MetaDataExtractorUtils::~MetaDataExtractorUtils() {}
+MetaDataExtractorUtils::~MetaDataExtractorUtils() = default;
 
 /**
  * Extract the instrument information from the workspace. If there
@@ -66,118 +65,6 @@ std::string MetaDataExtractorUtils::extractInstrument(
   }
 
   return instrument;
-}
-
-/**
- * Set the minimum and maximum of the workspace data. Code essentially copied
- * from SignalRange.cpp
- * @param workspace Rreference to an IMD workspace
- * @returns The minimum and maximum value of the workspace dataset.
- */
-QwtDoubleInterval MetaDataExtractorUtils::getMinAndMax(
-    const Mantid::API::IMDWorkspace *workspace) {
-  if (!workspace)
-    throw std::invalid_argument("The workspace is empty.");
-
-  auto iterators =
-      workspace->createIterators(PARALLEL_GET_MAX_THREADS, nullptr);
-
-  std::vector<QwtDoubleInterval> intervals(iterators.size());
-  // cppcheck-suppress syntaxError
-      PRAGMA_OMP( parallel for schedule(dynamic, 1))
-      for (int i = 0; i < int(iterators.size()); i++) {
-        Mantid::API::IMDIterator *it = iterators[i];
-
-        QwtDoubleInterval range = this->getRange(it);
-        intervals[i] = range;
-        // don't delete iterator in parallel. MSVC doesn't like it
-        // when the iterator points to a mock object.
-      }
-
-      // Combine the overall min/max
-      double minSignal = DBL_MAX;
-      double maxSignal = -DBL_MAX;
-
-      for (size_t i = 0; i < iterators.size(); i++) {
-        delete iterators[i];
-
-        double signal;
-        signal = intervals[i].minValue();
-        if (!std::isinf(signal) && signal < minSignal)
-          minSignal = signal;
-
-        signal = intervals[i].maxValue();
-        if (!std::isinf(signal) && signal > maxSignal)
-          maxSignal = signal;
-      }
-
-      // Set the lowest element to the smallest non-zero element.
-      if (minSignal == DBL_MAX) {
-        minSignal = defaultMin;
-        maxSignal = defaultMax;
-      }
-
-      QwtDoubleInterval minMaxContainer;
-
-      if (minSignal < maxSignal)
-        minMaxContainer = QwtDoubleInterval(minSignal, maxSignal);
-      else {
-        if (minSignal != 0)
-          // Possibly only one value in range
-          minMaxContainer = QwtDoubleInterval(minSignal * 0.5, minSignal * 1.5);
-        else
-          // Other default value
-          minMaxContainer = QwtDoubleInterval(defaultMin, defaultMax);
-      }
-
-      return minMaxContainer;
-}
-
-/**
- * Get the range of a workspace dataset for a single iterator. Code the same as
- * in SignalRange.cpp
- * @param it :: IMDIterator of what to find
- * @returns the min/max range, or INFINITY if not found
- */
-QwtDoubleInterval
-MetaDataExtractorUtils::getRange(Mantid::API::IMDIterator *it) {
-  if (!it)
-    return QwtDoubleInterval(defaultMin, defaultMax);
-  if (!it->valid())
-    return QwtDoubleInterval(defaultMin, defaultMax);
-
-  // Use no normalization
-  it->setNormalization(Mantid::API::VolumeNormalization);
-
-  double minSignal = DBL_MAX;
-  double minSignalZeroCheck = DBL_MAX;
-  double maxSignal = -DBL_MAX;
-  auto inf = std::numeric_limits<double>::infinity();
-
-  do {
-    double signal = it->getNormalizedSignal();
-
-    // Skip any 'infs' as it screws up the color scale
-    if (!std::isinf(signal)) {
-      if (signal == 0.0)
-        minSignalZeroCheck = signal;
-      if (signal < minSignal && signal > 0.0)
-        minSignal = signal;
-      if (signal > maxSignal)
-        maxSignal = signal;
-    }
-  } while (it->next());
-
-  if (minSignal == DBL_MAX) {
-    if (minSignalZeroCheck != DBL_MAX) {
-      minSignal = defaultMin;
-      maxSignal = defaultMax;
-    } else {
-      minSignal = inf;
-      maxSignal = inf;
-    }
-  }
-  return QwtDoubleInterval(minSignal, maxSignal);
 }
 }
 }

--- a/Vates/VatesAPI/src/MetadataJsonManager.cpp
+++ b/Vates/VatesAPI/src/MetadataJsonManager.cpp
@@ -7,8 +7,7 @@ namespace Mantid {
 namespace VATES {
 // Note that we need to have a non-empty default string
 MetadataJsonManager::MetadataJsonManager()
-    : instrument("_EMPTY_"), minValue(0.0), maxValue(1.0),
-      specialCoordinates(-1) {}
+    : instrument("_EMPTY_"), specialCoordinates(-1) {}
 
 MetadataJsonManager::~MetadataJsonManager() {}
 
@@ -21,8 +20,6 @@ std::string MetadataJsonManager::getSerializedJson() {
   metadataContainer.clear();
 
   metadataContainer["instrument"] = instrument;
-  metadataContainer["minValue"] = minValue;
-  metadataContainer["maxValue"] = maxValue;
   metadataContainer["specialCoordinates"] = specialCoordinates;
 
   return writer.write(metadataContainer);
@@ -40,22 +37,6 @@ void MetadataJsonManager::readInSerializedJson(
   bool parseSuccess = reader.parse(serializedJson, metadataContainer, false);
 
   if (parseSuccess) {
-    // Set the max value
-    if (metadataContainer.isObject() &&
-        metadataContainer.isMember("maxValue")) {
-      maxValue = metadataContainer["maxValue"].asDouble();
-    } else {
-      maxValue = 1.0;
-    }
-
-    // Set the min value
-    if (metadataContainer.isObject() &&
-        metadataContainer.isMember("minValue")) {
-      minValue = metadataContainer["minValue"].asDouble();
-    } else {
-      minValue = 0.0;
-    }
-
     // Set the instrument
     if (metadataContainer.isObject() &&
         metadataContainer.isMember("instrument")) {
@@ -73,35 +54,6 @@ void MetadataJsonManager::readInSerializedJson(
     }
   }
 }
-
-/**
- * Set the max value of the workspace's data range.
- * @param maxValue The max value.
- */
-void MetadataJsonManager::setMaxValue(double maxValue) {
-  this->maxValue = maxValue;
-}
-
-/**
- * Get the max value of teh workspace''s data range.
- * @return The max value or 0.0.
- */
-double MetadataJsonManager::getMaxValue() { return maxValue; }
-
-/**
- * Set the min value of the workspace's data range.
- * @param minValue The min value.
- */
-void MetadataJsonManager::setMinValue(double minValue) {
-  this->minValue = minValue;
-}
-
-/**
- * Get the min value of teh workspace's data range.
- * @returns The min value or 0.0;
- *
- */
-double MetadataJsonManager::getMinValue() { return minValue; }
 
 /**
  * Set the instrument.

--- a/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
+++ b/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
@@ -502,8 +502,6 @@ void vtkSplatterPlotFactory::validate() const {
  * Add meta data to the visual data set.
  */
 void vtkSplatterPlotFactory::addMetadata() const {
-  const double defaultValue = 0.1;
-
   if (this->dataSet) {
     m_metadataJsonManager->setInstrument(
         m_metaDataExtractor->extractInstrument(m_workspace.get()));

--- a/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
+++ b/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
@@ -52,7 +52,7 @@ vtkSplatterPlotFactory::vtkSplatterPlotFactory(const std::string &scalarName,
                                                const size_t numPoints,
                                                const double percentToUse)
     : m_scalarName(scalarName), m_numPoints(numPoints), m_buildSortedList(true),
-      m_wsName(""), slice(false), m_time(0.0), m_minValue(0.1), m_maxValue(0.1),
+      m_wsName(""), slice(false), m_time(0.0),
       m_metaDataExtractor(new MetaDataExtractorUtils()),
       m_metadataJsonManager(new MetadataJsonManager()),
       m_vatesConfigurations(new VatesConfigurations()) {
@@ -439,16 +439,6 @@ vtkSplatterPlotFactory::create(ProgressAction &progressUpdating) const {
 
   // Set the instrument
   m_instrument = m_metaDataExtractor->extractInstrument(m_workspace.get());
-  double *range = nullptr;
-
-  if (dataSet) {
-    range = dataSet->GetScalarRange();
-  }
-
-  if (range) {
-    m_minValue = range[0];
-    m_maxValue = range[1];
-  }
 
   // Check for the workspace type, i.e. if it is MDHisto or MDEvent
   IMDEventWorkspace_sptr eventWorkspace =
@@ -515,17 +505,6 @@ void vtkSplatterPlotFactory::addMetadata() const {
   const double defaultValue = 0.1;
 
   if (this->dataSet) {
-    double *range = dataSet->GetScalarRange();
-    if (range) {
-      m_minValue = range[0];
-      m_maxValue = range[1];
-    } else {
-      m_minValue = defaultValue;
-      m_maxValue = defaultValue;
-    }
-
-    m_metadataJsonManager->setMinValue(m_minValue);
-    m_metadataJsonManager->setMaxValue(m_maxValue);
     m_metadataJsonManager->setInstrument(
         m_metaDataExtractor->extractInstrument(m_workspace.get()));
     m_metadataJsonManager->setSpecialCoordinates(
@@ -606,18 +585,6 @@ void vtkSplatterPlotFactory::setTime(double time) {
   }
   m_time = time;
 }
-
-/**
-* Getter for the minimum value;
-* @return The minimum value of the data set.
-*/
-double vtkSplatterPlotFactory::getMinValue() { return m_minValue; }
-
-/**
-* Getter for the maximum value;
-* @return The maximum value of the data set.
-*/
-double vtkSplatterPlotFactory::getMaxValue() { return m_maxValue; }
 
 /**
 * Getter for the instrument.

--- a/Vates/VatesAPI/test/MDEWInMemoryLoadingPresenterTest.h
+++ b/Vates/VatesAPI/test/MDEWInMemoryLoadingPresenterTest.h
@@ -159,8 +159,6 @@ public:
     presenter.executeLoadMetadata();
     TSM_ASSERT("Should export geometry xml metadata on request.",
                !presenter.getGeometryXML().empty());
-    TSM_ASSERT("Should export min value metadata on request.",
-               presenter.getMinValue() <= presenter.getMaxValue())
     TSM_ASSERT("Should export instrument metadata on request",
                presenter.getInstrument().empty())
   }

--- a/Vates/VatesAPI/test/MDHWInMemoryLoadingPresenterTest.h
+++ b/Vates/VatesAPI/test/MDHWInMemoryLoadingPresenterTest.h
@@ -155,8 +155,6 @@ public:
 
     TSM_ASSERT("Should export geometry xml metadata on request.",
                !presenter.getGeometryXML().empty())
-    TSM_ASSERT("Should export min value metadata on request.",
-               presenter.getMinValue() <= presenter.getMaxValue())
     TSM_ASSERT("Should export instrument metadata on request",
                presenter.getInstrument().empty())
   }

--- a/Vates/VatesAPI/test/MetaDataExtractorUtilsTest.h
+++ b/Vates/VatesAPI/test/MetaDataExtractorUtilsTest.h
@@ -45,35 +45,6 @@ public:
     return AnalysisDataService::Instance().retrieve("MD_EVENT_WS_ID");
   }
 
-  void testShouldExtractMinAndMaxFromWorkspaceForMDHisto() {
-    // Arrange
-    Mantid::DataObjects::MDHistoWorkspace_sptr histoWorkspace =
-        makeFakeMDHistoWorkspace(1.0, 4);
-
-    // Act
-    MetaDataExtractorUtils extractor;
-    QwtDoubleInterval minMax = extractor.getMinAndMax(histoWorkspace.get());
-
-    // Assert
-    TSM_ASSERT("Should find the a min which is smaller/equal to max ",
-               minMax.minValue() <= minMax.maxValue())
-  }
-
-  void testShouldExtractMinAndMaxFromWorkspaceForMDEvent() {
-    // Arrange
-    Mantid::API::Workspace_sptr workspace = getReal4DWorkspace();
-    Mantid::API::IMDEventWorkspace_sptr eventWorkspace =
-        boost::dynamic_pointer_cast<Mantid::API::IMDEventWorkspace>(workspace);
-    MetaDataExtractorUtils extractor;
-
-    // Act
-    QwtDoubleInterval minMax = extractor.getMinAndMax(eventWorkspace.get());
-
-    // Assert
-    TSM_ASSERT("Should find the a min which is smaller/equal to max ",
-               minMax.minValue() <= minMax.maxValue())
-  }
-
   void testShouldNotFindInstrumentForBadWorkspace() {
     // Arrange
     // Return a table workspace.

--- a/Vates/VatesAPI/test/MetadataJsonManagerTest.h
+++ b/Vates/VatesAPI/test/MetadataJsonManagerTest.h
@@ -22,20 +22,11 @@ public:
 
     // Act
     std::string instrument = manager.getInstrument();
-    double minValue = manager.getMinValue();
-    double maxValue = manager.getMaxValue();
-
     // Assert
-    double expectedMinValue = 0.0;
-    double expectedMaxValue = 1.0;
     std::string expectedInstrument("_EMPTY_");
 
     TSM_ASSERT("The instrument string is empty, since it does not exist.",
                expectedInstrument == instrument);
-    TSM_ASSERT_EQUALS("The min default value is 0.0.", expectedMinValue,
-                      minValue);
-    TSM_ASSERT_EQUALS("The max default value is 1.0.", expectedMaxValue,
-                      maxValue);
   }
 
   void testSetValuesCanBeReadOut() {
@@ -43,28 +34,17 @@ public:
     MetadataJsonManager manager;
 
     std::string instrument = "OSIRIS";
-    double minValue = 123.0;
-    double maxValue = 124234.3;
-
     // Act
     manager.setInstrument(instrument);
-    manager.setMinValue(minValue);
-    manager.setMaxValue(maxValue);
-
     // Assert
     TSM_ASSERT_EQUALS("The instrument is read in and out.", instrument,
                       manager.getInstrument());
-    TSM_ASSERT_EQUALS("The min value is read in and out.", minValue,
-                      manager.getMinValue());
-    TSM_ASSERT_EQUALS("The max value is read in and out.", maxValue,
-                      manager.getMaxValue());
   }
 
   void testJsonStringIsReadInAndPopualtesContainer() {
     // Arrange
     MetadataJsonManager manager;
-    std::string jsonString =
-        "{\"instrument\": \"OSIRIS\", \"minValue\":1.0, \"maxValue\": 2.0}";
+    std::string jsonString = "{\"instrument\": \"OSIRIS\"}";
 
     // Act
     manager.readInSerializedJson(jsonString);
@@ -73,19 +53,12 @@ public:
 
     TSM_ASSERT("The instrument of the serialized Json string is detected.",
                manager.getInstrument() == "OSIRIS");
-    TSM_ASSERT_EQUALS(
-        "The min value of the serialized Json string is detected.", 1.0,
-        manager.getMinValue());
-    TSM_ASSERT_EQUALS(
-        "The max value of the serialized Json string is detected.", 2.0,
-        manager.getMaxValue());
   }
 
   void testJsonStringWhichDoesNotHaveFieldsProducesDefaultValues() {
     // Arrange
     MetadataJsonManager manager;
-    std::string jsonString = "{\"myInstrument\": \"OSIRIS\", "
-                             "\"myMinValue\":1.0, \"myMaxValue\": 2.0}";
+    std::string jsonString = "{\"myInstrument\": \"OSIRIS\"}";
 
     // Act
     manager.readInSerializedJson(jsonString);
@@ -95,20 +68,12 @@ public:
     TSM_ASSERT("The json object does not find the instrument field and returns "
                "default.",
                manager.getInstrument() == expectedInstrument);
-    TSM_ASSERT_EQUALS("The json object does not find the max value field and "
-                      "returns default.",
-                      0.0, manager.getMinValue());
-    TSM_ASSERT_EQUALS("The json object does not find the min value field and "
-                      "returns default.",
-                      1.0, manager.getMaxValue());
   }
 
   void testCorrectJsonStringIsProduced() {
     // Arrange
     MetadataJsonManager manager;
     manager.setInstrument("OSIRIS");
-    manager.setMaxValue(3.0);
-    manager.setMinValue(2.0);
 
     // Act
     std::string jsonString = manager.getSerializedJson();
@@ -120,10 +85,6 @@ public:
     TSM_ASSERT("Json string is being produced", !jsonString.empty());
     TSM_ASSERT_EQUALS("Json string contains inserted instrument.", "OSIRIS",
                       container["instrument"].asString());
-    TSM_ASSERT_EQUALS("Json string contains inserted min value.", 2.0,
-                      container["minValue"].asDouble());
-    TSM_ASSERT_EQUALS("Json string containns inserted max value.", 3.0,
-                      container["maxValue"].asDouble());
   }
 };
 #endif

--- a/Vates/VatesAPI/test/vtkSplatterPlotFactoryTest.h
+++ b/Vates/VatesAPI/test/vtkSplatterPlotFactoryTest.h
@@ -229,8 +229,6 @@ public:
     manager.readInSerializedJson(jsonOut);
     TSM_ASSERT("The instrument should be empty",
                manager.getInstrument().empty());
-    TSM_ASSERT_EQUALS("The max value is 1", 1.0, manager.getMaxValue());
-    TSM_ASSERT_EQUALS("The min value is 1", 1.0, manager.getMinValue());
   }
 };
 

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/AutoScaleRangeGenerator.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/AutoScaleRangeGenerator.h
@@ -91,17 +91,6 @@ private:
   /// Gets the log scale setting for the mode
   bool getLogScale();
 
-  /**
-   * Extract the min and max values of a source. If we are dealing with a filter
-   * which does not
-   * have the information then look upstream for the information
-   * @param source A pointer to a source
-   * @param minValue A reference to a min value.
-   * @param maxValue A reference to a max value.
-   */
-  void setMinBufferAndMaxBuffer(pqPipelineSource *source, double &minValue,
-                                double &maxValue);
-
   /// Md constants
   MantidQt::API::MdConstants m_mdConstants;
 

--- a/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.h
+++ b/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.h
@@ -61,14 +61,6 @@ public:
                  bool createRenderProxy = true);
   /// Default destructor.
   ~ThreeSliceView() override;
-
-  /// Correct the color scale range if not in automatic mode.
-  void correctColorScaleRange();
-  /**
-   * Correct an oddity in the creation of the 3D view so that the cuts
-   * are visibile.
-   */
-  // void correctVisibility();
   /**
    * ViewBase::destroyView
    */

--- a/Vates/VatesSimpleGui/ViewWidgets/src/ThreesliceView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/ThreesliceView.cpp
@@ -110,12 +110,6 @@ ModeControlWidget::Views ThreeSliceView::getViewType() {
   return ModeControlWidget::Views::THREESLICE;
 }
 
-void ThreeSliceView::correctColorScaleRange() {
-  QPair<double, double> range =
-      this->origRep->getLookupTable()->getScalarRange();
-  emit this->dataRange(range.first, range.second);
-}
-
 void ThreeSliceView::resetCamera() { this->m_mainView->resetCamera(); }
 }
 }

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -60,7 +60,8 @@ SliceViewer Improvements
 VSI Improvments
 ---------------
 - ParaView was updated to to `v5.3.0 <https://blog.kitware.com/paraview-5-3-0-release-notes/>`_.
-- The mapped array vtkMDHWSignalArray has been refactored to use the new vtkGenericDataArray class template. This minimized virtual indirection and allows advanced compiler optimizations such as vectorization.
+- The mapped array vtkMDHWSignalArray has been refactored to use the new vtkGenericDataArray class template. This interface minimizes virtual indirection and allows advanced compiler optimizations such as vectorization.
+- Minimize the number of times the workspace min and max values are calculated.
 
 |
 


### PR DESCRIPTION
Description of work.

This uses the new [FiniteRange member function](https://gitlab.kitware.com/paraview/paraview/merge_requests/1406) to obtain min and max values directly from ParaView and avoids doing the calculation a second time within Mantid.

**To test:**

<!-- Instructions for testing. -->

Load a variety of MDWorkspaces and PeaksWorkspaces in the VSI. Verify that the colormap still behaves as expected.

There is no GitHub issue associated with this pull request.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
