### PR TITLE
Fixed bin edges as vertical axis in CreateWorkspace

### DIFF
--- a/Framework/Algorithms/src/CreateWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateWorkspace.cpp
@@ -106,9 +106,10 @@ void CreateWorkspace::exec() {
   const std::string vUnit = getProperty("VerticalAxisUnit");
   const std::vector<std::string> vAxis = getProperty("VerticalAxisValues");
 
-  if ((vUnit != "SpectraNumber") && (static_cast<int>(vAxis.size()) != nSpec)) {
+  const int vAxisSize = static_cast<int>(vAxis.size());
+  if (vUnit != "SpectraNumber" && ((vUnit == "Text" && vAxisSize != nSpec) || (vAxisSize != nSpec && vAxisSize != nSpec + 1))) {
     throw std::invalid_argument(
-        "Number of y-axis labels must match number of histograms.");
+        "The number of vertical axis values doesn't match the number of histograms.");
   }
 
   // Verify length of vectors makes sense with NSpec
@@ -208,12 +209,11 @@ void CreateWorkspace::exec() {
         newAxis->setLabel(i, vAxis[i]);
       }
     } else {
-      const size_t vAxisLength = vAxis.size();
       NumericAxis *newAxis(nullptr);
-      if (vAxisLength == static_cast<size_t>(nSpec))
-        newAxis = new NumericAxis(vAxisLength); // treat as points
-      else if (vAxisLength == static_cast<size_t>(nSpec + 1))
-        newAxis = new BinEdgeAxis(vAxisLength); // treat as bin edges
+      if (vAxisSize == nSpec)
+        newAxis = new NumericAxis(vAxisSize); // treat as points
+      else if (vAxisSize == nSpec + 1)
+        newAxis = new BinEdgeAxis(vAxisSize); // treat as bin edges
       else
         throw std::range_error("Invalid vertical axis length. It must be the "
                                "same length as NSpec or 1 longer.");

--- a/Framework/Algorithms/src/CreateWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateWorkspace.cpp
@@ -107,9 +107,11 @@ void CreateWorkspace::exec() {
   const std::vector<std::string> vAxis = getProperty("VerticalAxisValues");
 
   const int vAxisSize = static_cast<int>(vAxis.size());
-  if (vUnit != "SpectraNumber" && ((vUnit == "Text" && vAxisSize != nSpec) || (vAxisSize != nSpec && vAxisSize != nSpec + 1))) {
-    throw std::invalid_argument(
-        "The number of vertical axis values doesn't match the number of histograms.");
+  if (vUnit != "SpectraNumber" &&
+      ((vUnit == "Text" && vAxisSize != nSpec) ||
+       (vAxisSize != nSpec && vAxisSize != nSpec + 1))) {
+    throw std::invalid_argument("The number of vertical axis values doesn't "
+                                "match the number of histograms.");
   }
 
   // Verify length of vectors makes sense with NSpec

--- a/Framework/Algorithms/src/CreateWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateWorkspace.cpp
@@ -106,12 +106,16 @@ void CreateWorkspace::exec() {
   const std::string vUnit = getProperty("VerticalAxisUnit");
   const std::vector<std::string> vAxis = getProperty("VerticalAxisValues");
 
+  // Verify the size of the vertical axis.
   const int vAxisSize = static_cast<int>(vAxis.size());
-  if (vUnit != "SpectraNumber" &&
-      ((vUnit == "Text" && vAxisSize != nSpec) ||
-       (vAxisSize != nSpec && vAxisSize != nSpec + 1))) {
-    throw std::invalid_argument("The number of vertical axis values doesn't "
+  if (vUnit != "SpectraNumber") {
+    // In the case of numerical axis, the vertical axis can represent either
+    // point data or bin edges.
+    if ((vUnit == "Text" && vAxisSize != nSpec) ||
+       (vAxisSize != nSpec && vAxisSize != nSpec + 1)) {
+      throw std::invalid_argument("The number of vertical axis values doesn't "
                                 "match the number of histograms.");
+    }
   }
 
   // Verify length of vectors makes sense with NSpec

--- a/Framework/Algorithms/src/CreateWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateWorkspace.cpp
@@ -112,9 +112,9 @@ void CreateWorkspace::exec() {
     // In the case of numerical axis, the vertical axis can represent either
     // point data or bin edges.
     if ((vUnit == "Text" && vAxisSize != nSpec) ||
-       (vAxisSize != nSpec && vAxisSize != nSpec + 1)) {
+        (vAxisSize != nSpec && vAxisSize != nSpec + 1)) {
       throw std::invalid_argument("The number of vertical axis values doesn't "
-                                "match the number of histograms.");
+                                  "match the number of histograms.");
     }
   }
 

--- a/Framework/Algorithms/test/CreateWorkspaceTest.h
+++ b/Framework/Algorithms/test/CreateWorkspaceTest.h
@@ -1,7 +1,9 @@
 #include <cxxtest/TestSuite.h>
 
-#include "MantidAPI/TextAxis.h"
 #include "MantidAlgorithms/CreateWorkspace.h"
+#include "MantidAPI/BinEdgeAxis.h"
+#include "MantidAPI/NumericAxis.h"
+#include "MantidAPI/TextAxis.h"
 #include "MantidKernel/Memory.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
@@ -78,35 +80,11 @@ public:
   }
 
   void testCreateTextAxis() {
-    Mantid::Algorithms::CreateWorkspace alg;
-    alg.initialize();
-    alg.setPropertyValue("OutputWorkspace", "test_CreateWorkspace");
-    alg.setPropertyValue("UnitX", "Wavelength");
-    alg.setPropertyValue("VerticalAxisUnit", "Text");
-
     std::vector<std::string> textAxis{"I've Got", "A Lovely", "Bunch Of",
                                       "Coconuts"};
-
-    alg.setProperty<std::vector<std::string>>("VerticalAxisValues", textAxis);
-    alg.setProperty<int>("NSpec", 4);
-
-    std::vector<double> values{1.0, 2.0, 3.0, 4.0};
-
-    alg.setProperty<std::vector<double>>("DataX",
-                                         std::vector<double>{1.1, 2.2});
-    alg.setProperty<std::vector<double>>("DataY", values);
-    alg.setProperty<std::vector<double>>("DataE", values);
-
-    alg.execute();
-
-    TS_ASSERT(alg.isExecuted());
-
     // Get hold of the output workspace
     Mantid::API::MatrixWorkspace_sptr workspace =
-        boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
-            Mantid::API::AnalysisDataService::Instance().retrieve(
-                "test_CreateWorkspace"));
-
+        executeVerticalAxisTest("Text", textAxis);
     TS_ASSERT(workspace->isHistogramData());
     TS_ASSERT_EQUALS(workspace->getNumberHistograms(), 4);
     TS_ASSERT_EQUALS(workspace->x(0)[0], 1.1);
@@ -122,6 +100,27 @@ public:
 
     // Remove workspace
     Mantid::API::AnalysisDataService::Instance().remove("test_CreateWorkspace");
+  }
+
+  void testFailureOnNumericVerticalAxisSizeMismatch() {
+    Mantid::Algorithms::CreateWorkspace alg;
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setPropertyValue("OutputWorkspace", "test_CreateWorkspace");
+    alg.setPropertyValue("UnitX", "Wavelength");
+    alg.setPropertyValue("VerticalAxisUnit", "MomentumTransfer");
+    const std::vector<std::string> vertValues{"0.0", "1.0", "2.0"};
+    alg.setProperty<std::vector<std::string>>("VerticalAxisValues", vertValues);
+    alg.setProperty<int>("NSpec", 4);
+
+    std::vector<double> values{1.0, 2.0, 3.0, 4.0};
+
+    alg.setProperty<std::vector<double>>("DataX",
+                                         std::vector<double>{1.1, 2.2});
+    alg.setProperty<std::vector<double>>("DataY", values);
+    alg.setProperty<std::vector<double>>("DataE", values);
+
+    TS_ASSERT_THROWS(alg.execute(), std::invalid_argument);
   }
 
   void testParenting() {
@@ -145,6 +144,73 @@ public:
     TS_ASSERT(output->run().hasProperty("ALogEntry"));
 
     AnalysisDataService::Instance().remove(outWS);
+  }
+
+  void testVerticalAxisValuesAsBinEdges() {
+    std::vector<std::string> edgeAxis{"1.1", "2.2", "3.3", "4.4", "5.5"};
+    Mantid::API::MatrixWorkspace_sptr workspace =
+        executeVerticalAxisTest("DeltaE", edgeAxis);
+
+    Mantid::API::BinEdgeAxis *axis =
+        dynamic_cast<Mantid::API::BinEdgeAxis *>(workspace->getAxis(1));
+    TS_ASSERT(axis != nullptr)
+    TS_ASSERT_EQUALS(axis->length(), 5)
+    TS_ASSERT_EQUALS(axis->getValue(0), 1.1);
+    TS_ASSERT_EQUALS(axis->getValue(1), 2.2);
+    TS_ASSERT_EQUALS(axis->getValue(2), 3.3);
+    TS_ASSERT_EQUALS(axis->getValue(3), 4.4);
+    TS_ASSERT_EQUALS(axis->getValue(4), 5.5);
+
+    // Remove workspace
+    Mantid::API::AnalysisDataService::Instance().remove("test_CreateWorkspace");
+  }
+
+  void testVerticalAxisValuesAsPoints() {
+    std::vector<std::string> pointAxis{"1.1", "2.2", "3.3", "4.4"};
+    Mantid::API::MatrixWorkspace_sptr workspace =
+        executeVerticalAxisTest("DeltaE", pointAxis);
+
+    Mantid::API::NumericAxis *axis =
+        dynamic_cast<Mantid::API::NumericAxis *>(workspace->getAxis(1));
+    TS_ASSERT(axis != nullptr)
+    TS_ASSERT_EQUALS(axis->length(), 4)
+    TS_ASSERT_EQUALS(axis->getValue(0), 1.1);
+    TS_ASSERT_EQUALS(axis->getValue(1), 2.2);
+    TS_ASSERT_EQUALS(axis->getValue(2), 3.3);
+    TS_ASSERT_EQUALS(axis->getValue(3), 4.4);
+
+    // Remove workspace
+    Mantid::API::AnalysisDataService::Instance().remove("test_CreateWorkspace");
+  }
+
+private:
+  MatrixWorkspace_sptr executeVerticalAxisTest(const std::string &vertUnit, const std::vector<std::string> &vertValues) {
+    Mantid::Algorithms::CreateWorkspace alg;
+    alg.initialize();
+    alg.setPropertyValue("OutputWorkspace", "test_CreateWorkspace");
+    alg.setPropertyValue("UnitX", "Wavelength");
+    alg.setPropertyValue("VerticalAxisUnit", vertUnit);
+
+    alg.setProperty<std::vector<std::string>>("VerticalAxisValues", vertValues);
+    alg.setProperty<int>("NSpec", 4);
+
+    std::vector<double> values{1.0, 2.0, 3.0, 4.0};
+
+    alg.setProperty<std::vector<double>>("DataX",
+                                         std::vector<double>{1.1, 2.2});
+    alg.setProperty<std::vector<double>>("DataY", values);
+    alg.setProperty<std::vector<double>>("DataE", values);
+
+    alg.execute();
+
+    TS_ASSERT(alg.isExecuted());
+
+    // Get hold of the output workspace
+    Mantid::API::MatrixWorkspace_sptr workspace =
+        boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
+            Mantid::API::AnalysisDataService::Instance().retrieve(
+                "test_CreateWorkspace"));
+    return workspace;
   }
 };
 

--- a/Framework/Algorithms/test/CreateWorkspaceTest.h
+++ b/Framework/Algorithms/test/CreateWorkspaceTest.h
@@ -184,7 +184,9 @@ public:
   }
 
 private:
