### PR TITLE
Muon analysis Group/pair selection

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
@@ -340,6 +340,8 @@ private:
   /// set labels for a single data set
   void updateLabels(std::string &name);
 
+  void setGroupsAndPairs();
+
   /// Get current plot style parameters. wsName and wsIndex are used to get
   /// default values if
   /// something is not specified

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1538,14 +1538,15 @@ void MuonAnalysis::updateFrontAndCombo(bool updateIndexAndPlot) {
 * sets the selected groups and pairs
 */
 void MuonAnalysis::setGroupsAndPairs() {
-	auto names = m_groupingHelper.parseGroupingTable().pairNames;
-	auto tmp = m_groupingHelper.parseGroupingTable().groupNames;
-	names.insert(std::end(names), std::make_move_iterator(tmp.begin()), std::make_move_iterator(tmp.end()));
-	QStringList GroupsAndPairsNames;
-	for (const auto &name : names) {
-		GroupsAndPairsNames << QString::fromStdString(name);
-	}
-	m_uiForm.fitBrowser->setAvailableGroups(GroupsAndPairsNames);
+  auto names = m_groupingHelper.parseGroupingTable().pairNames;
+  auto tmp = m_groupingHelper.parseGroupingTable().groupNames;
+  names.insert(std::end(names), std::make_move_iterator(tmp.begin()),
+               std::make_move_iterator(tmp.end()));
+  QStringList GroupsAndPairsNames;
+  for (const auto &name : names) {
+    GroupsAndPairsNames << QString::fromStdString(name);
+  }
+  m_uiForm.fitBrowser->setAvailableGroups(GroupsAndPairsNames);
 }
 
 /**
@@ -1897,7 +1898,7 @@ void MuonAnalysis::selectMultiPeak(const QString &wsName,
                    std::back_inserter(groupsAndPairs), &QString::fromStdString);
     std::transform(groups.pairNames.begin(), groups.pairNames.end(),
                    std::back_inserter(groupsAndPairs), &QString::fromStdString);
-	setGroupsAndPairs();
+    setGroupsAndPairs();
     m_uiForm.fitBrowser->setNumPeriods(m_numPeriods);
 
     // Set the selected run, group/pair and period

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1528,19 +1528,24 @@ void MuonAnalysis::updateFrontAndCombo(bool updateIndexAndPlot) {
   if (currentI >= m_uiForm.frontGroupGroupPairComboBox->count()) {
     currentI = 0;
   }
-  auto tmp = m_groupingHelper.parseGroupingTable().groupNames;
-  auto names = m_groupingHelper.parseGroupingTable().pairNames;
-  names.insert(std::end(names), std::begin(tmp), std::end(tmp));
-  QStringList GroupsAndPairsNames;
-  for (auto name : names) {
-    GroupsAndPairsNames << QString::fromStdString(name);
-  }
-  m_uiForm.fitBrowser->setAvailableGroups(GroupsAndPairsNames);
-
+  setGroupsAndPairs();
   if (updateIndexAndPlot) {
     setGroupOrPairIndexToPlot(currentI);
     plotCurrentGroupAndPairs();
   }
+}
+/**
+* sets the selected groups and pairs
+*/
+void MuonAnalysis::setGroupsAndPairs() {
+	auto names = m_groupingHelper.parseGroupingTable().pairNames;
+	auto tmp = m_groupingHelper.parseGroupingTable().groupNames;
+	names.insert(std::end(names), std::make_move_iterator(tmp.begin()), std::make_move_iterator(tmp.end()));
+	QStringList GroupsAndPairsNames;
+	for (const auto &name : names) {
+		GroupsAndPairsNames << QString::fromStdString(name);
+	}
+	m_uiForm.fitBrowser->setAvailableGroups(GroupsAndPairsNames);
 }
 
 /**
@@ -1892,14 +1897,7 @@ void MuonAnalysis::selectMultiPeak(const QString &wsName,
                    std::back_inserter(groupsAndPairs), &QString::fromStdString);
     std::transform(groups.pairNames.begin(), groups.pairNames.end(),
                    std::back_inserter(groupsAndPairs), &QString::fromStdString);
-    auto tmp = m_groupingHelper.parseGroupingTable().groupNames;
-    auto names = m_groupingHelper.parseGroupingTable().pairNames;
-    names.insert(std::end(names), std::begin(tmp), std::end(tmp));
-    QStringList GroupsAndPairsNames;
-    for (auto name : names) {
-      GroupsAndPairsNames << QString::fromStdString(name);
-    }
-    m_uiForm.fitBrowser->setAvailableGroups(GroupsAndPairsNames);
+	setGroupsAndPairs();
     m_uiForm.fitBrowser->setNumPeriods(m_numPeriods);
 
     // Set the selected run, group/pair and period

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1533,7 +1533,7 @@ void MuonAnalysis::updateFrontAndCombo(bool updateIndexAndPlot) {
   names.insert(std::end(names), std::begin(tmp), std::end(tmp));
   QStringList GroupsAndPairsNames;
   for (auto name : names) {
-	  GroupsAndPairsNames<<QString::fromStdString(name);
+    GroupsAndPairsNames << QString::fromStdString(name);
   }
   m_uiForm.fitBrowser->setAvailableGroups(GroupsAndPairsNames);
 
@@ -1892,13 +1892,13 @@ void MuonAnalysis::selectMultiPeak(const QString &wsName,
                    std::back_inserter(groupsAndPairs), &QString::fromStdString);
     std::transform(groups.pairNames.begin(), groups.pairNames.end(),
                    std::back_inserter(groupsAndPairs), &QString::fromStdString);
-	auto tmp = m_groupingHelper.parseGroupingTable().groupNames;
-	auto names = m_groupingHelper.parseGroupingTable().pairNames;
-	names.insert(std::end(names), std::begin(tmp), std::end(tmp)); 
-	QStringList GroupsAndPairsNames;
-	for (auto name : names) {
-		GroupsAndPairsNames<<QString::fromStdString(name);
-	}
+    auto tmp = m_groupingHelper.parseGroupingTable().groupNames;
+    auto names = m_groupingHelper.parseGroupingTable().pairNames;
+    names.insert(std::end(names), std::begin(tmp), std::end(tmp));
+    QStringList GroupsAndPairsNames;
+    for (auto name : names) {
+      GroupsAndPairsNames << QString::fromStdString(name);
+    }
     m_uiForm.fitBrowser->setAvailableGroups(GroupsAndPairsNames);
     m_uiForm.fitBrowser->setNumPeriods(m_numPeriods);
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1528,7 +1528,14 @@ void MuonAnalysis::updateFrontAndCombo(bool updateIndexAndPlot) {
   if (currentI >= m_uiForm.frontGroupGroupPairComboBox->count()) {
     currentI = 0;
   }
-  m_uiForm.fitBrowser->setAvailableGroups(groupsAndPairs);
+  auto tmp = m_groupingHelper.parseGroupingTable().groupNames;
+  auto names = m_groupingHelper.parseGroupingTable().pairNames;
+  names.insert(std::end(names), std::begin(tmp), std::end(tmp));
+  QStringList GroupsAndPairsNames;
+  for (auto name : names) {
+	  GroupsAndPairsNames<<QString::fromStdString(name);
+  }
+  m_uiForm.fitBrowser->setAvailableGroups(GroupsAndPairsNames);
 
   if (updateIndexAndPlot) {
     setGroupOrPairIndexToPlot(currentI);
@@ -1885,11 +1892,14 @@ void MuonAnalysis::selectMultiPeak(const QString &wsName,
                    std::back_inserter(groupsAndPairs), &QString::fromStdString);
     std::transform(groups.pairNames.begin(), groups.pairNames.end(),
                    std::back_inserter(groupsAndPairs), &QString::fromStdString);
-	auto naes = m_groupingHelper.parseGroupingTable().groupNames;
+	auto tmp = m_groupingHelper.parseGroupingTable().groupNames;
 	auto names = m_groupingHelper.parseGroupingTable().pairNames;
-
-
-    m_uiForm.fitBrowser->setAvailableGroups(groupsAndPairs);
+	names.insert(std::end(names), std::begin(tmp), std::end(tmp)); 
+	QStringList GroupsAndPairsNames;
+	for (auto name : names) {
+		GroupsAndPairsNames<<QString::fromStdString(name);
+	}
+    m_uiForm.fitBrowser->setAvailableGroups(GroupsAndPairsNames);
     m_uiForm.fitBrowser->setNumPeriods(m_numPeriods);
 
     // Set the selected run, group/pair and period
@@ -2550,8 +2560,6 @@ void MuonAnalysis::changeTab(int newTabIndex) {
       Muon::AnalysisOptions options(m_groupingHelper.parseGroupingTable());
 
 	  //use these to update the names of pairs/groups
-	  auto naes = m_groupingHelper.parseGroupingTable().groupNames;
-	  auto names = m_groupingHelper.parseGroupingTable().pairNames;
       m_uiForm.fitBrowser->setGroupNames(options.grouping.groupNames);
       auto isItGroup = m_dataLoader.isContainedIn(m_groupPairName,
                                                   options.grouping.groupNames);

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1885,6 +1885,10 @@ void MuonAnalysis::selectMultiPeak(const QString &wsName,
                    std::back_inserter(groupsAndPairs), &QString::fromStdString);
     std::transform(groups.pairNames.begin(), groups.pairNames.end(),
                    std::back_inserter(groupsAndPairs), &QString::fromStdString);
+	auto naes = m_groupingHelper.parseGroupingTable().groupNames;
+	auto names = m_groupingHelper.parseGroupingTable().pairNames;
+
+
     m_uiForm.fitBrowser->setAvailableGroups(groupsAndPairs);
     m_uiForm.fitBrowser->setNumPeriods(m_numPeriods);
 
@@ -2544,6 +2548,10 @@ void MuonAnalysis::changeTab(int newTabIndex) {
       m_uiForm.fitBrowser->setSingleFitLabel(m_currentDataName.toStdString());
     } else {
       Muon::AnalysisOptions options(m_groupingHelper.parseGroupingTable());
+
+	  //use these to update the names of pairs/groups
+	  auto naes = m_groupingHelper.parseGroupingTable().groupNames;
+	  auto names = m_groupingHelper.parseGroupingTable().pairNames;
       m_uiForm.fitBrowser->setGroupNames(options.grouping.groupNames);
       auto isItGroup = m_dataLoader.isContainedIn(m_groupPairName,
                                                   options.grouping.groupNames);

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -2558,8 +2558,6 @@ void MuonAnalysis::changeTab(int newTabIndex) {
       m_uiForm.fitBrowser->setSingleFitLabel(m_currentDataName.toStdString());
     } else {
       Muon::AnalysisOptions options(m_groupingHelper.parseGroupingTable());
-
-	  //use these to update the names of pairs/groups
       m_uiForm.fitBrowser->setGroupNames(options.grouping.groupNames);
       auto isItGroup = m_dataLoader.isContainedIn(m_groupPairName,
                                                   options.grouping.groupNames);

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -1028,15 +1028,13 @@ void MuonFitPropertyBrowser::setAvailableGroups(const QStringList &groups) {
   m_enumManager->setValue(m_groupsToFit, 0);
   // If it's the same list, do nothing
   if (groups.size() == m_groupBoxes.size()) {
-	  auto existingGroups = m_groupBoxes.keys();
-	  auto newGroups = groups;
-	  qSort(existingGroups);
-	  qSort(newGroups);
-	  if (existingGroups == newGroups) {
-		  return;
-		  
-	  }
-	  
+    auto existingGroups = m_groupBoxes.keys();
+    auto newGroups = groups;
+    qSort(existingGroups);
+    qSort(newGroups);
+    if (existingGroups == newGroups) {
+      return;
+    }
   }
   clearGroupCheckboxes();
   QSettings settings;
@@ -1428,11 +1426,11 @@ void MuonFitPropertyBrowser::setAllGroupsOrPairs(const bool isItGroup) {
   if (isItGroup) {
     // all groups is index 0
     m_enumManager->setValue(m_groupsToFit, 0);
-	setAllGroups();
+    setAllGroups();
   } else {
     // all pairs is index 1
     m_enumManager->setValue(m_groupsToFit, 1);
-	setAllPairs();
+    setAllPairs();
   }
 }
 void MuonFitPropertyBrowser::setGroupNames(

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -1027,19 +1027,10 @@ void MuonFitPropertyBrowser::setAvailableGroups(const QStringList &groups) {
 
   m_enumManager->setValue(m_groupsToFit, 0);
   // If it's the same list, do nothing
-  if (groups.size() == m_groupBoxes.size()) {
-    auto existingGroups = m_groupBoxes.keys();
-    auto newGroups = groups;
-    qSort(existingGroups);
-    qSort(newGroups);
-    if (existingGroups == newGroups) {
-      return;
-    }
-  }
-
   clearGroupCheckboxes();
   QSettings settings;
   for (const auto group : groups) {
+	  auto t = group.toStdString();
     addGroupCheckbox(group);
   }
 }

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -1027,10 +1027,20 @@ void MuonFitPropertyBrowser::setAvailableGroups(const QStringList &groups) {
 
   m_enumManager->setValue(m_groupsToFit, 0);
   // If it's the same list, do nothing
+  if (groups.size() == m_groupBoxes.size()) {
+	  auto existingGroups = m_groupBoxes.keys();
+	  auto newGroups = groups;
+	  qSort(existingGroups);
+	  qSort(newGroups);
+	  if (existingGroups == newGroups) {
+		  return;
+		  
+	  }
+	  
+  }
   clearGroupCheckboxes();
   QSettings settings;
   for (const auto group : groups) {
-	  auto t = group.toStdString();
     addGroupCheckbox(group);
   }
 }

--- a/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/MuonFitPropertyBrowser.cpp
@@ -1418,9 +1418,11 @@ void MuonFitPropertyBrowser::setAllGroupsOrPairs(const bool isItGroup) {
   if (isItGroup) {
     // all groups is index 0
     m_enumManager->setValue(m_groupsToFit, 0);
+	setAllGroups();
   } else {
     // all pairs is index 1
     m_enumManager->setValue(m_groupsToFit, 1);
+	setAllPairs();
   }
 }
 void MuonFitPropertyBrowser::setGroupNames(


### PR DESCRIPTION
In muon analysis the "all groups" selection in the multiple fitting did not select all of the groups when it initially loaded. Furthermore, the groups and pairs were found not to be passed correctly to the data analysis tab. This PR solves both problems. 

<!-- Instructions for testing. -->
1. Load some data into muon analysis. Make sure that a group is plotted.
2. Go to the Grouping Options tab
3. Add a group (including the detector numbers) and some pairs. 
4. Go to the settings tab and make sure multiple fitting is selected. 
5. Go to the data analysis tab. The selected groups should include all of the groups (and the ones added from step 3). 
6. Change the selection in Groups/Pairs to fit to all pairs. It should list all of the pairs (including the ones added in 3). 
7. Go back to the Grouping Options tab and add another pair. 
8. In the data analysis tab the new pair should show up when all pairs is selected. 


Fixes #19938 

**Release Notes** 
Not in the release notes as it was not reported by a user. 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
