### PR TITLE
Removed extra blank page on print all plots

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -7754,12 +7754,15 @@ void ApplicationWindow::printAllPlots() {
     dialog.setMinMax(0, plots);
     printer.setFromTo(0, plots);
 
+    bool firstPage = true;
     foreach (MdiSubWindow *w, windows) {
-      if (std::string(w->metaObject()->className()) == "MultiLayer" &&
-          printer.newPage()) {
-        MultiLayer *ml = dynamic_cast<MultiLayer *>(w);
-        if (ml)
-          ml->printAllLayers(paint);
+      if (std::string(w->metaObject()->className()) == "MultiLayer") {
+          if (firstPage || printer.newPage()) {
+              MultiLayer *ml = dynamic_cast<MultiLayer *>(w);
+              if (ml)
+                  ml->printAllLayers(paint);
+              firstPage = false;
+          }
       }
     }
     paint->end();

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -7757,12 +7757,12 @@ void ApplicationWindow::printAllPlots() {
     bool firstPage = true;
     foreach (MdiSubWindow *w, windows) {
       if (std::string(w->metaObject()->className()) == "MultiLayer") {
-          if (firstPage || printer.newPage()) {
-              MultiLayer *ml = dynamic_cast<MultiLayer *>(w);
-              if (ml)
-                  ml->printAllLayers(paint);
-              firstPage = false;
-          }
+        if (firstPage || printer.newPage()) {
+          MultiLayer *ml = dynamic_cast<MultiLayer *>(w);
+          if (ml)
+            ml->printAllLayers(paint);
+          firstPage = false;
+        }
       }
     }
     paint->end();


### PR DESCRIPTION
Fixed an issue when using File->Print All Plots where an extra blank page would be printed.

**To test:**

- Create/load some workspaces
- Plot multiple spectra plots
- File > Print All Plots
- Select Print To File (PDF)
- Print
- Open the file and check there are no blank pages

Fixes #11606 

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
