### PR TITLE
Option to remove edge in PredictPeaks

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
@@ -25,9 +25,7 @@ public:
   PredictPeaks();
 
   /// Algorithm's name for identification
-  const std::string name() const override {
-    return "PredictPeaks";
-  };
+  const std::string name() const override { return "PredictPeaks"; };
   /// Summary of algorithms purpose
   const std::string summary() const override {
     return "Using a known crystal lattice and UB matrix, predict where single "
@@ -36,9 +34,7 @@ public:
   }
 
   /// Algorithm's version for identification
-  int version() const override {
-    return 1;
-  };
+  int version() const override { return 1; };
   /// Algorithm's category for identification
   const std::string category() const override { return "Crystal\\Peaks"; }
 

--- a/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictPeaks.h
@@ -25,7 +25,9 @@ public:
   PredictPeaks();
 
   /// Algorithm's name for identification
-  const std::string name() const override { return "PredictPeaks"; };
+  const std::string name() const override {
+    return "PredictPeaks";
+  };
   /// Summary of algorithms purpose
   const std::string summary() const override {
     return "Using a known crystal lattice and UB matrix, predict where single "
@@ -34,7 +36,9 @@ public:
   }
 
   /// Algorithm's version for identification
-  int version() const override { return 1; };
+  int version() const override {
+    return 1;
+  };
   /// Algorithm's category for identification
   const std::string category() const override { return "Crystal\\Peaks"; }
 
@@ -64,7 +68,8 @@ private:
 
 private:
   void logNumberOfPeaksFound(size_t allowedPeakCount) const;
