### PR TITLE
Improve parallel scaling of MDNormSCD

### DIFF
--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -46,6 +46,7 @@ Improved
 - :ref:`ExportTimeSeriesLog <algm-ExportTimeSeriesLog>` now add information of exported log to the output work, which
   :ref:`AddSampleLog <algm-AddSampleLog>` can retrieve automatically.
 - ``ThreadPool`` now respects the value of ``OMP_NUM_THREADS`` environment variable (documented in [msdn](https://msdn.microsoft.com/en-us/library/yw6c0z19.aspx) and [gcc](https://gcc.gnu.org/onlinedocs/libgomp/OMP_005fNUM_005fTHREADS.html))
+- Improved parallel scaling of :ref:`MDNormSCD <algm-MDNormSCD>` with > 4 cores.
 
 Bug Fixes
 #########


### PR DESCRIPTION
Description of work.

A user noticed that the MDNormSCD algorithm runs much slower on our 12-32 core analysis computers than a 2-core laptop. A lot of time is spent in the critical section synchronizing updates to the signal array instead of doing work.

In this PR, I use `std::atomic::compare_exchange_weak` as suggested in [this reddit thread](https://www.reddit.com/r/cpp/comments/338pcj/atomic_addition_of_floats_using_compare_exchange/) to update the values of a temporary signal array before copying them into the MDHistoWorkspace. This appears to make a huge difference, reducing the execution time in the user's script from several minutes to 15 seconds (ndav3.sns.gov) and ~45 seconds (topaz.sns.gov)

**To test:**

@AndreiSavici Would you try this on one or more inputs and verify that it
  - Shows a considerable performance improvement
  - Still gives the correct result

@SimonHeybrock I would appreciate a second opinion on the atomic operations

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
