### PR TITLE
Move Techniques documentation from Python API to Categories.

### DIFF
--- a/docs/source/api/python/index.rst
+++ b/docs/source/api/python/index.rst
@@ -19,15 +19,6 @@ Matplotlib-like plotting interface
 
    mantidplot.pyplot <mantidplot/pyplot/index>
 
-Techniques
-----------
-
-.. toctree::
-   :glob:
-   :maxdepth: 1
-
-   techniques/*
-
 Reference
 ---------
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,10 +23,10 @@ Mantid Documentation
    algorithms/index
    algorithms/*
    concepts/index
-   techniques/index
    interfaces/index
    fitfunctions/*
    fitminimizers/index
+   techniques/index
    api/index
    release/index
 
@@ -42,10 +42,10 @@ This is the documentation for Mantid |release|.
 
 * `Algorithms <algorithms/index.html>`_
 * `Concepts <concepts/index.html>`_
-* `Techniques <techniques/index.html>`_
 * `Interfaces <interfaces/index.html>`_
 * `Fit Functions <fitfunctions/index.html>`_
 * `Fit Minimizers <fitminimizers/index.html>`_
+* `Techniques <techniques/index.html>`_
 * `API <api/index.html>`_
     - `Python <api/python/index.html>`_
     - `C++ <http://doxygen.mantidproject.org/>`_ (Doxygen)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ Mantid Documentation
    algorithms/index
    algorithms/*
    concepts/index
+   techniques/index
    interfaces/index
    fitfunctions/*
    fitminimizers/index
@@ -41,6 +42,7 @@ This is the documentation for Mantid |release|.
 
 * `Algorithms <algorithms/index.html>`_
 * `Concepts <concepts/index.html>`_
+* `Techniques <techniques/index.html>`_
 * `Interfaces <interfaces/index.html>`_
 * `Fit Functions <fitfunctions/index.html>`_
 * `Fit Minimizers <fitminimizers/index.html>`_

--- a/docs/source/techniques/ISISPowder-GEM-v1.rst
+++ b/docs/source/techniques/ISISPowder-GEM-v1.rst
@@ -697,3 +697,5 @@ On GEM this is set to the following:
                               (510, 19500),  # Bank 5
                               (510, 18000)   # Bank 6
                               ]
+
+.. categories:: Techniques

--- a/docs/source/techniques/ISISPowder-Index-v1.rst
+++ b/docs/source/techniques/ISISPowder-Index-v1.rst
@@ -52,3 +52,5 @@ Instrument Reference
 - :ref:`isis-powder-diffraction-gem-ref`
 - :ref:`isis-powder-diffraction-pearl-ref`
 - :ref:`isis-powder-diffraction-polaris-ref`
+
+.. categories:: Techniques

--- a/docs/source/techniques/ISISPowder-Pearl-v1.rst
+++ b/docs/source/techniques/ISISPowder-Pearl-v1.rst
@@ -847,3 +847,5 @@ On PEARL this is set to the following:
     vanadium_tof_cropping: (1400, 19990)
   # Long mode ON:
     vanadium_tof_cropping: (20295, 39993)
+
+.. categories:: Techniques

--- a/docs/source/techniques/ISISPowder-Polaris-v1.rst
+++ b/docs/source/techniques/ISISPowder-Polaris-v1.rst
@@ -689,3 +689,5 @@ On POLARIS this is set to the following:
                               (800, 19995),  # Bank 4
                               (800, 19995),  # Bank 5
                              ]
+
+.. categories:: Techniques

--- a/docs/source/techniques/ISISPowder-SampleDetails-v1.rst
+++ b/docs/source/techniques/ISISPowder-SampleDetails-v1.rst
@@ -226,3 +226,5 @@ advanced properties and chemical properties).
 ..  code-block:: python
 
     sample_obj.reset_sample_material()
+
+.. categories:: Techniques

--- a/docs/source/techniques/ISISPowder-Tutorials.rst
+++ b/docs/source/techniques/ISISPowder-Tutorials.rst
@@ -896,3 +896,5 @@ If you change a value within the advanced config file you will
 need to restart Mantid for it to take effect. If you are happy
 with the new value please ensure you forward it on to the Mantid
 development team to be distributed in future versions.
+
+.. categories:: Techniques

--- a/docs/source/techniques/calibration.rst
+++ b/docs/source/techniques/calibration.rst
@@ -18,3 +18,5 @@ in:
    :maxdepth: 1
 
    calibration_implementation
+
+.. categories:: Techniques

--- a/docs/source/techniques/calibration_implementation.rst
+++ b/docs/source/techniques/calibration_implementation.rst
@@ -23,3 +23,5 @@ IdealTube
 
 .. autoclass:: ideal_tube.IdealTube
    :members:              
+
+.. categories:: Techniques

--- a/docs/source/techniques/index.rst
+++ b/docs/source/techniques/index.rst
@@ -1,0 +1,19 @@
+.. Techniques master file
+   It contains a hidden root toctree directive so that Sphinx
+   has an internal index of all of the pages and doesn't
+   produce a plethora of warnings about most documents not being in
+   a toctree.
+   See http://sphinx-doc.org/tutorial.html#defining-document-structure
+
+.. _techniques contents:
+
+============
+ Techniques
+============
+
+.. toctree::
+   :hidden:
+   :glob:
+   :maxdepth: 1
+
+   *

--- a/docs/sphinxext/mantiddoc/directives/categories.py
+++ b/docs/sphinxext/mantiddoc/directives/categories.py
@@ -20,7 +20,7 @@ CATEGORIES_DIR = "categories"
 # List of category names that are considered the index for everything in that type
 # When this category is encountered an additional index.html is written to both the
 # directory of the document and the category directory
-INDEX_CATEGORIES = ["Algorithms", "FitFunctions", "Concepts", "Interfaces"]
+INDEX_CATEGORIES = ["Algorithms", "FitFunctions", "Concepts", "Techniques", "Interfaces"]
 
 class LinkItem(object):
     """


### PR DESCRIPTION
This PR moves the 'Techniques' documentation from the Python API documentation to the same level as 'Algorithms', 'Concepts' and 'Interfaces'. The idea is to make this documentation more discoverable and accessible.

**To test:**

Build the `docs-html` target and check that
1. the new 'Techniques' category appears on Mantid documentation main page.
2. the pages under the Techniques section [here](http://docs.mantidproject.org/nightly/api/python/index.html) are now in the new 'Techniques' category.
3. the old Techniques section above exists no more.

Fixes #19921. 

**Release Notes** 

*No changes in functionality, no release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
