### PR TITLE
Fix Instrument Window segfaulting when the instrument changes

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentTreeModel.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentTreeModel.h
@@ -1,14 +1,15 @@
 #ifndef INSTRUMENTTREEMODEL_H
 #define INSTRUMENTTREEMODEL_H
 
-#include <QAbstractItemModel>
-#include <QModelIndex>
+#include "MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h"
 
-#include <boost/shared_ptr.hpp>
+#include <QAbstractItemModel>
+//#include <QModelIndex>
+
+//#include <boost/shared_ptr.hpp>
 
 namespace MantidQt {
 namespace MantidWidgets {
-class InstrumentActor;
 
 /**
 * The InstrumentTreeModel is a class used by a QTreeView
@@ -23,7 +24,7 @@ class InstrumentActor;
 class InstrumentTreeModel : public QAbstractItemModel {
   Q_OBJECT
 public:
-  InstrumentTreeModel(const InstrumentActor *, QObject *parent);
+  InstrumentTreeModel(const InstrumentWidget *instrWidget, QObject *parent);
   ~InstrumentTreeModel() override;
 
   QVariant data(const QModelIndex &index, int role) const override;
@@ -37,8 +38,8 @@ public:
   int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
 private:
-  const InstrumentActor *
-      m_instrumentActor; ///< actor of instrument to which the model corresponds
+  /// instrument widget to which the model corresponds
+  const InstrumentWidget *m_instrWidget;
 };
 } // MantidWidgets
 } // MantidQt

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentTreeModel.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentTreeModel.h
@@ -4,9 +4,6 @@
 #include "MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h"
 
 #include <QAbstractItemModel>
-//#include <QModelIndex>
-
-//#include <boost/shared_ptr.hpp>
 
 namespace MantidQt {
 namespace MantidWidgets {

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentTreeWidget.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentTreeWidget.h
@@ -24,7 +24,7 @@ class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS InstrumentTreeWidget
   Q_OBJECT
 public:
   explicit InstrumentTreeWidget(QWidget *w);
-  void setInstrumentActor(InstrumentActor *instrActor);
+  void setInstrumentWidget(InstrumentWidget *w);
   void getSelectedBoundingBox(const QModelIndex &index, double &xmax,
                               double &ymax, double &zmax, double &xmin,
                               double &ymin, double &zmin);
@@ -39,7 +39,7 @@ signals:
   void componentSelected(const Mantid::Geometry::ComponentID);
 
 private:
-  InstrumentActor *m_instrActor;
+  InstrumentWidget *m_instrWidget;
   InstrumentTreeModel *m_treeModel;
 };
 } // MantidWidgets

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
@@ -115,7 +115,9 @@ public:
   void setScaleType(GraphOptions::ScaleType type);
   void setExponent(double nth_power);
   void setViewType(const QString &type);
-  const InstrumentActor &getInstrumentActor() const { return *m_instrumentActor; }
+  const InstrumentActor &getInstrumentActor() const {
+    return *m_instrumentActor;
+  }
   InstrumentActor &getInstrumentActor() { return *m_instrumentActor; }
   void resetInstrument(bool resetGeometry);
   void selectTab(int tab);

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidget.h
@@ -115,7 +115,8 @@ public:
   void setScaleType(GraphOptions::ScaleType type);
   void setExponent(double nth_power);
   void setViewType(const QString &type);
-  InstrumentActor *getInstrumentActor() const { return m_instrumentActor; }
+  const InstrumentActor &getInstrumentActor() const { return *m_instrumentActor; }
+  InstrumentActor &getInstrumentActor() { return *m_instrumentActor; }
   void resetInstrument(bool resetGeometry);
   void selectTab(int tab);
   void selectTab(Tab tab) { selectTab(int(tab)); }
@@ -256,7 +257,7 @@ protected:
   /// InstrumentActor holds a pointer to the workspace itself.
   QString m_workspaceName;
   /// Instrument actor is an interface to the instrument
-  InstrumentActor *m_instrumentActor;
+  std::unique_ptr<InstrumentActor> m_instrumentActor;
   /// Option to use or not OpenGL display for "unwrapped" view, 3D is always in
   /// OpenGL
   bool m_useOpenGL;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -188,7 +188,8 @@ class ComponentInfoController : public QObject {
 public:
   /// Constructor.
   ComponentInfoController(InstrumentWidgetPickTab *tab,
-                          const InstrumentWidget *instrWidget, QTextEdit *infoDisplay);
+                          const InstrumentWidget *instrWidget,
+                          QTextEdit *infoDisplay);
 public slots:
   void displayInfo(size_t pickID);
   void displayComparePeaksInfo(

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -188,7 +188,7 @@ class ComponentInfoController : public QObject {
 public:
   /// Constructor.
   ComponentInfoController(InstrumentWidgetPickTab *tab,
-                          InstrumentActor *instrActor, QTextEdit *infoDisplay);
+                          const InstrumentWidget *instrWidget, QTextEdit *infoDisplay);
 public slots:
   void displayInfo(size_t pickID);
   void displayComparePeaksInfo(
@@ -208,7 +208,7 @@ private:
   QString getPeakOverlayInfo();
 
   InstrumentWidgetPickTab *m_tab;
-  InstrumentActor *m_instrActor;
+  const InstrumentWidget *m_instrWidget;
   QTextEdit *m_selectionInfoDisplay;
 
   bool m_freezePlot;
@@ -234,7 +234,7 @@ public:
   };
 
   DetectorPlotController(InstrumentWidgetPickTab *tab,
-                         InstrumentActor *instrActor, OneCurvePlot *plot);
+                         InstrumentWidget *instrWidget, OneCurvePlot *plot);
   void setEnabled(bool on) { m_enabled = on; }
   void setPlotData(size_t pickID);
   void setPlotData(QList<int> detIDs);
@@ -273,7 +273,7 @@ private:
                                    const Mantid::Kernel::V3D &normal);
 
   InstrumentWidgetPickTab *m_tab;
-  InstrumentActor *m_instrActor;
+  InstrumentWidget *m_instrWidget;
   OneCurvePlot *m_plot;
 
   PlotType m_plotType;

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentTreeModel.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentTreeModel.cpp
@@ -19,9 +19,9 @@ namespace MantidWidgets {
 /**
 * Constructor for tree model to display instrument tree
 */
-InstrumentTreeModel::InstrumentTreeModel(const InstrumentActor *actor,
+InstrumentTreeModel::InstrumentTreeModel(const InstrumentWidget *instrWidget,
                                          QObject *parent)
-    : QAbstractItemModel(parent), m_instrumentActor(actor) {}
+    : QAbstractItemModel(parent), m_instrWidget(instrWidget) {}
 
 /**
 * Destructor for instrument display tree
@@ -37,7 +37,7 @@ InstrumentTreeModel::~InstrumentTreeModel() {}
 int InstrumentTreeModel::columnCount(const QModelIndex &parent) const {
   try {
     if (parent.isValid()) {
-      auto instr = m_instrumentActor->getInstrument();
+      auto instr = m_instrWidget->getInstrumentActor().getInstrument();
       boost::shared_ptr<const IComponent> comp = instr->getComponentByID(
           static_cast<Mantid::Geometry::ComponentID>(parent.internalPointer()));
       boost::shared_ptr<const ICompAssembly> objcomp =
@@ -62,7 +62,7 @@ QVariant InstrumentTreeModel::data(const QModelIndex &index, int role) const {
     if (role != Qt::DisplayRole)
       return QVariant();
 
-    auto instr = m_instrumentActor->getInstrument();
+    auto instr = m_instrWidget->getInstrumentActor().getInstrument();
 
     if (!index.isValid()) // not valid has to return the root node
       return QString(instr->getName().c_str());
@@ -109,7 +109,7 @@ QModelIndex InstrumentTreeModel::index(int row, int column,
   //"<<parent.isValid()<<'\n';
   try {
     boost::shared_ptr<const ICompAssembly> parentItem;
-    auto instr = m_instrumentActor->getInstrument();
+    auto instr = m_instrWidget->getInstrumentActor().getInstrument();
     if (!parent.isValid()) // invalid parent, has to be the root node i.e
                            // instrument
       return createIndex(row, column, instr->getComponentID());
@@ -152,7 +152,7 @@ QModelIndex InstrumentTreeModel::parent(const QModelIndex &index) const {
                           // for root return empty.
       return QModelIndex();
 
-    auto instr = m_instrumentActor->getInstrument();
+    auto instr = m_instrWidget->getInstrumentActor().getInstrument();
 
     if (instr->getComponentID() ==
         static_cast<Mantid::Geometry::ComponentID>(index.internalPointer()))
@@ -193,7 +193,7 @@ int InstrumentTreeModel::rowCount(const QModelIndex &parent) const {
     {
       return 1; // boost::dynamic_pointer_cast<ICompAssembly>(m_instrument)->nelements();
     } else {
-      auto instr = m_instrumentActor->getInstrument();
+      auto instr = m_instrWidget->getInstrumentActor().getInstrument();
       if (instr->getComponentID() == static_cast<Mantid::Geometry::ComponentID>(
                                          parent.internalPointer())) {
         return instr->nelements();

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentTreeWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentTreeWidget.cpp
@@ -18,14 +18,14 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 InstrumentTreeWidget::InstrumentTreeWidget(QWidget *w)
-    : QTreeView(w), m_instrActor(NULL), m_treeModel(NULL) {
+    : QTreeView(w), m_instrWidget(nullptr), m_treeModel(nullptr) {
   connect(this, SIGNAL(clicked(const QModelIndex)), this,
           SLOT(sendComponentSelectedSignal(const QModelIndex)));
 }
 
-void InstrumentTreeWidget::setInstrumentActor(InstrumentActor *instrActor) {
-  m_instrActor = instrActor;
-  m_treeModel = new InstrumentTreeModel(instrActor, this);
+void InstrumentTreeWidget::setInstrumentWidget(InstrumentWidget *w) {
+  m_instrWidget = w;
+  m_treeModel = new InstrumentTreeModel(w, this);
   setModel(m_treeModel);
   setSelectionMode(SingleSelection);
   setSelectionBehavior(SelectRows);
@@ -36,7 +36,7 @@ void InstrumentTreeWidget::getSelectedBoundingBox(const QModelIndex &index,
                                                   double &zmax, double &xmin,
                                                   double &ymin, double &zmin) {
   Mantid::Geometry::Instrument_const_sptr instrument =
-      m_instrActor->getInstrument();
+      m_instrWidget->getInstrumentActor().getInstrument();
   // Check whether its instrument
   boost::shared_ptr<const Mantid::Geometry::IComponent> selectedComponent;
   if (instrument->getComponentID() ==
@@ -66,7 +66,7 @@ void InstrumentTreeWidget::getSelectedBoundingBox(const QModelIndex &index,
         // int(instrument->getSample()->getComponentID()) << '\n';
         if (tmpObj->getComponentID() ==
             instrument->getSample()->getComponentID()) {
-          boundBox = m_instrActor->getWorkspace()
+          boundBox = m_instrWidget->getInstrumentActor().getWorkspace()
                          ->sample()
                          .getShape()
                          .getBoundingBox();
@@ -123,7 +123,7 @@ void InstrumentTreeWidget::sendComponentSelectedSignal(
   Mantid::Geometry::ComponentID id =
       static_cast<Mantid::Geometry::ComponentID>(index.internalPointer());
   auto visitor = SetVisibleComponentVisitor(id);
-  m_instrActor->accept(visitor);
+  m_instrWidget->getInstrumentActor().accept(visitor);
   emit componentSelected(id);
 }
 

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentTreeWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentTreeWidget.cpp
@@ -66,7 +66,8 @@ void InstrumentTreeWidget::getSelectedBoundingBox(const QModelIndex &index,
         // int(instrument->getSample()->getComponentID()) << '\n';
         if (tmpObj->getComponentID() ==
             instrument->getSample()->getComponentID()) {
-          boundBox = m_instrWidget->getInstrumentActor().getWorkspace()
+          boundBox = m_instrWidget->getInstrumentActor()
+                         .getWorkspace()
                          ->sample()
                          .getShape()
                          .getBoundingBox();

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
@@ -195,7 +195,6 @@ InstrumentWidget::InstrumentWidget(const QString &wsName, QWidget *parent,
 InstrumentWidget::~InstrumentWidget() {
   if (m_instrumentActor) {
     saveSettings();
-    delete m_instrumentActor;
   }
 }
 
@@ -250,8 +249,8 @@ void InstrumentWidget::init(bool resetGeometry, bool autoscaling,
                             double scaleMin, double scaleMax,
                             bool setDefaultView) {
   // Previously in (now removed) setWorkspaceName method
-  m_instrumentActor =
-      new InstrumentActor(m_workspaceName, autoscaling, scaleMin, scaleMax);
+  m_instrumentActor.reset(
+      new InstrumentActor(m_workspaceName, autoscaling, scaleMin, scaleMax));
   m_xIntegration->setTotalRange(m_instrumentActor->minBinValue(),
                                 m_instrumentActor->maxBinValue());
   m_xIntegration->setUnits(QString::fromStdString(
@@ -275,7 +274,7 @@ void InstrumentWidget::init(bool resetGeometry, bool autoscaling,
     }
     setupColorMap();
   } else {
-    surface->resetInstrumentActor(m_instrumentActor);
+    surface->resetInstrumentActor(m_instrumentActor.get());
     updateInfoText();
   }
 }
@@ -285,8 +284,6 @@ void InstrumentWidget::init(bool resetGeometry, bool autoscaling,
 * @param resetGeometry
 */
 void InstrumentWidget::resetInstrument(bool resetGeometry) {
-  delete m_instrumentActor;
-  m_instrumentActor = nullptr;
   init(resetGeometry, true, 0.0, 0.0, false);
   updateInstrumentDetectors();
 }
@@ -415,15 +412,15 @@ void InstrumentWidget::setSurfaceType(int type) {
       // create the surface
       if (surfaceType == FULL3D) {
         surface =
-            new Projection3D(m_instrumentActor, getInstrumentDisplayWidth(),
+            new Projection3D(m_instrumentActor.get(), getInstrumentDisplayWidth(),
                              getInstrumentDisplayHeight());
       } else if (surfaceType <= CYLINDRICAL_Z) {
-        surface = new UnwrappedCylinder(m_instrumentActor, sample_pos, axis);
+        surface = new UnwrappedCylinder(m_instrumentActor.get(), sample_pos, axis);
       } else if (surfaceType <= SPHERICAL_Z) {
-        surface = new UnwrappedSphere(m_instrumentActor, sample_pos, axis);
+        surface = new UnwrappedSphere(m_instrumentActor.get(), sample_pos, axis);
       } else // SIDE_BY_SIDE
       {
-        surface = new PanelsSurface(m_instrumentActor, sample_pos, axis);
+        surface = new PanelsSurface(m_instrumentActor.get(), sample_pos, axis);
       }
     } catch (InstrumentHasNoSampleError &) {
       QApplication::restoreOverrideCursor();
@@ -1217,7 +1214,7 @@ QString InstrumentWidget::getSettingsGroupName() const {
 QString InstrumentWidget::getInstrumentSettingsGroupName() const {
   return QString::fromAscii(InstrumentWidgetSettingsGroup) + "/" +
          QString::fromStdString(
-             getInstrumentActor()->getInstrument()->getName());
+             getInstrumentActor().getInstrument()->getName());
 }
 
 bool InstrumentWidget::hasWorkspace(const std::string &wsName) const {
@@ -1311,10 +1308,10 @@ void InstrumentWidget::overlayPeaksWorkspace(IPeaksWorkspace_sptr ws) {
  * @param ws :: mask workspace to overlay
  */
 void InstrumentWidget::overlayMaskedWorkspace(IMaskWorkspace_sptr ws) {
-  auto actor = getInstrumentActor();
-  actor->setMaskMatrixWorkspace(
+  auto &actor = getInstrumentActor();
+  actor.setMaskMatrixWorkspace(
       boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws));
-  actor->updateColors();
+  actor.updateColors();
   updateInstrumentDetectors();
   emit maskedWorkspaceOverlayed();
 }

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidget.cpp
@@ -411,13 +411,15 @@ void InstrumentWidget::setSurfaceType(int type) {
 
       // create the surface
       if (surfaceType == FULL3D) {
-        surface =
-            new Projection3D(m_instrumentActor.get(), getInstrumentDisplayWidth(),
-                             getInstrumentDisplayHeight());
+        surface = new Projection3D(m_instrumentActor.get(),
+                                   getInstrumentDisplayWidth(),
+                                   getInstrumentDisplayHeight());
       } else if (surfaceType <= CYLINDRICAL_Z) {
-        surface = new UnwrappedCylinder(m_instrumentActor.get(), sample_pos, axis);
+        surface =
+            new UnwrappedCylinder(m_instrumentActor.get(), sample_pos, axis);
       } else if (surfaceType <= SPHERICAL_Z) {
-        surface = new UnwrappedSphere(m_instrumentActor.get(), sample_pos, axis);
+        surface =
+            new UnwrappedSphere(m_instrumentActor.get(), sample_pos, axis);
       } else // SIDE_BY_SIDE
       {
         surface = new PanelsSurface(m_instrumentActor.get(), sample_pos, axis);

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
@@ -785,8 +785,8 @@ void InstrumentWidgetMaskTab::saveExcludeGroupToFile() {
   if (!fname.isEmpty()) {
     QList<int> dets;
     m_instrWidget->getSurface()->getMaskedDetectors(dets);
-    DetXMLFile mapFile(m_instrWidget->getInstrumentActor().getAllDetIDs(),
-                       dets, fname);
+    DetXMLFile mapFile(m_instrWidget->getInstrumentActor().getAllDetIDs(), dets,
+                       fname);
   }
 }
 

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetMaskTab.cpp
@@ -632,7 +632,7 @@ void InstrumentWidgetMaskTab::doubleChanged(QtProperty *prop) {
 void InstrumentWidgetMaskTab::applyMask() {
   storeMask();
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  m_instrWidget->getInstrumentActor()->applyMaskWorkspace();
+  m_instrWidget->getInstrumentActor().applyMaskWorkspace();
   enableApplyButtons();
   QApplication::restoreOverrideCursor();
 }
@@ -650,7 +650,7 @@ void InstrumentWidgetMaskTab::applyMaskToView() {
 */
 void InstrumentWidgetMaskTab::clearMask() {
   clearShapes();
-  m_instrWidget->getInstrumentActor()->clearMasks();
+  m_instrWidget->getInstrumentActor().clearMasks();
   m_instrWidget->updateInstrumentView();
   enableApplyButtons();
 }
@@ -666,7 +666,7 @@ Mantid::API::MatrixWorkspace_sptr
 InstrumentWidgetMaskTab::createMaskWorkspace(bool invertMask, bool temp) const {
   m_instrWidget->updateInstrumentView(); // to refresh the pick image
   Mantid::API::MatrixWorkspace_sptr inputWS =
-      m_instrWidget->getInstrumentActor()->getMaskMatrixWorkspace();
+      m_instrWidget->getInstrumentActor().getMaskMatrixWorkspace();
   Mantid::API::MatrixWorkspace_sptr outputWS;
   const std::string outputWorkspaceName = generateMaskWorkspaceName(temp);
 
@@ -785,7 +785,7 @@ void InstrumentWidgetMaskTab::saveExcludeGroupToFile() {
   if (!fname.isEmpty()) {
     QList<int> dets;
     m_instrWidget->getSurface()->getMaskedDetectors(dets);
-    DetXMLFile mapFile(m_instrWidget->getInstrumentActor()->getAllDetIDs(),
+    DetXMLFile mapFile(m_instrWidget->getInstrumentActor().getAllDetIDs(),
                        dets, fname);
   }
 }
@@ -931,11 +931,11 @@ void InstrumentWidgetMaskTab::saveMaskingToTableWorkspace(bool invertMask) {
 
   // Apply the view (no workspace) to a buffered mask workspace
   Mantid::API::MatrixWorkspace_sptr inputWS =
-      m_instrWidget->getInstrumentActor()->getMaskMatrixWorkspace();
+      m_instrWidget->getInstrumentActor().getMaskMatrixWorkspace();
 
   // Extract from MaskWorkspace to a TableWorkspace
-  double xmin = m_instrWidget->getInstrumentActor()->minBinValue();
-  double xmax = m_instrWidget->getInstrumentActor()->maxBinValue();
+  double xmin = m_instrWidget->getInstrumentActor().minBinValue();
+  double xmax = m_instrWidget->getInstrumentActor().maxBinValue();
   // std::cout << "[DB] Selected x-range: " << xmin << ", " << xmax << ".\n";
 
   // Always use the same name
@@ -1020,13 +1020,13 @@ InstrumentWidgetMaskTab::generateMaskWorkspaceName(bool temp) const {
 * enables/disables the apply and clear buttons.
 */
 void InstrumentWidgetMaskTab::enableApplyButtons() {
-  auto instrActor = m_instrWidget->getInstrumentActor();
+  const auto &instrActor = m_instrWidget->getInstrumentActor();
   auto mode = getMode();
 
-  m_maskBins = !m_instrWidget->getInstrumentActor()->wholeRange();
+  m_maskBins = !instrActor.wholeRange();
   bool hasMaskShapes = m_instrWidget->getSurface()->hasMasks();
-  bool hasMaskWorkspace = instrActor->hasMaskWorkspace();
-  bool hasBinMask = instrActor->hasBinMask();
+  bool hasMaskWorkspace = instrActor.hasMaskWorkspace();
+  bool hasBinMask = instrActor.hasBinMask();
   bool hasDetectorMask = hasMaskShapes || hasMaskWorkspace;
   bool hasMask = hasDetectorMask || hasBinMask;
 
@@ -1113,7 +1113,7 @@ void InstrumentWidgetMaskTab::storeDetectorMask(bool isROI) {
   // get detectors covered by the shapes
   m_instrWidget->getSurface()->getMaskedDetectors(dets);
   if (!dets.isEmpty()) {
-    auto wsMask = m_instrWidget->getInstrumentActor()->getMaskWorkspace();
+    auto wsMask = m_instrWidget->getInstrumentActor().getMaskWorkspace();
     // have to cast up to the MaskWorkspace to get access to clone()
 
     std::set<Mantid::detid_t> detList;
@@ -1122,8 +1122,8 @@ void InstrumentWidgetMaskTab::storeDetectorMask(bool isROI) {
       // but not if the mask is fresh and empty
       if (wsMask->getNumberMasked() > 0) {
         wsFresh = boost::dynamic_pointer_cast<Mantid::API::IMaskWorkspace>(
-            m_instrWidget->getInstrumentActor()->extractCurrentMask());
-        m_instrWidget->getInstrumentActor()->invertMaskWorkspace();
+            m_instrWidget->getInstrumentActor().extractCurrentMask());
+        m_instrWidget->getInstrumentActor().invertMaskWorkspace();
       }
     }
     foreach (int id, dets) { detList.insert(id); }
@@ -1143,14 +1143,14 @@ void InstrumentWidgetMaskTab::storeDetectorMask(bool isROI) {
       }
       if (isROI) {
         if (wsFresh)
-          m_instrWidget->getInstrumentActor()->setMaskMatrixWorkspace(
+          m_instrWidget->getInstrumentActor().setMaskMatrixWorkspace(
               boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
                   wsFresh));
         // need to invert the mask before displaying
-        m_instrWidget->getInstrumentActor()->invertMaskWorkspace();
+        m_instrWidget->getInstrumentActor().invertMaskWorkspace();
       }
       // update detector colours
-      m_instrWidget->getInstrumentActor()->updateColors();
+      m_instrWidget->getInstrumentActor().updateColors();
       m_instrWidget->updateInstrumentDetectors();
     }
   }
@@ -1164,7 +1164,7 @@ void InstrumentWidgetMaskTab::storeBinMask() {
   // get detectors covered by the shapes
   m_instrWidget->getSurface()->getMaskedDetectors(dets);
   // mask some bins
-  m_instrWidget->getInstrumentActor()->addMaskBinsData(dets);
+  m_instrWidget->getInstrumentActor().addMaskBinsData(dets);
   // remove masking shapes
   clearShapes();
   enableApplyButtons();
@@ -1245,9 +1245,9 @@ void InstrumentWidgetMaskTab::loadMaskViewFromProject(const std::string &name) {
   if (!maskWS)
     return; // if we couldn't load it then just fail silently
 
-  auto actor = m_instrWidget->getInstrumentActor();
-  actor->setMaskMatrixWorkspace(maskWS);
-  actor->updateColors();
+  auto &actor = m_instrWidget->getInstrumentActor();
+  actor.setMaskMatrixWorkspace(maskWS);
+  actor.updateColors();
   m_instrWidget->updateInstrumentDetectors();
   m_instrWidget->updateInstrumentView();
 }
@@ -1266,8 +1266,8 @@ InstrumentWidgetMaskTab::loadMask(const std::string &fileName) {
   using namespace Mantid::API;
 
   // build path and input properties etc.
-  auto actor = m_instrWidget->getInstrumentActor();
-  auto workspace = actor->getWorkspace();
+  const auto &actor = m_instrWidget->getInstrumentActor();
+  auto workspace = actor.getWorkspace();
   auto instrument = workspace->getInstrument();
   auto instrumentName = instrument->getName();
   auto tempName = "__" + workspace->getName() + "MaskView";
@@ -1349,8 +1349,8 @@ bool InstrumentWidgetMaskTab::saveMaskViewToProject(
 
   try {
     // get masked detector workspace from actor
-    auto actor = m_instrWidget->getInstrumentActor();
-    auto outputWS = actor->getMaskMatrixWorkspace();
+    const auto &actor = m_instrWidget->getInstrumentActor();
+    auto outputWS = actor.getMaskMatrixWorkspace();
 
     if (!outputWS)
       return false; // no mask workspace was found

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
@@ -796,7 +796,7 @@ std::string InstrumentWidgetPickTab::saveToProject() const {
 /**
 * Create and setup iteself.
 * @param tab :: QObject parent - the tab.
-* @param instrActor :: A pointer to the InstrumentActor instance.
+* @param instrWidget :: A pointer to an InstrumentWidget instance.
 * @param infoDisplay :: Widget on which to display the information.
 */
 ComponentInfoController::ComponentInfoController(
@@ -1115,7 +1115,7 @@ void ComponentInfoController::clear() { m_selectionInfoDisplay->clear(); }
 /**
 * Constructor.
 * @param tab :: The parent tab.
-* @param instrActor :: A pointer to the InstrumentActor.
+* @param instrWidget :: A pointer to a InstrumentWidget instance.
 * @param plot :: The plot widget.
 */
 DetectorPlotController::DetectorPlotController(InstrumentWidgetPickTab *tab,

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetPickTab.cpp
@@ -575,10 +575,9 @@ void InstrumentWidgetPickTab::initSurface() {
     connect(p3d, SIGNAL(finishedMove()), this,
             SLOT(updatePlotMultipleDetectors()));
   }
-  m_infoController = new ComponentInfoController(
-      this, m_instrWidget, m_selectionInfoDisplay);
-  m_plotController = new DetectorPlotController(
-      this, m_instrWidget, m_plot);
+  m_infoController =
+      new ComponentInfoController(this, m_instrWidget, m_selectionInfoDisplay);
+  m_plotController = new DetectorPlotController(this, m_instrWidget, m_plot);
   m_plotController->setTubeXUnits(
       static_cast<DetectorPlotController::TubeXUnits>(m_tubeXUnitsCache));
   m_plotController->setPlotType(
@@ -800,9 +799,9 @@ std::string InstrumentWidgetPickTab::saveToProject() const {
 * @param instrActor :: A pointer to the InstrumentActor instance.
 * @param infoDisplay :: Widget on which to display the information.
 */
-ComponentInfoController::ComponentInfoController(InstrumentWidgetPickTab *tab,
-                                                 const InstrumentWidget *instrWidget,
-                                                 QTextEdit *infoDisplay)
+ComponentInfoController::ComponentInfoController(
+    InstrumentWidgetPickTab *tab, const InstrumentWidget *instrWidget,
+    QTextEdit *infoDisplay)
     : QObject(tab), m_tab(tab), m_instrWidget(instrWidget),
       m_selectionInfoDisplay(infoDisplay), m_freezePlot(false),
       m_instrWidgetBlocked(false), m_currentPickID(-1) {}
@@ -901,7 +900,9 @@ QString ComponentInfoController::displayDetectorInfo(Mantid::detid_t detid) {
 */
 QString ComponentInfoController::displayNonDetectorInfo(
     Mantid::Geometry::ComponentID compID) {
-  auto component = m_instrWidget->getInstrumentActor().getInstrument()->getComponentByID(compID);
+  auto component =
+      m_instrWidget->getInstrumentActor().getInstrument()->getComponentByID(
+          compID);
   QString text = "Selected component: ";
   text += QString::fromStdString(component->getName()) + '\n';
   Mantid::Kernel::V3D pos = component->getPos();
@@ -1170,8 +1171,7 @@ void DetectorPlotController::setPlotData(QList<int> detIDs) {
   std::vector<double> x, y;
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
   const auto &actor = m_instrWidget->getInstrumentActor();
-  actor.sumDetectors(detIDs, x, y,
-                             static_cast<size_t>(m_plot->width()));
+  actor.sumDetectors(detIDs, x, y, static_cast<size_t>(m_plot->width()));
   QApplication::restoreOverrideCursor();
   if (!x.empty()) {
     m_plot->setData(&x[0], &y[0], static_cast<int>(y.size()),
@@ -1210,7 +1210,11 @@ void DetectorPlotController::plotSingle(int detid) {
 
   // set the data
   m_plot->setData(&x[0], &y[0], static_cast<int>(y.size()),
-                  m_instrWidget->getInstrumentActor().getWorkspace()->getAxis(0)->unit()->unitID());
+                  m_instrWidget->getInstrumentActor()
+                      .getWorkspace()
+                      ->getAxis(0)
+                      ->unit()
+                      ->unitID());
   m_plot->setLabel("Detector " + QString::number(detid));
 
   // find any markers
@@ -1467,8 +1471,7 @@ void DetectorPlotController::prepareDataForIntegralsPlot(
   size_t imin, imax;
   actor.getBinMinMaxIndex(wi, imin, imax);
 
-  Mantid::Kernel::V3D samplePos =
-      actor.getInstrument()->getSample()->getPos();
+  Mantid::Kernel::V3D samplePos = actor.getInstrument()->getSample()->getPos();
 
   const int n = ass->nelements();
   if (n == 0) {
@@ -1799,8 +1802,7 @@ void DetectorPlotController::addPeak(double x, double y) {
     alg->setPropertyValue("PeaksWorkspace", peakTableName);
     alg->setProperty("DetectorID", m_currentDetID);
     alg->setProperty("TOF", x);
-    alg->setProperty("Height",
-                     actor.getIntegratedCounts(m_currentDetID));
+    alg->setProperty("Height", actor.getIntegratedCounts(m_currentDetID));
     alg->setProperty("BinCount", y);
     alg->execute();
 

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetRenderTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetRenderTab.cpp
@@ -287,7 +287,7 @@ void InstrumentWidgetRenderTab::enable3DSurface(bool on) {
 */
 void InstrumentWidgetRenderTab::initSurface() {
   setAxis(QString::fromStdString(
-      m_instrWidget->getInstrumentActor()->getInstrument()->getDefaultAxis()));
+      m_instrWidget->getInstrumentActor().getInstrument()->getDefaultAxis()));
   auto surface = getSurface();
 
   // 3D axes switch needs to be shown for the 3D surface
@@ -296,7 +296,7 @@ void InstrumentWidgetRenderTab::initSurface() {
     p3d->set3DAxesState(areAxesOn());
   }
 
-  bool detectorsOnly = !m_instrWidget->getInstrumentActor()->areGuidesShown();
+  bool detectorsOnly = !m_instrWidget->getInstrumentActor().areGuidesShown();
   m_displayDetectorsOnly->blockSignals(true);
   m_displayDetectorsOnly->setChecked(detectorsOnly);
   m_displayDetectorsOnly->blockSignals(false);
@@ -449,7 +449,7 @@ void InstrumentWidgetRenderTab::showAxes(bool on) {
 * @param yes :: True of false for on and off.
 */
 void InstrumentWidgetRenderTab::displayDetectorsOnly(bool yes) {
-  m_instrWidget->getInstrumentActor()->showGuides(!yes);
+  m_instrWidget->getInstrumentActor().showGuides(!yes);
   m_instrWidget->updateInstrumentView();
   m_displayDetectorsOnly->blockSignals(true);
   m_displayDetectorsOnly->setChecked(yes);
@@ -474,13 +474,11 @@ void InstrumentWidgetRenderTab::showEvent(QShowEvent *) {
   if (surface) {
     surface->setInteractionMode(ProjectionSurface::MoveMode);
   }
-  InstrumentActor *actor = m_instrWidget->getInstrumentActor();
-  if (actor) {
-    auto visitor = SetAllVisibleVisitor(actor->areGuidesShown());
-    actor->accept(visitor);
-    getSurface()->updateView();
-    getSurface()->requestRedraw();
-  }
+  auto &actor = m_instrWidget->getInstrumentActor();
+  auto visitor = SetAllVisibleVisitor(actor.areGuidesShown());
+  actor.accept(visitor);
+  getSurface()->updateView();
+  getSurface()->requestRedraw();
 }
 
 void InstrumentWidgetRenderTab::flipUnwrappedView(bool on) {
@@ -644,11 +642,11 @@ void InstrumentWidgetRenderTab::surfaceTypeChanged(int index) {
 * Respond to external change of the colormap.
 */
 void InstrumentWidgetRenderTab::colorMapChanged() {
-  InstrumentActor *instrumentActor = m_instrWidget->getInstrumentActor();
-  setupColorBar(instrumentActor->getColorMap(), instrumentActor->minValue(),
-                instrumentActor->maxValue(),
-                instrumentActor->minPositiveValue(),
-                instrumentActor->autoscaling());
+  const auto &instrumentActor = m_instrWidget->getInstrumentActor();
+  setupColorBar(instrumentActor.getColorMap(), instrumentActor.minValue(),
+                instrumentActor.maxValue(),
+                instrumentActor.minPositiveValue(),
+                instrumentActor.autoscaling());
 }
 
 void InstrumentWidgetRenderTab::scaleTypeChanged(int type) {

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetRenderTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetRenderTab.cpp
@@ -644,8 +644,7 @@ void InstrumentWidgetRenderTab::surfaceTypeChanged(int index) {
 void InstrumentWidgetRenderTab::colorMapChanged() {
   const auto &instrumentActor = m_instrWidget->getInstrumentActor();
   setupColorBar(instrumentActor.getColorMap(), instrumentActor.minValue(),
-                instrumentActor.maxValue(),
-                instrumentActor.minPositiveValue(),
+                instrumentActor.maxValue(), instrumentActor.minPositiveValue(),
                 instrumentActor.autoscaling());
 }
 

--- a/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetTreeTab.cpp
+++ b/MantidQt/MantidWidgets/src/InstrumentView/InstrumentWidgetTreeTab.cpp
@@ -27,7 +27,7 @@ InstrumentWidgetTreeTab::InstrumentWidgetTreeTab(InstrumentWidget *instrWidget)
 }
 
 void InstrumentWidgetTreeTab::initSurface() {
-  m_instrumentTree->setInstrumentActor(m_instrWidget->getInstrumentActor());
+  m_instrumentTree->setInstrumentWidget(m_instrWidget);
 }
 
 /**

--- a/docs/source/release/v3.10.0/ui.rst
+++ b/docs/source/release/v3.10.0/ui.rst
@@ -112,6 +112,7 @@ Bugs Resolved
 - Fixed an issue where contour lines were displayed at the wrong location.
 - Fixed an issue where some workspaces might not get deleted from the workspace dock if group workspaces were present.
 - Fixed an issues in the Detectors table where monitor information did not show up correctly.
+- Fixed an issue where MantidPlot could crash if a workspace's instrument was changed while the Instrument Window was open.
 
 
 |


### PR DESCRIPTION
Changing a workspace's instrument while the Instrument Window is open would invalidate some pointers pointing to an `InstrumentActor` object. This could lead to segmentation fault later when user tried to use the Instrument Window. This PR fixes the segfault by forcing a single point access to the `InstrumentActor` object.

**To test:**

Try to reproduce the segfault first on master, then repeat on this branch to check that the segfault is really gone.
1. Use for instance [`LoadEmptyInstrument`](http://docs.mantidproject.org/nightly/algorithms/LoadEmptyInstrument-v1.html) to get a workspace with instrument.
2. Open Instrument Window for the workspace.
3. Choose the 'Pick' tab.
4. Execute `LoadEmptyInstrument` again with the same OutputWorkspace.
5. Try pointing the instrument's components in the Instrument Window. There is a change that MantidPlot segfaults if these changes are not applied. You might need to go back to step 4.


Fixes #16957.

*Release notes were updated accordingly.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
