### PR TITLE
Indirect - SofQW - remove polygon option

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMomentsScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMomentsScan.py
@@ -161,7 +161,7 @@ class SofQWMomentsScan(DataProcessorAlgorithm):
             sofqw_alg.setProperty("QAxisBinning", self._q_range)
             sofqw_alg.setProperty("EMode", 'Indirect')
             sofqw_alg.setProperty("ReplaceNaNs", True)
-            sofqw_alg.setProperty("Method", 'Polygon')
+            sofqw_alg.setProperty("Method", 'NormalisedPolygon')
             sofqw_alg.setProperty("OutputWorkspace", input_ws + '_sqw')
             sofqw_alg.execute()
             mtd.addOrReplace(input_ws + '_sqw', sofqw_alg.getProperty("OutputWorkspace").value)

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
@@ -71,7 +71,7 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_7">
       <item>
-       <layout class="QGridLayout" name="loOptions" columnstretch="0,10,0,0,10,0" columnminimumwidth="0,0,0,0,0,0">
+       <layout class="QGridLayout" name="loOptions" columnstretch="0,0,0,0,0,0">
         <item row="1" column="4">
          <widget class="QDoubleSpinBox" name="spELow">
           <property name="enabled">
@@ -138,6 +138,19 @@
           </property>
          </widget>
         </item>
+        <item row="0" column="0" colspan="2">
+         <widget class="QLabel" name="lbMethod">
+          <property name="minimumSize">
+           <size>
+            <width>43</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>The method used for Q Rebinning is Normalised Polygon</string>
+          </property>
+         </widget>
+        </item>
         <item row="3" column="4">
          <widget class="QDoubleSpinBox" name="spEHigh">
           <property name="enabled">
@@ -182,19 +195,6 @@
           </property>
           <property name="text">
            <string>E High:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="lbMethod">
-          <property name="minimumSize">
-           <size>
-            <width>43</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Method:</string>
           </property>
          </widget>
         </item>
@@ -344,41 +344,6 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="cbMethod">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>200</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="currentIndex">
-           <number>0</number>
-          </property>
-          <item>
-           <property name="text">
-            <string>Polygon</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>NormalisedPolygon</string>
-           </property>
-          </item>
-         </widget>
-        </item>
         <item row="0" column="2">
          <spacer name="horizontalSpacer">
           <property name="orientation">
@@ -485,7 +450,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>cbMethod</tabstop>
   <tabstop>spQLow</tabstop>
   <tabstop>spQWidth</tabstop>
   <tabstop>spQHigh</tabstop>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
@@ -138,19 +138,6 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="0" colspan="2">
-         <widget class="QLabel" name="lbMethod">
-          <property name="minimumSize">
-           <size>
-            <width>43</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>The method used for Q Rebinning is Normalised Polygon</string>
-          </property>
-         </widget>
-        </item>
         <item row="3" column="4">
          <widget class="QDoubleSpinBox" name="spEHigh">
           <property name="enabled">

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -62,7 +62,6 @@ void IndirectSqw::run() {
   QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
   QString sqwWsName = sampleWsName.left(sampleWsName.length() - 4) + "_sqw";
   QString eRebinWsName = sampleWsName.left(sampleWsName.length() - 4) + "_r";
-  QString method = m_uiForm.cbMethod->currentText();
 
   QString rebinString = m_uiForm.spQLow->text() + "," +
                         m_uiForm.spQWidth->text() + "," +
@@ -101,7 +100,7 @@ void IndirectSqw::run() {
   sqwAlg->setProperty("QAxisBinning", rebinString.toStdString());
   sqwAlg->setProperty("EMode", "Indirect");
   sqwAlg->setProperty("EFixed", eFixed.toStdString());
-  sqwAlg->setProperty("Method", method.toStdString());
+  sqwAlg->setProperty("Method", "NormalisedPolygon");
 
   m_batchAlgoRunner->addAlgorithm(sqwAlg, sqwInputProps);
 
@@ -112,7 +111,7 @@ void IndirectSqw::run() {
 
   sampleLogAlg->setProperty("LogName", "rebin_type");
   sampleLogAlg->setProperty("LogType", "String");
-  sampleLogAlg->setProperty("LogText", method.toStdString());
+  sampleLogAlg->setProperty("LogText", "NormalisedPolygon");
 
   BatchAlgorithmRunner::AlgorithmRuntimeProps inputToAddSampleLogProps;
   inputToAddSampleLogProps["Workspace"] = sqwWsName.toStdString();

--- a/docs/source/release/v3.10.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.10.0/indirect_inelastic.rst
@@ -39,6 +39,11 @@ Calibration
 
 - The range selector for resolution files is now dependent on the range of the spectrum, not the limit in the IPF
 
+SofQW
+~~~~~
+
+- The polygon option has been removed and the default method is NormalisedPolygon
+
 
 Data Analysis
 #############


### PR DESCRIPTION
The Indirect SofQW interface has been modified to only use the Normalised Polygon method for Q-Range Rebinning. The SofQWMomentsScan algorithm has also been modified use Normalised Polygon.

**To test:**

Testing Files:
[iris26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/1054612/iris26176_graphite002_red.zip)

Interfaces > Indirect > Data Reduction > SofQW
Load testing files
Q Low: `0.0`
Q Width: `0.1`
Q High: `2.0`

Press `Run`
Check `iris26176_graphite002_sqw` sample logs and ensure there is an entry `method` with a value of `NormalisedPolygon`


Fixes #19809 .

_Release Notes have been updated_

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
