### PR TITLE
Set IgnoreBinErrors to True for TOFTOF data reduction GUI

### DIFF
--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -454,7 +454,7 @@ class TOFTOFScriptElement(BaseScriptElement):
             l("# energy binning")
             l("rebinEnergy = '{:.3f}, {:.3f}, {:.3f}'"
               .format(self.binEstart, self.binEstep, self.binEend))
-            l("{} = Rebin({}, Params=rebinEnergy)" .format(gDataBinE, gLast))
+            l("{} = Rebin({}, Params=rebinEnergy, IgnoreBinErrors=True)" .format(gDataBinE, gLast))
             l()
             gLast = gDataBinE
 


### PR DESCRIPTION
Option IgnoreBinErrors set to True for the Rebin step in TOFTOF data reduction GUI (according to the request of the instrument scientist).

**To test:**

- Run Interfaces->Direct->DGS Reduction
- Choose facility MLZ and instrument TOFTOF
- Put some reasonable input parameters (or load settings from attached xml file
[settings.zip](https://github.com/mantidproject/mantid/files/985702/settings.zip))
- Click Export and save the Python script
- Open the Python script and check that in line 84 option 'IgnoreBinErrors=True' appears:
```python
gwsDataBinE = Rebin(gwsDataS, Params=rebinEnergy, IgnoreBinErrors=True)
```

Fixes #19505.

Does not need to be in the release notes.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
