### PR TITLE
Reference frame: scattering angle sign defining axis

### DIFF
--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -170,9 +170,9 @@ double DetectorInfo::signedTwoTheta(const size_t index) const {
     throw Kernel::Exception::InstrumentDefinitionError(
         "Source and sample are at same position!");
   }
-  // Get the instrument up axis.
+  // Get the axis defining the sign
   const auto &instrumentUpAxis =
-      m_instrument->getReferenceFrame()->vecPointingUp();
+      m_instrument->getReferenceFrame()->vecThetaSign();
 
   const auto sampleDetVec = position(index) - samplePos;
   double angle = sampleDetVec.angle(beamLine);
@@ -199,9 +199,9 @@ DetectorInfo::signedTwoTheta(const std::pair<size_t, size_t> &index) const {
     throw Kernel::Exception::InstrumentDefinitionError(
         "Source and sample are at same position!");
   }
-  // Get the instrument up axis.
+  // Get the axis defining the sign
   const auto &instrumentUpAxis =
-      m_instrument->getReferenceFrame()->vecPointingUp();
+      m_instrument->getReferenceFrame()->vecThetaSign();
 
   const auto sampleDetVec = position(index) - samplePos;
   double angle = sampleDetVec.angle(beamLine);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ReferenceFrame.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ReferenceFrame.h
@@ -46,6 +46,9 @@ public:
   /// Constructor
   ReferenceFrame(PointingAlong up, PointingAlong alongBeam,
                  Handedness handedness, std::string origin);
+  /// Alternative constructor with theta sign axis
+  ReferenceFrame(PointingAlong up, PointingAlong alongBeam, PointingAlong thetaSign,
+                 Handedness handedness, std::string origin);
   /// Gets the pointing up direction
   PointingAlong pointingUp() const;
   /// Gets the beam pointing along direction
@@ -63,6 +66,8 @@ public:
   const Mantid::Kernel::V3D vecPointingUp() const;
   /// Convert along beam axis into a 3D direction
   const Mantid::Kernel::V3D vecPointingAlongBeam() const;
+  /// Convert along the axis defining the 2theta sign
+  const Mantid::Kernel::V3D vecThetaSign() const;
   /// Pointing up axis as a string
   std::string pointingUpAxis() const;
   /// Pointing along beam axis as a string
@@ -81,6 +86,8 @@ private:
   PointingAlong m_up;
   /// Beam pointing along axis
   PointingAlong m_alongBeam;
+  /// Axis defining the 2theta sign
+  PointingAlong m_thetaSign;
   /// Handedness
   Handedness m_handedness;
   /// Origin
@@ -89,6 +96,8 @@ private:
   Mantid::Kernel::V3D m_vecPointingAlongBeam;
   /// Vector pointing up instrument
   Mantid::Kernel::V3D m_vecPointingUp;
+  /// Vector denoting the direction defining the 2theta sign
+  Mantid::Kernel::V3D m_vecThetaSign;
 };
 
 } // namespace Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ReferenceFrame.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ReferenceFrame.h
@@ -47,8 +47,9 @@ public:
   ReferenceFrame(PointingAlong up, PointingAlong alongBeam,
                  Handedness handedness, std::string origin);
   /// Alternative constructor with theta sign axis
