### PR TITLE
Fixed indent in muonAnalysis call to python

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1663,7 +1663,7 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
   s << "def plot_data(ws_name,errors, connect, window_to_use):";
   if (parsePlotType(m_uiForm.frontPlotFuncs) == PlotType::Asymmetry) {
     // clang-format off
-    s << "w = plotSpectrum(source = ws_name,"
+    s << "  w = plotSpectrum(source = ws_name,"
          "indices = 0,"
          "distribution = mantidqtpython.MantidQt.DistributionFalse,"
          "error_bars = errors," 
@@ -1672,7 +1672,7 @@ void MuonAnalysis::plotSpectrum(const QString &wsName, bool logScale) {
     // clang-format on
   } else {
     // clang-format off
-    s << "w = plotSpectrum(source = ws_name,"
+    s << "  w = plotSpectrum(source = ws_name,"
          "indices = 0,"
          "distribution = mantidqtpython.MantidQt.DistributionDefault,"
          "error_bars = errors,"


### PR DESCRIPTION
Fixed a missing indent in muon analysis call to python code. 

**To test:**

<!-- Instructions for testing. -->
Open the muon analysis GUI and load data from different instruments. It should work.

On Master the above produces an error about the indentation. 

No issue to fix

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
*Does not need to be in the release notes.* Because, it was added within this release cycle. 
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
