### PR TITLE
Fix active region calculation in RectangularBeamProfile

### DIFF
--- a/Framework/Algorithms/src/AnnularRingAbsorption.cpp
+++ b/Framework/Algorithms/src/AnnularRingAbsorption.cpp
@@ -182,11 +182,11 @@ AnnularRingAbsorption::createSampleShapeXML(const V3D &upAxis) const {
   // the MonteCarloAbsorption algorithm.
   const V3D bottomCentre{0.0, -sampleHeightCM / 2.0 / 100.0, 0.0}; // in metres.
   const std::string innerCylID = std::string("inner-cyl");
-  const std::string innerCyl = cylinderXML(innerCylID, bottomCentre, lowRadiusMtr,
-                                           upAxis, sampleHeightCM / 100.0);
+  const std::string innerCyl = cylinderXML(
+      innerCylID, bottomCentre, lowRadiusMtr, upAxis, sampleHeightCM / 100.0);
   const std::string outerCylID = std::string("outer-cyl");
-  const std::string outerCyl = cylinderXML(outerCylID, bottomCentre, uppRadiusMtr,
-                                           upAxis, sampleHeightCM / 100.0);
+  const std::string outerCyl = cylinderXML(
+      outerCylID, bottomCentre, uppRadiusMtr, upAxis, sampleHeightCM / 100.0);
 
   // Combine shapes
   boost::format algebra("<algebra val=\"(%1% (# %2%))\" />");

--- a/Framework/Algorithms/src/AnnularRingAbsorption.cpp
+++ b/Framework/Algorithms/src/AnnularRingAbsorption.cpp
@@ -178,12 +178,14 @@ AnnularRingAbsorption::createSampleShapeXML(const V3D &upAxis) const {
   const double lowRadiusMtr = (wallMidPtCM - 0.5 * sampleThickCM) / 100.;
   const double uppRadiusMtr = (wallMidPtCM + 0.5 * sampleThickCM) / 100.;
 
-  // Cylinders oriented along Y, with origin at centre of bottom base
+  // Cylinders oriented along Y, with origin at the centre as expected by
+  // the MonteCarloAbsorption algorithm.
+  const V3D bottomCentre{0.0, -sampleHeightCM / 2.0 / 100.0, 0.0}; // in metres.
   const std::string innerCylID = std::string("inner-cyl");
-  const std::string innerCyl = cylinderXML(innerCylID, V3D(), lowRadiusMtr,
+  const std::string innerCyl = cylinderXML(innerCylID, bottomCentre, lowRadiusMtr,
                                            upAxis, sampleHeightCM / 100.0);
   const std::string outerCylID = std::string("outer-cyl");
-  const std::string outerCyl = cylinderXML(outerCylID, V3D(), uppRadiusMtr,
+  const std::string outerCyl = cylinderXML(outerCylID, bottomCentre, uppRadiusMtr,
                                            upAxis, sampleHeightCM / 100.0);
 
   // Combine shapes

--- a/Framework/Algorithms/src/SampleCorrections/RectangularBeamProfile.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/RectangularBeamProfile.cpp
@@ -90,10 +90,10 @@ RectangularBeamProfile::defineActiveRegion(const API::Sample &sample) const {
   const auto &sampleMin(sampleBox.minPoint());
   const auto &sampleMax(sampleBox.maxPoint());
   V3D minPoint, maxPoint;
-  minPoint[m_horIdx] = m_min[m_horIdx];
-  maxPoint[m_horIdx] = m_min[m_horIdx] + m_width;
-  minPoint[m_upIdx] = m_min[m_upIdx];
-  maxPoint[m_upIdx] = m_min[m_upIdx] + m_height;
+  minPoint[m_horIdx] = std::max(sampleMin[m_horIdx], m_min[m_horIdx]);
+  maxPoint[m_horIdx] = std::min(sampleMax[m_horIdx], m_min[m_horIdx] + m_width);
+  minPoint[m_upIdx] = std::max(sampleMin[m_upIdx], m_min[m_upIdx]);
+  maxPoint[m_upIdx] = std::min(sampleMax[m_upIdx], m_min[m_upIdx] + m_height);
   minPoint[m_beamIdx] = sampleMin[m_beamIdx];
   maxPoint[m_beamIdx] = sampleMax[m_beamIdx];
 

--- a/Framework/Algorithms/test/AnnularRingAbsorptionTest.h
+++ b/Framework/Algorithms/test/AnnularRingAbsorptionTest.h
@@ -43,11 +43,11 @@ public:
     MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
     TS_ASSERT(outWS);
 
-    const double delta(1e-08);
+    const double delta(1e-04);
     const size_t middle_index = 4;
-    TS_ASSERT_DELTA(0.96859812, outWS->readY(0).front(), delta);
-    TS_ASSERT_DELTA(0.79254304, outWS->readY(0)[middle_index], delta);
-    TS_ASSERT_DELTA(0.67064972, outWS->readY(0).back(), delta);
+    TS_ASSERT_DELTA(0.9694, outWS->readY(0).front(), delta);
+    TS_ASSERT_DELTA(0.8035, outWS->readY(0)[middle_index], delta);
+    TS_ASSERT_DELTA(0.6530, outWS->readY(0).back(), delta);
   }
 
   //-------------------- Failure cases --------------------------------

--- a/Framework/Algorithms/test/RectangularBeamProfileTest.h
+++ b/Framework/Algorithms/test/RectangularBeamProfileTest.h
@@ -82,7 +82,22 @@ public:
     TS_ASSERT_EQUALS(V3D(1.0, 0, 0), ray.unitDir);
   }
 
-  void test_DefineActiveRegion() {
+  void test_DefineActiveRegion_beam_larger_than_sample() {
+    using Mantid::API::Sample;
+    using Mantid::Kernel::V3D;
+    const double width(3.3), height(6.9);
+    const V3D center;
+    RectangularBeamProfile profile(createTestFrame(), center, width, height);
+    Sample testSample;
+    testSample.setShape(*ComponentCreationHelper::createSphere(0.5));
+
+    auto region = profile.defineActiveRegion(testSample);
+    TS_ASSERT(region.isNonNull());
+    TS_ASSERT_EQUALS(V3D(-0.5, -0.5, -0.5), region.minPoint());
+    TS_ASSERT_EQUALS(V3D(0.5, 0.5, 0.5), region.maxPoint());
+  }
+
+  void test_DefineActiveRegion_beam_smaller_than_sample() {
     using Mantid::API::Sample;
     using Mantid::Kernel::V3D;
     const double width(0.1), height(0.2);

--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -80,6 +80,7 @@ Bugs
 
 - We have fixed a bug where Mantid could crash when deleting a large number of workspaces.
 - Fixed a bug in :ref:`ConvertToMD <algm-ConvertToMD>` causing it to fail with the error "Run::storeEnergyBinBoundaries - Inconsistent start & end values" if monitors were all NaN, Inf, or zero.
+- Fixed a bug in illuminated volume calculation which could make :ref:`MonteCarloAbsorption` fail.
 
 CurveFitting
 ------------


### PR DESCRIPTION
This PR fixes a problem in `RectangularBeamProfile::defineActiveRegion()` method which returned a bounding box which was constrained only by the beam dimensions in direction perpendicular to the beam. If the beam was larger than the sample the bounding box would have been too big.

The changes also exposed a bug in [`AnnularRingAbsorption`](http://docs.mantidproject.org/nightly/algorithms/AnnularRingAbsorption-v1.html): the algorithm placed the *bottom* of the sample shape at the origin of the global coordinate system while [`MonteCarloAbsorption`](http://docs.mantidproject.org/nightly/algorithms/MonteCarloAbsorption-v1.html) expects the sample *centre* to be at the origin. `AnnularRingAbsorption` should center the sample correctly now.

**To test:**

Before these changes are applied, the following script fails due to `MonteCarloAbsorption` failing to find a point in the sample within the bounding box returned by `defineActiveRegion()`:
```python
Load(Filename='<mantid build directory>/ExternalData/Testing/Data/UnitTest/ILL/IN4/084446.nxs', OutputWorkspace='ws')
ConvertUnits(InputWorkspace='ws', OutputWorkspace='ws', Target='Wavelength', EMode='Elastic')
SetSample(InputWorkspace='ws',
          Geometry={'Shape': 'FlatPlate', 'Width': 0.1, 'Height': 0.1, 'Thick': 0.5,
                    'Center': [0.0,0.0,0.0], 'Angle': 0.0},
          Material={'ChemicalFormula': 'V', 'SampleNumberDensity': 0.0721})
SetBeam(InputWorkspace='ws', Geometry={'Shape': 'Slit', 'Height': 10.0, 'Width': 10.0})
MonteCarloAbsorption(InputWorkspace='ws', OutputWorkspace='a')
```

Fixes #19189.


*Release notes were updated accordingly.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
