### PR TITLE
Windows build without precompiled headers

### DIFF
--- a/Framework/Geometry/src/Crystal/ReflectionCondition.cpp
+++ b/Framework/Geometry/src/Crystal/ReflectionCondition.cpp
@@ -1,6 +1,7 @@
 #include "MantidGeometry/Crystal/ReflectionCondition.h"
 #include "MantidKernel/System.h"
 #include <algorithm>
+#include <iterator>
 
 namespace Mantid {
 namespace Geometry {

--- a/Framework/Kernel/inc/MantidKernel/PropertyNexus.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyNexus.h
@@ -3,6 +3,7 @@
 
 #include "MantidKernel/System.h"
 #include <memory>
+#include <string>
 
 // Forward declare
 namespace NeXus {

--- a/Framework/Kernel/src/ChecksumHelper.cpp
+++ b/Framework/Kernel/src/ChecksumHelper.cpp
@@ -6,6 +6,7 @@
 #include <Poco/DigestStream.h>
 
 #include <fstream>
+#include <sstream>
 
 namespace Mantid {
 namespace Kernel {

--- a/Framework/Kernel/src/ProgressBase.cpp
+++ b/Framework/Kernel/src/ProgressBase.cpp
@@ -2,6 +2,7 @@
 #include "MantidKernel/Timer.h"
 #include <sstream>
 #include <stdexcept>
+#include <algorithm>
 
 namespace Mantid {
 namespace Kernel {

--- a/Framework/Kernel/src/PropertyManagerProperty.cpp
+++ b/Framework/Kernel/src/PropertyManagerProperty.cpp
@@ -2,6 +2,8 @@
 #include "MantidKernel/PropertyManager.h"
 #include "MantidKernel/PropertyManagerDataService.h"
 
+#include <sstream>
+
 namespace Mantid {
 namespace Kernel {
 

--- a/MantidQt/API/src/FileDialogHandler.cpp
+++ b/MantidQt/API/src/FileDialogHandler.cpp
@@ -3,6 +3,7 @@
 #include "MantidAPI/MultipleFileProperty.h"
 #include "MantidQtAPI/AlgorithmInputHistory.h"
 #include <boost/regex.hpp>
+#include <sstream>
 
 namespace { // anonymous namespace
 const boost::regex FILE_EXT_REG_EXP{"^.+\\s+\\((\\S+)\\)$"};


### PR DESCRIPTION
fixes #20208 -- the changes allow clean Windows build with precomiled headers disabled.

**To test:**

Clean compile under windows without precomiled headers in cmake before and after the changes. Before the compilation fails and after -- passes. 

Fixes #20208 <!-- and fix ##20208 or close #xxxx xor resolves #xxxx -->

**Release Notes** 
Minor internal change -- nothing to add to release notes. 

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
