### PR TITLE
clang-tidy check performance-inefficient-string-concatenation

### DIFF
--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1332,10 +1332,12 @@ bool Algorithm::processGroups() {
         // Default name = "in1_in2_out"
         const std::string inName = prop->value();
         std::string outName;
-        if (m_groupsHaveSimilarNames)
-          outName = inName + "_" + Strings::toString(entry + 1);
-        else
-          outName = outputBaseName + "_" + inName;
+        if (m_groupsHaveSimilarNames) {
+          outName.append(inName).append("_").append(
+              Strings::toString(entry + 1));
+        } else {
+          outName.append(outputBaseName).append("_").append(inName);
+        }
 
         auto inputProp = std::find_if(m_inputWorkspaceProps.begin(),
                                       m_inputWorkspaceProps.end(),

--- a/Framework/API/src/FunctionFactory.cpp
+++ b/Framework/API/src/FunctionFactory.cpp
@@ -125,8 +125,11 @@ IFunction_sptr FunctionFactoryImpl::createSimple(
         fun->setParameter(parName, boost::lexical_cast<double>(parValue));
       } catch (boost::bad_lexical_cast &) {
         throw std::runtime_error(
-            "Error in value of parameter " + parName + ".\n" + parValue +
-            " cannot be interpreted as a floating point value.");
+            std::string("Error in value of parameter ")
+                .append(parName)
+                .append(".\n")
+                .append(parValue)
+                .append(" cannot be interpreted as a floating point value."));
       }
     }
   } // for term

