### PR TITLE
Fix SliceViewer normalization

### DIFF
--- a/MantidQt/API/inc/MantidQtAPI/QwtRasterDataMD.h
+++ b/MantidQt/API/inc/MantidQtAPI/QwtRasterDataMD.h
@@ -59,6 +59,8 @@ public:
   void setNormalization(Mantid::API::MDNormalization normalization);
   Mantid::API::MDNormalization getNormalization() const;
 
+  void transferSettingsTo(QwtRasterDataMD* dest) const;
+
 protected:
   void copyFrom(const QwtRasterDataMD &source, QwtRasterDataMD &dest) const;
 

--- a/MantidQt/API/inc/MantidQtAPI/QwtRasterDataMD.h
+++ b/MantidQt/API/inc/MantidQtAPI/QwtRasterDataMD.h
@@ -59,7 +59,7 @@ public:
   void setNormalization(Mantid::API::MDNormalization normalization);
   Mantid::API::MDNormalization getNormalization() const;
 
-  void transferSettingsTo(QwtRasterDataMD* dest) const;
+  void transferSettingsTo(QwtRasterDataMD *dest) const;
 
 protected:
   void copyFrom(const QwtRasterDataMD &source, QwtRasterDataMD &dest) const;

--- a/MantidQt/API/src/QwtRasterDataMD.cpp
+++ b/MantidQt/API/src/QwtRasterDataMD.cpp
@@ -249,6 +249,11 @@ void QwtRasterDataMD::setSliceParams(
   }
 }
 
+void QwtRasterDataMD::transferSettingsTo(QwtRasterDataMD* dest) const {
+  this->copyFrom(*this, *dest);
+}
+
+
 //-----------------------------------------------------------------------------
 // Protected members
 //-----------------------------------------------------------------------------

--- a/MantidQt/API/src/QwtRasterDataMD.cpp
+++ b/MantidQt/API/src/QwtRasterDataMD.cpp
@@ -249,10 +249,9 @@ void QwtRasterDataMD::setSliceParams(
   }
 }
 
