### PR TITLE
Make background culling optional

### DIFF
--- a/Framework/API/inc/MantidAPI/IMDNode.h
+++ b/Framework/API/inc/MantidAPI/IMDNode.h
@@ -204,12 +204,14 @@ public:
   * @param signal [out] :: set to the integrated signal
   * @param errorSquared [out] :: set to the integrated squared error.
   * @param innerRadiusSquared :: radius^2 of inner background
+  * @param useOnePercentBackgroundCorrection :: if one percent correction should be applied to background.
    */
   virtual void
   integrateSphere(Mantid::API::CoordTransform &radiusTransform,
                   const coord_t radiusSquared, signal_t &signal,
                   signal_t &errorSquared,
-                  const coord_t innerRadiusSquared = 0.0) const = 0;
+                  const coord_t innerRadiusSquared = 0.0,
+                  const bool useOnePercentBackgroundCorrection=true) const = 0;
   /** Find the centroid of all events contained within by doing a weighted
   *average
   * of their coordinates.

--- a/Framework/API/inc/MantidAPI/IMDNode.h
+++ b/Framework/API/inc/MantidAPI/IMDNode.h
@@ -204,14 +204,14 @@ public:
   * @param signal [out] :: set to the integrated signal
   * @param errorSquared [out] :: set to the integrated squared error.
   * @param innerRadiusSquared :: radius^2 of inner background
-  * @param useOnePercentBackgroundCorrection :: if one percent correction should be applied to background.
+  * @param useOnePercentBackgroundCorrection :: if one percent correction should
+  *be applied to background.
    */
-  virtual void
-  integrateSphere(Mantid::API::CoordTransform &radiusTransform,
-                  const coord_t radiusSquared, signal_t &signal,
-                  signal_t &errorSquared,
-                  const coord_t innerRadiusSquared = 0.0,
-                  const bool useOnePercentBackgroundCorrection=true) const = 0;
+  virtual void integrateSphere(
+      Mantid::API::CoordTransform &radiusTransform, const coord_t radiusSquared,
+      signal_t &signal, signal_t &errorSquared,
+      const coord_t innerRadiusSquared = 0.0,
+      const bool useOnePercentBackgroundCorrection = true) const = 0;
   /** Find the centroid of all events contained within by doing a weighted
   *average
   * of their coordinates.

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBox.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBox.h
@@ -172,11 +172,11 @@ public:
   void calculateCentroid(coord_t *centroid, const int runindex) const override;
   coord_t *getCentroid() const override;
   void calculateDimensionStats(MDDimensionStats *stats) const;
-  void integrateSphere(Mantid::API::CoordTransform &radiusTransform,
-                       const coord_t radiusSquared, signal_t &signal,
-                       signal_t &errorSquared,
-                       const coord_t innerRadiusSquared = 0.0,
-                       const bool useOnePercentBackgroundCorrection=true) const override;
+  void integrateSphere(
+      Mantid::API::CoordTransform &radiusTransform, const coord_t radiusSquared,
+      signal_t &signal, signal_t &errorSquared,
+      const coord_t innerRadiusSquared = 0.0,
+      const bool useOnePercentBackgroundCorrection = true) const override;
   void centroidSphere(Mantid::API::CoordTransform &radiusTransform,
                       const coord_t radiusSquared, coord_t *centroid,
                       signal_t &signal) const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBox.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBox.h
@@ -175,7 +175,8 @@ public:
   void integrateSphere(Mantid::API::CoordTransform &radiusTransform,
                        const coord_t radiusSquared, signal_t &signal,
                        signal_t &errorSquared,
-                       const coord_t innerRadiusSquared = 0.0) const override;
+                       const coord_t innerRadiusSquared = 0.0,
+                       const bool useOnePercentBackgroundCorrection=true) const override;
   void centroidSphere(Mantid::API::CoordTransform &radiusTransform,
                       const coord_t radiusSquared, coord_t *centroid,
                       signal_t &signal) const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
@@ -555,7 +555,8 @@ TMDE(void MDBox)::generalBin(
 TMDE(void MDBox)::integrateSphere(Mantid::API::CoordTransform &radiusTransform,
                                   const coord_t radiusSquared, signal_t &signal,
                                   signal_t &errorSquared,
-                                  const coord_t innerRadiusSquared) const {
+                                  const coord_t innerRadiusSquared,
+                                  const bool useOnePercentBackgroundCorrection) const {
   // If the box is cached to disk, you need to retrieve it
   const std::vector<MDE> &events = this->getConstEvents();
   if (innerRadiusSquared == 0.0) {
@@ -588,8 +589,8 @@ TMDE(void MDBox)::integrateSphere(Mantid::API::CoordTransform &radiusTransform,
               });
 
     // Remove top 1% of background
-    const size_t endIndex =
-        static_cast<size_t>(0.99 * static_cast<double>(vals.size()));
+    const size_t endIndex = useOnePercentBackgroundCorrection ?
+        static_cast<size_t>(0.99 * static_cast<double>(vals.size())) : vals.size();
 
     for (size_t k = 0; k < endIndex; k++) {
       signal += vals[k].first;

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.h
@@ -127,12 +127,11 @@ public:
              Mantid::Geometry::MDImplicitFunction &function) const = 0;
 
   /** Sphere (peak) integration */
