### PR TITLE
Archive search for installer testing

### DIFF
--- a/Testing/SystemTests/lib/systemtests/stresstesting.py
+++ b/Testing/SystemTests/lib/systemtests/stresstesting.py
@@ -938,6 +938,7 @@ class MantidFrameworkConfig:
         # datasearch
         if self.__datasearch:
             config["datasearch.searcharchive"] = 'On'
+            config['network.default.timeout'] = '1'
 
         # Save this configuration
         config.saveConfig(self.__userPropsFile)

--- a/Testing/SystemTests/scripts/InstallerTests.py
+++ b/Testing/SystemTests/scripts/InstallerTests.py
@@ -3,10 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 """
 import os
 import sys
-import platform
-import shutil
 import subprocess
-import sys
 
 from getopt import getopt
 
@@ -69,7 +66,7 @@ if doInstall:
         installer.install()
         log("Application path " + installer.mantidPlotPath)
         installer.no_uninstall = False
-    except Exception,err:
+    except Exception as err:
         scriptfailure("Installing failed. "+str(err))
 else:
     installer.no_uninstall = True
@@ -81,7 +78,7 @@ try:
     if version and len(version) > 0:
         version_tested.write(version)
     version_tested.close()
-except Exception, err:
+except Exception as err:
     scriptfailure('Version test failed: '+str(err), installer)
 
 try:
@@ -91,7 +88,7 @@ try:
     if revision and len(version) > 0:
         revision_tested.write(revision)
     revision_tested.close()
-except Exception, err:
+except Exception as err:
     scriptfailure('Revision test failed: '+str(err), installer)
 
 log("Running system tests. Log files are: '%s' and '%s'" % (testRunLogPath,testRunErrPath))
@@ -118,7 +115,7 @@ try:
         testsRunErr.close()
     if p.returncode != 0:
         failure(installer)
-except Exception, exc:
+except Exception as exc:
     scriptfailure(str(exc),installer)
 except:
     failure(installer)

--- a/Testing/SystemTests/scripts/InstallerTests.py
+++ b/Testing/SystemTests/scripts/InstallerTests.py
@@ -20,6 +20,8 @@ parser.add_argument('-o', dest='out2stdout', action='store_true',
                     help='Output to the screen instead of log files')
 parser.add_argument('-R', dest='test_regex', metavar='regexp', default=None,
                     help='Optionally only run the test matched by the regex')
+parser.add_option("", "--archivesearch", dest="archivesearch", action="store_true",
+                  help="Turn on archive search for file finder.")
 log_levels = ['error', 'warning', 'notice', 'information', 'debug']
 parser.add_argument('-l', dest='log_level', metavar='level', default='notice',
                     choices=log_levels, help='Log level '+str(log_levels))
@@ -76,6 +78,8 @@ try:
                  THIS_MODULE_DIR, options.log_level, installer.python_cmd, installer.python_args)
     if options.test_regex is not None:
         run_test_cmd += " -R " + options.test_regex
+    if options.archivesearch:
+        run_test_cmd += ' --archivesearch'
     if options.out2stdout:
         print("Executing command '{0}'".format(run_test_cmd))
         p = subprocess.Popen(run_test_cmd, shell=True) # no PIPE: print on screen for debugging

--- a/Testing/SystemTests/scripts/InstallerTests.py
+++ b/Testing/SystemTests/scripts/InstallerTests.py
@@ -20,8 +20,8 @@ parser.add_argument('-o', dest='out2stdout', action='store_true',
                     help='Output to the screen instead of log files')
 parser.add_argument('-R', dest='test_regex', metavar='regexp', default=None,
                     help='Optionally only run the test matched by the regex')
-parser.add_option("", "--archivesearch", dest="archivesearch", action="store_true",
-                  help="Turn on archive search for file finder.")
+parser.add_argument('--archivesearch', dest='archivesearch', action='store_true',
+                    help='Turn on archive search for file finder')
 log_levels = ['error', 'warning', 'notice', 'information', 'debug']
 parser.add_argument('-l', dest='log_level', metavar='level', default='notice',
                     choices=log_levels, help='Log level '+str(log_levels))

--- a/Testing/SystemTests/scripts/InstallerTests.py
+++ b/Testing/SystemTests/scripts/InstallerTests.py
@@ -1,3 +1,4 @@
+from __future__ import (absolute_import, division, print_function)
 """Finds a package, installs it and runs the tests against it.
 """
 import os
@@ -9,7 +10,7 @@ import sys
 
 from getopt import getopt
 
-from mantidinstaller import (createScriptLog, log, stop, failure, scriptfailure, 
+from mantidinstaller import (createScriptLog, log, stop, failure, scriptfailure,
                              get_installer, run)
 
 THIS_MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -21,15 +22,15 @@ except:
     opt = [('-h','')]
 
 if ('-h','') in opt:
-    print "Usage: %s [OPTIONS]" % os.path.basename(sys.argv[0])
-    print
-    print "Valid options are:"
-    print "       -d Directory to look for packages. Defaults to current working directory"
-    print "       -n Run tests without installing Mantid (it must be already installed)"
-    print "       -o Output to the screen instead of log files"
-    print "       -h Display the usage"
-    print "       -R Optionally only run the test matched by the regex"
-    print "       -l Log level"
+    print("Usage: %s [OPTIONS]" % os.path.basename(sys.argv[0]))
+    print()
+    print("Valid options are:")
+    print("       -d Directory to look for packages. Defaults to current working directory")
+    print("       -n Run tests without installing Mantid (it must be already installed)")
+    print("       -o Output to the screen instead of log files")
+    print("       -h Display the usage")
+    print("       -R Optionally only run the test matched by the regex")
+    print("       -l Log level")
     sys.exit(0)
 
 doInstall = True
@@ -101,7 +102,7 @@ try:
     if test_regex is not None:
         run_test_cmd += " -R " + test_regex
     if out2stdout:
-        print "Executing command '{0}'".format(run_test_cmd)
+        print("Executing command '{0}'".format(run_test_cmd))
         p = subprocess.Popen(run_test_cmd, shell=True) # no PIPE: print on screen for debugging
         p.wait()
     else:

--- a/Testing/SystemTests/scripts/mantidinstaller.py
+++ b/Testing/SystemTests/scripts/mantidinstaller.py
@@ -1,3 +1,4 @@
+from __future__ import (absolute_import, division, print_function)
 """Defines classes for handling installation
 """
 import platform
@@ -9,18 +10,21 @@ import time
 
 scriptLog = None
 
+
 def createScriptLog(path):
     global scriptLog
     scriptLog = open(path,'w')
+
 
 def stop(installer):
     ''' Save the log, uninstall the package and exit with error code 0 '''
     try:
         installer.uninstall()
-    except Exception, exc:
+    except Exception as exc:
         log("Could not uninstall package %s: %s" % (installer.mantidInstaller, str(exc)))
     scriptLog.close()
     sys.exit(0)
+
 
 def log(txt):
     ''' Write text to the script log file '''
@@ -30,19 +34,21 @@ def log(txt):
         scriptLog.write(txt)
         if not txt.endswith('\n'):
             scriptLog.write('\n')
-        print txt
+        print(txt)
+
 
 def failure(installer):
     ''' Report failure of test(s), try to uninstall package and exit with code 1 '''
     try:
         installer.uninstall()
-    except Exception, exc:
+    except Exception as exc:
         log("Could not uninstall package %s: %s" % (installer.mantidInstaller, str(exc)))
         pass
 
     log('Tests failed')
-    print 'Tests failed'
+    print('Tests failed')
     sys.exit(1)
+
 
 def scriptfailure(txt, installer=None):
     '''Report failure of this script, try to uninstall package and exit with code 1 '''
@@ -52,7 +58,7 @@ def scriptfailure(txt, installer=None):
         try:
             installer.uninstall()
         except Exception:
-            log("Could not uninstall package %s " % self.mantidInstaller)
+            log("Could not uninstall package %s " % str(installer))
     scriptLog.close()
     sys.exit(1)
 
@@ -79,6 +85,7 @@ def get_installer(package_dir, do_install=True):
     else:
         raise scriptfailure("Unsupported platform")
 
+
 def run(cmd):
     """Run a command in a subprocess"""
     try:
@@ -86,7 +93,7 @@ def run(cmd):
         stdout, stderr = p.communicate()
         if p.returncode != 0:
             raise Exception('Returned with code '+str(p.returncode)+'\n'+ stdout)
-    except Exception,err:
+    except Exception as err:
         log('Error in subprocess %s:\n' % str(err))
         raise
     log(stdout)
@@ -141,6 +148,7 @@ class MantidInstaller(object):
     def do_uninstall(self):
         raise NotImplementedError("Override the do_uninstall method")
 
+
 class NSISInstaller(MantidInstaller):
     """Uses an NSIS installer
     to install Mantid
