### PR TITLE
Fixed copy elision warnings from using std::move in EnabledWhenProperty

### DIFF
--- a/Framework/Kernel/src/EnabledWhenProperty.cpp
+++ b/Framework/Kernel/src/EnabledWhenProperty.cpp
@@ -37,10 +37,9 @@ EnabledWhenProperty::EnabledWhenProperty(
     : // This method allows the Python interface to easily construct these
       // objects
       // Copy the object then forward onto our move constructor
-      EnabledWhenProperty(
-          std::make_shared<EnabledWhenProperty>(conditionOne),
-          std::make_shared<EnabledWhenProperty>(conditionTwo),
-          logicOperator) {}
+      EnabledWhenProperty(std::make_shared<EnabledWhenProperty>(conditionOne),
+                          std::make_shared<EnabledWhenProperty>(conditionTwo),
+                          logicOperator) {}
 
 /** Multiple conditions constructor - takes two shared pointers to
 * EnabledWhenProperty objects and returns the product of them

--- a/Framework/Kernel/src/EnabledWhenProperty.cpp
+++ b/Framework/Kernel/src/EnabledWhenProperty.cpp
@@ -38,8 +38,8 @@ EnabledWhenProperty::EnabledWhenProperty(
       // objects
       // Copy the object then forward onto our move constructor
       EnabledWhenProperty(
-          std::move(std::make_shared<EnabledWhenProperty>(conditionOne)),
-          std::move(std::make_shared<EnabledWhenProperty>(conditionTwo)),
+          std::make_shared<EnabledWhenProperty>(conditionOne),
+          std::make_shared<EnabledWhenProperty>(conditionTwo),
           logicOperator) {}
 
 /** Multiple conditions constructor - takes two shared pointers to

--- a/Framework/Kernel/src/VisibleWhenProperty.cpp
+++ b/Framework/Kernel/src/VisibleWhenProperty.cpp
@@ -30,8 +30,8 @@ VisibleWhenProperty::VisibleWhenProperty(
     : // For the python interface to be able to easily copy objects in
       // Make a deep copy and turn into a shared pointer and forward on
       VisibleWhenProperty(
-          std::move(std::make_shared<VisibleWhenProperty>(conditionOne)),
-          std::move(std::make_shared<VisibleWhenProperty>(conditionTwo)),
+          std::make_shared<VisibleWhenProperty>(conditionOne),
+          std::make_shared<VisibleWhenProperty>(conditionTwo),
           logicOperator) {}
 
 /** Multiple conditions constructor - takes two shared pointers to

--- a/Framework/Kernel/src/VisibleWhenProperty.cpp
+++ b/Framework/Kernel/src/VisibleWhenProperty.cpp
@@ -29,10 +29,9 @@ VisibleWhenProperty::VisibleWhenProperty(
     const VisibleWhenProperty &conditionTwo, eLogicOperator logicOperator)
     : // For the python interface to be able to easily copy objects in
       // Make a deep copy and turn into a shared pointer and forward on
-      VisibleWhenProperty(
-          std::make_shared<VisibleWhenProperty>(conditionOne),
-          std::make_shared<VisibleWhenProperty>(conditionTwo),
-          logicOperator) {}
+      VisibleWhenProperty(std::make_shared<VisibleWhenProperty>(conditionOne),
+                          std::make_shared<VisibleWhenProperty>(conditionTwo),
+                          logicOperator) {}
 
 /** Multiple conditions constructor - takes two shared pointers to
 * VisibleWhenProperty objects and returns the product of them


### PR DESCRIPTION
Description of work.
This PR fixes an issue where we were using a std::move which prevents the compiler using elision as a native optimization. This was detected by LLVM (through XCode)

**To test:**
Build against Clang or Xcode. Ensure warning is resolved

Fixes #19428 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
