### PR TITLE
DPDFReduction faulty signature being passed to underlying C function

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -243,9 +243,10 @@ class DPDFreduction(api.PythonAlgorithm):
             self._qbins.append(maxs[0])  # append maximum Q
 
         # Delete sample and empty can event workspaces to free memory.
-        sapi.DeleteWorkspace(wn_data)
-        if self._ecruns:
-            sapi.DeleteWorkspace(wn_ec_data)
+        if self._clean:
+            sapi.DeleteWorkspace(wn_data)
+            if self._ecruns:
+                sapi.DeleteWorkspace(wn_ec_data)
 
         # Convert to S(theta,E)
         ki = numpy.sqrt(Ei / ENERGY_TO_WAVEVECTOR)
@@ -417,13 +418,13 @@ class DPDFreduction(api.PythonAlgorithm):
         # split the high_zero_fraction indexes into chunks of consecutive indexes
         #  Example: if high_zero_fraction=[3,7,8,9,11,15,16], then we split into [3],[7,8,9], [11], [15,16]
         gaps = list()  # intensity gaps, because high zero fraction means low overall intensity
-        gap = [high_zero_fraction[0], ]
+        gap = [np.asscalar(high_zero_fraction[0]), ]
         for index in range(1, len(high_zero_fraction)):
             if high_zero_fraction[index] - high_zero_fraction[index - 1] == 1:
-                gap.append(high_zero_fraction[index])  # two consecutive indexes
+                gap.append(np.asscalar(high_zero_fraction[index]))  # two consecutive indexes
             else:
                 gaps.append(gap)
-                gap = [high_zero_fraction[index], ]
+                gap = [np.asscalar(high_zero_fraction[index]), ]
         gaps.append(gap)  # final dangling gap has to be appended
         return gaps  # a list of lists
 

--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -418,13 +418,13 @@ class DPDFreduction(api.PythonAlgorithm):
         # split the high_zero_fraction indexes into chunks of consecutive indexes
         #  Example: if high_zero_fraction=[3,7,8,9,11,15,16], then we split into [3],[7,8,9], [11], [15,16]
         gaps = list()  # intensity gaps, because high zero fraction means low overall intensity
-        gap = [np.asscalar(high_zero_fraction[0]), ]
+        gap = [numpy.asscalar(high_zero_fraction[0]), ]
         for index in range(1, len(high_zero_fraction)):
             if high_zero_fraction[index] - high_zero_fraction[index - 1] == 1:
-                gap.append(np.asscalar(high_zero_fraction[index]))  # two consecutive indexes
+                gap.append(numpy.asscalar(high_zero_fraction[index]))  # two consecutive indexes
             else:
                 gaps.append(gap)
-                gap = [np.asscalar(high_zero_fraction[index]), ]
+                gap = [numpy.asscalar(high_zero_fraction[index]), ]
         gaps.append(gap)  # final dangling gap has to be appended
         return gaps  # a list of lists
 

--- a/docs/source/release/v3.11.0/direct_inelastic.rst
+++ b/docs/source/release/v3.11.0/direct_inelastic.rst
@@ -7,3 +7,7 @@ Direct Inelastic Changes
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+Direct+Inelastic%22>`_
 
+Algorithms
+##########
+
+- A bug was fixed in :ref:`DPDFReduction <algm-DPDFReduction>` to comply with the signature of one of the underlying C-functions.


### PR DESCRIPTION
**To test:**
Download and unzip vanadium file [van48627.nxs.zip](https://github.com/mantidproject/mantid/files/1195081/van48627.nxs.zip) under directory `/tmp`, then in Mantidplot set your default instrument to SNS - ARCS and then run the reduction:
```
DPDFreduction(RunNumbers='49466',
    Vanadium='/tmp/van48627.nxs',
    EmptyCanRunNumbers='49531',
    EnergyBins=1.5,
    MomentumTransferBins=0.1,
    CleanWorkspaces=True,
    OutputWorkspace='slices_QE')
```
That's it, just verify that output workspace `slices_QE` is created.

Fixes #20159.

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
