### PR TITLE
 Fix sans save issue

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -461,7 +461,7 @@ private:
                                  QLineEdit *min, QLineEdit *max,
                                  QComboBox *selection, QString type);
   /// Checks if the save settings are valid for a particular workspace
-  bool areSaveSettingsValid(const QString& workspaceName);
+  bool areSaveSettingsValid(const QString &workspaceName);
   /// Update the beam center fields
   void updateBeamCenterCoordinates();
   /// Set the beam finder details

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -460,6 +460,8 @@ private:
   void checkWaveLengthAndQValues(bool &isValid, QString &message,
                                  QLineEdit *min, QLineEdit *max,
                                  QComboBox *selection, QString type);
+  /// Checks if the save settings are valid for a particular workspace
+  bool areSaveSettingsValid(const QString& workspaceName);
   /// Update the beam center fields
   void updateBeamCenterCoordinates();
   /// Set the beam finder details

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -200,6 +200,22 @@ void setTransmissionOnSaveCommand(
     }
   }
 }
+
+
+bool checkSaveOptions(QString& message, bool is1D, bool isCanSAS, bool isNistQxy) {
+  // Check we are dealing with 1D or 2D data
+  bool isValid = true;
+  if (is1D && isNistQxy) {
+      isValid = false;
+      message += "Save option issue: Cannot save in NistQxy format for 1D data.\n";
+  }
+
+  if (!is1D && isCanSAS) {
+      isValid = false;
+      message += "Save option issue: Cannot save in CanSAS format for 2D data.\n";
+  }
+  return isValid;
+}
 }
 
 //----------------------------------------------
@@ -2914,6 +2930,10 @@ void SANSRunWindow::handleDefSaveClick() {
         "A filename must be entered into the text box above to save this file");
   }
 
+  if (!areSaveSettingsValid(m_outputWS)) {
+    return;
+  }
+
   // If we save with a zero-error-free correction we need to swap the
   QString workspaceNameBuffer = m_outputWS;
   QString clonedWorkspaceName = m_outputWS + "_cloned_temp";
@@ -2995,6 +3015,31 @@ void SANSRunWindow::handleDefSaveClick() {
                           "console?");
   }
 }
+
+/**
+ * Checks if the save options are valid
+ */
+bool SANSRunWindow::areSaveSettingsValid(const QString& workspaceName) {
+  Mantid::API::MatrixWorkspace_sptr ws =
+      AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>(workspaceName.toStdString());
+  auto is1D = ws->getNumberHistograms() == 1;
+  auto isNistQxy = m_uiForm.saveNIST_Qxy_check->isChecked();
+  auto isCanSAS = m_uiForm.saveCan_check->isChecked();
+
+  QString message;
+
+  auto isValid = checkSaveOptions(message, is1D, isCanSAS, isNistQxy);
+
+  // Print the error message if there are any
+  if (!message.isEmpty()) {
+    QString warning = "Please correct these settings before proceeding:\n";
+    warning += message;
+    QMessageBox::warning(this, "Inconsistent input", warning);
+  }
+  return isValid;
+}
+
+
 /**
  * Set up controls based on the users selection in the combination box
  * @param new_index :: The new index that has been set
@@ -4515,12 +4560,32 @@ bool SANSRunWindow::areSettingsValid(States type) {
     message += "Sample width issue: Only values > 0 are allowed.\n";
   }
 
+
+  // Check save format consistency for batch mode reduction
+  // 1D --> cannot be Nist Qxy
+  // 2D --> cannot be CanSAS
+  auto isBatchMode = !m_uiForm.single_mode_btn->isChecked();
+  if (isBatchMode) {
+      auto is1D = type == OneD;
+      auto isCanSAS =  m_uiForm.saveCan_check->isChecked();
+      auto isNistQxy = m_uiForm.saveNIST_Qxy_check->isChecked();
+      QString saveMessage;
+      auto isValidSaveOption = checkSaveOptions(saveMessage, is1D, isCanSAS, isNistQxy);
+      if (!isValidSaveOption) {
+        isValid = false;
+        message += saveMessage;
+      }
+  }
+
+
   // Print the error message if there are any
   if (!message.isEmpty()) {
     QString warning = "Please correct these settings before proceeding:\n";
     warning += message;
     QMessageBox::warning(this, "Inconsistent input", warning);
   }
+
+
 
   return isValid;
 }

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -201,18 +201,19 @@ void setTransmissionOnSaveCommand(
   }
 }
 
-
-bool checkSaveOptions(QString& message, bool is1D, bool isCanSAS, bool isNistQxy) {
+bool checkSaveOptions(QString &message, bool is1D, bool isCanSAS,
+                      bool isNistQxy) {
   // Check we are dealing with 1D or 2D data
   bool isValid = true;
   if (is1D && isNistQxy) {
-      isValid = false;
-      message += "Save option issue: Cannot save in NistQxy format for 1D data.\n";
+    isValid = false;
+    message +=
+        "Save option issue: Cannot save in NistQxy format for 1D data.\n";
   }
 
   if (!is1D && isCanSAS) {
-      isValid = false;
-      message += "Save option issue: Cannot save in CanSAS format for 2D data.\n";
+    isValid = false;
+    message += "Save option issue: Cannot save in CanSAS format for 2D data.\n";
   }
   return isValid;
 }
@@ -3019,9 +3020,10 @@ void SANSRunWindow::handleDefSaveClick() {
 /**
  * Checks if the save options are valid
  */
