### PR TITLE
Fix performance regression in ExperimentInfo::getInstrument

### DIFF
--- a/Framework/API/inc/MantidAPI/ComponentInfo.h
+++ b/Framework/API/inc/MantidAPI/ComponentInfo.h
@@ -48,16 +48,19 @@ private:
   /// Reference to the actual ComponentInfo object (non-wrapping part).
   const Beamline::ComponentInfo &m_componentInfo;
   /// Collection of component ids
-  boost::shared_ptr<std::vector<Mantid::Geometry::IComponent *>> m_componentIds;
+  boost::shared_ptr<const std::vector<Mantid::Geometry::IComponent *>>
+      m_componentIds;
   /// Map of component ids to indexes
   boost::shared_ptr<std::unordered_map<Geometry::IComponent *, size_t>>
       m_compIDToIndex;
 
 public:
-  ComponentInfo(const Mantid::Beamline::ComponentInfo &componentInfo,
-                const std::vector<Mantid::Geometry::IComponent *> componentIds);
+  ComponentInfo(
+      const Mantid::Beamline::ComponentInfo &componentInfo,
+      boost::shared_ptr<const std::vector<Mantid::Geometry::IComponent *>>
+          componentIds);
   std::vector<size_t> detectorIndices(size_t componentIndex) const;
-  std::vector<Mantid::Geometry::IComponent *> componentIds() const;
+  const std::vector<Mantid::Geometry::IComponent *> &componentIds() const;
   size_t size() const;
   size_t indexOf(Geometry::IComponent *id) const;
 };

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -228,7 +228,7 @@ private:
 
   boost::shared_ptr<Beamline::ComponentInfo> m_componentInfo;
   std::unique_ptr<API::ComponentInfo> m_componentInfoWrapper;
-  std::vector<Geometry::ComponentID> m_componentIds;
+  boost::shared_ptr<const std::vector<Geometry::ComponentID>> m_componentIds;
 
   mutable std::unique_ptr<Beamline::SpectrumInfo> m_spectrumInfo;
   mutable std::unique_ptr<SpectrumInfo> m_spectrumInfoWrapper;

--- a/Framework/API/src/ComponentInfo.cpp
+++ b/Framework/API/src/ComponentInfo.cpp
@@ -19,10 +19,9 @@ namespace API {
  */
 ComponentInfo::ComponentInfo(
     const Mantid::Beamline::ComponentInfo &componentInfo,
-    std::vector<Mantid::Geometry::IComponent *> componentIds)
-    : m_componentInfo(componentInfo),
-      m_componentIds(boost::make_shared<std::vector<Geometry::ComponentID>>(
-          std::move(componentIds))),
+    boost::shared_ptr<const std::vector<Mantid::Geometry::IComponent *>>
+        componentIds)
+    : m_componentInfo(componentInfo), m_componentIds(std::move(componentIds)),
       m_compIDToIndex(boost::make_shared<
           std::unordered_map<Geometry::IComponent *, size_t>>()) {
   /*
@@ -41,7 +40,7 @@ ComponentInfo::detectorIndices(size_t componentIndex) const {
   return m_componentInfo.detectorIndices(componentIndex);
 }
 
-std::vector<Geometry::IComponent *> ComponentInfo::componentIds() const {
+const std::vector<Geometry::IComponent *> &ComponentInfo::componentIds() const {
   return *m_componentIds;
 }
 

--- a/Framework/API/test/ComponentInfoTest.h
+++ b/Framework/API/test/ComponentInfoTest.h
@@ -8,6 +8,8 @@
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument/ObjComponent.h"
 
+#include <boost/make_shared.hpp>
+
 using Mantid::API::ComponentInfo;
 
 class ComponentInfoTest : public CxxTest::TestSuite {

--- a/Framework/API/test/ComponentInfoTest.h
+++ b/Framework/API/test/ComponentInfoTest.h
@@ -31,8 +31,8 @@ public:
     Mantid::Geometry::ObjComponent comp2("component2");
     ComponentInfo info(
         internalInfo,
-        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>{&comp1,
-                                                                       &comp2});
+        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>(
+            std::vector<Mantid::Geometry::ComponentID>{&comp1, &comp2}));
     TS_ASSERT_EQUALS(info.size(), 2);
   }
 
@@ -49,8 +49,8 @@ public:
 
     ComponentInfo info(
         internalInfo,
-        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>{&comp1,
-                                                                       &comp2});
+        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>(
+            std::vector<Mantid::Geometry::ComponentID>{&comp1, &comp2}));
     TS_ASSERT_EQUALS(info.indexOf(comp1.getComponentID()), 0);
     TS_ASSERT_EQUALS(info.indexOf(comp2.getComponentID()), 1);
   }
@@ -79,9 +79,10 @@ public:
 
     ComponentInfo info(
         internalInfo,
-        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>{
-            &fakeComposite1, &fakeComposite2, &fakeDetector1, &fakeDetector2,
-            &fakeDetector3});
+        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>(
+            std::vector<Mantid::Geometry::ComponentID>{
+                &fakeComposite1, &fakeComposite2, &fakeDetector1,
+                &fakeDetector2, &fakeDetector3}));
     TS_ASSERT_EQUALS(info.detectorIndices(3 /*component index*/),
                      std::vector<size_t>({0, 2, 1}));
     TS_ASSERT_EQUALS(info.detectorIndices(4 /*component index*/),

--- a/Framework/API/test/ComponentInfoTest.h
+++ b/Framework/API/test/ComponentInfoTest.h
@@ -27,8 +27,10 @@ public:
     Mantid::Beamline::ComponentInfo internalInfo(detectorIndices, ranges);
     Mantid::Geometry::ObjComponent comp1("component1");
     Mantid::Geometry::ObjComponent comp2("component2");
-    ComponentInfo info(internalInfo, std::vector<Mantid::Geometry::ComponentID>{
-                                         &comp1, &comp2});
+    ComponentInfo info(
+        internalInfo,
+        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>{&comp1,
+                                                                       &comp2});
     TS_ASSERT_EQUALS(info.size(), 2);
   }
 
