### PR TITLE
Add Validator to NumSteps in PeakintensityVsRadius

### DIFF
--- a/Framework/Crystal/src/PeakIntensityVsRadius.cpp
+++ b/Framework/Crystal/src/PeakIntensityVsRadius.cpp
@@ -1,10 +1,10 @@
 #include "MantidCrystal/PeakIntensityVsRadius.h"
-#include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/TextAxis.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
 
 #include "MantidKernel/BoundedValidator.h"
 
@@ -53,7 +53,7 @@ void PeakIntensityVsRadius::init() {
   auto mustBePositive = boost::make_shared<BoundedValidator<int>>();
   mustBePositive->setLower(0);
   declareProperty(
-      "NumSteps", 10,// mustBePositive,
+      "NumSteps", 10, mustBePositive,
       "Number of steps, between start and end, to calculate radius.");
 
   declareProperty(
@@ -179,7 +179,7 @@ void PeakIntensityVsRadius::exec() {
     // Run the integrate algo with this background
     IAlgorithm_sptr alg =
         this->createChildAlgorithm("IntegratePeaksMD", progStep * double(step),
-                                   progStep * double(step + 1), false);
+                                   progStep *double(step + 1), false);
     alg->setProperty("InputWorkspace", inWS);
     alg->setProperty("PeaksWorkspace", peaksWS);
     alg->setProperty("PeakRadius", radius);

--- a/Framework/Crystal/src/PeakIntensityVsRadius.cpp
+++ b/Framework/Crystal/src/PeakIntensityVsRadius.cpp
@@ -179,7 +179,7 @@ void PeakIntensityVsRadius::exec() {
     // Run the integrate algo with this background
     IAlgorithm_sptr alg =
         this->createChildAlgorithm("IntegratePeaksMD", progStep * double(step),
-                                   progStep *double(step + 1), false);
+                                   progStep * double(step + 1), false);
     alg->setProperty("InputWorkspace", inWS);
     alg->setProperty("PeaksWorkspace", peaksWS);
     alg->setProperty("PeakRadius", radius);

--- a/Framework/Crystal/src/PeakIntensityVsRadius.cpp
+++ b/Framework/Crystal/src/PeakIntensityVsRadius.cpp
@@ -50,10 +50,10 @@ void PeakIntensityVsRadius::init() {
 
   declareProperty("RadiusStart", 0.0, "Radius at which to start integrating.");
   declareProperty("RadiusEnd", 1.0, "Radius at which to stop integrating.");
-  // auto mustBePositive = boost::make_shared<BoundedValidator<int>>();
-  // mustBePositive->setLower(0);
+  auto mustBePositive = boost::make_shared<BoundedValidator<int>>();
+  mustBePositive->setLower(0);
   declareProperty(
-      "NumSteps", 10, // mustBePositive,
+      "NumSteps", 10,// mustBePositive,
       "Number of steps, between start and end, to calculate radius.");
 
   declareProperty(

--- a/Framework/Crystal/src/PeakIntensityVsRadius.cpp
+++ b/Framework/Crystal/src/PeakIntensityVsRadius.cpp
@@ -6,7 +6,8 @@
 #include "MantidAPI/TextAxis.h"
 #include "MantidAPI/WorkspaceFactory.h"
 
-#include "MantidKernel/ListValidator.h"
+#include "MantidKernel/BoundedValidator.h"
+
 #include "MantidKernel/Strings.h"
 
 using namespace Mantid::Kernel;
@@ -49,8 +50,10 @@ void PeakIntensityVsRadius::init() {
 
   declareProperty("RadiusStart", 0.0, "Radius at which to start integrating.");
   declareProperty("RadiusEnd", 1.0, "Radius at which to stop integrating.");
+  // auto mustBePositive = boost::make_shared<BoundedValidator<int>>();
+  // mustBePositive->setLower(0);
   declareProperty(
-      "NumSteps", 10,
+      "NumSteps", 10, // mustBePositive,
       "Number of steps, between start and end, to calculate radius.");
 
   declareProperty(

--- a/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
+++ b/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
@@ -67,31 +67,20 @@ public:
         "PeakIntensityVsRadiusTest_peaks", peakWS);
   }
 
+#define TS_ASSERT_SUCCESSFUL_INITIALZATION(alg)                                \
+  TS_ASSERT_THROWS_NOTHING(alg.initialize())                                   \
+  TS_ASSERT(alg.isInitialized())
+
   /** Check the validateInputs() calls */
-  void doTestValid(bool pass, double BackgroundInnerFactor,
+  void doTestValid(bool assertExecuteSuccess, double BackgroundInnerFactor,
                    double BackgroundOuterFactor, double BackgroundInnerRadius,
                    double BackgroundOuterRadius, int NumSteps) {
     PeakIntensityVsRadius alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(
-        "InputWorkspace", "PeakIntensityVsRadiusTest_MDEWS"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(
-        "PeaksWorkspace", "PeakIntensityVsRadiusTest_peaks"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(
-        "OutputWorkspace", "PeakIntensityVsRadiusTest_OutputWS"));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("RadiusStart", 0.0));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("RadiusEnd", 1.5));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumSteps", NumSteps));
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setProperty("BackgroundInnerFactor", BackgroundInnerFactor));
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setProperty("BackgroundOuterFactor", BackgroundOuterFactor));
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setProperty("BackgroundInnerRadius", BackgroundInnerRadius));
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setProperty("BackgroundOuterRadius", BackgroundOuterRadius));
-    if (!pass) {
+    TS_ASSERT_SUCCESSFUL_INITIALZATION(alg);
+    assertNoThrowWhenSettingProperties(
+        BackgroundInnerFactor, BackgroundOuterFactor, BackgroundInnerRadius,
+        BackgroundOuterRadius, NumSteps);
+    if (!assertExecuteSuccess) {
       TS_ASSERT_THROWS_ANYTHING(alg.execute(););
     } else {
       TS_ASSERT_THROWS_NOTHING(alg.execute(););
@@ -130,16 +119,10 @@ public:
     doTestThrowsForInvalid(1.0, 2.0, 0, 0, -8);
   }
 
-  MatrixWorkspace_sptr doTest(double BackgroundInnerFactor,
-                              double BackgroundOuterFactor,
-                              double BackgroundInnerRadius,
-                              double BackgroundOuterRadius) {
-    // Name of the output workspace.
-    std::string outWSName("PeakIntensityVsRadiusTest_OutputWS");
-
-    PeakIntensityVsRadius alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
+  void assertNoThrowWhenSettingProperties(
+      std::string &outWsName, double BackgroundInnerFactor,
+      double BackgroundOuterFactor, double BackgroundInnerRadius,
+      double BackgroundOuterRadius int NumSteps) {
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(
         "InputWorkspace", "PeakIntensityVsRadiusTest_MDEWS"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(
@@ -148,7 +131,7 @@ public:
         alg.setPropertyValue("OutputWorkspace", outWSName));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("RadiusStart", 0.0));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("RadiusEnd", 1.5));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumSteps", 16));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumSteps", NumSteps));
     TS_ASSERT_THROWS_NOTHING(
         alg.setProperty("BackgroundInnerFactor", BackgroundInnerFactor));
     TS_ASSERT_THROWS_NOTHING(
@@ -157,6 +140,21 @@ public:
         alg.setProperty("BackgroundInnerRadius", BackgroundInnerRadius));
     TS_ASSERT_THROWS_NOTHING(
         alg.setProperty("BackgroundOuterRadius", BackgroundOuterRadius));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+  }
