### PR TITLE
Change peak zoom level for SliceViewer

### DIFF
--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/CompositePeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/CompositePeaksPresenter.h
@@ -30,9 +30,10 @@ Composite implmentation of the Peaks presenter. Holds 0 - N nested
 PeaksPresenters.
 Note that it's default behaviour is identical to that of the NullPeaksPresenter.
 ----------------------------------------------------------*/
-class EXPORT_OPT_MANTIDQT_SLICEVIEWER CompositePeaksPresenter : public PeaksPresenter,
-                                          public UpdateableOnDemand,
-                                          public ZoomableOnDemand {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER CompositePeaksPresenter
+    : public PeaksPresenter,
+      public UpdateableOnDemand,
+      public ZoomableOnDemand {
 public:
   // Overrriden methods from Peaks Presenter
   void update() override;

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/CompositePeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/CompositePeaksPresenter.h
@@ -30,7 +30,7 @@ Composite implmentation of the Peaks presenter. Holds 0 - N nested
 PeaksPresenters.
 Note that it's default behaviour is identical to that of the NullPeaksPresenter.
 ----------------------------------------------------------*/
-class DLLExport CompositePeaksPresenter : public PeaksPresenter,
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER CompositePeaksPresenter : public PeaksPresenter,
                                           public UpdateableOnDemand,
                                           public ZoomableOnDemand {
 public:

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ConcretePeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ConcretePeaksPresenter.h
@@ -25,7 +25,7 @@ ConcretePeaksPresenter
 
 Concrete implmentation of the Peaks presenter.
 ----------------------------------------------------------*/
-class DLLExport ConcretePeaksPresenter : public PeaksPresenter {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER ConcretePeaksPresenter : public PeaksPresenter {
 public:
   ConcretePeaksPresenter(
       PeakOverlayViewFactory_sptr viewFactory,

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ConcretePeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ConcretePeaksPresenter.h
@@ -25,7 +25,8 @@ ConcretePeaksPresenter
 
 Concrete implmentation of the Peaks presenter.
 ----------------------------------------------------------*/
-class EXPORT_OPT_MANTIDQT_SLICEVIEWER ConcretePeaksPresenter : public PeaksPresenter {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER ConcretePeaksPresenter
+    : public PeaksPresenter {
 public:
   ConcretePeaksPresenter(
       PeakOverlayViewFactory_sptr viewFactory,

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/EllipsoidPlaneSliceCalculator.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/EllipsoidPlaneSliceCalculator.h
@@ -57,6 +57,8 @@ public:
                     std::vector<double> radii,
                     Mantid::Kernel::V3D originEllipsoid, double zPlane) const;
 
+  static const double zoomOutFactor;
+
 private:
   SliceEllipseInfo
   getSolutionForEllipsoid(const Kernel::Matrix<double> &m, double zPlane,

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/EllipsoidPlaneSliceCalculator.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/EllipsoidPlaneSliceCalculator.h
@@ -56,9 +56,7 @@ public:
   getSlicePlaneInfo(std::vector<Mantid::Kernel::V3D> directions,
                     std::vector<double> radii,
                     Mantid::Kernel::V3D originEllipsoid, double zPlane) const;
-
-  static const double zoomOutFactor;
-
+  double getZoomOutFactor() const;
 private:
   SliceEllipseInfo
   getSolutionForEllipsoid(const Kernel::Matrix<double> &m, double zPlane,
@@ -66,6 +64,7 @@ private:
 
   bool checkIfIsEllipse(const Kernel::Matrix<double> &m) const;
   bool checkIfIsCircle(const Kernel::Matrix<double> &m) const;
+  const double m_zoomOutFactor = 2.;
 };
 }
 }

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/EllipsoidPlaneSliceCalculator.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/EllipsoidPlaneSliceCalculator.h
@@ -57,6 +57,7 @@ public:
                     std::vector<double> radii,
                     Mantid::Kernel::V3D originEllipsoid, double zPlane) const;
   double getZoomOutFactor() const;
+
 private:
   SliceEllipseInfo
   getSolutionForEllipsoid(const Kernel::Matrix<double> &m, double zPlane,

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/NullPeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/NullPeaksPresenter.h
@@ -12,7 +12,7 @@ NullPeaksPresenter
 This implementation prevents the client code having to run Null checks on the
 PeaksPresenter pointer before using it.
 ----------------------------------------------------------*/
-class DLLExport NullPeaksPresenter : public PeaksPresenter {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER NullPeaksPresenter : public PeaksPresenter {
 public:
   void update() override {}
   void updateWithSlicePoint(const PeakBoundingBox &) override {}

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/NullPeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/NullPeaksPresenter.h
@@ -12,7 +12,8 @@ NullPeaksPresenter
 This implementation prevents the client code having to run Null checks on the
 PeaksPresenter pointer before using it.
 ----------------------------------------------------------*/
-class EXPORT_OPT_MANTIDQT_SLICEVIEWER NullPeaksPresenter : public PeaksPresenter {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER NullPeaksPresenter
+    : public PeaksPresenter {
 public:
   void update() override {}
   void updateWithSlicePoint(const PeakBoundingBox &) override {}

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakBoundingBox.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakBoundingBox.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_SLICEVIEWER_PEAK_BOUNDING_BOX_H_
 #define MANTID_SLICEVIEWER_PEAK_BOUNDING_BOX_H_
 
-#include "MantidKernel/System.h"
+#include "DllOption.h"
 #include <string>
 #include <vector>
 #include "MantidGeometry/Crystal/PeakTransform.h"
@@ -14,7 +14,7 @@ IntToType Parameter Type. Simple mechanism for ensuring type
 safety when working with so many arguments of the same core type in
 PeakBoundingBox.
 */
-template <int I> class DLLExport DoubleParam {
+template <int I> class EXPORT_OPT_MANTIDQT_SLICEVIEWER DoubleParam {
 public:
   explicit DoubleParam(const double &val) : value(val) {}
   DoubleParam(const DoubleParam<I> &other) : value(other.value) {}
@@ -62,7 +62,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PeakBoundingBox {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakBoundingBox {
 private:
   /// Left edge
   Left m_left;

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakOverlayView.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakOverlayView.h
@@ -1,7 +1,6 @@
 #ifndef MANTID_SLICEVIEWER_PEAKOVERLAY_VIEW_H_
 #define MANTID_SLICEVIEWER_PEAKOVERLAY_VIEW_H_
 
-#include "MantidKernel/System.h"
 #include "MantidKernel/V2D.h"
 #include "MantidGeometry/Crystal/PeakTransform.h"
 #include "MantidQtSliceViewer/PeakPalette.h"
@@ -38,7 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PeakOverlayView {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakOverlayView {
 public:
   /// Set the position of the slice point.
   virtual void setSlicePoint(const double &, const std::vector<bool> &) = 0;

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakOverlayViewFactory.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakOverlayViewFactory.h
@@ -1,7 +1,6 @@
 #ifndef MANTID_SLICEVIEWER_PEAKOVERLAY_VIEW_FACTORY_H_
 #define MANTID_SLICEVIEWER_PEAKOVERLAY_VIEW_FACTORY_H_
 
-#include "MantidKernel/System.h"
 #include "MantidKernel/V3D.h"
 #include "MantidGeometry/Crystal/PeakTransform.h"
 #include "MantidQtSliceViewer/PeakOverlayView.h"
@@ -47,7 +46,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PeakOverlayViewFactory {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakOverlayViewFactory {
 public:
   /// Create a peak view from the index of a peak in the peaks workspace
   virtual boost::shared_ptr<PeakOverlayView>

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakOverlayViewFactoryBase.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakOverlayViewFactoryBase.h
@@ -36,7 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PeakOverlayViewFactoryBase : public PeakOverlayViewFactory {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakOverlayViewFactoryBase : public PeakOverlayViewFactory {
 protected:
   QwtPlot *m_plot;
   QWidget *m_parent;

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakOverlayViewFactoryBase.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakOverlayViewFactoryBase.h
@@ -36,7 +36,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakOverlayViewFactoryBase : public PeakOverlayViewFactory {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakOverlayViewFactoryBase
+    : public PeakOverlayViewFactory {
 protected:
   QwtPlot *m_plot;
   QWidget *m_parent;

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakPalette.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakPalette.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_SLICEVIEWER_PEAKPALETTE_H
 #define MANTID_SLICEVIEWER_PEAKPALETTE_H
 
-#include "MantidKernel/System.h"
+#include "DllOption.h"
 #include "MantidQtSliceViewer/PeakViewColor.h"
 #include <algorithm>
 #include <sstream>
@@ -12,7 +12,7 @@
 namespace MantidQt {
 namespace SliceViewer {
 
-template <typename C> class DLLExport PeakPalette {
+template <typename C> class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPalette {
 public:
   PeakPalette();
   PeakPalette(const PeakPalette &other);

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakPalette.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakPalette.h
@@ -10,130 +10,129 @@
 #include <QColor>
 
 namespace MantidQt {
-  namespace SliceViewer {
+namespace SliceViewer {
 
-    template <typename C> class DLLExport PeakPalette {
-    public:
-      PeakPalette();
-      PeakPalette(const PeakPalette &other);
-      PeakPalette &operator=(const PeakPalette &other);
-      C foregroundIndexToColour(const int index) const;
-      C backgroundIndexToColour(const int index) const;
-      void setForegroundColour(const int index, const C);
-      void setBackgroundColour(const int index, const C);
-      int paletteSize() const;
-      bool operator==(const PeakPalette &other) const;
-      ~PeakPalette();
+template <typename C> class DLLExport PeakPalette {
+public:
+  PeakPalette();
+  PeakPalette(const PeakPalette &other);
+  PeakPalette &operator=(const PeakPalette &other);
+  C foregroundIndexToColour(const int index) const;
+  C backgroundIndexToColour(const int index) const;
+  void setForegroundColour(const int index, const C);
+  void setBackgroundColour(const int index, const C);
+  int paletteSize() const;
+  bool operator==(const PeakPalette &other) const;
+  ~PeakPalette();
 
-    private:
-      typedef std::map<int, C> ColourMapType;
-      ColourMapType m_backgroundMap;
-      ColourMapType m_foregroundMap;
-      typename ColourMapType::iterator safeFetchPair(ColourMapType &map,
-        const int index) {
-        typename ColourMapType::iterator it = map.find(index);
-        if (it == map.end()) {
-          std::stringstream stream;
-          stream << "Index " << index << " is out of range";
-          throw std::out_of_range(stream.str());
-        }
-        return it;
-      }
+private:
+  typedef std::map<int, C> ColourMapType;
+  ColourMapType m_backgroundMap;
+  ColourMapType m_foregroundMap;
+  typename ColourMapType::iterator safeFetchPair(ColourMapType &map,
+                                                 const int index) {
+    typename ColourMapType::iterator it = map.find(index);
+    if (it == map.end()) {
+      std::stringstream stream;
+      stream << "Index " << index << " is out of range";
+      throw std::out_of_range(stream.str());
+    }
+    return it;
+  }
 
-      typename ColourMapType::const_iterator safeFetchPair(const ColourMapType &map,
-        const int index) const {
-        auto it = map.find(index);
-        if (it == map.end()) {
-          std::stringstream stream;
-          stream << "Index " << index << " is out of range";
-          throw std::out_of_range(stream.str());
-        }
-        return it;
-      }
-    };
+  typename ColourMapType::const_iterator safeFetchPair(const ColourMapType &map,
+                                                       const int index) const {
+    auto it = map.find(index);
+    if (it == map.end()) {
+      std::stringstream stream;
+      stream << "Index " << index << " is out of range";
+      throw std::out_of_range(stream.str());
+    }
+    return it;
+  }
+};
 
-    template <typename C> PeakPalette<C>::PeakPalette() {}
+template <typename C> PeakPalette<C>::PeakPalette() {}
 
-    template <typename C>
-    PeakPalette<C>::PeakPalette(const PeakPalette &other)
-      : m_backgroundMap(other.m_backgroundMap),
+template <typename C>
+PeakPalette<C>::PeakPalette(const PeakPalette &other)
+    : m_backgroundMap(other.m_backgroundMap),
       m_foregroundMap(other.m_foregroundMap) {}
 
-    template <typename C>
-    PeakPalette<C> &PeakPalette<C>::operator=(const PeakPalette<C> &other) {
-      m_foregroundMap.clear();
-      m_backgroundMap.clear();
-      if (this != &other) {
-        m_foregroundMap.insert(other.m_foregroundMap.begin(),
-          other.m_foregroundMap.end());
-        m_backgroundMap.insert(other.m_backgroundMap.begin(),
-          other.m_backgroundMap.end());
-      }
-      return *this;
-    }
+template <typename C>
+PeakPalette<C> &PeakPalette<C>::operator=(const PeakPalette<C> &other) {
+  m_foregroundMap.clear();
+  m_backgroundMap.clear();
+  if (this != &other) {
+    m_foregroundMap.insert(other.m_foregroundMap.begin(),
+                           other.m_foregroundMap.end());
+    m_backgroundMap.insert(other.m_backgroundMap.begin(),
+                           other.m_backgroundMap.end());
+  }
+  return *this;
+}
 
-    template <typename C> PeakPalette<C>::~PeakPalette() {}
+template <typename C> PeakPalette<C>::~PeakPalette() {}
 
-    template <typename C>
-    C PeakPalette<C>::foregroundIndexToColour(const int index) const {
-      auto it = safeFetchPair(m_foregroundMap, index);
-      return it->second;
-    }
+template <typename C>
+C PeakPalette<C>::foregroundIndexToColour(const int index) const {
+  auto it = safeFetchPair(m_foregroundMap, index);
+  return it->second;
+}
 
-    template <typename C>
-    C PeakPalette<C>::backgroundIndexToColour(const int index) const {
-      auto it = safeFetchPair(m_backgroundMap, index);
-      return it->second;
-    }
+template <typename C>
+C PeakPalette<C>::backgroundIndexToColour(const int index) const {
+  auto it = safeFetchPair(m_backgroundMap, index);
+  return it->second;
+}
 
-    template <typename C>
-    void PeakPalette<C>::setForegroundColour(const int index, const C colour) {
-      auto it = safeFetchPair(m_foregroundMap, index);
-      // overwrite
-      it->second = colour;
-    }
+template <typename C>
+void PeakPalette<C>::setForegroundColour(const int index, const C colour) {
+  auto it = safeFetchPair(m_foregroundMap, index);
+  // overwrite
+  it->second = colour;
+}
 
-    template <typename C>
-    void PeakPalette<C>::setBackgroundColour(const int index, const C colour) {
-      auto it = safeFetchPair(m_backgroundMap, index);
-      // owverwirte
-      it->second = colour;
-    }
+template <typename C>
+void PeakPalette<C>::setBackgroundColour(const int index, const C colour) {
+  auto it = safeFetchPair(m_backgroundMap, index);
+  // owverwirte
+  it->second = colour;
+}
 
-    template <typename C> int PeakPalette<C>::paletteSize() const {
-      if (m_foregroundMap.size() != m_backgroundMap.size()) {
-        throw std::runtime_error("The PeakPalette size is not consistent");
-      }
-      return static_cast<int>(m_foregroundMap.size());
-    }
+template <typename C> int PeakPalette<C>::paletteSize() const {
+  if (m_foregroundMap.size() != m_backgroundMap.size()) {
+    throw std::runtime_error("The PeakPalette size is not consistent");
+  }
+  return static_cast<int>(m_foregroundMap.size());
+}
 
-    template <typename C>
-    bool PeakPalette<C>::operator==(const PeakPalette &other) const {
-      bool areEqual = true;
-      if (other.paletteSize() != this->paletteSize()) {
+template <typename C>
+bool PeakPalette<C>::operator==(const PeakPalette &other) const {
+  bool areEqual = true;
+  if (other.paletteSize() != this->paletteSize()) {
+    areEqual = false;
+  } else {
+    for (int i = 0; i < this->paletteSize(); ++i) {
+      if (this->backgroundIndexToColour(i) !=
+          other.backgroundIndexToColour(i)) {
         areEqual = false;
+        break;
       }
-      else {
-        for (int i = 0; i < this->paletteSize(); ++i) {
-          if (this->backgroundIndexToColour(i) !=
-            other.backgroundIndexToColour(i)) {
-            areEqual = false;
-            break;
-          }
-          if (this->foregroundIndexToColour(i) !=
-            other.foregroundIndexToColour(i)) {
-            areEqual = false;
-            break;
-          }
-        }
+      if (this->foregroundIndexToColour(i) !=
+          other.foregroundIndexToColour(i)) {
+        areEqual = false;
+        break;
       }
-      return areEqual;
     }
+  }
+  return areEqual;
+}
 
-    // Forward declaration for template specialization
-    template <> DLLExport PeakPalette<QColor>::PeakPalette();
-    template <> DLLExport PeakPalette<PeakViewColor>::PeakPalette();
+// Forward declaration for template specialization
+template <> DLLExport PeakPalette<QColor>::PeakPalette();
+template <> DLLExport PeakPalette<PeakViewColor>::PeakPalette();
 
-  } // namespace
+} // namespace
 }
 #endif // MANTID_SLICEVIEWER_PEAKSPALETTE_H

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakPalette.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakPalette.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_SLICEVIEWER_PEAKPALETTE_H
 #define MANTID_SLICEVIEWER_PEAKPALETTE_H
 
-#include "DllOption.h"
+#include "MantidKernel/System.h"
 #include "MantidQtSliceViewer/PeakViewColor.h"
 #include <algorithm>
 #include <sstream>
@@ -10,129 +10,130 @@
 #include <QColor>
 
 namespace MantidQt {
-namespace SliceViewer {
+  namespace SliceViewer {
 
-template <typename C> class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPalette {
-public:
-  PeakPalette();
-  PeakPalette(const PeakPalette &other);
-  PeakPalette &operator=(const PeakPalette &other);
-  C foregroundIndexToColour(const int index) const;
-  C backgroundIndexToColour(const int index) const;
-  void setForegroundColour(const int index, const C);
-  void setBackgroundColour(const int index, const C);
-  int paletteSize() const;
-  bool operator==(const PeakPalette &other) const;
-  ~PeakPalette();
+    template <typename C> class DLLExport PeakPalette {
+    public:
+      PeakPalette();
+      PeakPalette(const PeakPalette &other);
+      PeakPalette &operator=(const PeakPalette &other);
+      C foregroundIndexToColour(const int index) const;
+      C backgroundIndexToColour(const int index) const;
+      void setForegroundColour(const int index, const C);
+      void setBackgroundColour(const int index, const C);
+      int paletteSize() const;
+      bool operator==(const PeakPalette &other) const;
+      ~PeakPalette();
 
-private:
-  typedef std::map<int, C> ColourMapType;
-  ColourMapType m_backgroundMap;
-  ColourMapType m_foregroundMap;
-  typename ColourMapType::iterator safeFetchPair(ColourMapType &map,
-                                                 const int index) {
-    typename ColourMapType::iterator it = map.find(index);
-    if (it == map.end()) {
-      std::stringstream stream;
-      stream << "Index " << index << " is out of range";
-      throw std::out_of_range(stream.str());
-    }
-    return it;
-  }
+    private:
+      typedef std::map<int, C> ColourMapType;
+      ColourMapType m_backgroundMap;
+      ColourMapType m_foregroundMap;
+      typename ColourMapType::iterator safeFetchPair(ColourMapType &map,
+        const int index) {
+        typename ColourMapType::iterator it = map.find(index);
+        if (it == map.end()) {
+          std::stringstream stream;
+          stream << "Index " << index << " is out of range";
+          throw std::out_of_range(stream.str());
+        }
+        return it;
+      }
 
-  typename ColourMapType::const_iterator safeFetchPair(const ColourMapType &map,
-                                                       const int index) const {
-    auto it = map.find(index);
-    if (it == map.end()) {
-      std::stringstream stream;
-      stream << "Index " << index << " is out of range";
-      throw std::out_of_range(stream.str());
-    }
-    return it;
-  }
-};
+      typename ColourMapType::const_iterator safeFetchPair(const ColourMapType &map,
+        const int index) const {
+        auto it = map.find(index);
+        if (it == map.end()) {
+          std::stringstream stream;
+          stream << "Index " << index << " is out of range";
+          throw std::out_of_range(stream.str());
+        }
+        return it;
+      }
+    };
 
-template <typename C> PeakPalette<C>::PeakPalette() {}
+    template <typename C> PeakPalette<C>::PeakPalette() {}
 
-template <typename C>
-PeakPalette<C>::PeakPalette(const PeakPalette &other)
-    : m_backgroundMap(other.m_backgroundMap),
+    template <typename C>
+    PeakPalette<C>::PeakPalette(const PeakPalette &other)
+      : m_backgroundMap(other.m_backgroundMap),
       m_foregroundMap(other.m_foregroundMap) {}
 
-template <typename C>
-PeakPalette<C> &PeakPalette<C>::operator=(const PeakPalette<C> &other) {
-  m_foregroundMap.clear();
-  m_backgroundMap.clear();
-  if (this != &other) {
-    m_foregroundMap.insert(other.m_foregroundMap.begin(),
-                           other.m_foregroundMap.end());
-    m_backgroundMap.insert(other.m_backgroundMap.begin(),
-                           other.m_backgroundMap.end());
-  }
-  return *this;
-}
-
-template <typename C> PeakPalette<C>::~PeakPalette() {}
-
-template <typename C>
-C PeakPalette<C>::foregroundIndexToColour(const int index) const {
-  auto it = safeFetchPair(m_foregroundMap, index);
-  return it->second;
-}
-
-template <typename C>
-C PeakPalette<C>::backgroundIndexToColour(const int index) const {
-  auto it = safeFetchPair(m_backgroundMap, index);
-  return it->second;
-}
-
-template <typename C>
-void PeakPalette<C>::setForegroundColour(const int index, const C colour) {
-  auto it = safeFetchPair(m_foregroundMap, index);
-  // overwrite
-  it->second = colour;
-}
-
-template <typename C>
-void PeakPalette<C>::setBackgroundColour(const int index, const C colour) {
-  auto it = safeFetchPair(m_backgroundMap, index);
-  // owverwirte
-  it->second = colour;
-}
-
-template <typename C> int PeakPalette<C>::paletteSize() const {
-  if (m_foregroundMap.size() != m_backgroundMap.size()) {
-    throw std::runtime_error("The PeakPalette size is not consistent");
-  }
-  return static_cast<int>(m_foregroundMap.size());
-}
-
-template <typename C>
-bool PeakPalette<C>::operator==(const PeakPalette &other) const {
-  bool areEqual = true;
-  if (other.paletteSize() != this->paletteSize()) {
-    areEqual = false;
-  } else {
-    for (int i = 0; i < this->paletteSize(); ++i) {
-      if (this->backgroundIndexToColour(i) !=
-          other.backgroundIndexToColour(i)) {
-        areEqual = false;
-        break;
+    template <typename C>
+    PeakPalette<C> &PeakPalette<C>::operator=(const PeakPalette<C> &other) {
+      m_foregroundMap.clear();
+      m_backgroundMap.clear();
+      if (this != &other) {
+        m_foregroundMap.insert(other.m_foregroundMap.begin(),
+          other.m_foregroundMap.end());
+        m_backgroundMap.insert(other.m_backgroundMap.begin(),
+          other.m_backgroundMap.end());
       }
-      if (this->foregroundIndexToColour(i) !=
-          other.foregroundIndexToColour(i)) {
-        areEqual = false;
-        break;
-      }
+      return *this;
     }
-  }
-  return areEqual;
-}
 
-// Forward declaration for template specialization
-template <> DLLExport PeakPalette<QColor>::PeakPalette();
-template <> DLLExport PeakPalette<PeakViewColor>::PeakPalette();
+    template <typename C> PeakPalette<C>::~PeakPalette() {}
 
-} // namespace
+    template <typename C>
+    C PeakPalette<C>::foregroundIndexToColour(const int index) const {
+      auto it = safeFetchPair(m_foregroundMap, index);
+      return it->second;
+    }
+
+    template <typename C>
+    C PeakPalette<C>::backgroundIndexToColour(const int index) const {
+      auto it = safeFetchPair(m_backgroundMap, index);
+      return it->second;
+    }
+
+    template <typename C>
+    void PeakPalette<C>::setForegroundColour(const int index, const C colour) {
+      auto it = safeFetchPair(m_foregroundMap, index);
+      // overwrite
+      it->second = colour;
+    }
+
+    template <typename C>
+    void PeakPalette<C>::setBackgroundColour(const int index, const C colour) {
+      auto it = safeFetchPair(m_backgroundMap, index);
+      // owverwirte
+      it->second = colour;
+    }
+
+    template <typename C> int PeakPalette<C>::paletteSize() const {
+      if (m_foregroundMap.size() != m_backgroundMap.size()) {
+        throw std::runtime_error("The PeakPalette size is not consistent");
+      }
+      return static_cast<int>(m_foregroundMap.size());
+    }
+
+    template <typename C>
+    bool PeakPalette<C>::operator==(const PeakPalette &other) const {
+      bool areEqual = true;
+      if (other.paletteSize() != this->paletteSize()) {
+        areEqual = false;
+      }
+      else {
+        for (int i = 0; i < this->paletteSize(); ++i) {
+          if (this->backgroundIndexToColour(i) !=
+            other.backgroundIndexToColour(i)) {
+            areEqual = false;
+            break;
+          }
+          if (this->foregroundIndexToColour(i) !=
+            other.foregroundIndexToColour(i)) {
+            areEqual = false;
+            break;
+          }
+        }
+      }
+      return areEqual;
+    }
+
+    // Forward declaration for template specialization
+    template <> DLLExport PeakPalette<QColor>::PeakPalette();
+    template <> DLLExport PeakPalette<PeakViewColor>::PeakPalette();
+
+  } // namespace
 }
 #endif // MANTID_SLICEVIEWER_PEAKSPALETTE_H

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakPrimitives.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakPrimitives.h
@@ -17,7 +17,8 @@ struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitives {
   int peakLineWidth;
 };
 
-struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitivesCross : public PeakPrimitives {
+struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitivesCross
+    : public PeakPrimitives {
   PeakPrimitivesCross(Mantid::Kernel::V3D peakOrigin,
                       double peakOpacityAtDistance, int peakLineWidth,
                       int peakHalfCrossWidth, int peakHalfCrossHeight)
@@ -28,7 +29,8 @@ struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitivesCross : public PeakPrimitiv
   int peakHalfCrossHeight;
 };
 
-struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitiveCircle : public PeakPrimitives {
+struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitiveCircle
+    : public PeakPrimitives {
   PeakPrimitiveCircle(Mantid::Kernel::V3D peakOrigin,
                       double peakOpacityAtDistance, int peakLineWidth,
                       double peakInnerRadiusX, double peakInnerRadiusY,
@@ -50,7 +52,8 @@ struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitiveCircle : public PeakPrimitiv
   double backgroundInnerRadiusY;
 };
 
-struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitivesEllipse : public PeakPrimitives {
+struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitivesEllipse
+    : public PeakPrimitives {
   PeakPrimitivesEllipse(Mantid::Kernel::V3D peakOrigin,
                         double peakOpacityAtDistance, int peakLineWidth,
                         double peakInnerRadiusMajorAxis,

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakPrimitives.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakPrimitives.h
@@ -1,12 +1,13 @@
 #ifndef MANTID_SLICEVIEWER_PEAK_PRIMITIVES_H
 #define MANTID_SLICEVIEWER_PEAK_PRIMITIVES_H
 
+#include "DllOption.h"
 #include "MantidKernel/V3D.h"
 
 namespace MantidQt {
 namespace SliceViewer {
 
-struct DLLExport PeakPrimitives {
+struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitives {
   PeakPrimitives(Mantid::Kernel::V3D peakOrigin, double peakOpacityAtDistance,
                  int peakLineWidth)
       : peakOrigin(peakOrigin), peakOpacityAtDistance(peakOpacityAtDistance),
@@ -16,7 +17,7 @@ struct DLLExport PeakPrimitives {
   int peakLineWidth;
 };
 
-struct DLLExport PeakPrimitivesCross : public PeakPrimitives {
+struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitivesCross : public PeakPrimitives {
   PeakPrimitivesCross(Mantid::Kernel::V3D peakOrigin,
                       double peakOpacityAtDistance, int peakLineWidth,
                       int peakHalfCrossWidth, int peakHalfCrossHeight)
@@ -27,7 +28,7 @@ struct DLLExport PeakPrimitivesCross : public PeakPrimitives {
   int peakHalfCrossHeight;
 };
 
-struct DLLExport PeakPrimitiveCircle : public PeakPrimitives {
+struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitiveCircle : public PeakPrimitives {
   PeakPrimitiveCircle(Mantid::Kernel::V3D peakOrigin,
                       double peakOpacityAtDistance, int peakLineWidth,
                       double peakInnerRadiusX, double peakInnerRadiusY,
@@ -49,7 +50,7 @@ struct DLLExport PeakPrimitiveCircle : public PeakPrimitives {
   double backgroundInnerRadiusY;
 };
 
-struct DLLExport PeakPrimitivesEllipse : public PeakPrimitives {
+struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakPrimitivesEllipse : public PeakPrimitives {
   PeakPrimitivesEllipse(Mantid::Kernel::V3D peakOrigin,
                         double peakOpacityAtDistance, int peakLineWidth,
                         double peakInnerRadiusMajorAxis,

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentation.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentation.h
@@ -1,7 +1,6 @@
 #ifndef MANTID_SLICEVIEWER_PEAK_REPRESENTATION_H
 #define MANTID_SLICEVIEWER_PEAK_REPRESENTATION_H
 
-#include "MantidKernel/System.h"
 #include "MantidQtSliceViewer/PeakPrimitives.h"
 #include "MantidQtSliceViewer/PeakViewColor.h"
 #include "MantidGeometry/Crystal/PeakTransform.h"
@@ -11,7 +10,7 @@ class QPainter;
 
 namespace MantidQt {
 namespace SliceViewer {
-struct DLLExport PeakRepresentationViewInformation {
+struct EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentationViewInformation {
   double windowHeight;
   double windowWidth;
   double viewHeight;
@@ -48,7 +47,7 @@ typedef boost::optional<double> optional_double;
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PeakRepresentation {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentation {
 public:
   virtual ~PeakRepresentation() {}
 

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationCross.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationCross.h
@@ -41,7 +41,8 @@ namespace SliceViewer {
   <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentationCross : public PeakRepresentation {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentationCross
+    : public PeakRepresentation {
 public:
   PeakRepresentationCross(const Mantid::Kernel::V3D &origin, const double &maxZ,
                           const double &minZ);

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationCross.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationCross.h
@@ -41,7 +41,7 @@ namespace SliceViewer {
   <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PeakRepresentationCross : public PeakRepresentation {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentationCross : public PeakRepresentation {
 public:
   PeakRepresentationCross(const Mantid::Kernel::V3D &origin, const double &maxZ,
                           const double &minZ);

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationEllipsoid.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationEllipsoid.h
@@ -60,6 +60,8 @@ public:
   void showBackgroundRadius(const bool show) override;
 
   static const double zeroRadius;
+  /// Get the zoom out factor
+  double getZoomOutFactor() const;
 
 protected:
   std::shared_ptr<PeakPrimitives> getDrawingInformation(

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationEllipsoid.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationEllipsoid.h
@@ -31,7 +31,7 @@ namespace SliceViewer {
   <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PeakRepresentationEllipsoid : public PeakRepresentation {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentationEllipsoid : public PeakRepresentation {
 public:
   PeakRepresentationEllipsoid(
       const Mantid::Kernel::V3D &origin, const std::vector<double> peakRadii,

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationEllipsoid.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationEllipsoid.h
@@ -31,7 +31,8 @@ namespace SliceViewer {
   <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentationEllipsoid : public PeakRepresentation {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentationEllipsoid
+    : public PeakRepresentation {
 public:
   PeakRepresentationEllipsoid(
       const Mantid::Kernel::V3D &origin, const std::vector<double> peakRadii,

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationSphere.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationSphere.h
@@ -30,7 +30,8 @@ namespace SliceViewer {
   <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentationSphere : public PeakRepresentation {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentationSphere
+    : public PeakRepresentation {
 public:
   PeakRepresentationSphere(const Mantid::Kernel::V3D &origin,
                            const double &peakRadius,

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationSphere.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationSphere.h
@@ -60,7 +60,7 @@ public:
    * The zoom-out factor ensures that the sphere can be viewed
    * in its entirety in full-screen or default mode.
    **/
-  static const double zoomOutFactor;
+  double getZoomOutFactor() const;
 
 protected:
   std::shared_ptr<PeakPrimitives> getDrawingInformation(
@@ -103,6 +103,8 @@ private:
   optional_double m_backgroundInnerRadiusAtDistance;
   /// Outer radius at distance.
   optional_double m_backgroundOuterRadiusAtDistance;
+  /// Zoom out factor
+  const double zoomOutFactor = 2.;
 };
 }
 }

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationSphere.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationSphere.h
@@ -55,6 +55,12 @@ public:
   /// Show the background radius
   void showBackgroundRadius(const bool show) override;
 
+  /**
+   * The zoom-out factor ensures that the sphere can be viewed
+   * in its entirety in full-screen or default mode.
+   **/
+  static const double zoomOutFactor;
+
 protected:
   std::shared_ptr<PeakPrimitives> getDrawingInformation(
       PeakRepresentationViewInformation viewInformation) override;

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationSphere.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeakRepresentationSphere.h
@@ -30,7 +30,7 @@ namespace SliceViewer {
   <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PeakRepresentationSphere : public PeakRepresentation {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER PeakRepresentationSphere : public PeakRepresentation {
 public:
   PeakRepresentationSphere(const Mantid::Kernel::V3D &origin,
                            const double &peakRadius,

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ProxyCompositePeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ProxyCompositePeaksPresenter.h
@@ -16,7 +16,7 @@ Proxy wrapper of the CompositePeaksPresenter. Allows the CompositePeaksPresenter
 to
 be used in situations where diluted power, via a restricted API is required.
 ----------------------------------------------------------*/
-class DLLExport ProxyCompositePeaksPresenter : public QObject,
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER ProxyCompositePeaksPresenter : public QObject,
                                                public UpdateableOnDemand {
 public:
   ProxyCompositePeaksPresenter(

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ProxyCompositePeaksPresenter.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ProxyCompositePeaksPresenter.h
@@ -16,8 +16,9 @@ Proxy wrapper of the CompositePeaksPresenter. Allows the CompositePeaksPresenter
 to
 be used in situations where diluted power, via a restricted API is required.
 ----------------------------------------------------------*/
-class EXPORT_OPT_MANTIDQT_SLICEVIEWER ProxyCompositePeaksPresenter : public QObject,
-                                               public UpdateableOnDemand {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER ProxyCompositePeaksPresenter
+    : public QObject,
+      public UpdateableOnDemand {
 public:
   ProxyCompositePeaksPresenter(
       boost::shared_ptr<CompositePeaksPresenter> compositePresenter);

--- a/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
+++ b/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
@@ -225,7 +225,6 @@ bool isBetweenEndpoints(double endpoint1, double endpoint2, double z) {
 namespace Mantid {
 namespace SliceViewer {
 
-const double EllipsoidPlaneSliceCalculator::zoomOutFactor = 2.;
 
 SliceEllipseInfo EllipsoidPlaneSliceCalculator::getSlicePlaneInfo(
     std::vector<Mantid::Kernel::V3D> directions, std::vector<double> radii,
@@ -464,18 +463,16 @@ MantidQt::SliceViewer::PeakBoundingBox getPeakBoundingBoxForEllipsoid(
   using namespace MantidQt::SliceViewer;
 
   // Corners
+  EllipsoidPlaneSliceCalculator calc;
+  auto zoomOutFactor = calc.getZoomOutFactor();
   const double leftValue =
-      originEllipsoid.X() -
-      EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[0];
+      originEllipsoid.X() - zoomOutFactor * projectionLengths[0];
   const double rightValue =
-      originEllipsoid.X() +
-      EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[0];
+      originEllipsoid.X() + zoomOutFactor * projectionLengths[0];
   const double bottomValue =
-      originEllipsoid.Y() -
-      EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[1];
+      originEllipsoid.Y() - zoomOutFactor * projectionLengths[1];
   const double topValue =
-      originEllipsoid.Y() +
-      EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[1];
+      originEllipsoid.Y() + zoomOutFactor * projectionLengths[1];
 
   Left left(leftValue);
   Right right(rightValue);
@@ -484,6 +481,10 @@ MantidQt::SliceViewer::PeakBoundingBox getPeakBoundingBoxForEllipsoid(
   SlicePoint slicePoint(originEllipsoid.Z());
 
   return PeakBoundingBox(left, right, top, bottom, slicePoint);
+}
+
+double EllipsoidPlaneSliceCalculator::getZoomOutFactor() const {
+  return m_zoomOutFactor;
 }
 }
 }

--- a/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
+++ b/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
@@ -225,6 +225,10 @@ bool isBetweenEndpoints(double endpoint1, double endpoint2, double z) {
 namespace Mantid {
 namespace SliceViewer {
 
+
+const double EllipsoidPlaneSliceCalculator::zoomOutFactor = 2.;
+
+
 SliceEllipseInfo EllipsoidPlaneSliceCalculator::getSlicePlaneInfo(
     std::vector<Mantid::Kernel::V3D> directions, std::vector<double> radii,
     Mantid::Kernel::V3D originEllipsoid, double zPlane) const {
@@ -459,21 +463,17 @@ MantidQt::SliceViewer::PeakBoundingBox getPeakBoundingBoxForEllipsoid(
   // Get the length of largest projection onto x,y,z
   auto projectionLengths = getProjectionLengths(directions, radii);
 
-  // The zoom-out factor ensures that the sphere can be viewed
-  // in its entirety in full-screen or default mode.
-  const double zoomOutFactor = 2.;
+  using namespace MantidQt::SliceViewer;
 
   // Corners
   const double leftValue =
-      originEllipsoid.X() - zoomOutFactor * projectionLengths[0];
+      originEllipsoid.X() - EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[0];
   const double rightValue =
-      originEllipsoid.X() + zoomOutFactor * projectionLengths[0];
+      originEllipsoid.X() + EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[0];
   const double bottomValue =
-      originEllipsoid.Y() - zoomOutFactor * projectionLengths[1];
+      originEllipsoid.Y() - EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[1];
   const double topValue =
-      originEllipsoid.Y() + zoomOutFactor * projectionLengths[1];
-
-  using namespace MantidQt::SliceViewer;
+      originEllipsoid.Y() + EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[1];
 
   Left left(leftValue);
   Right right(rightValue);

--- a/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
+++ b/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
@@ -464,10 +464,14 @@ MantidQt::SliceViewer::PeakBoundingBox getPeakBoundingBoxForEllipsoid(
   const double zoomOutFactor = 2.;
 
   // Corners
-  const double leftValue = originEllipsoid.X() - zoomOutFactor*projectionLengths[0];
-  const double rightValue = originEllipsoid.X() + zoomOutFactor*projectionLengths[0];
-  const double bottomValue = originEllipsoid.Y() - zoomOutFactor*projectionLengths[1];
-  const double topValue = originEllipsoid.Y() + zoomOutFactor*projectionLengths[1];
+  const double leftValue =
+      originEllipsoid.X() - zoomOutFactor * projectionLengths[0];
+  const double rightValue =
+      originEllipsoid.X() + zoomOutFactor * projectionLengths[0];
+  const double bottomValue =
+      originEllipsoid.Y() - zoomOutFactor * projectionLengths[1];
+  const double topValue =
+      originEllipsoid.Y() + zoomOutFactor * projectionLengths[1];
 
   using namespace MantidQt::SliceViewer;
 

--- a/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
+++ b/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
@@ -225,9 +225,7 @@ bool isBetweenEndpoints(double endpoint1, double endpoint2, double z) {
 namespace Mantid {
 namespace SliceViewer {
 
-
 const double EllipsoidPlaneSliceCalculator::zoomOutFactor = 2.;
-
 
 SliceEllipseInfo EllipsoidPlaneSliceCalculator::getSlicePlaneInfo(
     std::vector<Mantid::Kernel::V3D> directions, std::vector<double> radii,
@@ -467,13 +465,17 @@ MantidQt::SliceViewer::PeakBoundingBox getPeakBoundingBoxForEllipsoid(
 
   // Corners
   const double leftValue =
-      originEllipsoid.X() - EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[0];
+      originEllipsoid.X() -
+      EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[0];
   const double rightValue =
-      originEllipsoid.X() + EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[0];
+      originEllipsoid.X() +
+      EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[0];
   const double bottomValue =
-      originEllipsoid.Y() - EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[1];
+      originEllipsoid.Y() -
+      EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[1];
   const double topValue =
-      originEllipsoid.Y() + EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[1];
+      originEllipsoid.Y() +
+      EllipsoidPlaneSliceCalculator::zoomOutFactor * projectionLengths[1];
 
   Left left(leftValue);
   Right right(rightValue);

--- a/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
+++ b/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
@@ -225,7 +225,6 @@ bool isBetweenEndpoints(double endpoint1, double endpoint2, double z) {
 namespace Mantid {
 namespace SliceViewer {
 
-
 SliceEllipseInfo EllipsoidPlaneSliceCalculator::getSlicePlaneInfo(
     std::vector<Mantid::Kernel::V3D> directions, std::vector<double> radii,
     Mantid::Kernel::V3D originEllipsoid, double zPlane) const {

--- a/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
+++ b/MantidQt/SliceViewer/src/EllipsoidPlaneSliceCalculator.cpp
@@ -459,11 +459,15 @@ MantidQt::SliceViewer::PeakBoundingBox getPeakBoundingBoxForEllipsoid(
   // Get the length of largest projection onto x,y,z
   auto projectionLengths = getProjectionLengths(directions, radii);
 
+  // The zoom-out factor ensures that the sphere can be viewed
+  // in its entirety in full-screen or default mode.
+  const double zoomOutFactor = 2.;
+
   // Corners
-  const double leftValue = originEllipsoid.X() - projectionLengths[0];
-  const double rightValue = originEllipsoid.X() + projectionLengths[0];
-  const double bottomValue = originEllipsoid.Y() - projectionLengths[1];
-  const double topValue = originEllipsoid.Y() + projectionLengths[1];
+  const double leftValue = originEllipsoid.X() - zoomOutFactor*projectionLengths[0];
+  const double rightValue = originEllipsoid.X() + zoomOutFactor*projectionLengths[0];
+  const double bottomValue = originEllipsoid.Y() - zoomOutFactor*projectionLengths[1];
+  const double topValue = originEllipsoid.Y() + zoomOutFactor*projectionLengths[1];
 
   using namespace MantidQt::SliceViewer;
 

--- a/MantidQt/SliceViewer/src/PeakRepresentationEllipsoid.cpp
+++ b/MantidQt/SliceViewer/src/PeakRepresentationEllipsoid.cpp
@@ -330,5 +330,9 @@ void PeakRepresentationEllipsoid::doDraw(
   }
   painter.end();
 }
+
+double PeakRepresentationEllipsoid::getZoomOutFactor() const {
+  return Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor;
+}
 }
 }

--- a/MantidQt/SliceViewer/src/PeakRepresentationEllipsoid.cpp
+++ b/MantidQt/SliceViewer/src/PeakRepresentationEllipsoid.cpp
@@ -332,7 +332,7 @@ void PeakRepresentationEllipsoid::doDraw(
 }
 
 double PeakRepresentationEllipsoid::getZoomOutFactor() const {
-  return Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor;
+  return m_calculator->getZoomOutFactor();
 }
 }
 }

--- a/MantidQt/SliceViewer/src/PeakRepresentationSphere.cpp
+++ b/MantidQt/SliceViewer/src/PeakRepresentationSphere.cpp
@@ -9,7 +9,6 @@ namespace SliceViewer {
 
 const double PeakRepresentationSphere::zoomOutFactor = 2.;
 
-
 PeakRepresentationSphere::PeakRepresentationSphere(
     const Mantid::Kernel::V3D &origin, const double &peakRadius,
     const double &backgroundInnerRadius, const double &backgroundOuterRadius)
@@ -97,10 +96,16 @@ void PeakRepresentationSphere::showBackgroundRadius(const bool show) {
 PeakBoundingBox PeakRepresentationSphere::getBoundingBox() const {
   using Mantid::Kernel::V2D;
 
-  Left left(m_origin.X() - PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
-  Bottom bottom(m_origin.Y() - PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
-  Right right(m_origin.X() + PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
-  Top top(m_origin.Y() + PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
+  Left left(m_origin.X() -
+            PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
+  Bottom bottom(m_origin.Y() -
+                PeakRepresentationSphere::zoomOutFactor *
+                    m_backgroundOuterRadius);
+  Right right(m_origin.X() +
+              PeakRepresentationSphere::zoomOutFactor *
+                  m_backgroundOuterRadius);
+  Top top(m_origin.Y() +
+          PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
   SlicePoint slicePoint(m_origin.Z());
 
   return PeakBoundingBox(left, right, top, bottom, slicePoint);

--- a/MantidQt/SliceViewer/src/PeakRepresentationSphere.cpp
+++ b/MantidQt/SliceViewer/src/PeakRepresentationSphere.cpp
@@ -1,13 +1,11 @@
 #include "MantidQtSliceViewer/PeakRepresentationSphere.h"
-#include "MantidQtSliceViewer/PeakBoundingBox.h"
 #include "MantidKernel/V2D.h"
+#include "MantidQtSliceViewer/PeakBoundingBox.h"
 
 #include <QPainter>
 
 namespace MantidQt {
 namespace SliceViewer {
-
-const double PeakRepresentationSphere::zoomOutFactor = 2.;
 
 PeakRepresentationSphere::PeakRepresentationSphere(
     const Mantid::Kernel::V3D &origin, const double &peakRadius,
@@ -85,7 +83,7 @@ void PeakRepresentationSphere::movePosition(
 /**
  * Setter for showing/hiding the background radius.
  * @param show: Flag indicating what to do.
-*/
+ */
 void PeakRepresentationSphere::showBackgroundRadius(const bool show) {
   m_showBackgroundRadius = show;
 }
@@ -96,16 +94,12 @@ void PeakRepresentationSphere::showBackgroundRadius(const bool show) {
 PeakBoundingBox PeakRepresentationSphere::getBoundingBox() const {
   using Mantid::Kernel::V2D;
 
-  Left left(m_origin.X() -
-            PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
-  Bottom bottom(m_origin.Y() -
-                PeakRepresentationSphere::zoomOutFactor *
-                    m_backgroundOuterRadius);
-  Right right(m_origin.X() +
-              PeakRepresentationSphere::zoomOutFactor *
-                  m_backgroundOuterRadius);
-  Top top(m_origin.Y() +
-          PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
+  auto zoomOutFactor = getZoomOutFactor();
+
+  Left left(m_origin.X() - zoomOutFactor * m_backgroundOuterRadius);
+  Bottom bottom(m_origin.Y() - zoomOutFactor * m_backgroundOuterRadius);
+  Right right(m_origin.X() + zoomOutFactor * m_backgroundOuterRadius);
+  Top top(m_origin.Y() + zoomOutFactor * m_backgroundOuterRadius);
   SlicePoint slicePoint(m_origin.Z());
 
   return PeakBoundingBox(left, right, top, bottom, slicePoint);
@@ -205,6 +199,10 @@ void PeakRepresentationSphere::doDraw(
     painter.fillPath(backgroundRadiusFill, backgroundColor.colorSphere);
   }
   painter.end();
+}
+
+double PeakRepresentationSphere::getZoomOutFactor() const {
+  return zoomOutFactor;
 }
 }
 }

--- a/MantidQt/SliceViewer/src/PeakRepresentationSphere.cpp
+++ b/MantidQt/SliceViewer/src/PeakRepresentationSphere.cpp
@@ -96,10 +96,10 @@ PeakBoundingBox PeakRepresentationSphere::getBoundingBox() const {
   // The zoom-out factor ensures that the sphere can be viewed
   // in its entirety in full-screen or default mode.
   const double zoomOutFactor = 2.;
-  Left left(m_origin.X() - zoomOutFactor*m_backgroundOuterRadius);
-  Bottom bottom(m_origin.Y() - zoomOutFactor*m_backgroundOuterRadius);
-  Right right(m_origin.X() + zoomOutFactor*m_backgroundOuterRadius);
-  Top top(m_origin.Y() + zoomOutFactor*m_backgroundOuterRadius);
+  Left left(m_origin.X() - zoomOutFactor * m_backgroundOuterRadius);
+  Bottom bottom(m_origin.Y() - zoomOutFactor * m_backgroundOuterRadius);
+  Right right(m_origin.X() + zoomOutFactor * m_backgroundOuterRadius);
+  Top top(m_origin.Y() + zoomOutFactor * m_backgroundOuterRadius);
   SlicePoint slicePoint(m_origin.Z());
 
   return PeakBoundingBox(left, right, top, bottom, slicePoint);

--- a/MantidQt/SliceViewer/src/PeakRepresentationSphere.cpp
+++ b/MantidQt/SliceViewer/src/PeakRepresentationSphere.cpp
@@ -7,6 +7,9 @@
 namespace MantidQt {
 namespace SliceViewer {
 
+const double PeakRepresentationSphere::zoomOutFactor = 2.;
+
+
 PeakRepresentationSphere::PeakRepresentationSphere(
     const Mantid::Kernel::V3D &origin, const double &peakRadius,
     const double &backgroundInnerRadius, const double &backgroundOuterRadius)
@@ -93,13 +96,11 @@ void PeakRepresentationSphere::showBackgroundRadius(const bool show) {
  */
 PeakBoundingBox PeakRepresentationSphere::getBoundingBox() const {
   using Mantid::Kernel::V2D;
-  // The zoom-out factor ensures that the sphere can be viewed
-  // in its entirety in full-screen or default mode.
-  const double zoomOutFactor = 2.;
-  Left left(m_origin.X() - zoomOutFactor * m_backgroundOuterRadius);
-  Bottom bottom(m_origin.Y() - zoomOutFactor * m_backgroundOuterRadius);
-  Right right(m_origin.X() + zoomOutFactor * m_backgroundOuterRadius);
-  Top top(m_origin.Y() + zoomOutFactor * m_backgroundOuterRadius);
+
+  Left left(m_origin.X() - PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
+  Bottom bottom(m_origin.Y() - PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
+  Right right(m_origin.X() + PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
+  Top top(m_origin.Y() + PeakRepresentationSphere::zoomOutFactor * m_backgroundOuterRadius);
   SlicePoint slicePoint(m_origin.Z());
 
   return PeakBoundingBox(left, right, top, bottom, slicePoint);

--- a/MantidQt/SliceViewer/src/PeakRepresentationSphere.cpp
+++ b/MantidQt/SliceViewer/src/PeakRepresentationSphere.cpp
@@ -93,10 +93,13 @@ void PeakRepresentationSphere::showBackgroundRadius(const bool show) {
  */
 PeakBoundingBox PeakRepresentationSphere::getBoundingBox() const {
   using Mantid::Kernel::V2D;
-  Left left(m_origin.X() - m_backgroundOuterRadius);
-  Bottom bottom(m_origin.Y() - m_backgroundOuterRadius);
-  Right right(m_origin.X() + m_backgroundOuterRadius);
-  Top top(m_origin.Y() + m_backgroundOuterRadius);
+  // The zoom-out factor ensures that the sphere can be viewed
+  // in its entirety in full-screen or default mode.
+  const double zoomOutFactor = 2.;
+  Left left(m_origin.X() - zoomOutFactor*m_backgroundOuterRadius);
+  Bottom bottom(m_origin.Y() - zoomOutFactor*m_backgroundOuterRadius);
+  Right right(m_origin.X() + zoomOutFactor*m_backgroundOuterRadius);
+  Top top(m_origin.Y() + zoomOutFactor*m_backgroundOuterRadius);
   SlicePoint slicePoint(m_origin.Z());
 
   return PeakBoundingBox(left, right, top, bottom, slicePoint);

--- a/MantidQt/SliceViewer/test/EllipsoidPlaneSliceCalculatorTest.h
+++ b/MantidQt/SliceViewer/test/EllipsoidPlaneSliceCalculatorTest.h
@@ -50,8 +50,8 @@ public:
 
     // Assert
 
-    std::vector<std::pair<int, int>> indices = {{0, 1}, {0, 2}, {1, 0},
-                                                {1, 2}, {2, 0}, {2, 1}};
+    std::vector<std::pair<int, int>> indices = {
+        {0, 1}, {0, 2}, {1, 0}, {1, 2}, {2, 0}, {2, 1}};
 
     for (const auto &index : indices) {
       TSM_ASSERT("Non-diagonal element should be zero",

--- a/MantidQt/SliceViewer/test/EllipsoidPlaneSliceCalculatorTest.h
+++ b/MantidQt/SliceViewer/test/EllipsoidPlaneSliceCalculatorTest.h
@@ -1,13 +1,13 @@
 #ifndef SLICE_VIEWER_ELLIPSOID_PLANE_SLICE_CALCULATOR_TEST_H_
 #define SLICE_VIEWER_ELLIPSOID_PLANE_SLICE_CALCULATOR_TEST_H_
 
-#include <cxxtest/TestSuite.h>
-#include "MantidQtSliceViewer/EllipsoidPlaneSliceCalculator.h"
-#include "MantidKernel/V3D.h"
 #include "MantidKernel/Matrix.h"
-#include <unordered_map>
+#include "MantidKernel/V3D.h"
+#include "MantidQtSliceViewer/EllipsoidPlaneSliceCalculator.h"
 #include <algorithm>
+#include <cxxtest/TestSuite.h>
 #include <math.h>
+#include <unordered_map>
 
 namespace {
 bool radiusIsInListOfRadii(double radius, const std::vector<double> &radii) {
@@ -50,8 +50,8 @@ public:
 
     // Assert
 
-    std::vector<std::pair<int, int>> indices = {
-        {0, 1}, {0, 2}, {1, 0}, {1, 2}, {2, 0}, {2, 1}};
+    std::vector<std::pair<int, int>> indices = {{0, 1}, {0, 2}, {1, 0},
+                                                {1, 2}, {2, 0}, {2, 1}};
 
     for (const auto &index : indices) {
       TSM_ASSERT("Non-diagonal element should be zero",
@@ -427,22 +427,12 @@ public:
         directions, radii, origin);
 
     // Assert
-    const double expectedLeft =
-        origin[0] -
-        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
-            radii[0];
-    const double expectedRight =
-        origin[0] +
-        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
-            radii[0];
-    const double expectedTop =
-        origin[1] +
-        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
-            radii[1];
-    const double expectedBottom =
-        origin[1] -
-        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
-            radii[1];
+    Mantid::SliceViewer::EllipsoidPlaneSliceCalculator calc;
+    const auto zoomOutFactor = calc.getZoomOutFactor();
+    const double expectedLeft = origin[0] - zoomOutFactor * radii[0];
+    const double expectedRight = origin[0] + zoomOutFactor * radii[0];
+    const double expectedTop = origin[1] + zoomOutFactor * radii[1];
+    const double expectedBottom = origin[1] - zoomOutFactor * radii[1];
     const double expectedSlicePoint = origin[2];
 
     const double delta = 1e-5;
@@ -474,22 +464,16 @@ public:
         directions, radii, origin);
 
     // Assert
+    Mantid::SliceViewer::EllipsoidPlaneSliceCalculator calc;
+    const auto zoomOutFactor = calc.getZoomOutFactor();
     const double expectedLeft =
-        origin[0] -
-        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
-            radii[0] * std::cos(angleIn);
+        origin[0] - zoomOutFactor * radii[0] * std::cos(angleIn);
     const double expectedRight =
-        origin[0] +
-        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
-            radii[0] * std::cos(angleIn);
+        origin[0] + zoomOutFactor * radii[0] * std::cos(angleIn);
     const double expectedTop =
-        origin[1] +
-        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
-            radii[1] * std::cos(angleIn);
+        origin[1] + zoomOutFactor * radii[1] * std::cos(angleIn);
     const double expectedBottom =
-        origin[1] -
-        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
-            radii[1] * std::cos(angleIn);
+        origin[1] - zoomOutFactor * radii[1] * std::cos(angleIn);
     const double expectedSlicePoint = origin[2];
 
     const double delta = 1e-5;

--- a/MantidQt/SliceViewer/test/EllipsoidPlaneSliceCalculatorTest.h
+++ b/MantidQt/SliceViewer/test/EllipsoidPlaneSliceCalculatorTest.h
@@ -427,10 +427,22 @@ public:
         directions, radii, origin);
 
     // Assert
-    const double expectedLeft = origin[0] - Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[0];
-    const double expectedRight = origin[0] + Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[0] ;
-    const double expectedTop = origin[1] + Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[1];
-    const double expectedBottom = origin[1] - Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[1];
+    const double expectedLeft =
+        origin[0] -
+        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
+            radii[0];
+    const double expectedRight =
+        origin[0] +
+        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
+            radii[0];
+    const double expectedTop =
+        origin[1] +
+        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
+            radii[1];
+    const double expectedBottom =
+        origin[1] -
+        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
+            radii[1];
     const double expectedSlicePoint = origin[2];
 
     const double delta = 1e-5;
@@ -462,10 +474,22 @@ public:
         directions, radii, origin);
 
     // Assert
-    const double expectedLeft = origin[0] - Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[0] * std::cos(angleIn);
-    const double expectedRight = origin[0] + Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[0] * std::cos(angleIn);
-    const double expectedTop = origin[1] + Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[1] * std::cos(angleIn);
-    const double expectedBottom = origin[1] - Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[1] * std::cos(angleIn);
+    const double expectedLeft =
+        origin[0] -
+        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
+            radii[0] * std::cos(angleIn);
+    const double expectedRight =
+        origin[0] +
+        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
+            radii[0] * std::cos(angleIn);
+    const double expectedTop =
+        origin[1] +
+        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
+            radii[1] * std::cos(angleIn);
+    const double expectedBottom =
+        origin[1] -
+        Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor *
+            radii[1] * std::cos(angleIn);
     const double expectedSlicePoint = origin[2];
 
     const double delta = 1e-5;

--- a/MantidQt/SliceViewer/test/EllipsoidPlaneSliceCalculatorTest.h
+++ b/MantidQt/SliceViewer/test/EllipsoidPlaneSliceCalculatorTest.h
@@ -427,11 +427,11 @@ public:
         directions, radii, origin);
 
     // Assert
-    const double expectedLeft = -1.0;
-    const double expectedRight = 3.0;
-    const double expectedTop = 3.5;
-    const double expectedBottom = 0.5;
-    const double expectedSlicePoint = -1.0;
+    const double expectedLeft = origin[0] - Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[0];
+    const double expectedRight = origin[0] + Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[0] ;
+    const double expectedTop = origin[1] + Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[1];
+    const double expectedBottom = origin[1] - Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[1];
+    const double expectedSlicePoint = origin[2];
 
     const double delta = 1e-5;
     TSM_ASSERT_DELTA("Left should be at -1.0.", expectedLeft,
@@ -462,10 +462,10 @@ public:
         directions, radii, origin);
 
     // Assert
-    const double expectedLeft = -radii[0] * std::cos(angleIn) + origin[0];
-    const double expectedRight = radii[0] * std::cos(angleIn) + origin[0];
-    const double expectedTop = radii[1] * std::cos(angleIn) + origin[1];
-    const double expectedBottom = -radii[1] * std::cos(angleIn) + origin[1];
+    const double expectedLeft = origin[0] - Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[0] * std::cos(angleIn);
+    const double expectedRight = origin[0] + Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[0] * std::cos(angleIn);
+    const double expectedTop = origin[1] + Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[1] * std::cos(angleIn);
+    const double expectedBottom = origin[1] - Mantid::SliceViewer::EllipsoidPlaneSliceCalculator::zoomOutFactor * radii[1] * std::cos(angleIn);
     const double expectedSlicePoint = origin[2];
 
     const double delta = 1e-5;

--- a/MantidQt/SliceViewer/test/PeakRepresentationEllipsoidTest.h
+++ b/MantidQt/SliceViewer/test/PeakRepresentationEllipsoidTest.h
@@ -125,12 +125,13 @@ public:
     const auto boundingBox = peak.getBoundingBox();
 
     // Assert
-    // Looking at background radius, hence +2
-    const double expectedLeft(0 - (std::cos(angle) * (r1 + 2)));
-    const double expectedRight(0 + (std::cos(angle) * (r1 + 2)));
+    // Looking at background radius, hence + 2
+    auto zoomOutFactor = peak.getZoomOutFactor();
+    const double expectedLeft(0 - zoomOutFactor * (std::cos(angle) * (r1 + 2)));
+    const double expectedRight(0 + zoomOutFactor * (std::cos(angle) * (r1 + 2)));
 
-    const double expectedBottom(0 - (std::cos(angle) * (r2 + 2)));
-    const double expectedTop(0 + (std::cos(angle) * (r2 + 2)));
+    const double expectedBottom(0 - zoomOutFactor * (std::cos(angle) * (r2 + 2)));
+    const double expectedTop(0 + zoomOutFactor * (std::cos(angle) * (r2 + 2)));
 
     TS_ASSERT_EQUALS(expectedLeft, boundingBox.left());
     TS_ASSERT_EQUALS(expectedRight, boundingBox.right());
@@ -154,12 +155,13 @@ public:
     const auto boundingBox = peak.getBoundingBox();
 
     // Assert
-    // Looking at background radius, hence +2
-    const double expectedLeft(0 - (std::cos(angle) * (r1 + 2)) + originX);
-    const double expectedRight(0 + (std::cos(angle) * (r1 + 2)) + originX);
+    // Looking at background radius, hence + 2
+    auto zoomOutFactor = peak.getZoomOutFactor();
+    const double expectedLeft(0 - zoomOutFactor * (std::cos(angle) * (r1 + 2)) + originX);
+    const double expectedRight(0 + zoomOutFactor * (std::cos(angle) * (r1 + 2)) + originX);
 
-    const double expectedBottom(0 - (std::cos(angle) * (r2 + 2)) + originY);
-    const double expectedTop(0 + (std::cos(angle) * (r2 + 2)) + originY);
+    const double expectedBottom(0 - zoomOutFactor * (std::cos(angle) * (r2 + 2)) + originY);
+    const double expectedTop(0 + zoomOutFactor * (std::cos(angle) * (r2 + 2)) + originY);
 
     TS_ASSERT_EQUALS(expectedLeft, boundingBox.left());
     TS_ASSERT_EQUALS(expectedRight, boundingBox.right());

--- a/MantidQt/SliceViewer/test/PeakRepresentationEllipsoidTest.h
+++ b/MantidQt/SliceViewer/test/PeakRepresentationEllipsoidTest.h
@@ -128,9 +128,11 @@ public:
     // Looking at background radius, hence + 2
     auto zoomOutFactor = peak.getZoomOutFactor();
     const double expectedLeft(0 - zoomOutFactor * (std::cos(angle) * (r1 + 2)));
-    const double expectedRight(0 + zoomOutFactor * (std::cos(angle) * (r1 + 2)));
+    const double expectedRight(0 +
+                               zoomOutFactor * (std::cos(angle) * (r1 + 2)));
 
-    const double expectedBottom(0 - zoomOutFactor * (std::cos(angle) * (r2 + 2)));
+    const double expectedBottom(0 -
+                                zoomOutFactor * (std::cos(angle) * (r2 + 2)));
     const double expectedTop(0 + zoomOutFactor * (std::cos(angle) * (r2 + 2)));
 
     TS_ASSERT_EQUALS(expectedLeft, boundingBox.left());
@@ -157,11 +159,15 @@ public:
     // Assert
     // Looking at background radius, hence + 2
     auto zoomOutFactor = peak.getZoomOutFactor();
-    const double expectedLeft(0 - zoomOutFactor * (std::cos(angle) * (r1 + 2)) + originX);
-    const double expectedRight(0 + zoomOutFactor * (std::cos(angle) * (r1 + 2)) + originX);
+    const double expectedLeft(0 - zoomOutFactor * (std::cos(angle) * (r1 + 2)) +
+                              originX);
+    const double expectedRight(
+        0 + zoomOutFactor * (std::cos(angle) * (r1 + 2)) + originX);
 
-    const double expectedBottom(0 - zoomOutFactor * (std::cos(angle) * (r2 + 2)) + originY);
-    const double expectedTop(0 + zoomOutFactor * (std::cos(angle) * (r2 + 2)) + originY);
+    const double expectedBottom(
+        0 - zoomOutFactor * (std::cos(angle) * (r2 + 2)) + originY);
+    const double expectedTop(0 + zoomOutFactor * (std::cos(angle) * (r2 + 2)) +
+                             originY);
 
     TS_ASSERT_EQUALS(expectedLeft, boundingBox.left());
     TS_ASSERT_EQUALS(expectedRight, boundingBox.right());

--- a/MantidQt/SliceViewer/test/PeakRepresentationSphereTest.h
+++ b/MantidQt/SliceViewer/test/PeakRepresentationSphereTest.h
@@ -1,9 +1,9 @@
 #ifndef SLICE_VIEWER_PEAK_REPRESENTATION_SPHERE_TEST_H_
 #define SLICE_VIEWER_PEAK_REPRESENTATION_SPHERE_TEST_H_
 
-#include <cxxtest/TestSuite.h>
 #include "MantidQtSliceViewer/PeakRepresentationSphere.h"
 #include "MockObjects.h"
+#include <cxxtest/TestSuite.h>
 
 using namespace MantidQt::SliceViewer;
 using namespace testing;
@@ -183,18 +183,15 @@ public:
     const auto boundingBox = peak.getBoundingBox();
 
     // Assert
+    auto zoomOutFactor = peak.getZoomOutFactor();
     const double expectedLeft(origin.X() -
-                              PeakRepresentationSphere::zoomOutFactor *
-                                  outerBackgroundRadius);
+                              zoomOutFactor * outerBackgroundRadius);
     const double expectedBottom(origin.Y() -
-                                PeakRepresentationSphere::zoomOutFactor *
-                                    outerBackgroundRadius);
+                                zoomOutFactor * outerBackgroundRadius);
     const double expectedRight(origin.X() +
-                               PeakRepresentationSphere::zoomOutFactor *
-                                   outerBackgroundRadius);
+                               zoomOutFactor * outerBackgroundRadius);
     const double expectedTop(origin.Y() +
-                             PeakRepresentationSphere::zoomOutFactor *
-                                 outerBackgroundRadius);
+                             zoomOutFactor * outerBackgroundRadius);
 
     TS_ASSERT_EQUALS(expectedLeft, boundingBox.left());
     TS_ASSERT_EQUALS(expectedRight, boundingBox.right());
@@ -228,18 +225,15 @@ public:
     auto boundingBox = peak.getBoundingBox();
 
     // Assert
+    auto zoomOutFactor = peak.getZoomOutFactor();
     const double expectedLeft(origin.X() -
-                              PeakRepresentationSphere::zoomOutFactor *
-                                  outerBackgroundRadius);
+                              zoomOutFactor * outerBackgroundRadius);
     const double expectedBottom(origin.Y() -
-                                PeakRepresentationSphere::zoomOutFactor *
-                                    outerBackgroundRadius);
+                                zoomOutFactor * outerBackgroundRadius);
     const double expectedRight(origin.X() +
-                               PeakRepresentationSphere::zoomOutFactor *
-                                   outerBackgroundRadius);
+                               zoomOutFactor * outerBackgroundRadius);
     const double expectedTop(origin.Y() +
-                             PeakRepresentationSphere::zoomOutFactor *
-                                 outerBackgroundRadius);
+                             zoomOutFactor * outerBackgroundRadius);
 
     TS_ASSERT_EQUALS(expectedLeft, boundingBox.left());
     TS_ASSERT_EQUALS(expectedRight, boundingBox.right());
@@ -265,7 +259,7 @@ public:
         for (int z = 0; z < sizeInAxis; ++z) {
           Mantid::Kernel::V3D peakOrigin(x, y, z);
           m_peaks.push_back(boost::make_shared<
-              PeakRepresentationSphereExposeProtectedWrapper>(
+                            PeakRepresentationSphereExposeProtectedWrapper>(
               peakOrigin, radius, innerBackgroundRadius,
               outerBackgroundRadius));
         }

--- a/MantidQt/SliceViewer/test/PeakRepresentationSphereTest.h
+++ b/MantidQt/SliceViewer/test/PeakRepresentationSphereTest.h
@@ -259,7 +259,7 @@ public:
         for (int z = 0; z < sizeInAxis; ++z) {
           Mantid::Kernel::V3D peakOrigin(x, y, z);
           m_peaks.push_back(boost::make_shared<
-                            PeakRepresentationSphereExposeProtectedWrapper>(
+              PeakRepresentationSphereExposeProtectedWrapper>(
               peakOrigin, radius, innerBackgroundRadius,
               outerBackgroundRadius));
         }

--- a/MantidQt/SliceViewer/test/PeakRepresentationSphereTest.h
+++ b/MantidQt/SliceViewer/test/PeakRepresentationSphereTest.h
@@ -183,10 +183,10 @@ public:
     const auto boundingBox = peak.getBoundingBox();
 
     // Assert
-    const double expectedLeft(origin.X() - outerBackgroundRadius);
-    const double expectedBottom(origin.Y() - outerBackgroundRadius);
-    const double expectedRight(origin.X() + outerBackgroundRadius);
-    const double expectedTop(origin.Y() + outerBackgroundRadius);
+    const double expectedLeft(origin.X() - PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
+    const double expectedBottom(origin.Y() - PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
+    const double expectedRight(origin.X() + PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
+    const double expectedTop(origin.Y() + PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
 
     TS_ASSERT_EQUALS(expectedLeft, boundingBox.left());
     TS_ASSERT_EQUALS(expectedRight, boundingBox.right());
@@ -220,10 +220,10 @@ public:
     auto boundingBox = peak.getBoundingBox();
 
     // Assert
-    const double expectedLeft(origin.X() - outerBackgroundRadius);
-    const double expectedBottom(origin.Y() - outerBackgroundRadius);
-    const double expectedRight(origin.X() + outerBackgroundRadius);
-    const double expectedTop(origin.Y() + outerBackgroundRadius);
+    const double expectedLeft(origin.X() - PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
+    const double expectedBottom(origin.Y() - PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
+    const double expectedRight(origin.X() + PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
+    const double expectedTop(origin.Y() + PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
 
     TS_ASSERT_EQUALS(expectedLeft, boundingBox.left());
     TS_ASSERT_EQUALS(expectedRight, boundingBox.right());

--- a/MantidQt/SliceViewer/test/PeakRepresentationSphereTest.h
+++ b/MantidQt/SliceViewer/test/PeakRepresentationSphereTest.h
@@ -183,10 +183,18 @@ public:
     const auto boundingBox = peak.getBoundingBox();
 
     // Assert
-    const double expectedLeft(origin.X() - PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
-    const double expectedBottom(origin.Y() - PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
-    const double expectedRight(origin.X() + PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
-    const double expectedTop(origin.Y() + PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
+    const double expectedLeft(origin.X() -
+                              PeakRepresentationSphere::zoomOutFactor *
+                                  outerBackgroundRadius);
+    const double expectedBottom(origin.Y() -
+                                PeakRepresentationSphere::zoomOutFactor *
+                                    outerBackgroundRadius);
+    const double expectedRight(origin.X() +
+                               PeakRepresentationSphere::zoomOutFactor *
+                                   outerBackgroundRadius);
+    const double expectedTop(origin.Y() +
+                             PeakRepresentationSphere::zoomOutFactor *
+                                 outerBackgroundRadius);
 
     TS_ASSERT_EQUALS(expectedLeft, boundingBox.left());
     TS_ASSERT_EQUALS(expectedRight, boundingBox.right());
@@ -220,10 +228,18 @@ public:
     auto boundingBox = peak.getBoundingBox();
 
     // Assert
-    const double expectedLeft(origin.X() - PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
-    const double expectedBottom(origin.Y() - PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
-    const double expectedRight(origin.X() + PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
-    const double expectedTop(origin.Y() + PeakRepresentationSphere::zoomOutFactor * outerBackgroundRadius);
+    const double expectedLeft(origin.X() -
+                              PeakRepresentationSphere::zoomOutFactor *
+                                  outerBackgroundRadius);
+    const double expectedBottom(origin.Y() -
+                                PeakRepresentationSphere::zoomOutFactor *
+                                    outerBackgroundRadius);
+    const double expectedRight(origin.X() +
+                               PeakRepresentationSphere::zoomOutFactor *
+                                   outerBackgroundRadius);
+    const double expectedTop(origin.Y() +
+                             PeakRepresentationSphere::zoomOutFactor *
+                                 outerBackgroundRadius);
 
     TS_ASSERT_EQUALS(expectedLeft, boundingBox.left());
     TS_ASSERT_EQUALS(expectedRight, boundingBox.right());

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -61,6 +61,7 @@ Bugs Resolved
 SliceViewer Improvements
 ------------------------
 - Fixed a bug where the rebin button was toggled when the user switch axes.
+- Changed zoom level on peak. Now when zooming onto a spherical or ellipsoidal peak, the entire peak is visible when using the default window size.
 
 VSI Improvments
 ---------------


### PR DESCRIPTION
Fixes #19337 

Changes the zoom level on to peak. You should be able to see the entire peak 

**To test:**

1. Load a workspace with a corresponding spherical peak workspace
2. Open both in the slice viewer. Leave the default window size.
3. Select a peak. Confirm that the entire peak is visible

**Release notes**
See [here](https://github.com/mantidproject/mantid/pull/19338/commits/23ba03f5df3386f049eca4a0871014ee6ec85dd0)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
