### PR TITLE
Speedup FindUBUsingLatticeParametersTest by loading data only once

### DIFF
--- a/Framework/Crystal/test/FindUBUsingLatticeParametersTest.h
+++ b/Framework/Crystal/test/FindUBUsingLatticeParametersTest.h
@@ -133,15 +133,15 @@ public:
     // Use a tiny set of 3 peaks - the minimum required
     /// to successfully find a UB matrix this checks the case that we still
     /// get a UB (although perhaps not a very good one).
-    std::vector<size_t> rom_ws;
+    std::vector<size_t> rows;
     for (size_t i = 3; i < m_ws->rowCount(); ++i) {
-      rom_ws.push_back(i);
+      rows.push_back(i);
     }
 
     DataHandling::DeleteTableRows removeRowAlg;
     removeRowAlg.initialize();
     removeRowAlg.setPropertyValue("TableWorkspace", m_ws->getName());
-    removeRowAlg.setProperty("Rows", rom_ws);
+    removeRowAlg.setProperty("Rows", rows);
     removeRowAlg.execute();
 
     FindUBUsingLatticeParameters alg;

--- a/Framework/Crystal/test/FindUBUsingLatticeParametersTest.h
+++ b/Framework/Crystal/test/FindUBUsingLatticeParametersTest.h
@@ -84,7 +84,6 @@ public:
     TS_ASSERT_DELTA(latt.erroralpha(), 0.0994, 5e-4);
     TS_ASSERT_DELTA(latt.errorbeta(), 0.0773, 5e-4);
     TS_ASSERT_DELTA(latt.errorgamma(), 0.0906, 5e-4);
