### PR TITLE
MSVC - Use 64bit Toolchain and LTCG on Release Builds

### DIFF
--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -40,6 +40,26 @@ set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Zm${VISUALSTUDIO_COMPILERHEAPLIMIT}" )
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zm${VISUALSTUDIO_COMPILERHEAPLIMIT}" )
 endif()
 
+##########################################################################
+# Enable Link Time Code Generation (LTCG) whilst in Release Mode
+##########################################################################
+# Add /GL option to compiler to postpone code generation to link time
+set( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /GL " CACHE STRING "" FORCE)
+set( CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /GL" CACHE STRING "" FORCE)
+set( CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /GL" CACHE STRING "" FORCE)
+set( CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} /GL" CACHE STRING "" FORCE)
+
+# Inform the linker in advance we will be using LTCG so we don't accidentally
+# link twice during compilation wasting time
+set( CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG" CACHE STRING "" FORCE)
+set( CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "${CMAKE_EXE_LINKER_FLAGS_MINSIZEREL} /LTCG" CACHE STRING "" FORCE)
+
+set( CMAKE_MODULE_LINKER_RELEASE "${CMAKE_MODULE_LINKER_RELEASE} /LTCG" CACHE STRING "" FORCE)
+set( CMAKE_MODULE_LINKER_MINSIZEREL "${CMAKE_MODULE_LINKER_MINSIZEREL} /LTCG" CACHE STRING "" FORCE)
+
+set( CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /LTCG" CACHE STRING "" FORCE)
+set( CMAKE_SHARED_LINKER_FLAGS_MINSIZEREL "${CMAKE_SHARED_LINKER_FLAGS_MINSIZEREL} /LTCG" CACHE STRING "" FORCE)
+
 ###########################################################################
 # On Windows we want to bundle Python.
 ###########################################################################

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -19,6 +19,8 @@ set VS_VERSION=14
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Source the VS setup script
 set VS_VERSION=14
+:: Ask MSVC to use x64 tool-set when available 
+set PreferredToolArchitecture=x64
 call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" amd64
 set CM_GENERATOR=Visual Studio 14 2015 Win64
 ::set PARAVIEW_DIR=%PARAVIEW_NEXT_DIR%

--- a/buildconfig/windows/visual-studio.bat
+++ b/buildconfig/windows/visual-studio.bat
@@ -7,4 +7,5 @@
 call %~dp0buildenv.bat
 
 :: Start IDE
+set PreferredToolArchitecture=x64
 start "" "%VS140COMNTOOLS%\..\IDE\devenv.exe" Mantid.sln


### PR DESCRIPTION
Description of work.
*This PR is in progress.*

This PR makes MSVC use the 64bit toolchain (by default it uses 32bit compiler and linker) and enables LTCG on `Release` and `MinSizeRelease`

Pending some statistics on the following - with consultation with senior developers on pros / cons of enabling:
- Build time impact
- Performance improvement
- Executable size reduction

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
