### PR TITLE
Fixed Refl GUI QLineEdit warnings

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflEventWidget.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflEventWidget.ui
@@ -42,14 +42,7 @@
                   </widget>
                 </item>
                 <item row="0" column="1">
-                  <widget class="QLineEdit" name="uniformEvenEdit">
-                    <property name="sizeHint" stdset="0">
-                      <size>
-                        <width>10</width>
-                        <height>10</height>
-                      </size>
-                    </property>
-                  </widget>
+                  <widget class="QLineEdit" name="uniformEvenEdit"/>
                 </item>
                 <item row="0" column="2">
                   <widget class="QLabel" name="uniformEvenLabel">
@@ -79,14 +72,7 @@
                   </widget>
                 </item>
                 <item row="1" column="1">
-                  <widget class="QLineEdit" name="uniformEdit">
-                    <property name="sizeHint" stdset="0">
-                      <size>
-                        <width>10</width>
-                        <height>10</height>
-                      </size>
-                    </property>
-                  </widget>
+                  <widget class="QLineEdit" name="uniformEdit"/>
                 </item>
                 <item row="1" column="2">
                   <widget class="QLabel" name="uniformLabel">
@@ -134,14 +120,7 @@
               </widget>
             </item>
             <item>
-              <widget class="QLineEdit" name="customEdit">
-                <property name="sizeHint" stdset="0">
-                  <size>
-                    <width>10</width>
-                    <height>10</height>
-                  </size>
-                </property>
-              </widget>
+              <widget class="QLineEdit" name="customEdit"/>
             </item>
             <item>
               <spacer name="customSpacer">
@@ -180,14 +159,7 @@
               </widget>
             </item>
             <item>
-              <widget class="QLineEdit" name="logValueEdit">
-                <property name="sizeHint" stdset="0">
-                  <size>
-                    <width>10</width>
-                    <height>10</height>
-                  </size>
-                </property>
-              </widget>
+              <widget class="QLineEdit" name="logValueEdit"/>
             </item>
             <item>
               <widget class="QLabel" name="logValueTypeLabel">
@@ -197,14 +169,7 @@
               </widget>
             </item>
             <item>
-              <widget class="QLineEdit" name="logValueTypeEdit">
-                <property name="sizeHint" stdset="0">
-                  <size>
-                    <width>10</width>
-                    <height>10</height>
-                  </size>
-                </property>
-              </widget>
+              <widget class="QLineEdit" name="logValueTypeEdit"/>
             </item>
             <item>
               <spacer name="logValueSpacer1">


### PR DESCRIPTION
Description of work.

Qt warnings about QLineEdits were produced in the console when the Reflectometry interface was opened. This PR fixes this.

**To test:**

- Open the Reflectometry interface and ensure no Qt warnings are shown in the console.

<!-- Instructions for testing. -->

Fixes #19696.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
