### PR TITLE
Re #19551 removed extra monitor call from EXED idf

### DIFF
--- a/instrument/EXED_Definition.xml
+++ b/instrument/EXED_Definition.xml
@@ -22,7 +22,7 @@ last-modified="2017-04-21 14:58:37">
 </defaults>
 
 <!-- Detector components -->
-<component type="monitors" idlist="monitors"><location/></component>
+<!--<component type="monitors" idlist="monitors"><location/></component>-->
 <component type="panel02" idlist="panel02"><location y="-0.447"/></component>
 <component type="panel04" idlist="panel04"><location y="-0.4466"/></component>
 <component type="Tank">


### PR DESCRIPTION
Bug fix to remove extra monitor call

**To test:**

Load empty instrument Exed
examine components in instrument view.
Only one monitors instance with two monitors should be there.


Fixes #19551

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
