### PR TITLE
Engg: Remove hard coded EnginX strings in preparation for IMAT

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -159,6 +159,12 @@ public:
 
   void resetView();
 
+  std::string getCurrentInstrument() const override { return m_currentInst; }
+
+  void setCurrentInstrument(const std::string &newInstrument) override {
+    m_currentInst = newInstrument;
+  }
+
 protected:
   void initLayout();
 
@@ -240,6 +246,10 @@ private:
 
   /// presenter as in the model-view-presenter
   boost::scoped_ptr<IEnggDiffFittingPresenter> m_presenter;
+
+  /// current selected instrument
+  /// updated from the EnggDiffractionPresenter processInstChange
+  std::string m_currentInst = "";
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffFittingViewQtWidget.h
@@ -68,7 +68,6 @@ public:
   ~EnggDiffFittingViewQtWidget() override;
 
   /// From the IEnggDiffractionUserMsg interface
-  //@{
   void showStatus(const std::string &sts) override;
 
   void userWarning(const std::string &warn,
@@ -77,19 +76,14 @@ public:
   void userError(const std::string &err,
                  const std::string &description) override;
   void enableCalibrateFocusFitUserActions(bool enable) override;
-  //@}
 
   /// From the IEnggDiffractionSettings interface
-  //@{
   EnggDiffCalibSettings currentCalibSettings() const override;
 
   std::string focusingDir() const override;
-  //@}
 
   /// From the IEnggDiffractionPythonRunner interface
-  //@{
   virtual std::string enggRunPythonCode(const std::string &pyCode) override;
-  //@}
 
   void enable(bool enable);
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -312,9 +312,6 @@ private:
   /// paths the user has "browsed to", to add them to the search path
   std::vector<std::string> m_browsedToPaths;
 
-  /// string to use for ENGINX file names (as a prefix, etc.)
-  const static std::string g_enginxStr;
-
   /// The message to tell the user that an RB number is needed
   const static std::string g_shortMsgRBNumberRequired;
   const static std::string g_msgRBNumberRequired;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -376,6 +376,9 @@ private:
 
   /// Associated model for this presenter (MVP pattern)
   // const boost::scoped_ptr<EnggDiffractionModel> m_model;
+
+  /// the current selected instrument
+  std::string m_currentInst = "";
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtGUI.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtGUI.ui
@@ -111,6 +111,11 @@
           <string>ENGINX</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>IMAT</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -171,6 +171,8 @@ public:
 
   int currentMultiRunMode() const override { return g_currentRunMode; }
 
+  void updateTabsInstrument(const std::string &newInstrument) override;
+
 signals:
   void getBanks();
   void setBank();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffFittingView.h
@@ -278,6 +278,17 @@ public:
    * Save user settings (normally when closing the interface).
    */
   virtual void saveSettings() const = 0;
+
+  /**
+  * Gets the current selected instrument
+  */
+  virtual std::string getCurrentInstrument() const = 0;
+
+  /**
+   * Sets the currently selected instrument
+   * @param newInstrument the new instrument that is selected
+   */
+  virtual void setCurrentInstrument(const std::string &newInstrument) = 0;
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -4,9 +4,9 @@
 #include <string>
 #include <vector>
 
-#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionUserMsg.h"
-#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionSettings.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPythonRunner.h"
+#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionSettings.h"
+#include "MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionUserMsg.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -355,6 +355,13 @@ public:
   virtual void plotReplacingWindow(const std::string &wsName,
                                    const std::string &spectrum,
                                    const std::string &type) = 0;
+
+  /**
+  * Updates the instrument in all child tabs
+  *
+  * @param newInstrument name of the new instrument that will be set
+  */
+  virtual void updateTabsInstrument(const std::string &newInstrument) = 0;
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -245,7 +245,8 @@ void EnggDiffFittingPresenter::fittingRunNoChanged() {
 
   // split directory if 'ENGINX_' found by '_.'
   std::vector<std::string> splitBaseName;
-  if (parsedUserInput.find("ENGINX_") != std::string::npos) {
+  if (parsedUserInput.find(m_view->getCurrentInstrument() + "_") !=
+      std::string::npos) {
     boost::split(splitBaseName, parsedUserInput, boost::is_any_of("_."));
   }
 
@@ -939,7 +940,8 @@ void EnggDiffFittingPresenter::setDifcTzero(MatrixWorkspace_sptr wks) const {
         // so throw a runtime error
         throw std::runtime_error(
             "Failed to fit file: The data was not what is expected. "
-            "Does the file contain focused EnginX workspace?");
+            "Does the file contain focused " +
+            m_view->getCurrentInstrument() + " workspace?");
       }
     }
   }