-bool SANSRunWindow::areSaveSettingsValid(const QString& workspaceName) {
+bool SANSRunWindow::areSaveSettingsValid(const QString &workspaceName) {
   Mantid::API::MatrixWorkspace_sptr ws =
-      AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>(workspaceName.toStdString());
+      AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>(
+          workspaceName.toStdString());
   auto is1D = ws->getNumberHistograms() == 1;
   auto isNistQxy = m_uiForm.saveNIST_Qxy_check->isChecked();
   auto isCanSAS = m_uiForm.saveCan_check->isChecked();
@@ -3038,7 +3040,6 @@ bool SANSRunWindow::areSaveSettingsValid(const QString& workspaceName) {
   }
   return isValid;
 }
-
 
 /**
  * Set up controls based on the users selection in the combination box
@@ -4560,23 +4561,22 @@ bool SANSRunWindow::areSettingsValid(States type) {
     message += "Sample width issue: Only values > 0 are allowed.\n";
   }
 
-
   // Check save format consistency for batch mode reduction
   // 1D --> cannot be Nist Qxy
   // 2D --> cannot be CanSAS
   auto isBatchMode = !m_uiForm.single_mode_btn->isChecked();
   if (isBatchMode) {
-      auto is1D = type == OneD;
-      auto isCanSAS =  m_uiForm.saveCan_check->isChecked();
-      auto isNistQxy = m_uiForm.saveNIST_Qxy_check->isChecked();
-      QString saveMessage;
-      auto isValidSaveOption = checkSaveOptions(saveMessage, is1D, isCanSAS, isNistQxy);
-      if (!isValidSaveOption) {
-        isValid = false;
-        message += saveMessage;
-      }
+    auto is1D = type == OneD;
+    auto isCanSAS = m_uiForm.saveCan_check->isChecked();
+    auto isNistQxy = m_uiForm.saveNIST_Qxy_check->isChecked();
+    QString saveMessage;
+    auto isValidSaveOption =
+        checkSaveOptions(saveMessage, is1D, isCanSAS, isNistQxy);
+    if (!isValidSaveOption) {
+      isValid = false;
+      message += saveMessage;
+    }
   }
-
 
   // Print the error message if there are any
   if (!message.isEmpty()) {
@@ -4584,8 +4584,6 @@ bool SANSRunWindow::areSettingsValid(States type) {
     warning += message;
     QMessageBox::warning(this, "Inconsistent input", warning);
   }
-
-
 
   return isValid;
 }

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/SaveWorkspaces.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/SaveWorkspaces.h
@@ -95,7 +95,7 @@ private:
   QHash<QString, QString>
   provideZeroFreeWorkspaces(const QListWidget *workspaces);
   void removeZeroFreeWorkspaces(QHash<QString, QString> workspaces);
-
+  bool isValid();
 private slots:
   void saveSel();
   void setFileName(int row);

--- a/MantidQt/MantidWidgets/src/SaveWorkspaces.cpp
+++ b/MantidQt/MantidWidgets/src/SaveWorkspaces.cpp
@@ -313,6 +313,11 @@ QString SaveWorkspaces::getSaveAlgExt(const QString &algName) {
 *  have been selected to be saved
 */
 void SaveWorkspaces::saveSel() {
+  // Check if the save selection is valid
+  if (!isValid()) {
+    return;
+  }
+
   // For each selected workspace, provide an zero-error free clone
   QHash<QString, QString> workspaceMap =
       provideZeroFreeWorkspaces(m_workspaces);
@@ -350,6 +355,68 @@ void SaveWorkspaces::saveSel() {
                           "the selected formats");
   }
 }
