### PR TITLE
MatchPeaks cleanup temporary workspaces

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-branches
 from __future__ import (absolute_import, division, print_function)
-from mantid.api import *
+from mantid.api import PythonAlgorithm, MatrixWorkspaceProperty, ITableWorkspaceProperty, PropertyMode, MatrixWorkspace
 from mantid.simpleapi import *
 from mantid.kernel import Direction
 import numpy as np
@@ -105,14 +105,18 @@ class MatchPeaks(PythonAlgorithm):
         self._match_option = self.getProperty('MatchInput2ToCenter').value
         self._output_bin_range = self.getPropertyValue('BinRangeTable')
 
+
         if self._input_ws:
-            ReplaceSpecialValues(self._input_ws,NaNValue=0,InfinityValue=0)
+            ReplaceSpecialValues(InputWorkspace = self._input_ws, OutputWorkspace = self._input_ws,
+                                 NaNValue = 0, InfinityValue = 0)
 
         if self._input_2_ws:
-            ReplaceSpecialValues(self._input_2_ws, NaNValue=0, InfinityValue=0)
+            ReplaceSpecialValues(InputWorkspace = self._input_2_ws, OutputWorkspace = self._input_2_ws,
+                                 NaNValue = 0, InfinityValue = 0)
 
         if self._input_3_ws:
-            ReplaceSpecialValues(self._input_3_ws, NaNValue=0, InfinityValue=0)
+            ReplaceSpecialValues(InputWorkspace = self._input_3_ws, OutputWorkspace = self._input_3_ws,
+                                 NaNValue = 0, InfinityValue = 0)
 
     def validateInputs(self):
         issues = dict()
@@ -208,7 +212,9 @@ class MatchPeaks(PythonAlgorithm):
         if self._masking:
             mask_ws(output_ws, min_bin, max_bin)
 
-        if self._output_bin_range != '':
+        if self._output_bin_range:
+            self.log().error('Bin range table name:' + self._output_bin_range)
+            self.log().error('Creating the table for masked bin ranges.')
             # Create table with its columns containing bin range
             bin_range = CreateEmptyTableWorkspace(OutputWorkspace=self._output_bin_range)
             bin_range.addColumn(type="double", name='MinBin')

--- a/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
@@ -34,22 +34,19 @@ def mask_ws(ws_to_mask, xstart, xend):
 
 
 class MatchPeaks(PythonAlgorithm):
-    def __init__(self):
 
-        PythonAlgorithm.__init__(self)
+    # Mandatory workspaces
+    _input_ws = None
+    _output_ws = None
 
-        # Mandatory workspaces
-        self._input_ws = None
-        self._output_ws = None
+    # Optional workspace
+    _input_2_ws = None
+    _input_3_ws = None
+    _output_bin_range = None
 
-        # Optional workspace
-        self._input_2_ws = None
-        self._input_3_ws = None
-        self._output_bin_range = None
-
-        # Bool flags
-        self._masking = False
-        self._match_option = None
+    # Bool flags
+    _masking = False
+    _match_option = False
 
     def category(self):
         return "Transforms"
@@ -101,9 +98,10 @@ class MatchPeaks(PythonAlgorithm):
         self._input_2_ws = self.getPropertyValue('InputWorkspace2')
         self._input_3_ws = self.getPropertyValue('InputWorkspace3')
         self._output_ws = self.getPropertyValue('OutputWorkspace')
+        self._output_bin_range = self.getPropertyValue('BinRangeTable')
+
         self._masking = self.getProperty('MaskBins').value
         self._match_option = self.getProperty('MatchInput2ToCenter').value
