### PR TITLE
FindPeaksMD improvements for multiple runs

### DIFF
--- a/Framework/DataObjects/src/FakeMD.cpp
+++ b/Framework/DataObjects/src/FakeMD.cpp
@@ -137,8 +137,8 @@ void FakeMD::addFakePeak(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     }
 
     // Create and add the event.
-    eventHelper.insertMDEvent(signal, errorSquared, 1, pickDetectorID(),
-                              centers); // 1 = run number
+    eventHelper.insertMDEvent(signal, errorSquared, 0, pickDetectorID(),
+                              centers); // 0 = run index
   }
 
   ws->splitBox();
@@ -273,8 +273,8 @@ void FakeMD::addFakeRandomData(const std::vector<double> &params,
     }
 
     // Create and add the event.
-    eventHelper.insertMDEvent(signal, errorSquared, 1, pickDetectorID(),
-                              centers); // 1 = run number
+    eventHelper.insertMDEvent(signal, errorSquared, 0, pickDetectorID(),
+                              centers); // 0 = run index
   }
 
   /// Clean up the generators
@@ -350,8 +350,8 @@ void FakeMD::addFakeRegularData(const std::vector<double> &params,
     float errorSquared = 1.0;
 
     // Create and add the event.
-    eventHelper.insertMDEvent(signal, errorSquared, 1, pickDetectorID(),
-                              centers); // 1 = run number
+    eventHelper.insertMDEvent(signal, errorSquared, 0, pickDetectorID(),
+                              centers); // 0 = run index
   }
 }
 

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -313,7 +313,9 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   // Make sure all centroids are fresh
   // ws->getBox()->refreshCentroid();
 
-  if (ws->getNumExperimentInfo() == 0)
+  uint16_t nexp = ws->getNumExperimentInfo();
+
+  if (nexp == 0)
     throw std::runtime_error(
         "No instrument was found in the MDEventWorkspace. Cannot find peaks.");
 
@@ -444,8 +446,9 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       //  If no events from this experimental contribute to the box then skip
       MDBox<MDE, nd> *mdbox = dynamic_cast<MDBox<MDE, nd> *>(box);
       typename std::vector<MDE> &events = mdbox->getEvents();
-      if (std::none_of(events.cbegin(), events.cend(), [&iexp](MDE event) {
-            return event.getRunIndex() == iexp;
+      if (std::none_of(events.cbegin(), events.cend(), [&iexp, &nexp](
+                                                           MDE event) {
+            return event.getRunIndex() == iexp || event.getRunIndex() > nexp;
           }))
         continue;
 

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -444,7 +444,7 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       //  If no events from this experimental contribute to the box then skip
       MDBox<MDE, nd> *mdbox = dynamic_cast<MDBox<MDE, nd> *>(box);
       typename std::vector<MDE> &events = mdbox->getEvents();
-      if (std::none_of(events.cbegin(), events.cend(), [&iexp](auto event) {
+      if (std::none_of(events.cbegin(), events.cend(), [&iexp](MDE event) {
             return event.getRunIndex() == iexp;
           }))
         continue;

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -444,14 +444,15 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     // --- Convert the "boxes" to peaks ----
     for (auto box : peakBoxes) {
       //  If no events from this experimental contribute to the box then skip
-      MDBox<MDE, nd> *mdbox = dynamic_cast<MDBox<MDE, nd> *>(box);
-      typename std::vector<MDE> &events = mdbox->getEvents();
-      if (std::none_of(events.cbegin(), events.cend(), [&iexp, &nexp](
-                                                           MDE event) {
-            return event.getRunIndex() == iexp || event.getRunIndex() > nexp;
-          }))
-        continue;
-
+      if (nexp > 1) {
+        MDBox<MDE, nd> *mdbox = dynamic_cast<MDBox<MDE, nd> *>(box);
+        typename std::vector<MDE> &events = mdbox->getEvents();
+        if (std::none_of(events.cbegin(), events.cend(), [&iexp, &nexp](
+                                                             MDE event) {
+              return event.getRunIndex() == iexp || event.getRunIndex() >= nexp;
+            }))
+          continue;
+      }
 // The center of the box = Q in the lab frame
 
 #ifndef MDBOX_TRACK_CENTROID

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -441,6 +441,14 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
 
     // --- Convert the "boxes" to peaks ----
     for (auto box : peakBoxes) {
+      //  If no events from this experimental contribute to the box then skip
+      MDBox<MDE, nd> *mdbox = dynamic_cast<MDBox<MDE, nd> *>(box);
+      typename std::vector<MDE> &events = mdbox->getEvents();
+      if (std::none_of(events.cbegin(), events.cend(), [&iexp](auto event) {
+            return event.getRunIndex() == iexp;
+          }))
+        continue;
+
 // The center of the box = Q in the lab frame
 
 #ifndef MDBOX_TRACK_CENTROID

--- a/docs/source/release/v3.11.0/diffraction.rst
+++ b/docs/source/release/v3.11.0/diffraction.rst
@@ -27,4 +27,5 @@ and
 Single Crystal Diffraction
 --------------------------
 
-New algorithm :ref:`SingleCrystalDiffuseReduction <algm-SingleCrystalDiffuseReduction>` which performs the most common reductions done on Corelli (and elsewhere) for single crystal diffuse scattering.
+- New algorithm :ref:`SingleCrystalDiffuseReduction <algm-SingleCrystalDiffuseReduction>` which performs the most common reductions done on Corelli (and elsewhere) for single crystal diffuse scattering.
+- :ref:`FindPeaksMD <algm-FindPeaksMD>` has been modified to only add peaks to runs that contributed to that peak. This is a lot faster when multiple runs are in the same MDworkspace.


### PR DESCRIPTION
Add check in FindPeaksMD to only add peaks for a particular experiment info if events were contributed from the run. This is mush faster for multiple runs!


**To test:**
I used this for testing with corelli but you should try other instruments. FindPeaksMD went from ~35 minutes to ~25 seconds!
```
md=LoadMD('/SNS/users/rwp/testmd.nxs')
FindPeaksMD(InputWorkspace=md,DensityThresholdFactor=50000, OutputWorkspace='peaks')
```


Release notes added

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
