### PR TITLE
Add an IDF for HB3A

### DIFF
--- a/docs/source/release/v3.10.0/diffraction.rst
+++ b/docs/source/release/v3.10.0/diffraction.rst
@@ -30,7 +30,8 @@ Powder Diffraction
 Single Crystal Diffraction
 --------------------------
 
-- A new HB3A instrument definition file, for its 512 x 512 detector
+- A new HB3A instrument definition file, for its 512 x 512 detector, is created.  Its valid period is from February 2017 to late April 2017.
+- An IDF for HB3A with 256 by 256 detectors was created.  It was dated from late April 2017 because its original detector has been switched back.
 - New algorithm :ref:`DeltaPDF3D <algm-DeltaPDF3D>` for calculating the 3D-deltaPDF from a HKL MDHistoWorkspace
 
 

--- a/instrument/HB3A_Definition.xml
+++ b/instrument/HB3A_Definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2015-05-18 10:35:21.877396" name="HB3A" valid-from="2010-05-18 10:35:21" valid-to="2017-02-11 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2015-05-18 10:35:21.877396" name="HB3A" valid-from="2010-05-18 00:00:21" valid-to="2017-02-11 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Wenduo Zhou-->
   <!--SOURCE-->
   <component type="moderator">

--- a/instrument/HB3A_Definition_2017-04-25.xml
+++ b/instrument/HB3A_Definition_2017-04-25.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2017-02-18 10:35:21.877396" name="HB3A" valid-from="2017-02-12 10:35:21" valid-to="2017-04-24 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2017-05-08 10:35:21.877396" name="HB3A" valid-from="2017-04-25 00:00:00" valid-to="2100-12-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Wenduo Zhou-->
   <!--SOURCE-->
   <component type="moderator">
@@ -12,7 +12,7 @@
   </component>
   <type is="SamplePos" name="sample-position"/>
   <!--PANEL-->
-  <component idfillbyfirst="x" idstart="1" idstepbyrow="512" type="arm">
+  <component idfillbyfirst="x" idstart="1" idstepbyrow="256" type="arm">
     <location name="bank1">
       <parameter name="r-position">
 	      <logfile eq="1.0*value+0.3750" id="diffr"/>
@@ -40,14 +40,14 @@
 		  </location>
 	  </component>
   </type>
-  <type is="rectangular_detector" name="panel" type="pixel" xpixels="512" xstart="0.0564140625" xstep="-0.0002265625" ypixels="512" ystart="-0.0355703125" ystep="0.0002265625">
+  <type is="rectangular_detector" name="panel" type="pixel" xpixels="256" xstart="0.0252015625" xstep="-0.0001984375" ypixels="256" ystart="-0.022621875" ystep="0.0001984375">
  </type>
   <type is="detector" name="pixel">
     <cuboid id="pixel-shape">
-      <left-front-bottom-point x="-0.00011328125" y="-0.00011328125" z="0.0"/>
-      <left-front-top-point x="-0.00011328125" y="0.00011328125" z="0.0"/>
-      <left-back-bottom-point x="-0.00011328125" y="-0.00011328125" z="-0.0001"/>
-      <right-front-bottom-point x="0.00011328125" y="-0.00011328125" z="0.0"/>
+      <left-front-bottom-point x="-9.921875e-05" y="-9.921875e-05" z="0.0"/>
+      <left-front-top-point x="-9.921875e-05" y="9.921875e-05" z="0.0"/>
+      <left-back-bottom-point x="-9.921875e-05" y="-9.921875e-05" z="-0.0001"/>
+      <right-front-bottom-point x="9.921875e-05" y="-9.921875e-05" z="0.0"/>
     </cuboid>
     <algebra val="pixel-shape"/>
   </type>

--- a/instrument/HB3A_Definition_2017-04-25.xml
+++ b/instrument/HB3A_Definition_2017-04-25.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2017-05-08 10:35:21.877396" name="HB3A" valid-from="2017-04-25 00:00:00" valid-to="2100-12-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2017-05-08 10:35:21.877396" name="HB3A" valid-from="2017-04-25 00:00:01" valid-to="2100-12-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Wenduo Zhou-->
   <!--SOURCE-->
   <component type="moderator">


### PR DESCRIPTION
The detector of HB3A has been switched back to the 256 by 256 one since one week ago.  So its IDF should be modified accordingly.

**To test:**

The new IDF HB3A_Definition_2017-04-25.xml looks exactly the same as HB3A_Definition.xml except the valid period.   
The valid period of HB3A_Definition_2017-02-12.xml is also changed then.
A good test is to check the change of the valid period of these 2 files.

*There is no associate issue*
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
