### PR TITLE
Calibration changes for MaNDi

### DIFF
--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -262,12 +262,17 @@ void SCDCalibratePanels::exec() {
         V3D(boost::math::iround(peak.getH()), boost::math::iround(peak.getK()),
             boost::math::iround(peak.getL()));
     V3D Q2 = lattice0.qFromHKL(hkl);
-    peak.setInstrument(inst);
-    peak.setQSampleFrame(Q2);
-    peak.setHKL(hkl);
+    try {
+        peak.setInstrument(inst);
+        peak.setQSampleFrame(Q2);
+        peak.setHKL(hkl);
+    } catch (...) {
+      g_log.notice() << "Problem in applying calibration to peak "<<i<<"\n";
+    }
     PARALLEL_END_INTERUPT_REGION
   }
   PARALLEL_CHECK_INTERUPT_REGION
+
   // Find U again for optimized geometry and index peaks
   findU(peaksWs);
   // Save as DetCal and XML if requested

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -263,11 +263,11 @@ void SCDCalibratePanels::exec() {
             boost::math::iround(peak.getL()));
     V3D Q2 = lattice0.qFromHKL(hkl);
     try {
-        peak.setInstrument(inst);
-        peak.setQSampleFrame(Q2);
-        peak.setHKL(hkl);
+      peak.setInstrument(inst);
+      peak.setQSampleFrame(Q2);
+      peak.setHKL(hkl);
     } catch (...) {
-      g_log.notice() << "Problem in applying calibration to peak "<<i<<"\n";
+      g_log.notice() << "Problem in applying calibration to peak " << i << "\n";
     }
     PARALLEL_END_INTERUPT_REGION
   }

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -267,7 +267,8 @@ void SCDCalibratePanels::exec() {
       peak.setQSampleFrame(Q2);
       peak.setHKL(hkl);
     } catch (const std::exception &exc) {
-      g_log.notice() << "Problem in applying calibration to peak " << i <<" : "<< exc.what() << "\n";
+      g_log.notice() << "Problem in applying calibration to peak " << i << " : "
+                     << exc.what() << "\n";
     }
     PARALLEL_END_INTERUPT_REGION
   }

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -266,8 +266,8 @@ void SCDCalibratePanels::exec() {
       peak.setInstrument(inst);
       peak.setQSampleFrame(Q2);
       peak.setHKL(hkl);
-    } catch (...) {
-      g_log.notice() << "Problem in applying calibration to peak " << i << "\n";
+    } catch (const std::exception &exc) {
+      g_log.notice() << "Problem in applying calibration to peak " << i <<" : "<< exc.what() << "\n";
     }
     PARALLEL_END_INTERUPT_REGION
   }