-  void
-  integrateSphere(Mantid::API::CoordTransform &radiusTransform,
-                  const coord_t radiusSquared, signal_t &signal,
-                  signal_t &errorSquared,
-                  const coord_t innerRadiusSquared = 0.0,
-                  const bool useOnePercentBackgroundCorrection=true) const override = 0;
+  void integrateSphere(
+      Mantid::API::CoordTransform &radiusTransform, const coord_t radiusSquared,
+      signal_t &signal, signal_t &errorSquared,
+      const coord_t innerRadiusSquared = 0.0,
+      const bool useOnePercentBackgroundCorrection = true) const override = 0;
 
   /** Find the centroid around a sphere */
   void centroidSphere(Mantid::API::CoordTransform &radiusTransform,

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.h
@@ -131,7 +131,8 @@ public:
   integrateSphere(Mantid::API::CoordTransform &radiusTransform,
                   const coord_t radiusSquared, signal_t &signal,
                   signal_t &errorSquared,
-                  const coord_t innerRadiusSquared = 0.0) const override = 0;
+                  const coord_t innerRadiusSquared = 0.0,
+                  const bool useOnePercentBackgroundCorrection=true) const override = 0;
 
   /** Find the centroid around a sphere */
   void centroidSphere(Mantid::API::CoordTransform &radiusTransform,

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.h
@@ -150,11 +150,11 @@ public:
       MDBin<MDE, nd> & /*bin*/,
       Mantid::Geometry::MDImplicitFunction & /*function*/) const override {}
 