-  MatrixWorkspace_sptr executeVerticalAxisTest(const std::string &vertUnit, const std::vector<std::string> &vertValues) {
+  MatrixWorkspace_sptr
+  executeVerticalAxisTest(const std::string &vertUnit,
+                          const std::vector<std::string> &vertValues) {
     Mantid::Algorithms::CreateWorkspace alg;
     alg.initialize();
     alg.setPropertyValue("OutputWorkspace", "test_CreateWorkspace");

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -58,6 +58,7 @@ Bug Fixes
 - Fixed an issue where the log ``proton_charge_by_period`` was not loaded for :ref:`LoadEventNexus <algm-LoadEventNexus>`.
 - Fixed an issue where :ref:`algm-MonteCarloAbsorption` would use the wavelengths from the first histogram of *InputWorkspace* only making the algorithm unusable for workspaces with varying bins.
 - Fixed an issue with the ``GroupingPattern`` property in :ref:`algm-GroupDetectors`, where incorrect spectra were being used if spectrum numbers are not 1-based indices.
+- Fixed an issue with :ref:`algm-CreateWorkspace` where giving bin edges as ``VerticalAxisValues`` would fail.
 
 Deprecated
 ##########


### PR DESCRIPTION
This PR fixes a check in [`CreateWorkspace`](http://docs.mantidproject.org/nightly/algorithms/CreateWorkspace-v1.html) which would reject bin edges as vertical axis.

**To test:**

The following script should fail before these changes are applied:
```python
import numpy

ys = numpy.array([1.0])
xs = numpy.array([0.0])
vertAxis = "0.1, 0.2"
ws = CreateWorkspace(DataX=xs, DataY=ys, VerticalAxisUnit='MomentumTransfer', VerticalAxisValues=vertAxis)
```

Fixes #19525.

*Release notes were updated accordingly.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
