### PR TITLE
Fix issue in LoadFlexiNexus breaking VISION reduction.

### DIFF
--- a/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -334,9 +334,17 @@ void LoadFlexiNexus::addMetaData(NeXus::File *fin, Workspace_sptr ws,
       sample = it->second;
     } else {
       if (safeOpenpath(fin, it->second)) {
-        sample = fin->getStrData();
+        Info inf = fin->getInfo();
+        if (inf.dims.size() == 1) {
+          sample = fin->getStrData();
+        } else { // something special for 2-d array
+          std::vector<char> val_array;
+          fin->getData(val_array);
+          fin->closeData();
+          sample = std::string(val_array.begin(), val_array.end());
+        }
       } else {
-        sample = "Sampe plath not found";
+        sample = "Sample path not found";
       }
     }
   }


### PR DESCRIPTION
Description of work.

`LoadFlexiNexus` suffers the same issues with 2d character arrays for sample names as `LoadEventNexus`. This applies the same workaround added in #19995.

**To test:**

<!-- Instructions for testing. -->

run LoadFlexiNexus with `/SNS/VIS/IPTS-18972/nexus/VIS_32879.nxs.h5` and `/opt/mantidnightly/instrument/nexusdictionaries/vision-bank15.dic`

There is no GitHub issue associated with this pull request.

**Release Notes** 

*Does not need to be in the release notes.* Support for 2d character arrays for sample names was already announced in Mantid v3.10.1.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