-  void integrateSphere(Mantid::API::CoordTransform &radiusTransform,
-                       const coord_t radiusSquared, signal_t &signal,
-                       signal_t &errorSquared,
-                       const coord_t innerRadiusSquared = 0.0,
-                       const bool useOnePercentBackgroundCorrection=true) const override;
+  void integrateSphere(
+      Mantid::API::CoordTransform &radiusTransform, const coord_t radiusSquared,
+      signal_t &signal, signal_t &errorSquared,
+      const coord_t innerRadiusSquared = 0.0,
+      const bool useOnePercentBackgroundCorrection = true) const override;
 
   void centroidSphere(Mantid::API::CoordTransform &radiusTransform,
                       const coord_t radiusSquared, coord_t *centroid,

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.h
@@ -153,7 +153,8 @@ public:
   void integrateSphere(Mantid::API::CoordTransform &radiusTransform,
                        const coord_t radiusSquared, signal_t &signal,
                        signal_t &errorSquared,
-                       const coord_t innerRadiusSquared = 0.0) const override;
+                       const coord_t innerRadiusSquared = 0.0,
+                       const bool useOnePercentBackgroundCorrection=true) const override;
 
   void centroidSphere(Mantid::API::CoordTransform &radiusTransform,
                       const coord_t radiusSquared, coord_t *centroid,

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
@@ -1088,7 +1088,8 @@ TMDE(void MDGridBox)::integrateSphere(API::CoordTransform &radiusTransform,
                                       const coord_t radiusSquared,
                                       signal_t &signal,
                                       signal_t &errorSquared, 
-                                      const coord_t innerRadiusSquared) const {
+                                      const coord_t innerRadiusSquared,
+                                      const bool useOnePercentBackgroundCorrection) const {
   // We start by looking at the vertices at every corner of every box contained,
   // to see which boxes are partially contained/fully contained.
 
@@ -1234,7 +1235,7 @@ TMDE(void MDGridBox)::integrateSphere(API::CoordTransform &radiusTransform,
     if (partialBox) {
       // Use the detailed integration method.
       box->integrateSphere(radiusTransform, radiusSquared, signal,
-                           errorSquared, innerRadiusSquared);
+                           errorSquared, innerRadiusSquared, useOnePercentBackgroundCorrection);
       //        std::cout << ".signal=" << signal << "\n";
       numPartiallyContained++;
     }

--- a/Framework/DataObjects/test/MDBoxBaseTest.h
+++ b/Framework/DataObjects/test/MDBoxBaseTest.h
@@ -116,11 +116,11 @@ public:
   void calculateCentroid(coord_t * /*centroid*/,
                          const int /*runindex*/) const override{};
   coord_t *getCentroid() const override { return 0; };
-  void integrateSphere(Mantid::API::CoordTransform & /*radiusTransform*/,
-                       const coord_t /*radiusSquared*/, signal_t & /*signal*/,
-                       signal_t & /*errorSquared*/,
-                       const coord_t /*innerRadiusSquared*/,
-                       const bool /*useOnePercentBackgroundCorrection*/) const override{};
+  void integrateSphere(
+      Mantid::API::CoordTransform & /*radiusTransform*/,
+      const coord_t /*radiusSquared*/, signal_t & /*signal*/,
+      signal_t & /*errorSquared*/, const coord_t /*innerRadiusSquared*/,
+      const bool /*useOnePercentBackgroundCorrection*/) const override{};
   void centroidSphere(Mantid::API::CoordTransform & /*radiusTransform*/,
                       const coord_t /*radiusSquared*/, coord_t *,
                       signal_t &) const override{};

--- a/Framework/DataObjects/test/MDBoxBaseTest.h
+++ b/Framework/DataObjects/test/MDBoxBaseTest.h
@@ -119,7 +119,8 @@ public:
   void integrateSphere(Mantid::API::CoordTransform & /*radiusTransform*/,
                        const coord_t /*radiusSquared*/, signal_t & /*signal*/,
                        signal_t & /*errorSquared*/,
-                       const coord_t /*innerRadiusSquared*/) const override{};
+                       const coord_t /*innerRadiusSquared*/,
+                       const bool /*useOnePercentBackgroundCorrection*/) const override{};
   void centroidSphere(Mantid::API::CoordTransform & /*radiusTransform*/,
                       const coord_t /*radiusSquared*/, coord_t *,
                       signal_t &) const override{};

--- a/Framework/DataObjects/test/MDBoxTest.h
+++ b/Framework/DataObjects/test/MDBoxTest.h
@@ -459,7 +459,7 @@ public:
     signal_t signal = 0;
     signal_t errorSquared = 0;
     box.integrateSphere(sphere, radius * radius, signal, errorSquared,
-                        innerRadius, useOnePercent);
+                        innerRadius*innerRadius, useOnePercent);
     TS_ASSERT_DELTA(signal, 1.0 * numExpected, 1e-5);
     TS_ASSERT_DELTA(errorSquared, 1.5 * numExpected, 1e-5);
   }
@@ -485,7 +485,7 @@ public:
     dotest_integrateSphere(box, 5.0, 5.0, 5.0, 10., 9 * 9 * 9);
   }
 
-  void test_integrateSphereWithLowerRadiusBoundAndOnePercentCutoff() {
+  void test_integrateSphereWithLowerRadiusBoundAndNoOnePercentCutoff() {
     // One event at each integer coordinate value between 1 and 9
     MDBox<MDLeanEvent<3>, 3> box(sc.get());
     for (double x = 1.0; x < 10.0; x += 1.0)
@@ -509,11 +509,9 @@ public:
                                           false, 1.0);
 
     // The 1.3 shell contains 2 and the 1.05 inner shell contains 2
-    // dotest_integrateSphereWithInnerRadius(box, 5.11, 5.0, 5.0, 1.3f, 1.05f,
-    // false, 2.0);
+    dotest_integrateSphereWithInnerRadius(box, 5.6f, 5.0f, 5.0f, 0.7f, 0.4f,
+					  false, 2.0);
   }
