### PR TITLE
Read parameter map on load nexus for peaks

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1012,9 +1012,8 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(NXEntry &entry) {
     // This loads logs, sample, and instrument.
     peakWS->loadExperimentInfoNexus(getPropertyValue("Filename"), m_cppFile,
                                     parameterStr);
-    // Populate the instrument parameters in this workspace - this works around
-    // a bug
-    peakWS->populateInstrumentParameters();
+    // Populate the instrument parameters in this workspace
+    peakWS->readParameterMap(parameterStr);
   } catch (std::exception &e) {
     g_log.information("Error loading Instrument section of nxs file");
     g_log.information(e.what());


### PR DESCRIPTION
Description of work.
Second try for loading instrument parameters in peaks workspace

**To test:**
```python
w = LoadIsawPeaks('TOPAZ_3007.peaks')
print(w.getInstrument().getParameterNames())
SaveNexusProcessed(w,Filename='/tmp/peaks.nxs')

w2 = LoadNexusProcessed('/tmp/peaks.nxs')
print(w2.getInstrument().getParameterNames())
```
it works fine. Then close Mantid, restart it, and run only the second part:
```python
w2 = LoadNexusProcessed('/tmp/peaks.nxs')
print(w2.getInstrument().getParameterNames())
```

Fixes #19876

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
