### PR TITLE
Add link flags for Ubuntu 14.04 required for std::call_once.

### DIFF
--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -69,6 +69,12 @@ set_property ( TARGET Indexing PROPERTY FOLDER "MantidFramework" )
 
 target_link_libraries ( Indexing LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${MANTIDLIBS} )
 
+if( "${UNIX_CODENAME}" STREQUAL "trusty" )
+  # Special linking options are required for some older Ubuntu gcc builds to use std::thread, specific options found here:
+  # http://stackoverflow.com/questions/8649828/what-is-the-correct-link-options-to-use-stdthread-in-gcc-under-linux#comment35723468_8649908
+  target_link_libraries ( Indexing LINK_PRIVATE -Wl,--no-as-needed -pthread )
+endif()
+
 # Add the unit tests directory
 add_subdirectory ( test )
 


### PR DESCRIPTION
`std::call_once` uses `std::thread` internally. It segfaults on Ubuntu-14.04 unless special link flags are used:

http://stackoverflow.com/questions/8649828/what-is-the-correct-link-options-to-use-stdthread-in-gcc-under-linux#comment35723468_8649908

**To test:**

Code review should be sufficient (I tried this in a VM and it works, so I hope the nightly build does, too).

Fixes #19470.

No release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
