### PR TITLE
Resolve crash with double clicking table in Muon GUI

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
@@ -87,12 +87,12 @@ public:
   /// Destructor
   ~MuonAnalysis();
 
-  /// Sets index of group or pair to plot
-  /// and causes a replot
-  void setGroupOrPairAndReplot(int index);
-
   /// Gets current index of group or pair to plot
   int getGroupOrPairToPlot() const;
+
+  void setGroupOrPairIndexToPlot(int index);
+
+  void plotCurrentGroupAndPairs();
 
 signals:
   /// Request to hide/show Mantid toolbars
@@ -156,7 +156,7 @@ private slots:
   void runFrontPlotButton();
 
   /// Creates a plot of selected group/pair.
-  void plotSelectedItem();
+  void plotSelectedGroupPair();
 
   /// Link to the wiki for the home tab
   void muonAnalysisHelpClicked();
@@ -304,8 +304,8 @@ private:
   std::string getNewAnalysisWSName(Muon::ItemType itemType, int tableRow,
                                    Muon::PlotType plotType);
 
-  /// Update front anc pair combo box
-  void updateFrontAndCombo();
+  /// Update front and pair combo box
+  void updateFrontAndCombo(bool updateIndexAndPlot);
 
   /// Updates widgets related to period algebra
   void updatePeriodWidgets(size_t numPeriods);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
@@ -87,11 +87,13 @@ public:
   /// Destructor
   ~MuonAnalysis();
 
-  /// Gets current index of group or pair to plot
+  /// Gets current index of the group or pair to plot
   int getGroupOrPairToPlot() const;
 
+  /// Sets the current index of the group or pair to plot
   void setGroupOrPairIndexToPlot(int index);
 
+  /// Plots the currently selected group or pair
   void plotCurrentGroupAndPairs();
 
 signals:

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -377,13 +377,13 @@ void MuonAnalysis::runFrontPlotButton() {
     return;
   }
 
-  plotSelectedItem();
+  plotSelectedGroupPair();
 }
 
 /**
  * Creates a plot of selected group/pair.
  */
-void MuonAnalysis::plotSelectedItem() {
+void MuonAnalysis::plotSelectedGroupPair() {
   ItemType itemType;
   int tableRow;
 
@@ -911,8 +911,13 @@ void MuonAnalysis::groupTableChanged(int row, int column) {
     }
   }
 
-  // Put this call after grouping so that correct data is replotted
-  updateFrontAndCombo();
+  // Put this call after grouping. Don't update the current index
+  // or replot though (false flag).
+  // Note: A bug current exists where if we are re-plotting
+  // and the user calls the table changed method before plotting finishes
+  // (by clicking the table again) Qt will later crash.
+  // This false flag also prevents this (issue: #19701)
+  updateFrontAndCombo(false);
 }
 
 /**
@@ -940,7 +945,8 @@ void MuonAnalysis::pairTableChanged(int row, int column) {
       }
     }
     m_pairToRow = m_groupingHelper.whichPairToWhichRow();
-    updateFrontAndCombo();
+    // Don't replot if the pair table has been modified
+    updateFrontAndCombo(false);
   }
 
   // pair name been modified
@@ -972,7 +978,7 @@ void MuonAnalysis::pairTableChanged(int row, int column) {
     }
 
     m_pairToRow = m_groupingHelper.whichPairToWhichRow();
-    updateFrontAndCombo();
+    updateFrontAndCombo(false);
 
     // check to see if alpha is specified (if name!="") and if not
     // assign a default of 1.0
@@ -1002,7 +1008,7 @@ void MuonAnalysis::updatePairTable() {
       m_uiForm.pairTable->setCellWidget(i, 1, new QComboBox);
       m_uiForm.pairTable->setCellWidget(i, 2, new QComboBox);
     }
-    updateFrontAndCombo();
+    updateFrontAndCombo(false);
     return;
   } else if (numGroups() < 2 && numPairs() <= 0) {
     return;
@@ -1339,7 +1345,7 @@ void MuonAnalysis::inputFileChanged(const QStringList &files) {
   m_currentLabel = loadResult->label;
 
   if (m_uiForm.frontPlotButton->isEnabled())
-    plotSelectedItem();
+    plotSelectedGroupPair();
 }
 
 /**
@@ -1486,8 +1492,10 @@ void MuonAnalysis::updateFront() {
 /**
  * Update front including first re-populate pair list combo box
  * Also update multiple fitting
+ * Plots changes if requested
+ * @param updateIndexAndPlot :: If true updates and plots the current group/pair
  */
