### PR TITLE
BFGS empty matrix

### DIFF
--- a/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
@@ -191,7 +191,7 @@ double CostFuncLeastSquares::valDerivHessian(bool evalDeriv,
     m_dirtyDeriv = false;
   }
 
-  if (evalDeriv) {
+  if (evalHessian) {
     if (m_includePenalty) {
       size_t i = 0;
       for (size_t ip = 0; ip < np; ++ip) {

--- a/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
@@ -190,7 +190,7 @@ double CostFuncLeastSquares::valDerivHessian(bool evalDeriv,
     }
     m_dirtyDeriv = false;
   }
-
+   
   if (evalHessian) {
     if (m_includePenalty) {
       size_t i = 0;

--- a/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
@@ -190,7 +190,7 @@ double CostFuncLeastSquares::valDerivHessian(bool evalDeriv,
     }
     m_dirtyDeriv = false;
   }
-   
+
   if (evalHessian) {
     if (m_includePenalty) {
       size_t i = 0;

--- a/scripts/CompareFitMinimizers/fitting_benchmarking.py
+++ b/scripts/CompareFitMinimizers/fitting_benchmarking.py
@@ -266,7 +266,6 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
         # Note the ugly adhoc exception. We need to reconsider these WISH problems:
         if 'WISH17701' in prob.name:
             ignore_invalid = False
-
         status, chi2, covar_tbl, param_tbl, fit_wks = msapi.Fit(function, wks, Output='ws_fitting_test',
                                                                 Minimizer=minimizer,
                                                                 CostFunction=cost_function,


### PR DESCRIPTION
BFGS did not always work when called from python, this seemed to be because the Hessian matrix was not constructed. 

<!-- Instructions for testing. -->
To test check that all of the minimizers work when called from python. The easiest way is to run the fit benchmarking with all minimizers on neutron data.

Fixes #20196

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
