### PR TITLE
Fix cppcheck issues in Kernel::Diffraction

### DIFF
--- a/Framework/Kernel/src/Diffraction.cpp
+++ b/Framework/Kernel/src/Diffraction.cpp
@@ -57,7 +57,7 @@ struct tof_to_d_difc_only {
 
 /// Applies the equation d=(TOF-tzero)/difc
 struct tof_to_d_difc_and_tzero {
-  tof_to_d_difc_and_tzero(const double difc, const double tzero)
+  explicit tof_to_d_difc_and_tzero(const double difc, const double tzero)
       : factor(1. / difc), offset(-1. * tzero / difc) {}
 
   double operator()(const double tof) const { return factor * tof + offset; }
@@ -69,7 +69,7 @@ struct tof_to_d_difc_and_tzero {
 };
 
 struct tof_to_d {
-  tof_to_d(const double difc, const double difa, const double tzero) {
+  explicit tof_to_d(const double difc, const double difa, const double tzero) {
     factor1 = -0.5 * difc / difa;
     factor2 = 1. / difa;
     factor3 = (factor1 * factor1) - (tzero / difa);
@@ -111,7 +111,7 @@ std::function<double(double)> getTofToDConversionFunc(const double difc,
 // convert from d-spacing to time-of-flight
 namespace { // anonymous namespace
 struct d_to_tof_difc_only {
-  d_to_tof_difc_only(const double difc) { this->difc = difc; }
+  explicit d_to_tof_difc_only(const double difc) { this->difc = difc; }
 
   double operator()(const double dspacing) const { return difc * dspacing; }
 
@@ -119,7 +119,7 @@ struct d_to_tof_difc_only {
 };
 
 struct d_to_tof_difc_and_tzero {
-  d_to_tof_difc_and_tzero(const double difc, const double tzero) {
+  explicit d_to_tof_difc_and_tzero(const double difc, const double tzero) {
     this->difc = difc;
     this->tzero = tzero;
   }
@@ -133,7 +133,7 @@ struct d_to_tof_difc_and_tzero {
 };
 
 struct d_to_tof {
-  d_to_tof(const double difc, const double difa, const double tzero) {
+  explicit d_to_tof(const double difc, const double difa, const double tzero) {
     this->difc = difc;
     this->difa = difa;
     this->tzero = tzero;


### PR DESCRIPTION
There should be no `cppcheck` issues in `Kernel::Diffraction`.

**To test:**

If you have cppcheck installed, just `cmake --build . --target cppcheck`. Otherwise, look at the [cppcheck build result](http://builds.mantidproject.org/job/pull_requests-cppcheck/16112/cppcheckResult/).

*There is no associated issue.*

*Does not need to be in the release notes* because it is a static analysis fix.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
