### PR TITLE
CreateCacheFilename missing PropertyManager

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/CreateCacheFilename.py
+++ b/Framework/PythonInterface/plugins/algorithms/CreateCacheFilename.py
@@ -64,12 +64,21 @@ class CreateCacheFilename(PythonAlgorithm):
         """ Main Execution Body
         """
         # Inputs
-        prop_manager = self.getPropertyValue("PropertyManager")
+        prop_manager = self.getPropertyValue("PropertyManager").strip()
+        if len(prop_manager) > 0:
+            if mantid.PropertyManagerDataService.doesExist(prop_manager):
+                prop_manager = mantid.PropertyManagerDataService.retrieve(prop_manager)
+            else:
+                self.log().warning('PropertyManager "%s" does not exist - ignoring' % prop_manager)
+                prop_manager = None
+        else:
+            prop_manager = None
+
         other_props = self.getProperty("OtherProperties").value
+
         if not prop_manager and not other_props:
             raise ValueError("Either PropertyManager or OtherProperties should be supplied")
-        prop_manager = mantid.PropertyManagerDataService.retrieve(prop_manager)\
-            if prop_manager else None
+
         # default to all properties in the manager
         props = self.getProperty("Properties").value
         if not props and prop_manager:

--- a/Framework/PythonInterface/plugins/algorithms/CreateCacheFilename.py
+++ b/Framework/PythonInterface/plugins/algorithms/CreateCacheFilename.py
@@ -60,17 +60,26 @@ class CreateCacheFilename(PythonAlgorithm):
         self.declareProperty("OutputSignature", "", "Calculated sha1 hash", Direction.Output)
         return
 
+    def validateInputs(self):
+        issues = dict()
+
+        manager = self.getPropertyValue('PropertyManager').strip()
+        if len(manager) > 0 and not mantid.PropertyManagerDataService.doesExist(manager):
+            issues['PropertyManager'] = 'Does not exist'
+        elif len(manager) <= 0 and not self.getProperty('OtherProperties').value:
+            message = "Either PropertyManager or OtherProperties should be supplied"
+            issues['PropertyManager'] = message
+            issues['OtherProperties'] = message
+
+        return issues
+
     def PyExec(self):
         """ Main Execution Body
         """
         # Inputs
         prop_manager = self.getPropertyValue("PropertyManager").strip()
         if len(prop_manager) > 0:
-            if mantid.PropertyManagerDataService.doesExist(prop_manager):
-                prop_manager = mantid.PropertyManagerDataService.retrieve(prop_manager)
-            else:
-                self.log().warning('PropertyManager "%s" does not exist - ignoring' % prop_manager)
-                prop_manager = None
+            prop_manager = mantid.PropertyManagerDataService.retrieve(prop_manager)
         else:
             prop_manager = None
 


### PR DESCRIPTION
It was possible to get into the body of the algorithm with a bad name for the `PropertyManager`. This creates a `validateInputs` method to check for that.

**To test:**

Try it out with various states of `PropertyManager` and `OtherProperties`.

*There is no associated issue.*

*Does not need to be in the release notes* because most users would have never noticed the issue.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
