### PR TITLE
Fix spuriously failing system test for SANS

### DIFF
--- a/scripts/test/SANS/user_file/user_file_test_helper.py
+++ b/scripts/test/SANS/user_file/user_file_test_helper.py
@@ -1,5 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
-import os
+import tempfile
 import mantid
 
 sample_user_file = ("PRINT for changer\n"
@@ -79,12 +79,8 @@ sample_user_file = ("PRINT for changer\n"
 
 
 def create_user_file(user_file_content):
-    user_file_path = os.path.join(mantid.config.getString('defaultsave.directory'), 'sample_sans_user_file.txt')
-    if os.path.exists(user_file_path):
-        os.remove(user_file_path)
-
-    with open(user_file_path, 'w') as f:
-        f.write(user_file_content)
-
+    temp = tempfile.NamedTemporaryFile(delete=False)
+    temp.write(user_file_content)
+    user_file_path = temp.name
+    temp.close()
     return user_file_path
-

--- a/scripts/test/SANS/user_file/user_file_test_helper.py
+++ b/scripts/test/SANS/user_file/user_file_test_helper.py
@@ -79,7 +79,7 @@ sample_user_file = ("PRINT for changer\n"
 
 
 def create_user_file(user_file_content):
-    temp = tempfile.NamedTemporaryFile(delete=False)
+    temp = tempfile.NamedTemporaryFile(mode='w+', delete=False)
     temp.write(user_file_content)
     user_file_path = temp.name
     temp.close()


### PR DESCRIPTION
Two test cases created the same file and deleted it. Since they might run in parallel, this can cause issues. The test file generation now uses `tempfile` to create a named file with a unique name. It is unlikely that the two tests will end up with the same file name. 

**To test:**

Ensure that the unit tests for `user_file_state_director_test.py` and  `user_file_state_reader_test.py` pass.



**Release Notes** 
Not needed

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
