### PR TITLE
Removed links in old release notes to deleted CRY Powder docs

### DIFF
--- a/docs/source/release/v3.6.0/diffraction.rst
+++ b/docs/source/release/v3.6.0/diffraction.rst
@@ -44,10 +44,10 @@ Powder Diffraction
 -  Various fixes and optimizations to make
    :ref:`SNSPowderReduction <algm-SNSPowderReduction>`
    run faster.
--  New documentation page for the `ISIS Powder Diffraction <http://docs.mantidproject.org/v3.6.0/api/python/techniques/PowderDiffractionISIS-v1.html>`_
+-  New documentation page for the *ISIS Powder Diffraction*
    with comprehensive workflow-diagrams and usage example.
 -  Many small changes made to the ISIS Powder Diffraction script to
-   enable smoother process, which can be discovered on the `ISIS Powder Diffraction <http://docs.mantidproject.org/v3.6.0/api/python/techniques/PowderDiffractionISIS-v1.html>`_
+   enable smoother process, which can be discovered on the *ISIS Powder Diffraction*
    documentation page.
 
 Crystal Improvements

--- a/docs/source/release/v3.7.1/diffraction.rst
+++ b/docs/source/release/v3.7.1/diffraction.rst
@@ -29,10 +29,10 @@ Powder Diffraction Scripts
 - PowderISIS script has been renamed to CryPowderISIS and can be found within
   the following folder `scripts/CryPowderISIS`
 
-- `Pearl Powder Diffraction Script <http://docs.mantidproject.org/v3.7.1/api/python/techniques/PearlPowderDiffractionISIS-v1.html>`_ 
+- *Pearl Powder Diffraction Script* 
   documentation has been implemented and
   PowderISIS script documentation has been renamed to
-  `Crystallography Powder Diffraction Script <http://docs.mantidproject.org/v3.7.1/api/python/techniques/CryPowderDiffractionISIS-v1.html>`_
+  *Crystallography Powder Diffraction Script*
 
 Single Crystal Improvements
 ---------------------------

--- a/docs/source/release/v3.8.0/diffraction.rst
+++ b/docs/source/release/v3.8.0/diffraction.rst
@@ -95,7 +95,7 @@ Powder Diffraction
   look at the signal as well when looking at the ``Q``-range to use
   for the transform.
 
-- `Crystallography Powder Diffraction Script <http://docs.mantidproject.org/v3.8.0/api/python/techniques/CryPowderDiffractionISIS-v1.html>`_: S-Empty option has been enabled for
+- *Crystallography Powder Diffraction Script* S-Empty option has been enabled for
    the Crystallography Powder Diffraction Script. In order to use the
    S-Empty option, simply provide the S-Empty run number within the
    ``.pref`` file.
@@ -104,7 +104,7 @@ Powder Diffraction
   weights applied to events have changed by a factor of the duty cycle
   (:math:`c\approx0.498`) as requested by the instrument scientists.
 
-- `Pearl Powder Diffraction Script <http://docs.mantidproject.org/v3.8.0/api/python/techniques/PearlPowderDiffractionISIS-v1.html>`_: 
+- *Pearl Powder Diffraction Script* 
   A workflow diagram for ``pearl_run_focus`` function has been created.
 
 - :ref:`CalibrateRectangularDetectors


### PR DESCRIPTION
Description of work.
This PR fixes the links broken in the old release notes. This was noted by @AndreiSavici (thanks) in #19743 

**To test:**
Run the `docs-linkcheck` target all links should work (except `algm-savemdworkspacetovtk` if you don't build VATES).

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
