### PR TITLE
Mandi reduction for h5 file

### DIFF
--- a/MantidQt/CustomInterfaces/src/MantidEV.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEV.cpp
@@ -636,9 +636,9 @@ void MantidEV::loadEventFileEntered_slot() {
  */
 void MantidEV::loadEventFile_slot() {
   QString file_path = getFilePath(last_event_file);
-  QString Qfile_name =
-      QFileDialog::getOpenFileName(this, tr("Load event file"), file_path,
-                                   tr("Nexus Files (*.nxs *.h5);; All files(*)"));
+  QString Qfile_name = QFileDialog::getOpenFileName(
+      this, tr("Load event file"), file_path,
+      tr("Nexus Files (*.nxs *.h5);; All files(*)"));
 
   if (Qfile_name.length() > 0) {
     m_uiForm.EventFileName_ledt->setText(Qfile_name);

--- a/MantidQt/CustomInterfaces/src/MantidEV.cpp
+++ b/MantidQt/CustomInterfaces/src/MantidEV.cpp
@@ -638,7 +638,7 @@ void MantidEV::loadEventFile_slot() {
   QString file_path = getFilePath(last_event_file);
   QString Qfile_name =
       QFileDialog::getOpenFileName(this, tr("Load event file"), file_path,
-                                   tr("Nexus Files (*.nxs);; All files(*)"));
+                                   tr("Nexus Files (*.nxs *.h5);; All files(*)"));
 
   if (Qfile_name.length() > 0) {
     m_uiForm.EventFileName_ledt->setText(Qfile_name);

--- a/docs/source/release/v3.10.0/diffraction.rst
+++ b/docs/source/release/v3.10.0/diffraction.rst
@@ -14,6 +14,7 @@ Crystal Improvements
  - :ref:`algm-PDCalibration <algm-PDCalibration>` is better at giving out physically meaningful results. It will no longer create calibrations that will convert time-of-flight to negative or imaginary d-spacing.
  - :ref:`SaveIsawPeaks <algm-SaveIsawPeaks>` now saves the calibration data for all detector banks in instrument so the header may be longer
  - :ref:`LoadIsawPeaks <algm-LoadIsawPeaks>` now uses the calibration lines to calibrate the detectors banks for CORELLI
+ - :ref:SCD Event Data Reduction interface and SCD_Reduction python scripts work with both nxs and h5 extensions for data file.
 
 Engineering Diffraction
 -----------------------

--- a/scripts/SCD_Reduction/ReduceSCD_OneRun.py
+++ b/scripts/SCD_Reduction/ReduceSCD_OneRun.py
@@ -125,9 +125,11 @@ optimize_UB               = params_dictionary[ "optimize_UB" ]
 # Get the fully qualified input run file name, either from a specified data
 # directory or from findnexus
 #
-short_filename = "%s_%s_event.nxs" % (instrument_name, str(run))
+short_filename = "%s_%s" % (instrument_name, str(run))
 if data_directory is not None:
-    full_name = data_directory + "/" + short_filename
+    full_name = data_directory + "/" + short_filename + ".nxs.h5"
+    if not os.path.exists(full_name):
+        full_name = data_directory + "/" + short_filename + "_event.nxs"   
 else:
     candidates = FileFinder.findRuns(short_filename)
     full_name = ""
@@ -135,7 +137,7 @@ else:
         if os.path.exists(item):
             full_name = str(item)
 
-    if not full_name.endswith('nxs'):
+    if not full_name.endswith('nxs') and not full_name.endswith('h5'):
         print("Exiting since the data_directory was not specified and")
         print("findnexus failed for event NeXus file: " + instrument_name + " " + str(run))
         exit(0)
@@ -362,12 +364,12 @@ else:
                           CellType=cell_type, Centering=centering,
                           AllowPermutations=allow_perm,
                           Apply=True, Tolerance=tolerance )
-    if output_nexus:
-        SaveNexus(InputWorkspace=peaks_ws, Filename=run_conventional_integrate_file )
-    else:
-        SaveIsawPeaks(InputWorkspace=peaks_ws, AppendFile=False,
-                      Filename=run_conventional_integrate_file )
-        SaveIsawUB(InputWorkspace=peaks_ws, Filename=run_conventional_matrix_file )
+        if output_nexus:
+            SaveNexus(InputWorkspace=peaks_ws, Filename=run_conventional_integrate_file )
+        else:
+            SaveIsawPeaks(InputWorkspace=peaks_ws, AppendFile=False,
+                          Filename=run_conventional_integrate_file )
+            SaveIsawUB(InputWorkspace=peaks_ws, Filename=run_conventional_matrix_file )
 
 end_time = time.time()
 print('\nReduced run ' + str(run) + ' in ' + str(end_time - start_time) + ' sec')

--- a/scripts/SCD_Reduction/ReduceSCD_OneRun.py
+++ b/scripts/SCD_Reduction/ReduceSCD_OneRun.py
@@ -129,7 +129,7 @@ short_filename = "%s_%s" % (instrument_name, str(run))
 if data_directory is not None:
     full_name = data_directory + "/" + short_filename + ".nxs.h5"
     if not os.path.exists(full_name):
-        full_name = data_directory + "/" + short_filename + "_event.nxs"   
+        full_name = data_directory + "/" + short_filename + "_event.nxs"
 else:
     candidates = FileFinder.findRuns(short_filename)
     full_name = ""

--- a/scripts/SCD_Reduction/ReduceSCD_Parallel.py
+++ b/scripts/SCD_Reduction/ReduceSCD_Parallel.py
@@ -168,20 +168,23 @@ first_time = True
 
 if output_nexus:
     #Only need this for instrument for peaks_total
-    short_filename = "%s_%s_event.nxs" % (instrument_name, str(run_nums[0]))
+    short_filename = "%s_%s" % (instrument_name, str(run_nums[0]))
     if data_directory is not None:
-        full_name = data_directory + "/" + short_filename
+        full_name = data_directory + "/" + short_filename + ".nxs.h5"
+        if not os.path.exists(full_name):
+            full_name = data_directory + "/" + short_filename + "_event.nxs"
     else:
         candidates = FileFinder.findRuns(short_filename)
         full_name = ""
         for item in candidates:
             if os.path.exists(item):
                 full_name = str(item)
-
-        if not full_name.endswith('nxs'):
+    
+        if not full_name.endswith('nxs') and not full_name.endswith('h5'):
             print("Exiting since the data_directory was not specified and")
-            print("findnexus failed for event NeXus file: " + instrument_name + " " + str(run))
+            print("findnexus failed for event NeXus file: " + instrument_name + " " + str(run_nums[0]))
             exit(0)
+
     #
     # Load the first data file to find instrument
     #

--- a/scripts/SCD_Reduction/ReduceSCD_Parallel.py
+++ b/scripts/SCD_Reduction/ReduceSCD_Parallel.py
@@ -179,7 +179,7 @@ if output_nexus:
         for item in candidates:
             if os.path.exists(item):
                 full_name = str(item)
-    
+
         if not full_name.endswith('nxs') and not full_name.endswith('h5'):
             print("Exiting since the data_directory was not specified and")
             print("findnexus failed for event NeXus file: " + instrument_name + " " + str(run_nums[0]))


### PR DESCRIPTION
Description of work.
Browse for file in SCD Event Data Reduction interface works with both nxs and h5 extensions. Reduction script tries to load files with both extensions.

**To test:**
Open SCD Event Data Reduction interface and browse for files with h5 and nxs extensions.
```
mv MANDI_test.config.txt MANDI_test.config
python ReduceSCD_Parallel.py MANDI_test.config
```
[MANDI_test.config.txt](https://github.com/mantidproject/mantid/files/973829/MANDI_test.config.txt)


Fixes #19478 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
