### PR TITLE
Muon analysis GUI bugs

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
@@ -103,8 +103,6 @@ private slots:
   void guessAlphaClicked();
   void handleGroupBox();
   void handlePeriodBox();
-  void setChosenGroupSlot(QString &group);
-  void setChosenPeriodSlot(QString &period);
   /// Checks whether two specified periods are equal and, if they are, sets
   /// second one to None
   void checkForEqualPeriods();
@@ -569,6 +567,8 @@ private:
 
   /// Set the Grouping and Data Analysis tabs enabled/disabled
   void setAnalysisTabsEnabled(const bool enabled);
+
+  void setChosenGroupAndPeriods(const QString &wsName);
 };
 }
 }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -321,21 +321,20 @@ void MuonAnalysis::initLayout() {
 }
 
 void MuonAnalysis::setChosenGroupAndPeriods(const QString &wsName) {
-	const auto wsParams =
-		MuonAnalysisHelper::parseWorkspaceName(wsName.toStdString());
+  const auto wsParams =
+      MuonAnalysisHelper::parseWorkspaceName(wsName.toStdString());
 
-	const QString &groupToSet = QString::fromStdString(wsParams.itemName);
-	const QString &periodToSet = QString::fromStdString(wsParams.periods);
-	const auto &groups = m_dataSelector->getChosenGroups();
-	const auto &periods = m_dataSelector->getPeriodSelections();
-	if (!groups.contains(groupToSet)) {
-		m_uiForm.fitBrowser->setChosenGroup(groupToSet);
-	}
-	if (!periodToSet.isEmpty() && !periods.contains(periodToSet)) {
-		m_uiForm.fitBrowser->setChosenPeriods(periodToSet);
-	}
+  const QString &groupToSet = QString::fromStdString(wsParams.itemName);
+  const QString &periodToSet = QString::fromStdString(wsParams.periods);
+  const auto &groups = m_dataSelector->getChosenGroups();
+  const auto &periods = m_dataSelector->getPeriodSelections();
+  if (!groups.contains(groupToSet)) {
+    m_uiForm.fitBrowser->setChosenGroup(groupToSet);
+  }
+  if (!periodToSet.isEmpty() && !periods.contains(periodToSet)) {
+    m_uiForm.fitBrowser->setChosenPeriods(periodToSet);
+  }
 }
