### PR TITLE
Add option to SingleCrystalDiffuseReduction to keep temp data and norm workspaces

### DIFF
--- a/docs/source/algorithms/SingleCrystalDiffuseReduction-v1.rst
+++ b/docs/source/algorithms/SingleCrystalDiffuseReduction-v1.rst
@@ -43,9 +43,9 @@ The background is processed the same as the data except that the
 Goniometer is copied from the data before setting the UB. If a
 background is included three workspaces are create.
 
-"OutputWorkspace" + '_background' containing the normalised background.
+"OutputWorkspace" + '_normalizedBackground' containing the normalised background.
 
-"OutputWorkspace" + '_data' containing the normalised data.
+"OutputWorkspace" + '_normalizedData' containing the normalised data.
 
 And "OutputWorkspace" where OutputWorkspace = OutputWorkspace\_data - OutputWorkspace\_background * BackgroundScale
 
@@ -66,6 +66,23 @@ groups>` to apply.
 For example setting SymmetryOps to "P 31 2 1", "152" or "x,y,z;
 -y,x-y,z+1/3; -x+y,-x,z+2/3; y,x,-z; x-y,-y,-z+2/3; -x,-x+y,-z+1/3"
 are equivalent.
+
+Temporary Workspaces
+####################
+
+If the KeepTemporaryWorkspaces option is True the data and the
+normalization in addition to the nomalized data will be
+outputted. This allows you to run separate instances of
+SingleCrystalDiffuseReduction and combine the results. They will have
+names "OutputWorkspace" + '_data' and "OutputWorkspace" +
+'_normalization' respectively.
+
+Where "OutputWorkspace" = OutputWorkspace"+'_data' /
+"OutputWorkspace"+'_normalization'.
+
+If background is subtracted there will be similar "OutputWorkspace" +
+'_background_data' and "OutputWorkspace" +
+'_background_normalization' for the background.
 
 Workflow
 --------

--- a/docs/source/algorithms/SingleCrystalDiffuseReduction-v1.rst
+++ b/docs/source/algorithms/SingleCrystalDiffuseReduction-v1.rst
@@ -41,18 +41,21 @@ Background
 
 The background is processed the same as the data except that the
 Goniometer is copied from the data before setting the UB. If a
-background is included three workspaces are create.
+background is included three workspaces are create. If
+"OutputWorkspace" is set to "ws" you will get the following.
 
-"OutputWorkspace" + '_normalizedBackground' containing the normalised background.
+"ws_normalizedBackground" containing the normalised background.
 
-"OutputWorkspace" + '_normalizedData' containing the normalised data.
+"ws_normalizedData" containing the normalised data.
 
-And "OutputWorkspace" where OutputWorkspace = OutputWorkspace\_data - OutputWorkspace\_background * BackgroundScale
+And "ws" where
+
+.. math:: ws = ws\_normalizedData - ws\_normalizedBackground * BackgroundScale
 
 Should the background scale not be correct this allows you to redo the
 background subtraction without rerunning the reduction.
 
-If no background is used then the "OutputWorkspace" is just the normalised data.
+If no background is used then the "ws" is just the normalised data.
 
 Symmetries
 ##########
@@ -74,15 +77,20 @@ If the KeepTemporaryWorkspaces option is True the data and the
 normalization in addition to the nomalized data will be
 outputted. This allows you to run separate instances of
 SingleCrystalDiffuseReduction and combine the results. They will have
-names "OutputWorkspace" + '_data' and "OutputWorkspace" +
-'_normalization' respectively.
+names "ws_data" and "ws_normalization"
+respectively.
 
-Where "OutputWorkspace" = OutputWorkspace"+'_data' /
-"OutputWorkspace"+'_normalization'.
+Where
 
-If background is subtracted there will be similar "OutputWorkspace" +
-'_background_data' and "OutputWorkspace" +
-'_background_normalization' for the background.
+.. math:: ws\_normalizedData = \frac{ws\_data}{ws\_normalization}
+
+If background is subtracted there will be similar
+"ws_background_data" and
+"ws_background_normalization" for the background.
+
+Where
+
+.. math:: ws\_normalizedBackground = \frac{ws\_background\_data}{ws\_backgournd\_normalization}
 
 Workflow
 --------


### PR DESCRIPTION
Add option to SingleCrystalDiffuseReduction to keep temp data and norm workspaces. Also slightly changed the progress to be more accurate.

**To test:**
Try an [Usage example](http://docs.mantidproject.org/nightly/algorithms/SingleCrystalDiffuseReduction-v1.html#usage) with `KeepTemporaryWorkspaces=True` and check the outputs.

Release notes don't need to be updated as SingleCrystalDiffuseReduction was only added in this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
