### PR TITLE
Minor correction to TOFTOFMergeRuns to fix Refs #19474.

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/TOFTOFMergeRuns.py
+++ b/Framework/PythonInterface/plugins/algorithms/TOFTOFMergeRuns.py
@@ -122,6 +122,7 @@ class TOFTOFMergeRuns(PythonAlgorithm):
         if workspaceCount < 2:
             api.CloneWorkspace(InputWorkspace=input_workspace_list[0], OutputWorkspace=wsOutput)
             self.log().warning("Cannot merge one workspace. Clone is produced.")
+            self.setProperty("OutputWorkspace", wsOutput)
             return
 
         # check whether given workspaces can be merged

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TOFTOFMergeRunsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TOFTOFMergeRunsTest.py
@@ -87,6 +87,14 @@ class TOFTOFMergeRunsTest(unittest.TestCase):
         if "output_ws" is not None:
             AnalysisDataService.remove("output_ws")
 
+    def test_single_ws(self):
+        OutputWorkspaceName = "output_ws"
+        Inputws = self._input_ws_base.name()
+        alg_test = run_algorithm("TOFTOFMergeRuns",
+                                 InputWorkspaces=Inputws,
+                                 OutputWorkspace=OutputWorkspaceName)
+        self.assertTrue(alg_test.isExecuted())
+
     def cleanUp(self):
         if self._input_ws_base is not None:
             DeleteWorkspace(self._input_ws_base)


### PR DESCRIPTION
Minor correction to TOFTOFMergeRuns to fix the error. Created additional unit test.

**To test:**

```python
input_ws = Load(Filename="TOFTOFTestdata.nxs")
out_ws = TOFTOFMergeRuns(input_ws)
```
Check that the algorithm returns a copy of the input workspace and does not produce an error message.
<!-- Instructions for testing. -->

Fixes #19474.
Does not need to be in the release notes

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
