### PR TITLE
Remove output files from SaveGSS performance test

### DIFF
--- a/Framework/DataHandling/test/SaveGSSTest.h
+++ b/Framework/DataHandling/test/SaveGSSTest.h
@@ -10,6 +10,7 @@
 #include "cxxtest/TestSuite.h"
 
 #include <Poco/File.h>
+#include <Poco/Glob.h>
 #include <fstream>
 
 using namespace Mantid;
@@ -347,6 +348,7 @@ public:
 
     m_alg = new SaveGSS();
     m_alg->initialize();
+    m_alg->setProperty("Append", false);
     m_alg->setPropertyValue("InputWorkspace", wsName);
     m_alg->setProperty("Filename", filename);
     m_alg->setRethrows(true);
@@ -358,9 +360,14 @@ public:
     delete m_alg;
     m_alg = nullptr;
     Mantid::API::AnalysisDataService::Instance().remove(wsName);
-    Poco::File gsasfile(filename);
-    if (gsasfile.exists())
-      gsasfile.remove();
+
+    // Use glob to find any files that match the output pattern
+    std::set<std::string> returnedFiles;
+    Poco::Glob::glob(globPattern, returnedFiles);
+    for (const auto &filename : returnedFiles) {
+      Poco::File pocoFile{filename};
+      pocoFile.remove();
+    }
   }
 
 private:
@@ -369,6 +376,7 @@ private:
 
   const std::string wsName = "Test2BankWS";
   const std::string filename = "test_performance.gsa";
+  const std::string globPattern = "test_performance*.gsa";
 
   SaveGSS *m_alg = nullptr;
 };


### PR DESCRIPTION
Description of work.
By default SaveGSSTestPerformance appends to the output files and does not correctly remove them after each test. This leads to the files always growing in size. 
This PR sets the append flag to false and uses glob to make sure we remove all our output files correctly at the end of each test.

**To test:**
Run the `SaveGSSTestPerformance` test.
Ensure within `bin/Testing` no files called `test_performance*.gsa` exist after the test exists

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
