### PR TITLE
Handle special MatrixWorkspaces without axis correctly in workspace validators

### DIFF
--- a/Framework/API/src/IncreasingAxisValidator.cpp
+++ b/Framework/API/src/IncreasingAxisValidator.cpp
@@ -18,8 +18,13 @@ Kernel::IValidator_sptr IncreasingAxisValidator::clone() const {
   */
 std::string IncreasingAxisValidator::checkValidity(
     const MatrixWorkspace_sptr &value) const {
-  // 0 for X axis
-  Axis *xAxis = value->getAxis(0);
+  const Axis *xAxis{nullptr};
+  try {
+    // 0 for X axis
+    xAxis = value->getAxis(0);
+  } catch (Kernel::Exception::IndexError &) {
+    return "No X axis available in the workspace";
+  }
 
   // Left-most axis value should be less than the right-most, if ws has
   // more than one X axis value

--- a/Framework/API/src/NumericAxisValidator.cpp
+++ b/Framework/API/src/NumericAxisValidator.cpp
@@ -22,7 +22,13 @@ Kernel::IValidator_sptr NumericAxisValidator::clone() const {
 */
 std::string
 NumericAxisValidator::checkValidity(const MatrixWorkspace_sptr &value) const {
-  Mantid::API::Axis *axis = value->getAxis(m_axisNumber);
+  Mantid::API::Axis *axis;
+  try {
+    axis = value->getAxis(m_axisNumber);
+  } catch (Kernel::Exception::IndexError &) {
+    return "No axis at index " + std::to_string(m_axisNumber) + " available in the workspace";
+  }
+
   if (axis->isNumeric())
     return "";
   else

--- a/Framework/API/src/NumericAxisValidator.cpp
+++ b/Framework/API/src/NumericAxisValidator.cpp
@@ -26,7 +26,8 @@ NumericAxisValidator::checkValidity(const MatrixWorkspace_sptr &value) const {
   try {
     axis = value->getAxis(m_axisNumber);
   } catch (Kernel::Exception::IndexError &) {
-    return "No axis at index " + std::to_string(m_axisNumber) + " available in the workspace";
+    return "No axis at index " + std::to_string(m_axisNumber) +
+           " available in the workspace";
   }
 
   if (axis->isNumeric())

--- a/Framework/API/src/SpectraAxisValidator.cpp
+++ b/Framework/API/src/SpectraAxisValidator.cpp
@@ -26,7 +26,8 @@ SpectraAxisValidator::checkValidity(const MatrixWorkspace_sptr &value) const {
   try {
     axis = value->getAxis(m_axisNumber);
   } catch (Kernel::Exception::IndexError) {
-    return "No axis at index " + std::to_string(m_axisNumber) + " available in the workspace";
+    return "No axis at index " + std::to_string(m_axisNumber) +
+           " available in the workspace";
   }
 
   if (axis->isSpectra())

--- a/Framework/API/src/SpectraAxisValidator.cpp
+++ b/Framework/API/src/SpectraAxisValidator.cpp
@@ -22,7 +22,13 @@ Kernel::IValidator_sptr SpectraAxisValidator::clone() const {
 */
 std::string
 SpectraAxisValidator::checkValidity(const MatrixWorkspace_sptr &value) const {
-  Mantid::API::Axis *axis = value->getAxis(m_axisNumber);
+  Mantid::API::Axis *axis;
+  try {
+    axis = value->getAxis(m_axisNumber);
+  } catch (Kernel::Exception::IndexError) {
+    return "No axis at index " + std::to_string(m_axisNumber) + " available in the workspace";
+  }
+
   if (axis->isSpectra())
     return "";
   else

--- a/Framework/API/test/IncreasingAxisValidatorTest.h
+++ b/Framework/API/test/IncreasingAxisValidatorTest.h
@@ -4,8 +4,8 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/IncreasingAxisValidator.h"
-#include "MantidTestHelpers/FakeObjects.h"
 #include "MantidAPI/NumericAxis.h"
+#include "MantidTestHelpers/FakeObjects.h"
 
 #include <boost/shared_ptr.hpp>
 
@@ -40,6 +40,14 @@ public:
   void testRight() { TS_ASSERT_EQUALS(validator.isValid(m_right_ws), ""); }
 
   void testWrong() { TS_ASSERT_DIFFERS(validator.isValid(m_wrong_ws), ""); }
+
+  void testSingleValuedWorkspace() {
+    auto testWS = boost::make_shared<AxeslessWorkspaceTester>();
+    testWS->initialize(1, 3, 3);
+    std::string s;
+    TS_ASSERT_THROWS_NOTHING(s = validator.isValid(testWS))
+    TS_ASSERT_DIFFERS(s, "")
+  }
 
 private:
   Mantid::API::MatrixWorkspace_sptr m_wrong_ws; // Workspace with the wrong axis

--- a/Framework/API/test/NumericAxisValidatorTest.h
+++ b/Framework/API/test/NumericAxisValidatorTest.h
@@ -34,6 +34,15 @@ public:
         validator.isValid(ws),
         "A workspace with axis being a Numeric Axis is required here.");
   }
+
+  void test_axesless_workspace() {
+    auto ws = boost::make_shared<AxeslessWorkspaceTester>();
+    ws->initialize(2, 11 ,10);
+    NumericAxisValidator validator;
+    std::string s;
+    TS_ASSERT_THROWS_NOTHING(s = validator.isValid(ws))
+    TS_ASSERT_DIFFERS(s, "")
+  }
 };
 
 #endif /* MANTID_API_NUMERICAXISVALIDATORTEST_H_ */

--- a/Framework/API/test/NumericAxisValidatorTest.h
+++ b/Framework/API/test/NumericAxisValidatorTest.h
@@ -37,7 +37,7 @@ public:
 
   void test_axesless_workspace() {
     auto ws = boost::make_shared<AxeslessWorkspaceTester>();
-    ws->initialize(2, 11 ,10);
+    ws->initialize(2, 11, 10);
     NumericAxisValidator validator;
     std::string s;
     TS_ASSERT_THROWS_NOTHING(s = validator.isValid(ws))

--- a/Framework/API/test/SpectraAxisValidatorTest.h
+++ b/Framework/API/test/SpectraAxisValidatorTest.h
@@ -34,6 +34,15 @@ public:
     SpectraAxisValidator validator;
     TS_ASSERT_EQUALS(validator.isValid(ws), "");
   }
+
+  void test_axesless_workspace() {
+    auto ws = boost::make_shared<AxeslessWorkspaceTester>();
+    ws->initialize(2, 11, 10);
+    SpectraAxisValidator validator;
+    std::string s;
+    TS_ASSERT_THROWS_NOTHING(s = validator.isValid(ws))
+    TS_ASSERT_DIFFERS(s, "")
+  }
 };
 
 #endif /* MANTID_API_SPECTRAAXISVALIDATORTEST_H_ */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -125,8 +125,9 @@ public:
 protected:
   void init(const size_t &numspec, const size_t &j, const size_t &k) override {
     m_spec = numspec;
-    m_vec.resize(m_spec, SpectrumTester(HistogramData::getHistogramXMode(j, k),
-                                    HistogramData::Histogram::YMode::Counts));
+    m_vec.resize(m_spec,
+                 SpectrumTester(HistogramData::getHistogramXMode(j, k),
+                                HistogramData::Histogram::YMode::Counts));
     for (size_t i = 0; i < m_spec; i++) {
       m_vec[i].setMatrixWorkspace(this, i);
       m_vec[i].dataX().resize(j, 1.0);
@@ -151,7 +152,8 @@ protected:
     return new AxeslessWorkspaceTester(*this);
   }
   AxeslessWorkspaceTester *doCloneEmpty() const override {
-    throw std::runtime_error("Cloning of AxeslessWorkspaceTester is not implemented.");
+    throw std::runtime_error(
+        "Cloning of AxeslessWorkspaceTester is not implemented.");
   }
 
 private:

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -97,29 +97,23 @@ private:
 };
 
 //===================================================================================================================
-class WorkspaceTester : public MatrixWorkspace {
+class AxeslessWorkspaceTester : public MatrixWorkspace {
 public:
-  WorkspaceTester() : MatrixWorkspace(), spec(0) {}
-  ~WorkspaceTester() override {}
-
-  /// Returns a clone of the workspace
-  std::unique_ptr<WorkspaceTester> clone() const {
-    return std::unique_ptr<WorkspaceTester>(doClone());
-  }
+  AxeslessWorkspaceTester() : MatrixWorkspace(), m_spec(0) {}
 
   // Empty overrides of virtual methods
-  size_t getNumberHistograms() const override { return spec; }
-  const std::string id() const override { return "WorkspaceTester"; }
-  size_t size() const override { return vec.size() * blocksize(); }
+  size_t getNumberHistograms() const override { return m_spec; }
+  const std::string id() const override { return "AxeslessWorkspaceTester"; }
+  size_t size() const override { return m_vec.size() * blocksize(); }
   size_t blocksize() const override {
-    return vec.empty() ? 0 : vec[0].dataY().size();
+    return m_vec.empty() ? 0 : m_vec[0].dataY().size();
   }
   ISpectrum &getSpectrum(const size_t index) override {
-    vec[index].setMatrixWorkspace(this, index);
-    return vec[index];
+    m_vec[index].setMatrixWorkspace(this, index);
+    return m_vec[index];
   }
   const ISpectrum &getSpectrum(const size_t index) const override {
-    return vec[index];
+    return m_vec[index];
   }
   void generateHistogram(const std::size_t, const MantidVec &, MantidVec &,
                          MantidVec &, bool) const override {}
@@ -130,17 +124,55 @@ public:
 
 protected:
   void init(const size_t &numspec, const size_t &j, const size_t &k) override {
-    spec = numspec;
-    vec.resize(spec, SpectrumTester(HistogramData::getHistogramXMode(j, k),
+    m_spec = numspec;
+    m_vec.resize(m_spec, SpectrumTester(HistogramData::getHistogramXMode(j, k),
                                     HistogramData::Histogram::YMode::Counts));
-    for (size_t i = 0; i < spec; i++) {
-      vec[i].setMatrixWorkspace(this, i);
-      vec[i].dataX().resize(j, 1.0);
-      vec[i].dataY().resize(k, 1.0);
-      vec[i].dataE().resize(k, 1.0);
-      vec[i].addDetectorID(detid_t(i));
-      vec[i].setSpectrumNo(specnum_t(i + 1));
+    for (size_t i = 0; i < m_spec; i++) {
+      m_vec[i].setMatrixWorkspace(this, i);
+      m_vec[i].dataX().resize(j, 1.0);
+      m_vec[i].dataY().resize(k, 1.0);
+      m_vec[i].dataE().resize(k, 1.0);
+      m_vec[i].addDetectorID(detid_t(i));
+      m_vec[i].setSpectrumNo(specnum_t(i + 1));
     }
+  }
+  void init(const size_t &numspec,
+            const HistogramData::Histogram &histogram) override {
+    m_spec = numspec;
+    m_vec.resize(m_spec, SpectrumTester(histogram.xMode(), histogram.yMode()));
+    for (size_t i = 0; i < m_spec; i++) {
+      m_vec[i].setHistogram(histogram);
+      m_vec[i].addDetectorID(detid_t(i));
+      m_vec[i].setSpectrumNo(specnum_t(i + 1));
+    }
+  }
+
+  AxeslessWorkspaceTester *doClone() const override {
+    return new AxeslessWorkspaceTester(*this);
+  }
+  AxeslessWorkspaceTester *doCloneEmpty() const override {
+    throw std::runtime_error("Cloning of AxeslessWorkspaceTester is not implemented.");
+  }
+
+private:
+  std::vector<SpectrumTester> m_vec;
+  size_t m_spec;
+};
+
+class WorkspaceTester : public AxeslessWorkspaceTester {
+public:
+  WorkspaceTester() : AxeslessWorkspaceTester() {}
+
+  const std::string id() const override { return "WorkspaceTester"; }
+
+  /// Returns a clone of the workspace
+  std::unique_ptr<WorkspaceTester> clone() const {
+    return std::unique_ptr<WorkspaceTester>(doClone());
+  }
+
+protected:
+  void init(const size_t &numspec, const size_t &j, const size_t &k) override {
+    AxeslessWorkspaceTester::init(numspec, j, k);
 
     // Put an 'empty' axis in to test the getAxis method
     m_axes.resize(2);
@@ -149,13 +181,7 @@ protected:
   }
   void init(const size_t &numspec,
             const HistogramData::Histogram &histogram) override {
-    spec = numspec;
-    vec.resize(spec, SpectrumTester(histogram.xMode(), histogram.yMode()));
-    for (size_t i = 0; i < spec; i++) {
-      vec[i].setHistogram(histogram);
-      vec[i].addDetectorID(detid_t(i));
-      vec[i].setSpectrumNo(specnum_t(i + 1));
-    }
+    AxeslessWorkspaceTester::init(numspec, histogram);
 
     // Put an 'empty' axis in to test the getAxis method
     m_axes.resize(2);
@@ -170,8 +196,6 @@ private:
   WorkspaceTester *doCloneEmpty() const override {
     throw std::runtime_error("Cloning of WorkspaceTester is not implemented.");
   }
-  std::vector<SpectrumTester> vec;
-  size_t spec;
 };
 
 //===================================================================================================================

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -11,6 +11,7 @@ API
 
 - The default multiple file limit is now made facility dependent. It is 1000 for ILL, and 100 for all the others.
 - Frequency unit (GHz) included as an option to represent energy transfer.
+- Fixed a bug where certain validators would crash with SingleValuedWorkspaces instead of rejecting them.
 
 Algorithms
 ----------


### PR DESCRIPTION
`SingleValuedWorkspace` is a special `MatrixWorkspace` that doesn't have axes. When such object is asked an axis by `getAxis()`, the method throws. This pull request adds try-catch blocks to the axis validators (`IncreasingAxisValidator`, `NumericAxisValidator` and `SpectraAxisValidator`) to handle the situation correctly.

**To test:**

Create a `SingleValuedWorkspace` using [`CreateSingleValuedWorkspace`](http://docs.mantidproject.org/nightly/algorithms/CreateSingleValuedWorkspace-v1.html) in MantidPlot. Then open the automatically generated dialog of some algorithm which uses the above listed validators, for example [`ConvertSpectrumAxis`](http://docs.mantidproject.org/nightly/algorithms/ConvertSpectrumAxis-v2.html) should do the trick. The dialog should crash if these changes have not been applied.

Fixes #19377.

*Release notes were updated.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
