### PR TITLE
Geometry::ComponentInfo shapes

### DIFF
--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -68,6 +68,7 @@ private:
   boost::shared_ptr<const std::vector<size_t>> m_parentIndices;
   Mantid::Kernel::cow_ptr<std::vector<Eigen::Vector3d>> m_positions;
   Mantid::Kernel::cow_ptr<std::vector<Eigen::Quaterniond>> m_rotations;
+  Mantid::Kernel::cow_ptr<std::vector<Eigen::Vector3d>> m_scaleFactors;
   const size_t m_size = 0;
   const int64_t m_sourceIndex = -1;
   const int64_t m_sampleIndex = -1;
@@ -88,6 +89,7 @@ public:
                 boost::shared_ptr<const std::vector<size_t>> parentIndices,
                 boost::shared_ptr<std::vector<Eigen::Vector3d>> positions,
                 boost::shared_ptr<std::vector<Eigen::Quaterniond>> rotations,
+                boost::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
                 int64_t sourceIndex, int64_t sampleIndex);
 
   std::vector<size_t> detectorsInSubtree(const size_t componentIndex) const;
@@ -121,6 +123,9 @@ public:
   size_t sample() const;
   size_t root() const;
   double l1() const;
+  Eigen::Vector3d scaleFactor(const size_t componentIndex) const;
+  void setScaleFactor(const size_t componentIndex,
+                      const Eigen::Vector3d &scaleFactor);
 };
 } // namespace Beamline
 } // namespace Mantid

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -338,7 +338,6 @@ ComponentInfo::componentRangeInSubtree(const size_t index) const {
   const auto range = (*m_componentRanges)[rangesIndex];
   return {m_assemblySortedComponentIndices->begin() + range.first,
           m_assemblySortedComponentIndices->begin() + range.second};
-
 }
 Eigen::Vector3d ComponentInfo::scaleFactor(const size_t componentIndex) const {
   return (*m_scaleFactors)[componentIndex];

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -23,6 +23,7 @@ ComponentInfo::ComponentInfo(
     boost::shared_ptr<const std::vector<size_t>> parentIndices,
     boost::shared_ptr<std::vector<Eigen::Vector3d>> positions,
     boost::shared_ptr<std::vector<Eigen::Quaterniond>> rotations,
+    boost::shared_ptr<std::vector<Eigen::Vector3d>> scaleFactors,
     int64_t sourceIndex, int64_t sampleIndex)
     : m_assemblySortedDetectorIndices(std::move(assemblySortedDetectorIndices)),
       m_assemblySortedComponentIndices(
@@ -31,6 +32,7 @@ ComponentInfo::ComponentInfo(
       m_componentRanges(std::move(componentRanges)),
       m_parentIndices(std::move(parentIndices)),
       m_positions(std::move(positions)), m_rotations(std::move(rotations)),
+      m_scaleFactors(std::move(scaleFactors)),
       m_size(m_assemblySortedDetectorIndices->size() +
              m_detectorRanges->size()),
       m_sourceIndex(sourceIndex), m_sampleIndex(sampleIndex) {
@@ -55,6 +57,11 @@ ComponentInfo::ComponentInfo(
     throw std::invalid_argument("ComponentInfo must have component indices "
                                 "input of same size as the sum of "
                                 "non-detector and detector components");
+  }
+  if (m_scaleFactors->size() != m_size) {
+    throw std::invalid_argument(
+        "ComponentInfo should have been provided same "
+        "number of scale factors as number of components");
   }
 }
 
@@ -331,6 +338,15 @@ ComponentInfo::componentRangeInSubtree(const size_t index) const {
   const auto range = (*m_componentRanges)[rangesIndex];
   return {m_assemblySortedComponentIndices->begin() + range.first,
           m_assemblySortedComponentIndices->begin() + range.second};
+
+}
+Eigen::Vector3d ComponentInfo::scaleFactor(const size_t componentIndex) const {
+  return (*m_scaleFactors)[componentIndex];
+}
+
+void ComponentInfo::setScaleFactor(const size_t componentIndex,
+                                   const Eigen::Vector3d &scaleFactor) {
+  m_scaleFactors.access()[componentIndex] = scaleFactor;
 }
 
 } // namespace Beamline

--- a/Framework/DataHandling/src/SetScalingPSD.cpp
+++ b/Framework/DataHandling/src/SetScalingPSD.cpp
@@ -2,6 +2,7 @@
 #include "MantidDataHandling/SetScalingPSD.h"
 #include "LoadRaw/isisraw.h"
 #include "MantidAPI/Axis.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -236,8 +237,8 @@ void SetScalingPSD::movePos(API::MatrixWorkspace_sptr &WS,
                             std::map<int, Kernel::V3D> &posMap,
                             std::map<int, double> &scaleMap) {
 
-  Geometry::ParameterMap &pmap = WS->instrumentParameters();
   auto &detectorInfo = WS->mutableDetectorInfo();
+  auto &componentInfo = WS->mutableComponentInfo();
 
   double maxScale = -1e6, minScale = 1e6, aveScale = 0.0;
   int scaleCount = 0;
@@ -264,8 +265,8 @@ void SetScalingPSD::movePos(API::MatrixWorkspace_sptr &WS,
       if (maxScale < scale)
         maxScale = scale;
       aveScale += fabs(1.0 - scale);
-      scaleCount++;
-      pmap.addV3D(&detectorInfo.detector(i), "sca", V3D(1.0, scale, 1.0));
+      componentInfo.setScaleFactor(i, V3D(1.0, scale, 1.0));
+      ++scaleCount;
     }
     prog.report();
   }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -102,7 +102,8 @@ public:
     return m_componentIds->operator[](componentIndex);
   }
   const Geometry::Object &shape(const size_t componentIndex) const;
