### PR TITLE
ClearCacheTests to run in a temporary directory

### DIFF
--- a/Framework/Algorithms/test/ClearCacheTest.h
+++ b/Framework/Algorithms/test/ClearCacheTest.h
@@ -25,7 +25,7 @@ public:
   void setUp() override {
     const std::string TEST_SUFFIX = "TEMPORARY_ClearCacheUnitTest";
     m_originalInstDir =
-      Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
+        Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
 
     // change the local download directory by adding a unittest subdirectory
     auto testDirectories = m_originalInstDir;
@@ -36,7 +36,7 @@ public:
     testDirectories[0] = m_localInstDir;
 
     Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(
-      testDirectories);
+        testDirectories);
 
     // create a geometryCache subdirectory
     Poco::Path GeomPath = localDownloadPath;
@@ -66,7 +66,7 @@ public:
 
   void tearDown() override {
     Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(
-      m_originalInstDir);
+        m_originalInstDir);
     removeDirectories();
   }
 

--- a/Framework/Algorithms/test/ClearCacheTest.h
+++ b/Framework/Algorithms/test/ClearCacheTest.h
@@ -22,6 +22,54 @@ public:
   static ClearCacheTest *createSuite() { return new ClearCacheTest(); }
   static void destroySuite(ClearCacheTest *suite) { delete suite; }
 
+  void setUp() override {
+    const std::string TEST_SUFFIX = "TEMPORARY_ClearCacheUnitTest";
+    m_originalInstDir =
+      Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
+
+    // change the local download directory by adding a unittest subdirectory
+    auto testDirectories = m_originalInstDir;
+    Poco::Path localDownloadPath(m_originalInstDir[0]);
+    localDownloadPath.pushDirectory(TEST_SUFFIX);
+    m_localInstDir = localDownloadPath.toString();
+    createDirectory(localDownloadPath);
+    testDirectories[0] = m_localInstDir;
+
+    Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(
+      testDirectories);
+
+    // create a geometryCache subdirectory
+    Poco::Path GeomPath = localDownloadPath;
+    GeomPath.pushDirectory("geometryCache");
+    createDirectory(GeomPath);
+  }
+
+  void createDirectory(Poco::Path path) {
+    Poco::File file(path);
+    if (file.createDirectory()) {
+      m_directoriesToRemove.push_back(file);
+    }
+  }
+
+  void removeDirectories() {
+    for (auto directory : m_directoriesToRemove) {
+      try {
+        if (directory.exists()) {
+          directory.remove(true);
+        }
+      } catch (Poco::FileException &fe) {
+        std::cout << fe.what() << std::endl;
+      }
+    }
+    m_directoriesToRemove.clear();
+  }
+
+  void tearDown() override {
+    Mantid::Kernel::ConfigService::Instance().setInstrumentDirectories(
+      m_originalInstDir);
+    removeDirectories();
+  }
+
   void test_Init() {
     ClearCache alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
@@ -114,6 +162,10 @@ public:
     int filesRemoved = alg.getProperty("FilesRemoved");
     TS_ASSERT_EQUALS(filesRemoved, 0);
   }
+
+  std::string m_localInstDir;
+  std::vector<std::string> m_originalInstDir;
+  std::vector<Poco::File> m_directoriesToRemove;
 };
 
 #endif /* MANTID_ALGORITHMS_CLEARCACHETEST_H_ */


### PR DESCRIPTION
**Unit Test Change only**

Uses a setup and tear down to create a subdirectory in %appdata%, or .mantid/instruments to perform the actual test in, therefore it does not alter the directory used by other tests in Mantid.



**To test:**

1. Identify your download directory, it should be %appdata%/mantidproject/mantid/instrument for linux ~/.mantid/instrument
1. Put an create an xml file in the instrument directory (empty is fine)
1. Put an create a vtp file in the geomCache directory (empty is fine)
1. Run the ClearCacheTest unit test    ` ctest -C debug -R _ClearCacheTest  -V `
1. Check your two files where not affected
1. Remove your two files

Fixes #19767.

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
