### PR TITLE
Change use of removePeak according to erase-remove idiom

### DIFF
--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -72,7 +72,7 @@ public:
    */
   virtual void removePeak(int peakNum) = 0;
 
-  virtual void removePeaks(const std::vector<int> &badPeaks) = 0;
+  virtual void removePeaks(std::vector<int> &badPeaks) = 0;
 
   //---------------------------------------------------------------------------------------------
   /** Add a peak to the list

--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -72,7 +72,7 @@ public:
    */
   virtual void removePeak(int peakNum) = 0;
 
-  virtual void removePeaks(std::vector<int> &badPeaks) = 0;
+  virtual void removePeaks(std::vector<int> &&badPeaks) = 0;
 
   //---------------------------------------------------------------------------------------------
   /** Add a peak to the list

--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -72,6 +72,8 @@ public:
    */
   virtual void removePeak(int peakNum) = 0;
 
+  virtual void removePeaks(const std::vector<int>& badPeaks) = 0;
+
   //---------------------------------------------------------------------------------------------
   /** Add a peak to the list
    * @param ipeak :: Peak object to add (copy) into this.

--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -72,7 +72,7 @@ public:
    */
   virtual void removePeak(int peakNum) = 0;
 
-  virtual void removePeaks(const std::vector<int>& badPeaks) = 0;
+  virtual void removePeaks(const std::vector<int> &badPeaks) = 0;
 
   //---------------------------------------------------------------------------------------------
   /** Add a peak to the list

--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -72,7 +72,7 @@ public:
    */
   virtual void removePeak(int peakNum) = 0;
 
