### PR TITLE
Changing the font on the script window causes crash

### DIFF
--- a/MantidPlot/src/MultiTabScriptInterpreter.cpp
+++ b/MantidPlot/src/MultiTabScriptInterpreter.cpp
@@ -510,7 +510,7 @@ void MultiTabScriptInterpreter::showSelectFont() {
     fontToUse = m_fontFamily;
 
   const auto results = fontList->findItems(fontToUse, Qt::MatchExactly);
-  if (results.empty()) {
+  if (!results.empty()) {
     const auto item = results[0];
     fontList->setItemSelected(item, true);
     fontList->scrollToItem(item, QAbstractItemView::PositionAtTop);

--- a/MantidPlot/src/MultiTabScriptInterpreter.cpp
+++ b/MantidPlot/src/MultiTabScriptInterpreter.cpp
@@ -509,9 +509,12 @@ void MultiTabScriptInterpreter::showSelectFont() {
   if (database.families().contains(m_fontFamily))
     fontToUse = m_fontFamily;
 
-  QListWidgetItem *item = fontList->findItems(fontToUse, Qt::MatchExactly)[0];
-  fontList->setItemSelected(item, true);
-  fontList->scrollToItem(item, QAbstractItemView::PositionAtTop);
+  const auto results = fontList->findItems(fontToUse, Qt::MatchExactly);
+  if (results.size() > 0) {
+    const auto item = results[0];
+    fontList->setItemSelected(item, true);
+    fontList->scrollToItem(item, QAbstractItemView::PositionAtTop);
+  }
 
   QFrame *frameButtons = new QFrame();
   QBoxLayout *layoutButtons =

--- a/MantidPlot/src/MultiTabScriptInterpreter.cpp
+++ b/MantidPlot/src/MultiTabScriptInterpreter.cpp
@@ -510,7 +510,7 @@ void MultiTabScriptInterpreter::showSelectFont() {
     fontToUse = m_fontFamily;
 
   const auto results = fontList->findItems(fontToUse, Qt::MatchExactly);
-  if (results.size() > 0) {
+  if (results.empty()) {
     const auto item = results[0];
     fontList->setItemSelected(item, true);
     fontList->scrollToItem(item, QAbstractItemView::PositionAtTop);

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -42,6 +42,7 @@ Algorithm Toolbox
 
 Scripting Window
 ################
+- Fixed a bug where Mantid would crash when trying to select the font for the script window
 
 Documentation
 #############


### PR DESCRIPTION
Fixed a bug which could cause Mantid to crash when choosing the font for the script window.

**To test:**
 - Check you can reproduce by opening the script window, then choosing window -> select font
 - Check these changes fix the issue.
 - Code review.

Fixes #19345 .

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
