### PR TITLE
Fixed documentation for dynamicKuboToyabe

### DIFF
--- a/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp
+++ b/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp
@@ -128,8 +128,8 @@ double integral(double func(const double, const double, const double),
 
 // f1: function to integrate
 double f1(const double x, const double G, const double w0) {
-	// G = Delta in doc
-	// x = dummy time variable 
+  // G = Delta in doc
+  // x = dummy time variable
   return (exp(-G * G * x * x / 2) * sin(w0 * x));
 }
 
@@ -143,7 +143,7 @@ double ZFKT(const double x, const double G) {
 
 // Static non-zero field Kubo Toyabe relaxation function
 double HKT(const double x, const double G, const double F) {
-	// q = Delta^2 t^2 in doc
+  // q = Delta^2 t^2 in doc
   const double q = G * G * x * x;
   // Muon gyromagnetic ratio * 2 * PI
   const double gm = 2 * M_PI * PhysicalConstants::MuonGyromagneticRatio;
@@ -172,10 +172,10 @@ double HKT(const double x, const double G, const double F) {
       (1 - 2 * r * (1 - exp(-q / 2) * cos(w * x)) + 2 * r * r * w * ig);
 
   if (F > 2 * G) {
-	// longitudinal Gaussian field 
+    // longitudinal Gaussian field
     return ktb;
   } else {
-	 // 
+    //
     const double kz = ZFKT(x, G);
     return kz + F / 2 / G * (ktb - kz);
   }
@@ -228,7 +228,7 @@ double DynamicKuboToyabe::getDKT(double t, double G, double F, double v,
     // Generate dynamic Kubo Toyabe
     for (int k = 0; k < tsmax; k++) {
       double y = gStat[k];
-	  // do integration
+      // do integration
       for (int j = k - 1; j > 0; j--) {
         y = y * (1 - hop) + hop * gDyn[k - j] * gStat[j];
       }

--- a/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp
+++ b/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp
@@ -128,23 +128,26 @@ double integral(double func(const double, const double, const double),
 
 // f1: function to integrate
 double f1(const double x, const double G, const double w0) {
+	// G = Delta in doc
+	// x = dummy time variable 
   return (exp(-G * G * x * x / 2) * sin(w0 * x));
 }
 
 // Static Zero Field Kubo Toyabe relaxation function
+// Also called Lorentzian Kubo-Toyabe
 double ZFKT(const double x, const double G) {
-
+  // q = Delta^2 t^2 in doc
   const double q = G * G * x * x;
   return (0.3333333333 + 0.6666666667 * exp(-0.5 * q) * (1 - q));
 }
 
 // Static non-zero field Kubo Toyabe relaxation function
 double HKT(const double x, const double G, const double F) {
-
+	// q = Delta^2 t^2 in doc
   const double q = G * G * x * x;
   // Muon gyromagnetic ratio * 2 * PI
   const double gm = 2 * M_PI * PhysicalConstants::MuonGyromagneticRatio;
-
+  // w = omega_0 in doc
   double w;
   if (F > 2 * G) {
     // Use F
@@ -153,7 +156,7 @@ double HKT(const double x, const double G, const double F) {
     // Use G
     w = gm * 2 * G;
   }
-
+  // r = Delta^2/omega_0^2
   const double r = G * G / w / w;
 
   double ig;
@@ -169,8 +172,10 @@ double HKT(const double x, const double G, const double F) {
       (1 - 2 * r * (1 - exp(-q / 2) * cos(w * x)) + 2 * r * r * w * ig);
 
   if (F > 2 * G) {
+	// longitudinal Gaussian field 
     return ktb;
   } else {
+	 // 
     const double kz = ZFKT(x, G);
     return kz + F / 2 / G * (ktb - kz);
   }
@@ -223,6 +228,7 @@ double DynamicKuboToyabe::getDKT(double t, double G, double F, double v,
     // Generate dynamic Kubo Toyabe
     for (int k = 0; k < tsmax; k++) {
       double y = gStat[k];
+	  // do integration
       for (int j = k - 1; j > 0; j--) {
         y = y * (1 - hop) + hop * gDyn[k - j] * gStat[j];
       }

--- a/docs/source/fitfunctions/DynamicKuboToyabe.rst
+++ b/docs/source/fitfunctions/DynamicKuboToyabe.rst
@@ -12,7 +12,7 @@ Description
 Dynamic Kubo Toyabe fitting function for use by Muon scientists defined
 by
 
-.. math:: G_z \left(t\right) = g_z\left(t\right) e^{-\nu t} + \nu \int_0^t g_z\left(\tau\right) e^{-\nu\tau} G_z\left(t-\tau\right) d\tau
+.. math:: G_z \left(t\right) = g_z\left(t\right) + \nu \int_0^t g_z\left(\tau\right) G_z\left(t-\tau\right) d\tau
 
 where :math:`g_z\left(t\right)` is the static KT function, and :math:`\nu` the muon hopping rate.
 
@@ -30,6 +30,11 @@ small values will lead to long calculation times, while large values will produc
 .. attributes::
 
 .. properties::
+
+References
+----------
+
+[1]  `Hayano et al., PRB 20 (1979) 50 <https://journals.aps.org/prb/abstract/10.1103/PhysRevB.20.850>`_.
 
 .. categories::
 


### PR DESCRIPTION
There was a mistake in the documentation for the dynamic Kubo Toyabe function. I have corrected it (http://www.isis.stfc.ac.uk/groups/muons/muon-training-school/2005-relaxation-functions-rc7912.pdf) and added some comments to the code (for clarity). 

**To test:**

<!-- Instructions for testing. -->
Make sure that the documentation compiles and displays nicely. The link should take you to  https://journals.aps.org/prb/abstract/10.1103/PhysRevB.20.850

Fixes #19802 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
