### PR TITLE
Improve documentation for SmoothNeighbours

### DIFF
--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -135,19 +135,21 @@ void SmoothNeighbours::init() {
   declareProperty(
       "RadiusUnits", "Meters",
       boost::make_shared<StringListValidator>(radiusPropOptions),
-      "Units used to specify the radius?\n"
+      "Units used to specify the radius.\n"
       "  Meters : Radius is in meters.\n"
       "  NumberOfPixels : Radius is in terms of the number of pixels.");
 
   declareProperty(
       "Radius", 0.0, mustBePositiveDouble,
-      "The radius around a pixel to look for nearest neighbours to average. \n"
+      "The radius cut-off around a pixel to look for nearest neighbours to average. \n"
+      "This radius cut-off is applied to a set of nearest neighbours whose number is "
+      "defined in the NumberOfNeighbours property. See below for more details. \n"
       "If 0, will use the AdjX and AdjY parameters for rectangular detectors "
       "instead.");
 
   declareProperty("NumberOfNeighbours", 8, mustBePositive,
                   "Number of nearest neighbouring pixels.\n"
-                  "Alternative to providing the radius. The default is 8.");
+                  "The default is 8.");
 
   declareProperty("SumNumberOfNeighbours", 1,
                   "Sum nearest neighbouring pixels with same parent.\n"

--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -141,9 +141,12 @@ void SmoothNeighbours::init() {
 
   declareProperty(
       "Radius", 0.0, mustBePositiveDouble,
-      "The radius cut-off around a pixel to look for nearest neighbours to average. \n"
-      "This radius cut-off is applied to a set of nearest neighbours whose number is "
-      "defined in the NumberOfNeighbours property. See below for more details. \n"
+      "The radius cut-off around a pixel to look for nearest neighbours to "
+      "average. \n"
+      "This radius cut-off is applied to a set of nearest neighbours whose "
+      "number is "
+      "defined in the NumberOfNeighbours property. See below for more details. "
+      "\n"
       "If 0, will use the AdjX and AdjY parameters for rectangular detectors "
       "instead.");
 


### PR DESCRIPTION
The SmoothNeighbours documentation is misleading. The description of the NumberOfNeighbours property "Number of nearest neighbouring pixels. Alternative to providing the radius. The default is 8." suggests that it can be used instead of the "Radius" property, while in fact the Radius property and the NumberOfNeighbours property go hand-in-hand. The documentation in general is  quite good. It is mainly the text regarding these two properties which needs to be corrected.

**To test:**

Ensure that documentation makes more sense and the documentation formatting is ok.

No issue number and does not have to be in release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