-
-  void test_integrateSphereWithLowerRadiusBoundAndNoOnePercentCutoff() {}
 
   //-----------------------------------------------------------------------------------------
   /** refreshCache() tracks the centroid */

--- a/Framework/DataObjects/test/MDBoxTest.h
+++ b/Framework/DataObjects/test/MDBoxTest.h
@@ -459,7 +459,7 @@ public:
     signal_t signal = 0;
     signal_t errorSquared = 0;
     box.integrateSphere(sphere, radius * radius, signal, errorSquared,
-                        innerRadius*innerRadius, useOnePercent);
+                        innerRadius * innerRadius, useOnePercent);
     TS_ASSERT_DELTA(signal, 1.0 * numExpected, 1e-5);
     TS_ASSERT_DELTA(errorSquared, 1.5 * numExpected, 1e-5);
   }
@@ -510,7 +510,7 @@ public:
 
     // The 1.3 shell contains 2 and the 1.05 inner shell contains 2
     dotest_integrateSphereWithInnerRadius(box, 5.6f, 5.0f, 5.0f, 0.7f, 0.4f,
-					  false, 2.0);
+                                          false, 2.0);
   }
 
   //-----------------------------------------------------------------------------------------

--- a/Framework/DataObjects/test/MDBoxTest.h
+++ b/Framework/DataObjects/test/MDBoxTest.h
@@ -499,19 +499,13 @@ public:
     TS_ASSERT_EQUALS(box.getNPoints(), 9 * 9 * 9);
 
     // Too small shell
-    dotest_integrateSphereWithInnerRadius(box, 5.0, 5.0, 5.0, 0.5f, 0.4f, false, 0.0);
+    dotest_integrateSphereWithInnerRadius(box, 5.0f, 5.0f, 5.0f, 0.5f, 0.4f, false, 0.0);
 
     // The 0.7 shell contains 2 but the 1.15 inner shell excludes one of them
-    dotest_integrateSphereWithInnerRadius(box, 5.6, 5.0, 5.0, 0.7f, 0.31f, false, 1.0);
+    dotest_integrateSphereWithInnerRadius(box, 5.6f, 5.0f, 5.0f, 0.7f, 0.5f, false, 1.0);
 
     // The 1.3 shell contains 2 and the 1.05 inner shell contains 2
     //dotest_integrateSphereWithInnerRadius(box, 5.11, 5.0, 5.0, 1.3f, 1.05f, false, 2.0);
-
-
-
-    //dotest_integrateSphereWithInnerRadius(box, 0.5, 0.5, 0.5, 0.5, 0.0);
-   // dotest_integrateSphereWithInnerRadius(box, 5.0, 5.0, 5.0, 1.1f, 7.0);
-   // dotest_integrateSphereWithInnerRadius(box, 5.0, 5.0, 5.0, 10., 9 * 9 * 9);
   }
 
   void test_integrateSphereWithLowerRadiusBoundAndNoOnePercentCutoff() {

--- a/Framework/DataObjects/test/MDBoxTest.h
+++ b/Framework/DataObjects/test/MDBoxTest.h
@@ -445,6 +445,21 @@ public:
     TS_ASSERT_DELTA(errorSquared, 1.5 * numExpected, 1e-5);
   }
 
+  void dotest_integrateSphereWithInnerRadius(MDBox<MDLeanEvent<3>, 3> &box, coord_t x,
+                              coord_t y, coord_t z, const coord_t radius, const coord_t innerRadius, const bool useOnePercent,
+                              double numExpected) {
+    // The sphere transformation
+    bool dimensionsUsed[3] = {true, true, true};
+    coord_t center[3] = {x, y, z};
+    CoordTransformDistance sphere(3, center, dimensionsUsed);
+
+    signal_t signal = 0;
+    signal_t errorSquared = 0;
+    box.integrateSphere(sphere, radius * radius, signal, errorSquared, innerRadius, useOnePercent);
+    TS_ASSERT_DELTA(signal, 1.0 * numExpected, 1e-5);
+    TS_ASSERT_DELTA(errorSquared, 1.5 * numExpected, 1e-5);
+  }
+
   void test_integrateSphere() {
     // One event at each integer coordinate value between 1 and 9
     MDBox<MDLeanEvent<3>, 3> box(sc.get());
@@ -465,6 +480,44 @@ public:
     dotest_integrateSphere(box, 5.0, 5.0, 5.0, 1.1f, 7.0);
     dotest_integrateSphere(box, 5.0, 5.0, 5.0, 10., 9 * 9 * 9);
   }
