### PR TITLE
Saved instrument view shapes crash mantid.

### DIFF
--- a/MantidQt/MantidWidgets/src/InstrumentView/Shape2DCollection.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/Shape2DCollection.cpp
@@ -685,7 +685,9 @@ void Shape2DCollection::loadFromTableWorkspace(
   for (size_t i = 0; i < ws->rowCount(); ++i) {
     const auto params = col[i];
     auto shape = Shape2D::loadFromProject(params);
-    m_shapes.append(shape);
+    if (shape != nullptr) {
+      m_shapes.append(shape);
+    }
   }
   emit shapeCreated();
 }


### PR DESCRIPTION
An open table view truncate the parameter string for a shape. This leads to a null pointer returned by a factory method.

Added a check for a null pointer.

**To test:**

Instructions are in the issue description.

Fixes #19725.

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