+
+  MatrixWorkspace_sptr doTest(double BackgroundInnerFactor,
+                              double BackgroundOuterFactor,
+                              double BackgroundInnerRadius,
+                              double BackgroundOuterRadius, int NumSteps = 16) {
+    // Name of the output workspace.
+    std::string outWSName("PeakIntensityVsRadiusTest_OutputWS");
+
+    PeakIntensityVsRadius alg;
+    TS_ASSERT_SUCCESSFUL_INITIALZATION(alg);
+    assertNoThrowWhenSettingProperties(
+        BackgroundInnerFactor, BackgroundOuterFactor, BackgroundInnerRadius,
+        BackgroundOuterRadius, NumSteps);
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
 

--- a/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
+++ b/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
@@ -126,7 +126,7 @@ public:
                                           double BackgroundOuterFactor,
                                           double BackgroundInnerRadius,
                                           double BackgroundOuterRadius) {
-    auto int constexpr DEFAULT_NUM_STEPS = 16;
+    auto constexpr DEFAULT_NUM_STEPS = 16;
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(
         "InputWorkspace", "PeakIntensityVsRadiusTest_MDEWS"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(

--- a/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
+++ b/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
@@ -89,30 +89,30 @@ public:
   void ensureExecutionThrows(double BackgroundInnerFactor,
                              double BackgroundOuterFactor,
                              double BackgroundInnerRadius,
-                             double BackgroundOuterRadius, int NumSteps = 16) {
+                             double BackgroundOuterRadius) {
     doTestValid(false, BackgroundInnerFactor, BackgroundOuterFactor,
-                BackgroundInnerRadius, BackgroundOuterRadius, NumSteps);
+                BackgroundInnerRadius, BackgroundOuterRadius);
   }
 
   void ensureExecutionNoThrow(double BackgroundInnerFactor,
                               double BackgroundOuterFactor,
                               double BackgroundInnerRadius,
-                              double BackgroundOuterRadius, int NumSteps = 16) {
+                              double BackgroundOuterRadius) {
     doTestValid(true, BackgroundInnerFactor, BackgroundOuterFactor,
-                BackgroundInnerRadius, BackgroundOuterRadius, NumSteps);
+                BackgroundInnerRadius, BackgroundOuterRadius);
   }
 
   /** Check the validateInputs() calls */
   void doTestValid(bool assertExecuteSuccess, double BackgroundInnerFactor,
                    double BackgroundOuterFactor, double BackgroundInnerRadius,
-                   double BackgroundOuterRadius, int NumSteps) {
+                   double BackgroundOuterRadius) {
     PeakIntensityVsRadius alg;
     // Name of the output workspace.
     std::string outWSName("PeakIntensityVsRadiusTest_OutputWS");
     assertSuccessfulInitialization(alg);
     assertNoThrowWhenSettingProperties(
         alg, outWSName, BackgroundInnerFactor, BackgroundOuterFactor,
-        BackgroundInnerRadius, BackgroundOuterRadius, NumSteps);
+        BackgroundInnerRadius, BackgroundOuterRadius);
     if (assertExecuteSuccess) {
       TS_ASSERT_THROWS_NOTHING(alg.execute(););
     } else {
@@ -125,8 +125,8 @@ public:
                                           double BackgroundInnerFactor,
                                           double BackgroundOuterFactor,
                                           double BackgroundInnerRadius,
-                                          double BackgroundOuterRadius,
-                                          int NumSteps) {
+                                          double BackgroundOuterRadius) {
+    auto int constexpr DEFAULT_NUM_STEPS = 16;
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(
         "InputWorkspace", "PeakIntensityVsRadiusTest_MDEWS"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(
@@ -135,7 +135,7 @@ public:
         alg.setPropertyValue("OutputWorkspace", outWSName));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("RadiusStart", 0.0));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("RadiusEnd", 1.5));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumSteps", NumSteps));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumSteps", DEFAULT_NUM_STEPS));
     TS_ASSERT_THROWS_NOTHING(
         alg.setProperty("BackgroundInnerFactor", BackgroundInnerFactor));
     TS_ASSERT_THROWS_NOTHING(
@@ -172,7 +172,7 @@ public:
   MatrixWorkspace_sptr doTest(double BackgroundInnerFactor,
                               double BackgroundOuterFactor,
                               double BackgroundInnerRadius,
-                              double BackgroundOuterRadius, int NumSteps = 16) {
+                              double BackgroundOuterRadius) {
     // Name of the output workspace.
     std::string outWSName("PeakIntensityVsRadiusTest_OutputWS");
 
@@ -180,7 +180,7 @@ public:
     assertSuccessfulInitialization(alg);
     assertNoThrowWhenSettingProperties(
         alg, outWSName, BackgroundInnerFactor, BackgroundOuterFactor,
-        BackgroundInnerRadius, BackgroundOuterRadius, NumSteps);
+        BackgroundInnerRadius, BackgroundOuterRadius);
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
 
@@ -228,9 +228,6 @@ public:
     TS_ASSERT_LESS_THAN(ws->y(0)[5], 1000);
     assertFlatAfter1(ws);
   }
