### PR TITLE
Speed up CrystalField python tests

### DIFF
--- a/scripts/test/CrystalFieldTest.py
+++ b/scripts/test/CrystalFieldTest.py
@@ -542,7 +542,7 @@ class CrystalFieldFitTest(unittest.TestCase):
 
         chi2 = CalculateChiSquared(cf.makeMultiSpectrumFunction(), InputWorkspace=ws0, InputWorkspace_1=ws1)[1]
 
-        fit = CrystalFieldFit(cf, InputWorkspace=[ws0, ws1])
+        fit = CrystalFieldFit(cf, InputWorkspace=[ws0, ws1], MaxIterations=10)
         fit.fit()
 
         self.assertTrue(cf.chi2 < chi2)
@@ -1307,7 +1307,7 @@ class CrystalFieldFitTest(unittest.TestCase):
         cf.constraints('2<B22<6', '-0.2<B40<0.2', '-0.2<B42<0.2', '-0.2<B44<0.2')
         # Create a fit object
         fit = CrystalFieldFit(cf, InputWorkspace=ws)
-        fit.monte_carlo(NSamples=1000, Constraints='20<f1.PeakCentre<45,20<f2.PeakCentre<45', Seed=123)
+        fit.monte_carlo(NSamples=100, Constraints='20<f1.PeakCentre<45,20<f2.PeakCentre<45', Seed=123)
         # Run fit
         fit.fit()
         self.assertTrue(cf.chi2 > 0.0)
@@ -1332,7 +1332,7 @@ class CrystalFieldFitTest(unittest.TestCase):
         cf.constraints('2<B22<6', '-0.2<B40<0.2', '-0.2<B42<0.2', '-0.2<B44<0.2')
         # Create a fit object
         fit = CrystalFieldFit(cf, InputWorkspace=[ws1, ws2])
-        fit.monte_carlo(NSamples=1000, Constraints='20<f0.f1.PeakCentre<45,20<f0.f2.PeakCentre<45', Seed=123)
+        fit.monte_carlo(NSamples=100, Constraints='20<f0.f1.PeakCentre<45,20<f0.f2.PeakCentre<45', Seed=123)
         # Run fit
         fit.fit()
         self.assertTrue(cf.chi2 > 0.0)
@@ -1496,7 +1496,7 @@ class CrystalFieldFitTest(unittest.TestCase):
         fit = CrystalFieldFit(cf, InputWorkspace=ws)
         fit.estimate_parameters(50, ['B22', 'B40', 'B42', 'B44'],
                                 constraints='20<f1.PeakCentre<45,20<f2.PeakCentre<45',
-                                Type='Cross Entropy', NSamples=100)
+                                Type='Cross Entropy', NSamples=10, Seed=123)
         # Run fit
         fit.fit()
         self.assertTrue(cf.chi2 < 100.0)
@@ -1520,8 +1520,8 @@ class CrystalFieldFitTest(unittest.TestCase):
         # Create a fit object
         fit = CrystalFieldFit(cf, InputWorkspace=ws)
         fit.estimate_parameters(50, ['B22', 'B40', 'B42', 'B44'],
-                                constraints='20<f1.PeakCentre<45,20<f2.PeakCentre<45', NSamples=1000)
-        self.assertEqual(fit.get_number_estimates(), 10)
+                                constraints='20<f1.PeakCentre<45,20<f2.PeakCentre<45', NSamples=100, Seed=123)
+        self.assertTrue(fit.get_number_estimates() > 1)
         fit.fit()
         self.assertTrue(cf.chi2 < 100.0)
 
@@ -1647,7 +1647,7 @@ class CrystalFieldFitTest(unittest.TestCase):
         ws1 = makeWorkspace(*origin.getSpectrum(1))
         wscv = makeWorkspace(*origin.getHeatCapacity())
         wschi = makeWorkspace(*origin.getSusceptibility(Hdir='powder'))
