### PR TITLE
Move logging down to debug in AlignAndFocusPowderFromFiles

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -105,11 +105,12 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
         return args
 
     def __updateAlignAndFocusArgs(self, wkspname):
-        self.log().warning('__updateAlignAndFocusArgs(%s)!!!!!!!' % wkspname)
+        self.log().debug('__updateAlignAndFocusArgs(%s)' % wkspname)
         # if the files are missing, there is nothing to do
         if (CAL_FILE not in self.kwargs) and (GROUP_FILE not in self.kwargs):
-            self.log().warning('--> Nothing to do')
-        self.log().warning('--> Updating')
+            self.log().debug('--> Nothing to do')
+            return
+        self.log().debug('--> Updating')
 
         # delete the files from the list of kwargs
         if CAL_FILE in self.kwargs:


### PR DESCRIPTION
Some logging was left at `warning` level when it is fairly clear that it is for `debug`.

**To test:**

Code review should suffice.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
