### PR TITLE
Fix IntegrateFlux for case when you don't have events with momentum covering the range

### DIFF
--- a/Framework/MDAlgorithms/src/IntegrateFlux.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateFlux.cpp
@@ -191,6 +191,12 @@ void IntegrateFlux::integrateSpectraEvents(
       sum += evnt->weight();
       outY[i] = sum;
     }
+
+    while (x != X.end()) {
+      outY[i] = sum;
+      ++x;
+      ++i;
+    }
   }
 }
 


### PR DESCRIPTION
**Master:**
![flux_before](https://user-images.githubusercontent.com/5595210/29522156-45ad4660-8656-11e7-9226-50ff6eca650d.png)

**This branch:**
![flux_after](https://user-images.githubusercontent.com/5595210/29522182-5e385468-8656-11e7-92a3-926d6bb38cd7.png)


**To test:**

```
ws=Load('CNCS_7860')

ws=ConvertUnits(InputWorkspace=ws,Target='Momentum')
ws=CropWorkspace(InputWorkspace=ws,XMin=1,XMax=1.6)

ws=Rebin(InputWorkspace=ws,Params='1,1.6,1.6')
ws=SumSpectra(ws)

el=ws.getSpectrum(0)
el.divide(ws.readY(0)[0],0)

ws=Rebin(InputWorkspace=ws,Params='1,1.6,1.6')
flux=IntegrateFlux(ws)
```

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
