### PR TITLE
Allow event-mode monitors in reductions for ISIS SANS

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -227,6 +227,9 @@ private:
   QString saveBatchGrid(const QString &filename = "");
   /// Check that the workspace can have the zero errors removed
   bool isValidWsForRemovingZeroErrors(QString &originalWorkspaceName);
+  /// Set the monitor as event
+  void setLoadingOfMonitorsAsEventIfRequired();
+
   //@}
 public slots:
   /// apply mask

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
@@ -730,7 +730,7 @@
               </widget>
              </item>
              <item row="1" column="0">
-              <widget class="QCheckBox" name="checkBox">
+              <widget class="QCheckBox" name="monitor_as_event_checkbox">
                <property name="text">
                 <string>Monitors 
 as event</string>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1022</width>
+    <width>1086</width>
     <height>632</height>
    </rect>
   </property>
@@ -257,7 +257,7 @@
            <item>
             <widget class="QRadioButton" name="single_mode_btn">
              <property name="text">
-              <string>Single run mode</string>
+              <string>S&amp;ingle run mode</string>
              </property>
              <property name="checked">
               <bool>true</bool>
@@ -729,6 +729,14 @@
                </property>
               </widget>
              </item>
+             <item row="1" column="0">
+              <widget class="QCheckBox" name="checkBox">
+               <property name="text">
+                <string>Monitors 
+as event</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>
@@ -814,16 +822,6 @@
                </property>
               </widget>
              </item>
-             <item row="3" column="7">
-              <widget class="QCheckBox" name="saveCan_check">
-               <property name="toolTip">
-                <string>Select one or more file formats</string>
-               </property>
-               <property name="text">
-                <string>CanSAS  (1D)</string>
-               </property>
-              </widget>
-             </item>
              <item row="4" column="0">
               <widget class="QCheckBox" name="zeroErrorCheckBox">
                <property name="toolTip">
@@ -904,6 +902,16 @@ The NXcanSAS format can be used to save 1D and 2D data. </string>
                 </size>
                </property>
               </spacer>
+             </item>
+             <item row="3" column="7">
+              <widget class="QCheckBox" name="saveCan_check">
+               <property name="toolTip">
+                <string>Select one or more file formats</string>
+               </property>
+               <property name="text">
+                <string>CanSAS  (1D)</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </widget>

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -2443,7 +2443,7 @@ void SANSRunWindow::handleReduceButtonClick(const QString &typeStr) {
 
   if (!entriesAreValid(RUN)) {
     return;
-  }  
+  }
 
   QString py_code;
 
@@ -5143,10 +5143,10 @@ void SANSRunWindow::setLoadingOfMonitorsAsEventIfRequired() {
   // Check if the monitor is to be treated as event mode data
   auto doLoadMonitorAsEvent = m_uiForm.monitor_as_event_checkbox->isChecked();
   QString monitorAsEvent = doLoadMonitorAsEvent ? "True" : "False";
-  QString loadMonitorAsEvent = "i.set_monitor_as_event(" +monitorAsEvent + ")\n";
+  QString loadMonitorAsEvent =
+      "i.set_monitor_as_event(" + monitorAsEvent + ")\n";
   runPythonCode(loadMonitorAsEvent, false);
 }
-
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -2039,6 +2039,9 @@ bool SANSRunWindow::handleLoadButtonClick() {
     return false;
   }
 
+  // Set the handling of event monitors
+  setLoadingOfMonitorsAsEventIfRequired();
+
   QString error;
   // set the detector just before loading so to correctly move the instrument
   runReduceScriptFunction("\ni.ReductionSingleton().instrument.setDetector('" +
@@ -2440,7 +2443,7 @@ void SANSRunWindow::handleReduceButtonClick(const QString &typeStr) {
 
   if (!entriesAreValid(RUN)) {
     return;
-  }
+  }  
 
   QString py_code;
 
@@ -2455,6 +2458,9 @@ void SANSRunWindow::handleReduceButtonClick(const QString &typeStr) {
                        "reduction code, please check installation.");
     return;
   }
+
+  // Set the handling of event monitors
+  setLoadingOfMonitorsAsEventIfRequired();
 
   const static QString PYTHON_SEP("C++handleReduceButtonClickC++");
 
@@ -5132,6 +5138,15 @@ void SANSRunWindow::onUpdateGeometryRequest() {
   emit sendGeometryInformation(geometryName, sampleHeight, sampleWidth,
                                sampleThickness);
 }
+
+void SANSRunWindow::setLoadingOfMonitorsAsEventIfRequired() {
+  // Check if the monitor is to be treated as event mode data
+  auto doLoadMonitorAsEvent = m_uiForm.monitor_as_event_checkbox->isChecked();
+  QString monitorAsEvent = doLoadMonitorAsEvent ? "True" : "False";
+  QString loadMonitorAsEvent = "i.set_monitor_as_event(" +monitorAsEvent + ")\n";
+  runPythonCode(loadMonitorAsEvent, false);
+}
+
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/docs/source/release/v3.10.0/sans.rst
+++ b/docs/source/release/v3.10.0/sans.rst
@@ -5,6 +5,10 @@ SANS Changes
 .. contents:: Table of Contents
    :local:
 
