### PR TITLE
Indirect diffraction bug fixes

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -278,6 +278,11 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
             DeleteWorkspace(self._container_workspace)
             DeleteWorkspace(self._container_workspace + '_mon')
 
+        if self._vanadium_ws:
+            for van_ws in self._vanadium_ws:
+                DeleteWorkspace(van_ws)
+                DeleteWorkspace(van_ws+'_mon')
+
         # Rename output workspaces
         output_workspace_names = [rename_reduction(ws_name, self._sum_files) for ws_name in self._workspace_names]
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDiffractionReduction.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDiffractionReduction.ui
@@ -180,357 +180,192 @@
      </widget>
     </item>
     <item>
-     <widget class="QStackedWidget" name="swVanadium">
-      <property name="currentIndex">
-       <number>1</number>
+     <widget class="QGroupBox" name="gbCalibOnly">
+      <property name="title">
+       <string>Calibration</string>
       </property>
-      <widget class="QWidget" name="pageCalibration">
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <property name="margin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QGroupBox" name="gbCalibration">
-          <property name="title">
-           <string>Calibration</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <property name="margin">
-            <number>6</number>
-           </property>
-           <item row="4" column="0" colspan="2">
-            <widget class="MantidQt::API::MWRunFiles" name="rfVanadiumFile" native="true">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="label" stdset="0">
-              <string>Vanadium Runs</string>
-             </property>
-             <property name="multipleFiles" stdset="0">
-              <bool>true</bool>
-             </property>
-             <property name="instrumentOverride" stdset="0">
-              <string>OSIRIS</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QSpinBox" name="spDRange">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>11</number>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QCheckBox" name="ckManualDRange">
-             <property name="text">
-              <string>Manual dRange:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0" colspan="2">
-            <widget class="MantidQt::API::MWRunFiles" name="rfCalFile" native="true">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="label" stdset="0">
-              <string>Cal File</string>
-             </property>
-             <property name="multipleFiles" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="optional" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="fileExtensions" stdset="0">
-              <stringlist>
-               <string>.cal</string>
-              </stringlist>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="pageCalibOnly">
-       <layout class="QVBoxLayout" name="verticalLayout_8">
-        <property name="margin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QGroupBox" name="gbCalibOnly">
-          <property name="title">
-           <string>Calibration</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_3">
-           <item row="1" column="0">
-            <widget class="MantidQt::API::MWRunFiles" name="rfVanFile_only" native="true">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>41</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="findRunFiles" stdset="0">
-              <bool>true</bool>
-             </property>
-             <property name="label" stdset="0">
-              <string>Vanadium File</string>
-             </property>
-             <property name="multipleFiles" stdset="0">
-              <bool>true</bool>
-             </property>
-             <property name="optional" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QCheckBox" name="ckUseVanadium">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Use Vanadium File</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QCheckBox" name="ckUseCalib">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Use Calibration File</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="MantidQt::API::MWRunFiles" name="rfCalFile_only" native="true">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>41</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="findRunFiles" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="label" stdset="0">
-              <string>Cal File</string>
-             </property>
-             <property name="multipleFiles" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="optional" stdset="0">
-              <bool>true</bool>
-             </property>
-             <property name="fileExtensions" stdset="0">
-              <string>.cal</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-          <zorder>ckUseCalib</zorder>
-          <zorder>rfCalFile_only</zorder>
-          <zorder>rfVanFile_only</zorder>
-          <zorder>ckUseVanadium</zorder>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gbDspaceRebinCalibOnly">
-          <property name="title">
-           <string>Rebin in D-Spacing (optional)</string>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_9">
-           <property name="spacing">
-            <number>6</number>
-           </property>
-           <property name="margin">
-            <number>6</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="lbRebinStart_calibOnly">
-             <property name="text">
-              <string>Start:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leRebinStart_CalibOnly"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinStart_CalibOnly">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
-             </property>
-             <property name="text">
-              <string>*</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="lbRebinWidth_CalibOnly">
-             <property name="text">
-              <string>Width:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leRebinWidth_CalibOnly"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinWidth_CalibOnly">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
-             </property>
-             <property name="text">
-              <string>*</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="lbRebinEnd_CalibOnly">
-             <property name="text">
-              <string>End:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leRebinEnd_CalibOnly"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinEnd_CalibOnly">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
-             </property>
-             <property name="text">
-              <string>*</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="pageDSpaceRebin">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="1" column="0">
+        <widget class="MantidQt::API::MWRunFiles" name="rfVanFile_only" native="true">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>41</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="findRunFiles" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="label" stdset="0">
+          <string>Vanadium File</string>
+         </property>
+         <property name="multipleFiles" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="optional" stdset="0">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="ckUseCalib">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>22</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Use Calibration File</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="ckUseVanadium">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>22</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Use Vanadium File</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="MantidQt::API::MWRunFiles" name="rfCalFile_only" native="true">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>41</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="findRunFiles" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="label" stdset="0">
+          <string>Cal File</string>
+         </property>
+         <property name="multipleFiles" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="optional" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="fileExtensions" stdset="0">
+          <string>.cal</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QCheckBox" name="ckManualDRange">
+         <property name="text">
+          <string>Manual dRange:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QSpinBox" name="spDRange">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>11</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+      <zorder>ckUseCalib</zorder>
+      <zorder>rfCalFile_only</zorder>
+      <zorder>rfVanFile_only</zorder>
+      <zorder>ckUseVanadium</zorder>
+      <zorder>ckManualDRange</zorder>
+      <zorder>spDRange</zorder>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="gbDspaceRebinCalibOnly">
+      <property name="title">
+       <string>Rebin in D-Spacing (optional)</string>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_9">
+       <property name="spacing">
+        <number>6</number>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <property name="margin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QGroupBox" name="gbRebin">
-          <property name="title">
-           <string>Rebin in D-Spacing (optional)</string>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_7">
-           <property name="spacing">
-            <number>6</number>
-           </property>
-           <property name="margin">
-            <number>6</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="lbRebinStart">
-             <property name="text">
-              <string>Start:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leRebinStart"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinStart">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
-             </property>
-             <property name="text">
-              <string>*</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="lbRebinWidth">
-             <property name="text">
-              <string>Width:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leRebinWidth"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinWidth">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
-             </property>
-             <property name="text">
-              <string>*</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="lbRebinEnd">
-             <property name="text">
-              <string>End:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leRebinEnd"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinEnd">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
-             </property>
-             <property name="text">
-              <string>*</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
+       <property name="margin">
+        <number>6</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="lbRebinStart_calibOnly">
+         <property name="text">
+          <string>Start:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leRebinStart_CalibOnly"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="valRebinStart_CalibOnly">
+         <property name="styleSheet">
+          <string notr="true">color: rgb(170, 0, 0);</string>
+         </property>
+         <property name="text">
+          <string>*</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lbRebinWidth_CalibOnly">
+         <property name="text">
+          <string>Width:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leRebinWidth_CalibOnly"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="valRebinWidth_CalibOnly">
+         <property name="styleSheet">
+          <string notr="true">color: rgb(170, 0, 0);</string>
+         </property>
+         <property name="text">
+          <string>*</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lbRebinEnd_CalibOnly">
+         <property name="text">
+          <string>End:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leRebinEnd_CalibOnly"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="valRebinEnd_CalibOnly">
+         <property name="styleSheet">
+          <string notr="true">color: rgb(170, 0, 0);</string>
+         </property>
+         <property name="text">
+          <string>*</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </item>
     <item>
