### PR TITLE
Fix clang-tidy warnings in Vates subdirectory.

### DIFF
--- a/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
@@ -68,7 +68,7 @@ std::string vtkMDHWNexusReader::GetInputGeometryXML() {
     return std::string();
   }
   try {
-    return m_presenter->getGeometryXML().c_str();
+    return m_presenter->getGeometryXML();
   } catch (std::runtime_error &) {
     return std::string();
   }

--- a/Vates/ParaviewPlugins/ParaViewSources/SinglePeakMarkerSource/vtkSinglePeakMarkerSource.h
+++ b/Vates/ParaviewPlugins/ParaViewSources/SinglePeakMarkerSource/vtkSinglePeakMarkerSource.h
@@ -34,8 +34,9 @@
 class VTK_EXPORT vtkSinglePeakMarkerSource : public vtkPolyDataAlgorithm {
 public:
   static vtkSinglePeakMarkerSource *New();
-  vtkSinglePeakMarkerSource(const vtkSinglePeakMarkerSource &);
-  void operator=(const vtkSinglePeakMarkerSource &);
+  vtkSinglePeakMarkerSource(const vtkSinglePeakMarkerSource &) = delete;
+  vtkSinglePeakMarkerSource &
+  operator=(const vtkSinglePeakMarkerSource &) = delete;
   // clang-format off
   vtkTypeMacro(vtkSinglePeakMarkerSource, vtkPolyDataAlgorithm)
   void PrintSelf(ostream &os, vtkIndent indent) override;

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHexFactory.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHexFactory.h
@@ -12,8 +12,6 @@
 #include <boost/shared_ptr.hpp>
 #include <vector>
 
-using Mantid::DataObjects::MDEventWorkspace;
-
 namespace Mantid {
 namespace VATES {
 
@@ -86,7 +84,8 @@ private:
       const Mantid::API::IMDEventWorkspace_sptr &imdws) const;
 
   template <typename MDE, size_t nd>
-  void doCreate(typename MDEventWorkspace<MDE, nd>::sptr ws) const;
+  void doCreate(
+      typename Mantid::DataObjects::MDEventWorkspace<MDE, nd>::sptr ws) const;
 
   /// Template Method pattern to validate the factory before use.
   void validate() const override;

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkSplatterPlotFactory.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkSplatterPlotFactory.h
@@ -15,8 +15,6 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
 
-using Mantid::DataObjects::MDEventWorkspace;
-
 namespace Mantid {
 namespace VATES {
 
@@ -90,7 +88,8 @@ public:
 
 private:
   template <typename MDE, size_t nd>
-  void doCreate(typename MDEventWorkspace<MDE, nd>::sptr ws) const;
+  void doCreate(
+      typename Mantid::DataObjects::MDEventWorkspace<MDE, nd>::sptr ws) const;
 
   /// Check if the MDHisto workspace is 3D or 4D in nature
   bool doMDHisto4D(const Mantid::API::IMDHistoWorkspace *workspace) const;

--- a/Vates/VatesAPI/src/CompositePeaksPresenterVsi.cpp
+++ b/Vates/VatesAPI/src/CompositePeaksPresenterVsi.cpp
@@ -149,7 +149,7 @@ void CompositePeaksPresenterVsi::updateWorkspaces(
  * @returns If there are any peaks availbale.
  */
 bool CompositePeaksPresenterVsi::hasPeaks() {
-  return m_peaksPresenters.size() > 0;
+  return !m_peaksPresenters.empty();
 }
 
 /**

--- a/Vates/VatesAPI/src/MDEWLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDEWLoadingPresenter.cpp
@@ -157,10 +157,9 @@ void MDEWLoadingPresenter::appendMetadata(vtkDataSet *visualDataSet,
 
   // Add metadata to dataset.
   MetadataToFieldData convert;
-  convert(outputFD.GetPointer(), xmlString,
-          XMLDefinitions::metaDataId().c_str());
+  convert(outputFD.GetPointer(), xmlString, XMLDefinitions::metaDataId());
   convert(outputFD.GetPointer(), jsonString,
-          m_vatesConfigurations->getMetadataIdJson().c_str());
+          m_vatesConfigurations->getMetadataIdJson());
   visualDataSet->SetFieldData(outputFD.GetPointer());
 }
 

--- a/Vates/VatesAPI/src/MDHWLoadingPresenter.cpp
+++ b/Vates/VatesAPI/src/MDHWLoadingPresenter.cpp
@@ -223,10 +223,9 @@ void MDHWLoadingPresenter::appendMetadata(vtkDataSet *visualDataSet,
 
   // Add metadata to dataset.
   MetadataToFieldData convert;
-  convert(outputFD.GetPointer(), xmlString,
-          XMLDefinitions::metaDataId().c_str());
+  convert(outputFD.GetPointer(), xmlString, XMLDefinitions::metaDataId());
   convert(outputFD.GetPointer(), jsonString,
-          m_vatesConfigurations->getMetadataIdJson().c_str());
+          m_vatesConfigurations->getMetadataIdJson());
   visualDataSet->SetFieldData(outputFD.GetPointer());
 }
 

--- a/Vates/VatesAPI/src/MetaDataExtractorUtils.cpp
+++ b/Vates/VatesAPI/src/MetaDataExtractorUtils.cpp
@@ -36,7 +36,7 @@ std::string MetaDataExtractorUtils::extractInstrument(
   auto histoWorkspace =
       dynamic_cast<const Mantid::API::IMDHistoWorkspace *>(workspace);
 
-  std::string instrument = "";
+  std::string instrument;
 
   // Check which workspace is currently used and that it contains at least one
   // instrument.

--- a/Vates/VatesAPI/src/vtkMDHistoHex4DFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHex4DFactory.cpp
@@ -6,8 +6,6 @@
 #include "MantidVatesAPI/vtkMDHistoHex4DFactory.h"
 #include "MantidVatesAPI/ProgressAction.h"
 
-using Mantid::API::IMDWorkspace;
-using Mantid::Kernel::CPUTimer;
 using namespace Mantid::DataObjects;
 
 namespace Mantid {

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -20,9 +20,6 @@
 
 #include <cmath>
 
-using Mantid::API::IMDWorkspace;
-using Mantid::API::IMDHistoWorkspace;
-using Mantid::Kernel::CPUTimer;
 using namespace Mantid::DataObjects;
 using Mantid::Kernel::ReadLock;
 

--- a/Vates/VatesAPI/src/vtkMDHistoLineFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoLineFactory.cpp
@@ -13,7 +13,6 @@
 #include "MantidKernel/ReadLock.h"
 #include "MantidKernel/Logger.h"
 
-using Mantid::API::IMDWorkspace;
 using Mantid::DataObjects::MDHistoWorkspace;
 using Mantid::API::NullCoordTransform;
 

--- a/Vates/VatesAPI/src/vtkMDHistoQuadFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoQuadFactory.cpp
@@ -17,7 +17,6 @@
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/make_unique.h"
 
-using Mantid::API::IMDWorkspace;
 using Mantid::Kernel::CPUTimer;
 using Mantid::DataObjects::MDHistoWorkspace;
 using Mantid::DataObjects::MDHistoWorkspaceIterator;

--- a/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
+++ b/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
@@ -517,7 +517,7 @@ void vtkSplatterPlotFactory::addMetadata() const {
     // Add metadata to dataset.
     MetadataToFieldData convert;
     convert(outputFD.GetPointer(), jsonString,
-            m_vatesConfigurations->getMetadataIdJson().c_str());
+            m_vatesConfigurations->getMetadataIdJson());
     dataSet->SetFieldData(outputFD.GetPointer());
   }
 }
@@ -533,18 +533,16 @@ void vtkSplatterPlotFactory::setMetadata(vtkFieldData *fieldData,
   // the dataset
   FieldDataToMetadata convertFtoM;
   std::string xmlString = convertFtoM(fieldData, XMLDefinitions::metaDataId());
-  std::string jsonString =
-      convertFtoM(dataSet->GetFieldData(),
-                  m_vatesConfigurations->getMetadataIdJson().c_str());
+  std::string jsonString = convertFtoM(
+      dataSet->GetFieldData(), m_vatesConfigurations->getMetadataIdJson());
 
   // Create a new field data array
   MetadataToFieldData convertMtoF;
   vtkNew<vtkFieldData> outputFD;
   outputFD->ShallowCopy(fieldData);
-  convertMtoF(outputFD.GetPointer(), xmlString,
-              XMLDefinitions::metaDataId().c_str());
+  convertMtoF(outputFD.GetPointer(), xmlString, XMLDefinitions::metaDataId());
   convertMtoF(outputFD.GetPointer(), jsonString,
-              m_vatesConfigurations->getMetadataIdJson().c_str());
+              m_vatesConfigurations->getMetadataIdJson());
   dataSet->SetFieldData(outputFD.GetPointer());
 }
 

--- a/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/RebinnedSourcesManager.cpp
@@ -67,7 +67,7 @@ void RebinnedSourcesManager::addHandle(const std::string &workspaceName,
                                        Mantid::API::Workspace_sptr workspace) {
   // Check if the workspace which has experienced a change is being tracked in
   // our buffer
-  if (m_newWorkspacePairBuffer.size() == 0) {
+  if (m_newWorkspacePairBuffer.empty()) {
     return;
   }
 
@@ -212,7 +212,7 @@ void RebinnedSourcesManager::repipeRebinnedSource() {
   // e.g. when changing from BinMD to SliceMD, then we need to untrack the old,
   // rebinned
   // workspace
-  if (m_newRebinnedWorkspacePairBuffer.size() > 0) {
+  if (!m_newRebinnedWorkspacePairBuffer.empty()) {
     untrackWorkspaces(createKeyPairForSource(m_inputSource));
   }
 
@@ -257,7 +257,7 @@ void RebinnedSourcesManager::swapSources(pqPipelineSource *src1,
 
   // Check if the original source has a filter if such then repipe otherwise we
   // are done
-  if ((src1->getAllConsumers()).size() <= 0) {
+  if (src1->getAllConsumers().empty()) {
     // Need to press apply to finalize the internal setup of the source.
     // emit triggerAcceptForNewFilters();
     return;
@@ -767,7 +767,7 @@ void RebinnedSourcesManager::deleteSpecificSource(pqPipelineSource *source) {
     // Go to the end of the source and work your way back
     pqPipelineSource *tempSource = source;
 
-    while ((tempSource->getAllConsumers()).size() > 0) {
+    while (!tempSource->getAllConsumers().empty()) {
       tempSource = tempSource->getConsumer(0);
     }
 


### PR DESCRIPTION
Description of work.

This addresses several clang-tidy warnings in the Vates subdirectory. Most are harmless, though removing using directives in header files is important.

http://builds.mantidproject.org/view/Static%20Analysis/job/clang_tidy_vates/

**To test:**

<!-- Instructions for testing. -->

Code review is sufficient.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
