### PR TITLE
Reduce -Wconversion warnings from GCC 7.1

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/NearestNeighbours.h
+++ b/Framework/Kernel/inc/MantidKernel/NearestNeighbours.h
@@ -103,7 +103,7 @@ template <size_t N = 3> class DLLExport NearestNeighbours {
 
 public:
   // typedefs for code brevity
-  typedef Eigen::Matrix<double, N, 1> VectorType;
+  typedef Eigen::Matrix<double, N, 1ul> VectorType;
   typedef std::vector<std::tuple<VectorType, size_t, double>>
       NearestNeighbourResults;
 

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -9,6 +9,7 @@
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/StringTokenizer.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include <type_traits>
 
@@ -128,6 +129,7 @@ std::string toPrettyString(
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
+GCC_DIAG_OFF(unused-function)
 /** Explicit specialization for a property of type std::vector<bool>.
 *   This will catch Vectors of char, double, float etc.
 *   This simply concatenates the values using a delimiter
@@ -142,6 +144,7 @@ std::string toPrettyString(
   return Strings::shorten(Strings::join(value.begin(), value.end(), delimiter),
                           maxLength);
 }
+GCC_DIAG_ON(unused-function)
 #if __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -129,7 +129,9 @@ std::string toPrettyString(
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
+// clang-format off
 GCC_DIAG_OFF(unused-function)
+// clang-format on
 /** Explicit specialization for a property of type std::vector<bool>.
 *   This will catch Vectors of char, double, float etc.
 *   This simply concatenates the values using a delimiter
@@ -144,7 +146,9 @@ std::string toPrettyString(
   return Strings::shorten(Strings::join(value.begin(), value.end(), delimiter),
                           maxLength);
 }
+// clang-format off
 GCC_DIAG_ON(unused-function)
+// clang-format on
 #if __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -3,6 +3,7 @@
                                 // dominance, we have no way around it with the
                                 // design
 #endif
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h"
 #ifdef _MSC_VER
 #pragma warning(default : 4250)
@@ -50,6 +51,9 @@ typedef void (*declarePropertyType4)(boost::python::object &self,
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 // Overload types
 BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType1_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 2, 3)
@@ -57,6 +61,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 3, 6)
 BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload,
                                 PythonAlgorithm::declarePyAlgProperty, 4, 5)
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -109,7 +109,11 @@ void subscribe(AlgorithmFactoryImpl &self, const boost::python::object &obj) {
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -1,4 +1,5 @@
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/api/AlgorithmIDProxy.h"
 
 #include <boost/python/class.hpp>
@@ -60,12 +61,16 @@ boost::python::list runningInstancesOf(AlgorithmManagerImpl &self,
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 /// Define overload generators
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(create_overloads,
                                        AlgorithmManagerImpl::create, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createUnmanaged_overloads,
                                        AlgorithmManagerImpl::createUnmanaged, 1,
                                        2)
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -4,6 +4,7 @@
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/TextAxis.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
 
 #include <boost/python/class.hpp>
@@ -34,10 +35,12 @@ namespace bpl = boost::python;
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
-
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 // Overloads for operator() function which has 1 optional argument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Axis_getValue, Axis::getValue, 1, 2)
-
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -3,6 +3,7 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
 #include "MantidGeometry/IDTypes.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidPythonInterface/kernel/Policies/RemoveConst.h"
 #include <boost/python/class.hpp>
@@ -21,9 +22,13 @@ GET_POINTER_SPECIALIZATION(ExperimentInfo)
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 /// Overload generator for getInstrumentFilename
 BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload,
                                 ExperimentInfo::getInstrumentFilename, 1, 2)
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -1,4 +1,5 @@
 #include "MantidAPI/FileFinder.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include <boost/python/class.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/reference_existing_object.hpp>
@@ -13,7 +14,11 @@ namespace {
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -1,3 +1,4 @@
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h"
 
@@ -42,6 +43,9 @@ typedef void (IFunction::*setParameterType1)(size_t, const double &value, bool);
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads,
                                        setParameter, 2, 3)
 // setProperty(index,value,explicit)
@@ -56,6 +60,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(fixParameter_Overloads, fixParameter, 1,
                                        2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(fix_Overloads, fix, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(fixAll_Overloads, fixAll, 0, 1)
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -12,6 +12,11 @@ namespace {
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(-Wconversion)
+
 // Default parameter function overloads
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterNames,
                                        Component::getParameterNames, 0, 1)
@@ -40,11 +45,13 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamShortDescription,
                                        2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamDescription,
                                        Component::getParamDescription, 1, 2)
-}
+
+GCC_DIAG_ON(-Wconversion)
+
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
-
+}
 void export_Component() {
   class_<Component, bases<IComponent>, boost::noncopyable>("Component", no_init)
       .def("getParameterNames", &Component::getParameterNames,

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -1,3 +1,4 @@
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidGeometry/Instrument/Component.h"
 #include <boost/python/class.hpp>
 #include <boost/python/overloads.hpp>
@@ -15,7 +16,7 @@ namespace {
 
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
-GCC_DIAG_OFF(-Wconversion)
+GCC_DIAG_OFF(conversion)
 
 // Default parameter function overloads
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterNames,
@@ -46,7 +47,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamShortDescription,
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamDescription,
                                        Component::getParamDescription, 1, 2)
 
-GCC_DIAG_ON(-Wconversion)
+GCC_DIAG_ON(conversion)
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -1,5 +1,6 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/FacilityInfo.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidPythonInterface/kernel/Converters/PySequenceToVector.h"
 #include "MantidPythonInterface/kernel/StlExportDefinitions.h"
@@ -36,12 +37,15 @@ std::string getStringUsingCache(ConfigServiceImpl &self,
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
-
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 /// Overload generator for getInstrument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 0,
                                        1)
 /// Overload generator for getString
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -1,6 +1,7 @@
 #include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/Property.h"
 #include "MantidKernel/IPropertySettings.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidPythonInterface/kernel/StlExportDefinitions.h"
 #include "MantidPythonInterface/kernel/PythonObjectInstantiator.h"
@@ -29,8 +30,12 @@ GET_POINTER_SPECIALIZATION(Property)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(valueAsPrettyStrOverloader,
                                        valueAsPrettyStr, 0, 2)
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -1,4 +1,5 @@
 #include "MantidKernel/Statistics.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/kernel/NdArray.h"
 #include "MantidPythonInterface/kernel/Converters/NDArrayToVector.h"
 #include "MantidPythonInterface/kernel/Policies/VectorToNumpy.h"
@@ -101,9 +102,12 @@ Statistics getStatisticsNumpy(const NumPy::NdArray &data,
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 // Define an overload to handle the default argument
-BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1,
-                                2)
+BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1, 2)
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -106,7 +106,8 @@ Statistics getStatisticsNumpy(const NumPy::NdArray &data,
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GCC_DIAG_OFF(conversion)
 // Define an overload to handle the default argument
-BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1, 2)
+BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1,
+                                2)
 GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
+++ b/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
@@ -11,6 +11,7 @@
 
 #include "MantidAPI/Workspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/kernel/Policies/AsType.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h" // These are still concerned with workspace creation so attach them here
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
@@ -26,6 +27,9 @@ using namespace WorkspaceCreationHelper;
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GCC_DIAG_OFF(conversion)
 BOOST_PYTHON_FUNCTION_OVERLOADS(create2DWorkspaceWithFullInstrument_overloads,
                                 create2DWorkspaceWithFullInstrument, 2, 4)
 
@@ -35,7 +39,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(makeFakeMDHistoWorkspace_overloads,
 BOOST_PYTHON_FUNCTION_OVERLOADS(
     create2DWorkspaceWithRectangularInstrument_overloads,
     create2DWorkspaceWithRectangularInstrument, 3, 3)
-
+GCC_DIAG_ON(conversion)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
Description of work.

This fixes or suppresses most `-Wconversion` warnings that appeared after upgrading to GCC 7.1. Most are from the `BOOST_PYTHON_FUNCTION_OVERLOADS` macro where fixes would require changes to boost and of little/no benefit to our project.

**To test:**

<!-- Instructions for testing. -->

If the build pass, :squirrel:

There is no GitHub issue associated with this pull request.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
