### PR TITLE
LoadFITS Improved Memory usage and removed LoadAsRectangle property

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadFITS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadFITS.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/Workspace2D.h"
 
@@ -47,7 +48,8 @@ File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 
-class DLLExport LoadFITS : public API::IFileLoader<Kernel::FileDescriptor> {
+class DLLExport LoadFITS : public API::IFileLoader<Kernel::FileDescriptor>,
+                           public API::DeprecatedAlgorithm {
 public:
   LoadFITS();
 
@@ -110,7 +112,7 @@ private:
                           const FITSInfo &fileInfo, int binSize, double cmpp);
 
   // Reads the data from a single FITS file into a workspace (directly, fast)
-  void readDataToWorkspace(const FITSInfo &fileInfo, double cmpp,
+  void readDataToWorkspace(const FITSInfo &fileInfo,
                            DataObjects::Workspace2D_sptr ws,
                            std::vector<char> &buffer);
 

--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -716,7 +716,7 @@ LoadFITS::makeWorkspace(const FITSInfo &fileInfo, size_t &newFileNumber,
 
   if (loadAsRectImg && 1 == binSize) {
     // set data directly into workspace
-    readDataToWorkspace(fileInfo, cmpp, ws, buffer);
+    readDataToWorkspace(fileInfo, ws, buffer);
   } else {
     readDataToImgs(fileInfo, imageY, imageE, buffer);
     doFilterNoise(noiseThresh, imageY, imageE);
@@ -850,7 +850,7 @@ void LoadFITS::addAxesInfoAndLogs(Workspace2D_sptr ws, bool loadAsRectImg,
  *
  * @throws std::runtime_error if there are file input issues
  */
-void LoadFITS::readDataToWorkspace(const FITSInfo &fileInfo, double cmpp,
+void LoadFITS::readDataToWorkspace(const FITSInfo &fileInfo,
                                    Workspace2D_sptr ws,
                                    std::vector<char> &buffer) {
   const size_t bytespp = (fileInfo.bitsPerPixel / 8);

--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -7,8 +7,8 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidHistogramData/Points.h"
 #include "MantidHistogramData/LinearGenerator.h"
+#include "MantidHistogramData/Points.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
@@ -123,12 +123,12 @@ void LoadFITS::init() {
   declareProperty(make_unique<API::WorkspaceProperty<API::Workspace>>(
       "OutputWorkspace", "", Kernel::Direction::Output));
 
-  // declareProperty(
-  //     make_unique<Kernel::PropertyWithValue<bool>>("LoadAsRectImg", true,
-  //                                                  Kernel::Direction::Input),
-  //     "If enabled (not by default), the output Workspace2D will have "
-  //     "one histogram per row and one bin per pixel, such that a 2D "
-  //     "color plot (color fill plot) will display an image.");
+  declareProperty(
+      make_unique<Kernel::PropertyWithValue<bool>>("LoadAsRectImg", true,
+                                                   Kernel::Direction::Input),
+      "If enabled (not by default), the output Workspace2D will have "
+      "one histogram per row and one bin per pixel, such that a 2D "
+      "color plot (color fill plot) will display an image.");
 
   auto zeroOrPosDbl = boost::make_shared<BoundedValidator<double>>();
   zeroOrPosDbl->setLower(0.0);
@@ -168,10 +168,10 @@ void LoadFITS::exec() {
 
   int binSize = getProperty("BinSize");
   double noiseThresh = getProperty("FilterNoiseLevel");
-  bool loadAsRectImg = true;
   // This is disabled because not loading as a rectangle makes a
   // 16 MB image into a 7GB workspace.
   // bool loadAsRectImg = getProperty("LoadAsRectImg");
+  bool loadAsRectImg = true;
   const std::string outWSName = getPropertyValue("OutputWorkspace");
 
   doLoadFiles(paths, outWSName, loadAsRectImg, binSize, noiseThresh);
@@ -862,7 +862,7 @@ void LoadFITS::readDataToWorkspace(const FITSInfo &fileInfo, double cmpp,
   // Treat buffer as a series of bytes
   uint8_t *buffer8 = reinterpret_cast<uint8_t *>(buffer.data());
 
-  HistogramData::Points sharedX(ncols,HistogramData::LinearGenerator(0, 0));
+  HistogramData::Points sharedX(ncols, HistogramData::LinearGenerator(0, 0));
   HistogramData::PointStandardDeviations sharedErrors(
       ncols, HistogramData::LinearGenerator(0, 0));
   PARALLEL_FOR_NO_WSP_CHECK()

--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -7,7 +7,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidHistogramData/Counts.h"
+#include "MantidHistogramData/Points.h"
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/Unit.h"
@@ -862,15 +862,14 @@ void LoadFITS::readDataToWorkspace(const FITSInfo &fileInfo, double cmpp,
   // Treat buffer as a series of bytes
   uint8_t *buffer8 = reinterpret_cast<uint8_t *>(buffer.data());
 
-  HistogramData::Counts sharedXCounts(ncols,
-                                      HistogramData::LinearGenerator(0, 0));
-  HistogramData::CountStandardDeviations sharedErrors(
+  HistogramData::Points sharedX(ncols,HistogramData::LinearGenerator(0, 0));
+  HistogramData::PointStandardDeviations sharedErrors(
       ncols, HistogramData::LinearGenerator(0, 0));
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int i = 0; i < static_cast<int>(nrows); ++i) {
-    ws->setCounts(i, sharedXCounts);
+    ws->setPoints(i, sharedX);
     auto &yVals = ws->mutableY(i);
-    ws->setCountStandardDeviations(i, sharedErrors);
+    ws->setPointStandardDeviations(i, sharedErrors);
 
     for (size_t j = 0; j < ncols; ++j) {
       // Map from 2D->1D index

--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -386,16 +386,16 @@ void LoadFITS::headerSanityCheck(const FITSInfo &hdr,
     valid = false;
     g_log.error() << "File " << hdr.filePath
                   << ": the number of pixels in the first dimension differs "
-                     "from the first file loaded ("
-                  << hdrFirst.filePath << "): " << hdr.axisPixelLengths[0]
+                     "from the first file loaded (" << hdrFirst.filePath
+                  << "): " << hdr.axisPixelLengths[0]
                   << " != " << hdrFirst.axisPixelLengths[0] << '\n';
   }
   if (hdr.axisPixelLengths[1] != hdrFirst.axisPixelLengths[1]) {
     valid = false;
     g_log.error() << "File " << hdr.filePath
                   << ": the number of pixels in the second dimension differs"
-                     "from the first file loaded ("
-                  << hdrFirst.filePath << "): " << hdr.axisPixelLengths[0]
+                     "from the first file loaded (" << hdrFirst.filePath
+                  << "): " << hdr.axisPixelLengths[0]
                   << " != " << hdrFirst.axisPixelLengths[0] << '\n';
   }
 

--- a/Framework/DataHandling/test/LoadFITSTest.h
+++ b/Framework/DataHandling/test/LoadFITSTest.h
@@ -310,38 +310,54 @@ public:
       TS_ASSERT_THROWS_NOTHING(
           ws = boost::dynamic_pointer_cast<MatrixWorkspace>(out->getItem(i)));
 
-      TSM_ASSERT_EQUALS("The number of histograms should be the expected,dimension of the image",ws->getNumberHistograms(), g_SPECTRA_COUNT_ASRECT);
+      TSM_ASSERT_EQUALS("The number of histograms should be the "
+                        "expected,dimension of the image",
+                        ws->getNumberHistograms(), g_SPECTRA_COUNT_ASRECT);
     }
 
-    TSM_ASSERT_EQUALS("The output workspace group should have two workspaces ",out->size(),2);
+    TSM_ASSERT_EQUALS("The output workspace group should have two workspaces ",
+                      out->size(), 2);
 
     // and finally a basic check of values in the image, to be safe
     MatrixWorkspace_sptr ws0;
     TS_ASSERT_THROWS_NOTHING(
         ws0 = boost::dynamic_pointer_cast<MatrixWorkspace>(out->getItem(0)));
 
-    TSM_ASSERT_EQUALS("The title of the first output workspace is not the name of the first file",ws0->getTitle(), g_smallFname1);
+    TSM_ASSERT_EQUALS("The title of the first output workspace is not the name "
+                      "of the first file",
+                      ws0->getTitle(), g_smallFname1);
 
     size_t n = ws0->getNumberHistograms();
     TSM_ASSERT_EQUALS(
-        "The value at a given spectrum and bin (first one) is not as expected ",ws0->y(n - 1)[0],137);
+        "The value at a given spectrum and bin (first one) is not as expected ",
+        ws0->y(n - 1)[0], 137);
+
+    TSM_ASSERT_EQUALS("The value at a given spectrum and bin (middle one) is "
+                      "not as expected ",
+                      ws0->y(n - 1)[g_SPECTRA_COUNT_ASRECT / 2], 159);
 
     TSM_ASSERT_EQUALS(
-        "The value at a given spectrum and bin (middle one) is not as expected ",ws0->y(n - 1)[g_SPECTRA_COUNT_ASRECT / 2],159);
-
-    TSM_ASSERT_EQUALS(
-        "The value at a given spectrum and bin (last one) is not as expected ",ws0->y(n - 1).back(),142);
+        "The value at a given spectrum and bin (last one) is not as expected ",
+        ws0->y(n - 1).back(), 142);
 
     MatrixWorkspace_sptr ws1;
     TS_ASSERT_THROWS_NOTHING(
         ws1 = boost::dynamic_pointer_cast<MatrixWorkspace>(out->getItem(1)));
 
-    TSM_ASSERT_EQUALS("The title of the second output workspace is not the name of the second file",ws1->getTitle(), g_smallFname2);
-    TSM_ASSERT_EQUALS("The value at a given spectrum and bin (first one) is not as expected ",ws1->y(n - 1)[0],155);
+    TSM_ASSERT_EQUALS("The title of the second output workspace is not the "
+                      "name of the second file",
+                      ws1->getTitle(), g_smallFname2);
+    TSM_ASSERT_EQUALS(
+        "The value at a given spectrum and bin (first one) is not as expected ",
+        ws1->y(n - 1)[0], 155);
 
-    TSM_ASSERT_EQUALS("The value at a given spectrum and bin (middle one) is not as expected ",ws1->y(n - 1)[g_SPECTRA_COUNT_ASRECT / 2],199);
+    TSM_ASSERT_EQUALS("The value at a given spectrum and bin (middle one) is "
+                      "not as expected ",
+                      ws1->y(n - 1)[g_SPECTRA_COUNT_ASRECT / 2], 199);
 
-    TSM_ASSERT_EQUALS("The value at a given spectrum and bin (last one) is not as expected ",ws1->y(n - 1).back(),133);
+    TSM_ASSERT_EQUALS(
+        "The value at a given spectrum and bin (last one) is not as expected ",
+        ws1->y(n - 1).back(), 133);
   }
 
   void test_loadEmpty() {


### PR DESCRIPTION
Description of work.
This makes `LoadFITS` use the `sharedX` and `sharedE` HistogramData functionality to greatly reduce the memory consumption.

Additionally this PR hides the property for `LoadAsRectangle` because a single 16MB image was loaded into a 7GB workspace. No fix was added for that as `LoadFITS` might be deprecated and removed soon.
![16mb_image_2minutes_7gigs](https://cloud.githubusercontent.com/assets/9135965/24514456/46d8fb16-156c-11e7-969c-19752b4b537e.jpg)
 

**To test:**
- Run LoadFITS test
- Try loading a Fits image, here are a few: https://drive.google.com/open?id=0B2Mj8e56Z8xTNTZRV1NuSWs5QVU
<!-- Instructions for testing. -->

Fixes #18242.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