+
+
+  void test_integrateSphereWithLowerRadiusBoundAndOnePercentCutoff() {
+    // One event at each integer coordinate value between 1 and 9
+    MDBox<MDLeanEvent<3>, 3> box(sc.get());
+    for (double x = 1.0; x < 10.0; x += 1.0)
+      for (double y = 1.0; y < 10.0; y += 1.0)
+        for (double z = 1.0; z < 10.0; z += 1.0) {
+          MDLeanEvent<3> ev(1.0, 1.5);
+          ev.setCenter(0, x);
+          ev.setCenter(1, y);
+          ev.setCenter(2, z);
+          box.addEvent(ev);
+        }
+
+
+    TS_ASSERT_EQUALS(box.getNPoints(), 9 * 9 * 9);
+
+    // Too small shell
+    dotest_integrateSphereWithInnerRadius(box, 5.0, 5.0, 5.0, 0.5f, 0.4f, false, 0.0);
+
+    // The 0.7 shell contains 2 but the 1.15 inner shell excludes one of them
+    dotest_integrateSphereWithInnerRadius(box, 5.6, 5.0, 5.0, 0.7f, 0.31f, false, 1.0);
+
+    // The 1.3 shell contains 2 and the 1.05 inner shell contains 2
+    //dotest_integrateSphereWithInnerRadius(box, 5.11, 5.0, 5.0, 1.3f, 1.05f, false, 2.0);
+
+
+
+    //dotest_integrateSphereWithInnerRadius(box, 0.5, 0.5, 0.5, 0.5, 0.0);
+   // dotest_integrateSphereWithInnerRadius(box, 5.0, 5.0, 5.0, 1.1f, 7.0);
+   // dotest_integrateSphereWithInnerRadius(box, 5.0, 5.0, 5.0, 10., 9 * 9 * 9);
+  }
+
+  void test_integrateSphereWithLowerRadiusBoundAndNoOnePercentCutoff() {
+
+  }
+
 
   //-----------------------------------------------------------------------------------------
   /** refreshCache() tracks the centroid */

--- a/Framework/DataObjects/test/MDBoxTest.h
+++ b/Framework/DataObjects/test/MDBoxTest.h
@@ -445,9 +445,12 @@ public:
     TS_ASSERT_DELTA(errorSquared, 1.5 * numExpected, 1e-5);
   }
 
-  void dotest_integrateSphereWithInnerRadius(MDBox<MDLeanEvent<3>, 3> &box, coord_t x,
-                              coord_t y, coord_t z, const coord_t radius, const coord_t innerRadius, const bool useOnePercent,
-                              double numExpected) {
+  void dotest_integrateSphereWithInnerRadius(MDBox<MDLeanEvent<3>, 3> &box,
+                                             coord_t x, coord_t y, coord_t z,
+                                             const coord_t radius,
+                                             const coord_t innerRadius,
+                                             const bool useOnePercent,
+                                             double numExpected) {
     // The sphere transformation
     bool dimensionsUsed[3] = {true, true, true};
     coord_t center[3] = {x, y, z};
@@ -455,7 +458,8 @@ public:
 
     signal_t signal = 0;
     signal_t errorSquared = 0;
-    box.integrateSphere(sphere, radius * radius, signal, errorSquared, innerRadius, useOnePercent);
+    box.integrateSphere(sphere, radius * radius, signal, errorSquared,
+                        innerRadius, useOnePercent);
     TS_ASSERT_DELTA(signal, 1.0 * numExpected, 1e-5);
     TS_ASSERT_DELTA(errorSquared, 1.5 * numExpected, 1e-5);
   }
@@ -481,7 +485,6 @@ public:
     dotest_integrateSphere(box, 5.0, 5.0, 5.0, 10., 9 * 9 * 9);
   }
 
-
   void test_integrateSphereWithLowerRadiusBoundAndOnePercentCutoff() {
     // One event at each integer coordinate value between 1 and 9
     MDBox<MDLeanEvent<3>, 3> box(sc.get());
@@ -495,23 +498,22 @@ public:
           box.addEvent(ev);
         }
 
