### PR TITLE
Suppress -Wimplicit-fallthrough warnings for now

### DIFF
--- a/Framework/Beamline/CMakeLists.txt
+++ b/Framework/Beamline/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library ( Beamline ${SRC_FILES} ${INC_FILES} )
 set_target_properties ( Beamline PROPERTIES OUTPUT_NAME MantidBeamline
                                  COMPILE_DEFINITIONS IN_MANTID_BEAMLINE
                                  INSTALL_RPATH "@loader_path/../MacOS" )
-target_include_directories( Beamline PUBLIC ${EIGEN3_INCLUDE_DIR} )
+target_include_directories( Beamline SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR} )
 
 # Add to the 'Framework' group in VS
 set_property ( TARGET Beamline PROPERTY FOLDER "MantidFramework" )

--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -45,6 +45,11 @@ if ( CMAKE_COMPILER_IS_GNUCXX )
   if (NOT (GCC_COMPILER_VERSION VERSION_LESS "5.1"))
     set(GNUFLAGS "${GNUFLAGS} -Wsuggest-override")
   endif()
+  if (NOT (GCC_COMPILER_VERSION VERSION_LESS "7.1"))
+    # Consider enabling once [[fallthrough]] is available on all platforms.
+    # https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/
+    set(GNUFLAGS "${GNUFLAGS} -Wimplicit-fallthrough=0")
+  endif()
 elseif ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" )
   set(GNUFLAGS "${GNUFLAGS} -Wno-sign-conversion")
 endif()


### PR DESCRIPTION
Description of work.

This suppresses the -Wimplicit-fallthrough warnings for now. I added a note about potentially enabling it once we raise the minimum GCC version and have support for C++17 attributes.

**To test:**

<!-- Instructions for testing. -->

If the builds pass, :squirrel:.

There is no GitHub issue associated with this PR.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
