### PR TITLE
Indirect - SofQWMomentsScan - Validation

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMomentsScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMomentsScan.py
@@ -63,13 +63,13 @@ class SofQWMomentsScan(DataProcessorAlgorithm):
                                               validator=IntArrayMandatoryValidator()),
                              doc='Comma separated range of spectra number to use.')
 
-        rangeVal = FloatArrayLengthValidator(3)
+        range_val = FloatArrayLengthValidator(3)
 
         self.declareProperty(FloatArrayProperty(name='QRange',
-                                                validator=rangeVal),
+                                                validator=range_val),
                              doc='Range of background to subtract from raw data in time of flight. Start, Width, End')
         self.declareProperty(FloatArrayProperty(name='EnergyRange',
-                                                validator=rangeVal),
+                                                validator=range_val),
                              doc='Range of background to subtract from raw data in time of flight. Start, Width, End')
         self.declareProperty(name='DetailedBalance', defaultValue=Property.EMPTY_DBL,
                              doc='Apply the detailed balance correction')
@@ -329,21 +329,6 @@ class SofQWMomentsScan(DataProcessorAlgorithm):
         elif spectra_range[0] > spectra_range[1]:
             issues['SpectraRange'] = 'Range must be in format: lower,upper'
 
-        # Validate ranges
-        """
-        q_range = self.getProperty('QRange').value
-        if q_range is not None:
-            if len(q_range) != 3:
-                issues['QRange'] = 'Range must contain exactly two items'
-            elif q_range[0] > q_range[2]:
-                issues['QRange'] = 'Range must be in format: lower,upper'
-        energy_range = self.getProperty('EnergyRange').value
-        if energy_range is not None:
-            if len(energy_range) != 3:
-                issues['EnergyRange'] = 'Range must contain exactly two items'
-            elif energy_range[0] > energy_range[2]:
-                issues['EnergyRange'] = 'Range must be in format: lower,upper'
-        """
         return issues
 
     def _setup(self):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMomentsScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMomentsScan.py
@@ -59,14 +59,18 @@ class SofQWMomentsScan(DataProcessorAlgorithm):
         self.declareProperty(name='Reflection', defaultValue='',
                              validator=StringListValidator(['002', '004', '006']),
                              doc='Reflection number for instrument setup during run.')
-
         self.declareProperty(IntArrayProperty(name='SpectraRange', values=[0, 1],
                                               validator=IntArrayMandatoryValidator()),
                              doc='Comma separated range of spectra number to use.')
-        self.declareProperty(FloatArrayProperty(name='QRange'),
-                             doc='Range of background to subtract from raw data in time of flight.')
-        self.declareProperty(FloatArrayProperty(name='EnergyRange'),
-                             doc='Range of background to subtract from raw data in time of flight.')
+
+        rangeVal = FloatArrayLengthValidator(3)
+
+        self.declareProperty(FloatArrayProperty(name='QRange',
+                                                validator=rangeVal),
+                             doc='Range of background to subtract from raw data in time of flight. Start, Width, End')
+        self.declareProperty(FloatArrayProperty(name='EnergyRange',
+                                                validator=rangeVal),
+                             doc='Range of background to subtract from raw data in time of flight. Start, Width, End')
         self.declareProperty(name='DetailedBalance', defaultValue=Property.EMPTY_DBL,
                              doc='Apply the detailed balance correction')
 
@@ -326,6 +330,7 @@ class SofQWMomentsScan(DataProcessorAlgorithm):
             issues['SpectraRange'] = 'Range must be in format: lower,upper'
 
         # Validate ranges
+        """
         q_range = self.getProperty('QRange').value
         if q_range is not None:
             if len(q_range) != 3:
@@ -338,7 +343,7 @@ class SofQWMomentsScan(DataProcessorAlgorithm):
                 issues['EnergyRange'] = 'Range must contain exactly two items'
             elif energy_range[0] > energy_range[2]:
                 issues['EnergyRange'] = 'Range must be in format: lower,upper'
-
+        """
         return issues
 
     def _setup(self):


### PR DESCRIPTION
The validation of ranges in SofQWMomentsScan has been refactored.

**To test:**

Requires access to ISIS data archive.
In algorithms, search for `SofQWMomentsScan`
Input Files: `OSI100320`
Instrument: `OSIRIS`
SpectraRange: `963,1004`
QRange: `0, 0.1, 2`
EnergyRange: `-0.4, 0.01, 0.4`
GroupingMethod: `Individual`
Other fields can be left blank or as default.
Check that if `QRange` or `EnergyRange` do not have exactly 3 values, the validation is caught.

Fixes #19738 .

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
