### PR TITLE
Fix windows missing from project save view

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6060,7 +6060,7 @@ void ApplicationWindow::prepareSaveProject() {
       windows.push_back(win);
   }
 
-  for (auto window : windowsList()) {
+  for (auto window : getAllWindows()) {
     auto win = dynamic_cast<IProjectSerialisable *>(window);
     if (win)
       windows.push_back(win);

--- a/MantidQt/API/src/WindowIcons.cpp
+++ b/MantidQt/API/src/WindowIcons.cpp
@@ -55,6 +55,7 @@ void WindowIcons::initInternalLookup() {
   m_idToPixmapName["Note"] = "note_xpm";
   m_idToPixmapName["MultiLayer"] = "graph_xpm";
   m_idToPixmapName["Graph3D"] = "trajectory_xpm";
+  m_idToPixmapName["Graph"] = "graph_xpm";
   m_idToPixmapName["Workspace"] = "mantid_matrix_xpm";
   m_idToPixmapName["SliceViewer"] =
       ":/SliceViewer/icons/SliceViewerWindow_icon.png";

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ProjectSaveModel.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ProjectSaveModel.h
@@ -51,7 +51,8 @@ public:
   std::vector<std::string> getWorkspaceNames() const;
   /// Get all window information for a collection of workspaces
   std::vector<WindowInfo>
-  getWindowInformation(const std::vector<std::string> &wsNames, bool includeUnattached = false) const;
+  getWindowInformation(const std::vector<std::string> &wsNames,
+                       bool includeUnattached = false) const;
   /// Get all workspace information
   std::vector<WorkspaceInfo> getWorkspaceInformation() const;
   /// Get all window handles for this workspace
@@ -68,7 +69,8 @@ private:
   WorkspaceInfo
   makeWorkspaceInfoObject(Mantid::API::Workspace_const_sptr ws) const;
 
-  WindowInfo makeWindowInfoObject(MantidQt::API::IProjectSerialisable * window) const;
+  WindowInfo
+  makeWindowInfoObject(MantidQt::API::IProjectSerialisable *window) const;
 
   // Instance variables
 

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ProjectSaveModel.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ProjectSaveModel.h
@@ -51,7 +51,7 @@ public:
   std::vector<std::string> getWorkspaceNames() const;
   /// Get all window information for a collection of workspaces
   std::vector<WindowInfo>
-  getWindowInformation(const std::vector<std::string> &wsNames) const;
+  getWindowInformation(const std::vector<std::string> &wsNames, bool includeUnattached = false) const;
   /// Get all workspace information
   std::vector<WorkspaceInfo> getWorkspaceInformation() const;
   /// Get all window handles for this workspace
@@ -68,12 +68,16 @@ private:
   WorkspaceInfo
   makeWorkspaceInfoObject(Mantid::API::Workspace_const_sptr ws) const;
 
+  WindowInfo makeWindowInfoObject(MantidQt::API::IProjectSerialisable * window) const;
+
   // Instance variables
 
   /// Map to hold which windows are associated with a workspace
   std::unordered_map<std::string,
                      std::vector<MantidQt::API::IProjectSerialisable *>>
       m_workspaceWindows;
+
+  std::vector<MantidQt::API::IProjectSerialisable *> m_unattachedWindows;
 };
 
 } // CustomInterfaces

--- a/MantidQt/MantidWidgets/src/ProjectSaveModel.cpp
+++ b/MantidQt/MantidWidgets/src/ProjectSaveModel.cpp
@@ -30,11 +30,11 @@ ProjectSaveModel::ProjectSaveModel(
     // then track it so we can always add it to the included
     // window list
     if (wsNames.size() == 0) {
-        m_unattachedWindows.push_back(window);
-        continue;
+      m_unattachedWindows.push_back(window);
+      continue;
     }
 
-    // otherwise add a reference mapping the window to the 
+    // otherwise add a reference mapping the window to the
     // it's various connected workspaces
     for (auto &name : wsNames) {
       m_workspaceWindows[name].push_back(window);
@@ -117,8 +117,9 @@ std::vector<std::string> ProjectSaveModel::getWorkspaceNames() const {
  * @param wsNames :: vector of workspace names to find associated windows for
  * @return vector of window info objects associated with the workpaces
  */
-std::vector<WindowInfo> ProjectSaveModel::getWindowInformation(
-    const std::vector<std::string> &wsNames, bool includeUnattached) const {
+std::vector<WindowInfo>
+ProjectSaveModel::getWindowInformation(const std::vector<std::string> &wsNames,
+                                       bool includeUnattached) const {
   std::vector<WindowInfo> winInfo;
 
   for (auto window : getUniqueWindows(wsNames)) {
@@ -127,22 +128,23 @@ std::vector<WindowInfo> ProjectSaveModel::getWindowInformation(
   }
 
   if (includeUnattached) {
-      for (const auto window : m_unattachedWindows) {
-          auto info = makeWindowInfoObject(window);
-          winInfo.push_back(info);
-      }
+    for (const auto window : m_unattachedWindows) {
+      auto info = makeWindowInfoObject(window);
+      winInfo.push_back(info);
+    }
   }
 
   return winInfo;
 }
 
-WindowInfo ProjectSaveModel::makeWindowInfoObject(IProjectSerialisable * window) const {
-    WindowIcons icons;
-    WindowInfo info;
-    info.name = window->getWindowName();
-    info.type = window->getWindowType();
-    info.icon_id = icons.getIconID(window->getWindowType());
-    return info;
+WindowInfo
+ProjectSaveModel::makeWindowInfoObject(IProjectSerialisable *window) const {
+  WindowIcons icons;
+  WindowInfo info;
+  info.name = window->getWindowName();
+  info.type = window->getWindowType();
+  info.icon_id = icons.getIconID(window->getWindowType());
+  return info;
 }
 
 /**

--- a/MantidQt/MantidWidgets/src/ProjectSaveModel.cpp
+++ b/MantidQt/MantidWidgets/src/ProjectSaveModel.cpp
@@ -26,6 +26,16 @@ ProjectSaveModel::ProjectSaveModel(
 
   for (auto window : windows) {
     auto wsNames = window->getWorkspaceNames();
+    // if the window is not associated with any workspaces
+    // then track it so we can always add it to the included
+    // window list
+    if (wsNames.size() == 0) {
+        m_unattachedWindows.push_back(window);
+        continue;
+    }
+
+    // otherwise add a reference mapping the window to the 
+    // it's various connected workspaces
     for (auto &name : wsNames) {
       m_workspaceWindows[name].push_back(window);
     }
@@ -108,19 +118,31 @@ std::vector<std::string> ProjectSaveModel::getWorkspaceNames() const {
  * @return vector of window info objects associated with the workpaces
  */
 std::vector<WindowInfo> ProjectSaveModel::getWindowInformation(
-    const std::vector<std::string> &wsNames) const {
+    const std::vector<std::string> &wsNames, bool includeUnattached) const {
   std::vector<WindowInfo> winInfo;
-  WindowIcons icons;
 
   for (auto window : getUniqueWindows(wsNames)) {
+    auto info = makeWindowInfoObject(window);
+    winInfo.push_back(info);
+  }
+
+  if (includeUnattached) {
+      for (const auto window : m_unattachedWindows) {
+          auto info = makeWindowInfoObject(window);
+          winInfo.push_back(info);
+      }
+  }
+
+  return winInfo;
+}
+
+WindowInfo ProjectSaveModel::makeWindowInfoObject(IProjectSerialisable * window) const {
+    WindowIcons icons;
     WindowInfo info;
     info.name = window->getWindowName();
     info.type = window->getWindowType();
     info.icon_id = icons.getIconID(window->getWindowType());
-    winInfo.push_back(info);
-  }
-
-  return winInfo;
+    return info;
 }
 
 /**

--- a/MantidQt/MantidWidgets/src/ProjectSaveModel.cpp
+++ b/MantidQt/MantidWidgets/src/ProjectSaveModel.cpp
@@ -115,6 +115,8 @@ std::vector<std::string> ProjectSaveModel::getWorkspaceNames() const {
 /**
  * Get window information for a selection of workspaces
  * @param wsNames :: vector of workspace names to find associated windows for
+ * @param includeUnattached :: whether to append windows not attached to any
+ * workspace
  * @return vector of window info objects associated with the workpaces
  */
 std::vector<WindowInfo>

--- a/MantidQt/MantidWidgets/src/ProjectSavePresenter.cpp
+++ b/MantidQt/MantidWidgets/src/ProjectSavePresenter.cpp
@@ -20,7 +20,7 @@ ProjectSavePresenter::ProjectSavePresenter(IProjectSaveView *view)
     : m_view(view), m_model(m_view->getWindows()) {
   auto workspaceNames = m_model.getWorkspaceNames();
   auto info = m_model.getWorkspaceInformation();
-  auto winInfo = m_model.getWindowInformation(workspaceNames);
+  auto winInfo = m_model.getWindowInformation(workspaceNames, true);
   m_view->updateIncludedWindowsList(winInfo);
   m_view->updateWorkspacesList(info);
 }
@@ -49,7 +49,8 @@ void ProjectSavePresenter::notify(Notification notification) {
 void ProjectSavePresenter::includeWindowsForCheckedWorkspace() {
   auto wsNames = m_view->getCheckedWorkspaceNames();
   auto names = m_model.getWindowNames(wsNames);
-  auto info = m_model.getWindowInformation(wsNames);
+  // true flag gets windows unattached to workspaces as well
+  auto info = m_model.getWindowInformation(wsNames, true);
   m_view->updateIncludedWindowsList(info);
   m_view->removeFromExcludedWindowsList(names);
 }

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -60,6 +60,7 @@ Bugs Resolved
 -------------
 
 - Fixed an issue in the Script Window that caused the Convert Tabs to Spaces and vice versa operations to corrupt the script.
+- Fixed an issue where some graphs not associated with a workspace would not be shown in the project save as view.
 
 SliceViewer Improvements
 ------------------------


### PR DESCRIPTION
This will now include all windows, regardless of whether there is a
workspace attached.

**To test:**

 The easiest way to test this is to:
 -  create a table workspace with at least two columns
 - plot the columns 
 - try to save the workspace
 - With the fix, the window will now be shown in the "Included windows"

You should still be able to pick and choose which workspaces are included, but the unattached window will continue to be shown as included.

Fixes #19231 .

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
