### PR TITLE
Fix unit test for clang on Linux, same as osx

### DIFF
--- a/Framework/CurveFitting/test/Algorithms/VesuvioCalculateMSTest.h
+++ b/Framework/CurveFitting/test/Algorithms/VesuvioCalculateMSTest.h
@@ -135,7 +135,7 @@ void checkOutputValuesAsExpected(const Mantid::API::IAlgorithm_sptr &alg,
   const size_t checkIdx = 100;
 // OS X and GCC>=5 seems to do a terrible job with keeping the same precision
 // here.
-#if defined(__APPLE__) || (__GNUC__ >= 5)
+#if defined(__clang__) || (__GNUC__ >= 5)
   const double tolerance(1e-4);
 #else
   const double tolerance(1e-8);


### PR DESCRIPTION
`CurveFittingTest_VesuvioCalculateMSTest` fails on Linux when using clang, see http://builds.mantidproject.org/job/master_clean-archlinux-clang/340/testReport/junit/CurveFittingTest/VesuvioCalculateMSTest/test_exec_with_flat_plate_sample/

This changes the check on tolerance from `__APPLE__` to `__clang__` so as to apply to both clang on OSX and linux.

**To test:**
 * Code review should suffice

Does not need to be in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
