### PR TITLE
Add math.h to list of includes in some .cpp files

### DIFF
--- a/Framework/Algorithms/src/EQSANSResolution.cpp
+++ b/Framework/Algorithms/src/EQSANSResolution.cpp
@@ -2,6 +2,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/EQSANSResolution.h"
+#include <math.h>
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/src/EQSANSResolution.cpp
+++ b/Framework/Algorithms/src/EQSANSResolution.cpp
@@ -2,7 +2,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/EQSANSResolution.h"
-#include <math.h>
+#include <cmath>
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/src/Power.cpp
+++ b/Framework/Algorithms/src/Power.cpp
@@ -3,6 +3,7 @@
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/Power.h"
 #include "MantidKernel/Exception.h"
+#include <math.h>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;

--- a/Framework/Algorithms/src/Power.cpp
+++ b/Framework/Algorithms/src/Power.cpp
@@ -3,7 +3,7 @@
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/Power.h"
 #include "MantidKernel/Exception.h"
-#include <math.h>
+#include <cmath>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;

--- a/Framework/Algorithms/src/PowerLawCorrection.cpp
+++ b/Framework/Algorithms/src/PowerLawCorrection.cpp
@@ -3,6 +3,7 @@
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/PowerLawCorrection.h"
 #include "MantidKernel/ArrayProperty.h"
+#include <math.h>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;

--- a/Framework/Algorithms/src/PowerLawCorrection.cpp
+++ b/Framework/Algorithms/src/PowerLawCorrection.cpp
@@ -3,7 +3,7 @@
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/PowerLawCorrection.h"
 #include "MantidKernel/ArrayProperty.h"
-#include <math.h>
+#include <cmath>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;


### PR DESCRIPTION
`master` wasn't compiling so this adds `#import <math.h>` in three `.cpp` files that needed it.

**To test:**

If the builds pass, this can be merged.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
