### PR TITLE
ConvToMD: Remove extra calls to joinAll().

### DIFF
--- a/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
+++ b/Framework/MDAlgorithms/src/ConvToMDEventsWS.cpp
@@ -155,15 +155,9 @@ void ConvToMDEventsWS::runConversion(API::Progress *pProgress) {
     size_t nConverted = this->conversionChunk(wi);
     eventsAdded += nConverted;
     nEventsInWS += nConverted;
-    // Give this task to the scheduler
-    //%double cost = double(el.getNumberEvents());
-    // ts->push( new FunctionTask( func, cost) );
-
     // Keep a running total of how many events we've added
     if (bc->shouldSplitBoxes(nEventsInWS, eventsAdded, lastNumBoxes)) {
       if (runMultithreaded) {
-        // Do all the adding tasks
-        tp.joinAll();
         // Now do all the splitting tasks
         m_OutWSWrapper->pWorkspace()->splitAllIfNeeded(ts);
         if (ts->size() > 0)
@@ -184,7 +178,6 @@ void ConvToMDEventsWS::runConversion(API::Progress *pProgress) {
   }
   // Do a final splitting of everything
   if (runMultithreaded) {
-    tp.joinAll();
     m_OutWSWrapper->pWorkspace()->splitAllIfNeeded(ts);
     tp.joinAll();
   } else {


### PR DESCRIPTION
Description of work.

This removes two calls to ThreadPool::joinAll() that don't appear to be doing anything and take a lot of time. In MDAlgorithmsTest.ConvertToMDTestPerformance, test_EventNoUnitsConv goes from 9.3 seconds to 2.0 seconds and `test_EventFromTOFConv` goes from 9.4 to 2.1 seconds.

I added [a separate issue](https://github.com/mantidproject/mantid/issues/19519) to address observation that these tests are too small to utilize the threadpool and therefore don't measure parallel performance.

**To test:**

<!-- Instructions for testing. -->

1. Verify results above (ideally on a different platform)
2. Try running this on "real data" and check if performance improves.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
