### PR TITLE
Improve KafkaEventStreamDecoder test

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaEventStreamDecoder.h
+++ b/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaEventStreamDecoder.h
@@ -44,6 +44,9 @@ namespace LiveData {
 */
 class DLLExport KafkaEventStreamDecoder {
 public:
+  using CallbackFn = std::function<void()>;
+
+public:
   KafkaEventStreamDecoder(std::shared_ptr<IKafkaBroker> broker,
                           const std::string &eventTopic,
                           const std::string &runInfoTopic,
@@ -65,6 +68,14 @@ public:
   bool hasData() const noexcept;
   int runNumber() const noexcept { return m_runNumber; }
   bool hasReachedEndOfRun() noexcept;
+  ///@}
+
+  ///@name Callbacks
+  ///@{
+  void registerIterationEndCb(CallbackFn cb) {
+    m_cbIterationEnd = std::move(cb);
+  }
+  void registerErrorCb(CallbackFn cb) { m_cbError = std::move(cb); }
   ///@}
 
   ///@name Modifying
@@ -135,6 +146,10 @@ private:
   /// EndRun
   bool m_runStatusSeen;
   std::atomic<bool> m_extractedEndRunData;
+
+  // Callbacks
+  CallbackFn m_cbIterationEnd;
+  CallbackFn m_cbError;
 };
 
 } // namespace LiveData

--- a/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
@@ -119,7 +119,8 @@ KafkaEventStreamDecoder::KafkaEventStreamDecoder(
     : m_broker(broker), m_eventTopic(eventTopic), m_runInfoTopic(runInfoTopic),
       m_spDetTopic(spDetTopic), m_interrupt(false), m_localEvents(),
       m_specToIdx(), m_runStart(), m_runNumber(-1), m_thread(),
-      m_capturing(false), m_exception(), m_extractWaiting(false) {}
+      m_capturing(false), m_exception(), m_extractWaiting(false),
+      m_cbIterationEnd([] {}), m_cbError([] {}) {}
 
 /**
  * Destructor.
@@ -155,7 +156,7 @@ void KafkaEventStreamDecoder::startCapture(bool startNow) {
   m_runStream = m_broker->subscribe(m_runInfoTopic);
   m_spDetStream = m_broker->subscribe(m_spDetTopic);
 
-  auto m_thread = std::thread([this]() { this->captureImpl(); });
+  m_thread = std::thread([this]() { this->captureImpl(); });
   m_thread.detach();
 }
 
@@ -258,8 +259,10 @@ void KafkaEventStreamDecoder::captureImpl() noexcept {
   try {
     captureImplExcept();
   } catch (std::exception &exc) {
+    m_cbError();
     m_exception = boost::make_shared<std::runtime_error>(exc.what());
   } catch (...) {
+    m_cbError();
     m_exception = boost::make_shared<std::runtime_error>(
         "KafkaEventStreamDecoder: Unknown exception type caught.");
   }
@@ -282,8 +285,10 @@ void KafkaEventStreamDecoder::captureImplExcept() {
     // Pull in events
     m_eventStream->consumeMessage(&buffer);
     // No events, wait for some to come along...
-    if (buffer.empty())
+    if (buffer.empty()) {
+      m_cbIterationEnd();
       continue;
+    }
     auto evtMsg = ISISStream::GetEventMessage(
         reinterpret_cast<const uint8_t *>(buffer.c_str()));
     if (evtMsg->message_type() == ISISStream::MessageTypes_FramePart) {
@@ -324,7 +329,7 @@ void KafkaEventStreamDecoder::captureImplExcept() {
         // "Stop" or "Rename" run transition option.
         m_extractWaiting = true;
         m_extractedEndRunData = false;
-        g_log.debug() << "Reached end of run in data stream." << std::endl;
+        g_log.debug("Reached end of run in data stream.");
       }
     }
 
@@ -349,6 +354,7 @@ void KafkaEventStreamDecoder::captureImplExcept() {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
     }
+    m_cbIterationEnd();
   }
   g_log.debug("Event capture finished");
 }

--- a/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
@@ -13,6 +13,7 @@
 #include "MantidLiveData/Kafka/KafkaEventStreamDecoder.h"
 
 #include <Poco/Path.h>
+#include <condition_variable>
 #include <thread>
 
 class KafkaEventStreamDecoderTest : public CxxTest::TestSuite {
@@ -67,8 +68,9 @@ public:
     auto decoder = createTestDecoder(mockBroker);
     TSM_ASSERT("Decoder should not have create data buffers yet",
                !decoder->hasData());
-    TS_ASSERT_THROWS_NOTHING(decoder->startCapture());
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    startCapturing(*decoder, 1);
+
+    // Checks
     Workspace_sptr workspace;
     TSM_ASSERT("Decoder's data buffers should be created now",
                decoder->hasData());
@@ -103,8 +105,9 @@ public:
         .WillOnce(Return(new FakeISISRunInfoStreamSubscriber(2)))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
     auto decoder = createTestDecoder(mockBroker);
-    TS_ASSERT_THROWS_NOTHING(decoder->startCapture());
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Need 2 full loops to get both periods
+    startCapturing(*decoder, 2);
+
     Workspace_sptr workspace;
     TS_ASSERT_THROWS_NOTHING(workspace = decoder->extractData());
     TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
@@ -140,8 +143,8 @@ public:
         .WillOnce(Return(new FakeISISRunInfoStreamSubscriber(1)))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
     auto decoder = createTestDecoder(mockBroker);
-    TS_ASSERT_THROWS_NOTHING(decoder->startCapture());
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    startCapturing(*decoder, 1);
+
     TS_ASSERT_THROWS_NOTHING(decoder->extractData());
     TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
     TS_ASSERT(!decoder->isCapturing());
@@ -161,8 +164,8 @@ public:
         .WillOnce(Return(new FakeExceptionThrowingStreamSubscriber))
         .WillOnce(Return(new FakeExceptionThrowingStreamSubscriber));
     auto decoder = createTestDecoder(mockBroker);
-    TS_ASSERT_THROWS_NOTHING(decoder->startCapture());
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    startCapturing(*decoder, 1);
+
     TS_ASSERT_THROWS(decoder->extractData(), std::runtime_error);
     TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
     TS_ASSERT(!decoder->isCapturing());
@@ -179,8 +182,8 @@ public:
         .WillOnce(Return(new FakeISISRunInfoStreamSubscriber(1)))
         .WillOnce(Return(new FakeEmptyStreamSubscriber));
     auto decoder = createTestDecoder(mockBroker);
-    TS_ASSERT_THROWS_NOTHING(decoder->startCapture());
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    startCapturing(*decoder, 1);
+
     TS_ASSERT_THROWS(decoder->extractData(), std::runtime_error);
     TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
     TS_ASSERT(!decoder->isCapturing());
@@ -197,14 +200,39 @@ public:
         .WillOnce(Return(new FakeEmptyStreamSubscriber))
         .WillOnce(Return(new FakeISISSpDetStreamSubscriber));
     auto decoder = createTestDecoder(mockBroker);
-    TS_ASSERT_THROWS_NOTHING(decoder->startCapture());
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    startCapturing(*decoder, 1);
     TS_ASSERT_THROWS(decoder->extractData(), std::runtime_error);
     TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
     TS_ASSERT(!decoder->isCapturing());
   }
 
 private:
+  // Start decoding and wait until we have gathered enough data to test
+  void startCapturing(Mantid::LiveData::KafkaEventStreamDecoder &decoder,
+                      uint8_t maxIterations) {
+    // Register callback to know when a whole loop as been iterated through
+    m_niterations = 0;
+    auto callback = [this, maxIterations]() {
+      {
+        std::unique_lock<std::mutex> lock(this->m_callbackMutex);
+        this->m_niterations++;
+        if (this->m_niterations == maxIterations) {
+          lock.unlock();
+          this->m_callbackCondition.notify_one();
+        }
+      }
+    };
+    decoder.registerIterationEndCb(callback);
+    decoder.registerErrorCb(callback);
+    TS_ASSERT_THROWS_NOTHING(decoder.startCapture());
+    {
+      std::unique_lock<std::mutex> lk(m_callbackMutex);
+      this->m_callbackCondition.wait(lk, [this, &decoder, maxIterations]() {
+        return this->m_niterations == maxIterations;
+      });
+    }
+  }
+
   std::unique_ptr<Mantid::LiveData::KafkaEventStreamDecoder>
   createTestDecoder(std::shared_ptr<Mantid::LiveData::IKafkaBroker> broker) {
     using namespace Mantid::LiveData;
@@ -239,6 +267,11 @@ private:
     // be divisible by 6
     TS_ASSERT(eventWksp.getNumberEvents() % 6 == 0);
   }
+
+private:
+  std::mutex m_callbackMutex;
+  std::condition_variable m_callbackCondition;
+  uint8_t m_niterations = 0;
 };
 
 #endif /* MANTID_LIVEDATA_ISISKAFKAEVENTSTREAMDECODERTEST_H_ */


### PR DESCRIPTION
**Description of work.**

Uses condition variables instead of waiting on a fixed time period for the decoder to acquire enough information for the test. This should fix the unreliable nature of the test when run on the builders: [OSX](http://builds.mantidproject.org/job/pull_requests-osx/14290/testReport/), [Win7](http://builds.mantidproject.org/job/pull_requests-win7/15079/testReport/junit/LiveDataTest/KafkaEventStreamDecoderTest/test_Multiple_Period_Event_Stream/)

It required introducing the concept of a callback that could be registered and is called by the decoder at certain points. The tests then know where they are rather than assuming a given amount of time would be sufficient. The design is slightly more instrusive than I would like but the callbacks could prove useful outside of testing. 

@LamarMoore @matthew-d-jones What do you think of the approach?

**To test:**

It was difficult to get this to fail locally but having the system under load and then running the `KafkaEventStreamDecoderTest` seemed to make fail occasionally. It was more noticeable on the builders. 

*No issue*

**Release Notes** 
*Internal change. Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
