### PR TITLE
Parse the instrument tree in the base instrument

### DIFF
--- a/Framework/DataHandling/src/LoadInstrument.cpp
+++ b/Framework/DataHandling/src/LoadInstrument.cpp
@@ -185,7 +185,7 @@ void LoadInstrument::exec() {
       // instrument. As a consequence less time is spent and less memory is
       // used. Note that this is only possible since the tree in `instrument`
       // will not be modified once we add it to the IDS.
-      instrument->parseTree();
+      instrument->parseTreeAndCacheBeamline();
       // Add to data service for later retrieval
       InstrumentDataService::Instance().add(instrumentNameMangled, instrument);
     }

--- a/Framework/DataHandling/src/LoadInstrument.cpp
+++ b/Framework/DataHandling/src/LoadInstrument.cpp
@@ -179,6 +179,13 @@ void LoadInstrument::exec() {
       // Really create the instrument
       Progress prog(this, 0.0, 1.0, 100);
       instrument = parser.parseXML(&prog);
+      // Parse the instrument tree (internally create ComponentInfo and
+      // DetectorInfo. This is an optimization that avoid duplicate parsing of
+      // the instrument tree when loading multiple workspaces with the same
+      // instrument. As a consequence less time is spent and less memory is
+      // used. Note that this is only possible since the tree in `instrument`
+      // will not be modified once we added it to the IDS.
+      instrument->parseTree();
       // Add to data service for later retrieval
       InstrumentDataService::Instance().add(instrumentNameMangled, instrument);
     }

