### PR TITLE
Remove automatic vanadium creation from ISIS Powder

### DIFF
--- a/scripts/Diffraction/isis_powder/abstract_inst.py
+++ b/scripts/Diffraction/isis_powder/abstract_inst.py
@@ -107,16 +107,6 @@ class AbstractInst(object):
         # the instrument override the optional behaviour
         raise NotImplementedError("spline_vanadium_ws must be implemented per instrument")
 
-    # Optional overrides
-    @staticmethod
-    def _can_auto_gen_vanadium_cal():
-        """
-        Can be overridden and returned true by instruments who can automatically run generate vanadium calculation
-        if the splines cannot be found during the focus routine
-        :return: False by default, True by instruments who can automatically generate these
-        """
-        return False
-
     def _crop_banks_to_user_tof(self, focused_banks):
         """
         Crops to a user specified TOF range on a bank-by-bank basis. This is called after focusing a sample and
@@ -160,17 +150,6 @@ class AbstractInst(object):
         :return: List of bin widths or None if no rebinning should take place
         """
         return None
-
-    def _generate_auto_vanadium_calibration(self, run_details):
-        """
-        Used by focus if a vanadium spline was not found to automatically generate said spline if the instrument
-        has indicated support by overriding can_auto_gen_vanadium_cal
-        :param run_details: The run details of the current run
-        :return: None
-        """
-        # If the instrument overrides can_auto_gen_vanadium_cal it needs to implement this method to perform the
-        # automatic calibration
-        raise NotImplementedError("Automatic vanadium corrections have not been implemented for this instrument.")
 
     def _get_input_batching_mode(self):
         """

--- a/scripts/Diffraction/isis_powder/gem.py
+++ b/scripts/Diffraction/isis_powder/gem.py
@@ -52,9 +52,6 @@ class Gem(AbstractInst):
             run_number_string=run_number_string, inst_settings=self._inst_settings, is_vanadium_run=self._is_vanadium)
         return self._cached_run_details[run_number_string_key]
 
-    def _generate_auto_vanadium_calibration(self, run_details):
-        raise NotImplementedError()
-
     def _generate_output_file_name(self, run_number_string):
         return self._generate_input_file_name(run_number_string)
 

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -82,11 +82,6 @@ class Pearl(AbstractInst):
         common.remove_intermediate_workspace(monitor_ws)
         return normalised_ws
 
-    def _generate_auto_vanadium_calibration(self, run_details):
-        # The instrument scientists prefer everything to be explicit on this instrument so
-        # instead we don't try to run this automatically
-        raise NotImplementedError("You must run the create_vanadium method manually on Pearl")
-
     def _get_current_tt_mode(self):
         return self._inst_settings.tt_mode
 

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -52,10 +52,6 @@ class Polaris(AbstractInst):
                 ws_to_correct=ws_to_correct, multiple_scattering=self._inst_settings.multiple_scattering,
                 sample_details_obj=self._sample_details)
 
-    @staticmethod
-    def _can_auto_gen_vanadium_cal():
-        return True
-
     def _crop_banks_to_user_tof(self, focused_banks):
         return common.crop_banks_using_crop_list(focused_banks, self._inst_settings.focused_cropping_values)
 
@@ -68,9 +64,6 @@ class Polaris(AbstractInst):
         cropped_ws = common.crop_banks_using_crop_list(bank_list=van_ws_to_crop,
                                                        crop_values_list=self._inst_settings.van_crop_values)
         return cropped_ws
-
-    def _generate_auto_vanadium_calibration(self, run_details):
-        self.create_vanadium(run_in_range=run_details.run_number)
 
     @staticmethod
     def _generate_input_file_name(run_number):

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -124,11 +124,6 @@ def _individual_run_focusing(instrument, perform_vanadium_norm, run_number, abso
 def _test_splined_vanadium_exists(instrument, run_details):
     # Check the necessary splined vanadium file has been created
     if not os.path.isfile(run_details.splined_vanadium_file_path):
-        if instrument._can_auto_gen_vanadium_cal():
-            warnings.warn("\nAttempting to automatically generate vanadium calibration at this path: "
-                          + str(run_details.splined_vanadium_file_path) + " for these settings.\n")
-            instrument._generate_auto_vanadium_calibration(run_details=run_details)
-        else:
-            raise ValueError("Processed vanadium runs not found at this path: "
-                             + str(run_details.splined_vanadium_file_path) +
-                             " \nHave you created a vanadium calibration with these settings yet?\n")
+        raise ValueError("Processed vanadium runs not found at this path: "
+                         + str(run_details.splined_vanadium_file_path) +
+                         " \nHave you run the method to create a Vanadium spline with these settings yet?\n")

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -5,7 +5,6 @@ import mantid.simpleapi as mantid
 import isis_powder.routines.common as common
 from isis_powder.routines.common_enums import INPUT_BATCHING
 import os
-import warnings
 
 
 def focus(run_number_string, instrument, perform_vanadium_norm, absorb):


### PR DESCRIPTION
Description of work.
This PR removes a small step of ISIS Powder to create a Vanadium spline if one was not found whilst focusing. This has been a source of bugs and confusion. Currently it is also broken hence this is the best time to remove it

**To test:**
- Delete any existing Vanadium spline from the Calibration folder
- Run Focus with Polaris data set 
- Ensure a sane error message is thrown

Fixes #20225 

**Release Notes** 
*Does not need to be in the release notes. - This only was used on one instrument who didn't know it existed*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
