### PR TITLE
Fix ISIS Powder Instrument Settings test

### DIFF
--- a/scripts/test/ISISPowderInstrumentSettingsTest.py
+++ b/scripts/test/ISISPowderInstrumentSettingsTest.py
@@ -25,7 +25,7 @@ class ISISPowderInstrumentSettingsTest(unittest.TestCase):
         inst_settings_obj = instrument_settings.InstrumentSettings(param_map=[param_entry])
 
         # Check it still prints the acceptable values when it fails
-        with assertRaisesRegex(self, AttributeError, "a foo, A BAR"):
+        with assertRaisesRegex(self, AttributeError, "A BAR"):
             foo = inst_settings_obj.script_facing_name
             del foo
 


### PR DESCRIPTION
Description of work.
The unit test for ISIS Powder instrument settings previously checked that all valid enum values are printed when a user forget to set the property. This relies on the fact the `__dict__` object in Python 2 was ordered. Currently this causes the Python 3 tests to fail randomly on master. 

Instead we should test for only one of the values being printed which no longer rely on the order being consistent. 

**To test:**
Run `ISISPowderInstrumentSettingsTest` multiple times using a Python 3 build. If it does not fail say after 10 times the random order of the dict will have been triggered at least once.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