--- a/Framework/API/src/MuParserUtils.cpp
+++ b/Framework/API/src/MuParserUtils.cpp
@@ -36,7 +36,7 @@ const std::map<double, std::string> MUPARSER_CONSTANTS = {
  *  @param parser The parser to be initialized.
  */
 void DLLExport addDefaultConstants(mu::Parser &parser) {
-  for (const auto constant : MUPARSER_CONSTANTS) {
+  for (const auto &constant : MUPARSER_CONSTANTS) {
     parser.DefineConst(constant.second, constant.first);
   }
 }
@@ -46,7 +46,7 @@ const std::map<std::string, oneVarFun> MUPARSER_ONEVAR_FUNCTIONS = {
     {"erf", gsl_sf_erf}, {"erfc", gsl_sf_erfc}};
 
 void DLLExport extraOneVarFunctions(mu::Parser &parser) {
-  for (const auto function : MUPARSER_ONEVAR_FUNCTIONS) {
+  for (const auto &function : MUPARSER_ONEVAR_FUNCTIONS) {
     parser.DefineFun(function.first, function.second);
   }
 }

--- a/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp
@@ -1002,7 +1002,7 @@ bool FABADAMinimizer::IterationContinuation() {
       std::string failed = "";
       for (size_t i = 0; i < m_nParams; ++i) {
         if (!m_par_converged[i]) {
-          failed = failed + m_FitFunction->parameterName(i) + ", ";
+          failed.append(m_FitFunction->parameterName(i)).append(", ");
         }
       }
       failed.replace(failed.end() - 2, failed.end(), ".");

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -177,17 +177,13 @@ static string generateMappingfileName(EventWorkspace_sptr &wksp) {
   for (auto &dir : dirs) {
     if ((dir.length() > CAL_LEN) &&
         (dir.compare(dir.length() - CAL.length(), CAL.length(), CAL) == 0)) {
-      if (Poco::File(std::string(base.path())
-                         .append("/")
-                         .append(dir)
-                         .append("/calibrations/")
-                         .append(mapping))
-              .exists()) {
-        files.push_back(std::string(base.path())
-                            .append("/")
-                            .append(dir)
-                            .append("/calibrations/")
-                            .append(mapping));
+      std::string path = std::string(base.path())
+                             .append("/")
+                             .append(dir)
+                             .append("/calibrations/")
+                             .append(mapping);
+      if (Poco::File(path).exists()) {
+        files.push_back(path);
       }
     }
   }

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -177,14 +177,23 @@ static string generateMappingfileName(EventWorkspace_sptr &wksp) {
   for (auto &dir : dirs) {
     if ((dir.length() > CAL_LEN) &&
         (dir.compare(dir.length() - CAL.length(), CAL.length(), CAL) == 0)) {
-      if (Poco::File(base.path() + "/" + dir + "/calibrations/" + mapping)
-              .exists())
-        files.push_back(base.path() + "/" + dir + "/calibrations/" + mapping);
+      if (Poco::File(std::string(base.path())
+                         .append("/")
+                         .append(dir)
+                         .append("/calibrations/")
+                         .append(mapping))
+              .exists()) {
+        files.push_back(std::string(base.path())
+                            .append("/")
+                            .append(dir)
+                            .append("/calibrations/")
+                            .append(mapping));
+      }
     }
   }
 
   if (files.empty())
-    return "";
+    return std::string();
   else if (files.size() == 1)
     return files[0];
   else // just assume that the last one is the right one, this should never be

--- a/Framework/DataHandling/src/ImggAggregateWavelengths.cpp
+++ b/Framework/DataHandling/src/ImggAggregateWavelengths.cpp
@@ -514,8 +514,11 @@ ImggAggregateWavelengths::rangesFromStringProperty(
                       Mantid::Kernel::StringTokenizer::TOK_TRIM);
     if (2 != minMaxTokens.count()) {
       throw std::invalid_argument(
-          "Could not parse a minimum and maximum value separated by '" + sep +
-          "' from the string: " + str);
+          std::string(
+              "Could not parse a minimum and maximum value separated by '")
+              .append(sep)
+              .append("' from the string: ")
+              .append(str));
     }
 
     try {

--- a/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
+++ b/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
@@ -512,7 +512,7 @@ void LoadGroupXMLFile::parseXML() {
             this->getAttributeValueByName(pNode, "val", valfound);
         std::string finalvalue;
         if (valfound && !value.empty())
-          finalvalue = value + ", " + val_value;
+          finalvalue.append(value).append(", ").append(val_value);
         else if (value.empty())
           finalvalue = val_value;
         else
@@ -535,7 +535,7 @@ void LoadGroupXMLFile::parseXML() {
             this->getAttributeValueByName(pNode, "val", valfound);
         std::string finalvalue;
         if (valfound && !value.empty())
-          finalvalue = value + ", " + val_value;
+          finalvalue.append(value).append(", ").append(val_value);
         else if (value.empty())
           finalvalue = val_value;
         else
@@ -560,7 +560,7 @@ void LoadGroupXMLFile::parseXML() {
             this->getAttributeValueByName(pNode, "val", valfound);
         std::string finalvalue;
         if (valfound && !value.empty())
-          finalvalue = value + ", " + val_value;
+          finalvalue.append(value).append(", ").append(val_value);
         else if (value.empty())
           finalvalue = val_value;
         else

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -175,17 +175,13 @@ static string generateMappingfileName(EventWorkspace_sptr &wksp) {
   for (auto &dir : dirs) {
     if ((dir.length() > CAL_LEN) &&
         (dir.compare(dir.length() - CAL.length(), CAL.length(), CAL) == 0)) {
-      if (Poco::File(std::string(base.path())
-                         .append("/")
-                         .append(dir)
-                         .append("/calibrations/")
-                         .append(mapping))
-              .exists())
-        files.push_back(std::string(base.path())
-                            .append("/")
-                            .append(dir)
-                            .append("/calibrations/")
-                            .append(mapping));
+      std::string path = std::string(base.path())
+                             .append("/")
+                             .append(dir)
+                             .append("/calibrations/")
+                             .append(mapping);
+      if (Poco::File(path).exists())
+        files.push_back(path);
     }
   }
 

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -175,9 +175,17 @@ static string generateMappingfileName(EventWorkspace_sptr &wksp) {
   for (auto &dir : dirs) {
     if ((dir.length() > CAL_LEN) &&
         (dir.compare(dir.length() - CAL.length(), CAL.length(), CAL) == 0)) {
-      if (Poco::File(base.path() + "/" + dir + "/calibrations/" + mapping)
+      if (Poco::File(std::string(base.path())
+                         .append("/")
+                         .append(dir)
+                         .append("/calibrations/")
+                         .append(mapping))
               .exists())
-        files.push_back(base.path() + "/" + dir + "/calibrations/" + mapping);
+        files.push_back(std::string(base.path())
+                            .append("/")
+                            .append(dir)
+                            .append("/calibrations/")
+                            .append(mapping));
     }
   }
 

--- a/Framework/DataHandling/src/LoadMask.cpp
+++ b/Framework/DataHandling/src/LoadMask.cpp
@@ -96,7 +96,7 @@ void parseRangeText(const std::string &inputstr, std::vector<T> &singles,
     // a) Find '-':
     boost::trim(rawstring);
     bool containDash(true);
-    if (rawstring.find_first_of("-") == std::string::npos) {
+    if (rawstring.find_first_of('-') == std::string::npos) {
       containDash = false;
     }
 

--- a/Framework/DataHandling/src/LoadMcStas.cpp
+++ b/Framework/DataHandling/src/LoadMcStas.cpp
@@ -510,8 +510,9 @@ void LoadMcStas::readHistogramData(
 
     // ensure that specified name is given to workspace (eventWS) when added to
     // outputGroup
-    std::string nameOfGroupWS = getProperty("OutputWorkspace");
-    std::string nameUserSee = nameAttrValueTITLE + "_" + nameOfGroupWS;
+    std::string nameUserSee = std::string(nameAttrValueTITLE)
+                                  .append("_")
+                                  .append(getProperty("OutputWorkspace"));
     std::string extraProperty =
         "Outputworkspace_dummy_" + std::to_string(m_countNumWorkspaceAdded);
     declareProperty(Kernel::make_unique<WorkspaceProperty<Workspace>>(

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -1257,7 +1257,6 @@ LoadRawHelper::getLogFilenamesfromADS(const std::string &pathToRawFile) {
 
   std::string str;
   std::string path;
-  std::string logFile;
   std::set<std::string> logfilesList;
   Poco::Path logpath(pathToRawFile);
   size_t pos = pathToRawFile.find_last_of('/');
@@ -1276,10 +1275,7 @@ LoadRawHelper::getLogFilenamesfromADS(const std::string &pathToRawFile) {
     pos = fileName.find("txt");
     if (pos == std::string::npos)
       continue;
-    logFile = path + "/" + fileName;
-    if (logFile.empty())
-      continue;
-    logfilesList.insert(logFile);
+    logfilesList.insert(std::string(path).append("/").append(fileName));
   }
   return (logfilesList);
 }

--- a/Framework/DataHandling/src/LoadSpice2D.cpp
+++ b/Framework/DataHandling/src/LoadSpice2D.cpp
@@ -315,7 +315,8 @@ std::vector<int> LoadSpice2D::getData(const std::string &dataXpath = "//Data") {
 
   // iterate every detector in the xml file
   for (const auto &detector : detectors) {
-    std::string detectorXpath = dataXpath + "/" + detector;
+    std::string detectorXpath =
+        std::string(dataXpath).append("/").append(detector);
     // type : INT32[192,256]
     std::map<std::string, std::string> attributes =
         m_xmlHandler.get_attributes_from_tag(detectorXpath);

--- a/Framework/DataHandling/src/LoadSpiceAscii.cpp
+++ b/Framework/DataHandling/src/LoadSpiceAscii.cpp
@@ -515,11 +515,11 @@ std::string LoadSpiceAscii::processDateString(const std::string &rawdate,
     else if (formatterms[i].find('M') != std::string::npos) {
       month = dateterms[i];
       if (month.size() == 1)
-        month = "0" + month;
+        month.insert(0, 1, '0');
     } else {
       day = dateterms[i];
       if (day.size() == 1)
-        day = "0" + day;
+        day.insert(0, 1, '0');
     }
   }
 

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -210,10 +210,9 @@ std::vector<std::string> PDLoadCharacterizations::getFilenames() {
   std::vector<std::string> filenamesFromPropertyUnraveld;
   std::vector<std::vector<std::string>> filenamesFromProperty =
       this->getProperty("Filename");
-  for (auto outer : filenamesFromProperty) {
-    for (auto inner : outer) {
-      filenamesFromPropertyUnraveld.push_back(inner);
-    }
+  for (const auto &outer : filenamesFromProperty) {
+    filenamesFromPropertyUnraveld.insert(filenamesFromPropertyUnraveld.end(),
+                                         outer.cbegin(), outer.cend());
   }
   // error check that something sensible was supplied
   if (filenamesFromPropertyUnraveld.size() > 2) {

--- a/Framework/DataHandling/src/SaveFocusedXYE.cpp
+++ b/Framework/DataHandling/src/SaveFocusedXYE.cpp
@@ -137,7 +137,7 @@ void SaveFocusedXYE::exec() {
 
     if ((!split) && out) // Assign only one file
     {
-      const std::string file(filename + '.' + ext);
+      const std::string file(std::string(filename).append(".").append(ext));
       Poco::File fileObj(file);
       const bool exists = fileObj.exists();
       out.open(file.c_str(), mode);
@@ -147,7 +147,8 @@ void SaveFocusedXYE::exec() {
                       // filename-i.ext
     {
       number << "-" << i + startingbank;
-      const std::string file(filename + number.str() + "." + ext);
+      const std::string file(
+          std::string(filename).append(number.str()).append(".").append(ext));
       Poco::File fileObj(file);
       const bool exists = fileObj.exists();
       out.open(file.c_str(), mode);

--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -228,7 +228,7 @@ void SaveGSS::writeGSASFile(const std::string &outfilename, bool append,
       std::string ext = path.getExtension();
       // Chop off filename
       path.makeParent();
-      path.append(basename + number.str() + "." + ext);
+      path.append(basename).append(number.str()).append(".").append(ext);
       Poco::File fileobj(path);
       const bool exists = fileobj.exists();
       if (!exists || !append)

--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -228,7 +228,7 @@ void SaveGSS::writeGSASFile(const std::string &outfilename, bool append,
       std::string ext = path.getExtension();
       // Chop off filename
       path.makeParent();
-      path.append(basename).append(number.str()).append(".").append(ext);
+      path.append(basename + number.str() + "." + ext);
       Poco::File fileobj(path);
       const bool exists = fileobj.exists();
       if (!exists || !append)

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroupFactory.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroupFactory.h
@@ -236,8 +236,8 @@ public:
 
       if (transformedSymbol != hmSymbol && !symbolExists) {
         subscribeUsingGenerator<TransformationSpaceGroupGenerator>(
-            number, transformedSymbol, hmSymbol + "|" + transformation);
-
+            number, transformedSymbol,
+            std::string(hmSymbol).append("|").append(transformation));
         transformedSpaceGroupSymbols.push_back(transformedSymbol);
       }
     }

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -261,12 +261,15 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *prog) {
     // Each type in the IDF must be uniquely named, hence return error if type
     // has already been defined
     if (getTypeElement.find(typeName) != getTypeElement.end()) {
-      g_log.error("XML file: " + filename +
-                  "contains more than one type element named " + typeName);
+      g_log.error(std::string("XML file: ")
+                      .append(filename)
+                      .append("contains more than one type element named ")
+                      .append(typeName));
       throw Kernel::Exception::InstrumentDefinitionError(
-          "XML instrument file contains more than one type element named " +
-              typeName,
-          filename);
+          std::string(
+              "XML instrument file contains more than one type element named ")
+              .append(typeName)
+              .append(filename));
     }
     getTypeElement[typeName] = pTypeElem;
 
@@ -305,12 +308,15 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *prog) {
     // Each type in the IDF must be uniquely named, hence return error if type
     // has already been defined
     if (getTypeElement.find(typeName) != getTypeElement.end()) {
-      g_log.error("XML file: " + filename +
-                  "contains more than one type element named " + typeName);
+      g_log.error(std::string("XML file: ")
+                      .append(filename)
+                      .append("contains more than one type element named ")
+                      .append(typeName));
       throw Kernel::Exception::InstrumentDefinitionError(
-          "XML instrument file contains more than one type element named " +
-              typeName,
-          filename);
+          std::string(
+              "XML instrument file contains more than one type element named ")
+              .append(typeName)
+              .append(filename));
     }
     getTypeElement[typeName] = pTypeElem;
 

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -857,7 +857,7 @@ void ConfigServiceImpl::saveConfig(const std::string &filename) const {
       // If it does exist make sure the value is current
       std::string value = getString(key, false);
       Poco::replaceInPlace(value, "\\", "\\\\"); // replace single \ with double
-      updated_file += key + "=" + value;
+      updated_file.append(key).append("=").append(value);
       // Remove the key from the changed key list
       m_changed_keys.erase(key);
     }
@@ -957,9 +957,9 @@ void ConfigServiceImpl::getKeysRecursive(
   for (auto &rootKey : rootKeys) {
     std::string searchString;
     if (root.empty()) {
-      searchString = rootKey;
+      searchString.append(rootKey);
     } else {
-      searchString = root + "." + rootKey;
+      searchString.append(root).append(".").append(rootKey);
     }
 
     getKeysRecursive(searchString, allKeys);

--- a/Framework/Kernel/src/LogParser.cpp
+++ b/Framework/Kernel/src/LogParser.cpp
@@ -62,8 +62,10 @@ Kernel::Property *LogParser::createLogProperty(const std::string &logFName,
       // if the line doesn't start with a time treat it as a continuation of the
       // previous data
       if (change_times.empty() || isNumeric) { // if there are no previous data
-        std::string mess =
-            "Cannot parse log file " + logFName + ". Line:" + str;
+        std::string mess = std::string("Cannot parse log file ")
+                               .append(logFName)
+                               .append(". Line:")
+                               .append(str);
         g_log.error(mess);
         throw std::logic_error(mess);
       }

--- a/Framework/Kernel/src/MultiFileValidator.cpp
+++ b/Framework/Kernel/src/MultiFileValidator.cpp
@@ -66,7 +66,7 @@ std::string MultiFileValidator::checkValidity(
           accumulatedErrors =
               "Could not validate the following file(s): " + valueIt;
         else
-          accumulatedErrors = accumulatedErrors + ", " + valueIt;
+          accumulatedErrors.append(", ").append(valueIt);
       }
     }
   }

--- a/Framework/Kernel/src/NexusDescriptor.cpp
+++ b/Framework/Kernel/src/NexusDescriptor.cpp
@@ -245,7 +245,8 @@ void NexusDescriptor::walkFile(::NeXus::File &file, const std::string &rootPath,
   for (auto it = dirents.begin(); it != itend; ++it) {
     const std::string &entryName = it->first;
     const std::string &entryClass = it->second;
-    const std::string entryPath = rootPath + "/" + entryName;
+    const std::string entryPath =
+        std::string(rootPath).append("/").append(entryName);
     if (entryClass == "SDS") {
       pmap.emplace(entryPath, entryClass);
     } else if (entryClass == "CDF0.0") {

--- a/Framework/MDAlgorithms/src/CutMD.cpp
+++ b/Framework/MDAlgorithms/src/CutMD.cpp
@@ -446,7 +446,9 @@ void CutMD::exec() {
         vecStr = boost::algorithm::join(vec, ", ");
       }
 
-      const std::string value = label + ", " + unit + ", " + vecStr;
+      const std::string value =
+          std::string(label).append(", ").append(unit).append(", ").append(
+              vecStr);
       cutAlg->setProperty("BasisVector" + std::to_string(i), value);
     }
 

--- a/Framework/MDAlgorithms/src/MDTransfAxisNames.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfAxisNames.cpp
@@ -83,10 +83,10 @@ std::string makeAxisName(const Kernel::V3D &Dir,
       name += "-";
     }
     if (std::fabs(absDir[i] - 1) < eps) {
-      name += mainName + separator;
+      name.append(mainName).append(separator);
       continue;
     }
-    name += sprintfd(absDir[i], eps) + mainName + separator;
+    name.append(sprintfd(absDir[i], eps)).append(mainName).append(separator);
   }
 
   return name;


### PR DESCRIPTION
Description of work.

This applies changes suggested by the [performance-inefficient-string-concatenation check](https://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-string-concatenation.html) added in clang-tidy 4.0. I also addressed a few things found by `performance-faster-string-find` and `performance-for-range-copy`. 

**To test:**

<!-- Instructions for testing. -->

Review changes and check that the builds still pass.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
