### PR TITLE
Changes required for gsl v2.4

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h
@@ -7,8 +7,9 @@
 #include "MantidCurveFitting/Functions/BackgroundFunction.h"
 
 #include <boost/shared_ptr.hpp>
-#include <gsl/gsl_errno.h>
 #include <gsl/gsl_bspline.h>
+#include <gsl/gsl_errno.h>
+#include <gsl/gsl_version.h>
 
 namespace Mantid {
 namespace CurveFitting {
@@ -70,8 +71,10 @@ private:
 
   /// structure used by GSL internally
   boost::shared_ptr<gsl_bspline_workspace> m_bsplineWorkspace;
+#if GSL_MAJOR_VERSION < 2
   mutable boost::shared_ptr<gsl_bspline_deriv_workspace>
       m_bsplineDerivWorkspace;
+#endif
 };
 
 } // namespace Functions

--- a/Framework/CurveFitting/src/Functions/BSpline.cpp
+++ b/Framework/CurveFitting/src/Functions/BSpline.cpp
@@ -7,7 +7,6 @@
 #include "MantidAPI/FunctionFactory.h"
 
 #include <boost/lexical_cast.hpp>
-#include <gsl/gsl_version.h>
 
 namespace Mantid {
 namespace CurveFitting {
@@ -26,18 +25,20 @@ namespace {
 struct ReleaseBSplineWorkspace {
   void operator()(gsl_bspline_workspace *ws) { gsl_bspline_free(ws); }
 };
+#if GSL_MAJOR_VERSION < 2
 // shared pointer deleter for bspline derivative workspace
 struct ReleaseBSplineDerivativeWorkspace {
   void operator()(gsl_bspline_deriv_workspace *ws) {
     gsl_bspline_deriv_free(ws);
   }
 };
+#endif
 }
 
 /**
  * Constructor
  */
-BSpline::BSpline() : m_bsplineWorkspace(), m_bsplineDerivWorkspace() {
+BSpline::BSpline() {
   const size_t nbreak = 10;
   declareAttribute("Uniform", Attribute(true));
   declareAttribute("Order", Attribute(3));
@@ -180,7 +181,9 @@ void BSpline::resetGSLObjects() {
                                                 static_cast<size_t>(nbreak));
   m_bsplineWorkspace =
       boost::shared_ptr<gsl_bspline_workspace>(ws, ReleaseBSplineWorkspace());
+#if GSL_MAJOR_VERSION < 2
   m_bsplineDerivWorkspace.reset();
+#endif
 }
 
 /**


### PR DESCRIPTION
Description of work.

`gsl_bspline_deriv_workspace` was removed in gsl v2.4, requiring us to more aggressively remove it when it is unused.

[gsl 2.4 release notes](http://lists.gnu.org/archive/html/info-gsl/2017-06/msg00000.html)

**To test:**

<!-- Instructions for testing. -->

1. Verify by code review and the build servers that these changes don't break currently supported builds.
2. (optional) Build Mantid with gsl v2.4 and verify it still builds successfully and passes all tests.

There is no GitHub issue associated with this pull request.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
