### PR TITLE
Suppress gSoap warnings

### DIFF
--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -3,6 +3,17 @@
 #pragma clang diagnostic ignored "-Wcast-align"
 #endif
 
+#include "MantidKernel/WarningSuppressions.h"
+// ignore warnings in gSOAP
+// Long-term solution is to use gSOAP as an external library or external
+// project. see issue #19433
+// clang-format off
+GCC_DIAG_OFF(deprecated-declarations)
+CGG_DIAG_OFF(format-overflow=)
+CGG_DIAG_OFF(format-overflow=)
+GCC_DIAG_OFF(implicit-fallthrough=)
+// clang-format on
+
 /*
   stdsoap2.c[pp] 2.8.15
 
@@ -17007,6 +17018,13 @@ soap::~soap() {
 #endif
 
 /******************************************************************************/
+
+// clang-format off
+GCC_DIAG_ON(deprecated-declarations)
+CGG_DIAG_ON(format-overflow=)
+CGG_DIAG_ON(format-overflow=)
+GCC_DIAG_ON(implicit-fallthrough=)
+// clang-format on
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -13,7 +13,7 @@ GCC_DIAG_OFF(deprecated-declarations)
 GCC_DIAG_OFF(format-overflow)
 GCC_DIAG_OFF(format-truncation)
 GCC_DIAG_OFF(implicit-fallthrough)
-#endif 
+#endif
 // clang-format on
 
 /*

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -9,8 +9,8 @@
 // project. see issue #19433
 // clang-format off
 GCC_DIAG_OFF(deprecated-declarations)
-CGG_DIAG_OFF(format-overflow)
-CGG_DIAG_OFF(format-truncation)
+GCC_DIAG_OFF(format-overflow)
+GCC_DIAG_OFF(format-truncation)
 GCC_DIAG_OFF(implicit-fallthrough)
 // clang-format on
 
@@ -17021,8 +17021,8 @@ soap::~soap() {
 
 // clang-format off
 GCC_DIAG_ON(deprecated-declarations)
-CGG_DIAG_ON(format-overflow)
-CGG_DIAG_ON(format-truncation)
+GCC_DIAG_ON(format-overflow)
+GCC_DIAG_ON(format-truncation)
 GCC_DIAG_ON(implicit-fallthrough)
 // clang-format on
 

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -13,7 +13,7 @@ GCC_DIAG_OFF(deprecated-declarations)
 GCC_DIAG_OFF(format-overflow)
 GCC_DIAG_OFF(format-truncation)
 GCC_DIAG_OFF(implicit-fallthrough)
-#endif  
+#endif 
 // clang-format on
 
 /*

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -8,10 +8,12 @@
 // Long-term solution is to use gSOAP as an external library or external
 // project. see issue #19433
 // clang-format off
+#if defined(__GNUC__) && __GNUC__ >= 7
 GCC_DIAG_OFF(deprecated-declarations)
 GCC_DIAG_OFF(format-overflow)
 GCC_DIAG_OFF(format-truncation)
 GCC_DIAG_OFF(implicit-fallthrough)
+#endif  
 // clang-format on
 
 /*
@@ -17020,10 +17022,12 @@ soap::~soap() {
 /******************************************************************************/
 
 // clang-format off
+#if defined(__GNUC__) && __GNUC__ >= 7
 GCC_DIAG_ON(deprecated-declarations)
 GCC_DIAG_ON(format-overflow)
 GCC_DIAG_ON(format-truncation)
 GCC_DIAG_ON(implicit-fallthrough)
+#endif
 // clang-format on
 
 #ifdef __clang__

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -9,9 +9,9 @@
 // project. see issue #19433
 // clang-format off
 GCC_DIAG_OFF(deprecated-declarations)
-CGG_DIAG_OFF(format-overflow=)
-CGG_DIAG_OFF(format-truncation=)
-GCC_DIAG_OFF(implicit-fallthrough=)
+CGG_DIAG_OFF(format-overflow)
+CGG_DIAG_OFF(format-truncation)
+GCC_DIAG_OFF(implicit-fallthrough)
 // clang-format on
 
 /*
@@ -17021,9 +17021,9 @@ soap::~soap() {
 
 // clang-format off
 GCC_DIAG_ON(deprecated-declarations)
-CGG_DIAG_ON(format-overflow=)
-CGG_DIAG_ON(format-truncation=)
-GCC_DIAG_ON(implicit-fallthrough=)
+CGG_DIAG_ON(format-overflow)
+CGG_DIAG_ON(format-truncation)
+GCC_DIAG_ON(implicit-fallthrough)
 // clang-format on
 
 #ifdef __clang__

--- a/Framework/ICat/src/GSoap/stdsoap2.cpp
+++ b/Framework/ICat/src/GSoap/stdsoap2.cpp
@@ -10,7 +10,7 @@
 // clang-format off
 GCC_DIAG_OFF(deprecated-declarations)
 CGG_DIAG_OFF(format-overflow=)
-CGG_DIAG_OFF(format-overflow=)
+CGG_DIAG_OFF(format-truncation=)
 GCC_DIAG_OFF(implicit-fallthrough=)
 // clang-format on
 
@@ -17022,7 +17022,7 @@ soap::~soap() {
 // clang-format off
 GCC_DIAG_ON(deprecated-declarations)
 CGG_DIAG_ON(format-overflow=)
-CGG_DIAG_ON(format-overflow=)
+CGG_DIAG_ON(format-truncation=)
 GCC_DIAG_ON(implicit-fallthrough=)
 // clang-format on
 


### PR DESCRIPTION
Description of work.

This suppresses GCC 7 warnings from gSOAP. Instead of further modifying our local copy, the better long-term solution is to use gSOAP as an external library or external project. See issue #19433

**To test:**

<!-- Instructions for testing. -->

If the builds pass, :squirrel:

There is no GitHub issue associated with this pull request.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
