### PR TITLE
Swap order of statements to avoid race condition in Slice Viewer

### DIFF
--- a/MantidQt/API/src/AlgorithmRunner.cpp
+++ b/MantidQt/API/src/AlgorithmRunner.cpp
@@ -72,14 +72,13 @@ void AlgorithmRunner::startAlgorithm(Mantid::API::IAlgorithm_sptr alg) {
 
   cancelRunningAlgorithm();
 
-  // Start asynchronous execution
-  m_asyncAlg = alg;
-  m_asyncResult = new Poco::ActiveResult<bool>(m_asyncAlg->executeAsync());
-
   // Observe the algorithm
   alg->addObserver(m_finishedObserver);
   alg->addObserver(m_errorObserver);
   alg->addObserver(m_progressObserver);
+  // Start asynchronous execution
+  m_asyncAlg = alg;
+  m_asyncResult = new Poco::ActiveResult<bool>(m_asyncAlg->executeAsync());
 }
 
 /// Get back a pointer to the running algorithm


### PR DESCRIPTION
**Description of work**

Swaps the order of adding observers to an algorithm in the slice viewer to avoid a race condition when the algorithm starts asynchronously. This fixes the unreliable tests observed on the build servers.

**To test:**

I could only get this to fail originally on a RHEL 7 or OS X machine by running

`ctest -j8  --schedule-random --output-on-failure --repeat-until-fail 1000 -R SliceViewerMantidPlotTest_`

where `8` is the number of cores on the machine. Before this fix the test would fall over within the first 50 attempts. After this fix the test ran for ~2 hours without failure before I killed it to free up the server time. 


*Clears up random failure that users never saw. Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
