### PR TITLE
Fix parameter map access for physical instrument

### DIFF
--- a/Framework/DataHandling/test/LoadInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadInstrumentTest.h
@@ -424,6 +424,19 @@ public:
     TS_ASSERT_DIFFERS(physicalInst->getDetector(1).get(),
                       neutronicInst->getDetector(1).get());
 
+    // Physical instrument obtained via workspace: Make sure we do *not* get
+    // positions from DetectorInfo.
+    auto physInstFromWS = ws->getInstrument()->getPhysicalInstrument();
+    TS_ASSERT(physInstFromWS->isParametrized());
+    TS_ASSERT_DIFFERS(physInstFromWS->getDetector(1003)->getPos(),
+                      detectorInfo.position(detectorInfo.indexOf(1003)));
+    TS_ASSERT_EQUALS(physInstFromWS->getDetector(1000)->getPos(), V3D(0, 0, 0));
+    TS_ASSERT_EQUALS(physInstFromWS->getDetector(1001)->getPos(), V3D(0, 1, 0));
+    TS_ASSERT_EQUALS(physInstFromWS->getDetector(1002)->getPos(), V3D(1, 0, 0));
+    TS_ASSERT_EQUALS(physInstFromWS->getDetector(1003)->getPos(), V3D(1, 1, 0));
+    TS_ASSERT_EQUALS(physInstFromWS->getDetector(1004)->getPos(), V3D(2, 0, 0));
+    TS_ASSERT_EQUALS(physInstFromWS->getDetector(1005)->getPos(), V3D(2, 1, 0));
+
     // Clean up
     IDS.clear();
   }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -214,7 +214,7 @@ public:
   // Methods for use with indirect geometry instruments,
   // where the physical instrument differs from the 'neutronic' one
   boost::shared_ptr<const Instrument> getPhysicalInstrument() const;
-  void setPhysicalInstrument(boost::shared_ptr<const Instrument>);
+  void setPhysicalInstrument(std::unique_ptr<Instrument>);
 
   void getInstrumentParameters(double &l1, Kernel::V3D &beamline,
                                double &beamline_norm,
@@ -338,6 +338,7 @@ private:
 
   boost::shared_ptr<const Beamline::ComponentInfo> m_componentInfo{nullptr};
   boost::shared_ptr<const std::vector<Geometry::ComponentID>> m_componentIds;
+  bool m_isPhysicalInstrument{false};
 };
 namespace Conversion {
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Detector.h
@@ -95,6 +95,7 @@ private:
 protected:
   /// Constructor for parametrized version
   Detector(const Detector *base, const ParameterMap *map);
+  bool hasDetectorInfo() const;
 };
 
 } // namespace Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -391,7 +391,9 @@ private:
   /// associated with an ExperimentInfo object.
   boost::shared_ptr<const Beamline::ComponentInfo> m_componentInfo{nullptr};
   /// Pointer to the owning instrument for translating detector IDs into
-  /// detector indices when accessing the DetectorInfo object
+  /// detector indices when accessing the DetectorInfo object. If the workspace
+  /// distinguishes between a neutronic instrument and a physical instrument
+  /// the owning instrument is the neutronic one.
   const Instrument *m_instrument{nullptr};
 };
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -345,7 +345,7 @@ public:
   pmap_it end() { return m_map.end(); }
   pmap_cit end() const { return m_map.end(); }
 
-  bool hasDetectorInfo() const;
+  bool hasDetectorInfo(const Instrument *instrument) const;
   const Beamline::DetectorInfo &detectorInfo() const;
   bool hasComponentInfo() const;
   const Beamline::ComponentInfo &componentInfo() const;

