### PR TITLE
Fix WorkspaceCreation::create(const P &parent) for parent workspaces with varying bins

### DIFF
--- a/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
+++ b/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
@@ -292,8 +292,7 @@ void DiffractionEventCalibrateDetectors::exec() {
   // Get some stuff from the input workspace
   // We make a copy of the instrument since we will be moving detectors in
   // `inputW` but want to access original positions (etc.) via `detList` below.
-  const auto &dummyW = create<EventWorkspace>(*inputW, 1);
-  Instrument_const_sptr inst = dummyW->getInstrument();
+  Instrument_const_sptr inst(inputW->getInstrument()->baseInstrument()->clone());
 
   // Build a list of Rectangular Detectors
   std::vector<boost::shared_ptr<RectangularDetector>> detList;

--- a/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
+++ b/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
@@ -292,7 +292,8 @@ void DiffractionEventCalibrateDetectors::exec() {
   // Get some stuff from the input workspace
   // We make a copy of the instrument since we will be moving detectors in
   // `inputW` but want to access original positions (etc.) via `detList` below.
-  Instrument_const_sptr inst(inputW->getInstrument()->baseInstrument()->clone());
+  Instrument_const_sptr inst(
+      inputW->getInstrument()->baseInstrument()->clone());
 
   // Build a list of Rectangular Detectors
   std::vector<boost::shared_ptr<RectangularDetector>> detList;

--- a/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
+++ b/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
@@ -292,8 +292,9 @@ void DiffractionEventCalibrateDetectors::exec() {
   // Get some stuff from the input workspace
   // We make a copy of the instrument since we will be moving detectors in
   // `inputW` but want to access original positions (etc.) via `detList` below.
-  Instrument_const_sptr inst(
-      inputW->getInstrument()->baseInstrument()->clone());
+  const auto &dummyW = create<EventWorkspace>(*inputW, 1,
+                                              inputW->binEdges(0));
+  Instrument_const_sptr inst = dummyW->getInstrument();
 
   // Build a list of Rectangular Detectors
   std::vector<boost::shared_ptr<RectangularDetector>> detList;

--- a/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
+++ b/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
@@ -292,8 +292,7 @@ void DiffractionEventCalibrateDetectors::exec() {
   // Get some stuff from the input workspace
   // We make a copy of the instrument since we will be moving detectors in
   // `inputW` but want to access original positions (etc.) via `detList` below.
-  const auto &dummyW = create<EventWorkspace>(*inputW, 1,
-                                              inputW->binEdges(0));
+  const auto &dummyW = create<EventWorkspace>(*inputW, 1, inputW->binEdges(0));
   Instrument_const_sptr inst = dummyW->getInstrument();
 
   // Build a list of Rectangular Detectors

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -337,7 +337,7 @@ void DiffractionFocussing2::exec() {
  */
 void DiffractionFocussing2::execEvent() {
   // Create a new outputworkspace with not much in it
-  auto out = create<EventWorkspace>(*m_matrixInputW, m_validGroups.size());
+  auto out = create<EventWorkspace>(*m_matrixInputW, m_validGroups.size(), m_matrixInputW->histogram(0));
 
   MatrixWorkspace_const_sptr outputWS = getProperty("OutputWorkspace");
   bool inPlace = (m_matrixInputW == outputWS);

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -337,7 +337,8 @@ void DiffractionFocussing2::exec() {
  */
 void DiffractionFocussing2::execEvent() {
   // Create a new outputworkspace with not much in it
-  auto out = create<EventWorkspace>(*m_matrixInputW, m_validGroups.size(), m_matrixInputW->histogram(0));
+  auto out = create<EventWorkspace>(*m_matrixInputW, m_validGroups.size(),
+                                    m_matrixInputW->histogram(0));
 
   MatrixWorkspace_const_sptr outputWS = getProperty("OutputWorkspace");
   bool inPlace = (m_matrixInputW == outputWS);

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -338,7 +338,7 @@ void DiffractionFocussing2::exec() {
 void DiffractionFocussing2::execEvent() {
   // Create a new outputworkspace with not much in it
   auto out = create<EventWorkspace>(*m_matrixInputW, m_validGroups.size(),
-                                    m_matrixInputW->histogram(0));
+                                    m_matrixInputW->binEdges(0));
 
   MatrixWorkspace_const_sptr outputWS = getProperty("OutputWorkspace");
   bool inPlace = (m_matrixInputW == outputWS);

--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -310,7 +310,8 @@ void MergeRuns::execEvent() {
 
   // Create a new output event workspace, by copying the first WS in the list
   EventWorkspace_sptr inputWS = m_inEventWS[0];
-  auto outWS = create<EventWorkspace>(*inputWS, m_outputSize, inputWS->histogram(0));
+  auto outWS =
+      create<EventWorkspace>(*inputWS, m_outputSize, inputWS->histogram(0));
   const auto inputSize = inputWS->getNumberHistograms();
   for (size_t i = 0; i < inputSize; ++i)
     outWS->getSpectrum(i) = inputWS->getSpectrum(i);

--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -310,7 +310,7 @@ void MergeRuns::execEvent() {
 
   // Create a new output event workspace, by copying the first WS in the list
   EventWorkspace_sptr inputWS = m_inEventWS[0];
-  auto outWS = create<EventWorkspace>(*inputWS, m_outputSize);
+  auto outWS = create<EventWorkspace>(*inputWS, m_outputSize, inputWS->histogram(0));
   const auto inputSize = inputWS->getNumberHistograms();
   for (size_t i = 0; i < inputSize; ++i)
     outWS->getSpectrum(i) = inputWS->getSpectrum(i);

--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -311,7 +311,7 @@ void MergeRuns::execEvent() {
   // Create a new output event workspace, by copying the first WS in the list
   EventWorkspace_sptr inputWS = m_inEventWS[0];
   auto outWS =
-      create<EventWorkspace>(*inputWS, m_outputSize, inputWS->histogram(0));
+      create<EventWorkspace>(*inputWS, m_outputSize, inputWS->binEdges(0));
   const auto inputSize = inputWS->getNumberHistograms();
   for (size_t i = 0; i < inputSize; ++i)
     outWS->getSpectrum(i) = inputWS->getSpectrum(i);

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -408,7 +408,7 @@ RebinnedOutput_sptr SofQWNormalisedPolygon::setUpOutputWorkspace(
 
   // Create output workspace, bin edges are same as in inputWorkspace index 0
   auto outputWorkspace = create<RebinnedOutput>(inputWorkspace, yLength - 1,
-                                                inputWorkspace.histogram(0));
+                                                inputWorkspace.binEdges(0));
 
   // Create a binned numeric axis to replace the default vertical one
   Axis *const verticalAxis = new BinEdgeAxis(newAxis);

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -407,7 +407,7 @@ RebinnedOutput_sptr SofQWNormalisedPolygon::setUpOutputWorkspace(
       VectorHelper::createAxisFromRebinParams(binParams, newAxis));
 
   // Create output workspace, bin edges are same as in inputWorkspace index 0
-  auto outputWorkspace = create<RebinnedOutput>(inputWorkspace, yLength - 1);
+  auto outputWorkspace = create<RebinnedOutput>(inputWorkspace, yLength - 1, inputWorkspace.histogram(0));
 
   // Create a binned numeric axis to replace the default vertical one
   Axis *const verticalAxis = new BinEdgeAxis(newAxis);

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -407,7 +407,8 @@ RebinnedOutput_sptr SofQWNormalisedPolygon::setUpOutputWorkspace(
       VectorHelper::createAxisFromRebinParams(binParams, newAxis));
 
   // Create output workspace, bin edges are same as in inputWorkspace index 0
-  auto outputWorkspace = create<RebinnedOutput>(inputWorkspace, yLength - 1, inputWorkspace.histogram(0));
+  auto outputWorkspace = create<RebinnedOutput>(inputWorkspace, yLength - 1,
+                                                inputWorkspace.histogram(0));
 
   // Create a binned numeric axis to replace the default vertical one
   Axis *const verticalAxis = new BinEdgeAxis(newAxis);

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -449,7 +449,7 @@ void SumSpectra::doRebinnedOutput(MatrixWorkspace_sptr outputWorkspace,
  */
 void SumSpectra::execEvent(EventWorkspace_const_sptr localworkspace,
                            std::set<int> &indices) {
-  auto outputWorkspace = create<EventWorkspace>(*localworkspace, 1);
+  auto outputWorkspace = create<EventWorkspace>(*localworkspace, 1, localworkspace->histogram(0));
 
   Progress progress(this, 0, 1, indices.size());
 

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -450,7 +450,7 @@ void SumSpectra::doRebinnedOutput(MatrixWorkspace_sptr outputWorkspace,
 void SumSpectra::execEvent(EventWorkspace_const_sptr localworkspace,
                            std::set<int> &indices) {
   auto outputWorkspace =
-      create<EventWorkspace>(*localworkspace, 1, localworkspace->histogram(0));
+      create<EventWorkspace>(*localworkspace, 1, localworkspace->binEdges(0));
 
   Progress progress(this, 0, 1, indices.size());
 

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -449,7 +449,8 @@ void SumSpectra::doRebinnedOutput(MatrixWorkspace_sptr outputWorkspace,
  */
 void SumSpectra::execEvent(EventWorkspace_const_sptr localworkspace,
                            std::set<int> &indices) {
-  auto outputWorkspace = create<EventWorkspace>(*localworkspace, 1, localworkspace->histogram(0));
+  auto outputWorkspace =
+      create<EventWorkspace>(*localworkspace, 1, localworkspace->histogram(0));
 
   Progress progress(this, 0, 1, indices.size());
 

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -122,7 +122,8 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
   // Create the output workspace
   const size_t totalHists =
       event_ws1->getNumberHistograms() + event_ws2->getNumberHistograms();
-  auto output = create<EventWorkspace>(*event_ws1, totalHists, event_ws1->histogram(0));
+  auto output =
+      create<EventWorkspace>(*event_ws1, totalHists, event_ws1->histogram(0));
 
   // Initialize the progress reporting object
   m_progress = new API::Progress(this, 0.0, 1.0, totalHists);

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -123,7 +123,7 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
   const size_t totalHists =
       event_ws1->getNumberHistograms() + event_ws2->getNumberHistograms();
   auto output =
-      create<EventWorkspace>(*event_ws1, totalHists, event_ws1->histogram(0));
+      create<EventWorkspace>(*event_ws1, totalHists, event_ws1->binEdges(0));
 
   // Initialize the progress reporting object
   m_progress = new API::Progress(this, 0.0, 1.0, totalHists);

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -122,7 +122,7 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
   // Create the output workspace
   const size_t totalHists =
       event_ws1->getNumberHistograms() + event_ws2->getNumberHistograms();
-  auto output = create<EventWorkspace>(*event_ws1, totalHists);
+  auto output = create<EventWorkspace>(*event_ws1, totalHists, event_ws1->histogram(0));
 
   // Initialize the progress reporting object
   m_progress = new API::Progress(this, 0.0, 1.0, totalHists);

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
@@ -175,7 +175,8 @@ template <class T, class P, class IndexArg,
 std::unique_ptr<T> create(const P &parent, const IndexArg &indexArg,
                           const HistogramData::Histogram &histogram) {
   std::unique_ptr<T> ws = detail::createUninitialized<T, P>(parent);
-  ws->initialize(indexArg, HistogramData::Histogram(detail::stripData(histogram)));
+  ws->initialize(indexArg,
+                 HistogramData::Histogram(detail::stripData(histogram)));
   detail::initializeFromParent(parent, *ws);
 
   return ws;
@@ -195,7 +196,8 @@ template <class T, class IndexArg,
           typename std::enable_if<
               !std::is_base_of<API::MatrixWorkspace, IndexArg>::value>::type * =
               nullptr>
-std::unique_ptr<T> create(const IndexArg &indexArg, const HistogramData::Histogram &histogram) {
+std::unique_ptr<T> create(const IndexArg &indexArg,
+                          const HistogramData::Histogram &histogram) {
   auto ws = Kernel::make_unique<T>();
   HistogramData::Histogram histogramTemplate(histogram);
   if (std::is_base_of<DataObjects::EventWorkspace, T>::value) {

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
@@ -128,13 +128,6 @@ template <>
 MANTID_DATAOBJECTS_DLL std::unique_ptr<API::HistoWorkspace>
 createConcreteHelper();
 
-template <class T, class P, class = typename std::enable_if<std::is_base_of<
-                                API::MatrixWorkspace, P>::value>::type>
-std::unique_ptr<T> createUninitialized(const P &parent) {
-  std::unique_ptr<T> ws;
-  return ws;
-}
-
 MANTID_DATAOBJECTS_DLL void
 initializeFromParent(const API::MatrixWorkspace &parent,
                      API::MatrixWorkspace &ws);
@@ -145,11 +138,11 @@ template <class T, class P, class IndexArg, class HistArg,
               std::is_base_of<API::MatrixWorkspace, P>::value>::type>
 std::unique_ptr<T> create(const P &parent, const IndexArg &indexArg,
                           const HistArg &histArg) {
-  std::unique_ptr<T> ws;
   // Figure out (dynamic) target type:
   // - Type is same as parent if T is base of parent
   // - If T is not base of parent, conversion may occur. Currently only
   //   supported for EventWorkspace
+  std::unique_ptr<T> ws;
   if (std::is_base_of<API::HistoWorkspace, T>::value &&
       parent.id() == "EventWorkspace") {
     // Drop events, create Workspace2D or T whichever is more derived.
@@ -183,7 +176,8 @@ template <class T, class P,
                                                   P>::value>::type * = nullptr>
 std::unique_ptr<T> create(const P &parent) {
   const auto numHistograms = parent.getNumberHistograms();
-  auto ws = create<T>(parent, numHistograms, detail::stripData(parent.histogram(0)));
+  auto ws =
+      create<T>(parent, numHistograms, detail::stripData(parent.histogram(0)));
   for (size_t i = 0; i < numHistograms; ++i) {
     ws->setSharedX(i, parent.sharedX(i));
   }

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
@@ -163,11 +163,7 @@ template <class T, class P, class IndexArg, class HistArg,
 std::unique_ptr<T> create(const P &parent, const IndexArg &indexArg,
                           const HistArg &histArg) {
   std::unique_ptr<T> ws = detail::createUninitialized<T, P>(parent);
-  HistogramData::Histogram templateHisto(histArg);
-  if (std::is_base_of<DataObjects::EventWorkspace, T>::value) {
-    templateHisto = detail::stripData(templateHisto);
-  }
-  ws->initialize(indexArg, templateHisto);
+  ws->initialize(indexArg, HistogramData::Histogram(histArg));
   detail::initializeFromParent(parent, *ws);
 
   return ws;
@@ -179,11 +175,7 @@ template <class T, class IndexArg, class HistArg,
               nullptr>
 std::unique_ptr<T> create(const IndexArg &indexArg, const HistArg &histArg) {
   auto ws = Kernel::make_unique<T>();
-  HistogramData::Histogram templateHist(histArg);
-  if (std::is_base_of<DataObjects::EventWorkspace, T>::value) {
-    templateHist = detail::stripData(templateHist);
-  }
-  ws->initialize(indexArg, templateHist);
+  ws->initialize(indexArg, HistogramData::Histogram(histArg));
   return ws;
 }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/WorkspaceCreation.h
@@ -130,9 +130,8 @@ template <>
 MANTID_DATAOBJECTS_DLL std::unique_ptr<API::HistoWorkspace>
 createConcreteHelper();
 
-template <class T, class P,
-          class = typename std::enable_if<
-              std::is_base_of<API::MatrixWorkspace, P>::value>::type>
+template <class T, class P, class = typename std::enable_if<std::is_base_of<
+                                API::MatrixWorkspace, P>::value>::type>
 std::unique_ptr<T> createUninitialized(const P &parent) {
   std::unique_ptr<T> ws;
 

--- a/Framework/DataObjects/src/WorkspaceCreation.cpp
+++ b/Framework/DataObjects/src/WorkspaceCreation.cpp
@@ -8,9 +8,7 @@ namespace Mantid {
 namespace DataObjects {
 namespace detail {
 HistogramData::Histogram stripData(HistogramData::Histogram histogram) {
-  if (histogram.ptrY()) {
-    histogram.setSharedY(nullptr);
-  }
+  histogram.setSharedY(nullptr);
   histogram.setSharedE(nullptr);
   return histogram;
 }

--- a/Framework/DataObjects/src/WorkspaceCreation.cpp
+++ b/Framework/DataObjects/src/WorkspaceCreation.cpp
@@ -11,9 +11,7 @@ HistogramData::Histogram stripData(HistogramData::Histogram histogram) {
   if (histogram.ptrY()) {
     histogram.setSharedY(nullptr);
   }
-  if (histogram.ptrE()) {
-    histogram.setSharedE(nullptr);
-  }
+  histogram.setSharedE(nullptr);
   return histogram;
 }
 

--- a/Framework/DataObjects/src/WorkspaceCreation.cpp
+++ b/Framework/DataObjects/src/WorkspaceCreation.cpp
@@ -8,8 +8,12 @@ namespace Mantid {
 namespace DataObjects {
 namespace detail {
 HistogramData::Histogram stripData(HistogramData::Histogram histogram) {
-  histogram.setSharedY(nullptr);
-  histogram.setSharedE(nullptr);
+  if (histogram.ptrY()) {
+    histogram.setSharedY(nullptr);
+  }
+  if (histogram.ptrE()) {
+    histogram.setSharedE(nullptr);
+  }
   return histogram;
 }
 

--- a/Framework/DataObjects/test/WorkspaceCreationTest.h
+++ b/Framework/DataObjects/test/WorkspaceCreationTest.h
@@ -117,8 +117,7 @@ public:
   }
 
   void test_create_parent_varying_bins() {
-    auto parent =
-        create<Workspace2D>(make_indices(), make_data());
+    auto parent = create<Workspace2D>(make_indices(), make_data());
     const double binShift = -0.54;
     parent->mutableX(1) += binShift;
     const auto ws = create<Workspace2D>(*parent);
@@ -134,8 +133,7 @@ public:
   }
 
   void test_create_parent_varying_bins_from_event() {
-    auto parent =
-        create<EventWorkspace>(make_indices(), BinEdges{1, 2, 4});
+    auto parent = create<EventWorkspace>(make_indices(), BinEdges{1, 2, 4});
     const double binShift = -0.54;
     parent->mutableX(1) += binShift;
     const auto ws = create<EventWorkspace>(*parent);

--- a/Framework/DataObjects/test/WorkspaceCreationTest.h
+++ b/Framework/DataObjects/test/WorkspaceCreationTest.h
@@ -118,10 +118,27 @@ public:
 
   void test_create_parent_varying_bins() {
     auto parent =
-        create<Workspace2D>(make_indices(), Histogram(BinEdges{1, 2, 4}));
+        create<Workspace2D>(make_indices(), make_data());
     const double binShift = -0.54;
     parent->mutableX(1) += binShift;
     const auto ws = create<Workspace2D>(*parent);
+    check_indices(*ws);
+    TS_ASSERT_EQUALS(ws->x(0).rawData(), std::vector<double>({1, 2, 4}));
+    TS_ASSERT_EQUALS(
+        ws->x(1).rawData(),
+        std::vector<double>({1 + binShift, 2 + binShift, 4 + binShift}));
+    TS_ASSERT_EQUALS(ws->y(0).rawData(), std::vector<double>({0, 0}));
+    TS_ASSERT_EQUALS(ws->y(1).rawData(), std::vector<double>({0, 0}));
+    TS_ASSERT_EQUALS(ws->e(0).rawData(), std::vector<double>({0, 0}));
+    TS_ASSERT_EQUALS(ws->e(1).rawData(), std::vector<double>({0, 0}));
+  }
+
+  void test_create_parent_varying_bins_from_event() {
+    auto parent =
+        create<EventWorkspace>(make_indices(), BinEdges{1, 2, 4});
+    const double binShift = -0.54;
+    parent->mutableX(1) += binShift;
+    const auto ws = create<EventWorkspace>(*parent);
     check_indices(*ws);
     TS_ASSERT_EQUALS(ws->x(0).rawData(), std::vector<double>({1, 2, 4}));
     TS_ASSERT_EQUALS(
@@ -175,7 +192,7 @@ public:
     check_zeroed_data(*ws);
   }
 
-  void test_create_event_from_event() {
+  void test_create_parent_size_edges_from_event() {
     const auto parent =
         create<EventWorkspace>(make_indices(), Histogram(BinEdges{1, 2, 4}));
     std::unique_ptr<EventWorkspace> ws;
@@ -214,6 +231,13 @@ public:
     const auto parent = create<Workspace2D>(2, Histogram(BinEdges(2)));
     const auto ws = create<EventWorkspace>(*parent);
     TS_ASSERT_EQUALS(ws->id(), "EventWorkspace");
+  }
+
+  void test_create_event_from_event() {
+    const auto parent = create<Workspace2D>(2, Histogram(BinEdges{1, 2, 4}));
+    const auto ws = create<EventWorkspace>(*parent);
+    TS_ASSERT_EQUALS(ws->id(), "EventWorkspace");
+    check_zeroed_data(*ws);
   }
 
   void test_create_event_from_edges() {

--- a/Framework/DataObjects/test/WorkspaceCreationTest.h
+++ b/Framework/DataObjects/test/WorkspaceCreationTest.h
@@ -31,6 +31,13 @@ public:
     return indices;
   }
 
+  Histogram make_data() {
+    BinEdges edges{1, 2, 4};
+    Counts counts{3.0, 5.0};
+    CountStandardDeviations deviations{2.0, 4.0};
+    return Histogram{edges, counts, deviations};
+  }
+
   void check_size(const MatrixWorkspace &ws) {
     TS_ASSERT_EQUALS(ws.getNumberHistograms(), 2);
   }
@@ -55,7 +62,7 @@ public:
                      (std::set<detid_t>{2, 3}));
   }
 
-  void check_data(const MatrixWorkspace &ws) {
+  void check_zeroed_data(const MatrixWorkspace &ws) {
     TS_ASSERT_EQUALS(ws.x(0).rawData(), std::vector<double>({1, 2, 4}));
     TS_ASSERT_EQUALS(ws.x(1).rawData(), std::vector<double>({1, 2, 4}));
     TS_ASSERT_EQUALS(ws.y(0).rawData(), std::vector<double>({0, 0}));
@@ -64,32 +71,41 @@ public:
     TS_ASSERT_EQUALS(ws.e(1).rawData(), std::vector<double>({0, 0}));
   }
 
+  void check_data(const MatrixWorkspace &ws) {
+    TS_ASSERT_EQUALS(ws.x(0).rawData(), std::vector<double>({1, 2, 4}));
+    TS_ASSERT_EQUALS(ws.x(1).rawData(), std::vector<double>({1, 2, 4}));
+    TS_ASSERT_EQUALS(ws.y(0).rawData(), std::vector<double>({3, 5}));
+    TS_ASSERT_EQUALS(ws.y(1).rawData(), std::vector<double>({3, 5}));
+    TS_ASSERT_EQUALS(ws.e(0).rawData(), std::vector<double>({2, 4}));
+    TS_ASSERT_EQUALS(ws.e(1).rawData(), std::vector<double>({2, 4}));
+  }
+
   void test_create_size_Histogram() {
     const auto ws = create<Workspace2D>(2, Histogram(BinEdges{1, 2, 4}));
     check_default_indices(*ws);
-    check_data(*ws);
+    check_zeroed_data(*ws);
   }
 
   void test_create_size_fully_specified_Histogram() {
-    BinEdges edges{1, 2, 4};
-    Counts counts{3.0, 5.0};
-    CountStandardDeviations deviations{2.0, 4.0};
-    Histogram histo{edges, counts, deviations};
     std::unique_ptr<Workspace2D> ws;
-    TS_ASSERT_THROWS_NOTHING(ws = create<Workspace2D>(2, histo))
-    TS_ASSERT_EQUALS(ws->x(0).rawData(), std::vector<double>({1, 2, 4}));
-    TS_ASSERT_EQUALS(ws->x(1).rawData(), std::vector<double>({1, 2, 4}));
-    TS_ASSERT_EQUALS(ws->y(0).rawData(), std::vector<double>({3, 5}));
-    TS_ASSERT_EQUALS(ws->y(1).rawData(), std::vector<double>({3, 5}));
-    TS_ASSERT_EQUALS(ws->e(0).rawData(), std::vector<double>({2, 4}));
-    TS_ASSERT_EQUALS(ws->e(1).rawData(), std::vector<double>({2, 4}));
+    TS_ASSERT_THROWS_NOTHING(ws = create<Workspace2D>(2, make_data()))
+    check_data(*ws);
+  }
+
+  void test_create_parent_size_fully_specified_Histogram() {
+    const auto parent =
+        create<Workspace2D>(make_indices(), Histogram(BinEdges{-1, 0, 2}));
+    std::unique_ptr<Workspace2D> ws;
+    TS_ASSERT_THROWS_NOTHING(ws = create<Workspace2D>(*parent, 2, make_data()))
+    check_indices(*ws);
+    check_data(*ws);
   }
 
   void test_create_IndexInfo_Histogram() {
     const auto ws =
         create<Workspace2D>(make_indices(), Histogram(BinEdges{1, 2, 4}));
     check_indices(*ws);
-    check_data(*ws);
+    check_zeroed_data(*ws);
   }
 
   void test_create_parent() {
@@ -97,7 +113,7 @@ public:
         create<Workspace2D>(make_indices(), Histogram(BinEdges{1, 2, 4}));
     const auto ws = create<Workspace2D>(*parent);
     check_indices(*ws);
-    check_data(*ws);
+    check_zeroed_data(*ws);
   }
 
   void test_create_parent_varying_bins() {
@@ -122,7 +138,7 @@ public:
         create<Workspace2D>(make_indices(), Histogram(BinEdges{0, 1}));
     const auto ws = create<Workspace2D>(*parent, Histogram(BinEdges{1, 2, 4}));
     check_indices(*ws);
-    check_data(*ws);
+    check_zeroed_data(*ws);
   }
 
   void test_create_parent_same_size() {
@@ -131,7 +147,7 @@ public:
     const auto ws = create<Workspace2D>(*parent, 2, parent->histogram(0));
     // Same size -> Indices copied from parent
     check_indices(*ws);
-    check_data(*ws);
+    check_zeroed_data(*ws);
   }
 
   void test_create_parent_size() {
@@ -139,7 +155,7 @@ public:
     parent->getSpectrum(0).setSpectrumNo(7);
     const auto ws = create<Workspace2D>(*parent, 2, parent->histogram(0));
     check_default_indices(*ws);
-    check_data(*ws);
+    check_zeroed_data(*ws);
   }
 
   void test_create_parent_IndexInfo_same_size() {
@@ -148,7 +164,7 @@ public:
         create<Workspace2D>(*parent, make_indices(), parent->histogram(0));
     // If parent has same size, data in IndexInfo is ignored
     check_default_indices(*ws);
-    check_data(*ws);
+    check_zeroed_data(*ws);
   }
 
   void test_create_parent_IndexInfo() {
@@ -156,7 +172,7 @@ public:
     const auto ws =
         create<Workspace2D>(*parent, make_indices(), parent->histogram(0));
     check_indices(*ws);
-    check_data(*ws);
+    check_zeroed_data(*ws);
   }
 
   void test_create_event_from_event() {
@@ -167,7 +183,7 @@ public:
         ws = create<EventWorkspace>(*parent, 2, parent->histogram(0)))
     TS_ASSERT_EQUALS(ws->id(), "EventWorkspace");
     check_indices(*ws);
-    check_data(*ws);
+    check_zeroed_data(*ws);
   }
 
   void test_create_drop_events() {
@@ -204,7 +220,7 @@ public:
     std::unique_ptr<EventWorkspace> ws;
     TS_ASSERT_THROWS_NOTHING(ws = create<EventWorkspace>(2, BinEdges{1, 2, 4}))
     TS_ASSERT_EQUALS(ws->id(), "EventWorkspace");
-    check_data(*ws);
+    check_zeroed_data(*ws);
   }
 };
 

--- a/Framework/DataObjects/test/WorkspaceCreationTest.h
+++ b/Framework/DataObjects/test/WorkspaceCreationTest.h
@@ -93,7 +93,9 @@ public:
     const auto ws = create<Workspace2D>(*parent);
     check_indices(*ws);
     TS_ASSERT_EQUALS(ws->x(0).rawData(), std::vector<double>({1, 2, 4}));
-    TS_ASSERT_EQUALS(ws->x(1).rawData(), std::vector<double>({1 + binShift, 2 + binShift, 4 + binShift}));
+    TS_ASSERT_EQUALS(
+        ws->x(1).rawData(),
+        std::vector<double>({1 + binShift, 2 + binShift, 4 + binShift}));
     TS_ASSERT_EQUALS(ws->y(0).rawData(), std::vector<double>({0, 0}));
     TS_ASSERT_EQUALS(ws->y(1).rawData(), std::vector<double>({0, 0}));
     TS_ASSERT_EQUALS(ws->e(0).rawData(), std::vector<double>({0, 0}));

--- a/Framework/DataObjects/test/WorkspaceCreationTest.h
+++ b/Framework/DataObjects/test/WorkspaceCreationTest.h
@@ -144,7 +144,8 @@ public:
 
   void test_create_parent_IndexInfo_same_size() {
     const auto parent = create<Workspace2D>(2, Histogram(BinEdges{1, 2, 4}));
-    const auto ws = create<Workspace2D>(*parent, make_indices(), parent->histogram(0));
+    const auto ws =
+        create<Workspace2D>(*parent, make_indices(), parent->histogram(0));
     // If parent has same size, data in IndexInfo is ignored
     check_default_indices(*ws);
     check_data(*ws);
@@ -152,7 +153,8 @@ public:
 
   void test_create_parent_IndexInfo() {
     const auto parent = create<Workspace2D>(3, Histogram(BinEdges{1, 2, 4}));
-    const auto ws = create<Workspace2D>(*parent, make_indices(), parent->histogram(0));
+    const auto ws =
+        create<Workspace2D>(*parent, make_indices(), parent->histogram(0));
     check_indices(*ws);
     check_data(*ws);
   }
@@ -161,7 +163,8 @@ public:
     const auto parent =
         create<EventWorkspace>(make_indices(), Histogram(BinEdges{1, 2, 4}));
     std::unique_ptr<EventWorkspace> ws;
-    TS_ASSERT_THROWS_NOTHING(ws = create<EventWorkspace>(*parent, 2, parent->histogram(0)))
+    TS_ASSERT_THROWS_NOTHING(
+        ws = create<EventWorkspace>(*parent, 2, parent->histogram(0)))
     TS_ASSERT_EQUALS(ws->id(), "EventWorkspace");
     check_indices(*ws);
     check_data(*ws);

--- a/Framework/DataObjects/test/WorkspaceCreationTest.h
+++ b/Framework/DataObjects/test/WorkspaceCreationTest.h
@@ -180,7 +180,7 @@ public:
         create<EventWorkspace>(make_indices(), Histogram(BinEdges{1, 2, 4}));
     std::unique_ptr<EventWorkspace> ws;
     TS_ASSERT_THROWS_NOTHING(
-        ws = create<EventWorkspace>(*parent, 2, parent->histogram(0)))
+        ws = create<EventWorkspace>(*parent, 2, parent->binEdges(0)))
     TS_ASSERT_EQUALS(ws->id(), "EventWorkspace");
     check_indices(*ws);
     check_zeroed_data(*ws);

--- a/Framework/DataObjects/test/WorkspaceCreationTest.h
+++ b/Framework/DataObjects/test/WorkspaceCreationTest.h
@@ -85,6 +85,21 @@ public:
     check_data(*ws);
   }
 
+  void test_create_parent_varying_bins() {
+    auto parent =
+        create<Workspace2D>(make_indices(), Histogram(BinEdges{1, 2, 4}));
+    const double binShift = -0.54;
+    parent->mutableX(1) += binShift;
+    const auto ws = create<Workspace2D>(*parent);
+    check_indices(*ws);
+    TS_ASSERT_EQUALS(ws->x(0).rawData(), std::vector<double>({1, 2, 4}));
+    TS_ASSERT_EQUALS(ws->x(1).rawData(), std::vector<double>({1 + binShift, 2 + binShift, 4 + binShift}));
+    TS_ASSERT_EQUALS(ws->y(0).rawData(), std::vector<double>({0, 0}));
+    TS_ASSERT_EQUALS(ws->y(1).rawData(), std::vector<double>({0, 0}));
+    TS_ASSERT_EQUALS(ws->e(0).rawData(), std::vector<double>({0, 0}));
+    TS_ASSERT_EQUALS(ws->e(1).rawData(), std::vector<double>({0, 0}));
+  }
+
   void test_create_parent_Histogram() {
     const auto parent =
         create<Workspace2D>(make_indices(), Histogram(BinEdges{0, 1}));

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -57,7 +57,8 @@ As a consequence of these changes, :ref:`CopyInstrumentParmeters <algm-CopyInstr
 Bugs
 ----
 
-- We have fixed a bug where Mantid could crash when deleteing a large number of workspaces.
+- We have fixed a bug where Mantid could crash when deleting a large number of workspaces.
+- A bug was fixed where sometimes a workspace created using another one as a template would have incorrect X data. This happened only when the template workspace had varying bins between the histograms. In these cases the binning was not copied correctly from the template. The bug was discovered in :ref:`algm-MonteCarloAbsorption` but other algorithms may have been affected as well.
 
 CurveFitting
 ------------

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -39,7 +39,7 @@ Bug Fixes
 - Fixed two issues with absolute rotations that affected :ref:`RotateInstrumentComponent <algm-RotateInstrumentComponent>`. Previously, setting the absolute rotation of a component to ``R`` would result in its rotation being ``parent-rotation * R * inverse(relative-parent-rotation)``.
 - :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` has been modified to allow `EventWorkspace` as input
 - Fixed an issue where the log `proton_charge_by_period` was not loaded for `LoadEventNexus <algm-LoadEventNexus>`.
-
+- Fixed an issue where :ref:`algm-MonteCarloAbsorption` would use the wavelengths from the first histogram of *InputWorkspace* only making the algorithm unusable for workspaces with varying bins.
 
 Deprecated
 ##########
@@ -58,7 +58,6 @@ Bugs
 ----
 
 - We have fixed a bug where Mantid could crash when deleting a large number of workspaces.
-- A bug was fixed where sometimes a workspace created using another one as a template would have incorrect X data. This happened only when the template workspace had varying bins between the histograms. In these cases the binning was not copied correctly from the template. The bug was discovered in :ref:`algm-MonteCarloAbsorption` but other algorithms may have been affected as well.
 
 CurveFitting
 ------------


### PR DESCRIPTION
`WorkspaceCreation::create(const P &parent)` always copied the X data of the first histogram in the parent workspace to the created one. This would lead to incorrect binning in the created workspace if the parent had varying bins.

**To test:**

The symptoms can be seen e.g. when using the [MonteCarloAbsorption](http://docs.mantidproject.org/nightly/algorithms/MonteCarloAbsorption-v1.html) algorithm. In the following script, change the `buildDir` variable to point to Mantid's build dir and run.
```python
buildDir = <path-to-Mantid-build-directory>
ws = Load(Filename=buildDir + 'ExternalData/Testing/Data/UnitTest/ILL/IN4/084446.nxs')
ws = ConvertUnits(ws, Target='Wavelength', EMode='Direct')
geometry = {
    'Shape': 'Cylinder',
    'Height': 10.0,
    'Radius': 0.5,
    'Center': [0.0, 0.0, 0.0]
}
material = {
    'ChemicalFormula': 'O2',
    'SampleMassDensity': 1
}
SetSample(ws, Geometry=geometry, Material=material)
corrections = MonteCarloAbsorption(ws, 
    NumberOfWavelengthPoints=2, 
    EventsPerPoint=1)
```
After the unit conversion `ws` has varying bins for workspace indices > 300. Binning should be the same for `corrections` after this PR has been applied.

Fixes #19242.

*Release notes were updated accordingly.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
