### PR TITLE
ILL remove alternative instruments from `Facilities.xml`

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
@@ -70,6 +70,7 @@ private:
   std::vector<double> getAxis(const NeXus::NXDouble &) const;
   std::vector<double> getDurations(const NeXus::NXDouble &) const;
   std::vector<double> getMonitor(const NeXus::NXDouble &) const;
+  std::string getInstrumentFilePath(const std::string&) const;
 
   void fillDataScanMetaData(const NeXus::NXDouble &);
   void fillMovingInstrumentScan(const NeXus::NXUInt &,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
@@ -70,7 +70,7 @@ private:
   std::vector<double> getAxis(const NeXus::NXDouble &) const;
   std::vector<double> getDurations(const NeXus::NXDouble &) const;
   std::vector<double> getMonitor(const NeXus::NXDouble &) const;
-  std::string getInstrumentFilePath(const std::string&) const;
+  std::string getInstrumentFilePath(const std::string &) const;
 
   void fillDataScanMetaData(const NeXus::NXDouble &);
   void fillMovingInstrumentScan(const NeXus::NXUInt &,

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -6,6 +6,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataHandling/H5Util.h"
 #include "MantidGeometry/Instrument/ComponentHelper.h"
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/make_unique.h"
 #include "MantidKernel/TimeSeriesProperty.h"
@@ -15,6 +16,7 @@
 
 #include <H5Cpp.h>
 #include <nexus/napi.h>
+#include <Poco/Path.h>
 
 namespace Mantid {
 namespace DataHandling {
@@ -438,7 +440,7 @@ void LoadILLDiffraction::initWorkspace() {
 */
 void LoadILLDiffraction::loadStaticInstrument() {
   IAlgorithm_sptr loadInst = createChildAlgorithm("LoadInstrument");
-  loadInst->setPropertyValue("InstrumentName", m_instName);
+  loadInst->setPropertyValue("Filename", getInstrumentFilePath(m_instName));
   loadInst->setProperty<MatrixWorkspace_sptr>("Workspace", m_outWorkspace);
   loadInst->setProperty("RewriteSpectraMap", OptionalBool(true));
   loadInst->execute();
@@ -457,6 +459,21 @@ void LoadILLDiffraction::moveTwoThetaZero(double twoTheta0) {
   g_log.debug() << "Setting 2theta0 to " << twoTheta0;
 
   m_outWorkspace->mutableDetectorInfo().setRotation(*component, rotation);
+}
+
+/**
+* Makes up the full path of the relevant IDF dependent on resolution mode
+* @param instName : the name of the instrument (including the resolution mode
+* suffix)
+* @return : the full path to the corresponding IDF
+*/
+std::string
+LoadILLDiffraction::getInstrumentFilePath(const std::string &instName) const {
+
+  Poco::Path directory(ConfigService::Instance().getInstrumentDirectory());
+  Poco::Path file(instName + "_Definition.xml");
+  Poco::Path fullPath(directory, file);
+  return fullPath.toString();
 }
 
 } // namespace DataHandling

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -631,15 +631,7 @@
     <technique>Powder diffraction</technique>
   </instrument>
 
-  <instrument name="D20_lr">
-    <technique>Powder diffraction</technique>
-  </instrument>
-
   <instrument name="D20">
-    <technique>Powder diffraction</technique>
-  </instrument>
-
-  <instrument name="D20_hr">
     <technique>Powder diffraction</technique>
   </instrument>
 
@@ -648,10 +640,6 @@
   </instrument>
 
   <instrument name="D4">
-    <technique>Liquid diffraction</technique>
-  </instrument>
-
-  <instrument name="D4_hr">
     <technique>Liquid diffraction</technique>
   </instrument>
 


### PR DESCRIPTION
This removes the alternative resolution modes of ILL diffractometers from Facilities.xml, so they don't show up in the instruments list. No functional change expected.

**To test:**
The additional instrument names `(D20_hr, D20_lr, ...)` should not appear in First Time Setup under facility ILL.

<!-- Instructions for testing. -->

No issue associated.

Does not need to be in the release notes.

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.