### PR TITLE
Add support for 2d character arrays for sample name

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -20,12 +20,15 @@
 #undef CHAR
 #endif
 
-#include <nexus/NeXusFile.hpp>
 #include <nexus/NeXusException.hpp>
+#include <nexus/NeXusFile.hpp>
 
+#include <boost/lexical_cast.hpp>
+#include <boost/scoped_array.hpp>
+#include <functional>
 #include <memory>
 #include <mutex>
-#include <boost/lexical_cast.hpp>
+#include <numeric>
 
 namespace Mantid {
 
@@ -216,8 +219,8 @@ public:
   bool m_haveWeights;
 
   /// Pointer to the vector of weighted events
-  typedef std::vector<Mantid::DataObjects::WeightedEvent> *
-      WeightedEventVector_pt;
+  typedef std::vector<Mantid::DataObjects::WeightedEvent>
+      *WeightedEventVector_pt;
 
   /// Vector where index = event_id; value = ptr to std::vector<WeightedEvent>
   /// in the event list.
@@ -480,18 +483,35 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
     // let it drop on floor
   }
 
-  // get the sample name
+  // get the sample name - nested try/catch to leave the handle in an
+  // appropriate state
   try {
     file.openGroup("sample", "NXsample");
-    file.openData("name");
-    std::string name;
-    if (file.getInfo().type == ::NeXus::CHAR) {
-      name = file.getStrData();
+    try {
+      file.openData("name");
+      const auto info = file.getInfo();
+      std::string name;
+      if (info.type == ::NeXus::CHAR) {
+        if (info.dims.size() == 1) {
+          name = file.getStrData();
+        } else { // something special for 2-d array
+          const int64_t total_length =
+              std::accumulate(info.dims.begin(), info.dims.end(), 1,
+                              std::multiplies<int64_t>());
+          boost::scoped_array<char> val_array(new char[total_length]);
+          file.getData(val_array.get());
+          file.closeData();
+          name = std::string(val_array.get(), total_length);
+        }
+      }
+      file.closeData();
+
+      if (!name.empty()) {
+        WS->mutableSample().setName(name);
+      }
+    } catch (::NeXus::Exception &) {
+      // let it drop on floor
     }
-    if (!name.empty()) {
-      WS->mutableSample().setName(name);
-    }
-    file.closeData();
     file.closeGroup();
   } catch (::NeXus::Exception &) {
     // let it drop on floor

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -219,8 +219,8 @@ public:
   bool m_haveWeights;
 
   /// Pointer to the vector of weighted events
-  typedef std::vector<Mantid::DataObjects::WeightedEvent>
-      *WeightedEventVector_pt;
+  typedef std::vector<Mantid::DataObjects::WeightedEvent> *
+      WeightedEventVector_pt;
 
   /// Vector where index = event_id; value = ptr to std::vector<WeightedEvent>
   /// in the event list.


### PR DESCRIPTION
New DAS now writes the sample name as a 2d character array which leaves the nexus file in a funny state on failure. This is a fix for that.

**To test:**

Try `LoadEventNexus(Filename="HYS_166202", ...)` before and after merging. After will actually have a `duration` in the logs and a sample name.

*There is no associated issue.*

*Does not need to be in the release notes* because it fixes a bug that was never seen until this week.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
