### PR TITLE
Fix GoogleTest patching on Windows with whitespace in the source directory path

### DIFF
--- a/buildconfig/CMake/GoogleTest.in
+++ b/buildconfig/CMake/GoogleTest.in
@@ -10,8 +10,8 @@ ExternalProject_Add(googletest
   GIT_TAG           "release-${gtest_version}"
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
-  PATCH_COMMAND     "${GIT_EXECUTABLE}" apply --whitespace fix ${CMAKE_SOURCE_DIR}/buildconfig/CMake/googletest_override.patch
-            COMMAND "${GIT_EXECUTABLE}" apply --whitespace fix ${CMAKE_SOURCE_DIR}/buildconfig/CMake/googletest_static.patch
+  PATCH_COMMAND     "${GIT_EXECUTABLE}" apply --whitespace fix "${CMAKE_SOURCE_DIR}/buildconfig/CMake/googletest_override.patch"
+            COMMAND "${GIT_EXECUTABLE}" apply --whitespace fix "${CMAKE_SOURCE_DIR}/buildconfig/CMake/googletest_static.patch"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""


### PR DESCRIPTION
Fixes #20187 

Added quotes around the paths to the googletest `.patch` files in the CMake files.

Code review should be sufficient.
I think clean builds would be necessary on Jenkins to actually test that the changes don't introduce a problem.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
