### PR TITLE
Version passing in python test helper

### DIFF
--- a/Framework/PythonInterface/test/testhelpers/__init__.py
+++ b/Framework/PythonInterface/test/testhelpers/__init__.py
@@ -8,6 +8,9 @@ from six import iteritems
 # Define all mantid exported classes first
 import mantid
 
+#Add workspace creation namespace
+from . import WorkspaceCreationHelper
+
 # Define some pure-Python functions to add to the mix
 
 

--- a/Framework/PythonInterface/test/testhelpers/__init__.py
+++ b/Framework/PythonInterface/test/testhelpers/__init__.py
@@ -8,10 +8,8 @@ from six import iteritems
 # Define all mantid exported classes first
 import mantid
 
-# Add workspace creation namespace
-from . import WorkspaceCreationHelper
-
 # Define some pure-Python functions to add to the mix
+
 
 def run_algorithm(name, **kwargs):
     """Run a named algorithm and return the
@@ -24,6 +22,7 @@ def run_algorithm(name, **kwargs):
     alg = create_algorithm(name, **kwargs)
     alg.execute()
     return alg
+
 
 def create_algorithm(name, **kwargs):
     """Create a named algorithm, set the properties given by the keywords and return the
@@ -38,7 +37,11 @@ def create_algorithm(name, **kwargs):
         kwargs - A dictionary of property name:value pairs
     @returns The algorithm handle
     """
-    alg = mantid.api.AlgorithmManager.createUnmanaged(name)
+    if 'Version' in kwargs:
+        alg = mantid.api.AlgorithmManager.createUnmanaged(name, kwargs['Version'])
+        del kwargs['Version']
+    else:
+        alg = mantid.api.AlgorithmManager.createUnmanaged(name)
     alg.initialize()
     # Avoid problem that Load needs to set Filename first if it exists
     if name == 'Load' and 'Filename' in kwargs:
@@ -56,6 +59,7 @@ def create_algorithm(name, **kwargs):
         alg.setProperty(key, value)
     return alg
 
+
 # Case difference is to be consistent with the unittest module
 def assertRaisesNothing(testobj, callable, *args, **kwargs):
     """
@@ -69,10 +73,11 @@ def assertRaisesNothing(testobj, callable, *args, **kwargs):
             **kwargs - Keyword arguments, passed on as they are
     """
     try:
-         return callable(*args, **kwargs)
+        return callable(*args, **kwargs)
     except Exception as exc:
         testobj.fail("Assertion error. An exception was caught where none was expected in %s. Message: %s"
                      % (callable.__name__, str(exc)))
+
 
 def can_be_instantiated(cls):
     """The Python unittest assertRaises does not


### PR DESCRIPTION
This is a small fix in the way python test helper handles the algorithm version. See the issue description.

**To test:**
1. Pick a python algorithm test, that uses `run_algorithm` helper, e.g. FindEPPTest
2. Add `Version=1` to the argument list to `run_algorithm` call
3. Test should still pass with no error

<!-- Instructions for testing. -->

Fixes #19344 .

Does not need to be in the release notes.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.