### PR TITLE
Add unit tests for event workspace check

### DIFF
--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -4,7 +4,7 @@ import unittest
 # Need to import mantid before we import SANSUtility
 import mantid
 from mantid.simpleapi import *
-from mantid.api import (mtd, WorkspaceGroup, AlgorithmManager, AnalysisDataService)
+from mantid.api import (mtd, WorkspaceGroup, AlgorithmManager, AnalysisDataService, FileFinder)
 from mantid.kernel import (DateAndTime, time_duration, FloatTimeSeriesProperty,
                            BoolTimeSeriesProperty,StringTimeSeriesProperty,
                            StringPropertyWithValue, V3D, Quat)
@@ -1675,6 +1675,16 @@ class TestRenamingOfBatchModeWorkspaces(unittest.TestCase):
         args = ["SANS2D", "jsdlkfsldkfj", "test", workspace]
         self.assertRaises(RuntimeError, su.rename_workspace_correctly, *args)
         AnalysisDataService.remove("ws")
+
+
+class TestEventWorkspaceCheck(unittest.TestCase):
+    def test_that_can_identify_event_workspace(self):
+        file_name = FileFinder.findRuns("SANS2D00022048")[0]
+        self.assertTrue(su.can_load_as_event_workspace(file_name))
+
+    def test_that_can_identify_histo_workspace_as_not_being_event_workspace(self):
+        file_name = FileFinder.findRuns("SANS2D00022024")[0]
+        self.assertFalse(su.can_load_as_event_workspace(file_name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #19798 

Adds unit tests for the `can_load_event_workspace` function in `SANSUtility.py`

These tests are required for #19796

**To test:**

Make sure that the tests make sense and that the new tests pass on all platforms

No release notes required.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
