### PR TITLE
Error handling for when the default intrument has no listener

### DIFF
--- a/MantidQt/CustomDialogs/src/StartLiveDataDialog.cpp
+++ b/MantidQt/CustomDialogs/src/StartLiveDataDialog.cpp
@@ -434,9 +434,9 @@ void StartLiveDataDialog::initListenerPropLayout(const QString &listener) {
   }
 
   // update algorithm's properties
-if (ui.cmbInstrument->currentText().toStdString() != "") {
-    m_algorithm->setPropertyValue("Instrument",
-      ui.cmbInstrument->currentText().toStdString());
+  if (ui.cmbInstrument->currentText().toStdString() != "") {
+    m_algorithm->setPropertyValue(
+        "Instrument", ui.cmbInstrument->currentText().toStdString());
     m_algorithm->setPropertyValue("Listener", listener.toStdString());
     // create or clear the layout
     QLayout *layout = ui.listenerProps->layout();
@@ -499,8 +499,7 @@ void StartLiveDataDialog::updateConnectionChoices(const QString &inst_name) {
     auto selectName = QString::fromStdString(inst.liveListenerInfo().name());
     auto index = ui.cmbConnection->findText(selectName);
     ui.cmbConnection->setCurrentIndex(index);
-  }
-  catch (std::runtime_error &)     {
+  } catch (std::runtime_error &) {
     // the default instrument has no live listener, don't make a selection
   }
 }

--- a/MantidQt/CustomDialogs/src/StartLiveDataDialog.cpp
+++ b/MantidQt/CustomDialogs/src/StartLiveDataDialog.cpp
@@ -434,45 +434,47 @@ void StartLiveDataDialog::initListenerPropLayout(const QString &listener) {
   }
 
   // update algorithm's properties
-  m_algorithm->setPropertyValue("Instrument",
-                                ui.cmbInstrument->currentText().toStdString());
-  m_algorithm->setPropertyValue("Listener", listener.toStdString());
-  // create or clear the layout
-  QLayout *layout = ui.listenerProps->layout();
-  if (!layout) {
-    QGridLayout *listenerPropLayout = new QGridLayout(ui.listenerProps);
-    layout = listenerPropLayout;
-  } else {
-    QLayoutItem *child;
-    while ((child = layout->takeAt(0)) != NULL) {
-      child->widget()->close();
-      delete child;
+if (ui.cmbInstrument->currentText().toStdString() != "") {
+    m_algorithm->setPropertyValue("Instrument",
+      ui.cmbInstrument->currentText().toStdString());
+    m_algorithm->setPropertyValue("Listener", listener.toStdString());
+    // create or clear the layout
+    QLayout *layout = ui.listenerProps->layout();
+    if (!layout) {
+      QGridLayout *listenerPropLayout = new QGridLayout(ui.listenerProps);
+      layout = listenerPropLayout;
+    } else {
+      QLayoutItem *child;
+      while ((child = layout->takeAt(0)) != NULL) {
+        child->widget()->close();
+        delete child;
+      }
     }
-  }
 
-  // find the listener's properties
-  props = m_algorithm->getPropertiesInGroup("ListenerProperties");
+    // find the listener's properties
+    props = m_algorithm->getPropertiesInGroup("ListenerProperties");
 
-  // no properties - don't show the box
-  if (props.empty()) {
-    ui.listenerProps->setVisible(false);
-    return;
-  }
-
-  auto gridLayout = static_cast<QGridLayout *>(layout);
-  // add widgets for the listener's properties
-  for (auto prop = props.begin(); prop != props.end(); ++prop) {
-    int row = static_cast<int>(std::distance(props.begin(), prop));
-    QString propName = QString::fromStdString((**prop).name());
-    gridLayout->addWidget(new QLabel(propName), row, 0);
-    QLineEdit *propWidget = new QLineEdit();
-    gridLayout->addWidget(propWidget, row, 1);
-    if (!m_algProperties.contains(propName)) {
-      m_algProperties.append(propName);
+    // no properties - don't show the box
+    if (props.empty()) {
+      ui.listenerProps->setVisible(false);
+      return;
     }
-    tie(propWidget, propName, gridLayout);
+
+    auto gridLayout = static_cast<QGridLayout *>(layout);
+    // add widgets for the listener's properties
+    for (auto prop = props.begin(); prop != props.end(); ++prop) {
+      int row = static_cast<int>(std::distance(props.begin(), prop));
+      QString propName = QString::fromStdString((**prop).name());
+      gridLayout->addWidget(new QLabel(propName), row, 0);
+      QLineEdit *propWidget = new QLineEdit();
+      gridLayout->addWidget(propWidget, row, 1);
+      if (!m_algProperties.contains(propName)) {
+        m_algProperties.append(propName);
+      }
+      tie(propWidget, propName, gridLayout);
+    }
+    ui.listenerProps->setVisible(true);
   }
-  ui.listenerProps->setVisible(true);
 }
 
 /**
@@ -493,9 +495,14 @@ void StartLiveDataDialog::updateConnectionChoices(const QString &inst_name) {
   }
 
   // Select default item
-  auto selectName = QString::fromStdString(inst.liveListenerInfo().name());
-  auto index = ui.cmbConnection->findText(selectName);
-  ui.cmbConnection->setCurrentIndex(index);
+  try {
+    auto selectName = QString::fromStdString(inst.liveListenerInfo().name());
+    auto index = ui.cmbConnection->findText(selectName);
+    ui.cmbConnection->setCurrentIndex(index);
+  }
+  catch (std::runtime_error &)     {
+    // the default instrument has no live listener, don't make a selection
+  }
 }
 
 /**


### PR DESCRIPTION
re #19673

Add error handling for when the default instrument has no listener defined

**To test:**
1. Open Mantidplot
1. Set your default facility to the ILL
1. Launch the StartLiveData dialog
1. The dialog should appear without and unhandled exception, it not too usefull as there are no instruments with listeners at the ILL yet, but it launches and you can close it.
1. Close Mantidplot (while your facility is still ILL)
1. Build the docs-html target
1. It should not fail on the StartLiveData page

Fixes #19673 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
