### PR TITLE
Remove boost/type_traits for std type traits

### DIFF
--- a/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
+++ b/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
@@ -6,7 +6,7 @@
 #include "MantidKernel/SingletonHolder.h"
 
 #ifndef Q_MOC_RUN
-#include <boost/type_traits/is_base_of.hpp>
+#include <type_traits>
 #endif
 
 #include <map>
@@ -106,7 +106,7 @@ private:
     static void check(LoaderFormat format) {
       switch (format) {
       case Nexus:
-        if (!boost::is_base_of<IFileLoader<Kernel::NexusDescriptor>,
+        if (!std::is_base_of<IFileLoader<Kernel::NexusDescriptor>,
                                T>::value) {
           throw std::runtime_error(
               std::string("FileLoaderRegistryImpl::subscribe - Class '") +
@@ -116,7 +116,7 @@ private:
         }
         break;
       case Generic:
-        if (!boost::is_base_of<IFileLoader<Kernel::FileDescriptor>, T>::value) {
+        if (!std::is_base_of<IFileLoader<Kernel::FileDescriptor>, T>::value) {
           throw std::runtime_error(
               std::string("FileLoaderRegistryImpl::subscribe - Class '") +
               typeid(T).name() + "' registered as Generic loader but it does "

--- a/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
+++ b/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
@@ -4,7 +4,7 @@
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidAPI/IFileLoader.h"
 #include "MantidKernel/SingletonHolder.h"
-
+ 
 #ifndef Q_MOC_RUN
 #include <type_traits>
 #endif
@@ -14,12 +14,13 @@
 #include <vector>
 
 namespace Mantid {
-// Forward declaration
 namespace Kernel {
+
 class Logger;
+
 }
 namespace API {
-// Forward declaration
+
 class IAlgorithm;
 
 /**

--- a/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
+++ b/Framework/API/inc/MantidAPI/FileLoaderRegistry.h
@@ -4,7 +4,7 @@
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidAPI/IFileLoader.h"
 #include "MantidKernel/SingletonHolder.h"
- 
+
 #ifndef Q_MOC_RUN
 #include <type_traits>
 #endif
@@ -17,7 +17,6 @@ namespace Mantid {
 namespace Kernel {
 
 class Logger;
-
 }
 namespace API {
 
@@ -107,8 +106,7 @@ private:
     static void check(LoaderFormat format) {
       switch (format) {
       case Nexus:
-        if (!std::is_base_of<IFileLoader<Kernel::NexusDescriptor>,
-                               T>::value) {
+        if (!std::is_base_of<IFileLoader<Kernel::NexusDescriptor>, T>::value) {
           throw std::runtime_error(
               std::string("FileLoaderRegistryImpl::subscribe - Class '") +
               typeid(T).name() + "' registered as Nexus loader but it does not "

--- a/Framework/API/inc/MantidAPI/IMDHistoWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDHistoWorkspace.h
@@ -1,10 +1,10 @@
 #ifndef MANTID_API_IMDHISTOWORKSPACE_H_
 #define MANTID_API_IMDHISTOWORKSPACE_H_
 
-#include "MantidKernel/System.h"
 #include "MantidAPI/IMDHistoWorkspace_fwd.h"
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/MultipleExperimentInfos.h"
+#include "MantidKernel/System.h"
 
 namespace Mantid {
 namespace API {

--- a/Framework/API/src/IMDHistoWorkspace.cpp
+++ b/Framework/API/src/IMDHistoWorkspace.cpp
@@ -1,7 +1,9 @@
 #include "MantidAPI/IMDHistoWorkspace.h"
-#include "MantidKernel/System.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/IPropertyManager.h"
+#include "MantidKernel/System.h"
+
+#include <sstream>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/Framework/Algorithms/src/ConvertTableToMatrixWorkspace.cpp
+++ b/Framework/Algorithms/src/ConvertTableToMatrixWorkspace.cpp
@@ -10,11 +10,6 @@
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
 
-#include <boost/mpl/if.hpp>
-#include <boost/type_traits.hpp>
-
-#include <sstream>
-
 namespace Mantid {
 namespace Algorithms {
 

--- a/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
@@ -2,13 +2,15 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidCurveFitting/CostFunctions/CostFuncLeastSquares.h"
-#include "MantidCurveFitting/Jacobian.h"
-#include "MantidCurveFitting/SeqDomain.h"
-#include "MantidAPI/IConstraint.h"
 #include "MantidAPI/CompositeDomain.h"
 #include "MantidAPI/FunctionValues.h"
+#include "MantidAPI/IConstraint.h"
+#include "MantidCurveFitting/Jacobian.h"
+#include "MantidCurveFitting/SeqDomain.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/MultiThreaded.h"
+
+#include <sstream>
 
 namespace Mantid {
 namespace CurveFitting {

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -1,30 +1,16 @@
 #ifndef MANTID_DATAOBJECTS_TABLECOLUMN_H_
 #define MANTID_DATAOBJECTS_TABLECOLUMN_H_
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-
-#include "MantidAPI/Column.h"
-#include "MantidKernel/Logger.h"
-
-#include <vector>
-#include <typeinfo>
-#include <stdexcept>
+#include <boost/numeric/conversion/cast.hpp>
 #include <boost/shared_ptr.hpp>
 #include <limits>
-#include <boost/type_traits.hpp>
-#include <boost/numeric/conversion/cast.hpp>
+#include <sstream>
+#include <vector>
+
+#include "MantidAPI/Column.h"
 
 namespace Mantid {
-
-//----------------------------------------------------------------------
-// Forward declarations
-//----------------------------------------------------------------------
-
 namespace DataObjects {
-
-template <class T> class TableVector;
 
 /** \class TableColumn
 

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -1,12 +1,14 @@
-#include "MantidHistogramData/LinearGenerator.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidKernel/Exception.h"
+#include "MantidAPI/ISpectrum.h"
 #include "MantidAPI/RefAxis.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/WorkspaceFactory.h"
-#include "MantidAPI/ISpectrum.h"
-#include "MantidKernel/VectorHelper.h"
+#include "MantidHistogramData/LinearGenerator.h"
+#include "MantidKernel/Exception.h"
 #include "MantidKernel/IPropertyManager.h"
+#include "MantidKernel/VectorHelper.h"
+
+#include <sstream>
 
 using Mantid::API::ISpectrum;
 using Mantid::API::MantidImage;
@@ -283,7 +285,7 @@ Histogram1D &Workspace2D::getSpectrum(const size_t index) {
 /// Return const reference to Histogram1D at the given workspace index.
 const Histogram1D &Workspace2D::getSpectrum(const size_t index) const {
   if (index >= m_noVectors) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "Workspace2D::getSpectrum, histogram number " << index
        << " out of range " << m_noVectors;
     throw std::range_error(ss.str());

--- a/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
@@ -161,9 +161,9 @@ public:
   template <typename T>
   IPropertyManager *setProperty(const std::string &name,
                                 std::unique_ptr<T> value) {
-    setTypedProperty(name, std::move(value),
-                     std::is_convertible<std::unique_ptr<T>,
-                                           boost::shared_ptr<DataItem>>());
+    setTypedProperty(
+        name, std::move(value),
+        std::is_convertible<std::unique_ptr<T>, boost::shared_ptr<DataItem>>());
     this->afterPropertySet(name);
     return this;
   }

--- a/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
@@ -9,7 +9,7 @@
 
 #ifndef Q_MOC_RUN
 #include <boost/make_shared.hpp>
-#include <boost/type_traits.hpp>
+#include <type_traits>
 #endif
 
 #include <memory>
@@ -162,7 +162,7 @@ public:
   IPropertyManager *setProperty(const std::string &name,
                                 std::unique_ptr<T> value) {
     setTypedProperty(name, std::move(value),
-                     boost::is_convertible<std::unique_ptr<T>,
+                     std::is_convertible<std::unique_ptr<T>,
                                            boost::shared_ptr<DataItem>>());
     this->afterPropertySet(name);
     return this;
@@ -453,7 +453,7 @@ private:
   template <typename T>
   IPropertyManager *doSetProperty(const std::string &name, const T &value) {
     setTypedProperty(name, value,
-                     boost::is_convertible<T, boost::shared_ptr<DataItem>>());
+                     std::is_convertible<T, boost::shared_ptr<DataItem>>());
     this->afterPropertySet(name);
     return this;
   }
@@ -477,7 +477,7 @@ private:
     // wrong badly. To circumvent this we call `sizeof` here to force a compiler
     // error if T is an incomplete type.
     static_cast<void>(sizeof(T)); // DO NOT REMOVE, enforces complete type
-    setTypedProperty(name, value, boost::is_convertible<T *, DataItem *>());
+    setTypedProperty(name, value, std::is_convertible<T *, DataItem *>());
     this->afterPropertySet(name);
     return this;
   }
@@ -492,7 +492,7 @@ private:
    */
   template <typename T>
   IPropertyManager *setTypedProperty(const std::string &name, const T &value,
-                                     const boost::false_type &) {
+                                     const std::false_type &) {
     PropertyWithValue<T> *prop =
         dynamic_cast<PropertyWithValue<T> *>(getPointerToProperty(name));
     if (prop) {
@@ -513,7 +513,7 @@ private:
    */
   template <typename T>
   IPropertyManager *setTypedProperty(const std::string &name, const T &value,
-                                     const boost::true_type &) {
+                                     const std::true_type &) {
     // T is convertible to DataItem_sptr
     boost::shared_ptr<DataItem> data =
         boost::static_pointer_cast<DataItem>(value);
@@ -536,7 +536,7 @@ private:
   template <typename T>
   IPropertyManager *setTypedProperty(const std::string &name,
                                      std::unique_ptr<T> value,
-                                     const boost::true_type &) {
+                                     const std::true_type &) {
     // T is convertible to DataItem_sptr
     boost::shared_ptr<DataItem> data(std::move(value));
     std::string error = getPointerToProperty(name)->setDataItem(data);

--- a/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
@@ -11,12 +11,8 @@
 #include "MantidHistogramData/LinearGenerator.h"
 
 #include "MantidKernel/ListValidator.h"
-#include "MantidKernel/MandatoryValidator.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
-
-#include <boost/mpl/if.hpp>
-#include <boost/type_traits.hpp>
 
 #include <sstream>
 

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -5,11 +5,7 @@
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Crystal/EdgePixel.h"
 #include "MantidKernel/BoundedValidator.h"
-#include "MantidKernel/System.h"
 #include "MantidKernel/VMD.h"
-
-#include <boost/type_traits/integral_constant.hpp>
-#include <cmath>
 
 #include <map>
 #include <vector>

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/AsType.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/AsType.h
@@ -25,7 +25,7 @@
 #include <boost/python/detail/prefix.hpp>
 #include <boost/python/to_python_value.hpp>
 #include <boost/mpl/and.hpp>
-#include <boost/type_traits/is_convertible.hpp>
+#include <type_traits>
 
 /**
  * Policy that can convert to return type to a super type
@@ -74,7 +74,7 @@ template <class ReturnType> struct AsType {
     // Deduce if type is correct for policy, needs to be convertible to
     // ReturnType
     typedef typename boost::mpl::if_c<
-        boost::is_convertible<InputType, ReturnType>::value,
+        std::is_convertible<InputType, ReturnType>::value,
         AsTypeImpl<ReturnType, InputType>,
         AsType_Requires_New_Type_Automatically_Convertible_To_Original<
             InputType>>::type type;

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/MatrixToNumpy.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/MatrixToNumpy.h
@@ -27,10 +27,8 @@
 #include "MantidPythonInterface/kernel/Converters/PyArrayType.h"
 #include "MantidKernel/Matrix.h"
 
-#include <boost/type_traits/integral_constant.hpp>
-#include <boost/type_traits/is_reference.hpp>
-#include <boost/type_traits/remove_reference.hpp>
-#include <boost/type_traits/remove_const.hpp>
+#include <type_traits>
+
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/and.hpp>
 
@@ -87,11 +85,11 @@ template <typename ConversionPolicy> struct MatrixToNumpy {
   template <class T> struct apply {
     // Typedef that removes and const or reference qualifiers from the return
     // type
-    typedef typename boost::remove_const<
-        typename boost::remove_reference<T>::type>::type non_const_type;
+    typedef typename std::remove_const<
+        typename std::remove_reference<T>::type>::type non_const_type;
     // MPL compile-time check that T is a reference to a Kernel::Matrix
     typedef typename boost::mpl::if_c<
-        boost::mpl::and_<boost::is_reference<T>,
+        boost::mpl::and_<std::is_reference<T>,
                          is_matrix<non_const_type>>::value,
         ConvertMatrixToNDArray<non_const_type, ConversionPolicy>,
         MatrixToNumpy_Requires_Reference_To_Matrix_Return_Type<T>>::type type;

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/RemoveConst.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/RemoveConst.h
@@ -29,10 +29,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <boost/type_traits/is_const.hpp>
-#include <boost/type_traits/is_convertible.hpp>
-#include <boost/type_traits/is_pointer.hpp>
-#include <boost/type_traits/remove_const.hpp>
+#include <type_traits>
 
 /**
  * A bug in earlier boost versions, <= boost 1.41, means that
@@ -58,13 +55,13 @@ namespace {
 // MPL helper structs
 //-----------------------------------------------------------------------
 /// MPL struct to figure out if a type is a boost::shared_ptr<const T>
-/// The general one inherits from boost::false_type
-template <typename T> struct IsConstSharedPtr : boost::false_type {};
+/// The general one inherits from std::false_type
+template <typename T> struct IsConstSharedPtr : std::false_type {};
 
 /// Specialization for boost::shared_ptr<const T> types to inherit from
-/// boost::true_type
+/// std::true_type
 template <typename T>
-struct IsConstSharedPtr<boost::shared_ptr<const T>> : boost::true_type {};
+struct IsConstSharedPtr<boost::shared_ptr<const T>> : std::true_type {};
 
 //-----------------------------------------------------------------------
 // Polciy implementations
@@ -75,9 +72,9 @@ struct IsConstSharedPtr<boost::shared_ptr<const T>> : boost::true_type {};
 // call to this struct
 template <typename ConstPtrType> struct RemoveConstImpl {
   // Remove the pointer type to leave value type
-  typedef typename boost::remove_pointer<ConstPtrType>::type ValueType;
+  typedef typename std::remove_pointer<ConstPtrType>::type ValueType;
   // Remove constness
-  typedef typename boost::remove_const<ValueType>::type NonConstValueType;
+  typedef typename std::remove_const<ValueType>::type NonConstValueType;
 
   inline PyObject *operator()(const ConstPtrType &p) const {
     using namespace boost::python;
@@ -104,7 +101,7 @@ template <typename T> struct RemoveConst_Requires_Pointer_Return_Value {};
 template <typename ConstSharedPtr> struct RemoveConstSharedPtrImpl {
   typedef typename ConstSharedPtr::element_type ConstElementType;
   typedef
-      typename boost::remove_const<ConstElementType>::type NonConstElementType;
+      typename std::remove_const<ConstElementType>::type NonConstElementType;
   typedef typename boost::shared_ptr<NonConstElementType> NonConstSharedPtr;
 
   inline PyObject *operator()(const ConstSharedPtr &p) const {
@@ -134,7 +131,7 @@ struct RemoveConst {
   template <class T> struct apply {
     // Deduce if type is correct for policy, needs to be a "T*"
     typedef typename boost::mpl::if_c<
-        boost::is_pointer<T>::value, RemoveConstImpl<T>,
+        std::is_pointer<T>::value, RemoveConstImpl<T>,
         RemoveConst_Requires_Pointer_Return_Value<T>>::type type;
   };
 };

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/VectorToNumpy.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/VectorToNumpy.h
@@ -27,10 +27,7 @@
 #include "MantidPythonInterface/kernel/Converters/VectorToNDArray.h"
 #include "MantidPythonInterface/kernel/Converters/PyArrayType.h"
 
-#include <boost/type_traits/integral_constant.hpp>
-#include <boost/type_traits/is_reference.hpp>
-#include <boost/type_traits/remove_reference.hpp>
-#include <boost/type_traits/remove_const.hpp>
+#include <type_traits>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/if.hpp>
 #include <vector>
@@ -45,13 +42,13 @@ namespace // anonymous
 // MPL helper structs
 //-----------------------------------------------------------------------
 /// MPL struct to figure out if a type is a std::vector
-/// The general one inherits from boost::false_type
-template <typename T> struct is_std_vector : boost::false_type {};
+/// The general one inherits from std::false_type
+template <typename T> struct is_std_vector : std::false_type {};
 
 /// Specialization for std::vector types to inherit from
-/// boost::true_type
+/// std::true_type
 template <typename T>
-struct is_std_vector<std::vector<T>> : boost::true_type {};
+struct is_std_vector<std::vector<T>> : std::true_type {};
 
 //-----------------------------------------------------------------------
 // VectorRefToNumpyImpl - Policy for reference returns
@@ -89,11 +86,11 @@ template <typename ConversionPolicy> struct VectorRefToNumpy {
   // The boost::python framework calls return_value_policy::apply<T>::type
   template <class T> struct apply {
     // Typedef that removes and const or reference qualifiers from the type
-    typedef typename boost::remove_const<
-        typename boost::remove_reference<T>::type>::type non_const_type;
+    typedef typename std::remove_const<
+        typename std::remove_reference<T>::type>::type non_const_type;
     // MPL compile-time check that T is a reference to a std::vector
     typedef typename boost::mpl::if_c<
-        boost::mpl::and_<boost::is_reference<T>,
+        boost::mpl::and_<std::is_reference<T>,
                          is_std_vector<non_const_type>>::value,
         VectorRefToNumpyImpl<non_const_type, ConversionPolicy>,
         VectorRefToNumpy_Requires_Reference_To_StdVector_Return_Type<T>>::type
@@ -134,7 +131,7 @@ struct VectorToNumpy {
   // The boost::python framework calls return_value_policy::apply<T>::type
   template <class T> struct apply {
     // Typedef that removes any const from the type
-    typedef typename boost::remove_const<T>::type non_const_type;
+    typedef typename std::remove_const<T>::type non_const_type;
     // MPL compile-time check that T is a std::vector
     typedef typename boost::mpl::if_c<
         is_std_vector<non_const_type>::value,

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/VectorToNumpy.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Policies/VectorToNumpy.h
@@ -47,8 +47,7 @@ template <typename T> struct is_std_vector : std::false_type {};
 
 /// Specialization for std::vector types to inherit from
 /// std::true_type
-template <typename T>
-struct is_std_vector<std::vector<T>> : std::true_type {};
+template <typename T> struct is_std_vector<std::vector<T>> : std::true_type {};
 
 //-----------------------------------------------------------------------
 // VectorRefToNumpyImpl - Policy for reference returns


### PR DESCRIPTION
Description of work.

Switch from using `boost/type_traits` to the std `type_traits`. 

**To test:**

Code review.

<!-- Instructions for testing. -->

Fixes #19919. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
