### PR TITLE
ISISPowder use absorption correction on samples

### DIFF
--- a/scripts/Diffraction/isis_powder/gem_routines/gem_algs.py
+++ b/scripts/Diffraction/isis_powder/gem_routines/gem_algs.py
@@ -15,7 +15,8 @@ def calculate_van_absorb_corrections(ws_to_correct, multiple_scattering):
     absorb_dict = gem_advanced_config.absorption_correction_params
     sample_details_obj = absorb_corrections.create_vanadium_sample_details_obj(config_dict=absorb_dict)
     ws_to_correct = absorb_corrections.run_cylinder_absorb_corrections(
-        ws_to_correct=ws_to_correct, multiple_scattering=multiple_scattering, sample_details_obj=sample_details_obj)
+        ws_to_correct=ws_to_correct, multiple_scattering=multiple_scattering, sample_details_obj=sample_details_obj,
+        is_vanadium=True)
     return ws_to_correct
 
 

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -46,11 +46,12 @@ class Polaris(AbstractInst):
     def _apply_absorb_corrections(self, run_details, ws_to_correct):
         if self._is_vanadium:
             return polaris_algs.calculate_van_absorb_corrections(
-                ws_to_correct=ws_to_correct, multiple_scattering=self._inst_settings.multiple_scattering)
+                ws_to_correct=ws_to_correct, multiple_scattering=self._inst_settings.multiple_scattering,
+                is_vanadium=self._is_vanadium)
         else:
             return absorb_corrections.run_cylinder_absorb_corrections(
                 ws_to_correct=ws_to_correct, multiple_scattering=self._inst_settings.multiple_scattering,
-                sample_details_obj=self._sample_details)
+                sample_details_obj=self._sample_details, is_vanadium=self._is_vanadium)
 
     @staticmethod
     def _can_auto_gen_vanadium_cal():

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -8,13 +8,14 @@ from isis_powder.routines.run_details import create_run_details_object, \
 from isis_powder.polaris_routines import polaris_advanced_config
 
 
-def calculate_van_absorb_corrections(ws_to_correct, multiple_scattering):
+def calculate_van_absorb_corrections(ws_to_correct, multiple_scattering, is_vanadium):
     mantid.MaskDetectors(ws_to_correct, SpectraList=list(range(1, 55)))
 
     absorb_dict = polaris_advanced_config.absorption_correction_params
     sample_details_obj = absorb_corrections.create_vanadium_sample_details_obj(config_dict=absorb_dict)
     ws_to_correct = absorb_corrections.run_cylinder_absorb_corrections(
-        ws_to_correct=ws_to_correct, multiple_scattering=multiple_scattering, sample_details_obj=sample_details_obj)
+        ws_to_correct=ws_to_correct, multiple_scattering=multiple_scattering, sample_details_obj=sample_details_obj,
+        is_vanadium=is_vanadium)
     return ws_to_correct
 
 

