### PR TITLE
Refs #20180. Fix TOFTOF GUI 

### DIFF
--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -756,6 +756,7 @@
   </instrument>
 
   <instrument name="TOFTOF">
+    <zeropadding size="8" startRunNumber="69750"/>
     <technique>Neutron Spectroscopy</technique>
     <technique>Reactor Direct Geometry Spectroscopy</technique>
     <technique>TOF Direct Geometry Spectroscopy</technique>


### PR DESCRIPTION
Fixes TOFTOF GUI bugs described in #20180 

**To test:**

1. Start TOFTOF GUI via Interfaces->Direct->DGS Reduction, choose facility MLZ and instrument TOFTOF. After the window will appear, check that the energy binning step contains now 4 decimals (0.0100)

2. Make some random entries in the Data table (on the right side). Select some rows an press the delete key on the keyboard. Rows should be deleted.

3. Download TOFTOF test files
[testfiles.zip](https://github.com/mantidproject/mantid/files/1204602/testfiles.zip)
Test, that they can be loaded with Load algorithm:
```python
ws1 = Load('44512')
ws2 = Load('69750')
```

<!-- Instructions for testing. -->

Fixes #20180 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->
Does not need to be in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