-  virtual void removePeaks(std::vector<int> &&badPeaks) = 0;
+  virtual void removePeaks(std::vector<int> badPeaks) = 0;
 
   //---------------------------------------------------------------------------------------------
   /** Add a peak to the list

--- a/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
@@ -38,8 +38,7 @@ private:
   void integrate();
   void integrateEvent();
   int findPixelID(std::string bankName, int col, int row);
-  void removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace_sptr &peakWS,
-                       const int &edge);
+  void removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace *peakWS);
   Geometry::Instrument_const_sptr inst;
 
   /// Input 2D Workspace

--- a/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
@@ -38,6 +38,7 @@ private:
   void integrate();
   void integrateEvent();
   int findPixelID(std::string bankName, int col, int row);
+  void removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace_sptr& peakWS, const int& edge);
   Geometry::Instrument_const_sptr inst;
 
   /// Input 2D Workspace

--- a/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
@@ -38,7 +38,7 @@ private:
   void integrate();
   void integrateEvent();
   int findPixelID(std::string bankName, int col, int row);
-  void removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace *peakWS);
+  void removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace &peakWS);
   Geometry::Instrument_const_sptr inst;
 
   /// Input 2D Workspace

--- a/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/CentroidPeaks.h
@@ -38,7 +38,8 @@ private:
   void integrate();
   void integrateEvent();
   int findPixelID(std::string bankName, int col, int row);
-  void removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace_sptr& peakWS, const int& edge);
+  void removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace_sptr &peakWS,
+                       const int &edge);
   Geometry::Instrument_const_sptr inst;
 
   /// Input 2D Workspace

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -169,17 +169,7 @@ void CentroidPeaks::integrate() {
   }
   PARALLEL_CHECK_INTERUPT_REGION
 
-  for (int i = int(peakWS->getNumberPeaks()) - 1; i >= 0; --i) {
-    // Get a direct ref to that peak.
-    auto &peak = peakWS->getPeak(i);
-    int col = peak.getCol();
-    int row = peak.getRow();
-    std::string bankName = peak.getBankName();
-
-    if (edgePixel(inst, bankName, col, row, Edge)) {
-      peakWS->removePeak(i);
-    }
-  }
+  removeEdgePeaks(peakWS, Edge);
 
   // Save the output
   setProperty("OutPeaksWorkspace", peakWS);
@@ -299,17 +289,8 @@ void CentroidPeaks::integrateEvent() {
   }
   PARALLEL_CHECK_INTERUPT_REGION
 
-  for (int i = int(peakWS->getNumberPeaks()) - 1; i >= 0; --i) {
-    // Get a direct ref to that peak.
-    auto &peak = peakWS->getPeak(i);
-    int col = peak.getCol();
-    int row = peak.getRow();
-    std::string bankName = peak.getBankName();
+  removeEdgePeaks(peakWS, Edge);
 
-    if (edgePixel(inst, bankName, col, row, Edge)) {
-      peakWS->removePeak(i);
-    }
-  }
   // Save the output
   setProperty("OutPeaksWorkspace", peakWS);
 }
@@ -355,6 +336,22 @@ int CentroidPeaks::findPixelID(std::string bankName, int col, int row) {
         boost::dynamic_pointer_cast<const Detector>(component);
     return pixel->getID();
   }
+}
+
+void CentroidPeaks::removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace_sptr& peakWS, const int& edge) {
+    std::vector<int> badPeaks;
+    for (int i = int(peakWS->getNumberPeaks()) - 1; i >= 0; --i) {
+        // Get a direct ref to that peak.
+        auto &peak = peakWS->getPeak(i);
+        int col = peak.getCol();
+        int row = peak.getRow();
+        std::string bankName = peak.getBankName();
+
+        if (edgePixel(inst, bankName, col, row, edge)) {
+            badPeaks.push_back(i);
+        }
+    }
+    peakWS->removePeaks(badPeaks);
 }
 
 } // namespace Mantid

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -341,7 +341,7 @@ void CentroidPeaks::removeEdgePeaks(
   int Edge = getProperty("EdgePixels");
   std::vector<int> badPeaks;
   size_t numPeaks = peakWS->getNumberPeaks() - 1;
-  for (size_t i = 0; i < numPeaks;  i++) {
+  for (size_t i = 0; i < numPeaks; i++) {
     // Get a direct ref to that peak.
     const auto &peak = peakWS->getPeak(i);
     int col = peak.getCol();

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -168,7 +168,7 @@ void CentroidPeaks::integrate() {
     PARALLEL_END_INTERUPT_REGION
   }
   PARALLEL_CHECK_INTERUPT_REGION
-  removeEdgePeaks(peakWS.get());
+  removeEdgePeaks(*peakWS);
 
   // Save the output
   setProperty("OutPeaksWorkspace", peakWS);
@@ -287,7 +287,7 @@ void CentroidPeaks::integrateEvent() {
     PARALLEL_END_INTERUPT_REGION
   }
   PARALLEL_CHECK_INTERUPT_REGION
-  removeEdgePeaks(peakWS.get());
+  removeEdgePeaks(*peakWS);
 
   // Save the output
   setProperty("OutPeaksWorkspace", peakWS);
@@ -337,13 +337,13 @@ int CentroidPeaks::findPixelID(std::string bankName, int col, int row) {
 }
 
 void CentroidPeaks::removeEdgePeaks(
-    Mantid::DataObjects::PeaksWorkspace *peakWS) {
+    Mantid::DataObjects::PeaksWorkspace &peakWS) {
   int Edge = getProperty("EdgePixels");
   std::vector<int> badPeaks;
-  size_t numPeaks = peakWS->getNumberPeaks() - 1;
+  size_t numPeaks = peakWS.getNumberPeaks() - 1;
   for (int i = 0; i < static_cast<int>(numPeaks); i++) {
     // Get a direct ref to that peak.
-    const auto &peak = peakWS->getPeak(i);
+    const auto &peak = peakWS.getPeak(i);
     int col = peak.getCol();
     int row = peak.getRow();
     const std::string &bankName = peak.getBankName();
@@ -352,7 +352,7 @@ void CentroidPeaks::removeEdgePeaks(
       badPeaks.push_back(i);
     }
   }
-  peakWS->removePeaks(std::move(badPeaks));
+  peakWS.removePeaks(std::move(badPeaks));
 }
 
 } // namespace Mantid

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -338,20 +338,21 @@ int CentroidPeaks::findPixelID(std::string bankName, int col, int row) {
   }
 }
 
-void CentroidPeaks::removeEdgePeaks(Mantid::DataObjects::PeaksWorkspace_sptr& peakWS, const int& edge) {
-    std::vector<int> badPeaks;
-    for (int i = int(peakWS->getNumberPeaks()) - 1; i >= 0; --i) {
-        // Get a direct ref to that peak.
-        auto &peak = peakWS->getPeak(i);
-        int col = peak.getCol();
-        int row = peak.getRow();
-        std::string bankName = peak.getBankName();
+void CentroidPeaks::removeEdgePeaks(
+    Mantid::DataObjects::PeaksWorkspace_sptr &peakWS, const int &edge) {
+  std::vector<int> badPeaks;
+  for (int i = int(peakWS->getNumberPeaks()) - 1; i >= 0; --i) {
+    // Get a direct ref to that peak.
+    auto &peak = peakWS->getPeak(i);
+    int col = peak.getCol();
+    int row = peak.getRow();
+    std::string bankName = peak.getBankName();
 
-        if (edgePixel(inst, bankName, col, row, edge)) {
-            badPeaks.push_back(i);
-        }
+    if (edgePixel(inst, bankName, col, row, edge)) {
+      badPeaks.push_back(i);
     }
-    peakWS->removePeaks(badPeaks);
+  }
+  peakWS->removePeaks(badPeaks);
 }
 
 } // namespace Mantid

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -168,8 +168,7 @@ void CentroidPeaks::integrate() {
     PARALLEL_END_INTERUPT_REGION
   }
   PARALLEL_CHECK_INTERUPT_REGION
-
-  removeEdgePeaks(peakWS, Edge);
+  removeEdgePeaks(peakWS.get());
 
   // Save the output
   setProperty("OutPeaksWorkspace", peakWS);
@@ -288,8 +287,7 @@ void CentroidPeaks::integrateEvent() {
     PARALLEL_END_INTERUPT_REGION
   }
   PARALLEL_CHECK_INTERUPT_REGION
-
-  removeEdgePeaks(peakWS, Edge);
+  removeEdgePeaks(peakWS.get());
 
   // Save the output
   setProperty("OutPeaksWorkspace", peakWS);
@@ -339,7 +337,8 @@ int CentroidPeaks::findPixelID(std::string bankName, int col, int row) {
 }
 
 void CentroidPeaks::removeEdgePeaks(
-    Mantid::DataObjects::PeaksWorkspace_sptr &peakWS, const int &edge) {
+    Mantid::DataObjects::PeaksWorkspace *peakWS) {
+  int Edge = getProperty("EdgePixels");
   std::vector<int> badPeaks;
   for (int i = int(peakWS->getNumberPeaks()) - 1; i >= 0; --i) {
     // Get a direct ref to that peak.
@@ -348,7 +347,7 @@ void CentroidPeaks::removeEdgePeaks(
     int row = peak.getRow();
     std::string bankName = peak.getBankName();
 
-    if (edgePixel(inst, bankName, col, row, edge)) {
+    if (edgePixel(inst, bankName, col, row, Edge)) {
       badPeaks.push_back(i);
     }
   }

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -341,7 +341,7 @@ void CentroidPeaks::removeEdgePeaks(
   int Edge = getProperty("EdgePixels");
   std::vector<int> badPeaks;
   size_t numPeaks = peakWS->getNumberPeaks() - 1;
-  for (size_t i = 0; i < numPeaks; i++) {
+  for (int i = 0; i < static_cast<int>(numPeaks); i++) {
     // Get a direct ref to that peak.
     const auto &peak = peakWS->getPeak(i);
     int col = peak.getCol();

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -340,18 +340,19 @@ void CentroidPeaks::removeEdgePeaks(
     Mantid::DataObjects::PeaksWorkspace *peakWS) {
   int Edge = getProperty("EdgePixels");
   std::vector<int> badPeaks;
-  for (int i = int(peakWS->getNumberPeaks()) - 1; i >= 0; --i) {
+  size_t numPeaks = peakWS->getNumberPeaks() - 1;
+  for (size_t i = 0; i < numPeaks;  i++) {
     // Get a direct ref to that peak.
-    auto &peak = peakWS->getPeak(i);
+    const auto &peak = peakWS->getPeak(i);
     int col = peak.getCol();
     int row = peak.getRow();
-    std::string bankName = peak.getBankName();
+    const std::string &bankName = peak.getBankName();
 
     if (edgePixel(inst, bankName, col, row, Edge)) {
       badPeaks.push_back(i);
     }
   }
-  peakWS->removePeaks(badPeaks);
+  peakWS->removePeaks(std::move(badPeaks));
 }
 
 } // namespace Mantid

--- a/Framework/Crystal/src/DiffPeaksWorkspaces.cpp
+++ b/Framework/Crystal/src/DiffPeaksWorkspaces.cpp
@@ -96,7 +96,7 @@ void DiffPeaksWorkspaces::exec() {
 
     progress.report();
   }
-  output->removePeaks(badPeaks);
+  output->removePeaks(std::move(badPeaks));
   setProperty("OutputWorkspace", output);
 }
 

--- a/Framework/Crystal/src/DiffPeaksWorkspaces.cpp
+++ b/Framework/Crystal/src/DiffPeaksWorkspaces.cpp
@@ -75,6 +75,7 @@ void DiffPeaksWorkspaces::exec() {
 
   Progress progress(this, 0.0, 1.0, rhsPeaks.size());
 
+  std::vector<int> badPeaks;
   // Loop over the peaks in the second workspace, searching for a match in the
   // first
   for (const auto &currentPeak : rhsPeaks) {
@@ -88,14 +89,14 @@ void DiffPeaksWorkspaces::exec() {
       {
         // As soon as we find a match, remove it from the output and move onto
         // the next rhs peak
-        output->removePeak(j);
+        badPeaks.push_back(j);
         break;
       }
     }
 
     progress.report();
   }
-
+  output->removePeaks(badPeaks);
   setProperty("OutputWorkspace", output);
 }
 

--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -84,7 +84,7 @@ void OptimizeLatticeForCellType::exec() {
       const std::vector<Peak> &peaks = ws->getPeaks();
       if (edgePixel(inst, peaks[i].getBankName(), peaks[i].getCol(),
                     peaks[i].getRow(), edge)) {
-       badPeaks.push_back(i);
+        badPeaks.push_back(i);
       }
     }
     ws->removePeaks(badPeaks);

--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -77,15 +77,17 @@ void OptimizeLatticeForCellType::exec() {
   DataObjects::PeaksWorkspace_sptr ws = getProperty("PeaksWorkspace");
   Geometry::Instrument_const_sptr inst = ws->getInstrument();
 
+  std::vector<int> badPeaks;
   std::vector<DataObjects::PeaksWorkspace_sptr> runWS;
   if (edge > 0) {
     for (int i = int(ws->getNumberPeaks()) - 1; i >= 0; --i) {
       const std::vector<Peak> &peaks = ws->getPeaks();
       if (edgePixel(inst, peaks[i].getBankName(), peaks[i].getCol(),
                     peaks[i].getRow(), edge)) {
-        ws->removePeak(i);
+       badPeaks.push_back(i);
       }
     }
+    ws->removePeaks(badPeaks);
   }
   runWS.push_back(ws);
 

--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -87,7 +87,7 @@ void OptimizeLatticeForCellType::exec() {
         badPeaks.push_back(i);
       }
     }
-    ws->removePeaks(badPeaks);
+    ws->removePeaks(std::move(badPeaks));
   }
   runWS.push_back(ws);
 

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -118,7 +118,7 @@ void PeakIntegration::exec() {
         if (i + 1 > MinPeaks)
       MinPeaks = i + 1;
   }
-  peaksW->removePeaks(badPeaks);
+  peaksW->removePeaks(std::move(badPeaks));
   NumberPeaks = peaksW->getNumberPeaks();
   if (NumberPeaks <= 0) {
     g_log.error(

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -112,7 +112,7 @@ void PeakIntegration::exec() {
       size_t wi = wiEntry->second;
       if ((matchRun && peak.getRunNumber() != inputW->getRunNumber()) ||
           wi >= Numberwi)
-      badPeaks.push_back(i);
+        badPeaks.push_back(i);
     } else // This is for appending peak workspaces when running
            // SNSSingleCrystalReduction one bank at at time
         if (i + 1 > MinPeaks)

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -101,6 +101,7 @@ void PeakIntegration::exec() {
   int NumberPeaks = peaksW->getNumberPeaks();
   int MinPeaks = 0;
 
+  std::vector<int> badPeaks;
   for (int i = NumberPeaks - 1; i >= 0; i--) {
     Peak &peak = peaksW->getPeaks()[i];
     int pixelID = peak.getDetectorID();
@@ -111,12 +112,13 @@ void PeakIntegration::exec() {
       size_t wi = wiEntry->second;
       if ((matchRun && peak.getRunNumber() != inputW->getRunNumber()) ||
           wi >= Numberwi)
-        peaksW->removePeak(i);
+      badPeaks.push_back(i);
     } else // This is for appending peak workspaces when running
            // SNSSingleCrystalReduction one bank at at time
         if (i + 1 > MinPeaks)
       MinPeaks = i + 1;
   }
+  peaksW->removePeaks(badPeaks);
   NumberPeaks = peaksW->getNumberPeaks();
   if (NumberPeaks <= 0) {
     g_log.error(

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -608,7 +608,7 @@ void SaveHKL::exec() {
   for (auto it = banned.crbegin(); it != banned.crend(); ++it) {
     badPeaks.push_back(static_cast<int>(*it));
   }
-  peaksW->removePeaks(badPeaks);
+  peaksW->removePeaks(std::move(badPeaks));
   setProperty("OutputWorkspace", peaksW);
 }
 /**

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -604,9 +604,11 @@ void SaveHKL::exec() {
   out.flush();
   out.close();
   // delete banned peaks
+  std::vector<int> badPeaks;
   for (auto it = banned.crbegin(); it != banned.crend(); ++it) {
-    peaksW->removePeak(static_cast<int>(*it));
+    badPeaks.push_back(static_cast<int>(*it));
   }
+  peaksW->removePeaks(badPeaks);
   setProperty("OutputWorkspace", peaksW);
 }
 /**

--- a/Framework/DataHandling/src/DeleteTableRows.cpp
+++ b/Framework/DataHandling/src/DeleteTableRows.cpp
@@ -38,16 +38,18 @@ void DeleteTableRows::exec() {
   std::vector<size_t> rows = getProperty("Rows");
   // sort the row indices in reverse order
   std::set<size_t, std::greater<size_t>> sortedRows(rows.begin(), rows.end());
+  std::vector<int> badPeaks;
   auto it = sortedRows.begin();
   for (; it != sortedRows.end(); ++it) {
     if (*it >= tw->rowCount())
       continue;
     if (pw) {
-      pw->removePeak(static_cast<int>(*it));
+      badPeaks.push_back(static_cast<int>(*it));
     } else {
       tw->removeRow(*it);
     }
   }
+  pw->removePeaks(badPeaks);
   setProperty("TableWorkspace", tw);
 }
 

--- a/Framework/DataHandling/src/DeleteTableRows.cpp
+++ b/Framework/DataHandling/src/DeleteTableRows.cpp
@@ -40,11 +40,11 @@ void DeleteTableRows::exec() {
   std::set<size_t, std::greater<size_t>> sortedRows(rows.begin(), rows.end());
   std::vector<int> badPeaks;
   auto it = sortedRows.begin();
-  for (; it != sortedRows.end(); ++it) {
+  for (int i = 0; it != sortedRows.end(); ++it, ++i) {
     if (*it >= tw->rowCount())
       continue;
     if (pw) {
-      badPeaks.push_back(static_cast<int>(*it));
+      badPeaks.push_back(static_cast<int>(i));
     } else {
       tw->removeRow(*it);
     }

--- a/Framework/DataHandling/src/DeleteTableRows.cpp
+++ b/Framework/DataHandling/src/DeleteTableRows.cpp
@@ -2,7 +2,6 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidDataHandling/DeleteTableRows.h"
-#include "MantidDataObjects/Peak.h"
 #include "MantidAPI/IWorkspaceProperty.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/IPeaksWorkspace.h"

--- a/Framework/DataHandling/src/DeleteTableRows.cpp
+++ b/Framework/DataHandling/src/DeleteTableRows.cpp
@@ -38,18 +38,16 @@ void DeleteTableRows::exec() {
   std::vector<size_t> rows = getProperty("Rows");
   // sort the row indices in reverse order
   std::set<size_t, std::greater<size_t>> sortedRows(rows.begin(), rows.end());
-  std::vector<int> badPeaks;
   auto it = sortedRows.begin();
-  for (int i = 0; it != sortedRows.end(); ++it, ++i) {
+  for (; it != sortedRows.end(); ++it) {
     if (*it >= tw->rowCount())
       continue;
     if (pw) {
-      badPeaks.push_back(static_cast<int>(i));
+      pw->removePeak(static_cast<int>(*it));
     } else {
       tw->removeRow(*it);
     }
   }
-  pw->removePeaks(badPeaks);
   setProperty("TableWorkspace", tw);
 }
 

--- a/Framework/DataHandling/src/DeleteTableRows.cpp
+++ b/Framework/DataHandling/src/DeleteTableRows.cpp
@@ -39,18 +39,16 @@ void DeleteTableRows::exec() {
   std::vector<size_t> rows = getProperty("Rows");
   // sort the row indices in reverse order
   std::set<size_t, std::greater<size_t>> sortedRows(rows.begin(), rows.end());
-  std::vector<int> badPeaks;
   auto it = sortedRows.begin();
   for (; it != sortedRows.end(); ++it) {
     if (*it >= tw->rowCount())
       continue;
     if (pw) {
-      badPeaks.push_back(static_cast<int>(*it));
+      pw->removePeak(static_cast<int>(*it));
     } else {
       tw->removeRow(*it);
     }
   }
-  pw->removePeaks(badPeaks);
   setProperty("TableWorkspace", tw);
 }
 

--- a/Framework/DataHandling/src/DeleteTableRows.cpp
+++ b/Framework/DataHandling/src/DeleteTableRows.cpp
@@ -2,6 +2,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidDataHandling/DeleteTableRows.h"
+#include "MantidDataObjects/Peak.h"
 #include "MantidAPI/IWorkspaceProperty.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/IPeaksWorkspace.h"
@@ -38,16 +39,18 @@ void DeleteTableRows::exec() {
   std::vector<size_t> rows = getProperty("Rows");
   // sort the row indices in reverse order
   std::set<size_t, std::greater<size_t>> sortedRows(rows.begin(), rows.end());
+  std::vector<int> badPeaks;
   auto it = sortedRows.begin();
   for (; it != sortedRows.end(); ++it) {
     if (*it >= tw->rowCount())
       continue;
     if (pw) {
-      pw->removePeak(static_cast<int>(*it));
+      badPeaks.push_back(static_cast<int>(*it));
     } else {
       tw->removeRow(*it);
     }
   }
+  pw->removePeaks(badPeaks);
   setProperty("TableWorkspace", tw);
 }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -98,7 +98,7 @@ public:
   int getNumberPeaks() const override;
   std::string getConvention() const override;
   void removePeak(int peakNum) override;
-  void removePeaks(std::vector<int> &&badPeaks) override;
+  void removePeaks(std::vector<int> badPeaks) override;
   void addPeak(const Geometry::IPeak &peak) override;
   /// Move a peak object into this peaks workspace
   void addPeak(Peak &&peak);

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -98,7 +98,7 @@ public:
   int getNumberPeaks() const override;
   std::string getConvention() const override;
   void removePeak(int peakNum) override;
-  void removePeaks(const std::vector<Peak*>& it);
+  void removePeaks(const std::vector<int>& badPeaks);
   void addPeak(const Geometry::IPeak &peak) override;
   /// Move a peak object into this peaks workspace
   void addPeak(Peak &&peak);

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -98,7 +98,7 @@ public:
   int getNumberPeaks() const override;
   std::string getConvention() const override;
   void removePeak(int peakNum) override;
-  void removePeaks(std::vector<int> &badPeaks) override;
+  void removePeaks(std::vector<int> &&badPeaks) override;
   void addPeak(const Geometry::IPeak &peak) override;
   /// Move a peak object into this peaks workspace
   void addPeak(Peak &&peak);

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -98,7 +98,7 @@ public:
   int getNumberPeaks() const override;
   std::string getConvention() const override;
   void removePeak(int peakNum) override;
-  void removePeaks(const std::vector<int>& badPeaks);
+  void removePeaks(const std::vector<int> &badPeaks);
   void addPeak(const Geometry::IPeak &peak) override;
   /// Move a peak object into this peaks workspace
   void addPeak(Peak &&peak);

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -98,7 +98,7 @@ public:
   int getNumberPeaks() const override;
   std::string getConvention() const override;
   void removePeak(int peakNum) override;
-  void removePeaks(const std::vector<int> &badPeaks) override;
+  void removePeaks(std::vector<int> &badPeaks) override;
   void addPeak(const Geometry::IPeak &peak) override;
   /// Move a peak object into this peaks workspace
   void addPeak(Peak &&peak);

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -98,6 +98,7 @@ public:
   int getNumberPeaks() const override;
   std::string getConvention() const override;
   void removePeak(int peakNum) override;
+  void removePeaks(const std::vector<Peak*>& it);
   void addPeak(const Geometry::IPeak &peak) override;
   /// Move a peak object into this peaks workspace
   void addPeak(Peak &&peak);

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -98,7 +98,7 @@ public:
   int getNumberPeaks() const override;
   std::string getConvention() const override;
   void removePeak(int peakNum) override;
-  void removePeaks(const std::vector<int> &badPeaks);
+  void removePeaks(const std::vector<int> &badPeaks) override;
   void addPeak(const Geometry::IPeak &peak) override;
   /// Move a peak object into this peaks workspace
   void addPeak(Peak &&peak);

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -151,20 +151,20 @@ void PeaksWorkspace::removePeak(const int peakNum) {
 }
 
 /** Removes multiple peaks
-* @param badPeaks peaks to be removed
+* @param badPeaks peaks to be removed. Takes ownership of container.
 */
