### PR TITLE
LoadIsawDetCal and SNAP East and West

### DIFF
--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -461,20 +461,6 @@ void LoadIsawDetCal::doRotation(V3D rX, V3D rY, ComponentInfo &componentInfo,
   // Then find the corresponding relative position
   const auto componentIndex = componentInfo.indexOf(comp->getComponentID());
 
-  if (componentInfo.hasParent(componentIndex)) {
-    const auto parentIndex = componentInfo.parent(componentIndex);
-    auto rot0 = componentInfo.relativeRotation(parentIndex);
-    rot0.inverse();
-    Rot *= rot0;
-
-    if (componentInfo.hasParent(parentIndex)) {
-      const auto grandParentIndex = componentInfo.parent(parentIndex);
-      auto rot0 = componentInfo.relativeRotation(grandParentIndex);
-      rot0.inverse();
-      Rot *= rot0;
-    }
-  }
-
   componentInfo.setRotation(componentIndex, Rot);
 }
 

--- a/docs/source/release/v3.11.0/diffraction.rst
+++ b/docs/source/release/v3.11.0/diffraction.rst
@@ -9,6 +9,7 @@ Crystal Improvements
 --------------------
 
 - :ref:`SCDCalibratePanels <algm-SCDCalibratePanels>` now adjusts the sample offsets and has an option to optimize the initial time-of-flight for better calibration of single crystal data.
+- :ref:`LoadIsawDetCal <algm-LoadIsawDetCal>` has not correctly aligned the detectors for SNAP since release 3.9. This bug that only impacted SNAP has been fixed.
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
Description of work.
Get LoadIsawDetCal working for SNAP

**To test:**
```python
Load(Filename='/SNAP_30466_event.nxs', OutputWorkspace='SNAP_30466_event')
SaveIsawDetCal(InputWorkspace='SNAP_30466_event', Filename='snap.DetCal')
LoadIsawDetCal(InputWorkspace='SNAP_30466_event', Filename='snap.DetCal')
```
Show instrument before and after LoadIsawDetCal and check that they are the same.

Fixes #20232

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
