### PR TITLE
Fix deletion of group workspaces in DeleteWorkspaces

### DIFF
--- a/Framework/Algorithms/src/DeleteWorkspaces.cpp
+++ b/Framework/Algorithms/src/DeleteWorkspaces.cpp
@@ -35,7 +35,7 @@ void DeleteWorkspaces::exec() {
       deleteAlg->setPropertyValue("Workspace", wsName);
       bool success = deleteAlg->execute();
       if (!deleteAlg->isExecuted() || !success) {
-        g_log.error() << "Failed to delete " <<  wsName << ".\n";
+        g_log.error() << "Failed to delete " << wsName << ".\n";
       }
     }
     prog.report();

--- a/Framework/Algorithms/src/DeleteWorkspaces.cpp
+++ b/Framework/Algorithms/src/DeleteWorkspaces.cpp
@@ -27,7 +27,7 @@ void DeleteWorkspaces::exec() {
   for (auto wsName : wsNames) {
     // run delete workspace as a child algorithm
     if (Mantid::API::AnalysisDataService::Instance().doesExist(wsName)) {
-      // The existense of input workspaces should have been verified when
+      // The existence of input workspaces should have been verified when
       // properties were set. If a workspace is missing, it was probably
       // a group workspace whose contents were deleted before the group
       // itself.
@@ -36,7 +36,7 @@ void DeleteWorkspaces::exec() {
       deleteAlg->setPropertyValue("Workspace", wsName);
       bool success = deleteAlg->execute();
       if (!deleteAlg->isExecuted() || !success) {
-        g_log.error() << "Failed to delete wsName. \n";
+        g_log.error() << "Failed to delete " <<  wsName << ".\n";
       }
     }
     prog.report();

--- a/Framework/Algorithms/src/DeleteWorkspaces.cpp
+++ b/Framework/Algorithms/src/DeleteWorkspaces.cpp
@@ -1,5 +1,6 @@
 #include "MantidAlgorithms/DeleteWorkspaces.h"
 #include "MantidAPI/ADSValidator.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidKernel/ArrayProperty.h"
 
 namespace Mantid {
@@ -22,15 +23,21 @@ void DeleteWorkspaces::exec() {
   // Set up progress reporting
   API::Progress prog(this, 0.0, 1.0, wsNames.size());
 
+  // TODO: use const ref
   for (auto wsName : wsNames) {
     // run delete workspace as a child algorithm
-    auto deleteAlg = createChildAlgorithm("DeleteWorkspace", -1, -1, false);
-    deleteAlg->initialize();
-
-    deleteAlg->setPropertyValue("Workspace", wsName);
-    bool success = deleteAlg->execute();
-    if (!deleteAlg->isExecuted() || !success) {
-      g_log.error() << "Failed to delete wsName. \n";
+    if (Mantid::API::AnalysisDataService::Instance().doesExist(wsName)) {
+      // The existense of input workspaces should have been verified when
+      // properties were set. If a workspace is missing, it was probably
+      // a group workspace whose contents were deleted before the group
+      // itself.
+      auto deleteAlg = createChildAlgorithm("DeleteWorkspace", -1, -1, false);
+      deleteAlg->initialize();
+      deleteAlg->setPropertyValue("Workspace", wsName);
+      bool success = deleteAlg->execute();
+      if (!deleteAlg->isExecuted() || !success) {
+        g_log.error() << "Failed to delete wsName. \n";
+      }
     }
     prog.report();
   }

--- a/Framework/Algorithms/src/DeleteWorkspaces.cpp
+++ b/Framework/Algorithms/src/DeleteWorkspaces.cpp
@@ -23,8 +23,7 @@ void DeleteWorkspaces::exec() {
   // Set up progress reporting
   API::Progress prog(this, 0.0, 1.0, wsNames.size());
 
-  // TODO: use const ref
-  for (auto wsName : wsNames) {
+  for (const auto &wsName : wsNames) {
     // run delete workspace as a child algorithm
     if (Mantid::API::AnalysisDataService::Instance().doesExist(wsName)) {
       // The existence of input workspaces should have been verified when

--- a/Framework/Algorithms/test/DeleteWorkspacesTest.h
+++ b/Framework/Algorithms/test/DeleteWorkspacesTest.h
@@ -22,9 +22,9 @@ public:
     const std::string testName1 = "DeleteWorkspaces_testWS1";
     const std::string testName2 = "DeleteWorkspaces_testWS2";
     const std::string testName3 = "DeleteWorkspaces_testWS3";
-    createAndStoreWorspace(testName1);
-    createAndStoreWorspace(testName2);
-    createAndStoreWorspace(testName3, yLength);
+    createAndStoreWorkspace(testName1);
+    createAndStoreWorkspace(testName2);
+    createAndStoreWorkspace(testName3, yLength);
     TS_ASSERT_EQUALS(dataStore.size(), storeSizeAtStart + 3);
 
     Mantid::Algorithms::DeleteWorkspaces alg;
@@ -59,8 +59,8 @@ public:
     const std::string testName1 = "DeleteWorkspaces_testWS1";
     const std::string testName2 = "DeleteWorkspaces_testWS2";
 
-    createAndStoreWorspace(testName1);
-    createAndStoreWorspace(testName2);
+    createAndStoreWorkspace(testName1);
+    createAndStoreWorkspace(testName2);
 
     auto group = WorkspaceGroup_sptr(new WorkspaceGroup);
     dataStore.add("group", group);
@@ -90,8 +90,8 @@ public:
     const size_t storeSizeAtStart(dataStore.size());
     const std::string testName1 = "DeleteWorkspaces_testWS1";
     const std::string testName2 = "DeleteWorkspaces_testWS2";
-    createAndStoreWorspace(testName1);
-    createAndStoreWorspace(testName2);
+    createAndStoreWorkspace(testName1);
+    createAndStoreWorkspace(testName2);
     const std::string groupName = "DeleteWorkspaces_testGroup";
     Mantid::Algorithms::GroupWorkspaces groupingAlg;
     groupingAlg.initialize();
@@ -110,8 +110,7 @@ public:
     TS_ASSERT_EQUALS(dataStore.size(), storeSizeAtStart);
   }
 
-  // TODO: fix typo in name
-  void createAndStoreWorspace(std::string name, int ylength = 10) {
+  void createAndStoreWorkspace(std::string name, int ylength = 10) {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
 

--- a/Framework/Algorithms/test/DeleteWorkspacesTest.h
+++ b/Framework/Algorithms/test/DeleteWorkspacesTest.h
@@ -81,7 +81,7 @@ public:
     dataStore.clear();
   }
 
-  void test_ignore_group_if_workspaces_inside_get_deleted_first(){
+  void test_ignore_group_if_workspaces_inside_get_deleted_first() {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
 
@@ -95,7 +95,8 @@ public:
     const std::string groupName = "DeleteWorkspaces_testGroup";
     Mantid::Algorithms::GroupWorkspaces groupingAlg;
     groupingAlg.initialize();
-    groupingAlg.setPropertyValue("InputWorkspaces", testName1 + "," + testName2);
+    groupingAlg.setPropertyValue("InputWorkspaces",
+                                 testName1 + "," + testName2);
     groupingAlg.setPropertyValue("OutputWorkspace", groupName);
     groupingAlg.execute();
     TS_ASSERT_EQUALS(dataStore.size(), storeSizeAtStart + 3);
@@ -103,7 +104,8 @@ public:
     Mantid::Algorithms::DeleteWorkspaces alg;
     alg.initialize();
     alg.setRethrows(true);
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("WorkspaceList", testName1 + ", " + testName2 + ", " + groupName));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(
+        "WorkspaceList", testName1 + ", " + testName2 + ", " + groupName));
     TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT(alg.isExecuted());
 

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -101,6 +101,7 @@ Bugs Resolved
 - Fixed an issue where some graphs not associated with a workspace would not be shown in the project save as view.
 - Fixed an issue where the Spectrum Viewer could crash when a workspace contained infinities.
 - Fixed an issue where contour lines were displayed at the wrong location.
+- Fixed an issue where some workspaces might not get deleted from the workspace dock if group workspaces were present.
 
 
 |


### PR DESCRIPTION
The [`DeleteWorkspaces`](http://docs.mantidproject.org/nightly/algorithms/DeleteWorkspaces-v1.html) algorithm would fail, if the *WorkspaceList* property listed a group workspace after all its child workspaces. This would cause, for instance, the workspace deletion from MantidPlot's dock to fail in certain cases.

**To test:**

Follow the instructions to reproduce the bug in #19677 and check that all workspaces do get deleted after applying these changes.

Fixes #19677.


*Release notes were updated accordingly.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [x] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