--- a/scripts/Diffraction/isis_powder/routines/absorb_corrections.py
+++ b/scripts/Diffraction/isis_powder/routines/absorb_corrections.py
@@ -117,4 +117,3 @@ def _do_cylinder_absorb_corrections(ws_to_correct, multiple_scattering, is_vanad
     if previous_units != ws_units.tof:
         ws_to_correct = mantid.ConvertUnits(InputWorkspace=ws_to_correct, Target=previous_units)
     return ws_to_correct
-	

--- a/scripts/Diffraction/isis_powder/routines/absorb_corrections.py
+++ b/scripts/Diffraction/isis_powder/routines/absorb_corrections.py
@@ -117,6 +117,4 @@ def _do_cylinder_absorb_corrections(ws_to_correct, multiple_scattering, is_vanad
     if previous_units != ws_units.tof:
         ws_to_correct = mantid.ConvertUnits(InputWorkspace=ws_to_correct, Target=previous_units)
     return ws_to_correct
-
-
-
+	

--- a/scripts/Diffraction/isis_powder/routines/absorb_corrections.py
+++ b/scripts/Diffraction/isis_powder/routines/absorb_corrections.py
@@ -54,7 +54,9 @@ def run_cylinder_absorb_corrections(ws_to_correct, multiple_scattering, sample_d
     if not sample_details_obj.is_material_set():
         raise RuntimeError("The material for this sample has not been set yet. Please call"
                            " set_material on the SampleDetails object to set the material")
-
+    if multiple_scattering and not is_vanadium:
+        raise NotImplementedError("Multiple scattering absorption corrections are not yet implemented for "
+                                  "anisotropic samples")
     ws_to_correct = _calculate__cylinder_absorb_corrections(
         ws_to_correct=ws_to_correct, multiple_scattering=multiple_scattering,
         sample_details_obj=sample_details_obj, is_vanadium=is_vanadium)

--- a/scripts/Diffraction/isis_powder/routines/common_enums.py
+++ b/scripts/Diffraction/isis_powder/routines/common_enums.py
@@ -13,3 +13,4 @@ class WORKSPACE_UNITS(object):
     enum_friendly_name = "workspace units"
     d_spacing = "dSpacing"
     tof = "TOF"
+    wavelength = "Wavelength"

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -36,13 +36,13 @@ def _focus_one_ws(ws, run_number, instrument, perform_vanadium_norm, absorb):
     # Crop to largest acceptable TOF range
     input_workspace = instrument._crop_raw_to_expected_tof_range(ws_to_crop=input_workspace)
 
+    # Correct for absorption / multiple scattering if required
+    if absorb:
+        input_workspace = instrument._apply_absorb_corrections(run_details=run_details, ws_to_correct=input_workspace)
+
     # Align
     aligned_ws = mantid.AlignDetectors(InputWorkspace=input_workspace,
                                        CalibrationFile=run_details.offset_file_path)
-
-    # Correct for absorption / multiple scattering if required
-    if absorb:
-        aligned_ws = instrument._apply_absorb_corrections(run_details=run_details, ws_to_correct=aligned_ws)
 
     # Focus the spectra into banks
     focused_ws = mantid.DiffractionFocussing(InputWorkspace=aligned_ws,

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -42,7 +42,7 @@ def _focus_one_ws(ws, run_number, instrument, perform_vanadium_norm, absorb):
 
     # Correct for absorption / multiple scattering if required
     if absorb:
-        input_workspace = instrument._apply_absorb_corrections(run_details=run_details, ws_to_correct=input_workspace)
+        aligned_ws = instrument._apply_absorb_corrections(run_details=run_details, ws_to_correct=aligned_ws)
 
     # Focus the spectra into banks
     focused_ws = mantid.DiffractionFocussing(InputWorkspace=aligned_ws,

--- a/scripts/test/ISISPowderAbsorptionTest.py
+++ b/scripts/test/ISISPowderAbsorptionTest.py
@@ -17,7 +17,7 @@ class ISISPowderAbsorptionTest(unittest.TestCase):
 
         ws = mantid.CreateSampleWorkspace(Function='Flat background', NumBanks=1, BankPixelWidth=1, XMax=10, BinWidth=1)
         ws = absorb_corrections.run_cylinder_absorb_corrections(ws_to_correct=ws, multiple_scattering=False,
-                                                                sample_details_obj=sample_details)
+                                                                sample_details_obj=sample_details, is_vanadium=True)
 
         self.assertAlmostEqual(ws.dataY(0)[2], 1.16864808, delta=1e-8)
         self.assertAlmostEqual(ws.dataY(0)[5], 1.16872761, delta=1e-8)


### PR DESCRIPTION
**Description of work.**

Previously ISIS_Powder did not support absorption correction on non-vanadium samples. We now check whether a sample is vanadium or not. In both cases we use Mayers' Sample Correction, but in the case of a non-vanadium sample, we explicitly disable correction for multiple scattering (possibly to be added at some point in the future).

**To test:**

Run a focus on some powder data, first with the `do_absorb_corrections` flag set to `False`, then `True`. Plotting the resultant spectra on top of each other should show distinct evidence of absorption corrections taking place

<!-- Instructions for testing. -->

Fixes #20219 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
