### PR TITLE
Fix scale bug in old reflectometry interface

### DIFF
--- a/docs/source/release/v3.10.0/reflectometry.rst
+++ b/docs/source/release/v3.10.0/reflectometry.rst
@@ -49,6 +49,7 @@ ISIS Reflectometry (Old)
 ########################
 
 - Interface `ISIS Reflectometry` has been renamed to `ISIS Reflectometry (Old)`.
+- Fixed a bug where the stitched output was not scaled correctly.
 
 |
 

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -784,13 +784,14 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
                         # Populate runlist
                         first_wq = None
                         for i in range(0, len(runno)):
-                            theta, qmin, qmax, _wlam, _wqBinned, wq = self._do_run(runno[i], row, i)
+                            theta, qmin, qmax, _wlam, wqBinnedAndScaled, _wqUnBinnedAndUnScaled = \
+                                self._do_run(runno[i], row, i)
                             if not first_wq:
-                                first_wq = wq # Cache the first Q workspace
+                                first_wq = wqBinnedAndScaled # Cache the first Q workspace
                             theta = round(theta, 3)
                             qmin = round(qmin, 3)
                             qmax = round(qmax, 3)
-                            wksp.append(wq.name())
+                            wksp.append(wqBinnedAndScaled.name())
                             if self.tableMain.item(row, i * 5 + 1).text() == '':
                                 item = QtGui.QTableWidgetItem()
                                 item.setText(str(theta))


### PR DESCRIPTION
Fixes #19542

**To test:**

This can only be tested at ISIS

1. Open the old reflectometry GUI.
2. Select SURF
3. Make sure you log into iCat
4. Set the following entries.
   * Run(s): 118375
   * Angle1: 0.35
   * trans1: 118369
   * Run(s): 118376 
   * trans2: 118369
   * Run(s): 118377 
   * trans3: 118369
   * dq/q: 0.05
   * Enable stitched.
5. Leave the scale entry blank and press Process. Rename the resulting stitched workspace 
6. Do the same thing again as above, but set scale to 0.5
7. Compare the stitched workspace with the old (renamed) stitched workspace. They should be offset

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
