### PR TITLE
Added validation for event workspaces in ConjoinWorkspaces

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/WorkspaceJoiners.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/WorkspaceJoiners.h
@@ -56,8 +56,7 @@ protected:
 
   using Mantid::API::Algorithm::validateInputs;
   void validateInputs(const API::MatrixWorkspace &ws1,
-	  const API::MatrixWorkspace &ws2,
-	  const bool checkBinning);
+                      const API::MatrixWorkspace &ws2, const bool checkBinning);
   void validateInputs(const API::MatrixWorkspace &ws1,
                       const API::MatrixWorkspace &ws2);
   void getMinMax(const API::MatrixWorkspace &ws, specnum_t &min,

--- a/Framework/Algorithms/inc/MantidAlgorithms/WorkspaceJoiners.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/WorkspaceJoiners.h
@@ -56,7 +56,8 @@ protected:
 
   using Mantid::API::Algorithm::validateInputs;
   void validateInputs(const API::MatrixWorkspace &ws1,
-                      const API::MatrixWorkspace &ws2, const bool checkBinning = true);
+                      const API::MatrixWorkspace &ws2,
+                      const bool checkBinning = true);
   void getMinMax(const API::MatrixWorkspace &ws, specnum_t &min,
                  specnum_t &max);
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/WorkspaceJoiners.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/WorkspaceJoiners.h
@@ -56,6 +56,9 @@ protected:
 
   using Mantid::API::Algorithm::validateInputs;
   void validateInputs(const API::MatrixWorkspace &ws1,
+	  const API::MatrixWorkspace &ws2,
+	  const bool checkBinning);
+  void validateInputs(const API::MatrixWorkspace &ws1,
                       const API::MatrixWorkspace &ws2);
   void getMinMax(const API::MatrixWorkspace &ws, specnum_t &min,
                  specnum_t &max);

--- a/Framework/Algorithms/inc/MantidAlgorithms/WorkspaceJoiners.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/WorkspaceJoiners.h
@@ -56,9 +56,7 @@ protected:
 
   using Mantid::API::Algorithm::validateInputs;
   void validateInputs(const API::MatrixWorkspace &ws1,
-                      const API::MatrixWorkspace &ws2, const bool checkBinning);
-  void validateInputs(const API::MatrixWorkspace &ws1,
-                      const API::MatrixWorkspace &ws2);
+                      const API::MatrixWorkspace &ws2, const bool checkBinning = true);
   void getMinMax(const API::MatrixWorkspace &ws, specnum_t &min,
                  specnum_t &max);
 

