### PR TITLE
Fix IDF display in ISIS SANS Gui when using batch reduction

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -514,6 +514,11 @@ private:
   bool isValidUserFile();
   /// Update IDF file path
   void updateIDFFilePath();
+  /// Update IDF file path when running in Batch mode
+  void updateIDFFilePathForBatch();
+  //// Update IDF information
+  void updateIDFInfo(const QString& command);
+
 
   UserSubWindow *slicingWindow;
 };

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -517,8 +517,7 @@ private:
   /// Update IDF file path when running in Batch mode
   void updateIDFFilePathForBatch();
   //// Update IDF information
-  void updateIDFInfo(const QString& command);
-
+  void updateIDFInfo(const QString &command);
 
   UserSubWindow *slicingWindow;
 };

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -5129,7 +5129,7 @@ void SANSRunWindow::updateIDFFilePathForBatch() {
   // We base the IDF entry on the sample scatter entry of the first row
   auto *table_item = m_uiForm.batch_table->item(0, 0);
   auto scatter_sample_run = table_item->text();
-  QString getIdf = "i.get_idf_path_for_run(`" + scatter_sample_run + "`)\n";
+  QString getIdf = "i.get_idf_path_for_run(\"" + scatter_sample_run + "\")\n";
   updateIDFInfo(getIdf);
 }
 

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -5112,7 +5112,7 @@ bool SANSRunWindow::isValidUserFile() {
   return true;
 }
 
