### PR TITLE
Fix check_for_changes to account for new Qt paths

### DIFF
--- a/buildconfig/Jenkins/check_for_changes
+++ b/buildconfig/Jenkins/check_for_changes
@@ -40,7 +40,7 @@ case "$TYPE" in
 	# FOUND=1 iff changes are limited to docs or GUI only
 	# Find all changed files and grep for required type. -v inverts match so grep=0 means
 	# there are other changes besides this
-	if git diff --name-only ${BRANCH_TIP} ${BRANCH_BASE} -- | grep -q -E -v '^docs/|^MantidQt/|^MantidPlot/'; then
+	if git diff --name-only ${BRANCH_TIP} ${BRANCH_BASE} -- | grep -q -E -v '^docs/|^qt/|^MantidPlot/'; then
 	    exit $FOUND
 	else
 	    exit $NOTFOUND


### PR DESCRIPTION
The directory move meant that the directory names in the script were incorrect causing all tests to run regardless of the changes.

**To test:**

Code review

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
