### PR TITLE
Make EXTERNAL_ROOT a CMake cache variable

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -8,7 +8,7 @@ if( MSVC )
 
   # Use ExternalProject functionality as it already knows how to do clone/update
   include ( ExternalProject )
-  set( EXTERNAL_ROOT ${PROJECT_SOURCE_DIR}/external )
+  set( EXTERNAL_ROOT ${PROJECT_SOURCE_DIR}/external CACHE PATH "Location to clone third party dependencies to" )
   set( THIRD_PARTY_GIT_URL "https://github.com/mantidproject/thirdparty-msvc2015.git" )
   set ( THIRD_PARTY_GIT_SHA1 9af2288ba00e184b8659edbeedb12ce771b87bb5 )
   set ( THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty )


### PR DESCRIPTION
Made `EXTERNAL_ROOT` a CMake cache variable so that it can be set to a directory outside of Mantid source.

**To test:**
Code review should be sufficient. Will only have any effect if `EXTERNAL_ROOT` is manually configured to a non-default location.

Closes #20269 

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
