### PR TITLE
Fix OptimizeCrystalPlacement intermittent failure

### DIFF
--- a/Framework/Crystal/src/PeakHKLErrors.cpp
+++ b/Framework/Crystal/src/PeakHKLErrors.cpp
@@ -479,7 +479,7 @@ void PeakHKLErrors::functionDeriv1D(Jacobian *out, const double *xValues,
     for (int kk = 0; kk < static_cast<int>(nParams()); kk++) {
       out->set(i, kk, 0.0);
       out->set(i + 1, kk, 0.0);
-      out->set(i + 1, kk, 0.0);
+      out->set(i + 2, kk, 0.0);
     }
 
     double chi, phi, omega;


### PR DESCRIPTION
Description of work.

Fixes an index error when computing the Jacobian of `PeakHKLErrors`.

**To test:**

I could reliably get this to fail with

```
ctest -j 8 --repeat-until-fail 30 -R CrystalTest_OptimizeCrystalPlacement
```

before this changes. Afterwards it seems to keep running as expected.

No issue

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
