### PR TITLE
LR reduction from workspace

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
@@ -37,6 +37,9 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
     def PyInit(self):
         #TODO: Revisit the choice of names when we are entirely rid of the old code.
         self.declareProperty(StringArrayProperty("RunNumbers"), "List of run numbers to process")
+        self.declareProperty(WorkspaceProperty("InputWorkspace", "",
+                                               Direction.Input, PropertyMode.Optional),
+                             "Optionally, we can provide a workspace directly")
         self.declareProperty("NormalizationRunNumber", 0, "Run number of the normalization run to use")
         self.declareProperty(IntArrayProperty("SignalPeakPixelRange", [123, 137],
                                               IntArrayLengthValidator(2), direction=Direction.Input),
@@ -99,7 +102,6 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
         self.TOLERANCE = self.getProperty("SlitTolerance").value
 
         # DATA
-        dataRunNumbers = self.getProperty("RunNumbers").value
         dataPeakRange = self.getProperty("SignalPeakPixelRange").value
         dataBackRange = self.getProperty("SignalBackgroundPixelRange").value
 
@@ -114,18 +116,8 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
         if qStep > 0:  #force logarithmic binning
             qStep = -qStep
 
-        # If we have multiple files, add them
-        file_list = []
-        for item in dataRunNumbers:
-            # The standard mode of operation is to give a run number as input
-            try:
-                data_file = FileFinder.findRuns("REF_L%s" % item)[0]
-            except RuntimeError:
-                # Allow for a file name or file path as input
-                data_file = FileFinder.findRuns(item)[0]
-            file_list.append(data_file)
-        runs = reduce((lambda x, y: '%s+%s' % (x, y)), file_list)
-        ws_event_data = Load(Filename=runs, OutputWorkspace="REF_L_%s" % dataRunNumbers[0])
+        # Load the data
+        ws_event_data = self.load_data()
 
         # Compute the primary fraction using the unprocessed workspace
         apply_primary_fraction = self.getProperty("ApplyPrimaryFraction").value
@@ -326,6 +318,31 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
 
         self.setProperty('OutputWorkspace', mtd[name_output_ws])
 
+    def load_data(self):
+        """
+            Load the data. We can either load it from the specified
+            run numbers, or use the input workspace if no runs are specified.
+        """
+        dataRunNumbers = self.getProperty("RunNumbers").value
+        ws_event_data = self.getProperty("InputWorkspace").value
+
+        if len(dataRunNumbers) > 0:
+            # If we have multiple files, add them
+            file_list = []
+            for item in dataRunNumbers:
+                # The standard mode of operation is to give a run number as input
+                try:
+                    data_file = FileFinder.findRuns("REF_L%s" % item)[0]
+                except RuntimeError:
+                    # Allow for a file name or file path as input
+                    data_file = FileFinder.findRuns(item)[0]
+                file_list.append(data_file)
+            runs = reduce((lambda x, y: '%s+%s' % (x, y)), file_list)
+            ws_event_data = Load(Filename=runs, OutputWorkspace="REF_L_%s" % dataRunNumbers[0])
+        elif ws_event_data is None:
+            raise RuntimeError("No input data was specified")
+        return ws_event_data
+    
     def calculate_scattering_angle(self, ws_event_data):
         """
             Compute the scattering angle

--- a/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
@@ -342,7 +342,7 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
         elif ws_event_data is None:
             raise RuntimeError("No input data was specified")
         return ws_event_data
-    
+
     def calculate_scattering_angle(self, ws_event_data):
         """
             Compute the scattering angle


### PR DESCRIPTION
We want to add the possibility to pass an input workspace to the liquids reflectometer reduction instead of a run number or file path.

**To test:**
- Make sure the tests pass. All the changes should be exercised already.
- Review the code.

There is no GitHub issue for this PR. All the information is here.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
