### PR TITLE
Fix implicit cast warnings

### DIFF
--- a/Framework/Crystal/test/ConnectedComponentLabelingTest.h
+++ b/Framework/Crystal/test/ConnectedComponentLabelingTest.h
@@ -450,7 +450,8 @@ public:
         std::stringstream stream;
         stream << "Linear index: " << i
                << " should be labeled. Actually labeled with: " << actualValue;
-        TSM_ASSERT(stream.str(), outWS->getSignalAt(i) >= labelingId)
+        TSM_ASSERT(stream.str(),
+                   outWS->getSignalAt(i) >= static_cast<double>(labelingId))
         // Background is marked as -1.
       } else {
         TSM_ASSERT_EQUALS("Should not be labeled", outWS->getSignalAt(i),

--- a/Framework/Crystal/test/FindClusterFacesTest.h
+++ b/Framework/Crystal/test/FindClusterFacesTest.h
@@ -113,7 +113,7 @@ class FindClusterFacesTest : public CxxTest::TestSuite {
 
 private:
   void verify_table_row(ITableWorkspace_sptr &outWS, int expectedClusterId,
-                        size_t expectedWorkspaceIndex,
+                        double expectedWorkspaceIndex,
                         int expectedNormalDimensionIndex,
                         bool expectedMaxExtent, double expectedRadius = -1) {
     for (size_t rowIndex = 0; rowIndex < outWS->rowCount(); ++rowIndex) {
@@ -185,7 +185,7 @@ public:
     TSM_ASSERT_EQUALS("Two faces should be identified", outWS->rowCount(), 2);
 
     int clusterId = 1;
-    size_t expectedWorkspaceIndex = 1;
+    double expectedWorkspaceIndex = 1.;
     int expectedNormalDimensionIndex = 0;
     bool maxExtent = true;
     verify_table_row(outWS, clusterId, expectedWorkspaceIndex,

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -2604,18 +2604,18 @@ public:
   EventListTestPerformance() {
     // Source for a randome event list
     el_random_source.clear();
-    for (size_t i = 0; i < 2e6; i++)
+    for (size_t i = 0; i < 2000000; i++)
       el_random_source += TofEvent((rand() % 200000) * 0.05, rand() % 1000);
 
     // 10 million events, up to 1e5 tof
     el_sorted_original.clear();
-    for (size_t i = 0; i < 10e6; i++)
+    for (size_t i = 0; i < 10000000; i++)
       el_sorted_original +=
           TofEvent(static_cast<double>(i) / 100.0, rand() % 1000);
     el_sorted_original.setSortOrder(TOF_SORT);
 
     el_sorted_weighted.clear();
-    for (size_t i = 0; i < 10e6; i++)
+    for (size_t i = 0; i < 10000000; i++)
       el_sorted_weighted += WeightedEvent(static_cast<double>(i) / 100.0,
                                           rand() % 1000, 2.34, 4.56);
     el_sorted_weighted.setSortOrder(TOF_SORT);

--- a/MantidQt/CustomInterfaces/test/MDFLogValueFinderTest.h
+++ b/MantidQt/CustomInterfaces/test/MDFLogValueFinderTest.h
@@ -51,13 +51,16 @@ public:
     wsNames << QString::fromStdString(ws0.name())
             << QString::fromStdString(ws1.name());
     MDFLogValueFinder finder(wsNames);
-    double valIndex0, valIndex1, valString0, valString1;
+    double valIndex0 = 0.;
     TS_ASSERT_THROWS_NOTHING(
         valIndex0 = finder.getLogValue("dblProp", StatisticType::Mean, 0));
+    double valIndex1 = 0.;
     TS_ASSERT_THROWS_NOTHING(
         valIndex1 = finder.getLogValue("dblProp", StatisticType::Mean, 1));
+    double valString0 = 0.;
     TS_ASSERT_THROWS_NOTHING(valString0 = finder.getLogValue(
                                  "dblProp", StatisticType::Mean, wsNames[0]));
+    double valString1 = 0.;
     TS_ASSERT_THROWS_NOTHING(valString1 = finder.getLogValue(
                                  "dblProp", StatisticType::Mean, wsNames[1]));
     TS_ASSERT_EQUALS(valIndex0, valString0);


### PR DESCRIPTION
Fix some implicit cast warnings from gcc 6.3.

**To test:**

If the builds pass it is good to ship.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
