### PR TITLE
Fix type conversion warning on MSVC

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -495,9 +495,9 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
         if (info.dims.size() == 1) {
           name = file.getStrData();
         } else { // something special for 2-d array
-          const int64_t total_length =
-              std::accumulate(info.dims.begin(), info.dims.end(), 1,
-                              std::multiplies<int64_t>());
+          const int64_t total_length = std::accumulate(
+              info.dims.begin(), info.dims.end(), static_cast<int64_t>(1),
+              std::multiplies<int64_t>());
           boost::scoped_array<char> val_array(new char[total_length]);
           file.getData(val_array.get());
           file.closeData();


### PR DESCRIPTION
Fixes a warning that accidentally made it to master for the MSVC builds.

**To test:**

Compile and see that the warnings in `DataHandling` go away

No issue

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