-
-private:
-  PeakIntensityVsRadius m_alg;
 };
 
 #endif /* MANTID_CRYSTAL_PEAKINTENSITYVSRADIUSTEST_H_ */

--- a/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
+++ b/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
@@ -1,9 +1,10 @@
 #ifndef MANTID_CRYSTAL_PEAKINTENSITYVSRADIUSTEST_H_
 #define MANTID_CRYSTAL_PEAKINTENSITYVSRADIUSTEST_H_
 
-#include "MantidCrystal/PeakIntensityVsRadius.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidCrystal/PeakIntensityVsRadius.h"
 #include "MantidDataObjects/Peak.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Instrument.h"
@@ -11,7 +12,6 @@
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/V3D.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
-#include "MantidAPI/FrameworkManager.h"
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid;
@@ -99,15 +99,19 @@ public:
   }
 
   void doTestThrowsForInvalid(double BackgroundInnerFactor,
-    double BackgroundOuterFactor, double BackgroundInnerRadius,
-    double BackgroundOuterRadius, int NumSteps = 16) {
-    doTestValid(false, BackgroundInnerFactor, BackgroundOuterFactor, BackgroundInnerRadius, BackgroundOuterRadius, NumSteps);
+                              double BackgroundOuterFactor,
+                              double BackgroundInnerRadius,
+                              double BackgroundOuterRadius, int NumSteps = 16) {
+    doTestValid(false, BackgroundInnerFactor, BackgroundOuterFactor,
+                BackgroundInnerRadius, BackgroundOuterRadius, NumSteps);
   }
 
   void doTestNoThrowForValid(double BackgroundInnerFactor,
-    double BackgroundOuterFactor, double BackgroundInnerRadius,
-    double BackgroundOuterRadius, int NumSteps = 16) {
-    doTestValid(true, BackgroundInnerFactor, BackgroundOuterFactor, BackgroundInnerRadius, BackgroundOuterRadius, NumSteps);
+                             double BackgroundOuterFactor,
+                             double BackgroundInnerRadius,
+                             double BackgroundOuterRadius, int NumSteps = 16) {
+    doTestValid(true, BackgroundInnerFactor, BackgroundOuterFactor,
+                BackgroundInnerRadius, BackgroundOuterRadius, NumSteps);
   }
 
   void test_validateForValidInputs() {
@@ -165,6 +169,10 @@ public:
     return ws;
   }
 