-void SANSRunWindow::updateIDFInfo(const QString& command) {
+void SANSRunWindow::updateIDFInfo(const QString &command) {
   QString resultIdf(runPythonCode(command, false));
   resultIdf = resultIdf.simplified();
   if (resultIdf != m_constants.getPythonEmptyKeyword() &&
@@ -5127,7 +5127,7 @@ void SANSRunWindow::updateIDFFilePathForBatch() {
     return;
   }
   // We base the IDF entry on the sample scatter entry of the first row
-  auto* table_item = m_uiForm.batch_table->item(0, 0);
+  auto *table_item = m_uiForm.batch_table->item(0, 0);
   auto scatter_sample_run = table_item->text();
   QString getIdf = "i.get_idf_path_for_run(`" + scatter_sample_run + "`)\n";
   updateIDFInfo(getIdf);

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -2483,6 +2483,9 @@ void SANSRunWindow::handleReduceButtonClick(const QString &typeStr) {
       return;
     }
 
+    // Update the IDF file path for batch reductions
+    updateIDFFilePathForBatch();
+
     // check for the detectors combination option
     // transform the SANS Diagnostic gui option in: 'rear', 'front' , 'both',
     // 'merged', None WavRangeReduction option
@@ -5109,17 +5112,30 @@ bool SANSRunWindow::isValidUserFile() {
   return true;
 }
 
-void SANSRunWindow::updateIDFFilePath() {
-  QString getIdf = "i.get_current_idf_path_in_reducer()\n";
-  QString resultIdf(runPythonCode(getIdf, false));
-  auto teset1 = resultIdf.toStdString();
+void SANSRunWindow::updateIDFInfo(const QString& command) {
+  QString resultIdf(runPythonCode(command, false));
   resultIdf = resultIdf.simplified();
-  auto test2 = resultIdf.toStdString();
   if (resultIdf != m_constants.getPythonEmptyKeyword() &&
       !resultIdf.isEmpty()) {
-    auto test = resultIdf.toStdString();
     m_uiForm.current_idf_path->setText(resultIdf);
   }
+}
+
+void SANSRunWindow::updateIDFFilePathForBatch() {
+
+  if (m_uiForm.batch_table->rowCount() == 0) {
+    return;
+  }
+  // We base the IDF entry on the sample scatter entry of the first row
+  auto* table_item = m_uiForm.batch_table->item(0, 0);
+  auto scatter_sample_run = table_item->text();
+  QString getIdf = "i.get_idf_path_for_run(`" + scatter_sample_run + "`)\n";
+  updateIDFInfo(getIdf);
+}
+
+void SANSRunWindow::updateIDFFilePath() {
+  QString getIdf = "i.get_current_idf_path_in_reducer()\n";
+  updateIDFInfo(getIdf);
 }
 
 void SANSRunWindow::onUpdateGeometryRequest() {

--- a/docs/source/release/v3.10.0/sans.rst
+++ b/docs/source/release/v3.10.0/sans.rst
@@ -13,5 +13,6 @@ Bug Fixes
 - Fixed LOQ Batch mode bug where custom user file without a .txt ending was not being picked up.
 - Fixed Batch mode bug where the output name suffix was hardcoded to SANS2D. It now takes the individual instruments into account.
 - Fixed LOQ bug where prompt peak was not set correctly for monitor normalisation.
+- Fixed display of current IDF, which was not updated when operating in batch mode.
 
 `Full list of changes on github <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.10%22+is%3Amerged+label%3A%22Component%3A+SANS%22>`__

--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -1767,14 +1767,13 @@ def is_current_workspace_an_angle_workspace():
     return is_angle
 
 
-def MatchIDFInReducerAndWorkspace(file_name):
-    '''
-    This method checks if the IDF which gets loaded with the workspace associated
-    with the file name and the current instrument in the reducer singleton refer
-    to the same IDF. If not then switch the IDF in the reducer.
-    '''
-    is_matched = True
+def _get_idf_path_for_run(file_name):
+    """
+    This method finds the full file location for a run number
 
+    :param file_name: the file name or run number
+    :return: the full path to the corresponding IDF
+    """
     # Get measurement time from file
     measurement_time = su.get_measurement_time_from_file(file_name)
 
@@ -1783,16 +1782,30 @@ def MatchIDFInReducerAndWorkspace(file_name):
 
     # Get the path to the instrument definition file
     idf_path_workspace = ExperimentInfo.getInstrumentFilename(instrument_name, measurement_time)
-    idf_path_workspace = os.path.normpath(idf_path_workspace)
+    return os.path.normpath(idf_path_workspace)
+
+
+def get_idf_path_for_run(file_name):
+    idf_path_workspace = _get_idf_path_for_run(file_name)
+    print(idf_path_workspace)
+    return idf_path_workspace
+
+
+def MatchIDFInReducerAndWorkspace(file_name):
+    '''
+    This method checks if the IDF which gets loaded with the workspace associated
+    with the file name and the current instrument in the reducer singleton refer
+    to the same IDF. If not then switch the IDF in the reducer.
+    '''
+
+    # Get the IDF path
+    idf_path_workspace = _get_idf_path_for_run(file_name)
 
     # Get the idf from the reducer
     idf_path_reducer = get_current_idf_path_in_reducer()
 
-    if ((idf_path_reducer == idf_path_workspace) and
-            su.are_two_files_identical(idf_path_reducer, idf_path_reducer)):
-        is_matched = True
-    else:
-        is_matched = False
+    is_matched = ((idf_path_reducer == idf_path_workspace) and
+                  su.are_two_files_identical(idf_path_reducer, idf_path_reducer))
 
     return is_matched
 


### PR DESCRIPTION
Fixes #19537

The current IDF path display was not updated when running the reduction in batch mode. Now it does

### To test:

Please find sample data here: smb://olympic/babylon5/Scratch/Anton/SteveFiles
Make sure that the data is added to your Mantid path.

##### Test that when running new data in batch mode the correct IDF is displayed

1. Open the ISIS SANS GUI and select LOQ as the instrument
2. Load the user file: `USER_LOQ_171B_M4_Alexander_8mm_Changer_MAIN.txt`
  * Confirm that the IDF display on the top of the run tab is set to: `LOQ_Definition_20020226-.xml`
4. Switch to batch mode operation and load the file: `batch_mode_reduction.csv`
5. Press `1D Reduce`
  * Confirm that the IDF display on the top of the run tab is set to:  `LOQ_Definition_20151016.xml` . This is the correct IDF that should be displayed when reducing that particular data set.


### Rlease notes

The release notes can be found [here](/mantidproject/mantid/commit/2585b4e391d9ba06a3a1959f0738396ae62f154d)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
