### PR TITLE
Fix relative paths from category pages when built on Windows.

### DIFF
--- a/docs/sphinxext/mantiddoc/directives/categories.py
+++ b/docs/sphinxext/mantiddoc/directives/categories.py
@@ -70,7 +70,7 @@ class LinkItem(object):
         Returns:
           str: A string containing the link to reach this item
         """
-        link = relative_uri(base=base, to=self.location)
+        link = relative_uri(base=to_unix_style_path(base), to=self.location)
         if not link.endswith(ext):
             link += ext
         return link
@@ -106,12 +106,11 @@ class Category(LinkItem):
           name (str): The name of the category
           docname (str): Relative path to document from root directory
         """
+        docname = to_unix_style_path(docname)
 
-        if "\\" in docname:
-            docname = docname.replace("\\", "/")
         dirpath, filename = os.path.split(docname)
         html_dir = dirpath + "/" + CATEGORIES_DIR
-        self.html_path = html_dir + "/" + name.replace("\\\\", "/") + ".html"
+        self.html_path = html_dir + "/" + to_unix_style_path(name) + ".html"
         super(Category, self).__init__(name, self.html_path)
         self.pages = set([])
         self.subcategories = set([])
@@ -288,6 +287,18 @@ class CategoriesDirective(AlgorithmBaseDirective):
             category = env.categories[categ_name]
         return category
 
+
+#---------------------------------------------------------------------------------
+
+def to_unix_style_path(path):
+    """
+    Replaces any backslashes in the given string with forward slashes
+    and replace consecutive forward slashes with a single forward slash.
+
+    Arguments:
+      path: A string possibly containing backslashes
+    """
+    return path.replace("\\", "/").replace("//", "/")
 
 #---------------------------------------------------------------------------------
 


### PR DESCRIPTION
Description of work.

Fixes the links from the category index pages to the listed items when the documentation is built on Windows.

**To test:**

**Must be tested on Windows**

Before merging the fix verify that the offline help has dead links from the Algorithms,Fit Functions, Concepts & Interfaces pages. Merge the fix and rebuild the offline help. The links should now be working again.

Fixes #19678

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
