### PR TITLE
Fix bug in overriding grouping

### DIFF
--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -914,8 +914,7 @@ void AlignAndFocusPowder::loadCalFile(const std::string &calFilename,
     return;
 
   // load grouping file if it was already specified
-  bool loadMask = !m_maskWS;
-  if (loadMask && !groupFilename.empty()) {
+  if (!groupFilename.empty()) {
     g_log.information() << "Loading Grouping file \"" << groupFilename
                         << "\"\n";
     if (groupFilename.find(".cal") != std::string::npos) {
@@ -948,8 +947,9 @@ void AlignAndFocusPowder::loadCalFile(const std::string &calFilename,
   g_log.information() << "Loading Calibration file \"" << calFilename << "\"\n";
 
   // bunch of booleans to keep track of things
-  bool loadGrouping = !m_groupWS;
-  bool loadCalibration = !m_calibrationWS;
+  const bool loadMask = !m_maskWS;
+  const bool loadGrouping = !m_groupWS;
+  const bool loadCalibration = !m_calibrationWS;
 
   IAlgorithm_sptr alg = createChildAlgorithm("LoadDiffCal");
   alg->setProperty("InputWorkspace", m_inputW);

--- a/docs/source/release/v3.11.0/diffraction.rst
+++ b/docs/source/release/v3.11.0/diffraction.rst
@@ -18,8 +18,7 @@ Powder Diffraction
 - Added new diagrams showing the algorithms used in ISIS Powder scripts. These can be found at: :ref:`isis-powder-diffraction-workflow-ref`
 - LoadILLAscii, which could be used to load D2B ASCII data into an MD workspace, has been removed. :ref:`LoadILLDiffraction <algm-LoadILLDiffraction>` should be used instead.
 - :ref:`LoadILLDiffraction <algm-LoadILLDiffraction>` now supports loading D2B data with detector scans. The D2B IDF has been updated, as previously it contained some errors in the positions of the tubes and size of the pixels.
-
-|
+- :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>` now correctly supports overloading the grouping file in the presence of a masking workspace.
 
 Full list of `diffraction <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+Diffraction%22>`_
 and


### PR DESCRIPTION
There was a bug in how `SNSPowderReduction` is now being used in autoreduction. It is now being run twice with the grouping file being overloaded for the second pass. In this mode the overridden grouping file was not being loaded.

**To test:**

Run the script
```python
import os
import sys
sys.path.append("/opt/mantidnightly/bin")
from mantid.simpleapi import *
import mantid
cal_dir = "/SNS/PG3/shared/CALIBRATION/2017_1_2_11A_CAL/"
cal_file  = os.path.join(cal_dir, "PG3_PAC_d37828_2017_07_22_2BANKS.h5")
#char_file = os.path.join(cal_dir, "PG3_char_2017_05_20-HR.txt")
#cal_file  = os.path.join(cal_dir, "PG3_MICAS_d36952_2016_11_09.h5")
char_file = os.path.join(cal_dir, "PG3_char_2017_07_24-HR-PAC.txt") \
    + ',' + os.path.join(cal_dir, "PG3_char_2017_07_24-HR.txt")
group_file = os.path.join(cal_dir, 'Grouping', 'PG3_Grouping-IP.xml')

eventFileAbs='/SNS/PG3/IPTS-2767/nexus/PG3_37851.nxs.h5' #sys.argv[1]
outputDir='/tmp/' #sys.argv[2]+'/'

eventFile = os.path.split(eventFileAbs)[-1]
nexusDir = eventFileAbs.replace(eventFile, '')
runNumber = eventFile.split('_')[1].split('.')[0]
configService = mantid.config
dataSearchPath = configService.getDataSearchDirs()
dataSearchPath.append(nexusDir)
configService.setDataSearchDirs(";".join(dataSearchPath))

SNSPowderReduction(Filename=eventFileAbs,
                   PreserveEvents=True,PushDataPositive="AddMinimum",
                   CalibrationFile=cal_file, CharacterizationRunsFile=char_file,
                   LowResRef=0, RemovePromptPulseWidth=50,
                   Binning=-0.0004, BinInDspace=True,
                   BackgroundSmoothParams="5,2",
                   FilterBadPulses=10,
                   ScaleData =100,
                   SaveAs="gsas topas and fullprof", OutputDirectory=outputDir,
                   FinalDataUnits="dSpacing")

GeneratePythonScript(InputWorkspace="PG3_"+runNumber,
                     Filename=os.path.join(outputDir,"PG3_"+runNumber+'.py'))
ConvertUnits(InputWorkspace='PG3_'+runNumber, OutputWorkspace='PG3_'+runNumber,
    Target='dSpacing',
    EMode='Elastic')

# clear out memory
def isSpecialName(name):
    return name in ['characterizations', 'PG3_cal', 'PG3_mask']
names = [name for name in mtd.getObjectNames()
         if not isSpecialName(name)]
for name in names:
    DeleteWorkspace(name)

# run second time with other grouping
SNSPowderReduction(Filename=eventFileAbs,
                   PreserveEvents=True,PushDataPositive="AddMinimum",
                   CalibrationFile=cal_file, CharacterizationRunsFile=char_file,
                   OutputFilePrefix='IP_',
                   GroupingFile=group_file,
                   LowResRef=0, RemovePromptPulseWidth=50,
                   Binning=-0.0004, BinInDspace=True,
                   BackgroundSmoothParams="5,2",
                   FilterBadPulses=10,
                   ScaleData =100,
                   SaveAs="gsas topas and fullprof", OutputDirectory=outputDir,
                   FinalDataUnits="dSpacing")
```
The resulting workspace, `PG3_37851` should only have one spectrum, as opposed to the default grouping which has two.

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