+
+/**
+ * Checks if the save option selection is compatible with the dimensionality selection
+ * @return true if the save option selection is compatible with the dimensionality selection else false
+ */
+bool SaveWorkspaces::isValid() {
+  // Get the dimensionality of the workspaces
+  auto is1D = false;
+  auto is2D = false;
+
+  auto workspacesList = m_workspaces->selectedItems();
+  for (auto it = workspacesList.begin(); it != workspacesList.end(); ++it) {
+    auto wsName = (*it)->text();
+    auto workspace = AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>(wsName.toStdString());
+    if (workspace->getNumberHistograms() == 1) {
+      is1D = true;    
+    } else {
+      is2D = true;
+    }
+  }
+
+  // Check if the NistQxy or CanSAS were selected
+  auto isCanSAS = false;
+  auto isNistQxy = false;
+  for (SavFormatsConstIt i = m_savFormats.begin(); i != m_savFormats.end();
+       ++i) { // the key to a pointer to the check box that the user may have
+              // clicked
+    if (i.key()->isChecked()) { // we need to save in this format
+      if (i.value() == "SaveNISTDAT") {
+            isNistQxy = true;
+      }
+
+      if (i.value() == "SaveCanSAS1D") {
+            isCanSAS = true;
+      }
+    }
+  }
+
+  // Check for errors
+  QString message;
+  auto isValidOption = true;
+  if (is1D && isNistQxy) {
+    isValidOption = false;
+    message += "Save option issue: Cannot save in NistQxy format for 1D data.\n";
+  }
+
+  if (is2D && isCanSAS) {
+    isValidOption = false;
+    message += "Save option issue: Cannot save in CanSAS format for 2D data.\n";
+  }
+
+
+  // Print the error message if there are any
+  if (!message.isEmpty()) {
+    QString warning = "Please correct these save settings before proceeding:\n";
+    warning += message;
+    QMessageBox::warning(this, "Inconsistent input", warning);
+  }
+
+  return isValidOption;
+}
+
 /** Sets the filename to the name of the selected workspace
 *  @param row number of the row that is selected
 */