-
     TS_ASSERT_EQUALS(box.getNPoints(), 9 * 9 * 9);
 
     // Too small shell
-    dotest_integrateSphereWithInnerRadius(box, 5.0f, 5.0f, 5.0f, 0.5f, 0.4f, false, 0.0);
+    dotest_integrateSphereWithInnerRadius(box, 5.0f, 5.0f, 5.0f, 0.5f, 0.4f,
+                                          false, 0.0);
 
     // The 0.7 shell contains 2 but the 1.15 inner shell excludes one of them
-    dotest_integrateSphereWithInnerRadius(box, 5.6f, 5.0f, 5.0f, 0.7f, 0.5f, false, 1.0);
+    dotest_integrateSphereWithInnerRadius(box, 5.6f, 5.0f, 5.0f, 0.7f, 0.5f,
+                                          false, 1.0);
 
     // The 1.3 shell contains 2 and the 1.05 inner shell contains 2
-    //dotest_integrateSphereWithInnerRadius(box, 5.11, 5.0, 5.0, 1.3f, 1.05f, false, 2.0);
+    // dotest_integrateSphereWithInnerRadius(box, 5.11, 5.0, 5.0, 1.3f, 1.05f,
+    // false, 2.0);
   }
 
-  void test_integrateSphereWithLowerRadiusBoundAndNoOnePercentCutoff() {
-
-  }
-
+  void test_integrateSphereWithLowerRadiusBoundAndNoOnePercentCutoff() {}
 
   //-----------------------------------------------------------------------------------------
   /** refreshCache() tracks the centroid */

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -144,7 +144,7 @@ void IntegratePeaksMD2::init() {
       "If false, correct for volume off edge for both background and "
       "intensity.");
 
-  declareProperty("UseOnePercentBackgroundCorrection", false,
+  declareProperty("UseOnePercentBackgroundCorrection", true,
                   "If this options is enabled, then the the top 1% of the "
                   "background will be removed"
                   "before the background subtraction.");

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -144,11 +144,10 @@ void IntegratePeaksMD2::init() {
       "If false, correct for volume off edge for both background and "
       "intensity.");
 
-  declareProperty(
-        "UseOnePercentBackgroundCorrection", false,
-        "If this options is enabled, then the the top 1% of the background will be removed"
-        "before the background subtraction.");
-
+  declareProperty("UseOnePercentBackgroundCorrection", false,
+                  "If this options is enabled, then the the top 1% of the "
+                  "background will be removed"
+                  "before the background subtraction.");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -191,7 +190,8 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   /// Start radius of the background
   double BackgroundInnerRadius = getProperty("BackgroundInnerRadius");
   /// One percent background correction
-  bool useOnePercentBackgroundCorrection = getProperty("UseOnePercentBackgroundCorrection");
+  bool useOnePercentBackgroundCorrection =
+      getProperty("UseOnePercentBackgroundCorrection");
 
   if (BackgroundInnerRadius < PeakRadius)
     BackgroundInnerRadius = PeakRadius;
@@ -376,7 +376,8 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       // Perform the integration into whatever box is contained within.
       ws->getBox()->integrateSphere(
           sphere, static_cast<coord_t>(adaptiveRadius * adaptiveRadius), signal,
-          errorSquared, 0.0 /* innerRadiusSquared */, useOnePercentBackgroundCorrection);
+          errorSquared, 0.0 /* innerRadiusSquared */,
+          useOnePercentBackgroundCorrection);
 
       // Integrate around the background radius
 

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -143,6 +143,12 @@ void IntegratePeaksMD2::init() {
       "Only warning if all of peak outer radius is not on detector (default).\n"
       "If false, correct for volume off edge for both background and "
       "intensity.");
+
+  declareProperty(
+        "UseOnePercentBackgroundCorrection", false,
+        "If this options is enabled, then the the top 1% of the background will be removed"
+        "before the background subtraction.");
+
 }
 
 //----------------------------------------------------------------------------------------------
@@ -184,6 +190,9 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   double BackgroundOuterRadius = getProperty("BackgroundOuterRadius");
   /// Start radius of the background
   double BackgroundInnerRadius = getProperty("BackgroundInnerRadius");