-
+  /// Function to find peaks near detector edge
+  bool edgePixel(std::string bankName, int col, int row, int Edge);
   /// Reflection conditions possible
   std::vector<Mantid::Geometry::ReflectionCondition_sptr> m_refConds;
 

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -49,7 +49,7 @@ PredictPeaks::PredictPeaks()
 /** Initialize the algorithm's properties.
  */
 void PredictPeaks::init() {
-  declareProperty(make_unique<WorkspaceProperty<Workspace> >(
+  declareProperty(make_unique<WorkspaceProperty<Workspace>>(
                       "InputWorkspace", "", Direction::Input),
                   "An input workspace (MatrixWorkspace, MDEventWorkspace, or "
                   "PeaksWorkspace) containing:\n"
@@ -58,21 +58,21 @@ void PredictPeaks::init() {
                   "  - The goniometer rotation matrix.");
 
   declareProperty(
-      make_unique<PropertyWithValue<double> >("WavelengthMin", 0.1,
-                                              Direction::Input),
+      make_unique<PropertyWithValue<double>>("WavelengthMin", 0.1,
+                                             Direction::Input),
       "Minimum wavelength limit at which to start looking for single-crystal "
       "peaks.");
   declareProperty(
-      make_unique<PropertyWithValue<double> >("WavelengthMax", 100.0,
-                                              Direction::Input),
+      make_unique<PropertyWithValue<double>>("WavelengthMax", 100.0,
+                                             Direction::Input),
       "Maximum wavelength limit at which to stop looking for single-crystal "
       "peaks.");
 
-  declareProperty(make_unique<PropertyWithValue<double> >("MinDSpacing", 1.0,
-                                                          Direction::Input),
+  declareProperty(make_unique<PropertyWithValue<double>>("MinDSpacing", 1.0,
+                                                         Direction::Input),
                   "Minimum d-spacing of peaks to consider. Default = 1.0");
-  declareProperty(make_unique<PropertyWithValue<double> >("MaxDSpacing", 100.0,
-                                                          Direction::Input),
+  declareProperty(make_unique<PropertyWithValue<double>>("MaxDSpacing", 100.0,
+                                                         Direction::Input),
                   "Maximum d-spacing of peaks to consider.");
 
   // Build up a list of reflection conditions to use
@@ -90,7 +90,7 @@ void PredictPeaks::init() {
                   "a crystal structure assigned.");
 
   declareProperty(
-      make_unique<WorkspaceProperty<PeaksWorkspace> >(
+      make_unique<WorkspaceProperty<PeaksWorkspace>>(
           "HKLPeaksWorkspace", "", Direction::Input, PropertyMode::Optional),
       "Optional: An input PeaksWorkspace with the HKL of the peaks "
       "that we should predict. \n"
@@ -118,7 +118,7 @@ void PredictPeaks::init() {
   setPropertySettings("MaxDSpacing", makeSet());
   setPropertySettings("ReflectionCondition", makeSet());
 
-  declareProperty(make_unique<WorkspaceProperty<PeaksWorkspace> >(
+  declareProperty(make_unique<WorkspaceProperty<PeaksWorkspace>>(
                       "OutputWorkspace", "", Direction::Output),
                   "An output PeaksWorkspace.");
 
@@ -152,8 +152,7 @@ void PredictPeaks::exec() {
     try {
       DblMatrix goniometerMatrix = matrixWS->run().getGoniometerMatrix();
       gonioVec.push_back(goniometerMatrix);
-    }
-    catch (std::runtime_error &e) {
+    } catch (std::runtime_error &e) {
       // If there is no goniometer matrix, use identity matrix instead.
       g_log.error() << "Error getting the goniometer rotation matrix from the "
                        "InputWorkspace.\n" << e.what() << '\n';
@@ -162,7 +161,7 @@ void PredictPeaks::exec() {
   } else if (peaksWS) {
     // Sort peaks by run number so that peaks with equal goniometer matrices are
     // adjacent
-    std::vector<std::pair<std::string, bool> > criteria;
+    std::vector<std::pair<std::string, bool>> criteria;
     criteria.push_back(std::pair<std::string, bool>("RunNumber", true));
 
     peaksWS->sort(criteria);
@@ -193,8 +192,7 @@ void PredictPeaks::exec() {
         DblMatrix goniometerMatrix =
             mdWS->getExperimentInfo(i)->mutableRun().getGoniometerMatrix();
         gonioVec.push_back(goniometerMatrix);
-      }
-      catch (std::runtime_error &e) {
+      } catch (std::runtime_error &e) {
         // If there is no goniometer matrix, use identity matrix instead.
         gonioVec.push_back(DblMatrix(3, 3, true));
 
@@ -317,8 +315,8 @@ void PredictPeaks::logNumberOfPeaksFound(size_t allowedPeakCount) const {
 }
 
 /// Tries to set the internally stored instrument from an ExperimentInfo-object.
-void
-PredictPeaks::setInstrumentFromInputWorkspace(const ExperimentInfo_sptr &inWS) {
+void PredictPeaks::setInstrumentFromInputWorkspace(
+    const ExperimentInfo_sptr &inWS) {
   // Check that there is an input workspace that has a sample.
   if (!inWS || !inWS->getInstrument())
     throw std::invalid_argument("Did not specify a valid InputWorkspace with a "
@@ -328,8 +326,8 @@ PredictPeaks::setInstrumentFromInputWorkspace(const ExperimentInfo_sptr &inWS) {
 }
 
 /// Sets the run number from the supplied ExperimentInfo or throws an exception.
-void
-PredictPeaks::setRunNumberFromInputWorkspace(const ExperimentInfo_sptr &inWS) {
+void PredictPeaks::setRunNumberFromInputWorkspace(
+    const ExperimentInfo_sptr &inWS) {
   if (!inWS) {
     throw std::runtime_error("Failed to get run number");
   }
@@ -434,8 +432,8 @@ void PredictPeaks::fillPossibleHKLsUsingPeaksWorkspace(
  *
  * @param sample :: Sample, potentially with crystal structure
  */
-void
-PredictPeaks::setStructureFactorCalculatorFromSample(const Sample &sample) {
+void PredictPeaks::setStructureFactorCalculatorFromSample(
+    const Sample &sample) {
   bool calculateStructureFactors = getProperty("CalculateStructureFactors");
 
   if (calculateStructureFactors && sample.hasCrystalStructure()) {

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -10,6 +10,7 @@
 #include "MantidGeometry/Objects/InstrumentRayTracer.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
+#include "MantidGeometry/Instrument/RectangularDetector.h"
 
 using Mantid::Kernel::EnabledWhenProperty;
 
@@ -48,7 +49,7 @@ PredictPeaks::PredictPeaks()
 /** Initialize the algorithm's properties.
  */
 void PredictPeaks::init() {
-  declareProperty(make_unique<WorkspaceProperty<Workspace>>(
+  declareProperty(make_unique<WorkspaceProperty<Workspace> >(
                       "InputWorkspace", "", Direction::Input),
                   "An input workspace (MatrixWorkspace, MDEventWorkspace, or "
                   "PeaksWorkspace) containing:\n"
@@ -57,21 +58,21 @@ void PredictPeaks::init() {
                   "  - The goniometer rotation matrix.");
 
   declareProperty(
-      make_unique<PropertyWithValue<double>>("WavelengthMin", 0.1,
-                                             Direction::Input),
+      make_unique<PropertyWithValue<double> >("WavelengthMin", 0.1,
+                                              Direction::Input),
       "Minimum wavelength limit at which to start looking for single-crystal "
       "peaks.");
   declareProperty(
-      make_unique<PropertyWithValue<double>>("WavelengthMax", 100.0,
-                                             Direction::Input),
+      make_unique<PropertyWithValue<double> >("WavelengthMax", 100.0,
+                                              Direction::Input),
       "Maximum wavelength limit at which to stop looking for single-crystal "
       "peaks.");
 
-  declareProperty(make_unique<PropertyWithValue<double>>("MinDSpacing", 1.0,
-                                                         Direction::Input),
+  declareProperty(make_unique<PropertyWithValue<double> >("MinDSpacing", 1.0,
+                                                          Direction::Input),
                   "Minimum d-spacing of peaks to consider. Default = 1.0");
-  declareProperty(make_unique<PropertyWithValue<double>>("MaxDSpacing", 100.0,
-                                                         Direction::Input),
+  declareProperty(make_unique<PropertyWithValue<double> >("MaxDSpacing", 100.0,
+                                                          Direction::Input),
                   "Maximum d-spacing of peaks to consider.");
 
   // Build up a list of reflection conditions to use
@@ -89,7 +90,7 @@ void PredictPeaks::init() {
                   "a crystal structure assigned.");
 
   declareProperty(
-      make_unique<WorkspaceProperty<PeaksWorkspace>>(
+      make_unique<WorkspaceProperty<PeaksWorkspace> >(
           "HKLPeaksWorkspace", "", Direction::Input, PropertyMode::Optional),
       "Optional: An input PeaksWorkspace with the HKL of the peaks "
       "that we should predict. \n"
@@ -117,7 +118,7 @@ void PredictPeaks::init() {
   setPropertySettings("MaxDSpacing", makeSet());
   setPropertySettings("ReflectionCondition", makeSet());
 
-  declareProperty(make_unique<WorkspaceProperty<PeaksWorkspace>>(
+  declareProperty(make_unique<WorkspaceProperty<PeaksWorkspace> >(
                       "OutputWorkspace", "", Direction::Output),
                   "An output PeaksWorkspace.");
 
@@ -125,6 +126,8 @@ void PredictPeaks::init() {
                   "Use an extended detector space (if defined for the"
                   " instrument) to predict peaks which do not fall onto any"
                   "detector. This may produce a very high number of results.");
+  declareProperty("EdgePixels", 0,
+                  "Remove peaks that are at pixels this close to edge. ");
 }
 
 /** Execute the algorithm.
@@ -149,7 +152,8 @@ void PredictPeaks::exec() {
     try {
       DblMatrix goniometerMatrix = matrixWS->run().getGoniometerMatrix();
       gonioVec.push_back(goniometerMatrix);
-    } catch (std::runtime_error &e) {
+    }
+    catch (std::runtime_error &e) {
       // If there is no goniometer matrix, use identity matrix instead.
       g_log.error() << "Error getting the goniometer rotation matrix from the "
                        "InputWorkspace.\n" << e.what() << '\n';
@@ -158,7 +162,7 @@ void PredictPeaks::exec() {
   } else if (peaksWS) {
     // Sort peaks by run number so that peaks with equal goniometer matrices are
     // adjacent
-    std::vector<std::pair<std::string, bool>> criteria;
+    std::vector<std::pair<std::string, bool> > criteria;
     criteria.push_back(std::pair<std::string, bool>("RunNumber", true));
 
     peaksWS->sort(criteria);
@@ -189,7 +193,8 @@ void PredictPeaks::exec() {
         DblMatrix goniometerMatrix =
             mdWS->getExperimentInfo(i)->mutableRun().getGoniometerMatrix();
         gonioVec.push_back(goniometerMatrix);
-      } catch (std::runtime_error &e) {
+      }
+      catch (std::runtime_error &e) {
         // If there is no goniometer matrix, use identity matrix instead.
         gonioVec.push_back(DblMatrix(3, 3, true));
 
@@ -312,8 +317,8 @@ void PredictPeaks::logNumberOfPeaksFound(size_t allowedPeakCount) const {
 }
 
 /// Tries to set the internally stored instrument from an ExperimentInfo-object.
-void PredictPeaks::setInstrumentFromInputWorkspace(
-    const ExperimentInfo_sptr &inWS) {
+void
+PredictPeaks::setInstrumentFromInputWorkspace(const ExperimentInfo_sptr &inWS) {
   // Check that there is an input workspace that has a sample.
   if (!inWS || !inWS->getInstrument())
     throw std::invalid_argument("Did not specify a valid InputWorkspace with a "
@@ -323,8 +328,8 @@ void PredictPeaks::setInstrumentFromInputWorkspace(
 }
 
 /// Sets the run number from the supplied ExperimentInfo or throws an exception.
-void PredictPeaks::setRunNumberFromInputWorkspace(
-    const ExperimentInfo_sptr &inWS) {
+void
+PredictPeaks::setRunNumberFromInputWorkspace(const ExperimentInfo_sptr &inWS) {
   if (!inWS) {
     throw std::runtime_error("Failed to get run number");
   }
@@ -429,8 +434,8 @@ void PredictPeaks::fillPossibleHKLsUsingPeaksWorkspace(
  *
  * @param sample :: Sample, potentially with crystal structure
  */
-void PredictPeaks::setStructureFactorCalculatorFromSample(
-    const Sample &sample) {
+void
+PredictPeaks::setStructureFactorCalculatorFromSample(const Sample &sample) {
   bool calculateStructureFactors = getProperty("CalculateStructureFactors");
 
   if (calculateStructureFactors && sample.hasCrystalStructure()) {
@@ -489,10 +494,58 @@ void PredictPeaks::calculateQAndAddToOutput(const V3D &hkl,
   if (m_sfCalculator) {
     p.setIntensity(m_sfCalculator->getFSquared(hkl));
   }
-
+  int edge = this->getProperty("EdgePixels");
+  if (edge > 0) {
+    if (edgePixel(p.getBankName(), p.getCol(), p.getRow(), edge))
+      return;
+  }
   // Add it to the workspace
   m_pw->addPeak(p);
 }
+//-----------------------------------------------------------------------------------------
+/**
+  @param  bankName     Name of bank containing peak
+  @param  col          Column number containing peak
+  @param  row          Row number containing peak
+  @param  Edge         Number of edge points for each bank
+  @return True if peak is on edge
+*/
+bool PredictPeaks::edgePixel(std::string bankName, int col, int row, int Edge) {
+  if (bankName == "None")
+    return false;
+  boost::shared_ptr<const IComponent> parent =
+      m_inst->getComponentByName(bankName);
+  if (parent->type() == "RectangularDetector") {
+    boost::shared_ptr<const RectangularDetector> RDet =
+        boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 
+    return col < Edge || col >= (RDet->xpixels() - Edge) || row < Edge ||
+           row >= (RDet->ypixels() - Edge);
+  } else {
+    std::vector<IComponent_const_sptr> children;
+    boost::shared_ptr<const ICompAssembly> asmb =
+        boost::dynamic_pointer_cast<const ICompAssembly>(parent);
+    asmb->getChildren(children, false);
+    int startI = 1;
+    if (children[0]->getName() == "sixteenpack") {
+      startI = 0;
+      parent = children[0];
+      children.clear();
+      boost::shared_ptr<const ICompAssembly> asmb =
+          boost::dynamic_pointer_cast<const ICompAssembly>(parent);
+      asmb->getChildren(children, false);
+    }
+    boost::shared_ptr<const ICompAssembly> asmb2 =
+        boost::dynamic_pointer_cast<const ICompAssembly>(children[0]);
+    std::vector<IComponent_const_sptr> grandchildren;
+    asmb2->getChildren(grandchildren, false);
+    int NROWS = static_cast<int>(grandchildren.size());
+    int NCOLS = static_cast<int>(children.size());
+    // Wish pixels and tubes start at 1 not 0
+    return col - startI < Edge || col - startI >= (NCOLS - Edge) ||
+           row - startI < Edge || row - startI >= (NROWS - Edge);
+  }
+  return false;
+}
 } // namespace Mantid
 } // namespace Crystal

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -50,7 +50,7 @@ PredictPeaks::PredictPeaks()
 /** Initialize the algorithm's properties.
  */
 void PredictPeaks::init() {
-  declareProperty(make_unique<WorkspaceProperty<Workspace> >(
+  declareProperty(make_unique<WorkspaceProperty<Workspace>>(
                       "InputWorkspace", "", Direction::Input),
                   "An input workspace (MatrixWorkspace, MDEventWorkspace, or "
                   "PeaksWorkspace) containing:\n"
@@ -59,21 +59,21 @@ void PredictPeaks::init() {
                   "  - The goniometer rotation matrix.");
 
   declareProperty(
-      make_unique<PropertyWithValue<double> >("WavelengthMin", 0.1,
-                                              Direction::Input),
+      make_unique<PropertyWithValue<double>>("WavelengthMin", 0.1,
+                                             Direction::Input),
       "Minimum wavelength limit at which to start looking for single-crystal "
       "peaks.");
   declareProperty(
-      make_unique<PropertyWithValue<double> >("WavelengthMax", 100.0,
-                                              Direction::Input),
+      make_unique<PropertyWithValue<double>>("WavelengthMax", 100.0,
+                                             Direction::Input),
       "Maximum wavelength limit at which to stop looking for single-crystal "
       "peaks.");
 
-  declareProperty(make_unique<PropertyWithValue<double> >("MinDSpacing", 1.0,
-                                                          Direction::Input),
+  declareProperty(make_unique<PropertyWithValue<double>>("MinDSpacing", 1.0,
+                                                         Direction::Input),
                   "Minimum d-spacing of peaks to consider. Default = 1.0");
-  declareProperty(make_unique<PropertyWithValue<double> >("MaxDSpacing", 100.0,
-                                                          Direction::Input),
+  declareProperty(make_unique<PropertyWithValue<double>>("MaxDSpacing", 100.0,
+                                                         Direction::Input),
                   "Maximum d-spacing of peaks to consider.");
 
   // Build up a list of reflection conditions to use
@@ -91,7 +91,7 @@ void PredictPeaks::init() {
                   "a crystal structure assigned.");
 
   declareProperty(
-      make_unique<WorkspaceProperty<PeaksWorkspace> >(
+      make_unique<WorkspaceProperty<PeaksWorkspace>>(
           "HKLPeaksWorkspace", "", Direction::Input, PropertyMode::Optional),
       "Optional: An input PeaksWorkspace with the HKL of the peaks "
       "that we should predict. \n"
@@ -119,7 +119,7 @@ void PredictPeaks::init() {
   setPropertySettings("MaxDSpacing", makeSet());
   setPropertySettings("ReflectionCondition", makeSet());
 
-  declareProperty(make_unique<WorkspaceProperty<PeaksWorkspace> >(
+  declareProperty(make_unique<WorkspaceProperty<PeaksWorkspace>>(
                       "OutputWorkspace", "", Direction::Output),
                   "An output PeaksWorkspace.");
 
@@ -128,7 +128,7 @@ void PredictPeaks::init() {
                   " instrument) to predict peaks which do not fall onto any"
                   "detector. This may produce a very high number of results.");
 
-  auto nonNegativeInt = boost::make_shared<BoundedValidator<int> >();
+  auto nonNegativeInt = boost::make_shared<BoundedValidator<int>>();
   nonNegativeInt->setLower(0);
   declareProperty("EdgePixels", 0, nonNegativeInt,
                   "Remove peaks that are at pixels this close to edge. ");
@@ -156,8 +156,7 @@ void PredictPeaks::exec() {
     try {
       DblMatrix goniometerMatrix = matrixWS->run().getGoniometerMatrix();
       gonioVec.push_back(goniometerMatrix);
-    }
-    catch (std::runtime_error &e) {
+    } catch (std::runtime_error &e) {
       // If there is no goniometer matrix, use identity matrix instead.
       g_log.error() << "Error getting the goniometer rotation matrix from the "
                        "InputWorkspace.\n" << e.what() << '\n';
@@ -166,7 +165,7 @@ void PredictPeaks::exec() {
   } else if (peaksWS) {
     // Sort peaks by run number so that peaks with equal goniometer matrices are
     // adjacent
-    std::vector<std::pair<std::string, bool> > criteria;
+    std::vector<std::pair<std::string, bool>> criteria;
     criteria.push_back(std::pair<std::string, bool>("RunNumber", true));
 
     peaksWS->sort(criteria);
@@ -197,8 +196,7 @@ void PredictPeaks::exec() {
         DblMatrix goniometerMatrix =
             mdWS->getExperimentInfo(i)->mutableRun().getGoniometerMatrix();
         gonioVec.push_back(goniometerMatrix);
-      }
-      catch (std::runtime_error &e) {
+      } catch (std::runtime_error &e) {
         // If there is no goniometer matrix, use identity matrix instead.
         gonioVec.push_back(DblMatrix(3, 3, true));
 
@@ -321,8 +319,8 @@ void PredictPeaks::logNumberOfPeaksFound(size_t allowedPeakCount) const {
 }
 
 /// Tries to set the internally stored instrument from an ExperimentInfo-object.
-void
-PredictPeaks::setInstrumentFromInputWorkspace(const ExperimentInfo_sptr &inWS) {
+void PredictPeaks::setInstrumentFromInputWorkspace(
+    const ExperimentInfo_sptr &inWS) {
   // Check that there is an input workspace that has a sample.
   if (!inWS || !inWS->getInstrument())
     throw std::invalid_argument("Did not specify a valid InputWorkspace with a "
@@ -332,8 +330,8 @@ PredictPeaks::setInstrumentFromInputWorkspace(const ExperimentInfo_sptr &inWS) {
 }
 
 /// Sets the run number from the supplied ExperimentInfo or throws an exception.
-void
-PredictPeaks::setRunNumberFromInputWorkspace(const ExperimentInfo_sptr &inWS) {
+void PredictPeaks::setRunNumberFromInputWorkspace(
+    const ExperimentInfo_sptr &inWS) {
   if (!inWS) {
     throw std::runtime_error("Failed to get run number");
   }
@@ -438,8 +436,8 @@ void PredictPeaks::fillPossibleHKLsUsingPeaksWorkspace(
  *
  * @param sample :: Sample, potentially with crystal structure
  */
-void
-PredictPeaks::setStructureFactorCalculatorFromSample(const Sample &sample) {
+void PredictPeaks::setStructureFactorCalculatorFromSample(
+    const Sample &sample) {
   bool calculateStructureFactors = getProperty("CalculateStructureFactors");
 
   if (calculateStructureFactors && sample.hasCrystalStructure()) {

--- a/Framework/Crystal/test/PredictPeaksTest.h
+++ b/Framework/Crystal/test/PredictPeaksTest.h
@@ -49,7 +49,7 @@ public:
   void do_test_exec(std::string reflectionCondition, size_t expectedNumber,
                     std::vector<V3D> hkls, int convention = 1,
                     bool useExtendedDetectorSpace = false,
-                    bool addExtendedDetectorDefinition = false) {
+                    bool addExtendedDetectorDefinition = false, int edge = 0) {
     // Name of the output workspace.
     std::string outWSName("PredictPeaksTest_OutputWS");
 
@@ -90,6 +90,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("HKLPeaksWorkspace", hklPW));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("PredictPeaksOutsideDetectors",
                                              useExtendedDetectorSpace));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("EdgePixels", edge));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
 
@@ -103,9 +104,9 @@ public:
       return;
 
     TS_ASSERT_EQUALS(ws->getNumberPeaks(), expectedNumber);
-    V3D hklTest = {-10, -6, 1};
+    V3D hklTest = { -10, -6, 1 };
     hklTest *= convention;
-    if (expectedNumber > 1 && !addExtendedDetectorDefinition) {
+    if (expectedNumber > 5 && !addExtendedDetectorDefinition) {
       TS_ASSERT_EQUALS(ws->getPeak(0).getHKL(), hklTest);
     }
 
@@ -133,7 +134,7 @@ public:
   }
 
   void test_exec_withInputHKLList() {
-    std::vector<V3D> hkls{{-6, -9, 1}};
+    std::vector<V3D> hkls{ { -6, -9, 1 } };
     do_test_exec("Primitive", 1, hkls);
   }
 
@@ -169,7 +170,7 @@ public:
     WorkspaceCreationHelper::setGoniometer(inWS, GonioRotation, 0., 0.);
 
     DblMatrix ub = inWS->sample().getOrientedLattice().getUB();
-    PeaksWorkspace_sptr hklPW = getHKLpw(inst, {{-1, 0, 0}}, 0);
+    PeaksWorkspace_sptr hklPW = getHKLpw(inst, { { -1, 0, 0 } }, 0);
 
     PredictPeaks alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
@@ -209,6 +210,9 @@ public:
     Kernel::ConfigService::Instance().setString("Q.convention",
                                                 "Crystallography");
     do_test_exec("Primitive", 10, std::vector<V3D>(), -1);
+  }
+  void test_edge() {
+    do_test_exec("Primitive", 5, std::vector<V3D>(), 1, false, false, 10);
   }
 };
 

--- a/Framework/Crystal/test/PredictPeaksTest.h
+++ b/Framework/Crystal/test/PredictPeaksTest.h
@@ -104,7 +104,7 @@ public:
       return;
 
     TS_ASSERT_EQUALS(ws->getNumberPeaks(), expectedNumber);
-    V3D hklTest = { -10, -6, 1 };
+    V3D hklTest = {-10, -6, 1};
     hklTest *= convention;
     if (expectedNumber > 5 && !addExtendedDetectorDefinition) {
       TS_ASSERT_EQUALS(ws->getPeak(0).getHKL(), hklTest);
@@ -134,7 +134,7 @@ public:
   }
 
   void test_exec_withInputHKLList() {
-    std::vector<V3D> hkls{ { -6, -9, 1 } };
+    std::vector<V3D> hkls{{-6, -9, 1}};
     do_test_exec("Primitive", 1, hkls);
   }
 
@@ -170,7 +170,7 @@ public:
     WorkspaceCreationHelper::setGoniometer(inWS, GonioRotation, 0., 0.);
 
     DblMatrix ub = inWS->sample().getOrientedLattice().getUB();
-    PeaksWorkspace_sptr hklPW = getHKLpw(inst, { { -1, 0, 0 } }, 0);
+    PeaksWorkspace_sptr hklPW = getHKLpw(inst, {{-1, 0, 0}}, 0);
 
     PredictPeaks alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())

--- a/docs/source/release/v3.10.0/diffraction.rst
+++ b/docs/source/release/v3.10.0/diffraction.rst
@@ -9,6 +9,7 @@ Crystal Improvements
 --------------------
 
  - :ref:`algm-PredictPeaks` has a new option ``PredictPeaksOutsideDetectors`` which will predict peaks which fall outside of any defined detectors. This feature requires an extended detector space definition and will do nothing if this is not present in the IDF.
+ - :ref:`algm-PredictPeaks` has a new option ``EdgePixels`` which will not predict peaks which fall in the number of pixels input from the edge of detectors.
  - :ref:`StartLiveData <algm-StartLiveData>` will load "live" data streaming from MaNDi data server.
 
 Engineering Diffraction


### PR DESCRIPTION
Description of work.

**To test:**
```python
LoadEmptyInstrument(Filename='TOPAZ_Definition_2017-02-24.xml', OutputWorkspace='topaz')
LoadIsawUB(InputWorkspace='topaz', Filename='ls5637.mat')
PredictPeaks(InputWorkspace='topaz', WavelengthMin=0.5, WavelengthMax=3.5, MinDSpacing=0.5, OutputWorkspace='topaz_peaks_20edge', EdgePixels=20)
PredictPeaks(InputWorkspace='topaz', WavelengthMin=0.5, WavelengthMax=3.5, MinDSpacing=0.5, OutputWorkspace='topaz_peaks_0edge')
```
Show Instrument for topaz workspace and drag both topaz_peaks_0edge and topaz_peaks_20edge into plot.  Check that edge peaks are not in topaz_peaks_20edge.

Fixes #19456 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