-void QwtRasterDataMD::transferSettingsTo(QwtRasterDataMD* dest) const {
+void QwtRasterDataMD::transferSettingsTo(QwtRasterDataMD *dest) const {
   this->copyFrom(*this, *dest);
 }
-
 
 //-----------------------------------------------------------------------------
 // Protected members

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
@@ -271,7 +271,8 @@ private:
   void applyOrthogonalAxisScaleDraw();
 
   /// Transfer data between QwtRasterDataMD
-  void transferSettings(const API::QwtRasterDataMD* const from, API::QwtRasterDataMD* to) const;
+  void transferSettings(const API::QwtRasterDataMD *const from,
+                        API::QwtRasterDataMD *to) const;
 
 private:
   // -------------------------- Widgets ----------------------------

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
@@ -270,6 +270,9 @@ private:
   /// Apply the orthogonal axis scale draw
   void applyOrthogonalAxisScaleDraw();
 
+  /// Transfer data between QwtRasterDataMD
+  void transferSettings(const API::QwtRasterDataMD* const from, API::QwtRasterDataMD* to) const;
+
 private:
   // -------------------------- Widgets ----------------------------
 

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -698,11 +698,18 @@ void SliceViewer::switchQWTRaster(bool useNonOrthogonal) {
   m_coordinateTransform = createCoordinateTransform(m_ws, m_dimX, m_dimY);
 
   if (useNonOrthogonal && ui.btnNonOrthogonalToggle->isChecked()) {
-    m_data = Kernel::make_unique<API::QwtRasterDataMDNonOrthogonal>();
+    // Transfer the current settings
+    auto tempData =  Kernel::make_unique<API::QwtRasterDataMDNonOrthogonal>();
+    transferSettings(m_data.get(), tempData.get());
+    m_data = std::move(tempData);
     applyNonOrthogonalAxisScaleDraw();
   } else {
     applyOrthogonalAxisScaleDraw();
-    m_data = Kernel::make_unique<API::QwtRasterDataMD>();
+
+    // Transfer the current settings
+    auto tempData =  Kernel::make_unique<API::QwtRasterDataMD>();
+    transferSettings(m_data.get(), tempData.get());
+    m_data = std::move(tempData);
   }
 
   m_coordinateTransform = createCoordinateTransform(m_ws, m_dimX, m_dimY);
@@ -738,8 +745,11 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   m_data->setWorkspace(ws);
   m_plot->setWorkspace(ws);
   autoRebinIfRequired();
-  // Set the normalization appropriate
-  this->setNormalization(ws->displayNormalization(), false);
+
+  // Set the appropriate normalization
+  auto initialDisplayNormalization = ws->displayNormalization();
+  this->setNormalization(initialDisplayNormalization, false);
+  m_data->setNormalization(initialDisplayNormalization);
 
   // Only allow perpendicular lines if looking at a matrix workspace.
   bool matrix = bool(boost::dynamic_pointer_cast<MatrixWorkspace>(m_ws));
@@ -2998,6 +3008,13 @@ void SliceViewer::applyOrthogonalAxisScaleDraw() {
   m_plot->setAxisScaleDraw(QwtPlot::yLeft, axis1);
   this->updateDisplay();
 }
+
+/// Transfer data between QwtRasterDataMD instances
+void SliceViewer::transferSettings(const API::QwtRasterDataMD* const from,
+                                   API::QwtRasterDataMD* to) const {
+  from->transferSettingsTo(to);
+}
+
 
 } // namespace
 }

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -699,7 +699,7 @@ void SliceViewer::switchQWTRaster(bool useNonOrthogonal) {
 
   if (useNonOrthogonal && ui.btnNonOrthogonalToggle->isChecked()) {
     // Transfer the current settings
-    auto tempData =  Kernel::make_unique<API::QwtRasterDataMDNonOrthogonal>();
+    auto tempData = Kernel::make_unique<API::QwtRasterDataMDNonOrthogonal>();
     transferSettings(m_data.get(), tempData.get());
     m_data = std::move(tempData);
     applyNonOrthogonalAxisScaleDraw();
@@ -707,7 +707,7 @@ void SliceViewer::switchQWTRaster(bool useNonOrthogonal) {
     applyOrthogonalAxisScaleDraw();
 
     // Transfer the current settings
-    auto tempData =  Kernel::make_unique<API::QwtRasterDataMD>();
+    auto tempData = Kernel::make_unique<API::QwtRasterDataMD>();
     transferSettings(m_data.get(), tempData.get());
     m_data = std::move(tempData);
   }
@@ -3010,11 +3010,10 @@ void SliceViewer::applyOrthogonalAxisScaleDraw() {
 }
 
 /// Transfer data between QwtRasterDataMD instances
-void SliceViewer::transferSettings(const API::QwtRasterDataMD* const from,
-                                   API::QwtRasterDataMD* to) const {
+void SliceViewer::transferSettings(const API::QwtRasterDataMD *const from,
+                                   API::QwtRasterDataMD *to) const {
   from->transferSettingsTo(to);
 }
-
 
 } // namespace
 }

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -85,7 +85,7 @@ SliceViewer Improvements
 - Changed zoom level on peak. Now when zooming onto a spherical or ellipsoidal peak, the entire peak is visible when using the default window size.
 - Fixed a bug where swapping the dimensions did not rebin the workspace despite having autorebin enabled.
 - Fixed a bug where swapping the dimensions did not draw the axis scale correctly.
-
+- Fixed a bug where the normalization selection was not respected.
 
 VSI Improvments
 ###############


### PR DESCRIPTION
Fixes #19707

The SliceViewer had an issue with maintaining the normalization that was initially set. 
To reproduce:


**To test:**

1. Load data into the SliceViewer which has a display-normalization of `NoNormalization`.
2. Click on the Full-color-scale-range button
   * Confirm that the data range does not change.
3. Confirm that when you select VolumeNormalization and then click on the Full-color-scale-range button, you see that the data range changes.


#### Release notes

For release notes see [here](https://github.com/mantidproject/mantid/pull/19708/commits/95fc53811f876f0f68e51f1f0f86ce1940a31cf7)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
