### PR TITLE
Indirect - ConvFit - Fix incorrect column name for delta function EISF errors

### DIFF
--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -567,7 +567,7 @@ void ConvolutionFitSequential::calculateEISF(
         ampName.substr(0, (ampName.size() - std::string("Amplitude").size()));
     columnName += "EISF";
     auto errorColumnName = ampErrorName.substr(
-        0, (ampName.size() - std::string("Amplitude_Err").size()));
+        0, (ampErrorName.size() - std::string("Amplitude_Err").size()));
     errorColumnName += "EISF_Err";
 
     tableWs->addColumn("double", columnName);


### PR DESCRIPTION
Fixed an issue where the column name for EISF errors of a convolution delta function was incorrect. The previous string manipulation (substr) used incorrect values, which have been modified.

**To test:**
1. Load a sample workspace from a *_red.nxs file and an associated resolution workspace from a *_res.nxs
    file (test files attached).
2. Navigate to Interfaces > Indirect > Data Analysis and click on the ConvFit tab.
3. Input the created sample workspace into the sample field and the resolution workspace into the
    resolution field.
4. Set fit type to one/two lorentzians and make sure that under 'Delta Function', use is set to True.
5. Run the algorithm and open the created TableWorkspace.
6. Ensure that all Y-value column names match with their associated Error-value column names.

Test files:
[ConvFitFiles.zip](https://github.com/mantidproject/mantid/files/1155632/ConvFitFiles.zip)

<!-- Instructions for testing. -->

Fixes #20024. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
