### PR TITLE
Reduced number of memory allocations and shared_ptr access in workspace initialization.

### DIFF
--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -131,9 +131,9 @@ EventList::EventList(EventWorkspaceMRU *mru, specnum_t specNo)
 /** Constructor copying from an existing event list
  * @param rhs :: EventList object to copy*/
 EventList::EventList(const EventList &rhs)
-    : IEventList(rhs), m_histogram(HistogramData::Histogram::XMode::BinEdges,
-                                   HistogramData::Histogram::YMode::Counts),
-      mru{nullptr} {
+    : IEventList(rhs), m_histogram(rhs.m_histogram), mru{nullptr} {
+  // Note that operator= also assigns m_histogram, but the above use of the copy
+  // constructor avoid a memory allocation and is thus faster.
   this->operator=(rhs);
 }
 

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -83,17 +83,22 @@ void EventWorkspace::init(const std::size_t &NVectors,
     throw std::out_of_range(
         "Negative or 0 Number of Pixels specified to EventWorkspace::init");
   }
-  // Initialize the data
-  data.resize(NVectors, nullptr);
-  // Make sure SOMETHING exists for all initialized spots.
-  for (size_t i = 0; i < NVectors; i++)
-    data[i] = new EventList(mru, specnum_t(i));
 
   // Set each X vector to have one bin of 0 & extremely close to zero
   // Move the rhs very,very slightly just incase something doesn't like them
   // being the same
   HistogramData::BinEdges edges{0.0, std::numeric_limits<double>::min()};
-  this->setAllX(edges);
+
+  // Initialize the data
+  data.resize(NVectors, nullptr);
+  // Make sure SOMETHING exists for all initialized spots.
+  EventList el;
+  el.setHistogram(edges);
+  for (size_t i = 0; i < NVectors; i++) {
+    data[i] = new EventList(el);
+    data[i]->setMRU(mru);
+    data[i]->setSpectrumNo(specnum_t(i));
+  }
 
   // Create axes.
   m_axes.resize(2);
@@ -112,9 +117,13 @@ void EventWorkspace::init(const std::size_t &NVectors,
         "EventWorkspace cannot be initialized non-NULL Y or E data");
 
   data.resize(NVectors, nullptr);
-  for (size_t i = 0; i < NVectors; i++)
-    data[i] = new EventList(mru, specnum_t(i));
-  this->setAllX(histogram.binEdges());
+  EventList el;
+  el.setHistogram(histogram);
+  for (size_t i = 0; i < NVectors; i++) {
+    data[i] = new EventList(el);
+    data[i]->setMRU(mru);
+    data[i]->setSpectrumNo(specnum_t(i));
+  }
 
   m_axes.resize(2);
   m_axes[0] = new API::RefAxis(histogram.x().size(), this);

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -73,20 +73,16 @@ void Workspace2D::init(const std::size_t &NVectors, const std::size_t &XLength,
       XLength, HistogramData::LinearGenerator(1.0, 1.0));
   HistogramData::Counts y(YLength);
   HistogramData::CountStandardDeviations e(YLength);
+  Histogram1D spec(HistogramData::getHistogramXMode(XLength, YLength),
+                   HistogramData::Histogram::YMode::Counts);
+  spec.setX(x);
+  spec.setCounts(y);
+  spec.setCountStandardDeviations(e);
   for (size_t i = 0; i < m_noVectors; i++) {
-    // Create the spectrum upon init
-    auto spec =
-        new Histogram1D(HistogramData::getHistogramXMode(XLength, YLength),
-                        HistogramData::Histogram::YMode::Counts);
-    data[i] = spec;
-    // Set the data and X
-    spec->setX(x);
-    // Y,E arrays populated
-    spec->setCounts(y);
-    spec->setCountStandardDeviations(e);
+    data[i] = new Histogram1D(spec);
     // Default spectrum number = starts at 1, for workspace index 0.
-    spec->setSpectrumNo(specnum_t(i + 1));
-    spec->setDetectorID(detid_t(i + 1));
+    data[i]->setSpectrumNo(specnum_t(i + 1));
+    data[i]->setDetectorID(detid_t(i + 1));
   }
 
   // Add axes that reference the data
@@ -112,10 +108,10 @@ void Workspace2D::init(const std::size_t &NVectors,
     }
   }
 