+#define TS_ASSERT_FLAT_AFTER_1(ws)                                             \
+  TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[12], 1000, 1e-6); \
+  TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[15], 1000, 1e-6)
+
   void test_NoBackground() {
     MatrixWorkspace_sptr ws = doTest(0, 0, 0, 0);
     // Check the results
@@ -174,23 +182,24 @@ public:
     TS_ASSERT_DELTA(ws->x(0)[2], 0.2, 1e-6);
 
     TS_ASSERT_LESS_THAN(ws->y(0)[5], 1000);
-    TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[12], 1000, 1e-6);
-    TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[15], 1000, 1e-6);
+    TS_ASSERT_FLAT_AFTER_1(ws);
   }
+
+#define TS_ASSERT_FIRST_FOUR_Y_VALUES_CLOSE_TO_ZERO(ws)                        \
+  TS_ASSERT_DELTA(ws->y(0)[0], 0, 10);                                         \
+  TS_ASSERT_DELTA(ws->y(0)[1], 0, 10);                                         \
+  TS_ASSERT_DELTA(ws->y(0)[2], 0, 10);                                         \
+  TS_ASSERT_DELTA(ws->y(0)[3], 0, 10)
 
   void test_VariableBackground() {
     MatrixWorkspace_sptr ws = doTest(1.0, 2.0, 0, 0);
     // Check the results
     TSM_ASSERT_EQUALS("Two peaks", ws->getNumberHistograms(), 2);
+    TS_ASSERT_FIRST_FOUR_Y_VALUES_CLOSE_TO_ZERO(ws);
 
     // Points before 0.5 are approximately zero because the background shell is
     // in the peak.
-    TS_ASSERT_DELTA(ws->y(0)[0], 0, 10);
-    TS_ASSERT_DELTA(ws->y(0)[1], 0, 10);
-    TS_ASSERT_DELTA(ws->y(0)[2], 0, 10);
-    TS_ASSERT_DELTA(ws->y(0)[3], 0, 10);
-    TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[12], 1000, 1e-6);
-    TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[15], 1000, 1e-6);
+    TS_ASSERT_FLAT_AFTER_1(ws);
   }
 
   void test_FixedBackground() {
@@ -201,14 +210,9 @@ public:
 
     // Points before 0.5 are approximately zero because the background shell is
     // in the peak.
-    TS_ASSERT_DELTA(ws->y(0)[0], 0, 10);
-    TS_ASSERT_DELTA(ws->y(0)[1], 0, 10);
-    TS_ASSERT_DELTA(ws->y(0)[2], 0, 10);
-    TS_ASSERT_DELTA(ws->y(0)[3], 0, 10);
-    TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[12], 1000, 1e-6);
-    TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[15], 1000, 1e-6);
+    TS_ASSERT_FIRST_FOUR_Y_VALUES_CLOSE_TO_ZERO(ws);
+    TS_ASSERT_FLAT_AFTER_1(ws);
   }
