### PR TITLE
Enforce the associative property for ProductFunction

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -10,6 +10,7 @@ set ( SRC_FILES
 	src/AlgorithmProxy.cpp
 	src/AnalysisDataService.cpp
 	src/ArchiveSearchFactory.cpp
+	src/AssociativeCompositeFunction.cpp
 	src/Axis.cpp
 	src/BinEdgeAxis.cpp
 	src/BoxController.cpp
@@ -169,6 +170,7 @@ set ( INC_FILES
 	inc/MantidAPI/AlgorithmProxy.h
 	inc/MantidAPI/AnalysisDataService.h
 	inc/MantidAPI/ArchiveSearchFactory.h
+	inc/MantidAPI/AssociativeCompositeFunction.h
 	inc/MantidAPI/Axis.h
 	inc/MantidAPI/BinEdgeAxis.h
 	inc/MantidAPI/BoxController.h
@@ -358,6 +360,7 @@ set ( TEST_FILES
 	AlgorithmMPITest.h
 	AlgorithmTest.h
 	AnalysisDataServiceTest.h
+	AssociativeCompositeFunctionTest.h
 	AsynchronousTest.h
 	BinEdgeAxisTest.h
 	BoxControllerTest.h

--- a/Framework/API/inc/MantidAPI/AssociativeCompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/AssociativeCompositeFunction.h
@@ -1,0 +1,57 @@
+#ifndef MANTID_API_ASSOCIATIVECOMPOSITEFUNCTION_H_
+#define MANTID_API_ASSOCIATIVECOMPOSITEFUNCTION_H_
+
+#include "MantidAPI/CompositeFunction.h"
+
+namespace Mantid {
+    namespace API {
+/** Subclass of CompositeFunction that enforces the associative property. If ASF
+   denotes the composition operation, then:
+   ASF(ASF(f,g), h) == ASF(f, ASF(g, h)) == ASF(f, g, h)
+
+    @author Jose Borreguero, NScD Oak Ridge
+    @date 2017/08/15
+
+    Copyright &copy; 2009 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+    National Laboratory & European Spallation Source
+
+    This file is part of Mantid.
+
+    Mantid is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Mantid is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    File change history is stored at: <https://github.com/mantidproject/mantid>.
+    Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport AssociativeCompositeFunction : public CompositeFunction {
+public:
+    std::string name() const override { return "AssociativeCompositeFunction"; }
+
+    /// Mechanism to ascertain if the component function of
+    /// function f are to be separately treated
+    bool virtual isAssociative(IFunction_sptr f) const = 0;
+
+    /// Add a function at the back of the internal function list
+    virtual size_t addFunction(IFunction_sptr f) override;
+
+    /// Insert a function at a given index in the vector of component functions
+    void insertFunction(size_t i, IFunction_sptr f);
+
+    /// Replace a function
+    void replaceFunction(size_t i, IFunction_sptr f);
+};
+
+} // namespace API
+} // namespace Mantid
+
+#endif /*MANTID_API_ASSOCIATIVECOMPOSITEFUNCTION_H_*/

--- a/Framework/API/inc/MantidAPI/AssociativeCompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/AssociativeCompositeFunction.h
@@ -37,8 +37,8 @@ class DLLExport AssociativeCompositeFunction : public CompositeFunction {
 public:
     std::string name() const override { return "AssociativeCompositeFunction"; }
 
-    /// Mechanism to ascertain if the component function of
-    /// function f are to be separately treated
+    /// Mechanism to ascertain if the component functions of function f
+    /// are to be separately incorporated. Subclasses must override.
     bool virtual isAssociative(IFunction_sptr f) const = 0;
 
     /// Add a function at the back of the internal function list

--- a/Framework/API/inc/MantidAPI/AssociativeCompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/AssociativeCompositeFunction.h
@@ -4,7 +4,7 @@
 #include "MantidAPI/CompositeFunction.h"
 
 namespace Mantid {
-    namespace API {
+namespace API {
 /** Subclass of CompositeFunction that enforces the associative property. If ASF
    denotes the composition operation, then:
    ASF(ASF(f,g), h) == ASF(f, ASF(g, h)) == ASF(f, g, h)
@@ -35,20 +35,20 @@ namespace Mantid {
 */
 class DLLExport AssociativeCompositeFunction : public CompositeFunction {
 public:
-    std::string name() const override { return "AssociativeCompositeFunction"; }
+  std::string name() const override { return "AssociativeCompositeFunction"; }
 
-    /// Mechanism to ascertain if the component functions of function f
-    /// are to be separately incorporated. Subclasses must override.
-    bool virtual isAssociative(IFunction_sptr f) const = 0;
+  /// Mechanism to ascertain if the component functions of function f
+  /// are to be separately incorporated. Subclasses must override.
+  bool virtual isAssociative(IFunction_sptr f) const = 0;
 
-    /// Add a function at the back of the internal function list
-    virtual size_t addFunction(IFunction_sptr f) override;
+  /// Add a function at the back of the internal function list
+  virtual size_t addFunction(IFunction_sptr f) override;
 
-    /// Insert a function at a given index in the vector of component functions
-    void insertFunction(size_t idx, IFunction_sptr f);
+  /// Insert a function at a given index in the vector of component functions
+  void insertFunction(size_t idx, IFunction_sptr f);
 
-    /// Replace a function at a given index in the vector of component functions
-    void replaceFunction(size_t idx, IFunction_sptr f);
+  /// Replace a function at a given index in the vector of component functions
+  void replaceFunction(size_t idx, IFunction_sptr f);
 };
 
 } // namespace API

--- a/Framework/API/inc/MantidAPI/AssociativeCompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/AssociativeCompositeFunction.h
@@ -45,10 +45,10 @@ public:
     virtual size_t addFunction(IFunction_sptr f) override;
 
     /// Insert a function at a given index in the vector of component functions
-    void insertFunction(size_t i, IFunction_sptr f);
+    void insertFunction(size_t idx, IFunction_sptr f);
 
-    /// Replace a function
-    void replaceFunction(size_t i, IFunction_sptr f);
+    /// Replace a function at a given index in the vector of component functions
+    void replaceFunction(size_t idx, IFunction_sptr f);
 };
 
 } // namespace API

--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -19,7 +19,7 @@ namespace API {
    the member functions.
     Functions are added to a composite functions with addFunction method and can
    be retrieved with
-    getFinction(i) method. Function indices are defined by the order they are
+    getFunction(i) method. Function indices are defined by the order they are
    added. Parameter names
     are formed from the member function's index and its parameter name:
    f[index].[name]. For example,

--- a/Framework/API/inc/MantidAPI/CompositeFunction.h
+++ b/Framework/API/inc/MantidAPI/CompositeFunction.h
@@ -163,6 +163,8 @@ public:
   std::size_t nFunctions() const { return m_functions.size(); }
   /// Remove a function
   void removeFunction(size_t i);
+  /// Insert a function at a given index in the vector of component functions
+  void insertFunction(size_t i, IFunction_sptr f);
   /// Replace a function
   void replaceFunction(size_t i, IFunction_sptr f);
   /// Replace a function

--- a/Framework/API/src/AssociativeCompositeFunction.cpp
+++ b/Framework/API/src/AssociativeCompositeFunction.cpp
@@ -20,44 +20,45 @@ Kernel::Logger g_log("AssociativeCompositeFunction");
  * @return The index of the last added function
  */
 std::size_t AssociativeCompositeFunction::addFunction(IFunction_sptr f) {
-    if (isAssociative(f)) {
-        auto fa = boost::dynamic_pointer_cast<AssociativeCompositeFunction>(f);
-        for(std::size_t i=0; i < fa->nFunctions(); i++) {
-            CompositeFunction::addFunction(fa->getFunction(i));
-        }
-    } else {
-        CompositeFunction::addFunction(f);
+  if (isAssociative(f)) {
+    auto fa = boost::dynamic_pointer_cast<AssociativeCompositeFunction>(f);
+    for (std::size_t i = 0; i < fa->nFunctions(); i++) {
+      CompositeFunction::addFunction(fa->getFunction(i));
     }
-    return nFunctions() - 1;
+  } else {
+    CompositeFunction::addFunction(f);
+  }
+  return nFunctions() - 1;
 }
 
 /** Insert a function at a given index in the vector of component functions
  *  @param idx :: The index assigned to the new function.
  *  @param f :: A pointer to the new function
  */
-void AssociativeCompositeFunction::insertFunction(size_t idx, IFunction_sptr f) {
-    if (isAssociative(f)) {
-        auto fa = boost::dynamic_pointer_cast<AssociativeCompositeFunction>(f);
-        for(std::size_t i=0; i < fa->nFunctions(); i++) {
-            CompositeFunction::insertFunction(idx+i, fa->getFunction(i));
-        }
-    } else {
-        CompositeFunction::insertFunction(idx, f);
+void AssociativeCompositeFunction::insertFunction(size_t idx,
+                                                  IFunction_sptr f) {
+  if (isAssociative(f)) {
+    auto fa = boost::dynamic_pointer_cast<AssociativeCompositeFunction>(f);
+    for (std::size_t i = 0; i < fa->nFunctions(); i++) {
+      CompositeFunction::insertFunction(idx + i, fa->getFunction(i));
     }
+  } else {
+    CompositeFunction::insertFunction(idx, f);
+  }
 }
 
 /** Replace a function with a new one. The old function is deleted.
  * @param idx :: The index of the function to replace
  * @param f :: A pointer to the new function
  */
-void AssociativeCompositeFunction::replaceFunction(size_t idx, IFunction_sptr f) {
-    if (isAssociative(f)) {
-        removeFunction(idx);
-        insertFunction(idx, f);
-    } else {
-        CompositeFunction::replaceFunction(idx, f);
-    }
+void AssociativeCompositeFunction::replaceFunction(size_t idx,
+                                                   IFunction_sptr f) {
+  if (isAssociative(f)) {
+    removeFunction(idx);
+    insertFunction(idx, f);
+  } else {
+    CompositeFunction::replaceFunction(idx, f);
+  }
 }
-
 }
 }

--- a/Framework/API/src/AssociativeCompositeFunction.cpp
+++ b/Framework/API/src/AssociativeCompositeFunction.cpp
@@ -11,20 +11,24 @@ namespace {
 Kernel::Logger g_log("AssociativeCompositeFunction");
 }
 
-DECLARE_FUNCTION(AssociativeCompositeFunction)
+/** We do not declare this function, since it is pure virtual
+ * DECLARE_FUNCTION(AssociativeCompositeFunction)
+*/
 
 /** Add a function to the end of the vector of component functions
  * @param f :: A pointer to the added function
- * @return The function index
+ * @return The index of the last added function
  */
 std::size_t AssociativeCompositeFunction::addFunction(IFunction_sptr f) {
     if (isAssociative(f)) {
-        for (auto g : f->m_functions){
-            CompositeFunction::addFunction(g);
+        auto fa = boost::dynamic_pointer_cast<AssociativeCompositeFunction>(f);
+        for(std::size_t i=0; i < fa->nFunctions(); i++) {
+            CompositeFunction::addFunction(fa->getFunction(i));
         }
     } else {
         CompositeFunction::addFunction(f);
     }
+    return nFunctions() - 1;
 }
 
 /** Insert a function at a given index in the vector of component functions
@@ -33,8 +37,9 @@ std::size_t AssociativeCompositeFunction::addFunction(IFunction_sptr f) {
  */
 void AssociativeCompositeFunction::insertFunction(size_t i, IFunction_sptr f) {
     if (isAssociative(f)) {
-        for (auto g : f->m_functions){
-            CompositeFunction::insertFunction(i, g);
+        auto fa = boost::dynamic_pointer_cast<AssociativeCompositeFunction>(f);
+        for(std::size_t i=0; i < fa->nFunctions(); i++) {
+            CompositeFunction::insertFunction(i, fa->getFunction(i));
         }
     } else {
         CompositeFunction::insertFunction(i, f);
@@ -48,7 +53,7 @@ void AssociativeCompositeFunction::insertFunction(size_t i, IFunction_sptr f) {
 void AssociativeCompositeFunction::replaceFunction(size_t i, IFunction_sptr f) {
     if (isAssociative(f)) {
         removeFunction(i);
-        insertFunction(i, g);
+        insertFunction(i, f);
     } else {
         CompositeFunction::replaceFunction(i, f);
     }

--- a/Framework/API/src/AssociativeCompositeFunction.cpp
+++ b/Framework/API/src/AssociativeCompositeFunction.cpp
@@ -1,0 +1,58 @@
+#include "MantidAPI/AssociativeCompositeFunction.h"
+#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidKernel/Logger.h"
+
+namespace Mantid {
+namespace API {
+
+namespace {
+/// static logger
+Kernel::Logger g_log("AssociativeCompositeFunction");
+}
+
+DECLARE_FUNCTION(AssociativeCompositeFunction)
+
+/** Add a function to the end of the vector of component functions
+ * @param f :: A pointer to the added function
+ * @return The function index
+ */
+std::size_t AssociativeCompositeFunction::addFunction(IFunction_sptr f) {
+    if (isAssociative(f)) {
+        for (auto g : f->m_functions){
+            CompositeFunction::addFunction(g);
+        }
+    } else {
+        CompositeFunction::addFunction(f);
+    }
+}
+
+/** Insert a function at a given index in the vector of component functions
+ *  @param i :: The index assigned to the new function.
+ *  @param f :: A pointer to the new function
+ */
+void AssociativeCompositeFunction::insertFunction(size_t i, IFunction_sptr f) {
+    if (isAssociative(f)) {
+        for (auto g : f->m_functions){
+            CompositeFunction::insertFunction(i, g);
+        }
+    } else {
+        CompositeFunction::insertFunction(i, f);
+    }
+}
+
+/** Replace a function with a new one. The old function is deleted.
+ * @param i :: The index of the function to replace
+ * @param f :: A pointer to the new function
+ */
+void AssociativeCompositeFunction::replaceFunction(size_t i, IFunction_sptr f) {
+    if (isAssociative(f)) {
+        removeFunction(i);
+        insertFunction(i, g);
+    } else {
+        CompositeFunction::replaceFunction(i, f);
+    }
+}
+
+}
+}

--- a/Framework/API/src/AssociativeCompositeFunction.cpp
+++ b/Framework/API/src/AssociativeCompositeFunction.cpp
@@ -32,30 +32,30 @@ std::size_t AssociativeCompositeFunction::addFunction(IFunction_sptr f) {
 }
 
 /** Insert a function at a given index in the vector of component functions
- *  @param i :: The index assigned to the new function.
+ *  @param idx :: The index assigned to the new function.
  *  @param f :: A pointer to the new function
  */
-void AssociativeCompositeFunction::insertFunction(size_t i, IFunction_sptr f) {
+void AssociativeCompositeFunction::insertFunction(size_t idx, IFunction_sptr f) {
     if (isAssociative(f)) {
         auto fa = boost::dynamic_pointer_cast<AssociativeCompositeFunction>(f);
         for(std::size_t i=0; i < fa->nFunctions(); i++) {
-            CompositeFunction::insertFunction(i, fa->getFunction(i));
+            CompositeFunction::insertFunction(idx+i, fa->getFunction(i));
         }
     } else {
-        CompositeFunction::insertFunction(i, f);
+        CompositeFunction::insertFunction(idx, f);
     }
 }
 
 /** Replace a function with a new one. The old function is deleted.
- * @param i :: The index of the function to replace
+ * @param idx :: The index of the function to replace
  * @param f :: A pointer to the new function
  */
-void AssociativeCompositeFunction::replaceFunction(size_t i, IFunction_sptr f) {
+void AssociativeCompositeFunction::replaceFunction(size_t idx, IFunction_sptr f) {
     if (isAssociative(f)) {
-        removeFunction(i);
-        insertFunction(i, f);
+        removeFunction(idx);
+        insertFunction(idx, f);
     } else {
-        CompositeFunction::replaceFunction(i, f);
+        CompositeFunction::replaceFunction(idx, f);
     }
 }
 

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -461,7 +461,7 @@ void CompositeFunction::removeFunction(size_t i) {
  * @param f :: A pointer to the new function
  */
 void CompositeFunction::insertFunction(size_t i, IFunction_sptr f) {
-  auto old_nFunctions = nFunctions();  // number of functions before insertion
+  auto old_nFunctions = nFunctions(); // number of functions before insertion
   if (i >= old_nFunctions) {
     throw std::out_of_range("Function index (" + std::to_string(i) +
                             ") out of range (" + std::to_string(nFunctions()) +
@@ -476,8 +476,8 @@ void CompositeFunction::insertFunction(size_t i, IFunction_sptr f) {
   // Insert index for as many parameters owned by the new function
   size_t np_new = f->nParams();
   for (auto it = m_IFunction.begin(); it != m_IFunction.end(); it++) {
-    if (*it == i+1) {
-      m_IFunction.insert(it, np_new, i);  // insert right before
+    if (*it == i + 1) {
+      m_IFunction.insert(it, np_new, i); // insert right before
       break;
     }
   }

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -477,7 +477,7 @@ void CompositeFunction::insertFunction(size_t i, IFunction_sptr f) {
   size_t np_new = f->nParams();
   for (auto it = m_IFunction.begin(); it != m_IFunction.end(); it++) {
     if (*it == i+1) {
-      m_IFunction.insert(it - 1, np_new, i);  // insert right before
+      m_IFunction.insert(it, np_new, i);  // insert right before
       break;
     }
   }

--- a/Framework/API/test/AssociativeCompositeFunctionTest.h
+++ b/Framework/API/test/AssociativeCompositeFunctionTest.h
@@ -1,12 +1,15 @@
 #ifndef ASSOCIATIVECOMPOSITEFUNCTIONTEST_H_
 #define ASSOCIATIVECOMPOSITEFUNCTIONTEST_H_
 
+#include <string>
 #include <cxxtest/TestSuite.h>
+#include <boost/shared_array.hpp>
 
+#include "MantidAPI/IFunction.h"
 #include "MantidAPI/AssociativeCompositeFunction.h"
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/FunctionFactory.h"
-
+#include "MantidTestHelpers/FunctionTestHelper.h"
 
 using namespace Mantid;
 using namespace Mantid::API;
@@ -14,15 +17,20 @@ using namespace Mantid::API;
 
 /// Moc implementation of AssociativeCompositeFunction
 class AssociativeMoc : public AssociativeCompositeFunction {
+
 public:
+
     std::string name() const override { return "AssociativeMoc"; }
+
     bool isAssociative(API::IFunction_sptr f) const override {
-        if (boost::dynamic_pointer_cast<ProductFunction>(f)) {
+        if (boost::dynamic_pointer_cast<AssociativeMoc>(f)) {
             return true;
         }
         return false;
     }
+
 protected:
+
     /// overwrite IFunction base class method, which declare function parameters
     void init() override {};
 };
@@ -32,43 +40,144 @@ class AssociativeCompositeFunctionTest : public CxxTest::TestSuite {
 
 public:
 
+    /*
+     * Boilerplate
+     */
     static AssociativeCompositeFunctionTest *createSuite() {
         return new AssociativeCompositeFunctionTest();
     }
 
     static void destroySuite(AssociativeCompositeFunctionTest *suite) { delete suite; }
 
-    AssociativeCompositeFunctionTest(){
-        initializeFunctions();
-    };
+    /// Set up
+    AssociativeCompositeFunctionTest() : m_f() {
+        FunctionFactory::Instance().subscribe<Gauss>("Gauss");
+        FunctionFactory::Instance().subscribe<Linear>("Linear");
+        FunctionFactory::Instance().subscribe<Cubic>("Cubic");
+        FunctionFactory::Instance().subscribe<AssociativeMoc>("AssociativeMoc");
+        initializeMocFunctions();
+    }
 
-    testInitialization() {
-        // prod3 is a product within a product. It should become a product with three components
-        TS_ASSERT_EQUALS(m_f["prod3"]->asString(), "");
+    /// Tear down
+    ~AssociativeCompositeFunctionTest() override {
+        FunctionFactory::Instance().unsubscribe("Gauss");
+        FunctionFactory::Instance().unsubscribe("Linear");
+        FunctionFactory::Instance().unsubscribe("Cubic");
+        FunctionFactory::Instance().unsubscribe("AssociativeMoc");
+    }
+
+    /**
+     * Tests begin here
+     */
+
+    void testInitialization() {
+        std::string s("composite=AssociativeMoc,NumDeriv=false;" \
+                      "name=Linear,a=0,b=0;" \
+                      "name=Gauss,c=0,h=1,s=1;" \
+                      "name=Cubic,c0=0,c1=0,c2=0,c3=0");
+        TS_ASSERT_EQUALS(m_f["moc4"]->asString(), s);
+        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
+                 "name=Linear,a=0,b=0;" \
+                 "name=Gauss,c=0,h=1,s=1;" \
+                 "name=Cubic,c0=0,c1=0,c2=0,c3=0;" \
+                 "name=Linear,a=0,b=0");
+        TS_ASSERT_EQUALS(m_f["moc5"]->asString(), s);
+    }
+
+    void testAddFunction() {
+        auto f = functionAssociativeInitialized("(name=AssociativeMoc)");
+        f->addFunction(m_f["line"]);
+        TS_ASSERT_EQUALS(f->asString(), "composite=AssociativeMoc,NumDeriv=false;name=Linear,a=0,b=0");
+        f->addFunction(m_f["comp"]);
+        // "comp" does not unroll, it's not associative
+        std::string s("composite=AssociativeMoc,NumDeriv=false;" \
+                      "name=Linear,a=0,b=0;" \
+                      "(name=Gauss,c=0,h=1,s=1;name=Cubic,c0=0,c1=0,c2=0,c3=0)");
+        TS_ASSERT_EQUALS(f->asString(), s);
+        f->addFunction(m_f["moc2"]);
+        s.append(";name=Linear,a=0,b=0");
+        TS_ASSERT_EQUALS(f->asString(), s);
+        f->addFunction(m_f["moc3"]);
+        s.append(";name=Gauss,c=0,h=1,s=1;" \
+                 "name=Cubic,c0=0,c1=0,c2=0,c3=0");  // moc3 is unrolled
+        TS_ASSERT_EQUALS(f->asString(), s);
+    }
+
+    void testInsertFunction() {
+        std::string s("(composite=AssociativeMoc;name=Gauss;name=Cubic)");
+        auto f = functionAssociativeInitialized(s);
+        f->insertFunction(1, m_f["line"]);  // insert Linear before Cubic
+        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
+                 "name=Gauss,c=0,h=1,s=1;" \
+                 "name=Linear,a=0,b=0;" \
+                 "name=Cubic,c0=0,c1=0,c2=0,c3=0");
+        TS_ASSERT_EQUALS(f->asString(), s);
+        f->insertFunction(2, m_f["moc2"]);  // insert moc2 (Linear) before Cubic
+        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
+                 "name=Gauss,c=0,h=1,s=1;" \
+                 "name=Linear,a=0,b=0;" \
+                 "name=Linear,a=0,b=0;" \
+                 "name=Cubic,c0=0,c1=0,c2=0,c3=0");
+        //TS_ASSERT_EQUALS(f->asString(), s);
+        f->insertFunction(3, m_f["moc3"]);  // insert moc3 (Gauss * Cubic) before Cubic
+        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
+                 "name=Gauss,c=0,h=1,s=1;" \
+                 "name=Linear,a=0,b=0;" \
+                 "name=Linear,a=0,b=0;" \
+                 "name=Gauss,c=0,h=1,s=1;" \
+                 "name=Cubic,c0=0,c1=0,c2=0,c3=0;" \
+                 "name=Cubic,c0=0,c1=0,c2=0,c3=0");
+        //TS_ASSERT_EQUALS(f->asString(), s);
+    }
+
+    void testReplaceFunction() {
+        std::string s("(composite=AssociativeMoc;name=Gauss;name=Cubic)");
+        auto f = functionAssociativeInitialized(s);
+        f->replaceFunction(1, m_f["line"]);
+        //TS_ASSERT_EQUALS(f->asString(), s);
+        f->addFunction(m_f["comp"]);
+        //TS_ASSERT_EQUALS(f->asString(), s);
+        f->replaceFunction(0, m_f["moc2"]);
+        //TS_ASSERT_EQUALS(f->asString(), s);
+        f->insertFunction(1, m_f["moc3"]);
+        //TS_ASSERT_EQUALS(f->asString(), s);
     }
 
 private:
     // Initialize some functions that we'll use in the tests
-    void initializeFunctions() {
-        // aliases to certain function
+    void initializeMocFunctions() {
+        // aliases to certain functions
         std::map<std::string, std::string> aliases = {
-            {"exp", "name=ExpDecay"},
-            {"lin", "name=LinearBackground"},
-            {"comp", "name=Lorentzian;name=InelasticDiffSphere"},
-            {"conv", "(composite=Convolution;name=Resolution,X=(3.0,3.1),Y=(3.2,3.3);"
-                             "name=DeltaFunction)"},
-            {"prod1", "(name=AssociativeMoc)"},
-            {"prod2", "(composite=AssociativeMoc;name=ExpDecay;name=FlatBackground)"},
-            {"prod3", "(composite=AssociativeMoc;name=ExpDecay;"
-                              "(composite=ProductFunction;name=Gaussian;name=Quadratic))"}
+            {"line", "name=Linear"},
+            {"comp", "name=Gauss;name=Cubic"},
+            {"moc1", "(name=AssociativeMoc)"},
+            {"moc2", "(composite=AssociativeMoc;name=Linear)"},
+            // moc3 = Gauss * Linear
+            {"moc3", "(composite=AssociativeMoc;name=Gauss;name=Cubic)"},
+            // moc4 = Gauss * (Linear * Cubic)
+            {"moc4", "(composite=AssociativeMoc;name=Linear;"
+                        "(composite=AssociativeMoc;name=Gauss;name=Cubic))"},
+            // moc5 = (Gauss * Linear) * (Cubic * Gauss)
+            {"moc5", "(composite=AssociativeMoc;" \
+                     "(composite=AssociativeMoc;name=Linear;name=Gauss);" \
+                     "(composite=AssociativeMoc;name=Cubic;name=Linear))"},
         };
-        // Create the function objects
         for (auto& kv : aliases) {
-            m_f[kv.first] = FunctionFactory::Instance().createInitialized(kv.second);
+            //m_f[kv.first] = FunctionFactory::Instance().createInitialized(kv.second);
+            m_f.insert(std::pair<std::string, IFunction_sptr>(kv.first,
+               FunctionFactory::Instance().createInitialized(kv.second)));
         }
     }
+
+    boost::shared_ptr<AssociativeMoc> functionAssociativeInitialized(const std::string &s) {
+        auto f = FunctionFactory::Instance().createInitialized(s);
+        return boost::dynamic_pointer_cast<AssociativeMoc>(f);
+    }
+
     // a map containing aliases to function pointers
-    std::map<std::string, std::string> m_f;
-};
+    std::map<std::string, IFunction_sptr> m_f;
+
+};  /* class AssociativeCompositeFunctionTest */
+
 #endif /*ASSOCIATIVECOMPOSITEFUNCTIONTEST_H_*/
 

--- a/Framework/API/test/AssociativeCompositeFunctionTest.h
+++ b/Framework/API/test/AssociativeCompositeFunctionTest.h
@@ -14,179 +14,181 @@
 using namespace Mantid;
 using namespace Mantid::API;
 
-
 /// Moc implementation of AssociativeCompositeFunction
 class AssociativeMoc : public AssociativeCompositeFunction {
 
 public:
+  std::string name() const override { return "AssociativeMoc"; }
 
-    std::string name() const override { return "AssociativeMoc"; }
-
-    bool isAssociative(API::IFunction_sptr f) const override {
-        if (boost::dynamic_pointer_cast<AssociativeMoc>(f)) {
-            return true;
-        }
-        return false;
+  bool isAssociative(API::IFunction_sptr f) const override {
+    if (boost::dynamic_pointer_cast<AssociativeMoc>(f)) {
+      return true;
     }
+    return false;
+  }
 
 protected:
-
-    /// overwrite IFunction base class method, which declare function parameters
-    void init() override {};
+  /// overwrite IFunction base class method, which declare function parameters
+  void init() override{};
 };
-
 
 class AssociativeCompositeFunctionTest : public CxxTest::TestSuite {
 
 public:
+  /*
+   * Boilerplate
+   */
+  static AssociativeCompositeFunctionTest *createSuite() {
+    return new AssociativeCompositeFunctionTest();
+  }
 
-    /*
-     * Boilerplate
-     */
-    static AssociativeCompositeFunctionTest *createSuite() {
-        return new AssociativeCompositeFunctionTest();
-    }
+  static void destroySuite(AssociativeCompositeFunctionTest *suite) {
+    delete suite;
+  }
 
-    static void destroySuite(AssociativeCompositeFunctionTest *suite) { delete suite; }
+  /// Set up
+  AssociativeCompositeFunctionTest() : m_f() {
+    FunctionFactory::Instance().subscribe<Gauss>("Gauss");
+    FunctionFactory::Instance().subscribe<Linear>("Linear");
+    FunctionFactory::Instance().subscribe<Cubic>("Cubic");
+    FunctionFactory::Instance().subscribe<AssociativeMoc>("AssociativeMoc");
+    initializeMocFunctions();
+  }
 
-    /// Set up
-    AssociativeCompositeFunctionTest() : m_f() {
-        FunctionFactory::Instance().subscribe<Gauss>("Gauss");
-        FunctionFactory::Instance().subscribe<Linear>("Linear");
-        FunctionFactory::Instance().subscribe<Cubic>("Cubic");
-        FunctionFactory::Instance().subscribe<AssociativeMoc>("AssociativeMoc");
-        initializeMocFunctions();
-    }
+  /// Tear down
+  ~AssociativeCompositeFunctionTest() override {
+    FunctionFactory::Instance().unsubscribe("Gauss");
+    FunctionFactory::Instance().unsubscribe("Linear");
+    FunctionFactory::Instance().unsubscribe("Cubic");
+    FunctionFactory::Instance().unsubscribe("AssociativeMoc");
+  }
 
-    /// Tear down
-    ~AssociativeCompositeFunctionTest() override {
-        FunctionFactory::Instance().unsubscribe("Gauss");
-        FunctionFactory::Instance().unsubscribe("Linear");
-        FunctionFactory::Instance().unsubscribe("Cubic");
-        FunctionFactory::Instance().unsubscribe("AssociativeMoc");
-    }
+  /**
+   * Tests begin here
+   */
 
-    /**
-     * Tests begin here
-     */
+  void testInitialization() {
+    std::string s("composite=AssociativeMoc,NumDeriv=false;"
+                  "name=Linear,a=0,b=0;"
+                  "name=Gauss,c=0,h=1,s=1;"
+                  "name=Cubic,c0=0,c1=0,c2=0,c3=0");
+    TS_ASSERT_EQUALS(m_f["moc4"]->asString(), s);
+    s.assign("composite=AssociativeMoc,NumDeriv=false;"
+             "name=Linear,a=0,b=0;"
+             "name=Gauss,c=0,h=1,s=1;"
+             "name=Cubic,c0=0,c1=0,c2=0,c3=0;"
+             "name=Linear,a=0,b=0");
+    TS_ASSERT_EQUALS(m_f["moc5"]->asString(), s);
+  }
 
-    void testInitialization() {
-        std::string s("composite=AssociativeMoc,NumDeriv=false;" \
-                      "name=Linear,a=0,b=0;" \
-                      "name=Gauss,c=0,h=1,s=1;" \
-                      "name=Cubic,c0=0,c1=0,c2=0,c3=0");
-        TS_ASSERT_EQUALS(m_f["moc4"]->asString(), s);
-        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
-                 "name=Linear,a=0,b=0;" \
-                 "name=Gauss,c=0,h=1,s=1;" \
-                 "name=Cubic,c0=0,c1=0,c2=0,c3=0;" \
-                 "name=Linear,a=0,b=0");
-        TS_ASSERT_EQUALS(m_f["moc5"]->asString(), s);
-    }
+  void testAddFunction() {
+    auto f = functionAssociativeInitialized("(name=AssociativeMoc)");
+    f->addFunction(m_f["line"]);
+    TS_ASSERT_EQUALS(
+        f->asString(),
+        "composite=AssociativeMoc,NumDeriv=false;name=Linear,a=0,b=0");
+    f->addFunction(m_f["comp"]);
+    // "comp" does not unroll, it's not associative
+    std::string s("composite=AssociativeMoc,NumDeriv=false;"
+                  "name=Linear,a=0,b=0;"
+                  "(name=Gauss,c=0,h=1,s=1;name=Cubic,c0=0,c1=0,c2=0,c3=0)");
+    TS_ASSERT_EQUALS(f->asString(), s);
+    f->addFunction(m_f["moc2"]);
+    s.append(";name=Linear,a=0,b=0");
+    TS_ASSERT_EQUALS(f->asString(), s);
+    f->addFunction(m_f["moc3"]);
+    s.append(";name=Gauss,c=0,h=1,s=1;"
+             "name=Cubic,c0=0,c1=0,c2=0,c3=0"); // moc3 is unrolled
+    TS_ASSERT_EQUALS(f->asString(), s);
+  }
 
-    void testAddFunction() {
-        auto f = functionAssociativeInitialized("(name=AssociativeMoc)");
-        f->addFunction(m_f["line"]);
-        TS_ASSERT_EQUALS(f->asString(), "composite=AssociativeMoc,NumDeriv=false;name=Linear,a=0,b=0");
-        f->addFunction(m_f["comp"]);
-        // "comp" does not unroll, it's not associative
-        std::string s("composite=AssociativeMoc,NumDeriv=false;" \
-                      "name=Linear,a=0,b=0;" \
-                      "(name=Gauss,c=0,h=1,s=1;name=Cubic,c0=0,c1=0,c2=0,c3=0)");
-        TS_ASSERT_EQUALS(f->asString(), s);
-        f->addFunction(m_f["moc2"]);
-        s.append(";name=Linear,a=0,b=0");
-        TS_ASSERT_EQUALS(f->asString(), s);
-        f->addFunction(m_f["moc3"]);
-        s.append(";name=Gauss,c=0,h=1,s=1;" \
-                 "name=Cubic,c0=0,c1=0,c2=0,c3=0");  // moc3 is unrolled
-        TS_ASSERT_EQUALS(f->asString(), s);
-    }
+  void testInsertFunction() {
+    std::string s("(composite=AssociativeMoc;name=Gauss;name=Cubic)");
+    auto f = functionAssociativeInitialized(s);
+    f->insertFunction(1, m_f["line"]); // insert Linear before Cubic
+    s.assign("composite=AssociativeMoc,NumDeriv=false;"
+             "name=Gauss,c=0,h=1,s=1;"
+             "name=Linear,a=0,b=0;"
+             "name=Cubic,c0=0,c1=0,c2=0,c3=0");
+    TS_ASSERT_EQUALS(f->asString(), s);
+    f->insertFunction(2, m_f["moc2"]); // insert moc2 (Linear) before Cubic
+    s.assign("composite=AssociativeMoc,NumDeriv=false;"
+             "name=Gauss,c=0,h=1,s=1;"
+             "name=Linear,a=0,b=0;"
+             "name=Linear,a=0,b=0;"
+             "name=Cubic,c0=0,c1=0,c2=0,c3=0");
+    TS_ASSERT_EQUALS(f->asString(), s);
+    f->insertFunction(3,
+                      m_f["moc3"]); // insert moc3 (Gauss * Cubic) before Cubic
+    s.assign("composite=AssociativeMoc,NumDeriv=false;"
+             "name=Gauss,c=0,h=1,s=1;"
+             "name=Linear,a=0,b=0;"
+             "name=Linear,a=0,b=0;"
+             "name=Gauss,c=0,h=1,s=1;"
+             "name=Cubic,c0=0,c1=0,c2=0,c3=0;"
+             "name=Cubic,c0=0,c1=0,c2=0,c3=0");
+    TS_ASSERT_EQUALS(f->asString(), s);
+  }
 
-    void testInsertFunction() {
-        std::string s("(composite=AssociativeMoc;name=Gauss;name=Cubic)");
-        auto f = functionAssociativeInitialized(s);
-        f->insertFunction(1, m_f["line"]);  // insert Linear before Cubic
-        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
-                 "name=Gauss,c=0,h=1,s=1;" \
-                 "name=Linear,a=0,b=0;" \
-                 "name=Cubic,c0=0,c1=0,c2=0,c3=0");
-        TS_ASSERT_EQUALS(f->asString(), s);
-        f->insertFunction(2, m_f["moc2"]);  // insert moc2 (Linear) before Cubic
-        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
-                 "name=Gauss,c=0,h=1,s=1;" \
-                 "name=Linear,a=0,b=0;" \
-                 "name=Linear,a=0,b=0;" \
-                 "name=Cubic,c0=0,c1=0,c2=0,c3=0");
-        TS_ASSERT_EQUALS(f->asString(), s);
-        f->insertFunction(3, m_f["moc3"]);  // insert moc3 (Gauss * Cubic) before Cubic
-        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
-                 "name=Gauss,c=0,h=1,s=1;" \
-                 "name=Linear,a=0,b=0;" \
-                 "name=Linear,a=0,b=0;" \
-                 "name=Gauss,c=0,h=1,s=1;" \
-                 "name=Cubic,c0=0,c1=0,c2=0,c3=0;" \
-                 "name=Cubic,c0=0,c1=0,c2=0,c3=0");
-        TS_ASSERT_EQUALS(f->asString(), s);
-    }
-
-    void testReplaceFunction() {
-        std::string s("(composite=AssociativeMoc;name=Gauss;name=Cubic)");
-        auto f = functionAssociativeInitialized(s);
-        f->replaceFunction(1, m_f["line"]);  // Replace Cubic with Linear
-        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
-                 "name=Gauss,c=0,h=1,s=1;" \
-                 "name=Linear,a=0,b=0");
-        TS_ASSERT_EQUALS(f->asString(), s);
-        f->replaceFunction(0, m_f["moc2"]);  // Replace Gauss with moc2 (Linear)
-        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
-                  "name=Linear,a=0,b=0;" \
-                  "name=Linear,a=0,b=0");
-        TS_ASSERT_EQUALS(f->asString(), s);
-        f->insertFunction(1, m_f["moc3"]);  // Replace second Linear with moc3 (Gauss * Cubic)
-        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
-                 "name=Linear,a=0,b=0;" \
-                 "name=Gauss,c=0,h=1,s=1;" \
-                 "name=Cubic,c0=0,c1=0,c2=0,c3=0;" \
-                 "name=Linear,a=0,b=0");
-        TS_ASSERT_EQUALS(f->asString(), s);
-    }
+  void testReplaceFunction() {
+    std::string s("(composite=AssociativeMoc;name=Gauss;name=Cubic)");
+    auto f = functionAssociativeInitialized(s);
+    f->replaceFunction(1, m_f["line"]); // Replace Cubic with Linear
+    s.assign("composite=AssociativeMoc,NumDeriv=false;"
+             "name=Gauss,c=0,h=1,s=1;"
+             "name=Linear,a=0,b=0");
+    TS_ASSERT_EQUALS(f->asString(), s);
+    f->replaceFunction(0, m_f["moc2"]); // Replace Gauss with moc2 (Linear)
+    s.assign("composite=AssociativeMoc,NumDeriv=false;"
+             "name=Linear,a=0,b=0;"
+             "name=Linear,a=0,b=0");
+    TS_ASSERT_EQUALS(f->asString(), s);
+    f->insertFunction(
+        1, m_f["moc3"]); // Replace second Linear with moc3 (Gauss * Cubic)
+    s.assign("composite=AssociativeMoc,NumDeriv=false;"
+             "name=Linear,a=0,b=0;"
+             "name=Gauss,c=0,h=1,s=1;"
+             "name=Cubic,c0=0,c1=0,c2=0,c3=0;"
+             "name=Linear,a=0,b=0");
+    TS_ASSERT_EQUALS(f->asString(), s);
+  }
 
 private:
-    // Initialize some functions that we'll use in the tests
-    void initializeMocFunctions() {
-        // aliases to certain functions
-        std::map<std::string, std::string> aliases = {
-            {"line", "name=Linear"},
-            {"comp", "name=Gauss;name=Cubic"},
-            {"moc1", "(name=AssociativeMoc)"},
-            {"moc2", "(composite=AssociativeMoc;name=Linear)"},
-            // moc3 = Gauss * Linear
-            {"moc3", "(composite=AssociativeMoc;name=Gauss;name=Cubic)"},
-            // moc4 = Gauss * (Linear * Cubic)
-            {"moc4", "(composite=AssociativeMoc;name=Linear;"
-                        "(composite=AssociativeMoc;name=Gauss;name=Cubic))"},
-            // moc5 = (Gauss * Linear) * (Cubic * Gauss)
-            {"moc5", "(composite=AssociativeMoc;" \
-                     "(composite=AssociativeMoc;name=Linear;name=Gauss);" \
-                     "(composite=AssociativeMoc;name=Cubic;name=Linear))"},
-        };
-        for (auto& kv : aliases) {
-            //m_f[kv.first] = FunctionFactory::Instance().createInitialized(kv.second);
-            m_f.insert(std::pair<std::string, IFunction_sptr>(kv.first,
-               FunctionFactory::Instance().createInitialized(kv.second)));
-        }
+  // Initialize some functions that we'll use in the tests
+  void initializeMocFunctions() {
+    // aliases to certain functions
+    std::map<std::string, std::string> aliases = {
+        {"line", "name=Linear"},
+        {"comp", "name=Gauss;name=Cubic"},
+        {"moc1", "(name=AssociativeMoc)"},
+        {"moc2", "(composite=AssociativeMoc;name=Linear)"},
+        // moc3 = Gauss * Linear
+        {"moc3", "(composite=AssociativeMoc;name=Gauss;name=Cubic)"},
+        // moc4 = Gauss * (Linear * Cubic)
+        {"moc4", "(composite=AssociativeMoc;name=Linear;"
+                 "(composite=AssociativeMoc;name=Gauss;name=Cubic))"},
+        // moc5 = (Gauss * Linear) * (Cubic * Gauss)
+        {"moc5", "(composite=AssociativeMoc;"
+                 "(composite=AssociativeMoc;name=Linear;name=Gauss);"
+                 "(composite=AssociativeMoc;name=Cubic;name=Linear))"},
+    };
+    for (auto &kv : aliases) {
+      // m_f[kv.first] =
+      // FunctionFactory::Instance().createInitialized(kv.second);
+      m_f.insert(std::pair<std::string, IFunction_sptr>(
+          kv.first, FunctionFactory::Instance().createInitialized(kv.second)));
     }
+  }
 
-    boost::shared_ptr<AssociativeMoc> functionAssociativeInitialized(const std::string &s) {
-        auto f = FunctionFactory::Instance().createInitialized(s);
-        return boost::dynamic_pointer_cast<AssociativeMoc>(f);
-    }
+  boost::shared_ptr<AssociativeMoc>
+  functionAssociativeInitialized(const std::string &s) {
+    auto f = FunctionFactory::Instance().createInitialized(s);
+    return boost::dynamic_pointer_cast<AssociativeMoc>(f);
+  }
 
-    // a map containing aliases to function pointers
-    std::map<std::string, IFunction_sptr> m_f;
+  // a map containing aliases to function pointers
+  std::map<std::string, IFunction_sptr> m_f;
 
-};  /* class AssociativeCompositeFunctionTest */
+}; /* class AssociativeCompositeFunctionTest */
 
 #endif /*ASSOCIATIVECOMPOSITEFUNCTIONTEST_H_*/
-

--- a/Framework/API/test/AssociativeCompositeFunctionTest.h
+++ b/Framework/API/test/AssociativeCompositeFunctionTest.h
@@ -1,0 +1,74 @@
+#ifndef ASSOCIATIVECOMPOSITEFUNCTIONTEST_H_
+#define ASSOCIATIVECOMPOSITEFUNCTIONTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AssociativeCompositeFunction.h"
+#include "MantidAPI/IFunction1D.h"
+#include "MantidAPI/FunctionFactory.h"
+
+
+using namespace Mantid;
+using namespace Mantid::API;
+
+
+/// Moc implementation of AssociativeCompositeFunction
+class AssociativeMoc : public AssociativeCompositeFunction {
+public:
+    std::string name() const override { return "AssociativeMoc"; }
+    bool isAssociative(API::IFunction_sptr f) const override {
+        if (boost::dynamic_pointer_cast<ProductFunction>(f)) {
+            return true;
+        }
+        return false;
+    }
+protected:
+    /// overwrite IFunction base class method, which declare function parameters
+    void init() override {};
+};
+
+
+class AssociativeCompositeFunctionTest : public CxxTest::TestSuite {
+
+public:
+
+    static AssociativeCompositeFunctionTest *createSuite() {
+        return new AssociativeCompositeFunctionTest();
+    }
+
+    static void destroySuite(AssociativeCompositeFunctionTest *suite) { delete suite; }
+
+    AssociativeCompositeFunctionTest(){
+        initializeFunctions();
+    };
+
+    testInitialization() {
+        // prod3 is a product within a product. It should become a product with three components
+        TS_ASSERT_EQUALS(m_f["prod3"]->asString(), "");
+    }
+
+private:
+    // Initialize some functions that we'll use in the tests
+    void initializeFunctions() {
+        // aliases to certain function
+        std::map<std::string, std::string> aliases = {
+            {"exp", "name=ExpDecay"},
+            {"lin", "name=LinearBackground"},
+            {"comp", "name=Lorentzian;name=InelasticDiffSphere"},
+            {"conv", "(composite=Convolution;name=Resolution,X=(3.0,3.1),Y=(3.2,3.3);"
+                             "name=DeltaFunction)"},
+            {"prod1", "(name=AssociativeMoc)"},
+            {"prod2", "(composite=AssociativeMoc;name=ExpDecay;name=FlatBackground)"},
+            {"prod3", "(composite=AssociativeMoc;name=ExpDecay;"
+                              "(composite=ProductFunction;name=Gaussian;name=Quadratic))"}
+        };
+        // Create the function objects
+        for (auto& kv : aliases) {
+            m_f[kv.first] = FunctionFactory::Instance().createInitialized(kv.second);
+        }
+    }
+    // a map containing aliases to function pointers
+    std::map<std::string, std::string> m_f;
+};
+#endif /*ASSOCIATIVECOMPOSITEFUNCTIONTEST_H_*/
+

--- a/Framework/API/test/AssociativeCompositeFunctionTest.h
+++ b/Framework/API/test/AssociativeCompositeFunctionTest.h
@@ -118,7 +118,7 @@ public:
                  "name=Linear,a=0,b=0;" \
                  "name=Linear,a=0,b=0;" \
                  "name=Cubic,c0=0,c1=0,c2=0,c3=0");
-        //TS_ASSERT_EQUALS(f->asString(), s);
+        TS_ASSERT_EQUALS(f->asString(), s);
         f->insertFunction(3, m_f["moc3"]);  // insert moc3 (Gauss * Cubic) before Cubic
         s.assign("composite=AssociativeMoc,NumDeriv=false;" \
                  "name=Gauss,c=0,h=1,s=1;" \
@@ -127,20 +127,29 @@ public:
                  "name=Gauss,c=0,h=1,s=1;" \
                  "name=Cubic,c0=0,c1=0,c2=0,c3=0;" \
                  "name=Cubic,c0=0,c1=0,c2=0,c3=0");
-        //TS_ASSERT_EQUALS(f->asString(), s);
+        TS_ASSERT_EQUALS(f->asString(), s);
     }
 
     void testReplaceFunction() {
         std::string s("(composite=AssociativeMoc;name=Gauss;name=Cubic)");
         auto f = functionAssociativeInitialized(s);
-        f->replaceFunction(1, m_f["line"]);
-        //TS_ASSERT_EQUALS(f->asString(), s);
-        f->addFunction(m_f["comp"]);
-        //TS_ASSERT_EQUALS(f->asString(), s);
-        f->replaceFunction(0, m_f["moc2"]);
-        //TS_ASSERT_EQUALS(f->asString(), s);
-        f->insertFunction(1, m_f["moc3"]);
-        //TS_ASSERT_EQUALS(f->asString(), s);
+        f->replaceFunction(1, m_f["line"]);  // Replace Cubic with Linear
+        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
+                 "name=Gauss,c=0,h=1,s=1;" \
+                 "name=Linear,a=0,b=0");
+        TS_ASSERT_EQUALS(f->asString(), s);
+        f->replaceFunction(0, m_f["moc2"]);  // Replace Gauss with moc2 (Linear)
+        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
+                  "name=Linear,a=0,b=0;" \
+                  "name=Linear,a=0,b=0");
+        TS_ASSERT_EQUALS(f->asString(), s);
+        f->insertFunction(1, m_f["moc3"]);  // Replace second Linear with moc3 (Gauss * Cubic)
+        s.assign("composite=AssociativeMoc,NumDeriv=false;" \
+                 "name=Linear,a=0,b=0;" \
+                 "name=Gauss,c=0,h=1,s=1;" \
+                 "name=Cubic,c0=0,c1=0,c2=0,c3=0;" \
+                 "name=Linear,a=0,b=0");
+        TS_ASSERT_EQUALS(f->asString(), s);
     }
 
 private:

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -3,15 +3,14 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/WorkspaceFactory.h"
-#include "MantidAPI/ParamFunction.h"
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidTestHelpers/FakeObjects.h"
+#include "MantidTestHelpers/FunctionTestHelper.h"
 
 using namespace Mantid;
 using namespace Mantid::API;
@@ -84,113 +83,6 @@ private:
   size_t m_blocksize;
 };
 
-class Gauss : public IPeakFunction {
-public:
-  Gauss() {
-    declareParameter("c");
-    declareParameter("h", 1.);
-    declareParameter("s", 1.);
-  }
-
-  std::string name() const override { return "Gauss"; }
-
-  void functionLocal(double *out, const double *xValues,
-                     const size_t nData) const override {
-    double c = getParameter("c");
-    double h = getParameter("h");
-    double w = getParameter("s");
-    for (size_t i = 0; i < nData; i++) {
-      double x = xValues[i] - c;
-      out[i] = h * exp(-0.5 * x * x * w);
-    }
-  }
-  void functionDerivLocal(Jacobian *out, const double *xValues,
-                          const size_t nData) override {
-    // throw Mantid::Kernel::Exception::NotImplementedError("");
-    double c = getParameter("c");
-    double h = getParameter("h");
-    double w = getParameter("s");
-    for (size_t i = 0; i < nData; i++) {
-      double x = xValues[i] - c;
-      double e = h * exp(-0.5 * x * x * w);
-      out->set(static_cast<int>(i), 0, x * h * e * w);
-      out->set(static_cast<int>(i), 1, e);
-      out->set(static_cast<int>(i), 2, -0.5 * x * x * h * e);
-    }
-  }
-
-  double centre() const override { return getParameter(0); }
-
-  double height() const override { return getParameter(1); }
-
-  double fwhm() const override { return getParameter(2); }
-
-  void setCentre(const double c) override { setParameter(0, c); }
-  void setHeight(const double h) override { setParameter(1, h); }
-
-  void setFwhm(const double w) override { setParameter(2, w); }
-};
-
-class Linear : public ParamFunction, public IFunction1D {
-public:
-  Linear() {
-    declareParameter("a");
-    declareParameter("b");
-  }
-
-  std::string name() const override { return "Linear"; }
-
-  void function1D(double *out, const double *xValues,
-                  const size_t nData) const override {
-    double a = getParameter("a");
-    double b = getParameter("b");
-    for (size_t i = 0; i < nData; i++) {
-      out[i] = a + b * xValues[i];
-    }
-  }
-  void functionDeriv1D(Jacobian *out, const double *xValues,
-                       const size_t nData) override {
-    // throw Mantid::Kernel::Exception::NotImplementedError("");
-    for (size_t i = 0; i < nData; i++) {
-      out->set(static_cast<int>(i), 0, 1.);
-      out->set(static_cast<int>(i), 1, xValues[i]);
-    }
-  }
-};
-
-class Cubic : public ParamFunction, public IFunction1D {
-public:
-  Cubic() {
-    declareParameter("c0");
-    declareParameter("c1");
-    declareParameter("c2");
-    declareParameter("c3");
-  }
-
-  std::string name() const override { return "Cubic"; }
-
-  void function1D(double *out, const double *xValues,
-                  const size_t nData) const override {
-    double c0 = getParameter("c0");
-    double c1 = getParameter("c1");
-    double c2 = getParameter("c2");
-    double c3 = getParameter("c3");
-    for (size_t i = 0; i < nData; i++) {
-      double x = xValues[i];
-      out[i] = c0 + x * (c1 + x * (c2 + x * c3));
-    }
-  }
-  void functionDeriv1D(Jacobian *out, const double *xValues,
-                       const size_t nData) override {
-    for (size_t i = 0; i < nData; i++) {
-      double x = xValues[i];
-      out->set(static_cast<int>(i), 0, 1.);
-      out->set(static_cast<int>(i), 1, x);
-      out->set(static_cast<int>(i), 2, x * x);
-      out->set(static_cast<int>(i), 3, x * x * x);
-    }
-  }
-};
 
 class CompositeFunctionTest : public CxxTest::TestSuite {
 public:

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -83,7 +83,6 @@ private:
   size_t m_blocksize;
 };
 
-
 class CompositeFunctionTest : public CxxTest::TestSuite {
 public:
   static CompositeFunctionTest *createSuite() {
@@ -691,7 +690,8 @@ public:
     cub->setParameter("c0", 2.1);
     cub->setParameter("c1", 2.2);
     cub->setParameter("c2", 2.3);
-    cub->setParameter("c3", 2.4);    IFunction_sptr g2 = IFunction_sptr(new Gauss());
+    cub->setParameter("c3", 2.4);
+    IFunction_sptr g2 = IFunction_sptr(new Gauss());
     mfun->addFunction(cub);
 
     // fix the first parameter of each function
@@ -702,7 +702,7 @@ public:
     IFunction_sptr bk2 = IFunction_sptr(new Linear());
     bk2->setParameter("a", 4.1);
     bk2->setParameter("b", 4.2);
-    mfun->insertFunction(2, bk2);  // insert right after function g1
+    mfun->insertFunction(2, bk2); // insert right after function g1
 
     mfun->applyTies();
 

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -833,14 +833,14 @@ public:
     TS_ASSERT_EQUALS(mfun->parameterName(4), "f1.s");
     TS_ASSERT_EQUALS(mfun->getParameter(4), 1.3);
     TS_ASSERT(!mfun->isFixed(4));
-    // Check bk2
+    // Check bk2, the inserted function
     TS_ASSERT_EQUALS(mfun->parameterName(5), "f2.a");
     TS_ASSERT_EQUALS(mfun->getParameter(5), 4.1);
     TS_ASSERT(!mfun->isFixed(5));
     TS_ASSERT_EQUALS(mfun->parameterName(6), "f2.b")
     TS_ASSERT_EQUALS(mfun->getParameter(6), 4.2);
     TS_ASSERT(!mfun->isFixed(6));
-    // Check cub
+    // Check cub, the function "shifted upwards"
     TS_ASSERT_EQUALS(mfun->parameterName(7), "f3.c0");
     TS_ASSERT_EQUALS(mfun->getParameter(7), 12);
     TS_ASSERT(mfun->isFixed(7));

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -781,6 +781,80 @@ public:
     delete mfun;
   }
 
+  void testInsertFunction() {
+    CompositeFunction *mfun = new CompositeFunction;
+
+    IFunction_sptr bk1 = IFunction_sptr(new Linear());
+    bk1->setParameter("a", 0.1);
+    bk1->setParameter("b", 0.2);
+    mfun->addFunction(bk1);
+
+    IFunction_sptr g1 = IFunction_sptr(new Gauss());
+    g1->setParameter("c", 1.1);
+    g1->setParameter("h", 1.2);
+    g1->setParameter("s", 1.3);
+    mfun->addFunction(g1);
+
+    IFunction_sptr cub = IFunction_sptr(new Cubic());
+    cub->setParameter("c0", 2.1);
+    cub->setParameter("c1", 2.2);
+    cub->setParameter("c2", 2.3);
+    cub->setParameter("c3", 2.4);    IFunction_sptr g2 = IFunction_sptr(new Gauss());
+    mfun->addFunction(cub);
+
+    // fix the first parameter of each function
+    mfun->tie("f0.a", "10");
+    mfun->tie("f1.c", "11");
+    mfun->tie("f2.c0", "12");
+
+    IFunction_sptr bk2 = IFunction_sptr(new Linear());
+    bk2->setParameter("a", 4.1);
+    bk2->setParameter("b", 4.2);
+    mfun->insertFunction(2, bk2);  // insert right after function g1
+
+    mfun->applyTies();
+
+    TS_ASSERT_EQUALS(mfun->nFunctions(), 4);
+    TS_ASSERT_EQUALS(mfun->nParams(), 11);
+    // Check bk1
+    TS_ASSERT_EQUALS(mfun->parameterName(0), "f0.a");
+    TS_ASSERT_EQUALS(mfun->getParameter(0), 10);
+    TS_ASSERT(mfun->isFixed(0));
+    TS_ASSERT_EQUALS(mfun->parameterName(1), "f0.b")
+    TS_ASSERT_EQUALS(mfun->getParameter(1), 0.2);
+    TS_ASSERT(!mfun->isFixed(1));
+    // Check g1
+    TS_ASSERT_EQUALS(mfun->parameterName(2), "f1.c");
+    TS_ASSERT_EQUALS(mfun->getParameter(2), 11);
+    TS_ASSERT(mfun->isFixed(2));
+    TS_ASSERT_EQUALS(mfun->parameterName(3), "f1.h");
+    TS_ASSERT_EQUALS(mfun->getParameter(3), 1.2);
+    TS_ASSERT(!mfun->isFixed(3));
+    TS_ASSERT_EQUALS(mfun->parameterName(4), "f1.s");
+    TS_ASSERT_EQUALS(mfun->getParameter(4), 1.3);
+    TS_ASSERT(!mfun->isFixed(4));
+    // Check bk2
+    TS_ASSERT_EQUALS(mfun->parameterName(5), "f2.a");
+    TS_ASSERT_EQUALS(mfun->getParameter(5), 4.1);
+    TS_ASSERT(!mfun->isFixed(5));
+    TS_ASSERT_EQUALS(mfun->parameterName(6), "f2.b")
+    TS_ASSERT_EQUALS(mfun->getParameter(6), 4.2);
+    TS_ASSERT(!mfun->isFixed(6));
+    // Check cub
+    TS_ASSERT_EQUALS(mfun->parameterName(7), "f3.c0");
+    TS_ASSERT_EQUALS(mfun->getParameter(7), 12);
+    TS_ASSERT(mfun->isFixed(7));
+    TS_ASSERT_EQUALS(mfun->parameterName(8), "f3.c1")
+    TS_ASSERT_EQUALS(mfun->getParameter(8), 2.2);
+    TS_ASSERT(!mfun->isFixed(8));
+    TS_ASSERT_EQUALS(mfun->parameterName(9), "f3.c2");
+    TS_ASSERT_EQUALS(mfun->getParameter(9), 2.3);
+    TS_ASSERT(!mfun->isFixed(8));
+    TS_ASSERT_EQUALS(mfun->parameterName(10), "f3.c3")
+    TS_ASSERT_EQUALS(mfun->getParameter(10), 2.4);
+    TS_ASSERT(!mfun->isFixed(10));
+  }
+
   // replacing function has fewer parameters
   void testReplaceFunction() {
     IFunction_sptr g1 = IFunction_sptr(new Gauss());

--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -45,6 +45,7 @@ set ( SRC_FILES
 	src/FuncMinimizers/SteepestDescentMinimizer.cpp
 	src/FuncMinimizers/TrustRegionMinimizer.cpp
 	src/FunctionDomain1DSpectrumCreator.cpp
+	src/Functions/AdditionFunction.cpp
 	src/Functions/Abragam.cpp
 	src/Functions/BSpline.cpp
 	src/Functions/BackToBackExponential.cpp
@@ -203,6 +204,7 @@ set ( INC_FILES
 	inc/MantidCurveFitting/FuncMinimizers/TrustRegionMinimizer.h
 	inc/MantidCurveFitting/FunctionDomain1DSpectrumCreator.h
 	inc/MantidCurveFitting/Functions/Abragam.h
+	inc/MantidCurveFitting/Functions/AdditionFunction.h
 	inc/MantidCurveFitting/Functions/BSpline.h
 	inc/MantidCurveFitting/Functions/BackToBackExponential.h
 	inc/MantidCurveFitting/Functions/BackgroundFunction.h

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/AdditionFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/AdditionFunction.h
@@ -40,15 +40,15 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 
 class DLLExport AdditionFunction : public API::AssociativeCompositeFunction {
 public:
-    /// overwrite IFunction base class methods
-    std::string name() const override { return "AdditionFunction"; }
-    /// if f is of the same class then its component functions
-    /// are treated separately
-    bool isAssociative(API::IFunction_sptr f) const override;
+  /// overwrite IFunction base class methods
+  std::string name() const override { return "AdditionFunction"; }
+  /// if f is of the same class then its component functions
+  /// are treated separately
+  bool isAssociative(API::IFunction_sptr f) const override;
 
 protected:
-    /// overwrite IFunction base class method, which declare function parameters
-    void init() override {};
+  /// overwrite IFunction base class method, which declare function parameters
+  void init() override{};
 };
 
 } // namespace Functions

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/AdditionFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/AdditionFunction.h
@@ -1,0 +1,56 @@
+#ifndef MANTID_CURVEFITTING_ADDITIONFUNCTION_H_
+#define MANTID_CURVEFITTING_ADDITIONFUNCTION_H_
+
+#endif /*MANTID_CURVEFITTING_ADDITIONFUNCTION_H_*/
+
+#include "MantidAPI/IFunction.h"
+#include "MantidAPI/AssociativeCompositeFunction.h"
+
+namespace Mantid {
+namespace CurveFitting {
+namespace Functions {
+/**
+Same as CompositeFunction but enforcing the associative property
+of the + operator
+
+@author Jose Borreguero, NScD Oak Ridge
+@date 2017/08/16
+
+Copyright &copy; 2007-8 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+National Laboratory & European Spallation Source
+
+This file is part of Mantid.
+
+Mantid is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Mantid is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+File change history is stored at: <https://github.com/mantidproject/mantid>
+Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+
+class DLLExport AdditionFunction : public API::AssociativeCompositeFunction {
+public:
+    /// overwrite IFunction base class methods
+    std::string name() const override { return "AdditionFunction"; }
+    /// if f is of the same class then its component functions
+    /// are treated separately
+    bool isAssociative(API::IFunction_sptr f) const override;
+
+protected:
+    /// overwrite IFunction base class method, which declare function parameters
+    void init() override {};
+};
+
+} // namespace Functions
+} // namespace CurveFitting
+} // namespace Mantid

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductFunction.h
@@ -4,7 +4,8 @@
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
-#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/IFunction.h"
+#include "MantidAPI/AssociativeCompositeFunction.h"
 #include <boost/shared_array.hpp>
 #include <cmath>
 
@@ -39,10 +40,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport ProductFunction : public API::CompositeFunction {
+class DLLExport ProductFunction : public API::AssociativeCompositeFunction {
 public:
   /// overwrite IFunction base class methods
   std::string name() const override { return "ProductFunction"; }
+  /// if f is of the same class then its component functions
+  /// are treated separately
+  bool isAssociative(API::IFunction_sptr f) const override;
   /// Function you want to fit to.
   /// @param domain :: The space on which the function acts
   /// @param values :: The buffer for writing the calculated values. Must be big

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductFunction.h
@@ -66,4 +66,4 @@ protected:
 } // namespace CurveFitting
 } // namespace Mantid
 
-#endif /*MANTID_CURVEFITTING_PRODUCTFUNCTIONMW_H_*/
+#endif /*MANTID_CURVEFITTING_PRODUCTFUNCTION_H_*/

--- a/Framework/CurveFitting/src/Functions/AdditionFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/AdditionFunction.cpp
@@ -1,0 +1,29 @@
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidCurveFitting/Functions/AdditionFunction.h"
+#include "MantidAPI/FunctionFactory.h"
+
+namespace Mantid {
+namespace CurveFitting {
+namespace Functions {
+
+using namespace CurveFitting;
+
+DECLARE_FUNCTION(AdditionFunction)
+
+/** Ascertain if a function is of the same class. If so, its
+ * component functions will be incorporated separately when combined
+ * with this object.
+ *  @param f :: pointer to the query function
+ */
+bool AdditionFunction::isAssociative(API::IFunction_sptr f) const {
+    if (boost::dynamic_pointer_cast<AdditionFunction>(f)) {
+        return true;
+    }
+    return false;
+}
+
+} // namespace Functions
+} // namespace CurveFitting
+} // namespace Mantid

--- a/Framework/CurveFitting/src/Functions/AdditionFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/AdditionFunction.cpp
@@ -18,10 +18,10 @@ DECLARE_FUNCTION(AdditionFunction)
  *  @param f :: pointer to the query function
  */
 bool AdditionFunction::isAssociative(API::IFunction_sptr f) const {
-    if (boost::dynamic_pointer_cast<AdditionFunction>(f)) {
-        return true;
-    }
-    return false;
+  if (boost::dynamic_pointer_cast<AdditionFunction>(f)) {
+    return true;
+  }
+  return false;
 }
 
 } // namespace Functions

--- a/Framework/CurveFitting/src/Functions/ProductFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/ProductFunction.cpp
@@ -13,7 +13,7 @@ using namespace CurveFitting;
 DECLARE_FUNCTION(ProductFunction)
 
 /** Ascertain if a function is of the same class. If so, its
- * component functions will be treated separately when combined
+ * component functions will be incorporated separately when combined
  * with this object.
  *  @param f :: pointer to the query function
  */

--- a/Framework/CurveFitting/src/Functions/ProductFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/ProductFunction.cpp
@@ -12,6 +12,18 @@ using namespace CurveFitting;
 
 DECLARE_FUNCTION(ProductFunction)
 
+/** Ascertain if a function is of the same class. If so, its
+ * component functions will be treated separately when combined
+ * with this object.
+ *  @param f :: pointer to the query function
+ */
+bool ProductFunction::isAssociative(API::IFunction_sptr f) const {
+  if (boost::dynamic_pointer_cast<ProductFunction>(f)) {
+    return true;
+  }
+  return false;
+}
+
 /** Function you want to fit to.
  *  @param domain :: The buffer for writing the calculated values. Must be big
  * enough to accept dataSize() values

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FunctionTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FunctionTestHelper.h
@@ -1,0 +1,129 @@
+#ifndef FUNCTIONSTESTHELPER_H_
+#define FUNCTIONSTESTHELPER_H_
+
+#include "MantidAPI/IPeakFunction.h"
+#include "MantidAPI/ParamFunction.h"
+#include "MantidAPI/IFunction1D.h"
+#include "MantidAPI/FunctionFactory.h"
+
+using namespace Mantid;
+using namespace Mantid::API;
+
+/*
+ * Gaussian fit function
+ */
+class Gauss : public IPeakFunction {
+public:
+    Gauss() {
+        declareParameter("c");
+        declareParameter("h", 1.);
+        declareParameter("s", 1.);
+    }
+
+    std::string name() const override { return "Gauss"; }
+
+    void functionLocal(double *out, const double *xValues,
+                       const size_t nData) const override {
+        double c = getParameter("c");
+        double h = getParameter("h");
+        double w = getParameter("s");
+        for (size_t i = 0; i < nData; i++) {
+            double x = xValues[i] - c;
+            out[i] = h * exp(-0.5 * x * x * w);
+        }
+    }
+    void functionDerivLocal(Jacobian *out, const double *xValues,
+                            const size_t nData) override {
+        // throw Mantid::Kernel::Exception::NotImplementedError("");
+        double c = getParameter("c");
+        double h = getParameter("h");
+        double w = getParameter("s");
+        for (size_t i = 0; i < nData; i++) {
+            double x = xValues[i] - c;
+            double e = h * exp(-0.5 * x * x * w);
+            out->set(static_cast<int>(i), 0, x * h * e * w);
+            out->set(static_cast<int>(i), 1, e);
+            out->set(static_cast<int>(i), 2, -0.5 * x * x * h * e);
+        }
+    }
+
+    double centre() const override { return getParameter(0); }
+
+    double height() const override { return getParameter(1); }
+
+    double fwhm() const override { return getParameter(2); }
+
+    void setCentre(const double c) override { setParameter(0, c); }
+    void setHeight(const double h) override { setParameter(1, h); }
+
+    void setFwhm(const double w) override { setParameter(2, w); }
+};
+
+/*
+ * Linear fit function
+ */
+class Linear : public ParamFunction, public IFunction1D {
+public:
+    Linear() {
+        declareParameter("a");
+        declareParameter("b");
+    }
+
+    std::string name() const override { return "Linear"; }
+
+    void function1D(double *out, const double *xValues,
+                    const size_t nData) const override {
+        double a = getParameter("a");
+        double b = getParameter("b");
+        for (size_t i = 0; i < nData; i++) {
+            out[i] = a + b * xValues[i];
+        }
+    }
+    void functionDeriv1D(Jacobian *out, const double *xValues,
+                         const size_t nData) override {
+        // throw Mantid::Kernel::Exception::NotImplementedError("");
+        for (size_t i = 0; i < nData; i++) {
+            out->set(static_cast<int>(i), 0, 1.);
+            out->set(static_cast<int>(i), 1, xValues[i]);
+        }
+    }
+};
+
+/*
+ * Cubic fit function
+ */
+class Cubic : public ParamFunction, public IFunction1D {
+public:
+    Cubic() {
+        declareParameter("c0");
+        declareParameter("c1");
+        declareParameter("c2");
+        declareParameter("c3");
+    }
+
+    std::string name() const override { return "Cubic"; }
+
+    void function1D(double *out, const double *xValues,
+                    const size_t nData) const override {
+        double c0 = getParameter("c0");
+        double c1 = getParameter("c1");
+        double c2 = getParameter("c2");
+        double c3 = getParameter("c3");
+        for (size_t i = 0; i < nData; i++) {
+            double x = xValues[i];
+            out[i] = c0 + x * (c1 + x * (c2 + x * c3));
+        }
+    }
+    void functionDeriv1D(Jacobian *out, const double *xValues,
+                         const size_t nData) override {
+        for (size_t i = 0; i < nData; i++) {
+            double x = xValues[i];
+            out->set(static_cast<int>(i), 0, 1.);
+            out->set(static_cast<int>(i), 1, x);
+            out->set(static_cast<int>(i), 2, x * x);
+            out->set(static_cast<int>(i), 3, x * x * x);
+        }
+    }
+};
+
+#endif /* FUNCTIONSHELPER */

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FunctionTestHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FunctionTestHelper.h
@@ -14,49 +14,49 @@ using namespace Mantid::API;
  */
 class Gauss : public IPeakFunction {
 public:
-    Gauss() {
-        declareParameter("c");
-        declareParameter("h", 1.);
-        declareParameter("s", 1.);
+  Gauss() {
+    declareParameter("c");
+    declareParameter("h", 1.);
+    declareParameter("s", 1.);
+  }
+
+  std::string name() const override { return "Gauss"; }
+
+  void functionLocal(double *out, const double *xValues,
+                     const size_t nData) const override {
+    double c = getParameter("c");
+    double h = getParameter("h");
+    double w = getParameter("s");
+    for (size_t i = 0; i < nData; i++) {
+      double x = xValues[i] - c;
+      out[i] = h * exp(-0.5 * x * x * w);
     }
-
-    std::string name() const override { return "Gauss"; }
-
-    void functionLocal(double *out, const double *xValues,
-                       const size_t nData) const override {
-        double c = getParameter("c");
-        double h = getParameter("h");
-        double w = getParameter("s");
-        for (size_t i = 0; i < nData; i++) {
-            double x = xValues[i] - c;
-            out[i] = h * exp(-0.5 * x * x * w);
-        }
+  }
+  void functionDerivLocal(Jacobian *out, const double *xValues,
+                          const size_t nData) override {
+    // throw Mantid::Kernel::Exception::NotImplementedError("");
+    double c = getParameter("c");
+    double h = getParameter("h");
+    double w = getParameter("s");
+    for (size_t i = 0; i < nData; i++) {
+      double x = xValues[i] - c;
+      double e = h * exp(-0.5 * x * x * w);
+      out->set(static_cast<int>(i), 0, x * h * e * w);
+      out->set(static_cast<int>(i), 1, e);
+      out->set(static_cast<int>(i), 2, -0.5 * x * x * h * e);
     }
-    void functionDerivLocal(Jacobian *out, const double *xValues,
-                            const size_t nData) override {
-        // throw Mantid::Kernel::Exception::NotImplementedError("");
-        double c = getParameter("c");
-        double h = getParameter("h");
-        double w = getParameter("s");
-        for (size_t i = 0; i < nData; i++) {
-            double x = xValues[i] - c;
-            double e = h * exp(-0.5 * x * x * w);
-            out->set(static_cast<int>(i), 0, x * h * e * w);
-            out->set(static_cast<int>(i), 1, e);
-            out->set(static_cast<int>(i), 2, -0.5 * x * x * h * e);
-        }
-    }
+  }
 
-    double centre() const override { return getParameter(0); }
+  double centre() const override { return getParameter(0); }
 
-    double height() const override { return getParameter(1); }
+  double height() const override { return getParameter(1); }
 
-    double fwhm() const override { return getParameter(2); }
+  double fwhm() const override { return getParameter(2); }
 
-    void setCentre(const double c) override { setParameter(0, c); }
-    void setHeight(const double h) override { setParameter(1, h); }
+  void setCentre(const double c) override { setParameter(0, c); }
+  void setHeight(const double h) override { setParameter(1, h); }
 
-    void setFwhm(const double w) override { setParameter(2, w); }
+  void setFwhm(const double w) override { setParameter(2, w); }
 };
 
 /*
@@ -64,29 +64,29 @@ public:
  */
 class Linear : public ParamFunction, public IFunction1D {
 public:
-    Linear() {
-        declareParameter("a");
-        declareParameter("b");
-    }
+  Linear() {
+    declareParameter("a");
+    declareParameter("b");
+  }
 
-    std::string name() const override { return "Linear"; }
+  std::string name() const override { return "Linear"; }
 
-    void function1D(double *out, const double *xValues,
-                    const size_t nData) const override {
-        double a = getParameter("a");
-        double b = getParameter("b");
-        for (size_t i = 0; i < nData; i++) {
-            out[i] = a + b * xValues[i];
-        }
+  void function1D(double *out, const double *xValues,
+                  const size_t nData) const override {
+    double a = getParameter("a");
+    double b = getParameter("b");
+    for (size_t i = 0; i < nData; i++) {
+      out[i] = a + b * xValues[i];
     }
-    void functionDeriv1D(Jacobian *out, const double *xValues,
-                         const size_t nData) override {
-        // throw Mantid::Kernel::Exception::NotImplementedError("");
-        for (size_t i = 0; i < nData; i++) {
-            out->set(static_cast<int>(i), 0, 1.);
-            out->set(static_cast<int>(i), 1, xValues[i]);
-        }
+  }
+  void functionDeriv1D(Jacobian *out, const double *xValues,
+                       const size_t nData) override {
+    // throw Mantid::Kernel::Exception::NotImplementedError("");
+    for (size_t i = 0; i < nData; i++) {
+      out->set(static_cast<int>(i), 0, 1.);
+      out->set(static_cast<int>(i), 1, xValues[i]);
     }
+  }
 };
 
 /*
@@ -94,36 +94,36 @@ public:
  */
 class Cubic : public ParamFunction, public IFunction1D {
 public:
-    Cubic() {
-        declareParameter("c0");
-        declareParameter("c1");
-        declareParameter("c2");
-        declareParameter("c3");
-    }
+  Cubic() {
+    declareParameter("c0");
+    declareParameter("c1");
+    declareParameter("c2");
+    declareParameter("c3");
+  }
 
-    std::string name() const override { return "Cubic"; }
+  std::string name() const override { return "Cubic"; }
 
-    void function1D(double *out, const double *xValues,
-                    const size_t nData) const override {
-        double c0 = getParameter("c0");
-        double c1 = getParameter("c1");
-        double c2 = getParameter("c2");
-        double c3 = getParameter("c3");
-        for (size_t i = 0; i < nData; i++) {
-            double x = xValues[i];
-            out[i] = c0 + x * (c1 + x * (c2 + x * c3));
-        }
+  void function1D(double *out, const double *xValues,
+                  const size_t nData) const override {
+    double c0 = getParameter("c0");
+    double c1 = getParameter("c1");
+    double c2 = getParameter("c2");
+    double c3 = getParameter("c3");
+    for (size_t i = 0; i < nData; i++) {
+      double x = xValues[i];
+      out[i] = c0 + x * (c1 + x * (c2 + x * c3));
     }
-    void functionDeriv1D(Jacobian *out, const double *xValues,
-                         const size_t nData) override {
-        for (size_t i = 0; i < nData; i++) {
-            double x = xValues[i];
-            out->set(static_cast<int>(i), 0, 1.);
-            out->set(static_cast<int>(i), 1, x);
-            out->set(static_cast<int>(i), 2, x * x);
-            out->set(static_cast<int>(i), 3, x * x * x);
-        }
+  }
+  void functionDeriv1D(Jacobian *out, const double *xValues,
+                       const size_t nData) override {
+    for (size_t i = 0; i < nData; i++) {
+      double x = xValues[i];
+      out->set(static_cast<int>(i), 0, 1.);
+      out->set(static_cast<int>(i), 1, x);
+      out->set(static_cast<int>(i), 2, x * x);
+      out->set(static_cast<int>(i), 3, x * x * x);
     }
+  }
 };
 
 #endif /* FUNCTIONSHELPER */


### PR DESCRIPTION
Base class for composite functions that are associative, and implementation for `ProductFunction`.


Fixes #20250

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
