### PR TITLE
Add A as a unit of wavelength

### DIFF
--- a/Framework/Algorithms/src/EstimateResolutionDiffraction.cpp
+++ b/Framework/Algorithms/src/EstimateResolutionDiffraction.cpp
@@ -125,7 +125,7 @@ double EstimateResolutionDiffraction::getWavelength() {
         "LambdaReqeust is not a TimeSeriesProperty in double. ");
 
   string unit = cwltimeseries->units();
-  if (!((unit == "Angstrom") || (unit == "A"))) {
+  if ((unit != "Angstrom") && (unit != "A")) {
     throw runtime_error("Unit is not recognized: " + unit);
   }
 

--- a/Framework/Algorithms/src/EstimateResolutionDiffraction.cpp
+++ b/Framework/Algorithms/src/EstimateResolutionDiffraction.cpp
@@ -125,7 +125,7 @@ double EstimateResolutionDiffraction::getWavelength() {
         "LambdaReqeust is not a TimeSeriesProperty in double. ");
 
   string unit = cwltimeseries->units();
-  if (! ((unit == "Angstrom") || (unit == "A")) ) {
+  if (!((unit == "Angstrom") || (unit == "A"))) {
     throw runtime_error("Unit is not recognized: " + unit);
   }
 

--- a/Framework/Algorithms/src/EstimateResolutionDiffraction.cpp
+++ b/Framework/Algorithms/src/EstimateResolutionDiffraction.cpp
@@ -125,7 +125,7 @@ double EstimateResolutionDiffraction::getWavelength() {
         "LambdaReqeust is not a TimeSeriesProperty in double. ");
 
   string unit = cwltimeseries->units();
-  if (unit != "Angstrom") {
+  if (! ((unit == "Angstrom") || (unit == "A")) ) {
     throw runtime_error("Unit is not recognized: " + unit);
   }
 


### PR DESCRIPTION
New DAS uses `A` as the unit for the `LambdaRequest` logs. Add this to the list of acceptable units in `EstimateResolutionDiffraction`.

**To test:**

Try this before and after merging the branch.
```python
LoadEventNexus(Filename='PG3_37659', ...)
EstimateResolutionDiffraction(...)
```

*There is no associated issue.*

*Does not need to be in the release notes* because it is too minor.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