-
 };
 
 #endif /* MANTID_CRYSTAL_PEAKINTENSITYVSRADIUSTEST_H_ */

--- a/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
+++ b/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
@@ -70,7 +70,7 @@ public:
   /** Check the validateInputs() calls */
   void doTestValid(bool pass, double BackgroundInnerFactor,
                    double BackgroundOuterFactor, double BackgroundInnerRadius,
-                   double BackgroundOuterRadius) {
+                   double BackgroundOuterRadius, int NumSteps = 16) {
     PeakIntensityVsRadius alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
@@ -82,7 +82,7 @@ public:
         "OutputWorkspace", "PeakIntensityVsRadiusTest_OutputWS"));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("RadiusStart", 0.0));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("RadiusEnd", 1.5));
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumSteps", 16));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumSteps", NumSteps));
     TS_ASSERT_THROWS_NOTHING(
         alg.setProperty("BackgroundInnerFactor", BackgroundInnerFactor));
     TS_ASSERT_THROWS_NOTHING(
@@ -108,6 +108,7 @@ public:
     doTestValid(false, 0, 1.0, 0, 0.15);
     doTestValid(false, 1.0, 0, 0.15, 0);
     doTestValid(false, 1.0, 1.0, 0.12, 0.15);
+    doTestValid(true, 1.0, 2.0, 0, 0, -8);
   }
 
   MatrixWorkspace_sptr doTest(double BackgroundInnerFactor,
@@ -192,6 +193,8 @@ public:
     TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[12], 1000, 1e-6);
     TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[15], 1000, 1e-6);
   }
+
+  void test
 };
 
 #endif /* MANTID_CRYSTAL_PEAKINTENSITYVSRADIUSTEST_H_ */

--- a/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
+++ b/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
@@ -70,7 +70,7 @@ public:
   /** Check the validateInputs() calls */
   void doTestValid(bool pass, double BackgroundInnerFactor,
                    double BackgroundOuterFactor, double BackgroundInnerRadius,
-                   double BackgroundOuterRadius, int NumSteps = 16) {
+                   double BackgroundOuterRadius, int NumSteps) {
     PeakIntensityVsRadius alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
@@ -98,17 +98,32 @@ public:
     }
   }
 
