### PR TITLE
Add support for unicode string conversion in python2

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/api/AlgorithmTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/AlgorithmTest.py
@@ -1,10 +1,10 @@
 from __future__ import (absolute_import, division, print_function)
+import six
 
 import unittest
 from mantid.api import AlgorithmID, AlgorithmManager
 from testhelpers import run_algorithm
 
-###########################################################
 
 class AlgorithmTest(unittest.TestCase):
 
@@ -52,7 +52,29 @@ class AlgorithmTest(unittest.TestCase):
         self.assertTrue(ws.getMemorySize() > 0.0 )
 
         as_str = str(alg)
-        self.assertEquals(as_str, '{"name":"CreateWorkspace","properties":{"DataX":"1,2,3","DataY":"1,2,3","OutputWorkspace":"UNUSED_NAME_FOR_CHILD","UnitX":"Wavelength"},"version":1}\n')
+        self.assertEquals(as_str, '{"name":"CreateWorkspace","properties":{"DataX":"1,2,3","DataY":"1,2,3",'
+                          '"OutputWorkspace":"UNUSED_NAME_FOR_CHILD","UnitX":"Wavelength"},"version":1}\n')
+
+    def test_execute_succeeds_with_unicode_props(self):
+        data = [1.0,2.0,3.0]
+        unitx = 'Wavelength'
+        if six.PY2:
+            # force a property value to be unicode to assert conversion happens correctly
+            # this is only an issue in python2
+            unitx = unicode(unitx)
+
+        alg = run_algorithm('CreateWorkspace',DataX=data,DataY=data,NSpec=1,UnitX=unitx,child=True)
+        self.assertEquals(alg.isExecuted(), True)
+        self.assertEquals(alg.isRunning(), False)
+        self.assertEquals(alg.getProperty('NSpec').value, 1)
+        self.assertEquals(type(alg.getProperty('NSpec').value), int)
+        self.assertEquals(alg.getProperty('NSpec').name, 'NSpec')
+        ws = alg.getProperty('OutputWorkspace').value
+        self.assertTrue(ws.getMemorySize() > 0.0 )
+
+        as_str = str(alg)
+        self.assertEquals(as_str, '{"name":"CreateWorkspace","properties":{"DataX":"1,2,3","DataY":"1,2,3",'
+                          '"OutputWorkspace":"UNUSED_NAME_FOR_CHILD","UnitX":"Wavelength"},"version":1}\n')
 
     def test_getAlgorithmID_returns_AlgorithmID_object(self):
         alg = AlgorithmManager.createUnmanaged('Load')
@@ -84,13 +106,14 @@ class AlgorithmTest(unittest.TestCase):
     def test_createChildAlgorithm_respects_keyword_arguments(self):
         parent_alg = AlgorithmManager.createUnmanaged('Load')
         try:
-            child_alg = parent_alg.createChildAlgorithm(name='Rebin',version=1,startProgress=0.5,endProgress=0.9,enableLogging=True)
+            child_alg = parent_alg.createChildAlgorithm(name='Rebin',version=1,startProgress=0.5,
+                                                        endProgress=0.9,enableLogging=True)
         except Exception as exc:
             self.fail("Expected createChildAlgorithm not to throw but it did: %s" % (str(exc)))
 
         # Unknown keyword
-        self.assertRaises(Exception, parent_alg.createChildAlgorithm, name='Rebin',version=1,startProgress=0.5,endProgress=0.9,enableLogging=True, unknownKW=1)
+        self.assertRaises(Exception, parent_alg.createChildAlgorithm, name='Rebin',version=1,startProgress=0.5,
+                          endProgress=0.9,enableLogging=True, unknownKW=1)
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
Description of work.

**To test:**

While the particular file doesn't matter, testing both unicode strings and native types together is important. The ARCS file in the instructions below is in the unit tests.

1. Build against python2
1. Run `wksp = Load(Filename=unicode('ARCS_2963.nxs'), MetaDataOnly=True)` and get `ValueError: When converting parameter...`. 
1. Merge this branch
1. Run `wksp = Load(Filename=unicode('ARCS_2963.nxs'), MetaDataOnly=True)` and see that it now works

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
