### PR TITLE
Change openssl function in gsoap

### DIFF
--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -4547,7 +4547,7 @@ again:
               break;
             name = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(subj, i));
             if (name) {
-              if (!soap_tag_cmp(host, (const char *)M_ASN1_STRING_data(name)))
+              if (!soap_tag_cmp(host, (const char *)ASN1_STRING_data(name)))
                 ok = 1;
               else {
                 unsigned char *tmp = nullptr;


### PR DESCRIPTION
Mantid fails to compile with openssl 1.1.0 This fixes the "`M_ASN1_STRING_data’ was not declared in this scope" error with openssl 1.1.0.

This switches to using `ASN1_STRING_data` which is itself deprecated in `1.1.0` and will some point need to be changed to the new function [ASN1_STRING_get0_data](https://www.openssl.org/docs/manmaster/man3/ASN1_STRING_get0_data.html) :unamused: but this will work for now.

**To test:**
As long as everything still compiles and passes the tests it should be good.

I also started a build for this branch on Arch which has openssl 1.1.0 [here](http://builds.mantidproject.org/job/master_clean-archlinux/853/)

The better solution is to update gsoap version (openssl 1.1.0 support was added in [2.8.41](https://www.genivia.com/changelog.html)) but that is more work.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
