### PR TITLE
Vesuvio - Peak prediction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
@@ -104,7 +104,7 @@ class VesuvioPeakPrediction(VesuvioBase):
             for temp in self._temperature:
 
                 if temp == 0:
-                    temp = 1e-6
+                    temp = MIN_TEMPERATURE
 
                 kinetic, rms_momentum = self.mean_energy(temp, self._debye_temp, self._atomic_mass)
                 rms_disp = self.displacement(temp, self._debye_temp, self._atomic_mass)

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
@@ -26,19 +26,25 @@ class VesuvioPeakPrediction(VesuvioBase):
                              validator=StringListValidator(['Debye', 'Einstein']),
                              doc='Model used to make predictions')
 
-        self.declareProperty(FloatArrayProperty(name='Temperature', validator=FloatArrayMandatoryValidator()),
+        arrvalid=FloatArrayBoundedValidator()
+        arrvalid.setLower(0.0)
+
+        self.declareProperty(FloatArrayProperty(name='Temperature', validator=arrvalid),
                              doc='Temperature (K)')
 
-        self.declareProperty(name='AtomicMass', defaultValue=0.0,
-                             validator=FloatMandatoryValidator(),
+        floatvalid=FloatBoundedValidator(0.0)
+        floatvalid.setLowerExclusive(True)
+
+        self.declareProperty(name='AtomicMass', defaultValue=1.0,
+                             validator=floatvalid,
                              doc='Atomic Mass (AMU)')
 
-        self.declareProperty(name='Frequency', defaultValue=0.0,
-                             validator=FloatMandatoryValidator(),
+        self.declareProperty(name='Frequency', defaultValue=1.0,
+                             validator=floatvalid,
                              doc='Fundamental frequency of oscillator (mEV)')
 
-        self.declareProperty(name='DebyeTemperature', defaultValue=0.0,
-                             validator=FloatMandatoryValidator(),
+        self.declareProperty(name='DebyeTemperature', defaultValue=1.0,
+                             validator=floatvalid,
                              doc='Debye Temperature (K)')
 
     def setup(self):
@@ -68,8 +74,6 @@ class VesuvioPeakPrediction(VesuvioBase):
 
                 if temp == 0:
                     temp = 1e-6
-                elif temp < 0:
-                    raise ValueError
 
                 # Convert to mEV
                 temp_mev = temp / 11.604
@@ -89,6 +93,9 @@ class VesuvioPeakPrediction(VesuvioBase):
             vesuvio_params.addColumn('float', 'RMS Displacement(A)')
 
             for temp in self._temperature:
+
+                if temp == 0:
+                    temp = 1e-6
 
                 kinetic, rms_momentum = self.mean_energy(temp, self._debye_temp, self._atomic_mass)
                 rms_disp = self.displacement(temp, self._debye_temp, self._atomic_mass)

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
@@ -9,6 +9,8 @@ import numpy as np
 
 MIN_TEMPERATURE = 1e-6
 K_IN_MEV = scipy.constants.value('electron volt-kelvin relationship') / 1e3
+EINSTEIN_CONSTANT = 2.0717
+DEBYE_CONSTANT = 4.18036
 
 
 class VesuvioPeakPrediction(VesuvioBase):
@@ -67,8 +69,6 @@ class VesuvioPeakPrediction(VesuvioBase):
 
         self.setup()
 
-        print(K_IN_MEV)
-
         vesuvio_params = WorkspaceFactory.Instance().createTable()
         vesuvio_params.setTitle('Vesuvio Peak Parameters')
         vesuvio_params.addColumn('float', 'Temperature(K)')
@@ -91,7 +91,7 @@ class VesuvioPeakPrediction(VesuvioBase):
                 # Effective temperature in K
                 t_star = 2 * kinetic_energy * K_IN_MEV
                 # RMS moment
-                sig = math.sqrt(self._atomic_mass * kinetic_energy / 2.0717)
+                sig = math.sqrt(self._atomic_mass * kinetic_energy / EINSTEIN_CONSTANT)
 
                 vesuvio_params.addRow([temp, self._atomic_mass, self._frequency, kinetic_energy, t_star, sig])
 
@@ -134,7 +134,7 @@ class VesuvioPeakPrediction(VesuvioBase):
         w_bar = self.r_integral(y, dx, n)
 
         k = 3.0 * w_bar / 4.0  # mean kinetic energy in 3D in mEV
-        y_bar = math.sqrt(atomic_mass * w_bar / (2 * 4.18036))  # RMS momentum along Q
+        y_bar = math.sqrt(atomic_mass * w_bar / (2 * DEBYE_CONSTANT))  # RMS momentum along Q
 
         return k, y_bar
 
@@ -156,7 +156,7 @@ class VesuvioPeakPrediction(VesuvioBase):
             x = dx * (i - 1) + dx / 1e6
             y[i] = (3.0 * x ** 2 / debye_energy ** 3) / (x * math.tanh(x / (2 * temp)))
 
-        disp = math.sqrt(self.r_integral(y, dx, n) * 4.18036 / (2 * atomic_mass))
+        disp = math.sqrt(self.r_integral(y, dx, n) * DEBYE_CONSTANT / (2 * atomic_mass))
         return disp
 
     def r_integral(self, y, dx, n):

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
@@ -26,13 +26,13 @@ class VesuvioPeakPrediction(VesuvioBase):
                              validator=StringListValidator(['Debye', 'Einstein']),
                              doc='Model used to make predictions')
 
-        arrvalid=FloatArrayBoundedValidator()
+        arrvalid = FloatArrayBoundedValidator()
         arrvalid.setLower(0.0)
 
         self.declareProperty(FloatArrayProperty(name='Temperature', validator=arrvalid),
                              doc='Temperature (K)')
 
-        floatvalid=FloatBoundedValidator(0.0)
+        floatvalid = FloatBoundedValidator(0.0)
         floatvalid.setLowerExclusive(True)
 
         self.declareProperty(name='AtomicMass', defaultValue=1.0,
@@ -59,7 +59,7 @@ class VesuvioPeakPrediction(VesuvioBase):
 
         self.setup()
 
-        vesuvio_params = CreateEmptyTableWorkspace(OutputWorkspace='vesuvio_'+self._model.lower()+'_params')
+        vesuvio_params = CreateEmptyTableWorkspace(OutputWorkspace='vesuvio_' + self._model.lower() + '_params')
         vesuvio_params.setTitle('Vesuvio Peak Parameters')
         vesuvio_params.addColumn('float', 'Temperature(K)')
         vesuvio_params.addColumn('float', 'Atomic Mass(AMU)')
@@ -123,7 +123,6 @@ class VesuvioPeakPrediction(VesuvioBase):
         w_bar = self.r_integral(y, dx, n)
 
         k = 3.0 * w_bar / 4.0  # mean kinetic energy in 3D in mEV
-        eff_temp = 2.0 * k * 11.604 / 3.0  # effective temperature
         y_bar = math.sqrt(atomic_mass * w_bar / (2 * 4.18036))  # RMS momentum along Q
 
         return k, y_bar
@@ -158,8 +157,6 @@ class VesuvioPeakPrediction(VesuvioBase):
         rint = dx * (y[1] + y[n] + 4 * s_even + 2 * s_odd) / 3.0
 
         return rint
-
-
 
 
 AlgorithmFactory.subscribe(VesuvioPeakPrediction)

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
@@ -1,0 +1,160 @@
+from mantid.api import *
+from mantid.kernel import *
+from mantid import config
+from vesuvio.base import VesuvioBase
+from mantid.simpleapi import *
+
+import math
+import numpy as np
+
+
+class VesuvioPeakPrediction(VesuvioBase):
+    _model = None
+    _temperature = None
+    _atomic_mass = None
+    _frequency = None
+    _debye_temp = None
+
+    def summary(self):
+        return "Predicts parameters for Vesuvio peak widths using Debye or Einstein methods"
+
+    def category(self):
+        return 'Inelastic\\Indirect\\Vesuvio'
+
+    def PyInit(self):
+
+        self.declareProperty(name='Model', defaultValue='Einstein',
+                             validator=StringListValidator(['Debye', 'Einstein']),
+                             doc='Model used to make predictions')
+
+        self.declareProperty(FloatArrayProperty(name='Temperature', validator=FloatArrayMandatoryValidator()),
+                             doc='Temperature (K)')
+
+        self.declareProperty(name='AtomicMass', defaultValue=0.0,
+                             validator=FloatMandatoryValidator(),
+                             doc='Atomic Mass (AMU)')
+
+        self.declareProperty(name='Frequency', defaultValue=0.0,
+                             validator=FloatMandatoryValidator(),
+                             doc='Fundamental frequency of oscillator (mEV)')
+
+        self.declareProperty(name='DebyeTemperature', defaultValue=0.0,
+                             validator=FloatMandatoryValidator(),
+                             doc='Debye Temperature (K)')
+
+    def setup(self):
+
+        self._model = self.getPropertyValue('Model')
+        self._temperature = self.getProperty('Temperature').value
+        self._atomic_mass = self.getProperty('AtomicMass').value
+        self._frequency = self.getProperty('Frequency').value
+        self._debye_temp = self.getProperty('DebyeTemperature').value
+
+    def PyExec(self):
+
+        self.setup()
+
+        vesuvio_params = CreateEmptyTableWorkspace()
+        vesuvio_params.setTitle('Vesuvio Peak Parameters')
+        vesuvio_params.addColumn('float', 'Temperature')
+        vesuvio_params.addColumn('float', 'AtomicMass')
+
+        if self._model == 'Einstein':
+            vesuvio_params.addColumn('float', 'Frequency')
+            vesuvio_params.addColumn('float', 'Kinetic Energy')
+            vesuvio_params.addColumn('float', 'Effective Temp')
+            vesuvio_params.addColumn('float', 'RMS Momentum')
+
+            for temp in self._temperature:
+
+                if temp == 0:
+                    temp = 1e-6
+                elif temp < 0:
+                    raise ValueError
+
+                # Convert to mEV
+                temp_mev = temp / 11.604
+                # Kinetic Energy
+                kinetic_energy = 0.25 * self._frequency / math.tanh(self._frequency / (2 * temp_mev))
+                # Effective temperature in K
+                t_star = 2 * kinetic_energy * 11.604
+                # RMS moment
+                sig = math.sqrt(self._atomic_mass * kinetic_energy / 2.0717)
+
+                vesuvio_params.addRow([temp, self._atomic_mass, self._frequency, kinetic_energy, t_star, sig])
+
+        if self._model == 'Debye':
+            vesuvio_params.addColumn('float', 'Debye Temp')
+            vesuvio_params.addColumn('float', 'Kinetic Energy')
+            vesuvio_params.addColumn('float', 'RMS Momentum')
+            vesuvio_params.addColumn('float', 'RMS Displacement')
+
+            print(self._temperature)
+            for temp in self._temperature:
+
+                kinetic, rms_momentum = self.mean_energy(temp, self._debye_temp, self._atomic_mass)
+                rms_disp = self.displacement(temp, self._debye_temp, self._atomic_mass)
+
+                vesuvio_params.addRow([temp, self._atomic_mass, self._debye_temp, kinetic, rms_momentum, rms_disp])
+
+    def mean_energy(self, temp, debye_temp, atomic_mass):
+        """
+        temp: temperature in K
+        debye_temp: debye temperature in K
+        atomic_mass: atomic mass in AMU
+        """
+
+        n = 1000
+        y = np.empty(n + 1, float)
+        debye_energy = debye_temp / 11.604
+        temp /= 11.604
+
+        # calculate mean energy
+        dx = debye_energy / (n - 1)
+        for i in range(1, n + 1):
+            x = dx * (i - 1) + dx / 1e6
+            y[i] = x * (3.0 * x ** 2 / debye_energy ** 3) / (math.tanh(x / (2 * temp)))
+
+        w_bar = self.r_integral(y, dx, n)
+
+        k = 3.0 * w_bar / 4.0  # mean kinetic energy in 3D in mEV
+        eff_temp = 2.0 * k * 11.604 / 3.0  # effective temperature
+        y_bar = math.sqrt(atomic_mass * w_bar / (2 * 4.18036))  # RMS momentum along Q
+
+        return k, y_bar
+
+    def displacement(self, temp, debye_temp, atomic_mass):
+        """
+        temp: temperature in K
+        debye_temp: debye temperature in K
+        atomic_mass: atomic mass in AMU
+        """
+
+        n = 1000
+        y = np.empty(n + 1, float)
+        debye_energy = debye_temp / 11.604
+        temp /= 11.604
+
+        # calculate mean energy
+        dx = debye_energy / (n - 1)
+        for i in range(1, n + 1):
+            x = dx * (i - 1) + dx / 1e6
+            y[i] = (3.0 * x ** 2 / debye_energy ** 3) / (x * math.tanh(x / (2 * temp)))
+
+        disp = math.sqrt(self.r_integral(y, dx, n) * 4.18036 / (2 * atomic_mass))
+        return disp
+
+    def r_integral(self, y, dx, n):
+        """
+        Function to perform integration using Simpson's Rule
+        """
+        s_even = np.sum(y[2:n - 1:2])
+        s_odd = np.sum(y[3:n - 2:2])
+        rint = dx * (y[1] + y[n] + 4 * s_even + 2 * s_odd) / 3.0
+
+        return rint
+
+
+
+
+AlgorithmFactory.subscribe(VesuvioPeakPrediction)

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
@@ -1,6 +1,5 @@
 from mantid.api import *
 from mantid.kernel import *
-from mantid import config
 from vesuvio.base import VesuvioBase
 from mantid.simpleapi import *
 
@@ -54,16 +53,16 @@ class VesuvioPeakPrediction(VesuvioBase):
 
         self.setup()
 
-        vesuvio_params = CreateEmptyTableWorkspace()
+        vesuvio_params = CreateEmptyTableWorkspace(OutputWorkspace='vesuvio_'+self._model.lower()+'_params')
         vesuvio_params.setTitle('Vesuvio Peak Parameters')
-        vesuvio_params.addColumn('float', 'Temperature')
-        vesuvio_params.addColumn('float', 'AtomicMass')
+        vesuvio_params.addColumn('float', 'Temperature(K)')
+        vesuvio_params.addColumn('float', 'Atomic Mass(AMU)')
 
         if self._model == 'Einstein':
-            vesuvio_params.addColumn('float', 'Frequency')
-            vesuvio_params.addColumn('float', 'Kinetic Energy')
-            vesuvio_params.addColumn('float', 'Effective Temp')
-            vesuvio_params.addColumn('float', 'RMS Momentum')
+            vesuvio_params.addColumn('float', 'Frequency(mEV)')
+            vesuvio_params.addColumn('float', 'Kinetic Energy(mEV)')
+            vesuvio_params.addColumn('float', 'Effective Temp(K)')
+            vesuvio_params.addColumn('float', 'RMS Momentum(A)')
 
             for temp in self._temperature:
 
@@ -84,12 +83,11 @@ class VesuvioPeakPrediction(VesuvioBase):
                 vesuvio_params.addRow([temp, self._atomic_mass, self._frequency, kinetic_energy, t_star, sig])
 
         if self._model == 'Debye':
-            vesuvio_params.addColumn('float', 'Debye Temp')
-            vesuvio_params.addColumn('float', 'Kinetic Energy')
-            vesuvio_params.addColumn('float', 'RMS Momentum')
-            vesuvio_params.addColumn('float', 'RMS Displacement')
+            vesuvio_params.addColumn('float', 'Debye Temp(K)')
+            vesuvio_params.addColumn('float', 'Kinetic Energy(mEV)')
+            vesuvio_params.addColumn('float', 'RMS Momentum(A-1)')
+            vesuvio_params.addColumn('float', 'RMS Displacement(A)')
 
-            print(self._temperature)
             for temp in self._temperature:
 
                 kinetic, rms_momentum = self.mean_energy(temp, self._debye_temp, self._atomic_mass)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -86,6 +86,7 @@ set ( TEST_PY_FILES
   VelocityCrossCorrelationsTest.py
   VelocityAutoCorrelationsTest.py
   SelectNexusFilesByMetadataTest.py
+  VesuvioPeakPredictionTest.py
   VesuvioPreFitTest.py
   VesuvioResolutionTest.py
   VesuvioThicknessTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
@@ -24,7 +24,7 @@ class VesuvioPeakPredictionTest(unittest.TestCase):
 
         self.assertTrue(isinstance(vesuvio_einstein_params, ITableWorkspace))
         self.assertEqual(vesuvio_einstein_params.cell(1, 1), 63.5)
-        self.assertEqual(round(vesuvio_einstein_params.cell(2, 5), 7), 18.4738102)
+        self.assertEqual(round(vesuvio_einstein_params.cell(2, 5), 5), 18.47381)
 
     # -------------------------Failure Cases-------------------------
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
@@ -1,0 +1,57 @@
+import unittest
+from mantid.simpleapi import VesuvioPeakPrediction
+from mantid.api import mtd, ITableWorkspace
+
+
+class VesuvioPeakPredictionTest(unittest.TestCase):
+    def test_debye(self):
+        """
+        Test of debye model with multiple temperatures
+        """
+        VesuvioPeakPrediction(Model='Debye', Temperature=[100, 120, 240, 300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
+
+        vesuvio_params = mtd['vesuvio_debye_params']
+        self.assertTrue(isinstance(vesuvio_params, ITableWorkspace))
+        self.assertEqual(vesuvio_params.cell(1, 1), 63.5)
+        self.assertEqual(round(vesuvio_params.cell(2, 5), 7), 0.0694442)
+
+    def test_einstein(self):
+        """
+        Test of einstein model with multiple temperatures
+        """
+        VesuvioPeakPrediction(Model='Einstein', Temperature=[100, 120, 240, 300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
+
+        vesuvio_params = mtd['vesuvio_einstein_params']
+        self.assertTrue(isinstance(vesuvio_params, ITableWorkspace))
+        self.assertEqual(vesuvio_params.cell(1, 1), 63.5)
+        self.assertEqual(round(vesuvio_params.cell(2, 5), 7), 18.474165)
+
+    # -------------------------Failure Cases-------------------------
+
+    def test_temperature(self):
+        """
+        Test negative input temperature
+        """
+        self.assertRaises(ValueError, VesuvioPeakPrediction,
+                          Model='Debye', Temperature=[100, 0, 240, -20],
+                          AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
+
+    def test_frequency(self):
+        """
+        Test zero frequency
+        """
+        self.assertRaises(ValueError, VesuvioPeakPrediction,
+                          Model='Einstein', Temperature=[100, 0, 240],
+                          AtomicMass=63.5, Frequency=0.0, DebyeTemperature=347)
+
+    def test_debye_temp(self):
+        """
+        Test zero debye temp
+        """
+        self.assertRaises(ValueError, VesuvioPeakPrediction,
+                          Model='Debye', Temperature=[100, 0, 240],
+                          AtomicMass=63.5, Frequency=20, DebyeTemperature=-540)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
@@ -8,23 +8,23 @@ class VesuvioPeakPredictionTest(unittest.TestCase):
         """
         Test of debye model with multiple temperatures
         """
-        VesuvioPeakPrediction(Model='Debye', Temperature=[100, 120, 240, 300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
+        vesuvio_debye_params = VesuvioPeakPrediction(Model='Debye', Temperature=[100, 120, 240, 300],
+                                                     AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
 
-        vesuvio_params = mtd['vesuvio_debye_params']
-        self.assertTrue(isinstance(vesuvio_params, ITableWorkspace))
-        self.assertEqual(vesuvio_params.cell(1, 1), 63.5)
-        self.assertEqual(round(vesuvio_params.cell(2, 5), 7), 0.0694442)
+        self.assertTrue(isinstance(vesuvio_debye_params, ITableWorkspace))
+        self.assertEqual(vesuvio_debye_params.cell(1, 1), 63.5)
+        self.assertEqual(round(vesuvio_debye_params.cell(2, 5), 7), 0.0694458)
 
     def test_einstein(self):
         """
         Test of einstein model with multiple temperatures
         """
-        VesuvioPeakPrediction(Model='Einstein', Temperature=[100, 120, 240, 300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
+        vesuvio_einstein_params = VesuvioPeakPrediction(Model='Einstein', Temperature=[100, 120, 240, 300],
+                                                        AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
 
-        vesuvio_params = mtd['vesuvio_einstein_params']
-        self.assertTrue(isinstance(vesuvio_params, ITableWorkspace))
-        self.assertEqual(vesuvio_params.cell(1, 1), 63.5)
-        self.assertEqual(round(vesuvio_params.cell(2, 5), 7), 18.474165)
+        self.assertTrue(isinstance(vesuvio_einstein_params, ITableWorkspace))
+        self.assertEqual(vesuvio_einstein_params.cell(1, 1), 63.5)
+        self.assertEqual(round(vesuvio_einstein_params.cell(2, 5), 7), 18.4738102)
 
     # -------------------------Failure Cases-------------------------
 

--- a/docs/source/algorithms/VesuvioPeakPrediction-v1.rst
+++ b/docs/source/algorithms/VesuvioPeakPrediction-v1.rst
@@ -21,15 +21,15 @@ Usage
 
 .. testcode:: VesuvioPeakExample
 
-    VesuvioPeakPrediction(Model='Debye', Temperature=[300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
+    vesuvio_debye_params = VesuvioPeakPrediction(Model='Debye', Temperature=[300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
 
-    VesuvioPeakPrediction(Model='Einstein', Temperature=[300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
+    vesuvio_einstein_params= VesuvioPeakPrediction(Model='Einstein', Temperature=[300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
 
-    vp = mtd['vesuvio_debye_params']
+    vp = vesuvio_debye_params
     print('--------Debye--------')
     for c in vp.keys():
         print('%s: %f' %(c, vp.column(c)[0]))
-    vp = mtd['vesuvio_einstein_params']
+    vp = vesuvio_einstein_params
     print('\n--------Einstein--------')
     for c in vp.keys():
         print('%s: %f' %(c, vp.column(c)[0]))

--- a/docs/source/algorithms/VesuvioPeakPrediction-v1.rst
+++ b/docs/source/algorithms/VesuvioPeakPrediction-v1.rst
@@ -28,31 +28,31 @@ Usage
     vp = vesuvio_debye_params
     print('--------Debye--------')
     for c in vp.keys():
-        print('%s: %f' %(c, vp.column(c)[0]))
+        print('%s: %.4f' %(c, vp.column(c)[0]))
     vp = vesuvio_einstein_params
     print('\n--------Einstein--------')
     for c in vp.keys():
-        print('%s: %f' %(c, vp.column(c)[0]))
+        print('%s: %.4f' %(c, vp.column(c)[0]))
 
 **Output:**
 
 .. testoutput:: VesuvioPeakExample
 
     --------Debye--------
-    Temperature(K): 300.000000
-    Atomic Mass(AMU): 63.500000
-    Debye Temp(K): 347.000000
-    Kinetic Energy(mEV): 41.204617
-    RMS Momentum(A-1): 20.427128
-    RMS Displacement(A): 0.076896
+    Temperature(K): 300.0000
+    Atomic Mass(AMU): 63.5000
+    Debye Temp(K): 347.0000
+    Kinetic Energy(mEV): 41.2028
+    RMS Momentum(A-1): 20.4267
+    RMS Displacement(A): 0.0769
 
     --------Einstein--------
-    Temperature(K): 300.000000
-    Atomic Mass(AMU): 63.500000
-    Frequency(mEV): 20.000000
-    Kinetic Energy(mEV): 13.564904
-    Effective Temp(K): 314.814301
-    RMS Momentum(A): 20.390684
+    Temperature(K): 300.0000
+    Atomic Mass(AMU): 63.5000
+    Frequency(mEV): 20.0000
+    Kinetic Energy(mEV): 13.5644
+    Effective Temp(K): 314.8156
+    RMS Momentum(A): 20.3903
 
 .. testcleanup:: VesuvioPeakExample
 

--- a/docs/source/algorithms/VesuvioPeakPrediction-v1.rst
+++ b/docs/source/algorithms/VesuvioPeakPrediction-v1.rst
@@ -30,7 +30,7 @@ Usage
     for c in vp.keys():
         print('%s: %f' %(c, vp.column(c)[0]))
     vp = mtd['vesuvio_einstein_params']
-    print('--------Einstein--------')
+    print('\n--------Einstein--------')
     for c in vp.keys():
         print('%s: %f' %(c, vp.column(c)[0]))
 

--- a/docs/source/algorithms/VesuvioPeakPrediction-v1.rst
+++ b/docs/source/algorithms/VesuvioPeakPrediction-v1.rst
@@ -1,0 +1,60 @@
+
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+This algorithm uses either the Debye or Einstein method to calculate kinetic energy and root mean squared momentum
+and in the Debye case, root mean squared displacement, from a given temperature and atomic mass.
+The outputs from this can be used to help predict the nature of peaks in Vesuvio data.
+
+Usage
+-----
+
+**Example - VesuvioPeakPrediction**
+
+.. testcode:: VesuvioPeakExample
+
+    VesuvioPeakPrediction(Model='Debye', Temperature=[300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
+
+    VesuvioPeakPrediction(Model='Einstein', Temperature=[300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
+
+    vp = mtd['vesuvio_debye_params']
+    print('--------Debye--------')
+    for c in vp.keys():
+        print('%s: %f' %(c, vp.column(c)[0]))
+    vp = mtd['vesuvio_einstein_params']
+    print('--------Einstein--------')
+    for c in vp.keys():
+        print('%s: %f' %(c, vp.column(c)[0]))
+
+**Output:**
+
+.. testoutput:: VesuvioPeakExample
+
+    --------Debye--------
+    Temperature(K): 300.000000
+    Atomic Mass(AMU): 63.500000
+    Debye Temp(K): 347.000000
+    Kinetic Energy(mEV): 41.204617
+    RMS Momentum(A-1): 20.427128
+    RMS Displacement(A): 0.076896
+
+    --------Einstein--------
+    Temperature(K): 300.000000
+    Atomic Mass(AMU): 63.500000
+    Frequency(mEV): 20.000000
+    Kinetic Energy(mEV): 13.564904
+    Effective Temp(K): 314.814301
+    RMS Momentum(A): 20.390684
+
+.. testcleanup:: VesuvioPeakExample
+
+    DeleteWorkspace('vesuvio_einstein_params')
+    DeleteWorkspace('vesuvio_debye_params')

--- a/docs/source/release/v3.10.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.10.0/indirect_inelastic.rst
@@ -14,6 +14,7 @@ Algorithms
 - A new input property *RebinCanToSample* was added to :ref:`ApplyPaalmanPingsCorrection <algm-ApplyPaalmanPingsCorrection>` which enables or disables the rebinning of the empty container workspace.
 - :ref:`FlatPlatePaalmanPingsCorrection <algm-FlatPlatePaalmanPingsCorrection>` and :ref:`CylinderPaalmanPingsCorrection <algm-CylinderPaalmanPingsCorrection>` algorithms are extended for `Efixed` mode, where the correction will be computed for a single wavelength point.
 - :ref:`LoadVesuvio <algm-LoadVesuvio>` can now load NeXus files as well as raw files
+- :ref:`VesuvioPeakPrediction <algm-VesuvioPeakPrediction>` to predict parameters for Vesuvio peaks
 - :ref:`BASISReduction311 <algm-BASISReduction311>` has been deprecated (2017-03-11). Use :ref:`BASISReduction <algm-BASISReduction>` instead.
 - :ref:`BASISReduction <algm-BASISReduction>` includes now an option to compute and save the dynamic susceptibility.
 


### PR DESCRIPTION
Implement routine that uses 2 methods to calculate predictions for Vesuvio peak widths:
One of them is called KED and is based on the Debye model.
The other is called KEHO and is doing the same but using the Einstein model.

**To test:**

```python
VesuvioPeakPrediction(Model='Debye', Temperature=[300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
```
Compare results with original fortran code 
![image](https://cloud.githubusercontent.com/assets/12883435/24359219/96cc3020-12fb-11e7-8a8e-5e658d82d9b1.png)


```python
VesuvioPeakPrediction(Model='Einstein', Temperature=[300], AtomicMass=63.5, Frequency=20, DebyeTemperature=347)
```
Compare results with original fortran code
![image](https://cloud.githubusercontent.com/assets/12883435/24359148/5d5e5f02-12fb-11e7-85ec-d74e4eecfac0.png)



Fixes #19223.

_Release notes have been updated_

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
