### PR TITLE
Refactor InstrumentDefinitionParser::parseXML

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -5,7 +5,6 @@
 #include <vector>
 #include <Poco/AutoPtr.h>
 #include <Poco/DOM/Document.h>
-#include <MantidGeometry/Objects/ShapeFactory.h>
 #include "MantidKernel/System.h"
 #include "MantidKernel/V3D.h"
 #include "MantidGeometry/Instrument.h"
@@ -28,6 +27,7 @@ class IComponent;
 class Instrument;
 class ObjComponent;
 class Object;
+class ShapeFactory;
 
 /** Creates an instrument data from a XML instrument description file
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <Poco/AutoPtr.h>
 #include <Poco/DOM/Document.h>
+#include <MantidGeometry/Objects/ShapeFactory.h>
 #include "MantidKernel/System.h"
 #include "MantidKernel/V3D.h"
 #include "MantidGeometry/Instrument.h"
@@ -241,6 +242,19 @@ private:
   /// return 0 if the attribute doesn't exist. This is to follow the
   /// behavior of atof which always returns 0 if there is a problem.
   double attrToDouble(const Poco::XML::Element *pElem, const std::string &name);
+
+  void getTypeAndComponentPointers(
+      const Poco::XML::Element *pRootElem,
+      std::vector<Poco::XML::Element *> &typeElems,
+      std::vector<Poco::XML::Element *> &compElems) const;
+
+  void throwIfTypeNameNotUnique(const std::string &filename,
+                                const std::string &typeName) const;
+
+  void
+  createShapeIfTypeIsNotAnAssembly(Mantid::Geometry::ShapeFactory &shapeCreator,
+                                   size_t iType, Poco::XML::Element *pTypeElem,
+                                   const std::string &typeName);
 
 public: // for testing
   /// return absolute position of point which is set relative to the

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -265,12 +265,16 @@ private:
   /// element
   void adjustTypesContainingCombineComponentsElement(
       ShapeFactory &shapeCreator, const std::string &filename,
-      const std::vector<Poco::XML::Element *> &typeElems,
-      size_t numberOfTypes) const;
+      const std::vector<Poco::XML::Element *> &typeElems, size_t numberOfTypes);
 
   /// Create a vector of elements which contain a \<parameter\>
   void createVectorOfElementsContainingAParameterElement(
-    const Poco::XML::Element *pRootElem);
+      Poco::XML::Element *pRootElem);
+
+  /// Check IdList
+  void checkIdListExistsAndDefinesEnoughIDs(IdList idList,
+                                            Poco::XML::Element *pElem,
+                                            const std::string &filename) const;
 
 public: // for testing
   /// return absolute position of point which is set relative to the

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -78,7 +78,8 @@ public:
   };
 
   /// Parse XML contents
-  boost::shared_ptr<Instrument> parseXML(Kernel::ProgressBase *progressReporter);
+  boost::shared_ptr<Instrument>
+  parseXML(Kernel::ProgressBase *progressReporter);
 
   /// Add/overwrite any parameters specified in instrument with param values
   /// specified in <component-link> XML elements
@@ -266,6 +267,10 @@ private:
       ShapeFactory &shapeCreator, const std::string &filename,
       const std::vector<Poco::XML::Element *> &typeElems,
       size_t numberOfTypes) const;
+
+  /// Create a vector of elements which contain a \<parameter\>
+  void createVectorOfElementsContainingAParameterElement(
+    const Poco::XML::Element *pRootElem);
 
 public: // for testing
   /// return absolute position of point which is set relative to the

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -280,6 +280,17 @@ private:
   void checkComponentContainsLocationElement(Poco::XML::Element *pElem,
                                              const std::string &filename) const;
 
+  /// Aggregate locations and IDs for components
+  void parseLocationsForEachTopLevelComponent(
+      Kernel::ProgressBase *progressReporter, const std::string &filename,
+      const std::vector<Poco::XML::Element *> &compElems);
+
+  /// Collect some information about types for later use
+  void
+  collateTypeInformation(const std::string &filename,
+                         const std::vector<Poco::XML::Element *> &typeElems,
+                         ShapeFactory &shapeCreator);
+
 public: // for testing
   /// return absolute position of point which is set relative to the
   /// coordinate system of the input component

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -243,14 +243,18 @@ private:
   /// behavior of atof which always returns 0 if there is a problem.
   double attrToDouble(const Poco::XML::Element *pElem, const std::string &name);
 
+  /// Populate vectors of pointers to type and component xml elements
   void getTypeAndComponentPointers(
       const Poco::XML::Element *pRootElem,
       std::vector<Poco::XML::Element *> &typeElems,
       std::vector<Poco::XML::Element *> &compElems) const;
 
+  /// Throw exception if type name is not unique in the IDF
   void throwIfTypeNameNotUnique(const std::string &filename,
                                 const std::string &typeName) const;
 
+  /// Record type as an assembly if it contains a component, otherwise create a
+  /// shape for it
   void
   createShapeIfTypeIsNotAnAssembly(Mantid::Geometry::ShapeFactory &shapeCreator,
                                    size_t iType, Poco::XML::Element *pTypeElem,

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -276,6 +276,10 @@ private:
                                             Poco::XML::Element *pElem,
                                             const std::string &filename) const;
 
+  /// Check component has a \<location\> or \<locations\> element
+  void checkComponentContainsLocationElement(Poco::XML::Element *pElem,
+                                             const std::string &filename) const;
+
 public: // for testing
   /// return absolute position of point which is set relative to the
   /// coordinate system of the input component

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -260,6 +260,13 @@ private:
                                    size_t iType, Poco::XML::Element *pTypeElem,
                                    const std::string &typeName);
 
+  /// Adjust each type which contains a \<combine-components-into-one-shape\>
+  /// element
+  void adjustTypesContainingCombineComponentsElement(
+      ShapeFactory &shapeCreator, const std::string &filename,
+      const std::vector<Poco::XML::Element *> &typeElems,
+      size_t numberOfTypes) const;
+
 public: // for testing
   /// return absolute position of point which is set relative to the
   /// coordinate system of the input component

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentDefinitionParser.h
@@ -78,7 +78,7 @@ public:
   };
 
   /// Parse XML contents
-  boost::shared_ptr<Instrument> parseXML(Kernel::ProgressBase *prog);
+  boost::shared_ptr<Instrument> parseXML(Kernel::ProgressBase *progressReporter);
 
   /// Add/overwrite any parameters specified in instrument with param values
   /// specified in <component-link> XML elements

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -215,12 +215,12 @@ void InstrumentDefinitionParser::throwIfTypeNameNotUnique(
 //----------------------------------------------------------------------------------------------
 /** Fully parse the IDF XML contents and returns the instrument thus created
  *
- * @param prog :: Optional Progress reporter object. If NULL, no progress
- *reporting.
+ * @param progressReporter :: Optional Progress reporter object. If NULL, no
+ * progress reporting.
  * @return the instrument that was created
  */
 Instrument_sptr
-InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *prog) {
+InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *progressReporter) {
   auto pDoc = getDocument();
 
   // Get pointer to root element
@@ -303,12 +303,12 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *prog) {
   setLogfile(m_instrument.get(), pRootElem, m_instrument->getLogfileCache());
 
   // do analysis for each top level component element
-  if (prog)
-    prog->resetNumSteps(compElems.size(), 0.0, 1.0);
+  if (progressReporter)
+    progressReporter->resetNumSteps(compElems.size(), 0.0, 1.0);
 
   for (auto pElem : compElems) {
-    if (prog)
-      prog->report("Loading instrument Definition");
+    if (progressReporter)
+      progressReporter->report("Loading instrument Definition");
 
     {
       IdList idList; // structure to possibly be populated with detector IDs

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -292,25 +292,7 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *progressReporter) {
     {
       IdList idList; // structure to possibly be populated with detector IDs
 
-      // Get all <location> and <locations> elements contained in component
-      // element just for the purpose of a IDF syntax check
-      Poco::AutoPtr<NodeList> pNL_location =
-          pElem->getElementsByTagName("location");
-      Poco::AutoPtr<NodeList> pNL_locations =
-          pElem->getElementsByTagName("locations");
-      // do a IDF syntax check
-      if (pNL_location->length() == 0 && pNL_locations->length() == 0) {
-        g_log.error(std::string("A component element must contain at least one "
-                                "<location> or <locations> element") +
-                    " even if it is just an empty location element of the form "
-                    "<location />");
-        throw Kernel::Exception::InstrumentDefinitionError(
-            std::string("A component element must contain at least one "
-                        "<location> or <locations> element") +
-                " even if it is just an empty location element of the form "
-                "<location />",
-            filename);
-      }
+      checkComponentContainsLocationElement(pElem, filename);
 
       // Loop through all <location> and <locations> elements of this component
       // by looping all the child nodes and then see if any of these nodes are
@@ -363,6 +345,35 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *progressReporter) {
 
   // And give back what we created
   return m_instrument;
+}
+
+/**
+ * Component must contain a \<location\> or \<locations\>
+ * Throw an exception if it does not
+ *
+ * @param pNL_location ::
+ * @param pNL_locations ::
+ * @param filename :: Name of the IDF, for exception message
+ */
+void InstrumentDefinitionParser::checkComponentContainsLocationElement(
+    Element *pElem, const std::string &filename) const {
+  Poco::AutoPtr<NodeList> pNL_location =
+      pElem->getElementsByTagName("location");
+  Poco::AutoPtr<NodeList> pNL_locations =
+      pElem->getElementsByTagName("locations");
+
+  if (pNL_location->length() == 0 && pNL_locations->length() == 0) {
+    g_log.error(std::string("A component element must contain at least one "
+                            "<location> or <locations> element") +
+                " even if it is just an empty location element of the form "
+                "<location />");
+    throw Kernel::Exception::InstrumentDefinitionError(
+        std::string("A component element must contain at least one "
+                    "<location> or <locations> element") +
+            " even if it is just an empty location element of the form "
+            "<location />",
+        filename);
+  }
 }
 
 /**

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -292,9 +292,8 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *progressReporter) {
  * to indicate the shape for this assembly should be created later.
  *
  * @param filename :: Name of the IDF, for exception message
- * @param typeElems ::
- * @param shapeCreator ::
- * @param numberOfTypes  :: Total number of type elements
+ * @param typeElems :: Vector of pointers to type elements
+ * @param shapeCreator :: Factory for creating a shape
  */
 void InstrumentDefinitionParser::collateTypeInformation(
     const std::string &filename, const std::vector<Element *> &typeElems,

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -275,29 +275,8 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *progressReporter) {
 
   adjustTypesContainingCombineComponentsElement(shapeCreator, filename,
                                                 typeElems, numberOfTypes);
-
-  // create m_hasParameterElement
-  Poco::AutoPtr<NodeList> pNL_parameter =
-      pRootElem->getElementsByTagName("parameter");
-
-  unsigned long numParameter = pNL_parameter->length();
-  m_hasParameterElement.reserve(numParameter);
-
-  // It turns out that looping over all nodes and checking if their nodeName is
-  // equal to "parameter" is much quicker than looping over the pNL_parameter
-  // NodeList.
-  Poco::XML::NodeIterator it(pRootElem, Poco::XML::NodeFilter::SHOW_ELEMENT);
-  Poco::XML::Node *pNode = it.nextNode();
-  while (pNode) {
-    if (pNode->nodeName() == "parameter") {
-      auto pParameterElem = dynamic_cast<Element *>(pNode);
-      m_hasParameterElement.push_back(
-          dynamic_cast<Element *>(pParameterElem->parentNode()));
-    }
-    pNode = it.nextNode();
-  }
-
-  m_hasParameterElement_beenSet = true;
+  // Populates m_hasParameterElement
+  createVectorOfElementsContainingAParameterElement(pRootElem);
 
   // See if any parameters set at instrument level
   setLogfile(m_instrument.get(), pRootElem, m_instrument->getLogfileCache());
@@ -411,6 +390,36 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *progressReporter) {
 
   // And give back what we created
   return m_instrument;
+}
+
+/**
+ * Create a vector of elements which contain a \<parameter\>
+ *
+ * @param pRootElem :: Pointer to the root element
+ */
+void InstrumentDefinitionParser::
+    createVectorOfElementsContainingAParameterElement(
+        const Element *pRootElem) {
+  Poco::AutoPtr<NodeList> pNL_parameter =
+      pRootElem->getElementsByTagName("parameter");
+  unsigned long numParameter = pNL_parameter->length();
+  m_hasParameterElement.reserve(numParameter);
+
+  // It turns out that looping over all nodes and checking if their nodeName is
+  // equal to "parameter" is much quicker than looping over the pNL_parameter
+  // NodeList.
+  NodeIterator it(pRootElem, NodeFilter::SHOW_ELEMENT);
+  Node *pNode = it.nextNode();
+  while (pNode) {
+    if (pNode->nodeName() == "parameter") {
+      auto pParameterElem = dynamic_cast<Element *>(pNode);
+      m_hasParameterElement.push_back(
+          dynamic_cast<Element *>(pParameterElem->parentNode()));
+    }
+    pNode = it.nextNode();
+  }
+
+  m_hasParameterElement_beenSet = true;
 }
 
 /**

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -294,11 +294,10 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *progressReporter) {
 
       checkComponentContainsLocationElement(pElem, filename);
 
-      // Loop through all <location> and <locations> elements of this component
-      // by looping all the child nodes and then see if any of these nodes are
-      // either <location> or <locations> elements. Done this way order these
-      // locations are processed is the order they are listed in the IDF. The
-      // latter needed to get detector IDs assigned as expected
+      // Loop through all children of this component and see if any
+      // are a <location> or <locations>. Done this way, the
+      // order they are processed is the order they are listed in the
+      // IDF. This is necessary to match the order of the detector IDs.
       for (Node *pNode = pElem->firstChild(); pNode != nullptr;
            pNode = pNode->nextSibling()) {
         auto pChildElem = dynamic_cast<Element *>(pNode);

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -302,7 +302,7 @@ void InstrumentDefinitionParser::collateTypeInformation(
   const size_t numberOfTypes = typeElems.size();
   for (size_t iType = 0; iType < numberOfTypes; ++iType) {
     Element *pTypeElem = typeElems[iType];
-    std::__cxx11::string typeName = pTypeElem->getAttribute("name");
+    std::string typeName = pTypeElem->getAttribute("name");
 
     // If type contains <combine-components-into-one-shape> then make adjustment
     // after this loop has completed
@@ -478,7 +478,7 @@ void InstrumentDefinitionParser::adjustTypesContainingCombineComponentsElement(
     const std::vector<Element *> &typeElems, const size_t numberOfTypes) {
   for (size_t iType = 0; iType < numberOfTypes; ++iType) {
     Element *pTypeElem = typeElems[iType];
-    std::__cxx11::string typeName = pTypeElem->getAttribute("name");
+    std::string typeName = pTypeElem->getAttribute("name");
 
     // In this loop only interested in types containing
     // <combine-components-into-one-shape>

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -286,19 +286,7 @@ InstrumentDefinitionParser::parseXML(Kernel::ProgressBase *prog) {
     if (nelements == 0)
       continue;
 
-    // Each type in the IDF must be uniquely named, hence return error if type
-    // has already been defined
-    if (getTypeElement.find(typeName) != getTypeElement.end()) {
-      g_log.error(std::string("XML file: ")
-                      .append(filename)
-                      .append("contains more than one type element named ")
-                      .append(typeName));
-      throw Kernel::Exception::InstrumentDefinitionError(
-          std::string(
-              "XML instrument file contains more than one type element named ")
-              .append(typeName)
-              .append(filename));
-    }
+    throwIfTypeNameNotUnique(filename, typeName);
     getTypeElement[typeName] = pTypeElem;
 
     InstrumentDefinitionParser helper;


### PR DESCRIPTION
Closes #20116 

Refactored `InstrumentDefinitionParser::parseXML` for greater readability and resulting in some code deduplification. There are no changes to functionality.

On my machine `InstrumentDefinitionParserTestPerformance` takes 0.40 seconds averaged over 10 runs before and after these changes.
`./systemtest -R IDF` runs 5 tests, which all pass.

**To test:**

Please review code changes.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
