### PR TITLE
CubicSpline : fix sorting of y-values

### DIFF
--- a/Framework/CurveFitting/src/Functions/CubicSpline.cpp
+++ b/Framework/CurveFitting/src/Functions/CubicSpline.cpp
@@ -9,7 +9,6 @@
 #include <boost/lexical_cast.hpp>
 #include <stdexcept>
 #include <vector>
-#include <iostream>
 
 namespace Mantid {
 namespace CurveFitting {
@@ -82,7 +81,7 @@ void CubicSpline::setupInput(boost::scoped_array<double> &x,
   for (int i = 0; i < n; ++i) {
 
     x[i] = getAttribute("x" + std::to_string(i)).asDouble();
-    y[i] = getParameter("y" + std::to_string(i));
+    y[i] = getParameter(i);
 
     if (!xSortFlag) {
       // if x[i] is out of order with its neighbours

--- a/Framework/CurveFitting/src/Functions/CubicSpline.cpp
+++ b/Framework/CurveFitting/src/Functions/CubicSpline.cpp
@@ -76,23 +76,23 @@ void CubicSpline::function1D(double *out, const double *xValues,
 void CubicSpline::setupInput(boost::scoped_array<double> &x,
                              boost::scoped_array<double> &y, int n) const {
   // Populate data points from the input attributes and parameters
-  bool xSortFlag = false;
+  bool isSorted = true;
 
   for (int i = 0; i < n; ++i) {
 
     x[i] = getAttribute("x" + std::to_string(i)).asDouble();
     y[i] = getParameter(i);
 
-    if (!xSortFlag) {
+    if (isSorted) {
       // if x[i] is out of order with its neighbours
       if (i > 1 && i < n && (x[i - 1] < x[i - 2] || x[i - 1] > x[i])) {
-        xSortFlag = true;
+        isSorted = false;
       }
     }
   }
 
   // sort the data points if necessary
-  if (xSortFlag) {
+  if (!isSorted) {
     g_log.warning() << "Spline x parameters are not in ascending order. Values "
                        "will be sorted.\n";
 

--- a/Framework/CurveFitting/test/Functions/CubicSplineTest.h
+++ b/Framework/CurveFitting/test/Functions/CubicSplineTest.h
@@ -126,7 +126,7 @@ public:
   void testOutOfOrderInterploationPoints() {
     CubicSpline cspline;
 
-    setupCubicSpline(cspline, 10, 1);
+    setupCubicSpline(cspline, 10, 1.);
 
     // swap the values of some points
     cspline.setXAttribute(3, 1);
@@ -138,6 +138,9 @@ public:
     boost::scoped_array<double> refSet(new double[testDataSize]);
 
     generateTestData(testDataSize, refSet, x, 1);
+
+    // swap ref values
+    std::swap(refSet[1], refSet[3]);
 
     FunctionDomain1DView view(x.get(), testDataSize);
     FunctionValues testDataValues(view);

--- a/Framework/CurveFitting/test/Functions/CubicSplineTest.h
+++ b/Framework/CurveFitting/test/Functions/CubicSplineTest.h
@@ -126,7 +126,7 @@ public:
   void testOutOfOrderInterploationPoints() {
     CubicSpline cspline;
 
-    setupCubicSpline(cspline, 10, 1.);
+    setupCubicSpline(cspline, 10, 1);
 
     // swap the values of some points
     cspline.setXAttribute(3, 1);

--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -36,6 +36,11 @@ CurveFitting
 
 - :ref:`GramCharlier <func-GramCharlier>` is a new fit function primarily for use in neutron compton scattering.
 
+Bug fixes
+#########
+
+- :ref:`CubicSpline <func-CubicSpline>` is fixed to sort the y-values and x-values correctly.
+
 Improved
 ########
 


### PR DESCRIPTION
This PR fixes the issue in sorting of x-y arrays in CubicSpline, when the input x-array is not initially in ascending order. 

**To test:**

Code review & tests pass.

<!-- Instructions for testing. -->

Fixes #19990 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
