### PR TITLE
Fix wrong component comparison in SpecularReflationPos.Cor.

### DIFF
--- a/Framework/Algorithms/src/SpecularReflectionPositionCorrect.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionPositionCorrect.cpp
@@ -40,9 +40,9 @@ getParentComponent(IComponent_const_sptr &currentComponent) {
  */
 bool hasCommonParent(const std::vector<IDetector_const_sptr> &detectors) {
   bool sameParentComponent = true;
-  IComponent const *lastParentComponent = detectors[0]->getParent().get();
+  auto lastParentComponent = detectors[0]->getParent()->getComponentID();
   for (size_t i = 1; i < detectors.size(); ++i) {
-    IComponent const *currentParentComponent = detectors[i]->getParent().get();
+    auto currentParentComponent = detectors[i]->getParent()->getComponentID();
     if (lastParentComponent != currentParentComponent) {
       sameParentComponent = false; // Parent components are different.
       break;

--- a/Framework/Algorithms/src/SpecularReflectionPositionCorrect.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionPositionCorrect.cpp
@@ -39,17 +39,17 @@ getParentComponent(IComponent_const_sptr &currentComponent) {
  * @return True only if all detectors have the same immediate parent.
  */
 bool hasCommonParent(const std::vector<IDetector_const_sptr> &detectors) {
-  bool sameParentComponent = true;
-  auto lastParentComponent = detectors[0]->getParent()->getComponentID();
+  auto firstParent = detectors[0]->getParent();
+  if (!firstParent)
+    return false;
   for (size_t i = 1; i < detectors.size(); ++i) {
-    auto currentParentComponent = detectors[i]->getParent()->getComponentID();
-    if (lastParentComponent != currentParentComponent) {
-      sameParentComponent = false; // Parent components are different.
-      break;
-    }
-    lastParentComponent = currentParentComponent;
+    auto parent = detectors[i]->getParent();
+    if (!parent)
+      return false;
+    if (firstParent->getComponentID() != parent->getComponentID())
+      return false;
   }
-  return sameParentComponent;
+  return true;
 }
 }
 // Register the algorithm into the AlgorithmFactory


### PR DESCRIPTION
The old code compared the parent `shared_ptr`. However, `IComponent::getParent` returns a newly allocated `IComponent`, so this gives nonsense results. Instead the *base* component must be compared.

Miraculously, the old implementation mostly worked. The reason is most likely that the old pointer immediately went out of scope and the next loop iteration would typically allocate the next parent in the same memory location.

Marked as high priority since it influences builds of all PRs.

**To test:**

Code review.

No issue, fixes regular test failures on Linux build servers.

No release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
