### PR TITLE
Fix Boolean indexing for numpy 1.13

### DIFF
--- a/scripts/test/ConvertToWavelengthTest.py
+++ b/scripts/test/ConvertToWavelengthTest.py
@@ -115,7 +115,7 @@ class ConvertToWavelengthTest(unittest.TestCase):
     def cropped_x_range(cls, ws, index):
         det_ws_x = ws.readX(index)
         mask = ws.readY(index) != 0 # CropWorkspace will only zero out y values! so we need to translate those to an x range
-        cropped_x = det_ws_x[mask]
+        cropped_x = det_ws_x[:-1][mask]
         return cropped_x[0], cropped_x[-1]
 
     def test_convert(self):


### PR DESCRIPTION
Boolean indexes must now match the dimension of the axis that they index. See https://docs.scipy.org/doc/numpy-1.13.0/release.html#boolean-indexing-changes

`ConvertToWavelengthTest` currently fails with:
```
1685: ======================================================================
1685: ERROR: test_convert (__main__.ConvertToWavelengthTest)
1685: ----------------------------------------------------------------------
1685: Traceback (most recent call last):
1685:   File "/home/rwp/mantid/scripts/test/ConvertToWavelengthTest.py", line 131, in test_convert
1685:     x_min, x_max = ConvertToWavelengthTest.cropped_x_range(detector_ws, 0)
1685:   File "/home/rwp/mantid/scripts/test/ConvertToWavelengthTest.py", line 118, in cropped_x_range
1685:     cropped_x = det_ws_x[mask]
1685: IndexError: boolean index did not match indexed array along dimension 0; dimension is 176 but corresponding boolean dimension is 175
1685: 
1685: ----------------------------------------------------------------------
```

**To test:**
 Code review should be sufficient 

_Does not need to be in the release notes._

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