-void PeaksWorkspace::removePeaks(std::vector<int> &badPeaks) {
+void PeaksWorkspace::removePeaks(std::vector<int> &&badPeaks) {
   if (badPeaks.size() == 0)
     return;
-  auto first = peaks.begin();
-  auto end = peaks.end();
-  auto result = first;
   std::sort(badPeaks.begin(), badPeaks.end());
-  for (int i = 0; first < end; ++first, ++i) {
+  auto index = peaks.begin();
+  auto end = peaks.end();
+  auto result = index;
+  for (int i = 0; index < end; ++index, ++i) {
     // if index of peak is not in badPeaks
     if (!std::binary_search(badPeaks.begin(), badPeaks.end(), i)) {
       // include in result
-      *result = std::move(*first);
+      *result = std::move(*index);
       ++result;
     }
   }

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -153,16 +153,16 @@ void PeaksWorkspace::removePeak(const int peakNum) {
 /** Removes multiple peaks
 * @param badPeaks peaks to be removed
 */
-void PeaksWorkspace::removePeaks(const std::vector<int> &badPeaks) {
+void PeaksWorkspace::removePeaks(std::vector<int> &badPeaks) {
   if (badPeaks.size() == 0)
     return;
-  int i = 0;
   auto first = peaks.begin();
   auto end = peaks.end();
   auto result = first;
-  for (; first < end; ++first, ++i) {
+  std::sort(badPeaks.begin(), badPeaks.end());
+  for (int i = 0; first < end; ++first, ++i) {
     // if index of peak is not in badPeaks
-    if (std::find(badPeaks.begin(), badPeaks.end(), i) == badPeaks.end()) {
+    if (!std::binary_search(badPeaks.begin(), badPeaks.end(), i)) {
       // include in result
       *result = std::move(*first);
       ++result;

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -155,7 +155,7 @@ void PeaksWorkspace::removePeak(const int peakNum) {
 */
 void PeaksWorkspace::removePeaks(const std::vector<int> &badPeaks) {
   if (badPeaks.size() == 0)
-      return;
+    return;
   int i = 0;
   auto first = peaks.begin();
   auto end = peaks.end();

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -153,8 +153,8 @@ void PeaksWorkspace::removePeak(const int peakNum) {
 /** Removes multiple peaks
 * @param badPeaks peaks to be removed. Takes ownership of container.
 */
-void PeaksWorkspace::removePeaks(std::vector<int> &&badPeaks) {
-  if (badPeaks.size() == 0)
+void PeaksWorkspace::removePeaks(std::vector<int> badPeaks) {
+  if (badPeaks.empty())
     return;
   std::sort(badPeaks.begin(), badPeaks.end());
   auto index = peaks.begin();

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -158,16 +158,16 @@ void PeaksWorkspace::removePeaks(const std::vector<int> &badPeaks) {
   auto first = peaks.begin();
   auto result = first;
   for (Peak p : peaks) {
-    //if index of peak is not in badPeaks
+    // if index of peak is not in badPeaks
     if (std::find(badPeaks.begin(), badPeaks.end(), i) == badPeaks.end()) {
-      //include in result
+      // include in result
       *result = std::move(*first);
       ++result;
     }
     ++first;
     ++i;
   }
-  //erase peaks outside of result
+  // erase peaks outside of result
   peaks.erase(result, peaks.end());
 }
 

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -151,13 +151,23 @@ void PeaksWorkspace::removePeak(const int peakNum) {
 }
 
 /** Removes multiple peaks
-* @param badPeaks Pointers to peaks to be removed
+* @param badPeaks peaks to be removed
 */
-void PeaksWorkspace::removePeaks(const std::vector<Peak*>& badPeaks) {
-    peaks.erase(remove_if(peaks.begin(), peaks.end(),
-        [&badPeaks] (const Mantid::DataObjects::Peak& peak)
-    {return std::find(badPeaks.begin(), badPeaks.end(), &peak) != badPeaks.end(); }),
-        peaks.end());
+void PeaksWorkspace::removePeaks(const std::vector<int>& badPeaks) {
+    int i = 0;
+    auto first = peaks.begin();
+    auto result = first;
+    for (Peak p : peaks)
+    {
+        if (std::find(badPeaks.begin(), badPeaks.end(), i) == badPeaks.end())
+        {
+            *result = std::move(*first);
+            ++result;
+        }
+        ++first;
+        ++i;
+    }
+    peaks.erase(result, peaks.end());
 }
 
 //---------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -17,6 +17,7 @@
 #include "MantidKernel/Quat.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/V3D.h"
+
 #include <algorithm>
 #include <boost/shared_ptr.hpp>
 #include <cmath>
@@ -147,6 +148,16 @@ void PeaksWorkspace::removePeak(const int peakNum) {
         "PeaksWorkspace::removePeak(): peakNum is out of range.");
   }
   peaks.erase(peaks.begin() + peakNum);
+}
+
+/** Removes multiple peaks
+* @param badPeaks Pointers to peaks to be removed
+*/
+void PeaksWorkspace::removePeaks(const std::vector<Peak*>& badPeaks) {
+    peaks.erase(remove_if(peaks.begin(), peaks.end(),
+        [&badPeaks] (const Mantid::DataObjects::Peak& peak)
+    {return std::find(badPeaks.begin(), badPeaks.end(), &peak) != badPeaks.end(); }),
+        peaks.end());
 }
 
 //---------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -154,18 +154,19 @@ void PeaksWorkspace::removePeak(const int peakNum) {
 * @param badPeaks peaks to be removed
 */
 void PeaksWorkspace::removePeaks(const std::vector<int> &badPeaks) {
+  if (badPeaks.size() == 0)
+      return;
   int i = 0;
   auto first = peaks.begin();
+  auto end = peaks.end();
   auto result = first;
-  for (Peak p : peaks) {
+  for (; first < end; ++first, ++i) {
     // if index of peak is not in badPeaks
     if (std::find(badPeaks.begin(), badPeaks.end(), i) == badPeaks.end()) {
       // include in result
       *result = std::move(*first);
       ++result;
     }
-    ++first;
-    ++i;
   }
   // erase peaks outside of result
   peaks.erase(result, peaks.end());

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -151,7 +151,7 @@ void PeaksWorkspace::removePeak(const int peakNum) {
 }
 
 /** Removes multiple peaks
-* @param badPeaks peaks to be removed. Takes ownership of container.
+* @param badPeaks peaks to be removed
 */
 void PeaksWorkspace::removePeaks(std::vector<int> badPeaks) {
   if (badPeaks.empty())

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -153,21 +153,22 @@ void PeaksWorkspace::removePeak(const int peakNum) {
 /** Removes multiple peaks
 * @param badPeaks peaks to be removed
 */
-void PeaksWorkspace::removePeaks(const std::vector<int>& badPeaks) {
-    int i = 0;
-    auto first = peaks.begin();
-    auto result = first;
-    for (Peak p : peaks)
-    {
-        if (std::find(badPeaks.begin(), badPeaks.end(), i) == badPeaks.end())
-        {
-            *result = std::move(*first);
-            ++result;
-        }
-        ++first;
-        ++i;
+void PeaksWorkspace::removePeaks(const std::vector<int> &badPeaks) {
+  int i = 0;
+  auto first = peaks.begin();
+  auto result = first;
+  for (Peak p : peaks) {
+    //if index of peak is not in badPeaks
+    if (std::find(badPeaks.begin(), badPeaks.end(), i) == badPeaks.end()) {
+      //include in result
+      *result = std::move(*first);
+      ++result;
     }
-    peaks.erase(result, peaks.end());
+    ++first;
+    ++i;
+  }
+  //erase peaks outside of result
+  peaks.erase(result, peaks.end());
 }
 
 //---------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -487,21 +487,21 @@ public:
 
   void test_removePeaks() {
 
-      auto pw = buildPW();
-      Instrument_const_sptr inst = pw->getInstrument();
+    auto pw = buildPW();
+    Instrument_const_sptr inst = pw->getInstrument();
 
-      Peak p(inst, 1, 3.0);
-      Peak p2(inst, 2, 6.0);
-      Peak p3(inst, 3, 9.0);
-      pw->addPeak(p);
-      pw->addPeak(p2);
-      pw->addPeak(p3);
+    Peak p(inst, 1, 3.0);
+    Peak p2(inst, 2, 6.0);
+    Peak p3(inst, 3, 9.0);
+    pw->addPeak(p);
+    pw->addPeak(p2);
+    pw->addPeak(p3);
 
-      std::vector<int> badPeaks;
-      badPeaks.push_back(0);
-      badPeaks.push_back(2);
-      pw->removePeaks(badPeaks);
-      TS_ASSERT_EQUALS(pw->getNumberPeaks(), 1);
+    std::vector<int> badPeaks;
+    badPeaks.push_back(0);
+    badPeaks.push_back(2);
+    pw->removePeaks(badPeaks);
+    TS_ASSERT_EQUALS(pw->getNumberPeaks(), 1);
   }
 
 private:
@@ -519,7 +519,7 @@ private:
     pw->addPeak(p2);
     pw->addPeak(p3);
     pw->addPeak(p4);
-    
+
     return pw;
   }
 

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -485,6 +485,25 @@ public:
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
 
+  void test_removePeaks() {
+
+      auto pw = buildPW();
+      Instrument_const_sptr inst = pw->getInstrument();
+
+      Peak p(inst, 1, 3.0);
+      Peak p2(inst, 2, 6.0);
+      Peak p3(inst, 3, 9.0);
+      pw->addPeak(p);
+      pw->addPeak(p2);
+      pw->addPeak(p3);
+
+      std::vector<int> badPeaks;
+      badPeaks.push_back(0);
+      badPeaks.push_back(2);
+      pw->removePeaks(badPeaks);
+      TS_ASSERT_EQUALS(pw->getNumberPeaks(), 1);
+  }
+
 private:
   PeaksWorkspace_sptr createSaveTestPeaksWorkspace() {
     // Create peak workspace
@@ -500,7 +519,7 @@ private:
     pw->addPeak(p2);
     pw->addPeak(p3);
     pw->addPeak(p4);
-
+    
     return pw;
   }
 

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -486,11 +486,11 @@ public:
   }
 
   void test_removePeaks() {
-    //build peaksworkspace (note number of peaks = 1)
-    auto pw = buildPW(); 
+    // build peaksworkspace (note number of peaks = 1)
+    auto pw = buildPW();
     Instrument_const_sptr inst = pw->getInstrument();
 
-    //add peaks
+    // add peaks
     Peak p(inst, 1, 3.0);
     Peak p2(inst, 2, 6.0);
     Peak p3(inst, 3, 9.0);
@@ -498,7 +498,7 @@ public:
     pw->addPeak(p2);
     pw->addPeak(p3);
 
-    //number of peaks = 4, now remove 3
+    // number of peaks = 4, now remove 3
     std::vector<int> badPeaks;
     badPeaks.push_back(0);
     badPeaks.push_back(2);

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -499,7 +499,7 @@ public:
     pw->addPeak(p3);
 
     // number of peaks = 4, now remove 3
-    std::vector<int> badPeaks {0, 2, 3};
+    std::vector<int> badPeaks{0, 2, 3};
     pw->removePeaks(badPeaks);
     TS_ASSERT_EQUALS(pw->getNumberPeaks(), 1);
   }

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -486,10 +486,11 @@ public:
   }
 
   void test_removePeaks() {
-
-    auto pw = buildPW();
+    //build peaksworkspace (note number of peaks = 1)
+    auto pw = buildPW(); 
     Instrument_const_sptr inst = pw->getInstrument();
 
+    //add peaks
     Peak p(inst, 1, 3.0);
     Peak p2(inst, 2, 6.0);
     Peak p3(inst, 3, 9.0);
@@ -497,9 +498,11 @@ public:
     pw->addPeak(p2);
     pw->addPeak(p3);
 
+    //number of peaks = 4, now remove 3
     std::vector<int> badPeaks;
     badPeaks.push_back(0);
     badPeaks.push_back(2);
+    badPeaks.push_back(3);
     pw->removePeaks(badPeaks);
     TS_ASSERT_EQUALS(pw->getNumberPeaks(), 1);
   }

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -500,7 +500,7 @@ public:
 
     // number of peaks = 4, now remove 3
     std::vector<int> badPeaks{0, 2, 3};
-    pw->removePeaks(badPeaks);
+    pw->removePeaks(std::move(badPeaks));
     TS_ASSERT_EQUALS(pw->getNumberPeaks(), 1);
   }
 

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -499,10 +499,7 @@ public:
     pw->addPeak(p3);
 
     // number of peaks = 4, now remove 3
-    std::vector<int> badPeaks;
-    badPeaks.push_back(0);
-    badPeaks.push_back(2);
-    badPeaks.push_back(3);
+    std::vector<int> badPeaks {0, 2, 3};
     pw->removePeaks(badPeaks);
     TS_ASSERT_EQUALS(pw->getNumberPeaks(), 1);
   }


### PR DESCRIPTION
removePeak was being used inside loops to repeatedly erase peaks from a vector. Implemented a removePeaks method to remove multiple peaks at once and minimise calls to erase, according to the [erase-remove idiom.](https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom)

**To test:**

Code review and check build servers
<!-- Instructions for testing. -->

Fixes #19472

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
