### PR TITLE
Enable AlignAndFocusPowder to work for out-of-place output workspace

### DIFF
--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -328,8 +328,7 @@ void AlignAndFocusPowder::exec() {
       // out-of-place: clone the input EventWorkspace
       m_outputEW = m_inputEW->clone();
       m_outputW = boost::dynamic_pointer_cast<MatrixWorkspace>(m_outputEW);
-    }
-    else{
+    } else {
       // in-place
       m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
     }

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -323,11 +323,14 @@ void AlignAndFocusPowder::exec() {
   // Now setup the output workspace
   m_outputW = getProperty("OutputWorkspace");
   if (m_inputEW) {
+    // event workspace
     if (m_outputW != m_inputW) {
+      // out-of-place: clone the input EventWorkspace
       m_outputEW = m_inputEW->clone();
     }
-    m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
+    m_outputW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputEW);
   } else {
+    // workspace2D
     if (m_outputW != m_inputW) {
       m_outputW = WorkspaceFactory::Instance().create(m_inputW);
     }

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -327,8 +327,12 @@ void AlignAndFocusPowder::exec() {
     if (m_outputW != m_inputW) {
       // out-of-place: clone the input EventWorkspace
       m_outputEW = m_inputEW->clone();
+      m_outputW = boost::dynamic_pointer_cast<MatrixWorkspace>(m_outputEW);
     }
-    m_outputW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputEW);
+    else{
+      // in-place
+      m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
+    }
   } else {
     // workspace2D
     if (m_outputW != m_inputW) {


### PR DESCRIPTION
AlignAndFocusPowder fails if the output workspace is out-of-place, while it works in the case for in-place workspace.

**To test:**

The following script fails before being fixed.

```
dvalues = [2.0600,1.2615,1.0758,0.8920,0.8186,0.7283,0.6867,0.6307,0.5947,0.5642,0.5441,
           0.5150,0.4996, 0.4768,0.4645,0.4205,0.3916,0.3499,0.3257,0.3117]
CalibrateRectangularDetectors(RunNumber="PG3_27021", Binning="0.3,-0.0004,3",
                              PeakPositions=dvalues,
                              # control the peak fitting
                              MaxOffset=0.005,
                              CrossCorrelation=False,
                              PeakWindowMax=0.1,
                              # what function to fit with
                              BackgroundType="Flat",
                              PeakFunction="Gaussian",
                              # default grouping used in reduction
                              GroupDetectorsBy="All",
                              # how to save the results
                              SaveAs="calibration",
                              OutputDirectory="/tmp")
                              
                              
ws = Load(Filename='PG3_27021')

# out-of-place
AlignAndFocusPowder(InputWorkspace='ws', OutputWorkspace='outplace', GroupingWorkspace='PG3_27021group', CalibrationWorkspace='PG3_27021cal' , OffsetsWorkspace='PG3_27021offset',
    Params='-0.001', DSpacing=True, DMin=0.5, DMax=5.0, PreserveEvents=True, L2='2.0', Polar='150.0')
# in-place
AlignAndFocusPowder(InputWorkspace='ws', OutputWorkspace='ws', GroupingWorkspace='PG3_27021group', CalibrationWorkspace='PG3_27021cal' , OffsetsWorkspace='PG3_27021offset',
    Params='-0.001', DSpacing=True, DMin=0.5, DMax=5.0, PreserveEvents=True, L2='2.0', Polar='150.0')
```

Fixes #19703.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
