### PR TITLE
Instrument view crashes when picking a non-detector component.

### DIFF
--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
@@ -899,17 +899,17 @@ QString ComponentInfoController::displayDetectorInfo(Mantid::detid_t detid) {
 */
 QString ComponentInfoController::displayNonDetectorInfo(
     Mantid::Geometry::ComponentID compID) {
-  auto &component = *m_instrActor->getInstrument()->getComponentByID(compID);
+  auto component = m_instrActor->getInstrument()->getComponentByID(compID);
   QString text = "Selected component: ";
-  text += QString::fromStdString(component.getName()) + '\n';
-  Mantid::Kernel::V3D pos = component.getPos();
+  text += QString::fromStdString(component->getName()) + '\n';
+  Mantid::Kernel::V3D pos = component->getPos();
   text += "xyz: " + QString::number(pos.X()) + "," + QString::number(pos.Y()) +
           "," + QString::number(pos.Z()) + '\n';
   double r, t, p;
   pos.getSpherical(r, t, p);
   text += "rtp: " + QString::number(r) + "," + QString::number(t) + "," +
           QString::number(p) + '\n';
-  text += getParameterInfo(component);
+  text += getParameterInfo(*component);
   return text;
 }
 


### PR DESCRIPTION
Store the returned shared ptr in a local variable to prevent its destruction.

**To test:**

Instructions in the issue description.

Fixes #19722.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
