### PR TITLE
Fix warnings from cppcheck 1.80

### DIFF
--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -389,11 +389,10 @@ bool MergeRuns::validateInputsForEventWorkspaces(
 
   m_inEventWS.clear();
 
-  // Going to check that name of instrument matches - think that's the best
-  // possible at the moment
-  //   because if instrument is created from raw file it'll be a different
-  //   object
-  std::string instrument;
+  // TODO: Check that name of instrument matches - think that's the best
+  // possible at the moment because if instrument is created from raw file it'll
+  // be a different object
+  // std::string instrument;
 
   RunCombinationHelper combHelper;
 

--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -29,6 +29,7 @@ namespace {
  * @param Pointer to byte src
  */
 template <typename InterpretType> double toDouble(uint8_t *src) {
+  // cppcheck-suppress invalidPointerCast
   return static_cast<double>(*reinterpret_cast<InterpretType *>(src));
 }
 }

--- a/MantidPlot/src/SetColValuesDialog.cpp
+++ b/MantidPlot/src/SetColValuesDialog.cpp
@@ -70,7 +70,6 @@ SetColValuesDialog::SetColValuesDialog(ScriptingEnv *env, Table *t,
 
   // Ideally this would be checked at compile time. Until we have 'constexpr if`
   // on all platforms, the added complexity and minimal cost isn't worthwhile.
-  // cppcheck-suppress knownConditionTrueFalse
   if (sizeof(int) == 2) { // 16 bit signed integer
     start->setMaximum(0x7fff);
     end->setMaximum(0x7fff);

--- a/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/MantidQt/MantidWidgets/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -278,7 +278,6 @@ void GenericDataProcessorPresenter::process() {
   m_gqueue = GroupQueue();
 
   // Progress: each group and each row within count as a progress step.
-  int progress = 0;
   int maxProgress = 0;
 
   for (const auto &item : m_selectedData) {
@@ -325,10 +324,11 @@ void GenericDataProcessorPresenter::process() {
   }
 
   // Create progress reporter bar
-  if (maxProgress > 0)
+  if (maxProgress > 0) {
+    int progress = 0;
     m_progressReporter = new ProgressPresenter(progress, maxProgress,
                                                maxProgress, m_progressView);
-
+  }
   // Start processing the first group
   m_nextActionFlag = ReductionFlag::ReduceGroupFlag;
   resume();


### PR DESCRIPTION
Description of work.

cppcheck 1.80 generates several new warnings in Mantid. This fixes or suppresses those warnings, bring the new total to 1.

**To test:**

<!-- Instructions for testing. -->

* install cppcheck 1.80.
* run `cppcheck` target with `CPPCHECK_GENERATE_XML=TRUE`.
* verify only one about a potential memory leak remains.

There is no GitHub issue associated with this pull request.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
