### PR TITLE
Crash opening `SpecularReflectionPositionCorrect` dialog

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionPositionCorrect2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionPositionCorrect2.h
@@ -42,7 +42,6 @@ public:
   const std::string category() const override;
 
 private:
-  std::map<std::string, std::string> validateInputs() override;
   void init() override;
   void exec() override;
 };

--- a/Framework/Algorithms/src/SpecularReflectionPositionCorrect2.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionPositionCorrect2.cpp
@@ -87,29 +87,6 @@ void SpecularReflectionPositionCorrect2::init() {
       "An output workspace.");
 }
 
-/** Validate inputs
-*/
-std::map<std::string, std::string>
-SpecularReflectionPositionCorrect2::validateInputs() {
-
-  std::map<std::string, std::string> results;
-
-  MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
-  auto inst = inputWS->getInstrument();
-
-  // Detector
-  const std::string detectorName = getProperty("DetectorComponentName");
-  if (!inst->getComponentByName(detectorName))
-    results["DetectorComponentName"] = "Detector component not found.";
-
-  // Sample
-  const std::string sampleName = getProperty("SampleComponentName");
-  if (!inst->getComponentByName(sampleName))
-    results["SampleComponentName"] = "Sample component not found.";
-
-  return results;
-}
-
 //----------------------------------------------------------------------------------------------
 /** Execute the algorithm.
 */
@@ -132,11 +109,15 @@ void SpecularReflectionPositionCorrect2::exec() {
 
   // Detector
   const std::string detectorName = getProperty("DetectorComponentName");
+  if (!inst->getComponentByName(detectorName))
+    throw std::runtime_error("Detector component not found.");
   IComponent_const_sptr detector = inst->getComponentByName(detectorName);
   const V3D detectorPosition = detector->getPos();
 
   // Sample
   const std::string sampleName = getProperty("SampleComponentName");
+  if (!inst->getComponentByName(sampleName))
+    throw std::runtime_error("Sample component not found.");
   IComponent_const_sptr sample = inst->getComponentByName(sampleName);
   const V3D samplePosition = sample->getPos();
 


### PR DESCRIPTION
Mantid crashes when opening the dialog for the SpecularReflectionPositionCorrect algorithm on a workspace group. This was a result of my previous work in PR #18941. This PR fixes this issue.

**To test:**

- Load the file OFFSPEC41894
- Select the workspace group that was loaded
- Run the SpecularReflectionPositionCorrect algorithm from the Algorithms list or search box in MantidPlot. Mantid should no longer crash.
- Follow testing instructions from PR #18941 to ensure original functionality is still there.

Fixes #19404.

*Does not need to be in the release notes.*

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
