### PR TITLE
Change SingleCrystalDiffuseReduction from using MaskBTP to specifying a Mask file

### DIFF
--- a/docs/source/algorithms/SingleCrystalDiffuseReduction-v1.rst
+++ b/docs/source/algorithms/SingleCrystalDiffuseReduction-v1.rst
@@ -31,10 +31,9 @@ Masking
 #######
 
 The mask from the solid angle workspace is copied to the
-data. Additional masking is provided by :ref:`MaskBTP <algm-MaskBTP>`
-using the Bank, Tube and Pixel parameters. MaskBTP is only run once so
-it can only apply one additional mask to all the data, read
-:ref:`MaskBTP <algm-MaskBTP>` to see the usage.
+data. Additional masking is provided by a masking file. A masking file
+can be created my masking a data file then saving it using
+:ref:`SaveMask <algm-SaveMask>`.
 
 Background
 ##########


### PR DESCRIPTION
See title. As requested by instrument scientists.

**To test:**

Create a mask file for CORELLI then run one of the [usage examples](http://docs.mantidproject.org/nightly/algorithms/SingleCrystalDiffuseReduction-v1.html) with the MaskFile option and compare the results.

Release notes don't need to be updated as SingleCrystalDiffuseReduction was only added in this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
