### PR TITLE
ISIS Powder clarify error if diff TOF subtracting empty

### DIFF
--- a/scripts/Diffraction/isis_powder/routines/common.py
+++ b/scripts/Diffraction/isis_powder/routines/common.py
@@ -391,7 +391,12 @@ def subtract_summed_runs(ws_to_correct, empty_sample_ws_string, instrument, scal
     if scale_factor:
         empty_sample = mantid.Scale(InputWorkspace=empty_sample, OutputWorkspace=empty_sample, Factor=scale_factor,
                                     Operation="Multiply")
-    mantid.Minus(LHSWorkspace=ws_to_correct, RHSWorkspace=empty_sample, OutputWorkspace=ws_to_correct)
+    try:
+        mantid.Minus(LHSWorkspace=ws_to_correct, RHSWorkspace=empty_sample, OutputWorkspace=ws_to_correct)
+    except ValueError:
+        raise ValueError("The empty run(s) specified for this file do not have matching binning. Do the TOF windows of"
+                         " the empty and sample match?")
+
     remove_intermediate_workspace(empty_sample)
 
     return ws_to_correct

--- a/scripts/test/ISISPowderCommonTest.py
+++ b/scripts/test/ISISPowderCommonTest.py
@@ -465,6 +465,23 @@ class ISISPowderCommonTest(unittest.TestCase):
         common.run_normalise_by_current(ws)
         self.assertAlmostEqual(expected_value, ws.dataY(0)[0], delta=1e-8)
 
+    def test_spline_workspaces(self):
+        ws_list = []
+        for i in range(1, 4):
+            out_name = "test_spline_vanadium-" + str(i)
+            ws_list.append(mantid.CreateSampleWorkspace(OutputWorkspace=out_name, NumBanks=1, BankPixelWidth=1,
+                                                        XMax=100, BinWidth=1))
+
+        splined_list = common.spline_workspaces(focused_vanadium_spectra=ws_list, num_splines=10)
+        for ws in splined_list:
+            self.assertAlmostEqual(ws.dataY(0)[25], 0.28576649, delta=1e-8)
+            self.assertAlmostEqual(ws.dataY(0)[50], 0.37745918, delta=1e-8)
+            self.assertAlmostEqual(ws.dataY(0)[75], 0.28133096, delta=1e-8)
+
+        for input_ws, splined_ws in zip(ws_list, splined_list):
+            mantid.DeleteWorkspace(input_ws)
+            mantid.DeleteWorkspace(splined_ws)
+
     def test_subtract_summed_runs(self):
         # Load a vanadium workspace for this test
         sample_empty_number = "100"
@@ -490,22 +507,17 @@ class ISISPowderCommonTest(unittest.TestCase):
         mantid.DeleteWorkspace(returned_ws)
         mantid.DeleteWorkspace(scaled_ws)
 
-    def test_spline_workspaces(self):
-        ws_list = []
-        for i in range(1, 4):
-            out_name = "test_spline_vanadium-" + str(i)
-            ws_list.append(mantid.CreateSampleWorkspace(OutputWorkspace=out_name, NumBanks=1, BankPixelWidth=1,
-                                                        XMax=100, BinWidth=1))
+    def test_subtract_summed_runs_throw_on_tof_mismatch(self):
+        # Create a sample workspace which will have mismatched TOF range
+        sample_ws = mantid.CreateSampleWorkspace()
+        ws_file_name = "100"  # Load POL100
 
-        splined_list = common.spline_workspaces(focused_vanadium_spectra=ws_list, num_splines=10)
-        for ws in splined_list:
-            self.assertAlmostEqual(ws.dataY(0)[25], 0.28576649, delta=1e-8)
-            self.assertAlmostEqual(ws.dataY(0)[50], 0.37745918, delta=1e-8)
-            self.assertAlmostEqual(ws.dataY(0)[75], 0.28133096, delta=1e-8)
+        # This should throw as the TOF ranges do not match
+        with assertRaisesRegex(self, ValueError, "specified for this file do not have matching binning. Do the "):
+            common.subtract_summed_runs(ws_to_correct=sample_ws, instrument=ISISPowderMockInst(),
+                                        empty_sample_ws_string=ws_file_name)
 
-        for input_ws, splined_ws in zip(ws_list, splined_list):
-            mantid.DeleteWorkspace(input_ws)
-            mantid.DeleteWorkspace(splined_ws)
+        mantid.DeleteWorkspace(sample_ws)
 
 
 class ISISPowderMockInst(object):


### PR DESCRIPTION
Description of work.
This PR clarifies to the user what went wrong and what they must do when they attempt to subtract an empty run from a sample with different TOF windows

**To test:**
- Create and save a sample workspace with a differing TOF window (e.g. POL100 in the unit test folder)
- Set the empty run to a correct value
- Check exception is thrown and gives a sane value

Fixes #20252 

*Does not need to be in the release notes. As part of the work in #20152*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
