### PR TITLE
Fix system test cleanup

### DIFF
--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -73,8 +73,8 @@ echo "usagereports.enabled = 0" >> $userprops
 echo "CheckMantidVersion.OnStartup = 0" >> $userprops
 
 # Remove mismatch files which have not been cleaned up yet
-default_save_directory=$Workspace/build/Testing/SystemTests/scripts/
-find default_save_directory -name "*-mismatch*" -delete
+default_save_directory=${Workspace}/build/Testing/SystemTests/scripts/
+find ${default_save_directory} -name "*-mismatch*" -delete
 
 # Run
 PKGDIR=${WORKSPACE}/build

--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -72,6 +72,10 @@ echo "UpdateInstrumentDefinitions.OnStartup = 0" > $userprops
 echo "usagereports.enabled = 0" >> $userprops
 echo "CheckMantidVersion.OnStartup = 0" >> $userprops
 
+# Remove mismatch files which have not been cleaned up yet
+default_save_directory=$Workspace/build/Testing/SystemTests/scripts/
+find default_save_directory -name "*-mismatch*" -delete
+
 # Run
 PKGDIR=${WORKSPACE}/build
 python $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR $EXTRA_ARGS

--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -73,7 +73,7 @@ echo "usagereports.enabled = 0" >> $userprops
 echo "CheckMantidVersion.OnStartup = 0" >> $userprops
 
 # Remove mismatch files which have not been cleaned up yet
-default_save_directory=${Workspace}/build/Testing/SystemTests/scripts/
+default_save_directory=${WORKSPACE}/build/Testing/SystemTests/scripts/
 find ${default_save_directory} -name "*-mismatch*" -delete
 
 # Run


### PR DESCRIPTION
The `-mismatch` files were not cleaned up by the system test script on Rhel7.

**To test:**

This is not too easy to test. You could run the follow commands as a shell script and confirm that the commands do what they should be doing

```
current_location=$(pwd)

WORKSPACE=${current_location}/adkjfadfj2klsjdf2jnsdflkadlkfjadlkjf
default_save_directory=$WORKSPACE/build/Testing/SystemTests/scripts

################################
# Test folder setup
mkdir -p ${default_save_directory}
cd ${default_save_directory}
touch test-mismatch.nxs
touch test-mismatchadfkjasdlkfjadf.nxs
touch lakdjflakdjf.sdkflsdlkf
touch test.nxs
echo "Produced the following files:"
ls -al
echo "***********************"
cd ${current_location}
################################

echo "Running the deletion"

find ${default_save_directory} -name "*-mismatch*" -delete

cd ${default_save_directory}
echo "The following files are still around"
ls -al
echo "************************"

echo "Cleaning up the test folder"
cd ${current_location}
rm -r ${WORKSPACE}
```

*No issue number*

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
