### PR TITLE
Suppress clang 4.0 warnings on OS X

### DIFF
--- a/Framework/Algorithms/src/GetDetectorOffsets.cpp
+++ b/Framework/Algorithms/src/GetDetectorOffsets.cpp
@@ -98,7 +98,7 @@ void GetDetectorOffsets::exec() {
 
   m_dideal = getProperty("DIdeal");
 
-  size_t nspec = inputW->getNumberHistograms();
+  int64_t nspec = inputW->getNumberHistograms();
   // Create the output OffsetsWorkspace
   auto outputW = boost::make_shared<OffsetsWorkspace>(inputW->getInstrument());
   // Create the output MaskWorkspace
@@ -111,10 +111,10 @@ void GetDetectorOffsets::exec() {
   Progress prog(this, 0, 1.0, nspec);
   auto &spectrumInfo = maskWS->mutableSpectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputW))
-  for (size_t wi = 0; wi < nspec; ++wi) {
+  for (int64_t wi = 0; wi < nspec; ++wi) {
     PARALLEL_START_INTERUPT_REGION
     // Fit the peak
-    double offset = fitSpectra(static_cast<int64_t>(wi), isAbsolute);
+    double offset = fitSpectra(wi, isAbsolute);
     double mask = 0.0;
     if (std::abs(offset) > m_maxOffset) {
       offset = 0.0;

--- a/Framework/Algorithms/src/GetDetectorOffsets.cpp
+++ b/Framework/Algorithms/src/GetDetectorOffsets.cpp
@@ -98,7 +98,7 @@ void GetDetectorOffsets::exec() {
 
   m_dideal = getProperty("DIdeal");
 
-  int64_t nspec = inputW->getNumberHistograms();
+  size_t nspec = inputW->getNumberHistograms();
   // Create the output OffsetsWorkspace
   auto outputW = boost::make_shared<OffsetsWorkspace>(inputW->getInstrument());
   // Create the output MaskWorkspace
@@ -111,10 +111,10 @@ void GetDetectorOffsets::exec() {
   Progress prog(this, 0, 1.0, nspec);
   auto &spectrumInfo = maskWS->mutableSpectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputW))
-  for (int wi = 0; wi < nspec; ++wi) {
+  for (size_t wi = 0; wi < nspec; ++wi) {
     PARALLEL_START_INTERUPT_REGION
     // Fit the peak
-    double offset = fitSpectra(wi, isAbsolute);
+    double offset = fitSpectra(static_cast<int64_t>(wi), isAbsolute);
     double mask = 0.0;
     if (std::abs(offset) > m_maxOffset) {
       offset = 0.0;

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -417,11 +417,11 @@ bool Stitch1D::hasNonzeroErrors(MatrixWorkspace_sptr ws) {
   int64_t ws_size = static_cast<int64_t>(ws->getNumberHistograms());
   bool hasNonZeroErrors = false;
   PARALLEL_FOR_IF(Kernel::threadSafe(*ws))
-  for (int i = 0; i < ws_size; ++i) {
+  for (int64_t i = 0; i < ws_size; ++i) {
     PARALLEL_START_INTERUPT_REGION
     if (!hasNonZeroErrors) // Keep checking
     {
-      auto e = ws->e(i);
+      auto e = ws->e(static_cast<size_t>(i));
       auto it = std::find_if(e.begin(), e.end(), isNonzero);
       if (it != e.end()) {
         PARALLEL_CRITICAL(has_non_zero) {

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -421,7 +421,7 @@ bool Stitch1D::hasNonzeroErrors(MatrixWorkspace_sptr ws) {
     PARALLEL_START_INTERUPT_REGION
     if (!hasNonZeroErrors) // Keep checking
     {
-      auto e = ws->e(static_cast<size_t>(i));
+      auto e = ws->e(i);
       auto it = std::find_if(e.begin(), e.end(), isNonzero);
       if (it != e.end()) {
         PARALLEL_CRITICAL(has_non_zero) {

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp
@@ -14,6 +14,17 @@
 namespace Mantid {
 namespace PythonInterface {
 namespace Converters {
+
+extern template int NDArrayTypeIndex<bool>::typenum;
+extern template int NDArrayTypeIndex<int>::typenum;
+extern template int NDArrayTypeIndex<long>::typenum;
+extern template int NDArrayTypeIndex<long long>::typenum;
+extern template int NDArrayTypeIndex<unsigned int>::typenum;
+extern template int NDArrayTypeIndex<unsigned long>::typenum;
+extern template int NDArrayTypeIndex<unsigned long long>::typenum;
+extern template int NDArrayTypeIndex<float>::typenum;
+extern template int NDArrayTypeIndex<double>::typenum;
+
 namespace Impl {
 namespace {
 /**


### PR DESCRIPTION
This eliminates the compiler warnings on OS X with the newer compiler version. 

**To test:**

<!-- Instructions for testing. -->
Check that there is no more compiler warning on OS X with clang 4.0 (ornl-yosemite).

Fixes #19359 .

Does not need to be in the release notes.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.