### PR TITLE
Fix build warning caused by QDataProcessorWidget

### DIFF
--- a/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorWidget.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorWidget.cpp
@@ -596,9 +596,10 @@ std::string
 QDataProcessorWidget::runPythonAlgorithm(const std::string &pythonCode) {
 
   QString output = runPythonCode(QString::fromStdString(pythonCode));
-  return output.toStdString();
 
   emit runPythonAlgorithm(QString::fromStdString(pythonCode));
+
+  return output.toStdString();
 }
 
 /** Transfer runs to the table


### PR DESCRIPTION
Fixes a build warning. During the merge of the export of the data processor widget, the emmision of a signal was placed after a return statement. 

**To test:**

1. Confirm that the Linux build servers don't show any warning like: 
```
/home/anton/sources/Mantid2/mantid/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorWidget.cpp:602:1: warning: control reaches end of non-void function [-Wreturn-type]
```
2. Use some experiment number and run a reduction. Confirm that the reduction behaves normally.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