-  void test_validateInputs() {
-    doTestValid(true, 1.0, 2.0, 0, 0);
-    doTestValid(true, 0, 0, 0.12, 0.15);
-    doTestValid(true, 1.0, 0, 0, 0.15);
-    doTestValid(true, 0, 1.5, 0.15, 0);
+  void doTestThrowsForInvalid(double BackgroundInnerFactor,
+    double BackgroundOuterFactor, double BackgroundInnerRadius,
+    double BackgroundOuterRadius, int NumSteps = 16) {
+    doTestValid(false, BackgroundInnerFactor, BackgroundOuterFactor, BackgroundInnerRadius, BackgroundOuterRadius, NumSteps);
+  }
+
+  void doTestNoThrowForValid(double BackgroundInnerFactor,
+    double BackgroundOuterFactor, double BackgroundInnerRadius,
+    double BackgroundOuterRadius, int NumSteps = 16) {
+    doTestValid(true, BackgroundInnerFactor, BackgroundOuterFactor, BackgroundInnerRadius, BackgroundOuterRadius, NumSteps);
+  }
+
+  void test_validateForValidInputs() {
+    doTestNoThrowForValid(1.0, 2.0, 0, 0);
+    doTestNoThrowForValid(0, 0, 0.12, 0.15);
+    doTestNoThrowForValid(1.0, 0, 0, 0.15);
+    doTestNoThrowForValid(0, 1.5, 0.15, 0);
     // Can't specify fixed and variable
-    doTestValid(false, 1.0, 0, 0.15, 0);
-    doTestValid(false, 0, 1.0, 0, 0.15);
-    doTestValid(false, 1.0, 0, 0.15, 0);
-    doTestValid(false, 1.0, 1.0, 0.12, 0.15);
-    doTestValid(true, 1.0, 2.0, 0, 0, -8);
+  }
+
+  void test_validateForInvalidInputs() {
+    doTestThrowsForInvalid(1.0, 0, 0.15, 0);
+    doTestThrowsForInvalid(0, 1.0, 0, 0.15);
+    doTestThrowsForInvalid(1.0, 0, 0.15, 0);
+    doTestThrowsForInvalid(1.0, 1.0, 0.12, 0.15);
+    doTestThrowsForInvalid(1.0, 2.0, 0, 0, -8);
   }
 
   MatrixWorkspace_sptr doTest(double BackgroundInnerFactor,
@@ -194,7 +209,6 @@ public:
     TSM_ASSERT_DELTA("After 1.0, the signal is flat", ws->y(0)[15], 1000, 1e-6);
   }
 
-  void test
 };
 
 #endif /* MANTID_CRYSTAL_PEAKINTENSITYVSRADIUSTEST_H_ */

--- a/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
+++ b/Framework/Crystal/test/PeakIntensityVsRadiusTest.h
@@ -32,7 +32,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized())
   }
-  
+
   //-------------------------------------------------------------------------------
   /** Create the (blank) MDEW */
   static void createMDEW() {
@@ -152,9 +152,9 @@ public:
     assertInvalidPropertyValue(alg, "NumSteps", -8);
   }
 
-  template<typename PropertyType>
-  void assertInvalidPropertyValue(PeakIntensityVsRadius &alg, std::string const&name,
-                                  PropertyType value) {
+  template <typename PropertyType>
+  void assertInvalidPropertyValue(PeakIntensityVsRadius &alg,
+                                  std::string const &name, PropertyType value) {
     TS_ASSERT_THROWS_ANYTHING(alg.setProperty(name, value))
   }
 

--- a/docs/source/algorithms/PeakIntensityVsRadius-v1.rst
+++ b/docs/source/algorithms/PeakIntensityVsRadius-v1.rst
@@ -46,6 +46,12 @@ with the following parameters filled in:
 Usage
 -----
 
+**Example - PeakIntensityVsRadius:**
+
+The code itself works but disabled from doc tests as takes too long to complete. User should provide its own 
+event nexus file instead of **TOPAZ_3132_event.nxs** used within this example. The original **TOPAZ_3132_event.nxs**
+file is availible in `Mantid system tests repository <https://github.com/mantidproject/systemtests/tree/master/Data/TOPAZ_3132_event.nxs>`_.
+
 .. code-block:: python
 
     # Load a SCD data set from systemtests Data and find the peaks


### PR DESCRIPTION
Refactoring on PeakIntensityVsRadiusTests and fix for missing validator.

**To test:**
Run the test suite PeakIntensityVsRadiusTest

Fixes #8394.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
