### PR TITLE
Allow deletion of multiple rows in DataProcessorWidget for reductions without post-processing

### DIFF
--- a/qt/widgets/common/src/DataProcessorUI/DataProcessorOneLevelTreeManager.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/DataProcessorOneLevelTreeManager.cpp
@@ -129,14 +129,16 @@ void DataProcessorOneLevelTreeManager::appendGroup() {
 Delete row(s) from the model
 */
 void DataProcessorOneLevelTreeManager::deleteRow() {
-
   auto selectedRows = m_presenter->selectedParents();
-
-  if (selectedRows.empty())
-    return;
-
-  for (const auto &row : selectedRows) {
+  while(!selectedRows.empty()) {
+    // Remove a row
+    auto row = *selectedRows.begin();
     m_model->removeRow(row);
+
+    // Once one row has been deleted the selcted row
+    // indices are not valid any longer. We need
+    // to update them again.
+    selectedRows = m_presenter->selectedParents();
   }
 }
 

--- a/qt/widgets/common/test/DataProcessorUI/DataProcessorOneLevelTreeManagerTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/DataProcessorOneLevelTreeManagerTest.h
@@ -171,7 +171,7 @@ public:
     TS_ASSERT_THROWS_ANYTHING(manager.appendGroup());
   }
 
-  void test_delete_row() {
+  void test_delete_row_when_table_is_empty() {
     NiceMock<MockDataProcessorPresenter> presenter;
     DataProcessorOneLevelTreeManager manager(&presenter, reflWhitelist());
 
@@ -183,6 +183,22 @@ public:
     TS_ASSERT_THROWS_NOTHING(manager.deleteRow());
     TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter));
   }
+
+  void test_delete_row_with_populated_table() {
+    NiceMock<MockDataProcessorPresenter> presenter;
+    DataProcessorOneLevelTreeManager manager(&presenter, reflWhitelist());
+
+    EXPECT_CALL(presenter, selectedParents())
+        .Times(3)
+        .WillOnce(Return(std::set<int>{0, 1}))
+        .WillOnce(Return(std::set<int>{0}))
+        .WillOnce(Return(std::set<int>()));
+    EXPECT_CALL(presenter, selectedChildren()).Times(0);
+
+    TS_ASSERT_THROWS_NOTHING(manager.deleteRow());
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&presenter));
+  }
+
 
   void test_delete_group() {
     NiceMock<MockDataProcessorPresenter> presenter;

--- a/scripts/Interface/ui/dataprocessorinterface/data_processor_gui.py
+++ b/scripts/Interface/ui/dataprocessorinterface/data_processor_gui.py
@@ -4,10 +4,11 @@ try:
 except ImportError:
     canMantidPlot = False
 
-import ui_data_processor_window
 from PyQt4 import QtGui
-from mantid.simpleapi import *
 from mantidqtpython import MantidQt
+
+from . import ui_data_processor_window
+
 
 canMantidPlot = True
 


### PR DESCRIPTION
Fixes #20323

When the data processor widget is operated in "one-level" mode, ie without a post-processing algorithm, we get erratic behaviour when deleting multiple rows.

**To test:**

1. On any branch but this one enable the `DataProcesorInterface` python UI and comment out the post processing algorithm
2. Open the GUI and add two rows. Put an aribitrary number into the `Runs` column`
3. Select both rows and press `Delete Row`
   * Confirm that only one row is being deleted
4. Checkout this branch and perform the same routine
   * Confirm that both rows are deleted.

**Release Notes** 
*Does not have to be in the release notes*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
