### PR TITLE
Reduce the search time for icat unit test

### DIFF
--- a/Framework/ICat/test/CatalogSearchTest.h
+++ b/Framework/ICat/test/CatalogSearchTest.h
@@ -37,7 +37,7 @@ public:
       searchobj.initialize();
 
     searchobj.setPropertyValue("RunRange", "1000000-1000001");
-    //search ALF instrument it is much faster
+    // search ALF instrument it is much faster
     searchobj.setPropertyValue("Instrument", "ALF");
     searchobj.setPropertyValue("OutputWorkspace", "Investigations");
 
@@ -55,7 +55,7 @@ public:
     if (!searchobj.isInitialized())
       searchobj.initialize();
 
-    //This is a keyword that is chosen to return an empty dataset - very fast
+    // This is a keyword that is chosen to return an empty dataset - very fast
     searchobj.setPropertyValue("Keywords", ":-)");
     searchobj.setPropertyValue("Instrument", "HRPD");
     searchobj.setPropertyValue("OutputWorkspace", "Investigations");

--- a/Framework/ICat/test/CatalogSearchTest.h
+++ b/Framework/ICat/test/CatalogSearchTest.h
@@ -37,7 +37,8 @@ public:
       searchobj.initialize();
 
     searchobj.setPropertyValue("RunRange", "1000000-1000001");
-    searchobj.setPropertyValue("Instrument", "LOQ");
+    //search ALF instrument it is much faster
+    searchobj.setPropertyValue("Instrument", "ALF");
     searchobj.setPropertyValue("OutputWorkspace", "Investigations");
 
     TS_ASSERT_THROWS_NOTHING(searchobj.execute());
@@ -54,7 +55,8 @@ public:
     if (!searchobj.isInitialized())
       searchobj.initialize();
 
-    searchobj.setPropertyValue("Keywords", "000117");
+    //This is a keyword that is chosen to return an empty dataset - very fast
+    searchobj.setPropertyValue("Keywords", ":-)");
     searchobj.setPropertyValue("Instrument", "HRPD");
     searchobj.setPropertyValue("OutputWorkspace", "Investigations");
 


### PR DESCRIPTION
The current tests already only run if the icat website is available, but this tackles the individual tests that take some time, and changes the data queries for queries that execute faster.

**To test:**
1. Ensure unit tests pass, and the unit tests where not skipped.
1. review the changes to the test queires, you can run these in the gui if you want to check them.


re #19866 

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
