### PR TITLE
Add move constructor and move assignment to VMD.

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/VMD.h
+++ b/Framework/Kernel/inc/MantidKernel/VMD.h
@@ -48,6 +48,8 @@ public:
 
   VMDBase(const VMDBase &other);
   VMDBase &operator=(const VMDBase &other);
+  VMDBase(VMDBase &&other) noexcept;
+  VMDBase &operator=(VMDBase &&other) noexcept;
   VMDBase(size_t nd, const double *bareData);
   VMDBase(size_t nd, const float *bareData);
   VMDBase(const V3D &vector);

--- a/Framework/Kernel/src/VMD.cpp
+++ b/Framework/Kernel/src/VMD.cpp
@@ -144,8 +144,8 @@ VMDBase<TYPE> &VMDBase<TYPE>::operator=(const VMDBase &other) {
  * @param other :: move into this
  */
 template <typename TYPE>
-VMDBase<TYPE>::VMDBase(VMDBase &&other) noexcept
-    : nd(other.nd), data(other.data) {
+VMDBase<TYPE>::VMDBase(VMDBase &&other) noexcept : nd(other.nd),
+                                                   data(other.data) {
   other.data = nullptr;
   other.nd = 0;
 }

--- a/Framework/Kernel/src/VMD.cpp
+++ b/Framework/Kernel/src/VMD.cpp
@@ -140,6 +140,31 @@ VMDBase<TYPE> &VMDBase<TYPE>::operator=(const VMDBase &other) {
   return *this;
 }
 
+/** Move constructor
+ * @param other :: move into this
+ */
+template <typename TYPE>
+VMDBase<TYPE>::VMDBase(VMDBase &&other) noexcept
+    : nd(other.nd), data(other.data) {
+  other.data = nullptr;
+  other.nd = 0;
+}
+
+/** Move assignment
+ * @param other :: move into this
+ */
+template <typename TYPE>
+VMDBase<TYPE> &VMDBase<TYPE>::operator=(VMDBase &&other) noexcept {
+  if (this != &other) {
+    this->nd = other.nd;
+    other.nd = 0;
+    delete[] this->data;
+    this->data = other.data;
+    other.data = nullptr;
+  }
+  return *this;
+}
+
 /** Constructor
  * @param nd :: number of dimensions
  * @param bareData :: pointer to a nd-sized bare data array */


### PR DESCRIPTION
Description of work.

VMDBase could benefit from, but doesn't contain, a move constructor or move assignment operator. The default implementations don't correctly move the `data` pointer. 

**To test:**

<!-- Instructions for testing. -->

Code review and check the tests pass

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
