### PR TITLE
ConvFit support for BASIS files

### DIFF
--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -67,6 +67,10 @@ void ConvolutionFitSequential::init() {
                   "The function that describes the parameters of the fit.",
                   Direction::Input);
 
+  declareProperty("PassWSIndexToFunction", false,
+                  "For each spectrum in Input pass its workspace index to all "
+                  "functions that have attribute WorkspaceIndex.");
+
   std::vector<std::string> backType{"Fixed Flat", "Fit Flat", "Fit Linear"};
 
   declareProperty("BackgroundType", "Fixed Flat",
@@ -96,7 +100,8 @@ void ConvolutionFitSequential::init() {
                   Direction::Input);
 
   declareProperty("Convolve", true,
-                  "If true, the fit is treated as a convolution workspace.",
+                  "If true, output fitted model components will be convolved with "
+                  "the resolution.",
                   Direction::Input);
 
   declareProperty("Minimizer", "Levenberg-Marquardt",
@@ -130,6 +135,7 @@ void ConvolutionFitSequential::exec() {
   // Initialise variables with properties
   MatrixWorkspace_sptr inputWs = getProperty("InputWorkspace");
   const std::string function = getProperty("Function");
+  const bool passIndex = getProperty("PassWSIndexToFunction");
   const std::string backType =
       convertBackToShort(getProperty("backgroundType"));
   const double startX = getProperty("StartX");
@@ -197,10 +203,6 @@ void ConvolutionFitSequential::exec() {
     plotPeakInput += nextWs + ";";
     plotPeakStringProg.report("Constructing PlotPeak name");
   }
-
-  // We should always pass the workspace index, since it has no effect if
-  // the fit function does not contain parameter WorkspaceIndex
-  auto passIndex = true;
 
   // Run PlotPeaksByLogValue
   auto plotPeaks = createChildAlgorithm("PlotPeakByLogValue", 0.05, 0.90, true);

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -198,12 +198,9 @@ void ConvolutionFitSequential::exec() {
     plotPeakStringProg.report("Constructing PlotPeak name");
   }
 
-  // passWSIndex
-  auto passIndex = false;
-  if (funcName.find("Diff") != std::string::npos ||
-      funcName.find("Stretched") != std::string::npos) {
-    passIndex = true;
-  }
+  // We should always pass the workspace index, since it has no effect if
+  // the fit function does not contain parameter WorkspaceIndex
+  auto passIndex = true;
 
   // Run PlotPeaksByLogValue
   auto plotPeaks = createChildAlgorithm("PlotPeakByLogValue", 0.05, 0.90, true);

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -99,10 +99,11 @@ void ConvolutionFitSequential::init() {
                                           "negative",
                   Direction::Input);
 
-  declareProperty("Convolve", true,
-                  "If true, output fitted model components will be convolved with "
-                  "the resolution.",
-                  Direction::Input);
+  declareProperty(
+      "Convolve", true,
+      "If true, output fitted model components will be convolved with "
+      "the resolution.",
+      Direction::Input);
 
   declareProperty("Minimizer", "Levenberg-Marquardt",
                   boost::make_shared<MandatoryValidator<std::string>>(),

--- a/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
@@ -1019,7 +1019,7 @@ class ISISIndirectInelasticConvFit(ISISIndirectInelasticBase):
         ConvolutionFitSequential(
             InputWorkspace=self.sample,
             Function=self.func,
-            PassWSIndexToFunction=self.passWSIndexToFunction
+            PassWSIndexToFunction=self.passWSIndexToFunction,
             StartX=self.startx,
             EndX=self.endx,
             BackgroundType=self.bg,

--- a/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
@@ -1019,6 +1019,7 @@ class ISISIndirectInelasticConvFit(ISISIndirectInelasticBase):
         ConvolutionFitSequential(
             InputWorkspace=self.sample,
             Function=self.func,
+            PassWSIndexToFunction=self.passWSIndexToFunction
             StartX=self.startx,
             EndX=self.endx,
             BackgroundType=self.bg,
@@ -1062,6 +1063,7 @@ class OSIRISConvFit(ISISIndirectInelasticConvFit):
         self.func = 'name=LinearBackground,A0=0,A1=0;(composite=Convolution,FixResolution=true,NumDeriv=true;'\
                     'name=Resolution,Workspace=\"%s\";name=Lorentzian,Amplitude=2,FWHM=0.002,ties=(PeakCentre=0)'\
                     ',constraints=(FWHM>0.002))' % self.resolution
+        self.passWSIndexToFunction = False  # osi97935_graphite002_res is single histogram
         self.startx = -0.2
         self.endx = 0.2
         self.bg = 'Fit Linear'
@@ -1089,7 +1091,7 @@ class IRISConvFit(ISISIndirectInelasticConvFit):
                     '(composite=Convolution,FixResolution=true,NumDeriv=true;' \
                     'name=Resolution,Workspace="%s";name=Lorentzian,Amplitude=1.033150,FWHM=0.001576,'\
                     'ties=(PeakCentre=0.0),constraints=(FWHM>0.001))' % self.resolution
-
+        self.passWSIndexToFunction = False  # irs53664_graphite002_res is single histogram
         self.startx = -0.2
         self.endx = 0.2
         self.bg = 'Fit Linear'

--- a/docs/source/algorithms/ConvolutionFitSequential-v1.rst
+++ b/docs/source/algorithms/ConvolutionFitSequential-v1.rst
@@ -49,7 +49,7 @@ Usage
 
   # Run algorithm
   result_ws = ConvolutionFitSequential(InputWorkspace=sample,
-      Function=function, BackgroundType=bgType,
+      Function=function, PassWSIndexToFunction=True, BackgroundType=bgType,
       StartX=startX, EndX=endX, SpecMin=specMin, SpecMax=specMax,
       Convolve=convolve, Minimizer=minimizer, MaxIterations=maxIt)
   

--- a/docs/source/algorithms/ConvolutionFitSequential-v1.rst
+++ b/docs/source/algorithms/ConvolutionFitSequential-v1.rst
@@ -27,42 +27,45 @@ Usage
 
 .. testcode:: ConvolutionFitSequentialExample
 
-  # Create a host workspace
+  from __future__ import print_function
+
+  # Load sample and resolution files
   sample = Load('irs26176_graphite002_red.nxs')
   resolution = Load('irs26173_graphite002_red.nxs')
 
   # Set up algorithm parameters
-  function = "name=LinearBackground,A0=0,A1=0,ties=(A0=0.000000,A1=0.0);(composite=Convolution,FixResolution=true,NumDeriv=true;name=Resolution,Workspace=__ConvFit_Resolution,WorkspaceIndex=0;((composite=ProductFunction,NumDeriv=false;name=Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0.0175)))"
+  function = """name=LinearBackground,A0=0,A1=0,ties=(A0=0.000000,A1=0.0);
+  (composite=Convolution,FixResolution=true,NumDeriv=true;
+  name=Resolution,Workspace=resolution,WorkspaceIndex=0;
+  name=Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0.0175)"""
   bgType = "Fixed Flat"
   startX = -0.547608
   endX = 0.543217
   specMin = 0
   specMax = sample.getNumberHistograms() - 1
-  convolve = True
+  convolve = True  # Convolve the fitted model components with the resolution
   minimizer = "Levenberg-Marquardt"
   maxIt = 500
-  
-  # Build resolution workspace (normally done by the Convfit tab when files load)
-  AppendSpectra(InputWorkspace1=resolution.name(), InputWorkspace2=resolution.name(), OutputWorkspace="__ConvFit_Resolution")
-  for i in range(1, sample.getNumberHistograms()):
-    AppendSpectra(InputWorkspace1="__ConvFit_Resolution", InputWorkspace2=resolution.name(), OutputWorkspace="__ConvFit_Resolution")  
-  
+
   # Run algorithm
-  result_ws = ConvolutionFitSequential(InputWorkspace=sample, Function=function ,BackgroundType=bgType, StartX=startX, EndX=endX, SpecMin=specMin, SpecMax=specMax, Convolve=convolve, Minimizer=minimizer, MaxIterations=maxIt)
+  result_ws = ConvolutionFitSequential(InputWorkspace=sample,
+      Function=function, BackgroundType=bgType,
+      StartX=startX, EndX=endX, SpecMin=specMin, SpecMax=specMax,
+      Convolve=convolve, Minimizer=minimizer, MaxIterations=maxIt)
   
-  print "Result has %i Spectra" %result_ws.getNumberHistograms()
+  print("Result has %i Spectra" %result_ws.getNumberHistograms())
   
-  print "Amplitude 0: %.3f" %(result_ws.readY(0)[0])
-  print "Amplitude 1: %.3f" %(result_ws.readY(0)[1])
-  print "Amplitude 2: %.3f" %(result_ws.readY(0)[2])
+  print("Amplitude 0: %.3f" %(result_ws.readY(0)[0]))
+  print("Amplitude 1: %.3f" %(result_ws.readY(0)[1]))
+  print("Amplitude 2: %.3f" %(result_ws.readY(0)[2]))
   
-  print "X axis at 0: %.5f" %(result_ws.readX(0)[0])
-  print "X axis at 1: %.5f" %(result_ws.readX(0)[1])
-  print "X axis at 2: %.5f" %(result_ws.readX(0)[2])
+  print("X axis at 0: %.5f" %(result_ws.readX(0)[0]))
+  print("X axis at 1: %.5f" %(result_ws.readX(0)[1]))
+  print("X axis at 2: %.5f" %(result_ws.readX(0)[2]))
   
-  print "Amplitude Err 0: %.5f" %(result_ws.readE(0)[0])
-  print "Amplitude Err 1: %.5f" %(result_ws.readE(0)[1])
-  print "Amplitude Err 2: %.5f" %(result_ws.readE(0)[2])
+  print("Amplitude Err 0: %.5f" %(result_ws.readE(0)[0]))
+  print("Amplitude Err 1: %.5f" %(result_ws.readE(0)[1]))
+  print("Amplitude Err 2: %.5f" %(result_ws.readE(0)[2]))
 
 Output:  
   
@@ -72,17 +75,17 @@ Output:
   Result has 2 Spectra
   
   Amplitude 0: 4.314
-  Amplitude 1: 4.179
-  Amplitude 2: 3.979
+  Amplitude 1: 4.213
+  Amplitude 2: 4.555
 
   X axis at 0: 0.52531
   X axis at 1: 0.72917
   X axis at 2: 0.92340
   
   Amplitude Err 0: 0.00460
-  Amplitude Err 1: 0.00464
-  Amplitude Err 2: 0.00504
-  
+  Amplitude Err 1: 0.00468
+  Amplitude Err 2: 0.00577
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/release/v3.11.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.11.0/indirect_inelastic.rst
@@ -20,6 +20,14 @@ Bayes
 Data Analysis
 #############
 
+ConvFit
+~~~~~~~
+
+Bugfixes
+--------
+- Correct treatment of the resolution function: convolve sample and resolution spectra with same momentum transfer.
+- Backend :ref:`algm-ConvolutionFitSequential` now passes the workspace index by default to :ref:`algm-PlotPeakByLogValue`.
+
 Jump Fit
 ~~~~~~~~
 

--- a/docs/source/release/v3.11.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.11.0/indirect_inelastic.rst
@@ -26,7 +26,7 @@ ConvFit
 Bugfixes
 --------
 - Correct treatment of the resolution function: convolve sample and resolution spectra with same momentum transfer.
-- Backend :ref:`algm-ConvolutionFitSequential` now passes the workspace index by default to :ref:`algm-PlotPeakByLogValue`.
+- Property to pass the workspace index added to :ref:`algm-ConvolutionFitSequential`.
 
 Jump Fit
 ~~~~~~~~

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -325,6 +325,7 @@ IAlgorithm_sptr ConvFit::sequentialFit(const std::string &specMin,
   cfs->initialize();
   cfs->setProperty("InputWorkspace", m_cfInputWS->getName());
   cfs->setProperty("Function", function);
+  cfs->setProperty("PassWSIndexToFunction", true);
   cfs->setProperty("BackgroundType",
                    m_uiForm.cbBackground->currentText().toStdString());
   cfs->setProperty("StartX", m_properties["StartX"]->valueText().toStdString());

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -605,21 +605,19 @@ void ConvFit::extendResolutionWorkspace() {
     cloneAlg->initialize();
     cloneAlg->setProperty("InputWorkspace", resWsName.toStdString());
     cloneAlg->setProperty("OutputWorkspace", "__ConvFit_Resolution");
-    m_batchAlgoRunner->addAlgorithm(cloneAlg);
-    // Append to cloned workspace if neccessary
-    if (resolutionNumHist == 1) {
-      for (size_t i = 1; i < numHist; i++) {
-        IAlgorithm_sptr appendAlg =
-            AlgorithmManager::Instance().create("AppendSpectra");
-        appendAlg->setLogging(false);
-        appendAlg->initialize();
-        appendAlg->setProperty("InputWorkspace1", "__ConvFit_Resolution");
-        appendAlg->setProperty("InputWorkspace2", resWsName.toStdString());
-        appendAlg->setProperty("OutputWorkspace", "__ConvFit_Resolution");
-        m_batchAlgoRunner->addAlgorithm(appendAlg);
-      }
+    cloneAlg->execute();
+    // Append to cloned workspace if necessary
+    if (resolutionNumHist == 1 && numHist > 1) {
+      IAlgorithm_sptr appendAlg =
+              AlgorithmManager::Instance().create("AppendSpectra");
+      appendAlg->setLogging(false);
+      appendAlg->initialize();
+      appendAlg->setPropertyValue("InputWorkspace1", "__ConvFit_Resolution");
+      appendAlg->setPropertyValue("InputWorkspace2", resWsName.toStdString());
+      appendAlg->setProperty("Number", static_cast<int>(numHist-1));
+      appendAlg->setPropertyValue("OutputWorkspace", "__ConvFit_Resolution");
+      appendAlg->execute();
     }
-    m_batchAlgoRunner->executeBatchAsync();
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -587,17 +587,19 @@ void ConvFit::extendResolutionWorkspace() {
   if (m_cfInputWS && m_uiForm.dsResInput->isValid()) {
     const QString resWsName = m_uiForm.dsResInput->getCurrentDataName();
     // Check spectra consistency between resolution and sample
-    auto resolutionInputWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+    auto resolutionInputWS =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             resWsName.toStdString());
     size_t resolutionNumHist = resolutionInputWS->getNumberHistograms();
     size_t numHist = m_cfInputWS->getNumberHistograms();
-    if(resolutionNumHist != 1 && resolutionNumHist != numHist) {
-      std::string msg("Resolution must have either one or as many spectra as the sample");
+    if (resolutionNumHist != 1 && resolutionNumHist != numHist) {
+      std::string msg(
+          "Resolution must have either one or as many spectra as the sample");
       throw std::runtime_error(msg);
     }
     // Clone resolution workspace
     IAlgorithm_sptr cloneAlg =
-            AlgorithmManager::Instance().create("CloneWorkspace");
+        AlgorithmManager::Instance().create("CloneWorkspace");
     cloneAlg->setLogging(false);
     cloneAlg->initialize();
     cloneAlg->setProperty("InputWorkspace", resWsName.toStdString());
@@ -607,7 +609,7 @@ void ConvFit::extendResolutionWorkspace() {
     if (resolutionNumHist == 1) {
       for (size_t i = 1; i < numHist; i++) {
         IAlgorithm_sptr appendAlg =
-                AlgorithmManager::Instance().create("AppendSpectra");
+            AlgorithmManager::Instance().create("AppendSpectra");
         appendAlg->setLogging(false);
         appendAlg->initialize();
         appendAlg->setProperty("InputWorkspace1", "__ConvFit_Resolution");

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -609,12 +609,12 @@ void ConvFit::extendResolutionWorkspace() {
     // Append to cloned workspace if necessary
     if (resolutionNumHist == 1 && numHist > 1) {
       IAlgorithm_sptr appendAlg =
-              AlgorithmManager::Instance().create("AppendSpectra");
+          AlgorithmManager::Instance().create("AppendSpectra");
       appendAlg->setLogging(false);
       appendAlg->initialize();
       appendAlg->setPropertyValue("InputWorkspace1", "__ConvFit_Resolution");
       appendAlg->setPropertyValue("InputWorkspace2", resWsName.toStdString());
-      appendAlg->setProperty("Number", static_cast<int>(numHist-1));
+      appendAlg->setProperty("Number", static_cast<int>(numHist - 1));
       appendAlg->setPropertyValue("OutputWorkspace", "__ConvFit_Resolution");
       appendAlg->execute();
     }

--- a/qt/scientific_interfaces/Indirect/ConvFit.h
+++ b/qt/scientific_interfaces/Indirect/ConvFit.h
@@ -82,6 +82,7 @@ private:
   QtStringPropertyManager *m_stringManager;
   QtTreePropertyBrowser *m_cfTree;
   QMap<QtProperty *, QtProperty *> m_fixedProps;
+  // Pointer to sample workspace object
   Mantid::API::MatrixWorkspace_sptr m_cfInputWS;
   Mantid::API::MatrixWorkspace_sptr m_previewPlotData;
   QString m_cfInputWSName;


### PR DESCRIPTION
Things done:
- Correct treatment of the resolution function: convolve sample and resolution spectra with same momentum transfer.
- [ConvolutionFitSequential](http://docs.mantidproject.org/nightly/algorithms/ConvolutionFitSequential-v1.html) now passes the workspace index by default to [PlotPeakByLogValue](http://docs.mantidproject.org/nightly/algorithms/PlotPeakByLogValue-v1.html)
- Doctest compatible with python 3.x

**To test:**
The test compares manually running the interface against running a python script. Download and unzip testing files [example.zip](https://www.dropbox.com/s/yfg75laythx0yat/example.zip?dl=0) in directory `/tmp`. Then run the following script:
```
resolution_file = '/tmp/resolution.nxs'  # resolution file
data_file = '/tmp/data.nxs' # data file
resolution = Load(resolution_file)
data = Load(data_file)
n_h = data.getNumberHistograms()  # number of spectra
q = resolution.getAxis(1).extractValues() # list of Q values
# Model function
function = '''(composite=Convolution,FixResolution=true,NumDeriv=true;
name=Resolution,Workspace=resolution,WorkspaceIndex=0;
(name=DeltaFunction,Height=0.5,Centre=0;
name=Lorentzian,Amplitude=0.5,PeakCentre=0,FWHM=0.0035));
name=LinearBackground,A0=0,A1=0'''
# Carry out a sequential fit using Algorithm PlotPeakByLogValue
workspaces = ['data,i%d' % i for i in range(n_h)]
workspaces = ';'.join(workspaces)
PlotPeakByLogValue(Input=workspaces,
    OutputWorkspace='fit',
    Function=function,
    StartX=-0.0998,
    EndX=0.0998,
    FitType='Sequential',
    PassWSIndexToFunction=True,
    MaxIterations=500,
    CreateOutput=True,
    EvaluationType='CentrePoint')
# Create the workspace containing FWHM against Q
fwhm_values = list()
fwhm_errors = list()
for i in range(n_h):
    ws = mtd['data_{}_Parameters'.format(i)]
    row = ws.row(4)  # this is the row containing the FWHM value
    fwhm_values.append(row['Value'])
    fwhm_errors.append(row['Error'])
CreateWorkspace(q, fwhm_values, fwhm_errors, UnitX='MomentumTransfer', OutputWorkspace='fwhm', WorkspaceTitle='FWHM versus Q')
```
Plot output workspace `fwhm`.
Now run the ConvFit interface with the example files, and then plot FHWM. You should obtain the same plot as the one obtained from workspace `fwhm`.

Fixes #20192

Updated [release notes](https://github.com/mantidproject/mantid/blob/b522d28abba070868eb5bbea3fbc8a269c5c34ea/docs/source/release/v3.11.0/indirect_inelastic.rst)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
