### PR TITLE
Add forced reprocessing feature to DataProcessorWidget

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorMockObjects.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorMockObjects.h
@@ -64,6 +64,9 @@ public:
   // Settings
   MOCK_METHOD1(loadSettings, void(std::map<std::string, QVariant> &));
 
+  // Processing options
+  MOCK_METHOD1(setForcedReProcessing, void(bool));
+
   // Actions/commands
   // Gmock requires parameters and return values of mocked methods to be
   // copyable which means we have to mock addActions() via a proxy method
@@ -135,6 +138,7 @@ public:
   MOCK_CONST_METHOD2(giveUserWarning,
                      void(const std::string &prompt, const std::string &title));
   MOCK_METHOD0(publishCommandsMocked, void());
+  MOCK_METHOD1(setForcedReProcessing, void(bool));
 
 private:
   // Calls we don't care about

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorPresenter.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorPresenter.h
@@ -97,6 +97,7 @@ public:
   virtual void giveUserWarning(const std::string &prompt,
                                const std::string &title) const = 0;
   virtual bool isProcessing() const = 0;
+  virtual void setForcedReProcessing(bool forceReProcessing) = 0;
 };
 }
 }

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorView.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/DataProcessorView.h
@@ -107,6 +107,9 @@ public:
   virtual std::string getClipboard() const = 0;
   virtual std::string getProcessInstrument() const = 0;
   virtual DataProcessorPresenter *getPresenter() const = 0;
+
+  // Force re-processing of rows
+  virtual void setForcedReProcessing(bool forceReProcessing) = 0;
 };
 }
 }

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/GenericDataProcessorPresenter.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/GenericDataProcessorPresenter.h
@@ -141,6 +141,7 @@ public:
   void giveUserWarning(const std::string &prompt,
                        const std::string &title) const override;
   bool isProcessing() const override;
+  void setForcedReProcessing(bool forceReProcessing) override;
 
 protected:
   // The table view we're managing
@@ -296,6 +297,11 @@ private:
   // pause/resume reduction
   void pause();
   void resume();
+
+  // Check if run has been processed
+  bool isProcessed(int position) const;
+  bool isProcessed(int position, int parent) const;
+  bool m_forceProcessing = false;
 
   // List of workspaces the user can open
   QSet<QString> m_workspaceList;

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/QDataProcessorWidget.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataProcessorUI/QDataProcessorWidget.h
@@ -138,6 +138,9 @@ public:
   // Forward a main presenter to this view's presenter
   void accept(DataProcessorMainPresenter *);
 
+  // Force re-processing of rows
+  void setForcedReProcessing(bool forceReProcessing) override;
+
 private:
   // initialise the interface
   void createTable();

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -1672,6 +1672,7 @@ bool GenericDataProcessorPresenter::isProcessed(int position) const {
 
 /** Checks if a row in the table has been processed.
  * @param position :: the row to check
+ * @param parent :: the parent
  * @return :: true if the row has already been processed else false.
  */
 bool GenericDataProcessorPresenter::isProcessed(int position,

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -1674,7 +1674,8 @@ bool GenericDataProcessorPresenter::isProcessed(int position) const {
  * @param position :: the row to check
  * @return :: true if the row has already been processed else false.
  */
-bool GenericDataProcessorPresenter::isProcessed(int position, int parent) const {
+bool GenericDataProcessorPresenter::isProcessed(int position,
+                                                int parent) const {
   // processing truth table
   // isProcessed      manager    force
   //    0               1          1
@@ -1687,9 +1688,9 @@ bool GenericDataProcessorPresenter::isProcessed(int position, int parent) const 
 /** Set the forced reprocessing flag
  * @param forceReProcessing :: the row to check
  */
-void GenericDataProcessorPresenter::setForcedReProcessing(bool forceReProcessing) {
+void GenericDataProcessorPresenter::setForcedReProcessing(
+    bool forceReProcessing) {
   m_forceProcessing = forceReProcessing;
 }
-
 }
 }

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorWidget.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorWidget.cpp
@@ -649,5 +649,10 @@ void QDataProcessorWidget::transfer(const QList<QString> &runs) {
   m_presenter->transfer(runsMap);
 }
 
+void QDataProcessorWidget::setForcedReProcessing(bool forceReProcessing) {
+  m_presenter->setForcedReProcessing(forceReProcessing);
+}
+
+
 } // namespace MantidWidgets
 } // namespace Mantid

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorWidget.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/QDataProcessorWidget.cpp
@@ -653,6 +653,5 @@ void QDataProcessorWidget::setForcedReProcessing(bool forceReProcessing) {
   m_presenter->setForcedReProcessing(forceReProcessing);
 }
 
-
 } // namespace MantidWidgets
 } // namespace Mantid

--- a/MantidQt/Python/mantidqt.sip
+++ b/MantidQt/Python/mantidqt.sip
@@ -1555,6 +1555,7 @@ QDataProcessorWidget(const MantidQt::MantidWidgets::DataProcessorWhiteList &,
 void accept(MantidQt::MantidWidgets::DataProcessorMainPresenter *);
 void setInstrumentList(const QString &instruments, const QString &defaultInstrument);
 void transfer(const QList<QString> &);
+void setForcedReProcessing(bool);
 
 signals:
 void runPythonCode(const QString &);


### PR DESCRIPTION
Fixes #20112

Adds a forced reprocessing option to the DataProcessorWidget.

**To test:**

This is not something that can be easily tested  This might need a separate GUI for testing. When we release the new SANS GUI this feature is required and can be tested there. Things that can be done now:
1. Code review
1. Ensure all tests are ok
1. Confirm that forced reprocessing is off by default, hence there should be no impact on Reflectometry


**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