@@ -173,6 +181,7 @@ class NSISInstaller(MantidInstaller):
         log("Waiting 30 seconds for uninstaller to finish")
         time.sleep(30)
 
+
 class LinuxInstaller(MantidInstaller):
     """Defines common properties for linux-based packages"""
 
@@ -194,6 +203,7 @@ class LinuxInstaller(MantidInstaller):
         self.mantidPlotPath = install_prefix + '/bin/MantidPlot'
         self.python_cmd = install_prefix + '/bin/mantidpython'
 
+
 class DebInstaller(LinuxInstaller):
     """Uses a deb package to install mantid
     """
@@ -212,6 +222,7 @@ class DebInstaller(LinuxInstaller):
         package_name = os.path.basename(self.mantidInstaller).split("_")[0]
         run('sudo dpkg --purge %s' % package_name)
 
+
 class RPMInstaller(LinuxInstaller):
     """Uses a rpm package to install mantid
     """
@@ -229,7 +240,7 @@ class RPMInstaller(LinuxInstaller):
             pass
         try:
             run('sudo yum -y install ' + self.mantidInstaller)
-        except Exception, exc:
+        except Exception as exc:
             # This reports an error if the same package is already installed
             if 'does not update installed package' in str(exc):
                 log("Current version is up-to-date, continuing.\n")
