### PR TITLE
Fix -Wpessimizing-move warning.

### DIFF
--- a/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp
@@ -54,8 +54,8 @@ void clearPositionAndRotationParameters(ParameterMap *pmap,
  */
 InstrumentVisitor::InstrumentVisitor(
     boost::shared_ptr<const Instrument> instrument)
-    : m_orderedDetectorIds(boost::make_shared<std::vector<detid_t>>(std::move(
-          instrument->getDetectorIDs(false /*Do not skip monitors*/)))),
+    : m_orderedDetectorIds(boost::make_shared<std::vector<detid_t>>(
+          instrument->getDetectorIDs(false /*Do not skip monitors*/))),
       m_componentIds(boost::make_shared<std::vector<ComponentID>>(
           m_orderedDetectorIds->size(), nullptr)),
       m_assemblySortedDetectorIndices(


### PR DESCRIPTION
Description of work.

This fixes a warning found with a later version of AppleClang

```
[313/3456] Building CXX object Framework/Geometry/CMakeFiles/Geometry.dir/src/Instrument/InstrumentVisitor.cpp.o
/Users/svh/Documents/MantidProject/mantid/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp:57:69: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
    : m_orderedDetectorIds(boost::make_shared<std::vector<detid_t>>(std::move(
                                                                    ^
/Users/svh/Documents/MantidProject/mantid/Framework/Geometry/src/Instrument/InstrumentVisitor.cpp:57:69: note: remove std::move call here
    : m_orderedDetectorIds(boost::make_shared<std::vector<detid_t>>(std::move(
                                                                    ^~~~~~~~~~
1 warning generated.
```

**To test:**

<!-- Instructions for testing. -->

If the builds pass :squirrel:

There is no GitHub issue associated with this pull request.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
