### PR TITLE
Use std::make_unique with MSVC

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/make_unique.h
+++ b/Framework/Kernel/inc/MantidKernel/make_unique.h
@@ -11,41 +11,42 @@
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3656.htm
 
 namespace Mantid {
-
 namespace Kernel {
 
-#if __cplusplus > 201103L // C++14
+#if __cplusplus >= 201402L ||                                                  \
+    (defined(_MSC_VER) && (_MSC_VER > 1700)) // C++14 or MSVC 2013+
 
 using std::make_unique;
 
-#else  // C++11
+#else // C++11
 
 template <class T> struct _Unique_if {
-  typedef std::unique_ptr<T> _Single_object;
+  using _Single_object = std::unique_ptr<T>;
 };
 
 template <class T> struct _Unique_if<T[]> {
-  typedef std::unique_ptr<T[]> _Unknown_bound;
+  using _Unknown_bound = std::unique_ptr<T[]>;
 };
 
 template <class T, size_t N> struct _Unique_if<T[N]> {
-  struct __invalid_type {};
+  using _Known_bound = void;
 };
+
+template <class T, class... Args>
+typename _Unique_if<T>::_Single_object make_unique(Args &&... args) {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
 
 template <class T>
 typename _Unique_if<T>::_Unknown_bound make_unique(size_t n) {
-  typedef typename std::remove_extent<T>::type U;
+  using U = typename std::remove_extent<T>::type;
   return std::unique_ptr<T>(new U[n]());
 }
 
 template <class T, class... Args>
-inline typename _Unique_if<T>::_Single_object make_unique(Args &&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
+typename _Unique_if<T>::_Known_bound make_unique(Args &&...) = delete;
 
-template <class T, class... Args>
-inline typename _Unique_if<T>::_Known_bound make_unique(Args &&...) = delete;
 #endif // __cplusplus == 201402L
-} // namespace Kernel
-} // namespace Mantid
+}
+}
 #endif // Mantid_make_unique_h

--- a/Framework/Kernel/inc/MantidKernel/make_unique.h
+++ b/Framework/Kernel/inc/MantidKernel/make_unique.h
@@ -19,7 +19,7 @@ namespace Kernel {
 
 using std::make_unique;
 
-#else // C++11
+#else  // C++11
 
 template <class T> struct _Unique_if {
   using _Single_object = std::unique_ptr<T>;

--- a/Framework/Kernel/inc/MantidKernel/make_unique.h
+++ b/Framework/Kernel/inc/MantidKernel/make_unique.h
@@ -11,6 +11,7 @@
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3656.htm
 
 namespace Mantid {
+
 namespace Kernel {
 
 #if __cplusplus >= 201402L ||                                                  \
@@ -29,13 +30,8 @@ template <class T> struct _Unique_if<T[]> {
 };
 
 template <class T, size_t N> struct _Unique_if<T[N]> {
-  using _Known_bound = void;
+  struct __invalid_type {};
 };
-
-template <class T, class... Args>
-typename _Unique_if<T>::_Single_object make_unique(Args &&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
 
 template <class T>
 typename _Unique_if<T>::_Unknown_bound make_unique(size_t n) {
@@ -44,9 +40,13 @@ typename _Unique_if<T>::_Unknown_bound make_unique(size_t n) {
 }
 
 template <class T, class... Args>
-typename _Unique_if<T>::_Known_bound make_unique(Args &&...) = delete;
+inline typename _Unique_if<T>::_Single_object make_unique(Args &&... args) {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
 
+template <class T, class... Args>
+inline typename _Unique_if<T>::_Known_bound make_unique(Args &&...) = delete;
 #endif // __cplusplus == 201402L
-}
-}
+} // namespace Kernel
+} // namespace Mantid
 #endif // Mantid_make_unique_h


### PR DESCRIPTION
Description of work.

This updates Mantid::Kernel::make_unique to use std::make_unique with Visual Studio. Where possible, I also replaced `typedef` with the newer `using` syntax. 

**To test:**

<!-- Instructions for testing. -->

If the builds pass, :squirrel:

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
