### PR TITLE
Fix Framework builds on Windows when OpenCascade is disabled

### DIFF
--- a/Framework/Geometry/src/Rendering/CacheGeometryGenerator.cpp
+++ b/Framework/Geometry/src/Rendering/CacheGeometryGenerator.cpp
@@ -1,13 +1,13 @@
 #include <vector>
 #include <cmath>
-#include "MantidKernel/V3D.h"
 #include "MantidKernel/Matrix.h"
 #include "MantidGeometry/Objects/Object.h"
 #include "MantidGeometry/Rendering/CacheGeometryGenerator.h"
 #include "MantidGeometry/Rendering/GeometryHandler.h"
-#include "MantidGeometry/Rendering/OCGeometryHandler.h"
 
-#include <boost/make_shared.hpp>
+#ifdef ENABLE_OPENCASCADE
+#include "MantidGeometry/Rendering/OCGeometryHandler.h"
+#endif
 
 namespace Mantid {
 


### PR DESCRIPTION
An `#ifdef` now avoids including `OCGeometryHandler.h` when `OpenCascade` is not enabled. Removed two unused includes whilst I was there.

**To test:**

Code review and passing Jenkins builds should be sufficient, or set CMake variable `ENABLE_OPENCASCADE=OFF` and confirm `Framework` target can be built successfully on Windows.

<!-- Instructions for testing. -->

Fixes #20153

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
