### PR TITLE
EQSANS changes for sample position

### DIFF
--- a/Framework/Algorithms/src/EQSANSTofStructure.cpp
+++ b/Framework/Algorithms/src/EQSANSTofStructure.cpp
@@ -118,14 +118,15 @@ void EQSANSTofStructure::execEvent(
   const size_t numHists = inputWS->getNumberHistograms();
   Progress progress(this, 0.0, 1.0, numHists);
 
-  // Get the nominal sample-to-detector distance (in mm)
+  // This now points to the correct distance and makes the naming clearer
+  // Get the nominal sample flange-to-detector distance (in mm)
   Mantid::Kernel::Property *prop =
-      inputWS->run().getProperty("sample_detector_distance");
+      inputWS->run().getProperty("sampleflange_detector_distance");
   auto dp = dynamic_cast<Mantid::Kernel::PropertyWithValue<double> *>(prop);
   if (!dp) {
-    throw std::runtime_error("sample_detector_distance log not found.");
+    throw std::runtime_error("sampleflange_detector_distance log not found.");
   }
-  const double SDD = *dp / 1000.0;
+  const double SFDD = *dp / 1000.0;
 
   const auto &spectrumInfo = inputWS->spectrumInfo();
   const auto l1 = spectrumInfo.l1();
@@ -141,7 +142,7 @@ void EQSANSTofStructure::execEvent(
       continue;
     }
     const auto l2 = spectrumInfo.l2(ispec);
-    double tof_factor = (l1 + l2) / (l1 + SDD);
+    double tof_factor = (l1 + l2) / (l1 + SFDD);
 
     // Get the pointer to the output event list
     std::vector<TofEvent> &events = inputWS->getSpectrum(ispec).getEvents();
@@ -431,6 +432,7 @@ double EQSANSTofStructure::getTofOffset(EventWorkspace_const_sptr inputWS,
   else
     det_name = temp[0];
 
+  // Checked 8/11/2017 here detector_z is sfdd which has been updated in eqsansload.cpp
   double source_z = inputWS->getInstrument()->getSource()->getPos().Z();
   double detector_z =
       inputWS->getInstrument()->getComponentByName(det_name)->getPos().Z();
@@ -452,6 +454,7 @@ double EQSANSTofStructure::getTofOffset(EventWorkspace_const_sptr inputWS,
     g_log.information() << i << "    " << chopper_actual_phase[i] << "  "
                         << chopper_wl_1[i] << "  " << chopper_wl_2[i] << '\n';
 
+  // Checked 8/10/2017
   double low_wl_discard = 3.9560346 * low_tof_cut / source_to_detector;
   double high_wl_discard = 3.9560346 * high_tof_cut / source_to_detector;
 

--- a/Framework/Algorithms/src/EQSANSTofStructure.cpp
+++ b/Framework/Algorithms/src/EQSANSTofStructure.cpp
@@ -432,7 +432,8 @@ double EQSANSTofStructure::getTofOffset(EventWorkspace_const_sptr inputWS,
   else
     det_name = temp[0];
 
-  // Checked 8/11/2017 here detector_z is sfdd which has been updated in eqsansload.cpp
+  // Checked 8/11/2017 here detector_z is sfdd which has been updated
+  // in eqsansload.cpp
   double source_z = inputWS->getInstrument()->getSource()->getPos().Z();
   double detector_z =
       inputWS->getInstrument()->getComponentByName(det_name)->getPos().Z();

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/EQSANSAzimuthalAverage1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/EQSANSAzimuthalAverage1D.py
@@ -353,6 +353,9 @@ class EQSANSAzimuthalAverage1D(PythonAlgorithm):
         """
         log_binning = self.getProperty("LogBinning").value
         nbins = self.getProperty("NumberOfBins").value
+
+        # This code has been checked that it is using the correct property from the workspace
+        # it just so happens that this is not pointing to what it used to - see EQSANSLoad.cpp
         sample_detector_distance = workspace.getRun().getProperty("sample_detector_distance").value
         nx_pixels = int(workspace.getInstrument().getNumberParameter("number-of-x-pixels")[0])
         ny_pixels = int(workspace.getInstrument().getNumberParameter("number-of-y-pixels")[0])

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSAzimuthalAverage1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSAzimuthalAverage1D.py
@@ -200,6 +200,7 @@ class SANSAzimuthalAverage1D(PythonAlgorithm):
             qmin = workspace.getRun().getProperty("qmin").value
             qmax = workspace.getRun().getProperty("qmax").value
         else:
+            #  Checked 8/10/2017 -  this is using the right distance for calculating q
             sample_detector_distance = workspace.getRun().getProperty("sample_detector_distance").value
             nx_pixels = int(workspace.getInstrument().getNumberParameter("number-of-x-pixels")[0])
             ny_pixels = int(workspace.getInstrument().getNumberParameter("number-of-y-pixels")[0])

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -87,6 +87,12 @@ void EQSANSLoad::init() {
   declareProperty("SampleDetectorDistanceOffset", EMPTY_DBL(),
                   "Offset to the sample to detector distance (use only when "
                   "using the distance found in the meta data), in mm");
+  declareProperty("SampleOffset", EMPTY_DBL(),
+                  "Offset to be applied to the sample position (use only when "
+                  "using the detector distance found in the meta data), in mm");
+  declareProperty("DetectorOffset", EMPTY_DBL(),
+                  "Offset to be applied to the detector position (use only when "
+                  "using the distance found in the meta data), in mm");
   declareProperty("LoadMonitors", true,
                   "If true, the monitor workspace will be loaded");
   declareProperty("OutputMessage", "", Direction::Output);
@@ -547,11 +553,13 @@ void EQSANSLoad::exec() {
     }
   }
 
-  // Get the sample-detector distance
-  double sdd = 0.0;
-  const double sample_det_dist = getProperty("SampleDetectorDistance");
-  if (!isEmpty(sample_det_dist)) {
-    sdd = sample_det_dist;
+  // Get the sample flange-to-detector distance
+  // We have to call it "SampleDetectorDistance" in the workspace or break the Nexus files
+  double sfdd = 0.0;
+  double s2d = 0.0;
+  const double sampleflange_det_dist = getProperty("SampleDetectorDistance");
+  if (!isEmpty(sampleflange_det_dist)) {
+    sfdd = sampleflange_det_dist;
   } else {
     if (!dataWS->run().hasProperty("detectorZ")) {
       g_log.error()
@@ -569,27 +577,43 @@ void EQSANSLoad::exec() {
     if (!dp)
       throw std::runtime_error("Could not cast (interpret) the property " +
                                dzName + " as a time series property value.");
-    sdd = dp->getStatistics().mean;
+    sfdd = dp->getStatistics().mean;
+    s2d = sfdd;
 
-    // Modify SDD according to offset if given
+    // Modify SDD according to the DetectorDistance offset if given
+    const double sampleflange_det_offset =
+      getProperty("DetectorOffset");
+    if (!isEmpty(sampleflange_det_offset))
+      sfdd += sampleflange_det_offset;
+
+    // Modify S2D according to the SampleDistance offset if given
+    // This assumes that a positive offset moves the sample toward the detector
+    const double sampleflange_sample_offset =
+      getProperty("SampleOffset");
+    if (!isEmpty(sampleflange_sample_offset))
+      s2d = s2d - sampleflange_sample_offset + sampleflange_det_offset;
+
+    // Modify SDD according to SampleDetectorDistanceOffset offset if given
     const double sample_det_offset =
-        getProperty("SampleDetectorDistanceOffset");
+      getProperty("SampleDetectorDistanceOffset");
     if (!isEmpty(sample_det_offset))
-      sdd += sample_det_offset;
+      s2d += sample_det_offset;
+
   }
-  dataWS->mutableRun().addProperty("sample_detector_distance", sdd, "mm", true);
+  dataWS->mutableRun().addProperty("sampleflange_detector_distance", sfdd, "mm", true);
+  dataWS->mutableRun().addProperty("sample_detector_distance", s2d, "mm", true);
 
   // Move the detector to its correct position
   IAlgorithm_sptr mvAlg =
       createChildAlgorithm("MoveInstrumentComponent", 0.2, 0.4);
   mvAlg->setProperty<MatrixWorkspace_sptr>("Workspace", dataWS);
   mvAlg->setProperty("ComponentName", "detector1");
-  mvAlg->setProperty("Z", sdd / 1000.0);
+  mvAlg->setProperty("Z", sfdd / 1000.0);
   mvAlg->setProperty("RelativePosition", false);
   mvAlg->executeAsChildAlg();
-  g_log.information() << "Moving detector to " << sdd / 1000.0 << " meters\n";
+  g_log.information() << "Moving detector to " << sfdd / 1000.0 << " meters\n";
   m_output_message += "   Detector position: " +
-                      Poco::NumberFormatter::format(sdd / 1000.0, 3) + " m\n";
+                      Poco::NumberFormatter::format(sfdd / 1000.0, 3) + " m\n";
 
   // Get the run number so we can find the proper config file
   int run_number = 0;
@@ -733,9 +757,11 @@ void EQSANSLoad::exec() {
   }
 
   // Convert to wavelength
+  // Checked on 8/10/17 - changed from "sdd" to "sfdd" as was done above
+  // sfdd + ssd gives total distance (corrected by offset) from the source
   const double ssd =
       fabs(dataWS->getInstrument()->getSource()->getPos().Z()) * 1000.0;
-  const double conversion_factor = 3.9560346 / (sdd + ssd);
+  const double conversion_factor = 3.9560346 / (sfdd + ssd);
   m_output_message += "   TOF to wavelength conversion factor: " +
                       Poco::NumberFormatter::format(conversion_factor) + "\n";
 

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -593,7 +593,8 @@ void EQSANSLoad::exec() {
       s2d = s2d - sampleflange_sample_offset + sampleflange_det_offset;
 
     // Modify SDD according to SampleDetectorDistanceOffset offset if given
-    const double sample_det_offset = getProperty("SampleDetectorDistanceOffset");
+    const double sample_det_offset =
+      getProperty("SampleDetectorDistanceOffset");
     if (!isEmpty(sample_det_offset))
       s2d += sample_det_offset;
   }

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -90,9 +90,10 @@ void EQSANSLoad::init() {
   declareProperty("SampleOffset", EMPTY_DBL(),
                   "Offset to be applied to the sample position (use only when "
                   "using the detector distance found in the meta data), in mm");
-  declareProperty("DetectorOffset", EMPTY_DBL(),
-                  "Offset to be applied to the detector position (use only when "
-                  "using the distance found in the meta data), in mm");
+  declareProperty(
+      "DetectorOffset", EMPTY_DBL(),
+      "Offset to be applied to the detector position (use only when "
+      "using the distance found in the meta data), in mm");
   declareProperty("LoadMonitors", true,
                   "If true, the monitor workspace will be loaded");
   declareProperty("OutputMessage", "", Direction::Output);
@@ -554,7 +555,7 @@ void EQSANSLoad::exec() {
   }
 
   // Get the sample flange-to-detector distance
-  // We have to call it "SampleDetectorDistance" in the workspace or break the Nexus files
+  // We have to call it "SampleDetectorDistance" in the workspace
   double sfdd = 0.0;
   double s2d = 0.0;
   const double sampleflange_det_dist = getProperty("SampleDetectorDistance");
@@ -581,26 +582,23 @@ void EQSANSLoad::exec() {
     s2d = sfdd;
 
     // Modify SDD according to the DetectorDistance offset if given
-    const double sampleflange_det_offset =
-      getProperty("DetectorOffset");
+    const double sampleflange_det_offset = getProperty("DetectorOffset");
     if (!isEmpty(sampleflange_det_offset))
       sfdd += sampleflange_det_offset;
 
     // Modify S2D according to the SampleDistance offset if given
     // This assumes that a positive offset moves the sample toward the detector
-    const double sampleflange_sample_offset =
-      getProperty("SampleOffset");
+    const double sampleflange_sample_offset = getProperty("SampleOffset");
     if (!isEmpty(sampleflange_sample_offset))
       s2d = s2d - sampleflange_sample_offset + sampleflange_det_offset;
 
     // Modify SDD according to SampleDetectorDistanceOffset offset if given
-    const double sample_det_offset =
-      getProperty("SampleDetectorDistanceOffset");
+    const double sample_det_offset = getProperty("SampleDetectorDistanceOffset");
     if (!isEmpty(sample_det_offset))
       s2d += sample_det_offset;
-
   }
-  dataWS->mutableRun().addProperty("sampleflange_detector_distance", sfdd, "mm", true);
+  dataWS->mutableRun().addProperty("sampleflange_detector_distance", sfdd, "mm",
+                                   true);
   dataWS->mutableRun().addProperty("sample_detector_distance", s2d, "mm", true);
 
   // Move the detector to its correct position

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -594,7 +594,7 @@ void EQSANSLoad::exec() {
 
     // Modify SDD according to SampleDetectorDistanceOffset offset if given
     const double sample_det_offset =
-      getProperty("SampleDetectorDistanceOffset");
+        getProperty("SampleDetectorDistanceOffset");
     if (!isEmpty(sample_det_offset))
       s2d += sample_det_offset;
   }

--- a/Framework/WorkflowAlgorithms/src/EQSANSQ2D.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSQ2D.cpp
@@ -90,6 +90,8 @@ void EQSANSQ2D::exec() {
     qmax = getRunProperty(inputWS, "qmax");
     g_log.debug() << "Using Qmax from run properties = " << qmax << std::endl;
   } else {
+    //This is pointing to the correct parameter in the workspace, which has been
+    //changed to the right distance in EQSANSLoad.cpp
     const double sample_detector_distance =
         getRunProperty(inputWS, "sample_detector_distance");
 
@@ -109,6 +111,8 @@ void EQSANSQ2D::exec() {
     double dymax = pixel_size_y * std::max(beam_ctr_y, ny_pixels - beam_ctr_y);
     double maxdist = std::max(dxmax, dymax);
 
+    //This uses the correct parameter in the workspace, which has been
+    //changed to the right distance in EQSANSLoad.cpp
     qmax = 4 * M_PI / wavelength_min *
            std::sin(0.5 * std::atan(maxdist / sample_detector_distance));
     g_log.debug() << "Using calculated Qmax = " << qmax << std::endl;

--- a/Framework/WorkflowAlgorithms/src/EQSANSQ2D.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSQ2D.cpp
@@ -90,8 +90,8 @@ void EQSANSQ2D::exec() {
     qmax = getRunProperty(inputWS, "qmax");
     g_log.debug() << "Using Qmax from run properties = " << qmax << std::endl;
   } else {
-    //This is pointing to the correct parameter in the workspace, which has been
-    //changed to the right distance in EQSANSLoad.cpp
+    // This is pointing to the correct parameter in the workspace,
+    // which has been changed to the right distance in EQSANSLoad.cpp
     const double sample_detector_distance =
         getRunProperty(inputWS, "sample_detector_distance");
 
@@ -111,8 +111,8 @@ void EQSANSQ2D::exec() {
     double dymax = pixel_size_y * std::max(beam_ctr_y, ny_pixels - beam_ctr_y);
     double maxdist = std::max(dxmax, dymax);
 
-    //This uses the correct parameter in the workspace, which has been
-    //changed to the right distance in EQSANSLoad.cpp
+    // This uses the correct parameter in the workspace, which has been
+    // changed to the right distance in EQSANSLoad.cpp
     qmax = 4 * M_PI / wavelength_min *
            std::sin(0.5 * std::atan(maxdist / sample_detector_distance));
     g_log.debug() << "Using calculated Qmax = " << qmax << std::endl;

--- a/Framework/WorkflowAlgorithms/src/SetupEQSANSReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/SetupEQSANSReduction.cpp
@@ -54,8 +54,12 @@ void SetupEQSANSReduction::init() {
   declareProperty(
       "SampleDetectorDistance", EMPTY_DBL(),
       "Sample to detector distance to use (overrides meta data), in mm");
-  declareProperty("SampleDetectorDistanceOffset", EMPTY_DBL(),
-                  "Offset to the sample to detector distance (use only when "
+
+  declareProperty("SampleOffset", EMPTY_DBL(),
+                  "Offset applies to the sample position (use only when "
+                  "using the detector distance found in the meta data), in mm");
+  declareProperty("DetectorOffset", EMPTY_DBL(),
+                  "Offset applies to the detector position (use only when "
                   "using the distance found in the meta data), in mm");
 
   declareProperty(
@@ -81,6 +85,8 @@ void SetupEQSANSReduction::init() {
   setPropertyGroup("SampleDetectorDistance", load_grp);
   setPropertyGroup("SampleDetectorDistanceOffset", load_grp);
 
+  setPropertyGroup("SampleOffset", load_grp);
+  setPropertyGroup("DetectorOffset", load_grp);
   setPropertyGroup("SolidAngleCorrection", load_grp);
   setPropertyGroup("DetectorTubes", load_grp);
 
@@ -658,6 +664,10 @@ void SetupEQSANSReduction::exec() {
   loadAlg->setProperty("SampleDetectorDistance", sdd);
   const double sddOffset = getProperty("SampleDetectorDistanceOffset");
   loadAlg->setProperty("SampleDetectorDistanceOffset", sddOffset);
+  const double dOffset = getProperty("DetectorOffset");
+  loadAlg->setProperty("DetectorOffset", dOffset);
+  const double sOffset = getProperty("SampleOffset");
+  loadAlg->setProperty("SampleOffset", sOffset);
   const double wlStep = getProperty("WavelengthStep");
   loadAlg->setProperty("WavelengthStep", wlStep);
 

--- a/Framework/WorkflowAlgorithms/src/SetupEQSANSReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/SetupEQSANSReduction.cpp
@@ -57,7 +57,7 @@ void SetupEQSANSReduction::init() {
 
   declareProperty("SampleDetectorDistanceOffset", EMPTY_DBL(),
                   "Offset to the sample to detector distance (use only when "
-                  "using the detector distance found in the meta data), in mm");                  
+                  "using the detector distance found in the meta data), in mm");
   declareProperty("SampleOffset", EMPTY_DBL(),
                   "Offset applies to the sample position (use only when "
                   "using the detector distance found in the meta data), in mm");

--- a/Framework/WorkflowAlgorithms/src/SetupEQSANSReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/SetupEQSANSReduction.cpp
@@ -55,6 +55,9 @@ void SetupEQSANSReduction::init() {
       "SampleDetectorDistance", EMPTY_DBL(),
       "Sample to detector distance to use (overrides meta data), in mm");
 
+  declareProperty("SampleDetectorDistanceOffset", EMPTY_DBL(),
+                  "Offset to the sample to detector distance (use only when "
+                  "using the detector distance found in the meta data), in mm");                  
   declareProperty("SampleOffset", EMPTY_DBL(),
                   "Offset applies to the sample position (use only when "
                   "using the detector distance found in the meta data), in mm");


### PR DESCRIPTION
After an instrument upgrade, the EQSANS reduction needs more flexibility in defining the position of the sample relative to the detector. Two new property were added to offset both the sample position and detector position.

This code was submitted by W. Heller.

**To test:**

- Make sure all the tests pass.
- Review the changes

There is no ticket for this PR, all the information is here.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
