### PR TITLE
setSignalAt Python crash with MDHistoWorkspace

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
@@ -180,13 +180,14 @@ void setErrorSquaredArray(IMDHistoWorkspace &self,
 /**
  * Set the signal at a specific index in the workspace
  */
-void setSignalAt(IMDHistoWorkspace &self, const size_t index, const double value) {
-    if (index >= self.getNPoints())
-        throw std::invalid_argument("setSignalAt: The index is greater than the number of bins in the workspace");
+void setSignalAt(IMDHistoWorkspace &self, const size_t index,
+                 const double value) {
+  if (index >= self.getNPoints())
+    throw std::invalid_argument("setSignalAt: The index is greater than the "
+                                "number of bins in the workspace");
 
-    self.setSignalAt(index, value);
+  self.setSignalAt(index, value);
 }
-
 }
 
 void export_IMDHistoWorkspace() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
@@ -176,6 +176,17 @@ void setErrorSquaredArray(IMDHistoWorkspace &self,
     self.setErrorSquaredAt(i, extract<double>(flattened[i])());
   }
 }
+
+/**
+ * Set the signal at a specific index in the workspace
+ */
+void setSignalAt(IMDHistoWorkspace &self, const size_t index, const double value) {
+    if (index >= self.getNPoints())
+        throw std::invalid_argument("setSignalAt: The index is greater than the number of bins in the workspace");
+
+    self.setSignalAt(index, value);
+}
+
 }
 
 void export_IMDHistoWorkspace() {
@@ -204,7 +215,7 @@ void export_IMDHistoWorkspace() {
            return_value_policy<copy_non_const_reference>(),
            "Return the squared-errors at the linear index")
 
-      .def("setSignalAt", &IMDHistoWorkspace::setSignalAt,
+      .def("setSignalAt", &setSignalAt,
            (arg("self"), arg("index"), arg("value")),
            "Sets the signal at the specified index.")
 

--- a/Framework/PythonInterface/test/python/mantid/api/MDHistoWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MDHistoWorkspaceTest.py
@@ -12,6 +12,7 @@ except NameError:
     # Defined for backwards compatability with Python 2
     def long(x): return x
 
+
 class MDHistoWorkspaceTest(unittest.TestCase):
     """
     Test the interface to MDHistoWorkspaces
@@ -61,6 +62,16 @@ class MDHistoWorkspaceTest(unittest.TestCase):
 
         mtd.remove('demo')
 
+    def test_setSignalAt_throws_if_index_is_invalid(self):
+        run_algorithm('CreateMDHistoWorkspace', SignalInput='1,2,3,4,5,6,7,8,9',ErrorInput='1,1,1,1,1,1,1,1,1',
+                      Dimensionality='2',Extents='-1,1,-1,1',NumberOfBins='3,3',Names='A,B',Units='U,T',OutputWorkspace='demo')
+        testWS = mtd['demo']
+        index = testWS.getLinearIndex(3, 3)
+        self.assertRaises(ValueError, testWS.setSignalAt, index, 1.0)
+        index = testWS.getLinearIndex(0, 3)
+        self.assertRaises(ValueError, testWS.setSignalAt, index, 1.0)
+        mtd.remove('demo')
+
     def test_set_signal_array_throws_if_input_array_is_of_incorrect_size(self):
         run_algorithm('CreateMDHistoWorkspace', SignalInput='1,2,3,4,5,6,7,8,9',ErrorInput='1,1,1,1,1,1,1,1,1',
                       Dimensionality='2',Extents='-1,1,-1,1',NumberOfBins='3,3',Names='A,B',Units='U,T',OutputWorkspace='demo')
@@ -77,7 +88,6 @@ class MDHistoWorkspaceTest(unittest.TestCase):
         testWS.setSignalArray(signal)
         new_signal = testWS.getSignalArray()
         self._verify_numpy_data(new_signal, signal)
-
 
     def test_set_error_array_passes_numpy_values_to_workspace(self):
         run_algorithm('CreateMDHistoWorkspace', SignalInput='1,2,3,4,5,6,7,8,9',ErrorInput='1,1,1,1,1,1,1,1,1',
@@ -96,7 +106,6 @@ class MDHistoWorkspaceTest(unittest.TestCase):
         self.assertTrue(len(expected.shape), len(test_array.shape))
         self.assertTrue(not numpy.all(test_array.flags.writeable))
         self.assertTrue(numpy.all(numpy.equal(expected, test_array)))
-
 
     """ Note: Look at each test for PlusMD MinusMD, and MDHistoWorkspaceTest for detailed tests including checking results.
     These tests only check that they do run. """

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -111,6 +111,7 @@ Python
      # Create a new axis reference
      s_axis = SpectraAxis.create(ws1)
 
+- Fixed a bug on MDHistogramWorkspaces where passing an index larger than the size of the dimensions of the workspace to ``setSignalAt`` would crash Mantid.
 
 Python Algorithms
 #################


### PR DESCRIPTION
I found I could crash Mantid by passing a linear index that is larger than the dimensions of the workspace to the `setSignalAt` method.

**To test:**
The following script shoudl reproduce the issue:

```python
ws = CreateMDWorkspace(Dimensions=3, Extents=[-10,10,-10,10,-10,10], Names="H,K,L", Units="A-1, A-1, A-1")
ws_rebinned = BinMD(InputWorkspace=ws, AxisAligned=False, 
                                    BasisVector0='H,A-1,1,0,0', BasisVector1='K,A-1,0,1,0', BasisVector2='L,A-1,0,0,1', 
                                    OutputExtents=[-10,10,-10,10,-10,10], OutputBins='300,300,1', Parallel=True, OutputWorkspace='ws_rebinned')

index = ws_rebinned.getLinearIndex(300, 300, 300)
ws_rebinned.setSignalAt(index, 1)
```

Fixes #19329 .

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