--- a/Framework/Crystal/src/SCDPanelErrors.cpp
+++ b/Framework/Crystal/src/SCDPanelErrors.cpp
@@ -189,6 +189,7 @@ void SCDPanelErrors::eval(double xshift, double yshift, double zshift,
         V3D(boost::math::iround(peak.getH()), boost::math::iround(peak.getK()),
             boost::math::iround(peak.getL()));
     V3D Q2 = lattice.qFromHKL(hkl);
+  try {
     DataObjects::Peak peak2(inst, peak.getDetectorID(), peak.getWavelength(),
                             hkl, peak.getGoniometerMatrix());
     Units::Wavelength wl;
@@ -200,6 +201,11 @@ void SCDPanelErrors::eval(double xshift, double yshift, double zshift,
     out[i * 3] = Q3[0] - Q2[0];
     out[i * 3 + 1] = Q3[1] - Q2[1];
     out[i * 3 + 2] = Q3[2] - Q2[2];
+  } catch (std::runtime_error &) {
+    out[i * 3] = std::numeric_limits<double>::infinity();
+    out[i * 3 + 1] = std::numeric_limits<double>::infinity();
+    out[i * 3 + 2] = std::numeric_limits<double>::infinity();
+  }
   }
   moveDetector(-xshift, -yshift, -zshift, -xrotate, -yrotate, -zrotate,
                1.0 / scalex, 1.0 / scaley, m_bank, m_workspace);

--- a/Framework/Crystal/src/SCDPanelErrors.cpp
+++ b/Framework/Crystal/src/SCDPanelErrors.cpp
@@ -189,23 +189,23 @@ void SCDPanelErrors::eval(double xshift, double yshift, double zshift,
         V3D(boost::math::iround(peak.getH()), boost::math::iround(peak.getK()),
             boost::math::iround(peak.getL()));
     V3D Q2 = lattice.qFromHKL(hkl);
-  try {
-    DataObjects::Peak peak2(inst, peak.getDetectorID(), peak.getWavelength(),
-                            hkl, peak.getGoniometerMatrix());
-    Units::Wavelength wl;
+    try {
+      DataObjects::Peak peak2(inst, peak.getDetectorID(), peak.getWavelength(),
+                              hkl, peak.getGoniometerMatrix());
+      Units::Wavelength wl;
 
-    wl.initialize(peak2.getL1(), peak2.getL2(), peak2.getScattering(), 0,
-                  peak2.getInitialEnergy(), 0.0);
-    peak2.setWavelength(wl.singleFromTOF(peak.getTOF() + tShift));
-    V3D Q3 = peak2.getQSampleFrame();
-    out[i * 3] = Q3[0] - Q2[0];
-    out[i * 3 + 1] = Q3[1] - Q2[1];
-    out[i * 3 + 2] = Q3[2] - Q2[2];
-  } catch (std::runtime_error &) {
-    out[i * 3] = std::numeric_limits<double>::infinity();
-    out[i * 3 + 1] = std::numeric_limits<double>::infinity();
-    out[i * 3 + 2] = std::numeric_limits<double>::infinity();
-  }
+      wl.initialize(peak2.getL1(), peak2.getL2(), peak2.getScattering(), 0,
+                    peak2.getInitialEnergy(), 0.0);
+      peak2.setWavelength(wl.singleFromTOF(peak.getTOF() + tShift));
+      V3D Q3 = peak2.getQSampleFrame();
+      out[i * 3] = Q3[0] - Q2[0];
+      out[i * 3 + 1] = Q3[1] - Q2[1];
+      out[i * 3 + 2] = Q3[2] - Q2[2];
+    } catch (std::runtime_error &) {
+      out[i * 3] = std::numeric_limits<double>::infinity();
+      out[i * 3 + 1] = std::numeric_limits<double>::infinity();
+      out[i * 3 + 2] = std::numeric_limits<double>::infinity();
+    }
   }
   moveDetector(-xshift, -yshift, -zshift, -xrotate, -yrotate, -zrotate,
                1.0 / scalex, 1.0 / scaley, m_bank, m_workspace);

--- a/docs/source/algorithms/SCDCalibratePanels-v1.rst
+++ b/docs/source/algorithms/SCDCalibratePanels-v1.rst
@@ -30,7 +30,9 @@ modify the instrument parameters, p, and then find  Q in the sample frame,
 NINT is the nearest integer function.
 B is fixed from the input lattice parameters, but U is modified by :ref:`CalculateUMatrix <algm-CalculateUMatrix>` 
 for all peaks before and after optimization.
-The initial path, L1, is optimized for all peaks before and after each panel or pack's parameters are optimized.
+When the peaks are indexed, sample offsets are adjusted to better index the peaks. 
+The initial time-of-flight, T0, is optimized for all peaks before any parameters are optimized. 
+The initial path, L1, is optimized for all peaks before and after all panels or packs' parameters are optimized.
 The panels and packs' parameters are optimized in parallel.
 An option is available to adjust the panel widths and heights for Rectangular Detectors in a second iteration with all the other parameters fixed.
 


### PR DESCRIPTION
A few weak MaNDi peaks need try/catch for changing Q.

**To test:**
https://www.dropbox.com/s/f4u3ifre37j8gc7/natrolite_Niggli.integrate?dl=0
```python
#MANDI Detector calibration using new SCDCalibratePanels, 07/14/2017
LoadIsawPeaks(Filename='natrolite_Niggli.integrate', OutputWorkspace='Natrolite_Peaks')
FindUBUsingIndexedPeaks(PeaksWorkspace='Natrolite_Peaks', Tolerance=0.20000000000000001)
IndexPeaks(PeaksWorkspace='Natrolite_Peaks', Tolerance=0.25, RoundHKLs=False)

SCDCalibratePanels(PeakWorkspace='Natrolite_Peaks', 
  a=6.5840, b=9.7254, c=9.8911, 
  alpha=83.531, beta=70.560, gamma=70.215, 
  ChangeT0=True, EdgePixels=16, 
  DetCalFilename='MANDI_2017B.DetCal')

#Reindex and refine lattice constant for Natrolite crystal using new MANDI detector calibration
LoadIsawDetCal(InputWorkspace='Natrolite_Peaks', Filename='MANDI_2017B.DetCal')
FindUBUsingFFT(PeaksWorkspace='Natrolite_Peaks', MinD=5, MaxD=11, Tolerance=0.18)
IndexPeaks(PeaksWorkspace='Natrolite_Peaks', RoundHKLs=False)
```

Fixes #20051 

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
