### PR TITLE
Easy fixes to cppcheck 1.78 warnings.

### DIFF
--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -942,11 +942,9 @@ void LoadFITS::readDataToImgs(const FITSInfo &fileInfo, MantidImage &imageY,
         val = static_cast<double>(*reinterpret_cast<uint64_t *>(tmp));
       // cppcheck doesn't realise that these are safe casts
       if (fileInfo.bitsPerPixel == 32 && fileInfo.isFloat) {
-        // cppcheck-suppress invalidPointerCast
         val = static_cast<double>(*reinterpret_cast<float *>(tmp));
       }
       if (fileInfo.bitsPerPixel == 64 && fileInfo.isFloat) {
-        // cppcheck-suppress invalidPointerCast
         val = *reinterpret_cast<double *>(tmp);
       }
       val = fileInfo.scale * val - fileInfo.offset;

--- a/MantidPlot/src/Graph3D.h
+++ b/MantidPlot/src/Graph3D.h
@@ -312,7 +312,7 @@ public slots:
 
   //! \name Colors
   //@{
-  void setDataColors(const QColor &cMax, const QColor &cMin);
+  void setDataColors(const QColor &cMin, const QColor &cMax);
 
   void changeTransparency(double t);
   void setTransparency(double t);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Tomography/ImggFormats.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Tomography/ImggFormats.h
@@ -42,7 +42,8 @@ std::vector<std::string> fileExtension(Format fmt);
 
 std::string fileExtension(const std::string &format);
 
-bool isFileExtension(std::string extension, const std::string &shortName);
+bool isFileExtension(const std::string &extension,
+                     const std::string &shortName);
 
 std::string description(Format fmt);
 

--- a/MantidQt/CustomInterfaces/src/Tomography/ImggFormats.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/ImggFormats.cpp
@@ -73,9 +73,8 @@ std::string fileExtension(const std::string &format) {
  */
 bool isFileExtension(const std::string &extension,
                      const std::string &shortName) {
-  std::string lowExt = extension;
-  size_t pos = lowExt.find_last_of('.');
-  lowExt = lowExt.substr(pos + 1);
+  size_t pos = extension.find_last_of('.');
+  std::string lowExt = lowExt.substr(pos + 1);
 
   std::transform(lowExt.begin(), lowExt.end(), lowExt.begin(), ::tolower);
 

--- a/MantidQt/CustomInterfaces/src/Tomography/ImggFormats.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/ImggFormats.cpp
@@ -71,7 +71,8 @@ std::string fileExtension(const std::string &format) {
  * @param extension a file name extension like .fits, or a filename
  * @param shortName name of a file format
  */
-bool isFileExtension(std::string extension, const std::string &shortName) {
+bool isFileExtension(const std::string &extension,
+                     const std::string &shortName) {
   std::string lowExt = extension;
   size_t pos = lowExt.find_last_of('.');
   lowExt = lowExt.substr(pos + 1);

--- a/MantidQt/CustomInterfaces/src/Tomography/ImggFormats.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/ImggFormats.cpp
@@ -74,8 +74,7 @@ std::string fileExtension(const std::string &format) {
 bool isFileExtension(const std::string &extension,
                      const std::string &shortName) {
   size_t pos = extension.find_last_of('.');
-  std::string lowExt = lowExt.substr(pos + 1);
-
+  std::string lowExt = extension.substr(pos + 1);
   std::transform(lowExt.begin(), lowExt.end(), lowExt.begin(), ::tolower);
 
   const auto &valid = extensions.at(shortName);


### PR DESCRIPTION
Description of work.

This fixes 4 warnings found with cppcheck 1.78. 

**To test:**

<!-- Instructions for testing. -->

Code review is sufficient.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

@mantidproject/gatekeepers After merging, please update the number of allowed cppcheck warnings.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