@@ -1077,10 +1079,11 @@ void MantidQt::CustomInterfaces::EnggDiffFittingPresenter::
   // generate file name
   std::string fileName;
   if (g_multi_run.size() > 1) {
-    fileName = "ENGINX_" + g_multi_run.front() + "-" + g_multi_run.back() +
-               "_Single_Peak_Fitting.csv";
+    fileName = m_view->getCurrentInstrument() + "_" + g_multi_run.front() +
+               "-" + g_multi_run.back() + "_Single_Peak_Fitting.csv";
   } else {
-    fileName = "ENGINX_" + runNumber + "_Single_Peak_Fitting.csv";
+    fileName = m_view->getCurrentInstrument() + "_" + runNumber +
+               "_Single_Peak_Fitting.csv";
   }
 
   // separate folder for Single Peak Fitting output;

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -1354,7 +1354,8 @@ void EnggDiffFittingPresenter::runEvaluateFunctionAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm EvaluateFunction, "
                      "Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1371,7 +1372,8 @@ void EnggDiffFittingPresenter::runCropWorkspaceAlg(std::string workspaceName) {
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm CropWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1388,7 +1390,8 @@ void EnggDiffFittingPresenter::runAppendSpectraAlg(std::string workspace1Name,
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm AppendWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1405,7 +1408,8 @@ void EnggDiffFittingPresenter::runRebinToWorkspaceAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm RebinToWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1448,8 +1452,8 @@ void EnggDiffFittingPresenter::getDifcTzero(MatrixWorkspace_const_sptr wks,
     g_log.warning()
         << "Could not retrieve the DIFC, DIFA, TZERO values from the workspace "
         << wks->getName() << ". Using default, which is not adjusted for this "
-                             "workspace/run: DIFA: " << difa
-        << ", DIFC: " << difc << ", TZERO: " << tzero
+                             "workspace/run: DIFA: "
+        << difa << ", DIFC: " << difc << ", TZERO: " << tzero
         << ". Error details: " << rexc.what() << '\n';
   }
 }
@@ -1494,8 +1498,8 @@ void EnggDiffFittingPresenter::runAlignDetectorsAlg(std::string workspaceName) {
     row << detID << difc << difa << tzero;
   } catch (std::runtime_error &rexc) {
     g_log.error() << "Failed to prepare calibration table input to convert "
-                     "units with the algorithm " << algName
-                  << ". Error details: " << rexc.what() << '\n';
+                     "units with the algorithm "
+                  << algName << ". Error details: " << rexc.what() << '\n';
     return;
   }
 
