### PR TITLE
Fix autorebin when dimensions are swapped

### DIFF
--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -1697,6 +1697,10 @@ void SliceViewer::changedShownDim(int index, int dim, int oldDim) {
   }
   // Show the new slice. This finds m_dimX and m_dimY
   this->updateDisplay();
+
+  // AutoRebin if required
+  autoRebinIfRequired();
+
   // Send out a signal
   emit changedShownDim(m_dimX, m_dimY);
 }

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -65,6 +65,7 @@ SliceViewer Improvements
 ------------------------
 - Fixed a bug where the rebin button was toggled when the user switch axes.
 - Changed zoom level on peak. Now when zooming onto a spherical or ellipsoidal peak, the entire peak is visible when using the default window size.
+- Fixed a bug where swapping the dimensions did not rebin the workspace despite having autorebin enabled.
 
 VSI Improvments
 ---------------


### PR DESCRIPTION
Fixes #19449

This PR fixes an issue where the workspace was not rebinned after the dimension was swapped, despite

**To test:**

1. Load a workspace into the SliceViewer
2. Enable autorebin and set the binning quite high to 400
3. Switch the axes
4. Confirm that the image has been rebinned.

**Release notes:**
See [here](https://github.com/mantidproject/mantid/commit/ffee6a73e03f87b821d2f8d3e51737064a5b35fa)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
