### PR TITLE
Remove variable definition from header ColorScaleGuard.h.

### DIFF
--- a/Vates/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
@@ -3,23 +3,17 @@
 #include "MantidKernel/System.h"
 #include "MantidKernel/Logger.h"
 
-namespace {
-Mantid::Kernel::Logger g_log("ColorScaleGuard");
-}
-
 namespace Mantid {
 namespace VATES {
 
 class DLLExport ColorScaleLock {
 public:
-  ColorScaleLock() : m_isLocked(false){};
-  ~ColorScaleLock() {}
   bool isLocked() { return m_isLocked; }
   void lock() { m_isLocked = true; }
   void unlock() { m_isLocked = false; }
 
 private:
-  bool m_isLocked;
+  bool m_isLocked{false};
 };
 
 class DLLExport ColorScaleLockGuard {


### PR DESCRIPTION
Description of work.

[clang-tidy](http://builds.mantidproject.org/view/Static%20Analysis/job/clang_tidy_vates/112/warnings14Result/category.940372812/) found a variable definition in the header ColorScaleGuard.h, which can lead to ODR violations. Since g_log is never used, removing it is the easiest option. 

**To test:**

<!-- Instructions for testing. -->

Code review is sufficient.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
