### PR TITLE
Peaks workspace has instrument parameters

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1012,6 +1012,9 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(NXEntry &entry) {
     // This loads logs, sample, and instrument.
     peakWS->loadExperimentInfoNexus(getPropertyValue("Filename"), m_cppFile,
                                     parameterStr);
+    // Populate the instrument parameters in this workspace - this works around
+    // a bug
+    peakWS->populateInstrumentParameters();
   } catch (std::exception &e) {
     g_log.information("Error loading Instrument section of nxs file");
     g_log.information(e.what());


### PR DESCRIPTION
Fixed so parameters are loaded with peaks workspace.  Bug found by Andrei caused second print in test to be empty.

**To test:**
```python
p1=LoadIsawPeaks(Filename='TOPAZ_3007.peaks')
SaveNexusProcessed(p1,Filename='/tmp/peaks.nxs')
p2=LoadNexusProcessed(Filename='/tmp/peaks.nxs')
print(p1.getInstrument().getParameterNames())
print(p2.getInstrument().getParameterNames())
```

Fixes #19876 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
