### PR TITLE
PyChop LET time-distance plot bug

### DIFF
--- a/scripts/PyChop/ISISDisk.py
+++ b/scripts/PyChop/ISISDisk.py
@@ -190,10 +190,13 @@ class ISISDisk:
             res = []
             for en in Et:
                 Ef = Eis[ie] - en
-                fac = (Ef/Eis[ie])**1.5
-                chopRes = (2*chop_width[ie]/t_mod_chop) * (1+((self.samp_det+self.chop_samp+lastChopDist)/self.samp_det)*fac)
-                modRes = (2*mod_width[ie]/t_mod_chop) * (1+(self.chop_samp/self.samp_det)*fac)
-                res.append(np.sqrt(chopRes**2 + modRes**2)*Eis[ie])
+                if (Ef > 0):
+                    fac = (Ef/Eis[ie])**1.5
+                    chopRes = (2*chop_width[ie]/t_mod_chop) * (1+((self.samp_det+self.chop_samp+lastChopDist)/self.samp_det)*fac)
+                    modRes = (2*mod_width[ie]/t_mod_chop) * (1+(self.chop_samp/self.samp_det)*fac)
+                    res.append(np.sqrt(chopRes**2 + modRes**2)*Eis[ie])
+                else:
+                    res.append(np.nan)
             if len(ie_list) == 1:
                 res_list = res
             else:
@@ -450,6 +453,6 @@ class ISISDisk:
         if Ei:
             idx1 = (np.abs(Eis - Ei) / np.abs(Eis)) < 0.1
             idx += idx1
-        Eis = np.array([Eis[i] for i in range(len(Eis)) if idx[i]])
-        lines = np.array([lines[i] for i in range(len(lines)) if idx[i]])
+        Eis = Eis[idx]
+        lines = np.array(lines)[idx]
         return Eis, lines

--- a/scripts/PyChop/ISISDisk.py
+++ b/scripts/PyChop/ISISDisk.py
@@ -451,5 +451,5 @@ class ISISDisk:
             idx1 = (np.abs(Eis - Ei) / np.abs(Eis)) < 0.1
             idx += idx1
         Eis = np.array([Eis[i] for i in range(len(Eis)) if idx[i]])
-        lines = np.array([lines[i] for i in range(len(Eis)) if idx[i]])
+        lines = np.array([lines[i] for i in range(len(lines)) if idx[i]])
         return Eis, lines


### PR DESCRIPTION
Fixes an error in the list comprehension to remove high energy reps with zero intensity for `PyChop` on `LET`.

**To test:**

Run PyChop, and select LET as the instrument. Check the "Show multi-reps" box and check that the number of reps plotted in the resolution tab and the time-distance tab is the same - see the issue for further details.

Fixes #19688.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
