### PR TITLE
Skip Wish calibrate test until fitting is fixed

### DIFF
--- a/Testing/SystemTests/tests/analysis/WishCalibrate.py
+++ b/Testing/SystemTests/tests/analysis/WishCalibrate.py
@@ -30,6 +30,9 @@ class WishCalibration(stresstesting.MantidStressTest):
         self.calibration_out_path = tempfile.NamedTemporaryFile().name
         self.correction_out_path = tempfile.NamedTemporaryFile().name
 
+    def skipTests(self):
+        return True
+
     def cleanup(self):
         mantid.mtd.clear()
         try:
@@ -38,17 +41,8 @@ class WishCalibration(stresstesting.MantidStressTest):
         except OSError:
             print("Failed to remove an temp output file in WishCalibration")
 
-    def excludeInPullRequests(self):
-        # Skip in PR's as we require a lot of fitting and the CSV saving / loading can be really IO
-        # intensive slowing this test right down
-        return True
-
     def requiredFiles(self):
         return [self.calibration_ref_name, self.correction_ref_name]
-
-    def requiredMemoryMB(self):
-        # Require at least 8GB if we are going to do this test
-        return 8096
 
     def validate(self):
         calibration_ref_path = mantid.FileFinder.getFullPath(self.calibration_ref_name)


### PR DESCRIPTION
Description of work.
Disables WISH calibrate test until we resolve the issues in #20029 

**To test:**
Check the WISH Calibrate test did not run and was skipped

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
