### PR TITLE
Indirect - Remove Error Bars

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -191,8 +191,7 @@ void IndirectDiffractionReduction::plotResults() {
       const auto workspaceExists =
           AnalysisDataService::Instance().doesExist(it);
       if (workspaceExists)
-        pyInput += "plotSpectrum('" + QString::fromStdString(it) +
-                   "', 0)\n";
+        pyInput += "plotSpectrum('" + QString::fromStdString(it) + "', 0)\n";
       else
         showInformationBox(QString::fromStdString(
             "Workspace '" + it + "' not found\nUnable to plot workspace"));

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -192,7 +192,7 @@ void IndirectDiffractionReduction::plotResults() {
           AnalysisDataService::Instance().doesExist(it);
       if (workspaceExists)
         pyInput += "plotSpectrum('" + QString::fromStdString(it) +
-                   "', 0, error_bars = True)\n";
+                   "', 0)\n";
       else
         showInformationBox(QString::fromStdString(
             "Workspace '" + it + "' not found\nUnable to plot workspace"));

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -259,7 +259,7 @@ void IndirectTab::plotSpectrum(const QStringList &workspaceNames, int wsIndex) {
   pyInput += workspaceNames.join("','");
   pyInput += "'], ";
   pyInput += QString::number(wsIndex);
-  pyInput += ", error_bars = True)\n";
+  pyInput += ")\n";
 
   m_pythonRunner.runPythonCode(pyInput);
 }
@@ -303,7 +303,7 @@ void IndirectTab::plotSpectrum(const QStringList &workspaceNames, int specStart,
   pyInput += QString::number(specStart);
   pyInput += ",";
   pyInput += QString::number(specEnd + 1);
-  pyInput += ")), error_bars = True)\n";
+  pyInput += ")))\n";
 
   m_pythonRunner.runPythonCode(pyInput);
 }
@@ -355,7 +355,7 @@ void IndirectTab::plotSpectra(const QStringList &workspaceNames,
     pyInput += " ,";
     pyInput += QString::number(wsIndices[i]);
   }
-  pyInput += "], error_bars = True)\n";
+  pyInput += "])\n";
   m_pythonRunner.runPythonCode(pyInput);
 }
 
@@ -418,7 +418,7 @@ void IndirectTab::plotTimeBin(const QStringList &workspaceNames, int binIndex) {
   pyInput += workspaceNames.join("','");
   pyInput += "'], ";
   pyInput += QString::number(binIndex);
-  pyInput += ", error_bars=True)\n";
+  pyInput += ")\n";
 
   m_pythonRunner.runPythonCode(pyInput);
 }

--- a/docs/source/release/v3.10.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.10.0/indirect_inelastic.rst
@@ -55,6 +55,7 @@ Improvements
 - OSIRIS diffraction now rebins container workspaces to match the sample workspace
 - :ref:`ISISIndirectDiffractionReduction <algm-ISISIndirectDiffractionReduction>` now fully supports VESUVIO data
 - Inelastic pixel ID's in BASIS instrument definition file grouped into continuous physical pixels.
+- Removed error bars as default
 
 
 Bugfixes

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -629,7 +629,7 @@ def plot_reduction(workspace_name, plot_type):
         from mantidplot import plotSpectrum
         num_spectra = mtd[workspace_name].getNumberHistograms()
         try:
-            plotSpectrum(workspace_name, range(0, num_spectra), error_bars=True)
+            plotSpectrum(workspace_name, range(0, num_spectra))
         except RuntimeError:
             logger.notice('Spectrum plotting canceled by user')
 


### PR DESCRIPTION
Removed error bars displayed as standard when `plot` button pressed on Indirect Interfaces. 

**To test:**

To test:
Run through a couple of indirect interfaces and ensure a graph with error bars is displayed when plot is clicked.
For Example: (requires access to ISIS data archive)
Instrument: IRIS
Indirect > Data Reduction > Calibration
Run No: 26173
Indirect > Data Reduction > Energy Transfer
Run No: 26176
Use 26173_calib workspace as calibration

Indirect > Data Analysis > Elwin
Use 26176_red workspace as input
Indirect > Data Analysis > MSDFit
Use 26176_elwin_eq2 workspace as input

Fixes #19557.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
