### PR TITLE
Allow PropertyManager creation directly from a Python dict

### DIFF
--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Registry/PropertyManagerFactory.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Registry/PropertyManagerFactory.h
@@ -1,0 +1,42 @@
+#ifndef MANTID_PYTHONINTERFACE_PROPERTYMANAGERFACTORY_H
+#define MANTID_PYTHONINTERFACE_PROPERTYMANAGERFACTORY_H
+/*
+  Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+#include <boost/shared_ptr.hpp>
+#include <boost/python/dict.hpp>
+
+namespace Mantid {
+namespace Kernel {
+class PropertyManager;
+}
+namespace PythonInterface {
+namespace Registry {
+
+/// Create a C++ PropertyMananager from a Python dictionary
+boost::shared_ptr<Kernel::PropertyManager>
+createPropertyManager(const boost::python::dict &mapping);
+}
+}
+}
+
+#endif // MANTID_PYTHONINTERFACE_PROPERTYMANAGERFACTORY_H

--- a/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -75,6 +75,7 @@ set ( SRC_FILES
   src/Converters/PyObjectToVMD.cpp
   src/Converters/WrapWithNumpy.cpp
   src/Registry/MappingTypeHandler.cpp
+  src/Registry/PropertyManagerFactory.cpp
   src/Registry/PropertyWithValueFactory.cpp
   src/Registry/SequenceTypeHandler.cpp
   src/Registry/TypeRegistry.cpp
@@ -109,6 +110,7 @@ set ( INC_FILES
   ${HEADER_DIR}/kernel/Policies/VectorToNumpy.h
   ${HEADER_DIR}/kernel/Registry/MappingTypeHandler.h
   ${HEADER_DIR}/kernel/Registry/PropertyValueHandler.h
+  ${HEADER_DIR}/kernel/Registry/PropertyManagerFactory.h
   ${HEADER_DIR}/kernel/Registry/PropertyWithValueFactory.h
   ${HEADER_DIR}/kernel/Registry/SequenceTypeHandler.h
   ${HEADER_DIR}/kernel/Registry/TypedPropertyValueHandler.h

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyManager.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyManager.cpp
@@ -4,31 +4,32 @@
                                 // design
 #endif
 #include "MantidPythonInterface/kernel/GetPointer.h"
+#include "MantidPythonInterface/kernel/Registry/PropertyManagerFactory.h"
 #include "MantidKernel/IPropertyManager.h"
 #include "MantidKernel/PropertyManager.h"
 
 #include <boost/python/class.hpp>
+#include <boost/python/make_constructor.hpp>
 
+using Mantid::PythonInterface::Registry::createPropertyManager;
 using Mantid::Kernel::IPropertyManager;
 using Mantid::Kernel::PropertyManager;
+using Mantid::Kernel::PropertyManager_sptr;
 
 using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(PropertyManager)
 
 void export_PropertyManager() {
-  typedef boost::shared_ptr<PropertyManager> PropertyManager_sptr;
 
   // The second argument defines the actual type held within the Python object.
-  // This means that when a PropertyManager is constructed in Python it actually
-  // used
-  // a shared_ptr to the object rather than a raw pointer. This knowledge is
-  // used by
-  // DataServiceExporter::extractCppValue to assume that it can always extract a
-  // shared_ptr
-  // type
+  // This means that when a PropertyManager is constructed in Python
+  // it actually used a shared_ptr to the object rather than a raw pointer.
+  // This knowledge is used by DataServiceExporter::extractCppValue to assume
+  // that it can always extract a shared_ptr type
   class_<PropertyManager, PropertyManager_sptr, bases<IPropertyManager>,
-         boost::noncopyable>("PropertyManager");
+         boost::noncopyable>("PropertyManager")
+      .def("__init__", make_constructor(&createPropertyManager));
 }
 
 #ifdef _MSC_VER

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyManagerDataService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyManagerDataService.cpp
@@ -1,5 +1,6 @@
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidPythonInterface/kernel/DataServiceExporter.h"
+#include "MantidPythonInterface/kernel/Registry/PropertyManagerFactory.h"
 
 #include "MantidKernel/PropertyManagerDataService.h"
 #include "MantidKernel/PropertyManager.h"
@@ -10,10 +11,36 @@
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using Mantid::PythonInterface::DataServiceExporter;
+using Mantid::PythonInterface::Registry::createPropertyManager;
 using namespace boost::python;
 
 /// Weak pointer to DataItem typedef
 typedef boost::weak_ptr<PropertyManager> PropertyManager_wptr;
+
+namespace {
+/**
+ * Add a dictionary to the data service directly. It creates a PropertyManager
+ * on the way in.
+ * @param self A reference to the PropertyManagerDataService
+ * @param name The name of the object
+ * @param mapping A dict object
+ */
+void addFromDict(PropertyManagerDataServiceImpl &self, const std::string &name,
+                 const dict &mapping) {
+  self.add(name, createPropertyManager(mapping));
+}
+/**
+ * Add or replace a dictionary to the data service directly. It creates
+ * a PropertyManager on the way in.
+ * @param self A reference to the PropertyManagerDataService
+ * @param name The name of the object
+ * @param mapping A dict object
+ */
+void addOrReplaceFromDict(PropertyManagerDataServiceImpl &self,
+                          const std::string &name, const dict &mapping) {
+  self.addOrReplace(name, createPropertyManager(mapping));
+}
+}
 
 GET_POINTER_SPECIALIZATION(PropertyManagerDataServiceImpl)
 
