### PR TITLE
Remove code preventing 2D reductions for wavelength ranges in ISIS SANS

### DIFF
--- a/docs/source/release/v3.10.0/sans.rst
+++ b/docs/source/release/v3.10.0/sans.rst
@@ -28,5 +28,6 @@ Bug Fixes
 - Fixed Batch mode bug where merged reductions set in the GUI were not respected.
 - Fixed display of current IDF, which was not updated when operating in batch mode.
 - Fixed a bug where the user could try to save 1D data in the CanSAS format and caused a crash.
+- Enabled wavelength-range based reductions in 2D.
 
 `Full list of changes on github <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.10%22+is%3Amerged+label%3A%22Component%3A+SANS%22>`__

--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -731,12 +731,6 @@ def CompWavRanges(wavelens, plot=True, combineDet=None, resetSetup=True):
 
     _printMessage('CompWavRanges( %s,plot=%s)' % (str(wavelens), plot))
 
-    # this only makes sense for 1D reductions
-    if ReductionSingleton().to_Q.output_type == '2D':
-        issueWarning('This wave ranges check is a 1D analysis, ignoring 2D setting')
-        _printMessage('Set1D()')
-        ReductionSingleton().to_Q.output_type = '1D'
-
     if not isinstance(wavelens, type([])) or len(wavelens) < 2:
         if not isinstance(wavelens, type((1,))):
             raise RuntimeError(


### PR DESCRIPTION
Rob reported that wavelength-based range reductions don't work for 2D reductions and that they revert to 1D reductions. Digging into the code I found that this was added by [design](https://github.com/mantidproject/mantid/blob/master/scripts/SANS/ISISCommandInterface.py#L734:L738 ). 

I asked the scientists if this feature should be available for 2D and Richard responded:
>I can’t think of any reason to restrict the list of wavelength bands to only 1d reductions, 2d should be fine,

This is a fairly low risk change, since this kind of reduction is used rather seldomly. Also it has been confirmed by scientists that this is (now) the correct behaviour. 

**To test:**

Please find the test data here: smb://olympic/babylon5/Scratch/Anton/BenchMarkingSANS2D_D20

1. Add the test data to the Mantid path
2. Open the ISIS SANS GUI
3. Select SANS2DTUBES as the instrument
4. Load the user file: USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_REAR.txt
5. For the sample scatter add: SANS2D00034484
6. Press the Load button
7. Go to the Reduction Settings tab and on the wavelength row set the wavelength step type to "Ranges Lin"
8. Add "4,5,6" into the wavelength field. See below
![image](https://cloud.githubusercontent.com/assets/8955784/26824111/fbc3ce46-4aa7-11e7-9ad8-69889c733e9b.png)
9. Go to the Run numbers tab and press "2D Reduce"
10. After the reduction has finished confirm that the ADS has the workspaces:
  * 34484rear_2D_4.0_5.0
  *  34484rear_2D_4.0_6.0
  * 34484rear_2D_5.0_6.0
11. Confirm that these workspaces have more than one spectrum/histogram

**Release notes **
Can be found [here](https://github.com/mantidproject/mantid/pull/19810/commits/f037be6b47d470db91a54f7feeae727e12a7de78)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
