### PR TITLE
ISIS Reflectometry interface: Fixed a couple of errors with the 'Open Table' dialog

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorWorkspaceCommand.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorWorkspaceCommand.h
@@ -40,8 +40,6 @@ public:
   void execute() override {
     // Tell the presenter which of the available workspaces was selected
     m_presenter->setModel(m_name);
-    // Now notify the presenter
-    m_presenter->notify(DataProcessorPresenter::OpenTableFlag);
   };
   std::string name() override { return m_name; }
   std::string icon() override { return std::string("://worksheet.png"); }

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -914,8 +914,9 @@ void GenericDataProcessorPresenter::importTable() {
   // result will hold the name of the output workspace
   // otherwise this should be an empty string.
   QString outputWorkspaceName = QString::fromStdString(result);
-  auto toOpen = outputWorkspaceName.trimmed().toStdString();
-  m_view->setModel(toOpen);
+  std::string toOpen = outputWorkspaceName.trimmed().toStdString();
+  if (!toOpen.empty())
+    m_view->setModel(toOpen);
 }
 
 /**

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorCommandsTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/DataProcessorCommandsTest.h
@@ -330,9 +330,6 @@ public:
 
     // The presenter should set the name of the ws
     EXPECT_CALL(mockPresenter, setModel("workspace")).Times(Exactly(1));
-    // The presenter should be notified with the OpenTableFlag
-    EXPECT_CALL(mockPresenter, notify(DataProcessorPresenter::OpenTableFlag))
-        .Times(Exactly(1));
     // Execute the command
     command.execute();
     // Verify expectations


### PR DESCRIPTION
See related issue (#19212) for details. There are two separate bugs regarding when the dialog is brought up:
- Opening a new table when current is dirty and clicking 'no' on the dialog brings it up a second time.
- Clicking on 'Import .TBL' but closing it without importing still brings up the dialog.

**To test:**
- The interface can be accessed from Interfaces->Reflectometry->ISIS Reflectometry.
- On `Runs` tab, create a couple of tables by adding some details in their rows and save them. When clicking on `Open Table` to access a different table, you should see the 'Open Table' dialog and clicking 'no' or close button on this should not bring it up again.
- Click on `Import .TBL` and close it without importing anything. The dialog should not be displayed.

Fixes #19212.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