@@ -28,5 +55,8 @@ void export_PropertyManagerDataService() {
   pmdType.def("Instance", &PropertyManagerDataService::Instance,
               return_value_policy<reference_existing_object>(),
               "Return a reference to the singleton instance")
-      .staticmethod("Instance");
+      .staticmethod("Instance")
+      // adds an overload from a dictionary
+      .def("add", &addFromDict)
+      .def("addOrReplace", &addOrReplaceFromDict);
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/MappingTypeHandler.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/MappingTypeHandler.cpp
@@ -1,16 +1,14 @@
 #include "MantidPythonInterface/kernel/Registry/MappingTypeHandler.h"
+#include "MantidPythonInterface/kernel/Registry/PropertyManagerFactory.h"
 #include "MantidPythonInterface/kernel/Registry/PropertyWithValueFactory.h"
 
 #include "MantidKernel/PropertyManager.h"
 #include "MantidKernel/PropertyManagerProperty.h"
 #include "MantidKernel/PropertyWithValue.h"
 
-#include <boost/make_shared.hpp>
 #include <boost/python/dict.hpp>
-#include <boost/python/extract.hpp>
 
 using boost::python::dict;
-using boost::python::extract;
 using boost::python::handle;
 using boost::python::len;
 using boost::python::object;
@@ -22,31 +20,6 @@ using Kernel::PropertyManager_sptr;
 using Kernel::PropertyWithValue;
 namespace PythonInterface {
 namespace Registry {
-
-namespace {
-/**
- * Create a new PropertyManager from the given dict
- * @param mapping A wrapper around a Python dict instance
- * @return A shared_ptr to a new PropertyManager
- */
-PropertyManager_sptr createPropertyManager(const dict &mapping) {
-  auto pmgr = boost::make_shared<PropertyManager>();
-#if PY_MAJOR_VERSION >= 3
-  object view(mapping.attr("items")());
-  object itemIter(handle<>(PyObject_GetIter(view.ptr())));
-#else
-  object itemIter(mapping.attr("iteritems")());
-#endif
-  auto length = len(mapping);
-  for (ssize_t i = 0; i < length; ++i) {
-    const object keyValue(handle<>(PyIter_Next(itemIter.ptr())));
-    const std::string cppkey = extract<std::string>(keyValue[0])();
-    pmgr->declareProperty(PropertyWithValueFactory::create(cppkey, keyValue[1],
-                                                           Direction::Input));
-  }
-  return pmgr;
-}
-}
 
 /**
  * Sets the named property in the PropertyManager by extracting a new

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyManagerFactory.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyManagerFactory.cpp
@@ -1,0 +1,43 @@
+#include "MantidPythonInterface/kernel/Registry/PropertyManagerFactory.h"
+#include "MantidPythonInterface/kernel/Registry/PropertyWithValueFactory.h"
+#include "MantidKernel/PropertyManager.h"
+
+#include <boost/make_shared.hpp>
+#include <boost/python/extract.hpp>
+
+using boost::python::extract;
+using boost::python::handle;
+using boost::python::object;
+
+namespace Mantid {
+using Kernel::Direction;
+using Kernel::PropertyManager;
+
+namespace PythonInterface {
+namespace Registry {
+
+/**
+ * @param mapping A Python dictionary instance
+ * @return A new C++ PropertyManager instance
+ */
+boost::shared_ptr<Kernel::PropertyManager>
+createPropertyManager(const boost::python::dict &mapping) {
+  auto pmgr = boost::make_shared<PropertyManager>();
+#if PY_MAJOR_VERSION >= 3
+  object view(mapping.attr("items")());
+  object itemIter(handle<>(PyObject_GetIter(view.ptr())));
+#else
+  object itemIter(mapping.attr("iteritems")());
+#endif
+  auto length = len(mapping);
+  for (ssize_t i = 0; i < length; ++i) {
+    const object keyValue(handle<>(PyIter_Next(itemIter.ptr())));
+    const std::string cppkey = extract<std::string>(keyValue[0])();
+    pmgr->declareProperty(PropertyWithValueFactory::create(cppkey, keyValue[1],
+                                                           Direction::Input));
+  }
+  return pmgr;
+}
+}
+}
+}

