### PR TITLE
Refs #19492 Fix regression in ConvertToMD

### DIFF
--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -330,7 +330,7 @@ void ConvertToMD::copyMetaData(API::IMDEventWorkspace_sptr &mdEventWS) const {
   bool detector_found(false);
   const auto &spectrumInfo = m_InWS2D->spectrumInfo();
   for (size_t i = 0; i < m_InWS2D->getNumberHistograms(); ++i) {
-    if (spectrumInfo.hasDetectors(i) && spectrumInfo.isMonitor(i)) {
+    if (spectrumInfo.hasDetectors(i) && !spectrumInfo.isMonitor(i)) {
       spectra_index = i;
       detector_found = true;
       g_log.debug() << "Using spectra N " << i

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -74,7 +74,7 @@ Bugs
 ----
 
 - We have fixed a bug where Mantid could crash when deleting a large number of workspaces.
-- Fixed a bug in :ref:`ConvertToMD <algm-ConvertToMD>` causing it to fail if monitors were all NaN, Inf, or zero.
+- Fixed a bug in :ref:`ConvertToMD <algm-ConvertToMD>` causing it to fail with the error "Run::storeEnergyBinBoundaries - Inconsistent start & end values" if monitors were all NaN, Inf, or zero.
 
 CurveFitting
 ------------

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -74,6 +74,7 @@ Bugs
 ----
 
 - We have fixed a bug where Mantid could crash when deleting a large number of workspaces.
+- Fixed a bug in :ref:`ConvertToMD <algm-ConvertToMD>` causing it to fail if monitors were all NaN, Inf, or zero.
 
 CurveFitting
 ------------


### PR DESCRIPTION
This fixes a bug introduced into ConvertToMD where the values for the monitors were being used as values for the bins in `ConvertToMD`

**To test:**

Here's a script what should fail with the error described in the bug report. It should be fixed with these changes. The WISH file in located in `cycle_15_4`.

```python
LoadRaw(Filename='WISH00033602.raw', OutputWorkspace='33602', LoadLogFiles=False)
CropWorkspace(InputWorkspace='33602', OutputWorkspace='33602', XMin=6000, XMax=99900, StartWorkspaceIndex=0, EndWorkspaceIndex=10)
NormaliseByCurrent(InputWorkspace='33602', OutputWorkspace='33602')
ConvertUnits(InputWorkspace='33602', OutputWorkspace='33602', Target='dSpacing')
ReplaceSpecialValues(InputWorkspace='33602', OutputWorkspace='33602', NaNValue=0, InfinityValue=0)
ConvertToDiffractionMDWorkspace(InputWorkspace='33602', OutputWorkspace='33602_MD')
```

Fixes #19492.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
