### PR TITLE
Fix for has_hash function throwing when TableWorkspace in ADS

### DIFF
--- a/scripts/SANS/sans/common/log_tagger.py
+++ b/scripts/SANS/sans/common/log_tagger.py
@@ -96,7 +96,10 @@ def has_hash(tag, hashed_value, workspace):
     if isinstance(workspace, WorkspaceGroup):
         return False
 
-    check_if_valid_tag_and_workspace(tag, workspace)
+    try:
+        check_if_valid_tag_and_workspace(tag, workspace)
+    except RuntimeException:
+        return False
 
     if not has_tag(tag, workspace):
         return False

--- a/scripts/SANS/sans/common/log_tagger.py
+++ b/scripts/SANS/sans/common/log_tagger.py
@@ -98,7 +98,7 @@ def has_hash(tag, hashed_value, workspace):
 
     try:
         check_if_valid_tag_and_workspace(tag, workspace)
-    except RuntimeException:
+    except RuntimeError:
         return False
 
     if not has_tag(tag, workspace):


### PR DESCRIPTION
If there is anything in the ads that isn't a WorkspaceGroup or a MatrixWorkspace, such as a TableWorkspace, then has_hash throws an exception.  I'm making the argument that, if it's not a MatrixWorkspace, then it doesn't have the hash, so the answer is simply false and not an exception.  This fixes the issue #20256, since it's now possible to search through the ads for a hash without the exception crashing the routine.

Description of work.

**To test:**

<!-- Instructions for testing. -->

Fixes #20256 

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