--- a/Framework/PythonInterface/test/python/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/kernel/CMakeLists.txt
@@ -27,6 +27,7 @@ set ( TEST_PY_FILES
   PropertyHistoryTest.py
   PropertyWithValueTest.py
   PropertyManagerTest.py
+  PropertyManagerDataServiceTest.py
   PropertyManagerPropertyTest.py
   PythonPluginsTest.py
   StatisticsTest.py

--- a/Framework/PythonInterface/test/python/mantid/kernel/PropertyManagerDataServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PropertyManagerDataServiceTest.py
@@ -1,0 +1,40 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+from mantid.kernel import PropertyManager, PropertyManagerDataService
+
+class PropertyManagerDataServiceTest(unittest.TestCase):
+
+    def test_add_existing_mgr_object(self):
+        name = "PropertyManagerDataServiceTest_test_add_existing_mgr_object"
+        values = {'key': 100.5}
+        mgr = PropertyManager(values)
+        self._do_add_test(name, mgr)
+
+    def test_add_straight_from_dict(self):
+        name = "PropertyManagerDataServiceTest_test_add_straight_from_dict"
+        values = {'key': 100.5}
+        self._do_add_test(name, values)
+
+    def test_addOrReplace_straight_from_dict(self):
+        name = "PropertyManagerDataServiceTest_addOrReplace_straight_from_dict"
+        values = {'key': 100.5}
+        values2 = {'key2': 50}
+        self._do_addOrReplace_test(name, values, values2)
+
+    def _do_add_test(self, name, value):
+        pmds = PropertyManagerDataService.Instance()
+        pmds.add(name, value)
+        self.assertTrue(name in pmds)
+        pmds.remove(name)
+
+    def _do_addOrReplace_test(self, name, value, value2):
+        pmds = PropertyManagerDataService.Instance()
+        pmds.add(name, value)
+        pmds.addOrReplace(name, value2)
+        pmgr = pmds[name]
+        self.assertEquals(value2['key2'], pmgr['key2'].value)
+        pmds.remove(name)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/kernel/PropertyManagerTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PropertyManagerTest.py
@@ -4,7 +4,7 @@ import unittest
 from mantid.kernel import PropertyManager, IPropertyManager
 
 class PropertyManagerTest(unittest.TestCase):
-    def test_propertymanager(self):
+    def test_propertymanager_population(self):
         manager = PropertyManager()
 
         # check that it is empty
@@ -63,6 +63,22 @@ class PropertyManagerTest(unittest.TestCase):
         self.assertTrue(len(manager), 3)
         del manager["f"]
         self.assertTrue(len(manager), 2)
+
+    def test_propertymanager_can_be_created_from_dict(self):
+        values = {
+            "int": 5,
+            "float": 20.0,
+            "str": 'a string'
+        }
+        pmgr = PropertyManager(values)
+        self.assertEquals(len(pmgr), 3)
+        self.assertEquals(5, pmgr["int"].value)
+        self.assertEquals(20.0, pmgr["float"].value)
+        self.assertEquals('a string', pmgr["str"].value)
+
+    def test_propertymanager_cannot_be_created_from_arbitrary_sequence(self):
+        with self.assertRaises(Exception):
+            PropertyManager((1,2,3,4,5))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Description of work**

This work adds the necessary Python exports so that a C++ `PropertyManager` can be created directly from a Python dictionary without have to pass it to an algorithm property.

In addition a `dict` can now be passed directly to the `PropertyMananagerDataService` directly to avoid creating a possibly redundant temporary variable. 

**To test:**

Check the unit tests and use them to test out the functionality.

No issue number.

**Release Notes** 
No release notes changes.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
