### PR TITLE
Indirect - Reduction - ASCII Saving - Save ASCII in 7 column format

### DIFF
--- a/docs/source/release/v3.11.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.11.0/indirect_inelastic.rst
@@ -27,5 +27,6 @@ Bugfixes
 
 - An issue has been fixed in :ref:`algm-IndirectILLEnergyTransfer` when handling the data with mirror sense, that have shifted 0 monitor counts in the left and right wings. This was causing the left and right workspaces to have different x-axis binning and to fail to sum during the unmirroring step. 
 - An issue has been fixed in :ref:`algm-IndirectILLReductionFWS` when the scaling of the data after vanadium calibration was not applied.
+- ASCII files are now saved in 7 column format, in the energy transfer tab - TOSCA request. 
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+Indirect+Inelastic%22>`_

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -681,8 +681,9 @@ def save_reduction(workspace_names, formats, x_units='DeltaE'):
                       Filename=workspace_name + '.nxspe')
 
         if 'ascii' in formats:
-            # Changed to version 2 to enable re-loading of files into mantid
-            saveAsciiAlg = AlgorithmManager.createUnmanaged('SaveAscii', 2)
+            # Reverted to version 1 of load ASCII - issues arose from the
+            # TOSCA team - 7 column data should be saved.
+            saveAsciiAlg = AlgorithmManager.createUnmanaged('SaveAscii', 1)
             saveAsciiAlg.initialize()
             saveAsciiAlg.setProperty('InputWorkspace', workspace_name)
             saveAsciiAlg.setProperty('Filename', workspace_name + '.dat')


### PR DESCRIPTION
Confusion surrounding requests from the TOSCA instrument scientists led to changing the ASCII saving version to version 2 in IndirectReductionCommon - 3 column format.

This change was asked to be reverted by the TOSCA instrument scientists - and so has been changed back to version 1.

**To test:**
1. Navigate to Interfaces > Indirect > Data Reduction.
2. Ensure the selected instrument is TOSCA.
3. Enter 17411 into the Run Files field.
4. Check the checkbox labelled 'ASCII' found under Select Save Formats.
5. Run the algorithm and then click save in the interface.
6. Open the saved file in your default save directory and check it is saved in 7 column format.

Fixes #20098. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
Added change to the release notes.
---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
