### PR TITLE
Fix function string outputted by MultiDomainFunction.

### DIFF
--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -219,8 +219,8 @@ protected:
   /// Get status of parameter
   ParameterStatus getParameterStatus(size_t i) const override;
   /// Writes itself into a string
-  std::string
-  writeToString(const std::string &parentLocalAttributesStr = "") const override;
+  std::string writeToString(
+      const std::string &parentLocalAttributesStr = "") const override;
 
   size_t paramOffset(size_t i) const { return m_paramOffsets[i]; }
 

--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -67,7 +67,8 @@ public:
   /// Returns the function's name
   std::string name() const override { return "CompositeFunction"; }
   /// Writes itself into a string
-  std::string asString(const std::string &parentLocalAttributesStr = "") const override;
+  std::string
+  asString(const std::string &parentLocalAttributesStr = "") const override;
   /// Sets the workspace for each member function
   void setWorkspace(boost::shared_ptr<const Workspace> ws) override;
   /// Set matrix workspace

--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -67,7 +67,7 @@ public:
   /// Returns the function's name
   std::string name() const override { return "CompositeFunction"; }
   /// Writes itself into a string
-  std::string asString() const override;
+  std::string asString(const std::string &parentLocalAttributesStr = "") const override;
   /// Sets the workspace for each member function
   void setWorkspace(boost::shared_ptr<const Workspace> ws) override;
   /// Set matrix workspace

--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -66,9 +66,6 @@ public:
 
   /// Returns the function's name
   std::string name() const override { return "CompositeFunction"; }
-  /// Writes itself into a string
-  std::string
-  asString(const std::string &parentLocalAttributesStr = "") const override;
   /// Sets the workspace for each member function
   void setWorkspace(boost::shared_ptr<const Workspace> ws) override;
   /// Set matrix workspace
@@ -221,6 +218,9 @@ protected:
   void setParameterStatus(size_t i, ParameterStatus status) override;
   /// Get status of parameter
   ParameterStatus getParameterStatus(size_t i) const override;
+  /// Writes itself into a string
+  std::string
+  writeToString(const std::string &parentLocalAttributesStr = "") const override;
 
   size_t paramOffset(size_t i) const { return m_paramOffsets[i]; }
 

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -324,7 +324,7 @@ public:
   /// Returns the function's name
   virtual std::string name() const = 0;
   /// Writes itself into a string
-  virtual std::string asString() const;
+  virtual std::string asString(const std::string &localAttributesStr = "") const;
   /// Virtual copy constructor
   virtual boost::shared_ptr<IFunction> clone() const;
   /// Set the workspace.

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -324,7 +324,8 @@ public:
   /// Returns the function's name
   virtual std::string name() const = 0;
   /// Writes itself into a string
-  virtual std::string asString(const std::string &localAttributesStr = "") const;
+  virtual std::string
+  asString(const std::string &localAttributesStr = "") const;
   /// Virtual copy constructor
   virtual boost::shared_ptr<IFunction> clone() const;
   /// Set the workspace.

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -324,8 +324,7 @@ public:
   /// Returns the function's name
   virtual std::string name() const = 0;
   /// Writes itself into a string
-  virtual std::string
-  asString(const std::string &localAttributesStr = "") const;
+  std::string asString() const;
   /// Virtual copy constructor
   virtual boost::shared_ptr<IFunction> clone() const;
   /// Set the workspace.
@@ -590,6 +589,9 @@ protected:
                               const API::IFunction::Attribute &value) const;
   /// Add a new tie. Derived classes must provide storage for ties
   virtual void addTie(std::unique_ptr<ParameterTie> tie);
+  /// Writes itself into a string
+  virtual std::string
+  writeToString(const std::string &parentLocalAttributesStr = "") const;
 
   friend class ParameterTie;
   friend class CompositeFunction;

