### PR TITLE
Fix latex error in CountReflections docs

### DIFF
--- a/docs/source/algorithms/CountReflections-v1.rst
+++ b/docs/source/algorithms/CountReflections-v1.rst
@@ -30,7 +30,7 @@ From this assignment it is possible to calculate the following indicators:
 
 Furthermore, the algorithm optionally produces a list of missing reflections. In this list,
 each missing unique reflection is expanded to all symmetry equivalents according to the point
-group. For example, if the reflection family :math:`\left{001\right}` was missing
+group. For example, if the reflection family :math:`\{001\}` was missing
 with point group :math:`\bar{1}`, the list would contain :math:`(001)` and :math:`(00\bar{1})`.
 
 The reason for expanding the unique reflections is to make the list more useful as an input


### PR DESCRIPTION
Description of work.
This PR fixes a latex error in CountReflections

**To test:**
Build the doc test target. 
Open `CountReflections` algorithm page. 
If there is not latex warning (will be obvious as it takes half the page in a warning box) this PR passes

Not associated issue.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
