### PR TITLE
Use 10 digits when formatting double in cxxtest

### DIFF
--- a/Testing/Tools/cxxtest/cxxtest/ValueTraits.h
+++ b/Testing/Tools/cxxtest/cxxtest/ValueTraits.h
@@ -327,7 +327,7 @@ namespace CxxTest
         const char *asString( void ) const { return _asString; }
         
     private:
-        enum { MAX_DIGITS_ON_LEFT = 24, DIGITS_ON_RIGHT = 4, BASE = 10 };
+        enum { MAX_DIGITS_ON_LEFT = 24, DIGITS_ON_RIGHT = 10, BASE = 10 };
         char _asString[1 + MAX_DIGITS_ON_LEFT + 1 + DIGITS_ON_RIGHT + 1];
 
         static unsigned requiredDigitsOnLeft( double t );


### PR DESCRIPTION
**Description of work**

Increase the number of digits after the decimal place printed when a `double` is formatted by `cxxtest`. 

**To test:**

Code review.

No issue

**Release Notes** 
*Internal change. Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
