### PR TITLE
PDCalibration improvements

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
@@ -63,9 +63,13 @@ private:
                                    const double tzero);
   void setCalibrationValues(const detid_t detid, const double difc,
                             const double difa, const double tzero);
-  void fitDIFCtZeroDIFA(const std::vector<double> &d,
-                        const std::vector<double> &tof, double &difc,
-                        double &t0, double &difa);
+  void fitDIFCtZeroDIFA_BLUE(const std::vector<double> &d,
+                             const std::vector<double> &tof, double &difc,
+                             double &t0, double &difa);
+  void fitDIFCtZeroDIFA_LM(const std::vector<double> &d,
+                           const std::vector<double> &tof,
+                           const std::vector<double> &height2, double &difc,
+                           double &t0, double &difa);
   API::MatrixWorkspace_sptr m_uncalibratedWS;
   API::ITableWorkspace_sptr m_calibrationTable;
   API::ITableWorkspace_sptr m_peakPositionTable;

--- a/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
@@ -71,7 +71,6 @@ private:
   API::ITableWorkspace_sptr m_calibrationTable;
   API::ITableWorkspace_sptr m_peakPositionTable;
   std::vector<double> m_peaksInDspacing;
-  std::string calParams;
   std::map<detid_t, size_t> m_detidToRow;
   double m_tofMin{0.};
   double m_tofMax{0.};
@@ -80,6 +79,7 @@ private:
   double m_difaMin{0.};
   double m_difaMax{0.};
   bool m_hasDasIds{false};
+  size_t m_numberMaxParams{0};
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
@@ -63,9 +63,6 @@ private:
                                    const double tzero);
   void setCalibrationValues(const detid_t detid, const double difc,
                             const double difa, const double tzero);
-  void fitDIFCtZeroDIFA_BLUE(const std::vector<double> &d,
-                             const std::vector<double> &tof, double &difc,
-                             double &t0, double &difa);
   void fitDIFCtZeroDIFA_LM(const std::vector<double> &d,
                            const std::vector<double> &tof,
                            const std::vector<double> &height2, double &difc,

--- a/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
@@ -55,6 +55,7 @@ private:
   API::MatrixWorkspace_sptr load(const std::string filename);
   void loadOldCalibration();
   void createNewCalTable();
+  void createInformationWorkspaces();
   std::function<double(double)> getDSpacingToTof(const detid_t detid);
   std::vector<double> dSpacingWindows(const std::vector<double> &centres,
                                       const double widthMax);
@@ -67,6 +68,7 @@ private:
                         double &t0, double &difa);
   API::MatrixWorkspace_sptr m_uncalibratedWS;
   API::ITableWorkspace_sptr m_calibrationTable;
+  API::ITableWorkspace_sptr m_peakPositionTable;
   std::vector<double> m_peaksInDspacing;
   std::string calParams;
   std::map<detid_t, size_t> m_detidToRow;

