### PR TITLE
Fix for wrong detector selection ISIS SANS GUI when running batch mode

### DIFF
--- a/docs/source/release/v3.10.0/sans.rst
+++ b/docs/source/release/v3.10.0/sans.rst
@@ -13,5 +13,7 @@ Bug Fixes
 - Fixed LOQ Batch mode bug where custom user file without a .txt ending was not being picked up.
 - Fixed Batch mode bug where the output name suffix was hardcoded to SANS2D. It now takes the individual instruments into account.
 - Fixed LOQ bug where prompt peak was not set correctly for monitor normalisation.
+- Fixed Batch mode bug where merged reductions set in the GUI were not respected.
+
 
 `Full list of changes on github <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.10%22+is%3Amerged+label%3A%22Component%3A+SANS%22>`__

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -226,6 +226,10 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},
     original_user_file = ReductionSingleton().user_settings.filename
     current_user_file = original_user_file
 
+    # Store the original combineDet which was set either by the input. this should be used whenever we are using the
+    # original user file
+    original_combine_det = combineDet
+
     # Now loop over all the lines and do a reduction (hopefully) for each
     for run in runinfo:
         # Set the user file, if it is required
@@ -235,12 +239,16 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},
                                                        original_user_file=original_user_file,
                                                        original_settings = settings,
                                                        original_prop_man_settings = prop_man_settings)
-            # When we set a new user file, that means that the combineDet feature could be invalid,
-            # ie if the detector under investigation changed in the user file. We need to change this
-            # here too. But only if it is not None.
-            if combineDet is not None:
-                new_combineDet = ReductionSingleton().instrument.get_detector_selection()
-                combineDet = su.get_correct_combinDet_setting(ins_name, new_combineDet)
+
+            if current_user_file == original_user_file:
+                combineDet = original_combine_det
+            else:
+                # When we set a new user file, that means that the combineDet feature could be invalid,
+                # ie if the detector under investigation changed in the user file. We need to change this
+                # here too. But only if it is not None.
+                if combineDet is not None:
+                    new_combineDet = ReductionSingleton().instrument.get_detector_selection()
+                    combineDet = su.get_correct_combinDet_setting(ins_name, new_combineDet)
         except (RuntimeError, ValueError) as e:
             sanslog.warning("Error in Batchmode user files: Could not reset the specified user file %s. More info: %s" %(
                 str(run['user_file']), str(e)))

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -1997,7 +1997,7 @@ def get_correct_combinDet_setting(instrument_name, detector_selection):
     detector_selection = detector_selection.upper()
     # If we are dealing with LOQ, then the correct combineDet selection is
     if instrument_name == "LOQ":
-        if detector_selection == "MAIN":
+        if detector_selection == "MAIN" or detector_selection == "MAIN-DETECTOR-BANK":
             new_combine_detector_selection = 'rear'
         elif detector_selection == "HAB":
             new_combine_detector_selection = 'front'
@@ -2012,9 +2012,9 @@ def get_correct_combinDet_setting(instrument_name, detector_selection):
 
     # If we are dealing with SANS2D, then the correct combineDet selection is
     if instrument_name == "SANS2D":
-        if detector_selection == "REAR":
+        if detector_selection == "REAR" or detector_selection == "REAR-DETECTOR":
             new_combine_detector_selection = 'rear'
-        elif detector_selection == "FRONT":
+        elif detector_selection == "FRONT" or detector_selection == "FRONT-DETECTOR":
             new_combine_detector_selection = 'front'
         elif detector_selection == "MERGED":
             new_combine_detector_selection = 'merged'

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -1598,10 +1598,13 @@ class TestSelectNewDetector(unittest.TestCase):
     def test_that_for_SANS2D_correct_settings_are_selected(self):
         self.assertTrue(su.get_correct_combinDet_setting("SANS2d", "rear") == "rear")
         self.assertTrue(su.get_correct_combinDet_setting("SANS2D", "FRONT") == "front")
+        self.assertTrue(su.get_correct_combinDet_setting("SANS2d", "rear-detector") == "rear")
+        self.assertTrue(su.get_correct_combinDet_setting("SANS2D", "FRONT-DETECTOR") == "front")
         self.assertTrue(su.get_correct_combinDet_setting("sAnS2d", "boTH") == "both")
         self.assertTrue(su.get_correct_combinDet_setting("sans2d", "merged") == "merged")
 
     def test_that_for_LOQ_correct_settings_are_selected(self):
+        self.assertTrue(su.get_correct_combinDet_setting("Loq", "main-detector-bank") == "rear")
         self.assertTrue(su.get_correct_combinDet_setting("Loq", "main") == "rear")
         self.assertTrue(su.get_correct_combinDet_setting("LOQ", "Hab") == "front")
         self.assertTrue(su.get_correct_combinDet_setting("lOQ", "boTH") == "both")


### PR DESCRIPTION
Fixes #19534

When running batch mode in ISIS SANS, the detector selection from the GUI was not respected, when merged detectors were selected.

## To test:

Please find relevant test data here: \\olympic\Babylon5\Scratch\Anton\SANS2DTUBES_Batch_BUG

### Test that can select a merged reduction when a rear-detector was initially set by the user file

1. Open the ISIS SANS GUI
2. Set the instrument to SANS2DTUBES
3. Load the user file: USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger.txt
4. Go the the settings tab, confirm that "rear-detector" is selected and set it to "merged"
5. Go to the run tab and switch to batch mode. Open the batch file: batchTest_no.csv
   * Confirm that you don't see a row-specific user file
6. Press "1D Reduce"
   * Confirm that you get the reduced workspaces for "rear-detector", "front-detector" and "merged", they will have the names test_file_rear, test_file_front and test_file_merged, respectively.

Delete all files except for TUBE_SANS2D_BOTH_31681_25Sept15.

### Test that can select a rear-detector reduction when a front-detector was initially set by the user file

1. Open the ISIS SANS GUI
2. Set the instrument to SANS2DTUBES
3. Load the user file: USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_FRONT.txt
4. Go the the settings tab, confirm that "front-detector" is selected and set it to "rear-detector"
5. Go to the run tab and switch to batch mode. Open the batch file: batchTest_no.csv
   * Confirm that you don't see a row-specific user file
6. Press "1D Reduce"
   * Confirm that you get the reduced workspace for "rear-detector" which should be named  test_file_rear

Delete all files except for TUBE_SANS2D_BOTH_31681_25Sept15.


### Test that row-specific user_file overrides the original user file

1. Open the ISIS SANS GUI
2. Set the instrument to SANS2DTUBES
3. Load the user file: USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger.txt
4. Go the the settings tab, confirm that "rear-detector" is selected, do nothing.
5. Go to the run tab and switch to batch mode. Open the batch file: batchTest_FRONT.csv
   * Confirm that you see the row-specific user file  USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_FRONT
6. Press "1D Reduce"
   * Confirm that you get the reduced workspace for "front-detector" which should be named  test_file_front

Delete all files except for TUBE_SANS2D_BOTH_31681_25Sept15.


### Release notes

Release notes can be found [here](https://github.com/mantidproject/mantid/pull/19546/commits/14d08d71b93336bd66d2761b10eb5a6fd63d1a92)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