-        wsmag = makeWorkspace(*origin.getMagneticMoment(Hdir=[0,1,0]))
+        wsmag = makeWorkspace(*origin.getMagneticMoment(Hdir=[0,1,0], Hmag=np.linspace(0,30,3)))
         wsmom = makeWorkspace(*origin.getMagneticMoment(H=100, T=np.linspace(1,300,300), Unit='cgs'))
 
         # Fits single physical properties dataset
@@ -1677,23 +1677,23 @@ class CrystalFieldFitTest(unittest.TestCase):
         cf.PhysicalProperty = PhysicalProperties('M(H)',Hdir=[0,1,0])
         fit = CrystalFieldFit(Model=cf, InputWorkspace=[ws0, wsmag], MaxIterations=100)
         fit.fit()
-        self.assertAlmostEqual(cf['B20'], 0.37737, 4)
-        self.assertAlmostEqual(cf['B22'], 3.97700087765, 4)
-        self.assertAlmostEqual(cf['B40'], -0.0317867635188, 4)
-        self.assertAlmostEqual(cf['B42'], -0.116110640723, 4)
-        self.assertAlmostEqual(cf['B44'], -0.125439939584, 4)
+        self.assertAlmostEqual(cf['B20'], 0.37737, 3)
+        self.assertAlmostEqual(cf['B22'], 3.97700087765, 3)
+        self.assertAlmostEqual(cf['B40'], -0.0317867635188, 3)
+        self.assertAlmostEqual(cf['B42'], -0.116110640723, 3)
+        self.assertAlmostEqual(cf['B44'], -0.125439939584, 3)
 
         # Fits multiple INS spectra and multiple physical properties
         cf = CrystalField('Ce', 'C2v', B20=0.37, B22=3.97, B40=-0.0317, B42=-0.116, B44=-0.12,
                           Temperature=[10, 100], FWHM=[1.1, 1.2])
         cf.PhysicalProperty = [PhysicalProperties('susc', 'powder'), PhysicalProperties('M(H)', Hdir=[0,1,0])]
-        fit = CrystalFieldFit(Model=cf, InputWorkspace=[ws0, ws1, wschi, wsmag], MaxIterations=100)
+        fit = CrystalFieldFit(Model=cf, InputWorkspace=[ws0, ws1, wschi, wsmag], MaxIterations=1)
         fit.fit()
-        self.assertAlmostEqual(cf['B20'], 0.37737, 4)
-        self.assertAlmostEqual(cf['B22'], 3.97700087765, 4)
-        self.assertAlmostEqual(cf['B40'], -0.0317867635188, 4)
-        self.assertAlmostEqual(cf['B42'], -0.116110640723, 4)
-        self.assertAlmostEqual(cf['B44'], -0.125439939584, 4)
+        self.assertAlmostEqual(cf['B20'], 0.37737, 1)
+        self.assertAlmostEqual(cf['B22'], 3.97700087765, 1)
+        self.assertAlmostEqual(cf['B40'], -0.0317867635188, 1)
+        self.assertAlmostEqual(cf['B42'], -0.116110640723, 1)
+        self.assertAlmostEqual(cf['B44'], -0.125439939584, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changes the python `CrystalFieldTest` which uses `Fit` (or `EstimateParameters`) to reduce `MaxIterations` (or `NSamples`) used (with relaxed `assert` on the fitted parameters) so the tests runs faster. On my RHEL7 quad-core desktop the test used to take 18s, now it takes 5s. On the build servers the test now takes about 18s compared to around 30s before.

In the original issue #19471, it was suggested that these tests could all be moved into `SystemsTest` instead, which might be worthwhile for some of the longer running tests. However, these tests are not really workflow tests, and in all cases test a single fitting call (albeit one which can take quite long because they involve multiple datasets and/or large number of calls to the underlying fit functions).

**To test:**

Check that everything compiles and all tests still pass. Check that the time to run `PythonScriptsTest_CrystalFieldTest` has decreased.

Fixes #19471.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