@@ -288,16 +299,16 @@ if __name__ == "__main__":
 
     command, package_dir = args[0], args[1]
     package_dir = os.path.abspath(package_dir)
-    print "Searching for packages in '%s'" % package_dir
+    print("Searching for packages in '%s'" % package_dir)
     installer = get_installer(package_dir)
     if command.lower() == "install":
-        print "Installing package '%s'" % installer.mantidInstaller
+        print("Installing package '%s'" % installer.mantidInstaller)
         installer.install()
         if options.dump_exe_path is not None:
             with open(options.dump_exe_path, 'w') as f:
                 f.write(installer.mantidPlotPath)
     elif command.lower() == "uninstall":
-        print "Removing package '%s'" % installer.mantidInstaller
+        print("Removing package '%s'" % installer.mantidInstaller)
         installer.uninstall()
     else:
         raise RuntimeError("Invalid command '%s'. Options are: install, uninstall" % command)

--- a/Testing/SystemTests/scripts/mantidinstaller.py
+++ b/Testing/SystemTests/scripts/mantidinstaller.py
@@ -286,29 +286,25 @@ class DMGInstaller(MantidInstaller):
 # If called as a standalone script then this can be used to install/uninstall
 # Mantid
 if __name__ == "__main__":
-    import optparse
-    parser = optparse.OptionParser("Usage: %prog <command> <pkg directory>",
+    import argparse
+    parser = argparse.ArgumentParser(#"Usage: %prog <command> <pkg directory>",
                                    description="Commands available: install, uninstall")
-    parser.add_option("-d", "--dump-exe-path", dest="dump_exe_path",
-                      help="Filepath to write the full path of the MantidPlot executable")
-    (options, args) = parser.parse_args()
-    # All arguments are required
-    if len(args) != 2:
-        parser.print_help()
-        sys.exit(1)
+    parser.add_argument('command', choices=['install', 'uninstall'], help='command to run')
+    parser.add_argument('directory', help='package directory')
+    parser.add_argument('-d', '--dump-exe-path', dest='dump_exe_path',
+                        help='Filepath to write the full path of the MantidPlot executable')
 
-    command, package_dir = args[0], args[1]
-    package_dir = os.path.abspath(package_dir)
+    options = parser.parse_args()
+
+    package_dir = os.path.abspath(options.directory)
     print("Searching for packages in '%s'" % package_dir)
     installer = get_installer(package_dir)
-    if command.lower() == "install":
+    if options.command == "install":
         print("Installing package '%s'" % installer.mantidInstaller)
         installer.install()
         if options.dump_exe_path is not None:
             with open(options.dump_exe_path, 'w') as f:
                 f.write(installer.mantidPlotPath)
-    elif command.lower() == "uninstall":
+    elif options.command == "uninstall":
         print("Removing package '%s'" % installer.mantidInstaller)
         installer.uninstall()
-    else:
-        raise RuntimeError("Invalid command '%s'. Options are: install, uninstall" % command)

--- a/Testing/SystemTests/scripts/mantidinstaller.py
+++ b/Testing/SystemTests/scripts/mantidinstaller.py
@@ -287,8 +287,7 @@ class DMGInstaller(MantidInstaller):
 # Mantid
 if __name__ == "__main__":
     import argparse
-    parser = argparse.ArgumentParser(#"Usage: %prog <command> <pkg directory>",
-                                   description="Commands available: install, uninstall")
+    parser = argparse.ArgumentParser(description="Commands available: install, uninstall")
     parser.add_argument('command', choices=['install', 'uninstall'], help='command to run')
     parser.add_argument('directory', help='package directory')
     parser.add_argument('-d', '--dump-exe-path', dest='dump_exe_path',

--- a/Testing/SystemTests/scripts/runSystemTests.py
+++ b/Testing/SystemTests/scripts/runSystemTests.py
@@ -34,7 +34,8 @@ parser.add_option("-a", "--exec-args", dest="execargs",
 parser.add_option("", "--frameworkLoc",
                   help="location of the stress test framework (default=%s)" % DEFAULT_FRAMEWORK_LOC)
 parser.add_option("", "--disablepropmake", action="store_false", dest="makeprop",
-                  help="By default this will move your properties file out of the way and create a new one. This option turns off this behavior.")
+                  help="By default this will move your properties file out of the "
+                  + "way and create a new one. This option turns off this behavior.")
 parser.add_option("-R", "--tests-regex", dest="testsInclude",
                   help="String specifying which tests to run. Simply uses 'string in testname'.")
 parser.add_option("-E", "--excluderegex", dest="testsExclude",
@@ -63,19 +64,19 @@ import stresstesting
 # Parse files containing the search and save directories, unless otherwise given
 data_paths = options.datapaths
 if data_paths is None or data_paths == "":
-  with open(DATA_DIRS_LIST_PATH, 'r') as f_handle:
-    data_paths = f_handle.read().strip()
+    with open(DATA_DIRS_LIST_PATH, 'r') as f_handle:
+        data_paths = f_handle.read().strip()
 
 save_dir = options.savedir
 if save_dir is None or save_dir == "":
-  with open(SAVE_DIR_LIST_PATH, 'r') as f_handle:
-    save_dir = f_handle.read().strip()
+    with open(SAVE_DIR_LIST_PATH, 'r') as f_handle:
+        save_dir = f_handle.read().strip()
 # Configure properties file
 mtdconf = stresstesting.MantidFrameworkConfig(loglevel=options.loglevel,
                                               data_dirs=data_paths, save_dir=save_dir,
                                               archivesearch=options.archivesearch)
 if options.makeprop:
-  mtdconf.config()
+    mtdconf.config()
 
 # run the tests
 execargs = options.execargs
@@ -84,9 +85,9 @@ reporter = stresstesting.XmlResultReporter(showSkipped=options.showskipped)
 mgr = stresstesting.TestManager(mtdconf.testDir, runner, output = [reporter],
                                 testsInclude=options.testsInclude, testsExclude=options.testsExclude)
 try:
-  mgr.executeTests()
+    mgr.executeTests()
 except KeyboardInterrupt:
-  mgr.markSkipped("KeyboardInterrupt")
+    mgr.markSkipped("KeyboardInterrupt")
 
 # report the errors
 success = reporter.reportStatus()
@@ -96,17 +97,17 @@ xml_report.close()
 
 # put the configuration back to its original state
 if options.makeprop:
-  mtdconf.restoreconfig()
+    mtdconf.restoreconfig()
 
 print()
 if mgr.skippedTests == mgr.totalTests:
-  print("All tests were skipped")
-  success = False # fail if everything was skipped
+    print("All tests were skipped")
+    success = False # fail if everything was skipped
 else:
-  percent = 1.-float(mgr.failedTests)/float(mgr.totalTests-mgr.skippedTests)
-  percent = int(100. * percent)
-  print("%d%s tests passed, %d tests failed out of %d (%d skipped)" % \
-      (percent, '%', mgr.failedTests, (mgr.totalTests-mgr.skippedTests), mgr.skippedTests))
+    percent = 1.-float(mgr.failedTests)/float(mgr.totalTests-mgr.skippedTests)
+    percent = int(100. * percent)
+    print("%d%s tests passed, %d tests failed out of %d (%d skipped)" %
+          (percent, '%', mgr.failedTests, (mgr.totalTests-mgr.skippedTests), mgr.skippedTests))
 print('All tests passed? ' + str(success))
 if not success:
-  sys.exit(1)
+    sys.exit(1)

--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -4,7 +4,7 @@
 #
 # Notes:
 #
-# WORKSPACE, JOB_NAME, NODE_LABEL GIT_COMMIT are environment variables that 
+# WORKSPACE, JOB_NAME, NODE_LABEL GIT_COMMIT are environment variables that
 # are set by Jenkins. The last one corresponds to any labels set on a slave.
 ###############################################################################
 
@@ -22,6 +22,11 @@ echo "SHA1=${sha1}"
 ###############################################################################
 if [ -z "$MANTID_DATA_STORE" ]; then
   export MANTID_DATA_STORE=$HOME/MantidExternalData
+fi
+
+# -z checks for empty string
+if [ -z "$EXTRA_ARGS" ]; then
+  EXTRA_ARGS=''
 fi
 
 ###############################################################################
@@ -69,5 +74,4 @@ echo "CheckMantidVersion.OnStartup = 0" >> $userprops
 
 # Run
 PKGDIR=${WORKSPACE}/build
-python $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR
-
+python $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR $EXTRA_ARGS


### PR DESCRIPTION
ORNL has the desire to run more system tests that are normally skipped during the nightly builds. Adding `--archivesearch` as an option to the installer tests (and passed on to system tests) is all that is necessary to improve the discovery of bugs that are only found by more expensive system tests on more realistic data. Once setup, there will be an extra job run on [baldrick](http://builds.mantidproject.org/computer/ornl-baldrick/) downstream of [master_clean-rhel7](http://builds.mantidproject.org/job/master_clean-rhel7/).

I apologize for making the code python3 compatible as well in the same PR. The changes that matter are in `InstallerTests.py#L23` and `systemtests`.

**To test:**

This is mostly a code review.

*There is no associated issue.*

*Does not need to be in the release notes* as it affects testing rather than something that directly is seen by users.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
