### PR TITLE
Fix cropping error when summing in Q

### DIFF
--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -479,6 +479,9 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::makeIvsLam() {
       result = directBeamCorrection(result);
       result = monitorCorrection(result);
     }
+    // Crop to wavelength limits
+    g_log.debug("Cropping output workspace\n");
+    result = cropWavelength(result);
     if (m_normaliseTransmission) {
       g_log.debug("Normalising input workspace by transmission run\n");
       result = transOrAlgCorrection(result, false);
@@ -497,15 +500,14 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::makeIvsLam() {
       result = directBeamCorrection(result);
       result = monitorCorrection(result);
     }
+    // Crop to wavelength limits
+    g_log.debug("Cropping output workspace\n");
+    result = cropWavelength(result);
     if (m_normaliseTransmission) {
       g_log.debug("Normalising output workspace by transmission run\n");
       result = transOrAlgCorrection(result, true);
     }
   }
-
-  // Crop to wavelength limits
-  g_log.debug("Cropping output workspace\n");
-  result = cropWavelength(result);
 
   return result;
 }

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -445,16 +445,14 @@ public:
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 18);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 8);
 
-    TS_ASSERT_DELTA(outLam->x(0)[0], 1.5338, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 6.5622, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[10], 8.7173, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[17], 13.7457, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 1.8323, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 1.7985, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[10], 2.0212, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[17], 1.9430, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.8597, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.8582, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 12.5229, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 0.0, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 3.6539, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 3.1458, 0.0001);
   }
 
   void test_sum_in_q_non_flat_sample() {
@@ -469,16 +467,14 @@ public:
     setupAlgorithm(alg, 1.5, 15.0, "1");
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "NonFlatSample");
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 18);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 8);
 
-    TS_ASSERT_DELTA(outLam->x(0)[0], 1.5339, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 6.5110, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[10], 8.6440, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[17], 13.6211, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 1.8386, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 1.6622, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[10], 1.9205, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[17], 1.7303, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.8675, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.8147, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 12.4109, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 0.0, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 3.6513, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 3.6137, 0.0001);
   }
 
   void test_sum_in_q_direct_beam() {
@@ -494,9 +490,14 @@ public:
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 18);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 8);
 
-    TS_ASSERT_DELTA(outLam->y(0)[0], 0.2911, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.8603, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.8547, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 12.5140, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 0.0, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 0.5803, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 0.5048, 0.0001);
   }
 
   void test_sum_in_q_monitor_normalization() {
@@ -524,16 +525,14 @@ public:
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 18);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 10);
 
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.1244, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 5.6420, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[10], 8.0067, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[17], 13.5243, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 7.6861, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 1.4879, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[10], 1.5523, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[17], 1.6371, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[0], -0.6336, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[5], 6.8626, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[9], 12.8596, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 7.2899, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[5], 2.6136, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[9], 2.0315, 0.0001);
   }
 
   void test_sum_in_q_transmission_correction_run() {
@@ -545,10 +544,14 @@ public:
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 18);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 8);
 
-    TS_ASSERT_DELTA(outLam->y(0)[0], 0.8015, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 0.5722, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.8597, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.8582, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 12.5229, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 0.0, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 1.1625, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 1.0009, 0.0001);
   }
 
   void test_sum_in_q_exponential_correction() {
@@ -562,10 +565,14 @@ public:
     alg.setProperty("CorrectionAlgorithm", "ExponentialCorrection");
     alg.setProperty("C0", 0.2);
     alg.setProperty("C1", 0.1);
-    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 18);
+    MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 8);
 
-    TS_ASSERT_DELTA(outLam->y(0)[0], 11.3636, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 17.7963, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.8603, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.8547, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 12.5140, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 0.0, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 36.1423, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 59.3020, 0.0001);
   }
 
   void test_sum_in_q_IvsQ() {
@@ -580,14 +587,16 @@ public:
     alg.setProperty("SummationType", "SumInQ");
     alg.setProperty("ReductionType", "DivergentBeam");
     alg.setProperty("ThetaIn", 25.0);
-    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 18);
+    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 8);
 
     // X range in outQ
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.3327, 0.0001);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.5100, 0.0001);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.3391, 0.0001);
+    TS_ASSERT_DELTA(outQ->x(0)[3], 0.5235, 0.0001);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 1.9044, 0.0001);
     // Y counts
