### PR TITLE
Indirect Diffraction Rebin

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -278,6 +278,11 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
             DeleteWorkspace(self._container_workspace)
             DeleteWorkspace(self._container_workspace + '_mon')
 
+        if self._vanadium_ws:
+            for van_ws in self._vanadium_ws:
+                DeleteWorkspace(van_ws)
+                DeleteWorkspace(van_ws+'_mon')
+
         # Rename output workspaces
         output_workspace_names = [rename_reduction(ws_name, self._sum_files) for ws_name in self._workspace_names]
 

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -300,10 +300,22 @@ void IndirectDiffractionReduction::saveReductions() {
  */
 void IndirectDiffractionReduction::runGenericReduction(QString instName,
                                                        QString mode) {
+
+  QString rebinStart = "";
+  QString rebinWidth = "";
+  QString rebinEnd = "";
+
   // Get rebin string
-  QString rebinStart = m_uiForm.leRebinStart_CalibOnly->text();
-  QString rebinWidth = m_uiForm.leRebinWidth_CalibOnly->text();
-  QString rebinEnd = m_uiForm.leRebinEnd_CalibOnly->text();
+  if (mode == "diffspec") {
+     rebinStart = m_uiForm.leRebinStart_CalibOnly->text();
+     rebinWidth = m_uiForm.leRebinWidth_CalibOnly->text();
+     rebinEnd = m_uiForm.leRebinEnd_CalibOnly->text();
+  }
+  else if (mode =="diffonly") {
+     rebinStart = m_uiForm.leRebinStart->text();
+     rebinWidth = m_uiForm.leRebinWidth->text();
+     rebinEnd = m_uiForm.leRebinEnd->text();
+  }
 
   QString rebin = "";
   if (!rebinStart.isEmpty() && !rebinWidth.isEmpty() && !rebinEnd.isEmpty())

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -301,9 +301,9 @@ void IndirectDiffractionReduction::saveReductions() {
 void IndirectDiffractionReduction::runGenericReduction(QString instName,
                                                        QString mode) {
   // Get rebin string
-  QString rebinStart = m_uiForm.leRebinStart->text();
-  QString rebinWidth = m_uiForm.leRebinWidth->text();
-  QString rebinEnd = m_uiForm.leRebinEnd->text();
+  QString rebinStart = m_uiForm.leRebinStart_CalibOnly->text();
+  QString rebinWidth = m_uiForm.leRebinWidth_CalibOnly->text();
+  QString rebinEnd = m_uiForm.leRebinEnd_CalibOnly->text();
 
   QString rebin = "";
   if (!rebinStart.isEmpty() && !rebinWidth.isEmpty() && !rebinEnd.isEmpty())

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -307,14 +307,13 @@ void IndirectDiffractionReduction::runGenericReduction(QString instName,
 
   // Get rebin string
   if (mode == "diffspec") {
-     rebinStart = m_uiForm.leRebinStart_CalibOnly->text();
-     rebinWidth = m_uiForm.leRebinWidth_CalibOnly->text();
-     rebinEnd = m_uiForm.leRebinEnd_CalibOnly->text();
-  }
-  else if (mode =="diffonly") {
-     rebinStart = m_uiForm.leRebinStart->text();
-     rebinWidth = m_uiForm.leRebinWidth->text();
-     rebinEnd = m_uiForm.leRebinEnd->text();
+    rebinStart = m_uiForm.leRebinStart_CalibOnly->text();
+    rebinWidth = m_uiForm.leRebinWidth_CalibOnly->text();
+    rebinEnd = m_uiForm.leRebinEnd_CalibOnly->text();
+  } else if (mode == "diffonly") {
+    rebinStart = m_uiForm.leRebinStart->text();
+    rebinWidth = m_uiForm.leRebinWidth->text();
+    rebinEnd = m_uiForm.leRebinEnd->text();
   }
 
   QString rebin = "";


### PR DESCRIPTION
The Indirect Diffraction interface now correctly performs a rebin in d-spacing when in diffspec mode

**To test:**

Requires access to ISIS data archive

Interfaces>Indirect>Diffraction

Instrument: IRIS
Mode: diffspec

Run: 26176
Vanadium: 26173

Fill in some values for rebin eg `3.0` `0.01` `5.0`

press Run

ensure resulting workspace has been rebinned in d-spacing as specified.

Fixes #19610 .

Does not need to be in the release notes.



---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
