### PR TITLE
Print button in MantidPlot help

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/pqHelpWindow.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/pqHelpWindow.h
@@ -58,10 +58,12 @@ public slots:
   virtual void showPage(const QString &url);
   virtual void showPage(const QUrl &url);
 
-  /// Tires to locate a file name index.html in the given namespace and then
+  /// Tries to locate a file name index.html in the given namespace and then
   /// shows that page.
   virtual void showHomePage(const QString &namespace_name);
   virtual void showHomePage();
+
+  /// Prints the current open page
   virtual void printPage();
 
 signals:

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/pqHelpWindow.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/pqHelpWindow.h
@@ -62,6 +62,7 @@ public slots:
   /// shows that page.
   virtual void showHomePage(const QString &namespace_name);
   virtual void showHomePage();
+  virtual void printPage();
 
 signals:
   /// fired to relay warning messages from the help system.

--- a/MantidQt/MantidWidgets/src/pqHelpWindow.cxx
+++ b/MantidQt/MantidWidgets/src/pqHelpWindow.cxx
@@ -42,6 +42,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QNetworkProxy>
 #include <QNetworkReply>
 #include <QPointer>
+#include <QPrinter>
+#include <QPrintDialog>
 #include <QPushButton>
 #include <QTextBrowser>
 #include <QTextStream>
@@ -196,6 +198,7 @@ pqHelpWindow::pqHelpWindow(
   // add a navigation toolbar
   QToolBar *navigation = new QToolBar("Navigation");
   QPushButton *home = new QPushButton("Home");
+  QPushButton *print = new QPushButton("Print");
 
   m_forward = new QToolButton();
   m_forward->setArrowType(Qt::RightArrow);
@@ -210,6 +213,7 @@ pqHelpWindow::pqHelpWindow(
   m_backward->setAutoRaise(true);
 
   navigation->addWidget(home);
+  navigation->addWidget(print);
   navigation->addWidget(m_backward);
   navigation->addWidget(m_forward);
   navigation->setAllowedAreas(Qt::TopToolBarArea | Qt::RightToolBarArea);
@@ -258,6 +262,7 @@ pqHelpWindow::pqHelpWindow(
 
   // connect the navigation buttons
   connect(home, SIGNAL(clicked()), this, SLOT(showHomePage()));
+  connect(print, SIGNAL(clicked()), this, SLOT(printPage()));
   connect(m_forward,  SIGNAL(clicked()), m_browser, SLOT(forward()));
   connect(m_backward, SIGNAL(clicked()), m_browser, SLOT(back()));
   connect(m_forward,  SIGNAL(clicked()), this, SLOT(updateNavButtons()));
@@ -317,6 +322,17 @@ void pqHelpWindow::showPage(const QUrl& url)
   {
     MantidDesktopServices::openUrl(url);
   }
+}
+
+//-----------------------------------------------------------------------------
+void pqHelpWindow::printPage()
+{
+   QPrinter printer;
+   QPrintDialog *dialog = new QPrintDialog(&printer, this);
+   dialog->setWindowTitle(tr("Print Document"));
+   if (dialog->exec() != QDialog::Accepted)
+       return;
+   m_browser->print(&printer);
 }
 
 //-----------------------------------------------------------------------------

--- a/MantidQt/MantidWidgets/src/pqHelpWindow.cxx
+++ b/MantidQt/MantidWidgets/src/pqHelpWindow.cxx
@@ -328,9 +328,9 @@ void pqHelpWindow::showPage(const QUrl& url)
 //-----------------------------------------------------------------------------
 void pqHelpWindow::printPage() {
   QPrinter printer;
-  QPrintDialog *dialog = new QPrintDialog(&printer, this);
-  dialog->setWindowTitle(tr("Print Document"));
-  if (dialog->exec() != QDialog::Accepted)
+  QPrintDialog dialog(&printer, this);
+  dialog.setWindowTitle(tr("Print Document"));
+  if (dialog.exec() != QDialog::Accepted)
     return;
   m_browser->print(&printer);
 }

--- a/MantidQt/MantidWidgets/src/pqHelpWindow.cxx
+++ b/MantidQt/MantidWidgets/src/pqHelpWindow.cxx
@@ -198,7 +198,8 @@ pqHelpWindow::pqHelpWindow(
   // add a navigation toolbar
   QToolBar *navigation = new QToolBar("Navigation");
   QPushButton *home = new QPushButton("Home");
-  QPushButton *print = new QPushButton("Print");
+  QPushButton *print = new QPushButton("Print...");
+  print->setToolTip("Print the current page");
 
   m_forward = new QToolButton();
   m_forward->setArrowType(Qt::RightArrow);
@@ -325,14 +326,13 @@ void pqHelpWindow::showPage(const QUrl& url)
 }
 
 //-----------------------------------------------------------------------------
-void pqHelpWindow::printPage()
-{
-   QPrinter printer;
-   QPrintDialog *dialog = new QPrintDialog(&printer, this);
-   dialog->setWindowTitle(tr("Print Document"));
-   if (dialog->exec() != QDialog::Accepted)
-       return;
-   m_browser->print(&printer);
+void pqHelpWindow::printPage() {
+  QPrinter printer;
+  QPrintDialog *dialog = new QPrintDialog(&printer, this);
+  dialog->setWindowTitle(tr("Print Document"));
+  if (dialog->exec() != QDialog::Accepted)
+    return;
+  m_browser->print(&printer);
 }
 
 //-----------------------------------------------------------------------------

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -19,6 +19,7 @@ User Interface
 
 - MantidPlot now respects the system scaling on high-resolution displays. All icons and bitmaps will now be sized
   appropriately rather than being too small to be usable (Windows only).
+- A new Print button has been added to the MantidPlot help window.
 - Masked bins are greyed out in the table view of the workspaces (except for EventWorkspaces):
 
 .. figure:: ../../images/maskedbins.jpg  


### PR DESCRIPTION
This adds a print functionality to the MantidPlot help window.

**To test:**

<!-- Instructions for testing. -->

1. Build the MantidPlot with the documentation
2. Go to MantidPlot help
3. Navigate to some page and click `Print` button
4. Confirm in the modal window and see what comes out of the printer

Fixes #19527 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
