### PR TITLE
Use unix-style paths everywhere in category directive

### DIFF
--- a/docs/sphinxext/mantiddoc/directives/categories.py
+++ b/docs/sphinxext/mantiddoc/directives/categories.py
@@ -10,6 +10,7 @@ from __future__ import (absolute_import, division, print_function)
 from mantiddoc.directives.base import AlgorithmBaseDirective, algorithm_name_and_version #pylint: disable=unused-import
 from sphinx.util.osutil import relative_uri
 import os
+import posixpath
 from six import iteritems, itervalues
 
 CATEGORY_PAGE_TEMPLATE = "category.html"
@@ -36,9 +37,7 @@ class LinkItem(object):
           name (str): Display name of document
           location (str): Location of item relative to source directory
         """
-        name = str(name)
-        name = name.replace("\\\\","\\")
-        self.name = name
+        self.name = str(name).replace("\\\\","/")
         self.location = location
 
     def __eq__(self, other):
@@ -108,7 +107,7 @@ class Category(LinkItem):
         """
         docname = to_unix_style_path(docname)
 
-        dirpath, filename = os.path.split(docname)
+        dirpath, filename = posixpath.split(docname)
         html_dir = dirpath + "/" + CATEGORIES_DIR
         self.html_path = html_dir + "/" + to_unix_style_path(name) + ".html"
         super(Category, self).__init__(name, self.html_path)
@@ -353,19 +352,19 @@ def create_category_pages(app):
         context["outpath"] = category.html_path
 
         #jinja appends .html to output name
-        category_html_path_noext = os.path.splitext(category.html_path)[0]
+        category_html_path_noext = posixpath.splitext(category.html_path)[0]
         yield (category_html_path_noext, context, template)
 
         # Now any additional index pages if required
         if category.name in INDEX_CATEGORIES:
             # index in categories directory
-            category_html_dir = os.path.join(category.name.lower(), 'categories')
-            category_html_path_noext = os.path.join(category_html_dir, 'index')
+            category_html_dir = posixpath.join(category.name.lower(), 'categories')
+            category_html_path_noext = posixpath.join(category_html_dir, 'index')
             yield (category_html_path_noext, context, template)
 
             # index in document directory
-            document_dir = os.path.dirname(category_html_dir)
-            category_html_path_noext = os.path.join(document_dir, 'index')
+            document_dir = posixpath.dirname(category_html_dir)
+            category_html_path_noext = posixpath.join(document_dir, 'index')
             context['outpath'] = category_html_path_noext + '.html'
             yield (category_html_path_noext, context, template)
 # enddef


### PR DESCRIPTION
Description of work.

Fixes broken links to css assets when the documentation is built on Windows.

**To test:**

Build the html or Qt help docs on Windows and verify that the algorithms and concepts index pages have can find the appropriate stylesheets.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
