### PR TITLE
Sample displacment and t0 opt for SCDCalibrate

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels.h
@@ -69,12 +69,16 @@ private:
   void saveNexus(std::string outputFile, API::MatrixWorkspace_sptr outputWS);
   /// Function to optimize L1
   void findL1(int nPeaks, DataObjects::PeaksWorkspace_sptr peaksWs);
+  /// Function to optimize T0
+  void findT0(int nPeaks, DataObjects::PeaksWorkspace_sptr peaksWs);
 
   void exec() override;
 
   void init() override;
 
   API::ITableWorkspace_sptr Result;
+
+  double mT0 = 0.0;
 
   /**
    * Saves the new instrument to an xml file that can be used with the

--- a/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
@@ -46,8 +46,8 @@ public:
   /// overwrite IFunction base class methods
   std::string name() const override { return "SCDPanelErrors"; }
   const std::string category() const override { return "General"; }
-  void function1D(double *out, const double *xValues, const size_t nData) const
-      override;
+  void function1D(double *out, const double *xValues,
+                  const size_t nData) const override;
   ///  function derivatives
   void functionDeriv1D(API::Jacobian *out, const double *xValues,
                        const size_t nData) override;

--- a/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDPanelErrors.h
@@ -46,8 +46,8 @@ public:
   /// overwrite IFunction base class methods
   std::string name() const override { return "SCDPanelErrors"; }
   const std::string category() const override { return "General"; }
-  void function1D(double *out, const double *xValues,
-                  const size_t nData) const override;
+  void function1D(double *out, const double *xValues, const size_t nData) const
+      override;
   ///  function derivatives
   void functionDeriv1D(API::Jacobian *out, const double *xValues,
                        const size_t nData) override;
@@ -77,7 +77,8 @@ private:
   /// Evaluate the function for a list of arguments and given scaling factor
   void eval(double xshift, double yshift, double zshift, double xrotate,
             double yrotate, double zrotate, double scalex, double scaley,
-            double *out, const double *xValues, const size_t nData) const;
+            double *out, const double *xValues, const size_t nData,
+            double tShift) const;
 
   /// Fill in the workspace and bank names
   void setupData() const;

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -50,15 +50,15 @@ const std::string SCDCalibratePanels::category() const {
 void SCDCalibratePanels::exec() {
   PeaksWorkspace_sptr peaksWs = getProperty("PeakWorkspace");
   // We must sort the peaks
-  std::vector<std::pair<std::string, bool> > criteria{ { "BankName", true } };
+  std::vector<std::pair<std::string, bool>> criteria{{"BankName", true}};
   peaksWs->sort(criteria);
   // Remove peaks on edge
   int edge = this->getProperty("EdgePixels");
   if (edge > 0) {
     Geometry::Instrument_const_sptr inst = peaksWs->getInstrument();
     std::vector<Peak> &peaks = peaksWs->getPeaks();
-    auto it = std::remove_if(peaks.begin(), peaks.end(),
-                             [&peaksWs, edge, inst](const Peak &pk) {
+    auto it = std::remove_if(peaks.begin(), peaks.end(), [&peaksWs, edge, inst](
+                                                             const Peak &pk) {
       return edgePixel(inst, pk.getBankName(), pk.getCol(), pk.getRow(), edge);
     });
     peaks.erase(it, peaks.end());
@@ -138,8 +138,7 @@ void SCDCalibratePanels::exec() {
     IAlgorithm_sptr fit_alg;
     try {
       fit_alg = createChildAlgorithm("Fit", -1, -1, false);
-    }
-    catch (Exception::NotFoundError &) {
+    } catch (Exception::NotFoundError &) {
       g_log.error("Can't locate Fit algorithm");
       throw;
     }
@@ -178,8 +177,7 @@ void SCDCalibratePanels::exec() {
       IAlgorithm_sptr fit2_alg;
       try {
         fit2_alg = createChildAlgorithm("Fit", -1, -1, false);
-      }
-      catch (Exception::NotFoundError &) {
+      } catch (Exception::NotFoundError &) {
         g_log.error("Can't locate Fit algorithm");
         throw;
       }
@@ -332,8 +330,7 @@ void SCDCalibratePanels::exec() {
           RowY[icount] = theoretical.getRow();
           TofX[icount] = peak.getTOF();
           TofY[icount] = theoretical.getTOF();
-        }
-        catch (...) {
+        } catch (...) {
           // g_log.debug() << "Problem only in printing peaks\n";
         }
         icount++;
@@ -368,8 +365,7 @@ void SCDCalibratePanels::findL1(int nPeaks,
   IAlgorithm_sptr fitL1_alg;
   try {
     fitL1_alg = createChildAlgorithm("Fit", -1, -1, false);
-  }
-  catch (Exception::NotFoundError &) {
+  } catch (Exception::NotFoundError &) {
     g_log.error("Can't locate Fit algorithm");
     throw;
   }
@@ -409,8 +405,7 @@ void SCDCalibratePanels::findT0(int nPeaks,
   IAlgorithm_sptr fitT0_alg;
   try {
     fitT0_alg = createChildAlgorithm("Fit", -1, -1, false);
-  }
-  catch (Exception::NotFoundError &) {
+  } catch (Exception::NotFoundError &) {
     g_log.error("Can't locate Fit algorithm");
     throw;
   }
@@ -461,8 +456,7 @@ void SCDCalibratePanels::findU(DataObjects::PeaksWorkspace_sptr peaksWs) {
   IAlgorithm_sptr ub_alg;
   try {
     ub_alg = createChildAlgorithm("CalculateUMatrix", -1, -1, false);
-  }
-  catch (Exception::NotFoundError &) {
+  } catch (Exception::NotFoundError &) {
     g_log.error("Can't locate CalculateUMatrix algorithm");
     throw;
   }
@@ -546,11 +540,11 @@ void SCDCalibratePanels::saveIsawDetCal(
 }
 
 void SCDCalibratePanels::init() {
-  declareProperty(Kernel::make_unique<WorkspaceProperty<PeaksWorkspace> >(
+  declareProperty(Kernel::make_unique<WorkspaceProperty<PeaksWorkspace>>(
                       "PeakWorkspace", "", Kernel::Direction::InOut),
                   "Workspace of Indexed Peaks");
 
-  auto mustBePositive = boost::make_shared<BoundedValidator<double> >();
+  auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
   mustBePositive->setLower(0.0);
 
   declareProperty("a", EMPTY_DBL(), mustBePositive,
@@ -581,7 +575,7 @@ void SCDCalibratePanels::init() {
                   "Remove peaks that are at pixels this close to edge. ");
 
   // ---------- outputs
-  const std::vector<std::string> detcalExts{ ".DetCal", ".Det_Cal" };
+  const std::vector<std::string> detcalExts{".DetCal", ".Det_Cal"};
   declareProperty(
       Kernel::make_unique<FileProperty>("DetCalFilename", "SCDCalibrate.DetCal",
                                         FileProperty::Save, detcalExts),

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -437,9 +437,12 @@ void SCDCalibratePanels::findU(DataObjects::PeaksWorkspace_sptr peaksWs) {
   ub_alg->executeAsChildAlg();
 
   // Reindex peaks with new UB
-  Mantid::API::IAlgorithm_sptr alg = createChildAlgorithm("IndexPeaks");
+  Mantid::API::IAlgorithm_sptr alg = createChildAlgorithm("OptimizeCrystalPlacement");
   alg->setPropertyValue("PeaksWorkspace", peaksWs->getName());
-  alg->setProperty("Tolerance", 0.15);
+  alg->setPropertyValue("ModifiedPeaksWorkspace", peaksWs->getName());
+  alg->setProperty("AdjustSampleOffsets", true);
+  alg->setProperty("MaxAngularChange", 0.0);
+  alg->setProperty("MaxIndexingError", 0.15);
   alg->executeAsChildAlg();
   g_log.notice() << peaksWs->sample().getOrientedLattice().getUB() << "\n";
 }

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -14,6 +14,7 @@
 #include "MantidCrystal/SCDPanelErrors.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/Sample.h"
+#include "MantidAPI/Run.h"
 #include <fstream>
 #include "MantidGeometry/Crystal/IndexingUtils.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
@@ -48,15 +49,15 @@ const std::string SCDCalibratePanels::category() const {
 void SCDCalibratePanels::exec() {
   PeaksWorkspace_sptr peaksWs = getProperty("PeakWorkspace");
   // We must sort the peaks
-  std::vector<std::pair<std::string, bool>> criteria{{"BankName", true}};
+  std::vector<std::pair<std::string, bool> > criteria{ { "BankName", true } };
   peaksWs->sort(criteria);
   // Remove peaks on edge
   int edge = this->getProperty("EdgePixels");
   if (edge > 0) {
     Geometry::Instrument_const_sptr inst = peaksWs->getInstrument();
     std::vector<Peak> &peaks = peaksWs->getPeaks();
-    auto it = std::remove_if(peaks.begin(), peaks.end(), [&peaksWs, edge, inst](
-                                                             const Peak &pk) {
+    auto it = std::remove_if(peaks.begin(), peaks.end(),
+                             [&peaksWs, edge, inst](const Peak &pk) {
       return edgePixel(inst, pk.getBankName(), pk.getCol(), pk.getRow(), edge);
     });
     peaks.erase(it, peaks.end());
@@ -71,10 +72,13 @@ void SCDCalibratePanels::exec() {
 
   int nPeaks = static_cast<int>(peaksWs->getNumberPeaks());
   bool changeL1 = getProperty("ChangeL1");
+  bool changeT0 = getProperty("ChangeT0");
   bool changeSize = getProperty("ChangePanelSize");
 
   if (changeL1)
     findL1(nPeaks, peaksWs);
+  if (changeT0)
+    findT0(nPeaks, peaksWs);
   boost::container::flat_set<string> MyBankNames;
   for (int i = 0; i < nPeaks; ++i) {
     MyBankNames.insert(peaksWs->getPeak(i).getBankName());
@@ -132,7 +136,8 @@ void SCDCalibratePanels::exec() {
     IAlgorithm_sptr fit_alg;
     try {
       fit_alg = createChildAlgorithm("Fit", -1, -1, false);
-    } catch (Exception::NotFoundError &) {
+    }
+    catch (Exception::NotFoundError &) {
       g_log.error("Can't locate Fit algorithm");
       throw;
     }
@@ -140,7 +145,7 @@ void SCDCalibratePanels::exec() {
     fun_str << "name=SCDPanelErrors,Workspace=" + bankName << ",Bank=" << iBank;
     fit_alg->setPropertyValue("Function", fun_str.str());
     std::ostringstream tie_str;
-    tie_str << "ScaleWidth=1.0,ScaleHeight=1.0";
+    tie_str << "ScaleWidth=1.0,ScaleHeight=1.0,T0Shift =" << mT0;
     fit_alg->setProperty("Ties", tie_str.str());
     fit_alg->setProperty("InputWorkspace", q3DWS);
     fit_alg->setProperty("CreateOutput", true);
@@ -171,7 +176,8 @@ void SCDCalibratePanels::exec() {
       IAlgorithm_sptr fit2_alg;
       try {
         fit2_alg = createChildAlgorithm("Fit", -1, -1, false);
-      } catch (Exception::NotFoundError &) {
+      }
+      catch (Exception::NotFoundError &) {
         g_log.error("Can't locate Fit algorithm");
         throw;
       }
@@ -179,7 +185,8 @@ void SCDCalibratePanels::exec() {
       std::ostringstream tie_str2;
       tie_str2 << "XShift=" << xShift << ",YShift=" << yShift
                << ",ZShift=" << zShift << ",XRotate=" << xRotate
-               << ",YRotate=" << yRotate << ",ZRotate=" << zRotate;
+               << ",YRotate=" << yRotate << ",ZRotate=" << zRotate
+               << ",T0Shift =" << mT0;
       fit2_alg->setProperty("Ties", tie_str2.str());
       fit2_alg->setProperty("InputWorkspace", q3DWS);
       fit2_alg->setProperty("CreateOutput", true);
@@ -219,6 +226,12 @@ void SCDCalibratePanels::exec() {
     findL1(nPeaks, peaksWs);
     parameter_workspaces.push_back("params_L1");
     fit_workspaces.push_back("fit_L1");
+  }
+  // Try again to optimize T0
+  if (changeT0) {
+    findT0(nPeaks, peaksWs);
+    parameter_workspaces.push_back("params_T0");
+    fit_workspaces.push_back("fit_T0");
   }
   std::sort(parameter_workspaces.begin(), parameter_workspaces.end());
   std::sort(fit_workspaces.begin(), fit_workspaces.end());
@@ -260,7 +273,12 @@ void SCDCalibratePanels::exec() {
   findU(peaksWs);
   // Save as DetCal and XML if requested
   string DetCalFileName = getProperty("DetCalFilename");
-  saveIsawDetCal(inst, MyBankNames, 0.0, DetCalFileName);
+  API::Run &run = peaksWs->mutableRun();
+  double mT0 = 0.0;
+  if (run.hasProperty("T0")) {
+    mT0 = run.getPropertyValueAsType<double>("T0");
+  }
+  saveIsawDetCal(inst, MyBankNames, mT0, DetCalFileName);
   string XmlFileName = getProperty("XmlFilename");
   saveXmlFile(XmlFileName, MyBankNames, *inst);
   // create table of theoretical vs calculated
@@ -313,7 +331,8 @@ void SCDCalibratePanels::exec() {
           RowY[icount] = theoretical.getRow();
           TofX[icount] = peak.getTOF();
           TofY[icount] = theoretical.getTOF();
-        } catch (...) {
+        }
+        catch (...) {
           // g_log.debug() << "Problem only in printing peaks\n";
         }
         icount++;
@@ -345,33 +364,11 @@ void SCDCalibratePanels::findL1(int nPeaks,
       API::WorkspaceFactory::Instance().create("Workspace2D", 1, 3 * nPeaks,
                                                3 * nPeaks));
 
-  auto &outSp = L1WS->getSpectrum(0);
-  auto &yVec = outSp.mutableY();
-  auto &eVec = outSp.mutableE();
-  auto &xVec = outSp.mutableX();
-  yVec = 0.0;
-
-  for (int i = 0; i < nPeaks; i++) {
-    const DataObjects::Peak &peak = peaksWs->getPeak(i);
-
-    // 1/sigma is considered the weight for the fit
-    double weight = 1.;                // default is even weighting
-    if (peak.getSigmaIntensity() > 0.) // prefer weight by sigmaI
-      weight = 1.0 / peak.getSigmaIntensity();
-    else if (peak.getIntensity() > 0.) // next favorite weight by I
-      weight = 1.0 / peak.getIntensity();
-    else if (peak.getBinCount() > 0.) // then by counts in peak centre
-      weight = 1.0 / peak.getBinCount();
-    for (int j = 0; j < 3; j++) {
-      int k = i * 3 + j;
-      xVec[k] = k;
-      eVec[k] = weight;
-    }
-  }
   IAlgorithm_sptr fitL1_alg;
   try {
     fitL1_alg = createChildAlgorithm("Fit", -1, -1, false);
-  } catch (Exception::NotFoundError &) {
+  }
+  catch (Exception::NotFoundError &) {
     g_log.error("Can't locate Fit algorithm");
     throw;
   }
@@ -380,7 +377,7 @@ void SCDCalibratePanels::findL1(int nPeaks,
           << ",Bank=moderator";
   std::ostringstream tie_str;
   tie_str << "XShift=0.0,YShift=0.0,XRotate=0.0,YRotate=0.0,ZRotate=0.0,"
-             "ScaleWidth=1.0,ScaleHeight=1.0";
+             "ScaleWidth=1.0,ScaleHeight=1.0,T0Shift =" << mT0;
   fitL1_alg->setPropertyValue("Function", fun_str.str());
   fitL1_alg->setProperty("Ties", tie_str.str());
   fitL1_alg->setProperty("InputWorkspace", L1WS);
@@ -402,11 +399,53 @@ void SCDCalibratePanels::findL1(int nPeaks,
                  << fitL1Status << " Chi2overDoF " << chisqL1 << "\n";
 }
 
+void SCDCalibratePanels::findT0(int nPeaks,
+                                DataObjects::PeaksWorkspace_sptr peaksWs) {
+  MatrixWorkspace_sptr T0WS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+      API::WorkspaceFactory::Instance().create("Workspace2D", 1, 3 * nPeaks,
+                                               3 * nPeaks));
+
+  IAlgorithm_sptr fitT0_alg;
+  try {
+    fitT0_alg = createChildAlgorithm("Fit", -1, -1, false);
+  }
+  catch (Exception::NotFoundError &) {
+    g_log.error("Can't locate Fit algorithm");
+    throw;
+  }
+  std::ostringstream fun_str;
+  fun_str << "name=SCDPanelErrors,Workspace=" << peaksWs->getName()
+          << ",Bank=none";
+  std::ostringstream tie_str;
+  tie_str
+      << "XShift=0.0,YShift=0.0,ZShift=0.0,XRotate=0.0,YRotate=0.0,ZRotate=0.0,"
+         "ScaleWidth=1.0,ScaleHeight=1.0";
+  fitT0_alg->setPropertyValue("Function", fun_str.str());
+  fitT0_alg->setProperty("Ties", tie_str.str());
+  fitT0_alg->setProperty("InputWorkspace", T0WS);
+  fitT0_alg->setProperty("CreateOutput", true);
+  fitT0_alg->setProperty("Output", "fit");
+  fitT0_alg->executeAsChildAlg();
+  std::string fitT0Status = fitT0_alg->getProperty("OutputStatus");
+  double chisqT0 = fitT0_alg->getProperty("OutputChi2overDoF");
+  MatrixWorkspace_sptr fitT0 = fitT0_alg->getProperty("OutputWorkspace");
+  AnalysisDataService::Instance().addOrReplace("fit_T0", fitT0);
+  ITableWorkspace_sptr paramsT0 = fitT0_alg->getProperty("OutputParameters");
+  AnalysisDataService::Instance().addOrReplace("params_T0", paramsT0);
+  mT0 = paramsT0->getRef<double>("Value", 0);
+  API::Run &run = peaksWs->mutableRun();
+  // set T0 in the run parameters
+  run.addProperty<double>("T0", mT0, true);
+  g_log.notice() << "T0 = " << mT0 << "  " << fitT0Status << " Chi2overDoF "
+                 << chisqT0 << "\n";
+}
+
 void SCDCalibratePanels::findU(DataObjects::PeaksWorkspace_sptr peaksWs) {
   IAlgorithm_sptr ub_alg;
   try {
     ub_alg = createChildAlgorithm("CalculateUMatrix", -1, -1, false);
-  } catch (Exception::NotFoundError &) {
+  }
+  catch (Exception::NotFoundError &) {
     g_log.error("Can't locate CalculateUMatrix algorithm");
     throw;
   }
@@ -437,7 +476,8 @@ void SCDCalibratePanels::findU(DataObjects::PeaksWorkspace_sptr peaksWs) {
   ub_alg->executeAsChildAlg();
 
   // Reindex peaks with new UB
-  Mantid::API::IAlgorithm_sptr alg = createChildAlgorithm("OptimizeCrystalPlacement");
+  Mantid::API::IAlgorithm_sptr alg =
+      createChildAlgorithm("OptimizeCrystalPlacement");
   alg->setPropertyValue("PeaksWorkspace", peaksWs->getName());
   alg->setPropertyValue("ModifiedPeaksWorkspace", peaksWs->getName());
   alg->setProperty("AdjustSampleOffsets", true);
@@ -489,11 +529,11 @@ void SCDCalibratePanels::saveIsawDetCal(
 }
 
 void SCDCalibratePanels::init() {
-  declareProperty(Kernel::make_unique<WorkspaceProperty<PeaksWorkspace>>(
+  declareProperty(Kernel::make_unique<WorkspaceProperty<PeaksWorkspace> >(
                       "PeakWorkspace", "", Kernel::Direction::InOut),
                   "Workspace of Indexed Peaks");
 
-  auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
+  auto mustBePositive = boost::make_shared<BoundedValidator<double> >();
   mustBePositive->setLower(0.0);
 
   declareProperty("a", EMPTY_DBL(), mustBePositive,
@@ -515,6 +555,7 @@ void SCDCalibratePanels::init() {
                   "Lattice Parameter gamma in degrees (Leave empty to use "
                   "lattice constants in peaks workspace)");
   declareProperty("ChangeL1", true, "Change the L1(source to sample) distance");
+  declareProperty("ChangeT0", false, "Change the T0 (initial TOF)");
   declareProperty("ChangePanelSize", true, "Change the height and width of the "
                                            "detectors.  Implemented only for "
                                            "RectangularDetectors.");
@@ -523,7 +564,7 @@ void SCDCalibratePanels::init() {
                   "Remove peaks that are at pixels this close to edge. ");
 
   // ---------- outputs
-  const std::vector<std::string> detcalExts{".DetCal", ".Det_Cal"};
+  const std::vector<std::string> detcalExts{ ".DetCal", ".Det_Cal" };
   declareProperty(
       Kernel::make_unique<FileProperty>("DetCalFilename", "SCDCalibrate.DetCal",
                                         FileProperty::Save, detcalExts),

--- a/Framework/Crystal/src/SCDPanelErrors.cpp
+++ b/Framework/Crystal/src/SCDPanelErrors.cpp
@@ -45,6 +45,7 @@ SCDPanelErrors::SCDPanelErrors() : m_setupFinished(false) {
   declareParameter("ZRotate", 0.0, "Rotate angle in Z");
   declareParameter("ScaleWidth", 1.0, "Scale width of detector");
   declareParameter("ScaleHeight", 1.0, "Scale height of detector");
+  declareParameter("T0Shift", 0.0, "Scale height of detector");
   declareAttribute("FileName", Attribute("", true));
   declareAttribute("Workspace", Attribute(""));
   declareAttribute("Bank", Attribute(""));
@@ -67,6 +68,8 @@ void SCDPanelErrors::moveDetector(double x, double y, double z, double rotx,
                                   double roty, double rotz, double scalex,
                                   double scaley, std::string detname,
                                   Workspace_sptr inputW) const {
+  if (detname.compare("none") == 0.0)
+    return;
   // CORELLI has sixteenpack under bank
   DataObjects::PeaksWorkspace_sptr inputP =
       boost::dynamic_pointer_cast<DataObjects::PeaksWorkspace>(inputW);
@@ -164,7 +167,8 @@ void SCDPanelErrors::moveDetector(double x, double y, double z, double rotx,
 void SCDPanelErrors::eval(double xshift, double yshift, double zshift,
                           double xrotate, double yrotate, double zrotate,
                           double scalex, double scaley, double *out,
-                          const double *xValues, const size_t nData) const {
+                          const double *xValues, const size_t nData,
+                          double tShift) const {
   UNUSED_ARG(xValues);
   if (nData == 0)
     return;
@@ -191,8 +195,8 @@ void SCDPanelErrors::eval(double xshift, double yshift, double zshift,
 
     wl.initialize(peak2.getL1(), peak2.getL2(), peak2.getScattering(), 0,
                   peak.getInitialEnergy(), 0.0);
-
-    peak2.setWavelength(wl.singleFromTOF(peak.getTOF()));
+    std::cout << peak.getTOF() << "  " << tShift << "\n";
+    peak2.setWavelength(wl.singleFromTOF(peak.getTOF() + tShift));
     V3D Q3 = peak2.getQSampleFrame();
     out[i * 3] = Q3[0] - Q2[0];
     out[i * 3 + 1] = Q3[1] - Q2[1];
@@ -218,8 +222,9 @@ void SCDPanelErrors::function1D(double *out, const double *xValues,
   const double zrotate = getParameter("ZRotate");
   const double scalex = getParameter("ScaleWidth");
   const double scaley = getParameter("ScaleHeight");
+  const double tShift = getParameter("T0Shift");
   eval(xshift, yshift, zshift, xrotate, yrotate, zrotate, scalex, scaley, out,
-       xValues, nData);
+       xValues, nData, tShift);
 }
 
 /**
@@ -287,7 +292,8 @@ void SCDPanelErrors::load(const std::string &fname) {
     loadAlg->setPropertyValue("Filename", fname);
     loadAlg->setPropertyValue("OutputWorkspace", "_SCDPanelErrors_fit_data_");
     loadAlg->execute();
-  } catch (std::runtime_error &) {
+  }
+  catch (std::runtime_error &) {
     throw std::runtime_error(
         "Unable to load Nexus file for SCDPanelErrors function.");
   }

--- a/Framework/Crystal/src/SCDPanelErrors.cpp
+++ b/Framework/Crystal/src/SCDPanelErrors.cpp
@@ -291,8 +291,7 @@ void SCDPanelErrors::load(const std::string &fname) {
     loadAlg->setPropertyValue("Filename", fname);
     loadAlg->setPropertyValue("OutputWorkspace", "_SCDPanelErrors_fit_data_");
     loadAlg->execute();
-  }
-  catch (std::runtime_error &) {
+  } catch (std::runtime_error &) {
     throw std::runtime_error(
         "Unable to load Nexus file for SCDPanelErrors function.");
   }

--- a/Framework/Crystal/src/SCDPanelErrors.cpp
+++ b/Framework/Crystal/src/SCDPanelErrors.cpp
@@ -45,7 +45,7 @@ SCDPanelErrors::SCDPanelErrors() : m_setupFinished(false) {
   declareParameter("ZRotate", 0.0, "Rotate angle in Z");
   declareParameter("ScaleWidth", 1.0, "Scale width of detector");
   declareParameter("ScaleHeight", 1.0, "Scale height of detector");
-  declareParameter("T0Shift", 0.0, "Scale height of detector");
+  declareParameter("T0Shift", 0.0, "Shift for TOF");
   declareAttribute("FileName", Attribute("", true));
   declareAttribute("Workspace", Attribute(""));
   declareAttribute("Bank", Attribute(""));
@@ -194,8 +194,7 @@ void SCDPanelErrors::eval(double xshift, double yshift, double zshift,
     Units::Wavelength wl;
 
     wl.initialize(peak2.getL1(), peak2.getL2(), peak2.getScattering(), 0,
-                  peak.getInitialEnergy(), 0.0);
-    std::cout << peak.getTOF() << "  " << tShift << "\n";
+                  peak2.getInitialEnergy(), 0.0);
     peak2.setWavelength(wl.singleFromTOF(peak.getTOF() + tShift));
     V3D Q3 = peak2.getQSampleFrame();
     out[i * 3] = Q3[0] - Q2[0];

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -162,8 +162,7 @@ void SaveIsawPeaks::exec() {
     const API::Run &run = ws->run();
     double T0 = 0.0;
     if (run.hasProperty("T0")) {
-      Kernel::Property *prop = run.getProperty("T0");
-      T0 = boost::lexical_cast<double, std::string>(prop->value());
+      T0 = run.getPropertyValueAsType<double>("T0");
       if (T0 != 0) {
         g_log.notice() << "T0 = " << T0 << '\n';
       }

--- a/Framework/Crystal/test/SCDCalibratePanelsTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanelsTest.h
@@ -54,9 +54,9 @@ public:
     // rounding errors in the algorithm LoadIsawPeaks and floating point math in
     // the instrument code. Ideally the assertions should be on something else.
     TS_ASSERT_DELTA(-0.0050, results->cell<double>(0, 1), 1e-3);
-    TS_ASSERT_DELTA(0.0013, results->cell<double>(1, 1), 3e-4);
+    TS_ASSERT_DELTA(0.0013, results->cell<double>(1, 1), 4e-4);
     TS_ASSERT_DELTA(0.0008, results->cell<double>(2, 1), 2e-4);
-    TS_ASSERT_DELTA(0.0, results->cell<double>(3, 1), 1.0);
+    TS_ASSERT_DELTA(0.0, results->cell<double>(3, 1), 1.2);
     TS_ASSERT_DELTA(0.0, results->cell<double>(4, 1), 1.0);
     TS_ASSERT_DELTA(0.1133, results->cell<double>(5, 1), 0.36);
     TS_ASSERT_DELTA(1.0024, results->cell<double>(6, 1), 3e-3);

--- a/Framework/Crystal/test/SCDCalibratePanelsTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanelsTest.h
@@ -55,13 +55,13 @@ public:
     // the instrument code. Ideally the assertions should be on something else.
     TS_ASSERT_DELTA(-0.0050, results->cell<double>(0, 1), 1e-3);
     TS_ASSERT_DELTA(0.0013, results->cell<double>(1, 1), 3e-4);
-    TS_ASSERT_DELTA(0.0012, results->cell<double>(2, 1), 2e-4);
+    TS_ASSERT_DELTA(0.0008, results->cell<double>(2, 1), 2e-4);
     TS_ASSERT_DELTA(0.0, results->cell<double>(3, 1), 1.0);
     TS_ASSERT_DELTA(0.0, results->cell<double>(4, 1), 1.0);
     TS_ASSERT_DELTA(0.1133, results->cell<double>(5, 1), 0.36);
     TS_ASSERT_DELTA(1.0024, results->cell<double>(6, 1), 3e-3);
     TS_ASSERT_DELTA(0.9986, results->cell<double>(7, 1), 1e-2);
-    TS_ASSERT_DELTA(0.2710, results->cell<double>(8, 1), 0.2);
+    TS_ASSERT_DELTA(0.2710, results->cell<double>(9, 1), 0.2);
     ITableWorkspace_sptr resultsL1 =
         AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(
             "params_L1");

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -280,6 +280,28 @@ void LoadIsawDetCal::exec() {
       detScaling.scaleX = CM_TO_M * width / det->xsize();
       detScaling.scaleY = CM_TO_M * height / det->ysize();
       detScaling.componentName = detname;
+      // Scaling will need both scale factors if LoadIsawPeaks or LoadIsawDetCal
+      // has already
+      // applied a calibration
+      if (inputW) {
+        Geometry::ParameterMap &pmap = inputW->instrumentParameters();
+        auto oldscalex = pmap.getDouble(detname, std::string("scalex"));
+        auto oldscaley = pmap.getDouble(detname, std::string("scaley"));
+        if (!oldscalex.empty())
+          detScaling.scaleX *= oldscalex[0];
+        if (!oldscaley.empty())
+          detScaling.scaleY *= oldscaley[0];
+      }
+      if (inputP) {
+        Geometry::ParameterMap &pmap = inputP->instrumentParameters();
+        auto oldscalex = pmap.getDouble(detname, std::string("scalex"));
+        auto oldscaley = pmap.getDouble(detname, std::string("scaley"));
+        if (!oldscalex.empty())
+          detScaling.scaleX *= oldscalex[0];
+        if (!oldscaley.empty())
+          detScaling.scaleY *= oldscaley[0];
+      }
+
       rectangularDetectorScalings.push_back(detScaling);
 
       doRotation(rX, rY, detectorInfo, det);

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -39,12 +39,12 @@ using namespace DataObjects;
 /** Initialisation method
 */
 void LoadIsawDetCal::init() {
-  declareProperty(Kernel::make_unique<WorkspaceProperty<Workspace> >(
+  declareProperty(Kernel::make_unique<WorkspaceProperty<Workspace>>(
                       "InputWorkspace", "", Direction::InOut,
                       boost::make_shared<InstrumentValidator>()),
                   "The workspace containing the geometry to be calibrated.");
 
-  const auto exts = std::vector<std::string>({ ".DetCal" });
+  const auto exts = std::vector<std::string>({".DetCal"});
   declareProperty(
       Kernel::make_unique<API::MultipleFileProperty>("Filename", exts),
       "The input filename of the ISAW DetCal file (Two files "
@@ -133,7 +133,7 @@ void LoadIsawDetCal::exec() {
   std::string line;
   std::string detname;
   // Build a list of Rectangular Detectors
-  std::vector<boost::shared_ptr<RectangularDetector> > detList;
+  std::vector<boost::shared_ptr<RectangularDetector>> detList;
   for (int i = 0; i < inst->nelements(); i++) {
     boost::shared_ptr<RectangularDetector> det;
     boost::shared_ptr<ICompAssembly> assem;
@@ -406,7 +406,7 @@ Instrument_sptr LoadIsawDetCal::getCheckInst(API::Workspace_sptr ws) {
 
 std::vector<std::string> LoadIsawDetCal::getFilenames() {
   std::vector<std::string> filenamesFromPropertyUnraveld;
-  std::vector<std::vector<std::string> > filenamesFromProperty =
+  std::vector<std::vector<std::string>> filenamesFromProperty =
       this->getProperty("Filename");
   for (const auto &outer : filenamesFromProperty) {
     std::copy(outer.begin(), outer.end(),

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -39,12 +39,12 @@ using namespace DataObjects;
 /** Initialisation method
 */
 void LoadIsawDetCal::init() {
-  declareProperty(Kernel::make_unique<WorkspaceProperty<Workspace>>(
+  declareProperty(Kernel::make_unique<WorkspaceProperty<Workspace> >(
                       "InputWorkspace", "", Direction::InOut,
                       boost::make_shared<InstrumentValidator>()),
                   "The workspace containing the geometry to be calibrated.");
 
-  const auto exts = std::vector<std::string>({".DetCal"});
+  const auto exts = std::vector<std::string>({ ".DetCal" });
   declareProperty(
       Kernel::make_unique<API::MultipleFileProperty>("Filename", exts),
       "The input filename of the ISAW DetCal file (Two files "
@@ -133,7 +133,7 @@ void LoadIsawDetCal::exec() {
   std::string line;
   std::string detname;
   // Build a list of Rectangular Detectors
-  std::vector<boost::shared_ptr<RectangularDetector>> detList;
+  std::vector<boost::shared_ptr<RectangularDetector> > detList;
   for (int i = 0; i < inst->nelements(); i++) {
     boost::shared_ptr<RectangularDetector> det;
     boost::shared_ptr<ICompAssembly> assem;
@@ -218,12 +218,21 @@ void LoadIsawDetCal::exec() {
         alg1->setProperty<MatrixWorkspace_sptr>("OutputWorkspace", inputW);
         if (run.hasProperty("T0")) {
           double T0IDF = run.getPropertyValueAsType<double>("T0");
-          alg1->setProperty("Offset", mT0 - T0IDF);
+          mT0 += T0IDF;
+          alg1->setProperty("Offset", mT0);
         } else {
           alg1->setProperty("Offset", mT0);
         }
         alg1->executeAsChildAlg();
         inputW = alg1->getProperty("OutputWorkspace");
+        // set T0 in the run parameters
+        run.addProperty<double>("T0", mT0, true);
+      } else if (inputP) {
+        API::Run &run = inputP->mutableRun();
+        if (run.hasProperty("T0")) {
+          double T0IDF = run.getPropertyValueAsType<double>("T0");
+          mT0 += T0IDF;
+        }
         // set T0 in the run parameters
         run.addProperty<double>("T0", mT0, true);
       }
@@ -375,7 +384,7 @@ Instrument_sptr LoadIsawDetCal::getCheckInst(API::Workspace_sptr ws) {
 
 std::vector<std::string> LoadIsawDetCal::getFilenames() {
   std::vector<std::string> filenamesFromPropertyUnraveld;
-  std::vector<std::vector<std::string>> filenamesFromProperty =
+  std::vector<std::vector<std::string> > filenamesFromProperty =
       this->getProperty("Filename");
   for (const auto &outer : filenamesFromProperty) {
     std::copy(outer.begin(), outer.end(),

--- a/docs/source/release/v3.11.0/diffraction.rst
+++ b/docs/source/release/v3.11.0/diffraction.rst
@@ -8,6 +8,7 @@ Diffraction Changes
 Crystal Improvements
 --------------------
 
+- SCDCalibratePanels now uses sample displacement and optimized T0 for the calibration.  :ref:`SCDCalibratePanels <algm-SCDCalibratePanels>` 
 Engineering Diffraction
 -----------------------
 

--- a/docs/source/release/v3.11.0/diffraction.rst
+++ b/docs/source/release/v3.11.0/diffraction.rst
@@ -8,7 +8,8 @@ Diffraction Changes
 Crystal Improvements
 --------------------
 
-- SCDCalibratePanels now uses sample displacement and optimized T0 for the calibration.  :ref:`SCDCalibratePanels <algm-SCDCalibratePanels>` 
+- :ref:`SCDCalibratePanels <algm-SCDCalibratePanels>` now adjusts the sample offsets and has an option to optimize the initial time-of-flight for better calibration of single crystal data.
+
 Engineering Diffraction
 -----------------------
 


### PR DESCRIPTION
Description of work.
Added sample displacement and optimization of T0 back to single crystal calibration.

**To test:**
https://www.dropbox.com/s/5eidrhs9ehnfkge/Si2mm_Cubic_F.integrate?dl=0
```python
LoadIsawPeaks(Filename='Si2mm_Cubic_F.integrate', OutputWorkspace='peaks_ws')
SCDCalibratePanels(PeakWorkspace='peaks_ws', a=5.431, b=5.431, c=5.431, alpha=90, beta=90, gamma=90, DetCalFilename='SCDCalibrate.DetCal',ChangeL1=False,ChangeT0=True)
```
Fixes #19900 

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