+  Histogram1D spec(initializedHistogram.xMode(), initializedHistogram.yMode());
+  spec.setHistogram(initializedHistogram);
   for (size_t i = 0; i < m_noVectors; i++) {
-    data[i] = new Histogram1D(initializedHistogram.xMode(),
-                              initializedHistogram.yMode());
-    data[i]->setHistogram(initializedHistogram);
+    data[i] = new Histogram1D(spec);
     // Default spectrum number = starts at 1, for workspace index 0.
     data[i]->setSpectrumNo(specnum_t(i + 1));
     data[i]->setDetectorID(detid_t(i + 1));


### PR DESCRIPTION
`Workspace2D` and `EventWorkspace` both initialize `HistogramData::Histogram` in their `init()` methods (indirectly, either via `Histogram1D` or `EventList`). Previously this was written in a suboptimal way that caused more shared_ptr access (atomic increment/decrement operations) and memory allocations than necessary. The improvements here may give speedups on the percent level.

Profiling results when running one of the tests from `DiffractionFocussing2TestPerformance`: Contributions of Histogram init reduced from about `6.0%` to `1.7%`.

Before:
```
+    0.75%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::HistogramData::Histogram::~Histogram
+    0.57%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::Histogram1D::~Histogram1D
+    0.44%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::HistogramData::Histogram::setCounts<Mantid::HistogramData::Counts&>
+    0.40%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::make_shared<Mantid::HistogramData::HistogramX, int>
+    0.37%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::HistogramData::Histogram::setCountStandardDeviations<Mantid::HistogramData::CountStandardDeviations&>
+    0.33%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventList::generateCountsHistogram
+    0.32%  AlgorithmsTest  libMantidHistogramData.so  [.] Mantid::HistogramData::Histogram::initX<Mantid::HistogramData::BinEdges>
+    0.30%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::Histogram1D::setX
+    0.30%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::HistogramData::Histogram::Histogram<Mantid::HistogramData::BinEdges, Mantid::HistogramData::Counts, Mantid::HistogramData::CountVariances>
+    0.27%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::make_shared<Mantid::HistogramData::HistogramY, unsigned long&>
+    0.25%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::make_shared<Mantid::HistogramData::HistogramE, unsigned long&>
+    0.23%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::HistogramData::Histogram::setCounts<int>
+    0.22%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::HistogramData::Histogram::setCountStandardDeviations<int>
+    0.18%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::API::ISpectrum::setHistogram<Mantid::HistogramData::BinEdges const&>
+    0.12%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::Histogram1D::Histogram1D
+    0.08%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::Kernel::make_cow<Mantid::HistogramData::HistogramE, std::vector<double, std::allocator<double> > >
+    0.08%  AlgorithmsTest  libMantidKernel.so         [.] Mantid::Kernel::VectorHelper::rebinHistogram
+    0.07%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::make_shared<Mantid::HistogramData::HistogramY>
+    0.06%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventList::checkAndSanitizeHistogram
+    0.06%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::make_shared<Mantid::HistogramData::HistogramY, std::vector<double, std::allocator<double> > >
+    0.06%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::make_shared<Mantid::HistogramData::HistogramY, Mantid::HistogramData::HistogramY&>
+    0.06%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::make_shared<Mantid::HistogramData::HistogramE>
+    0.05%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::Workspace2D::getNumberHistograms
+    0.04%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::make_shared<Mantid::HistogramData::HistogramE, Mantid::HistogramData::HistogramE&>
+    0.03%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramX*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramX> >::dispose
+    0.03%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramX*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramX> >::~sp_counted_impl_pd
+    0.03%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventList::mutableHistogramRef
+    0.03%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramE*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramE> >::~sp_counted_impl_pd
+    0.03%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::HistogramData::Histogram::Histogram
+    0.02%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramE*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramE> >::dispose
+    0.02%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramY*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramY> >::dispose
+    0.02%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventList::generateErrorsHistogram
+    0.02%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramY*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramY> >::~sp_counted_impl_pd
+    0.02%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZN6Mantid13HistogramData9Histogram22checkAndSetYModeCountsEv@plt
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramX*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramX> >::get_untyped_deleter
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventWorkspace::getNumberHistograms
+    0.01%  AlgorithmsTest  libMantidHistogramData.so  [.] Mantid::HistogramData::Histogram::checkAndSetYModeCounts
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventList::generateHistogram
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramY*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramY> >::get_untyped_deleter
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZN6Mantid11DataObjects11Histogram1DC1ENS_13HistogramData9Histogram5XModeENS3_5YModeE@plt
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZN6Mantid11DataObjects11Histogram1D4setXERKNS_6Kernel7cow_ptrINS_13HistogramData10HistogramXEEE@plt
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramE*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramE> >::get_untyped_deleter
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZN6Mantid13HistogramData17getHistogramXModeEmm@plt
+    0.01%  AlgorithmsTest  libMantidHistogramData.so  [.] Mantid::HistogramData::getHistogramXMode
+    0.00%  AlgorithmsTest  libMantidAlgorithms.so     [.] _ZN6Mantid6Kernel12VectorHelper14rebinHistogramERKSt6vectorIdSaIdEES6_S6_S6_RS4_S7_b@plt
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZN6Mantid11DataObjects17EventWorkspaceMRU7insertEEmNS_6Kernel7cow_ptrINS_13HistogramData10HistogramEEEEPKNS0_9EventListE@plt
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZN6Mantid13HistogramData9Histogram5initXINS0_8BinEdgesEEEvRKT_@plt
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZN6Mantid3API9ISpectrum12setHistogramIJRKNS_13HistogramData8BinEdgesEEEEvDpOT_@plt
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZNK6Mantid11DataObjects9EventList23generateCountsHistogramERKSt6vectorIdSaIdEERS4_@plt
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZNK6Mantid11DataObjects9EventList23generateErrorsHistogramERKSt6vectorIdSaIdEERS4_@plt
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZN6Mantid11DataObjects17EventWorkspaceMRU7insertYEmNS_6Kernel7cow_ptrINS_13HistogramData10HistogramYEEEPKNS0_9EventListE@plt

```

After:

```
+    0.49%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::Histogram1D::Histogram1D
+    0.30%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::HistogramData::Histogram::setFrequencyVariances<std::vector<double, std::allocator<double> > const&>
+    0.24%  AlgorithmsTest  libMantidDataObjects.so    [.] std::vector<Mantid::Kernel::MRUList<Mantid::DataObjects::TypeWithMarker<Mantid::Kernel::cow_ptr<Mantid::HistogramData::HistogramY> > >*, std::allocator<Mantid::Kernel::MRUList<Mantid::D
+    0.21%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventList::generateCountsHistogram
+    0.17%  AlgorithmsTest  libMantidHistogramData.so  [.] Mantid::HistogramData::Histogram::initX<Mantid::HistogramData::BinEdges>
+    0.10%  AlgorithmsTest  libMantidKernel.so         [.] Mantid::Kernel::VectorHelper::rebinHistogram
+    0.06%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::Histogram1D::Histogram1D
+    0.04%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventList::generateCountsHistogramTimeAtSample
+    0.03%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::HistogramData::Histogram::Histogram<Mantid::HistogramData::BinEdges, Mantid::HistogramData::Counts, Mantid::HistogramData::CountVariances>
+    0.02%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramE*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramE> >::~sp_counted_impl_pd
+    0.02%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramE*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramE> >::~sp_counted_impl_pd
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventWorkspace::generateHistogramPulseTime
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramX*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramX> >::~sp_counted_impl_pd
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramY*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramY> >::get_deleter
+    0.01%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramE*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramE> >::get_deleter
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventWorkspace::getNumberHistograms
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramDx*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramDx> >::get_deleter
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramDx*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramDx> >::~sp_counted_impl_pd
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] _ZN6Mantid11DataObjects11Histogram1DD1Ev@plt
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramY*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramY> >::~sp_counted_impl_pd
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramE*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramE> >::get_untyped_deleter
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] Mantid::DataObjects::EventList::checkAndSanitizeHistogram
+    0.00%  AlgorithmsTest  libMantidAlgorithms.so     [.] _ZN6Mantid6Kernel12VectorHelper14rebinHistogramERKSt6vectorIdSaIdEES6_S6_S6_RS4_S7_b@plt
+    0.00%  AlgorithmsTest  libMantidDataObjects.so    [.] boost::detail::sp_counted_impl_pd<Mantid::HistogramData::HistogramX*, boost::detail::sp_ms_deleter<Mantid::HistogramData::HistogramX> >::get_deleter
```

**To test:**

Code review. No related issue.

Internal change, no release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
