### PR TITLE
Improve error messages in `PDLoadCharacterizations`

### DIFF
--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -1,19 +1,20 @@
 #include "MantidDataHandling/PDLoadCharacterizations.h"
 #include "MantidAPI/FileProperty.h"
-#include "MantidAPI/MultipleFileProperty.h"
 #include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/MultipleFileProperty.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/Property.h"
-#include "MantidKernel/Strings.h"
 #include "MantidKernel/StringTokenizer.h"
+#include "MantidKernel/Strings.h"
+#include <Poco/File.h>
+#include <Poco/Path.h>
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 #include <fstream>
-#include <set>
 #include <iostream>
+#include <set>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -250,11 +251,15 @@ std::vector<std::string> PDLoadCharacterizations::getFilenames() {
   for (const auto &filename : filenames) {
     if (filename.empty())
       continue;
-    boost::filesystem::path path(filename);
-    if (!boost::filesystem::exists(path))
+
+    Poco::File file(filename);
+    if (!file.exists())
       throw Exception::FileError("File does not exist", filename);
-    if (!boost::filesystem::is_regular(path))
+    Poco::Path path(filename);
+    if (!path.isFile())
       throw Exception::FileError("File is not a regular file", filename);
+    if (!file.canRead())
+      throw Exception::FileError("Cannot read file", filename);
   }
   return filenames;
 }

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -247,14 +247,14 @@ std::vector<std::string> PDLoadCharacterizations::getFilenames() {
   }
 
   // check that things exist
-  for (const auto &filename: filenames) {
-      if (filename.empty())
-          continue;
-      boost::filesystem::path path(filename);
-      if (!boost::filesystem::exists(path))
-          throw Exception::FileError("File does not exist", filename);
-      if (!boost::filesystem::is_regular(path))
-          throw Exception::FileError("File is not a regular file", filename);
+  for (const auto &filename : filenames) {
+    if (filename.empty())
+      continue;
+    boost::filesystem::path path(filename);
+    if (!boost::filesystem::exists(path))
+      throw Exception::FileError("File does not exist", filename);
+    if (!boost::filesystem::is_regular(path))
+      throw Exception::FileError("File is not a regular file", filename);
   }
   return filenames;
 }

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -40,7 +40,7 @@ set ( TESTING_TIMEOUT 300 CACHE INTEGER
 ###########################################################################
 
 set ( Boost_NO_BOOST_CMAKE TRUE )
-find_package ( Boost 1.53.0 REQUIRED date_time regex serialization filesystem)
+find_package ( Boost 1.53.0 REQUIRED date_time regex serialization )
 include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
 add_definitions ( -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB )
 # Need this defined globally for our log time values

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -40,7 +40,7 @@ set ( TESTING_TIMEOUT 300 CACHE INTEGER
 ###########################################################################
 
 set ( Boost_NO_BOOST_CMAKE TRUE )
-find_package ( Boost 1.53.0 REQUIRED date_time regex serialization )
+find_package ( Boost 1.53.0 REQUIRED date_time regex serialization filesystem)
 include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
 add_definitions ( -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB )
 # Need this defined globally for our log time values


### PR DESCRIPTION
Give people better error messages when a file doesn't exist.

**To test:**

Run `PDLoadCharacterizations` with different files/directories for the various properties. It should give clearer error messages.

*There is no associated issue.*

*Does not need to be in the release notes* because it is a change to logging.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
