### PR TITLE
ManageUserDirectories add missing slashes

### DIFF
--- a/MantidQt/API/inc/MantidQtAPI/ManageUserDirectories.h
+++ b/MantidQt/API/inc/MantidQtAPI/ManageUserDirectories.h
@@ -20,6 +20,7 @@ private:
   virtual void initLayout();
   void loadProperties();
   void saveProperties();
+  void appendSlashIfNone(QString &path) const;
   QListWidget *listWidget();
 
 private slots:

--- a/MantidQt/API/src/ManageUserDirectories.cpp
+++ b/MantidQt/API/src/ManageUserDirectories.cpp
@@ -133,8 +133,9 @@ void ManageUserDirectories::saveProperties() {
 void ManageUserDirectories::appendSlashIfNone(QString &path) const {
   path = path.trimmed();
   if (!(path.endsWith("/") || path.endsWith("\\") || path.isEmpty())) {
-	  // Don't need to add to a \\, as it would just get changed to a / immediately after
-	  path.append("/");
+    // Don't need to add to a \\, as it would just get changed to a /
+    // immediately after
+    path.append("/");
   }
 }
 

--- a/MantidQt/API/src/ManageUserDirectories.cpp
+++ b/MantidQt/API/src/ManageUserDirectories.cpp
@@ -132,10 +132,9 @@ void ManageUserDirectories::saveProperties() {
 */
 void ManageUserDirectories::appendSlashIfNone(QString &path) const {
   path = path.trimmed();
-  if (path.endsWith("/") || path.endsWith("\\") || path.isEmpty()) {
-    return;
-  } else {
-    path.append("/");
+  if (!(path.endsWith("/") || path.endsWith("\\") || path.isEmpty())) {
+	  // Don't need to add to a \\, as it would just get changed to a / immediately after
+	  path.append("/");
   }
 }
 

--- a/MantidQt/API/src/ManageUserDirectories.cpp
+++ b/MantidQt/API/src/ManageUserDirectories.cpp
@@ -125,7 +125,8 @@ void ManageUserDirectories::saveProperties() {
 }
 
 /**
- * Appends a forward slash to the end of a path if there is no slash (forward or back) there already
+ * Appends a forward slash to the end of a path if there is no slash (forward or 
+ * back) there already, and strip whitespace from the path.
  *
  * @param path :: A reference to the path
 */

--- a/MantidQt/API/src/ManageUserDirectories.cpp
+++ b/MantidQt/API/src/ManageUserDirectories.cpp
@@ -94,15 +94,15 @@ void ManageUserDirectories::saveProperties() {
   QStringList userDirs;
 
   for (int i = 0; i < m_uiForm.lwDataSearchDirs->count(); i++) {
-	  QString dir = m_uiForm.lwDataSearchDirs->item(i)->text();
-	  appendSlashIfNone(dir);
-	  dataDirs.append(dir);
+    QString dir = m_uiForm.lwDataSearchDirs->item(i)->text();
+    appendSlashIfNone(dir);
+    dataDirs.append(dir);
   }
 
   for (int i = 0; i < m_uiForm.lwUserSearchDirs->count(); i++) {
-	  QString dir = m_uiForm.lwUserSearchDirs->item(i)->text();
-	  appendSlashIfNone(dir);
-      userDirs.append(dir);
+    QString dir = m_uiForm.lwUserSearchDirs->item(i)->text();
+    appendSlashIfNone(dir);
+    userDirs.append(dir);
   }
 
   newDataDirs = dataDirs.join(";");
@@ -125,19 +125,18 @@ void ManageUserDirectories::saveProperties() {
 }
 
 /**
- * Appends a forward slash to the end of a path if there is no slash (forward or 
+ * Appends a forward slash to the end of a path if there is no slash (forward or
  * back) there already, and strip whitespace from the path.
  *
  * @param path :: A reference to the path
 */
 void ManageUserDirectories::appendSlashIfNone(QString &path) const {
-	path = path.trimmed();
-	if (path.endsWith("/") || path.endsWith("\\") || path.isEmpty()) {
-		return;
-	}
-	else {
-		path.append("/");
-	}
+  path = path.trimmed();
+  if (path.endsWith("/") || path.endsWith("\\") || path.isEmpty()) {
+    return;
+  } else {
+    path.append("/");
+  }
 }
 
 QListWidget *ManageUserDirectories::listWidget() {

--- a/MantidQt/API/src/ManageUserDirectories.cpp
+++ b/MantidQt/API/src/ManageUserDirectories.cpp
@@ -94,11 +94,15 @@ void ManageUserDirectories::saveProperties() {
   QStringList userDirs;
 
   for (int i = 0; i < m_uiForm.lwDataSearchDirs->count(); i++) {
-    dataDirs.append(m_uiForm.lwDataSearchDirs->item(i)->text());
+	  QString dir = m_uiForm.lwDataSearchDirs->item(i)->text();
+	  appendSlashIfNone(dir);
+	  dataDirs.append(dir);
   }
 
   for (int i = 0; i < m_uiForm.lwUserSearchDirs->count(); i++) {
-    userDirs.append(m_uiForm.lwUserSearchDirs->item(i)->text());
+	  QString dir = m_uiForm.lwUserSearchDirs->item(i)->text();
+	  appendSlashIfNone(dir);
+      userDirs.append(dir);
   }
 
   newDataDirs = dataDirs.join(";");
@@ -108,6 +112,7 @@ void ManageUserDirectories::saveProperties() {
 
   newSaveDir = m_uiForm.leDefaultSave->text();
   newSaveDir.replace('\\', '/');
+  appendSlashIfNone(newSaveDir);
 
   Mantid::Kernel::ConfigServiceImpl &config =
       Mantid::Kernel::ConfigService::Instance();
@@ -117,6 +122,21 @@ void ManageUserDirectories::saveProperties() {
   config.setString("defaultsave.directory", newSaveDir.toStdString());
   config.setString("pythonscripts.directories", newUserDirs.toStdString());
   config.saveConfig(m_userPropFile.toStdString());
+}
+
+/**
+ * Appends a forward slash to the end of a path if there is no slash (forward or back) there already
+ *
+ * @param path :: A reference to the path
+*/
+void ManageUserDirectories::appendSlashIfNone(QString &path) const {
+	path = path.trimmed();
+	if (path.endsWith("/") || path.endsWith("\\") || path.isEmpty()) {
+		return;
+	}
+	else {
+		path.append("/");
+	}
 }
 
 QListWidget *ManageUserDirectories::listWidget() {


### PR DESCRIPTION
Slashes are now added to paths in the ManageUserDirectories dialog if they are not already there. This means that paths are treated as paths to directories, so can be loaded and joined correctly.

**To test:**

Open the 'Manage User Directories' dialog, add one of the following paths. 

- Path with no slash at the end
- Path of empty spaces
- Path with spaces at one (or both) ends
- Empty path

On reopening the dialog, the path should appear with a slash appended where appropriate.

Fixes #6098 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.* - This is a minor change which Mantid should have previously handled

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