-    TS_ASSERT_DELTA(outQ->y(0)[0], 1.9348, 0.0001);
-    TS_ASSERT_DELTA(outQ->y(0)[7], 2.0204, 0.0001);
+    TS_ASSERT_DELTA(outQ->y(0)[0], 3.1887, 0.0001);
+    TS_ASSERT_DELTA(outQ->y(0)[3], 3.6419, 0.0001);
+    TS_ASSERT_DELTA(outQ->y(0)[7], 0.0, 0.0001);
   }
 
 private:

--- a/docs/source/algorithms/ReflectometryReductionOne-v2.rst
+++ b/docs/source/algorithms/ReflectometryReductionOne-v2.rst
@@ -40,10 +40,12 @@ already reduced using this algorithm.
 If summation is to be done in wavelength, then this is done first. The the
 conversion to wavelength and normalisation by monitors and direct beam is done,
 followed by the transmission correction. Transmission correction is always
-done, even if the input was already in wavelength.
+done, even if the input was already in wavelength. The resulting workspace is
+cropped in wavelength according to :literal:`WavelengthMin` and
+:literal:`WavelengthMax`, which are both mandatory properties.
 
-If summation is to be done in Q, this is done after the normalisations, but
-again, only if the original input was not already in wavelength.
+If summation is to be done in Q, this is done after the normalisations and
+cropping, but again, only if the original input was not already in wavelength.
 
 Finally, the output workspace in wavelength is converted to momentum transfer
 (Q).
@@ -120,11 +122,15 @@ property. If the :literal:`CorrectionAlgorithm` property is set to
 algorithm is used, with *C0* and *C1* taken from the :literal:`C0` and :literal:`C1`
 properties.
 
-Sum in Q and crop
-#################
+Sum in Q
+########
 
-If summing in Q, the summation is done now, after all normalisations have been
-done. The summation is done using the algorithm proposed by Cubitt et al
+If summing in Q, the summation is done now, after all normalisations and
+cropping have been done. As with summation in :math:`\lambda`, the summation is
+only done if the original workspace was not in :math:`\lambda` (otherwise we
+assume the reduction has already been done).
+
+The summation is done using the algorithm proposed by Cubitt et al
 (J. Appl. Crystallogr., 48 (6) (2015)). This involves a projection to an
 arbitrary reference angle, :math:`2\theta_R`, with a "virtual" wavelength,
 :math:`\lambda_v`. This is the wavelength the neutron would have had if it had
@@ -133,9 +139,8 @@ arrived at :math:`2\theta_R` with the same momentum transfer
 :math:`\lambda_v` and the projections from all pixels are summed in
 :math:`\lambda_v`.
 
-In all cases, the 1D array in :math:`\lambda` is then cropped in wavelength
-according to :literal:`WavelengthMin` and :literal:`WavelengthMax`, which are
-both mandatory properties.
+The resulting 1D workspace in :math:`\lambda_v` at :math:`2\theta_R` becomes
+the output workspace in wavelength.
 
 .. diagram:: ReflectometryReductionOne_SumInQ-v2_wkflw.dot
 