--- a/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -309,6 +309,8 @@ MatrixWorkspace_sptr CreateSampleWorkspace::createHistogramWorkspace(
     bool isRandom) {
   BinEdges x(numBins + 1, LinearGenerator(x0, binDelta));
 
+  // there is a oddity here that y is evaluated from x=0, and x is from XMin
+  // changing it requires changing unit tests that use this algorithm
   std::vector<double> xValues(cbegin(x), cend(x) - 1);
   Counts y(evalFunction(functionString, xValues, isRandom ? 1 : 0));
 
@@ -432,6 +434,7 @@ CreateSampleWorkspace::evalFunction(const std::string &functionString,
     std::string replaceStr = boost::lexical_cast<std::string>(replace_val);
     replaceAll(parsedFuncString, token, replaceStr);
   }
+  g_log.information(parsedFuncString);
 
   IFunction_sptr func_sptr =
       FunctionFactory::Instance().createInitialized(parsedFuncString);

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -554,13 +554,13 @@ void PDCalibration::exec() {
 }
 
 namespace { // anonymous namespace
-/**
- * Helper function for calculating costs in gsl.
- * @param v vector of parameters that are being modified by gsl (difc, tzero,
- * difa)
- * @param params The parameters being used for the fit
- * @return Sum of the errors
- */
+            /**
+             * Helper function for calculating costs in gsl.
+             * @param v vector of parameters that are being modified by gsl (difc, tzero,
+             * difa)
+             * @param params The parameters being used for the fit
+             * @return Sum of the errors
+             */
 double gsl_costFunction(const gsl_vector *v, void *peaks) {
   // this array is [numPeaks, numParams, vector<tof>, vector<dspace>,
   // vector<height^2>]

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -506,13 +506,26 @@ void PDCalibration::exec() {
   }
   PARALLEL_CHECK_INTERUPT_REGION
 
+  // sort the calibration workspaces
+  { // limit scope
+    auto alg = createChildAlgorithm("SortTableWorkspace");
+    alg->setProperty("InputWorkspace", m_calibrationTable);
+    alg->setProperty("OutputWorkspace", m_calibrationTable);
+    alg->setProperty("Columns", "detid");
+    alg->executeAsChildAlg();
+    m_calibrationTable = alg->getProperty("OutputWorkspace");
+  }
+  setProperty("OutputCalibrationTable", m_calibrationTable);
+
   // fix-up the diagnostic workspaces
-  auto alg = createChildAlgorithm("SortTableWorkspace");
-  alg->setProperty("InputWorkspace", m_peakPositionTable);
-  alg->setProperty("OutputWorkspace", m_peakPositionTable);
-  alg->setProperty("Columns", "detid");
-  alg->executeAsChildAlg();
-  m_peakPositionTable = alg->getProperty("OutputWorkspace");
+  { // limit scope
+    auto alg = createChildAlgorithm("SortTableWorkspace");
+    alg->setProperty("InputWorkspace", m_peakPositionTable);
+    alg->setProperty("OutputWorkspace", m_peakPositionTable);
+    alg->setProperty("Columns", "detid");
+    alg->executeAsChildAlg();
+    m_peakPositionTable = alg->getProperty("OutputWorkspace");
+  }
 
   // set the diagnostic workspaces out
   const std::string partials_prefix = getPropertyValue("DiagnosticWorkspaces");
@@ -863,7 +876,6 @@ void PDCalibration::loadOldCalibration() {
     m_calibrationTable->addColumn("int", "dasid");
   m_calibrationTable->addColumn("double", "tofmin");
   m_calibrationTable->addColumn("double", "tofmax");
-  setProperty("OutputCalibrationTable", m_calibrationTable);
 
   // copy over the values
   for (std::size_t rowNum = 0; rowNum < calibrationTableOld->rowCount();

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -409,7 +409,7 @@ void PDCalibration::exec() {
       continue;
 
     auto alg = createChildAlgorithm("FindPeaks");
-    alg->setLoggingOffset(2);
+    alg->setLoggingOffset(3);
     alg->setProperty("InputWorkspace", m_uncalibratedWS);
     alg->setProperty("WorkspaceIndex", static_cast<int>(wkspIndex));
     alg->setProperty("PeakPositions", peaks.inTofPos);
@@ -509,6 +509,7 @@ void PDCalibration::exec() {
   // sort the calibration workspaces
   { // limit scope
     auto alg = createChildAlgorithm("SortTableWorkspace");
+    alg->setLoggingOffset(1);
     alg->setProperty("InputWorkspace", m_calibrationTable);
     alg->setProperty("OutputWorkspace", m_calibrationTable);
     alg->setProperty("Columns", "detid");
@@ -520,6 +521,7 @@ void PDCalibration::exec() {
   // fix-up the diagnostic workspaces
   { // limit scope
     auto alg = createChildAlgorithm("SortTableWorkspace");
+    alg->setLoggingOffset(1);
     alg->setProperty("InputWorkspace", m_peakPositionTable);
     alg->setProperty("OutputWorkspace", m_peakPositionTable);
     alg->setProperty("Columns", "detid");
@@ -766,6 +768,7 @@ MatrixWorkspace_sptr PDCalibration::load(const std::string filename) {
   const double filterBadPulses = getProperty("FilterBadPulses");
 
   auto alg = createChildAlgorithm("LoadEventAndCompress");
+  alg->setLoggingOffset(1);
   alg->setProperty("Filename", filename);
   alg->setProperty("MaxChunkSize", maxChunkSize);
   alg->setProperty("FilterByTofMin", m_tofMin);
@@ -800,6 +803,7 @@ MatrixWorkspace_sptr PDCalibration::loadAndBin() {
 
     g_log.information("Subtracting background");
     auto algMinus = createChildAlgorithm("Minus");
+    algMinus->setLoggingOffset(1);
     algMinus->setProperty("LHSWorkspace", signalWS);
     algMinus->setProperty("RHSWorkspace", backWS);
     algMinus->setProperty("OutputWorkspace", signalWS);
@@ -809,6 +813,7 @@ MatrixWorkspace_sptr PDCalibration::loadAndBin() {
 
     g_log.information("Compressing data");
     auto algCompress = createChildAlgorithm("CompressEvents");
+    algCompress->setLoggingOffset(1);
     algCompress->setProperty("InputWorkspace", signalWS);
     algCompress->setProperty("OutputWorkspace", signalWS);
     algCompress->executeAsChildAlg();
@@ -823,6 +828,7 @@ MatrixWorkspace_sptr PDCalibration::loadAndBin() {
 API::MatrixWorkspace_sptr PDCalibration::rebin(API::MatrixWorkspace_sptr wksp) {
   g_log.information("Binning data in time-of-flight");
   auto rebin = createChildAlgorithm("Rebin");
+  rebin->setLoggingOffset(1);
   rebin->setProperty("InputWorkspace", wksp);
   rebin->setProperty("OutputWorkspace", wksp);
   rebin->setProperty("Params", getPropertyValue("TofBinning"));
@@ -846,6 +852,7 @@ void PDCalibration::loadOldCalibration() {
   // load the old one
   std::string filename = getProperty("PreviousCalibration");
   auto alg = createChildAlgorithm("LoadDiffCal");
+  alg->setLoggingOffset(1);
   alg->setProperty("Filename", filename);
   alg->setProperty("WorkspaceName", "NOMold"); // TODO
   alg->setProperty("MakeGroupingWorkspace", false);
@@ -902,6 +909,7 @@ void PDCalibration::createNewCalTable() {
   // create new calibraion table for when an old one isn't loaded
   // using the signal workspace and CalculateDIFC
   auto alg = createChildAlgorithm("CalculateDIFC");
+  alg->setLoggingOffset(1);
   alg->setProperty("InputWorkspace", m_uncalibratedWS);
   alg->executeAsChildAlg();
   API::MatrixWorkspace_const_sptr difcWS = alg->getProperty("OutputWorkspace");

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -50,7 +50,6 @@ DECLARE_ALGORITHM(PDCalibration)
 
 namespace { // anonymous
 const auto isNonZero = [](const double value) { return value != 0.; };
-const double CHISQ_BAD = 1.e9; // hopefully much worse than possible
 }
 
 /// private inner class
@@ -367,11 +366,11 @@ void PDCalibration::exec() {
   double maxChiSquared = getProperty("MaxChiSq");
 
   const std::string calParams = getPropertyValue("CalibrationParameters");
-  if (calParams == "DIFC")
+  if (calParams == std::string("DIFC"))
     m_numberMaxParams = 1;
-  else if ("DIFC+TZERO")
+  else if (calParams == std::string("DIFC+TZERO"))
     m_numberMaxParams = 2;
-  else if ("DIFC+TZERO+DIFA")
+  else if (calParams == std::string("DIFC+TZERO+DIFA"))
     m_numberMaxParams = 3;
   else
     throw std::runtime_error(

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -733,6 +733,10 @@ void PDCalibration::fitDIFCtZeroDIFA_LM(const std::vector<double> &d,
       errsum = errsum / static_cast<double>(numPeaks - numParams);
       // save the best and forget the rest
       if (errsum < best_errsum) {
+        if (difa_local > m_difaMax || difa_local < m_difaMin)
+          continue; // unphysical fit
+        if (t0_local > m_tzeroMax || t0_local < m_tzeroMin)
+          continue; // unphysical fit
         best_errsum = errsum;
         best_difc = difc_local;
         best_t0 = t0_local;

--- a/Framework/Kernel/src/Diffraction.cpp
+++ b/Framework/Kernel/src/Diffraction.cpp
@@ -110,6 +110,18 @@ std::function<double(double)> getTofToDConversionFunc(const double difc,
 // ----------------------------------------------------------------------------
 // convert from d-spacing to time-of-flight
 namespace { // anonymous namespace
+struct d_to_tof_difc_only {
+  d_to_tof_difc_only(const double difc) {
+    this->difc = difc;
+  }
+
+  double operator()(const double dspacing) const {
+    return difc * dspacing;
+  }
+
+  double difc;
+};
+
 struct d_to_tof_difc_and_tzero {
   d_to_tof_difc_and_tzero(const double difc, const double tzero) {
     this->difc = difc;
@@ -145,7 +157,10 @@ std::function<double(double)> getDToTofConversionFunc(const double difc,
                                                       const double difa,
                                                       const double tzero) {
   if (difa == 0.) {
-    return d_to_tof_difc_and_tzero(difc, tzero);
+    if (tzero == 0.)
+      return d_to_tof_difc_only(difc);
+    else
+      return d_to_tof_difc_and_tzero(difc, tzero);
   } else {
     return d_to_tof(difc, difa, tzero);
   }

--- a/Framework/Kernel/src/Diffraction.cpp
+++ b/Framework/Kernel/src/Diffraction.cpp
@@ -111,13 +111,9 @@ std::function<double(double)> getTofToDConversionFunc(const double difc,
 // convert from d-spacing to time-of-flight
 namespace { // anonymous namespace
 struct d_to_tof_difc_only {
-  d_to_tof_difc_only(const double difc) {
-    this->difc = difc;
-  }
+  d_to_tof_difc_only(const double difc) { this->difc = difc; }
 
-  double operator()(const double dspacing) const {
-    return difc * dspacing;
-  }
+  double operator()(const double dspacing) const { return difc * dspacing; }
 
   double difc;
 };

--- a/docs/source/release/v3.11.0/diffraction.rst
+++ b/docs/source/release/v3.11.0/diffraction.rst
@@ -15,18 +15,21 @@ Engineering Diffraction
 -----------------------
 
 Powder Diffraction
+------------------
 
 - Added new diagrams showing the algorithms used in ISIS Powder scripts. These can be found at: :ref:`isis-powder-diffraction-workflow-ref`
 - LoadILLAscii, which could be used to load D2B ASCII data into an MD workspace, has been removed. :ref:`LoadILLDiffraction <algm-LoadILLDiffraction>` should be used instead.
 - :ref:`LoadILLDiffraction <algm-LoadILLDiffraction>` now supports loading D2B data with detector scans. The D2B IDF has been updated, as previously it contained some errors in the positions of the tubes and size of the pixels.
 - :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>` now correctly supports overloading the grouping file in the presence of a masking workspace.
+- :ref:`PDCalibration <algm-PDCalibration>` has changed how it calculates constants from peak positions to use a simplex optimization rather than Gauss-Markov method.
 
-Full list of `diffraction <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+Diffraction%22>`_
-and
-`imaging <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+Imaging%22>`_ changes on GitHub.
 
 Single Crystal Diffraction
 --------------------------
 
 - New algorithm :ref:`SingleCrystalDiffuseReduction <algm-SingleCrystalDiffuseReduction>` which performs the most common reductions done on Corelli (and elsewhere) for single crystal diffuse scattering.
 - :ref:`FindPeaksMD <algm-FindPeaksMD>` has been modified to only add peaks to runs that contributed to that peak. This is a lot faster when multiple runs are in the same MDworkspace.
+
+Full list of `diffraction <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+Diffraction%22>`_
+and
+`imaging <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+Imaging%22>`_ changes on GitHub.


### PR DESCRIPTION
Add an output workspace for giving the user more information on how the calibration went. In the process, discovered that the calibration was pretty bad so converted from Gauss-Markov to simplex for finding final calibration information. 

**To test:**

Try this before and after merging with powgen data and see that there is a diagnostic workspace and the data lines up better.

```python
LoadEventNexus(Filename='PG3_37861', OutputWorkspace='PG3_37861') #/SNS/PG3/IPTS-2767/nexus/PG3_37659.nxs.h5', OutputWorkspace='PG3_37659')
PDCalibration(SignalWorkspace='PG3_37861', TofBinning='300,-0.0005,16667',
              PeakPositions='2.06,1.2615,1.0758,0.892,0.8186,0.7283,0.6867,0.6307,0.5947,0.5642,0.5441,0.515,0.4996,0.4768,0.4645,0.4205,0.3916,0.3499,0.3257,0.3117',
              PeakWindow=0.02, Tolerance=2, MinGuessedPeakWidth=4, MaxGuessedPeakWidth=14,
              MinimumPeakHeight=5, MaxChiSq=50, TZEROrange='0,10', OutputCalibrationTable='PDCalib', DiagnosticWorkspaces='diag') # DiagnosticWorkspaces doesn't exist on `master`
AlignDetectors(InputWorkspace='PG3_37861', OutputWorkspace='PG3_37861',
               CalibrationWorkspace='PDCalib')
```

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
