### PR TITLE
T0 no longer doubled with DetCal file

### DIFF
--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -39,12 +39,12 @@ using namespace DataObjects;
 /** Initialisation method
 */
 void LoadIsawDetCal::init() {
-  declareProperty(Kernel::make_unique<WorkspaceProperty<Workspace> >(
+  declareProperty(Kernel::make_unique<WorkspaceProperty<Workspace>>(
                       "InputWorkspace", "", Direction::InOut,
                       boost::make_shared<InstrumentValidator>()),
                   "The workspace containing the geometry to be calibrated.");
 
-  const auto exts = std::vector<std::string>({ ".DetCal" });
+  const auto exts = std::vector<std::string>({".DetCal"});
   declareProperty(
       Kernel::make_unique<API::MultipleFileProperty>("Filename", exts),
       "The input filename of the ISAW DetCal file (Two files "
@@ -133,7 +133,7 @@ void LoadIsawDetCal::exec() {
   std::string line;
   std::string detname;
   // Build a list of Rectangular Detectors
-  std::vector<boost::shared_ptr<RectangularDetector> > detList;
+  std::vector<boost::shared_ptr<RectangularDetector>> detList;
   for (int i = 0; i < inst->nelements(); i++) {
     boost::shared_ptr<RectangularDetector> det;
     boost::shared_ptr<ICompAssembly> assem;
@@ -403,7 +403,7 @@ Instrument_sptr LoadIsawDetCal::getCheckInst(API::Workspace_sptr ws) {
 
 std::vector<std::string> LoadIsawDetCal::getFilenames() {
   std::vector<std::string> filenamesFromPropertyUnraveld;
-  std::vector<std::vector<std::string> > filenamesFromProperty =
+  std::vector<std::vector<std::string>> filenamesFromProperty =
       this->getProperty("Filename");
   for (const auto &outer : filenamesFromProperty) {
     std::copy(outer.begin(), outer.end(),


### PR DESCRIPTION
Description of work.
Bug was in LoadIsawDetCal not SaveIsawDetCal.  T0's should not be summed.

**To test:**
https://www.dropbox.com/s/5eidrhs9ehnfkge/Si2mm_Cubic_F.integrate?dl=0
```python
LoadIsawPeaks(Filename='Si2mm_Cubic_F.integrate', OutputWorkspace='peaks_ws')
SCDCalibratePanels(PeakWorkspace='peaks_ws', a=5.431, b=5.431, c=5.431, alpha=90, beta=90, gamma=90, DetCalFilename='SCDCalibrate.DetCal',ChangeL1=False,ChangeT0=True)
topaz=mtd["peaks_ws"]
run = topaz.getRun()
print run.getProperty('T0').value

LoadIsawDetCal(InputWorkspace='peaks_ws', Filename='/home/vel/workspace/SCDCalibrate.DetCal')
topaz=mtd["peaks_ws"]
run = topaz.getRun()
print run.getProperty('T0').value

Load(Filename='TOPAZ_15647_event.nxs', OutputWorkspace='TOPAZ_15647_event')
LoadIsawDetCal(InputWorkspace='TOPAZ_15647_event', Filename='/home/vel/workspace/SCDCalibrate.DetCal')
topaz=mtd["TOPAZ_15647_event"]
run = topaz.getRun()
print run.getProperty('T0').value
LoadIsawDetCal(InputWorkspace='TOPAZ_15647_event', Filename='/home/vel/workspace/SCDCalibrate.DetCal')
topaz=mtd["TOPAZ_15647_event"]
run = topaz.getRun()
print run.getProperty('T0').value

topaz=mtd["TOPAZ_15647_event"]
run = topaz.getRun()
print run.getProperty('T0').value
```
Fixes #20067 

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
