### PR TITLE
Redefine normalization estimate in EstimateMuonAsymmetryFromCounts

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/MuonAsymmetryHelper.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MuonAsymmetryHelper.h
@@ -50,7 +50,6 @@ size_t startIndexFromTime(const HistogramData::BinEdges &xData,
                           const double startX);
 size_t endIndexFromTime(const HistogramData::BinEdges &xData,
                         const double endX);
-
 } // namespace Mantid
 
 #endif /*MANTID_MUONASYMMETRYHELPER_H_*/

--- a/Framework/Algorithms/src/MuonAsymmetryHelper.cpp
+++ b/Framework/Algorithms/src/MuonAsymmetryHelper.cpp
@@ -95,7 +95,7 @@ double estimateNormalisationConst(const HistogramData::Histogram &histogram,
   for (size_t k = i0; k < iN; k++) {
 	  denominator += exp(-xData[k] / MUON_LIFETIME_MICROSECONDS);
   }
-  return summation  / (denominator *= numGoodFrames);
+  return summation  / (denominator * numGoodFrames);
 }
 /**
 * Finds the first index in bin edges that is after

--- a/Framework/Algorithms/src/MuonAsymmetryHelper.cpp
+++ b/Framework/Algorithms/src/MuonAsymmetryHelper.cpp
@@ -92,7 +92,7 @@ double estimateNormalisationConst(const HistogramData::Histogram &histogram,
   auto iyN = std::next(yData.rawData().begin(), iN);
   double summation = std::accumulate(iy0, iyN, 0.0);
   double denominator = 0.0;
-  for (int k = i0; k < iN; k++) {
+  for (size_t k = i0; k < iN; k++) {
 	  denominator += exp(-xData[k] / MUON_LIFETIME_MICROSECONDS);
   }
   return summation  / (denominator *= numGoodFrames);

--- a/Framework/Algorithms/src/MuonAsymmetryHelper.cpp
+++ b/Framework/Algorithms/src/MuonAsymmetryHelper.cpp
@@ -65,7 +65,6 @@ normaliseCounts(const HistogramData::Histogram &histogram,
 
   return result;
 }
-
 /**
 * Estimates normalisation constant via
 * N_0 = (Delta/f)*(sum_i W_i)/(int_a^b exp(-t/tau)dt )
@@ -89,14 +88,14 @@ double estimateNormalisationConst(const HistogramData::Histogram &histogram,
   size_t i0 = startIndexFromTime(xData, startX);
   size_t iN = endIndexFromTime(xData, endX);
   // remove an extra index as XData is bin boundaries and not point data
-  auto it0 = std::next(yData.rawData().begin(), i0);
-  auto itN = std::next(yData.rawData().begin(), iN);
-  double summation = std::accumulate(it0, itN, 0.0);
-  double Delta = xData[1] - xData[0];
-  double denominator = MUON_LIFETIME_MICROSECONDS * numGoodFrames *
-                       (exp(-startX / MUON_LIFETIME_MICROSECONDS) -
-                        exp(-endX / MUON_LIFETIME_MICROSECONDS));
-  return summation * Delta / denominator;
+  auto iy0 = std::next(yData.rawData().begin(), i0);
+  auto iyN = std::next(yData.rawData().begin(), iN);
+  double summation = std::accumulate(iy0, iyN, 0.0);
+  double denominator = 0.0;
+  for (int k = i0; k < iN; k++) {
+	  denominator += exp(-xData[k] / MUON_LIFETIME_MICROSECONDS);
+  }
+  return summation  / (denominator *= numGoodFrames);
 }
 /**
 * Finds the first index in bin edges that is after
@@ -124,5 +123,4 @@ size_t endIndexFromTime(const HistogramData::BinEdges &xData,
       std::upper_bound(xData.rawData().begin(), xData.rawData().end(), endX);
   return std::distance(xData.rawData().begin(), lower - 1);
 }
-
 } // namespace Mantid

--- a/Framework/Algorithms/src/MuonAsymmetryHelper.cpp
+++ b/Framework/Algorithms/src/MuonAsymmetryHelper.cpp
@@ -93,9 +93,9 @@ double estimateNormalisationConst(const HistogramData::Histogram &histogram,
   double summation = std::accumulate(iy0, iyN, 0.0);
   double denominator = 0.0;
   for (size_t k = i0; k < iN; k++) {
-	  denominator += exp(-xData[k] / MUON_LIFETIME_MICROSECONDS);
+    denominator += exp(-xData[k] / MUON_LIFETIME_MICROSECONDS);
   }
-  return summation  / (denominator * numGoodFrames);
+  return summation / (denominator * numGoodFrames);
 }
 /**
 * Finds the first index in bin edges that is after

--- a/Framework/Algorithms/test/EstimateMuonAsymmetryFromCountsTest.h
+++ b/Framework/Algorithms/test/EstimateMuonAsymmetryFromCountsTest.h
@@ -103,9 +103,9 @@ public:
       TS_ASSERT_DELTA(outWS->x(j)[19], 0.3800, Delta);
       TS_ASSERT_DELTA(outWS->x(j)[49], 0.9800, Delta);
       // Test some Y values
-      TS_ASSERT_DELTA(outWS->y(j)[10], 0.0635, Delta);
-      TS_ASSERT_DELTA(outWS->y(j)[19], -0.0727, Delta);
-      TS_ASSERT_DELTA(outWS->y(j)[49], 0.1153, Delta);
+      TS_ASSERT_DELTA(outWS->y(j)[10], 0.0366, Delta);
+      TS_ASSERT_DELTA(outWS->y(j)[19], -0.0961, Delta);
+      TS_ASSERT_DELTA(outWS->y(j)[49], 0.0871, Delta);
       // Test some E values
       TS_ASSERT_DELTA(outWS->e(j)[10], 0.0002, Delta);
       TS_ASSERT_DELTA(outWS->e(j)[19], 0.0003, Delta);

--- a/Framework/WorkflowAlgorithms/test/IMuonAsymmetryCalculatorTest.h
+++ b/Framework/WorkflowAlgorithms/test/IMuonAsymmetryCalculatorTest.h
@@ -246,17 +246,17 @@ public:
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
       TS_ASSERT_EQUALS(ws->blocksize(), 3);
 
-      TS_ASSERT_DELTA(ws->readY(0)[0], 0.0101, 0.001);
-      TS_ASSERT_DELTA(ws->readY(0)[1], 0.8199, 0.001);
-      TS_ASSERT_DELTA(ws->readY(0)[2], 2.2276, 0.001);
+      TS_ASSERT_DELTA(ws->readY(0)[0], -0.4059, 0.001);
+      TS_ASSERT_DELTA(ws->readY(0)[1], 0.0702, 0.001);
+      TS_ASSERT_DELTA(ws->readY(0)[2], 0.8981, 0.001);
 
       TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
       TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
-      TS_ASSERT_DELTA(ws->readE(0)[0], 0.1010, 0.01);
-      TS_ASSERT_DELTA(ws->readE(0)[1], 0.1819, 0.01);
-      TS_ASSERT_DELTA(ws->readE(0)[2], 0.3227, 0.01);
+      TS_ASSERT_DELTA(ws->readE(0)[0], 0.0594, 0.01);
+      TS_ASSERT_DELTA(ws->readE(0)[1], 0.1070, 0.01);
+      TS_ASSERT_DELTA(ws->readE(0)[2], 0.1898, 0.01);
     }
   }
 
@@ -287,13 +287,13 @@ public:
       TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
-      TS_ASSERT_DELTA(ws->readY(0)[0], 0.0393, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[0], 0.0231, 0.0001);
       TS_ASSERT_DELTA(ws->readY(0)[1], 0.0000, 0.0001);
-      TS_ASSERT_DELTA(ws->readY(0)[2], -0.0978, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[2], -0.0575, 0.0001);
 
-      TS_ASSERT_DELTA(ws->readE(0)[0], 0.1456, 0.0001);
-      TS_ASSERT_DELTA(ws->readE(0)[1], 0.2573, 0.0001);
-      TS_ASSERT_DELTA(ws->readE(0)[2], 0.4496, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[0], 0.0856, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[1], 0.1513, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[2], 0.2643, 0.0001);
     }
   }
 
@@ -324,13 +324,13 @@ public:
       TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
-      TS_ASSERT_DELTA(ws->readY(0)[0], -0.0231, 0.0001);
-      TS_ASSERT_DELTA(ws->readY(0)[1], 0.8199, 0.0001);
-      TS_ASSERT_DELTA(ws->readY(0)[2], 2.3104, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[0], -0.4255, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[1], 0.0702, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[2], 0.9467, 0.0001);
 
-      TS_ASSERT_DELTA(ws->readE(0)[0], 0.0715, 0.0001);
-      TS_ASSERT_DELTA(ws->readE(0)[1], 0.1320, 0.0001);
-      TS_ASSERT_DELTA(ws->readE(0)[2], 0.2387, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[0], 0.0421, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[1], 0.0776, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[2], 0.1403, 0.0001);
     }
   }
 
@@ -367,13 +367,13 @@ public:
       TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
-      TS_ASSERT_DELTA(ws->readY(0)[0], -0.0278, 0.0001);
-      TS_ASSERT_DELTA(ws->readY(0)[1], 0.8199, 0.0001);
-      TS_ASSERT_DELTA(ws->readY(0)[2], 2.3220, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[0], -0.4282, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[1], 0.0702, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[2], 0.9536, 0.0001);
 
-      TS_ASSERT_DELTA(ws->readE(0)[0], 0.0576, 0.0001);
-      TS_ASSERT_DELTA(ws->readE(0)[1], 0.1070, 0.0001);
-      TS_ASSERT_DELTA(ws->readE(0)[2], 0.1945, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[0], 0.0338, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[1], 0.0629, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[2], 0.1144, 0.0001);
     }
   }
 
@@ -410,13 +410,13 @@ public:
       TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
       TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
 
-      TS_ASSERT_DELTA(ws->readY(0)[0], 0.0148, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[0], 0.0087, 0.0001);
       TS_ASSERT_DELTA(ws->readY(0)[1], 0.0000, 0.0001);
-      TS_ASSERT_DELTA(ws->readY(0)[2], -0.0367, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[2], -0.0216, 0.0001);
 
-      TS_ASSERT_DELTA(ws->readE(0)[0], 0.1199, 0.0001);
-      TS_ASSERT_DELTA(ws->readE(0)[1], 0.2248, 0.0001);
-      TS_ASSERT_DELTA(ws->readE(0)[2], 0.4111, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[0], 0.0705, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[1], 0.1322, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[2], 0.2417, 0.0001);
     }
   }
 

--- a/docs/source/algorithms/EstimateMuonAsymmetryFromCounts-v1.rst
+++ b/docs/source/algorithms/EstimateMuonAsymmetryFromCounts-v1.rst
@@ -46,8 +46,8 @@ Output:
 
 .. testoutput:: ExSimple
 
-   Asymmetry:  ['-0.12', '1.07', '0.09', '-0.66', '-0.73']   
-   Normalization constant: 17.98
+   Asymmetry:  ['-0.38', '0.45', '-0.24', '-0.76', '-0.81']   
+   Normalization constant: 25.62
 
 .. categories::
 

--- a/docs/source/algorithms/MuonProcess-v1.rst
+++ b/docs/source/algorithms/MuonProcess-v1.rst
@@ -179,6 +179,7 @@ Output:
 .. testoutput:: ExGroupAsymmetryMultiPeriod
 
    Output: [-0.6449185   0.78829245  0.36003367]
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/MuonProcess-v1.rst
+++ b/docs/source/algorithms/MuonProcess-v1.rst
@@ -178,8 +178,7 @@ Output:
 
 .. testoutput:: ExGroupAsymmetryMultiPeriod
 
-   Output: [-0.73202334  0.89476186  0.40866102]
-
+   Output: [-0.6449185   0.78829245  0.36003367]
 .. categories::
 
 .. sourcelink::


### PR DESCRIPTION
Updated the EstimateMuonAsymmetryFromCounts algorithm to use an equivalent definition of the norm. The integral (and associated terms) have been replaced by a summation. 

**To test:**
Load oscillatory data (MUSR is good) into  the Muon analysis GUI and make sure that the TF Asymmetry mode is active in the settings tab. Check that the plot averages around a value of zero (it wont be exact). 

Fixes #19702 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