-
 
 /**
 * Muon Analysis help (slot)
@@ -1500,17 +1499,16 @@ void MuonAnalysis::updateFrontAndCombo() {
 
   int numG = numGroups();
   int numP = numPairs();
-  QStringList groupsAndPairs; 
+  QStringList groupsAndPairs;
   for (int i = 0; i < numG; i++) {
-	  m_uiForm.frontGroupGroupPairComboBox->addItem(
-		  m_uiForm.groupTable->item(m_groupToRow[i], 0)->text());
-	  groupsAndPairs << m_uiForm.groupTable->item(m_groupToRow[i], 0)->text();
+    m_uiForm.frontGroupGroupPairComboBox->addItem(
+        m_uiForm.groupTable->item(m_groupToRow[i], 0)->text());
+    groupsAndPairs << m_uiForm.groupTable->item(m_groupToRow[i], 0)->text();
   }
   for (int i = 0; i < numP; i++) {
-	  m_uiForm.frontGroupGroupPairComboBox->addItem(
-		  m_uiForm.pairTable->item(m_pairToRow[i], 0)->text());
-	  groupsAndPairs << m_uiForm.groupTable->item(m_pairToRow[i], 0)->text();
-
+    m_uiForm.frontGroupGroupPairComboBox->addItem(
+        m_uiForm.pairTable->item(m_pairToRow[i], 0)->text());
+    groupsAndPairs << m_uiForm.groupTable->item(m_pairToRow[i], 0)->text();
   }
   m_uiForm.fitBrowser->setAvailableGroups(groupsAndPairs);
   // If it doesn't match then reset
@@ -1875,7 +1873,7 @@ void MuonAnalysis::selectMultiPeak(const QString &wsName,
 
     // Set the selected run, group/pair and period
     m_fitDataPresenter->setAssignedFirstRun(wsName, filePath);
-	setChosenGroupAndPeriods(wsName);
+    setChosenGroupAndPeriods(wsName);
   }
 
   QString code;
@@ -2512,7 +2510,7 @@ void MuonAnalysis::changeTab(int newTabIndex) {
       const boost::optional<QString> filePath =
           m_uiForm.mwRunFiles->getUserInput().toString();
       m_fitDataPresenter->setSelectedWorkspace(m_currentDataName, filePath);
-	  setChosenGroupAndPeriods(m_currentDataName);
+      setChosenGroupAndPeriods(m_currentDataName);
       selectMultiPeak(m_currentDataName, filePath);
     }
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1503,18 +1503,24 @@ void MuonAnalysis::updateFrontAndCombo() {
   for (int i = 0; i < numG; i++) {
     m_uiForm.frontGroupGroupPairComboBox->addItem(
         m_uiForm.groupTable->item(m_groupToRow[i], 0)->text());
-    groupsAndPairs << m_uiForm.groupTable->item(m_groupToRow[i], 0)->text();
+	auto groupName=m_uiForm.groupTable->item(m_groupToRow[i], 0)->text();
+	if (groupName.toStdString() != "") {
+		groupsAndPairs << groupName;
+	}
   }
   for (int i = 0; i < numP; i++) {
     m_uiForm.frontGroupGroupPairComboBox->addItem(
         m_uiForm.pairTable->item(m_pairToRow[i], 0)->text());
-    groupsAndPairs << m_uiForm.groupTable->item(m_pairToRow[i], 0)->text();
+	auto pairName= m_uiForm.groupTable->item(m_pairToRow[i], 0)->text();
+	if (pairName.toStdString() != "") {
+		groupsAndPairs << pairName;
+	}
   }
-  m_uiForm.fitBrowser->setAvailableGroups(groupsAndPairs);
   // If it doesn't match then reset
   if (currentI >= m_uiForm.frontGroupGroupPairComboBox->count()) {
     currentI = 0;
   }
+  m_uiForm.fitBrowser->setAvailableGroups(groupsAndPairs);
 
   setGroupOrPairAndReplot(currentI);
 }

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1503,18 +1503,18 @@ void MuonAnalysis::updateFrontAndCombo() {
   for (int i = 0; i < numG; i++) {
     m_uiForm.frontGroupGroupPairComboBox->addItem(
         m_uiForm.groupTable->item(m_groupToRow[i], 0)->text());
-	auto groupName=m_uiForm.groupTable->item(m_groupToRow[i], 0)->text();
-	if (groupName.toStdString() != "") {
-		groupsAndPairs << groupName;
-	}
+    auto groupName = m_uiForm.groupTable->item(m_groupToRow[i], 0)->text();
+    if (groupName.toStdString() != "") {
+      groupsAndPairs << groupName;
+    }
   }
   for (int i = 0; i < numP; i++) {
     m_uiForm.frontGroupGroupPairComboBox->addItem(
         m_uiForm.pairTable->item(m_pairToRow[i], 0)->text());
-	auto pairName= m_uiForm.groupTable->item(m_pairToRow[i], 0)->text();
-	if (pairName.toStdString() != "") {
-		groupsAndPairs << pairName;
-	}
+    auto pairName = m_uiForm.groupTable->item(m_pairToRow[i], 0)->text();
+    if (pairName.toStdString() != "") {
+      groupsAndPairs << pairName;
+    }
   }
   // If it doesn't match then reset
   if (currentI >= m_uiForm.frontGroupGroupPairComboBox->count()) {

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisFitDataPresenter.cpp
@@ -787,20 +787,6 @@ void MuonAnalysisFitDataPresenter::setUpDataSelector(
   m_dataSelector->setWorkspaceDetails(
       numberString, QString::fromStdString(wsParams.instrument), filePath);
 
-  // Set selected groups/pairs and periods here too
-  // (unless extra groups/periods are already selected, in which case don't
-  // unselect them)
-  const QString &groupToSet = QString::fromStdString(wsParams.itemName);
-  const QString &periodToSet = QString::fromStdString(wsParams.periods);
-  const auto &groups = m_dataSelector->getChosenGroups();
-  const auto &periods = m_dataSelector->getPeriodSelections();
-  if (!groups.contains(groupToSet)) {
-    emit setChosenGroupSignal(groupToSet);
-  }
-  if (!periodToSet.isEmpty() && !periods.contains(periodToSet)) {
-    emit setChosenPeriodSignal(periodToSet);
-  }
-
   // If given an optional file path to "current run", cache it for later use
   if (filePath && !wsParams.runs.empty()) {
     m_currentRun = Muon::CurrentRun(wsParams.runs.front(), filePath.get());

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitPropertyBrowser.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitPropertyBrowser.h
@@ -112,7 +112,7 @@ public:
   void setAllGroups();
   void setAllPairs();
   void clearChosenPeriods() const;
-  void setChosenGroup(QString &group);
+  void setChosenGroup(const QString &group);
   void setChosenPeriods(const QString &period);
   void setSingleFitLabel(std::string name);
 public slots:

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -187,7 +187,7 @@ void MuonFitPropertyBrowser::init() {
   m_settingsGroup = m_browser->addProperty(settingsGroup);
   m_multiFitSettingsGroup = m_browser->addProperty(multiFitSettingsGroup);
   connect(m_browser, SIGNAL(currentItemChanged(QtBrowserItem *)), this,
-	  SLOT(currentItemChanged(QtBrowserItem *)));
+          SLOT(currentItemChanged(QtBrowserItem *)));
 
   m_btnGroup = new QGroupBox(tr("Reselect Data"));
   QHBoxLayout *btnLayout = new QHBoxLayout;
@@ -1108,8 +1108,8 @@ void MuonFitPropertyBrowser::setAllPairs() {
 * selection of groups/pairs
 */
 void MuonFitPropertyBrowser::genGroupWindow() {
-	//reset group window
-	m_groupWindow = new QDialog(this); 
+  // reset group window
+  m_groupWindow = new QDialog(this);
   QtGroupPropertyManager *groupManager =
       new QtGroupPropertyManager(m_groupWindow);
   QVBoxLayout *layout = new QVBoxLayout(m_groupWindow);
@@ -1276,8 +1276,8 @@ void MuonFitPropertyBrowser::setChosenPeriods(const QString &period) {
 * selection of periods
 */
 void MuonFitPropertyBrowser::genPeriodWindow() {
-	//reset period window
-	m_periodWindow = new QDialog(this);
+  // reset period window
+  m_periodWindow = new QDialog(this);
   QtGroupPropertyManager *groupManager =
       new QtGroupPropertyManager(m_periodWindow);
   QVBoxLayout *layout = new QVBoxLayout(m_periodWindow);
@@ -1300,8 +1300,8 @@ void MuonFitPropertyBrowser::genPeriodWindow() {
 * a combination of periods
 */
 void MuonFitPropertyBrowser::genCombinePeriodWindow() {
-	//reset combine window
-	m_comboWindow = new QDialog(this);
+  // reset combine window
+  m_comboWindow = new QDialog(this);
   QVBoxLayout *layout = new QVBoxLayout(m_comboWindow);
   QFormLayout *formLayout = new QFormLayout;
   m_positiveCombo = new QLineEdit();

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -178,9 +178,6 @@ void MuonFitPropertyBrowser::init() {
   multiFitSettingsGroup->addSubProperty(m_showPeriods);
   m_enumManager->setEnumNames(m_showPeriods, m_showPeriodValue);
 
-  connect(m_browser, SIGNAL(currentItemChanged(QtBrowserItem *)), this,
-          SLOT(currentItemChanged(QtBrowserItem *)));
-
   /* Create editors and assign them to the managers */
   createEditors(w);
 
@@ -189,6 +186,8 @@ void MuonFitPropertyBrowser::init() {
   m_functionsGroup = m_browser->addProperty(functionsGroup);
   m_settingsGroup = m_browser->addProperty(settingsGroup);
   m_multiFitSettingsGroup = m_browser->addProperty(multiFitSettingsGroup);
+  connect(m_browser, SIGNAL(currentItemChanged(QtBrowserItem *)), this,
+	  SLOT(currentItemChanged(QtBrowserItem *)));
 
   m_btnGroup = new QGroupBox(tr("Reselect Data"));
   QHBoxLayout *btnLayout = new QHBoxLayout;
@@ -1012,7 +1011,7 @@ void MuonFitPropertyBrowser::setAvailableGroups(const QStringList &groups) {
 * Selects a single group/pair
 * @param group :: [input] Group/pair to select
 */
-void MuonFitPropertyBrowser::setChosenGroup(QString &group) {
+void MuonFitPropertyBrowser::setChosenGroup(const QString &group) {
   clearChosenGroups();
   for (auto iter = m_groupBoxes.constBegin(); iter != m_groupBoxes.constEnd();
        ++iter) {
@@ -1109,7 +1108,8 @@ void MuonFitPropertyBrowser::setAllPairs() {
 * selection of groups/pairs
 */
 void MuonFitPropertyBrowser::genGroupWindow() {
-
+	//reset group window
+	m_groupWindow = new QDialog; 
   QtGroupPropertyManager *groupManager =
       new QtGroupPropertyManager(m_groupWindow);
   QVBoxLayout *layout = new QVBoxLayout(m_groupWindow);
@@ -1276,6 +1276,8 @@ void MuonFitPropertyBrowser::setChosenPeriods(const QString &period) {
 * selection of periods
 */
 void MuonFitPropertyBrowser::genPeriodWindow() {
+	//reset period window
+	m_periodWindow = new QDialog;
   QtGroupPropertyManager *groupManager =
       new QtGroupPropertyManager(m_periodWindow);
   QVBoxLayout *layout = new QVBoxLayout(m_periodWindow);
@@ -1298,6 +1300,8 @@ void MuonFitPropertyBrowser::genPeriodWindow() {
 * a combination of periods
 */
 void MuonFitPropertyBrowser::genCombinePeriodWindow() {
+	//reset combine window
+	m_comboWindow = new QDialog;
   QVBoxLayout *layout = new QVBoxLayout(m_comboWindow);
   QFormLayout *formLayout = new QFormLayout;
   m_positiveCombo = new QLineEdit();

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -1109,7 +1109,7 @@ void MuonFitPropertyBrowser::setAllPairs() {
 */
 void MuonFitPropertyBrowser::genGroupWindow() {
 	//reset group window
-	m_groupWindow = new QDialog; 
+	m_groupWindow = new QDialog(this); 
   QtGroupPropertyManager *groupManager =
       new QtGroupPropertyManager(m_groupWindow);
   QVBoxLayout *layout = new QVBoxLayout(m_groupWindow);
@@ -1277,7 +1277,7 @@ void MuonFitPropertyBrowser::setChosenPeriods(const QString &period) {
 */
 void MuonFitPropertyBrowser::genPeriodWindow() {
 	//reset period window
-	m_periodWindow = new QDialog;
+	m_periodWindow = new QDialog(this);
   QtGroupPropertyManager *groupManager =
       new QtGroupPropertyManager(m_periodWindow);
   QVBoxLayout *layout = new QVBoxLayout(m_periodWindow);
@@ -1301,7 +1301,7 @@ void MuonFitPropertyBrowser::genPeriodWindow() {
 */
 void MuonFitPropertyBrowser::genCombinePeriodWindow() {
 	//reset combine window
-	m_comboWindow = new QDialog;
+	m_comboWindow = new QDialog(this);
   QVBoxLayout *layout = new QVBoxLayout(m_comboWindow);
   QFormLayout *formLayout = new QFormLayout;
   m_positiveCombo = new QLineEdit();


### PR DESCRIPTION
Some bug fixes to remove messages from the terminal window when using muon analysis. 

The master branch currently produces the following messages when muon analysis is started: ``QObject::connect: Cannot connect (null)::currentItemChanged(QtBrowserItem *) to MantidQt::MantidWidgets::MuonFitPropertyBrowser::currentItemChanged(QtBrowserItem *)
Object::connect: No such signal MantidQt::MantidWidgets::MuonFitDataSelector::selectedGroupsChanged() in ../../MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp:2134
Object::connect:  (sender name:   'MuonFitDataSelector')
Object::connect:  (receiver name: 'MuonAnalysis')
Object::connect: No such signal MantidQt::MantidWidgets::MuonFitDataSelector::selectedPeriodsChanged() in ../../MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp:2136
Object::connect:  (sender name:   'MuonFitDataSelector')
Object::connect:  (receiver name: 'MuonAnalysis')
Object::connect: No such signal MantidQt::CustomInterfaces::MuonAnalysis::setChosenGroupSignal(QString &) in ../../MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp:321
Object::connect:  (sender name:   'MuonAnalysis')
Object::connect:  (receiver name: 'MuonAnalysis')
Object::connect: No such signal MantidQt::CustomInterfaces::MuonAnalysis::setChosenPeriodSignal(QString &) in ../../MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp:323
Object::connect:  (sender name:   'MuonAnalysis')
Object::connect:  (receiver name: 'MuonAnalysis')
``

This new branch should not produce these messages.

- Load some data (I suggest into HIFI 84447) muon analysis
- go to the settings tab and make sure multiple fitting is selected. 
- Go to the data analysis tab and change the selected groups and selected periods to custom. This should produce some pop ups. 
- Click the Reselect Data buttons (Groups/Pairs and Periods). In master this would produce messages about the layout already being set. In this version that should not happen. 

- In the Grouping Options tab add a group and/or pair. 
- Make sure it is in multiple fitting mode.
- In data analysis press custom for the Groups/Pairs and the added data should be included in the pop up. 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