--- a/Framework/API/inc/MantidAPI/ImmutableCompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/ImmutableCompositeFunction.h
@@ -84,8 +84,8 @@ protected:
   /// Add default constraints
   void addDefaultConstraints(const std::string &constraints);
   /// Writes itself into a string
-  std::string
-  writeToString(const std::string &parentLocalAttributesStr = "") const override;
+  std::string writeToString(
+      const std::string &parentLocalAttributesStr = "") const override;
 
 private:
   /// Keep paramater aliases

--- a/Framework/API/inc/MantidAPI/ImmutableCompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/ImmutableCompositeFunction.h
@@ -46,7 +46,7 @@ public:
   /// Returns the function's name
   std::string name() const override { return "ImmutableCompositeFunction"; }
   /// Writes itself into a string
-  std::string asString() const override;
+  std::string asString(const std::string &parentLocalAttributesStr = "") const override;
   /// Set i-th parameter
   void setParameter(size_t i, const double &value,
                     bool explicitlySet = true) override {

--- a/Framework/API/inc/MantidAPI/ImmutableCompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/ImmutableCompositeFunction.h
@@ -46,7 +46,8 @@ public:
   /// Returns the function's name
   std::string name() const override { return "ImmutableCompositeFunction"; }
   /// Writes itself into a string
-  std::string asString(const std::string &parentLocalAttributesStr = "") const override;
+  std::string
+  asString(const std::string &parentLocalAttributesStr = "") const override;
   /// Set i-th parameter
   void setParameter(size_t i, const double &value,
                     bool explicitlySet = true) override {

--- a/Framework/API/inc/MantidAPI/ImmutableCompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/ImmutableCompositeFunction.h
@@ -45,9 +45,6 @@ public:
 
   /// Returns the function's name
   std::string name() const override { return "ImmutableCompositeFunction"; }
-  /// Writes itself into a string
-  std::string
-  asString(const std::string &parentLocalAttributesStr = "") const override;
   /// Set i-th parameter
   void setParameter(size_t i, const double &value,
                     bool explicitlySet = true) override {
@@ -86,6 +83,9 @@ protected:
   void addDefaultTies(const std::string &ties);
   /// Add default constraints
   void addDefaultConstraints(const std::string &constraints);
+  /// Writes itself into a string
+  std::string
+  writeToString(const std::string &parentLocalAttributesStr = "") const override;
 
 private:
   /// Keep paramater aliases

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -36,9 +36,9 @@ CompositeFunction::CompositeFunction()
 void CompositeFunction::init() {}
 
 /**
- * Writes itself into a string. Functions derived from CompositeFunction must
- * override this method with something like this:
- *   std::string NewFunction::asString()const
+ * Writes itself into a string. Functions derived from CompositeFunction may
+ * need to override this method with something like this:
+ *   std::string NewFunction::writeToString()const
  *   {
  *      ostr << "composite=" << this->name() << ';';
  *      // write NewFunction's own attributes and parameters
@@ -52,7 +52,7 @@ void CompositeFunction::init() {}
  * @return the string representation of the composite function
  */
 std::string
-CompositeFunction::asString(const std::string &parentLocalAttributesStr) const {
+CompositeFunction::writeToString(const std::string &parentLocalAttributesStr) const {
   std::ostringstream ostr;
 
   // if empty just return function name
@@ -89,7 +89,7 @@ CompositeFunction::asString(const std::string &parentLocalAttributesStr) const {
                            << localAttValue;
       }
     }
-    ostr << fun->asString(localAttributesStr.str());
+    ostr << fun->writeToString(localAttributesStr.str());
     if (isComp)
       ostr << ')';
     if (i < nFunctions() - 1) {

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -46,9 +46,11 @@ void CompositeFunction::init() {}
  *      // write NewFunction's own ties and constraints
  *      // ostr << ";constraints=(" << ... <<")";
  *   }
+ * @param parentLocalAttributesStr :: A preformatted string with parent's local attributes.
+ *    Can be passed in by a CompositeFunction (eg MultiDomainFunction).
  * @return the string representation of the composite function
  */
-std::string CompositeFunction::asString() const {
+std::string CompositeFunction::asString(const std::string &parentLocalAttributesStr) const {
   std::ostringstream ostr;
 
   // if empty just return function name
@@ -57,7 +59,7 @@ std::string CompositeFunction::asString() const {
   }
 
   if (name() != "CompositeFunction" || nAttributes() > 1 ||
-      getAttribute("NumDeriv").asBool()) {
+      getAttribute("NumDeriv").asBool() || !parentLocalAttributesStr.empty()) {
     ostr << "composite=" << name();
     std::vector<std::string> attr = this->getAttributeNames();
     for (const auto &attName : attr) {
@@ -66,24 +68,25 @@ std::string CompositeFunction::asString() const {
         ostr << ',' << attName << '=' << attValue;
       }
     }
-    ostr << ';';
+    ostr << parentLocalAttributesStr << ';';
   }
+  const auto localAttr = this->getLocalAttributeNames();
   for (size_t i = 0; i < nFunctions(); i++) {
-    const auto localAttr = this->getLocalAttributeNames();
     IFunction_sptr fun = getFunction(i);
     bool isComp =
         boost::dynamic_pointer_cast<CompositeFunction>(fun) != nullptr;
     if (isComp)
       ostr << '(';
-    ostr << fun->asString();
+    std::ostringstream localAttributesStr;
     for (const auto &localAttName : localAttr) {
       const std::string localAttValue =
           this->getLocalAttribute(i, localAttName).value();
       if (!localAttValue.empty()) {
         // local attribute names are prefixed by dollar sign
-        ostr << ',' << '$' << localAttName << '=' << localAttValue;
+        localAttributesStr << ',' << '$' << localAttName << '=' << localAttValue;
       }
     }
+    ostr << fun->asString(localAttributesStr.str());
     if (isComp)
       ostr << ')';
     if (i < nFunctions() - 1) {

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -46,11 +46,13 @@ void CompositeFunction::init() {}
  *      // write NewFunction's own ties and constraints
  *      // ostr << ";constraints=(" << ... <<")";
  *   }
- * @param parentLocalAttributesStr :: A preformatted string with parent's local attributes.
+ * @param parentLocalAttributesStr :: A preformatted string with parent's local
+ * attributes.
  *    Can be passed in by a CompositeFunction (eg MultiDomainFunction).
  * @return the string representation of the composite function
  */
-std::string CompositeFunction::asString(const std::string &parentLocalAttributesStr) const {
+std::string
+CompositeFunction::asString(const std::string &parentLocalAttributesStr) const {
   std::ostringstream ostr;
 
   // if empty just return function name
@@ -83,7 +85,8 @@ std::string CompositeFunction::asString(const std::string &parentLocalAttributes
           this->getLocalAttribute(i, localAttName).value();
       if (!localAttValue.empty()) {
         // local attribute names are prefixed by dollar sign
-        localAttributesStr << ',' << '$' << localAttName << '=' << localAttValue;
+        localAttributesStr << ',' << '$' << localAttName << '='
+                           << localAttValue;
       }
     }
     ostr << fun->asString(localAttributesStr.str());

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -51,8 +51,8 @@ void CompositeFunction::init() {}
  *    Can be passed in by a CompositeFunction (eg MultiDomainFunction).
  * @return the string representation of the composite function
  */
-std::string
-CompositeFunction::writeToString(const std::string &parentLocalAttributesStr) const {
+std::string CompositeFunction::writeToString(
+    const std::string &parentLocalAttributesStr) const {
   std::ostringstream ostr;
 
   // if empty just return function name

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -399,9 +399,7 @@ std::string IFunction::writeConstraints() const {
  * IFunction
  * @return string representation of the function
  */
-std::string IFunction::asString() const {
-  return writeToString();
-}
+std::string IFunction::asString() const { return writeToString(); }
 
 /**
  * Writes this function into a string.

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -395,13 +395,23 @@ std::string IFunction::writeConstraints() const {
 }
 
 /**
- * Writes a string that can be used in Fit.IFunction to create a copy of this
+ * Writes a string that can be used in FunctionFunctory to create a copy of this
  * IFunction
- * @param localAttributesStr :: A preformatted string with local attributes.
- *    Can be passed in by a CompositeFunction (eg MultiDomainFunction).
  * @return string representation of the function
  */
-std::string IFunction::asString(const std::string &localAttributesStr) const {
+std::string IFunction::asString() const {
+  return writeToString();
+}
+
+/**
+ * Writes this function into a string.
+ * @param parentLocalAttributesStr :: A preformatted string with local
+ * attributes of a parent composite function. Can be passed in by a
+ * CompositeFunction (eg MultiDomainFunction).
+ * @return string representation of the function
+ */
+std::string
+IFunction::writeToString(const std::string &parentLocalAttributesStr) const {
   std::ostringstream ostr;
   ostr << "name=" << this->name();
   // print the attributes
@@ -442,7 +452,7 @@ std::string IFunction::asString(const std::string &localAttributesStr) const {
          << ")";
   }
   // "local" attributes of a parent composite function
-  ostr << localAttributesStr;
+  ostr << parentLocalAttributesStr;
   return ostr.str();
 }
 

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -397,9 +397,11 @@ std::string IFunction::writeConstraints() const {
 /**
  * Writes a string that can be used in Fit.IFunction to create a copy of this
  * IFunction
+ * @param localAttributesStr :: A preformatted string with local attributes.
+ *    Can be passed in by a CompositeFunction (eg MultiDomainFunction).
  * @return string representation of the function
  */
-std::string IFunction::asString() const {
+std::string IFunction::asString(const std::string &localAttributesStr) const {
   std::ostringstream ostr;
   ostr << "name=" << this->name();
   // print the attributes
@@ -439,6 +441,8 @@ std::string IFunction::asString() const {
     ostr << ",ties=(" << Kernel::Strings::join(ties.begin(), ties.end(), ",")
          << ")";
   }
+  // "local" attributes of a parent composite function
+  ostr << localAttributesStr;
   return ostr.str();
 }
 

--- a/Framework/API/src/ImmutableCompositeFunction.cpp
+++ b/Framework/API/src/ImmutableCompositeFunction.cpp
@@ -16,7 +16,8 @@ using std::size_t;
  * Overridden method creates an initialization string which makes it look like a
  * siple function.
  */
-std::string ImmutableCompositeFunction::asString(const std::string &parentLocalAttributesStr) const {
+std::string ImmutableCompositeFunction::asString(
+    const std::string &parentLocalAttributesStr) const {
   return IFunction::asString(parentLocalAttributesStr);
 }
 

--- a/Framework/API/src/ImmutableCompositeFunction.cpp
+++ b/Framework/API/src/ImmutableCompositeFunction.cpp
@@ -16,9 +16,9 @@ using std::size_t;
  * Overridden method creates an initialization string which makes it look like a
  * siple function.
  */
-std::string ImmutableCompositeFunction::asString(
+std::string ImmutableCompositeFunction::writeToString(
     const std::string &parentLocalAttributesStr) const {
-  return IFunction::asString(parentLocalAttributesStr);
+  return IFunction::writeToString(parentLocalAttributesStr);
 }
 
 /**

--- a/Framework/API/src/ImmutableCompositeFunction.cpp
+++ b/Framework/API/src/ImmutableCompositeFunction.cpp
@@ -16,8 +16,8 @@ using std::size_t;
  * Overridden method creates an initialization string which makes it look like a
  * siple function.
  */
-std::string ImmutableCompositeFunction::asString() const {
-  return IFunction::asString();
+std::string ImmutableCompositeFunction::asString(const std::string &parentLocalAttributesStr) const {
+  return IFunction::asString(parentLocalAttributesStr);
 }
 
 /**

--- a/Framework/API/test/FunctionFactoryTest.h
+++ b/Framework/API/test/FunctionFactoryTest.h
@@ -444,7 +444,15 @@ public:
     const auto mdfunc = boost::dynamic_pointer_cast<MultiDomainFunction>(fun);
     TS_ASSERT(mdfunc);
     if (mdfunc) {
-      TS_ASSERT_EQUALS(mdfunc->asString(), fnString);
+      TS_ASSERT_EQUALS(mdfunc->asString(),
+                       "composite=MultiDomainFunction,NumDeriv=true;(composite="
+                       "CompositeFunction,NumDeriv=false,$domains=i;name="
+                       "FunctionFactoryTest_FunctA,a0=0,a1=0.5;name="
+                       "FunctionFactoryTest_FunctB,b0=0.1,b1=0.2,ties=(b1=0.2))"
+                       ";(composite=CompositeFunction,NumDeriv=false,$domains="
+                       "i;name=FunctionFactoryTest_FunctA,a0=0,a1=0.5;name="
+                       "FunctionFactoryTest_FunctB,b0=0.1,b1=0.2);ties=(f1.f1."
+                       "b1=f0.f1.b1)");
       TS_ASSERT_EQUALS(mdfunc->nFunctions(), 2);
 
       // test the domains for each function

--- a/Framework/API/test/MultiDomainFunctionTest.h
+++ b/Framework/API/test/MultiDomainFunctionTest.h
@@ -478,8 +478,8 @@ public:
                       "name=MultiDomainFunctionTest_Function; "
                       "(name=MultiDomainFunctionTest_Function;name="
                       "MultiDomainFunctionTest_Function))";
-    auto f =  FunctionFactory::Instance().createInitialized(ini);
-    auto g =  FunctionFactory::Instance().createInitialized(f->asString());
+    auto f = FunctionFactory::Instance().createInitialized(ini);
+    auto g = FunctionFactory::Instance().createInitialized(f->asString());
     TS_ASSERT_EQUALS(g->asString(),
                      "composite=MultiDomainFunction,NumDeriv=false;(composite="
                      "CompositeFunction,NumDeriv=false,$domains=i;name="

--- a/Framework/API/test/MultiDomainFunctionTest.h
+++ b/Framework/API/test/MultiDomainFunctionTest.h
@@ -468,6 +468,30 @@ public:
                      "name=MultiDomainFunctionTest_Function,A=2,B=4");
   }
 
+  void test_string_nested_composite() {
+    std::string ini = "composite=MultiDomainFunction;"
+                      "(composite=CompositeFunction,$domains=i;"
+                      "name=MultiDomainFunctionTest_Function; "
+                      "(name=MultiDomainFunctionTest_Function;name="
+                      "MultiDomainFunctionTest_Function));"
+                      "(composite=CompositeFunction,$domains=i;"
+                      "name=MultiDomainFunctionTest_Function; "
+                      "(name=MultiDomainFunctionTest_Function;name="
+                      "MultiDomainFunctionTest_Function))";
+    auto f =  FunctionFactory::Instance().createInitialized(ini);
+    auto g =  FunctionFactory::Instance().createInitialized(f->asString());
+    TS_ASSERT_EQUALS(g->asString(),
+                     "composite=MultiDomainFunction,NumDeriv=false;(composite="
+                     "CompositeFunction,NumDeriv=false,$domains=i;name="
+                     "MultiDomainFunctionTest_Function,A=0,B=0;(name="
+                     "MultiDomainFunctionTest_Function,A=0,B=0;name="
+                     "MultiDomainFunctionTest_Function,A=0,B=0));(composite="
+                     "CompositeFunction,NumDeriv=false,$domains=i;name="
+                     "MultiDomainFunctionTest_Function,A=0,B=0;(name="
+                     "MultiDomainFunctionTest_Function,A=0,B=0;name="
+                     "MultiDomainFunctionTest_Function,A=0,B=0))");
+  }
+
 private:
   MultiDomainFunction multi;
   JointDomain domain;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
@@ -36,7 +36,8 @@ public:
   std::string name() const override { return "CrystalFieldSpectrum"; }
   const std::string category() const override { return "General"; }
   void buildTargetFunction() const override;
-  std::string asString(const std::string &parentLocalAttributesStr = "") const override;
+  std::string
+  asString(const std::string &parentLocalAttributesStr = "") const override;
 
 protected:
   void updateTargetFunction() const override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
@@ -38,8 +38,8 @@ public:
   void buildTargetFunction() const override;
 
 protected:
-  std::string
-  writeToString(const std::string &parentLocalAttributesStr = "") const override;
+  std::string writeToString(
+      const std::string &parentLocalAttributesStr = "") const override;
   void updateTargetFunction() const override;
 
 private:

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
@@ -36,7 +36,7 @@ public:
   std::string name() const override { return "CrystalFieldSpectrum"; }
   const std::string category() const override { return "General"; }
   void buildTargetFunction() const override;
-  std::string asString() const override;
+  std::string asString(const std::string &parentLocalAttributesStr = "") const override;
 
 protected:
   void updateTargetFunction() const override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
@@ -36,10 +36,10 @@ public:
   std::string name() const override { return "CrystalFieldSpectrum"; }
   const std::string category() const override { return "General"; }
   void buildTargetFunction() const override;
-  std::string
-  asString(const std::string &parentLocalAttributesStr = "") const override;
 
 protected:
+  std::string
+  writeToString(const std::string &parentLocalAttributesStr = "") const override;
   void updateTargetFunction() const override;
 
 private:

--- a/Framework/CurveFitting/src/Functions/CrystalFieldSpectrum.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldSpectrum.cpp
@@ -97,7 +97,7 @@ void CrystalFieldSpectrum::updateTargetFunction() const {
 }
 
 /// Custom string conversion method
-std::string CrystalFieldSpectrum::asString(
+std::string CrystalFieldSpectrum::writeToString(
     const std::string &parentLocalAttributesStr) const {
   std::ostringstream ostr;
   ostr << "name=" << this->name();

--- a/Framework/CurveFitting/src/Functions/CrystalFieldSpectrum.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldSpectrum.cpp
@@ -97,7 +97,7 @@ void CrystalFieldSpectrum::updateTargetFunction() const {
 }
 
 /// Custom string conversion method
-std::string CrystalFieldSpectrum::asString() const {
+std::string CrystalFieldSpectrum::asString(const std::string &parentLocalAttributesStr) const {
   std::ostringstream ostr;
   ostr << "name=" << this->name();
   // Print the attributes
@@ -108,6 +108,7 @@ std::string CrystalFieldSpectrum::asString() const {
       ostr << ',' << attName << '=' << attValue;
     }
   }
+  ostr << parentLocalAttributesStr;
   std::vector<std::string> ties;
   // Print own parameters
   for (size_t i = 0; i < m_nOwnParams; i++) {

--- a/Framework/CurveFitting/src/Functions/CrystalFieldSpectrum.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldSpectrum.cpp
@@ -97,7 +97,8 @@ void CrystalFieldSpectrum::updateTargetFunction() const {
 }
 
 /// Custom string conversion method
-std::string CrystalFieldSpectrum::asString(const std::string &parentLocalAttributesStr) const {
+std::string CrystalFieldSpectrum::asString(
+    const std::string &parentLocalAttributesStr) const {
   std::ostringstream ostr;
   ostr << "name=" << this->name();
   // Print the attributes


### PR DESCRIPTION
Added an argument to `IFunction::asString` method to insert parent's "local" attributes into the right position of the child's string.

**To test:**

Run the script from the issue description.

Fixes #19909.

*Does not need to be in the release notes* because it's unlikely that the bug has been noticed by users.


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