+Features
+--------
+- Add functionality to handle event-mode monitors. This can be used to perform time slicing of the transission measurement.
+
 Bug Fixes
 ---------
 - Fixed wrong first spectrum number for LARMOR. The first non-monitor spectrum number is 11, but it had been set to 10.

--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -1820,6 +1820,16 @@ def get_current_idf_path_in_reducer():
     return idf_path_reducer
 
 
+def set_monitor_as_event(load_monitors_as_events=False):
+    ReductionSingleton().load_monitors_as_events = load_monitors_as_events
+
+
+def get_monitor_as_event():
+    load_monitors_as_events = ReductionSingleton().load_monitors_as_events
+    print(str(load_monitors_as_events))
+    return load_monitors_as_events
+
+
 ##################### Accesor functions for BackgroundCorrection
 def set_background_correction(run_number, is_time_based, is_mon, is_mean, mon_numbers=None):
     '''

--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -40,6 +40,7 @@ except ImportError:
 
 _VERBOSE_ = False
 LAST_SAMPLE = None
+TRANSMISSION_SUFFIX = "_transmissions"
 
 
 def SetVerboseMode(state):
@@ -677,9 +678,20 @@ def _WavRangeReduction(name_suffix=None):
             if group_name[-2] == "_":
                 group_name = group_name[:-2]
             _group_workspaces(slices, group_name)
+
+            # Group the transmission slices if required
+            if ReductionSingleton().has_time_sliced_transmissions():
+                group_name_transmissions = group_name + TRANSMISSION_SUFFIX
+                ReductionSingleton().group_transmission_slices(group_name_transmissions)
+
             return group_name
         else:
-            return ReductionSingleton()._reduce()
+            reduced_workspace_name = ReductionSingleton()._reduce()
+            if ReductionSingleton().has_time_sliced_transmissions():
+                # Note that a time slice over the full time is also a time slice
+                group_name_transmissions = reduced_workspace_name + TRANSMISSION_SUFFIX
+                ReductionSingleton().group_transmission_slices(group_name_transmissions)
+            return reduced_workspace_name
 
     result = ""
     if ReductionSingleton().get_sample().loader.periods_in_file == 1:

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -102,8 +102,6 @@ class SkipReduction(RuntimeError):
     pass
 
 
-
-
 def addRunToStore(parts, run_store):
     """ Add a CSV line to the input data store (run_store)
         @param parts: the parts of a CSV line

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -34,11 +34,12 @@ from __future__ import (absolute_import, division, print_function)
 from ISISCommandInterface import *
 import SANSUtility as su
 from mantid.simpleapi import *
-from mantid.api import WorkspaceGroup
+from mantid.api import WorkspaceGroup, AnalysisDataService, FileFinder
 from mantid.kernel import Logger
 import copy
 import sys
 import re
+import os
 from reduction_settings import REDUCTION_SETTINGS_OBJ_NAME
 from isis_reduction_steps import UserFile
 sanslog = Logger("SANS")
@@ -99,6 +100,8 @@ class SkipEntry(RuntimeError):
 
 class SkipReduction(RuntimeError):
     pass
+
+
 
 
 def addRunToStore(parts, run_store):
@@ -277,6 +280,7 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},
             # wavelength range where the final argument can either be
             # DefaultTrans or CalcTrans:
             reduced = WavRangeReduction(combineDet=combineDet, out_fit_settings=scale_shift)
+            old_reduced_workspace_name = reduced
 
         except SkipEntry as reason:
             #this means that a load step failed, the warning and the fact that the results aren't there is enough for the user
@@ -344,7 +348,10 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},
 
         file = run['output_as']
         #saving if optional and doesn't happen if the result workspace is left blank. Is this feature used?
+        transmission_outputter = TransmissionOutputter(old_workspace_name=old_reduced_workspace_name,
+                                                       new_workspace_name=final_name)
         if file:
+            transmission_outputter.save_transmission()
             save_names = []
             for n in names:
                 w = mtd[n]
@@ -392,7 +399,8 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},
             # If we performed a zero-error correction, then we should get rid of the cloned workspaces
             if save_as_zero_error_free:
                 delete_cloned_workspaces(save_names_dict)
-
+        else:
+            transmission_outputter.dont_save_transmission()
         if plotresults == 1:
             for final_name in names:
                 PlotResult(final_name)
@@ -597,3 +605,66 @@ def sanitize_name(filename):
     # ensure that most user selections are supported
     keepcharacters = (' ','.','_')
     return "".join(c for c in filename if c.isalnum() or c in keepcharacters).rstrip()
+
+
+class TransmissionWorkspaceProvider(object):
+    def __init__(self, original_name):
+        super(TransmissionWorkspaceProvider, self).__init__()
+        self._original_transmission_name = original_name + TRANSMISSION_SUFFIX
+
+    @staticmethod
+    def _get_transmission_workspace_name(transmission_workspace_name):
+        if AnalysisDataService.doesExist(transmission_workspace_name):
+            transmission_workspace = AnalysisDataService.retrieve(transmission_workspace_name)
+            return transmission_workspace
+        return None
+
+    def get_renamed_transmission_workspace(self, new_name):
+        transmission_workspace = self._get_transmission_workspace_name(self._original_transmission_name)
+        new_transmission_name = new_name + TRANSMISSION_SUFFIX
+        if transmission_workspace:
+            if self._original_transmission_name != new_transmission_name:
+                RenameWorkspace(InputWorkspace=transmission_workspace, OutputWorkspace=new_transmission_name)
+            return new_transmission_name
+
+        return None
+
+
+class TransmissionOutputter(object):
+    def __init__(self, old_workspace_name, new_workspace_name):
+        super(TransmissionOutputter, self).__init__()
+        self._old_workspace_name = old_workspace_name
+        self._new_workspace_name = new_workspace_name
+
+    @staticmethod
+    def _remove_if_file_already_exists(file_name):
+        # If it is a full file path remove it
+        if os.path.exists(file_name):
+            os.remove(file_name)
+        else:
+            full_file_path = FileFinder.getFullPath(file_name)
+            if full_file_path is not None and os.path.exists(full_file_path):
+                os.remove(full_file_path)
+
+    def save_transmission(self):
+        transmission_provider = TransmissionWorkspaceProvider(original_name=self._old_workspace_name)
+        new_transmission_workspace_name = transmission_provider.get_renamed_transmission_workspace(
+            self._new_workspace_name)
+
+        if new_transmission_workspace_name is not None:
+            # Store as RKH
+            file_name_rkh = new_transmission_workspace_name + ".txt"
+            self._remove_if_file_already_exists(file_name_rkh)
+
+            # Store as processed Nexus
+            file_name_nexus = new_transmission_workspace_name + ".nxs"
+            self._remove_if_file_already_exists(file_name_nexus)
+
+            transmission_workspace = AnalysisDataService.retrieve(new_transmission_workspace_name)
+
+            SaveRKH(InputWorkspace=transmission_workspace, Filename=file_name_rkh, Append=True)
+            SaveNexus(InputWorkspace=transmission_workspace, Filename=file_name_nexus, Append=True)
+
+    def dont_save_transmission(self):
+        transmission_provider = TransmissionWorkspaceProvider(original_name=self._old_workspace_name)
+        _ = transmission_provider.get_renamed_transmission_workspace(self._new_workspace_name)  # noqa

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -296,18 +296,28 @@ def fromEvent2Histogram(ws_event, ws_monitor, binning = ""):
 
     name = '__monitor_tmp'
 
-    if binning != "":
-        aux_hist = Rebin(ws_event, binning, False)
-        Rebin(ws_monitor, binning, False, OutputWorkspace=name)
+    # Two scenarios can appear here:
+    # 1. The monitor is a histogram-mode workspace.
+    # 2. The monitor is an event worspace
+
+    if isinstance(ws_monitor, IEventWorkspace):
+        if binning != "":
+            aux_hist = Rebin(ws_event, binning, False)
+            Rebin(ws_monitor, binning, False, OutputWorkspace=name)
+        else:
+            raise RuntimeError("Cannot provide binning from event monitor workspace. "
+                               "Make sure that Eventstime has been set.")
     else:
-        aux_hist = RebinToWorkspace(ws_event, ws_monitor, False)
-        ws_monitor.clone(OutputWorkspace=name)
+        if binning != "":
+            aux_hist = Rebin(ws_event, binning, False)
+            Rebin(ws_monitor, binning, False, OutputWorkspace=name)
+        else:
+            aux_hist = RebinToWorkspace(ws_event, ws_monitor, False)
+            ws_monitor.clone(OutputWorkspace=name)
 
     ConjoinWorkspaces(name, aux_hist, CheckOverlapping=True)
     CopyInstrumentParameters(ws_event, OutputWorkspace=name)
-
     ws_hist = RenameWorkspace(name, OutputWorkspace=str(ws_event))
-
     return ws_hist
 
 
@@ -365,12 +375,60 @@ def slice2histogram(ws_event, time_start, time_stop, monitor, binning=""):
 
     sliced_ws = sliceByTimeWs(ws_event, time_start, time_stop)
     sliced_ws = RenameWorkspace(sliced_ws, OutputWorkspace=ws_event.name())
-
     part_c, part_t = getChargeAndTime(sliced_ws)
-    scaled_monitor = monitor * (part_c/tot_c)
+
+    # If the monitor is an event workspace then we need to slice it too
+    if isinstance(monitor, IEventWorkspace):
+        scaled_monitor = sliceByTimeWs(monitor, time_start, time_stop)
+    else:
+        scaled_monitor = monitor * (part_c/tot_c)
 
     hist = fromEvent2Histogram(sliced_ws, scaled_monitor, binning)
     return hist, (tot_t, tot_c, part_t, part_c)
+
+
+def get_slice_parameters(reducer):
+    if not reducer.is_can():
+        start_slice_time, stop_slice_time = reducer.getCurrSliceLimit()
+    else:
+        start_slice_time = -1
+        stop_slice_time = -1
+
+    if "events.binning" in reducer.settings:
+        binning = reducer.settings["events.binning"]
+    else:
+        raise RuntimeError("Cannot provide binning from event monitor workspace. "
+                           "Make sure that Eventstime has been set.")
+    return binning, start_slice_time, stop_slice_time
+
+
+def get_sliced_monitor(reducer, monitor, do_scale=True):
+    if isinstance(monitor, IEventWorkspace):
+        binning, start_slice_time, stop_slice_time = get_slice_parameters(reducer)
+        _, tot_t = getChargeAndTime(monitor)
+
+        # If no slice is required then return the monitor
+        if (start_slice_time == -1) and (stop_slice_time == -1):
+            monitor_workspace_name = monitor.name()
+            Rebin(InputWorkspace=monitor, Params=binning, PreserveEvents=False, OutputWorkspace=monitor_workspace_name)
+            return mtd[monitor_workspace_name]
+
+        # If only one of them is odd, then reset it
+        if start_slice_time == -1:
+            start_slice_time = 0.0
+        if stop_slice_time == -1:
+            stop_slice_time = tot_t + 0.001
+
+        original_monitor_name = monitor.name()
+        sliced_ws = sliceByTimeWs(monitor, start_slice_time, stop_slice_time)
+        sliced_ws_name = sliced_ws.name()
+        Rebin(InputWorkspace=sliced_ws, Params=binning, PreserveEvents=False, OutputWorkspace=sliced_ws_name)
+        RenameWorkspace(mtd[sliced_ws_name], OutputWorkspace=original_monitor_name)
+        return mtd[original_monitor_name]
+    else:
+        if reducer.event2hist.scale != 1 and do_scale:
+            monitor *= reducer.event2hist.scale
+        return monitor
 
 
 def sliceParser(str_to_parser):

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -427,7 +427,7 @@ def get_sliced_monitor(reducer, monitor, do_scale=True):
         RenameWorkspace(mtd[sliced_ws_name], OutputWorkspace=original_monitor_name)
         return mtd[original_monitor_name]
     else:
-        if reducer.event2hist.scale != 1 and do_scale:
+        if reducer.event2hist.scale != 1. and do_scale:
             monitor *= reducer.event2hist.scale
         return monitor
 

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -384,6 +384,7 @@ def slice2histogram(ws_event, time_start, time_stop, monitor, binning=""):
         scaled_monitor = monitor * (part_c/tot_c)
 
     hist = fromEvent2Histogram(sliced_ws, scaled_monitor, binning)
+    DeleteWorkspace(Workspace=scaled_monitor)
     return hist, (tot_t, tot_c, part_t, part_c)
 
 

--- a/scripts/SANS/isis_reducer.py
+++ b/scripts/SANS/isis_reducer.py
@@ -416,12 +416,11 @@ class ISISReducer(Reducer):
                self.transmission_fitted_slices_sample or self.transmission_fitted_slices_can  # noqa
 
     def group_transmission_slices(self, group_name):
-        # If the Workspace Group already exists then we delete the child workspaces and add the new transmission
-        # workspaces to it.
+        # If the Workspace Group already exists then we un-group the workspace. This leaves the child workspaces around
         if AnalysisDataService.doesExist(group_name):
             group_ws = AnalysisDataService.retrieve(group_name)
 
-            # If the workspace is not a workspace group then we might be overriding important data, so don't do anything
+            # If the workspace is not a WorkspaceGroup then we might be overriding important data, so don't do anything
             # but provide a log
             if not isinstance(group_ws, WorkspaceGroup):
                 logger.warning("There is a non-WorkspaceGroup workspace in the ADS with the name {}. This was going to"
@@ -429,10 +428,8 @@ class ISISReducer(Reducer):
                                "aborted. To avoid this message, rename your workspace.".format(group_name))
                 return
 
-            # Delete all sub workspaces
-            sub_workspace_names = group_ws.getNames()
-            for element in sub_workspace_names:
-                AnalysisDataService.remove(element)
+            # Ungroup the WorkspaceGroup
+            UnGroupWorkspace(InputWorkspace=group_ws)
 
         # Add the workspaces to the group workspace
         workspaces_to_add = []

--- a/scripts/SANS/isis_reducer.py
+++ b/scripts/SANS/isis_reducer.py
@@ -388,7 +388,7 @@ class ISISReducer(Reducer):
         self._unwrap_monitors = False
 
         # Load monitors as event
-        self.load_monitors_as_events = True
+        self.load_monitors_as_events = False
 
     def set_instrument(self, configuration):
         """

--- a/scripts/SANS/isis_reducer.py
+++ b/scripts/SANS/isis_reducer.py
@@ -413,7 +413,7 @@ class ISISReducer(Reducer):
 
     def has_time_sliced_transmissions(self):
         return self.transmission_unfitted_slices_sample or self.transmission_unfitted_slices_can or\
-        self.transmission_fitted_slices_sample or self.transmission_fitted_slices_can  # no qa
+               self.transmission_fitted_slices_sample or self.transmission_fitted_slices_can  # noqa
 
     def group_transmission_slices(self, group_name):
         # If the Workspace Group already exists then we delete the child workspaces and add the new transmission

--- a/scripts/SANS/isis_reducer.py
+++ b/scripts/SANS/isis_reducer.py
@@ -387,6 +387,9 @@ class ISISReducer(Reducer):
         # Unwrap monitors
         self._unwrap_monitors = False
 
+        # Load monitors as event
+        self.load_monitors_as_events = True
+
     def set_instrument(self, configuration):
         """
             Sets the instrument and put in the default beam center (usually the
@@ -989,3 +992,11 @@ class ISISReducer(Reducer):
         self._unwrap_monitors = value
 
     unwrap_monitors = property(get_unwrap_monitors, set_unwrap_monitors, None, None)
+
+    def get_load_monitors_as_events(self):
+        return self.load_monitors_as_events
+
+    def set_load_monitors_as_events(self, value):
+        self.load_monitors_as_events = value
+
+    load_monitors_as_event = property(get_load_monitors_as_events, set_load_monitors_as_events, None, None)

--- a/scripts/SANS/isis_reducer.py
+++ b/scripts/SANS/isis_reducer.py
@@ -389,6 +389,65 @@ class ISISReducer(Reducer):
 
         # Load monitors as event
         self.load_monitors_as_events = False
+        self.transmission_unfitted_slices_sample = []
+        self.transmission_unfitted_slices_can = []
+        self.transmission_fitted_slices_sample = []
+        self.transmission_fitted_slices_can = []
+
+    def record_transmission_workspaces(self, fitted, unfitted, is_fitting_off):
+        """
+        Get a handle on the transmission workspaces if the transmissions are provided in event mode.
+        @param fitted: the fitted workspace
+        @param unfitted: the unfitted workspace
+        @param is_fitting_off: a flag which tells us if the fitted workspace has been produced
+        """
+        if self.load_monitors_as_event:
+            if self.is_can():
+                if not is_fitting_off:
+                    self.transmission_fitted_slices_can.append(fitted)
+                self.transmission_unfitted_slices_can.append(unfitted)
+            else:
+                if not is_fitting_off:
+                    self.transmission_fitted_slices_sample.append(fitted)
+                self.transmission_fitted_slices_sample.append(unfitted)
+
+    def has_time_sliced_transmissions(self):
+        return self.transmission_unfitted_slices_sample or self.transmission_unfitted_slices_can or\
+        self.transmission_fitted_slices_sample or self.transmission_fitted_slices_can  # no qa
+
+    def group_transmission_slices(self, group_name):
+        # If the Workspace Group already exists then we delete the child workspaces and add the new transmission
+        # workspaces to it.
+        if AnalysisDataService.doesExist(group_name):
+            group_ws = AnalysisDataService.retrieve(group_name)
+
+            # If the workspace is not a workspace group then we might be overriding important data, so don't do anything
+            # but provide a log
+            if not isinstance(group_ws, WorkspaceGroup):
+                logger.warning("There is a non-WorkspaceGroup workspace in the ADS with the name {}. This was going to"
+                               " be used for grouping time sliced transmission workspaces. The grouping has been "
+                               "aborted. To avoid this message, rename your workspace.".format(group_name))
+                return
+
+            # Delete all sub workspaces
+            sub_workspace_names = group_ws.getNames()
+            for element in sub_workspace_names:
+                AnalysisDataService.remove(element)
+
+        # Add the workspaces to the group workspace
+        workspaces_to_add = []
+        workspaces_to_add.extend(self.transmission_fitted_slices_sample)
+        workspaces_to_add.extend(self.transmission_unfitted_slices_sample)
+        workspaces_to_add.extend(self.transmission_fitted_slices_can)
+        workspaces_to_add.extend(self.transmission_unfitted_slices_can)
+        if workspaces_to_add:
+            GroupWorkspaces(InputWorkspaces=workspaces_to_add, OutputWorkspace=group_name)
+
+        # Reset the transmission workspace caches
+        self.transmission_fitted_slices_sample = []
+        self.transmission_unfitted_slices_sample = []
+        self.transmission_fitted_slices_can = []
+        self.transmission_unfitted_slices_can = []
 
     def set_instrument(self, configuration):
         """
@@ -470,13 +529,15 @@ class ISISReducer(Reducer):
         name += '_' + self.to_wavelen.get_range()
         name += self.mask.get_phi_limits_tag()
 
+        return self.add_slice_suffix(name)
+
+    def add_slice_suffix(self, name):
         if self.getNumSlices() > 0:
             limits = self.getCurrSliceLimit()
             if limits[0] != -1:
                 name += '_t%.2f' % limits[0]
             if limits[1] != -1:
                 name += '_T%.2f' % limits[1]
-
         return name
 
     # pylint: disable=global-statement

--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -25,7 +25,7 @@ from SANSUtility import (GetInstrumentDetails, MaskByBinRange,
                          extract_child_ws_for_added_eventdata, load_monitors_for_multiperiod_event_data,
                          MaskWithCylinder, get_masked_det_ids, get_masked_det_ids_from_mask_file, INCIDENT_MONITOR_TAG,
                          can_load_as_event_workspace, is_convertible_to_float, correct_q_resolution_for_can,
-                         is_valid_user_file_extension, ADD_TAG)
+                         is_valid_user_file_extension, ADD_TAG, get_sliced_monitor)
 import DarkRunCorrection as DarkCorr
 
 import SANSUserFileParser as UserFileParser
@@ -118,11 +118,11 @@ class LoadRun(object):
 
     wksp_name = property(get_wksp_name, None, None, None)
 
-    def _load_transmission(self, inst=None, is_can=False, extra_options=None):
+    def _load_transmission(self, inst=None, is_can=False, extra_options=None, load_monitors_as_events=False):
         if extra_options is None:
             extra_options = dict()
         if '.raw' in self._data_file or '.RAW' in self._data_file:
-            self._load(inst, is_can, extra_options)
+            self._load(inst, is_can, extra_options, load_monitors_as_events=False)
             return
 
         # the intention of the code below is a good idea. Hence the reason why
@@ -134,7 +134,7 @@ class LoadRun(object):
         # change the code below which is not commented out can be deleted and
         # the code commented out can be uncomment and modified as necessary
 
-        self._load(inst, is_can, extra_options)
+        self._load(inst, is_can, extra_options, load_monitors_as_events=load_monitors_as_events)
 
         workspace = self._get_workspace_name()
         if workspace in mtd:
@@ -157,12 +157,27 @@ class LoadRun(object):
                     # except:
                     # self._load(inst, is_can, extra_options)
 
-    def _load(self, inst=None, is_can=False, extra_options=None):
+    def _load_event_workspace_with_monitors_as_event(self, extra_options):
+        """
+        Since LoadNexusMonitors does not work with event-based monitors we need
+        to load the data and the monitors together
+
+        @param extra_options: a dictionary with extra options
+        """
+        extra_options['LoadMonitors'] = True
+        extra_options['MonitorsAsEvents'] = True
+        extra_options['LoadEventMonitors'] = True
+        extra_options['LoadHistoMonitors'] = True
+        output_load_returns = Load(self._data_file, **extra_options)
+        return output_load_returns.OutputWorkspace
+
+    def _load(self, inst=None, is_can=False, extra_options=None, load_monitors_as_events=False):
         """
             Load a workspace and read the logs into the passed instrument reference
             @param inst: a reference to the current instrument
             @param iscan: set this to True for can runs
             @param extra_options: arguments to pass on to the Load Algorithm.
+            @param load_monitors_as_events: if the monitors are to be loaded as event data.
             @return: number of periods in the workspace
         """
         if extra_options is None:
@@ -176,41 +191,47 @@ class LoadRun(object):
 
         extra_options['OutputWorkspace'] = workspace
 
-        outWs = Load(self._data_file, **extra_options)
-
+        # During loading we distinguish between
+        # data sets where we explicitly want to load the monitors as events
+        # and all other configurations.
         appendix = "_monitors"
-
-        # We need to check if we are dealing with a group workspace which is made up of added event data. Note that
-        # we can also have a group workspace which is associated with period data, which don't want to deal with here.
-        added_event_data_flag = False
-        if isinstance(outWs, WorkspaceGroup) and check_child_ws_for_name_and_type_for_added_eventdata(outWs):
-            extract_child_ws_for_added_eventdata(outWs, appendix)
-            added_event_data_flag = True
-            # Reload the outWs, it has changed from a group workspace to an event workspace
-            outWs = mtd[workspace]
-
         monitor_ws_name = workspace + appendix
 
-        # Handle simple EventWorkspace data
-        if not added_event_data_flag:
-            if isinstance(outWs, IEventWorkspace):
-                try:
-                    LoadNexusMonitors(self._data_file, OutputWorkspace=monitor_ws_name)
-                except ValueError as details:
-                    sanslog.warning('The file does not contain monitors. \n' +
-                                    'The normalization might behave differently than you expect.\n'
-                                    ' Further details: ' + str(details) + '\n')
-            else:
-                if monitor_ws_name in mtd:
-                    DeleteWorkspace(monitor_ws_name)
+        if load_monitors_as_events:
+            outWs = self._load_event_workspace_with_monitors_as_event(extra_options)
+        else:
+            outWs = Load(self._data_file, **extra_options)
 
-        # Handle Multi-period Event data
-        if not added_event_data_flag:
-            if isinstance(outWs, WorkspaceGroup) and len(outWs) > 0 and check_child_ws_for_name_and_type_for_added_eventdata(outWs):
-                pass
-            elif isinstance(outWs, WorkspaceGroup) and len(outWs) > 0 and isinstance(outWs[0], IEventWorkspace):
-                load_monitors_for_multiperiod_event_data(workspace=outWs, data_file=self._data_file,
-                                                         monitor_appendix=appendix)
+            # We need to check if we are dealing with a group workspace which is made up of added event data. Note that
+            # we can also have a group workspace which is associated with period data, which don't want to deal with here.
+            added_event_data_flag = False
+            if isinstance(outWs, WorkspaceGroup) and check_child_ws_for_name_and_type_for_added_eventdata(outWs):
+                extract_child_ws_for_added_eventdata(outWs, appendix)
+                added_event_data_flag = True
+                # Reload the outWs, it has changed from a group workspace to an event workspace
+                outWs = mtd[workspace]
+
+
+            # Handle simple EventWorkspace data
+            if not added_event_data_flag:
+                if isinstance(outWs, IEventWorkspace):
+                    try:
+                        LoadNexusMonitors(self._data_file, OutputWorkspace=monitor_ws_name)
+                    except ValueError as details:
+                        sanslog.warning('The file does not contain monitors. \n' +
+                                        'The normalization might behave differently than you expect.\n'
+                                        ' Further details: ' + str(details) + '\n')
+                else:
+                    if monitor_ws_name in mtd:
+                        DeleteWorkspace(monitor_ws_name)
+
+            # Handle Multi-period Event data
+            if not added_event_data_flag:
+                if isinstance(outWs, WorkspaceGroup) and len(outWs) > 0 and check_child_ws_for_name_and_type_for_added_eventdata(outWs):
+                    pass
+                elif isinstance(outWs, WorkspaceGroup) and len(outWs) > 0 and isinstance(outWs[0], IEventWorkspace):
+                    load_monitors_for_multiperiod_event_data(workspace=outWs, data_file=self._data_file,
+                                                             monitor_appendix=appendix)
 
         loader_name = ''
         try:
@@ -331,14 +352,16 @@ class LoadRun(object):
 
         try:
             if self._is_trans and reducer.instrument.name() != 'LOQ':
-                # Unfortunatelly, LOQ in transmission acquire 3 monitors the 3 monitor usually
+                # Unfortunately LOQ in transmission acquire 3 monitors the 3 monitor usually
                 # is the first spectrum for detector. This causes the following method to fail
                 # when it tries to load only monitors. Hence, we are forced to skip this method
                 # for LOQ. ticket #8559
-                self._load_transmission(reducer.instrument, extra_options=spectrum_limits)
+                self._load_transmission(reducer.instrument, extra_options=spectrum_limits,
+                                        load_monitors_as_events=reducer.load_monitors_as_events)
             else:
                 # the spectrum_limits is not the default only for transmission data
-                self._load(reducer.instrument, extra_options=spectrum_limits)
+                self._load(reducer.instrument, extra_options=spectrum_limits,
+                           load_monitors_as_events=reducer.load_monitors_as_events)
         except RuntimeError as details:
             sanslog.warning(str(details))
             self._wksp_name = ''
@@ -1909,6 +1932,10 @@ class CropDetBank(ReductionStep):
             monitor_ws = reducer.get_sample().get_monitor()
             monitor_name = monitor_ws.name()
 
+            if isinstance(monitor_ws, IEventWorkspace):
+                raise RuntimeError("The dark run subtraction cannot handle monitor event workspaces yet. "
+                                   "Please contact a developer.")
+
             # Run the subtraction
             was_event_workspace = reducer.is_based_on_event()
             scatter_ws, monitor_ws = reducer.dark_run_subtraction.execute(scatter_ws, monitor_ws,
@@ -1945,9 +1972,9 @@ class NormalizeToMonitor(ReductionStep):
             normalization_spectrum = reducer.instrument.get_incident_mon()
 
         sanslog.notice('Normalizing to monitor ' + str(normalization_spectrum))
-
         self.output_wksp = str(workspace) + INCIDENT_MONITOR_TAG
         mon = reducer.get_sample().get_monitor(normalization_spectrum - 1)
+        mon = get_sliced_monitor(reducer, mon)
 
         # Unwrap the monitors of the scatter workspace
         if reducer.unwrap_monitors:
@@ -1955,9 +1982,6 @@ class NormalizeToMonitor(ReductionStep):
             temp_mon = UnwrapMonitorsInTOF(InputWorkspace=mon, WavelengthMin=wavelength_min, WavelengthMax=wavelength_max)
             DeleteWorkspace(mon)
             mon = temp_mon
-
-        if reducer.event2hist.scale != 1:
-            mon *= reducer.event2hist.scale
 
         if str(mon) != self.output_wksp:
             RenameWorkspace(mon, OutputWorkspace=self.output_wksp)
@@ -2148,6 +2172,9 @@ class TransmissionCalc(ReductionStep):
         # that we have to exclude unused spectra as the interpolation runs into
         # problems if we don't.
         extract_spectra(mtd[inputWS], trans_det_ids, tmpWS)
+
+        # Get the sliced version of the transmission/direct workspace
+        _ = get_sliced_monitor(reducer, mtd[tmpWS], do_scale=False)
 
         # If the transmission and direct workspaces require an unwrapping of the monitors then do it here
         if reducer.unwrap_monitors:

--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -211,7 +211,6 @@ class LoadRun(object):
                 # Reload the outWs, it has changed from a group workspace to an event workspace
                 outWs = mtd[workspace]
 
-
             # Handle simple EventWorkspace data
             if not added_event_data_flag:
                 if isinstance(outWs, IEventWorkspace):
@@ -2174,7 +2173,7 @@ class TransmissionCalc(ReductionStep):
         extract_spectra(mtd[inputWS], trans_det_ids, tmpWS)
 
         # Get the sliced version of the transmission/direct workspace
-        _ = get_sliced_monitor(reducer, mtd[tmpWS], do_scale=False)
+        _ = get_sliced_monitor(reducer, mtd[tmpWS], do_scale=False)  # noqa
 
         # If the transmission and direct workspaces require an unwrapping of the monitors then do it here
         if reducer.unwrap_monitors:

--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -2466,10 +2466,12 @@ class TransmissionCalc(ReductionStep):
         fitted_name += self.CAN_SAMPLE_SUFFIXES[reducer.is_can()]
         fitted_name += '_' + str(lambda_min) + '_' + str(lambda_max)
 
-        if reducer.load_monitors_as_event:
-            fitted_name = reducer.add_slice_suffix(fitted_name)
+        # If the data set is a can then we always slice the full workspace. Hence we should not encode the slice in the
+        # name
+        if not reducer.is_can():
+            if reducer.load_monitors_as_event:
+                fitted_name = reducer.add_slice_suffix(fitted_name)
         unfitted = fitted_name + "_unfitted"
-
         return fitted_name, unfitted
 
     def _get_fit_property(self, selector, property_name):

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -1789,6 +1789,22 @@ class TestMonitorSlicing(unittest.TestCase):
         self.assertAlmostEqual(sliced_monitor.dataY(3)[0], 10.0, places=7)
         self._clean_up()
 
+    def test_that_take_entire_workspace_if_can_has_been_specified(self):
+        event_monitor = self._create_event_workspace()
+        start_time = "2010-01-01T00:00:00"
+        addSampleLogEntry('proton_charge', event_monitor, start_time=start_time, extra_time_shift=0.0,
+                          number_of_times=30)
+        self.assertTrue(isinstance(event_monitor, IEventWorkspace))
+        reducer = self.get_mock_reducer(min_limit=0., max_limit=1000., settings={"events.binning": "0,200,20000"},
+                                        is_can=True)
+        sliced_monitor = su.get_sliced_monitor(reducer=reducer, monitor=event_monitor, do_scale=True)
+        self.assertTrue(isinstance(sliced_monitor, Workspace2D))
+        self.assertAlmostEqual(sliced_monitor.dataY(0)[0], 10.0, places=7)
+        self.assertAlmostEqual(sliced_monitor.dataY(1)[0], 10.0, places=7)
+        self.assertAlmostEqual(sliced_monitor.dataY(2)[0], 10.0, places=7)
+        self.assertAlmostEqual(sliced_monitor.dataY(3)[0], 10.0, places=7)
+        self._clean_up()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -1797,6 +1797,7 @@ class TestMonitorSlicing(unittest.TestCase):
         self.assertTrue(isinstance(event_monitor, IEventWorkspace))
         reducer = self.get_mock_reducer(min_limit=0., max_limit=1000., settings={"events.binning": "0,200,20000"},
                                         is_can=True)
+
         sliced_monitor = su.get_sliced_monitor(reducer=reducer, monitor=event_monitor, do_scale=True)
         self.assertTrue(isinstance(sliced_monitor, Workspace2D))
         self.assertAlmostEqual(sliced_monitor.dataY(0)[0], 10.0, places=7)


### PR DESCRIPTION
Fixes #19396

For the next cycle the SANS2D scientists will have to be able to perform time slicing of transmission runs. One way of solving this is to record the transmission runs as event and then to time slice the file accordingly.

This branch has been successfully used by instrument scientists during the current measurement cycle. If this feature should be deployed will have to be discussed with the SANS team. 


**To test:**
Code review. We are getting scientific validation from Sarah.

**Release notes:**
See [here](https://github.com/mantidproject/mantid/pull/19401/commits/f7bf5c96de254bf940863e722884613eef72b64c)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
