### PR TITLE
Improved error message in Rebin when sentinel values not set

### DIFF
--- a/Framework/HistogramData/src/Rebin.cpp
+++ b/Framework/HistogramData/src/Rebin.cpp
@@ -40,7 +40,11 @@ Histogram rebinCounts(const Histogram &input, const BinEdges &binEdges) {
     auto owidth = xo_high - xo_low;
     auto nwidth = xn_high - xn_low;
 
-    if (owidth <= 0.0 || nwidth <= 0.0)
+	if (xo_high < -1e100 || xo_low < -1e100) {
+		throw InvalidBinEdgesError("One or more x-values was unusually low (below -1e100). This usually occurs when a monitor spectrum has not been masked after ConvertUnits has been run on the workspace");
+	}
+
+	if (owidth <= 0.0 || nwidth <= 0.0)
       throw InvalidBinEdgesError("Negative or zero bin widths not allowed.");
 
     if (xn_high <= xo_low)

--- a/Framework/HistogramData/src/Rebin.cpp
+++ b/Framework/HistogramData/src/Rebin.cpp
@@ -40,7 +40,7 @@ Histogram rebinCounts(const Histogram &input, const BinEdges &binEdges) {
     auto owidth = xo_high - xo_low;
     auto nwidth = xn_high - xn_low;
 
-	if (xo_high < -1e100 || xo_low < -1e100) {
+	if (xo_high == -DBL_MAX || xo_low == -DBL_MAX) {
 		throw InvalidBinEdgesError("One or more x-values was unusually low (below -1e100). This usually occurs when a monitor spectrum has not been masked after ConvertUnits has been run on the workspace");
 	}
 

--- a/Framework/HistogramData/src/Rebin.cpp
+++ b/Framework/HistogramData/src/Rebin.cpp
@@ -41,7 +41,7 @@ Histogram rebinCounts(const Histogram &input, const BinEdges &binEdges) {
     auto nwidth = xn_high - xn_low;
 
     if (owidth <= 0.0 || nwidth <= 0.0){
-      if (xo_high == -DBL_MAX || xo_low == -DBL_MAX) {
+      if (xo_high == -DBL_MAX && xo_low == -DBL_MAX) {
 	throw InvalidBinEdgesError("One or more x-values was unusually low "
 				   "(below -1e100). This usually occurs when a "
 				   "monitor spectrum has not been masked after "

--- a/Framework/HistogramData/src/Rebin.cpp
+++ b/Framework/HistogramData/src/Rebin.cpp
@@ -40,9 +40,12 @@ Histogram rebinCounts(const Histogram &input, const BinEdges &binEdges) {
     auto owidth = xo_high - xo_low;
     auto nwidth = xn_high - xn_low;
 
-	if (xo_high == -DBL_MAX || xo_low == -DBL_MAX) {
-		throw InvalidBinEdgesError("One or more x-values was unusually low (below -1e100). This usually occurs when a monitor spectrum has not been masked after ConvertUnits has been run on the workspace");
-	}
+    if (xo_high == -DBL_MAX || xo_low == -DBL_MAX) {
+      throw InvalidBinEdgesError("One or more x-values was unusually low "
+                                 "(below -1e100). This usually occurs when a "
+                                 "monitor spectrum has not been masked after "
+                                 "ConvertUnits has been run on the workspace");
+    }
 
     if (owidth <= 0.0 || nwidth <= 0.0)
       throw InvalidBinEdgesError("Negative or zero bin widths not allowed.");

--- a/Framework/HistogramData/src/Rebin.cpp
+++ b/Framework/HistogramData/src/Rebin.cpp
@@ -40,18 +40,18 @@ Histogram rebinCounts(const Histogram &input, const BinEdges &binEdges) {
     auto owidth = xo_high - xo_low;
     auto nwidth = xn_high - xn_low;
 
-    if (owidth <= 0.0 || nwidth <= 0.0){
+    if (owidth <= 0.0 || nwidth <= 0.0) {
       if (xo_high == -DBL_MAX && xo_low == -DBL_MAX) {
-	throw InvalidBinEdgesError("One or more x-values was unusually low "
-				   "(below -1e100). This usually occurs when a "
-				   "monitor spectrum has not been masked after "
-				   "ConvertUnits has been run on the workspace");
-      }
-      else {
-	throw InvalidBinEdgesError("Negative or zero bin widths not allowed.");
+        throw InvalidBinEdgesError(
+            "One or more x-values was unusually low "
+            "(below -1e100). This usually occurs when a "
+            "monitor spectrum has not been masked after "
+            "ConvertUnits has been run on the workspace");
+      } else {
+        throw InvalidBinEdgesError("Negative or zero bin widths not allowed.");
       }
     }
-    
+
     if (xn_high <= xo_low)
       inew++; /* old and new bins do not overlap */
     else if (xo_high <= xn_low)

--- a/Framework/HistogramData/src/Rebin.cpp
+++ b/Framework/HistogramData/src/Rebin.cpp
@@ -40,16 +40,18 @@ Histogram rebinCounts(const Histogram &input, const BinEdges &binEdges) {
     auto owidth = xo_high - xo_low;
     auto nwidth = xn_high - xn_low;
 
-    if (xo_high == -DBL_MAX || xo_low == -DBL_MAX) {
-      throw InvalidBinEdgesError("One or more x-values was unusually low "
-                                 "(below -1e100). This usually occurs when a "
-                                 "monitor spectrum has not been masked after "
-                                 "ConvertUnits has been run on the workspace");
+    if (owidth <= 0.0 || nwidth <= 0.0){
+      if (xo_high == -DBL_MAX || xo_low == -DBL_MAX) {
+	throw InvalidBinEdgesError("One or more x-values was unusually low "
+				   "(below -1e100). This usually occurs when a "
+				   "monitor spectrum has not been masked after "
+				   "ConvertUnits has been run on the workspace");
+      }
+      else {
+	throw InvalidBinEdgesError("Negative or zero bin widths not allowed.");
+      }
     }
-
-    if (owidth <= 0.0 || nwidth <= 0.0)
-      throw InvalidBinEdgesError("Negative or zero bin widths not allowed.");
-
+    
     if (xn_high <= xo_low)
       inew++; /* old and new bins do not overlap */
     else if (xo_high <= xn_low)

--- a/Framework/HistogramData/src/Rebin.cpp
+++ b/Framework/HistogramData/src/Rebin.cpp
@@ -40,11 +40,14 @@ Histogram rebinCounts(const Histogram &input, const BinEdges &binEdges) {
     auto owidth = xo_high - xo_low;
     auto nwidth = xn_high - xn_low;
 
-	if (xo_high < -1e100 || xo_low < -1e100) {
-		throw InvalidBinEdgesError("One or more x-values was unusually low (below -1e100). This usually occurs when a monitor spectrum has not been masked after ConvertUnits has been run on the workspace");
-	}
+    if (xo_high < -1e100 || xo_low < -1e100) {
+      throw InvalidBinEdgesError("One or more x-values was unusually low "
+                                 "(below -1e100). This usually occurs when a "
+                                 "monitor spectrum has not been masked after "
+                                 "ConvertUnits has been run on the workspace");
+    }
 
-	if (owidth <= 0.0 || nwidth <= 0.0)
+    if (owidth <= 0.0 || nwidth <= 0.0)
       throw InvalidBinEdgesError("Negative or zero bin widths not allowed.");
 
     if (xn_high <= xo_low)


### PR DESCRIPTION
**Description of work.**

It was found that, when rebinning a workspace containing monitors after running ConvertUnits on that workspace, an InvalidBinEdgesError was thrown. This is due to cells in the monitor being assigned to `DBL_MIN` as no sensible value could be produced. No more elegant fix could be found, but a more meaningful error message is now given when the above occurs.

**To test:**
```
from mantid.kernel import *
from mantid.api import *
from mantid.simpleapi import Load, ConvertUnits, Rebin
from numpy import *

_tmpws = LoadRaw(Filename="MAR11015.raw", LoadMonitors="Include") # Excluding Monitors fixes this
_tmpws = ConvertUnits(InputWorkspace=_tmpws, Target="DeltaE",
                      EMode="Direct", EFixed="12.9729")
_tmpws = Rebin(InputWorkspace=_tmpws, Params="-11,0.01,11")
```

Running this script used to produce `Negative or zero bin widths not allowed.` - not very meaningful for the user in this case. It should now output `One or more x-values was unusually low (below -1e100). This usually occurs when a monitor spectrum has not been masked after ConvertUnits has been run on the workspace`.
<!-- Instructions for testing. -->

Fixes #20000  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