--- a/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -55,7 +55,7 @@ void ConjoinWorkspaces::exec() {
   }
 
   if (event_ws1 && event_ws2) {
-    this->validateInputs(*event_ws1, *event_ws2);
+    this->validateInputs(*event_ws1, *event_ws2, false);
 
     // Check there is no overlap
     if (this->getProperty("CheckOverlapping")) {

--- a/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -74,22 +74,22 @@ void ConjoinWorkspaces::exec() {
     // Set the result workspace to the first input
     setProperty("InputWorkspace1", output);
   } else {
-	  // Check that the input workspaces meet the requirements for this algorithm
-	  this->validateInputs(*ws1, *ws2);
+    // Check that the input workspaces meet the requirements for this algorithm
+    this->validateInputs(*ws1, *ws2);
 
-	  if (this->getProperty("CheckOverlapping")) {
-		  this->checkForOverlap(*ws1, *ws2, true);
-		  m_overlapChecked = true;
-	  }
+    if (this->getProperty("CheckOverlapping")) {
+      this->checkForOverlap(*ws1, *ws2, true);
+      m_overlapChecked = true;
+    }
 
-	  MatrixWorkspace_sptr output = execWS2D(*ws1, *ws2);
-	  // Copy the history from the original workspace
-	  output->history().addHistory(ws1->getHistory());
+    MatrixWorkspace_sptr output = execWS2D(*ws1, *ws2);
+    // Copy the history from the original workspace
+    output->history().addHistory(ws1->getHistory());
 
-	  // Delete the second input workspace from the ADS
-	  AnalysisDataService::Instance().remove(getPropertyValue("InputWorkspace2"));
-	  // Set the result workspace to the first input
-	  setProperty("InputWorkspace1", output);
+    // Delete the second input workspace from the ADS
+    AnalysisDataService::Instance().remove(getPropertyValue("InputWorkspace2"));
+    // Set the result workspace to the first input
+    setProperty("InputWorkspace1", output);
   }
 }
 

--- a/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -55,6 +55,8 @@ void ConjoinWorkspaces::exec() {
   }
 
   if (event_ws1 && event_ws2) {
+    this->validateInputs(*event_ws1, *event_ws2);
+
     // We do not need to check that binning is compatible, just that there is no
     // overlap
     // make sure we should bother checking
@@ -71,25 +73,24 @@ void ConjoinWorkspaces::exec() {
     AnalysisDataService::Instance().remove(getPropertyValue("InputWorkspace2"));
     // Set the result workspace to the first input
     setProperty("InputWorkspace1", output);
-    return;
+  } else {
+	  // Check that the input workspaces meet the requirements for this algorithm
+	  this->validateInputs(*ws1, *ws2);
+
+	  if (this->getProperty("CheckOverlapping")) {
+		  this->checkForOverlap(*ws1, *ws2, true);
+		  m_overlapChecked = true;
+	  }
+
+	  MatrixWorkspace_sptr output = execWS2D(*ws1, *ws2);
+	  // Copy the history from the original workspace
+	  output->history().addHistory(ws1->getHistory());
+
+	  // Delete the second input workspace from the ADS
+	  AnalysisDataService::Instance().remove(getPropertyValue("InputWorkspace2"));
+	  // Set the result workspace to the first input
+	  setProperty("InputWorkspace1", output);
   }
-
-  // Check that the input workspaces meet the requirements for this algorithm
-  this->validateInputs(*ws1, *ws2);
-
-  if (this->getProperty("CheckOverlapping")) {
-    this->checkForOverlap(*ws1, *ws2, true);
-    m_overlapChecked = true;
-  }
-
-  MatrixWorkspace_sptr output = execWS2D(*ws1, *ws2);
-  // Copy the history from the original workspace
-  output->history().addHistory(ws1->getHistory());
-
-  // Delete the second input workspace from the ADS
-  AnalysisDataService::Instance().remove(getPropertyValue("InputWorkspace2"));
-  // Set the result workspace to the first input
-  setProperty("InputWorkspace1", output);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -57,9 +57,7 @@ void ConjoinWorkspaces::exec() {
   if (event_ws1 && event_ws2) {
     this->validateInputs(*event_ws1, *event_ws2);
 
-    // We do not need to check that binning is compatible, just that there is no
-    // overlap
-    // make sure we should bother checking
+    // Check there is no overlap
     if (this->getProperty("CheckOverlapping")) {
       this->checkForOverlap(*event_ws1, *event_ws2, false);
       m_overlapChecked = true;

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -164,7 +164,8 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
 }
 
 /** Checks that the two input workspace have common size and the same
-* instrument & unit. There is an option to check whether their binning is compatible
+* instrument & unit. There is an option to check whether their binning is
+* compatible
 *  Also calls the checkForOverlap method.
 *  @param ws1 :: The first input workspace
 *  @param ws2 :: The second input workspace

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -163,59 +163,62 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
   return std::move(output);
 }
 
-/** Checks that the two input workspace have common binning & size, the same
-* instrument & unit.
+/** Checks that the two input workspace have common size and the same
+* instrument & unit. There is an option to check whether their binning is compatible
 *  Also calls the checkForOverlap method.
 *  @param ws1 :: The first input workspace
 *  @param ws2 :: The second input workspace
-*  @param checkBinning :: A flag for whether to check that the workspaces have compatible binning
+*  @param checkBinning :: A flag for whether to check that the workspaces have
+* compatible binning
 *  @throw std::invalid_argument If the workspaces are not compatible
 */
-void Mantid::Algorithms::WorkspaceJoiners::validateInputs(const API::MatrixWorkspace & ws1, const API::MatrixWorkspace & ws2, const bool checkBinning){
-	// Workspaces with point data are allowed to have different binning
-	if (checkBinning) {
-		// This is the full check for common binning
-		if (!WorkspaceHelpers::commonBoundaries(ws1) ||
-			!WorkspaceHelpers::commonBoundaries(ws2)) {
-			g_log.error("Both input workspaces must have common binning for all "
-				"their spectra");
-			throw std::invalid_argument("Both input workspaces must have common "
-				"binning for all their spectra");
-		}
-	}
+void Mantid::Algorithms::WorkspaceJoiners::validateInputs(
+    const API::MatrixWorkspace &ws1, const API::MatrixWorkspace &ws2,
+    const bool checkBinning) {
+  // Workspaces with point data are allowed to have different binning
+  if (checkBinning) {
+    // This is the full check for common binning
+    if (!WorkspaceHelpers::commonBoundaries(ws1) ||
+        !WorkspaceHelpers::commonBoundaries(ws2)) {
+      g_log.error("Both input workspaces must have common binning for all "
+                  "their spectra");
+      throw std::invalid_argument("Both input workspaces must have common "
+                                  "binning for all their spectra");
+    }
+  }
 
-	if (ws1.getInstrument()->getName() != ws2.getInstrument()->getName()) {
-		const std::string message("The input workspaces are not compatible because "
-			"they come from different instruments");
-		g_log.error(message);
-		throw std::invalid_argument(message);
-	}
+  if (ws1.getInstrument()->getName() != ws2.getInstrument()->getName()) {
+    const std::string message("The input workspaces are not compatible because "
+                              "they come from different instruments");
+    g_log.error(message);
+    throw std::invalid_argument(message);
+  }
 
-	Unit_const_sptr ws1_unit = ws1.getAxis(0)->unit();
-	Unit_const_sptr ws2_unit = ws2.getAxis(0)->unit();
-	const std::string ws1_unitID = (ws1_unit ? ws1_unit->unitID() : "");
-	const std::string ws2_unitID = (ws2_unit ? ws2_unit->unitID() : "");
+  Unit_const_sptr ws1_unit = ws1.getAxis(0)->unit();
+  Unit_const_sptr ws2_unit = ws2.getAxis(0)->unit();
+  const std::string ws1_unitID = (ws1_unit ? ws1_unit->unitID() : "");
+  const std::string ws2_unitID = (ws2_unit ? ws2_unit->unitID() : "");
 
-	if (ws1_unitID != ws2_unitID) {
-		const std::string message("The input workspaces are not compatible because "
-			"they have different units on the X axis");
-		g_log.error(message);
-		throw std::invalid_argument(message);
-	}
+  if (ws1_unitID != ws2_unitID) {
+    const std::string message("The input workspaces are not compatible because "
+                              "they have different units on the X axis");
+    g_log.error(message);
+    throw std::invalid_argument(message);
+  }
 
-	if (ws1.isDistribution() != ws2.isDistribution()) {
-		const std::string message(
-			"The input workspaces have inconsistent distribution flags");
-		g_log.error(message);
-		throw std::invalid_argument(message);
-	}
+  if (ws1.isDistribution() != ws2.isDistribution()) {
+    const std::string message(
+        "The input workspaces have inconsistent distribution flags");
+    g_log.error(message);
+    throw std::invalid_argument(message);
+  }
 
-	if (!WorkspaceHelpers::matchingBins(ws1, ws2, true)) {
-		const std::string message("The input workspaces are not compatible because "
-			"they have different binning");
-		g_log.error(message);
-		throw std::invalid_argument(message);
-	}
+  if (!WorkspaceHelpers::matchingBins(ws1, ws2, true)) {
+    const std::string message("The input workspaces are not compatible because "
+                              "they have different binning");
+    g_log.error(message);
+    throw std::invalid_argument(message);
+  }
 }
 
 /** Checks that the two input workspace have common binning & size, the same
@@ -227,7 +230,7 @@ void Mantid::Algorithms::WorkspaceJoiners::validateInputs(const API::MatrixWorks
  */
 void WorkspaceJoiners::validateInputs(const MatrixWorkspace &ws1,
                                       const MatrixWorkspace &ws2) {
-	validateInputs(ws1, ws2, true);
+  validateInputs(ws1, ws2, true);
 }
 
 /**

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -164,6 +164,61 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
 }
 
 /** Checks that the two input workspace have common binning & size, the same
+* instrument & unit.
+*  Also calls the checkForOverlap method.
+*  @param ws1 :: The first input workspace
+*  @param ws2 :: The second input workspace
+*  @param checkBinning :: A flag for whether to check that the workspaces have compatible binning
+*  @throw std::invalid_argument If the workspaces are not compatible
+*/
+void Mantid::Algorithms::WorkspaceJoiners::validateInputs(const API::MatrixWorkspace & ws1, const API::MatrixWorkspace & ws2, const bool checkBinning){
+	// Workspaces with point data are allowed to have different binning
+	if (checkBinning) {
+		// This is the full check for common binning
+		if (!WorkspaceHelpers::commonBoundaries(ws1) ||
+			!WorkspaceHelpers::commonBoundaries(ws2)) {
+			g_log.error("Both input workspaces must have common binning for all "
+				"their spectra");
+			throw std::invalid_argument("Both input workspaces must have common "
+				"binning for all their spectra");
+		}
+	}
+
+	if (ws1.getInstrument()->getName() != ws2.getInstrument()->getName()) {
+		const std::string message("The input workspaces are not compatible because "
+			"they come from different instruments");
+		g_log.error(message);
+		throw std::invalid_argument(message);
+	}
+
+	Unit_const_sptr ws1_unit = ws1.getAxis(0)->unit();
+	Unit_const_sptr ws2_unit = ws2.getAxis(0)->unit();
+	const std::string ws1_unitID = (ws1_unit ? ws1_unit->unitID() : "");
+	const std::string ws2_unitID = (ws2_unit ? ws2_unit->unitID() : "");
+
+	if (ws1_unitID != ws2_unitID) {
+		const std::string message("The input workspaces are not compatible because "
+			"they have different units on the X axis");
+		g_log.error(message);
+		throw std::invalid_argument(message);
+	}
+
+	if (ws1.isDistribution() != ws2.isDistribution()) {
+		const std::string message(
+			"The input workspaces have inconsistent distribution flags");
+		g_log.error(message);
+		throw std::invalid_argument(message);
+	}
+
+	if (!WorkspaceHelpers::matchingBins(ws1, ws2, true)) {
+		const std::string message("The input workspaces are not compatible because "
+			"they have different binning");
+		g_log.error(message);
+		throw std::invalid_argument(message);
+	}
+}
+
+/** Checks that the two input workspace have common binning & size, the same
  * instrument & unit.
  *  Also calls the checkForOverlap method.
  *  @param ws1 :: The first input workspace
@@ -172,50 +227,7 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
  */
 void WorkspaceJoiners::validateInputs(const MatrixWorkspace &ws1,
                                       const MatrixWorkspace &ws2) {
-  // Workspaces with point data are allowed to have different binning
-  if (ws1.isHistogramData() || ws2.isHistogramData()) {
-    // This is the full check for common binning
-    if (!WorkspaceHelpers::commonBoundaries(ws1) ||
-        !WorkspaceHelpers::commonBoundaries(ws2)) {
-      g_log.error("Both input workspaces must have common binning for all "
-                  "their spectra");
-      throw std::invalid_argument("Both input workspaces must have common "
-                                  "binning for all their spectra");
-    }
-  }
-
-  if (ws1.getInstrument()->getName() != ws2.getInstrument()->getName()) {
-    const std::string message("The input workspaces are not compatible because "
-                              "they come from different instruments");
-    g_log.error(message);
-    throw std::invalid_argument(message);
-  }
-
-  Unit_const_sptr ws1_unit = ws1.getAxis(0)->unit();
-  Unit_const_sptr ws2_unit = ws2.getAxis(0)->unit();
-  const std::string ws1_unitID = (ws1_unit ? ws1_unit->unitID() : "");
-  const std::string ws2_unitID = (ws2_unit ? ws2_unit->unitID() : "");
-
-  if (ws1_unitID != ws2_unitID) {
-    const std::string message("The input workspaces are not compatible because "
-                              "they have different units on the X axis");
-    g_log.error(message);
-    throw std::invalid_argument(message);
-  }
-
-  if (ws1.isDistribution() != ws2.isDistribution()) {
-    const std::string message(
-        "The input workspaces have inconsistent distribution flags");
-    g_log.error(message);
-    throw std::invalid_argument(message);
-  }
-
-  if (!WorkspaceHelpers::matchingBins(ws1, ws2, true)) {
-    const std::string message("The input workspaces are not compatible because "
-                              "they have different binning");
-    g_log.error(message);
-    throw std::invalid_argument(message);
-  }
+	validateInputs(ws1, ws2, true);
 }
 
 /**

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -172,14 +172,17 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
  */
 void WorkspaceJoiners::validateInputs(const MatrixWorkspace &ws1,
                                       const MatrixWorkspace &ws2) {
-  // This is the full check for common binning
-  if (!WorkspaceHelpers::commonBoundaries(ws1) ||
-      !WorkspaceHelpers::commonBoundaries(ws2)) {
-    g_log.error(
-        "Both input workspaces must have common binning for all their spectra");
-    throw std::invalid_argument(
-        "Both input workspaces must have common binning for all their spectra");
-  }
+	// Workspaces with point data are allowed to have different binning
+	if (ws1.isHistogramData() || ws2.isHistogramData()) {
+		// This is the full check for common binning
+		if (!WorkspaceHelpers::commonBoundaries(ws1) ||
+			!WorkspaceHelpers::commonBoundaries(ws2)) {
+			g_log.error(
+				"Both input workspaces must have common binning for all their spectra");
+			throw std::invalid_argument(
+				"Both input workspaces must have common binning for all their spectra");
+		}
+	}
 
   if (ws1.getInstrument()->getName() != ws2.getInstrument()->getName()) {
     const std::string message("The input workspaces are not compatible because "

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -172,17 +172,17 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
  */
 void WorkspaceJoiners::validateInputs(const MatrixWorkspace &ws1,
                                       const MatrixWorkspace &ws2) {
-	// Workspaces with point data are allowed to have different binning
-	if (ws1.isHistogramData() || ws2.isHistogramData()) {
-		// This is the full check for common binning
-		if (!WorkspaceHelpers::commonBoundaries(ws1) ||
-			!WorkspaceHelpers::commonBoundaries(ws2)) {
-			g_log.error(
-				"Both input workspaces must have common binning for all their spectra");
-			throw std::invalid_argument(
-				"Both input workspaces must have common binning for all their spectra");
-		}
-	}
+  // Workspaces with point data are allowed to have different binning
+  if (ws1.isHistogramData() || ws2.isHistogramData()) {
+    // This is the full check for common binning
+    if (!WorkspaceHelpers::commonBoundaries(ws1) ||
+        !WorkspaceHelpers::commonBoundaries(ws2)) {
+      g_log.error("Both input workspaces must have common binning for all "
+                  "their spectra");
+      throw std::invalid_argument("Both input workspaces must have common "
+                                  "binning for all their spectra");
+    }
+  }
 
   if (ws1.getInstrument()->getName() != ws2.getInstrument()->getName()) {
     const std::string message("The input workspaces are not compatible because "

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -170,7 +170,7 @@ MatrixWorkspace_sptr WorkspaceJoiners::execEvent() {
 *  @param ws1 :: The first input workspace
 *  @param ws2 :: The second input workspace
 *  @param checkBinning :: A flag for whether to check that the workspaces have
-* compatible binning
+* compatible binning (default true)
 *  @throw std::invalid_argument If the workspaces are not compatible
 */
 void Mantid::Algorithms::WorkspaceJoiners::validateInputs(
@@ -220,18 +220,6 @@ void Mantid::Algorithms::WorkspaceJoiners::validateInputs(
     g_log.error(message);
     throw std::invalid_argument(message);
   }
-}
-
-/** Checks that the two input workspace have common binning & size, the same
- * instrument & unit.
- *  Also calls the checkForOverlap method.
- *  @param ws1 :: The first input workspace
- *  @param ws2 :: The second input workspace
- *  @throw std::invalid_argument If the workspaces are not compatible
- */
-void WorkspaceJoiners::validateInputs(const MatrixWorkspace &ws1,
-                                      const MatrixWorkspace &ws2) {
-  validateInputs(ws1, ws2, true);
 }
 
 /**

--- a/Framework/Algorithms/test/ConjoinWorkspacesTest.h
+++ b/Framework/Algorithms/test/ConjoinWorkspacesTest.h
@@ -4,11 +4,15 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAlgorithms/ConjoinWorkspaces.h"
+#include "MantidAlgorithms/CropWorkspace.h"
+#include "MantidAlgorithms/Rebin.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceHistory.h"
 #include "MantidDataHandling/LoadRaw3.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+#include <string>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
@@ -148,6 +152,20 @@ public:
     TS_ASSERT(!conj.isExecuted());
   }
 
+  void testMismatchedEventWorkspace() {
+	  auto ws1 = setupMismatchedWorkspace(0, 2, "100,200,700");
+	  auto ws2 = setupMismatchedWorkspace(3, 5, "100,200,1000");
+
+	  ConjoinWorkspaces conj;
+	  conj.initialize();
+	  conj.setRethrows(true);
+
+	  conj.setProperty("InputWorkspace1", ws1);
+	  conj.setProperty("InputWorkspace2", ws2);
+	  TS_ASSERT_THROWS(conj.execute(), std::invalid_argument);
+	  TS_ASSERT(!conj.isExecuted());
+  }
+
   void testDoCheckForOverlap() {
     MatrixWorkspace_sptr ws1, ws2;
     int numPixels = 10;
@@ -241,6 +259,36 @@ public:
 private:
   const std::string ws1Name;
   const std::string ws2Name;
+
+  MatrixWorkspace_sptr setupMismatchedWorkspace(int startIndex, int endIndex, const std::string& rebinParams) const {
+	  MatrixWorkspace_sptr ews =
+		  WorkspaceCreationHelper::createEventWorkspace(10, 10);
+
+	  // Crop ews to have first 3 spectra, ews2 to have second 3
+	  CropWorkspace crop;
+	  crop.setChild(true);
+	  crop.initialize();
+	  crop.setProperty("InputWorkspace", ews);
+	  crop.setProperty("StartWorkspaceIndex", startIndex);
+	  crop.setProperty("EndWorkspaceIndex", endIndex);
+	  crop.setProperty("OutputWorkspace", "out");
+	  crop.execute();
+
+	  MatrixWorkspace_sptr cropped = crop.getProperty("OutputWorkspace");
+
+	  Rebin rebin;
+	  rebin.setChild(true);
+	  rebin.initialize();
+	  rebin.setProperty("InputWorkspace", cropped);
+	  rebin.setProperty("Params", rebinParams);
+	  rebin.setProperty("OutputWorkspace", "out");
+	  rebin.execute();
+
+	  MatrixWorkspace_sptr out = rebin.getProperty("OutputWorkspace");
+	  return out;
+
+  }
+
 };
 
 #endif /*CONJOINWORKSPACESTEST_H_*/

--- a/Framework/Algorithms/test/ConjoinWorkspacesTest.h
+++ b/Framework/Algorithms/test/ConjoinWorkspacesTest.h
@@ -153,17 +153,17 @@ public:
   }
 
   void testMismatchedEventWorkspace() {
-	  auto ws1 = setupMismatchedWorkspace(0, 2, "100,200,700");
-	  auto ws2 = setupMismatchedWorkspace(3, 5, "100,200,1000");
+    auto ws1 = setupMismatchedWorkspace(0, 2, "100,200,700");
+    auto ws2 = setupMismatchedWorkspace(3, 5, "100,200,1000");
 
-	  ConjoinWorkspaces conj;
-	  conj.initialize();
-	  conj.setRethrows(true);
+    ConjoinWorkspaces conj;
+    conj.initialize();
+    conj.setRethrows(true);
 
-	  conj.setProperty("InputWorkspace1", ws1);
-	  conj.setProperty("InputWorkspace2", ws2);
-	  TS_ASSERT_THROWS(conj.execute(), std::invalid_argument);
-	  TS_ASSERT(!conj.isExecuted());
+    conj.setProperty("InputWorkspace1", ws1);
+    conj.setProperty("InputWorkspace2", ws2);
+    TS_ASSERT_THROWS(conj.execute(), std::invalid_argument);
+    TS_ASSERT(!conj.isExecuted());
   }
 
   void testDoCheckForOverlap() {
@@ -260,35 +260,35 @@ private:
   const std::string ws1Name;
   const std::string ws2Name;
 
-  MatrixWorkspace_sptr setupMismatchedWorkspace(int startIndex, int endIndex, const std::string& rebinParams) const {
-	  MatrixWorkspace_sptr ews =
-		  WorkspaceCreationHelper::createEventWorkspace(10, 10);
+  MatrixWorkspace_sptr
+  setupMismatchedWorkspace(int startIndex, int endIndex,
+                           const std::string &rebinParams) const {
+    MatrixWorkspace_sptr ews =
+        WorkspaceCreationHelper::createEventWorkspace(10, 10);
 
-	  // Crop ews to have first 3 spectra, ews2 to have second 3
-	  CropWorkspace crop;
-	  crop.setChild(true);
-	  crop.initialize();
-	  crop.setProperty("InputWorkspace", ews);
-	  crop.setProperty("StartWorkspaceIndex", startIndex);
-	  crop.setProperty("EndWorkspaceIndex", endIndex);
-	  crop.setProperty("OutputWorkspace", "out");
-	  crop.execute();
+    // Crop ews to have first 3 spectra, ews2 to have second 3
+    CropWorkspace crop;
+    crop.setChild(true);
+    crop.initialize();
+    crop.setProperty("InputWorkspace", ews);
+    crop.setProperty("StartWorkspaceIndex", startIndex);
+    crop.setProperty("EndWorkspaceIndex", endIndex);
+    crop.setProperty("OutputWorkspace", "out");
+    crop.execute();
 
-	  MatrixWorkspace_sptr cropped = crop.getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr cropped = crop.getProperty("OutputWorkspace");
 
-	  Rebin rebin;
-	  rebin.setChild(true);
-	  rebin.initialize();
-	  rebin.setProperty("InputWorkspace", cropped);
-	  rebin.setProperty("Params", rebinParams);
-	  rebin.setProperty("OutputWorkspace", "out");
-	  rebin.execute();
+    Rebin rebin;
+    rebin.setChild(true);
+    rebin.initialize();
+    rebin.setProperty("InputWorkspace", cropped);
+    rebin.setProperty("Params", rebinParams);
+    rebin.setProperty("OutputWorkspace", "out");
+    rebin.execute();
 
-	  MatrixWorkspace_sptr out = rebin.getProperty("OutputWorkspace");
-	  return out;
-
+    MatrixWorkspace_sptr out = rebin.getProperty("OutputWorkspace");
+    return out;
   }
-
 };
 
 #endif /*CONJOINWORKSPACESTEST_H_*/

--- a/Testing/SystemTests/tests/analysis/ISIS_LETReduction.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_LETReduction.py
@@ -106,7 +106,6 @@ class ReduceLET_OneRep(ReductionWrapper):
         LoadEventNexus(Filename='LET00006278.nxs',OutputWorkspace=sample_ws,
                        SingleBankPixelsOnly='0',LoadMonitors='1',
                        MonitorsAsEvents='1')
-        ConjoinWorkspaces(InputWorkspace1=sample_ws, InputWorkspace2=monitors_ws)
         #prop.sample_run = sample_ws
 
         ebin = prop.energy_bins
@@ -114,7 +113,9 @@ class ReduceLET_OneRep(ReductionWrapper):
 
         (energybin,tbin,t_elastic) = find_binning_range(ei,ebin)
         Rebin(InputWorkspace=sample_ws,OutputWorkspace=sample_ws, Params=tbin, PreserveEvents='1')
+        Rebin(InputWorkspace=monitors_ws,OutputWorkspace=monitors_ws, Params=tbin, PreserveEvents='1')
 
+        ConjoinWorkspaces(InputWorkspace1=sample_ws, InputWorkspace2=monitors_ws)
         prop.bkgd_range=[int(t_elastic),int(tbin[2])]
 
         ebinstring = str(energybin[0])+','+str(energybin[1])+','+str(energybin[2])


### PR DESCRIPTION
Validate EventWorkspaces according to their bins

**To test:**

```python
ws = CreateSampleWorkspace("Event")
ws2 = CreateSampleWorkspace("Event")

ws_cropped = CropWorkspace(ws, StartWorkspaceIndex=0, EndWorkspaceIndex=2)
ws2_cropped = CropWorkspace(ws2, StartWorkspaceIndex=3, EndWorkspaceIndex=5)

ws2_cropped = Rebin(ws2_cropped, Params="100,200,700")

ConjoinWorkspaces(ws_cropped, ws2_cropped)
```

Running the above script in Mantid should produce a ValueError, where previously there was an unhandled exception.

Fixes #5564 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