--- a/docs/source/diagrams/ReflectometryReductionOne_ConvertToWavelength-v2_wkflw.dot
+++ b/docs/source/diagrams/ReflectometryReductionOne_ConvertToWavelength-v2_wkflw.dot
@@ -2,10 +2,10 @@ digraph ReflectometryReductionOne {
 splines=line
 label = "\n"
 rankdir = TB;
- $global_style
+ //$global_style
 
 subgraph params {
- $param_style
+ //$param_style
   inputWS             [label="InputWorkspace"]
   outputWS            [label="OutputWorkspaceWavelength"]
   procCommands        [label="ProcessingInstructions"]
@@ -18,12 +18,12 @@ subgraph params {
 }
 
 subgraph decisions {
- $decision_style
+ //$decision_style
   checkSumInLam   [label="Sum in &lambda;?"]
 }
 
 subgraph algorithms {
- $algorithm_style
+ //$algorithm_style
   convertDet    [label="ConvertUnits\n(AlignBins = True)"]
   convertDB     [label="ConvertUnits\n(AlignBins = True)"]
   convertMon    [label="ConvertUnits\n(AlignBins = True)", group=g11]
@@ -37,11 +37,11 @@ subgraph algorithms {
 }
 
 subgraph processes {
- $process_style
+ //$process_style
 }
 
 subgraph values {
- $value_style
+ //$value_style
 }
 
 inputWS			-> checkSumInLam	[label="Detectors"]
@@ -72,7 +72,6 @@ monIntWavMax        -> intMon
 
 divideDetRDB        -> divideDetMon
 intMon              -> divideDetMon
-
 divideDetMon        -> outputWS
 
 {rank=same; groupDet; groupDetRDB; cropMonWS}

--- a/docs/source/diagrams/ReflectometryReductionOne_ConvertToWavelength-v2_wkflw.dot
+++ b/docs/source/diagrams/ReflectometryReductionOne_ConvertToWavelength-v2_wkflw.dot
@@ -2,10 +2,10 @@ digraph ReflectometryReductionOne {
 splines=line
 label = "\n"
 rankdir = TB;
- //$global_style
+ $global_style
 
 subgraph params {
- //$param_style
+ $param_style
   inputWS             [label="InputWorkspace"]
   outputWS            [label="OutputWorkspaceWavelength"]
   procCommands        [label="ProcessingInstructions"]
@@ -18,12 +18,12 @@ subgraph params {
 }
 
 subgraph decisions {
- //$decision_style
+ $decision_style
   checkSumInLam   [label="Sum in &lambda;?"]
 }
 
 subgraph algorithms {
- //$algorithm_style
+ $algorithm_style
   convertDet    [label="ConvertUnits\n(AlignBins = True)"]
   convertDB     [label="ConvertUnits\n(AlignBins = True)"]
   convertMon    [label="ConvertUnits\n(AlignBins = True)", group=g11]
@@ -37,11 +37,11 @@ subgraph algorithms {
 }
 
 subgraph processes {
- //$process_style
+ $process_style
 }
 
 subgraph values {
- //$value_style
+ $value_style
 }
 
 inputWS			-> checkSumInLam	[label="Detectors"]

--- a/docs/source/diagrams/ReflectometryReductionOne_HighLvl-v2_wkflw.dot
+++ b/docs/source/diagrams/ReflectometryReductionOne_HighLvl-v2_wkflw.dot
@@ -1,9 +1,9 @@
 digraph ReflectometryReductionOne {
 label = "\n"
- //$global_style
+ $global_style
 
 subgraph params {
- //$param_style
+ $param_style
   inputWS       [label="InputWorkspace"]
   wavMin        [label="WavelengthMin", group=gwav]
   wavMax        [label="WavelengthMax", group=gwav]
@@ -12,17 +12,17 @@ subgraph params {
 }
 
 subgraph decisions {
- //$decision_style
+ $decision_style
   checkXUnit      [label="X axis in &lambda;?"]
 }
 
 subgraph algorithms {
- //$algorithm_style
+ $algorithm_style
   cropWav       [label="CropWorkspace", group=g1]
 }
 
 subgraph processes {
- //$process_style
+ $process_style
   convertUnits    [label="Convert to &lambda;,\noptionally sum in &lambda;, and\nnormalize by monitors"]
   applyCorrTrans  [label="Apply transmission\n corrections"]
   sumInQ          [label="Optionally sum in Q"]
@@ -30,7 +30,7 @@ subgraph processes {
 }
 
 subgraph values {
- //$value_style
+ $value_style
 }
 
 inputWS         -> checkXUnit

--- a/docs/source/diagrams/ReflectometryReductionOne_HighLvl-v2_wkflw.dot
+++ b/docs/source/diagrams/ReflectometryReductionOne_HighLvl-v2_wkflw.dot
@@ -1,40 +1,46 @@
 digraph ReflectometryReductionOne {
 label = "\n"
- $global_style
+ //$global_style
 
 subgraph params {
- $param_style
+ //$param_style
   inputWS       [label="InputWorkspace"]
+  wavMin        [label="WavelengthMin", group=gwav]
+  wavMax        [label="WavelengthMax", group=gwav]
   outputWSWL    [label="OutputWorkspaceWavelength"]
   outputWSFinal [label="OutputWorkspace"]
 }
 
 subgraph decisions {
- $decision_style
+ //$decision_style
   checkXUnit      [label="X axis in &lambda;?"]
 }
 
 subgraph algorithms {
- $algorithm_style
+ //$algorithm_style
+  cropWav       [label="CropWorkspace", group=g1]
 }
 
 subgraph processes {
- $process_style
+ //$process_style
   convertUnits    [label="Convert to &lambda;,\noptionally sum in &lambda;, and\nnormalize by monitors"]
   applyCorrTrans  [label="Apply transmission\n corrections"]
-  sumInQ          [label="Optionally sum in Q,\nand crop"]
+  sumInQ          [label="Optionally sum in Q"]
   convertMom      [label="Convert to momentum\ntransfer"]
 }
 
 subgraph values {
- $value_style
+ //$value_style
 }
 
 inputWS         -> checkXUnit
-checkXUnit      -> applyCorrTrans [label="Yes"]
+checkXUnit      -> cropWav        [label="Yes"]
 checkXUnit      -> convertUnits   [label="No"]
-convertUnits    -> applyCorrTrans
+convertUnits    -> cropWav
+wavMin          -> cropWav
+wavMax          -> cropWav
 
+cropWav         -> applyCorrTrans
 applyCorrTrans  -> sumInQ
 sumInQ          -> outputWSWL
 

--- a/docs/source/diagrams/ReflectometryReductionOne_SumInQ-v2_wkflw.dot
+++ b/docs/source/diagrams/ReflectometryReductionOne_SumInQ-v2_wkflw.dot
@@ -1,43 +1,37 @@
 digraph ReflectometryReductionOne {
 label = "\n"
- $global_style
+ //$global_style
 
 subgraph params {
- $param_style
+ //$param_style
   inputWorkspace     [label="OutputWorkspaceWavelength", group=g1]
   outputWorkspaceWav [label="OutputWorkspaceWavelength"]
-  wavMin             [label="WavelengthMin", group=gwav]
-  wavMax             [label="WavelengthMax", group=gwav]
 }
 
 subgraph decisions {
- $decision_style
-  checkSumInQ        [label="Sum in Q?"]
+ //$decision_style
+  checkSumInQ        [label="Sum in Q and input X axis was not in &lambda;?"]
 }
 
 subgraph algorithms {
- $algorithm_style
-  cropWav           [label="CropWorkspace"]
+ //$algorithm_style
 }
 
 subgraph processes {
- $process_style
+ //$process_style
   projectCounts      [label=<Project input counts to &lambda;<sub>v</sub> at 2&theta;<sub>R</sub>>]
   sumInQ             [label=<Sum in &lambda;<sub>v</sub>>]
 }
 
 subgraph values {
- $value_style
+ //$value_style
 }
 
 inputWorkspace     -> checkSumInQ
 checkSumInQ        -> projectCounts      [label="Yes"]
-checkSumInQ        -> cropWav            [label="No"]
+checkSumInQ        -> outputWorkspaceWav [label="No"]
 projectCounts      -> sumInQ
-sumInQ             -> cropWav
-wavMin             -> cropWav
-wavMax             -> cropWav
-cropWav            -> outputWorkspaceWav
+sumInQ             -> outputWorkspaceWav
 
 }
 

--- a/docs/source/diagrams/ReflectometryReductionOne_SumInQ-v2_wkflw.dot
+++ b/docs/source/diagrams/ReflectometryReductionOne_SumInQ-v2_wkflw.dot
@@ -1,30 +1,30 @@
 digraph ReflectometryReductionOne {
 label = "\n"
- //$global_style
+ $global_style
 
 subgraph params {
- //$param_style
+ $param_style
   inputWorkspace     [label="OutputWorkspaceWavelength", group=g1]
   outputWorkspaceWav [label="OutputWorkspaceWavelength"]
 }
 
 subgraph decisions {
- //$decision_style
+ $decision_style
   checkSumInQ        [label="Sum in Q and input X axis was not in &lambda;?"]
 }
 
 subgraph algorithms {
- //$algorithm_style
+ $algorithm_style
 }
 
 subgraph processes {
- //$process_style
+ $process_style
   projectCounts      [label=<Project input counts to &lambda;<sub>v</sub> at 2&theta;<sub>R</sub>>]
   sumInQ             [label=<Sum in &lambda;<sub>v</sub>>]
 }
 
 subgraph values {
- //$value_style
+ $value_style
 }
 
 inputWorkspace     -> checkSumInQ


### PR DESCRIPTION
This PR fixes a minor bug with the new summation in Q functionality in `ReflectometryReductionOne` (added in PR #19502). The cropping in wavelength was being done after the summation in Q, but it needs to be done before, because the summation involves a projection to a different coordinate system. I've moved it to before the transmission correction, because this is where it used to be done before that PR.

**To test:**
See the instructions in the linked issue.

Fixes #19709 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [x] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
