### PR TITLE
Fix warnings from clang-tidy misc-string-compare

### DIFF
--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1663,12 +1663,11 @@ void ExperimentInfo::populateWithParameter(
       m_detectorInfo->setMasked(detectorInfo().indexOf(det->getID()),
                                 paramValue);
     }
-  } else if (name == "x" || name == "y" ||
-             name == "z") {
+  } else if (name == "x" || name == "y" || name == "z") {
     paramMapForPosAndRot.addPositionCoordinate(paramInfo.m_component, name,
                                                paramValue);
-  } else if (name == "rot" || name == "rotx" ||
-             name == "roty" || name == "rotz") {
+  } else if (name == "rot" || name == "rotx" || name == "roty" ||
+             name == "rotz") {
     // Effectively this is dropping any parameters named 'rot'.
     paramMapForPosAndRot.addRotationParam(paramInfo.m_component, name,
                                           paramValue, pDescription);

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1591,7 +1591,7 @@ void ExperimentInfo::readParameterMap(const std::string &parameterStr) {
 
     const auto &paramType = tokens[1];
     const auto &paramName = tokens[2];
-    if (paramName.compare("masked") == 0) {
+    if (paramName == "masked") {
       bool value = getParam<bool>(paramType, paramValue);
       if (value) {
         // Do not add masking to ParameterMap, it is stored in DetectorInfo
@@ -1651,7 +1651,7 @@ void ExperimentInfo::populateWithParameter(
     pDescription = &paramInfo.m_description;
 
   // Some names are special. Values should be convertible to double
-  if (name.compare("masked") == 0) {
+  if (name == "masked") {
     bool value(paramValue);
     if (value) {
       // Do not add masking to ParameterMap, it is stored in DetectorInfo
@@ -1663,16 +1663,16 @@ void ExperimentInfo::populateWithParameter(
       m_detectorInfo->setMasked(detectorInfo().indexOf(det->getID()),
                                 paramValue);
     }
-  } else if (name.compare("x") == 0 || name.compare("y") == 0 ||
-             name.compare("z") == 0) {
+  } else if (name == "x" || name == "y" ||
+             name == "z") {
     paramMapForPosAndRot.addPositionCoordinate(paramInfo.m_component, name,
                                                paramValue);
-  } else if (name.compare("rot") == 0 || name.compare("rotx") == 0 ||
-             name.compare("roty") == 0 || name.compare("rotz") == 0) {
+  } else if (name == "rot" || name == "rotx" ||
+             name == "roty" || name == "rotz") {
     // Effectively this is dropping any parameters named 'rot'.
     paramMapForPosAndRot.addRotationParam(paramInfo.m_component, name,
                                           paramValue, pDescription);
-  } else if (category.compare("fitting") == 0) {
+  } else if (category == "fitting") {
     std::ostringstream str;
     str << paramInfo.m_value << " , " << paramInfo.m_fittingFunction << " , "
         << name << " , " << paramInfo.m_constraint[0] << " , "
@@ -1682,12 +1682,12 @@ void ExperimentInfo::populateWithParameter(
         << (*(paramInfo.m_interpolation));
     paramMap.add("fitting", paramInfo.m_component, name, str.str(),
                  pDescription);
-  } else if (category.compare("string") == 0) {
+  } else if (category == "string") {
     paramMap.addString(paramInfo.m_component, name, paramInfo.m_value,
                        pDescription);
-  } else if (category.compare("bool") == 0) {
+  } else if (category == "bool") {
     paramMap.addBool(paramInfo.m_component, name, paramValue, pDescription);
-  } else if (category.compare("int") == 0) {
+  } else if (category == "int") {
     paramMap.addInt(paramInfo.m_component, name, paramValue, pDescription);
   } else { // assume double
     paramMap.addDouble(paramInfo.m_component, name, paramValue, pDescription);

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -784,13 +784,13 @@ void IFunction::setMatrixWorkspace(
                 dynamic_cast<IFunctionWithLocation *>(this);
             if (testWithLocation == nullptr ||
                 (!fitParam.getLookUpTable().containData() &&
-                 fitParam.getFormula() == "")) {
+                 fitParam.getFormula().empty())) {
               setParameter(i, fitParam.getValue());
             } else {
               double centreValue = testWithLocation->centre();
               Kernel::Unit_sptr centreUnit; // unit of value used in formula or
                                             // to look up value in lookup table
-              if (fitParam.getFormula() == "")
+              if (fitParam.getFormula().empty())
                 centreUnit = fitParam.getLookUpTable().getXUnit(); // from table
               else {
                 if (!fitParam.getFormulaUnit().empty()) {
@@ -827,7 +827,7 @@ void IFunction::setMatrixWorkspace(
               // a unit of its own. If set convert param value
               // See section 'Using fitting parameters in
               // www.mantidproject.org/IDF
-              if (fitParam.getFormula() == "") {
+              if (fitParam.getFormula().empty()) {
                 // so from look up table
                 Kernel::Unit_sptr resultUnit =
                     fitParam.getLookUpTable().getYUnit(); // from table

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -778,19 +778,19 @@ void IFunction::setMatrixWorkspace(
 
           // check first if this parameter is actually specified for this
           // function
-          if (name().compare(fitParam.getFunction()) == 0) {
+          if (name() == fitParam.getFunction()) {
             // update value
             IFunctionWithLocation *testWithLocation =
                 dynamic_cast<IFunctionWithLocation *>(this);
             if (testWithLocation == nullptr ||
                 (!fitParam.getLookUpTable().containData() &&
-                 fitParam.getFormula().compare("") == 0)) {
+                 fitParam.getFormula() == "")) {
               setParameter(i, fitParam.getValue());
             } else {
               double centreValue = testWithLocation->centre();
               Kernel::Unit_sptr centreUnit; // unit of value used in formula or
                                             // to look up value in lookup table
-              if (fitParam.getFormula().compare("") == 0)
+              if (fitParam.getFormula() == "")
                 centreUnit = fitParam.getLookUpTable().getXUnit(); // from table
               else {
                 if (!fitParam.getFormulaUnit().empty()) {
@@ -827,7 +827,7 @@ void IFunction::setMatrixWorkspace(
               // a unit of its own. If set convert param value
               // See section 'Using fitting parameters in
               // www.mantidproject.org/IDF
-              if (fitParam.getFormula().compare("") == 0) {
+              if (fitParam.getFormula() == "") {
                 // so from look up table
                 Kernel::Unit_sptr resultUnit =
                     fitParam.getLookUpTable().getYUnit(); // from table
@@ -931,7 +931,7 @@ double IFunction::convertValue(double value, Kernel::Unit_sptr &outUnit,
                                size_t wsIndex) const {
   // only required if formula or look-up-table different from ws unit
   const auto &wsUnit = ws->getAxis(0)->unit();
-  if (outUnit->unitID().compare(wsUnit->unitID()) == 0)
+  if (outUnit->unitID() == wsUnit->unitID())
     return value;
 
   // first check if it is possible to do a quick conversion and convert
@@ -960,7 +960,7 @@ void IFunction::convertValue(std::vector<double> &values,
                              size_t wsIndex) const {
   // only required if  formula or look-up-table different from ws unit
   const auto &wsUnit = ws->getAxis(0)->unit();
-  if (outUnit->unitID().compare(wsUnit->unitID()) == 0)
+  if (outUnit->unitID() == wsUnit->unitID())
     return;
 
   // first check if it is possible to do a quick conversion convert

--- a/Framework/API/src/IPowderDiffPeakFunction.cpp
+++ b/Framework/API/src/IPowderDiffPeakFunction.cpp
@@ -203,7 +203,7 @@ bool IPowderDiffPeakFunction::hasProfileParameter(std::string paramname) {
   if (candname == m_sortedProfileParameterNames.end())
     return false;
 
-  return candname->compare(paramname) != 0;
+  return *candname != paramname;
 }
 
 //-------------------------  External Functions

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -464,19 +464,19 @@ void Run::calculateGoniometerMatrix() {
                     boost::lexical_cast<std::string>(maxAngle) +
                     ".  Used mean = " +
                     boost::lexical_cast<std::string>(angle) + ".");
-      if (axisName.compare("omega") == 0) {
+      if (axisName == "omega") {
         g_log.warning("To set to last angle, replace omega with " +
                       boost::lexical_cast<std::string>(lastAngle) +
                       ": "
                       "SetGoniometer(Workspace=\'workspace\',Axis0=omega,0,1,0,"
                       "1\',Axis1='chi,0,0,1,1',Axis2='phi,0,1,0,1')");
-      } else if (axisName.compare("chi") == 0) {
+      } else if (axisName == "chi") {
         g_log.warning("To set to last angle, replace chi with " +
                       boost::lexical_cast<std::string>(lastAngle) +
                       ": "
                       "SetGoniometer(Workspace=\'workspace\',Axis0=omega,0,1,0,"
                       "1\',Axis1='chi,0,0,1,1',Axis2='phi,0,1,0,1')");
-      } else if (axisName.compare("phi") == 0) {
+      } else if (axisName == "phi") {
         g_log.warning("To set to last angle, replace phi with " +
                       boost::lexical_cast<std::string>(lastAngle) +
                       ": "

--- a/Framework/Algorithms/src/AddNote.cpp
+++ b/Framework/Algorithms/src/AddNote.cpp
@@ -128,7 +128,7 @@ void AddNote::removeExisting(API::MatrixWorkspace_sptr &logWS,
  */
 void AddNote::createOrUpdate(API::Run &run, const std::string &name) {
   std::string time = getProperty("Time");
-  if (time.compare(std::string("")) == 0) {
+  if (time == std::string("")) {
     namespace pt = boost::posix_time;
     auto dateTimeObj = DateAndTime(pt::second_clock::local_time());
     time = dateTimeObj.toISO8601String();

--- a/Framework/Algorithms/src/AddNote.cpp
+++ b/Framework/Algorithms/src/AddNote.cpp
@@ -128,7 +128,7 @@ void AddNote::removeExisting(API::MatrixWorkspace_sptr &logWS,
  */
 void AddNote::createOrUpdate(API::Run &run, const std::string &name) {
   std::string time = getProperty("Time");
-  if (time == std::string("")) {
+  if (time.empty()) {
     namespace pt = boost::posix_time;
     auto dateTimeObj = DateAndTime(pt::second_clock::local_time());
     time = dateTimeObj.toISO8601String();

--- a/Framework/Algorithms/src/AddSampleLog.cpp
+++ b/Framework/Algorithms/src/AddSampleLog.cpp
@@ -223,10 +223,10 @@ void AddSampleLog::addTimeSeriesProperty(Run &run_obj,
                                          const std::string &prop_number_type) {
   // set up the number type right
   bool is_int_series(false);
-  if (prop_number_type.compare(intTypeOption) == 0) {
+  if (prop_number_type == intTypeOption) {
     // integer type
     is_int_series = true;
-  } else if (prop_number_type.compare(autoTypeOption) == 0) {
+  } else if (prop_number_type == autoTypeOption) {
     // auto type. by default
     if (prop_value.size() == 0)
       g_log.warning("For sample log in TimeSeriesProperty and values are given "
@@ -239,7 +239,7 @@ void AddSampleLog::addTimeSeriesProperty(Run &run_obj,
         is_int_series = true;
       }
     }
-  } else if (prop_number_type.compare(doubleTypeOption) != 0) {
+  } else if (prop_number_type != doubleTypeOption) {
     // unsupported type: anything but double, integer or auto
     g_log.error() << "TimeSeriesProperty with data type " << prop_number_type
                   << " is not supported.\n";
@@ -315,7 +315,7 @@ void AddSampleLog::setTimeSeriesData(Run &run_obj,
   bool epochtime(false);
   std::string timeunit;
   getMetaData(data_ws, epochtime, timeunit);
-  bool is_second = timeunit.compare("Second") == 0;
+  bool is_second = timeunit == "Second";
 
   // convert the data in workspace to time series property value
   std::vector<DateAndTime> time_vec =
@@ -442,7 +442,7 @@ void AddSampleLog::getMetaData(API::MatrixWorkspace_const_sptr dataws,
     // get the meta data from the input workspace
     std::string epochtimestr =
         dataws->run().getProperty("IsEpochTime")->value();
-    epochtime = epochtimestr.compare("true") == 0;
+    epochtime = epochtimestr == "true";
     timeunit = dataws->run().getProperty("TimeUnit")->value();
   } else {
     // get the meta data from input

--- a/Framework/Algorithms/src/CalMuonDeadTime.cpp
+++ b/Framework/Algorithms/src/CalMuonDeadTime.cpp
@@ -192,13 +192,13 @@ void CalMuonDeadTime::exec() {
     API::IFunction_sptr result = fit->getProperty("Function");
 
     // Check order of names
-    if (result->parameterName(0).compare("A0") != 0) {
+    if (result->parameterName(0) != "A0") {
       g_log.error() << "Parameter 0 should be A0, but is "
                     << result->parameterName(0) << '\n';
       throw std::invalid_argument(
           "Parameters are out of order @ 0, should be A0");
     }
-    if (result->parameterName(1).compare("A1") != 0) {
+    if (result->parameterName(1) != "A1") {
       g_log.error() << "Parameter 1 should be A1, but is "
                     << result->parameterName(1) << '\n';
       throw std::invalid_argument(

--- a/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis.cpp
@@ -121,7 +121,7 @@ void ConvertSpectrumAxis::exec() {
     // Set up binding to memeber funtion. Avoids condition as part of loop over
     // nHistograms.
     boost::function<double(const IDetector &)> thetaFunction;
-    if (unitTarget.compare("signed_theta") == 0) {
+    if (unitTarget == "signed_theta") {
       thetaFunction =
           boost::bind(&MatrixWorkspace::detectorSignedTwoTheta, inputWS, _1);
     } else {

--- a/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
@@ -102,8 +102,7 @@ void ConvertSpectrumAxis2::createThetaMap(API::Progress &progress,
                                           API::MatrixWorkspace_sptr &inputWS) {
   // Not sure about default, previously there was a call to a null function?
   bool signedTheta = false;
-  if (targetUnit == "signed_theta" ||
-      targetUnit == "SignedTheta") {
+  if (targetUnit == "signed_theta" || targetUnit == "SignedTheta") {
     signedTheta = true;
   } else if (targetUnit == "theta" || targetUnit == "Theta") {
     signedTheta = false;

--- a/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
@@ -102,8 +102,8 @@ void ConvertSpectrumAxis2::createThetaMap(API::Progress &progress,
                                           API::MatrixWorkspace_sptr &inputWS) {
   // Not sure about default, previously there was a call to a null function?
   bool signedTheta = false;
-  if (targetUnit.compare("signed_theta") == 0 ||
-      targetUnit.compare("SignedTheta") == 0) {
+  if (targetUnit == "signed_theta" ||
+      targetUnit == "SignedTheta") {
     signedTheta = true;
   } else if (targetUnit == "theta" || targetUnit == "Theta") {
     signedTheta = false;

--- a/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
@@ -358,21 +358,21 @@ void CreateGroupingWorkspace::exec() {
   }
 
   // Validation for 2_4Grouping input used only for SNAP
-  if (inst->getName().compare("SNAP") != 0 &&
-      grouping.compare("2_4Grouping") == 0) {
+  if (inst->getName() != "SNAP" &&
+      grouping == "2_4Grouping") {
     const std::string message("2_4Grouping only works for SNAP.");
     g_log.error(message);
     throw std::invalid_argument(message);
   }
 
   if (GroupNames.empty() && OldCalFilename.empty()) {
-    if (grouping.compare("All") == 0) {
+    if (grouping == "All") {
       GroupNames = inst->getName();
-    } else if (inst->getName().compare("SNAP") == 0 &&
-               grouping.compare("Group") == 0) {
+    } else if (inst->getName() == "SNAP" &&
+               grouping == "Group") {
       GroupNames = "East,West";
-    } else if (inst->getName().compare("SNAP") == 0 &&
-               grouping.compare("2_4Grouping") == 0) {
+    } else if (inst->getName() == "SNAP" &&
+               grouping == "2_4Grouping") {
       GroupNames = "Column1,Column2,Column3,Column4,Column5,Column6,";
     } else {
       sortnames = true;
@@ -407,7 +407,7 @@ void CreateGroupingWorkspace::exec() {
   // Make the grouping one of three ways:
   if (!GroupNames.empty()) {
     detIDtoGroup = makeGroupingByNames(GroupNames, inst, prog, sortnames);
-    if (grouping.compare("2_4Grouping") == 0) {
+    if (grouping == "2_4Grouping") {
       std::map<detid_t, int>::const_iterator it_end = detIDtoGroup.end();
       std::map<detid_t, int>::const_iterator it;
       for (it = detIDtoGroup.begin(); it != it_end; ++it) {

--- a/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
@@ -358,8 +358,7 @@ void CreateGroupingWorkspace::exec() {
   }
 
   // Validation for 2_4Grouping input used only for SNAP
-  if (inst->getName() != "SNAP" &&
-      grouping == "2_4Grouping") {
+  if (inst->getName() != "SNAP" && grouping == "2_4Grouping") {
     const std::string message("2_4Grouping only works for SNAP.");
     g_log.error(message);
     throw std::invalid_argument(message);
@@ -368,11 +367,9 @@ void CreateGroupingWorkspace::exec() {
   if (GroupNames.empty() && OldCalFilename.empty()) {
     if (grouping == "All") {
       GroupNames = inst->getName();
-    } else if (inst->getName() == "SNAP" &&
-               grouping == "Group") {
+    } else if (inst->getName() == "SNAP" && grouping == "Group") {
       GroupNames = "East,West";
-    } else if (inst->getName() == "SNAP" &&
-               grouping == "2_4Grouping") {
+    } else if (inst->getName() == "SNAP" && grouping == "2_4Grouping") {
       GroupNames = "Column1,Column2,Column3,Column4,Column5,Column6,";
     } else {
       sortnames = true;

--- a/Framework/Algorithms/src/CreateLogTimeCorrection.cpp
+++ b/Framework/Algorithms/src/CreateLogTimeCorrection.cpp
@@ -50,7 +50,7 @@ void CreateLogTimeCorrection::exec() {
 
   //   Check whether the output workspace name is same as input
   string outwsname = getPropertyValue("OutputWorkspace");
-  if (outwsname.compare(dataWS->getName()) == 0) {
+  if (outwsname == dataWS->getName()) {
     stringstream errmsg;
     errmsg << "It is not allowed to use the same name by both input matrix "
               "workspace and output table workspace.";

--- a/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
+++ b/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp
@@ -307,7 +307,7 @@ void DiffractionEventCalibrateDetectors::exec() {
 
     det = boost::dynamic_pointer_cast<RectangularDetector>((*inst)[i]);
     if (det) {
-      if (det->getName().compare(onebank) == 0)
+      if (det->getName() == onebank)
         detList.push_back(det);
       if (!doOneBank)
         detList.push_back(det);
@@ -320,7 +320,7 @@ void DiffractionEventCalibrateDetectors::exec() {
         for (int j = 0; j < assem->nelements(); j++) {
           det = boost::dynamic_pointer_cast<RectangularDetector>((*assem)[j]);
           if (det) {
-            if (det->getName().compare(onebank) == 0)
+            if (det->getName() == onebank)
               detList.push_back(det);
             if (!doOneBank)
               detList.push_back(det);
@@ -336,7 +336,7 @@ void DiffractionEventCalibrateDetectors::exec() {
                 det = boost::dynamic_pointer_cast<RectangularDetector>(
                     (*assem2)[k]);
                 if (det) {
-                  if (det->getName().compare(onebank) == 0)
+                  if (det->getName() == onebank)
                     detList.push_back(det);
                   if (!doOneBank)
                     detList.push_back(det);

--- a/Framework/Algorithms/src/EstimateResolutionDiffraction.cpp
+++ b/Framework/Algorithms/src/EstimateResolutionDiffraction.cpp
@@ -125,7 +125,7 @@ double EstimateResolutionDiffraction::getWavelength() {
         "LambdaReqeust is not a TimeSeriesProperty in double. ");
 
   string unit = cwltimeseries->units();
-  if (unit.compare("Angstrom") != 0) {
+  if (unit != "Angstrom") {
     throw runtime_error("Unit is not recognized: " + unit);
   }
 

--- a/Framework/Algorithms/src/ExportTimeSeriesLog.cpp
+++ b/Framework/Algorithms/src/ExportTimeSeriesLog.cpp
@@ -152,7 +152,7 @@ void ExportTimeSeriesLog::exportLog(const std::string &logname,
 
   // Get start time, stop time and unit factor
   double timeunitfactor = 1.;
-  if (timeunit.compare("Seconds") == 0)
+  if (timeunit == "Seconds")
     timeunitfactor = 1.E-9;
 
   // Get index for start time

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -295,15 +295,15 @@ void FilterEvents::processAlgorithmProperties() {
   //-------------------------------------------------------------------------
   // Type of correction
   string correctiontype = getPropertyValue("CorrectionToSample");
-  if (correctiontype.compare("None") == 0)
+  if (correctiontype == "None")
     m_tofCorrType = NoneCorrect;
-  else if (correctiontype.compare("Customized") == 0)
+  else if (correctiontype == "Customized")
     m_tofCorrType = CustomizedCorrect;
-  else if (correctiontype.compare("Direct") == 0)
+  else if (correctiontype == "Direct")
     m_tofCorrType = DirectCorrect;
-  else if (correctiontype.compare("Elastic") == 0)
+  else if (correctiontype == "Elastic")
     m_tofCorrType = ElasticCorrect;
-  else if (correctiontype.compare("Indirect") == 0)
+  else if (correctiontype == "Indirect")
     m_tofCorrType = IndirectCorrect;
   else {
     g_log.error() << "Correction type '" << correctiontype
@@ -321,9 +321,9 @@ void FilterEvents::processAlgorithmProperties() {
 
   // Spectrum skip
   string skipappr = getPropertyValue("SpectrumWithoutDetector");
-  if (skipappr.compare("Skip") == 0)
+  if (skipappr == "Skip")
     m_specSkipType = EventFilterSkipNoDet;
-  else if (skipappr.compare("Skip only if TOF correction") == 0)
+  else if (skipappr == "Skip only if TOF correction")
     m_specSkipType = EventFilterSkipNoDetTOFCorr;
   else
     throw runtime_error("An unrecognized option for SpectrumWithoutDetector");
@@ -1130,9 +1130,9 @@ void FilterEvents::setupCustomizedTOFCorrection() {
     hasshift = true;
 
   bool usedetid;
-  if (colnames[0].compare("DetectorID") == 0)
+  if (colnames[0] == "DetectorID")
     usedetid = true;
-  else if (colnames[0].compare("Spectrum") == 0)
+  else if (colnames[0] == "Spectrum")
     usedetid = false;
   else {
     usedetid = false;

--- a/Framework/Algorithms/src/GenerateEventsFilter.cpp
+++ b/Framework/Algorithms/src/GenerateEventsFilter.cpp
@@ -284,13 +284,13 @@ void GenerateEventsFilter::processInputTime() {
   // Obtain time unit converter
   std::string timeunit = this->getProperty("UnitOfTime");
   m_timeUnitConvertFactorToNS = -1.0;
-  if (timeunit.compare("Seconds") == 0) {
+  if (timeunit == "Seconds") {
     // (second)
     m_timeUnitConvertFactorToNS = 1.0E9;
-  } else if (timeunit.compare("Nanoseconds") == 0) {
+  } else if (timeunit == "Nanoseconds") {
     // (nano-seconds)
     m_timeUnitConvertFactorToNS = 1.0;
-  } else if (timeunit.compare("Percent") == 0) {
+  } else if (timeunit == "Percent") {
     // (percent of total run time)
     int64_t runtime_ns =
         m_runEndTime.totalNanoseconds() - runstarttime.totalNanoseconds();
@@ -519,10 +519,10 @@ void GenerateEventsFilter::setFilterByLogValue(std::string logname) {
       getProperty("FilterLogValueByChangingDirection");
   bool filterIncrease;
   bool filterDecrease;
-  if (filterdirection.compare("Both") == 0) {
+  if (filterdirection == "Both") {
     filterIncrease = true;
     filterDecrease = true;
-  } else if (filterdirection.compare("Increase") == 0) {
+  } else if (filterdirection == "Increase") {
     filterIncrease = true;
     filterDecrease = false;
   } else {
@@ -644,7 +644,7 @@ void GenerateEventsFilter::processSingleValueFilter(double minvalue,
   int wsindex = 0;
   makeFilterBySingleValue(minvalue, maxvalue,
                           static_cast<double>(timetolerance_ns) * 1.0E-9,
-                          logboundary.compare("centre") == 0, filterincrease,
+                          logboundary == "centre", filterincrease,
                           filterdecrease, m_startTime, m_stopTime, wsindex);
 
   // Create information table workspace
@@ -769,12 +769,12 @@ void GenerateEventsFilter::processMultipleValueFilters(double minvalue,
   if (m_useParallel) {
     // Make filters in parallel
     makeMultipleFiltersByValuesParallel(
-        indexwsindexmap, logvalueranges, logboundary.compare("centre") == 0,
+        indexwsindexmap, logvalueranges, logboundary == "centre",
         filterincrease, filterdecrease, m_startTime, m_stopTime);
   } else {
     // Make filters in serial
     makeMultipleFiltersByValues(
-        indexwsindexmap, logvalueranges, logboundary.compare("centre") == 0,
+        indexwsindexmap, logvalueranges, logboundary == "centre",
         filterincrease, filterdecrease, m_startTime, m_stopTime);
   }
 }

--- a/Framework/Algorithms/src/GenerateEventsFilter.cpp
+++ b/Framework/Algorithms/src/GenerateEventsFilter.cpp
@@ -773,9 +773,9 @@ void GenerateEventsFilter::processMultipleValueFilters(double minvalue,
         filterincrease, filterdecrease, m_startTime, m_stopTime);
   } else {
     // Make filters in serial
-    makeMultipleFiltersByValues(
-        indexwsindexmap, logvalueranges, logboundary == "centre",
-        filterincrease, filterdecrease, m_startTime, m_stopTime);
+    makeMultipleFiltersByValues(indexwsindexmap, logvalueranges,
+                                logboundary == "centre", filterincrease,
+                                filterdecrease, m_startTime, m_stopTime);
   }
 }
 

--- a/Framework/Algorithms/src/GeneratePeaks.cpp
+++ b/Framework/Algorithms/src/GeneratePeaks.cpp
@@ -193,14 +193,14 @@ void GeneratePeaks::processAlgProperties(std::string &peakfunctype,
     bkgdfunctype = strs[0];
   }
 
-  if (bkgdfunctype.compare("Auto") == 0) {
+  if (bkgdfunctype == "Auto") {
     m_useAutoBkgd = true;
     bkgdfunctype = "Quadratic";
-  } else if (bkgdfunctype.compare("None") == 0) {
+  } else if (bkgdfunctype == "None") {
     m_useAutoBkgd = false;
     m_genBackground = false;
-  } else if (bkgdfunctype.compare("Linear") == 0 ||
-             bkgdfunctype.compare("Flat") == 0) {
+  } else if (bkgdfunctype == "Linear" ||
+             bkgdfunctype == "Flat") {
     m_useAutoBkgd = false;
     bkgdfunctype = bkgdfunctype + "Background";
   }
@@ -518,9 +518,9 @@ void GeneratePeaks::processTableColumnNames() {
   // Initial check
   std::vector<std::string> colnames = m_funcParamWS->getColumnNames();
 
-  if (colnames[0].compare("spectrum") != 0)
+  if (colnames[0] != "spectrum")
     throw std::runtime_error("First column must be 'spectrum' in integer. ");
-  if (colnames.back().compare("chi2") != 0)
+  if (colnames.back() != "chi2")
     throw std::runtime_error("Last column must be 'chi2'.");
 
   // Process column names in case that there are not same as parameter names

--- a/Framework/Algorithms/src/GeneratePeaks.cpp
+++ b/Framework/Algorithms/src/GeneratePeaks.cpp
@@ -199,8 +199,7 @@ void GeneratePeaks::processAlgProperties(std::string &peakfunctype,
   } else if (bkgdfunctype == "None") {
     m_useAutoBkgd = false;
     m_genBackground = false;
-  } else if (bkgdfunctype == "Linear" ||
-             bkgdfunctype == "Flat") {
+  } else if (bkgdfunctype == "Linear" || bkgdfunctype == "Flat") {
     m_useAutoBkgd = false;
     bkgdfunctype = bkgdfunctype + "Background";
   }

--- a/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
+++ b/Framework/Algorithms/src/GetDetOffsetsMultiPeaks.cpp
@@ -1183,7 +1183,7 @@ void GetDetOffsetsMultiPeaks::addInfoToReportWS(
 
   // Peak width delta(d)/d
   m_resolutionWS->mutableX(wi)[0] = static_cast<double>(wi);
-  if (offsetresult.fitoffsetstatus.compare("success") == 0) {
+  if (offsetresult.fitoffsetstatus == "success") {
     // Only add successfully calculated value
     m_resolutionWS->mutableY(wi)[0] = offsetresult.resolution;
     m_resolutionWS->mutableE(wi)[0] = offsetresult.dev_resolution;

--- a/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
+++ b/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp
@@ -158,9 +158,9 @@ void GetTimeSeriesLogInformation::processTimeRange() {
   // Time unit option
   string timeoption = this->getProperty("TimeRangeOption");
   int timecase = 0;
-  if (timeoption.compare("Absolute Time (nano second)") == 0)
+  if (timeoption == "Absolute Time (nano second)")
     timecase = 1;
-  else if (timeoption.compare("Relative Time (second)") == 0)
+  else if (timeoption == "Relative Time (second)")
     timecase = 0;
   else
     timecase = -1;

--- a/Framework/Algorithms/src/MaskBinsFromTable.cpp
+++ b/Framework/Algorithms/src/MaskBinsFromTable.cpp
@@ -149,9 +149,9 @@ void MaskBinsFromTable::processMaskBinWorkspace(
   for (int i = 0; i < static_cast<int>(colnames.size()); ++i) {
     string colname = colnames[i];
     transform(colname.begin(), colname.end(), colname.begin(), ::tolower);
-    if (colname.compare("xmin") == 0)
+    if (colname == "xmin")
       id_xmin = i;
-    else if (colname.compare("xmax") == 0)
+    else if (colname == "xmax")
       id_xmax = i;
     else if (boost::algorithm::starts_with(colname, "spec")) {
       id_spec = i;

--- a/Framework/Algorithms/src/MergeRuns/SampleLogsBehaviour.cpp
+++ b/Framework/Algorithms/src/MergeRuns/SampleLogsBehaviour.cpp
@@ -344,7 +344,7 @@ std::shared_ptr<Property> SampleLogsBehaviour::addPropertyForList(
   // See if property exists already - merging an output of MergeRuns
   returnProp.reset(ws.getLog(item)->clone());
 
-  if (returnProp->type().compare("string") != 0) {
+  if (returnProp->type() != "string") {
     ws.mutableRun().addProperty(item, value, true);
     returnProp.reset(ws.getLog(item)->clone());
   }
@@ -584,7 +584,7 @@ bool SampleLogsBehaviour::isWithinTolerance(const SampleLogBehaviour &behaviour,
  */
 bool SampleLogsBehaviour::stringPropertiesMatch(
     const SampleLogBehaviour &behaviour, const Property *addeeWSProperty) {
-  return behaviour.property->value().compare(addeeWSProperty->value()) == 0;
+  return behaviour.property->value() == addeeWSProperty->value();
 }
 
 /**

--- a/Framework/Algorithms/src/NormaliseByDetector.cpp
+++ b/Framework/Algorithms/src/NormaliseByDetector.cpp
@@ -118,7 +118,7 @@ void NormaliseByDetector::processHistogram(size_t wsIndex,
     const Geometry::FitParameter &fitParam =
         tryParseFunctionParameter(param, det);
 
-    if (fitParam.getFormula() == "") {
+    if (fitParam.getFormula().empty()) {
       throw std::runtime_error(
           "A Forumla has not been provided for a fit function");
     } else {

--- a/Framework/Algorithms/src/NormaliseByDetector.cpp
+++ b/Framework/Algorithms/src/NormaliseByDetector.cpp
@@ -118,12 +118,12 @@ void NormaliseByDetector::processHistogram(size_t wsIndex,
     const Geometry::FitParameter &fitParam =
         tryParseFunctionParameter(param, det);
 
-    if (fitParam.getFormula().compare("") == 0) {
+    if (fitParam.getFormula() == "") {
       throw std::runtime_error(
           "A Forumla has not been provided for a fit function");
     } else {
       std::string resultUnitStr = fitParam.getResultUnit();
-      if (!resultUnitStr.empty() && resultUnitStr.compare("Wavelength") != 0) {
+      if (!resultUnitStr.empty() && resultUnitStr != "Wavelength") {
         throw std::runtime_error(
             "Units for function parameters must be in Wavelength");
       }

--- a/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -504,9 +504,9 @@ void ReflectometryReductionOne::exec() {
   }
   const std::string strAnalysisMode = getProperty("AnalysisMode");
   const bool isPointDetector =
-      (pointDetectorAnalysis.compare(strAnalysisMode) == 0);
+      (pointDetectorAnalysis == strAnalysisMode);
   const bool isMultiDetector =
-      (multiDetectorAnalysis.compare(strAnalysisMode) == 0);
+      (multiDetectorAnalysis == strAnalysisMode);
 
   const MinMax wavelengthInterval =
       this->getMinMax("WavelengthMin", "WavelengthMax");

--- a/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -503,10 +503,8 @@ void ReflectometryReductionOne::exec() {
     theta = temp;
   }
   const std::string strAnalysisMode = getProperty("AnalysisMode");
-  const bool isPointDetector =
-      (pointDetectorAnalysis == strAnalysisMode);
-  const bool isMultiDetector =
-      (multiDetectorAnalysis == strAnalysisMode);
+  const bool isPointDetector = (pointDetectorAnalysis == strAnalysisMode);
+  const bool isMultiDetector = (multiDetectorAnalysis == strAnalysisMode);
 
   const MinMax wavelengthInterval =
       this->getMinMax("WavelengthMin", "WavelengthMax");

--- a/Framework/Algorithms/src/RemoveExpDecay.cpp
+++ b/Framework/Algorithms/src/RemoveExpDecay.cpp
@@ -185,13 +185,13 @@ double MuonRemoveExpDecay::calNormalisationConst(API::MatrixWorkspace_sptr ws,
   std::vector<std::string> paramnames = result->getParameterNames();
 
   // Check order of names
-  if (paramnames[0].compare("A0") != 0) {
+  if (paramnames[0] != "A0") {
     g_log.error() << "Parameter 0 should be A0, but is " << paramnames[0]
                   << '\n';
     throw std::invalid_argument(
         "Parameters are out of order @ 0, should be A0");
   }
-  if (paramnames[1].compare("A1") != 0) {
+  if (paramnames[1] != "A1") {
     g_log.error() << "Parameter 1 should be A1, but is " << paramnames[1]
                   << '\n';
     throw std::invalid_argument(

--- a/Framework/Algorithms/src/SetUncertainties.cpp
+++ b/Framework/Algorithms/src/SetUncertainties.cpp
@@ -77,11 +77,11 @@ void SetUncertainties::init() {
 void SetUncertainties::exec() {
   MatrixWorkspace_const_sptr inputWorkspace = getProperty("InputWorkspace");
   std::string errorType = getProperty("SetError");
-  bool zeroError = (errorType.compare(ZERO) == 0);
+  bool zeroError = (errorType == ZERO);
   bool takeSqrt =
-      ((errorType.compare(SQRT) == 0) || (errorType.compare(SQRT_OR_ONE) == 0));
-  bool resetOne = ((errorType.compare(ONE_IF_ZERO) == 0) ||
-                   (errorType.compare(SQRT_OR_ONE) == 0));
+      ((errorType == SQRT) || (errorType == SQRT_OR_ONE));
+  bool resetOne = ((errorType == ONE_IF_ZERO) ||
+                   (errorType == SQRT_OR_ONE));
 
   // Create the output workspace. This will copy many aspects from the input
   // one.
@@ -101,7 +101,7 @@ void SetUncertainties::exec() {
     outputWorkspace->setSharedX(i, inputWorkspace->sharedX(i));
     outputWorkspace->setSharedY(i, inputWorkspace->sharedY(i));
     // copy the E or set to zero depending on the mode
-    if (errorType.compare(ONE_IF_ZERO) == 0) {
+    if (errorType == ONE_IF_ZERO) {
       outputWorkspace->setSharedE(i, inputWorkspace->sharedE(i));
     } else {
       outputWorkspace->mutableE(i) = 0.0;

--- a/Framework/Algorithms/src/SetUncertainties.cpp
+++ b/Framework/Algorithms/src/SetUncertainties.cpp
@@ -78,10 +78,8 @@ void SetUncertainties::exec() {
   MatrixWorkspace_const_sptr inputWorkspace = getProperty("InputWorkspace");
   std::string errorType = getProperty("SetError");
   bool zeroError = (errorType == ZERO);
-  bool takeSqrt =
-      ((errorType == SQRT) || (errorType == SQRT_OR_ONE));
-  bool resetOne = ((errorType == ONE_IF_ZERO) ||
-                   (errorType == SQRT_OR_ONE));
+  bool takeSqrt = ((errorType == SQRT) || (errorType == SQRT_OR_ONE));
+  bool resetOne = ((errorType == ONE_IF_ZERO) || (errorType == SQRT_OR_ONE));
 
   // Create the output workspace. This will copy many aspects from the input
   // one.

--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -411,8 +411,8 @@ void SmoothNeighbours::findNeighboursUbiqutious() {
             neighbParent = det.getParent();
             neighbGParent = neighbParent->getParent();
             if (noNeigh >= sum ||
-                neighbParent->getName().compare(parent->getName()) != 0 ||
-                neighbGParent->getName().compare(grandparent->getName()) != 0 ||
+                neighbParent->getName() != parent->getName() ||
+                neighbGParent->getName() != grandparent->getName() ||
                 used[neighWI])
               continue;
             noNeigh++;

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -335,7 +335,7 @@ int CentroidPeaks::findPixelID(std::string bankName, int col, int row) {
   Geometry::Instrument_const_sptr Iptr = inWS->getInstrument();
   boost::shared_ptr<const IComponent> parent =
       Iptr->getComponentByName(bankName);
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 
@@ -358,12 +358,12 @@ int CentroidPeaks::findPixelID(std::string bankName, int col, int row) {
 }
 bool CentroidPeaks::edgePixel(std::string bankName, int col, int row,
                               int Edge) {
-  if (bankName.compare("None") == 0)
+  if (bankName == "None")
     return false;
   Geometry::Instrument_const_sptr Iptr = inWS->getInstrument();
   boost::shared_ptr<const IComponent> parent =
       Iptr->getComponentByName(bankName);
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 

--- a/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
+++ b/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
@@ -1751,7 +1751,7 @@ int IntegratePeakTimeSlices::findNameInVector(
 
 {
   for (size_t i = 0; i < nameList.size(); i++)
-    if (oneName.compare(nameList[i]) == 0)
+    if (oneName == nameList[i])
       return static_cast<int>(i);
 
   return -1;

--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -124,7 +124,7 @@ std::string LoadIsawPeaks::readHeader(PeaksWorkspace_sptr outWS,
   if (r.length() < 1)
     throw std::logic_error(std::string("No first line of Peaks file"));
 
-  if (r != std::string("Version:"))
+  if (r != "Version:")
     throw std::logic_error(
         std::string("No Version: on first line of Peaks file"));
 
@@ -349,7 +349,7 @@ std::string LoadIsawPeaks::readPeakBlockHeader(std::string lastStr,
     }
   }
 
-  if (s != std::string("1"))
+  if (s != "1")
     return s;
 
   run = std::stoi(getWord(in, false));
@@ -396,7 +396,7 @@ void LoadIsawPeaks::appendFile(PeaksWorkspace_sptr outWS,
   if (!in.good() || s.length() < 1)
     throw std::runtime_error("End of Peaks file before peaks");
 
-  if (s != std::string("0"))
+  if (s != "0")
     throw std::logic_error("No header for Peak segments");
 
   readToEndOfLine(in, true);

--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -36,7 +36,7 @@ using namespace Mantid::Geometry;
 int LoadIsawPeaks::confidence(Kernel::FileDescriptor &descriptor) const {
   const std::string &extn = descriptor.extension();
   // If the extension is peaks or integrate then give it a go
-  if (extn.compare(".peaks") != 0 && extn.compare(".integrate") != 0)
+  if (extn != ".peaks" && extn != ".integrate")
     return 0;
 
   int confidence(0);
@@ -49,7 +49,7 @@ int LoadIsawPeaks::confidence(Kernel::FileDescriptor &descriptor) const {
     if (r.length() < 1)
       throw std::logic_error(std::string("No first line of Peaks file"));
 
-    if (r.compare("Version:") != 0)
+    if (r != "Version:")
       throw std::logic_error(
           std::string("No Version: on first line of Peaks file"));
 
@@ -124,7 +124,7 @@ std::string LoadIsawPeaks::readHeader(PeaksWorkspace_sptr outWS,
   if (r.length() < 1)
     throw std::logic_error(std::string("No first line of Peaks file"));
 
-  if (r.compare(std::string("Version:")) != 0)
+  if (r != std::string("Version:"))
     throw std::logic_error(
         std::string("No Version: on first line of Peaks file"));
 
@@ -226,7 +226,7 @@ DataObjects::Peak LoadIsawPeaks::readPeak(PeaksWorkspace_sptr outWS,
   if (s.length() < 1)
     throw std::runtime_error("Empty peak line encountered.");
 
-  if (s.compare("2") == 0) {
+  if (s == "2") {
     readToEndOfLine(in, true);
     for (s = getWord(in, false); s.length() < 1 && in.good();
          s = getWord(in, true)) {
@@ -237,7 +237,7 @@ DataObjects::Peak LoadIsawPeaks::readPeak(PeaksWorkspace_sptr outWS,
   if (s.length() < 1)
     throw std::runtime_error("Empty peak line encountered.");
 
-  if (s.compare("3") != 0)
+  if (s != "3")
     throw std::runtime_error("Empty peak line encountered.");
 
   seqNum = std::stoi(getWord(in, false));
@@ -289,7 +289,7 @@ int LoadIsawPeaks::findPixelID(Instrument_const_sptr inst, std::string bankName,
   boost::shared_ptr<const IComponent> parent =
       getCachedBankByName(bankName, inst);
 
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 
@@ -300,7 +300,7 @@ int LoadIsawPeaks::findPixelID(Instrument_const_sptr inst, std::string bankName,
     boost::shared_ptr<const Geometry::ICompAssembly> asmb =
         boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(parent);
     asmb->getChildren(children, false);
-    if (children[0]->getName().compare("sixteenpack") == 0) {
+    if (children[0]->getName() == "sixteenpack") {
       asmb = boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(
           children[0]);
       children.clear();
@@ -340,7 +340,7 @@ std::string LoadIsawPeaks::readPeakBlockHeader(std::string lastStr,
   if (s.length() < 1)
     return std::string();
 
-  if (s.compare("0") == 0) {
+  if (s == "0") {
     readToEndOfLine(in, true);
     s = getWord(in, false);
     while (s.length() < 1) {
@@ -349,7 +349,7 @@ std::string LoadIsawPeaks::readPeakBlockHeader(std::string lastStr,
     }
   }
 
-  if (s.compare(std::string("1")) != 0)
+  if (s != std::string("1"))
     return s;
 
   run = std::stoi(getWord(in, false));
@@ -396,7 +396,7 @@ void LoadIsawPeaks::appendFile(PeaksWorkspace_sptr outWS,
   if (!in.good() || s.length() < 1)
     throw std::runtime_error("End of Peaks file before peaks");
 
-  if (s.compare(std::string("0")) != 0)
+  if (s != std::string("0"))
     throw std::logic_error("No header for Peak segments");
 
   readToEndOfLine(in, true);

--- a/Framework/Crystal/src/MaskPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/MaskPeaksWorkspace.cpp
@@ -101,7 +101,7 @@ void MaskPeaksWorkspace::exec() {
 
     // the detector component for the peak will have all pixels that we mask
     const string &bankName = peak.getBankName();
-    if (bankName.compare("None") == 0)
+    if (bankName == "None")
       continue;
     Geometry::IComponent_const_sptr comp = inst->getComponentByName(bankName);
     if (!comp) {
@@ -266,7 +266,7 @@ int MaskPeaksWorkspace::findPixelID(std::string bankName, int col, int row) {
   Geometry::Instrument_const_sptr Iptr = m_inputW->getInstrument();
   boost::shared_ptr<const IComponent> parent =
       Iptr->getComponentByName(bankName);
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 

--- a/Framework/Crystal/src/NormaliseVanadium.cpp
+++ b/Framework/Crystal/src/NormaliseVanadium.cpp
@@ -89,7 +89,7 @@ void NormaliseVanadium::exec() {
 
     Mantid::Kernel::Units::Wavelength wl;
     auto timeflight = inSpec.points();
-    if (unitStr.compare("TOF") == 0)
+    if (unitStr == "TOF")
       wl.fromTOF(timeflight.mutableRawData(), timeflight.mutableRawData(), L1,
                  L2, scattering, 0, 0, 0);
 

--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -244,12 +244,12 @@ OptimizeLatticeForCellType::getLatticeFunction(const std::string &cellType,
 bool OptimizeLatticeForCellType::edgePixel(PeaksWorkspace_sptr ws,
                                            std::string bankName, int col,
                                            int row, int Edge) {
-  if (bankName.compare("None") == 0)
+  if (bankName == "None")
     return false;
   Geometry::Instrument_const_sptr Iptr = ws->getInstrument();
   boost::shared_ptr<const IComponent> parent =
       Iptr->getComponentByName(bankName);
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -56,11 +56,11 @@ const std::string SCDCalibratePanels::category() const {
 bool SCDCalibratePanels::edgePixel(const PeaksWorkspace &ws,
                                    const std::string &bankName, int col,
                                    int row, int Edge) {
-  if (bankName.compare("None") == 0)
+  if (bankName == "None")
     return false;
   auto Iptr = ws.getInstrument();
   auto parent = Iptr->getComponentByName(bankName);
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     auto RDet = boost::dynamic_pointer_cast<const RectangularDetector>(parent);
     return col < Edge || col >= (RDet->xpixels() - Edge) || row < Edge ||
            row >= (RDet->ypixels() - Edge);

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -415,8 +415,8 @@ void SaveHKL::exec() {
           // Distance to center of detector
           boost::shared_ptr<const IComponent> det0 =
               inst->getComponentByName(p.getBankName());
-          if (inst->getName().compare("CORELLI") ==
-              0) // for Corelli with sixteenpack under bank
+          if (inst->getName() ==
+              "CORELLI") // for Corelli with sixteenpack under bank
           {
             std::vector<Geometry::IComponent_const_sptr> children;
             boost::shared_ptr<const Geometry::ICompAssembly> asmb =
@@ -721,21 +721,21 @@ double SaveHKL::spectrumCalc(double TOF, int iSpec,
   return spect;
 }
 void SaveHKL::sizeBanks(std::string bankName, int &nCols, int &nRows) {
-  if (bankName.compare("None") == 0)
+  if (bankName == "None")
     return;
   boost::shared_ptr<const IComponent> parent =
       ws->getInstrument()->getComponentByName(bankName);
   if (!parent)
     return;
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 
     nCols = RDet->xpixels();
     nRows = RDet->ypixels();
   } else {
-    if (ws->getInstrument()->getName().compare("CORELLI") ==
-        0) // for Corelli with sixteenpack under bank
+    if (ws->getInstrument()->getName() ==
+        "CORELLI") // for Corelli with sixteenpack under bank
     {
       std::vector<Geometry::IComponent_const_sptr> children;
       boost::shared_ptr<const Geometry::ICompAssembly> asmb =

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -169,8 +169,8 @@ void SaveIsawPeaks::exec() {
         // Retrieve it
         boost::shared_ptr<const IComponent> det =
             inst->getComponentByName(bankName);
-        if (inst->getName().compare("CORELLI") ==
-            0) // for Corelli with sixteenpack under bank
+        if (inst->getName() ==
+            "CORELLI") // for Corelli with sixteenpack under bank
         {
           std::vector<Geometry::IComponent_const_sptr> children;
           boost::shared_ptr<const Geometry::ICompAssembly> asmb =
@@ -376,7 +376,7 @@ void SaveIsawPeaks::exec() {
 V3D SaveIsawPeaks::findPixelPos(std::string bankName, int col, int row) {
   boost::shared_ptr<const IComponent> parent =
       inst->getComponentByName(bankName);
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 
@@ -387,7 +387,7 @@ V3D SaveIsawPeaks::findPixelPos(std::string bankName, int col, int row) {
     boost::shared_ptr<const Geometry::ICompAssembly> asmb =
         boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(parent);
     asmb->getChildren(children, false);
-    if (children[0]->getName().compare("sixteenpack") == 0) {
+    if (children[0]->getName() == "sixteenpack") {
       asmb = boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(
           children[0]);
       children.clear();
@@ -408,11 +408,11 @@ V3D SaveIsawPeaks::findPixelPos(std::string bankName, int col, int row) {
 }
 void SaveIsawPeaks::sizeBanks(std::string bankName, int &NCOLS, int &NROWS,
                               double &xsize, double &ysize) {
-  if (bankName.compare("None") == 0)
+  if (bankName == "None")
     return;
   boost::shared_ptr<const IComponent> parent =
       inst->getComponentByName(bankName);
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 
@@ -425,7 +425,7 @@ void SaveIsawPeaks::sizeBanks(std::string bankName, int &NCOLS, int &NROWS,
     boost::shared_ptr<const Geometry::ICompAssembly> asmb =
         boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(parent);
     asmb->getChildren(children, false);
-    if (children[0]->getName().compare("sixteenpack") == 0) {
+    if (children[0]->getName() == "sixteenpack") {
       asmb = boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(
           children[0]);
       children.clear();

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -217,13 +217,13 @@ void SaveLauenorm::exec() {
   out.close();
 }
 void SaveLauenorm::sizeBanks(std::string bankName, int &nCols, int &nRows) {
-  if (bankName.compare("None") == 0)
+  if (bankName == "None")
     return;
   boost::shared_ptr<const IComponent> parent =
       ws->getInstrument()->getComponentByName(bankName);
   if (!parent)
     return;
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 

--- a/Framework/Crystal/src/SetGoniometer.cpp
+++ b/Framework/Crystal/src/SetGoniometer.cpp
@@ -58,7 +58,7 @@ void SetGoniometer::exec() {
   // Create the goniometer
   Goniometer gon;
 
-  if (gonioDefined.compare("Universal") == 0)
+  if (gonioDefined == "Universal")
     gon.makeUniversalGoniometer();
   else
     for (size_t i = 0; i < NUM_AXES; i++) {

--- a/Framework/Crystal/src/StatisticsOfPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/StatisticsOfPeaksWorkspace.cpp
@@ -143,7 +143,7 @@ void StatisticsOfPeaksWorkspace::exec() {
     else
       sequence = p.getBankName();
 
-    if (sequence.compare(oldSequence) != 0 && tempWS->getNumberPeaks() > 0) {
+    if (sequence != oldSequence && tempWS->getNumberPeaks() > 0) {
       if (tempWS->getNumberPeaks() > 1)
         doSortHKL(tempWS, oldSequence);
       tempWS = WorkspaceFactory::Instance().createPeaks();
@@ -174,12 +174,12 @@ void StatisticsOfPeaksWorkspace::doSortHKL(Mantid::API::Workspace_sptr ws,
   statsAlg->setProperty("PointGroup", pointGroup);
   statsAlg->setProperty("LatticeCentering", latticeCentering);
   statsAlg->setProperty("RowName", runName);
-  if (runName.compare("Overall") != 0)
+  if (runName != "Overall")
     statsAlg->setProperty("Append", true);
   statsAlg->executeAsChildAlg();
   PeaksWorkspace_sptr statsWksp = statsAlg->getProperty("OutputWorkspace");
   ITableWorkspace_sptr tablews = statsAlg->getProperty("StatisticsTable");
-  if (runName.compare("Overall") == 0)
+  if (runName == "Overall")
     setProperty("OutputWorkspace", statsWksp);
   setProperty("StatisticsTable", tablews);
 }

--- a/Framework/Crystal/src/TOFExtinction.cpp
+++ b/Framework/Crystal/src/TOFExtinction.cpp
@@ -101,44 +101,44 @@ void TOFExtinction::exec() {
     double tbar = absor_sphere(twoth, wl);
     // Extinction Correction
 
-    if (cType.compare("Type I Zachariasen") == 0) {
+    if (cType == "Type I Zachariasen") {
       // Apply correction to fsq with Type-I Z for testing
       double EgLaueI = getEgLaue(Eg, twoth, wl, divBeam, betaBeam);
       double Xqt = getXqt(EgLaueI, cell, wl, twoth, tbar, fsq);
       y_corr = getZachariasen(Xqt);
       sigfsq_ys = getSigFsqr(EgLaueI, cell, wl, twoth, tbar, fsq, sigfsq);
-    } else if (cType.compare("Type I Gaussian") == 0) {
+    } else if (cType == "Type I Gaussian") {
       // Apply correction to fsq with Type-I BCG for testing
       double EgLaueI =
           M_SQRT2 * getEgLaue(Eg, twoth, wl, divBeam, betaBeam) * 2.0 / 3.0;
       double Xqt = getXqt(EgLaueI, cell, wl, twoth, tbar, fsq);
       y_corr = getGaussian(Xqt, twoth);
       sigfsq_ys = getSigFsqr(EgLaueI, cell, wl, twoth, tbar, fsq, sigfsq);
-    } else if (cType.compare("Type I Lorentzian") == 0) {
+    } else if (cType == "Type I Lorentzian") {
       // Apply correction to fsq with Type-I BCL for testing
       double EgLaueI = getEgLaue(Eg, twoth, wl, divBeam, betaBeam);
       double Xqt = getXqt(EgLaueI, cell, wl, twoth, tbar, fsq);
       y_corr = getLorentzian(Xqt, twoth);
       sigfsq_ys = getSigFsqr(EgLaueI, cell, wl, twoth, tbar, fsq, sigfsq);
-    } else if (cType.compare("Type II Zachariasen") == 0) {
+    } else if (cType == "Type II Zachariasen") {
       // Apply correction to fsq with Type-II Z for testing
       double EsLaue = getEgLaue(r_crystallite, twoth, wl, divBeam, betaBeam);
       double Xqt = getXqt(EsLaue, cell, wl, twoth, tbar, fsq);
       y_corr = getZachariasen(Xqt);
       sigfsq_ys = getSigFsqr(EsLaue, cell, wl, twoth, tbar, fsq, sigfsq);
-    } else if (cType.compare("Type II Gaussian") == 0) {
+    } else if (cType == "Type II Gaussian") {
       // Apply correction to fsq with Type-II BCG for testing
       double EsLaue = getEgLaue(r_crystallite, twoth, wl, divBeam, betaBeam);
       double Xqt = getXqt(EsLaue, cell, wl, twoth, tbar, fsq);
       y_corr = getGaussian(Xqt, twoth);
       sigfsq_ys = getSigFsqr(EsLaue, cell, wl, twoth, tbar, fsq, sigfsq);
-    } else if (cType.compare("Type II Lorentzian") == 0) {
+    } else if (cType == "Type II Lorentzian") {
       // Apply correction to fsq with Type-II BCL for testing
       double EsLaue = getEgLaue(r_crystallite, twoth, wl, divBeam, betaBeam);
       double Xqt = getXqt(EsLaue, cell, wl, twoth, tbar, fsq);
       y_corr = getLorentzian(Xqt, twoth);
       sigfsq_ys = getSigFsqr(EsLaue, cell, wl, twoth, tbar, fsq, sigfsq);
-    } else if (cType.compare("Type I&II Zachariasen") == 0) {
+    } else if (cType == "Type I&II Zachariasen") {
       // Apply correction to fsq with Type-II Z for testing
       double EgLaueI = getEgLaue(Eg, twoth, wl, divBeam, betaBeam);
       double EsLaue = getEgLaue(r_crystallite, twoth, wl, divBeam, betaBeam);
@@ -146,21 +146,21 @@ void TOFExtinction::exec() {
       double Xqt = getXqtII(Rg, cell, wl, twoth, tbar, fsq);
       y_corr = getTypeIIZachariasen(Xqt);
       sigfsq_ys = getSigFsqr(EsLaue, cell, wl, twoth, tbar, fsq, sigfsq);
-    } else if (cType.compare("Type I&II Gaussian") == 0) {
+    } else if (cType == "Type I&II Gaussian") {
       // Apply correction to fsq with Type-II BCG for testing
       double EgLaueI = getEgLaue(Eg, twoth, wl, divBeam, betaBeam);
       double Rg = getRgGaussian(EgLaueI, r_crystallite, wl, twoth);
       double Xqt = getXqtII(Rg, cell, wl, twoth, tbar, fsq);
       y_corr = getTypeIIGaussian(Xqt, twoth);
       sigfsq_ys = getSigFsqr(Rg, cell, wl, twoth, tbar, fsq, sigfsq);
-    } else if (cType.compare("Type I&II Lorentzian") == 0) {
+    } else if (cType == "Type I&II Lorentzian") {
       // Apply correction to fsq with Type-II BCL for testing
       double EgLaueI = getEgLaue(Eg, twoth, wl, divBeam, betaBeam);
       double Rg = getRgLorentzian(EgLaueI, r_crystallite, wl, twoth);
       double Xqt = getXqtII(Rg, cell, wl, twoth, tbar, fsq);
       y_corr = getTypeIILorentzian(Xqt, twoth);
       sigfsq_ys = getSigFsqr(Rg, cell, wl, twoth, tbar, fsq, sigfsq);
-    } else if (cType.compare("None, Scaling Only") == 0) {
+    } else if (cType == "None, Scaling Only") {
       y_corr = 1.0; // No extinction correction
       sigfsq_ys = sigfsq;
     }

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BivariateNormal.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BivariateNormal.h
@@ -140,7 +140,7 @@ public:
   }
 
   bool hasAttribute(const std::string &attName) const override {
-    return attName.compare("CalcVariances") == 0;
+    return attName == "CalcVariances";
   }
 
   bool CalcVxx, CalcVyy, CalcVxy;

--- a/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp
+++ b/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp
@@ -295,9 +295,9 @@ void FitPowderDiffPeaks::processInputProperties() {
 
   // fitting algorithm option
   string fitmode = getProperty("FittingMode");
-  if (fitmode.compare("Robust") == 0) {
+  if (fitmode == "Robust") {
     m_fitMode = ROBUSTFIT;
-  } else if (fitmode.compare("Confident") == 0) {
+  } else if (fitmode == "Confident") {
     m_fitMode = TRUSTINPUTFIT;
   } else {
     throw runtime_error(
@@ -310,9 +310,9 @@ void FitPowderDiffPeaks::processInputProperties() {
 
   // peak parameter generation option
   string genpeakparamalg = getProperty("PeakParametersStartingValueFrom");
-  if (genpeakparamalg.compare("(HKL) & Calculation") == 0) {
+  if (genpeakparamalg == "(HKL) & Calculation") {
     m_genPeakStartingValue = HKLCALCULATION;
-  } else if (genpeakparamalg.compare("From Bragg Peak Table") == 0) {
+  } else if (genpeakparamalg == "From Bragg Peak Table") {
     m_genPeakStartingValue = FROMBRAGGTABLE;
   } else {
     throw runtime_error(
@@ -1288,7 +1288,7 @@ bool FitPowderDiffPeaks::fitSinglePeakConfident(
   // a) Fit peak height
   for (size_t iparam = 0; iparam < peakparamnames.size(); ++iparam) {
     string &parname = peakparams[iparam];
-    if (parname.compare("I") == 0)
+    if (parname == "I")
       peak->unfix(iparam);
     else
       peak->fix(iparam);
@@ -1333,7 +1333,7 @@ bool FitPowderDiffPeaks::fitSinglePeakConfident(
   double chi2planB;
   for (size_t iparam = 0; iparam < peakparamnames.size(); ++iparam) {
     string parname = peakparams[iparam];
-    if (parname.compare("A") == 0)
+    if (parname == "A")
       peak->fix(iparam);
     else
       peak->unfix(iparam);
@@ -1344,7 +1344,7 @@ bool FitPowderDiffPeaks::fitSinglePeakConfident(
   // iii. Fit "A" only
   for (size_t iparam = 0; iparam < peakparamnames.size(); ++iparam) {
     string parname = peakparams[iparam];
-    if (parname.compare("A") == 0 || parname.compare("I") == 0)
+    if (parname == "A" || parname == "I")
       peak->unfix(iparam);
     else
       peak->fix(iparam);
@@ -1368,7 +1368,7 @@ bool FitPowderDiffPeaks::fitSinglePeakConfident(
   double chi2planC;
   for (size_t iparam = 0; iparam < peakparamnames.size(); ++iparam) {
     string parname = peakparams[iparam];
-    if (parname.compare("A") != 0)
+    if (parname != "A")
       peak->fix(iparam);
     else
       peak->unfix(iparam);
@@ -1379,7 +1379,7 @@ bool FitPowderDiffPeaks::fitSinglePeakConfident(
   // iii. Fit peak height and everything else but "A"
   for (size_t iparam = 0; iparam < peakparamnames.size(); ++iparam) {
     string parname = peakparams[iparam];
-    if (parname.compare("A") == 0)
+    if (parname == "A")
       peak->fix(iparam);
     else
       peak->unfix(iparam);
@@ -1961,7 +1961,7 @@ bool FitPowderDiffPeaks::doFitMultiplePeaks(
   // a) Set up fit/fix
   vector<string> peakparnames = peakfuncs[0]->getParameterNames();
   for (size_t ipn = 0; ipn < peakparnames.size(); ++ipn) {
-    bool isI = peakparnames[ipn].compare("I") == 0;
+    bool isI = peakparnames[ipn] == "I";
 
     for (size_t ipk = 0; ipk < numpeaks; ++ipk) {
       BackToBackExponential_sptr thispeak = peakfuncs[ipk];
@@ -2195,7 +2195,7 @@ std::string FitPowderDiffPeaks::parseFitResult(API::IAlgorithm_sptr fitalg,
   chi2 = fitalg->getProperty("OutputChi2overDoF");
   string fitstatus = fitalg->getProperty("OutputStatus");
 
-  fitsuccess = (fitstatus.compare("success") == 0);
+  fitsuccess = (fitstatus == "success");
 
   rss << "  [Algorithm Fit]:  Chi^2 = " << chi2
       << "; Fit Status = " << fitstatus;
@@ -2250,7 +2250,7 @@ void FitPowderDiffPeaks::importInstrumentParameterFromTable(
     throw std::runtime_error(errss.str());
   }
 
-  if (colnames[0].compare("Name") != 0 || colnames[1].compare("Value") != 0) {
+  if (colnames[0] != "Name" || colnames[1] != "Value") {
     stringstream errss;
     errss << "Input parameter table workspace does not have the columns in "
              "order as  "
@@ -2306,11 +2306,11 @@ void FitPowderDiffPeaks::parseBraggPeakTable(
       string coltype = coltypes[icol];
       string colname = paramnames[icol];
 
-      if (coltype.compare("int") == 0) {
+      if (coltype == "int") {
         // Integer
         int temp = peakws->cell<int>(irow, icol);
         intmap.emplace(colname, temp);
-      } else if (coltype.compare("double") == 0) {
+      } else if (coltype == "double") {
         // Double
         double temp = peakws->cell<double>(irow, icol);
         doublemap.emplace(colname, temp);
@@ -2826,7 +2826,7 @@ FitPowderDiffPeaks::genPeak(map<string, int> hklmap,
 
       // Set peak parameters
       for (const auto &parname : tnb2bfuncparnames) {
-        if (parname.compare("Height") != 0) {
+        if (parname != "Height") {
           auto miter = m_instrumentParmaeters.find(parname);
           if (miter == m_instrumentParmaeters.end()) {
             stringstream errss;
@@ -2878,7 +2878,7 @@ FitPowderDiffPeaks::genPeak(map<string, int> hklmap,
       if (miter != parammap.end()) {
         // Parameter exist in input
         double parvalue = miter->second;
-        if (b2bexpname.compare("S2") == 0) {
+        if (b2bexpname == "S2") {
           newpeakptr->setParameter("S", sqrt(parvalue));
         } else {
           newpeakptr->setParameter(b2bexpname, parvalue);

--- a/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
@@ -1080,8 +1080,7 @@ void LeBailFit::parseBraggPeaksParametersTable() {
                   << " < 3 as required.\n";
     throw std::runtime_error("Input parameter workspace is wrong. ");
   }
-  if (colnames[0] != "H" || colnames[1] != "K" ||
-      colnames[2] != "L") {
+  if (colnames[0] != "H" || colnames[1] != "K" || colnames[2] != "L") {
     stringstream errss;
     errss << "Input Bragg peak parameter TableWorkspace does not have the "
              "columns in order.  "

--- a/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
@@ -851,19 +851,19 @@ void LeBailFit::processInputProperties() {
   // d) Determine Functionality (function mode)
   std::string function = this->getProperty("Function");
   m_fitMode = FIT; // Default: LeBailFit
-  if (function.compare("Calculation") == 0) {
+  if (function == "Calculation") {
     // peak calculation
     m_fitMode = CALCULATION;
-  } else if (function.compare("CalculateBackground") == 0) {
+  } else if (function == "CalculateBackground") {
     // automatic background points selection
     m_fitMode = BACKGROUNDPROCESS;
-  } else if (function.compare("MonteCarlo") == 0) {
+  } else if (function == "MonteCarlo") {
     // Monte Carlo random walk refinement
     m_fitMode = MONTECARLO;
-  } else if (function.compare("LeBailFit") == 0) {
+  } else if (function == "LeBailFit") {
     // Le Bail Fit mode
     m_fitMode = FIT;
-  } else if (function.compare("RefineBackground") == 0) {
+  } else if (function == "RefineBackground") {
     // Refine background mode
     m_fitMode = BACKGROUNDPROCESS;
   } else {
@@ -941,7 +941,7 @@ void LeBailFit::parseInstrumentParametersTable() {
     // c) Parse each term
     for (size_t icol = 0; icol < numcols; ++icol) {
       colname = colnames[icol];
-      if (colname.compare("FitOrTie") != 0 && colname.compare("Name") != 0) {
+      if (colname != "FitOrTie" && colname != "Name") {
         // double data
         g_log.debug() << "Col-name = " << colname << ", ";
         trow >> dblvalue;
@@ -1080,8 +1080,8 @@ void LeBailFit::parseBraggPeaksParametersTable() {
                   << " < 3 as required.\n";
     throw std::runtime_error("Input parameter workspace is wrong. ");
   }
-  if (colnames[0].compare("H") != 0 || colnames[1].compare("K") != 0 ||
-      colnames[2].compare("L") != 0) {
+  if (colnames[0] != "H" || colnames[1] != "K" ||
+      colnames[2] != "L") {
     stringstream errss;
     errss << "Input Bragg peak parameter TableWorkspace does not have the "
              "columns in order.  "
@@ -1092,7 +1092,7 @@ void LeBailFit::parseBraggPeaksParametersTable() {
 
   // Has peak height?
   bool hasPeakHeight = false;
-  if (colnames.size() >= 4 && colnames[3].compare("PeakHeight") == 0) {
+  if (colnames.size() >= 4 && colnames[3] == "PeakHeight") {
     // Has a column for peak height
     hasPeakHeight = true;
   }

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
@@ -162,9 +162,9 @@ void RefinePowderInstrumentParameters::exec() {
   m_MaxNumberStoredParameters = static_cast<size_t>(tempint);
 
   string algoption = getProperty("RefinementAlgorithm");
-  if (algoption.compare("DirectFit") == 0)
+  if (algoption == "DirectFit")
     refinealgorithm = DirectFit;
-  else if (algoption.compare("MonteCarlo") == 0)
+  else if (algoption == "MonteCarlo")
     refinealgorithm = MonteCarlo;
   else
     throw runtime_error("RefinementAlgorithm other than DirectFit and "
@@ -400,7 +400,7 @@ bool RefinePowderInstrumentParameters::fitFunction(IFunction_sptr func,
   g_log.debug() << "Function Fit:  Chi^2 = " << gslchi2
                 << "; Fit Status = " << fitstatus << '\n';
 
-  bool fitgood = (fitstatus.compare("success") == 0);
+  bool fitgood = (fitstatus == "success");
 
   return fitgood;
 }
@@ -867,25 +867,25 @@ void RefinePowderInstrumentParameters::genPeaksFromTable(
 
     API::TableRow row = peakparamws->getRow(ir);
     for (auto &colname : colnames) {
-      if (colname.compare("H") == 0)
+      if (colname == "H")
         row >> h;
-      else if (colname.compare("K") == 0)
+      else if (colname == "K")
         row >> k;
-      else if (colname.compare("L") == 0)
+      else if (colname == "L")
         row >> l;
-      else if (colname.compare("Alpha") == 0)
+      else if (colname == "Alpha")
         row >> alpha;
-      else if (colname.compare("Beta") == 0)
+      else if (colname == "Beta")
         row >> beta;
-      else if (colname.compare("Sigma2") == 0)
+      else if (colname == "Sigma2")
         row >> sigma2;
-      else if (colname.compare("Sigma") == 0)
+      else if (colname == "Sigma")
         row >> sigma;
-      else if (colname.compare("Chi2") == 0)
+      else if (colname == "Chi2")
         row >> chi2;
-      else if (colname.compare("Height") == 0)
+      else if (colname == "Height")
         row >> height;
-      else if (colname.compare("TOF_h") == 0)
+      else if (colname == "TOF_h")
         row >> tof_h;
       else {
         try {
@@ -939,7 +939,7 @@ void RefinePowderInstrumentParameters::importParametersFromTable(
     throw std::runtime_error("Input parameter workspace is wrong. ");
   }
 
-  if (colnames[0].compare("Name") != 0 || colnames[1].compare("Value") != 0) {
+  if (colnames[0] != "Name" || colnames[1] != "Value") {
     g_log.error() << "Input parameter table workspace does not have the "
                      "columns in order.  "
                   << " It must be Name, Value, FitOrTie.\n";
@@ -981,11 +981,11 @@ void RefinePowderInstrumentParameters::importMonteCarloParametersFromTable(
   istep = imax;
 
   for (size_t i = 0; i < colnames.size(); ++i) {
-    if (colnames[i].compare("Max") == 0)
+    if (colnames[i] == "Max")
       imax = i;
-    else if (colnames[i].compare("Min") == 0)
+    else if (colnames[i] == "Min")
       imin = i;
-    else if (colnames[i].compare("StepSize") == 0)
+    else if (colnames[i] == "StepSize")
       istep = i;
   }
 
@@ -1080,7 +1080,7 @@ hkl, double lattice)
   */
 void RefinePowderInstrumentParameters::calculateThermalNeutronSpecial(
     IFunction_sptr m_Function, const HistogramX &xVals, vector<double> &vec_n) {
-  if (m_Function->name().compare("ThermalNeutronDtoTOFFunction") != 0) {
+  if (m_Function->name() != "ThermalNeutronDtoTOFFunction") {
     g_log.warning() << "Function (" << m_Function->name()
                     << " is not ThermalNeutronDtoTOFFunction.  And it is not "
                        "required to calculate n.\n";
@@ -1117,9 +1117,9 @@ void RefinePowderInstrumentParameters::genPeakCentersWorkspace(
 
   string stdoption = getProperty("StandardError");
   enum { ConstantValue, InvertedPeakHeight } stderroroption;
-  if (stdoption.compare("ConstantValue") == 0) {
+  if (stdoption == "ConstantValue") {
     stderroroption = ConstantValue;
-  } else if (stdoption.compare("InvertedPeakHeight") == 0) {
+  } else if (stdoption == "InvertedPeakHeight") {
     stderroroption = InvertedPeakHeight;
   } else {
     stringstream errss;

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters3.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters3.cpp
@@ -180,9 +180,9 @@ void RefinePowderInstrumentParameters3::processInputProperties() {
 
   // Fit mode
   string fitmode = getProperty("RefinementAlgorithm");
-  if (fitmode.compare("OneStepFit") == 0)
+  if (fitmode == "OneStepFit")
     m_fitMode = FIT;
-  else if (fitmode.compare("MonteCarlo") == 0)
+  else if (fitmode == "MonteCarlo")
     m_fitMode = MONTECARLO;
   else {
     m_fitMode = FIT;
@@ -191,9 +191,9 @@ void RefinePowderInstrumentParameters3::processInputProperties() {
 
   // Stanard error mode
   string stdmode = getProperty("StandardError");
-  if (stdmode.compare("ConstantValue") == 0)
+  if (stdmode == "ConstantValue")
     m_stdMode = CONSTANT;
-  else if (stdmode.compare("UseInputValue") == 0)
+  else if (stdmode == "UseInputValue")
     m_stdMode = USEINPUT;
   else {
     m_stdMode = USEINPUT;
@@ -1003,7 +1003,7 @@ bool RefinePowderInstrumentParameters3::doFitFunction(
   string tempfitstatus = fitalg->getProperty("OutputStatus");
   fitstatus = tempfitstatus;
 
-  bool goodfit = fitstatus.compare("success") == 0;
+  bool goodfit = fitstatus == "success";
 
   stringstream dbss;
   dbss << "Fit Result (GSL):  Chi^2 = " << chi2

--- a/Framework/CurveFitting/src/Functions/NeutronBk2BkExpConvPVoigt.cpp
+++ b/Framework/CurveFitting/src/Functions/NeutronBk2BkExpConvPVoigt.cpp
@@ -120,21 +120,21 @@ double NeutronBk2BkExpConvPVoigt::getPeakParameter(std::string paramname) {
   // Get value
   double paramvalue(EMPTY_DBL());
 
-  if (paramname.compare("Alpha") == 0)
+  if (paramname == "Alpha")
     paramvalue = m_Alpha;
-  else if (paramname.compare("Beta") == 0)
+  else if (paramname == "Beta")
     paramvalue = m_Beta;
-  else if (paramname.compare("Sigma2") == 0)
+  else if (paramname == "Sigma2")
     paramvalue = m_Sigma2;
-  else if (paramname.compare("Gamma") == 0)
+  else if (paramname == "Gamma")
     paramvalue = m_Gamma;
-  else if (paramname.compare("d_h") == 0)
+  else if (paramname == "d_h")
     paramvalue = m_dcentre;
-  else if (paramname.compare("Eta") == 0)
+  else if (paramname == "Eta")
     paramvalue = m_eta;
-  else if (paramname.compare("TOF_h") == 0)
+  else if (paramname == "TOF_h")
     paramvalue = m_centre;
-  else if (paramname.compare("FWHM") == 0)
+  else if (paramname == "FWHM")
     paramvalue = m_fwhm;
   else {
     stringstream errss;
@@ -293,7 +293,7 @@ void NeutronBk2BkExpConvPVoigt::setParameter(size_t i, const double &value,
 void NeutronBk2BkExpConvPVoigt::setParameter(const std::string &name,
                                              const double &value,
                                              bool explicitlySet) {
-  if (name.compare("LatticeConstant") == 0) {
+  if (name == "LatticeConstant") {
     // Lattice parameter
     if (fabs(m_unitCellSize - value) > 1.0E-8) {
       // If change in value is non-trivial

--- a/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
+++ b/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
@@ -257,13 +257,13 @@ void ProcessBackground::exec() {
 
   // 2. Do different work
   std::string option = getProperty("Options");
-  if (option.compare("RemovePeaks") == 0) {
+  if (option == "RemovePeaks") {
     removePeaks();
-  } else if (option.compare("DeleteRegion") == 0) {
+  } else if (option == "DeleteRegion") {
     deleteRegion();
-  } else if (option.compare("AddRegion") == 0) {
+  } else if (option == "AddRegion") {
     addRegion();
-  } else if (option.compare("SelectBackgroundPoints") == 0) {
+  } else if (option == "SelectBackgroundPoints") {
 
     selectBkgdPoints();
   } else {
@@ -456,7 +456,7 @@ void ProcessBackground::selectBkgdPoints() {
   // explicitly
   string outbkgdparwsname =
       getPropertyValue("OutputBackgroundParameterWorkspace");
-  if (!outbkgdparwsname.empty() && outbkgdparwsname.compare("_dummy02") != 0) {
+  if (!outbkgdparwsname.empty() && outbkgdparwsname != "_dummy02") {
     // Will fit the selected background
     string bkgdfunctype = getPropertyValue("OutputBackgroundType");
     fitBackgroundFunction(bkgdfunctype);
@@ -525,10 +525,10 @@ void ProcessBackground::selectFromGivenXValues() {
   }
 
   // Select background points according to mode
-  if (mode.compare("All Background Points") == 0) {
+  if (mode == "All Background Points") {
     // Select (possibly) all background points
     m_outputWS = autoBackgroundSelection(bkgdWS);
-  } else if (mode.compare("Input Background Points Only") == 0) {
+  } else if (mode == "Input Background Points Only") {
     // Use the input background points only
     m_outputWS = bkgdWS;
   } else {
@@ -622,7 +622,7 @@ ProcessBackground::autoBackgroundSelection(Workspace2D_sptr bkgdWS) {
   std::string fitStatus = fit->getProperty("OutputStatus");
   bool allowedfailure = (fitStatus.find("cannot") < fitStatus.size()) &&
                         (fitStatus.find("tolerance") < fitStatus.size());
-  if (fitStatus.compare("success") != 0 && !allowedfailure) {
+  if (fitStatus != "success" && !allowedfailure) {
     g_log.error() << "ProcessBackground: Fit Status = " << fitStatus
                   << ".  Not to update fit result\n";
     throw std::runtime_error("Bad Fit");
@@ -646,11 +646,11 @@ BackgroundFunction_sptr
 ProcessBackground::createBackgroundFunction(const string backgroundtype) {
   Functions::BackgroundFunction_sptr bkgdfunction;
 
-  if (backgroundtype.compare("Polynomial") == 0) {
+  if (backgroundtype == "Polynomial") {
     bkgdfunction = boost::dynamic_pointer_cast<Functions::BackgroundFunction>(
         boost::make_shared<Functions::Polynomial>());
     bkgdfunction->initialize();
-  } else if (backgroundtype.compare("Chebyshev") == 0) {
+  } else if (backgroundtype == "Chebyshev") {
     Chebyshev_sptr cheby = boost::make_shared<Functions::Chebyshev>();
     bkgdfunction =
         boost::dynamic_pointer_cast<Functions::BackgroundFunction>(cheby);
@@ -797,7 +797,7 @@ void ProcessBackground::fitBackgroundFunction(std::string bkgdfunctiontype) {
   std::string fitStatus = fit->getProperty("OutputStatus");
   bool allowedfailure = (fitStatus.find("cannot") < fitStatus.size()) &&
                         (fitStatus.find("tolerance") < fitStatus.size());
-  if (fitStatus.compare("success") != 0 && !allowedfailure) {
+  if (fitStatus != "success" && !allowedfailure) {
     g_log.error() << "ProcessBackground: Fit Status = " << fitStatus
                   << ".  Not to update fit result\n";
     throw std::runtime_error("Bad Fit");
@@ -959,9 +959,9 @@ void RemovePeaks::parsePeakTableWorkspace(TableWorkspace_sptr peaktablews,
   int index_fwhm = -1;
   for (int i = 0; i < static_cast<int>(colnames.size()); ++i) {
     string colname = colnames[i];
-    if (colname.compare("TOF_h") == 0)
+    if (colname == "TOF_h")
       index_centre = i;
-    else if (colname.compare("FWHM") == 0)
+    else if (colname == "FWHM")
       index_fwhm = i;
   }
 

--- a/Framework/CurveFitting/src/Functions/ThermalNeutronBk2BkExpConvPVoigt.cpp
+++ b/Framework/CurveFitting/src/Functions/ThermalNeutronBk2BkExpConvPVoigt.cpp
@@ -195,21 +195,21 @@ ThermalNeutronBk2BkExpConvPVoigt::getPeakParameter(std::string paramname) {
   // 2. Get value
   double paramvalue;
 
-  if (paramname.compare("Alpha") == 0)
+  if (paramname == "Alpha")
     paramvalue = m_Alpha;
-  else if (paramname.compare("Beta") == 0)
+  else if (paramname == "Beta")
     paramvalue = m_Beta;
-  else if (paramname.compare("Sigma2") == 0)
+  else if (paramname == "Sigma2")
     paramvalue = m_Sigma2;
-  else if (paramname.compare("Gamma") == 0)
+  else if (paramname == "Gamma")
     paramvalue = m_Gamma;
-  else if (paramname.compare("d_h") == 0)
+  else if (paramname == "d_h")
     paramvalue = m_dcentre;
-  else if (paramname.compare("Eta") == 0)
+  else if (paramname == "Eta")
     paramvalue = m_eta;
-  else if (paramname.compare("TOF_h") == 0)
+  else if (paramname == "TOF_h")
     paramvalue = m_centre;
-  else if (paramname.compare("FWHM") == 0)
+  else if (paramname == "FWHM")
     paramvalue = m_fwhm;
   else {
     stringstream errss;
@@ -611,7 +611,7 @@ void ThermalNeutronBk2BkExpConvPVoigt::setParameter(size_t i,
 void ThermalNeutronBk2BkExpConvPVoigt::setParameter(const std::string &name,
                                                     const double &value,
                                                     bool explicitlySet) {
-  if (name.compare("LatticeConstant") == 0) {
+  if (name == "LatticeConstant") {
     // Lattice parameter
     if (fabs(m_unitCellSize - value) > 1.0E-8) {
       // If change in value is non-trivial

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -330,8 +330,7 @@ bool LoadEventNexus::runLoadInstrument(const std::string &nexusfilename,
       }
     }
   }
-  if (instrument ==
-      "POWGEN3") // hack for powgen b/c of bad long name
+  if (instrument == "POWGEN3") // hack for powgen b/c of bad long name
     instrument = "POWGEN";
   if (instrument == "NOM") // hack for nomad
     instrument = "NOMAD";

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -330,10 +330,10 @@ bool LoadEventNexus::runLoadInstrument(const std::string &nexusfilename,
       }
     }
   }
-  if (instrument.compare("POWGEN3") ==
-      0) // hack for powgen b/c of bad long name
+  if (instrument ==
+      "POWGEN3") // hack for powgen b/c of bad long name
     instrument = "POWGEN";
-  if (instrument.compare("NOM") == 0) // hack for nomad
+  if (instrument == "NOM") // hack for nomad
     instrument = "NOMAD";
 
   if (instrument.empty())
@@ -508,7 +508,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
     std::string units;
     for (std::vector< ::NeXus::AttrInfo>::const_iterator it = infos.begin();
          it != infos.end(); ++it) {
-      if (it->name.compare("units") == 0) {
+      if (it->name == "units") {
         units = file.getStrAttr(*it);
         break;
       }

--- a/Framework/DataHandling/src/CreateChunkingFromInstrument.cpp
+++ b/Framework/DataHandling/src/CreateChunkingFromInstrument.cpp
@@ -379,8 +379,7 @@ void CreateChunkingFromInstrument::exec() {
       getGroupNames(this->getPropertyValue(PARAM_CHUNK_NAMES));
   if (groupLevel == "All") {
     return; // nothing to do
-  } else if (inst->getName() == "SNAP" &&
-             groupLevel == "Group") {
+  } else if (inst->getName() == "SNAP" && groupLevel == "Group") {
     groupNames.clear();
     groupNames.emplace_back("East");
     groupNames.emplace_back("West");

--- a/Framework/DataHandling/src/CreateChunkingFromInstrument.cpp
+++ b/Framework/DataHandling/src/CreateChunkingFromInstrument.cpp
@@ -195,7 +195,7 @@ bool startsWith(const string &str, const string &prefix) {
   if (str.length() < prefix.length())
     return false;
 
-  return (str.substr(0, prefix.length()).compare(prefix) == 0);
+  return (str.substr(0, prefix.length()) == prefix);
 }
 
 /**
@@ -236,7 +236,7 @@ string parentName(IComponent_const_sptr comp, const string &prefix) {
 string parentName(IComponent_const_sptr comp, const vector<string> &names) {
   // handle the special case of the component has the name
   for (const auto &name : names)
-    if (name.compare(comp->getName()) == 0)
+    if (name == comp->getName())
       return name;
 
   // find the parent with the correct name
@@ -244,7 +244,7 @@ string parentName(IComponent_const_sptr comp, const vector<string> &names) {
   if (parent) {
     // see if this is the parent
     for (const auto &name : names)
-      if (name.compare(parent->getName()) == 0)
+      if (name == parent->getName())
         return name;
 
     // or recurse
@@ -377,10 +377,10 @@ void CreateChunkingFromInstrument::exec() {
   string groupLevel = this->getPropertyValue(PARAM_CHUNK_BY);
   vector<string> groupNames =
       getGroupNames(this->getPropertyValue(PARAM_CHUNK_NAMES));
-  if (groupLevel.compare("All") == 0) {
+  if (groupLevel == "All") {
     return; // nothing to do
-  } else if (inst->getName().compare("SNAP") == 0 &&
-             groupLevel.compare("Group") == 0) {
+  } else if (inst->getName() == "SNAP" &&
+             groupLevel == "Group") {
     groupNames.clear();
     groupNames.emplace_back("East");
     groupNames.emplace_back("West");

--- a/Framework/DataHandling/src/LoadANSTOHelper.cpp
+++ b/Framework/DataHandling/src/LoadANSTOHelper.cpp
@@ -430,7 +430,7 @@ bool File::append(const std::string &path, const std::string &name,
     if (fileName.length() == 0)
       break;
 
-    if (fileName.compare(name) == 0)
+    if (fileName == name)
       targetPosition = lastHeaderPosition;
     else if (targetPosition != -1)
       throw std::runtime_error(

--- a/Framework/DataHandling/src/LoadCanSAS1D.cpp
+++ b/Framework/DataHandling/src/LoadCanSAS1D.cpp
@@ -57,7 +57,7 @@ DECLARE_FILELOADER_ALGORITHM(LoadCanSAS1D)
  */
 int LoadCanSAS1D::confidence(Kernel::FileDescriptor &descriptor) const {
   const std::string &extn = descriptor.extension();
-  if (extn.compare(".xml") != 0)
+  if (extn != ".xml")
     return 0;
 
   std::istream &is = descriptor.data();
@@ -77,7 +77,7 @@ int LoadCanSAS1D::confidence(Kernel::FileDescriptor &descriptor) const {
     // Get pointer to root element
     Element *pRootElem = pDoc->documentElement();
     if (pRootElem) {
-      if (pRootElem->tagName().compare("SASroot") == 0) {
+      if (pRootElem->tagName() == "SASroot") {
         confidence = 80;
       }
     }

--- a/Framework/DataHandling/src/LoadDaveGrp.cpp
+++ b/Framework/DataHandling/src/LoadDaveGrp.cpp
@@ -26,8 +26,8 @@ LoadDaveGrp::LoadDaveGrp() : ifile(), line(), nGroups(0), xLength(0) {}
  */
 int LoadDaveGrp::confidence(Kernel::FileDescriptor &descriptor) const {
   const std::string &extn = descriptor.extension();
-  if (extn.compare(".grp") != 0 && extn.compare(".sqe") != 0 &&
-      extn.compare(".txt") != 0 && extn.compare(".dat") != 0)
+  if (extn != ".grp" && extn != ".sqe" &&
+      extn != ".txt" && extn != ".dat")
     return 0;
 
   if (!descriptor.isAscii())

--- a/Framework/DataHandling/src/LoadDaveGrp.cpp
+++ b/Framework/DataHandling/src/LoadDaveGrp.cpp
@@ -26,8 +26,7 @@ LoadDaveGrp::LoadDaveGrp() : ifile(), line(), nGroups(0), xLength(0) {}
  */
 int LoadDaveGrp::confidence(Kernel::FileDescriptor &descriptor) const {
   const std::string &extn = descriptor.extension();
-  if (extn != ".grp" && extn != ".sqe" &&
-      extn != ".txt" && extn != ".dat")
+  if (extn != ".grp" && extn != ".sqe" && extn != ".txt" && extn != ".dat")
     return 0;
 
   if (!descriptor.isAscii())

--- a/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
+++ b/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
@@ -438,7 +438,7 @@ void LoadGroupXMLFile::parseXML() {
 
     const Poco::XML::XMLString value = pNode->innerText();
 
-    if (pNode->nodeName().compare("detector-grouping") == 0) {
+    if (pNode->nodeName() == "detector-grouping") {
       // Node "detector-grouping" (first level)
 
       // Optional instrument name
@@ -453,7 +453,7 @@ void LoadGroupXMLFile::parseXML() {
           getAttributeValueByName(pNode, "description", m_userGiveDescription);
 
     } // "detector-grouping"
-    else if (pNode->nodeName().compare("group") == 0) {
+    else if (pNode->nodeName() == "group") {
       // Group Node:  get ID, set map
       // a) Find group ID
       bool foundid;
@@ -498,7 +498,7 @@ void LoadGroupXMLFile::parseXML() {
         m_groupSpectraMap[curgroupid] = tempspectrumids;
       }
     } // "group"
-    else if (pNode->nodeName().compare("component") == 0) {
+    else if (pNode->nodeName() == "component") {
       // Node "component" = value
       auto it = m_groupComponentsMap.find(curgroupid);
       if (it == m_groupComponentsMap.end()) {
@@ -521,7 +521,7 @@ void LoadGroupXMLFile::parseXML() {
       }
 
     } // Component
-    else if (pNode->nodeName().compare("detids") == 0) {
+    else if (pNode->nodeName() == "detids") {
       // Node "detids"
       auto it = m_groupDetectorsMap.find(curgroupid);
       if (it == m_groupDetectorsMap.end()) {
@@ -546,7 +546,7 @@ void LoadGroupXMLFile::parseXML() {
                           parsedRange.end());
       }
     } // "detids"
-    else if (pNode->nodeName().compare("ids") == 0) {
+    else if (pNode->nodeName() == "ids") {
       // Node ids: for spectrum number
       auto it = m_groupSpectraMap.find(curgroupid);
       if (it == m_groupSpectraMap.end()) {
@@ -592,7 +592,7 @@ std::string LoadGroupXMLFile::getAttributeValueByName(Poco::XML::Node *pNode,
   // 2. Loop to find
   for (unsigned long i = 0; i < att->length(); ++i) {
     Poco::XML::Node *cNode = att->item(i);
-    if (cNode->localName().compare(attributename) == 0) {
+    if (cNode->localName() == attributename) {
       value = cNode->getNodeValue();
       found = true;
       break;

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1778,7 +1778,7 @@ void LoadEventNexus::deleteBanks(EventWorkspaceCollection_sptr workspace,
     std::string det_name = det->getName();
     for (auto &bankName : bankNames) {
       size_t pos = bankName.find("_events");
-      if (det_name.compare(bankName.substr(0, pos)) == 0)
+      if (det_name == bankName.substr(0, pos))
         keep = true;
       if (keep)
         break;

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -98,7 +98,7 @@ std::map<std::string, std::string> LoadIsawDetCal::validateInputs() {
     Workspace_const_sptr wksp = getProperty("InputWorkspace");
     const auto instname = getInstName(wksp);
 
-    if (instname.compare("SNAP") != 0) {
+    if (instname != "SNAP") {
       result["Filename"] = "Two files is only valid for SNAP";
     }
   } else if (filenames.size() > 2) {
@@ -175,7 +175,7 @@ void LoadIsawDetCal::exec() {
   }
   std::unordered_set<int> uniqueBanks; // for CORELLI and WISH
   std::string bankPart = "bank";
-  if (instname.compare("WISH") == 0)
+  if (instname == "WISH")
     bankPart = "WISHpanel";
   if (detList.empty()) {
     // Get all children
@@ -205,7 +205,7 @@ void LoadIsawDetCal::exec() {
       std::stringstream(line) >> count >> mL1 >> mT0;
       setProperty("TimeOffset", mT0);
       // Convert from cm to m
-      if (instname.compare("WISH") == 0)
+      if (instname == "WISH")
         center(0.0, 0.0, -mL1, "undulator", ws, detectorInfo);
       else
         center(0.0, 0.0, -mL1, "moderator", ws, detectorInfo);
@@ -235,7 +235,7 @@ void LoadIsawDetCal::exec() {
     std::stringstream(line) >> count >> id >> nrows >> ncols >> width >>
         height >> depth >> detd >> x >> y >> z >> base_x >> base_y >> base_z >>
         up_x >> up_y >> up_z;
-    if (id == 10 && filenames.size() == 2 && instname.compare("SNAP") == 0) {
+    if (id == 10 && filenames.size() == 2 && instname == "SNAP") {
       input.close();
       input.open(filenames[1].c_str());
       while (std::getline(input, line)) {
@@ -284,7 +284,7 @@ void LoadIsawDetCal::exec() {
     // Retrieve it
     auto comp = inst->getComponentByName(bankName);
     // for Corelli with sixteenpack under bank
-    if (instname.compare("CORELLI") == 0) {
+    if (instname == "CORELLI") {
       std::vector<Geometry::IComponent_const_sptr> children;
       boost::shared_ptr<const Geometry::ICompAssembly> asmb =
           boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(

--- a/Framework/DataHandling/src/LoadMask.cpp
+++ b/Framework/DataHandling/src/LoadMask.cpp
@@ -189,8 +189,7 @@ void parseISISStringToVector(const std::string &ins,
         boost::lexical_cast<Mantid::specnum_t>(splitstrings[index]));
 
     // ii)  push the ending vector
-    if (index == splitstrings.size() - 1 ||
-        splitstrings[index + 1] != "-") {
+    if (index == splitstrings.size() - 1 || splitstrings[index + 1] != "-") {
       // the next one is not '-'
       ranges.push_back(
           boost::lexical_cast<Mantid::specnum_t>(splitstrings[index]));

--- a/Framework/DataHandling/src/LoadMask.cpp
+++ b/Framework/DataHandling/src/LoadMask.cpp
@@ -156,7 +156,7 @@ void parseISISStringToVector(const std::string &ins,
     vector<string> temps;
     boost::split(temps, splitstrings[index], boost::is_any_of("-"),
                  boost::token_compress_on);
-    if (splitstrings[index].compare("-") == 0 || temps.size() == 1) {
+    if (splitstrings[index] == "-" || temps.size() == 1) {
       // Nothing to split
       index++;
     } else if (temps.size() == 2) {
@@ -190,7 +190,7 @@ void parseISISStringToVector(const std::string &ins,
 
     // ii)  push the ending vector
     if (index == splitstrings.size() - 1 ||
-        splitstrings[index + 1].compare("-") != 0) {
+        splitstrings[index + 1] != "-") {
       // the next one is not '-'
       ranges.push_back(
           boost::lexical_cast<Mantid::specnum_t>(splitstrings[index]));
@@ -334,7 +334,7 @@ void LoadMask::exec() {
   if (m_sourceMapWS) { // check if the instruments are compatible
     auto t_inst_name = m_maskWS->getInstrument()->getName();
     auto r_inst_name = m_sourceMapWS->getInstrument()->getName();
-    if (t_inst_name.compare(r_inst_name) != 0) {
+    if (t_inst_name != r_inst_name) {
       throw std::invalid_argument("If reference workspace is provided, it has "
                                   "to have instrument with the same name as "
                                   "specified by 'Instrument' property");
@@ -661,12 +661,12 @@ void LoadMask::parseXML() {
   while (pNode) {
     const Poco::XML::XMLString value = pNode->innerText();
 
-    if (pNode->nodeName().compare("group") == 0) {
+    if (pNode->nodeName() == "group") {
       // Node "group"
       ingroup = true;
       tomask = true;
 
-    } else if (pNode->nodeName().compare("component") == 0) {
+    } else if (pNode->nodeName() == "component") {
       // Node "component"
       if (ingroup) {
         parseComponent(value, tomask, m_maskCompIdSingle, m_uMaskCompIdSingle);
@@ -674,7 +674,7 @@ void LoadMask::parseXML() {
         g_log.error() << "XML File hierarchical (component) error!\n";
       }
 
-    } else if (pNode->nodeName().compare("ids") == 0) {
+    } else if (pNode->nodeName() == "ids") {
       // Node "ids"
       if (ingroup) {
         parseRangeText(value, singleSp, pairSp);
@@ -683,7 +683,7 @@ void LoadMask::parseXML() {
                       << "  Inner Text = " << pNode->innerText() << '\n';
       }
 
-    } else if (pNode->nodeName().compare("detids") == 0) {
+    } else if (pNode->nodeName() == "detids") {
       // Node "detids"
       if (ingroup) {
         if (tomask) {
@@ -695,7 +695,7 @@ void LoadMask::parseXML() {
         g_log.error() << "XML File (detids) hierarchical error!\n";
       }
 
-    } else if (pNode->nodeName().compare("detector-masking") == 0) {
+    } else if (pNode->nodeName() == "detector-masking") {
       // Node "detector-masking".  Check default value
       m_defaultToUse = true;
     } // END-IF-ELSE: pNode->nodeName()

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -46,7 +46,7 @@ using Mantid::HistogramData::BinEdges;
  */
 int LoadNXSPE::identiferConfidence(const std::string &value) {
   int confidence = 0;
-  if (value.compare("NXSPE") == 0) {
+  if (value == "NXSPE") {
     confidence = 99;
   } else {
     boost::regex re("^NXSP", boost::regex::icase);

--- a/Framework/DataHandling/src/LoadNXcanSAS.cpp
+++ b/Framework/DataHandling/src/LoadNXcanSAS.cpp
@@ -453,7 +453,7 @@ LoadNXcanSAS::LoadNXcanSAS() {}
 
 int LoadNXcanSAS::confidence(Kernel::NexusDescriptor &descriptor) const {
   const std::string &extn = descriptor.extension();
-  if (extn.compare(".nxs") != 0 && extn.compare(".h5") != 0) {
+  if (extn != ".nxs" && extn != ".h5") {
     return 0;
   }
 

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -602,7 +602,7 @@ LoadNexusLogs::createTimeSeries(::NeXus::File &file,
       throw;
     }
   }
-  if (start.compare("No Time") == 0) {
+  if (start == "No Time") {
     start = freqStart;
   }
 

--- a/Framework/DataHandling/src/LoadPDFgetNFile.cpp
+++ b/Framework/DataHandling/src/LoadPDFgetNFile.cpp
@@ -40,10 +40,10 @@ int LoadPDFgetNFile::confidence(Kernel::FileDescriptor &descriptor) const {
   // check the file extension
   const std::string &extn = descriptor.extension();
   // Only allow known file extensions
-  if (extn.compare("sq") != 0 && extn.compare("sqa") != 0 &&
-      extn.compare("sqb") != 0 && extn.compare("gr") != 0 &&
-      extn.compare("ain") != 0 && extn.compare("braw") != 0 &&
-      extn.compare("bsmo") != 0) {
+  if (extn != "sq" && extn != "sqa" &&
+      extn != "sqb" && extn != "gr" &&
+      extn != "ain" && extn != "braw" &&
+      extn != "bsmo") {
     return 0;
   }
 
@@ -190,7 +190,7 @@ void LoadPDFgetNFile::parseColumnNameLine(std::string line) {
   }
 
   string header = terms[0];
-  if (header.compare("#L") != 0) {
+  if (header != "#L") {
     stringstream errmsg;
     errmsg << "Expecting header as #L.  Input line has header as " << header
            << ". Unable to proceed. ";
@@ -236,11 +236,11 @@ void LoadPDFgetNFile::parseDataLine(string line) {
   for (size_t i = 0; i < numcols; ++i) {
     string temps = terms[i];
     double tempvalue;
-    if (temps.compare("NaN") == 0) {
+    if (temps == "NaN") {
       // FIXME:  Need to discuss with Peter about how to treat NaN value
       // tempvalue = DBL_MAX-1.0;
       tempvalue = 0.0;
-    } else if (temps.compare("-NaN") == 0) {
+    } else if (temps == "-NaN") {
       // tempvalue = -DBL_MAX+1.0;
       // FIXME:  Need to discuss with Peter about how to treat NaN value
       tempvalue = 0.0;
@@ -257,10 +257,10 @@ void LoadPDFgetNFile::setUnit(Workspace2D_sptr ws) {
   // 1. Set X
   string xcolname = mColumnNames[0];
 
-  if (xcolname.compare("Q") == 0) {
+  if (xcolname == "Q") {
     string unit = "MomentumTransfer";
     ws->getAxis(0)->setUnit(unit);
-  } else if (xcolname.compare("r") == 0) {
+  } else if (xcolname == "r") {
     ws->getAxis(0)->unit() = UnitFactory::Instance().create("Label");
     Unit_sptr unit = ws->getAxis(0)->unit();
     boost::shared_ptr<Units::Label> label =
@@ -275,9 +275,9 @@ void LoadPDFgetNFile::setUnit(Workspace2D_sptr ws) {
   // 2. Set Y
   string ycolname = mColumnNames[1];
   string ylabel;
-  if (ycolname.compare("G(r)") == 0) {
+  if (ycolname == "G(r)") {
     ylabel = "PDF";
-  } else if (ycolname.compare("S") == 0) {
+  } else if (ycolname == "S") {
     ylabel = "S";
   } else {
     ylabel = "Intensity";

--- a/Framework/DataHandling/src/LoadPDFgetNFile.cpp
+++ b/Framework/DataHandling/src/LoadPDFgetNFile.cpp
@@ -40,10 +40,8 @@ int LoadPDFgetNFile::confidence(Kernel::FileDescriptor &descriptor) const {
   // check the file extension
   const std::string &extn = descriptor.extension();
   // Only allow known file extensions
-  if (extn != "sq" && extn != "sqa" &&
-      extn != "sqb" && extn != "gr" &&
-      extn != "ain" && extn != "braw" &&
-      extn != "bsmo") {
+  if (extn != "sq" && extn != "sqa" && extn != "sqb" && extn != "gr" &&
+      extn != "ain" && extn != "braw" && extn != "bsmo") {
     return 0;
   }
 

--- a/Framework/DataHandling/src/LoadSpice2D.cpp
+++ b/Framework/DataHandling/src/LoadSpice2D.cpp
@@ -97,7 +97,7 @@ void store_value(DataObjects::Workspace2D_sptr ws, int specID, double value,
  * be used
  */
 int LoadSpice2D::confidence(Kernel::FileDescriptor &descriptor) const {
-  if (descriptor.extension().compare(".xml") != 0)
+  if (descriptor.extension() != ".xml")
     return 0;
 
   std::istream &is = descriptor.data();
@@ -122,7 +122,7 @@ int LoadSpice2D::confidence(Kernel::FileDescriptor &descriptor) const {
     // Get pointer to root element
     Element *pRootElem = pDoc->documentElement();
     if (pRootElem) {
-      if (pRootElem->tagName().compare("SPICErack") == 0) {
+      if (pRootElem->tagName() == "SPICErack") {
         confidence = 80;
       }
     }

--- a/Framework/DataHandling/src/LoadSpiceAscii.cpp
+++ b/Framework/DataHandling/src/LoadSpiceAscii.cpp
@@ -36,7 +36,7 @@ static bool endswith(const std::string &s, const std::string &subs) {
   // get a substring
   std::string tail = s.substr(s.size() - subs.size());
 
-  return tail.compare(subs) == 0;
+  return tail == subs;
 }
 
 static bool checkIntersection(std::vector<std::string> v1,
@@ -320,7 +320,7 @@ API::ITableWorkspace_sptr LoadSpiceAscii::createDataWS(
       boost::make_shared<DataObjects::TableWorkspace>();
   size_t ipt = -1;
   for (size_t i = 0; i < titles.size(); ++i) {
-    if (titles[i].compare("Pt.") == 0) {
+    if (titles[i] == "Pt.") {
       outws->addColumn("int", titles[i]);
       ipt = i;
     } else {
@@ -555,7 +555,7 @@ std::string LoadSpiceAscii::processTimeString(const std::string &rawtime,
     std::vector<std::string> terms;
     boost::split(terms, rawtime, boost::is_any_of(" "));
     bool pm = false;
-    if (terms[1].compare("PM") == 0)
+    if (terms[1] == "PM")
       pm = true;
 
     std::vector<std::string> terms2;

--- a/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
+++ b/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
@@ -59,10 +59,10 @@ void SpiceXMLNode::setParameters(const std::string &nodetype,
                                  const std::string &nodeunit,
                                  const std::string &nodedescription) {
   // data type
-  if (nodetype.compare("FLOAT32") == 0) {
+  if (nodetype == "FLOAT32") {
     m_typefullname = nodetype;
     m_typechar = FLOAT32;
-  } else if (nodetype.compare("INT32") == 0) {
+  } else if (nodetype == "INT32") {
     m_typefullname = nodetype;
     m_typechar = INT32;
   }
@@ -391,7 +391,7 @@ LoadSpiceXML2DDet::parseSpiceXML(const std::string &xmlfilename) {
       g_log.debug() << "Parent node " << nodename << " has " << numchildren
                     << " children."
                     << "\n";
-      if (nodename.compare("SPICErack") == 0) {
+      if (nodename == "SPICErack") {
         // SPICErack is the main parent node.  start_time and end_time are there
         unsigned long numattr = pNode->attributes()->length();
         for (unsigned long j = 0; j < numattr; ++j) {
@@ -421,13 +421,13 @@ LoadSpiceXML2DDet::parseSpiceXML(const std::string &xmlfilename) {
         std::string attname = pNode->attributes()->item(j)->nodeName();
         g_log.debug() << "     attribute " << j << " name = " << attname << ", "
                       << "value = " << atttext << "\n";
-        if (attname.compare("type") == 0) {
+        if (attname == "type") {
           // type
           nodetype = atttext;
-        } else if (attname.compare("unit") == 0) {
+        } else if (attname == "unit") {
           // unit
           nodeunit = atttext;
-        } else if (attname.compare("description") == 0) {
+        } else if (attname == "description") {
           // description
           nodedescription = atttext;
         }
@@ -487,7 +487,7 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspace(
   for (size_t n = 0; n < numxmlnodes; ++n) {
     // Process node for detector's count
     const SpiceXMLNode &xmlnode = vecxmlnode[n];
-    if (xmlnode.getName().compare(detnodename) == 0) {
+    if (xmlnode.getName() == detnodename) {
       // Get node value string (256x256 as a whole)
       const std::string detvaluestr = xmlnode.getValue();
 
@@ -585,7 +585,7 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspace(
                       << " (int) value = " << ivalue << "\n";
       } else {
         std::string str_value(nodevalue);
-        if (nodename.compare("start_time") == 0) {
+        if (nodename == "start_time") {
           // replace 2015-01-17 13:36:45 by  2015-01-17T13:36:45
           str_value = nodevalue;
           str_value.replace(10, 1, "T");
@@ -634,7 +634,7 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspaceVersion2(
   for (size_t n = 0; n < numxmlnodes; ++n) {
     // Process node for detector's count
     const SpiceXMLNode &xmlnode = vecxmlnode[n];
-    if (xmlnode.getName().compare(detnodename) == 0) {
+    if (xmlnode.getName() == detnodename) {
       // Get node value string (256x256 as a whole)
       const std::string detvaluestr = xmlnode.getValue();
 
@@ -654,7 +654,7 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspaceVersion2(
         int ivalue = std::stoi(nodevalue);
         int_log_map.emplace(nodename, ivalue);
       } else {
-        if (nodename.compare("start_time") == 0) {
+        if (nodename == "start_time") {
           // replace 2015-01-17 13:36:45 by  2015-01-17T13:36:45
           std::string str_value(nodevalue);
           str_value.replace(10, 1, "T");

--- a/Framework/DataHandling/src/LoadSwans.cpp
+++ b/Framework/DataHandling/src/LoadSwans.cpp
@@ -51,7 +51,7 @@ const std::string LoadSwans::summary() const { return "Loads SNS SWANS Data"; }
 int LoadSwans::confidence(Kernel::FileDescriptor &descriptor) const {
   // since this is a test loader, the confidence will always be 0!
   // I don't want the Load algorithm to pick this one!
-  if (descriptor.extension().compare(".dat") != 0)
+  if (descriptor.extension() != ".dat")
     return 1;
   else
     return 0;

--- a/Framework/DataHandling/src/LoadTBL.cpp
+++ b/Framework/DataHandling/src/LoadTBL.cpp
@@ -293,7 +293,7 @@ void LoadTBL::exec() {
   boost::split(columnHeadings, line, boost::is_any_of(","),
                boost::token_compress_off);
   for (auto entry = columnHeadings.begin(); entry != columnHeadings.end();) {
-    if (std::string(*entry).compare("") == 0) {
+    if (std::string(*entry) == "") {
       // erase the empty values
       entry = columnHeadings.erase(entry);
     } else {
@@ -400,7 +400,7 @@ void LoadTBL::exec() {
       // the columns vector to the TableWorkspace
       for (auto heading = columnHeadings.begin();
            heading != columnHeadings.end();) {
-        if (std::string(*heading).compare("") == 0) {
+        if (std::string(*heading) == "") {
           // there is no need to have empty column headings.
           heading = columnHeadings.erase(heading);
         } else {

--- a/Framework/DataHandling/src/LoadTBL.cpp
+++ b/Framework/DataHandling/src/LoadTBL.cpp
@@ -293,7 +293,7 @@ void LoadTBL::exec() {
   boost::split(columnHeadings, line, boost::is_any_of(","),
                boost::token_compress_off);
   for (auto entry = columnHeadings.begin(); entry != columnHeadings.end();) {
-    if (std::string(*entry) == "") {
+    if (entry->empty()) {
       // erase the empty values
       entry = columnHeadings.erase(entry);
     } else {
@@ -400,7 +400,7 @@ void LoadTBL::exec() {
       // the columns vector to the TableWorkspace
       for (auto heading = columnHeadings.begin();
            heading != columnHeadings.end();) {
-        if (std::string(*heading) == "") {
+        if (heading->empty()) {
           // there is no need to have empty column headings.
           heading = columnHeadings.erase(heading);
         } else {

--- a/Framework/DataHandling/src/LoadVulcanCalFile.cpp
+++ b/Framework/DataHandling/src/LoadVulcanCalFile.cpp
@@ -123,11 +123,11 @@ void LoadVulcanCalFile::processInOutProperites() {
   // Grouping
   string grouptypestr = getPropertyValue("Grouping");
   size_t numeffbanks = 6;
-  if (grouptypestr.compare("6Modules") == 0) {
+  if (grouptypestr == "6Modules") {
     m_groupingType = VULCAN_OFFSET_BANK;
-  } else if (grouptypestr.compare("2Banks") == 0) {
+  } else if (grouptypestr == "2Banks") {
     m_groupingType = VULCAN_OFFSET_MODULE;
-  } else if (grouptypestr.compare("1Bank") == 0) {
+  } else if (grouptypestr == "1Bank") {
     m_groupingType = VULCAN_OFFSET_STACK;
   } else {
     stringstream ess;

--- a/Framework/DataHandling/src/PatchBBY.cpp
+++ b/Framework/DataHandling/src/PatchBBY.cpp
@@ -161,7 +161,7 @@ void PatchBBY::exec() {
         hdfFiles++;
       else if (itr->rfind(".bin") == len - 4)
         binFiles++;
-      else if (itr->compare(HistoryStr) == 0) {
+      else if (*itr == HistoryStr) {
         if (std::distance(itr, files.end()) != 1)
           throw std::invalid_argument(
               "invalid BBY file (history has to be at the end)");

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -408,11 +408,11 @@ void SaveAscii2::populateAngleMetaData() {
 */
 void SaveAscii2::populateAllMetaData() {
   for (const auto &metaDataType : m_metaData) {
-    if (metaDataType.compare("spectrumnumber") == 0)
+    if (metaDataType == "spectrumnumber")
       populateSpectrumNumberMetaData();
-    if (metaDataType.compare("q") == 0)
+    if (metaDataType == "q")
       populateQMetaData();
-    if (metaDataType.compare("angle") == 0)
+    if (metaDataType == "angle")
       populateAngleMetaData();
   }
 }

--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -261,10 +261,10 @@ void SaveGSS::writeGSASFile(const std::string &outfilename, bool append,
     }
 
     // Write data
-    if (RALF.compare(outputFormat) == 0) {
+    if (RALF == outputFormat) {
       this->writeRALFdata(bankid, multiplybybinwidth, tmpbuffer,
                           inputWS->histogram(histoIndex));
-    } else if (SLOG.compare(outputFormat) == 0) {
+    } else if (SLOG == outputFormat) {
       this->writeSLOGdata(bankid, multiplybybinwidth, tmpbuffer,
                           inputWS->histogram(histoIndex));
     } else {
@@ -372,7 +372,7 @@ void SaveGSS::writeHeaders(const std::string &format, std::stringstream &os,
   std::ios::fmtflags fflags(os.flags());
 
   // Run number
-  if (format.compare(SLOG) == 0) {
+  if (format == SLOG) {
     os << "Sample Run: ";
     writeLogValue(os, runinfo, "run_number");
     os << " Vanadium Run: ";
@@ -403,7 +403,7 @@ void SaveGSS::writeHeaders(const std::string &format, std::stringstream &os,
     os << "\n";
   }
 
-  if (format.compare(SLOG) == 0) {
+  if (format == SLOG) {
     os << "# "; // make the next line a comment
   }
   os << inputWS->getTitle() << "\n";
@@ -414,7 +414,7 @@ void SaveGSS::writeHeaders(const std::string &format, std::stringstream &os,
   if (getProperty("MultiplyByBinWidth"))
     os << "# with Y multiplied by the bin widths.\n";
   os << "# Primary flight path " << primaryflightpath << "m \n";
-  if (format.compare(SLOG) == 0) {
+  if (format == SLOG) {
     os << "# Sample Temperature: ";
     writeLogValue(os, runinfo, "SampleTemp");
     os << " Freq: ";
@@ -429,9 +429,9 @@ void SaveGSS::writeHeaders(const std::string &format, std::stringstream &os,
     const Mantid::API::AlgorithmHistories &algohist =
         inputWS->getHistory().getAlgorithmHistories();
     for (const auto &algo : algohist) {
-      if (algo->name().compare("NormaliseByCurrent") == 0)
+      if (algo->name() == "NormaliseByCurrent")
         norm_by_current = true;
-      if (algo->name().compare("NormaliseToMonitor") == 0)
+      if (algo->name() == "NormaliseToMonitor")
         norm_by_monitor = true;
     }
     os << "#";

--- a/Framework/DataHandling/src/SaveIsawDetCal.cpp
+++ b/Framework/DataHandling/src/SaveIsawDetCal.cpp
@@ -73,7 +73,7 @@ void SaveIsawDetCal::exec() {
   // We cannot assume the peaks have bank type detector modules, so we have a
   // string to check this
   std::string bankPart = "bank";
-  if (inst->getName().compare("WISH") == 0)
+  if (inst->getName() == "WISH")
     bankPart = "WISHpanel";
 
   std::set<int> uniqueBanks;
@@ -158,8 +158,8 @@ void SaveIsawDetCal::exec() {
     // Retrieve it
     boost::shared_ptr<const IComponent> det =
         inst->getComponentByName(bankName);
-    if (inst->getName().compare("CORELLI") ==
-        0) // for Corelli with sixteenpack under bank
+    if (inst->getName() ==
+        "CORELLI") // for Corelli with sixteenpack under bank
     {
       std::vector<Geometry::IComponent_const_sptr> children;
       boost::shared_ptr<const Geometry::ICompAssembly> asmb =
@@ -224,7 +224,7 @@ void SaveIsawDetCal::exec() {
 V3D SaveIsawDetCal::findPixelPos(std::string bankName, int col, int row) {
   boost::shared_ptr<const IComponent> parent =
       inst->getComponentByName(bankName);
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 
@@ -235,7 +235,7 @@ V3D SaveIsawDetCal::findPixelPos(std::string bankName, int col, int row) {
     boost::shared_ptr<const Geometry::ICompAssembly> asmb =
         boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(parent);
     asmb->getChildren(children, false);
-    if (children[0]->getName().compare("sixteenpack") == 0) {
+    if (children[0]->getName() == "sixteenpack") {
       asmb = boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(
           children[0]);
       children.clear();
@@ -257,11 +257,11 @@ V3D SaveIsawDetCal::findPixelPos(std::string bankName, int col, int row) {
 
 void SaveIsawDetCal::sizeBanks(std::string bankName, int &NCOLS, int &NROWS,
                                double &xsize, double &ysize) {
-  if (bankName.compare("None") == 0)
+  if (bankName == "None")
     return;
   boost::shared_ptr<const IComponent> parent =
       inst->getComponentByName(bankName);
-  if (parent->type().compare("RectangularDetector") == 0) {
+  if (parent->type() == "RectangularDetector") {
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 
@@ -274,7 +274,7 @@ void SaveIsawDetCal::sizeBanks(std::string bankName, int &NCOLS, int &NROWS,
     boost::shared_ptr<const Geometry::ICompAssembly> asmb =
         boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(parent);
     asmb->getChildren(children, false);
-    if (children[0]->getName().compare("sixteenpack") == 0) {
+    if (children[0]->getName() == "sixteenpack") {
       asmb = boost::dynamic_pointer_cast<const Geometry::ICompAssembly>(
           children[0]);
       children.clear();

--- a/Framework/DataHandling/src/SaveIsawDetCal.cpp
+++ b/Framework/DataHandling/src/SaveIsawDetCal.cpp
@@ -158,8 +158,7 @@ void SaveIsawDetCal::exec() {
     // Retrieve it
     boost::shared_ptr<const IComponent> det =
         inst->getComponentByName(bankName);
-    if (inst->getName() ==
-        "CORELLI") // for Corelli with sixteenpack under bank
+    if (inst->getName() == "CORELLI") // for Corelli with sixteenpack under bank
     {
       std::vector<Geometry::IComponent_const_sptr> children;
       boost::shared_ptr<const Geometry::ICompAssembly> asmb =

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -302,7 +302,7 @@ void Peak::setDetectorID(int id) {
   // Use the grand-parent whenever possible
   m_bankName = parent->getName();
   // For CORELLI, one level above sixteenpack
-  if (m_bankName.compare("sixteenpack") == 0) {
+  if (m_bankName == "sixteenpack") {
     parent = parent->getParent();
     m_bankName = parent->getName();
   }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -255,7 +255,7 @@ public:
 
     pmap_cit it;
     for (it = m_map.begin(); it != m_map.end(); ++it) {
-      if (compName.compare(((const IComponent *)(*it).first)->getName()) == 0) {
+      if (compName == ((const IComponent *)(*it).first)->getName()) {
         boost::shared_ptr<Parameter> param =
             get((const IComponent *)(*it).first, name);
         if (param)

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -255,9 +255,8 @@ public:
 
     pmap_cit it;
     for (it = m_map.begin(); it != m_map.end(); ++it) {
-      if (compName == ((const IComponent *)(*it).first)->getName()) {
-        boost::shared_ptr<Parameter> param =
-            get((const IComponent *)(*it).first, name);
+      if (compName == it->first->getName()) {
+        boost::shared_ptr<Parameter> param = get(it->first, name);
         if (param)
           retval.push_back(param->value<T>());
       }

--- a/Framework/Geometry/src/Instrument/FitParameter.cpp
+++ b/Framework/Geometry/src/Instrument/FitParameter.cpp
@@ -20,7 +20,7 @@ Kernel::Logger g_log("FitParameter");
 */
 std::string FitParameter::getConstraint() const {
 
-  if (m_constraintMin.compare("") == 0 && m_constraintMax.compare("") == 0)
+  if (m_constraintMin == "" && m_constraintMax == "")
     return std::string("");
 
   std::stringstream constraint;
@@ -67,7 +67,7 @@ double FitParameter::getValue(const double &at) const {
     return m_value;
   }
 
-  if (m_formula.compare("") != 0) {
+  if (m_formula != "") {
     size_t found;
     std::string equationStr = m_formula;
     std::string toReplace = "centre"; // replace this string in formula

--- a/Framework/Geometry/src/Instrument/FitParameter.cpp
+++ b/Framework/Geometry/src/Instrument/FitParameter.cpp
@@ -20,8 +20,8 @@ Kernel::Logger g_log("FitParameter");
 */
 std::string FitParameter::getConstraint() const {
 
-  if (m_constraintMin == "" && m_constraintMax == "")
-    return std::string("");
+  if (m_constraintMin.empty() && m_constraintMax.empty())
+    return std::string();
 
   std::stringstream constraint;
   size_t foundMinPercentage, foundMaxPercentage;
@@ -29,14 +29,14 @@ std::string FitParameter::getConstraint() const {
   foundMaxPercentage = m_constraintMax.find('%');
   double min = 0;
   double max = 0;
-  if (m_constraintMin.compare("")) {
+  if (m_constraintMin.empty()) {
     if (foundMinPercentage != std::string::npos)
       min = std::stod(m_constraintMin.substr(0, m_constraintMin.size() - 1)) *
             m_value * 0.01;
     else
       min = std::stod(m_constraintMin);
   }
-  if (m_constraintMax.compare("")) {
+  if (m_constraintMax.empty()) {
     if (foundMaxPercentage != std::string::npos)
       max = std::stod(m_constraintMax.substr(0, m_constraintMax.size() - 1)) *
             m_value * 0.01;
@@ -44,9 +44,7 @@ std::string FitParameter::getConstraint() const {
       max = std::stod(m_constraintMax);
   }
 
-  if (m_constraintMin.compare("") && m_constraintMax.compare("")) {
-    constraint << min << " < " << m_name << " < " << max;
-  } else if (m_constraintMin.compare("")) {
+  if (m_constraintMin.empty()) {
     constraint << min << " < " << m_name;
   } else {
     constraint << m_name << " < " << max;
@@ -67,7 +65,7 @@ double FitParameter::getValue(const double &at) const {
     return m_value;
   }
 
-  if (m_formula != "") {
+  if (!m_formula.empty()) {
     size_t found;
     std::string equationStr = m_formula;
     std::string toReplace = "centre"; // replace this string in formula

--- a/Framework/Geometry/src/Instrument/FitParameter.cpp
+++ b/Framework/Geometry/src/Instrument/FitParameter.cpp
@@ -29,14 +29,14 @@ std::string FitParameter::getConstraint() const {
   foundMaxPercentage = m_constraintMax.find('%');
   double min = 0;
   double max = 0;
-  if (m_constraintMin.empty()) {
+  if (!m_constraintMin.empty()) {
     if (foundMinPercentage != std::string::npos)
       min = std::stod(m_constraintMin.substr(0, m_constraintMin.size() - 1)) *
             m_value * 0.01;
     else
       min = std::stod(m_constraintMin);
   }
-  if (m_constraintMax.empty()) {
+  if (!m_constraintMax.empty()) {
     if (foundMaxPercentage != std::string::npos)
       max = std::stod(m_constraintMax.substr(0, m_constraintMax.size() - 1)) *
             m_value * 0.01;
@@ -44,7 +44,9 @@ std::string FitParameter::getConstraint() const {
       max = std::stod(m_constraintMax);
   }
 
-  if (m_constraintMin.empty()) {
+  if (!(m_constraintMin.empty() && m_constraintMax.empty())) {
+    constraint << min << " < " << m_name << " < " << max;
+  } else if (!m_constraintMin.empty()) {
     constraint << min << " < " << m_name;
   } else {
     constraint << m_name << " < " << max;

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -137,7 +137,7 @@ void Goniometer::pushAxis(std::string name, double axisx, double axisy,
     std::vector<GoniometerAxis>::iterator it;
     // check if such axis is already defined
     for (it = motors.begin(); it < motors.end(); ++it) {
-      if (name == (*it).name)
+      if (name == it->name)
         throw std::invalid_argument("Motor name already defined");
     }
     GoniometerAxis a(name, V3D(axisx, axisy, axisz), angle, sense, angUnit);
@@ -154,8 +154,8 @@ void Goniometer::setRotationAngle(std::string name, double value) {
   bool changed = false;
   std::vector<GoniometerAxis>::iterator it;
   for (it = motors.begin(); it < motors.end(); ++it) {
-    if (name == (*it).name) {
-      (*it).angle = value;
+    if (name == it->name) {
+      it->angle = value;
       changed = true;
     }
   }
@@ -189,7 +189,7 @@ const GoniometerAxis &Goniometer::getAxis(size_t axisnumber) const {
 /// @param axisname :: axis name
 const GoniometerAxis &Goniometer::getAxis(std::string axisname) const {
   for (auto it = motors.begin(); it < motors.end(); ++it) {
-    if (axisname == (*it).name) {
+    if (axisname == it->name) {
       return (*it);
     }
   }

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -137,7 +137,7 @@ void Goniometer::pushAxis(std::string name, double axisx, double axisy,
     std::vector<GoniometerAxis>::iterator it;
     // check if such axis is already defined
     for (it = motors.begin(); it < motors.end(); ++it) {
-      if (name.compare((*it).name) == 0)
+      if (name == (*it).name)
         throw std::invalid_argument("Motor name already defined");
     }
     GoniometerAxis a(name, V3D(axisx, axisy, axisz), angle, sense, angUnit);
@@ -154,7 +154,7 @@ void Goniometer::setRotationAngle(std::string name, double value) {
   bool changed = false;
   std::vector<GoniometerAxis>::iterator it;
   for (it = motors.begin(); it < motors.end(); ++it) {
-    if (name.compare((*it).name) == 0) {
+    if (name == (*it).name) {
       (*it).angle = value;
       changed = true;
     }
@@ -189,7 +189,7 @@ const GoniometerAxis &Goniometer::getAxis(size_t axisnumber) const {
 /// @param axisname :: axis name
 const GoniometerAxis &Goniometer::getAxis(std::string axisname) const {
   for (auto it = motors.begin(); it < motors.end(); ++it) {
-    if (axisname.compare((*it).name) == 0) {
+    if (axisname == (*it).name) {
       return (*it);
     }
   }

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -876,9 +876,9 @@ void InstrumentDefinitionParser::setValidityRange(
 
 PointingAlong axisNameToAxisType(std::string &input) {
   PointingAlong direction;
-  if (input.compare("x") == 0) {
+  if (input == "x") {
     direction = X;
-  } else if (input.compare("y") == 0) {
+  } else if (input == "y") {
     direction = Y;
   } else {
     direction = Z;
@@ -981,7 +981,7 @@ void InstrumentDefinitionParser::readDefaults(Poco::XML::Element *defaults) {
     // Convert to input types
     PointingAlong alongBeam = axisNameToAxisType(s_alongBeam);
     PointingAlong pointingUp = axisNameToAxisType(s_pointingUp);
-    Handedness handedness = s_handedness.compare("right") == 0 ? Right : Left;
+    Handedness handedness = s_handedness == "right" ? Right : Left;
 
     // Overwrite the default reference frame.
     m_instrument->setReferenceFrame(boost::make_shared<ReferenceFrame>(
@@ -1094,11 +1094,11 @@ void InstrumentDefinitionParser::appendAssembly(
     category = pType->getAttribute("is");
 
   // check if special Component
-  if (category.compare("SamplePos") == 0 ||
-      category.compare("samplePos") == 0) {
+  if (category == "SamplePos" ||
+      category == "samplePos") {
     m_instrument->markAsSamplePos(ass);
   }
-  if (category.compare("Source") == 0 || category.compare("source") == 0) {
+  if (category == "Source" || category == "source") {
     m_instrument->markAsSource(ass);
   }
 
@@ -1116,7 +1116,7 @@ void InstrumentDefinitionParser::appendAssembly(
 
   Node *pNode = it.nextNode();
   while (pNode) {
-    if (pNode->nodeName().compare("location") == 0) {
+    if (pNode->nodeName() == "location") {
       // pLocElem is the location of a type. This type is here an assembly and
       // pElem below is a <location> within this type
       const Element *pElem = static_cast<Element *>(pNode);
@@ -1143,7 +1143,7 @@ void InstrumentDefinitionParser::appendAssembly(
         }
       }
     }
-    if (pNode->nodeName().compare("locations") == 0) {
+    if (pNode->nodeName() == "locations") {
       const Element *pLocationsElems = static_cast<Element *>(pNode);
       const Element *pParentLocationsElem =
           InstrumentDefinitionParser::getParentComponent(pLocationsElems);
@@ -1249,14 +1249,14 @@ void InstrumentDefinitionParser::createDetectorOrMonitor(
   }
 
   try {
-    if (category.compare("Monitor") == 0 || category.compare("monitor") == 0)
+    if (category == "Monitor" || category == "monitor")
       m_instrument->markAsMonitor(detector);
     else {
       // for backwards compatebility look for mark-as="monitor"
       if ((pCompElem->hasAttribute("mark-as") &&
-           pCompElem->getAttribute("mark-as").compare("monitor") == 0) ||
+           pCompElem->getAttribute("mark-as") == "monitor") ||
           (pLocElem->hasAttribute("mark-as") &&
-           pLocElem->getAttribute("mark-as").compare("monitor") == 0)) {
+           pLocElem->getAttribute("mark-as") == "monitor")) {
         m_instrument->markAsMonitor(detector);
       } else
         m_instrument->markAsDetectorIncomplete(detector);
@@ -1448,10 +1448,10 @@ void InstrumentDefinitionParser::createStructuredDetector(
 
   while (pNode) {
     Element *check = static_cast<Element *>(pNode);
-    if (pNode->nodeName().compare("type") == 0 && check->hasAttribute("is")) {
+    if (pNode->nodeName() == "type" && check->hasAttribute("is")) {
       std::string is = check->getAttribute("is");
       if (StructuredDetector::compareName(is) &&
-          typeName.compare(check->getAttribute("name")) == 0) {
+          typeName == check->getAttribute("name")) {
         pElem = check;
         break;
       }
@@ -1475,7 +1475,7 @@ void InstrumentDefinitionParser::createStructuredDetector(
   pNode = it.nextNode();
 
   while (pNode) {
-    if (pNode->nodeName().compare("vertex") == 0) {
+    if (pNode->nodeName() == "vertex") {
       Element *pVertElem = static_cast<Element *>(pNode);
 
       if (pVertElem->hasAttribute("x"))
@@ -1603,15 +1603,15 @@ void InstrumentDefinitionParser::appendLeaf(Geometry::ICompAssembly *parent,
     parent->add(comp);
 
     // check if special Source or SamplePos Component
-    if (category.compare("Source") == 0 || category.compare("source") == 0) {
+    if (category == "Source" || category == "source") {
       m_instrument->markAsSource(comp);
     }
-    if (category.compare("SamplePos") == 0 ||
-        category.compare("samplePos") == 0) {
+    if (category == "SamplePos" ||
+        category == "samplePos") {
       m_instrument->markAsSamplePos(comp);
     }
-    if (category.compare("ChopperPos") == 0 ||
-        category.compare("chopperPos") == 0) {
+    if (category == "ChopperPos" ||
+        category == "chopperPos") {
       m_instrument->markAsChopperPoint(comp);
     }
 
@@ -1713,7 +1713,7 @@ void InstrumentDefinitionParser::populateIdList(Poco::XML::Element *pE,
 
     Node *pNode = it.nextNode();
     while (pNode) {
-      if (pNode->nodeName().compare("id") == 0) {
+      if (pNode->nodeName() == "id") {
         Element *pIDElem = static_cast<Element *>(pNode);
 
         if (pIDElem->hasAttribute("val")) {
@@ -1984,7 +1984,7 @@ void InstrumentDefinitionParser::setLogfile(
     // we are only interest in the top level parameter elements hence
     // the reason for the if statement below
     if (!((pNL_comp->item(i))->nodeType() == Node::ELEMENT_NODE &&
-          ((pNL_comp->item(i))->nodeName()).compare("parameter") == 0))
+          ((pNL_comp->item(i))->nodeName()) == "parameter"))
       continue;
 
     Element *pParamElem = static_cast<Element *>(pNL_comp->item(i));
@@ -1998,7 +1998,7 @@ void InstrumentDefinitionParser::setLogfile(
 
     std::string paramName = pParamElem->getAttribute("name");
 
-    if (paramName.compare("rot") == 0 || paramName.compare("pos") == 0) {
+    if (paramName == "rot" || paramName == "pos") {
       g_log.error()
           << "XML element with name or type = " << comp->getName()
           << " contains <parameter> element with name=\"" << paramName << "\"."
@@ -2100,7 +2100,7 @@ void InstrumentDefinitionParser::setLogfile(
     std::string fittingFunction;
     std::string tie;
 
-    if (type.compare("fitting") == 0) {
+    if (type == "fitting") {
       size_t found = paramName.find(':');
       if (found != std::string::npos) {
         // check that only one : in name

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -1094,8 +1094,7 @@ void InstrumentDefinitionParser::appendAssembly(
     category = pType->getAttribute("is");
 
   // check if special Component
-  if (category == "SamplePos" ||
-      category == "samplePos") {
+  if (category == "SamplePos" || category == "samplePos") {
     m_instrument->markAsSamplePos(ass);
   }
   if (category == "Source" || category == "source") {
@@ -1606,12 +1605,10 @@ void InstrumentDefinitionParser::appendLeaf(Geometry::ICompAssembly *parent,
     if (category == "Source" || category == "source") {
       m_instrument->markAsSource(comp);
     }
-    if (category == "SamplePos" ||
-        category == "samplePos") {
+    if (category == "SamplePos" || category == "samplePos") {
       m_instrument->markAsSamplePos(comp);
     }
-    if (category == "ChopperPos" ||
-        category == "chopperPos") {
+    if (category == "ChopperPos" || category == "chopperPos") {
       m_instrument->markAsChopperPoint(comp);
     }
 

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -174,7 +174,7 @@ const std::string ParameterMap::getDescription(const std::string &compName,
   pmap_cit it;
   std::string result;
   for (it = m_map.begin(); it != m_map.end(); ++it) {
-    if (compName.compare(((const IComponent *)(*it).first)->getName()) == 0) {
+    if (compName == ((const IComponent *)(*it).first)->getName()) {
       boost::shared_ptr<Parameter> param =
           get((const IComponent *)(*it).first, name);
       if (param) {
@@ -199,7 +199,7 @@ ParameterMap::getShortDescription(const std::string &compName,
   pmap_cit it;
   std::string result;
   for (it = m_map.begin(); it != m_map.end(); ++it) {
-    if (compName.compare(it->first->getName()) == 0) {
+    if (compName == it->first->getName()) {
       boost::shared_ptr<Parameter> param = get(it->first, name);
       if (param) {
         result = param->getShortDescription();
@@ -424,11 +424,11 @@ void ParameterMap::addPositionCoordinate(
 
   // adjust position
 
-  if (name.compare(posx()) == 0)
+  if (name == posx())
     position.setX(value);
-  else if (name.compare(posy()) == 0)
+  else if (name == posy())
     position.setY(value);
-  else if (name.compare(posz()) == 0)
+  else if (name == posz())
     position.setZ(value);
   else {
     g_log.warning() << "addPositionCoordinate() called with unrecognized "
@@ -483,15 +483,15 @@ void ParameterMap::addRotationParam(const IComponent *comp,
 
   // adjust rotation
   Quat quat;
-  if (name.compare(rotx()) == 0) {
+  if (name == rotx()) {
     addDouble(comp, rotx(), deg);
     quat = Quat(deg, V3D(1, 0, 0)) * Quat(rotY, V3D(0, 1, 0)) *
            Quat(rotZ, V3D(0, 0, 1));
-  } else if (name.compare(roty()) == 0) {
+  } else if (name == roty()) {
     addDouble(comp, roty(), deg);
     quat = Quat(rotX, V3D(1, 0, 0)) * Quat(deg, V3D(0, 1, 0)) *
            Quat(rotZ, V3D(0, 0, 1));
-  } else if (name.compare(rotz()) == 0) {
+  } else if (name == rotz()) {
     addDouble(comp, rotz(), deg);
     quat = Quat(rotX, V3D(1, 0, 0)) * Quat(rotY, V3D(0, 1, 0)) *
            Quat(deg, V3D(0, 0, 1));

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -174,9 +174,8 @@ const std::string ParameterMap::getDescription(const std::string &compName,
   pmap_cit it;
   std::string result;
   for (it = m_map.begin(); it != m_map.end(); ++it) {
-    if (compName == ((const IComponent *)(*it).first)->getName()) {
-      boost::shared_ptr<Parameter> param =
-          get((const IComponent *)(*it).first, name);
+    if (compName == it->first->getName()) {
+      boost::shared_ptr<Parameter> param = get(it->first, name);
       if (param) {
         result = param->getDescription();
         if (!result.empty())

--- a/Framework/Geometry/src/Instrument/RectangularDetector.cpp
+++ b/Framework/Geometry/src/Instrument/RectangularDetector.cpp
@@ -488,7 +488,7 @@ RectangularDetector::getComponentByName(const std::string &cname,
 
   // check that the searched for name starts with the detector's
   // name as they are generated
-  if (cname.substr(0, MEMBER_NAME.length()).compare(MEMBER_NAME) != 0) {
+  if (cname.substr(0, MEMBER_NAME.length()) != MEMBER_NAME) {
     return boost::shared_ptr<const IComponent>();
   } else {
     return CompAssembly::getComponentByName(cname, nlevels);

--- a/Framework/Geometry/src/Instrument/StructuredDetector.cpp
+++ b/Framework/Geometry/src/Instrument/StructuredDetector.cpp
@@ -467,7 +467,7 @@ StructuredDetector::getComponentByName(const std::string &cname,
 
   // check that the searched for name starts with the detector's
   // name as they are generated
-  if (cname.substr(0, MEMBER_NAME.length()).compare(MEMBER_NAME) != 0) {
+  if (cname.substr(0, MEMBER_NAME.length()) != MEMBER_NAME) {
     return boost::shared_ptr<const IComponent>();
   } else {
     return CompAssembly::getComponentByName(cname, nlevels);

--- a/Framework/Geometry/src/Instrument/XMLInstrumentParameter.cpp
+++ b/Framework/Geometry/src/Instrument/XMLInstrumentParameter.cpp
@@ -132,7 +132,7 @@ double XMLInstrumentParameter::createParamValue(
     const bool bUsingStandardStatistics =
         statisics_choice != statistics_types.end();
 
-    if (m_extractSingleValueAs.compare("mean") == 0) {
+    if (m_extractSingleValueAs == "mean") {
       extractedValue = timeMean(logData);
     } else if (bUsingStandardStatistics) {
       extractedValue =

--- a/Framework/Geometry/src/Rendering/vtkGeometryCacheReader.cpp
+++ b/Framework/Geometry/src/Rendering/vtkGeometryCacheReader.cpp
@@ -106,7 +106,7 @@ void vtkGeometryCacheReader::readCacheForObject(Object *obj) {
 Poco::XML::Element *
 vtkGeometryCacheReader::getElementByObjectName(std::string name) {
   Element *pRoot = mDoc->documentElement();
-  if (pRoot == nullptr || pRoot->nodeName().compare("VTKFile") != 0)
+  if (pRoot == nullptr || pRoot->nodeName() != "VTKFile")
     return nullptr;
   Element *pPolyData = pRoot->getChildElement("PolyData");
   if (pPolyData == nullptr)
@@ -130,7 +130,7 @@ void vtkGeometryCacheReader::readPoints(Poco::XML::Element *pEle,
     g_log.error("Cannot allocate memory for triangle cache of Object ");
     return;
   }
-  if (pEle->getAttribute("format").compare("ascii") == 0) { // Read from Ascii
+  if (pEle->getAttribute("format") == "ascii") { // Read from Ascii
     std::stringstream buf;
     buf << pEle->innerText();
     for (int i = 0; i < (*noOfPoints) * 3; i++) {
@@ -156,7 +156,7 @@ void vtkGeometryCacheReader::readTriangles(Poco::XML::Element *pEle,
     g_log.error("Cannot allocate memory for triangle cache of Object ");
     return;
   }
-  if (pEle->getAttribute("format").compare("ascii") == 0) { // Read from Ascii
+  if (pEle->getAttribute("format") == "ascii") { // Read from Ascii
     std::stringstream buf;
     buf << pEle->innerText();
     for (int i = 0; i < (*noOfTriangles) * 3; i++) {

--- a/Framework/ICat/src/CatalogDownloadDataFiles.cpp
+++ b/Framework/ICat/src/CatalogDownloadDataFiles.cpp
@@ -131,7 +131,7 @@ bool CatalogDownloadDataFiles::isDataFile(const std::string &fileName) {
   std::string extension = Poco::Path(fileName).getExtension();
   std::transform(extension.begin(), extension.end(), extension.begin(),
                  tolower);
-  return (extension.compare("raw") == 0 || extension.compare("nxs") == 0);
+  return (extension == "raw" || extension == "nxs");
 }
 
 /**

--- a/Framework/ICat/src/CatalogPublish.cpp
+++ b/Framework/ICat/src/CatalogPublish.cpp
@@ -207,7 +207,7 @@ bool CatalogPublish::isDataFile(const std::string &filePath) {
   std::string extension = Poco::Path(filePath).getExtension();
   std::transform(extension.begin(), extension.end(), extension.begin(),
                  tolower);
-  return extension.compare("raw") == 0 || extension.compare("nxs") == 0;
+  return extension == "raw" || extension == "nxs";
 }
 
 /**

--- a/Framework/Kernel/src/Atom.cpp
+++ b/Framework/Kernel/src/Atom.cpp
@@ -3226,14 +3226,14 @@ Atom getAtom(const uint16_t z_number, const uint16_t a_number) {
  */
 Atom getAtom(const std::string &symbol, const uint16_t a_number) {
   // special cases for aliases
-  if (symbol.compare("D") == 0)
+  if (symbol == "D")
     return H2;
-  if (symbol.compare("T") == 0)
+  if (symbol == "T")
     return H3;
 
   // linear search
   for (auto &atom : ATOMS) {
-    if (symbol.compare(atom.symbol) == 0) {
+    if (symbol == atom.symbol) {
       if (a_number == atom.a_number) {
         return atom;
       }

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1741,8 +1741,8 @@ std::string ConfigServiceImpl::getFacilityFilename(const std::string &fName) {
       this->getString("UpdateInstrumentDefinitions.OnStartup");
 
   auto instrDir = directoryNames.begin();
-  if (updateInstrStr.compare("1") == 0 || updateInstrStr.compare("on") == 0 ||
-      updateInstrStr.compare("On") == 0) {
+  if (updateInstrStr == "1" || updateInstrStr == "on" ||
+      updateInstrStr == "On") {
     // do nothing
   } else {
     instrDir++; // advance to after the first value

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -141,7 +141,7 @@ void PropertyManager::splitByTime(
     }
 
     // Now the property does the splitting.
-    bool isProtonCharge = prop->name().compare("proton_charge") == 0;
+    bool isProtonCharge = prop->name() == "proton_charge";
     prop->splitByTime(splitter, output_properties, isProtonCharge);
 
   } // for each property

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -1026,7 +1026,7 @@ int isMember(const std::vector<std::string> &group,
              const std::string &candidate) {
   int num(-1);
   for (size_t i = 0; i < group.size(); i++) {
-    if (candidate.compare(group[i]) == 0) {
+    if (candidate == group[i]) {
       num = int(i);
       return num;
     }

--- a/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
@@ -80,7 +80,7 @@ bool ISISLiveEventDataListener::connect(
   // If we don't have an address, force a connection to the test server running
   // on
   // localhost on the default port
-  if (address.host().toString().compare("0.0.0.0") == 0) {
+  if (address.host().toString() == "0.0.0.0") {
     Poco::Net::SocketAddress tempAddress("127.0.0.1:10000");
     try {
       m_socket.connect(tempAddress); // BLOCKING connect

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -140,7 +140,7 @@ bool SNSLiveEventDataListener::connect(const Poco::Net::SocketAddress &address)
   // If we don't have an address, force a connection to the test server running
   // on
   // localhost on the default port
-  if (address.host().toString().compare("0.0.0.0") == 0) {
+  if (address.host().toString() == "0.0.0.0") {
     Poco::Net::SocketAddress tempAddress("localhost:31415");
     try {
       m_socket.connect(tempAddress); // BLOCKING connect

--- a/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
@@ -246,9 +246,9 @@ API::MatrixWorkspace_sptr ConvertCWPDMDToSpectra::reducePowderData(
 
   // Convert unit to unit char bit
   char unitchar = 't'; // default 2theta
-  if (targetunit.compare("dSpacing") == 0)
+  if (targetunit == "dSpacing")
     unitchar = 'd';
-  else if (targetunit.compare("Momentum Transfer (Q)") == 0)
+  else if (targetunit == "Momentum Transfer (Q)")
     unitchar = 'q';
 
   binMD(dataws, unitchar, map_runwavelength, vecx, vecy, vec_excludeddets);
@@ -381,15 +381,15 @@ void ConvertCWPDMDToSpectra::findXBoundary(
 
       // convert unit optionally
       double outx = -1;
-      if (targetunit.compare("2theta") == 0)
+      if (targetunit == "2theta")
         outx = twotheta;
       else {
         if (wavelength <= 0)
           throw std::runtime_error("Wavelength is not defined!");
 
-        if (targetunit.compare("dSpacing") == 0)
+        if (targetunit == "dSpacing")
           outx = calculateDspaceFrom2Theta(twotheta, wavelength);
-        else if (targetunit.compare("Momentum Transfer (Q)") == 0)
+        else if (targetunit == "Momentum Transfer (Q)")
           outx = calculateQFrom2Theta(twotheta, wavelength);
         else
           throw std::runtime_error("Unrecognized unit.");

--- a/Framework/MDAlgorithms/src/ConvertCWSDExpToMomentum.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWSDExpToMomentum.cpp
@@ -499,14 +499,14 @@ bool ConvertCWSDExpToMomentum::getInputs(bool virtualinstrument,
     errss << "InputWorkspace must have 6 columns.  But now it has "
           << datacolnames.size() << " columns. \n";
   } else {
-    if (datacolnames[m_iColFilename].compare("File Name") != 0 &&
-        datacolnames[m_iColFilename].compare("Filename") != 0)
+    if (datacolnames[m_iColFilename] != "File Name" &&
+        datacolnames[m_iColFilename] != "Filename")
       errss << "Data file name Table (InputWorkspace)'s Column "
             << m_iColFilename << " must be 'File Name' or 'Filename' but not "
             << datacolnames[m_iColFilename] << ". "
             << "\n";
-    if (datacolnames[m_iColStartDetID].compare("Starting DetID") != 0 &&
-        datacolnames[m_iColStartDetID].compare("StartDetID") != 0)
+    if (datacolnames[m_iColStartDetID] != "Starting DetID" &&
+        datacolnames[m_iColStartDetID] != "StartDetID")
       errss << "Data file name Table (InputWorkspace)'s Column "
             << m_iColStartDetID
             << " must be 'Staring DetID' or 'StartDetID' but not "

--- a/Framework/MDAlgorithms/src/GetSpiceDataRawCountsFromMD.cpp
+++ b/Framework/MDAlgorithms/src/GetSpiceDataRawCountsFromMD.cpp
@@ -95,21 +95,21 @@ void GetSpiceDataRawCountsFromMD::exec() {
   std::vector<double> vecX;
   std::vector<double> vecY;
   std::string ylabel;
-  if (mode.compare("Pt.") == 0) {
+  if (mode == "Pt.") {
     // export detector counts for one specific Pt./run number
     int runnumber = getProperty("Pt");
     if (isEmpty(runnumber))
       throw std::runtime_error("For 'Pt.', value of 'Pt.' must be specified.");
     exportDetCountsOfRun(datamdws, monitormdws, runnumber, vecX, vecY, xlabel,
                          ylabel, donormalize);
-  } else if (mode.compare("Detector") == 0) {
+  } else if (mode == "Detector") {
     int detid = getProperty("DetectorID");
     if (isEmpty(detid))
       throw std::runtime_error(
           "For mode 'Detector', value of 'DetectorID' must be specified.");
     exportIndividualDetCounts(datamdws, monitormdws, detid, vecX, vecY, xlabel,
                               ylabel, donormalize);
-  } else if (mode.compare("Sample Log") == 0) {
+  } else if (mode == "Sample Log") {
     std::string samplelogname = getProperty("SampleLogName");
     if (samplelogname.empty())
       throw std::runtime_error(

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
@@ -246,7 +246,7 @@ void IntegratePeaksMD::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   std::string profileFunction = getProperty("ProfileFunction");
   std::string integrationOption = getProperty("IntegrationOption");
   std::ofstream out;
-  if (cylinderBool && profileFunction.compare("NoFit") != 0) {
+  if (cylinderBool && profileFunction != "NoFit") {
     std::string outFile = getProperty("InputWorkspace");
     outFile.append(profileFunction);
     outFile.append(".dat");
@@ -455,7 +455,7 @@ void IntegratePeaksMD::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         wsProfile2D->setHistogram(i, points, signal_fit);
       }
 
-      if (profileFunction.compare("NoFit") == 0) {
+      if (profileFunction == "NoFit") {
         signal = 0.;
         auto &y = wsProfile2D->y(i);
         // sum signal between range
@@ -547,7 +547,7 @@ void IntegratePeaksMD::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
 
         // Calculate intensity
         signal = 0.0;
-        if (integrationOption.compare("Sum") == 0) {
+        if (integrationOption == "Sum") {
 
           for (size_t j = peakMin; j <= peakMax; j++)
             if (std::isfinite(yy[j]))

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -253,7 +253,7 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   std::string profileFunction = getProperty("ProfileFunction");
   std::string integrationOption = getProperty("IntegrationOption");
   std::ofstream out;
-  if (cylinderBool && profileFunction.compare("NoFit") != 0) {
+  if (cylinderBool && profileFunction != "NoFit") {
     std::string outFile = getProperty("InputWorkspace");
     outFile.append(profileFunction);
     outFile.append(".dat");
@@ -467,7 +467,7 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         wsProfile2D->setHistogram(i, points, signal_fit);
       }
 
-      if (profileFunction.compare("NoFit") == 0) {
+      if (profileFunction == "NoFit") {
         signal = 0.;
         for (size_t j = 0; j < numSteps; j++) {
           if (j < peakMin || j > peakMax)
@@ -560,7 +560,7 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
 
         // Calculate intensity
         signal = 0.0;
-        if (integrationOption.compare("Sum") == 0) {
+        if (integrationOption == "Sum") {
           for (size_t j = peakMin; j <= peakMax; j++)
             if (std::isfinite(yy[j]))
               signal += yy[j];

--- a/Framework/MDAlgorithms/src/LoadSQW.cpp
+++ b/Framework/MDAlgorithms/src/LoadSQW.cpp
@@ -62,7 +62,7 @@ int LoadSQW::confidence(Kernel::FileDescriptor &descriptor) const {
 
   // only .sqw can be considered
   const std::string &extn = descriptor.extension();
-  if (extn.compare(".sqw") != 0)
+  if (extn != ".sqw")
     return 0;
 
   if (descriptor.isAscii()) {

--- a/Framework/MDAlgorithms/src/LoadSQW2.cpp
+++ b/Framework/MDAlgorithms/src/LoadSQW2.cpp
@@ -77,7 +77,7 @@ const std::string LoadSQW2::summary() const {
 int LoadSQW2::confidence(Kernel::FileDescriptor &descriptor) const {
   // only .sqw can be considered
   const std::string &extn = descriptor.extension();
-  if (extn.compare(".sqw") != 0)
+  if (extn != ".sqw")
     return 0;
 
   if (descriptor.isAscii()) {

--- a/Framework/MDAlgorithms/src/MDWSDescription.cpp
+++ b/Framework/MDAlgorithms/src/MDWSDescription.cpp
@@ -450,7 +450,7 @@ MDWSDescription::getCoordinateSystem() const {
  * @return True only if in Q3D mode
  */
 bool MDWSDescription::isQ3DMode() const {
-  return this->AlgID.compare("Q3D") == 0;
+  return this->AlgID == "Q3D";
 }
 
 bool MDWSDescription::hasLattice() const {

--- a/Framework/MDAlgorithms/src/MDWSDescription.cpp
+++ b/Framework/MDAlgorithms/src/MDWSDescription.cpp
@@ -449,9 +449,7 @@ MDWSDescription::getCoordinateSystem() const {
  * Is the algorithm running in Q3D mode?
  * @return True only if in Q3D mode
  */
-bool MDWSDescription::isQ3DMode() const {
-  return this->AlgID == "Q3D";
-}
+bool MDWSDescription::isQ3DMode() const { return this->AlgID == "Q3D"; }
 
 bool MDWSDescription::hasLattice() const {
   return m_InWS->sample().hasOrientedLattice();

--- a/Framework/MDAlgorithms/src/UnitsConversionHelper.cpp
+++ b/Framework/MDAlgorithms/src/UnitsConversionHelper.cpp
@@ -25,7 +25,7 @@ UnitsConversionHelper::analyzeUnitsConversion(const std::string &UnitsFrom,
                                               const std::string &UnitsTo,
                                               bool forceViaTOF) {
   // if units are equal, no conversion is necessary;
-  if (UnitsFrom.compare(UnitsTo) == 0)
+  if (UnitsFrom == UnitsTo)
     return CnvrtToMD::ConvertNo;
 
   // get all known units:
@@ -48,7 +48,7 @@ UnitsConversionHelper::analyzeUnitsConversion(const std::string &UnitsFrom,
     return CnvrtToMD::ConvertFast;
   } else {
     // are the input units TOF?
-    if (UnitsFrom.compare("TOF") == 0) {
+    if (UnitsFrom == "TOF") {
       return CnvrtToMD::ConvertFromTOF;
     } else { // convert using TOF
       m_TargetUnit = Kernel::UnitFactory::Instance().create(UnitsTo);

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -1028,7 +1028,7 @@ bool NexusFileIO::checkAttributeName(const std::string &target) const {
   const std::vector< ::NeXus::AttrInfo> infos = m_filehandle->getAttrInfos();
   // clang-format on
   for (const auto &info : infos) {
-    if (target.compare(info.name) == 0)
+    if (target == info.name)
       return true;
   }
 
@@ -1266,7 +1266,7 @@ int getNexusEntryTypes(const std::string &fileName,
   while ((stat = NXgetnextentry(fileH, nxname, nxclass, &nxdatatype)) ==
          NX_OK) {
     std::string nxc(nxclass);
-    if (nxc.compare("NXentry") == 0)
+    if (nxc == "NXentry")
       entryList.push_back(nxname);
   }
   // for each entry found, look for "analysis" or "definition" text data fields
@@ -1279,9 +1279,9 @@ int getNexusEntryTypes(const std::string &fileName,
            NX_OK) {
       std::string nxc(nxclass), nxn(nxname);
       // if a data field
-      if (nxc.compare("SDS") == 0)
+      if (nxc == "SDS")
         // if one of the two names we are looking for
-        if (nxn.compare("definition") == 0 || nxn.compare("analysis") == 0) {
+        if (nxn == "definition" || nxn == "analysis") {
           NXopendata(fileH, nxname);
           stat = NXgetinfo(fileH, &rank, dims, &type);
           if (stat == NX_ERROR)

--- a/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
@@ -127,7 +127,7 @@ ResultType performBinaryOp(const LHSType lhs, const RHSType rhs,
     }
   } catch (std::runtime_error &exc) {
     error = exc.what();
-    if (error.compare("algorithm") == 0) {
+    if (error == "algorithm") {
       error = "Unknown binary operation requested: " + op;
       throw std::runtime_error(error);
     } else {

--- a/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -189,7 +189,7 @@ void LoadFlexiNexus::load2DWorkspace(NeXus::File *fin) {
   } else {
     const std::string xname(it->second);
     ws->getAxis(0)->title() = xname;
-    if (xname.compare("TOF") == 0) {
+    if (xname == "TOF") {
       g_log.debug() << "Setting X-unit to be TOF\n";
       ws->getAxis(0)->setUnit("TOF");
     }

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -171,7 +171,7 @@ void ConvolutionFitSequential::exec() {
   if (delta) {
     outputWsName += "Delta";
   }
-  if (LorentzNum.compare("0") != 0) {
+  if (LorentzNum != "0") {
     outputWsName += LorentzNum + "L";
   } else {
     outputWsName += convertFuncToShort(funcName);
@@ -240,7 +240,7 @@ void ConvolutionFitSequential::exec() {
 
   Progress workflowProg(this, 0.91, 0.94, 4);
   auto paramNames = std::vector<std::string>();
-  if (funcName.compare("DeltaFunction") == 0) {
+  if (funcName == "DeltaFunction") {
     paramNames.emplace_back("Height");
   } else {
     auto func = FunctionFactory::Instance().createFunction(funcName);
@@ -251,7 +251,7 @@ void ConvolutionFitSequential::exec() {
       paramNames.push_back(func->parameterName(i));
       workflowProg.report("Finding parameters to process");
     }
-    if (funcName.compare("Lorentzian") == 0) {
+    if (funcName == "Lorentzian") {
       // remove peak centre
       size_t pos = find(paramNames.begin(), paramNames.end(), "PeakCentre") -
                    paramNames.begin();
@@ -385,7 +385,7 @@ ConvolutionFitSequential::findValuesFromFunction(const std::string &function) {
     auto nextPos = fitType.find_first_of(',');
     fitType = fitType.substr(5, nextPos - 5);
     functionName = fitType;
-    if (fitType.compare("Lorentzian") == 0) {
+    if (fitType == "Lorentzian") {
       std::string newSub = function.substr(0, startPos);
       bool isTwoL = checkForTwoLorentz(newSub);
       if (isTwoL) {
@@ -611,7 +611,7 @@ ConvolutionFitSequential::convertBackToShort(const std::string &original) {
 std::string
 ConvolutionFitSequential::convertFuncToShort(const std::string &original) {
   std::string result;
-  if (original.compare("DeltaFunction") != 0) {
+  if (original != "DeltaFunction") {
     if (original.at(0) == 'E') {
       result += "E";
     } else if (original.at(0) == 'I') {

--- a/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
@@ -172,7 +172,7 @@ void ProcessIndirectFitParameters::exec() {
 
   workflowProg.report("Setting unit");
   // Set units for the xAxis
-  if (xUnit.compare("") != 0) {
+  if (xUnit != "") {
     outputWs->getAxis(0)->setUnit(xUnit);
   }
 

--- a/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
@@ -172,7 +172,7 @@ void ProcessIndirectFitParameters::exec() {
 
   workflowProg.report("Setting unit");
   // Set units for the xAxis
-  if (xUnit != "") {
+  if (!xUnit.empty()) {
     outputWs->getAxis(0)->setUnit(xUnit);
   }
 

--- a/Framework/WorkflowAlgorithms/src/RefReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/RefReduction.cpp
@@ -182,7 +182,7 @@ MatrixWorkspace_sptr RefReduction::processData(const std::string polarization) {
   // Get scattering angle in degrees
   double theta = getProperty("Theta");
   const std::string instrument = getProperty("Instrument");
-  const bool integrateY = instrument.compare("REF_M") == 0;
+  const bool integrateY = instrument == "REF_M";
 
   // Get pixel ranges in real pixels
   int xmin = 0;
@@ -345,7 +345,7 @@ MatrixWorkspace_sptr RefReduction::processData(const std::string polarization) {
   MatrixWorkspace_sptr outputWS = grpAlg->getProperty("OutputWorkspace");
 
   const std::string prefix = getPropertyValue("OutputWorkspacePrefix");
-  if (polarization.compare(PolStateNone) == 0) {
+  if (polarization == PolStateNone) {
     declareProperty(Kernel::make_unique<WorkspaceProperty<>>(
         "OutputWorkspace", prefix, Direction::Output));
     setProperty("OutputWorkspace", outputWS);
@@ -402,7 +402,7 @@ MatrixWorkspace_sptr RefReduction::processNormalization() {
   }
 
   const std::string instrument = getProperty("Instrument");
-  const bool integrateY = instrument.compare("REF_M") == 0;
+  const bool integrateY = instrument == "REF_M";
   if (integrateY) {
     if (!cropLowRes)
       low_res_max = NY_PIXELS - 1;
@@ -507,7 +507,7 @@ IEventWorkspace_sptr RefReduction::loadData(const std::string dataRun,
       m_output_message += "    |Loading from " + path + "\n";
       IAlgorithm_sptr loadAlg = createChildAlgorithm("LoadEventNexus", 0, 0.2);
       loadAlg->setProperty("Filename", path);
-      if (polarization.compare(PolStateNone) != 0)
+      if (polarization != PolStateNone)
         loadAlg->setProperty("NXentryName", polarization);
       try {
         loadAlg->executeAsChildAlg();
@@ -525,7 +525,7 @@ IEventWorkspace_sptr RefReduction::loadData(const std::string dataRun,
       }
 
       // Move the detector to the right position
-      if (instrument.compare("REF_M") == 0) {
+      if (instrument == "REF_M") {
         const auto &detInfo = rawWS->detectorInfo();
         const size_t detIndex0 = detInfo.indexOf(0);
         double det_distance = detInfo.position(detIndex0).Z();
@@ -701,7 +701,7 @@ MatrixWorkspace_sptr RefReduction::subtractBackground(
     MatrixWorkspace_sptr dataWS, MatrixWorkspace_sptr rawWS, int peakMin,
     int peakMax, int bckMin, int bckMax, int lowResMin, int lowResMax) {
   const std::string instrument = getProperty("Instrument");
-  const bool integrateY = instrument.compare("REF_M") == 0;
+  const bool integrateY = instrument == "REF_M";
 
   int xmin = 0;
   int xmax = 0;

--- a/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
@@ -145,7 +145,7 @@ void SANSBeamFinder::exec() {
   if (m_reductionManager->existsProperty("InstrumentName")) {
     const std::string instrumentName =
         m_reductionManager->getPropertyValue("InstrumentName");
-    specialMapping = instrumentName.compare("HFIRSANS") == 0;
+    specialMapping = instrumentName == "HFIRSANS";
   }
 
   // Find beam center


### PR DESCRIPTION
Description of work.

This applies changes suggested by [clang-tidy's misc-string-compare check](https://clang.llvm.org/extra/clang-tidy/checks/misc-string-compare.html). In addition to being clearer code, using the equality/inequality check may also be faster.

**To test:**

<!-- Instructions for testing. -->

Code review and checking the build is sufficient.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
