### PR TITLE
Fix slice viewer bug where rebin mode was toggled when axis is changed

### DIFF
--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -2423,13 +2423,19 @@ void SliceViewer::setNonOrthogonalbtn() {
 }
 
 void SliceViewer::disableOrthogonalAnalysisTools(bool checked) {
-  if (ui.btnDoLine->isChecked()) {
-    ui.btnDoLine->toggle();
-  }
-  if (ui.btnRebinMode->isChecked()) {
-    ui.btnRebinMode->toggle();
+  if (checked) {
+    // ---------------------------------------------------------------------------
+    // If non-orthogonal is enabled, then turn off
+    // 1. The cut line tool
+    if (ui.btnDoLine->isChecked()) {
+      ui.btnDoLine->toggle();
+    }
   }
 
+  // ---------------------------------------------------------------------------
+  // If non-orthogonal is enabled, then turn off
+  // 1. The cut line tool
+  // 2. The rebin tool
   if (checked) {
     m_nonOrthogonalOverlay->enable();
     adjustSize();
@@ -2437,6 +2443,10 @@ void SliceViewer::disableOrthogonalAnalysisTools(bool checked) {
     m_nonOrthogonalOverlay->disable();
   }
 
+  // ---------------------------------------------------------------------------
+  // If we are in the orthogonal mode, then we turn off
+  // 1. Cut line feature
+  // 2. Peak overlay feature
   if (checked) { // change tooltips to explain why buttons are disabled
     ui.btnDoLine->setToolTip(
         QString("Cut line is disabled in NonOrthogonal view"));
@@ -2459,6 +2469,8 @@ void SliceViewer::disableOrthogonalAnalysisTools(bool checked) {
   ui.btnClearLine->setDisabled(checked);
   ui.btnPeakOverlay->setDisabled(checked);
 
+  // ---------------------------------------------------------------------------
+  // Change aspect ratio depending on non-orthogonal enabled or not.
   if (m_lockAspectRatiosActionAll->isChecked() && checked) {
     m_lastRatioState = All;
   }

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -60,6 +60,7 @@ Bugs Resolved
 
 SliceViewer Improvements
 ------------------------
+- Fixed a bug where the rebin button was toggled when the user switch axes.
 
 VSI Improvments
 ---------------


### PR DESCRIPTION
Fixes #19314 

The rebin button was toggled when the user switched the axes in the slice viewer. This PR fixes this.

#### For testing

1. Use orthogonal MD workspaces and test that rebinning is not turned off when the axis is switched.
2. Use non-orthogonal MD workspaces and test that the rebinning is not turned off when the axis is switched.

#### Release notes

Please see [here](https://github.com/mantidproject/mantid/pull/19316/commits/19b13538a71cd1cb2c3b9dc345f5564058c5eb28)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
