### PR TITLE
Fix for one-level tree in DataProcessorWidget

### DIFF
--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -744,7 +744,7 @@ std::string GenericDataProcessorPresenter::getPostprocessedWorkspaceName(
     const GroupData &groupData, const std::string &prefix) {
 
   if (!m_postprocess)
-    throw std::runtime_error("Cannot retrieve post-processed workspace name");
+    return std::string();
 
   /* This method calculates, for a given set of rows, the name of the output
   * (post-processed) workspace */

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -3322,9 +3322,8 @@ public:
         presenter.notify(DataProcessorPresenter::ExpandSelectionFlag));
     TS_ASSERT_THROWS_ANYTHING(
         presenter.notify(DataProcessorPresenter::PlotGroupFlag));
-    TS_ASSERT_THROWS(presenter.getPostprocessedWorkspaceName(
-                         std::map<int, std::vector<std::string>>()),
-                     std::runtime_error);
+    TS_ASSERT(presenter.getPostprocessedWorkspaceName(
+              std::map<int, std::vector<std::string>>()) == "");
   }
 
   void testPostprocessMap() {

--- a/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/MantidQt/MantidWidgets/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -3323,7 +3323,7 @@ public:
     TS_ASSERT_THROWS_ANYTHING(
         presenter.notify(DataProcessorPresenter::PlotGroupFlag));
     TS_ASSERT(presenter.getPostprocessedWorkspaceName(
-              std::map<int, std::vector<std::string>>()) == "");
+                  std::map<int, std::vector<std::string>>()) == "");
   }
 
   void testPostprocessMap() {


### PR DESCRIPTION
Recent changes in the data processor widget have caused the DataProcessorWidget to break for one-level trees. This PR fixes this.

**To test:**

To prepare:
1. In `Mantid.properties.template` add to the line `mantidqt.python_interfaces = ...` the entry `Utility/DataProcessorInterface.py`. This will register the sample GUI in MantidPlot

2. Remove post processing from the sample GUI: In `data_processor_gui.py` comment out `        #post_alg = MantidQt.MantidWidgets.DataProcessorPostprocessingAlgorithm('Stitch1DMany', 'IvsQ_', 'InputWorkspaces, OutputWorkspaces')` and remove the variable `post_alg` from the `QDataProcessorWidget` constructor. 

1. Open Mantid and select Interfaces>Utility>DataProcessorInterface
2. Select POLREF as the instrument
3. Add two rows where the `Run(s)` entry is set to `14884` for both rows.
4. Press `Process`
   * Confirm that an it finishes and no exception is thrown. 

**Release notes:**
Does not have to be in the release notes. Is not user facing yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
