### PR TITLE
Do not sort events in LoadLiveData

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/LoadLiveData.h
+++ b/Framework/LiveData/inc/MantidLiveData/LoadLiveData.h
@@ -1,10 +1,10 @@
 #ifndef MANTID_LIVEDATA_LOADLIVEDATA_H_
 #define MANTID_LIVEDATA_LOADLIVEDATA_H_
 
-#include "MantidKernel/System.h"
 #include "MantidAPI/Algorithm.h"
-#include "MantidLiveData/LiveDataAlgorithm.h"
 #include "MantidAPI/Workspace_fwd.h"
+#include "MantidKernel/System.h"
+#include "MantidLiveData/LiveDataAlgorithm.h"
 
 namespace Mantid {
 namespace LiveData {
@@ -65,8 +65,6 @@ private:
   void appendChunk(Mantid::API::Workspace_sptr chunkWS);
   API::Workspace_sptr appendMatrixWSChunk(API::Workspace_sptr accumWS,
                                           Mantid::API::Workspace_sptr chunkWS);
-
-  void doSortEvents(Mantid::API::Workspace_sptr ws);
 
   /// The "accumulation" workspace = after adding, but before post-processing
   Mantid::API::Workspace_sptr m_accumWS;

--- a/Framework/LiveData/test/LoadLiveDataTest.h
+++ b/Framework/LiveData/test/LoadLiveDataTest.h
@@ -1,18 +1,18 @@
 #ifndef MANTID_LIVEDATA_LOADLIVEDATATEST_H_
 #define MANTID_LIVEDATA_LOADLIVEDATATEST_H_
 
-#include "MantidLiveData/LoadLiveData.h"
-#include "MantidDataObjects/EventWorkspace.h"
 #include "MantidAPI/FrameworkManager.h"
-#include "MantidKernel/System.h"
-#include "MantidKernel/Timer.h"
-#include <cxxtest/TestSuite.h>
-#include <numeric>
+#include "MantidAPI/LiveListenerFactory.h"
+#include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/ConfigService.h"
-#include "MantidAPI/LiveListenerFactory.h"
+#include "MantidKernel/System.h"
+#include "MantidKernel/Timer.h"
+#include "MantidLiveData/LoadLiveData.h"
 #include "MantidTestHelpers/FacilityHelper.h"
 #include "TestGroupDataListener.h"
+#include <cxxtest/TestSuite.h>
+#include <numeric>
 
 using namespace Mantid;
 using namespace Mantid::LiveData;
@@ -112,7 +112,6 @@ public:
     TS_ASSERT_EQUALS(ws2->getNumberEvents(), 200);
     TSM_ASSERT("Workspace changed when replaced", ws1 != ws2);
     TS_ASSERT_EQUALS(AnalysisDataService::Instance().size(), 1);
-    TSM_ASSERT("Events are sorted", ws2->getSpectrum(0).isSortedByTof());
   }
 
   //--------------------------------------------------------------------------------------------
@@ -127,7 +126,6 @@ public:
     ws2 = doExec<EventWorkspace>("Append");
     TS_ASSERT_EQUALS(ws2->getNumberHistograms(), 4);
     TS_ASSERT_EQUALS(AnalysisDataService::Instance().size(), 1);
-    TSM_ASSERT("Events are sorted", ws2->getSpectrum(0).isSortedByTof());
   }
 
   //--------------------------------------------------------------------------------------------
@@ -146,7 +144,6 @@ public:
     TS_ASSERT_EQUALS(ws2->getNumberEvents(), 400);
 
     TSM_ASSERT("Workspace being added stayed the same pointer", ws1 == ws2);
-    TSM_ASSERT("Events are sorted", ws2->getSpectrum(0).isSortedByTof());
     TS_ASSERT_EQUALS(AnalysisDataService::Instance().size(), 1);
 
     // Test monitor workspace is present
@@ -237,9 +234,6 @@ public:
     TS_ASSERT_EQUALS(ws->blocksize(), 20);
     TS_ASSERT_DELTA(ws->dataX(0)[0], 40e3, 1e-4);
     TS_ASSERT_EQUALS(AnalysisDataService::Instance().size(), 2);
-
-    TSM_ASSERT("Events are sorted", ws_accum->getSpectrum(0).isSortedByTof());
-    TSM_ASSERT("Events are sorted", ws->getSpectrum(0).isSortedByTof());
   }
 
   //--------------------------------------------------------------------------------------------
@@ -267,9 +261,6 @@ public:
     TS_ASSERT_EQUALS(ws->blocksize(), 20);
     TS_ASSERT_DELTA(ws->dataX(0)[0], 40e3, 1e-4);
     TS_ASSERT_EQUALS(AnalysisDataService::Instance().size(), 2);
-
-    TSM_ASSERT("Events are sorted", ws_accum->getSpectrum(0).isSortedByTof());
-    TSM_ASSERT("Events are sorted", ws->getSpectrum(0).isSortedByTof());
   }
 
   //--------------------------------------------------------------------------------------------


### PR DESCRIPTION
`LoadLiveData` executes periodically whilst a live listener is running in order to accumulate data in an output workspace. I've removed event sorting from it as it can have a huge impact on performance (see #19353) and sorting is done whenever it is required anyway. This could save a lot of processing time, worst case scenario is that it just moves the computation to the listener post-processing step.

**To test:**

Could be tested by checking there are no errors when running an event data live listener (ADARA at SNS, Kafka at ISIS).
If at ISIS follow procedure here: https://github.com/mantidproject/mantid/pull/18450#issuecomment-283654382

Fixes #19353.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
