### PR TITLE
Fix min range in Integration for 0 events

### DIFF
--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -142,7 +142,8 @@ void Integration::exec() {
           "Range lists not supported for EventWorkspaces.");
     }
     // Get the eventworkspace rebinned to apply the upper and lowerrange
-    double evntMinRange = std::max(minRange, eventInputWS->getEventXMin());
+    double evntMinRange =
+        isEmpty(minRange) ? eventInputWS->getEventXMin() : minRange;
     double evntMaxRange =
         isEmpty(maxRange) ? eventInputWS->getEventXMax() : maxRange;
     localworkspace =


### PR DESCRIPTION
When working with live data you sometimes get chucks with zero events and `Integration` fails when this happens with something like
`Invalid value for property Params (dbl list) "1.79769e+308,-1.79769e+308,1000": Bin boundary values must be given in order of increasing value`

It shouldn't fail like this if you provide `RangeLower` and `RangeUpper`. This also makes the handling of `minRange` and `maxRange` consistent.

This reverts the changes to this line which was part of #18983 

**To test:**
This should now work.
```
ws = CreateSampleWorkspace(WorkspaceType="Event",NumEvents=0)
out=Integration(ws, RangeLower=0, RangeUpper=1000)
```


*As this was only changed in this release it does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
