### PR TITLE
Indirect - SofQW NaN values not being changed to 0

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -101,6 +101,7 @@ void IndirectSqw::run() {
   sqwAlg->setProperty("EMode", "Indirect");
   sqwAlg->setProperty("EFixed", eFixed.toStdString());
   sqwAlg->setProperty("Method", "NormalisedPolygon");
+  sqwAlg->setProperty("ReplaceNaNs", true);
 
   m_batchAlgoRunner->addAlgorithm(sqwAlg, sqwInputProps);
 

--- a/docs/source/release/v3.11.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.11.0/indirect_inelastic.rst
@@ -19,6 +19,7 @@ Jump Fit
 
 Improvements
 ------------
+- The *S(Q, W)* interface now automatically replaces NaN values with 0.
 
 
 Bugfixes


### PR DESCRIPTION
When running the indirect algorithm SofQW, through the interface, NaN values were not replaced with 0.

Set the ReplaceNaNs property to true when using the interface to run the SofQW algorithm.

**To test:**
1. Load a *_red.nxs file (have attached such a file) into a workspace.
2. Access the SofQW Algorithm by navigating to Interfaces > Indirect > Data Reduction and clicking on the S(Q, W) tab.
3. Use the created workspace as the input and enter valid values into all fields (e.g. Q Low - 0, Q Width - 0.1, Q High - 2).
4. Ensure there are no NaN values in the newly created *_sqw output workspace.

Example File:
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/1155298/irs26176_graphite002_red.zip)

<!-- Instructions for testing. -->

Fixes #20018. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description]
(http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
