### PR TITLE
Add pixel width to REF_M  and REF_M IDF

### DIFF
--- a/instrument/REF_L_Parameters.xml
+++ b/instrument/REF_L_Parameters.xml
@@ -11,6 +11,9 @@
       <value val="304"/>
     </parameter>
 
+    <parameter name="pixel-width">
+      <value val="0.7"/>
+    </parameter>
   </component-link>
 
 </parameter-file>

--- a/instrument/REF_M_Parameters.xml
+++ b/instrument/REF_M_Parameters.xml
@@ -10,7 +10,11 @@
     <parameter name="number-of-y-pixels">
       <value val="256"/>
     </parameter>
-      
+
+    <parameter name="pixel-width">
+      <value val="0.7"/>
+    </parameter>
+
    <parameter name="MultiDetectorStart">
        <value val="1"/>
    </parameter>


### PR DESCRIPTION
We need to add the pixel width as a parameter to REF_M and REF_L IDFs.
The REF_M software is already prepared to use those values.

**To test:**
-Inspect code
-Make sure tests pass

There is no Github issue for this PR. All the info is here.


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