@@ -738,14 +573,9 @@
   <tabstop>ckUseCan</tabstop>
   <tabstop>ckCanScale</tabstop>
   <tabstop>spCanScale</tabstop>
-  <tabstop>leRebinStart</tabstop>
-  <tabstop>leRebinWidth</tabstop>
-  <tabstop>leRebinEnd</tabstop>
   <tabstop>leRebinStart_CalibOnly</tabstop>
   <tabstop>leRebinWidth_CalibOnly</tabstop>
   <tabstop>leRebinEnd_CalibOnly</tabstop>
-  <tabstop>ckManualDRange</tabstop>
-  <tabstop>spDRange</tabstop>
   <tabstop>ckIndividualGrouping</tabstop>
   <tabstop>cbPlotType</tabstop>
   <tabstop>ckGSS</tabstop>
@@ -816,7 +646,7 @@
      <y>316</y>
     </hint>
     <hint type="destinationlabel">
-     <x>39</x>
+     <x>58</x>
      <y>325</y>
     </hint>
    </hints>
@@ -848,7 +678,7 @@
      <y>268</y>
     </hint>
     <hint type="destinationlabel">
-     <x>249</x>
+     <x>268</x>
      <y>287</y>
     </hint>
    </hints>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDiffractionReduction.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDiffractionReduction.ui