+  /// One percent background correction
+  bool useOnePercentBackgroundCorrection = getProperty("UseOnePercentBackgroundCorrection");
+
   if (BackgroundInnerRadius < PeakRadius)
     BackgroundInnerRadius = PeakRadius;
   /// Cylinder Length to use around peaks for cylinder
@@ -367,7 +376,7 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       // Perform the integration into whatever box is contained within.
       ws->getBox()->integrateSphere(
           sphere, static_cast<coord_t>(adaptiveRadius * adaptiveRadius), signal,
-          errorSquared);
+          errorSquared, 0.0 /* innerRadiusSquared */, useOnePercentBackgroundCorrection);
 
       // Integrate around the background radius
 
@@ -383,7 +392,8 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
             static_cast<coord_t>((adaptiveQBackgroundMultiplier * lenQpeak +
                                   BackgroundInnerRadius) *
                                  (adaptiveQBackgroundMultiplier * lenQpeak +
-                                  BackgroundInnerRadius)));
+                                  BackgroundInnerRadius)),
+            useOnePercentBackgroundCorrection);
 
         // Relative volume of peak vs the BackgroundOuterRadius sphere
         double ratio = (PeakRadius / BackgroundOuterRadius);

--- a/docs/source/algorithms/IntegratePeaksMD-v2.rst
+++ b/docs/source/algorithms/IntegratePeaksMD-v2.rst
@@ -60,7 +60,7 @@ the provided radii. Errors are also summed in quadrature.
    -  The volume of integration is :math:`V_{shell}`.
    -  **BackgroundInnerRadius** allows you to give some space between
       the peak and the background area.
-   -  The top 1% of the background events are removed so that there are no intensity spikes near the edges.
+   -  If the option **UseOnePercentBackgroundCorrection** is enabled, which it is by default, then the top one percent of the background events are removed so that there are no intensity spikes near the edges.
 
 -  **AdaptiveQMultiplier** can be used for the radius to vary as a function of the modulus of Q. If the AdaptiveQBackground option is set to True, the background radius also changes so each peak has a different integration radius.  Q includes the 2*pi factor.
 

--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -29,6 +29,7 @@ Improved
 - :ref:`FilterEvents <algm-FilterEvents-v1>` has refactored on splitting sample logs.
 - :ref:`FilterEvents <algm-FilterEvents-v1>` now copies units for the logs in the filtered workspaces
 - :ref:`SimpleShapeMonteCarloAbsorption <algm-SimpleShapeMonteCarloAbsorption>` has been added to simplify sample environment inputs for MonteCarloAbsorption
+- :ref:`IntegreatePeaksMD <algm-IntegratePeaksMD-v2>` allows now to for optional culling of the top one percent of the background events.
 
 Deprecated
 ##########

--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -29,7 +29,7 @@ Improved
 - :ref:`FilterEvents <algm-FilterEvents-v1>` has refactored on splitting sample logs.
 - :ref:`FilterEvents <algm-FilterEvents-v1>` now copies units for the logs in the filtered workspaces
 - :ref:`SimpleShapeMonteCarloAbsorption <algm-SimpleShapeMonteCarloAbsorption>` has been added to simplify sample environment inputs for MonteCarloAbsorption
-- :ref:`IntegreatePeaksMD <algm-IntegratePeaksMD-v2>` allows now to for optional culling of the top one percent of the background events.
+- :ref:`IntegreatePeaksMD <algm-IntegratePeaksMD-v2>` makes the culling of the top one percent of the background events optional.
 
 Deprecated
 ##########


### PR DESCRIPTION
Fixes #20174

The algorithm `IntegratePeaksMD` sums the counts around a peak and separately the counts in a shell-like volume in the background around the peak. It then subtracts the integrated background from the integrated peak. Since the peak can spill into the background region, the top 1% of `MDBox`es in the background region are discarded. This has been requested by `TOPAZ`. For `WISH` this has become a problem since discarding `1%` of the background skews the SNR to values that make us believe we are dealing with a peak when we are actually dealing with background. Therefore the `1%` culling is being made optional in this PR. 

**To test:**

Ensure that the code makes sense. To see the differences you would have to test this on NoMachine. This might be not easily possible. The `WISH` scientists have had a look at this functionality on NoMachine though. 

**Release Notes** 

See [here](https://github.com/mantidproject/mantid/pull/20181/files#diff-d43ebaec89d7bc36364c8bf4c9f97673)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
