### PR TITLE
Move to Eigen 3.3.4

### DIFF
--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -1,14 +1,12 @@
 include(ExternalProject)
 
-# Use version 3.2.10 of Eigen
-# A newer version existed at the time of choosing this version (3.3.2), but this had warnings when building
-set(eigen_version "3.2.10")
+set(eigen_version "3.3.3")
 
 option(USE_SYSTEM_EIGEN "Use the system installed Eigen - v${eigen_version}?" OFF)
 
 if(USE_SYSTEM_EIGEN)
   message(STATUS "Using system Eigen")
-  find_package(Eigen3 3.2 REQUIRED)
+  find_package(Eigen3 3.3 REQUIRED)
 else()
   message(STATUS "Using Eigen in ExternalProject")
 

--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(eigen_version "3.3.3")
+set(eigen_version "3.3.4")
 
 option(USE_SYSTEM_EIGEN "Use the system installed Eigen - v${eigen_version}?" OFF)
 

--- a/buildconfig/CMake/Eigen.in
+++ b/buildconfig/CMake/Eigen.in
@@ -1,12 +1,11 @@
 cmake_minimum_required ( VERSION 3.5 )
 include( ExternalProject )
 ExternalProject_Add(eigen
-  URL               "https://bitbucket.org/eigen/eigen/get/3.2.10.tar.gz"
-  URL_HASH          "MD5=8ad10ac703a78143a4062c9bda9d8fd3"
+  URL               "https://bitbucket.org/eigen/eigen/get/3.3.3.tar.gz"
+  URL_HASH          "MD5=f21cee193e15e55cfd15ebbc16fc00a7"
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/eigen-src"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""
   TEST_COMMAND      ""
 )
-

--- a/buildconfig/CMake/Eigen.in
+++ b/buildconfig/CMake/Eigen.in
@@ -1,8 +1,8 @@
 cmake_minimum_required ( VERSION 3.5 )
 include( ExternalProject )
 ExternalProject_Add(eigen
-  URL               "https://bitbucket.org/eigen/eigen/get/3.3.3.tar.gz"
-  URL_HASH          "MD5=f21cee193e15e55cfd15ebbc16fc00a7"
+  URL               "https://bitbucket.org/eigen/eigen/get/3.3.4.tar.gz"
+  URL_HASH          "MD5=1a47e78efe365a97de0c022d127607c3"
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/eigen-src"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""


### PR DESCRIPTION
Moving to a newer version of Eigen gets rid of warnings on gcc 6.3.

**To test:**

Try it out and see that things still work.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
