### PR TITLE
Apply clang-format stuff moved to qt folder

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/ReflFromStdStringMap.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflFromStdStringMap.cpp
@@ -9,9 +9,10 @@ fromStdStringMap(std::map<std::string, std::string> const &inMap) {
   std::transform(inMap.begin(), inMap.end(), std::inserter(out, out.begin()),
                  [](std::pair<std::string, std::string> const &kvp)
                      -> std::pair<QString, QString> {
-                   return std::make_pair(QString::fromStdString(kvp.first),
-                                         QString::fromStdString(kvp.second));
-                 });
+                       return std::make_pair(
+                           QString::fromStdString(kvp.first),
+                           QString::fromStdString(kvp.second));
+                     });
   return out;
 }
 

--- a/qt/scientific_interfaces/ISISSANS/SANSBackgroundCorrectionWidget.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSBackgroundCorrectionWidget.h
@@ -36,8 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTIDQT_ISISSANS_DLL SANSBackgroundCorrectionWidget
-    : public QWidget {
+class MANTIDQT_ISISSANS_DLL SANSBackgroundCorrectionWidget : public QWidget {
   Q_OBJECT
 public:
   SANSBackgroundCorrectionWidget(QWidget *parent = 0);

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.h
@@ -38,8 +38,7 @@ class PlotController;
  * multi-dataset fit
  * and displaying the results.
  */
-class MANTIDQT_MULTIDATASETFIT_DLL MultiDatasetFit
-    : public API::UserSubWindow {
+class MANTIDQT_MULTIDATASETFIT_DLL MultiDatasetFit : public API::UserSubWindow {
   Q_OBJECT
 public:
   /// The name of the interface as registered into the factory

--- a/qt/scientific_interfaces/Muon/IALCBaselineModellingModel.h
+++ b/qt/scientific_interfaces/Muon/IALCBaselineModellingModel.h
@@ -36,8 +36,7 @@ namespace CustomInterfaces {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTIDQT_MUONINTERFACE_DLL IALCBaselineModellingModel
-    : public QObject {
+class MANTIDQT_MUONINTERFACE_DLL IALCBaselineModellingModel : public QObject {
   Q_OBJECT
 
 public:

--- a/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisFitDataPresenter.h
@@ -61,8 +61,7 @@ public:
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTIDQT_MUONINTERFACE_DLL MuonAnalysisFitDataPresenter
-    : public QObject {
+class MANTIDQT_MUONINTERFACE_DLL MuonAnalysisFitDataPresenter : public QObject {
   Q_OBJECT
 public:
   /// Constructor overload with default arguments

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.h
@@ -42,7 +42,7 @@ namespace MuonAnalysisHelper {
 
 /// Sets double validator for specified field
 MANTIDQT_MUONINTERFACE_DLL void setDoubleValidator(QLineEdit *field,
-                                                      bool allowEmpty = false);
+                                                   bool allowEmpty = false);
 
 /// Returns a first period MatrixWorkspace in a run workspace
 MANTIDQT_MUONINTERFACE_DLL Mantid::API::MatrixWorkspace_sptr
@@ -87,8 +87,8 @@ findConsecutiveRuns(const std::vector<int> &runs);
 
 /// Replaces sample log value
 MANTIDQT_MUONINTERFACE_DLL void replaceLogValue(const std::string &wsName,
-                                                   const std::string &logName,
-                                                   const std::string &logValue);
+                                                const std::string &logName,
+                                                const std::string &logValue);
 
 /// Finds all of the values for a log
 MANTIDQT_MUONINTERFACE_DLL std::vector<std::string>
@@ -130,8 +130,8 @@ MANTIDQT_MUONINTERFACE_DLL bool isReloadGroupingNecessary(
 
 /// Parse run label into instrument and runs
 MANTIDQT_MUONINTERFACE_DLL void parseRunLabel(const std::string &label,
-                                                 std::string &instrument,
-                                                 std::vector<int> &runNumbers);
+                                              std::string &instrument,
+                                              std::vector<int> &runNumbers);
 
 /// Get colors for workspaces to go in table
 MANTIDQT_MUONINTERFACE_DLL QMap<int, QColor> getWorkspaceColors(


### PR DESCRIPTION
The clang-format job wasn't updated for the new folders after #20162 This fixes the formatting and checks that the builds don't break before I update the job.


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
