### PR TITLE
DetectorInfo convertToDetectorScan method

### DIFF
--- a/Framework/API/inc/MantidAPI/DetectorInfo.h
+++ b/Framework/API/inc/MantidAPI/DetectorInfo.h
@@ -130,7 +130,7 @@ public:
       const std::pair<Kernel::DateAndTime, Kernel::DateAndTime> &interval);
 
   void merge(const DetectorInfo &other);
-  void convertToTimeIndexded(
+  void convertToDetectorScan(
       const std::vector<std::pair<int64_t, int64_t>> &timeRanges);
 
   boost::shared_ptr<const std::unordered_map<detid_t, size_t>>

--- a/Framework/API/inc/MantidAPI/DetectorInfo.h
+++ b/Framework/API/inc/MantidAPI/DetectorInfo.h
@@ -130,6 +130,8 @@ public:
       const std::pair<Kernel::DateAndTime, Kernel::DateAndTime> &interval);
 
   void merge(const DetectorInfo &other);
+  void convertToTimeIndexded(
+      const std::vector<std::pair<int64_t, int64_t>> &timeRanges);
 
   boost::shared_ptr<const std::unordered_map<detid_t, size_t>>
   detIdToIndexMap() const;

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -448,14 +448,19 @@ void DetectorInfo::merge(const DetectorInfo &other) {
 
 /**
  * Creates a time indexded DetectorInfo object based on the scan intervals
- *given. The DetectorInfo object must not be currently time indexded.
+ *given. The DetectorInfo object must not be currently time indexded. The scan
+ *intervals must be the same for every detector, and they must not overlap and
+ *must be in a chronological order.
+ *
+ * These restrictions cover the currently required cases of detector scans. More
+ *complex scans can still be built up using DetectorInfo::merge().
  *
  * @param scanIntervals A vector of sequential, non-overlapping start and end
- *time pairs given in nanoseconds
+ *scan time pairs given in nanoseconds
  */
-void DetectorInfo::convertToTimeIndexded(
+void DetectorInfo::convertToDetectorScan(
     const std::vector<std::pair<int64_t, int64_t>> &scanIntervals) {
-  m_detectorInfo.convertToTimeIndexded(scanIntervals);
+  m_detectorInfo.convertToDetectorScan(scanIntervals);
 }
 
 const Geometry::IDetector &DetectorInfo::getDetector(const size_t index) const {

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -446,6 +446,18 @@ void DetectorInfo::merge(const DetectorInfo &other) {
   m_detectorInfo.merge(other.m_detectorInfo);
 }
 
+/**
+ * Creates a time indexded DetectorInfo object based on the scan intervals
+ *given. The DetectorInfo object must not be currently time indexded.
+ *
+ * @param scanIntervals A vector of sequential, non-overlapping start and end
+ *time pairs given in nanoseconds
+ */
+void DetectorInfo::convertToTimeIndexded(
+    const std::vector<std::pair<int64_t, int64_t>> &scanIntervals) {
+  m_detectorInfo.convertToTimeIndexded(scanIntervals);
+}
+
 const Geometry::IDetector &DetectorInfo::getDetector(const size_t index) const {
   size_t thread = static_cast<size_t>(PARALLEL_THREAD_NUMBER);
   if (m_lastIndex[thread] != index) {

--- a/Framework/API/src/DetectorInfo.cpp
+++ b/Framework/API/src/DetectorInfo.cpp
@@ -447,8 +447,8 @@ void DetectorInfo::merge(const DetectorInfo &other) {
 }
 
 /**
- * Creates a time indexded DetectorInfo object based on the scan intervals
- *given. The DetectorInfo object must not be currently time indexded. The scan
+ * Creates a time indexed DetectorInfo object based on the scan intervals
+ *given. The DetectorInfo object must not be currently time indexed. The scan
  *intervals must be the same for every detector, and they must not overlap and
  *must be in a chronological order.
  *

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -94,7 +94,7 @@ public:
                        const std::pair<int64_t, int64_t> &interval);
 
   void merge(const DetectorInfo &other);
-  void convertToTimeIndexded(
+  void convertToDetectorScan(
       const std::vector<std::pair<int64_t, int64_t>> &timeRanges);
 
 private:

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -94,6 +94,8 @@ public:
                        const std::pair<int64_t, int64_t> &interval);
 
   void merge(const DetectorInfo &other);
+  void convertToTimeIndexded(
+      const std::vector<std::pair<int64_t, int64_t>> &timeRanges);
 
 private:
   size_t linearIndex(const std::pair<size_t, size_t> &index) const;

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -265,38 +265,46 @@ void DetectorInfo::merge(const DetectorInfo &other) {
 
 /**
  * Creates a time indexded DetectorInfo object based on the scan intervals
- *given. The DetectorInfo object must not be currently time indexded.
+ *given. The DetectorInfo object must not be currently time indexded. The scan
+ *intervals must be the same for every detector, and they must not overlap and
+ *must be in a chronological order.
+ *
+ * These restrictions cover the currently required cases of detector scans. More
+ *complex scans can still be built up using DetectorInfo::merge().
  *
  * @param scanIntervals A vector of sequential, non-overlapping start and end
- *time pairs given in nanoseconds
+ *scan time pairs given in nanoseconds
  */
-void DetectorInfo::convertToTimeIndexded(
+void DetectorInfo::convertToDetectorScan(
     const std::vector<std::pair<int64_t, int64_t>> &scanIntervals) {
-
-  // TODO: Check scan intervals do not overlap
 
   if (isScanning())
     throw std::runtime_error(
         "Can not convert a workspace that is already scanning.");
+
+  for (size_t i = 1; i < scanIntervals.size(); ++i)
+    if (scanIntervals[i].first < scanIntervals[i - 1].second)
+      throw std::runtime_error(
+          "Scan intervals given overlap or are unordered.");
 
   if (!m_scanCounts)
     initScanCounts();
   if (!m_indexMap)
     initIndices();
 
-  auto scanCounts(m_scanCounts);
-  const auto size = m_positions->size();
+  const auto detectorInfoSize = m_positions->size();
 
   // Safely set the time range for the first entries
-  for (size_t linearIndex = 0; linearIndex < size; ++linearIndex)
+  for (size_t linearIndex = 0; linearIndex < detectorInfoSize; ++linearIndex)
     setScanInterval(linearIndex, scanIntervals[0]);
 
   for (size_t scanIndex = 1; scanIndex < scanIntervals.size(); ++scanIndex) {
-    for (size_t linearIndex = 0; linearIndex < size; ++linearIndex) {
+    for (size_t linearIndex = 0; linearIndex < detectorInfoSize;
+         ++linearIndex) {
       auto newIndex1 = getIndex(m_indices, linearIndex);
       auto newIndex = std::pair<size_t, size_t>(newIndex1.first, scanIndex);
       const size_t detIndex = newIndex.first;
-      scanCounts.access()[detIndex]++;
+      m_scanCounts.access()[detIndex]++;
       m_indexMap.access()[detIndex].push_back((*m_indices).size());
       m_indices.access().push_back(newIndex);
       m_isMasked.access().push_back((*m_isMasked)[linearIndex]);
@@ -305,7 +313,6 @@ void DetectorInfo::convertToTimeIndexded(
       m_scanIntervals.access().push_back(scanIntervals[scanIndex]);
     }
   }
-  m_scanCounts = std::move(scanCounts);
 }
 
 /// Returns the linear index for a pair of detector index and time index.

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -264,8 +264,8 @@ void DetectorInfo::merge(const DetectorInfo &other) {
 }
 
 /**
- * Creates a time indexded DetectorInfo object based on the scan intervals
- *given. The DetectorInfo object must not be currently time indexded. The scan
+ * Creates a time indexed DetectorInfo object based on the scan intervals
+ *given. The DetectorInfo object must not be currently time indexed. The scan
  *intervals must be the same for every detector, and they must not overlap and
  *must be in a chronological order.
  *

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -287,9 +287,9 @@ void DetectorInfo::convertToTimeIndexded(
   auto scanCounts(m_scanCounts);
   const auto size = m_positions->size();
 
-  std::cout << "Scan interval size:" << m_scanIntervals.access().size()
-            << std::endl;
-  m_scanIntervals.access().push_back(scanIntervals[0]);
+  // Safely set the time range for the first entries
+  for (size_t linearIndex = 0; linearIndex < size; ++linearIndex)
+    setScanInterval(linearIndex, scanIntervals[0]);
 
   for (size_t scanIndex = 1; scanIndex < scanIntervals.size(); ++scanIndex) {
     for (size_t linearIndex = 0; linearIndex < size; ++linearIndex) {

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -521,6 +521,21 @@ public:
     TS_ASSERT_THROWS_NOTHING(a2.merge(b));
     TS_ASSERT(a1.isEquivalent(a2));
   }
+
+  void test_convert_to_scanning() {
+    DetectorInfo a(PosVec(2), RotVec(2), {1});
+    auto scanIntervals = std::vector<std::pair<int64_t, int64_t>>();
+    std::pair<int64_t, int64_t> interval1(0, 1);
+    std::pair<int64_t, int64_t> interval2(1, 2);
+    std::pair<int64_t, int64_t> interval3(2, 3);
+    scanIntervals.push_back(interval1);
+    scanIntervals.push_back(interval2);
+    scanIntervals.push_back(interval3);
+    TS_ASSERT_THROWS_NOTHING(a.convertToTimeIndexded(scanIntervals));
+    TS_ASSERT_EQUALS(a.scanInterval({0, 0}), interval1);
+    TS_ASSERT_EQUALS(a.scanInterval({0, 1}), interval2);
+    TS_ASSERT_EQUALS(a.scanInterval({0, 2}), interval3);
+  }
 };
 
 #endif /* MANTID_BEAMLINE_DETECTORINFOTEST_H_ */

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -605,6 +605,21 @@ public:
                             const std::runtime_error &e, std::string(e.what()),
                             "Scan intervals given overlap or are unordered.")
   }
+
+  void test_convert_scanning_workspace_with_start_after_end_scan_interval() {
+    DetectorInfo a(PosVec(2), RotVec(2), {1});
+    auto b(a);
+    std::pair<int64_t, int64_t> interval1(1, 0);
+    std::pair<int64_t, int64_t> interval2(0, 1);
+    auto scanIntervals = std::vector<std::pair<int64_t, int64_t>>();
+    scanIntervals.push_back(interval1);
+    scanIntervals.push_back(interval2);
+
+    TS_ASSERT_THROWS_EQUALS(
+        a.convertToDetectorScan(scanIntervals), const std::runtime_error &e,
+        std::string(e.what()),
+        "DetectorInfo: cannot set scan interval with start >= end")
+  }
 };
 
 #endif /* MANTID_BEAMLINE_DETECTORINFOTEST_H_ */

--- a/Framework/DataObjects/inc/MantidDataObjects/ScanningWorkspaceBuilder.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/ScanningWorkspaceBuilder.h
@@ -87,7 +87,8 @@ private:
 
   HistogramData::Histogram m_histogram;
 
-  std::vector<std::pair<Kernel::DateAndTime, Kernel::DateAndTime>> m_scanIntervals;
+  std::vector<std::pair<Kernel::DateAndTime, Kernel::DateAndTime>>
+      m_scanIntervals;
   std::vector<std::vector<Kernel::V3D>> m_positions;
   std::vector<std::vector<Kernel::Quat>> m_rotations;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/ScanningWorkspaceBuilder.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/ScanningWorkspaceBuilder.h
@@ -87,7 +87,7 @@ private:
 
   HistogramData::Histogram m_histogram;
 
-  std::vector<std::pair<Kernel::DateAndTime, Kernel::DateAndTime>> m_timeRanges;
+  std::vector<std::pair<Kernel::DateAndTime, Kernel::DateAndTime>> m_scanIntervals;
   std::vector<std::vector<Kernel::V3D>> m_positions;
   std::vector<std::vector<Kernel::Quat>> m_rotations;
 

--- a/Framework/DataObjects/src/ScanningWorkspaceBuilder.cpp
+++ b/Framework/DataObjects/src/ScanningWorkspaceBuilder.cpp
@@ -226,8 +226,8 @@ void ScanningWorkspaceBuilder::buildOutputDetectorInfo(
     DetectorInfo &outputDetectorInfo) const {
   std::vector<std::pair<int64_t, int64_t>> scanIntervals;
   for (const auto &scanInterval : m_scanIntervals) {
-    scanIntervals.push_back(
-        {scanInterval.first.nanoseconds(), scanInterval.second.nanoseconds()});
+    scanIntervals.push_back({scanInterval.first.totalNanoseconds(),
+                             scanInterval.second.totalNanoseconds()});
   }
 
   outputDetectorInfo.convertToDetectorScan(scanIntervals);

--- a/Framework/DataObjects/src/ScanningWorkspaceBuilder.cpp
+++ b/Framework/DataObjects/src/ScanningWorkspaceBuilder.cpp
@@ -230,7 +230,7 @@ void ScanningWorkspaceBuilder::buildOutputDetectorInfo(
         {scanInterval.first.nanoseconds(), scanInterval.second.nanoseconds()});
   }
 
-  outputDetectorInfo.convertToTimeIndexded(scanIntervals);
+  outputDetectorInfo.convertToDetectorScan(scanIntervals);
 }
 
 void ScanningWorkspaceBuilder::buildRotations(

--- a/Framework/DataObjects/src/ScanningWorkspaceBuilder.cpp
+++ b/Framework/DataObjects/src/ScanningWorkspaceBuilder.cpp
@@ -64,7 +64,7 @@ void ScanningWorkspaceBuilder::setHistogram(
 void ScanningWorkspaceBuilder::setTimeRanges(const std::vector<
     std::pair<Kernel::DateAndTime, Kernel::DateAndTime>> timeRanges) {
   verifyTimeIndexSize(timeRanges.size(), "start time, end time pairs");
-  m_timeRanges = std::move(timeRanges);
+  m_scanIntervals = std::move(timeRanges);
 }
 
 /**
@@ -193,7 +193,7 @@ MatrixWorkspace_sptr ScanningWorkspaceBuilder::buildWorkspace() const {
 
   auto &outputDetectorInfo = outputWorkspace->mutableDetectorInfo();
   for (size_t i = 0; i < m_nDetectors; ++i)
-    outputDetectorInfo.setScanInterval(i, m_timeRanges[0]);
+    outputDetectorInfo.setScanInterval(i, m_scanIntervals[0]);
 
   buildOutputDetectorInfo(outputDetectorInfo);
 
@@ -224,15 +224,13 @@ MatrixWorkspace_sptr ScanningWorkspaceBuilder::buildWorkspace() const {
 
 void ScanningWorkspaceBuilder::buildOutputDetectorInfo(
     DetectorInfo &outputDetectorInfo) const {
-  auto mergeWorkspace =
-      create<Workspace2D>(m_instrument, m_nDetectors, m_histogram.binEdges());
-  for (size_t i = 1; i < m_nTimeIndexes; ++i) {
-    auto &mergeDetectorInfo = mergeWorkspace->mutableDetectorInfo();
-    for (size_t j = 0; j < m_nDetectors; ++j) {
-      mergeDetectorInfo.setScanInterval(j, m_timeRanges[i]);
-    }
-    outputDetectorInfo.merge(mergeDetectorInfo);
+  std::vector<std::pair<int64_t, int64_t>> scanIntervals;
+  for (const auto &scanInterval : m_scanIntervals) {
+    scanIntervals.push_back(
+        {scanInterval.first.nanoseconds(), scanInterval.second.nanoseconds()});
   }
+
+  outputDetectorInfo.convertToTimeIndexded(scanIntervals);
 }
 
 void ScanningWorkspaceBuilder::buildRotations(
@@ -323,7 +321,7 @@ void ScanningWorkspaceBuilder::verifyDetectorSize(
 }
 
 void ScanningWorkspaceBuilder::validateInputs() const {
-  if (m_timeRanges.empty())
+  if (m_scanIntervals.empty())
     throw std::logic_error("Can not build workspace - time ranges have not "
                            "been set. Please call setTimeRanges() before "
                            "building.");


### PR DESCRIPTION
Add a method to detector info to provide a set of start and end times, and convert the workspace to a detector scan workspace. This is now used in scanning workspace builder instead of `DetectorInfo::merge()`.

**To test:**

Code review.

Try loading the attached file for D20 with and without the changes, preferably on a release branch. Check the speed up (on my PC 19s without changes, 5s with).

[d20_det_scan.zip](https://github.com/mantidproject/mantid/files/1211628/d20_det_scan.zip)

Fixes #20027.

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