-  ReferenceFrame(PointingAlong up, PointingAlong alongBeam, PointingAlong thetaSign,
-                 Handedness handedness, std::string origin);
+  ReferenceFrame(PointingAlong up, PointingAlong alongBeam,
+                 PointingAlong thetaSign, Handedness handedness,
+                 std::string origin);
   /// Gets the pointing up direction
   PointingAlong pointingUp() const;
   /// Gets the beam pointing along direction

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -958,7 +958,8 @@ void InstrumentDefinitionParser::readDefaults(Poco::XML::Element *defaults) {
     Element *handednessElement =
         referenceFrameElement->getChildElement("handedness");
     Element *originElement = referenceFrameElement->getChildElement("origin");
-    Element *thetaSignElement = referenceFrameElement->getChildElement("theta-sign");
+    Element *thetaSignElement =
+        referenceFrameElement->getChildElement("theta-sign");
 
     // Defaults
     XMLString s_alongBeam("z");
@@ -983,7 +984,7 @@ void InstrumentDefinitionParser::readDefaults(Poco::XML::Element *defaults) {
     // Extract theta sign axis if specified.
     XMLString s_thetaSign(s_pointingUp);
     if (thetaSignElement) {
-        s_thetaSign = thetaSignElement->getAttribute("axis");
+      s_thetaSign = thetaSignElement->getAttribute("axis");
     }
 
     // Convert to input types

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -958,6 +958,7 @@ void InstrumentDefinitionParser::readDefaults(Poco::XML::Element *defaults) {
     Element *handednessElement =
         referenceFrameElement->getChildElement("handedness");
     Element *originElement = referenceFrameElement->getChildElement("origin");
+    Element *thetaSignElement = referenceFrameElement->getChildElement("theta-sign");
 
     // Defaults
     XMLString s_alongBeam("z");
@@ -979,14 +980,21 @@ void InstrumentDefinitionParser::readDefaults(Poco::XML::Element *defaults) {
       s_origin = originElement->getAttribute("val");
     }
 
+    // Extract theta sign axis if specified.
+    XMLString s_thetaSign(s_pointingUp);
+    if (thetaSignElement) {
+        s_thetaSign = thetaSignElement->getAttribute("axis");
+    }
+
     // Convert to input types
     PointingAlong alongBeam = axisNameToAxisType(s_alongBeam);
     PointingAlong pointingUp = axisNameToAxisType(s_pointingUp);
+    PointingAlong thetaSign = axisNameToAxisType(s_thetaSign);
     Handedness handedness = s_handedness == "right" ? Right : Left;
 
     // Overwrite the default reference frame.
     m_instrument->setReferenceFrame(boost::make_shared<ReferenceFrame>(
-        pointingUp, alongBeam, handedness, s_origin));
+        pointingUp, alongBeam, thetaSign, handedness, s_origin));
   }
 }
 