-  double solidAngle(const size_t componentIndex, const Kernel::V3D& observer) const;
+  double solidAngle(const size_t componentIndex,
+                    const Kernel::V3D &observer) const;
   friend class Instrument;
 };
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -14,8 +14,8 @@ class V3D;
 }
 
 namespace Geometry {
-
 class IComponent;
+class Object;
 }
 
 namespace Beamline {
@@ -54,19 +54,24 @@ private:
   /// Pointer to the actual ComponentInfo object (non-wrapping part).
   std::unique_ptr<Beamline::ComponentInfo> m_componentInfo;
   /// Collection of component ids
-  boost::shared_ptr<const std::vector<Mantid::Geometry::IComponent *>>
-      m_componentIds;
+  boost::shared_ptr<const std::vector<Geometry::IComponent *>> m_componentIds;
   /// Map of component ids to indexes
   boost::shared_ptr<const std::unordered_map<Geometry::IComponent *, size_t>>
       m_compIDToIndex;
+
+  /// Shapes for each component
+  boost::shared_ptr<std::vector<boost::shared_ptr<const Geometry::Object>>>
+      m_shapes;
 
 public:
   ComponentInfo(
       std::unique_ptr<Beamline::ComponentInfo> componentInfo,
       boost::shared_ptr<const std::vector<Mantid::Geometry::IComponent *>>
           componentIds,
-      boost::shared_ptr<const std::unordered_map<
-          Geometry::IComponent *, size_t>> componentIdToIndexMap);
+      boost::shared_ptr<const std::unordered_map<Geometry::IComponent *,
+                                                 size_t>> componentIdToIndexMap,
+      boost::shared_ptr<std::vector<boost::shared_ptr<const Geometry::Object>>>
+          shapes);
   ComponentInfo(const ComponentInfo &other);
   ~ComponentInfo();
 
@@ -93,7 +98,7 @@ public:
   const IComponent *componentID(const size_t componentIndex) const {
     return m_componentIds->operator[](componentIndex);
   }
-
+  const Geometry::Object &shape(const size_t componentIndex) const;
   friend class Instrument;
 };
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -102,6 +102,7 @@ public:
     return m_componentIds->operator[](componentIndex);
   }
   const Geometry::Object &shape(const size_t componentIndex) const;
+  double solidAngle(const size_t componentIndex, const Kernel::V3D& observer) const;
   friend class Instrument;
 };
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -93,6 +93,9 @@ public:
   size_t source() const;
   size_t sample() const;
   double l1() const;
