### PR TITLE
Fix build error with USE_SYSTEM_EIGEN=ON

### DIFF
--- a/Framework/Beamline/CMakeLists.txt
+++ b/Framework/Beamline/CMakeLists.txt
@@ -31,11 +31,9 @@ endif(UNITY_BUILD)
 add_library ( Beamline ${SRC_FILES} ${INC_FILES} )
 # Set the name of the generated library
 set_target_properties ( Beamline PROPERTIES OUTPUT_NAME MantidBeamline
-  COMPILE_DEFINITIONS IN_MANTID_BEAMLINE )
-
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties ( Beamline PROPERTIES INSTALL_RPATH "@loader_path/../MacOS")
-endif ()
+                                 COMPILE_DEFINITIONS IN_MANTID_BEAMLINE
+                                 INSTALL_RPATH "@loader_path/../MacOS" )
+target_include_directories( Beamline PUBLIC ${EIGEN3_INCLUDE_DIR} )
 
 # Add to the 'Framework' group in VS
 set_property ( TARGET Beamline PROPERTY FOLDER "MantidFramework" )

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -472,7 +472,7 @@ add_library ( Kernel ${SRC_FILES} ${INC_FILES} )
 set_target_properties ( Kernel PROPERTIES OUTPUT_NAME MantidKernel
                                           COMPILE_DEFINITIONS "IN_MANTID_KERNEL;PSAPI_VERSION=1" )
 
-target_include_directories ( Kernel PRIVATE ${GSL_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
+target_include_directories ( Kernel PUBLIC ${EIGEN3_INCLUDE_DIR} PRIVATE ${GSL_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
 
 if (OSX_VERSION VERSION_GREATER 10.8)
   set_target_properties ( Kernel PROPERTIES INSTALL_RPATH "@loader_path/../MacOS")

--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -22,6 +22,6 @@ else()
   execute_process(COMMAND ${CMAKE_COMMAND} . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/eigen-download )
   execute_process(COMMAND ${CMAKE_COMMAND} --build . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/eigen-download )
 
-  find_package(Eigen3 3.2 REQUIRED PATHS ${CMAKE_BINARY_DIR}/eigen-src)
+  set(EIGEN3_INCLUDE_DIR "${CMAKE_BINARY_DIR}/eigen-src" CACHE PATH "Eigen include directory")
   ## Include the source directory.
 endif()

--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -22,6 +22,6 @@ else()
   execute_process(COMMAND ${CMAKE_COMMAND} . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/eigen-download )
   execute_process(COMMAND ${CMAKE_COMMAND} --build . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/eigen-download )
 
+  find_package(Eigen3 3.2 REQUIRED PATHS ${CMAKE_BINARY_DIR}/eigen-src)
   ## Include the source directory.
-  include_directories("${CMAKE_BINARY_DIR}/eigen-src" "${CMAKE_BINARY_DIR}/eigen-src")
 endif()


### PR DESCRIPTION
Description of work.

This uses `find_package` and `target_include_directories` to only add the Eigen3 include directories where they are needed. I made both includes `PUBLIC` since Eigen is used in the header.

This allows Mantid to build when `USE_SYSTEM_EIGEN=ON` and in general should simplify the include paths for libraries that don't (yet) use Eigen.

**To test:**

<!-- Instructions for testing. -->

Verify Mantid still builds and the tests pass.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
