### PR TITLE
Allow one-level tree without post processing

### DIFF
--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -487,8 +487,10 @@ Post-processes the workspaces created by the given rows together.
 void GenericDataProcessorPresenter::postProcessGroup(
     const GroupData &groupData) {
 
-  // If no post processing has been defined, then we are dealing with a one-level tree
-  // where all rows are in one group. We don't want to perform post-processing in
+  // If no post processing has been defined, then we are dealing with a
+  // one-level tree
+  // where all rows are in one group. We don't want to perform post-processing
+  // in
   // this case.
   if (!m_postprocess)
     return;

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -487,8 +487,11 @@ Post-processes the workspaces created by the given rows together.
 void GenericDataProcessorPresenter::postProcessGroup(
     const GroupData &groupData) {
 
+  // If no post processing has been defined, then we are dealing with a one-level tree
+  // where all rows are in one group. We don't want to perform post-processing in
+  // this case.
   if (!m_postprocess)
-    throw std::runtime_error("Cannot post-process workspaces");
+    return;
 
   // The input workspace names
   std::vector<std::string> inputNames;


### PR DESCRIPTION
Fixes #19960

At the moment if you don't specify a post-processing algorithm in the DataProcessorWidget, you get an error if you have more than two rows.

**To test:**

To prepare:
1. In `Mantid.properties.template` add to the line `mantidqt.python_interfaces = ...` the entry `Utility/DataProcessorInterface.py`. This will register the sample GUI in MantidPlot

2. Remove post processing from the sample GUI: In `data_processor_gui.py` comment out `        #post_alg = MantidQt.MantidWidgets.DataProcessorPostprocessingAlgorithm('Stitch1DMany', 'IvsQ_', 'InputWorkspaces, OutputWorkspaces')` and remove the variable `post_alg` from the `QDataProcessorWidget` constructor. 

1. Open Mantid and select Interfaces>Utility>DataProcessorInterface
2. Select POLREF as the instrument
3. Add two rows where the `Run(s)` entry is set to `14884` for both rows.
4. Press `Process`
   * Confirm that an it finishes and no exception is thrown. 

**Release notes:**
Does not have to be in the release notes. Is not user facing yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
