### PR TITLE
Fix MDEventInserter use of run_number instead of run_index

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventInserter.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventInserter.h
@@ -63,15 +63,15 @@ public:
   determined internally using type information on the MDEventType.
   @param signal : intensity
   @param errorSQ : squared value of the error
-  @param runno : run number
+  @param runindex : run index (index into the vector of ExperimentInfo)
   @param detectno : detector number
   @param coords : pointer to coordinates array
   */
-  void insertMDEvent(float signal, float errorSQ, uint16_t runno,
+  void insertMDEvent(float signal, float errorSQ, uint16_t runindex,
                      int32_t detectno, Mantid::coord_t *coords) {
     // compile-time overload selection based on nested type information on the
     // MDEventType.
-    insertMDEvent(signal, errorSQ, runno, detectno, coords,
+    insertMDEvent(signal, errorSQ, runindex, detectno, coords,
                   IntToType<MDEventType::is_full_mdevent>());
   }
 
@@ -94,14 +94,14 @@ private:
   Creates a FULL MDEvent and adds it to the MDEW.
   @param signal : intensity
   @param errorSQ : squared value of the error
-  @param runno : run number
+  @param runindex : run index
   @param detectno : detector number
   @param coords : pointer to coordinates array
   */
-  void insertMDEvent(float signal, float errorSQ, uint16_t runno,
+  void insertMDEvent(float signal, float errorSQ, uint16_t runindex,
                      int32_t detectno, Mantid::coord_t *coords,
                      IntToType<true>) {
-    m_ws->addEvent(MDEventType(signal, errorSQ, runno, detectno, coords));
+    m_ws->addEvent(MDEventType(signal, errorSQ, runindex, detectno, coords));
   }
 };
 

--- a/Framework/DataObjects/src/FakeMD.cpp
+++ b/Framework/DataObjects/src/FakeMD.cpp
@@ -137,8 +137,8 @@ void FakeMD::addFakePeak(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     }
 
     // Create and add the event.
-    eventHelper.insertMDEvent(signal, errorSquared, 1, pickDetectorID(),
-                              centers); // 1 = run number
+    eventHelper.insertMDEvent(signal, errorSquared, 0, pickDetectorID(),
+                              centers); // 0 = run index
   }
 
   ws->splitBox();
@@ -273,8 +273,8 @@ void FakeMD::addFakeRandomData(const std::vector<double> &params,
     }
 
     // Create and add the event.
-    eventHelper.insertMDEvent(signal, errorSquared, 1, pickDetectorID(),
-                              centers); // 1 = run number
+    eventHelper.insertMDEvent(signal, errorSquared, 0, pickDetectorID(),
+                              centers); // 0 = run index
   }
 
   /// Clean up the generators
@@ -350,8 +350,8 @@ void FakeMD::addFakeRegularData(const std::vector<double> &params,
     float errorSquared = 1.0;
 
     // Create and add the event.
-    eventHelper.insertMDEvent(signal, errorSquared, 1, pickDetectorID(),
-                              centers); // 1 = run number
+    eventHelper.insertMDEvent(signal, errorSquared, 0, pickDetectorID(),
+                              centers); // 0 = run index
   }
 }
 

--- a/Framework/DataObjects/test/MDEventInserterTest.h
+++ b/Framework/DataObjects/test/MDEventInserterTest.h
@@ -69,7 +69,7 @@ public:
     Mantid::coord_t coord1[2] = {-1, -1};
     float expectedSignal = 1;
     float expectedErrorSq = 2;
-    inserter.insertMDEvent(expectedSignal, expectedErrorSq, 1, 1, coord1);
+    inserter.insertMDEvent(expectedSignal, expectedErrorSq, 0, 1, coord1);
     ws2d->refreshCache();
 
     // Check the mdevent via the parent box.
@@ -78,7 +78,7 @@ public:
     TS_ASSERT_EQUALS(expectedErrorSq, ws2d->getBox()->getErrorSquared());
 
     // Add another md event
-    inserter.insertMDEvent(expectedSignal, expectedErrorSq, 1, 1, coord1);
+    inserter.insertMDEvent(expectedSignal, expectedErrorSq, 0, 1, coord1);
     ws2d->refreshCache();
     TS_ASSERT_EQUALS(2, ws2d->getNPoints());
   }
@@ -101,7 +101,7 @@ public:
     Mantid::coord_t coord1[2] = {-1, -1};
     float expectedSignal = 1;
     float expectedErrorSq = 2;
-    inserter.insertMDEvent(expectedSignal, expectedErrorSq, 1, 1, coord1);
+    inserter.insertMDEvent(expectedSignal, expectedErrorSq, 0, 1, coord1);
     ws2d->refreshCache();
 
     // Check the mdevent via the parent box.
@@ -110,7 +110,7 @@ public:
     TS_ASSERT_EQUALS(expectedErrorSq, ws2d->getBox()->getErrorSquared());
 
     // Add another md event
-    inserter.insertMDEvent(expectedSignal, expectedErrorSq, 1, 1, coord1);
+    inserter.insertMDEvent(expectedSignal, expectedErrorSq, 0, 1, coord1);
     ws2d->refreshCache();
     TS_ASSERT_EQUALS(2, ws2d->getNPoints());
   }


### PR DESCRIPTION
@OwenArnold It looks like you wrote MDEventInserter so tell me if I'm wrong.

An MDEvent has the run index (index into the vector of ExperimentInfo of the workspace) not the run number in the object, see [here](https://github.com/mantidproject/mantid/blob/master/Framework/DataObjects/inc/MantidDataObjects/MDEvent.h#L19-L20)

`insertMDEvent` incorrectly described this property as the run number which has resulted in some incorrect usage of MDEvents. This fixes `insertMDEvent`.

After this is merged the remaining incorrect usages should be fixed, I will create issues for the following, from what I see they are
```
ConvertCWSDExpToMomentum
ConvertSpiceDataToRealSpace
ConvertCWSDMDtoHKL
IntegratePeaksCWSD
ImportMDEventWorkspace
```

**To test:**
 * Code review should suffice


Does not need to be in the release notes, internal changes only


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
