### PR TITLE
Clean up of MuonFitPropertyBrowser 

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitPropertyBrowser.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitPropertyBrowser.h
@@ -72,12 +72,6 @@ public:
   std::string outputName() const override;
   /// Prefix for simultaneous fit results
   static const std::string SIMULTANEOUS_PREFIX;
-  /// custom label
-  static const std::string CUSTOM_LABEL;
-  static const std::string ALL_GROUPS_LABEL;
-  static const std::string ALL_PAIRS_LABEL;
-  static const std::string ALL_PERIODS_LABEL;
-
   /// Set label for simultaneous fit results
   void setSimultaneousLabel(const std::string &label) override {
     m_simultaneousLabel = label;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitPropertyBrowser.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MuonFitPropertyBrowser.h
@@ -72,6 +72,12 @@ public:
   std::string outputName() const override;
   /// Prefix for simultaneous fit results
   static const std::string SIMULTANEOUS_PREFIX;
+  /// custom label
+  static const std::string CUSTOM_LABEL;
+  static const std::string ALL_GROUPS_LABEL;
+  static const std::string ALL_PAIRS_LABEL;
+  static const std::string ALL_PERIODS_LABEL;
+
   /// Set label for simultaneous fit results
   void setSimultaneousLabel(const std::string &label) override {
     m_simultaneousLabel = label;

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -59,6 +59,10 @@
 
 namespace {
 Mantid::Kernel::Logger g_log("MuonFitPropertyBrowser");
+const std::string CUSTOM_LABEL{"Custom"};
+const std::string ALL_GROUPS_LABEL{"All Groups"};
+const std::string ALL_PAIRS_LABEL{"All Pairs"};
+const std::string ALL_PERIODS_LABEL{"All Periods"};
 }
 
 namespace MantidQt {
@@ -67,10 +71,6 @@ namespace MantidWidgets {
 using namespace Mantid::API;
 
 const std::string MuonFitPropertyBrowser::SIMULTANEOUS_PREFIX{"MuonSimulFit_"};
-const std::string MuonFitPropertyBrowser::CUSTOM_LABEL{"Custom"};
-const std::string MuonFitPropertyBrowser::ALL_GROUPS_LABEL{"All Groups"};
-const std::string MuonFitPropertyBrowser::ALL_PAIRS_LABEL{"All Pairs"};
-const std::string MuonFitPropertyBrowser::ALL_PERIODS_LABEL{"All Periods"};
 
 /**
  * Constructor

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -67,6 +67,10 @@ namespace MantidWidgets {
 using namespace Mantid::API;
 
 const std::string MuonFitPropertyBrowser::SIMULTANEOUS_PREFIX{"MuonSimulFit_"};
+const std::string MuonFitPropertyBrowser::CUSTOM_LABEL{"Custom"};
+const std::string MuonFitPropertyBrowser::ALL_GROUPS_LABEL{"All Groups"};
+const std::string MuonFitPropertyBrowser::ALL_PAIRS_LABEL{"All Pairs"};
+const std::string MuonFitPropertyBrowser::ALL_PERIODS_LABEL{"All Periods"};
 
 /**
  * Constructor
@@ -158,9 +162,9 @@ void MuonFitPropertyBrowser::init() {
   multiFitSettingsGroup->addSubProperty(m_startX);
   multiFitSettingsGroup->addSubProperty(m_endX);
   m_groupsToFit = m_enumManager->addProperty("Groups/Pairs to fit");
-  m_groupsToFitOptions << "All groups"
-                       << "All Pairs"
-                       << "Custom";
+  m_groupsToFitOptions << QString::fromStdString(ALL_GROUPS_LABEL)
+                       << QString::fromStdString(ALL_PAIRS_LABEL)
+                       << QString::fromStdString(CUSTOM_LABEL);
   m_showGroupValue << "groups";
   m_showGroup = m_enumManager->addProperty("Selected Groups");
   m_enumManager->setEnumNames(m_groupsToFit, m_groupsToFitOptions);
@@ -173,10 +177,10 @@ void MuonFitPropertyBrowser::init() {
   tmp = "bwd";
   addGroupCheckbox(tmp);
   m_periodsToFit = m_enumManager->addProperty("Periods to fit");
-  m_periodsToFitOptions << "All Periods"
+  m_periodsToFitOptions << QString::fromStdString(ALL_PERIODS_LABEL)
                         << "1"
                         << "2"
-                        << "Custom";
+                        << QString::fromStdString(CUSTOM_LABEL);
   m_showPeriodValue << "1";
   m_showPeriods = m_enumManager->addProperty("Selected Periods");
   m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);
@@ -341,13 +345,13 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
     int j = m_enumManager->value(m_groupsToFit);
     std::string option = m_groupsToFitOptions[j].toStdString();
 
-    if (option == "All groups") {
+    if (option == ALL_GROUPS_LABEL) {
       setAllGroups();
       m_reselectGroupBtn->setEnabled(false);
-    } else if (option == "All Pairs") {
+    } else if (option == ALL_PAIRS_LABEL) {
       setAllPairs();
       m_reselectGroupBtn->setEnabled(false);
-    } else if (option == "Custom") {
+    } else if (option == CUSTOM_LABEL) {
       m_reselectGroupBtn->setEnabled(true);
       genGroupWindow();
     }
@@ -356,10 +360,10 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
   } else if (prop == m_periodsToFit) {
     int j = m_enumManager->value(m_periodsToFit);
     std::string option = m_periodsToFitOptions[j].toStdString();
-    if (option == "Custom") {
+    if (option == CUSTOM_LABEL) {
       m_reselectPeriodBtn->setEnabled(true);
       genPeriodWindow();
-    } else if (option == "All Periods") {
+    } else if (option == ALL_PERIODS_LABEL) {
       setAllPeriods();
       m_reselectPeriodBtn->setEnabled(false);
     } else {
@@ -1182,7 +1186,7 @@ void MuonFitPropertyBrowser::setAllPeriods() {
 void MuonFitPropertyBrowser::setNumPeriods(size_t numPeriods) {
   m_periodsToFitOptions.clear();
   if (numPeriods > 1) {
-    m_periodsToFitOptions << "All Periods";
+    m_periodsToFitOptions << QString::fromStdString(ALL_PERIODS_LABEL);
   }
   // create more boxes
   for (size_t i = 0; i != numPeriods; i++) {
@@ -1203,7 +1207,7 @@ void MuonFitPropertyBrowser::setNumPeriods(size_t numPeriods) {
     m_multiFitSettingsGroup->property()->addSubProperty(m_showPeriods);
     m_generateBtn->setDisabled(false);
 
-    m_periodsToFitOptions << "Custom";
+    m_periodsToFitOptions << QString::fromStdString(CUSTOM_LABEL);
     m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);
   }
 }
@@ -1272,7 +1276,7 @@ void MuonFitPropertyBrowser::addPeriodCheckbox(const QString &name) {
   setChosenPeriods(active);
   m_enumManager->setValue(m_periodsToFit, j);
   auto option = m_periodsToFitOptions[j].toStdString();
-  if (option == "All Periods") {
+  if (option ==ALL_PERIODS_LABEL) {
     setAllPeriods();
   }
 }

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -162,9 +162,7 @@ void MuonFitPropertyBrowser::init() {
   multiFitSettingsGroup->addSubProperty(m_startX);
   multiFitSettingsGroup->addSubProperty(m_endX);
   m_groupsToFit = m_enumManager->addProperty("Groups/Pairs to fit");
-  m_groupsToFitOptions << ALL_GROUPS_LABEL
-                       << ALL_PAIRS_LABEL
-                       << CUSTOM_LABEL;
+  m_groupsToFitOptions << ALL_GROUPS_LABEL << ALL_PAIRS_LABEL << CUSTOM_LABEL;
   m_showGroupValue << "groups";
   m_showGroup = m_enumManager->addProperty("Selected Groups");
   m_enumManager->setEnumNames(m_groupsToFit, m_groupsToFitOptions);

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -59,10 +59,10 @@
 
 namespace {
 Mantid::Kernel::Logger g_log("MuonFitPropertyBrowser");
-const std::string CUSTOM_LABEL{"Custom"};
-const std::string ALL_GROUPS_LABEL{"All Groups"};
-const std::string ALL_PAIRS_LABEL{"All Pairs"};
-const std::string ALL_PERIODS_LABEL{"All Periods"};
+const QString CUSTOM_LABEL{"Custom"};
+const QString ALL_GROUPS_LABEL{"All Groups"};
+const QString ALL_PAIRS_LABEL{"All Pairs"};
+const QString ALL_PERIODS_LABEL{"All Periods"};
 }
 
 namespace MantidQt {
@@ -162,9 +162,9 @@ void MuonFitPropertyBrowser::init() {
   multiFitSettingsGroup->addSubProperty(m_startX);
   multiFitSettingsGroup->addSubProperty(m_endX);
   m_groupsToFit = m_enumManager->addProperty("Groups/Pairs to fit");
-  m_groupsToFitOptions << QString::fromStdString(ALL_GROUPS_LABEL)
-                       << QString::fromStdString(ALL_PAIRS_LABEL)
-                       << QString::fromStdString(CUSTOM_LABEL);
+  m_groupsToFitOptions << ALL_GROUPS_LABEL
+                       << ALL_PAIRS_LABEL
+                       << CUSTOM_LABEL;
   m_showGroupValue << "groups";
   m_showGroup = m_enumManager->addProperty("Selected Groups");
   m_enumManager->setEnumNames(m_groupsToFit, m_groupsToFitOptions);
@@ -177,8 +177,8 @@ void MuonFitPropertyBrowser::init() {
   tmp = "bwd";
   addGroupCheckbox(tmp);
   m_periodsToFit = m_enumManager->addProperty("Periods to fit");
-  m_periodsToFitOptions << QString::fromStdString(ALL_PERIODS_LABEL) << "1"
-                        << "2" << QString::fromStdString(CUSTOM_LABEL);
+  m_periodsToFitOptions << ALL_PERIODS_LABEL << "1"
+                        << "2" << CUSTOM_LABEL;
   m_showPeriodValue << "1";
   m_showPeriods = m_enumManager->addProperty("Selected Periods");
   m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);
@@ -341,7 +341,7 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
     return;
   if (prop == m_groupsToFit) {
     int j = m_enumManager->value(m_groupsToFit);
-    std::string option = m_groupsToFitOptions[j].toStdString();
+    QString option = m_groupsToFitOptions[j];
 
     if (option == ALL_GROUPS_LABEL) {
       setAllGroups();
@@ -357,7 +357,7 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
 
   } else if (prop == m_periodsToFit) {
     int j = m_enumManager->value(m_periodsToFit);
-    std::string option = m_periodsToFitOptions[j].toStdString();
+    QString option = m_periodsToFitOptions[j];
     if (option == CUSTOM_LABEL) {
       m_reselectPeriodBtn->setEnabled(true);
       genPeriodWindow();
@@ -367,7 +367,7 @@ void MuonFitPropertyBrowser::enumChanged(QtProperty *prop) {
     } else {
       for (auto iter = m_periodBoxes.constBegin();
            iter != m_periodBoxes.constEnd(); ++iter) {
-        if (option == iter.key().toStdString()) {
+        if (option == iter.key()) {
           m_boolManager->setValue(iter.value(), true);
         } else {
           m_boolManager->setValue(iter.value(), false);
@@ -1184,7 +1184,7 @@ void MuonFitPropertyBrowser::setAllPeriods() {
 void MuonFitPropertyBrowser::setNumPeriods(size_t numPeriods) {
   m_periodsToFitOptions.clear();
   if (numPeriods > 1) {
-    m_periodsToFitOptions << QString::fromStdString(ALL_PERIODS_LABEL);
+    m_periodsToFitOptions << ALL_PERIODS_LABEL;
   }
   // create more boxes
   for (size_t i = 0; i != numPeriods; i++) {
@@ -1205,7 +1205,7 @@ void MuonFitPropertyBrowser::setNumPeriods(size_t numPeriods) {
     m_multiFitSettingsGroup->property()->addSubProperty(m_showPeriods);
     m_generateBtn->setDisabled(false);
 
-    m_periodsToFitOptions << QString::fromStdString(CUSTOM_LABEL);
+    m_periodsToFitOptions << CUSTOM_LABEL;
     m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);
   }
 }
@@ -1273,8 +1273,7 @@ void MuonFitPropertyBrowser::addPeriodCheckbox(const QString &name) {
   m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);
   setChosenPeriods(active);
   m_enumManager->setValue(m_periodsToFit, j);
-  auto option = m_periodsToFitOptions[j].toStdString();
-  if (option == ALL_PERIODS_LABEL) {
+  if (m_periodsToFitOptions[j] == ALL_PERIODS_LABEL) {
     setAllPeriods();
   }
 }

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -177,10 +177,8 @@ void MuonFitPropertyBrowser::init() {
   tmp = "bwd";
   addGroupCheckbox(tmp);
   m_periodsToFit = m_enumManager->addProperty("Periods to fit");
-  m_periodsToFitOptions << QString::fromStdString(ALL_PERIODS_LABEL)
-                        << "1"
-                        << "2"
-                        << QString::fromStdString(CUSTOM_LABEL);
+  m_periodsToFitOptions << QString::fromStdString(ALL_PERIODS_LABEL) << "1"
+                        << "2" << QString::fromStdString(CUSTOM_LABEL);
   m_showPeriodValue << "1";
   m_showPeriods = m_enumManager->addProperty("Selected Periods");
   m_enumManager->setEnumNames(m_periodsToFit, m_periodsToFitOptions);
@@ -1276,7 +1274,7 @@ void MuonFitPropertyBrowser::addPeriodCheckbox(const QString &name) {
   setChosenPeriods(active);
   m_enumManager->setValue(m_periodsToFit, j);
   auto option = m_periodsToFitOptions[j].toStdString();
-  if (option ==ALL_PERIODS_LABEL) {
+  if (option == ALL_PERIODS_LABEL) {
     setAllPeriods();
   }
 }


### PR DESCRIPTION
There were a set of strings that where repeated several times throughout the file. These have been replaced by const function calls to prevent typos. 

**To test:**

<!-- Instructions for testing. -->
Load muon analysis with multiple period data (HIFI is good). Make sure multiple fitting is selected in the settings tab. Then in the data analysis tab check that changing the Groups/Periods selected causes the appropriate selection of data (custom creates a pop up box). 


Fixes #19713 

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.
Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
