### PR TITLE
Re #20319: Replaced implicit conversion of boost::optional to bool with explicit conversion before assert.

### DIFF
--- a/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.cpp
@@ -70,7 +70,7 @@ void ALCPeakFittingPresenter::onPeakPickerChanged() {
   // If PeakPicker is changed, it should be enabled, which means a peak function
   // should be selected
   // (See onCurrentFunctionChanged)
-  assert(index);
+  assert(bool(index));
 
   auto peakFunc = m_view->peakPicker();
 


### PR DESCRIPTION
Fixed #20319 using an explicit `bool()` conversion in the troublemaking `assert`.

**To test:**
- Code review and CI checks should be sufficient.
- Could try compiling `MantidScientificInterfacesMuon` in an affected system configuration.
<!-- Instructions for testing. -->

Fixes #20319. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
