### PR TITLE
Add absolute import

### DIFF
--- a/scripts/Interface/reduction_gui/reduction/eqsans_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/eqsans_reduction.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 """
 import time
 import os
-from scripter import BaseReductionScripter
+from reduction_gui.reduction.scripter import BaseReductionScripter
 
 HAS_MANTID = False
 try:


### PR DESCRIPTION
In modernizing code to be python 2/3 compatible, an absolute import error snuck in. This fixes that mistake.

**To test:**

On `master`, start up "Interfaces"->"Diffraction"->"Powder Diffraction Reduction" and get the error `ImportError: No module named scripter`. Merge this branch and do the same thing without an error.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