--- a/MantidQt/MantidWidgets/src/SaveWorkspaces.cpp
+++ b/MantidQt/MantidWidgets/src/SaveWorkspaces.cpp
@@ -357,8 +357,10 @@ void SaveWorkspaces::saveSel() {
 }
 
 /**
- * Checks if the save option selection is compatible with the dimensionality selection
- * @return true if the save option selection is compatible with the dimensionality selection else false
+ * Checks if the save option selection is compatible with the dimensionality
+ * selection
+ * @return true if the save option selection is compatible with the
+ * dimensionality selection else false
  */
 bool SaveWorkspaces::isValid() {
   // Get the dimensionality of the workspaces
@@ -368,9 +370,11 @@ bool SaveWorkspaces::isValid() {
   auto workspacesList = m_workspaces->selectedItems();
   for (auto it = workspacesList.begin(); it != workspacesList.end(); ++it) {
     auto wsName = (*it)->text();
-    auto workspace = AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>(wsName.toStdString());
+    auto workspace =
+        AnalysisDataService::Instance()
+            .retrieveWS<Mantid::API::MatrixWorkspace>(wsName.toStdString());
     if (workspace->getNumberHistograms() == 1) {
-      is1D = true;    
+      is1D = true;
     } else {
       is2D = true;
     }
@@ -384,11 +388,11 @@ bool SaveWorkspaces::isValid() {
               // clicked
     if (i.key()->isChecked()) { // we need to save in this format
       if (i.value() == "SaveNISTDAT") {
-            isNistQxy = true;
+        isNistQxy = true;
       }
 
       if (i.value() == "SaveCanSAS1D") {
-            isCanSAS = true;
+        isCanSAS = true;
       }
     }
   }
@@ -398,14 +402,14 @@ bool SaveWorkspaces::isValid() {
   auto isValidOption = true;
   if (is1D && isNistQxy) {
     isValidOption = false;
-    message += "Save option issue: Cannot save in NistQxy format for 1D data.\n";
+    message +=
+        "Save option issue: Cannot save in NistQxy format for 1D data.\n";
   }
 
   if (is2D && isCanSAS) {
     isValidOption = false;
     message += "Save option issue: Cannot save in CanSAS format for 2D data.\n";
   }
-
 
   // Print the error message if there are any
   if (!message.isEmpty()) {

--- a/docs/source/release/v3.10.0/sans.rst
+++ b/docs/source/release/v3.10.0/sans.rst
@@ -27,5 +27,6 @@ Bug Fixes
 - Fixed LOQ bug where prompt peak was not set correctly for monitor normalisation.
 - Fixed Batch mode bug where merged reductions set in the GUI were not respected.
 - Fixed display of current IDF, which was not updated when operating in batch mode.
+- Fixed a bug where the user could try to save 1D data in the CanSAS format and caused a crash.
 
 `Full list of changes on github <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.10%22+is%3Amerged+label%3A%22Component%3A+SANS%22>`__


### PR DESCRIPTION
Fixes #19775

This prevents the user from selecting the CanSAS formatting when saving 1D reductions.

### To test:

Please find the test data here: smb://olympic/babylon5/Scratch/Anton/Steve_Bug


##### Batch Reductions

1. Open the ISIS SANS GUI and set the instrument to LOQ
2. Set the user file to: USER_LOQ_171C_M3_Alexander_6mm_Changer_MERGED.TXT
3. Switch to batch mode and load the file test-with-shirin.csv
4. In the save group select CanSAS and press the 2D reduce button
   * Confirm that a checkbox with a sensible warning pops up
5. Uncheck CanSAS and press 2D Reduce
   * Confirm that the reduction runs just fine. ( You might have to uncheck the Fit checkbox on the Reduction Settings tab)
6. In the save group select NistQxy and press the 1D reduce button
   * Confirm that a checkbox with a sensible warning pops up
7. Uncheck NistQxy and press 1D Reduce
   * Confirm that the reduction runs just fine. ( You might have to uncheck the Fit checkbox on the Reduction Settings tab)

##### Single Reduction V1

1. Open the ISIS SANS GUI and set the instrument to LOQ
2. Set the user file to: USER_LOQ_171C_M3_Alexander_6mm_Changer_MERGED.TXT
3. Switch to batch mode and load the file test-with-shirin.csv
4. Switch to single mode, now the entries should be populated
5. Run a 1D reduction 
6. After the reduction has completed, select NistQxy and press the Save Results button
   * Confirm that a pop up with a sensible message appears
7. Uncheck NistQxy and press Save Results
   * Confirm that the files were saved out and that no pop up has appeared
8. Run a 2D reduction ( you might have to disable the Fit checkbox on the Reduction Settings tab)
9. After the reduction has completed, select CanSAS and press the Save Results button
   * Confirm that a pop up with a sensible message appears
10. Uncheck CanSAS and press Save Results
    * Confirm that the files were saved out and that no pop up has appeared

##### Single Reduction V2

1. Open the ISIS SANS GUI and set the instrument to LOQ
2. Set the user file to: USER_LOQ_171C_M3_Alexander_6mm_Changer_MERGED.TXT
3. Switch to batch mode and load the file test-with-shirin.csv
4. Switch to single mode, now the entries should be populated
5. Run a 1D reduction 
6. Press the Save Other button and select the workspace with the name 100254HAB_1D_2.2_10.0 and select NistQxy. Press Save
     * Confirm that a pop up with a sensible message appears
7. Uncheck NistQxy
    * Confirm that the files were saved out and that no pop up has appeared
8. Run a 2D reduction 
9. Press the Save Other button and select the workspace with the name 100254HAB_2D_2.2_10.0 and select CanSAS. Press Save
     * Confirm that a pop up with a sensible message appears
10. Uncheck CanSAS
    * Confirm that the files were saved out and that no pop up has appeared

### Releas Notes:

See [here](https://github.com/mantidproject/mantid/pull/19776/commits/063983463aaf45f29dc43f120668bc6982537e88)



---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
