### PR TITLE
Fix deleted algoritm links

### DIFF
--- a/docs/source/release/v3.6.0/diffraction.rst
+++ b/docs/source/release/v3.6.0/diffraction.rst
@@ -44,10 +44,10 @@ Powder Diffraction
 -  Various fixes and optimizations to make
    :ref:`SNSPowderReduction <algm-SNSPowderReduction>`
    run faster.
--  New documentation page for the :ref:`ISIS Powder Diffraction <isis-powder-diffraction>`
+-  New documentation page for the `ISIS Powder Diffraction <http://docs.mantidproject.org/v3.6.0/api/python/techniques/PowderDiffractionISIS-v1.html>`_
    with comprehensive workflow-diagrams and usage example.
 -  Many small changes made to the ISIS Powder Diffraction script to
-   enable smoother process, which can be discovered on the :ref:`ISIS Powder Diffraction <isis-powder-diffraction>`
+   enable smoother process, which can be discovered on the `ISIS Powder Diffraction <http://docs.mantidproject.org/v3.6.0/api/python/techniques/PowderDiffractionISIS-v1.html>`_
    documentation page.
 
 Crystal Improvements

--- a/docs/source/release/v3.7.1/diffraction.rst
+++ b/docs/source/release/v3.7.1/diffraction.rst
@@ -29,9 +29,10 @@ Powder Diffraction Scripts
 - PowderISIS script has been renamed to CryPowderISIS and can be found within
   the following folder `scripts/CryPowderISIS`
 
-- :ref:`pearl-powder-diffraction-ref` documentation has been implemented and
+- `Pearl Powder Diffraction Script <http://docs.mantidproject.org/v3.7.1/api/python/techniques/PearlPowderDiffractionISIS-v1.html>`_ 
+  documentation has been implemented and
   PowderISIS script documentation has been renamed to
-  :ref:`cry-powder-diffraction-ref`
+  `Crystallography Powder Diffraction Script <http://docs.mantidproject.org/v3.7.1/api/python/techniques/CryPowderDiffractionISIS-v1.html>`_
 
 Single Crystal Improvements
 ---------------------------
@@ -123,10 +124,13 @@ Graphical user interface
 Imaging
 -------
 
-- The new algorithm :ref:`ImggAggregateWavelengths <algm-ImggAggregateWavelengths>`
+- The new algorithm `ImggAggregateWavelengths 
+  <http://docs.mantidproject.org/v3.7.1/algorithms/ImggAggregateWavelengths-v1.html>`_
   aggregates stacks of images from wavelength dependent data.
 
-- The algorithm `ImggTomographicReconstruction <algm-ImggTomographicReconstruction>` has been introduced. This is a
+- The algorithm `ImggTomographicReconstruction 
+  <http://docs.mantidproject.org/v3.7.1/algorithms/ImggTomographicReconstruction-v1.html>`_ 
+  has been introduced. This is a
   first experimental version that implements the Filtered
   Back-Projection (FBP) reconstruction method using the FBP
   implementation of the `TomoPy package
@@ -156,9 +160,8 @@ Improvements in the tomographic reconstruction graphical user interface
 
 - The energy bands tab can now produce multiple output bands in one
   pass, and supports different aggregation methods via the new
-  algorithm :ref:`ImggAggregateWavelengths
-  <algm-ImggAggregateWavelengths>`.
-
+  algorithm `ImggAggregateWavelengths 
+  <http://docs.mantidproject.org/v3.7.1/algorithms/ImggAggregateWavelengths-v1.html>`_.
 
 
 Full list of `diffraction <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.7%22+is%3Amerged+label%3A%22Component%3A+Diffraction%22>`_

--- a/docs/source/release/v3.7.1/framework.rst
+++ b/docs/source/release/v3.7.1/framework.rst
@@ -63,10 +63,10 @@ New
 - :ref:`GetIPTS <algm-GetIPTS>` Returns the IPTS directory of the specified ORNL run.
 - :ref:`GSASIIRefineFitPeaks <algm-GSASIIRefineFitPeaks>` uses the GSAS-II
   software to refine lattice parameters (whole pattern refinement) and fit
