### PR TITLE
Adding f26 requirement for python2

### DIFF
--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -5,7 +5,7 @@
 %endif
 
 Name:           mantid-developer
-Version:        1.22
+Version:        1.23
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -33,7 +33,7 @@ Requires: hdf-devel
 Requires: hdf5-devel
 Requires: h5py >= 2.3.1
 Requires: jsoncpp-devel >= 0.7.0
-Requires: librdkafka-dev
+Requires: librdkafka-devel
 Requires: muParser-devel
 Requires: mxml-devel
 Requires: nexus >= 4.2
@@ -54,6 +54,7 @@ Requires: python-matplotlib
 %{?fedora:Requires: python2-matplotlib-qt4}
 %{?el7:Requires: python-matplotlib-qt4}
 Requires: python-pip
+%{?fedora:Requires: python2-qtconsole}
 Requires: python-sphinx
 Requires: python2-sphinx-bootstrap-theme
 Requires: PyYAML
@@ -103,6 +104,7 @@ Requires: python3-dateutil
 Requires: python3-h5py
 Requires: python3-ipython-gui
 Requires: python3-matplotlib
+%{?fedora:Requires: python3-qtconsole}
 Requires: python3-PyYAML
 Requires: python3-mock
 Requires: boost-python3-devel
@@ -131,8 +133,11 @@ required for Mantid development.
 
 %changelog
 
+* Thu Jul 20 2017 Peter Peterson <petersonpf@ornl.gov>
+- Added python-qtconsole for fedora
+
 * Sat Feb 18 2017 Stuart Campbell <scampbell@bnl.gov>
-- Updated to use upstream sphinx-bootstrap-theme 
+- Updated to use upstream sphinx-bootstrap-theme
 
 * Mon Jan 09 2017 Lamar Moore <lamar.moore@stfc.ac.uk>
 - Require librdkafka-dev


### PR DESCRIPTION
On fedora 26, `python2-qtconsole` is not included by other packages. This adds it in. Also fixing a bug in specification of `librdkafka-devel`.

**To test:**

A code review should suffice, but you can `rpmbuild -ba` if you like.

*There is no associated issue.*

*Does not need to be in the release notes* because it is the developer package.

---



#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
