### PR TITLE
Simplify function Detector::getPhi()

### DIFF
--- a/Framework/Geometry/src/Instrument/Detector.cpp
+++ b/Framework/Geometry/src/Instrument/Detector.cpp
@@ -95,10 +95,10 @@ double Detector::getSignedTwoTheta(const V3D &observer, const V3D &axis,
 /// Get the phi angle between the detector with reference to the origin
 ///@return The angle
 double Detector::getPhi() const {
-  double phi = 0.0, dummy;
-  this->getPos().getSpherical(dummy, dummy, phi);
-  return phi * M_PI / 180.0;
+  const Kernel::V3D pos = this->getPos();
+  return std::atan2(pos[1], pos[0]);
 }
+
 /**
  * Calculate the phi angle between detector and beam, and then offset.
  * @param offset in radians

--- a/Framework/Geometry/src/Instrument/Detector.cpp
+++ b/Framework/Geometry/src/Instrument/Detector.cpp
@@ -92,8 +92,11 @@ double Detector::getSignedTwoTheta(const V3D &observer, const V3D &axis,
   return angle;
 }
 
-/// Get the phi angle between the detector with reference to the origin
-///@return The angle
+/** Get the phi angle between the detector with reference to the origin
+ * This function will not be supported in Instrument-2.0 due to its ambiguity.
+ * DO NOT USE IN NEW CODE
+ * @return The angle
+ */
 double Detector::getPhi() const {
   const Kernel::V3D pos = this->getPos();
   return std::atan2(pos[1], pos[0]);


### PR DESCRIPTION
Description of work.

This simplifies the expression for `Detector::getPhi()` to a single trigonometric function. It's the same change I suggested in PR #18962.

**To test:**

<!-- Instructions for testing. -->

Review changes and check the build servers.

There is no GitHub issue associated with this pull request.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
