### PR TITLE
Change LoadCIF to parse ICSD spacegroup notation

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
@@ -77,7 +77,7 @@ class SpaceGroupBuilder(object):
     def _getCleanSpaceGroupSymbol(self, rawSpaceGroupSymbol):
         # Remove :1 and :H from the symbol. Those are not required at the moment because they are the default.
         # Also substitute 'R' and 'Z' endings used by ICSD to indicate alternative origin choice or settings
-        mappings = {':[1H]':'', ':[1h]':'', ' S$':'', ' H$':'', ' Z$':' :2', ' R$':' :r'}
+        mappings = {':[1Hh]':'', ' S$':'', ' H$':'', ' Z$':' :2', ' R$':' :r'}
         for k, v in mappings.items():
             rawSpaceGroupSymbol = re.sub(k, v, rawSpaceGroupSymbol)
         return rawSpaceGroupSymbol.strip()

--- a/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
@@ -77,7 +77,7 @@ class SpaceGroupBuilder(object):
     def _getCleanSpaceGroupSymbol(self, rawSpaceGroupSymbol):
         # Remove :1 and :H from the symbol. Those are not required at the moment because they are the default.
         # Also substitute 'R' and 'Z' endings used by ICSD to indicate alternative origin choice or settings
-        mappings = {':[1H]':'', ':[1h]':'', 'S$':'', 'H$':'', 'Z$':':2', 'R$':':r'}
+        mappings = {':[1H]':'', ':[1h]':'', ' S$':'', ' H$':'', ' Z$':':2', ' R$':':r'}
         for k, v in mappings.items():
             rawSpaceGroupSymbol = re.sub(k, v, rawSpaceGroupSymbol)
         return rawSpaceGroupSymbol.strip()

--- a/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
@@ -76,8 +76,11 @@ class SpaceGroupBuilder(object):
 
     def _getCleanSpaceGroupSymbol(self, rawSpaceGroupSymbol):
         # Remove :1 and :H from the symbol. Those are not required at the moment because they are the default.
-        removalRe = re.compile(':[1H]', re.IGNORECASE)
-        return re.sub(removalRe, '', rawSpaceGroupSymbol).strip()
+        # Also substitute 'R' and 'Z' endings used by ICSD to indicate alternative origin choice or settings
+        mappings = {':[1H]':'', ':[1h]':'', 'Z$':':2', 'R$':':r'}
+        for k, v in mappings.items():
+            rawSpaceGroupSymbol = re.sub(k, v, rawSpaceGroupSymbol)
+        return rawSpaceGroupSymbol.strip()
 
     def _getSpaceGroupFromNumber(self, cifData):
         spaceGroupNumber = [int(cifData[x]) for x in

--- a/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
@@ -77,7 +77,7 @@ class SpaceGroupBuilder(object):
     def _getCleanSpaceGroupSymbol(self, rawSpaceGroupSymbol):
         # Remove :1 and :H from the symbol. Those are not required at the moment because they are the default.
         # Also substitute 'R' and 'Z' endings used by ICSD to indicate alternative origin choice or settings
-        mappings = {':[1H]':'', ':[1h]':'', ' S$':'', ' H$':'', ' Z$':':2', ' R$':':r'}
+        mappings = {':[1H]':'', ':[1h]':'', ' S$':'', ' H$':'', ' Z$':' :2', ' R$':' :r'}
         for k, v in mappings.items():
             rawSpaceGroupSymbol = re.sub(k, v, rawSpaceGroupSymbol)
         return rawSpaceGroupSymbol.strip()

--- a/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
@@ -77,7 +77,7 @@ class SpaceGroupBuilder(object):
     def _getCleanSpaceGroupSymbol(self, rawSpaceGroupSymbol):
         # Remove :1 and :H from the symbol. Those are not required at the moment because they are the default.
         # Also substitute 'R' and 'Z' endings used by ICSD to indicate alternative origin choice or settings
-        mappings = {':[1H]':'', ':[1h]':'', 'Z$':':2', 'R$':':r'}
+        mappings = {':[1H]':'', ':[1h]':'', 'S$':'', 'H$':'', 'Z$':':2', 'R$':':r'}
         for k, v in mappings.items():
             rawSpaceGroupSymbol = re.sub(k, v, rawSpaceGroupSymbol)
         return rawSpaceGroupSymbol.strip()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
@@ -61,6 +61,10 @@ class SpaceGroupBuilderTest(unittest.TestCase):
 
         self.assertEqual(fn('P m -3 m :1'), 'P m -3 m')
         self.assertEqual(fn('P m -3 m :H'), 'P m -3 m')
+        self.assertEqual(fn('F d -3 m S'), 'F d -3 m')
+        self.assertEqual(fn('F d -3 m Z'), 'F d -3 m :2')
+        self.assertEqual(fn('R 3 H'), 'R 3')
+        self.assertEqual(fn('R 3 R'), 'R 3 :r')
 
     def test_getSpaceGroupFromNumber_invalid(self):
         invalid_old = {u'_symmetry_int_tables_number': u'400'}

--- a/scripts/Inelastic/CrystalField/__init__.py
+++ b/scripts/Inelastic/CrystalField/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 from .fitting import CrystalField, CrystalFieldFit, CrystalFieldMulti
 from .function import PeaksFunction, Background, Function, ResolutionModel, PhysicalProperties
+from .pointcharge import PointCharge
 __all__ = ['CrystalField', 'CrystalFieldFit', 'CrystalFieldMulti', 'PeaksFunction',
-           'Background', 'Function', 'ResolutionModel', 'PhysicalProperties']
+           'Background', 'Function', 'ResolutionModel', 'PhysicalProperties', 'PointCharge']

--- a/scripts/Inelastic/CrystalField/__init__.py
+++ b/scripts/Inelastic/CrystalField/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 from .fitting import CrystalField, CrystalFieldFit, CrystalFieldMulti
 from .function import PeaksFunction, Background, Function, ResolutionModel, PhysicalProperties
-from .pointcharge import PointCharge
 __all__ = ['CrystalField', 'CrystalFieldFit', 'CrystalFieldMulti', 'PeaksFunction',
-           'Background', 'Function', 'ResolutionModel', 'PhysicalProperties', 'PointCharge']
+           'Background', 'Function', 'ResolutionModel', 'PhysicalProperties']


### PR DESCRIPTION
Changes `LoadCIF` python algorithm to translate spacegroup strings from the notation used by the Inorganic Crystal Structures Database (ICSD) to that used by Mantid. Specifically:

- ICSD uses the suffix `H` and `R` (upper case) to indicate whether the structure uses the hexagonal or rhombohedral settings, whilst Mantid uses `:h` or `:r`
- ICSD uses the suffix `S` for the default origin choice of orthorhombic, tetragonal or cubic spacegroups, and `Z` for the alternate choice, whereas Mantid uses `:1` and `:2`.
- In addition, the default origin choice or setting (`:h` or `:1`) is omitted in the Mantid spacegroup string, but is specified explicitly by ICSD.

**To test:**

Create a workspace and use LoadCIF with a CIF file from ICSD ( http://icsd.cds.rsc.org/search/basic.xhtml ) from spacegroups with multiple settings / origin choices (e.g. any structure with spacegroup numbers 146, 148, 155, 160, 161, 167 for hexagonal / rhombohedral; and 48, 50, 59, 85-88, 125-126, 129-130, 133-134, 201, 203, 222, 227-228).

Before this PR it should fail with a `RuntimeError: Can not create space group from supplied CIF-file.` After this, it should work.

<!-- Instructions for testing. -->

Fixes #19355

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