@@ -180,13 +180,13 @@
      </widget>
     </item>
     <item>
-     <widget class="QGroupBox" name="gbCalibOnly">
+     <widget class="QGroupBox" name="gbCalib">
       <property name="title">
        <string>Calibration</string>
       </property>
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="1" column="0">
-        <widget class="MantidQt::API::MWRunFiles" name="rfVanFile_only" native="true">
+        <widget class="MantidQt::API::MWRunFiles" name="rfVanFile" native="true">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -237,7 +237,7 @@
         </widget>
        </item>
        <item row="3" column="0">
-        <widget class="MantidQt::API::MWRunFiles" name="rfCalFile_only" native="true">
+        <widget class="MantidQt::API::MWRunFiles" name="rfCalFile" native="true">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -286,15 +286,15 @@
        </item>
       </layout>
       <zorder>ckUseCalib</zorder>
-      <zorder>rfCalFile_only</zorder>
-      <zorder>rfVanFile_only</zorder>
+      <zorder>rfCalFile</zorder>
+      <zorder>rfVanFile</zorder>
       <zorder>ckUseVanadium</zorder>
       <zorder>ckManualDRange</zorder>
       <zorder>spDRange</zorder>
      </widget>
     </item>
     <item>
-     <widget class="QGroupBox" name="gbDspaceRebinCalibOnly">
+     <widget class="QGroupBox" name="gbDspaceRebin">
       <property name="title">
        <string>Rebin in D-Spacing (optional)</string>
       </property>
@@ -306,17 +306,17 @@
         <number>6</number>
        </property>
        <item>
-        <widget class="QLabel" name="lbRebinStart_calibOnly">
+        <widget class="QLabel" name="lbRebinStart">
          <property name="text">
           <string>Start:</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="leRebinStart_CalibOnly"/>
+        <widget class="QLineEdit" name="leRebinStart"/>
        </item>
        <item>
-        <widget class="QLabel" name="valRebinStart_CalibOnly">
+        <widget class="QLabel" name="valRebinStart">
          <property name="styleSheet">
           <string notr="true">color: rgb(170, 0, 0);</string>
          </property>
@@ -326,17 +326,17 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="lbRebinWidth_CalibOnly">
+        <widget class="QLabel" name="lbRebinWidth">
          <property name="text">
           <string>Width:</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="leRebinWidth_CalibOnly"/>
+        <widget class="QLineEdit" name="leRebinWidth"/>
        </item>
        <item>
-        <widget class="QLabel" name="valRebinWidth_CalibOnly">
+        <widget class="QLabel" name="valRebinWidth">
          <property name="styleSheet">
           <string notr="true">color: rgb(170, 0, 0);</string>
          </property>
@@ -346,17 +346,17 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="lbRebinEnd_CalibOnly">
+        <widget class="QLabel" name="lbRebinEnd">
          <property name="text">
           <string>End:</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="leRebinEnd_CalibOnly"/>
+        <widget class="QLineEdit" name="leRebinEnd"/>
        </item>
        <item>
-        <widget class="QLabel" name="valRebinEnd_CalibOnly">
+        <widget class="QLabel" name="valRebinEnd">
          <property name="styleSheet">
           <string notr="true">color: rgb(170, 0, 0);</string>
          </property>
