### PR TITLE
Fix z order warning in ResNorm ui file

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ResNorm.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ResNorm.ui
@@ -229,11 +229,6 @@
          </widget>
         </item>
        </layout>
-       <zorder>pbSave</zorder>
-       <zorder>lblPlot</zorder>
-       <zorder>cbPlot</zorder>
-       <zorder>pbPlot</zorder>
-       <zorder>horizontalSpacer_18</zorder>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
Description of work.
Fixes a z order assignment warning in `ResNorm.ui` the fix was copied from #694

**To test:**
Build the `CustomInterfaces` target on a Linux machine and check there are no warnings about z order assignment.

Open the following interface
- Indirect
- Bayes 
- ResNorm tab

Check the layout is correct

Fixes N/A.

*Does not need to be in the release notes. - This was a compiler warning*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
