### PR TITLE
Fixed bug in Refl GUI that allowed table workspaces to be available for saving

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSaveTabPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSaveTabPresenter.h
@@ -64,9 +64,6 @@ private:
   /// Obtains all available workspace names
   std::vector<std::string> getAvailableWorkspaceNames();
 
-  /// Predicate to checks if a workspace is of a group or table workspace type
-  struct isGroupOrTable;
-
   /// The view
   IReflSaveTabView *m_view;
   /// The main presenter

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSaveTabPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflSaveTabPresenter.h
@@ -64,6 +64,9 @@ private:
   /// Obtains all available workspace names
   std::vector<std::string> getAvailableWorkspaceNames();
 
+  /// Predicate to checks if a workspace is of a group or table workspace type
+  struct isGroupOrTable;
+
   /// The view
   IReflSaveTabView *m_view;
   /// The main presenter

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflSaveTabPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflSaveTabPresenter.cpp
@@ -205,8 +205,7 @@ struct ReflSaveTabPresenter::isGroupOrTable {
 /** Obtains all available workspace names to save
 * @return :: list of workspace names
 */
-std::vector<std::string>
-ReflSaveTabPresenter::getAvailableWorkspaceNames() {
+std::vector<std::string> ReflSaveTabPresenter::getAvailableWorkspaceNames() {
   auto allNames = AnalysisDataService::Instance().getObjectNames();
   // Exclude workspace groups and table workspaces as they cannot be saved to
   // ascii

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflSaveTabPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflSaveTabPresenter.cpp
@@ -192,16 +192,6 @@ void ReflSaveTabPresenter::suggestSaveDir() {
   m_view->setSavePath(path);
 }
 
-/** Predicate to checks if a workspace is either of group or table types or not
-*/
-struct ReflSaveTabPresenter::isGroupOrTable {
-
-  bool operator()(const std::string &wsName) {
-    return AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(wsName) ||
-           AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(wsName);
-  }
-};
-
 /** Obtains all available workspace names to save
 * @return :: list of workspace names
 */
@@ -210,8 +200,14 @@ std::vector<std::string> ReflSaveTabPresenter::getAvailableWorkspaceNames() {
   // Exclude workspace groups and table workspaces as they cannot be saved to
   // ascii
   std::vector<std::string> validNames;
-  std::remove_copy_if(allNames.begin(), allNames.end(),
-                      std::back_inserter(validNames), isGroupOrTable());
+  std::remove_copy_if(
+      allNames.begin(), allNames.end(), std::back_inserter(validNames),
+      [](const std::string &wsName) {
+        return AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+                   wsName) ||
+               AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(
+                   wsName);
+      });
 
   return validNames;
 }

--- a/MantidQt/CustomInterfaces/test/ReflSaveTabPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflSaveTabPresenterTest.h
@@ -44,6 +44,7 @@ public:
     createWS(wsNames[0]);
     createWS(wsNames[1]);
     createWS(wsNames[2]);
+    createTableWS("tableWS");
 
     // Group workspaces 1 and 2 together
     IAlgorithm_sptr groupAlg =
@@ -53,7 +54,8 @@ public:
     groupAlg->execute();
 
     EXPECT_CALL(mockView, clearWorkspaceList()).Times(Exactly(1));
-    // Workspace 'groupWs' should not be included in the workspace list
+    // Workspaces 'groupWs' and 'tableWS' should not be included in the
+    // workspace list
     EXPECT_CALL(mockView, setWorkspaceList(wsNames)).Times(Exactly(1));
     presenter.notify(IReflSaveTabPresenter::populateWorkspaceListFlag);
     AnalysisDataService::Instance().clear();
@@ -210,6 +212,12 @@ public:
 private:
   void createWS(std::string name) {
     Workspace2D_sptr ws = WorkspaceCreationHelper::create2DWorkspace(10, 10);
+    AnalysisDataService::Instance().addOrReplace(name, ws);
+  }
+
+  void createTableWS(std::string name) {
+    ITableWorkspace_sptr ws =
+        WorkspaceFactory::Instance().createTable("TableWorkspace");
     AnalysisDataService::Instance().addOrReplace(name, ws);
   }
 

--- a/docs/source/interfaces/ISIS_Reflectometry.rst
+++ b/docs/source/interfaces/ISIS_Reflectometry.rst
@@ -510,11 +510,12 @@ ASCII formats. The filenames are saved in the form [Prefix][Workspace Name].[ext
 |                               | to be used for filtering workspace names.            |
 +-------------------------------+------------------------------------------------------+
 | List Of Workspaces            | The left listbox will contain any workspaces loaded  |
-|                               | into mantid. Double clicking on one will fill        |
-|                               | the right list box with the parameters it contains.  |
-|                               | This listbox supports multi-select in order to       |
-|                               | allow for multiple workspaces to be saved out        |
-|                               | at the same time with the same settings.             |
+|                               | into mantid (excluding group and table workspaces).  |
+|                               | Double clicking on one will fill the right list box  |
+|                               | with the parameters it contains. This listbox        |
+|                               | supports multi-select in order to allow for multiple |
+|                               | workspaces to be saved out at the same time with the |
+|                               | same settings.                                       |
 +-------------------------------+------------------------------------------------------+
 | List Of Logged Parameters     | The right listbox starts out empty, but will fill    |
 |                               | with parameter names when a workspace in the left    |

--- a/docs/source/release/v3.10.0/reflectometry.rst
+++ b/docs/source/release/v3.10.0/reflectometry.rst
@@ -27,6 +27,7 @@ ISIS Reflectometry
 ##################
 
 - Interface `ISIS Reflectometry (Polref)` has been renamed to `ISIS Reflectometry`.
+- Fixed a bug that incorrectly allowed table workspaces to appear in the list of workspaces in the `Save ASCII` tab.
 - Fixed a bug where the contents of the processing table where not saved to the selected table workspace.
 - Added two new buttons `Expand Groups` and `Collapse Groups` which expand and collapse all groups in the table respectively.
 - Fixed a bug when removing rows from the processing table.


### PR DESCRIPTION
Description of work.

In the `Save ASCII` tab of the Reflectometry interface, the `List of Workspaces` list shows all the workspaces that can are available for saving in ASCII format. This however mistakenly included table workspaces which could not be saved to ASCII format. Attempting to select one and save it resulted in Mantid crashing. This PR fixes this issue by preventing table workspaces from appearing in the list.

**To test:**

- Code review.
- Open the `Reflectometry` interface and import `INTER_NR_test2.tbl`, giving the output table workspace some name.
- Navigate to the `Save ASCII` tab and refresh `List of Workspaces`. The table workspace name should no longer appear there.

<!-- Instructions for testing. -->

Fixes #19692.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Release notes have been updated*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