-        self._output_bin_range = self.getPropertyValue('BinRangeTable')
 
         if self._input_ws:
             ReplaceSpecialValues(InputWorkspace = self._input_ws, OutputWorkspace = self._input_ws,

--- a/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
@@ -213,8 +213,6 @@ class MatchPeaks(PythonAlgorithm):
             mask_ws(output_ws, min_bin, max_bin)
 
         if self._output_bin_range:
-            self.log().error('Bin range table name:' + self._output_bin_range)
-            self.log().error('Creating the table for masked bin ranges.')
             # Create table with its columns containing bin range
             bin_range = CreateEmptyTableWorkspace(OutputWorkspace=self._output_bin_range)
             bin_range.addColumn(type="double", name='MinBin')

--- a/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/MatchPeaks.py
@@ -105,7 +105,6 @@ class MatchPeaks(PythonAlgorithm):
         self._match_option = self.getProperty('MatchInput2ToCenter').value
         self._output_bin_range = self.getPropertyValue('BinRangeTable')
 
-
         if self._input_ws:
             ReplaceSpecialValues(InputWorkspace = self._input_ws, OutputWorkspace = self._input_ws,
                                  NaNValue = 0, InfinityValue = 0)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
@@ -293,7 +293,7 @@ class IndirectILLReductionQENS(PythonAlgorithm):
                 Scale(InputWorkspace=back_calibration, Factor=self._back_calib_scaling, OutputWorkspace=back_calibration)
                 Minus(LHSWorkspace=calibration, RHSWorkspace=back_calibration, OutputWorkspace=calibration)
 
-            MatchPeaks(InputWorkspace=calibration,OutputWorkspace=calibration,MaskBins=True)
+            MatchPeaks(InputWorkspace=calibration,OutputWorkspace=calibration,MaskBins=True,BinRangeTable = '')
             Integration(InputWorkspace=calibration,RangeLower=self._peak_range[0],RangeUpper=self._peak_range[1],
                         OutputWorkspace=calibration)
             self._warn_negative_integral(calibration,'in calibration run.')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
@@ -293,7 +293,10 @@ class IndirectILLReductionQENS(PythonAlgorithm):
                 Scale(InputWorkspace=back_calibration, Factor=self._back_calib_scaling, OutputWorkspace=back_calibration)
                 Minus(LHSWorkspace=calibration, RHSWorkspace=back_calibration, OutputWorkspace=calibration)
 
-            MatchPeaks(InputWorkspace=calibration, OutputWorkspace=calibration, MaskBins=True)
+            # MatchPeaks does not play nicely with the ws groups
+            for ws in mtd[calibration]:
+                MatchPeaks(InputWorkspace=ws.getName(), OutputWorkspace=ws.getName(), MaskBins=True, BinRangeTable = '')
+
             Integration(InputWorkspace=calibration,RangeLower=self._peak_range[0],RangeUpper=self._peak_range[1],
                         OutputWorkspace=calibration)
             self._warn_negative_integral(calibration,'in calibration run.')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
@@ -426,10 +426,10 @@ class IndirectILLReductionQENS(PythonAlgorithm):
             if self._unmirror_option < 6:  # do unmirror 0, i.e. nothing
                 CloneWorkspace(InputWorkspace = name, OutputWorkspace = outname)
             elif self._unmirror_option == 6:
-                MatchPeaks(InputWorkspace = name, OutputWorkspace = outname, MaskBins = True)
+                MatchPeaks(InputWorkspace = name, OutputWorkspace = outname, MaskBins = True, BinRangeTable = '')
             elif self._unmirror_option == 7:
                 MatchPeaks(InputWorkspace = name, InputWorkspace2 = mtd[alignment].getItem(0).getName(),
-                           MatchInput2ToCenter = True, OutputWorkspace = outname, MaskBins = True)
+                           MatchInput2ToCenter = True, OutputWorkspace = outname, MaskBins = True, BinRangeTable = '')
 
         elif wings == 2:  # two wing
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReductionQENS.py
@@ -293,7 +293,7 @@ class IndirectILLReductionQENS(PythonAlgorithm):
                 Scale(InputWorkspace=back_calibration, Factor=self._back_calib_scaling, OutputWorkspace=back_calibration)
                 Minus(LHSWorkspace=calibration, RHSWorkspace=back_calibration, OutputWorkspace=calibration)
 
-            MatchPeaks(InputWorkspace=calibration,OutputWorkspace=calibration,MaskBins=True,BinRangeTable = '')
+            MatchPeaks(InputWorkspace=calibration, OutputWorkspace=calibration, MaskBins=True)
             Integration(InputWorkspace=calibration,RangeLower=self._peak_range[0],RangeUpper=self._peak_range[1],
                         OutputWorkspace=calibration)
             self._warn_negative_integral(calibration,'in calibration run.')

--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -55,6 +55,10 @@ Python
 Python Algorithms
 #################
 
+Bugfixes
+########
+
+- :ref:`MatchPeaks <algm-MatchPeaks-v1>` is fixed to not to leave temporary hidden workspaces behind.
 
 Python Fit Functions
 ####################


### PR DESCRIPTION
This PR fixes an issue in `MatchPeaks` algorithm, when temporary hidden names were auto generated because of missing output workspace name in one of the child algorithms invoked.

**To test:**
1. Set in Mantid preferences to show hidden workspaces.
2. Run the following 2 snippets, at the end there should be no hidden workspace left, i.e. starting with `__`. 

```
ws = CreateSampleWorkspace()
out = MatchPeaks(ws)
```

```
red = IndirectILLReductionQENS("ILL/IN16B/090661.nxs") # file is in unit tests
``` 


<!-- Instructions for testing. -->

Fixes #20074 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.