### PR TITLE
Save project dialog bug

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6074,9 +6074,7 @@ int ApplicationWindow::execSaveProjectDialog() {
   return m_projectSaveView->exec();
 }
 
-void ApplicationWindow::prepareSaveProject() {
-  execSaveProjectDialog();
-}
+void ApplicationWindow::prepareSaveProject() { execSaveProjectDialog(); }
 
 /**
  * The project was just saved. Update the main window.

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6075,8 +6075,7 @@ int ApplicationWindow::execSaveProjectDialog() {
 }
 
 void ApplicationWindow::prepareSaveProject() {
-  auto result = execSaveProjectDialog();
-  (void)result;
+  execSaveProjectDialog();
 }
 
 /**

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6051,7 +6051,7 @@ bool ApplicationWindow::saveProject(bool compress) {
   return true;
 }
 
-void ApplicationWindow::prepareSaveProject() {
+int ApplicationWindow::execSaveProjectDialog() {
   std::vector<IProjectSerialisable *> windows;
 
   for (auto window : getSerialisableWindows()) {
@@ -6071,7 +6071,12 @@ void ApplicationWindow::prepareSaveProject() {
       projectname, *serialiser, windows, this);
   connect(m_projectSaveView, SIGNAL(projectSaved()), this,
           SLOT(postSaveProject()));
-  m_projectSaveView->exec();
+  return m_projectSaveView->exec();
+}
+
+void ApplicationWindow::prepareSaveProject() {
+  auto result = execSaveProjectDialog();
+  (void)result;
 }
 
 /**
@@ -9790,7 +9795,11 @@ void ApplicationWindow::closeEvent(QCloseEvent *ce) {
         QMessageBox::information(this, tr("MantidPlot"), savemsg, tr("Yes"),
                                  tr("No"), tr("Cancel"), 0, 2);
     if (result == 0) {
-      prepareSaveProject();
+      auto response = execSaveProjectDialog();
+      if (response != QDialog::Accepted) {
+        ce->ignore();
+        return;
+      }
     } else if (result == 2) {
       // User wanted to cancel, do nothing
       ce->ignore();

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -11811,8 +11811,7 @@ void ApplicationWindow::createActions() {
   actionCloseAllWindows = new MantidQt::MantidWidgets::TrackedAction(
       QIcon(getQPixmap("quit_xpm")), tr("&Quit"), this);
   actionCloseAllWindows->setShortcut(tr("Ctrl+Q"));
-  connect(actionCloseAllWindows, SIGNAL(triggered()), this,
-          SLOT(close()));
+  connect(actionCloseAllWindows, SIGNAL(triggered()), this, SLOT(close()));
 
   actionDeleteFitTables = new MantidQt::MantidWidgets::TrackedAction(
       QIcon(getQPixmap("close_xpm")), tr("Delete &Fit Tables"), this);

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -9840,6 +9840,7 @@ void ApplicationWindow::closeEvent(QCloseEvent *ce) {
   scriptingEnv()->finalize();
 
   ce->accept();
+  qApp->closeAllWindows();
 }
 
 void ApplicationWindow::customEvent(QEvent *e) {
@@ -11810,8 +11811,8 @@ void ApplicationWindow::createActions() {
   actionCloseAllWindows = new MantidQt::MantidWidgets::TrackedAction(
       QIcon(getQPixmap("quit_xpm")), tr("&Quit"), this);
   actionCloseAllWindows->setShortcut(tr("Ctrl+Q"));
-  connect(actionCloseAllWindows, SIGNAL(triggered()), qApp,
-          SLOT(closeAllWindows()));
+  connect(actionCloseAllWindows, SIGNAL(triggered()), this,
+          SLOT(close()));
 
   actionDeleteFitTables = new MantidQt::MantidWidgets::TrackedAction(
       QIcon(getQPixmap("close_xpm")), tr("Delete &Fit Tables"), this);

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -270,6 +270,8 @@ public slots:
   void saveProjectAs(const QString &fileName = QString(),
                      bool compress = false);
   bool saveProject(bool compress = false);
+  /// Run the project saver dialog
+  int execSaveProjectDialog();
   /// Show the project saver dialog
   void prepareSaveProject();
   /// Update application window post save

--- a/MantidPlot/src/ApplicationWindow.h
+++ b/MantidPlot/src/ApplicationWindow.h
@@ -603,7 +603,6 @@ public slots:
   void closeActiveWindow();
   void closeSimilarWindows();
   void closeWindow(MdiSubWindow *window);
-  void prepareToCloseMantid();
 
   //!  Does all the cleaning work before actually deleting a window!
   void removeWindowFromLists(MdiSubWindow *w);

--- a/MantidPlot/src/ProjectSaveView.cpp
+++ b/MantidPlot/src/ProjectSaveView.cpp
@@ -205,6 +205,9 @@ void ProjectSaveView::save(bool checked) {
   emit projectSaved();
 
   close();
+  // Set the result code after calling close() because
+  // close() sets it to QDialog::Rejected
+  setResult(QDialog::Accepted);
 }
 
 /**


### PR DESCRIPTION
Moved the call to save the project to the event handler of `ApplicationWindow`'s `close` event. This way it is called from both the "close" button and the File->Quit menu.

**To test:**

Create some windows, including main windows such as SliceViewer. Close mantid by different ways. It should offer to save the project.

Fixes #19562.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
