### PR TITLE
OS X support for high DPI screens

### DIFF
--- a/docs/source/release/v3.11.0/ui.rst
+++ b/docs/source/release/v3.11.0/ui.rst
@@ -14,6 +14,8 @@ Windows
 OS X
 ####
 
+- MantidPlot will now support smart scaling on high DPI (4K) screens on OS X.
+
 User Interface
 --------------
 

--- a/installers/MacInstaller/Info.plist.in
+++ b/installers/MacInstaller/Info.plist.in
@@ -32,5 +32,9 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2011 ISIS Rutherford Appleton Laboratory and NScD Oak Ridge National Laboratory</string>
+	<key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHighResolutionCapable</key>
+    <string>True</string>
 </dict>
 </plist>

--- a/installers/MacInstaller/Info.plist.in
+++ b/installers/MacInstaller/Info.plist.in
@@ -33,8 +33,8 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2011 ISIS Rutherford Appleton Laboratory and NScD Oak Ridge National Laboratory</string>
 	<key>NSPrincipalClass</key>
-    <string>NSApplication</string>
-    <key>NSHighResolutionCapable</key>
-    <string>True</string>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
 </dict>
 </plist>


### PR DESCRIPTION
MantidPlot showed up blur on 4K screens with OS X. This fixes the scaling.

**To test:**
You have to be on 4K screen with OS X.

Install OS X packages built with and without this change. 
Open MantidPlot and compare the graphics and especially the texts.
Optionally go through several interfaces/viewers and see if there is nothing dramatically off.

<!-- Instructions for testing. -->

No issue.

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.