--- a/Framework/Geometry/src/Instrument.cpp
+++ b/Framework/Geometry/src/Instrument.cpp
@@ -162,9 +162,14 @@ Instrument_const_sptr Instrument::getPhysicalInstrument() const {
   if (m_map) {
     if (m_instr->getPhysicalInstrument()) {
       // A physical instrument should use the same parameter map as the 'main'
-      // instrument
-      return Instrument_const_sptr(
-          new Instrument(m_instr->getPhysicalInstrument(), m_map_nonconst));
+      // instrument. This constructor automatically sets the instrument as the
+      // owning instrument in the ParameterMap. We need to undo this immediately
+      // since the ParameterMap must always be owned by the neutronic
+      // instrument.
+      auto instrument = boost::make_shared<Instrument>(
+          m_instr->getPhysicalInstrument(), m_map_nonconst);
+      m_map_nonconst->setInstrument(m_instr.get());
+      return instrument;
     } else {
       return Instrument_const_sptr();
     }

--- a/Framework/Geometry/src/Instrument/Detector.cpp
+++ b/Framework/Geometry/src/Instrument/Detector.cpp
@@ -172,8 +172,8 @@ void Detector::registerContents(ComponentVisitor &componentVisitor) const {
 
 bool Detector::hasDetectorInfo() const {
   const IComponent *root = this;
-  while (this->m_parent)
-    root = this->m_parent;
+  while (auto parent = root->getBareParent())
+    root = parent;
   auto instrument = dynamic_cast<const Instrument *>(root);
   return m_map->hasDetectorInfo(instrument);
 }

--- a/Framework/Geometry/src/Instrument/Detector.cpp
+++ b/Framework/Geometry/src/Instrument/Detector.cpp
@@ -171,7 +171,7 @@ void Detector::registerContents(ComponentVisitor &componentVisitor) const {
 }
 
 bool Detector::hasDetectorInfo() const {
-  const IComponent *root = this;
+  const IComponent *root = m_base;
   while (auto parent = root->getBareParent())
     root = parent;
   auto instrument = dynamic_cast<const Instrument *>(root);

--- a/Framework/Geometry/src/Instrument/Detector.cpp
+++ b/Framework/Geometry/src/Instrument/Detector.cpp
@@ -1,3 +1,4 @@
+#include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Instrument/ComponentVisitor.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
@@ -126,7 +127,7 @@ det_topology Detector::getTopology(V3D &center) const {
 
 /// Return the relative position to the parent
 Kernel::V3D Detector::getRelativePos() const {
-  if (m_map && m_map->hasDetectorInfo())
+  if (m_map && hasDetectorInfo())
     return Kernel::toV3D(m_map->detectorInfo().position(index())) -
            getParent()->getPos();
   return ObjComponent::getRelativePos();
@@ -134,14 +135,14 @@ Kernel::V3D Detector::getRelativePos() const {
 
 /// Return the absolute position of the Detector
 Kernel::V3D Detector::getPos() const {
-  if (m_map && m_map->hasDetectorInfo())
+  if (m_map && hasDetectorInfo())
     return Kernel::toV3D(m_map->detectorInfo().position(index()));
   return ObjComponent::getPos();
 }
 
 /// Return the relative rotation to the parent
 Kernel::Quat Detector::getRelativeRot() const {
-  if (m_map && m_map->hasDetectorInfo()) {
+  if (m_map && hasDetectorInfo()) {
     auto inverseParentRot = getParent()->getRotation();
     inverseParentRot.inverse();
     // Note the unusual order. This matches the convention in Component::getPos
@@ -154,7 +155,7 @@ Kernel::Quat Detector::getRelativeRot() const {
 
 /// Return the absolute rotation of the Detector
 Kernel::Quat Detector::getRotation() const {
-  if (m_map && m_map->hasDetectorInfo())
+  if (m_map && hasDetectorInfo())
     return Kernel::toQuat(m_map->detectorInfo().rotation(index()));
   return ObjComponent::getRotation();
 }
@@ -167,6 +168,14 @@ size_t Detector::index() const { return m_map->detectorIndex(m_id); }
 
 void Detector::registerContents(ComponentVisitor &componentVisitor) const {
   componentVisitor.registerDetector(*this);
+}
+
+bool Detector::hasDetectorInfo() const {
+  const IComponent *root = this;
+  while (this->m_parent)
+    root = this->m_parent;
+  auto instrument = dynamic_cast<const Instrument *>(root);
+  return m_map->hasDetectorInfo(instrument);
 }
 
 } // Namespace Geometry

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -17,6 +17,7 @@
 #include "MantidKernel/ProgressBase.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidKernel/make_unique.h"
 
 #include <Poco/DOM/DOMParser.h>
 #include <Poco/DOM/DOMWriter.h>
@@ -2461,9 +2462,9 @@ InstrumentDefinitionParser::getAppliedCachingOption() const {
 
 void InstrumentDefinitionParser::createNeutronicInstrument() {
   // Create a copy of the instrument
-  auto physical = boost::make_shared<Instrument>(*m_instrument);
+  auto physical = Kernel::make_unique<Instrument>(*m_instrument);
   // Store the physical instrument 'inside' the neutronic instrument
-  m_instrument->setPhysicalInstrument(physical);
+  m_instrument->setPhysicalInstrument(std::move(physical));
 
   // Now we manipulate the original instrument (m_instrument) to hold
   // neutronic positions

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1152,14 +1152,20 @@ ParameterMap::create(const std::string &className,
   return ParameterFactory::create(className, name);
 }
 
-/// Only for use by ExperimentInfo. Returns returns true if this instrument
-/// contains a DetectorInfo.
-bool ParameterMap::hasDetectorInfo() const {
+/** Only for use by ExperimentInfo. Returns returns true if this instrument
+ contains a DetectorInfo.
+
+ The `instrument` argument is needed for the special case of having a neutronic
+ *and* a physical instrument. `Instrument` uses the same parameter map for both,
+ but the DetectorInfo is only for the neutronic instrument. */
+bool ParameterMap::hasDetectorInfo(const Instrument *instrument) const {
+  if (instrument != m_instrument)
+    return false;
   return static_cast<bool>(m_detectorInfo);
 }
 /// Only for use by ExperimentInfo. Returns a reference to the DetectorInfo.
 const Beamline::DetectorInfo &ParameterMap::detectorInfo() const {
-  if (!hasDetectorInfo())
+  if (!hasDetectorInfo(m_instrument))
     throw std::runtime_error("Cannot return reference to NULL DetectorInfo");
   return *m_detectorInfo;
 }

--- a/Framework/Geometry/src/Instrument/RectangularDetectorPixel.cpp
+++ b/Framework/Geometry/src/Instrument/RectangularDetectorPixel.cpp
@@ -45,7 +45,7 @@ RectangularDetectorPixel::RectangularDetectorPixel(
  * @return position relative to the 0,0 point of the parent panel
  */
 Kernel::V3D RectangularDetectorPixel::getRelativePos() const {
-  if (m_map && m_map->hasDetectorInfo())
+  if (m_map && hasDetectorInfo())
     return Detector::getRelativePos();
   // Calculate the x,y position
   double x = m_panel->xstart() + double(m_col) * m_panel->xstep();


### PR DESCRIPTION
Recent changes to position access via the parameter map incorrectly caused the physical instrument to read its positions from `DetectorInfo`. `DetectorInfo` contains only positions for the neutronic instrument. This is fixed here. The solution should be seen as an temporary one, since once Instrument-2.0 has progressed further, it is planned to deal with the physical/neutronic distinction in a different way. However, "temporary" probably will still be a rather long time, so when reviewing please make sure that this solution is reasonable.

**To test:**

- Code review.
- Check that InstrumentView now correctly shows the *physical* instrument instead of the neutronic one (as it used to be). Cannot be tested with BASIS currently, until its IDF is fixed.

No related issue, but this solves parts of #19386 (but also the BASIS IDF needs to be fixed for that).

No release notes, issue was introduced after last release.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
