### PR TITLE
BinMD only once for SliceViewer entry

### DIFF
--- a/MantidQt/SliceViewer/src/DimensionSliceWidget.cpp
+++ b/MantidQt/SliceViewer/src/DimensionSliceWidget.cpp
@@ -13,11 +13,11 @@ DimensionSliceWidget::DimensionSliceWidget(QWidget *parent)
 
   QObject::connect(ui.horizontalSlider, SIGNAL(valueChanged(double)), this,
                    SLOT(sliderMoved()));
-  QObject::connect(ui.doubleSpinBox, SIGNAL(valueChanged(double)), this,
+  QObject::connect(ui.doubleSpinBox, SIGNAL(editingFinished()), this,
                    SLOT(spinBoxChanged()));
-  QObject::connect(ui.spinThickness, SIGNAL(valueChanged(double)), this,
+  QObject::connect(ui.spinThickness, SIGNAL(editingFinished()), this,
                    SLOT(spinThicknessChanged()));
-  QObject::connect(ui.spinBins, SIGNAL(valueChanged(int)), this,
+  QObject::connect(ui.spinBins, SIGNAL(editingFinished()), this,
                    SLOT(spinBinsChanged()));
   QObject::connect(ui.btnX, SIGNAL(toggled(bool)), this, SLOT(btnXYChanged()));
   QObject::connect(ui.btnY, SIGNAL(toggled(bool)), this, SLOT(btnXYChanged()));

--- a/MantidQt/SliceViewer/src/DimensionSliceWidget.cpp
+++ b/MantidQt/SliceViewer/src/DimensionSliceWidget.cpp
@@ -198,7 +198,10 @@ bool DimensionSliceWidget::showRebinControls() const {
 int DimensionSliceWidget::getNumBins() const { return ui.spinBins->value(); }
 
 /** Sets the number of bins to rebin to */
-void DimensionSliceWidget::setNumBins(int val) { ui.spinBins->setValue(val); }
+void DimensionSliceWidget::setNumBins(int val) {
+  ui.spinBins->setValue(val);
+  spinBinsChanged();
+}
 
 //-------------------------------------------------------------------------------------------------
 /** @return the thickness to integrate when rebinning */
@@ -209,6 +212,7 @@ double DimensionSliceWidget::getThickness() const {
 /** Sets the thickness to integrate when rebinning */
 void DimensionSliceWidget::setThickness(double val) {
   ui.spinThickness->setValue(val);
+  spinThicknessChanged();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/MantidQt/SliceViewer/src/DimensionSliceWidget.cpp
+++ b/MantidQt/SliceViewer/src/DimensionSliceWidget.cpp
@@ -38,6 +38,7 @@ void DimensionSliceWidget::sliderMoved() {
 
   // This will, in turn, emit the changedSlicePoint() signal
   ui.doubleSpinBox->setValue(m_slicePoint);
+  spinBoxChanged();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/MantidQt/SliceViewer/test/SliceViewerPythonInterfaceTest.py
+++ b/MantidQt/SliceViewer/test/SliceViewerPythonInterfaceTest.py
@@ -451,7 +451,6 @@ class SliceViewerPythonInterfaceTest(unittest.TestCase):
 
         sv.setRebinThickness(2, 1.0)
         sv.setRebinNumBins(50, 200)
-        sv.refreshRebin()
         sv.setRebinMode(True)
 
         time.sleep(1)
@@ -471,7 +470,6 @@ class SliceViewerPythonInterfaceTest(unittest.TestCase):
 
         sv.setRebinThickness(2, 1.0)
         sv.setRebinNumBins(10, 10)
-        sv.refreshRebin()
         sv.setRebinMode(True)
 
         time.sleep(1)
@@ -493,7 +491,6 @@ class SliceViewerPythonInterfaceTest(unittest.TestCase):
         # rebin the workspace
         sv.setRebinThickness(2, 1.0)
         sv.setRebinNumBins(50, 200)
-        sv.refreshRebin()
         sv.setRebinMode(True)
 
         # check that the first rebin was successful
@@ -515,7 +512,6 @@ class SliceViewerPythonInterfaceTest(unittest.TestCase):
         # rebin the second (MDHisto) workspace
         sv.setRebinThickness(2, 1.0)
         sv.setRebinNumBins(30, 100)
-        sv.refreshRebin()
         sv.setRebinMode(True)
 
         # check rebinning was successful

--- a/docs/source/release/v3.11.0/ui.rst
+++ b/docs/source/release/v3.11.0/ui.rst
@@ -53,6 +53,8 @@ Bugs Resolved
 SliceViewer Improvements
 ------------------------
 
+- SliceViewer input of number of bins, thickness, and slice point now waits until the editing is finished to rebin or changing slice point instead of changing with each digit entered.
+
 VSI Improvments
 ---------------
 - ParaView has been updated to to `v5.4.0 <https://blog.kitware.com/paraview-5-4-0-release-notes/>`_.


### PR DESCRIPTION
Description of work.
BinMD should not be called 3 times if a 3 digit number is entered.

**To test:**

<!-- Instructions for testing. -->
Open MD workspace with sliceviewer.  Enable rebin mode and check that BinMD is only call once if you change the number of bins or thickness.
```python
Load(Filename='TOPAZ_3131_event.nxs', OutputWorkspace='TOPAZ_3131_event')
FilterBadPulses(InputWorkspace='TOPAZ_3131_event', OutputWorkspace='TOPAZ_3131_event', LowerCutoff=25)
ConvertToMD(InputWorkspace='TOPAZ_3131_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', LorentzCorrection=True, OutputWorkspace='TOPAZ_3131_md', MinValues='-25,-25,-25', MaxValues='25,25,25', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=13, MinRecursionDepth=7)

svw = plotSlice('TOPAZ_3131_md')
svw.setSlicePoint(2,15.173)
svw.setColorScaleMin(1)
svw.setColorScaleLog(True)
svw.setRebinMode(True)
svw.setRebinThickness(2,0.2)
svw.setRebinNumBins(200,200)
```

Fixes #20211

**Release Notes** 

*Added to the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