--- a/Framework/DataHandling/src/LoadInstrument.cpp
+++ b/Framework/DataHandling/src/LoadInstrument.cpp
@@ -180,11 +180,11 @@ void LoadInstrument::exec() {
       Progress prog(this, 0.0, 1.0, 100);
       instrument = parser.parseXML(&prog);
       // Parse the instrument tree (internally create ComponentInfo and
-      // DetectorInfo. This is an optimization that avoid duplicate parsing of
+      // DetectorInfo). This is an optimization that avoids duplicate parsing of
       // the instrument tree when loading multiple workspaces with the same
       // instrument. As a consequence less time is spent and less memory is
       // used. Note that this is only possible since the tree in `instrument`
-      // will not be modified once we added it to the IDS.
+      // will not be modified once we add it to the IDS.
       instrument->parseTree();
       // Add to data service for later retrieval
       InstrumentDataService::Instance().add(instrumentNameMangled, instrument);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -247,9 +247,9 @@ public:
   /// Add a component to the instrument
   virtual int add(IComponent *component) override;
 
-  void parseTree();
-  const ComponentInfo *componentInfo() const;
-  const DetectorInfo *detectorInfo() const;
+  void parseTreeAndCacheBeamline();
+  std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
+  makeBeamline(ParameterMap &pmap, const ParameterMap *source = nullptr) const;
 
 private:
   /// Save information about a set of detectors to Nexus
@@ -262,6 +262,10 @@ private:
   /// Add a plottable component
   void appendPlottable(const CompAssembly &ca,
                        std::vector<IObjComponent_const_sptr> &lst) const;
+
+  std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
+  makeWrappers(ParameterMap &pmap, const ComponentInfo &componentInfo,
+               const DetectorInfo &detectorInfo) const;
 
   /// Map which holds detector-IDs and pointers to detector components, and
   /// monitor flags.

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -19,11 +19,9 @@ namespace Mantid {
 /// Typedef of a map from detector ID to detector shared pointer.
 typedef std::map<detid_t, Geometry::IDetector_const_sptr> detid2det_map;
 
-namespace Beamline {
+namespace Geometry {
 class ComponentInfo;
 class DetectorInfo;
-}
-namespace Geometry {
 class XMLInstrumentParameter;
 class ParameterMap;
 class ReferenceFrame;
@@ -249,6 +247,10 @@ public:
   /// Add a component to the instrument
   virtual int add(IComponent *component) override;
 
+  void parseTree();
+  const ComponentInfo *componentInfo() const;
+  const DetectorInfo *detectorInfo() const;
+
 private:
   /// Save information about a set of detectors to Nexus
   void saveDetectorSetInfoToNexus(::NeXus::File *file,
@@ -327,13 +329,11 @@ private:
   /// Pointer to the reference frame object.
   boost::shared_ptr<ReferenceFrame> m_referenceFrame;
 
-  /// Pointer to the DetectorInfo object. NULL unless the instrument is
-  /// associated with an ExperimentInfo object.
-  boost::shared_ptr<const Beamline::DetectorInfo> m_detectorInfo{nullptr};
+  /// Pointer to the DetectorInfo object. May be NULL.
+  boost::shared_ptr<const DetectorInfo> m_detectorInfo{nullptr};
 
-  /// Pointer to the ComponentInfo object. NULL unless the instrument is
-  /// associated with an ExperimentInfo object.
-  boost::shared_ptr<const Beamline::ComponentInfo> m_componentInfo{nullptr};
+  /// Pointer to the ComponentInfo object. May be NULL.
+  boost::shared_ptr<const ComponentInfo> m_componentInfo{nullptr};
 
   /// Flag - is this the physical rather than neutronic instrument
   bool m_isPhysicalInstrument{false};

--- a/Framework/Geometry/inc/MantidGeometry/Instrument.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument.h
@@ -267,9 +267,6 @@ private:
   /// monitor flags.
   std::vector<std::tuple<detid_t, IDetector_const_sptr, bool>> m_detectorCache;
 
-  /// Mappings to obtain component index
-  boost::shared_ptr<const std::vector<Geometry::ComponentID>> m_componentCache;
-
   /// Purpose to hold copy of source component. For now assumed to be just one
   /// component
   const IComponent *m_sourceCache;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -23,7 +23,7 @@ class ComponentInfo;
 }
 
 namespace Geometry {
-class ParameterMap;
+class Instrument;
 
 /** ComponentInfo : Provides a component centric view on to the instrument.
   Indexes are per component.
@@ -94,7 +94,7 @@ public:
     return m_componentIds->operator[](componentIndex);
   }
 
-  friend class ParameterMap;
+  friend class Instrument;
 };
 
 } // namespace Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
@@ -23,7 +23,6 @@ class SpectrumInfo;
 namespace Geometry {
 class IDetector;
 class Instrument;
-class ParameterMap;
 
 /** Geometry::DetectorInfo is an intermediate step towards a DetectorInfo that
   is part of Instrument-2.0. The aim is to provide a nearly identical interface
@@ -128,7 +127,7 @@ public:
   void merge(const DetectorInfo &other);
 
   friend class API::SpectrumInfo;
-  friend class ParameterMap;
+  friend class Instrument;
 
 private:
   const Geometry::IDetector &getDetector(const size_t index) const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
@@ -125,6 +125,9 @@ private:
   void markAsSourceOrSample(Mantid::Geometry::IComponent *componentId,
                             const size_t componentIndex);
 
+  std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
+  makeWrappers() const;
+
 public:
   InstrumentVisitor(boost::shared_ptr<const Instrument> instrument);
 
@@ -156,8 +159,9 @@ public:
 
   boost::shared_ptr<std::vector<detid_t>> detectorIds() const;
 
-  std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
-  makeWrappers() const;
+  static std::pair<std::unique_ptr<ComponentInfo>,
+                   std::unique_ptr<DetectorInfo>>
+  makeWrappers(const Instrument &instrument, ParameterMap *pmap = nullptr);
 };
 } // namespace Geometry
 } // namespace Mantid

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -367,8 +367,6 @@ private:
   component_map_cit positionOf(const IComponent *comp, const char *name,
                                const char *type) const;
 
-  void relinkWrappers();
-
   /// internal list of parameter files loaded
   std::vector<std::string> m_parameterFileNames;
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -367,6 +367,8 @@ private:
   component_map_cit positionOf(const IComponent *comp, const char *name,
                                const char *type) const;
 
+  void relinkWrappers();
+
   /// internal list of parameter files loaded
   std::vector<std::string> m_parameterFileNames;
 

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -318,9 +318,9 @@ InstrumentVisitor::makeWrappers(const Instrument &instrument,
                  boost::shared_ptr<const Instrument>(&instrument, NoDeleting()),
                  boost::shared_ptr<ParameterMap>(pmap, NoDeleting()))
            : boost::shared_ptr<const Instrument>(&instrument, NoDeleting());
-    InstrumentVisitor visitor(parInstrument);
-    visitor.walkInstrument();
-    return visitor.makeWrappers();
+  InstrumentVisitor visitor(parInstrument);
+  visitor.walkInstrument();
+  return visitor.makeWrappers();
 }
 
 } // namespace Geometry

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -6,6 +6,7 @@
 #include "MantidGeometry/IDetector.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
+#include "MantidGeometry/Instrument/ParComponentFactory.h"
 #include "MantidKernel/EigenConversionHelpers.h"
 #include "MantidKernel/make_unique.h"
 #include "MantidBeamline/ComponentInfo.h"
@@ -307,6 +308,19 @@ InstrumentVisitor::makeWrappers() const {
       std::move(detInfo), m_instrument, detectorIds(), detectorIdToIndexMap());
 
   return {std::move(compInfoWrapper), std::move(detInfoWrapper)};
+}
+
+std::pair<std::unique_ptr<ComponentInfo>, std::unique_ptr<DetectorInfo>>
+InstrumentVisitor::makeWrappers(const Instrument &instrument,
+                                ParameterMap *pmap) {
+  const auto parInstrument =
+      pmap ? ParComponentFactory::createInstrument(
+                 boost::shared_ptr<const Instrument>(&instrument, NoDeleting()),
+                 boost::shared_ptr<ParameterMap>(pmap, NoDeleting()))
+           : boost::shared_ptr<const Instrument>(&instrument, NoDeleting());
+    InstrumentVisitor visitor(parInstrument);
+    visitor.walkInstrument();
+    return visitor.makeWrappers();
 }
 
 } // namespace Geometry

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -1,7 +1,6 @@
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
-#include "MantidGeometry/Instrument/InstrumentVisitor.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
 #include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidGeometry/IDetector.h"

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -6,8 +6,6 @@
 #include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidKernel/Cache.h"
-#include "MantidBeamline/ComponentInfo.h"
-#include "MantidBeamline/DetectorInfo.h"
 #include "MantidKernel/MultiThreaded.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ParameterFactory.h"
@@ -77,11 +75,9 @@ ParameterMap::ParameterMap(const ParameterMap &other)
           Kernel::make_unique<Kernel::Cache<const ComponentID, BoundingBox>>(
               *other.m_boundingBoxMap)),
       m_instrument(other.m_instrument) {
-  if (!other.m_detectorInfo)
-    return;
-  m_detectorInfo = Kernel::make_unique<DetectorInfo>(*other.m_detectorInfo);
-  m_componentInfo = Kernel::make_unique<ComponentInfo>(*other.m_componentInfo);
-  relinkWrappers();
+  if (m_instrument)
+    std::tie(m_componentInfo, m_detectorInfo) =
+        m_instrument->makeBeamline(*this, &other);
 }
 
 // Defined as default in source for forward declaration with std::unique_ptr.
@@ -1235,30 +1231,7 @@ void ParameterMap::setInstrument(const Instrument *instrument) {
     throw std::logic_error("ParameterMap::setInstrument must be called with "
                            "base instrument, not a parametrized instrument");
   m_instrument = instrument;
-
-  if (empty() && instrument->componentInfo()) {
-    m_detectorInfo =
-        Kernel::make_unique<DetectorInfo>(*instrument->detectorInfo());
-    m_componentInfo =
-        Kernel::make_unique<ComponentInfo>(*instrument->componentInfo());
-    relinkWrappers();
-  } else {
-    std::tie(m_componentInfo, m_detectorInfo) =
-        InstrumentVisitor::makeWrappers(*m_instrument, this);
-  }
-}
-
-/// Sets up links between m_detectorInfo, m_componentInfo, and m_instrument.
-void ParameterMap::relinkWrappers() {
-  m_componentInfo->m_componentInfo->setDetectorInfo(
-      m_detectorInfo->m_detectorInfo.get());
-  m_detectorInfo->m_detectorInfo->setComponentInfo(
-      m_componentInfo->m_componentInfo.get());
-
-  const auto parInstrument = ParComponentFactory::createInstrument(
-      boost::shared_ptr<const Instrument>(m_instrument, NoDeleting()),
-      boost::shared_ptr<ParameterMap>(this, NoDeleting()));
-  m_detectorInfo->m_instrument = parInstrument;
+  std::tie(m_componentInfo, m_detectorInfo) = m_instrument->makeBeamline(*this);
 }
 
 } // Namespace Geometry


### PR DESCRIPTION
Parsing the instrument tree in the base instrument when it is being added to the IDS has two big advantages when loading more than one workspace with the same instrument:
- We avoid repeated parsing of the same tree.
- Data in instruments (`DetectorInfo` and `ComponentInfo`) will be shared between workspaces. Previously this was the case only for workspaces that were created from a parent workspaces, but not indenpendently created workspaces with the same instrument. Note that if there are parameters that modify the instrument sharing will still be (partially) broken. 

Speedup example (second load and beyond) for TOPAZ:
`master`:
```
LoadEmptyInstrument-[Notice] LoadEmptyInstrument successful, Duration 6.08 seconds
LoadEmptyInstrument-[Notice] LoadEmptyInstrument started
LoadEmptyInstrument-[Notice] LoadEmptyInstrument successful, Duration 4.01 seconds
LoadEmptyInstrument-[Notice] LoadEmptyInstrument started
LoadEmptyInstrument-[Notice] LoadEmptyInstrument successful, Duration 3.44 seconds
LoadEmptyInstrument-[Notice] LoadEmptyInstrument started
LoadEmptyInstrument-[Notice] LoadEmptyInstrument successful, Duration 3.40 seconds
LoadEmptyInstrument-[Notice] LoadEmptyInstrument started
LoadEmptyInstrument-[Notice] LoadEmptyInstrument successful, Duration 3.16 seconds
LoadEmptyInstrument-[Notice] LoadEmptyInstrument started
LoadEmptyInstrument-[Notice] LoadEmptyInstrument successful, Duration 3.71 seconds
LoadEmptyInstrument-[Notice] LoadEmptyInstrument started
LoadEmptyInstrument-[Notice] LoadEmptyInstrument successful, Duration 3.58 seconds
```

This branch:
```
LoadEmptyInstrument successful, Duration 5.93 seconds
LoadEmptyInstrument started
LoadEmptyInstrument successful, Duration 2.70 seconds
LoadEmptyInstrument started
LoadEmptyInstrument successful, Duration 1.95 seconds
LoadEmptyInstrument started
LoadEmptyInstrument successful, Duration 2.16 seconds
LoadEmptyInstrument started
LoadEmptyInstrument successful, Duration 1.87 seconds
LoadEmptyInstrument started
LoadEmptyInstrument successful, Duration 2.09 seconds
LoadEmptyInstrument started
LoadEmptyInstrument successful, Duration 1.98 seconds
```


**To test:**

Code review.

Fixes #20163.

Release notes: Probably worth adding this to the release notes, but probably we should just do this once this feature branch is ready for merging into master such that we can summarize all improvements?

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
