### PR TITLE
Change to c++11 function

### DIFF
--- a/Framework/CurveFitting/src/FuncMinimizers/DTRSMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/DTRSMinimizer.cpp
@@ -258,7 +258,7 @@ double dotProduct(const DoubleFortranVector &v1,
 /// @param v :: The vector.
 /// @param n :: The number of elements to examine.
 double maxVal(const DoubleFortranVector &v, int n) {
-  double res = -std::numeric_limits<double>::max();
+  double res = std::numeric_limits<double>::lowest();
   for (int i = 1; i <= n; ++i) {
     auto val = v(i);
     if (val > res) {

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -354,7 +354,7 @@ public:
 
   void generateCountsHistogramPulseTime(
       const double &xMin, const double &xMax, MantidVec &Y,
-      const double TofMin = -std::numeric_limits<double>::max(),
+      const double TofMin = std::numeric_limits<double>::lowest(),
       const double TofMax = std::numeric_limits<double>::max()) const;
 
 protected:

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1624,7 +1624,7 @@ EventList::compressEventsHelper(const std::vector<T> &events,
   out.reserve(events.size() / 20);
 
   // The last TOF to which we are comparing.
-  double lastTof = -std::numeric_limits<double>::max();
+  double lastTof = std::numeric_limits<double>::lowest();
   // For getting an accurate average TOF
   double totalTof = 0;
   int num = 0;
@@ -1701,7 +1701,7 @@ void EventList::compressEventsParallelHelper(
     localOut.reserve(numPerBlock / 20);
 
     // The last TOF to which we are comparing.
-    double lastTof = -std::numeric_limits<double>::max();
+    double lastTof = std::numeric_limits<double>::lowest();
     // For getting an accurate average TOF
     double totalTof = 0;
     int num = 0;

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -327,7 +327,7 @@ double EventWorkspace::getEventXMin() const {
  */
 double EventWorkspace::getEventXMax() const {
   // set to crazy values to start
-  double xmax = -1.0 * std::numeric_limits<double>::max();
+  double xmax = std::numeric_limits<double>::lowest();
   size_t numWorkspace = this->data.size();
   for (size_t workspaceIndex = 0; workspaceIndex < numWorkspace;
        workspaceIndex++) {

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -1135,7 +1135,7 @@ const std::string &MantidMatrix::getWorkspaceName() { return m_strName; }
 void findYRange(MatrixWorkspace_const_sptr ws, double &miny, double &maxy) {
   // this is here to fill m_min and m_max with numbers that aren't nan
   miny = std::numeric_limits<double>::max();
-  maxy = -std::numeric_limits<double>::max();
+  maxy = std::numeric_limits<double>::lowest();
 
   if (ws) {
 
@@ -1145,7 +1145,7 @@ void findYRange(MatrixWorkspace_const_sptr ws, double &miny, double &maxy) {
       const auto &Y = ws->y(wi);
 
       local_min = std::numeric_limits<double>::max();
-      local_max = -std::numeric_limits<double>::max();
+      local_max = std::numeric_limits<double>::lowest();
 
       for (size_t i = 0; i < Y.size(); i++) {
         double aux = Y[i];
@@ -1172,7 +1172,7 @@ void findYRange(MatrixWorkspace_const_sptr ws, double &miny, double &maxy) {
   // Make up some reasonable values if nothing was found
   if (miny == std::numeric_limits<double>::max())
     miny = 0;
-  if (maxy == -std::numeric_limits<double>::max())
+  if (maxy == std::numeric_limits<double>::lowest())
     maxy = miny + 1e6;
 
   if (maxy == miny) {

--- a/MantidQt/MantidWidgets/src/FitOptionsBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/FitOptionsBrowser.cpp
@@ -795,7 +795,7 @@ QtProperty *FitOptionsBrowser::addDoubleProperty(const QString &propertyName) {
   }
   QtProperty *property = m_doubleManager->addProperty(propertyName);
   m_doubleManager->setDecimals(property, m_decimals);
-  m_doubleManager->setRange(property, -std::numeric_limits<double>::max(),
+  m_doubleManager->setRange(property, std::numeric_limits<double>::lowest(),
                             std::numeric_limits<double>::max());
   this->addProperty(propertyName, property,
                     &FitOptionsBrowser::getDoubleProperty,


### PR DESCRIPTION
c++11 introduced `std::numeric_limits::lowest` which should be used rather than `-1*std::numeric_limits::max`.

**To test:**

If the builds pass, it is fine.

*There is no associated issue*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