-void MuonAnalysis::updateFrontAndCombo() {
+void MuonAnalysis::updateFrontAndCombo(bool updateIndexAndPlot) {
   // for now brute force clearing and adding new context
   // could go for softer approach and check if is necessary
   // to completely reset this combo box
@@ -1522,7 +1530,10 @@ void MuonAnalysis::updateFrontAndCombo() {
   }
   m_uiForm.fitBrowser->setAvailableGroups(groupsAndPairs);
 
-  setGroupOrPairAndReplot(currentI);
+  if (updateIndexAndPlot) {
+    setGroupOrPairIndexToPlot(currentI);
+    plotCurrentGroupAndPairs();
+  }
 }
 
 /**
@@ -2732,7 +2743,8 @@ void MuonAnalysis::syncGroupTablePlotTypeWithHome() {
     // This is not the best solution, but I don't have anything brighter at the
     // moment and it
     // was working like that for some time without anybody complaining.
-    setGroupOrPairAndReplot(0);
+    setGroupOrPairIndexToPlot(0);
+    plotCurrentGroupAndPairs();
   }
 
   m_uiForm.frontPlotFuncs->setCurrentIndex(plotTypeIndex);
@@ -3015,8 +3027,11 @@ void MuonAnalysis::openDirectoryDialog() {
  * The point of using this function is so that the UI is never out of sync
  * @param index :: [input] Index of which group/pair to plot
  */
-void MuonAnalysis::setGroupOrPairAndReplot(int index) {
+void MuonAnalysis::setGroupOrPairIndexToPlot(int index) {
   m_uiForm.frontGroupGroupPairComboBox->setCurrentIndex(index);
+}
+
+void MuonAnalysis::plotCurrentGroupAndPairs() {
   // Replot, whichever tab we're currently on
   if (m_loaded && isAutoUpdateEnabled()) {
     runFrontPlotButton();
@@ -3037,7 +3052,8 @@ int MuonAnalysis::getGroupOrPairToPlot() const {
  */
 void MuonAnalysis::fillGroupingTable(const Grouping &grouping) {
   int defaultIndex = m_groupingHelper.fillGroupingTable(grouping);
-  setGroupOrPairAndReplot(defaultIndex);
+  setGroupOrPairIndexToPlot(defaultIndex);
+  plotCurrentGroupAndPairs();
 }
 
 /**

--- a/docs/source/release/v3.10.0/muon.rst
+++ b/docs/source/release/v3.10.0/muon.rst
@@ -19,6 +19,11 @@ Algorithms
 -  :ref:`EstimateMuonAsymmetryFromCounts <algm-EstimateMuonAsymmetryFromCounts-v1>`: new algorithm to estimate the asymmetry.
 -  :ref:`CalculateMuonAsymmetry <algm-CalculateMuonAsymmetry-v1>`: new algorithm to calculate the asymmetry by using a fitting function.
 
+Bug Fixes
+---------
+- Mantid would sometimes crash when the user was adding groups/pairs. This has been fixed by removing the automatic plotting from the group/pairs tab.
+
+
 |
 
 `Full list of changes <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.10%22+is%3Amerged+label%3A%22Component%3A+Muon%22>`_


### PR DESCRIPTION
Description of work.
This PR resolves a crash where Mantid would crash within the Muon GUI. Previously when `GroupTableChanged` was called it implicitly updates the selected bank and replotted this. 
If the user was to click the table again (such as a double click in another box) Qt would crash if it hadn't finished running the plotting code.  

To resolve this I've separated the code to update the index and plot for clarity. I've also added a flag to indicate if we want the selected group (on the home page) to change which will implicitly plot that group instead. 

@AnthonyLim23 - It's worth noting with these changes the currently selected bank on the home page will **not** automatically update to the most recent bank. This might initially catch users out who relied on this implicit behaviour.

**To test:**
- Open the Muon GUI
- Load a Muon run (any will do such as one from HIFI)
- Go to the grouping window
- Enter a new name 
- Click of the box so the new name is entered
- Go back to the new name, delete the text
- Without clicking anything else double click (must be double) the detector ID box
- If it no longer crashes this test passed.

Fixes #19701.

*Does not need to be in the release notes. - Has only been noticed in unscripted testing*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