-
   }
 
   void test_fixAll() {

--- a/Framework/Crystal/test/FindUBUsingLatticeParametersTest.h
+++ b/Framework/Crystal/test/FindUBUsingLatticeParametersTest.h
@@ -22,6 +22,13 @@ using namespace Mantid::Kernel;
 
 class FindUBUsingLatticeParametersTest : public CxxTest::TestSuite {
 public:
+  FindUBUsingLatticeParametersTest() { m_ws = loadPeaksWorkspace(); }
+
+  ~FindUBUsingLatticeParametersTest() {
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(m_ws->getName());
+  }
+
   void test_Init() {
     FindUBUsingLatticeParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
@@ -29,13 +36,12 @@ public:
   }
 
   void test_exec() {
-    auto ws = loadPeaksWorkspace();
 
     FindUBUsingLatticeParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(
-        alg.setPropertyValue("PeaksWorkspace", ws->getName()));
+        alg.setPropertyValue("PeaksWorkspace", m_ws->getName()));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("a", "14.131"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("b", "19.247"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("c", "8.606"));
@@ -48,9 +54,9 @@ public:
     TS_ASSERT(alg.isExecuted());
 
     // Check that we set an oriented lattice
-    TS_ASSERT(ws->mutableSample().hasOrientedLattice());
+    TS_ASSERT(m_ws->mutableSample().hasOrientedLattice());
     // Check that the UB matrix is the same as in TOPAZ_3007.mat
-    OrientedLattice latt = ws->mutableSample().getOrientedLattice();
+    OrientedLattice latt = m_ws->mutableSample().getOrientedLattice();
 
     double correct_UB[] = {0.04542050,  0.040619900, 0.0122354,
                            -0.00140347, -0.00318493, -0.1165450,
@@ -79,18 +85,14 @@ public:
     TS_ASSERT_DELTA(latt.errorbeta(), 0.0773, 5e-4);
     TS_ASSERT_DELTA(latt.errorgamma(), 0.0906, 5e-4);
 
-    // Remove workspace from the data service.
-    AnalysisDataService::Instance().remove(ws->getName());
   }
 
   void test_fixAll() {
-    auto ws = loadPeaksWorkspace();
-
     FindUBUsingLatticeParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(
-        alg.setPropertyValue("PeaksWorkspace", ws->getName()));
+        alg.setPropertyValue("PeaksWorkspace", m_ws->getName()));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("a", "14.131"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("b", "19.247"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("c", "8.606"));
@@ -104,9 +106,9 @@ public:
     TS_ASSERT(alg.isExecuted());
 
     // Check that we set an oriented lattice
-    TS_ASSERT(ws->mutableSample().hasOrientedLattice());
+    TS_ASSERT(m_ws->mutableSample().hasOrientedLattice());
     // Check that the UB matrix is the same as in TOPAZ_3007.mat
-    OrientedLattice latt = ws->mutableSample().getOrientedLattice();
+    OrientedLattice latt = m_ws->mutableSample().getOrientedLattice();
 
     double correct_UB[] = {0.04542050,  0.040619900, 0.0127661,
                            -0.00198382, -0.00264404, -0.1165450,
@@ -125,32 +127,28 @@ public:
     TS_ASSERT_DELTA(latt.alpha(), 90.0, 5e-10);
     TS_ASSERT_DELTA(latt.beta(), 105.071, 5e-10);
     TS_ASSERT_DELTA(latt.gamma(), 90.0, 5e-10);
-
-    // Remove workspace from the data service.
-    AnalysisDataService::Instance().remove(ws->getName());
   }
 
   void test_smallNumberOfPeaks() {
     // Use a tiny set of 3 peaks - the minimum required
     /// to successfully find a UB matrix this checks the case that we still
     /// get a UB (although perhaps not a very good one).
-    auto ws = loadPeaksWorkspace();
-    std::vector<size_t> rows;
-    for (size_t i = 3; i < ws->rowCount(); ++i) {
-      rows.push_back(i);
+    std::vector<size_t> rom_ws;
+    for (size_t i = 3; i < m_ws->rowCount(); ++i) {
+      rom_ws.push_back(i);
     }
 
     DataHandling::DeleteTableRows removeRowAlg;
     removeRowAlg.initialize();
-    removeRowAlg.setPropertyValue("TableWorkspace", ws->getName());
-    removeRowAlg.setProperty("Rows", rows);
+    removeRowAlg.setPropertyValue("TableWorkspace", m_ws->getName());
+    removeRowAlg.setProperty("Rows", rom_ws);
     removeRowAlg.execute();
 
     FindUBUsingLatticeParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(
-        alg.setPropertyValue("PeaksWorkspace", ws->getName()));
+        alg.setPropertyValue("PeaksWorkspace", m_ws->getName()));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("a", "14.131"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("b", "19.247"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("c", "8.606"));
@@ -164,9 +162,9 @@ public:
     TS_ASSERT(alg.isExecuted());
 
     // Check that we set an oriented lattice
-    TS_ASSERT(ws->mutableSample().hasOrientedLattice());
+    TS_ASSERT(m_ws->mutableSample().hasOrientedLattice());
     // Check that the UB matrix is the same as in TOPAZ_3007.mat
-    OrientedLattice latt = ws->mutableSample().getOrientedLattice();
+    OrientedLattice latt = m_ws->mutableSample().getOrientedLattice();
 
     double correct_UB[] = {0.0450,  0.0407,  0.0127, -0.0008, -0.0044,
                            -0.1158, -0.0584, 0.0307, -0.0242};
@@ -182,9 +180,6 @@ public:
     TS_ASSERT_DELTA(latt.alpha(), 92.6267, 5e-4);
     TS_ASSERT_DELTA(latt.beta(), 103.7440, 5e-4);
     TS_ASSERT_DELTA(latt.gamma(), 90.0272, 5e-4);
-
-    // Remove workspace from the data service.
-    AnalysisDataService::Instance().remove(ws->getName());
   }
 
 private:
@@ -209,6 +204,9 @@ private:
     TS_ASSERT(ws);
     return ws;
   }
+
+  /// Input peaks workspace
+  PeaksWorkspace_sptr m_ws;
 };
 
 #endif /* MANTID_CRYSTAL_FIND_UB_USING_LATTICE_PARAMETERS_TEST_H_ */


### PR DESCRIPTION
Only load the test file once. This saves ~30s on my local machine.

Description of work.

**To test:**
 - Run `FindUBUsingLatticeParametersTest` with and without changes
 - With changes should be faster 

Refs #19866.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
