### PR TITLE
Fixed off-by-one access and lost memory in TimeSeriesProperty

### DIFF
--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -614,43 +614,49 @@ void TimeSeriesProperty<TYPE>::splitByTimeVector(
                   << "Time index = " << index_tsp_time << "\n\n";
 
     bool continue_add = true;
+    const size_t tspTimeVecSize = tsp_time_vec.size();
     while (continue_add) {
+      if (index_tsp_time == tspTimeVecSize) {
+        // last entry. quit all loops
+        continue_add = false;
+        continue_search = false;
+        break;
+      }
+
       // add current entry
       g_log.debug() << "Add entry " << index_tsp_time << " to target " << target
                     << "\n";
       if (outputs[target]->size() == 0 ||
-          outputs[target]->lastTime() < tsp_time) {
+          outputs[target]->lastTime() < tsp_time_vec[index_tsp_time]) {
         // avoid to add duplicate entry
         outputs[target]->addValue(m_values[index_tsp_time].time(),
                                   m_values[index_tsp_time].value());
       }
 
-      // advance to next entry
-      ++index_tsp_time;
-
       g_log.debug() << "\tEntry time " << tsp_time_vec[index_tsp_time]
                     << ", stop time " << split_stop_time << "\n";
 
-      if (index_tsp_time == tsp_time_vec.size()) {
-        // last entry. quit all loops
-        continue_add = false;
-        continue_search = false;
-      } else if (tsp_time_vec[index_tsp_time] > split_stop_time) {
-        // next entry is out of this splitter: add the next one and quit
-        if (outputs[target]->lastTime() < m_values[index_tsp_time].time()) {
-          // avoid the duplicate cases occured in fast frequency issue
-          outputs[target]->addValue(m_values[index_tsp_time].time(),
-                                    m_values[index_tsp_time].value());
+      const size_t nextTspIndex = index_tsp_time + 1;
+      if (nextTspIndex < tspTimeVecSize) {
+        if (tsp_time_vec[nextTspIndex] > split_stop_time) {
+          // next entry is out of this splitter: add the next one and quit
+          if (outputs[target]->lastTime() < m_values[nextTspIndex].time()) {
+            // avoid the duplicate cases occurred in fast frequency issue
+            outputs[target]->addValue(m_values[nextTspIndex].time(),
+                                      m_values[nextTspIndex].value());
+          }
+          // FIXME - in future, need to find out WHETHER there is way to
+          // skip the
+          // rest without going through the whole sequence
+          continue_add = false;
+          // reset time entry as the next splitter will add
+          // --index_tsp_time;
         }
-        // FIXME - in future, need to find out WHETHER there is way to skip the
-        // rest without going through the whole sequence
-        continue_add = false;
-        // reset time entry as the next splitter will add
-        // --index_tsp_time;
-      } else {
-        // advance to next time
-        tsp_time = tsp_time_vec[index_tsp_time];
       }
+
+      // advance to next entry
+      ++index_tsp_time;
+
     } // END-WHILE continue add
 
     // make splitters to advance to next

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -786,7 +786,9 @@ public:
       TS_ASSERT_EQUALS(out_3->nthValue(j), j + 4);
     }
 
-    return;
+    for (auto outputPtr : outputs) {
+      delete outputPtr;
+    }
   }
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
Description of work.
As part of the issue fixing various issues from Valgrind in Kernel I picked up on a off-by-one error in TimeSeriesProperty.

If the `nextTspIndex` fell outside of the bounds of the vector (e.g. we are parsing right up to the last entry) we would read the value still. This went unnoticed as we would then go on to discard the incorrect value instead of using it.
By rearranging the loop slightly we can avoid the off by one access whilst still retaining existing behaviour.

There is also a fix for a memory leak in the unit test. Unfortunately because of the interface it is non-trivial to switch to using `unique_ptr` instead of a bare new / delete

**To test:**
Code review
Ensure unit tests pass

Part of #19893 . (Other PR is here: #19981 )

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
