### PR TITLE
Fix performance regressions in ComponentInfo::setRotation and setPosition.

### DIFF
--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -56,8 +56,7 @@ private:
   const int64_t m_sampleIndex = -1;
   DetectorInfo *m_detectorInfo; // ExperimentInfo is the owner.
 
-  void scanningCheck(size_t componentIndex) const;
-  void checkDetectorInfo() const;
+  void failIfScanning() const;
 
 public:
   ComponentInfo();

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -41,6 +41,7 @@ class MANTID_BEAMLINE_DLL ComponentInfo {
 
 private:
   boost::shared_ptr<const std::vector<size_t>> m_assemblySortedDetectorIndices;
+  /// Contains only indices of non-detector components
   boost::shared_ptr<const std::vector<size_t>> m_assemblySortedComponentIndices;
   /// Ranges of component ids that are contiguous blocks of detectors.
   boost::shared_ptr<const std::vector<std::pair<size_t, size_t>>>

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -38,8 +38,24 @@ class DetectorInfo;
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 class MANTID_BEAMLINE_DLL ComponentInfo {
-
 private:
+  class Range {
+  private:
+    const std::vector<size_t>::const_iterator m_begin;
+    const std::vector<size_t>::const_iterator m_end;
+
+  public:
+    Range(std::vector<size_t>::const_iterator &&begin,
+          std::vector<size_t>::const_iterator &&end)
+        : m_begin(std::move(begin)), m_end(std::move(end)) {}
+    bool empty() const { return m_begin == m_end; }
+    auto begin() const -> decltype(m_begin) { return m_begin; }
+    auto end() const -> decltype(m_end) { return m_end; }
+  };
+
+  Range detectorRangeInSubtree(const size_t index) const;
+  Range componentRangeInSubtree(const size_t index) const;
+
   boost::shared_ptr<const std::vector<size_t>> m_assemblySortedDetectorIndices;
   /// Contains only indices of non-detector components
   boost::shared_ptr<const std::vector<size_t>> m_assemblySortedComponentIndices;

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -197,7 +197,7 @@ inline void DetectorInfo::setRotation(const size_t index,
 
 /// Set the rotation of the detector with given index.
 inline void DetectorInfo::setRotation(const std::pair<size_t, size_t> &index,
-                               const Eigen::Quaterniond &rotation) {
+                                      const Eigen::Quaterniond &rotation) {
   m_rotations.access()[linearIndex(index)] = rotation.normalized();
 }
 

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -136,30 +136,6 @@ void DetectorInfo::setMasked(const std::pair<size_t, size_t> &index,
   m_isMasked.access()[linearIndex(index)] = masked;
 }
 
-/// Returns the position of the detector with given index.
-Eigen::Vector3d
-DetectorInfo::position(const std::pair<size_t, size_t> &index) const {
-  return (*m_positions)[linearIndex(index)];
-}
-
-/// Returns the rotation of the detector with given index.
-Eigen::Quaterniond
-DetectorInfo::rotation(const std::pair<size_t, size_t> &index) const {
-  return (*m_rotations)[linearIndex(index)];
-}
-
-/// Set the position of the detector with given index.
-void DetectorInfo::setPosition(const std::pair<size_t, size_t> &index,
-                               const Eigen::Vector3d &position) {
-  m_positions.access()[linearIndex(index)] = position;
-}
-
-/// Set the rotation of the detector with given index.
-void DetectorInfo::setRotation(const std::pair<size_t, size_t> &index,
-                               const Eigen::Quaterniond &rotation) {
-  m_rotations.access()[linearIndex(index)] = rotation.normalized();
-}
-
 /// Returns the scan count of the detector with given detector index.
 size_t DetectorInfo::scanCount(const size_t index) const {
   if (!m_scanCounts)
@@ -277,17 +253,6 @@ Eigen::Vector3d DetectorInfo::samplePosition() const {
                              "cannot determine samplePosition");
   }
   return m_componentInfo->samplePosition();
-}
-
-/// Returns the linear index for a pair of detector index and time index.
-size_t DetectorInfo::linearIndex(const std::pair<size_t, size_t> &index) const {
-  // The most common case are beamlines with static detectors. In that case the
-  // time index is always 0 and we avoid expensive map lookups. Linear indices
-  // are ordered such that the first block contains everything for time index 0
-  // so even in the time dependent case no translation is necessary.
-  if (index.second == 0)
-    return index.first;
-  return (*m_indexMap)[index.first][index.second];
 }
 
 void DetectorInfo::initScanCounts() {

--- a/Framework/Beamline/test/ComponentInfoTest.h
+++ b/Framework/Beamline/test/ComponentInfoTest.h
@@ -41,8 +41,7 @@ makeTreeExampleAndReturnGeometricArguments() {
       boost::make_shared<const std::vector<size_t>>(
           std::vector<size_t>{0, 2, 1});
   auto bankSortedComponentIndices =
-      boost::make_shared<const std::vector<size_t>>(
-          std::vector<size_t>{0, 1, 3, 2, 4});
+      boost::make_shared<const std::vector<size_t>>(std::vector<size_t>{3, 4});
   auto parentIndices = boost::make_shared<const std::vector<size_t>>(
       std::vector<size_t>{3, 3, 4, 4, 4});
 
@@ -54,9 +53,9 @@ makeTreeExampleAndReturnGeometricArguments() {
 
   std::vector<std::pair<size_t, size_t>> componentRanges;
   componentRanges.push_back(
-      std::make_pair(0, 3)); // sub-assembly (contains two detectors and self)
+      std::make_pair(0, 1)); // sub-assembly (contains self)
   componentRanges.push_back(std::make_pair(
-      0, 5)); // instrument assembly (with 4 sub-components and self)
+      0, 2)); // instrument assembly (with 1 sub-component and self)
 
   // Set non-detectors at different positions
   auto compPositions = boost::make_shared<std::vector<Eigen::Vector3d>>();
@@ -102,8 +101,7 @@ std::tuple<ComponentInfo, boost::shared_ptr<DetectorInfo>> makeTreeExample() {
       boost::make_shared<const std::vector<size_t>>(
           std::vector<size_t>{0, 2, 1});
   auto bankSortedComponentIndices =
-      boost::make_shared<const std::vector<size_t>>(
-          std::vector<size_t>{0, 2, 3, 1, 4});
+      boost::make_shared<const std::vector<size_t>>(std::vector<size_t>{3, 4});
   auto parentIndices = boost::make_shared<const std::vector<size_t>>(
       std::vector<size_t>{3, 3, 4, 4, 4});
   std::vector<std::pair<size_t, size_t>> detectorRanges;
@@ -112,9 +110,9 @@ std::tuple<ComponentInfo, boost::shared_ptr<DetectorInfo>> makeTreeExample() {
 
   std::vector<std::pair<size_t, size_t>> componentRanges;
   componentRanges.push_back(
-      std::make_pair(0, 3)); // sub-assembly (contains two detectors and self)
+      std::make_pair(0, 1)); // sub-assembly (contains self)
   componentRanges.push_back(std::make_pair(
-      0, 5)); // instrument assembly (with 4 sub-components and self)
+      0, 2)); // instrument assembly (with 1 sub-component and self)
 
   auto positions = boost::make_shared<std::vector<Eigen::Vector3d>>(
       2, Eigen::Vector3d{0, 0, 0}); // 2 positions provided. 2 non-detectors
@@ -166,8 +164,7 @@ public:
         boost::make_shared<const std::vector<size_t>>(
             std::vector<size_t>{0, 1, 2});
     auto bankSortedComponentIndices =
-        boost::make_shared<const std::vector<size_t>>(
-            std::vector<size_t>{0, 1, 2});
+        boost::make_shared<const std::vector<size_t>>(std::vector<size_t>{});
     auto parentIndices = boost::make_shared<const std::vector<size_t>>(
         std::vector<size_t>{9, 9, 9}); // These indices are invalid, but that's
                                        // ok as not being tested here
@@ -459,7 +456,7 @@ public:
     TS_ASSERT_EQUALS(
         compInfo.componentsInSubtree(4 /*component index of root*/),
         std::vector<size_t>(
-            {0, 2, 3, 1, 4})); // Note inclusion of self comp index
+            {0, 2, 1, 3, 4})); // Note inclusion of self comp index
 
     TS_ASSERT_EQUALS(
         compInfo.componentsInSubtree(3 /*component index of sub-assembly*/),

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -91,8 +91,8 @@ InstrumentVisitor::InstrumentVisitor(
                    : nullptr;
 
   const auto nDetectors = m_orderedDetectorIds->size();
-  m_assemblySortedDetectorIndices->reserve(nDetectors);  // Exact
-  m_componentIdToIndexMap->reserve(nDetectors);          // Approximation
+  m_assemblySortedDetectorIndices->reserve(nDetectors); // Exact
+  m_componentIdToIndexMap->reserve(nDetectors);         // Approximation
 }
 
 void InstrumentVisitor::walkInstrument() {

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -92,7 +92,6 @@ InstrumentVisitor::InstrumentVisitor(
 
   const auto nDetectors = m_orderedDetectorIds->size();
   m_assemblySortedDetectorIndices->reserve(nDetectors);  // Exact
-  m_assemblySortedComponentIndices->reserve(nDetectors); // Approximation
   m_componentIdToIndexMap->reserve(nDetectors);          // Approximation
 }
 
@@ -217,7 +216,6 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
     (*m_componentIdToIndexMap)[detector.getComponentID()] = detectorIndex;
     (*m_componentIds)[detectorIndex] = detector.getComponentID();
     m_assemblySortedDetectorIndices->push_back(detectorIndex);
-    m_assemblySortedComponentIndices->push_back(detectorIndex);
     (*m_detectorPositions)[detectorIndex] =
         Kernel::toVector3d(detector.getPos());
     (*m_detectorRotations)[detectorIndex] =


### PR DESCRIPTION
This is mainly a problem for SCDCalibratePanels. Performance should be
back to normal.

The code is a bit ugly now and could be made nicer if we had spans as in GSL or `boost:hana`. Tried looking into stealing from there, but it is not so simple.

**To test:**

- Code review.
- Maybe compare perormance to master, but probably it is sufficient to do that just once before we merge this feature branch into master.

No issue, no release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