@@ -43,8 +45,10 @@ public:
     Mantid::Geometry::ObjComponent comp1("component1");
     Mantid::Geometry::ObjComponent comp2("component2");
 
-    ComponentInfo info(internalInfo, std::vector<Mantid::Geometry::ComponentID>{
-                                         &comp1, &comp2});
+    ComponentInfo info(
+        internalInfo,
+        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>{&comp1,
+                                                                       &comp2});
     TS_ASSERT_EQUALS(info.indexOf(comp1.getComponentID()), 0);
     TS_ASSERT_EQUALS(info.indexOf(comp2.getComponentID()), 1);
   }
@@ -71,10 +75,11 @@ public:
     Mantid::Geometry::ObjComponent fakeDetector2("fakeDetector2");
     Mantid::Geometry::ObjComponent fakeDetector3("fakeDetector3");
 
-    ComponentInfo info(internalInfo,
-                       std::vector<Mantid::Geometry::ComponentID>{
-                           &fakeComposite1, &fakeComposite2, &fakeDetector1,
-                           &fakeDetector2, &fakeDetector3});
+    ComponentInfo info(
+        internalInfo,
+        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>{
+            &fakeComposite1, &fakeComposite2, &fakeDetector1, &fakeDetector2,
+            &fakeDetector3});
     TS_ASSERT_EQUALS(info.detectorIndices(3 /*component index*/),
                      std::vector<size_t>({0, 2, 1}));
     TS_ASSERT_EQUALS(info.detectorIndices(4 /*component index*/),

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -252,8 +252,9 @@ public:
   setDetectorInfo(boost::shared_ptr<const Beamline::DetectorInfo> detectorInfo);
   void setComponentInfo(
       boost::shared_ptr<const Beamline::ComponentInfo> componentInfo,
-      std::vector<Geometry::ComponentID> componentIds);
-  const std::vector<Geometry::ComponentID> &componentIds() const;
+      boost::shared_ptr<const std::vector<Geometry::ComponentID>> componentIds);
+  boost::shared_ptr<const std::vector<Geometry::ComponentID>>
+  componentIds() const;
   boost::shared_ptr<ParameterMap> makeLegacyParameterMap() const;
 
 private:
@@ -336,7 +337,7 @@ private:
   boost::shared_ptr<const Beamline::DetectorInfo> m_detectorInfo{nullptr};
 
   boost::shared_ptr<const Beamline::ComponentInfo> m_componentInfo{nullptr};
