### PR TITLE
ISIS_Powder - Fix GEM spectra index starting at 0

### DIFF
--- a/scripts/Diffraction/isis_powder/gem_routines/gem_algs.py
+++ b/scripts/Diffraction/isis_powder/gem_routines/gem_algs.py
@@ -10,7 +10,7 @@ from isis_powder.gem_routines import gem_advanced_config
 
 def calculate_van_absorb_corrections(ws_to_correct, multiple_scattering):
     # First 100 detectors are monitors or not connected to DAE
-    mantid.MaskDetectors(ws_to_correct, SpectraList=list(range(0, 101)))
+    mantid.MaskDetectors(ws_to_correct, SpectraList=list(range(1, 101)))
 
     absorb_dict = gem_advanced_config.absorption_correction_params
     sample_details_obj = absorb_corrections.create_vanadium_sample_details_obj(config_dict=absorb_dict)


### PR DESCRIPTION
Description of work.
This PR resolves an issue where the spectra index starts a 0 in code but one in the data files. This causes mask detectors to fail.

This was noticed on master when writing a new set of system tests. The fix which is identical had been applied to POLARIS however it appears I forgot to apply this to GEM. With the changes the new scripts will now correctly mask detectors.

**To test:**
Code review

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