@@ -1544,9 +1548,11 @@ void EnggDiffFittingPresenter::runConvertUnitsAlg(std::string workspaceName) {
     ConvertUnits->execute();
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm ConvertUnits to convert "
-                     "workspace to " << targetUnit
+                     "workspace to "
+                  << targetUnit
                   << ", Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 
@@ -1564,7 +1570,8 @@ void EnggDiffFittingPresenter::runCloneWorkspaceAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm CreateWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what()) << '\n';
+                         static_cast<std::string>(re.what())
+                  << '\n';
   }
 }
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -1357,8 +1357,7 @@ void EnggDiffFittingPresenter::runEvaluateFunctionAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm EvaluateFunction, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 
@@ -1375,8 +1374,7 @@ void EnggDiffFittingPresenter::runCropWorkspaceAlg(std::string workspaceName) {
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm CropWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 
@@ -1393,8 +1391,7 @@ void EnggDiffFittingPresenter::runAppendSpectraAlg(std::string workspace1Name,
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm AppendWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 
@@ -1411,8 +1408,7 @@ void EnggDiffFittingPresenter::runRebinToWorkspaceAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm RebinToWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 
@@ -1455,8 +1451,8 @@ void EnggDiffFittingPresenter::getDifcTzero(MatrixWorkspace_const_sptr wks,
     g_log.warning()
         << "Could not retrieve the DIFC, DIFA, TZERO values from the workspace "
         << wks->getName() << ". Using default, which is not adjusted for this "
-                             "workspace/run: DIFA: "
-        << difa << ", DIFC: " << difc << ", TZERO: " << tzero
+                             "workspace/run: DIFA: " << difa
+        << ", DIFC: " << difc << ", TZERO: " << tzero
         << ". Error details: " << rexc.what() << '\n';
   }
 }
@@ -1501,8 +1497,8 @@ void EnggDiffFittingPresenter::runAlignDetectorsAlg(std::string workspaceName) {
     row << detID << difc << difa << tzero;
   } catch (std::runtime_error &rexc) {
     g_log.error() << "Failed to prepare calibration table input to convert "
-                     "units with the algorithm "
-                  << algName << ". Error details: " << rexc.what() << '\n';
+                     "units with the algorithm " << algName
+                  << ". Error details: " << rexc.what() << '\n';
     return;
   }
 
@@ -1551,11 +1547,9 @@ void EnggDiffFittingPresenter::runConvertUnitsAlg(std::string workspaceName) {
     ConvertUnits->execute();
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm ConvertUnits to convert "
-                     "workspace to "
-                  << targetUnit
+                     "workspace to " << targetUnit
                   << ", Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 
@@ -1573,8 +1567,7 @@ void EnggDiffFittingPresenter::runCloneWorkspaceAlg(
   } catch (std::runtime_error &re) {
     g_log.error() << "Could not run the algorithm CreateWorkspace, "
                      "Error description: " +
-                         static_cast<std::string>(re.what())
-                  << '\n';
+                         static_cast<std::string>(re.what()) << '\n';
   }
 }
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -2630,17 +2630,18 @@ std::string EnggDiffractionPresenter::outFileNameFactory(
 
   // calibration output files
   if (inputWorkspace.std::string::find("curves") != std::string::npos) {
-    fullFilename = "ob+ENGINX_" + runNo + "_" + bank + "_bank" + format;
+    fullFilename =
+        "ob+" + m_currentInst + "_" + runNo + "_" + bank + "_bank" + format;
 
     // focus output files
   } else if (inputWorkspace.std::string::find("texture") != std::string::npos) {
-    fullFilename = "ENGINX_" + runNo + "_texture_" + bank + format;
+    fullFilename = m_currentInst + "_" + runNo + "_texture_" + bank + format;
   } else if (inputWorkspace.std::string::find("cropped") != std::string::npos) {
-    fullFilename = "ENGINX_" + runNo + "_cropped_" +
+    fullFilename = m_currentInst + "_" + runNo + "_cropped_" +
                    boost::lexical_cast<std::string>(g_croppedCounter) + format;
     g_croppedCounter++;
   } else {
-    fullFilename = "ENGINX_" + runNo + "_bank_" + bank + format;
+    fullFilename = m_currentInst + "_" + runNo + "_bank_" + bank + format;
   }
   return fullFilename;
 }
@@ -2907,6 +2908,8 @@ EnggDiffractionPresenter::outFilesGeneralDir(const std::string &addComponent) {
  * Produces the root path where output files are going to be written.
  */
 Poco::Path EnggDiffractionPresenter::outFilesRootDir() {
+  // TODO decide whether to move into settings or use mantid's default directory
+  // after discussion with users
   const std::string rootDir = "EnginX_Mantid";
   Poco::Path dir;
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -267,8 +267,7 @@ void EnggDiffractionPresenter::grabCalibParms(const std::string &fname) {
             g_log.warning()
                 << "Error when trying to extract parameters from this line:  "
                 << line << ". This calibration file may not load correctly. "
-                           "Error details: "
-                << rexc.what() << '\n';
+                           "Error details: " << rexc.what() << '\n';
           }
         } else {
           g_log.warning() << "Could not parse correctly a parameters "
@@ -986,8 +985,7 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
         << "The calibration calculations failed. One of the "
            "algorithms did not execute correctly. See log messages for "
            "further details. Error: " +
-               std::string(rexc.what())
-        << '\n';
+               std::string(rexc.what()) << '\n';
   } catch (std::invalid_argument &) {
     g_log.error()
         << "The calibration calculations failed. Some input properties "
@@ -1530,8 +1528,7 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
   g_lastValidRun = runNo;
 
   g_log.notice() << "Generating new focusing workspace(s) and file(s) into "
-                    "this directory: "
-                 << dir << '\n';
+                    "this directory: " << dir << '\n';
 
   // TODO: this is almost 100% common with doNewCalibrate() - refactor
   EnggDiffCalibSettings cs = m_view->currentCalibSettings();
@@ -1576,8 +1573,7 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
         loadDetectorGroupingCSV(dgFile, bankIDs, specs);
       } catch (std::runtime_error &re) {
         g_log.error() << "Error loading detector grouping file: " + dgFile +
-                             ". Detailed error: " + re.what()
-                      << '\n';
+                             ". Detailed error: " + re.what() << '\n';
         bankIDs.clear();
         specs.clear();
       }
@@ -1593,8 +1589,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
         fpath.append(effectiveFilenames[idx]).toString();
     g_log.notice() << "Generating new focused file (bank " +
                           boost::lexical_cast<std::string>(bankIDs[idx]) +
-                          ") for run " + runNo + " into: "
-                   << effectiveFilenames[idx] << '\n';
+                          ") for run " + runNo +
+                          " into: " << effectiveFilenames[idx] << '\n';
     try {
       m_focusFinishedOK = false;
       doFocusing(cs, fullFilename, runNo, bankIDs[idx], specs[idx], dgFile);
@@ -1603,13 +1599,12 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
       g_log.error() << "The focusing calculations failed. One of the algorithms"
                        "did not execute correctly. See log messages for "
                        "further details. Error: " +
-                           std::string(rexc.what())
-                    << '\n';
+                           std::string(rexc.what()) << '\n';
     } catch (std::invalid_argument &ia) {
       g_log.error() << "The focusing failed. Some input properties "
                        "were not valid. "
-                       "See log messages for details. Error: "
-                    << ia.what() << '\n';
+                       "See log messages for details. Error: " << ia.what()
+                    << '\n';
     }
   }
 
@@ -1706,8 +1701,7 @@ void EnggDiffractionPresenter::focusingFinished() {
     if (lastRun != lastValid) {
       g_log.warning()
           << "Focussing process has been stopped, last successful "
-             "run number: "
-          << g_lastValidRun
+             "run number: " << g_lastValidRun
           << " , total number of focus run that could not be processed: "
           << (lastRun - lastValid) << '\n';
       m_view->showStatus("Focusing stopped. Ready");
@@ -1952,8 +1946,7 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "This is possibly because some of the settings are not "
                        "consistent. Please check the log messages for "
                        "details. Details: " +
-                           std::string(ia.what())
-                    << '\n';
+                           std::string(ia.what()) << '\n';
       throw;
     } catch (std::runtime_error &re) {
       g_log.error() << "Failed to calculate Vanadium corrections. "
@@ -1962,15 +1955,14 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "There was no obvious error in the input properties "
                        "but the algorithm failed. Please check the log "
                        "messages for details." +
-                           std::string(re.what())
-                    << '\n';
+                           std::string(re.what()) << '\n';
       throw;
     }
   } else {
     g_log.notice() << "Found precalculated Vanadium correction features for "
-                      "Vanadium run "
-                   << vanNo << ". Re-using these files: " << preIntegFilename
-                   << ", and " << preCurvesFilename << '\n';
+                      "Vanadium run " << vanNo
+                   << ". Re-using these files: " << preIntegFilename << ", and "
+                   << preCurvesFilename << '\n';
     try {
       loadVanadiumPrecalcWorkspaces(preIntegFilename, preCurvesFilename,
                                     vanIntegWS, vanCurvesWS, vanNo, specNos);
@@ -2863,8 +2855,8 @@ EnggDiffractionPresenter::outFilesUserDir(const std::string &addToDir) {
     }
   } catch (Poco::FileAccessDeniedException &e) {
     g_log.error() << "Error caused by file access/permission, path to user "
-                     "directory: "
-                  << dir.toString() << ". Error details: " << e.what() << '\n';
+                     "directory: " << dir.toString()
+                  << ". Error details: " << e.what() << '\n';
   } catch (std::runtime_error &re) {
     g_log.error() << "Error while finding/creating a user path: "
                   << dir.toString() << ". Error details: " << re.what() << '\n';
@@ -2895,8 +2887,8 @@ EnggDiffractionPresenter::outFilesGeneralDir(const std::string &addComponent) {
     }
   } catch (Poco::FileAccessDeniedException &e) {
     g_log.error() << "Error caused by file access/permission, path to "
-                     "general directory: "
-                  << dir.toString() << ". Error details: " << e.what() << '\n';
+                     "general directory: " << dir.toString()
+                  << ". Error details: " << e.what() << '\n';
   } catch (std::runtime_error &re) {
     g_log.error() << "Error while finding/creating a general path: "
                   << dir.toString() << ". Error details: " << re.what() << '\n';

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -612,6 +612,7 @@ void EnggDiffractionPresenter::processLogMsg() {
 
 void EnggDiffractionPresenter::processInstChange() {
   m_currentInst = m_view->currentInstrument();
+  m_view->updateTabsInstrument(m_currentInst);
 }
 
 void EnggDiffractionPresenter::processRBNumberChange() {
@@ -1086,7 +1087,6 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
 
   // save vanIntegWS and vanCurvesWS as open genie
   // see where spec number comes from
-
   loadOrCalcVanadiumWorkspaces(vanFileHint, cs.m_inputDirCalib, vanIntegWS,
                                vanCurvesWS, cs.m_forceRecalcOverwrite, specNos);
 
@@ -1941,7 +1941,7 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
   // if pre calculated not found ..
   if (forceRecalc || !foundPrecalc) {
     g_log.notice() << "Calculating Vanadium corrections. This may take a "
-                      "few seconds...\n";
+                      "while...\n";
     try {
       calcVanadiumWorkspaces(vanNo, vanIntegWS, vanCurvesWS);
     } catch (std::invalid_argument &ia) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -3,8 +3,8 @@
 #include "MantidQtAPI/AlgorithmInputHistory.h"
 #include "MantidQtAPI/AlgorithmRunner.h"
 #include "MantidQtAPI/HelpWindow.h"
-#include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h"
 #include "MantidQtAPI/MWRunFiles.h"
+#include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h"
 
 #include <Poco/DirectoryIterator.h>
 #include <Poco/Path.h>
@@ -1114,6 +1114,11 @@ void EnggDiffractionViewQtGUI::closeEvent(QCloseEvent *event) {
 void EnggDiffractionViewQtGUI::openHelpWin() {
   MantidQt::API::HelpWindow::showCustomInterface(
       nullptr, QString("Engineering_Diffraction"));
+}
+
+void EnggDiffractionViewQtGUI::updateTabsInstrument(
+    const std::string &newInstrument) {
+  m_fittingWidget->setCurrentInstrument(newInstrument);
 }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffFittingPresenterTest.h
@@ -439,6 +439,10 @@ public:
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     pres.notify(IEnggDiffFittingPresenter::browsePeaks);
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
   void test_browse_peaks_list_with_warning() {
@@ -464,6 +468,10 @@ public:
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     pres.notify(IEnggDiffFittingPresenter::browsePeaks);
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
   void test_save_peaks_list() {
@@ -481,6 +489,10 @@ public:
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     pres.notify(IEnggDiffFittingPresenter::savePeaks);
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
   void test_save_peaks_list_with_warning() {
@@ -504,6 +516,10 @@ public:
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
 
     pres.notify(IEnggDiffFittingPresenter::savePeaks);
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
   void test_add_peaks_to_empty_list() {
@@ -528,6 +544,10 @@ public:
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     pres.notify(IEnggDiffFittingPresenter::addPeaks);
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
   void test_add_peaks_with_disabled_peak_picker() {
@@ -551,6 +571,10 @@ public:
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     pres.notify(IEnggDiffFittingPresenter::addPeaks);
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
   void test_add_valid_peaks_to_list_with_comma() {
@@ -573,6 +597,10 @@ public:
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     pres.notify(IEnggDiffFittingPresenter::addPeaks);
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
   void test_add_customised_valid_peaks_to_list_without_comma() {
@@ -598,6 +626,10 @@ public:
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     pres.notify(IEnggDiffFittingPresenter::addPeaks);
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
   void test_add_invalid_peaks_to_list() {
@@ -621,6 +653,10 @@ public:
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     pres.notify(IEnggDiffFittingPresenter::addPeaks);
+    TSM_ASSERT(
+        "Mock not used as expected. Some EXPECT_CALL conditions were not "
+        "satisfied.",
+        testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
   void test_shutDown() {

--- a/MantidQt/CustomInterfaces/test/EnggDiffFittingViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffFittingViewMock.h
@@ -143,6 +143,12 @@ public:
 
   // virtual void resetCanvas
   MOCK_METHOD0(resetCanvas, void());
+
+  // virtual std::string getCurrentInstrument() const = 0;
+  MOCK_CONST_METHOD0(getCurrentInstrument, std::string());
+
+  // virtual void setCurrentInstrument(const std::string &newInstrument) = 0;
+  MOCK_METHOD1(setCurrentInstrument, void(const std::string &newInstrument));
 };
 
 GCC_DIAG_ON_SUGGEST_OVERRIDE

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -315,10 +315,9 @@ public:
 
     const std::string filename =
         "UNKNOWNINST_" + vanNo + "_" + ceriaNo + "_" + "foo.prm";
-    EXPECT_CALL(mockView,
-                askNewCalibrationFilename("UNKNOWNINST_" + vanNo + "_" +
-                                          ceriaNo + "_both_banks.prm"))
-        .Times(0);
+    EXPECT_CALL(mockView, askNewCalibrationFilename(
+                              "UNKNOWNINST_" + vanNo + "_" + ceriaNo +
+                              "_both_banks.prm")).Times(0);
     //  .WillOnce(Return(filename)); // if enabled ask user output filename
 
     // Should not try to use options for focusing
@@ -536,10 +535,9 @@ public:
 
     const std::string filename =
         "UNKNOWNINST_" + vanNo + "_" + ceriaNo + "_" + "foo.prm";
-    EXPECT_CALL(mockView,
-                askNewCalibrationFilename("UNKNOWNINST_" + vanNo + "_" +
-                                          ceriaNo + "_both_banks.prm"))
-        .Times(0);
+    EXPECT_CALL(mockView, askNewCalibrationFilename(
+                              "UNKNOWNINST_" + vanNo + "_" + ceriaNo +
+                              "_both_banks.prm")).Times(0);
     //  .WillOnce(Return(filename)); // if enabled ask user output filename
 
     // with the normal thread should disable actions at the beginning
@@ -606,10 +604,9 @@ public:
 
     const std::string filename =
         "UNKNOWNINST_" + vanNo + "_" + ceriaNo + "_" + "foo.prm";
-    EXPECT_CALL(mockView,
-                askNewCalibrationFilename("UNKNOWNINST_" + vanNo + "_" +
-                                          ceriaNo + "_both_banks.prm"))
-        .Times(0);
+    EXPECT_CALL(mockView, askNewCalibrationFilename(
+                              "UNKNOWNINST_" + vanNo + "_" + ceriaNo +
+                              "_both_banks.prm")).Times(0);
     //  .WillOnce(Return(filename)); // if enabled ask user output filename
 
     // Should not try to use options for focusing

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -4,6 +4,7 @@
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h"
 
+#include "EnggDiffFittingViewMock.h"
 #include "EnggDiffractionViewMock.h"
 #include <cxxtest/TestSuite.h>
 
@@ -1385,20 +1386,23 @@ public:
 
     // by setting this here, when initialising the presenter, the function will
     // be called and the instrument name will be updated
-    // we are calling it twice, once on initialisation and a second time after
-    // notify!
     const std::string instrumentName = "ENGINX";
+
+    // we are calling it twice, once on presenter initialisation
+    // and a second time after when using pres.notify!
     EXPECT_CALL(mockView, currentInstrument())
         .Times(2)
         .WillRepeatedly(Return(instrumentName));
 
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
+    // we don't expect any warnings or errors
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     // should not change status
     EXPECT_CALL(mockView, showStatus(testing::_)).Times(0);
+    EXPECT_CALL(mockView, updateTabsInstrument(testing::_)).Times(1);
 
     pres.notify(IEnggDiffractionPresenter::InstrumentChange);
     TSM_ASSERT(

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -175,6 +175,14 @@ public:
 
   void test_loadExistingCalibWithAcceptableName() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
+
+    // by setting this here, when initialising the presenter, the function will
+    // be called and the instrument name will be updated
+    const std::string instrumentName = "ENGINX";
+    EXPECT_CALL(mockView, currentInstrument())
+        .Times(1)
+        .WillOnce(Return(instrumentName));
+
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
     // will need basic calibration settings from the user
@@ -183,10 +191,12 @@ public:
         .Times(1)
         .WillOnce(Return(calibSettings));
 
+    // update the selected instrument
     const std::string mockFname = "ENGINX_111111_222222_foo_bar.par";
     EXPECT_CALL(mockView, askExistingCalibFilename())
         .Times(1)
         .WillOnce(Return(mockFname));
+
     EXPECT_CALL(mockView, newCalibLoaded(testing::_, testing::_, mockFname))
         .Times(1);
 
@@ -304,9 +314,10 @@ public:
 
     const std::string filename =
         "UNKNOWNINST_" + vanNo + "_" + ceriaNo + "_" + "foo.prm";
-    EXPECT_CALL(mockView, askNewCalibrationFilename(
-                              "UNKNOWNINST_" + vanNo + "_" + ceriaNo +
-                              "_both_banks.prm")).Times(0);
+    EXPECT_CALL(mockView,
+                askNewCalibrationFilename("UNKNOWNINST_" + vanNo + "_" +
+                                          ceriaNo + "_both_banks.prm"))
+        .Times(0);
     //  .WillOnce(Return(filename)); // if enabled ask user output filename
 
     // Should not try to use options for focusing
@@ -524,9 +535,10 @@ public:
 
     const std::string filename =
         "UNKNOWNINST_" + vanNo + "_" + ceriaNo + "_" + "foo.prm";
-    EXPECT_CALL(mockView, askNewCalibrationFilename(
-                              "UNKNOWNINST_" + vanNo + "_" + ceriaNo +
-                              "_both_banks.prm")).Times(0);
+    EXPECT_CALL(mockView,
+                askNewCalibrationFilename("UNKNOWNINST_" + vanNo + "_" +
+                                          ceriaNo + "_both_banks.prm"))
+        .Times(0);
     //  .WillOnce(Return(filename)); // if enabled ask user output filename
 
     // with the normal thread should disable actions at the beginning
@@ -593,9 +605,10 @@ public:
 
     const std::string filename =
         "UNKNOWNINST_" + vanNo + "_" + ceriaNo + "_" + "foo.prm";
-    EXPECT_CALL(mockView, askNewCalibrationFilename(
-                              "UNKNOWNINST_" + vanNo + "_" + ceriaNo +
-                              "_both_banks.prm")).Times(0);
+    EXPECT_CALL(mockView,
+                askNewCalibrationFilename("UNKNOWNINST_" + vanNo + "_" +
+                                          ceriaNo + "_both_banks.prm"))
+        .Times(0);
     //  .WillOnce(Return(filename)); // if enabled ask user output filename
 
     // Should not try to use options for focusing
@@ -1369,10 +1382,19 @@ public:
 
   void test_instChange() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
+
+    // by setting this here, when initialising the presenter, the function will
+    // be called and the instrument name will be updated
+    // we are calling it twice, once on initialisation and a second time after
+    // notify!
+    const std::string instrumentName = "ENGINX";
+    EXPECT_CALL(mockView, currentInstrument())
+        .Times(2)
+        .WillRepeatedly(Return(instrumentName));
+
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
-    // 1 error, no warnings
-    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(1);
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     // should not change status

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -180,6 +180,9 @@ public:
 
   // virtual void plotCalibOutput();
   MOCK_METHOD1(plotCalibOutput, void(const std::string &pyCode));
+
+  // virtual void updateTabsInstrument(const std::string & newInstrument) = 0;
+  MOCK_METHOD1(updateTabsInstrument, void(const std::string &newInstrument));
 };
 GCC_DIAG_ON_SUGGEST_OVERRIDE
 


### PR DESCRIPTION
Description of work.

Removed most hard coded EnginX name in preparation for adding IMAT.
Some are left because it's not clear to me what to do with them, for example:
`std::string EnggDiffractionViewQtGUI::guessGSASTemplatePath() const` has `template_ENGINX_241391_236516_North_and_South_banks.par`, and `std::string EnggDiffractionViewQtGUI::guessDefaultFullCalibrationPath() const` has `ENGINX_full_pixel_calibration_vana194547_ceria193749.csv`.

**To test:**
- Play around with GUI
- Run unit tests

<!-- Instructions for testing. -->

Partially Fixes #17433.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