--- a/Framework/Geometry/src/Instrument/ReferenceFrame.cpp
+++ b/Framework/Geometry/src/Instrument/ReferenceFrame.cpp
@@ -15,11 +15,35 @@ namespace Geometry {
 */
 ReferenceFrame::ReferenceFrame(PointingAlong up, PointingAlong alongBeam,
                                Handedness handedness, std::string origin)
-    : m_up(up), m_alongBeam(alongBeam), m_handedness(handedness),
-      m_origin(origin) {
+    : m_up(up), m_alongBeam(alongBeam), m_thetaSign(up),
+      m_handedness(handedness), m_origin(origin) {
   if (up == alongBeam) {
     throw std::invalid_argument(
         "Cannot have up direction the same as the beam direction");
+  }
+  init();
+}
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+@param up : pointing up axis
+@param alongBeam : axis pointing along the beam
+@param thetaSign : axis defining the sign of 2theta
+@param handedness : Handedness
+@param origin : origin
+*/
+ReferenceFrame::ReferenceFrame(PointingAlong up, PointingAlong alongBeam,
+                               PointingAlong thetaSign, Handedness handedness,
+                               std::string origin)
+    : m_up(up), m_alongBeam(alongBeam), m_thetaSign(thetaSign),
+      m_handedness(handedness), m_origin(origin) {
+  if (up == alongBeam) {
+    throw std::invalid_argument(
+        "Cannot have up direction the same as the beam direction");
+  }
+  if (thetaSign == alongBeam) {
+    throw std::invalid_argument(
+        "Scattering angle sign axis cannot be the same as the beam direction");
   }
   init();
 }
@@ -72,6 +96,7 @@ std::string directionToString(const PointingAlong &direction) {
 void ReferenceFrame::init() {
   m_vecPointingUp = directionToVector(m_up);
   m_vecPointingAlongBeam = directionToVector(m_alongBeam);
+  m_vecThetaSign = directionToVector(m_thetaSign);
 }
 
 /**
@@ -148,6 +173,12 @@ Getter for the up instrument direction
 @return up direction.
 */
 const V3D ReferenceFrame::vecPointingUp() const { return m_vecPointingUp; }
+
+/**
+Getter for the direction defining the theta sign
+@return theta sign direction.
+*/
+const V3D ReferenceFrame::vecThetaSign() const { return m_vecThetaSign; }
 
 /**
 Getter for the along beam vector.

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -148,6 +148,24 @@ public:
     TS_ASSERT(frame->origin().empty());
   }
 
+  void test_extract_ref_info_theta_sign() {
+    std::string filename = ConfigService::Instance().getInstrumentDirectory() +
+                           "/IDFs_for_UNIT_TESTING/IDF_for_UNIT_TESTING6.xml";
+    std::string xmlText = Strings::loadFile(filename);
+    boost::shared_ptr<const Instrument> i;
+
+    // Parse the XML
+    InstrumentDefinitionParser parser(filename, "For Unit Testing", xmlText);
+    TS_ASSERT_THROWS_NOTHING(i = parser.parseXML(NULL););
+
+    // Extract the reference frame object
+    boost::shared_ptr<const ReferenceFrame> frame = i->getReferenceFrame();
+
+    // Test that values have been populated with expected values (those from
+    // file).
+    TS_ASSERT_EQUALS(V3D(1., 0., 0.), frame->vecThetaSign());
+  }
+
   void
   test_parse_IDF_for_unit_testing() // IDF stands for Instrument Definition File
   {

--- a/Framework/Geometry/test/ReferenceFrameTest.h
+++ b/Framework/Geometry/test/ReferenceFrameTest.h
@@ -140,6 +140,35 @@ public:
     TS_ASSERT_EQUALS(1, z_vec[2]);
   }
 
+  void testGetThetaSignAxisVector() {
+    // Default constructor, theta-sign axis is the same as up
+    ReferenceFrame y(Y, X, Right, "source");
+    V3D y_vec = y.vecThetaSign();
+    TS_ASSERT_EQUALS(0, y_vec[0]);
+    TS_ASSERT_EQUALS(1, y_vec[1]);
+    TS_ASSERT_EQUALS(0, y_vec[2]);
+
+    // Again up but with explicit constructor
+    ReferenceFrame y2(Y, X, Y, Right, "source");
+    V3D y_vec2 = y2.vecThetaSign();
+    TS_ASSERT_EQUALS(0, y_vec2[0]);
+    TS_ASSERT_EQUALS(1, y_vec2[1]);
+    TS_ASSERT_EQUALS(0, y_vec2[2]);
+
+    // Theta sign is the third axis
+    ReferenceFrame x(Y, Z, X, Right, "source");
+    V3D x_vec = x.vecThetaSign();
+    TS_ASSERT_EQUALS(1, x_vec[0]);
+    TS_ASSERT_EQUALS(0, x_vec[1]);
+    TS_ASSERT_EQUALS(0, x_vec[2]);
+
+    // Error if theta sign is along the beam
+    TS_ASSERT_THROWS_EQUALS(
+        ReferenceFrame z(Y, Z, Z, Right, "source"),
+        const std::invalid_argument &e, std::string(e.what()),
+        "Scattering angle sign axis cannot be the same as the beam direction");
+  }
+
   void testAxisLabelReturns() {
     ReferenceFrame x(Y, X, Right, "source");
     TS_ASSERT_EQUALS("Y", x.pointingUpAxis());

--- a/docs/source/concepts/InstrumentDefinitionFile.rst
+++ b/docs/source/concepts/InstrumentDefinitionFile.rst
@@ -320,7 +320,7 @@ example of specifying a Source and SamplePos is shown below
 
 
 Using detector/monitor IDs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Any component that is either a detector or monitor must be assigned a
 unique detector/monitor ID numbers (note this is *not* spectrum
@@ -1405,6 +1405,8 @@ this component relative to its parent component.
 Reference frame in which instrument is described. The author/reader of
 an IDF can chose the reference coordinate system in which the instrument
 is described. The default reference system is the one shown below.
+The direction here means the direction of the beam if it was not
+modified by any mirrors etc.
 
 .. code-block:: xml
 
@@ -1419,8 +1421,16 @@ is described. The default reference system is the one shown below.
 
 This reference frame is e.g. used when a signed theta detector values
 are calculated where it is needed to know which direction is defined as
-up. The direction here means the direction of the beam if it was not
-modified by any mirrors etc.
+up. By default, the axis defining the sign of the scattering angle is the one pointing up.
+Optionally this can be customized by inserting the following line into the reference-frame node:
+
+.. code-block:: xml
+
+      <theta-sign axis="x"/>
+
+In this case, negative x will correspond to negative theta.
+Note that both the pointing-up and theta-sign axes cannot be the same as the along-beam axis.
+
 
 .. _default-view:
 

--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -5,6 +5,10 @@ Framework Changes
 .. contents:: Table of Contents
    :local:
 
+Concepts
+--------
+- The reference frame in :ref:`IDF <InstrumentDefinitionFile>` can now be customized in terms of setting the axis defining the 2theta sign.
+
 Algorithms
 ----------
 

--- a/instrument/D20_Definition.xml
+++ b/instrument/D20_Definition.xml
@@ -14,7 +14,7 @@ valid-to="2100-01-31 23:59:59" last-modified="2017-02-27 17:20:42">
       <along-beam axis="z" />
       <pointing-up axis="y" />
       <handedness val="right" />
-      <theta-sign axis="x"/>
+      <theta-sign axis="x" />
     </reference-frame>
   </defaults>
   <!-- Source position -->

--- a/instrument/D20_Definition.xml
+++ b/instrument/D20_Definition.xml
@@ -14,6 +14,7 @@ valid-to="2100-01-31 23:59:59" last-modified="2017-02-27 17:20:42">
       <along-beam axis="z" />
       <pointing-up axis="y" />
       <handedness val="right" />
+      <theta-sign axis="x"/>
     </reference-frame>
   </defaults>
   <!-- Source position -->

--- a/instrument/D20_hr_Definition.xml
+++ b/instrument/D20_hr_Definition.xml
@@ -14,6 +14,7 @@ valid-to="2100-01-31 23:59:59" last-modified="2017-02-27 17:19:28">
       <along-beam axis="z" />
       <pointing-up axis="y" />
       <handedness val="right" />
+      <theta-sign axis="x" />
     </reference-frame>
   </defaults>
   <!-- Source position -->

--- a/instrument/D20_lr_Definition.xml
+++ b/instrument/D20_lr_Definition.xml
@@ -14,6 +14,7 @@ valid-to="2100-01-31 23:59:59" last-modified="2017-02-27 17:21:05">
       <along-beam axis="z" />
       <pointing-up axis="y" />
       <handedness val="right" />
+      <theta-sign axis="x" />
     </reference-frame>
   </defaults>
   <!-- Source position -->

--- a/instrument/D4C_Definition.xml
+++ b/instrument/D4C_Definition.xml
@@ -14,6 +14,7 @@ valid-to="2100-01-31 23:59:59" last-modified="2017-02-27 17:13:17">
       <along-beam axis="z" />
       <pointing-up axis="y" />
       <handedness val="right" />
+      <theta-sign axis="x" />
     </reference-frame>
   </defaults>
   <!-- Source position -->

--- a/instrument/D4C_hr_Definition.xml
+++ b/instrument/D4C_hr_Definition.xml
@@ -14,6 +14,7 @@ valid-to="2100-01-31 23:59:59" last-modified="2017-02-27 17:13:51">
       <along-beam axis="z" />
       <pointing-up axis="y" />
       <handedness val="right" />
+      <theta-sign axis="x" />
     </reference-frame>
   </defaults>
   <!-- Source position -->

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -639,7 +639,7 @@
     <technique>Powder diffraction</technique>
   </instrument>
 
-  <instrument name="D4">
+  <instrument name="D4C">
     <technique>Liquid diffraction</technique>
   </instrument>
 

--- a/instrument/IDFs_for_UNIT_TESTING/IDF_for_UNIT_TESTING6.xml
+++ b/instrument/IDFs_for_UNIT_TESTING/IDF_for_UNIT_TESTING6.xml
@@ -1,0 +1,402 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<instrument name="For Unit Testing" valid-from   ="1900-01-31 23:59:59"
+                                         valid-to     ="2100-01-31 23:59:59"
+                                         last-modified="Hello!">
+
+  <defaults>
+    <length unit="meter"/>
+    <angle unit="degree"/>
+    <location x="0.0" y="0.0" z="0.0" ang="0.0" axis-x="0.0" axis-y="0.0" axis-z="1.0"/>
+    <reference-frame>
+      <!-- The z-axis is set parallel to and in the direction of the beam. the 
+           y-axis points up and the coordinate system is right handed. -->
+      <along-beam axis="z"/>
+      <pointing-up axis="y"/>
+      <handedness val="right"/>
+      <theta-sign axis="x"/>
+    </reference-frame>
+    <!-- Comment 'components-are-facing' out if you don't want the
+    components defined in this file to face a position by default -->
+    <components-are-facing x="0.0" y="0.0" z="0.0" />    
+  </defaults>
+
+
+  <!-- LIST OF PHYSICAL COMPONENTS (which the instrument consists of) -->
+
+  <!-- detector components -->
+
+<component type="cylinder-right" idlist="cylinder-right">
+  <location x="0.0" y="10.0" z="0.0" />
+</component>
+
+<component type="cylinder-left" idlist="cylinder-left">
+  <location x="0.0" y="-10.0" z="0.0" />
+</component>
+
+<component type="cylinder-above" idlist="cylinder-above">
+  <location x="0.0" y="0.0" z="10.0" />
+</component>
+
+<component type="cylinder-below" idlist="cylinder-below">
+  <location x="0.0" y="0.0" z="-10.0" />
+</component>
+
+<component type="cylinder-below" idlist="cylinder-further-below">
+  <location x="0.0" y="0.0" z="-100.0"> <facing x="1.0" z="-100.0"/> </location>
+</component>
+
+<component type="infinite-cone-test" idlist="infinite-cone-test">
+  <location x="0.0" y="0.0" z="-200.0"> <facing val="none"/> </location>
+</component>
+
+<component type="cone-test" idlist="cone-test">
+  <location x="0.0" y="0.0" z="-200.0"> <facing val="none"/> </location>
+</component>
+
+<component type="hexahedron-test" idlist="hexahedron-test">
+  <location x="0.0" y="0.0" z="100.0"> <facing val="none"/> </location>
+</component>
+
+<component type="tapered-guide-test" idlist="tapered-guide-test">
+  <location x="0.0" y="0.0" z="100.0"> <facing val="none"/> </location>
+</component>
+
+<component type="cuboid-rotating-test" idlist="cuboid-rotating-test">
+  <location x="0.0" y="100.0" z="0.0"> </location>
+  <location x="0.0" y="200.0" z="0.0">  <facing rot="45"/> </location> 
+</component>
+
+<component type="cuboid-rotating-test" idlist="cuboid-rotating-test2">
+  <location x="0.0" y="200.0" z="0.0">  </location>
+  <location x="0.0" y="200.0" z="0.0" rot="45"> </location>  
+</component>
+
+<component type="cuboid-alternate-test" idlist="cuboid-alternate-test">
+  <location x="0.0" y="0.0" z="0.0">  </location>
+</component>
+  
+<component type="infinite-cylinder-test" idlist="infinite-cylinder-test">
+  <location x="0.0" y="0.0" z="0.0"> <facing val="none"/> </location>
+</component>
+
+<component type="finite-cylinder-test" idlist="finite-cylinder-test">
+  <location x="0.0" y="0.0" z="0.0"> <facing val="none"/> </location>
+</component>
+
+<component type="complement-test" idlist="complement-test">
+  <location x="0.0" y="0.0" z="0.0"> <facing val="none"/> </location>
+</component>
+
+<component type="rotation-of-element-test" idlist="rotation-of-element-test">
+  <location x="0.0" y="0.0" z="0.0" rot="90"> <facing val="none"/> </location>
+  <location x="0.0" y="0.0" z="0.0" rot="90" axis-x="1" axis-y="0" axis-z="0"> <facing val="none"/> </location>
+  <location x="0.0" y="0.0" z="0.0"> <facing val="none"/> </location>
+</component>
+
+<component type="cylinder-right" idlist="tests locations tag">
+  <locations x="0.0" y="0.0" z="0.0" z-end="1.0" n-elements="10" rot="90"/> 
+  <locations y="-1.0" y-end="1.0" n-elements="10" name="tube"/>  
+  <locations y="-1.0" y-end="1.0" n-elements="10" name="tube" name-count-start="1"/>  
+</component>
+
+<component type="locations nested test" idlist="tests locations tag 2">
+  <location /> 
+</component>
+
+<type name="locations nested test">
+  <component type="cylinder-right">
+    <locations x="0.0" y="0.0" z="0.0" y-end="1.0" n-elements="10"/>
+  </component>
+</type>
+
+
+  <!-- source and sample-position components -->
+
+  <component type="undulator">
+    <location z="-17.0"> <facing val="none"/> </location>
+  </component>
+
+  <component type="nickel-holder">
+    <location> <facing val="none"/> </location>
+  </component>
+
+
+  <!-- DEFINITION OF TYPES -->
+
+  <!-- Source types -->
+
+  <type name="undulator" is="Source">
+    <properties />
+    
+    <cylinder id="some-shape">
+      <centre-of-bottom-base r="0.0" t="0.0" p="0.0" />
+      <axis x="0.0" y="0.0" z="1.0" /> 
+      <radius val="0.01" />
+      <height val="0.03" />
+    </cylinder>
+    <sphere id="some-shape2">
+      <centre x="0.0"  y="0.0" z="0.0" />
+      <radius val="0.01" />
+    </sphere>     
+    <algebra val="some-shape some-shape2" />  <!-- intersection example -->
+  </type>    
+  
+  <!-- Sample-position types -->
+
+  <type name="nickel-holder" is="SamplePos">
+    <properties />
+    
+    <sphere id="some-shape1">
+      <centre x="0.0"  y="0.0" z="0.0" />
+      <radius val="0.03" />
+    </sphere>
+    <sphere id="some-shape2">
+      <centre x="10.0"  y="0.0" z="0.0" />
+      <radius val="0.03" />
+    </sphere>    
+    <algebra val="some-shape1 : some-shape2" />  <!-- union example -->
+  </type>
+
+  <!-- Detectors types -->
+
+  <type name="cylinder-right" is="detector">
+    <properties />
+
+    <cylinder id="some-shape">
+      <centre-of-bottom-base r="0.0" t="0.0" p="0.0" />
+      <axis x="0.0" y="0.0" z="1.0" /> 
+      <radius val="0.01" />
+      <height val="0.03" />
+    </cylinder> 
+    <algebra val="some-shape" />    
+    
+  </type>
+
+  <type name="cylinder-left" is="detector">
+  <properties />
+
+    <cylinder id="some-shape">
+      <centre-of-bottom-base r="0.0" t="0.0" p="0.0" />
+      <axis x="0.0" y="0.0" z="1.0" /> 
+      <radius val="0.01" />
+      <height val="0.03" />
+    </cylinder> 
+    <algebra val="some-shape" />  
+  
+  </type>
+
+  <type name="cylinder-above" is="detector">
+    <properties />
+
+    <cylinder id="some-shape">
+      <centre-of-bottom-base r="0.0" t="0.0" p="0.0" />
+      <axis x="0.0" y="0.0" z="1.0" /> 
+      <radius val="0.01" />
+      <height val="0.03" />
+    </cylinder> 
+    <algebra val="some-shape" />    
+    
+  </type>
+
+  <type name="cylinder-below" is="detector">
+  <properties />
+
+    <cylinder id="some-shape">
+      <centre-of-bottom-base r="0.0" t="0.0" p="0.0" />
+      <axis x="0.0" y="0.0" z="1.0" /> 
+      <radius val="0.01" />
+      <height val="0.03" />
+    </cylinder> 
+    <algebra val="some-shape" />  
+  
+  </type>
+  
+  <type name="infinite-cone-test" is="detector">
+    <infinite-cone id="some-shape">
+      <tip-point x="0.0" y="0.0" z="0" />
+      <axis x="0.0" y="0.0" z="1.0" />
+      <angle val="1.0" />
+    </infinite-cone>
+    <algebra val="some-shape" />  
+  </type> 
+
+  <type name="cone-test" is="detector">
+    <cone id="some-shape">
+      <tip-point x="0.0" y="0.0" z="0" />
+      <axis x="0.0" y="0.0" z="1.0" />
+      <angle val="1.0" />
+      <height val="1.0" />
+    </cone>
+    <algebra val="some-shape" />  
+  </type>   
+  
+  <type name="hexahedron-test" is="detector">
+    <hexahedron id="some-shape">
+      <left-back-bottom-point  x="0.0" y="0.0" z="0.0"  />
+      <left-front-bottom-point x="1.0" y="0.0" z="0.0"  />
+      <right-front-bottom-point x="1.0" y="1.0" z="0.0"  />
+      <right-back-bottom-point  x="0.0" y="1.0" z="0.0"  />
+      <left-back-top-point  x="0.0" y="0.0" z="2.0"  />
+      <left-front-top-point  x="0.5" y="0.0" z="2.0"  />
+      <right-front-top-point  x="0.5" y="0.5" z="2.0"  />
+      <right-back-top-point  x="0.0" y="0.5" z="2.0"  />
+    </hexahedron>
+    <algebra val="some-shape" />  
+  </type>    
+  
+  <type name="tapered-guide-test" is="detector">
+    <tapered-guide id="some-shape">
+      <aperture-start height="2.0" width="2.0" />
+      <length val="2.0" />
+      <aperture-end height="4.0" width="4.0" />
+      <centre x="0.0" y="0.0" z="-1.0" />
+      <axis x="0.0" y="0.0" z="1" />
+    </tapered-guide>
+    <algebra val="some-shape" />
+  </type>
+  
+  <type name="cuboid-rotating-test" is="detector">
+    <cuboid id="approximate-shape">
+      <left-front-bottom-point x="0.0025" y="-0.1" z="0.0"  />
+      <left-front-top-point  x="0.0025" y="-0.1" z="0.02"  />
+      <left-back-bottom-point  x="-0.0025" y="-0.1" z="0.0"  />
+      <right-front-bottom-point  x="0.0025" y="0.1" z="0.0"  />
+    </cuboid>
+    <algebra val="approximate-shape" /> 
+  </type>    
+
+  <type name="cuboid-alternate-test" is="detector">
+    <cuboid id="some-shape">
+      <height val="0.2" />
+      <width val="0.1" />
+      <depth val="0.4" />
+      <centre x="1.0" y="1.0" z="1.0" />
+      <axis x="0" y="0" z="1" />
+    </cuboid>
+    <algebra val="some-shape" />
+  </type> 
+  
+  <type name="infinite-cylinder-test" is="detector">
+    <infinite-cylinder id="some-shape">
+      <centre x="0.0" y="0.0" z="0.0" />
+      <axis x="0.0" y="0.0" z="1.0" /> 
+      <radius val="1.0" />
+    </infinite-cylinder> 
+    <algebra val="some-shape" /> 
+  </type>   
+
+  <type name="finite-cylinder-test" is="detector">
+    <cylinder id="some-shape">
+      <centre-of-bottom-base x="0.0" y="0.0" z="0.0" />
+      <axis x="0.0" y="0.0" z="1.0" /> 
+      <radius val="1.0" />
+      <height val="5.0" />
+    </cylinder> 
+    <algebra val="some-shape" />
+  </type>    
+  
+  <type name="complement-test" is="detector">    
+    <cylinder id="stick">
+      <centre-of-bottom-base x="-0.5" y="0.0" z="0.0" />
+      <axis x="1.0" y="0.0" z="0.0" /> 
+      <radius val="0.05" />
+      <height val="1.0" />
+    </cylinder>
+    <sphere id="some-sphere">
+      <centre x="0.0"  y="0.0" z="0.0" />
+      <radius val="0.5" />
+    </sphere>     
+    <algebra val="some-sphere # stick" />  <!-- complement example -->    
+  </type>  
+  
+  <type name="rotation-of-element-test" is="detector">
+    <cuboid id="some-shape">
+      <left-front-bottom-point x="0.0025" y="-0.1" z="0.0"  />
+      <left-front-top-point  x="0.0025" y="-0.1" z="0.02"  />
+      <left-back-bottom-point  x="-0.0025" y="-0.1" z="0.0"  />
+      <right-front-bottom-point  x="0.0025" y="0.1" z="0.0"  />
+    </cuboid>
+    <algebra val="some-shape" />
+  </type>      
+  
+  
+  
+
+  <!-- DETECTOR ID LISTS -->
+  
+  <idlist idname="cylinder-right">
+    <id start="1" end="1" />
+    <!-- <id val="1" />  -->
+  </idlist>
+  
+  <idlist idname="cylinder-left">
+    <id start="2" end="2" />
+    <!-- <id val="2" />  -->
+  </idlist>
+  
+  <idlist idname="cylinder-above">
+    <id val="3" />
+  </idlist>
+  
+  <idlist idname="cylinder-below">
+    <id start="4" end="4" />
+  </idlist>
+  
+  <idlist idname="cylinder-further-below">
+    <id val="5" />
+  </idlist>    
+  
+  <idlist idname="infinite-cone-test">
+    <id val="6" />
+  </idlist>     
+  
+  <idlist idname="cone-test">
+    <id val="7" />
+  </idlist>    
+  
+  <idlist idname="hexahedron-test">
+    <id val="8" />
+  </idlist> 
+  
+  <idlist idname="tapered-guide-test">
+    <id val="9" />
+  </idlist> 
+  
+  <idlist idname="cuboid-rotating-test">
+    <id start="10" end="11" />
+  </idlist>    
+
+  <idlist idname="cuboid-rotating-test2">
+    <id start="1000" end="1001" />
+  </idlist>  
+
+  <idlist idname="cuboid-alternate-test">
+    <id val="18" />
+  </idlist>
+  
+  <idlist idname="infinite-cylinder-test">
+    <id val="12" />
+  </idlist> 
+  
+  <idlist idname="finite-cylinder-test">
+    <id val="13" />
+  </idlist>   
+  
+  <idlist idname="complement-test">
+    <id val="14" />
+  </idlist>   
+  
+  <idlist idname="rotation-of-element-test">
+    <id start="15" end="17" />
+  </idlist>   
+  
+  <idlist idname="tests locations tag">
+    <id start="100" end="109" />
+    <id start="110" end="119" /> 
+    <id start="120" end="129" />    
+  </idlist>  
+  
+  <idlist idname="tests locations tag 2">
+    <id start="200" end="209" />
+  </idlist>  
+</instrument>

--- a/instrument/Schema/IDF/1.0/IDFSchema.xsd
+++ b/instrument/Schema/IDF/1.0/IDFSchema.xsd
@@ -390,7 +390,11 @@
                     <xs:element name="handedness">
                       <xs:complexType>
                         <xs:attribute name="val"/>
-                        <!--<xs:attribute name="axis" />-->
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element name="theta-sign">
+                      <xs:complexType>
+                        <xs:attribute name="axis"/>
                       </xs:complexType>
                     </xs:element>
                   </xs:choice>


### PR DESCRIPTION
This PR adds a possibility in the IDF to set the axis defining the 2theta sign.
Until now, 2theta sign was the sign of the coordinate on the axis pointing up.
I. e. normally the pointing up axis is y, so negative y would mean negative 2theta.
For D20 at ILL, negative x should mean negative 2theta.
This adds the possibility to customise the desired behaviour, without altering the previous default one.

Merge the corresponding amend in geometry [PR #96](https://github.com/mantidproject/mantidgeometry/pull/96)

**To test:**

<!-- Instructions for testing. -->
0. Code review & tests pass.
1. Load `ILL/D20/967100.nxs` from unit tests.
2. ConvertSpectrumAxis to signed_theta (in Direct mode, leave EFixed blank).
3. Resulting spectrum axis should span from about -6 to 147 degrees.

Fixes #19963 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