@@ -573,9 +573,9 @@
   <tabstop>ckUseCan</tabstop>
   <tabstop>ckCanScale</tabstop>
   <tabstop>spCanScale</tabstop>
-  <tabstop>leRebinStart_CalibOnly</tabstop>
-  <tabstop>leRebinWidth_CalibOnly</tabstop>
-  <tabstop>leRebinEnd_CalibOnly</tabstop>
+  <tabstop>leRebinStart</tabstop>
+  <tabstop>leRebinWidth</tabstop>
+  <tabstop>leRebinEnd</tabstop>
   <tabstop>ckIndividualGrouping</tabstop>
   <tabstop>cbPlotType</tabstop>
   <tabstop>ckGSS</tabstop>
@@ -638,7 +638,7 @@
   <connection>
    <sender>ckUseCalib</sender>
    <signal>toggled(bool)</signal>
-   <receiver>rfCalFile_only</receiver>
+   <receiver>rfCalFile</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -670,7 +670,7 @@
   <connection>
    <sender>ckUseVanadium</sender>
    <signal>toggled(bool)</signal>
-   <receiver>rfVanFile_only</receiver>
+   <receiver>rfVanFile</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -77,9 +77,9 @@ void IndirectDiffractionReduction::initLayout() {
   m_uiForm.leRebinStart->setValidator(m_valDbl);
   m_uiForm.leRebinWidth->setValidator(m_valDbl);
   m_uiForm.leRebinEnd->setValidator(m_valDbl);
-  m_uiForm.leRebinStart_CalibOnly->setValidator(m_valDbl);
-  m_uiForm.leRebinWidth_CalibOnly->setValidator(m_valDbl);
-  m_uiForm.leRebinEnd_CalibOnly->setValidator(m_valDbl);
+  //m_uiForm.leRebinStart_CalibOnly->setValidator(m_valDbl);
+  //m_uiForm.leRebinWidth_CalibOnly->setValidator(m_valDbl);
+  //m_uiForm.leRebinEnd_CalibOnly->setValidator(m_valDbl);
 
   // Update the list of plot options when individual grouping is toggled
   connect(m_uiForm.ckIndividualGrouping, SIGNAL(stateChanged(int)), this,
@@ -301,9 +301,9 @@ void IndirectDiffractionReduction::saveReductions() {
 void IndirectDiffractionReduction::runGenericReduction(QString instName,
                                                        QString mode) {
   // Get rebin string
-  QString rebinStart = m_uiForm.leRebinStart_CalibOnly->text();
-  QString rebinWidth = m_uiForm.leRebinWidth_CalibOnly->text();
-  QString rebinEnd = m_uiForm.leRebinEnd_CalibOnly->text();
+  QString rebinStart = m_uiForm.leRebinStart->text();
+  QString rebinWidth = m_uiForm.leRebinWidth->text();
+  QString rebinEnd = m_uiForm.leRebinEnd->text();
 
   QString rebin = "";
   if (!rebinStart.isEmpty() && !rebinWidth.isEmpty() && !rebinEnd.isEmpty())
@@ -335,13 +335,13 @@ void IndirectDiffractionReduction::runGenericReduction(QString instName,
   // Check if Cal file is used
   if (instName == "OSIRIS" && mode == "diffspec") {
     if (m_uiForm.ckUseCalib->isChecked()) {
-      const auto calFile = m_uiForm.rfCalFile_only->getText().toStdString();
+      const auto calFile = m_uiForm.rfCalFile->getText().toStdString();
       msgDiffReduction->setProperty("CalFile", calFile);
     }
   }
   if (mode == "diffspec") {
     const auto vanFile =
-        m_uiForm.rfVanFile_only->getFilenames().join(",").toStdString();
+        m_uiForm.rfVanFile->getFilenames().join(",").toStdString();
     msgDiffReduction->setProperty("VanadiumFiles", vanFile);
   }
   msgDiffReduction->setProperty("SumFiles", m_uiForm.ckSumFiles->isChecked());
@@ -414,7 +414,7 @@ void IndirectDiffractionReduction::runOSIRISdiffonlyReduction() {
       "Sample", m_uiForm.rfSampleFiles->getFilenames().join(",").toStdString());
   osirisDiffReduction->setProperty(
       "Vanadium",
-      m_uiForm.rfVanadiumFile->getFilenames().join(",").toStdString());
+      m_uiForm.rfVanFile->getFilenames().join(",").toStdString());
   osirisDiffReduction->setProperty(
       "CalFile", m_uiForm.rfCalFile->getFirstFilename().toStdString());
   osirisDiffReduction->setProperty("LoadLogFiles",
@@ -524,7 +524,7 @@ void IndirectDiffractionReduction::instrumentSelected(
   // Set the search instrument for runs
   m_uiForm.rfSampleFiles->setInstrumentOverride(instrumentName);
   m_uiForm.rfCanFiles->setInstrumentOverride(instrumentName);
-  m_uiForm.rfVanFile_only->setInstrumentOverride(instrumentName);
+  m_uiForm.rfVanFile->setInstrumentOverride(instrumentName);
 
   MatrixWorkspace_sptr instWorkspace = loadInstrument(
       instrumentName.toStdString(), reflectionName.toStdString());
@@ -537,44 +537,29 @@ void IndirectDiffractionReduction::instrumentSelected(
   m_uiForm.spSpecMin->setValue(static_cast<int>(specMin));
   m_uiForm.spSpecMax->setValue(static_cast<int>(specMax));
 
-  // Determine whether we need vanadium input
-  std::vector<std::string> correctionVector =
-      instrument->getStringParameter("Workflow.Diffraction.Correction");
-  bool vanadiumNeeded = false;
-  bool calibNeeded = false;
-  if (correctionVector.size() > 0) {
-    vanadiumNeeded = (correctionVector[0] == "Vanadium");
-    calibNeeded = (correctionVector[0] == "Calibration");
-  }
 
-  if (vanadiumNeeded)
-    m_uiForm.swVanadium->setCurrentIndex(0);
-  else if (calibNeeded)
-    m_uiForm.swVanadium->setCurrentIndex(1);
-  else if (reflectionName != "diffspec")
-    m_uiForm.swVanadium->setCurrentIndex(2);
-  else
-    m_uiForm.swVanadium->setCurrentIndex(1);
-
-  // Hide options that the current instrument config cannot process
 
   // Disable calibration for IRIS
   if (instrumentName == "IRIS") {
-    m_uiForm.ckUseCalib->setEnabled(false);
-    m_uiForm.ckUseCalib->setToolTip("IRIS does not support calibration files");
-    m_uiForm.ckUseCalib->setChecked(false);
+    m_uiForm.ckUseCalib->setVisible(false);
+    m_uiForm.rfCalFile->setVisible(false);
   } else {
-    m_uiForm.ckUseCalib->setEnabled(true);
-    m_uiForm.ckUseCalib->setToolTip("");
-    m_uiForm.ckUseCalib->setChecked(true);
+    m_uiForm.ckUseCalib->setVisible(true);
+    m_uiForm.rfCalFile->setVisible(true);
   }
 
   if (instrumentName == "OSIRIS" && reflectionName == "diffonly") {
     // Disable individual grouping
-    m_uiForm.ckIndividualGrouping->setToolTip(
-        "OSIRIS cannot group detectors individually in diffonly mode");
-    m_uiForm.ckIndividualGrouping->setEnabled(false);
-    m_uiForm.ckIndividualGrouping->setChecked(false);
+    m_uiForm.gbGeneralOptions->setVisible(false);
+    // Disable rebin
+    m_uiForm.gbDspaceRebin->setVisible(false);
+    // needs both vanadium & calib files, no need for checkboxes
+    m_uiForm.ckUseCan->setVisible(false);
+    m_uiForm.rfCalFile->setEnabled(true);
+    m_uiForm.ckUseVanadium->setVisible(false);
+    m_uiForm.rfVanFile->setEnabled(true);
+
+
 
     // Disable sum files
     m_uiForm.ckSumFiles->setToolTip("OSIRIS cannot sum files in diffonly mode");
@@ -628,7 +613,7 @@ void IndirectDiffractionReduction::loadSettings() {
   m_uiForm.rfSampleFiles->readSettings(settings.group());
   m_uiForm.rfCalFile->readSettings(settings.group());
   m_uiForm.rfCalFile->setUserInput(settings.value("last_cal_file").toString());
-  m_uiForm.rfVanadiumFile->setUserInput(
+  m_uiForm.rfVanFile->setUserInput(
       settings.value("last_van_files").toString());
   settings.endGroup();
 }
@@ -638,7 +623,7 @@ void IndirectDiffractionReduction::saveSettings() {
 
   settings.beginGroup(m_settingsGroup);
   settings.setValue("last_cal_file", m_uiForm.rfCalFile->getText());
-  settings.setValue("last_van_files", m_uiForm.rfVanadiumFile->getText());
+  settings.setValue("last_van_files", m_uiForm.rfVanFile->getText());
   settings.endGroup();
 }
 
@@ -691,7 +676,7 @@ bool IndirectDiffractionReduction::validateVanCal() {
   if (!m_uiForm.rfCalFile->isValid())
     return false;
 
-  if (!m_uiForm.rfVanadiumFile->isValid())
+  if (!m_uiForm.rfVanFile->isValid())
     return false;
 
   return true;
@@ -704,31 +689,31 @@ bool IndirectDiffractionReduction::validateVanCal() {
 */
 bool IndirectDiffractionReduction::validateCalOnly() {
   // Check Calib file valid
-  if (m_uiForm.ckUseCalib->isChecked() && !m_uiForm.rfCalFile_only->isValid())
+  if (m_uiForm.ckUseCalib->isChecked() && !m_uiForm.rfCalFile->isValid())
     return false;
 
   // Check rebin values valid
-  QString rebStartTxt = m_uiForm.leRebinStart_CalibOnly->text();
-  QString rebStepTxt = m_uiForm.leRebinWidth_CalibOnly->text();
-  QString rebEndTxt = m_uiForm.leRebinEnd_CalibOnly->text();
+  QString rebStartTxt = m_uiForm.leRebinStart->text();
+  QString rebStepTxt = m_uiForm.leRebinWidth->text();
+  QString rebEndTxt = m_uiForm.leRebinEnd->text();
 
   bool rebinValid = true;
   // Need all or none
   if (rebStartTxt.isEmpty() && rebStepTxt.isEmpty() && rebEndTxt.isEmpty()) {
     rebinValid = true;
-    m_uiForm.valRebinStart_CalibOnly->setText("");
-    m_uiForm.valRebinWidth_CalibOnly->setText("");
-    m_uiForm.valRebinEnd_CalibOnly->setText("");
+    m_uiForm.valRebinStart->setText("");
+    m_uiForm.valRebinWidth->setText("");
+    m_uiForm.valRebinEnd->setText("");
   } else {
 
-    CHECK_VALID(rebStartTxt, m_uiForm.valRebinStart_CalibOnly);
-    CHECK_VALID(rebStepTxt, m_uiForm.valRebinWidth_CalibOnly);
-    CHECK_VALID(rebEndTxt, m_uiForm.valRebinEnd_CalibOnly);
+    CHECK_VALID(rebStartTxt, m_uiForm.valRebinStart);
+    CHECK_VALID(rebStepTxt, m_uiForm.valRebinWidth);
+    CHECK_VALID(rebEndTxt, m_uiForm.valRebinEnd);
 
     if (rebinValid && rebStartTxt.toDouble() >= rebEndTxt.toDouble()) {
       rebinValid = false;
-      m_uiForm.valRebinStart_CalibOnly->setText("*");
-      m_uiForm.valRebinEnd_CalibOnly->setText("*");
+      m_uiForm.valRebinStart->setText("*");
+      m_uiForm.valRebinEnd->setText("*");
     }
   }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -301,9 +301,9 @@ void IndirectDiffractionReduction::saveReductions() {
 void IndirectDiffractionReduction::runGenericReduction(QString instName,
                                                        QString mode) {
   // Get rebin string
-  QString rebinStart = m_uiForm.leRebinStart->text();
-  QString rebinWidth = m_uiForm.leRebinWidth->text();
-  QString rebinEnd = m_uiForm.leRebinEnd->text();
+  QString rebinStart = m_uiForm.leRebinStart_CalibOnly->text();
+  QString rebinWidth = m_uiForm.leRebinWidth_CalibOnly->text();
+  QString rebinEnd = m_uiForm.leRebinEnd_CalibOnly->text();
 
   QString rebin = "";
   if (!rebinStart.isEmpty() && !rebinWidth.isEmpty() && !rebinEnd.isEmpty())

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -77,9 +77,9 @@ void IndirectDiffractionReduction::initLayout() {
   m_uiForm.leRebinStart->setValidator(m_valDbl);
   m_uiForm.leRebinWidth->setValidator(m_valDbl);
   m_uiForm.leRebinEnd->setValidator(m_valDbl);
-  //m_uiForm.leRebinStart_CalibOnly->setValidator(m_valDbl);
-  //m_uiForm.leRebinWidth_CalibOnly->setValidator(m_valDbl);
-  //m_uiForm.leRebinEnd_CalibOnly->setValidator(m_valDbl);
+  // m_uiForm.leRebinStart_CalibOnly->setValidator(m_valDbl);
+  // m_uiForm.leRebinWidth_CalibOnly->setValidator(m_valDbl);
+  // m_uiForm.leRebinEnd_CalibOnly->setValidator(m_valDbl);
 
   // Update the list of plot options when individual grouping is toggled
   connect(m_uiForm.ckIndividualGrouping, SIGNAL(stateChanged(int)), this,
@@ -413,8 +413,7 @@ void IndirectDiffractionReduction::runOSIRISdiffonlyReduction() {
   osirisDiffReduction->setProperty(
       "Sample", m_uiForm.rfSampleFiles->getFilenames().join(",").toStdString());
   osirisDiffReduction->setProperty(
-      "Vanadium",
-      m_uiForm.rfVanFile->getFilenames().join(",").toStdString());
+      "Vanadium", m_uiForm.rfVanFile->getFilenames().join(",").toStdString());
   osirisDiffReduction->setProperty(
       "CalFile", m_uiForm.rfCalFile->getFirstFilename().toStdString());
   osirisDiffReduction->setProperty("LoadLogFiles",
@@ -541,8 +540,6 @@ void IndirectDiffractionReduction::instrumentSelected(
   m_uiForm.ckManualDRange->setVisible(false);
   m_uiForm.spDRange->setVisible(false);
 
-
-
   if (instrumentName == "OSIRIS" && reflectionName == "diffonly") {
     // Disable individual grouping
     m_uiForm.gbGeneralOptions->setVisible(false);
@@ -589,8 +586,7 @@ void IndirectDiffractionReduction::instrumentSelected(
   if (instrumentName == "IRIS") {
     m_uiForm.ckUseCalib->setVisible(false);
     m_uiForm.rfCalFile->setVisible(false);
-  }
-  else {
+  } else {
     m_uiForm.ckUseCalib->setVisible(true);
     m_uiForm.rfCalFile->setVisible(true);
   }
@@ -598,11 +594,9 @@ void IndirectDiffractionReduction::instrumentSelected(
   // Disable calibration for diffonly
   if (instrumentName != "OSIRIS" && reflectionName == "diffonly") {
     m_uiForm.gbCalib->setVisible(false);
-  }
-  else {
+  } else {
     m_uiForm.gbCalib->setVisible(true);
   }
-
 }
 
 /**
@@ -636,8 +630,7 @@ void IndirectDiffractionReduction::loadSettings() {
   m_uiForm.rfSampleFiles->readSettings(settings.group());
   m_uiForm.rfCalFile->readSettings(settings.group());
   m_uiForm.rfCalFile->setUserInput(settings.value("last_cal_file").toString());
-  m_uiForm.rfVanFile->setUserInput(
-      settings.value("last_van_files").toString());
+  m_uiForm.rfVanFile->setUserInput(settings.value("last_van_files").toString());
   settings.endGroup();
 }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -537,16 +537,11 @@ void IndirectDiffractionReduction::instrumentSelected(
   m_uiForm.spSpecMin->setValue(static_cast<int>(specMin));
   m_uiForm.spSpecMax->setValue(static_cast<int>(specMax));
 
+  // manual d-range is disabled by default
+  m_uiForm.ckManualDRange->setVisible(false);
+  m_uiForm.spDRange->setVisible(false);
 
 
-  // Disable calibration for IRIS
-  if (instrumentName == "IRIS") {
-    m_uiForm.ckUseCalib->setVisible(false);
-    m_uiForm.rfCalFile->setVisible(false);
-  } else {
-    m_uiForm.ckUseCalib->setVisible(true);
-    m_uiForm.rfCalFile->setVisible(true);
-  }
 
   if (instrumentName == "OSIRIS" && reflectionName == "diffonly") {
     // Disable individual grouping
@@ -554,12 +549,14 @@ void IndirectDiffractionReduction::instrumentSelected(
     // Disable rebin
     m_uiForm.gbDspaceRebin->setVisible(false);
     // needs both vanadium & calib files, no need for checkboxes
-    m_uiForm.ckUseCan->setVisible(false);
+    m_uiForm.ckUseCalib->setVisible(false);
     m_uiForm.rfCalFile->setEnabled(true);
     m_uiForm.ckUseVanadium->setVisible(false);
     m_uiForm.rfVanFile->setEnabled(true);
 
-
+    // enable manual d-range
+    m_uiForm.ckManualDRange->setVisible(true);
+    m_uiForm.spDRange->setVisible(true);
 
     // Disable sum files
     m_uiForm.ckSumFiles->setToolTip("OSIRIS cannot sum files in diffonly mode");
@@ -573,13 +570,39 @@ void IndirectDiffractionReduction::instrumentSelected(
     m_uiForm.ckSumFiles->setChecked(true);
 
     // Re-enable individual grouping
-    m_uiForm.ckIndividualGrouping->setToolTip("");
-    m_uiForm.ckIndividualGrouping->setEnabled(true);
+    m_uiForm.gbGeneralOptions->setVisible(true);
+
+    // Re-enable rebin
+    m_uiForm.gbDspaceRebin->setVisible(true);
+    // re-enable checkboxes
+    m_uiForm.ckUseCalib->setVisible(true);
+    m_uiForm.rfCalFile->setEnabled(m_uiForm.ckUseCalib->isChecked());
+    m_uiForm.ckUseVanadium->setVisible(true);
+    m_uiForm.rfVanFile->setEnabled(m_uiForm.ckUseVanadium->isChecked());
 
     // Re-enable spectra range
     m_uiForm.spSpecMin->setEnabled(true);
     m_uiForm.spSpecMax->setEnabled(true);
   }
+
+  // Disable calibration for IRIS
+  if (instrumentName == "IRIS") {
+    m_uiForm.ckUseCalib->setVisible(false);
+    m_uiForm.rfCalFile->setVisible(false);
+  }
+  else {
+    m_uiForm.ckUseCalib->setVisible(true);
+    m_uiForm.rfCalFile->setVisible(true);
+  }
+
+  // Disable calibration for diffonly
+  if (instrumentName != "OSIRIS" && reflectionName == "diffonly") {
+    m_uiForm.gbCalib->setVisible(false);
+  }
+  else {
+    m_uiForm.gbCalib->setVisible(true);
+  }
+
 }
 
 /**


### PR DESCRIPTION
The Indirect Diffraction interface now correctly performs a rebin in d-spacing when in diffspec mode

**To test:**

Requires access to ISIS data archive

Interfaces>Indirect>Diffraction

Instrument: IRIS
Mode: diffspec

Run: 26176
Vanadium: 26173

Fill in some values for rebin eg `3.0` `0.01` `5.0`

press `Run`

ensure resulting workspace has been rebinned in d-spacing as specified.

Fixes #19610 .

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
