### PR TITLE
Skip system tests on pull requests

### DIFF
--- a/Testing/SystemTests/scripts/InstallerTests.py
+++ b/Testing/SystemTests/scripts/InstallerTests.py
@@ -22,8 +22,8 @@ parser.add_argument('-R', dest='test_regex', metavar='regexp', default=None,
                     help='Optionally only run the test matched by the regex')
 parser.add_argument('--archivesearch', dest='archivesearch', action='store_true',
                     help='Turn on archive search for file finder')
-parser.add_option("", "--exclude-in-pull-requests", dest="exclude_in_pr_builds",action="store_true",
-                  help="Skip tests that are not run in pull request builds")
+parser.add_argument('--exclude-in-pull-requests', dest="exclude_in_pr_builds",action="store_true",
+                    help="Skip tests that are not run in pull request builds")
 log_levels = ['error', 'warning', 'notice', 'information', 'debug']
 parser.add_argument('-l', dest='log_level', metavar='level', default='notice',
                     choices=log_levels, help='Log level '+str(log_levels))

--- a/Testing/SystemTests/scripts/InstallerTests.py
+++ b/Testing/SystemTests/scripts/InstallerTests.py
@@ -22,6 +22,8 @@ parser.add_argument('-R', dest='test_regex', metavar='regexp', default=None,
                     help='Optionally only run the test matched by the regex')
 parser.add_argument('--archivesearch', dest='archivesearch', action='store_true',
                     help='Turn on archive search for file finder')
+parser.add_option("", "--exclude-in-pull-requests", dest="exclude_in_pr_builds",action="store_true",
+                  help="Skip tests that are not run in pull request builds")
 log_levels = ['error', 'warning', 'notice', 'information', 'debug']
 parser.add_argument('-l', dest='log_level', metavar='level', default='notice',
                     choices=log_levels, help='Log level '+str(log_levels))
@@ -80,6 +82,8 @@ try:
         run_test_cmd += " -R " + options.test_regex
     if options.archivesearch:
         run_test_cmd += ' --archivesearch'
+    if options.exclude_in_pr_builds:
+        run_test_cmd += ' --exclude-in-pull-requests'
     if options.out2stdout:
         print("Executing command '{0}'".format(run_test_cmd))
         p = subprocess.Popen(run_test_cmd, shell=True) # no PIPE: print on screen for debugging

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -309,5 +309,9 @@ fi
 # Linux checks it install okay
 ###############################################################################
 if [[ ${SYSTEMTESTS} == true ]]; then
-  $SCRIPT_DIR/systemtests
+  if [[ ${PRBUILD} == true ]]; then
+    $SCRIPT_DIR/systemtests --exclude-in-pull-requests
+  else
+    $SCRIPT_DIR/systemtests
+  fi
 fi

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -310,7 +310,7 @@ fi
 ###############################################################################
 if [[ ${SYSTEMTESTS} == true ]]; then
   if [[ ${PRBUILD} == true ]]; then
-    $SCRIPT_DIR/systemtests --exclude-in-pull-requests
+    EXTRA_ARGS="--exclude-in-pull-requests" $SCRIPT_DIR/systemtests
   else
     $SCRIPT_DIR/systemtests
   fi


### PR DESCRIPTION
With the new addition of `--exclude-in-pull-requests` to the `systemtest` script, enable it in pull request builds.

**To test:**

Code review should be fine.

*There is no associated issue.*

*Does not need to be in the release notes* because it only affects build servers

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