-  std::vector<Geometry::ComponentID> m_componentIds;
+  boost::shared_ptr<const std::vector<Geometry::ComponentID>> m_componentIds;
 };
 namespace Conversion {
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -354,8 +354,7 @@ public:
   void
   setDetectorInfo(boost::shared_ptr<const Beamline::DetectorInfo> detectorInfo);
   void setComponentInfo(
-      boost::shared_ptr<const Beamline::ComponentInfo> componentInfo,
-      std::vector<Geometry::ComponentID> componentIds);
+      boost::shared_ptr<const Beamline::ComponentInfo> componentInfo);
   void setInstrument(const Instrument *instrument);
 
 private:
@@ -391,8 +390,6 @@ private:
   /// Pointer to the ComponentInfo object. NULL unless the instrument is
   /// associated with an ExperimentInfo object.
   boost::shared_ptr<const Beamline::ComponentInfo> m_componentInfo{nullptr};
-  /// Component ids.
-  std::vector<Geometry::ComponentID> m_componentIds;
   /// Pointer to the owning instrument for translating detector IDs into
   /// detector indices when accessing the DetectorInfo object
   const Instrument *m_instrument{nullptr};

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -1263,7 +1263,8 @@ const Beamline::ComponentInfo &Instrument::componentInfo() const {
  * @return const ref to a vector of ComponentIds. Throws a std::runtime_error if
  * Component Info not set.
  */
-const std::vector<Geometry::ComponentID> &Instrument::componentIds() const {
+boost::shared_ptr<const std::vector<Geometry::ComponentID>>
+Instrument::componentIds() const {
   if (!hasComponentInfo()) {
     throw std::runtime_error(
         "Cannot return component ids with a NULL ComponentInfo");
@@ -1284,7 +1285,7 @@ void Instrument::setDetectorInfo(
  */
 void Instrument::setComponentInfo(
     boost::shared_ptr<const Beamline::ComponentInfo> componentInfo,
-    std::vector<Geometry::ComponentID> componentIds) {
+    boost::shared_ptr<const std::vector<Geometry::ComponentID>> componentIds) {
   m_componentInfo = std::move(componentInfo);
   m_componentIds = std::move(componentIds);
 }

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1185,20 +1185,6 @@ const Beamline::ComponentInfo &ParameterMap::componentInfo() const {
   return *m_componentInfo;
 }
 
-/**
- * @brief ParameterMap::componentIds
- * @return const ref to vector of component ids. Throws a std::runtime_error if
- * the ComponentInfo has not been set.
- */
-const std::vector<Geometry::ComponentID> &ParameterMap::componentIds() const {
-  // Component ids do not make sense without a ComponentInfo
-  if (!hasComponentInfo()) {
-    throw std::runtime_error(
-        "Cannot return component ids when ComponentInfo is NULL");
-  }
-  return m_componentIds;
-}
-
 /// Only for use by Detector. Returns a detector index for a detector ID.
 size_t ParameterMap::detectorIndex(const detid_t detID) const {
   return m_instrument->detectorIndex(detID);
@@ -1212,10 +1198,8 @@ void ParameterMap::setDetectorInfo(
 
 /// Only for use by ExperimentInfo. Sets the pointer to the ComponentInfo.
 void ParameterMap::setComponentInfo(
-    boost::shared_ptr<const Beamline::ComponentInfo> componentInfo,
-    std::vector<Geometry::ComponentID> componentIds) {
+    boost::shared_ptr<const Beamline::ComponentInfo> componentInfo) {
   m_componentInfo = std::move(componentInfo);
-  m_componentIds = std::move(componentIds);
 }
 
 /// Only for use by Instrument. Sets the pointer to the owning instrument.


### PR DESCRIPTION
Recent changes around `ComponentInfo` caused some moderately expensive copies of vectors of component Ids in `ExperimentInfo::getInstrument()`. This PR replaces this with `shared_ptr` --
`ExperimentInfo::getInstrument` is slow otherwise. This is a problem, since `getInstrument` is called by `getDetector`, i.e., for every spectrum in a workspace.

**To test:**

No releated issue, but this was discovered by @VickieLynch as part of https://github.com/mantidproject/mantid/issues/19385.

No release notes, issue was introduced after last release.

Marked as high priority due to serious slowdowns in nightly builds, e.g., when opening the instrument view.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
