### PR TITLE
Fix failing unittest ISISPowderInstrumentSettingsTest for python 3.6

### DIFF
--- a/scripts/Diffraction/isis_powder/routines/instrument_settings.py
+++ b/scripts/Diffraction/isis_powder/routines/instrument_settings.py
@@ -7,7 +7,7 @@ import warnings
 
 # Have to patch warnings at runtime to not print the source code. This is even advertised as a 'feature' of
 # the warnings library in the documentation: https://docs.python.org/3/library/warnings.html#warnings.showwarning
-def _warning_no_source(msg, *_):
+def _warning_no_source(msg, *_, **__):
     return str(msg) + '\n'
 
 warnings.formatwarning = _warning_no_source


### PR DESCRIPTION
In python 3.6 warnings.formatwarning is now passed a keyword argument (`line`) which needs to be captured.

Fixes failing unit test PythonScriptsTest_ISISPowderInstrumentSettingsTest when using python 3.6 since #19497 was merged.

Without this you get:
```
1693: ======================================================================
1693: ERROR: test_set_attribute_is_found (__main__.ISISPowderInstrumentSettingsTest)
1693: ----------------------------------------------------------------------
1693: Traceback (most recent call last):
1693:   File "/home/rwp/mantid/scripts/test/ISISPowderInstrumentSettingsTest.py", line 46, in test_set_attribute_is_found
1693:     inst_settings_obj = instrument_settings.InstrumentSettings(param_map=[param_entry], kwargs=keyword_args)
1693:   File "/home/rwp/mantid/scripts/Diffraction/isis_powder/routines/instrument_settings.py", line 29, in __init__
1693:     warnings.warn("No config file was specified. If one was meant to be used the path to a YAML config file"
1693:   File "/usr/lib/python3.6/warnings.py", line 101, in _showwarnmsg
1693:     _showwarnmsg_impl(msg)
1693:   File "/usr/lib/python3.6/warnings.py", line 28, in _showwarnmsg_impl
1693:     text = _formatwarnmsg(msg)
1693:   File "/usr/lib/python3.6/warnings.py", line 116, in _formatwarnmsg
1693:     msg.filename, msg.lineno, line=msg.line)
1693: TypeError: _warning_no_source() got an unexpected keyword argument 'line'
```
This is a failing test on [Arch](http://builds.mantidproject.org/job/master_clean-archlinux_python3/) and [OSX](http://builds.mantidproject.org/job/master_clean-osx-10.11-python3/) with python 3

Description of work.

**To test:**
 * @DavidFair It's your code so have a look
 * @quantumsteve check you check that this passed on OSX with python 3

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
