### PR TITLE
Indirect - Diffraction - Check 'Use Vanadium' checkbox before using vanadium files

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -126,9 +126,8 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
 
         num_samples = len(input_files)
         num_vanadium = len(self.getProperty('VanadiumFiles').value)
-        sum_files = self.getProperty("SumFiles").value
 
-        if not sum_files and num_samples != num_vanadium and num_vanadium != 0:
+        if num_samples != num_vanadium and num_vanadium != 0:
             run_num_mismatch = 'You must input the same number of sample and vanadium runs'
             issues['InputFiles'] = run_num_mismatch
             issues['VanadiumFiles'] = run_num_mismatch

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -126,7 +126,6 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
 
         num_samples = len(input_files)
         num_vanadium = len(self.getProperty('VanadiumFiles').value)
-
         if num_samples != num_vanadium and num_vanadium != 0:
             run_num_mismatch = 'You must input the same number of sample and vanadium runs'
             issues['InputFiles'] = run_num_mismatch

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -126,7 +126,9 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
 
         num_samples = len(input_files)
         num_vanadium = len(self.getProperty('VanadiumFiles').value)
-        if num_samples != num_vanadium and num_vanadium != 0:
+        sum_files = self.getProperty("SumFiles").value
+
+        if not sum_files and num_samples != num_vanadium and num_vanadium != 0:
             run_num_mismatch = 'You must input the same number of sample and vanadium runs'
             issues['InputFiles'] = run_num_mismatch
             issues['VanadiumFiles'] = run_num_mismatch

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -351,9 +351,12 @@ void IndirectDiffractionReduction::runGenericReduction(QString instName,
     }
   }
   if (mode == "diffspec") {
-    const auto vanFile =
+
+    if (m_uiForm.ckUseVanadium->isChecked()) {
+      const auto vanFile =
         m_uiForm.rfVanFile_only->getFilenames().join(",").toStdString();
-    msgDiffReduction->setProperty("VanadiumFiles", vanFile);
+      msgDiffReduction->setProperty("VanadiumFiles", vanFile);
+    }
   }
   msgDiffReduction->setProperty("SumFiles", m_uiForm.ckSumFiles->isChecked());
   msgDiffReduction->setProperty("LoadLogFiles",

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -354,7 +354,7 @@ void IndirectDiffractionReduction::runGenericReduction(QString instName,
 
     if (m_uiForm.ckUseVanadium->isChecked()) {
       const auto vanFile =
-        m_uiForm.rfVanFile_only->getFilenames().join(",").toStdString();
+          m_uiForm.rfVanFile_only->getFilenames().join(",").toStdString();
       msgDiffReduction->setProperty("VanadiumFiles", vanFile);
     }
   }


### PR DESCRIPTION
Added a check to ensure that selected vanadium files are not used unless the 'Use Vanadium' checkbox is checked.

**To test:**
1. Navigate to Interfaces > Indirect > Diffraction.
2. Ensure 'diffspec' is selected in the Reflection drop-down menu.
3. Select an input *_red.nxs (sample) file.
4. Check the 'Use Vanadium File' checkbox.
5. Select one or more vanadium sample files.
6. Uncheck the 'Use Vanadium File' checkbox.
7. Ensure the algorithm does not use the vanadium sample file for calibration.

<!-- Instructions for testing. -->

Fixes #20034 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
