### PR TITLE
Improved error checking in WorkspaceOpOverloads

### DIFF
--- a/Framework/API/src/WorkspaceOpOverloads.cpp
+++ b/Framework/API/src/WorkspaceOpOverloads.cpp
@@ -539,8 +539,9 @@ void WorkspaceHelpers::makeDistribution(MatrixWorkspace_sptr workspace,
 
   const size_t numberOfSpectra = workspace->getNumberHistograms();
   // check X vs Y data size
-  if (workspace->x(0).size() == workspace->y(0).size()){
-	  throw std::runtime_error("Workspace is using point data for x (should be bin edges).");
+  if (workspace->x(0).size() == workspace->y(0).size()) {
+    throw std::runtime_error(
+        "Workspace is using point data for x (should be bin edges).");
   }
   for (size_t i = 0; i < numberOfSpectra; ++i) {
     if (forwards) {

--- a/Framework/API/src/WorkspaceOpOverloads.cpp
+++ b/Framework/API/src/WorkspaceOpOverloads.cpp
@@ -538,8 +538,7 @@ void WorkspaceHelpers::makeDistribution(MatrixWorkspace_sptr workspace,
                              "into distributions.");
 
   const size_t numberOfSpectra = workspace->getNumberHistograms();
-  // check X vs Y data size
-  if (workspace->x(0).size() == workspace->y(0).size()) {
+  if (workspace->histogram(0).xMode() == HistogramData::Histogram::XMode::Points) {
     throw std::runtime_error(
         "Workspace is using point data for x (should be bin edges).");
   }

--- a/Framework/API/src/WorkspaceOpOverloads.cpp
+++ b/Framework/API/src/WorkspaceOpOverloads.cpp
@@ -540,8 +540,7 @@ void WorkspaceHelpers::makeDistribution(MatrixWorkspace_sptr workspace,
   const size_t numberOfSpectra = workspace->getNumberHistograms();
   // check X vs Y data size
   if (workspace->x(0).size() == workspace->y(0).size()){
-	  std::cout << "catch" << std::endl;
-	  throw std::runtime_error("Workspace is not histogram.");
+	  throw std::runtime_error("Workspace is using point data for x (should be bin edges).");
   }
   for (size_t i = 0; i < numberOfSpectra; ++i) {
     if (forwards) {

--- a/Framework/API/src/WorkspaceOpOverloads.cpp
+++ b/Framework/API/src/WorkspaceOpOverloads.cpp
@@ -538,7 +538,8 @@ void WorkspaceHelpers::makeDistribution(MatrixWorkspace_sptr workspace,
                              "into distributions.");
 
   const size_t numberOfSpectra = workspace->getNumberHistograms();
-  if (workspace->histogram(0).xMode() == HistogramData::Histogram::XMode::Points) {
+  if (workspace->histogram(0).xMode() ==
+      HistogramData::Histogram::XMode::Points) {
     throw std::runtime_error(
         "Workspace is using point data for x (should be bin edges).");
   }

--- a/Framework/API/src/WorkspaceOpOverloads.cpp
+++ b/Framework/API/src/WorkspaceOpOverloads.cpp
@@ -538,6 +538,11 @@ void WorkspaceHelpers::makeDistribution(MatrixWorkspace_sptr workspace,
                              "into distributions.");
 
   const size_t numberOfSpectra = workspace->getNumberHistograms();
+  // check X vs Y data size
+  if (workspace->x(0).size() == workspace->y(0).size()){
+	  std::cout << "catch" << std::endl;
+	  throw std::runtime_error("Workspace is not histogram.");
+  }
   for (size_t i = 0; i < numberOfSpectra; ++i) {
     if (forwards) {
       workspace->convertToFrequencies(i);

--- a/Framework/API/test/WorkspaceOpOverloadsTest.h
+++ b/Framework/API/test/WorkspaceOpOverloadsTest.h
@@ -204,7 +204,6 @@ public:
     TS_ASSERT_EQUALS(ws->readY(1)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readE(0)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readE(1)[0], 1.0)
-
   }
 
   void test_makeDistribution_fails_for_point_data() {
@@ -213,7 +212,7 @@ public:
     TS_ASSERT(!ws->isDistribution());
 
     TS_ASSERT_THROWS(WorkspaceHelpers::makeDistribution(ws),
-        std::runtime_error);
+                     std::runtime_error);
   }
 };
 

--- a/Framework/API/test/WorkspaceOpOverloadsTest.h
+++ b/Framework/API/test/WorkspaceOpOverloadsTest.h
@@ -204,6 +204,13 @@ public:
     TS_ASSERT_EQUALS(ws->readY(1)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readE(0)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readE(1)[0], 1.0)
+
+	// MakeDistribution throws exception if input WS uses point data
+	auto ws2 = boost::make_shared<WorkspaceTester>();
+	ws2->initialize(2, 2, 2);
+	TS_ASSERT(!ws->isDistribution());
+
+	TS_ASSERT_THROWS(WorkspaceHelpers::makeDistribution(ws2), std::runtime_error);
   }
 };
 

--- a/Framework/API/test/WorkspaceOpOverloadsTest.h
+++ b/Framework/API/test/WorkspaceOpOverloadsTest.h
@@ -205,12 +205,13 @@ public:
     TS_ASSERT_EQUALS(ws->readE(0)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readE(1)[0], 1.0)
 
-	// MakeDistribution throws exception if input WS uses point data
-	auto ws2 = boost::make_shared<WorkspaceTester>();
-	ws2->initialize(2, 2, 2);
-	TS_ASSERT(!ws->isDistribution());
+    // MakeDistribution throws exception if input WS uses point data
+    auto ws2 = boost::make_shared<WorkspaceTester>();
+    ws2->initialize(2, 2, 2);
+    TS_ASSERT(!ws->isDistribution());
 
-	TS_ASSERT_THROWS(WorkspaceHelpers::makeDistribution(ws2), std::runtime_error);
+    TS_ASSERT_THROWS(WorkspaceHelpers::makeDistribution(ws2),
+                     std::runtime_error);
   }
 };
 

--- a/Framework/API/test/WorkspaceOpOverloadsTest.h
+++ b/Framework/API/test/WorkspaceOpOverloadsTest.h
@@ -205,13 +205,15 @@ public:
     TS_ASSERT_EQUALS(ws->readE(0)[0], 1.0)
     TS_ASSERT_EQUALS(ws->readE(1)[0], 1.0)
 
-    // MakeDistribution throws exception if input WS uses point data
-    auto ws2 = boost::make_shared<WorkspaceTester>();
-    ws2->initialize(2, 2, 2);
+  }
+
+  void test_makeDistribution_fails_for_point_data() {
+    auto ws = boost::make_shared<WorkspaceTester>();
+    ws->initialize(2, 2, 2);
     TS_ASSERT(!ws->isDistribution());
 
-    TS_ASSERT_THROWS(WorkspaceHelpers::makeDistribution(ws2),
-                     std::runtime_error);
+    TS_ASSERT_THROWS(WorkspaceHelpers::makeDistribution(ws),
+        std::runtime_error);
   }
 };
 


### PR DESCRIPTION
Fixes #14442.

Added a check in makeDistribution to throw an error if the input workspace uses point data when it expects bin edges. 

**To test:**
1. Create a 2D workspace with the isHist parameter set to false
1. Run the workspace through makeDistribution
1. Confirm exception is thrown
1. Create another 2D workspace with the isHist parameter set to true
1. Run the second workspace through makeDistribution
1. Confirm no exception is thrown

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
