### PR TITLE
Fix Fedora build

### DIFF
--- a/buildconfig/CMake/FindSphinx.cmake
+++ b/buildconfig/CMake/FindSphinx.cmake
@@ -5,42 +5,27 @@
 # If the module is found the following variables are
 # set:
 #  SPHINX_FOUND
-#  SPHINX_EXECUTABLE
+#  SPHINX_PACKAGE_DIR
 #
 #=============================================================
 # main()
 #=============================================================
 
-find_program( SPHINX_EXECUTABLE NAME sphinx-build.cmd sphinx-build
-  PATHS ${CMAKE_LIBRARY_PATH}/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/Scripts
-  PATH_SUFFIXES bin
-  DOC "Sphinx documentation generator"
-)
 
-if (SPHINX_EXECUTABLE)
-    # run sphinx-build to attempt to get the version
-    execute_process (COMMAND ${SPHINX_EXECUTABLE} --version
-                     OUTPUT_STRIP_TRAILING_WHITESPACE
-                     OUTPUT_VARIABLE version_string
-                     ERROR_VARIABLE version_error_string
-                     ERROR_STRIP_TRAILING_WHITESPACE)
+FIND_FILE(_find_sphinx_py FindSphinx.py PATHS ${CMAKE_MODULE_PATH})
 
-    # if it wasn't successful it is hiding in stderr
-    if (NOT version_string)
-        if ( version_error_string )
-            string (REGEX REPLACE "\n" ";" version_string ${version_error_string})
-            list (GET version_string 0 version_string)
-        else ( version_error_string )
-            set ( version_string "1.1.0" )
-        endif ( version_error_string )
-    endif (NOT version_string)
+# import sphinx-build to attempt to get the version
+execute_process (COMMAND ${PYTHON_EXECUTABLE} ${_find_sphinx_py} OUTPUT_VARIABLE sphinx_output
+                                                                 RESULT_VARIABLE sphinx_result)
+list(GET sphinx_output 0 version_string)
+list(GET sphinx_output 1 SPHINX_PACKAGE_DIR)
 
-    # chop out the version number
-    string (REGEX REPLACE ".*([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" SPHINX_VERSION ${version_string})
-endif (SPHINX_EXECUTABLE)
+if (${sphinx_result} STREQUAL "0" AND version_string)
+  # chop out the version number
+  string (REGEX REPLACE ".*([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" SPHINX_VERSION ${version_string})
+endif ()
 
 include(FindPackageHandleStandardArgs)
 
-find_package_handle_standard_args(Sphinx DEFAULT_MSG SPHINX_EXECUTABLE )
+find_package_handle_standard_args(Sphinx DEFAULT_MSG SPHINX_PACKAGE_DIR)
 
-mark_as_advanced ( SPHINX_EXECUTABLE )

--- a/buildconfig/CMake/FindSphinx.py
+++ b/buildconfig/CMake/FindSphinx.py
@@ -1,2 +1,2 @@
 import sphinx
-print('{0};{1}'.format(sphinx.__version__,sphinx.package_dir))
+print('{0};{1}'.format(sphinx.__version__, sphinx.package_dir))

--- a/buildconfig/CMake/FindSphinx.py
+++ b/buildconfig/CMake/FindSphinx.py
@@ -1,0 +1,2 @@
+import sphinx
+print('{0};{1}'.format(sphinx.__version__,sphinx.package_dir))


### PR DESCRIPTION
Description of work.

builds on Fedora 24 and Fedora 25 are failing because they cannot find sphinx. The `SPHINX_EXECUTABLE` has been renamed `/bin/sphinx-build-2` and `/bin/sphinx-build-3`, depending on which python version is being used.

Since we do not use `SPHINX_EXECUTABLE`, the easier option is the try importing sphinx and checking the version. Since `find_package_handle_standard_args` seems to require at least one `REQUIRED_VAR`, I'm also extracting the `package_dir`.

**To test:**

<!-- Instructions for testing. -->

Check [fedora 24](http://builds.mantidproject.org/job/master_clean-fedora24/) and [fedora 25](http://builds.mantidproject.org/job/master_clean-fedora25/) builds.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
