### PR TITLE
updated the amplitude in GausOsc

### DIFF
--- a/Framework/CurveFitting/src/Functions/GausOsc.cpp
+++ b/Framework/CurveFitting/src/Functions/GausOsc.cpp
@@ -18,7 +18,7 @@ using namespace API;
 DECLARE_FUNCTION(GausOsc)
 
 void GausOsc::init() {
-  declareParameter("A", 10.0, "Amplitude at time 0");
+  declareParameter("A", 0.20, "Amplitude at time 0");
   declareParameter("Sigma", 0.2, "Decay rate");
   declareParameter("Frequency", 0.1, "Frequency of oscillation");
   declareParameter("Phi", 0.0, "Frequency of oscillation");

--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -320,9 +320,9 @@ public:
       e[i] = 1.0;
     }
     const double sqrh = 0.70710678; // cos( 45 degrees )
-    y = {1.e-4 * sqrh,  0.00,  -1.2e-2 * sqrh,  -5.6e-2, -18.2e-2 * sqrh,  0.0,
-         0.8008 * sqrh, 1.144, 1.287 * sqrh, 0.0,  -0.8008 * sqrh, -0.4368,
-         -0.182 * sqrh, 0.0,   1.2e-2 * sqrh,   0.16e-2, 1.e-4 * sqrh,   0.00};
+    y = {1.e-4 * sqrh, 0.00, -1.2e-2 * sqrh, -5.6e-2, -18.2e-2 * sqrh, 0.0,
+         0.8008 * sqrh, 1.144, 1.287 * sqrh, 0.0, -0.8008 * sqrh, -0.4368,
+         -0.182 * sqrh, 0.0, 1.2e-2 * sqrh, 0.16e-2, 1.e-4 * sqrh, 0.00};
 
     Fit fit;
     fit.initialize();

--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -320,9 +320,9 @@ public:
       e[i] = 1.0;
     }
     const double sqrh = 0.70710678; // cos( 45 degrees )
-    y = {0.01 * sqrh,  0.00,  -1.2 * sqrh,  -5.6, -18.2 * sqrh,  0.0,
-         80.08 * sqrh, 114.4, 128.7 * sqrh, 0.0,  -80.08 * sqrh, -43.68,
-         -18.2 * sqrh, 0.0,   1.2 * sqrh,   0.16, 0.01 * sqrh,   0.00};
+    y = {1.e-4 * sqrh,  0.00,  -1.2e-2 * sqrh,  -5.6e-2, -18.2e-2 * sqrh,  0.0,
+         0.8008 * sqrh, 1.144, 1.287 * sqrh, 0.0,  -0.8008 * sqrh, -0.4368,
+         -0.182 * sqrh, 0.0,   1.2e-2 * sqrh,   0.16e-2, 1.e-4 * sqrh,   0.00};
 
     Fit fit;
     fit.initialize();
@@ -336,7 +336,7 @@ public:
 
     // Test the fitting parameters
     IFunction_sptr func = fit.getProperty("Function");
-    TS_ASSERT_DELTA(func->getParameter("A"), 129.300, 0.001);
+    TS_ASSERT_DELTA(func->getParameter("A"), 1.29300, 0.00001);
     TS_ASSERT_DELTA(func->getParameter("Sigma"), 0.348, 0.001);
     TS_ASSERT_DELTA(func->getParameter("Frequency"), 1 / 8.0,
                     0.01);                                    // Period of 8


### PR DESCRIPTION
The GausOsc had an initial amplitude of 10. A more realistic value is 0.2. This PR updates the default value. 

**To test:**
Open some data, create a GaussOsc function. Check that the amplitude (A) is 0.2 and not 10.
**Release Notes** 
Does not need to be in the release notes.
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
