### PR TITLE
Fix axis scaling in SliceViewer

### DIFF
--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -2996,6 +2996,7 @@ void SliceViewer::applyOrthogonalAxisScaleDraw() {
   auto *axis1 = new QwtScaleDraw();
   m_plot->setAxisScaleDraw(QwtPlot::xBottom, axis0);
   m_plot->setAxisScaleDraw(QwtPlot::yLeft, axis1);
+  this->updateDisplay();
 }
 
 } // namespace

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -73,6 +73,8 @@ SliceViewer Improvements
 - Fixed a bug where the rebin button was toggled when the user switch axes.
 - Changed zoom level on peak. Now when zooming onto a spherical or ellipsoidal peak, the entire peak is visible when using the default window size.
 - Fixed a bug where swapping the dimensions did not rebin the workspace despite having autorebin enabled.
+- Fixed a bug where swapping the dimensions did not draw the axis scale correctly.
+
 
 VSI Improvments
 ---------------


### PR DESCRIPTION
Fixes #19591

This PR fixes an issue where swapping the dimensions to a non-q-based workspace did not update the axis scaling correctly.

### For Testing

###### Confirm bug

1. Open Mantid (any 3.9+ version without this fix)
2. Create a sample workspace with more than one spectrum
3. Open it in the SliceViewer
4. Swap the X and Y dimension
   * Confirm that the axes scales are not painted

###### Confirm bug fix
 
1. Open Mantid with this fix
2. Create a sample workspace with more than one spectrum
3. Open it in the SliceViewer
4. Swap the X and Y dimension
   * Confirm that the axes scales are painted


#### Releaes Notes

See [here](https://github.com/mantidproject/mantid/commit/7959cf6e10bb34d14221a18f8a1f7ab827bf5c39)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
