### PR TITLE
Add caching to multiple file property

### DIFF
--- a/Framework/API/inc/MantidAPI/MultipleFileProperty.h
+++ b/Framework/API/inc/MantidAPI/MultipleFileProperty.h
@@ -174,6 +174,14 @@ private:
   /// The action type of this property
   /// Load (dafault) or OptionalLoad are supported
   unsigned int m_action;
+  /// Last value of propValue used in
+  /// MultipleFileProperty::setValueAsMultipleFiles
+  /// and MultipleFileProperty::setValueAsSingleFile
+  std::string m_oldPropValue;
+  /// Last value of the found files used in
+  /// MultipleFileProperty::setValueAsMultipleFiles
+  /// and MultipleFileProperty::setValueAsSingleFile
+  std::vector<std::vector<std::string>> m_oldFoundValue;
 };
 
 } // namespace API

--- a/Framework/API/test/MultipleFilePropertyTest.h
+++ b/Framework/API/test/MultipleFilePropertyTest.h
@@ -77,6 +77,7 @@ private:
   std::string m_dirWithWhitespace;
   std::unordered_set<std::string> m_tempDirs;
   std::vector<std::string> m_exts;
+  std::string m_oldArchiveSearchSetting;
 
   Mantid::Kernel::ConfigServiceImpl &g_config;
 
@@ -97,6 +98,7 @@ public:
       : m_multiFileLoadingSetting(), m_oldDataSearchDirectories(),
         m_oldDefaultFacility(), m_oldDefaultInstrument(), m_dummyFilesDir(),
         m_dirWithWhitespace(), m_tempDirs(), m_exts{".raw", ".nxs"},
+        m_oldArchiveSearchSetting(),
         g_config(Mantid::Kernel::ConfigService::Instance()) {
     m_dummyFilesDir =
         createAbsoluteDirectory("_MultipleFilePropertyTestDummyFiles");
@@ -157,11 +159,13 @@ public:
     m_oldDataSearchDirectories = g_config.getString("datasearch.directories");
     m_oldDefaultFacility = g_config.getString("default.facilities");
     m_oldDefaultInstrument = g_config.getString("default.instrument");
+    m_oldArchiveSearchSetting = g_config.getString("datasearch.searcharchive");
 
     g_config.setString("datasearch.directories",
                        m_dummyFilesDir + ";" + m_dirWithWhitespace + ";");
     g_config.setString("default.facility", "ISIS");
     g_config.setString("default.instrument", "TOSCA");
+    g_config.setString("datasearch.searcharchive", "Off");
 
     // Make sure that multi file loading is enabled for each test.
     m_multiFileLoadingSetting =
@@ -173,6 +177,7 @@ public:
     g_config.setString("datasearch.directories", m_oldDataSearchDirectories);
     g_config.setString("default.facility", m_oldDefaultFacility);
     g_config.setString("default.instrument", m_oldDefaultInstrument);
+    g_config.setString("datasearch.searcharchive", m_oldArchiveSearchSetting);
 
     // Replace user's preference after the test has run.
     Kernel::ConfigService::Instance().setString("loading.multifile",


### PR DESCRIPTION
Much like `FileProperty`, add caching of found files to `MultipleFileProperty`.

**To test:**

Review the code and make sure that `APITest_MultipleFilePropertyTest` isn't slower than it was before merging this change. Also test `Load` from the GUI with archive search turned on. It should have less lag when pressing the `Run` button after filling in the filename when multiple files are accepted.

*There was no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
