### PR TITLE
Fix an SNSPowderReduction issue with Table splitters

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -1523,10 +1523,10 @@ class SNSPowderReduction(DataProcessorAlgorithm):
 
             if time0 > 3600. * 24 * 356:
                 # longer than 1 Y. Cannot be relative time.
-                is_relative_time = True
+                is_relative_time = False
             else:
                 # even just shorter than 1 year, but there was no experiment in 1991.
-                is_relative_time = False
+                is_relative_time = True
 
         if self._splitinfotablews is None:
             # split without information table


### PR DESCRIPTION
Fix a bug in SNSPowderReduction with spitters given in TableWorkspace.  The logic to set up relative time or absolute time is wrong. 

**To test:**

Run the script given in issue #19299.

Fixes #19299 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
