### PR TITLE
Add invalid ICAT login test

### DIFF
--- a/MantidQt/CustomInterfaces/test/ReflRunsTabPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflRunsTabPresenterTest.h
@@ -14,7 +14,9 @@
 using namespace MantidQt::CustomInterfaces;
 using namespace testing;
 
+namespace {
 ACTION(ICATRuntimeException) { throw std::runtime_error(""); }
+}
 
 //=====================================================================================
 // Functional tests

--- a/MantidQt/CustomInterfaces/test/ReflRunsTabPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflRunsTabPresenterTest.h
@@ -327,7 +327,7 @@ public:
     std::vector<DataProcessorPresenter *> tablePresenterVec;
     tablePresenterVec.push_back(&mockTablePresenter);
     ReflRunsTabPresenter presenter(&mockRunsTabView, &mockProgress,
-      tablePresenterVec);
+                                   tablePresenterVec);
     presenter.acceptMainPresenter(&mockMainPresenter);
 
     std::stringstream pythonSrc;


### PR DESCRIPTION
This PR adds a unit test for using invalid credentials for ICAT when using the Reflectometry interface.

**Testing instructions**
- Ensure all unit tests pass

Fixes #15415.

*Does not need to be in the release notes.*

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
