### PR TITLE
SetDetScale unit test :: replace topaz peaks file

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1012,9 +1012,8 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(NXEntry &entry) {
     // This loads logs, sample, and instrument.
     peakWS->loadExperimentInfoNexus(getPropertyValue("Filename"), m_cppFile,
                                     parameterStr);
-    // Populate the instrument parameters in this workspace - this works around
-    // a bug
-    peakWS->populateInstrumentParameters();
+    // Populate the instrument parameters in this workspace
+    peakWS->readParameterMap(parameterStr);
   } catch (std::exception &e) {
     g_log.information("Error loading Instrument section of nxs file");
     g_log.information(e.what());

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SetDetScaleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SetDetScaleTest.py
@@ -9,7 +9,7 @@ from mantid.api import *
 class SetDetScaleTest(unittest.TestCase):
 
     def testScaleDetectors(self):
-        w = LoadIsawPeaks('TOPAZ_3007.peaks')
+        w = LoadNexusProcessed('TOPAZ_3007.peaks.nxs')
         x = w.getInstrument().getNumberParameter("detScale17")[0]
         y = w.getInstrument().getNumberParameter("detScale49")[0]
         self.assertEqual(x, 1.18898)


### PR DESCRIPTION
After the fix in `LoadNexusProcessed`, one more unit test is made faster by replacing the raw file with it's processed counterpart.

Tests pass.

<!-- Instructions for testing. -->

Fixes #19866 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.