+  Kernel::V3D scaleFactor(const size_t componentIndex) const;
+  void setScaleFactor(const size_t componentIndex,
+                      const Kernel::V3D &scaleFactor);
   size_t root();
 
   const IComponent *componentID(const size_t componentIndex) const {

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentVisitor.h
@@ -8,6 +8,7 @@ namespace Geometry {
 class ICompAssembly;
 class IDetector;
 class IComponent;
+class IObjComponent;
 
 /** ComponentVisitor : Visitor for IComponents. Enables parsing of a full doubly
   linked InstrumentTree without need for dynamic casts. Public methods are
@@ -39,6 +40,8 @@ class ComponentVisitor {
 public:
   virtual size_t registerComponentAssembly(const ICompAssembly &assembly) = 0;
   virtual size_t registerGenericComponent(const IComponent &component) = 0;
+  virtual size_t
+  registerGenericObjComponent(const IObjComponent &objComponent) = 0;
   virtual size_t registerDetector(const IDetector &detector) = 0;
   virtual ~ComponentVisitor() {}
 };

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
@@ -124,12 +124,12 @@ private:
   /// Sample index to set
   int64_t m_sampleIndex = -1;
 
+  /// Null shared (empty shape)
+  boost::shared_ptr<const Mantid::Geometry::Object> m_nullShape;
+
   /// Shapes stored in fly-weight fashion
   boost::shared_ptr<
       std::vector<boost::shared_ptr<const Mantid::Geometry::Object>>> m_shapes;
-
-  /// Null shared (empty shape)
-  boost::shared_ptr<const Mantid::Geometry::Object> m_nullShape;
 
   void markAsSourceOrSample(Mantid::Geometry::IComponent *componentId,
                             const size_t componentIndex);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
@@ -22,7 +22,9 @@ class DetectorInfo;
 class ICompAssembly;
 class IComponent;
 class IDetector;
+class IObjComponent;
 class Instrument;
+class Object;
 class ParameterMap;
 /** InstrumentVisitor : Visitor for components with access to Info wrapping
   features.
@@ -122,6 +124,13 @@ private:
   /// Sample index to set
   int64_t m_sampleIndex = -1;
 
+  /// Shapes stored in fly-weight fashion
+  boost::shared_ptr<
+      std::vector<boost::shared_ptr<const Mantid::Geometry::Object>>> m_shapes;
+
+  /// Null shared (empty shape)
+  boost::shared_ptr<const Mantid::Geometry::Object> m_nullShape;
+
   void markAsSourceOrSample(Mantid::Geometry::IComponent *componentId,
                             const size_t componentIndex);
 
@@ -138,6 +147,10 @@ public:
 
   virtual size_t registerGenericComponent(
       const Mantid::Geometry::IComponent &component) override;
+
+  virtual size_t registerGenericObjComponent(
+      const Mantid::Geometry::IObjComponent &objComponent) override;
+
   virtual size_t
   registerDetector(const Mantid::Geometry::IDetector &detector) override;
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/InstrumentVisitor.h
@@ -131,6 +131,9 @@ private:
   boost::shared_ptr<
       std::vector<boost::shared_ptr<const Mantid::Geometry::Object>>> m_shapes;
 
+  /// Scale factors
+  boost::shared_ptr<std::vector<Eigen::Vector3d>> m_scaleFactors;
+
   void markAsSourceOrSample(Mantid::Geometry::IComponent *componentId,
                             const size_t componentIndex);
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ObjComponent.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ObjComponent.h
@@ -95,6 +95,9 @@ public:
   /// Return the material this component is made from
   const Kernel::Material material() const override;
 
+  virtual size_t
+  registerContents(class ComponentVisitor &componentVisitor) const override;
+
 protected:
   /// The physical geometry representation
   // Made a pointer to a const object. Since this is a shared object we

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -96,6 +96,7 @@ public:
   static const std::string &pString();
   static const std::string &pV3D();
   static const std::string &pQuat();
+  static const std::string &scale();
 
   const std::string diff(const ParameterMap &rhs,
                          const bool &firstDiffOnly = false) const;

--- a/Framework/Geometry/src/Instrument/Component.cpp
+++ b/Framework/Geometry/src/Instrument/Component.cpp
@@ -294,9 +294,13 @@ void Component::rotate(double angle, const V3D &axis) {
 */
 V3D Component::getScaleFactor() const {
   if (m_map) {
-    Parameter_sptr par = m_map->get(m_base, "sca");
-    if (par) {
-      return par->value<V3D>();
+    if (hasComponentInfo()) {
+      return m_map->componentInfo().scaleFactor(index());
+    } else {
+      Parameter_sptr par = m_map->get(m_base, ParameterMap::scale());
+      if (par) {
+        return par->value<V3D>();
+      }
     }
   }
   return V3D(1, 1, 1);

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -1,13 +1,35 @@
 #include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Objects/Object.h"
 #include "MantidGeometry/IComponent.h"
 #include "MantidBeamline/ComponentInfo.h"
 #include "MantidKernel/EigenConversionHelpers.h"
 #include "MantidKernel/make_unique.h"
 #include <exception>
 #include <string>
+#include <Eigen/Geometry>
 
 namespace Mantid {
 namespace Geometry {
+
+namespace {
+  /**
+   * Rotate point by inverse of rotation held at componentIndex
+   */
+  const Eigen::Vector3d undoRotation(const Eigen::Vector3d& point, const Beamline::ComponentInfo& compInfo, const size_t componentIndex){
+    auto unRotateTransform = Eigen::Affine3d(compInfo.rotation(componentIndex).inverse());
+    auto tmp = Eigen::AngleAxisd(compInfo.rotation(componentIndex));
+    auto tmp1 = tmp.angle() * 180 / M_PI;
+    return unRotateTransform * point;
+  }
+  /**
+   * Put the point into the frame of the shape.
+   * 1. Subtract component position (puts component pos at origin, same as shape coordinate system).
+   * 2. Apply inverse rotation of component to point. Unrotates the component into shape coordinate frame, with observer reorientated.
+   */
+  const Kernel::V3D toShapeFrame(const Kernel::V3D& point, const Beamline::ComponentInfo& compInfo, const size_t componentIndex) {
+    return Kernel::toV3D(undoRotation(Kernel::toVector3d(point)-compInfo.position(componentIndex), compInfo, componentIndex)); 
+  }
+}
 
 /**
  * Constructor.
@@ -139,5 +161,18 @@ void ComponentInfo::setScaleFactor(const size_t componentIndex,
                                   Kernel::toVector3d(scaleFactor));
 }
 
+double  ComponentInfo::solidAngle(const size_t componentIndex, const Kernel::V3D& observer) const{
+
+  // This is the observer position in the shape's coordinate system.
+  const Kernel::V3D relativeObserver = toShapeFrame(observer, *m_componentInfo, componentIndex);
+  const Kernel::V3D scaleFactor = this->scaleFactor(componentIndex);
+  if ((scaleFactor - Kernel::V3D(1.0, 1.0, 1.0)).norm() < 1e-12)
+    return shape(componentIndex).solidAngle(relativeObserver);
+  else {
+    // This function will scale the object shape when calculating the solid
+    // angle.
+    return shape(componentIndex).solidAngle(relativeObserver, scaleFactor);
+  }
+}
 } // namespace Geometry
 } // namespace Mantid

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -77,7 +77,7 @@ ComponentInfo::ComponentInfo(const ComponentInfo &other)
     : m_componentInfo(
           Kernel::make_unique<Beamline::ComponentInfo>(*other.m_componentInfo)),
       m_componentIds(other.m_componentIds),
-      m_compIDToIndex(other.m_compIDToIndex) {}
+      m_compIDToIndex(other.m_compIDToIndex), m_shapes(other.m_shapes) {}
 
 // Defined as default in source for forward declaration with std::unique_ptr.
 ComponentInfo::~ComponentInfo() = default;

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -129,5 +129,15 @@ const Object &ComponentInfo::shape(const size_t componentIndex) const {
   return *(*m_shapes)[componentIndex];
 }
 
+Kernel::V3D ComponentInfo::scaleFactor(const size_t componentIndex) const {
+  return Kernel::toV3D(m_componentInfo->scaleFactor(componentIndex));
+}
+
+void ComponentInfo::setScaleFactor(const size_t componentIndex,
+                                   const Kernel::V3D &scaleFactor) {
+  m_componentInfo->setScaleFactor(componentIndex,
+                                  Kernel::toVector3d(scaleFactor));
+}
+
 } // namespace Geometry
 } // namespace Mantid

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -12,23 +12,30 @@ namespace Mantid {
 namespace Geometry {
 
 namespace {
-  /**
-   * Rotate point by inverse of rotation held at componentIndex
-   */
-  const Eigen::Vector3d undoRotation(const Eigen::Vector3d& point, const Beamline::ComponentInfo& compInfo, const size_t componentIndex){
-    auto unRotateTransform = Eigen::Affine3d(compInfo.rotation(componentIndex).inverse());
-    auto tmp = Eigen::AngleAxisd(compInfo.rotation(componentIndex));
-    auto tmp1 = tmp.angle() * 180 / M_PI;
-    return unRotateTransform * point;
-  }
-  /**
-   * Put the point into the frame of the shape.
-   * 1. Subtract component position (puts component pos at origin, same as shape coordinate system).
-   * 2. Apply inverse rotation of component to point. Unrotates the component into shape coordinate frame, with observer reorientated.
-   */
-  const Kernel::V3D toShapeFrame(const Kernel::V3D& point, const Beamline::ComponentInfo& compInfo, const size_t componentIndex) {
-    return Kernel::toV3D(undoRotation(Kernel::toVector3d(point)-compInfo.position(componentIndex), compInfo, componentIndex)); 
-  }
+/**
+ * Rotate point by inverse of rotation held at componentIndex
+ */
+const Eigen::Vector3d undoRotation(const Eigen::Vector3d &point,
+                                   const Beamline::ComponentInfo &compInfo,
+                                   const size_t componentIndex) {
+  auto unRotateTransform =
+      Eigen::Affine3d(compInfo.rotation(componentIndex).inverse());
+  return unRotateTransform * point;
+}
+/**
+ * Put the point into the frame of the shape.
+ * 1. Subtract component position (puts component pos at origin, same as shape
+ * coordinate system).
+ * 2. Apply inverse rotation of component to point. Unrotates the component into
+ * shape coordinate frame, with observer reorientated.
+ */
+const Kernel::V3D toShapeFrame(const Kernel::V3D &point,
+                               const Beamline::ComponentInfo &compInfo,
+                               const size_t componentIndex) {
+  return Kernel::toV3D(undoRotation(Kernel::toVector3d(point) -
+                                        compInfo.position(componentIndex),
+                                    compInfo, componentIndex));
+}
 }
 
 /**
@@ -161,10 +168,12 @@ void ComponentInfo::setScaleFactor(const size_t componentIndex,
                                   Kernel::toVector3d(scaleFactor));
 }
 
-double  ComponentInfo::solidAngle(const size_t componentIndex, const Kernel::V3D& observer) const{
+double ComponentInfo::solidAngle(const size_t componentIndex,
+                                 const Kernel::V3D &observer) const {
 
   // This is the observer position in the shape's coordinate system.
-  const Kernel::V3D relativeObserver = toShapeFrame(observer, *m_componentInfo, componentIndex);
+  const Kernel::V3D relativeObserver =
+      toShapeFrame(observer, *m_componentInfo, componentIndex);
   const Kernel::V3D scaleFactor = this->scaleFactor(componentIndex);
   if ((scaleFactor - Kernel::V3D(1.0, 1.0, 1.0)).norm() < 1e-12)
     return shape(componentIndex).solidAngle(relativeObserver);

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -14,8 +14,8 @@ namespace Geometry {
  * @param componentInfo : Internal Beamline ComponentInfo
  * @param componentIds : ComponentIDs ordered by component
  * @param componentIdToIndexMap : ID -> index translation map
- * index
- */
+ * @param shapes : Shapes for each component
+ * */
 ComponentInfo::ComponentInfo(
     std::unique_ptr<Beamline::ComponentInfo> componentInfo,
     boost::shared_ptr<const std::vector<Mantid::Geometry::IComponent *>>

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -21,10 +21,13 @@ ComponentInfo::ComponentInfo(
     boost::shared_ptr<const std::vector<Mantid::Geometry::IComponent *>>
         componentIds,
     boost::shared_ptr<const std::unordered_map<Geometry::IComponent *, size_t>>
-        componentIdToIndexMap)
+        componentIdToIndexMap,
+    boost::shared_ptr<std::vector<boost::shared_ptr<const Geometry::Object>>>
+        shapes)
     : m_componentInfo(std::move(componentInfo)),
       m_componentIds(std::move(componentIds)),
-      m_compIDToIndex(std::move(componentIdToIndexMap)) {
+      m_compIDToIndex(std::move(componentIdToIndexMap)),
+      m_shapes(std::move(shapes)) {
 
   if (m_componentIds->size() != m_compIDToIndex->size()) {
     throw std::invalid_argument("Inconsistent ID and Mapping input containers "
@@ -121,5 +124,10 @@ void ComponentInfo::setRotation(const size_t componentIndex,
   m_componentInfo->setRotation(componentIndex,
                                Kernel::toQuaterniond(newRotation));
 }
+
+const Object &ComponentInfo::shape(const size_t componentIndex) const {
+  return *(*m_shapes)[componentIndex];
+}
+
 } // namespace Geometry
 } // namespace Mantid

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -34,8 +34,7 @@ makeDetIdToIndexMap(const std::vector<detid_t> &detIds) {
   return std::move(detIdToIndex);
 }
 
-void clearPositionAndRotationParameters(ParameterMap *pmap,
-                                        const IComponent &comp) {
+void clearLegacyParameters(ParameterMap *pmap, const IComponent &comp) {
   if (!pmap)
     return;
   pmap->clearParametersByName(ParameterMap::pos(), &comp);
@@ -46,6 +45,7 @@ void clearPositionAndRotationParameters(ParameterMap *pmap,
   pmap->clearParametersByName(ParameterMap::rotx(), &comp);
   pmap->clearParametersByName(ParameterMap::roty(), &comp);
   pmap->clearParametersByName(ParameterMap::rotz(), &comp);
+  pmap->clearParametersByName(ParameterMap::scale(), &comp);
 }
 }
 
@@ -151,7 +151,6 @@ InstrumentVisitor::registerComponentAssembly(const ICompAssembly &assembly) {
   m_componentIds->emplace_back(assembly.getComponentID());
   m_positions->emplace_back(Kernel::toVector3d(assembly.getPos()));
   m_rotations->emplace_back(Kernel::toQuaterniond(assembly.getRotation()));
-  clearPositionAndRotationParameters(m_pmap, assembly);
   // Now that we know what the index of the parent is we can apply it to the
   // children
   for (const auto &child : children) {
@@ -160,6 +159,7 @@ InstrumentVisitor::registerComponentAssembly(const ICompAssembly &assembly) {
   markAsSourceOrSample(assembly.getComponentID(), componentIndex);
   m_shapes->emplace_back(m_nullShape);
   m_scaleFactors->emplace_back(Kernel::toVector3d(assembly.getScaleFactor()));
+  clearLegacyParameters(m_pmap, assembly);
   return componentIndex;
 }
 
@@ -189,10 +189,10 @@ InstrumentVisitor::registerGenericComponent(const IComponent &component) {
   // Unless this is the root component this parent is not correct and will be
   // updated later in the register call of the parent.
   m_parentComponentIndices->push_back(componentIndex);
-  clearPositionAndRotationParameters(m_pmap, component);
   markAsSourceOrSample(component.getComponentID(), componentIndex);
   m_shapes->emplace_back(m_nullShape);
   m_scaleFactors->emplace_back(Kernel::toVector3d(component.getScaleFactor()));
+  clearLegacyParameters(m_pmap, component);
   return componentIndex;
 }
 
@@ -259,7 +259,7 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
     if (m_instrument->isMonitorViaIndex(detectorIndex)) {
       m_monitorIndices->push_back(detectorIndex);
     }
-    clearPositionAndRotationParameters(m_pmap, detector);
+    clearLegacyParameters(m_pmap, detector);
   }
   /* Note that positions and rotations for detectors are currently
   NOT stored! These go into DetectorInfo at present. push_back works for other

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -109,7 +109,7 @@ InstrumentVisitor::InstrumentVisitor(
   const auto nDetectors = m_orderedDetectorIds->size();
   m_assemblySortedDetectorIndices->reserve(nDetectors); // Exact
   m_componentIdToIndexMap->reserve(nDetectors);         // Approximation
-  m_shapes->reserve(nDetectors);                         // Approximation
+  m_shapes->reserve(nDetectors);                        // Approximation
 }
 
 void InstrumentVisitor::walkInstrument() {

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -83,7 +83,9 @@ InstrumentVisitor::InstrumentVisitor(
       m_instrument(std::move(instrument)), m_pmap(nullptr),
       m_nullShape(boost::make_shared<const Object>()),
       m_shapes(boost::make_shared<std::vector<boost::shared_ptr<const Object>>>(
-          m_orderedDetectorIds->size(), m_nullShape)) {
+          m_orderedDetectorIds->size(), m_nullShape)),
+      m_scaleFactors(boost::make_shared<std::vector<Eigen::Vector3d>>(
+          m_orderedDetectorIds->size(), Eigen::Vector3d{1, 1, 1})) {
 
   if (m_instrument->isParametrized()) {
     m_pmap = m_instrument->getParameterMap().get();
@@ -157,6 +159,7 @@ InstrumentVisitor::registerComponentAssembly(const ICompAssembly &assembly) {
   }
   markAsSourceOrSample(assembly.getComponentID(), componentIndex);
   m_shapes->emplace_back(m_nullShape);
+  m_scaleFactors->emplace_back(Kernel::toVector3d(assembly.getScaleFactor()));
   return componentIndex;
 }
 
@@ -189,6 +192,7 @@ InstrumentVisitor::registerGenericComponent(const IComponent &component) {
   clearPositionAndRotationParameters(m_pmap, component);
   markAsSourceOrSample(component.getComponentID(), componentIndex);
   m_shapes->emplace_back(m_nullShape);
+  m_scaleFactors->emplace_back(Kernel::toVector3d(component.getScaleFactor()));
   return componentIndex;
 }
 
@@ -250,6 +254,8 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
     (*m_detectorRotations)[detectorIndex] =
         Kernel::toQuaterniond(detector.getRotation());
     (*m_shapes)[detectorIndex] = std::move(detector.shape());
+    (*m_scaleFactors)[detectorIndex] =
+        Kernel::toVector3d(detector.getScaleFactor());
     if (m_instrument->isMonitorViaIndex(detectorIndex)) {
       m_monitorIndices->push_back(detectorIndex);
     }
@@ -307,8 +313,8 @@ InstrumentVisitor::componentInfo() const {
   return Kernel::make_unique<Mantid::Beamline::ComponentInfo>(
       m_assemblySortedDetectorIndices, m_detectorRanges,
       m_assemblySortedComponentIndices, m_componentRanges,
-      m_parentComponentIndices, m_positions, m_rotations, m_sourceIndex,
-      m_sampleIndex);
+      m_parentComponentIndices, m_positions, m_rotations, m_scaleFactors,
+      m_sourceIndex, m_sampleIndex);
 }
 
 std::unique_ptr<Beamline::DetectorInfo>

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -81,9 +81,9 @@ InstrumentVisitor::InstrumentVisitor(
           m_orderedDetectorIds->size())),
       m_monitorIndices(boost::make_shared<std::vector<size_t>>()),
       m_instrument(std::move(instrument)), m_pmap(nullptr),
-      m_shapes(
-          boost::make_shared<std::vector<boost::shared_ptr<const Object>>>()),
-      m_nullShape(boost::make_shared<const Object>()) {
+      m_nullShape(boost::make_shared<const Object>()),
+      m_shapes(boost::make_shared<std::vector<boost::shared_ptr<const Object>>>(
+          m_orderedDetectorIds->size(), m_nullShape)) {
 
   if (m_instrument->isParametrized()) {
     m_pmap = m_instrument->getParameterMap().get();
@@ -249,7 +249,7 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
         Kernel::toVector3d(detector.getPos());
     (*m_detectorRotations)[detectorIndex] =
         Kernel::toQuaterniond(detector.getRotation());
-    m_shapes->emplace_back(std::move(detector.shape()));
+    (*m_shapes)[detectorIndex] = std::move(detector.shape());
     if (m_instrument->isMonitorViaIndex(detectorIndex)) {
       m_monitorIndices->push_back(detectorIndex);
     }

--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -4,9 +4,11 @@
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/ICompAssembly.h"
 #include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/IObjComponent.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
+#include "MantidGeometry/Objects/Object.h"
 #include "MantidKernel/EigenConversionHelpers.h"
 #include "MantidKernel/make_unique.h"
 #include "MantidBeamline/ComponentInfo.h"
@@ -78,7 +80,10 @@ InstrumentVisitor::InstrumentVisitor(
       m_detectorRotations(boost::make_shared<std::vector<Eigen::Quaterniond>>(
           m_orderedDetectorIds->size())),
       m_monitorIndices(boost::make_shared<std::vector<size_t>>()),
-      m_instrument(std::move(instrument)), m_pmap(nullptr) {
+      m_instrument(std::move(instrument)), m_pmap(nullptr),
+      m_shapes(
+          boost::make_shared<std::vector<boost::shared_ptr<const Object>>>()),
+      m_nullShape(boost::make_shared<const Object>()) {
 
   if (m_instrument->isParametrized()) {
     m_pmap = m_instrument->getParameterMap().get();
@@ -102,6 +107,7 @@ InstrumentVisitor::InstrumentVisitor(
   const auto nDetectors = m_orderedDetectorIds->size();
   m_assemblySortedDetectorIndices->reserve(nDetectors); // Exact
   m_componentIdToIndexMap->reserve(nDetectors);         // Approximation
+  m_shapes->reserve(nDetectors);                         // Approximation
 }
 
 void InstrumentVisitor::walkInstrument() {
@@ -150,6 +156,7 @@ InstrumentVisitor::registerComponentAssembly(const ICompAssembly &assembly) {
     (*m_parentComponentIndices)[child] = componentIndex;
   }
   markAsSourceOrSample(assembly.getComponentID(), componentIndex);
+  m_shapes->emplace_back(m_nullShape);
   return componentIndex;
 }
 
@@ -181,6 +188,7 @@ InstrumentVisitor::registerGenericComponent(const IComponent &component) {
   m_parentComponentIndices->push_back(componentIndex);
   clearPositionAndRotationParameters(m_pmap, component);
   markAsSourceOrSample(component.getComponentID(), componentIndex);
+  m_shapes->emplace_back(m_nullShape);
   return componentIndex;
 }
 
@@ -191,6 +199,18 @@ void InstrumentVisitor::markAsSourceOrSample(ComponentID componentId,
   } else if (componentId == m_sourceId) {
     m_sourceIndex = componentIndex;
   }
+}
+
+/**
+ * @brief InstrumentVisitor::registerGenericObjComponent
+ * @param objComponent : IObjComponent being visited
+ * @return Component index of this component
+ */
+size_t InstrumentVisitor::registerGenericObjComponent(
+    const Mantid::Geometry::IObjComponent &objComponent) {
+  auto index = registerGenericComponent(objComponent);
+  (*m_shapes)[index] = objComponent.shape();
+  return index;
 }
 
 /**
@@ -229,6 +249,7 @@ size_t InstrumentVisitor::registerDetector(const IDetector &detector) {
         Kernel::toVector3d(detector.getPos());
     (*m_detectorRotations)[detectorIndex] =
         Kernel::toQuaterniond(detector.getRotation());
+    m_shapes->emplace_back(std::move(detector.shape()));
     if (m_instrument->isMonitorViaIndex(detectorIndex)) {
       m_monitorIndices->push_back(detectorIndex);
     }
@@ -309,7 +330,7 @@ InstrumentVisitor::makeWrappers() const {
   detInfo->setComponentInfo(compInfo.get());
 
   auto compInfoWrapper = Kernel::make_unique<ComponentInfo>(
-      std::move(compInfo), componentIds(), componentIdToIndexMap());
+      std::move(compInfo), componentIds(), componentIdToIndexMap(), m_shapes);
   auto detInfoWrapper = Kernel::make_unique<DetectorInfo>(
       std::move(detInfo), m_instrument, detectorIds(), detectorIdToIndexMap());
 

--- a/Framework/Geometry/src/Instrument/ObjComponent.cpp
+++ b/Framework/Geometry/src/Instrument/ObjComponent.cpp
@@ -1,5 +1,6 @@
 #include "MantidGeometry/Instrument/ObjComponent.h"
 #include "MantidGeometry/Instrument/ComponentVisitor.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Objects/Object.h"
 #include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidGeometry/Objects/Track.h"
@@ -139,6 +140,11 @@ int ObjComponent::interceptSurface(Track &track) const {
 * set
 */
 double ObjComponent::solidAngle(const V3D &observer) const {
+  if(m_map){
+    if(hasComponentInfo()){
+      return m_map->componentInfo().solidAngle(index(), observer);
+    }
+  }
   // If the form of this component is not defined, throw NullPointerException
   if (!shape())
     throw Kernel::Exception::NullPointerException("ObjComponent::solidAngle",

--- a/Framework/Geometry/src/Instrument/ObjComponent.cpp
+++ b/Framework/Geometry/src/Instrument/ObjComponent.cpp
@@ -140,8 +140,8 @@ int ObjComponent::interceptSurface(Track &track) const {
 * set
 */
 double ObjComponent::solidAngle(const V3D &observer) const {
-  if(m_map){
-    if(hasComponentInfo()){
+  if (m_map) {
+    if (hasComponentInfo()) {
       return m_map->componentInfo().solidAngle(index(), observer);
     }
   }

--- a/Framework/Geometry/src/Instrument/ObjComponent.cpp
+++ b/Framework/Geometry/src/Instrument/ObjComponent.cpp
@@ -1,4 +1,5 @@
 #include "MantidGeometry/Instrument/ObjComponent.h"
+#include "MantidGeometry/Instrument/ComponentVisitor.h"
 #include "MantidGeometry/Objects/Object.h"
 #include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidGeometry/Objects/Track.h"
@@ -322,6 +323,15 @@ void ObjComponent::initDraw() const {
   if (shape() != nullptr)
     shape()->initDraw();
   Handle()->Initialize();
+}
+
+/**
+ * Register the contents of this ObjComponent
+ */
+size_t
+ObjComponent::registerContents(class ComponentVisitor &componentVisitor) const {
+
+  return componentVisitor.registerGenericObjComponent(*this);
 }
 
 } // namespace Geometry

--- a/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -42,6 +42,8 @@ const std::string STRING_PARAM_NAME = "string";
 const std::string V3D_PARAM_NAME = "V3D";
 const std::string QUAT_PARAM_NAME = "Quat";
 
+const std::string SCALE_PARAM_NAME = "sca";
+
 // static logger reference
 Kernel::Logger g_log("ParameterMap");
 
@@ -115,6 +117,9 @@ const std::string &ParameterMap::pString() { return STRING_PARAM_NAME; }
 const std::string &ParameterMap::pV3D() { return V3D_PARAM_NAME; }
 
 const std::string &ParameterMap::pQuat() { return QUAT_PARAM_NAME; }
+
+// Scale
+const std::string &ParameterMap::scale() { return SCALE_PARAM_NAME; }
 
 /**
  * Compares the values in this object with that given for inequality

--- a/Framework/Geometry/test/ComponentInfoTest.h
+++ b/Framework/Geometry/test/ComponentInfoTest.h
@@ -8,13 +8,19 @@
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument/ObjComponent.h"
 #include "MantidGeometry/Objects/Object.h"
+#include "MantidGeometry/Surfaces/Cylinder.h"
+#include "MantidGeometry/Surfaces/Plane.h"
+#include "MantidGeometry/Surfaces/Surface.h"
+#include "MantidGeometry/Surfaces/Sphere.h"
 #include "MantidKernel/EigenConversionHelpers.h"
 #include "MantidKernel/make_unique.h"
+#include "MantidTestHelpers/ComponentCreationHelper.h"
 #include <boost/make_shared.hpp>
+#include <Eigen/Geometry>
 
-using Mantid::Geometry::ComponentInfo;
 using namespace Mantid;
 using namespace Mantid::Kernel;
+using namespace Mantid::Geometry;
 
 namespace {
 
@@ -33,6 +39,69 @@ makeComponentIDMap(const boost::shared_ptr<
     (*idMap)[(*componentIds)[i]] = i;
   }
   return idMap;
+}
+
+// Make a Beamline ComponentInfo for a single component
+std::unique_ptr<Beamline::ComponentInfo> makeSingleComponentInfo(
+    Eigen::Vector3d position, Eigen::Quaterniond rotation,
+    Eigen::Vector3d scaleFactor = Eigen::Vector3d{1, 1, 1}) {
+
+  auto detectorIndices =
+      boost::make_shared<std::vector<size_t>>(); // No detectors in this example
+  auto detectorRanges =
+      boost::make_shared<std::vector<std::pair<size_t, size_t>>>();
+  detectorRanges->push_back(
+      std::make_pair(0, 0)); // One component with no detectors
+
+  auto componentIndices = boost::make_shared<std::vector<size_t>>(
+      std::vector<size_t>{0}); // No detectors in this example
+  auto componentRanges =
+      boost::make_shared<std::vector<std::pair<size_t, size_t>>>();
+  componentRanges->push_back(
+      std::make_pair(0, 0)); // One component with no sub-components
+
+  auto parentIndices = boost::make_shared<const std::vector<size_t>>(
+      std::vector<size_t>()); // These indices are invalid, but that's
+                              // ok as not being tested here
+
+  auto positions =
+      boost::make_shared<std::vector<Eigen::Vector3d>>(1, position);
+  auto rotations =
+      boost::make_shared<std::vector<Eigen::Quaterniond>>(1, rotation);
+  auto scaleFactors =
+      boost::make_shared<std::vector<Eigen::Vector3d>>(1, scaleFactor);
+  return Kernel::make_unique<Beamline::ComponentInfo>(
+      detectorIndices, detectorRanges, componentIndices, componentRanges,
+      parentIndices, positions, rotations, scaleFactors, -1, -1);
+}
+
+boost::shared_ptr<Object> createCappedCylinder() {
+  std::string C31 = "cx 0.5"; // cylinder x-axis radius 0.5
+  std::string C32 = "px 1.2";
+  std::string C33 = "px -3.2";
+
+  // First create some surfaces
+  std::map<int, boost::shared_ptr<Surface>> CylSurMap;
+  CylSurMap[31] = boost::make_shared<Cylinder>();
+  CylSurMap[32] = boost::make_shared<Plane>();
+  CylSurMap[33] = boost::make_shared<Plane>();
+
+  CylSurMap[31]->setSurface(C31);
+  CylSurMap[32]->setSurface(C32);
+  CylSurMap[33]->setSurface(C33);
+  CylSurMap[31]->setName(31);
+  CylSurMap[32]->setName(32);
+  CylSurMap[33]->setName(33);
+
+  // Capped cylinder (id 21)
+  // using surface ids: 31 (cylinder) 32 (plane (top) ) and 33 (plane (base))
+  std::string ObjCapCylinder = "-31 -32 33";
+
+  auto retVal = boost::make_shared<Object>();
+  retVal->setObject(21, ObjCapCylinder);
+  retVal->populate(CylSurMap);
+
+  return retVal;
 }
 }
 
@@ -89,6 +158,60 @@ public:
                        makeComponentIDMap(componentIds), shapes);
     TS_ASSERT_EQUALS(info.indexOf(comp1.getComponentID()), 0);
     TS_ASSERT_EQUALS(info.indexOf(comp2.getComponentID()), 1);
+  }
+
+  void test_simple_solidAngle() {
+    auto position = Eigen::Vector3d{0, 0, 0};
+    // No rotation
+    auto rotation = Eigen::Quaterniond(Eigen::Affine3d::Identity().rotation());
+    auto internalInfo = std::move(makeSingleComponentInfo(position, rotation));
+    Mantid::Geometry::ObjComponent comp1("component1", createCappedCylinder());
+
+    auto componentIds =
+        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>(
+            std::vector<Mantid::Geometry::ComponentID>{&comp1});
+
+    const double radius = 1.0;
+    auto shapes = boost::make_shared<
+        std::vector<boost::shared_ptr<const Geometry::Object>>>();
+    shapes->push_back(ComponentCreationHelper::createSphere(radius));
+
+    ComponentInfo info(std::move(internalInfo), componentIds,
+                       makeComponentIDMap(componentIds), shapes);
+
+    double satol = 1e-9; // tolerance for solid angle
+
+    // Put observer on surface of sphere and solid angle is 2PI
+    V3D observer{radius, 0, 0};
+    TS_ASSERT_DELTA(info.solidAngle(0, observer), 2 * M_PI, satol);
+    // Put observer at center of sphere and solid angle is full 4PI square
+    // radians
+    observer = V3D{0, 0, 0};
+    TS_ASSERT_DELTA(info.solidAngle(0, observer), 4 * M_PI, satol);
+  }
+
+  // Test adapted from ObjComponentTest
+  void test_solidAngle() {
+
+    auto position = Eigen::Vector3d{10, 0, 0};
+    auto rotation = Eigen::Quaterniond(
+        Eigen::AngleAxisd(M_PI / 2, Eigen::Vector3d::UnitZ()));
+    auto internalInfo = std::move(makeSingleComponentInfo(position, rotation));
+    Mantid::Geometry::ObjComponent comp1("component1", createCappedCylinder());
+
+    auto componentIds =
+        boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>(
+            std::vector<Mantid::Geometry::ComponentID>{&comp1});
+
+    auto shapes = boost::make_shared<
+        std::vector<boost::shared_ptr<const Geometry::Object>>>();
+    shapes->push_back(createCappedCylinder());
+
+    ComponentInfo info(std::move(internalInfo), componentIds,
+                       makeComponentIDMap(componentIds), shapes);
+
+    double satol = 2e-2; // tolerance for solid angle
+    TS_ASSERT_DELTA(info.solidAngle(0, V3D(10, 1.7, 0)), 1.840302, satol);
   }
 };
 

--- a/Framework/Geometry/test/ComponentInfoTest.h
+++ b/Framework/Geometry/test/ComponentInfoTest.h
@@ -7,9 +7,9 @@
 #include "MantidBeamline/ComponentInfo.h"
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument/ObjComponent.h"
+#include "MantidGeometry/Objects/Object.h"
 #include "MantidKernel/EigenConversionHelpers.h"
 #include "MantidKernel/make_unique.h"
-
 #include <boost/make_shared.hpp>
 
 using Mantid::Geometry::ComponentInfo;
@@ -79,8 +79,14 @@ public:
     auto componentIds =
         boost::make_shared<std::vector<Mantid::Geometry::ComponentID>>(
             std::vector<Mantid::Geometry::ComponentID>{&comp1, &comp2});
+
+    auto shapes = boost::make_shared<
+        std::vector<boost::shared_ptr<const Geometry::Object>>>();
+    shapes->push_back(boost::make_shared<const Geometry::Object>());
+    shapes->push_back(boost::make_shared<const Geometry::Object>());
+
     ComponentInfo info(std::move(internalInfo), componentIds,
-                       makeComponentIDMap(componentIds));
+                       makeComponentIDMap(componentIds), shapes);
     TS_ASSERT_EQUALS(info.indexOf(comp1.getComponentID()), 0);
     TS_ASSERT_EQUALS(info.indexOf(comp2.getComponentID()), 1);
   }

--- a/Framework/Geometry/test/ComponentInfoTest.h
+++ b/Framework/Geometry/test/ComponentInfoTest.h
@@ -69,10 +69,10 @@ public:
 
     auto positions = boost::make_shared<std::vector<Eigen::Vector3d>>(2);
     auto rotations = boost::make_shared<std::vector<Eigen::Quaterniond>>(2);
-
+    auto scaleFactors = boost::make_shared<std::vector<Eigen::Vector3d>>(2);
     auto internalInfo = Kernel::make_unique<Beamline::ComponentInfo>(
         detectorIndices, detectorRanges, componentIndices, componentRanges,
-        parentIndices, positions, rotations, -1, -1);
+        parentIndices, positions, rotations, scaleFactors, -1, -1);
     Mantid::Geometry::ObjComponent comp1("component1");
     Mantid::Geometry::ObjComponent comp2("component2");
 

--- a/Framework/Geometry/test/InstrumentVisitorTest.h
+++ b/Framework/Geometry/test/InstrumentVisitorTest.h
@@ -401,10 +401,11 @@ public:
     // Add a scale factor for the detector
 
     Mantid::Kernel::V3D detScaling{2, 2, 2};
-    pmap->addV3D(detector->getComponentID(), "sca", detScaling);
+    pmap->addV3D(detector->getComponentID(), ParameterMap::scale(), detScaling);
     // Add as scale factor for the instrument
     Mantid::Kernel::V3D instrScaling{3, 3, 3};
-    pmap->addV3D(visitee->getComponentID(), "sca", instrScaling);
+    pmap->addV3D(visitee->getComponentID(), ParameterMap::scale(),
+                 instrScaling);
     // Sanity check inputs
     TS_ASSERT_EQUALS(pmap->size(), 2);
 

--- a/Framework/Geometry/test/InstrumentVisitorTest.h
+++ b/Framework/Geometry/test/InstrumentVisitorTest.h
@@ -370,11 +370,13 @@ public:
         InstrumentVisitor::makeWrappers(*instrument, nullptr /*parameter map*/);
     auto componentInfo = std::move(std::get<0>(wrappers));
 
+    // Instrument
     const auto &instrumentShape = componentInfo->shape(componentInfo->root());
     TSM_ASSERT("CompAssemblies should have no shape",
                !instrumentShape.hasValidShape());
+    // Bank 1
     const auto &subAssemblyShape =
-        componentInfo->shape(componentInfo->root() - 1);
+        componentInfo->shape(componentInfo->root() - 3);
     TSM_ASSERT("CompAssemblies should have no shape",
                !subAssemblyShape.hasValidShape());
     const auto &detectorShape =


### PR DESCRIPTION
"Shape" and "Scale Factor" are done through `ComponentInfo` such that one one ObjComponent's responsibilities, Solid Angle, can now be done directly in `ComponentInfo`

As this is an internal change, a code review should be sufficient. No release notes needed.

supersedes PR #20176

fixes #20175