-- :ref:`ImggAggregateWavelengths <algm-ImggAggregateWavelengths>` aggregates stacks of images from wavelength dependent imaging into one or more output bands.
-- :ref:`ImggTomographicReconstruction
-  <algm-ImggTomographicReconstruction>` implements a method for 3D
-  tomographic reconstruction from projection images.
+- `ImggAggregateWavelengths <http://docs.mantidproject.org/v3.7.1/algorithms/ImggAggregateWavelengths-v1.html>`_ 
+  aggregates stacks of images from wavelength dependent imaging into one or more output bands.
+- `ImggTomographicReconstruction <http://docs.mantidproject.org/v3.7.1/algorithms/ImggTomographicReconstruction-v1.html>`_
+  implements a method for 3D tomographic reconstruction from projection images.
 - :ref:`SaveFITS <algm-SaveFITS>` saves images in FITS format.
 
 Renamed

--- a/docs/source/release/v3.8.0/diffraction.rst
+++ b/docs/source/release/v3.8.0/diffraction.rst
@@ -95,8 +95,7 @@ Powder Diffraction
   look at the signal as well when looking at the ``Q``-range to use
   for the transform.
 
-- `Crystallography Powder Diffraction Script <http://docs.mantidproject.org/v3.8.0/api/python/techniques/CryPowderDiffractionISIS-v1.html>`_: 
-   S-Empty option has been enabled for
+- `Crystallography Powder Diffraction Script <http://docs.mantidproject.org/v3.8.0/api/python/techniques/CryPowderDiffractionISIS-v1.html>`_: S-Empty option has been enabled for
    the Crystallography Powder Diffraction Script. In order to use the
    S-Empty option, simply provide the S-Empty run number within the
    ``.pref`` file.
@@ -106,8 +105,7 @@ Powder Diffraction
   (:math:`c\approx0.498`) as requested by the instrument scientists.
 
 - `Pearl Powder Diffraction Script <http://docs.mantidproject.org/v3.8.0/api/python/techniques/PearlPowderDiffractionISIS-v1.html>`_: 
-  A workflow diagram for
-  ``pearl_run_focus`` function has been created.
+  A workflow diagram for ``pearl_run_focus`` function has been created.
 
 - :ref:`CalibrateRectangularDetectors
   <algm-CalibrateRectangularDetectors>` has been modified to output

--- a/docs/source/release/v3.8.0/diffraction.rst
+++ b/docs/source/release/v3.8.0/diffraction.rst
@@ -95,7 +95,8 @@ Powder Diffraction
   look at the signal as well when looking at the ``Q``-range to use
   for the transform.
 
-- :ref:`cry-powder-diffraction-ref`: S-Empty option has been enabled for
+- `Crystallography Powder Diffraction Script <http://docs.mantidproject.org/v3.8.0/api/python/techniques/CryPowderDiffractionISIS-v1.html>`_: 
+   S-Empty option has been enabled for
    the Crystallography Powder Diffraction Script. In order to use the
    S-Empty option, simply provide the S-Empty run number within the
    ``.pref`` file.
@@ -104,7 +105,8 @@ Powder Diffraction
   weights applied to events have changed by a factor of the duty cycle
   (:math:`c\approx0.498`) as requested by the instrument scientists.
 
-- :ref:`pearl-powder-diffraction-ref`: A workflow diagram for
+- `Pearl Powder Diffraction Script <http://docs.mantidproject.org/v3.8.0/api/python/techniques/PearlPowderDiffractionISIS-v1.html>`_: 
+  A workflow diagram for
   ``pearl_run_focus`` function has been created.
 
 - :ref:`CalibrateRectangularDetectors


### PR DESCRIPTION
Fixed broken links in documentation due to algorithms techniques that were deleted
**To test:**
Build documentation. There should be no sphinx warnings. Release notes for deleted algorithms point to the pages on the web instead of the offline help.

<!-- Instructions for testing. -->

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
