### PR TITLE
EQSANSLoad fixed for adara logs

### DIFF
--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -265,29 +265,39 @@ void EQSANSLoad::getSourceSlitSize() {
   Mantid::Kernel::Property *prop = dataWS->run().getProperty(slit1Name);
   Mantid::Kernel::TimeSeriesProperty<double> *dp =
       dynamic_cast<Mantid::Kernel::TimeSeriesProperty<double> *>(prop);
-  if (!dp)
+  Mantid::Kernel::TimeSeriesProperty<int> *ip =
+      dynamic_cast<Mantid::Kernel::TimeSeriesProperty<int> *>(prop);
+  int slit1;
+  if (dp) slit1 = static_cast<int>(dp->getStatistics().mean);
+  else if (ip) slit1 = static_cast<int>(ip->getStatistics().mean);
+  else
     throw std::runtime_error("Could not cast (interpret) the property " +
                              slit1Name + " as a time series property with "
-                                         "floating point values.");
-  int slit1 = static_cast<int>(dp->getStatistics().mean);
+                                         "int or floating point values.");
 
   const std::string slit2Name = "vBeamSlit2";
   prop = dataWS->run().getProperty(slit2Name);
   dp = dynamic_cast<Mantid::Kernel::TimeSeriesProperty<double> *>(prop);
-  if (!dp)
+  ip = dynamic_cast<Mantid::Kernel::TimeSeriesProperty<int> *>(prop);
+  int slit2;
+  if (dp) slit2 = static_cast<int>(dp->getStatistics().mean);
+  else if (ip) slit2 = static_cast<int>(ip->getStatistics().mean);
+  else
     throw std::runtime_error("Could not cast (interpret) the property " +
                              slit2Name + " as a time series property with "
-                                         "floating point values.");
-  int slit2 = static_cast<int>(dp->getStatistics().mean);
+                                         "int or floating point values.");
 
   const std::string slit3Name = "vBeamSlit3";
   prop = dataWS->run().getProperty(slit3Name);
   dp = dynamic_cast<Mantid::Kernel::TimeSeriesProperty<double> *>(prop);
-  if (!dp)
+  ip = dynamic_cast<Mantid::Kernel::TimeSeriesProperty<int> *>(prop);
+  int slit3;
+  if (dp) slit3 = static_cast<int>(dp->getStatistics().mean);
+  else if (ip) slit3 = static_cast<int>(ip->getStatistics().mean);
+  else
     throw std::runtime_error("Could not cast (interpret) the property " +
                              slit3Name + " as a time series property with "
-                                         "floating point values.");
-  int slit3 = static_cast<int>(dp->getStatistics().mean);
+                                         "int or floating point values.");
 
   if (slit1 < 0 && slit2 < 0 && slit3 < 0) {
     m_output_message += "   Could not determine source aperture diameter\n";

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -268,8 +268,10 @@ void EQSANSLoad::getSourceSlitSize() {
   Mantid::Kernel::TimeSeriesProperty<int> *ip =
       dynamic_cast<Mantid::Kernel::TimeSeriesProperty<int> *>(prop);
   int slit1;
-  if (dp) slit1 = static_cast<int>(dp->getStatistics().mean);
-  else if (ip) slit1 = static_cast<int>(ip->getStatistics().mean);
+  if (dp)
+    slit1 = static_cast<int>(dp->getStatistics().mean);
+  else if (ip)
+    slit1 = static_cast<int>(ip->getStatistics().mean);
   else
     throw std::runtime_error("Could not cast (interpret) the property " +
                              slit1Name + " as a time series property with "
@@ -280,8 +282,10 @@ void EQSANSLoad::getSourceSlitSize() {
   dp = dynamic_cast<Mantid::Kernel::TimeSeriesProperty<double> *>(prop);
   ip = dynamic_cast<Mantid::Kernel::TimeSeriesProperty<int> *>(prop);
   int slit2;
-  if (dp) slit2 = static_cast<int>(dp->getStatistics().mean);
-  else if (ip) slit2 = static_cast<int>(ip->getStatistics().mean);
+  if (dp)
+    slit2 = static_cast<int>(dp->getStatistics().mean);
+  else if (ip)
+    slit2 = static_cast<int>(ip->getStatistics().mean);
   else
     throw std::runtime_error("Could not cast (interpret) the property " +
                              slit2Name + " as a time series property with "
@@ -292,8 +296,10 @@ void EQSANSLoad::getSourceSlitSize() {
   dp = dynamic_cast<Mantid::Kernel::TimeSeriesProperty<double> *>(prop);
   ip = dynamic_cast<Mantid::Kernel::TimeSeriesProperty<int> *>(prop);
   int slit3;
-  if (dp) slit3 = static_cast<int>(dp->getStatistics().mean);
-  else if (ip) slit3 = static_cast<int>(ip->getStatistics().mean);
+  if (dp)
+    slit3 = static_cast<int>(dp->getStatistics().mean);
+  else if (ip)
+    slit3 = static_cast<int>(ip->getStatistics().mean);
   else
     throw std::runtime_error("Could not cast (interpret) the property " +
                              slit3Name + " as a time series property with "


### PR DESCRIPTION
Description of work.
Read vBeamSlit logs as int or double time series so both old das and adara logs are read correctly.

**To test:**
```python
#Old das (double)
EQSANSLoad(Filename='EQSANS_76025.nxs.h5', OutputWorkspace='EQSANS_76025')
#Adara (int)
EQSANSLoad(Filename='EQSANS_86025.nxs.h5', OutputWorkspace='EQSANS_86025')

Then look at values in vBeamSlit logs.
```

<!-- Instructions for testing. -->

Fixes #20126 

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
