### PR TITLE
Fix cppcheck warnings in AlignedCutter.

### DIFF
--- a/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.h
+++ b/qt/paraview_ext/PVPlugins/Representations/AlignedCutter.h
@@ -59,12 +59,12 @@ public:
   static AlignedCutter *New();
 
 protected:
-  AlignedCutter(vtkImplicitFunction *cf = NULL);
+  explicit AlignedCutter(vtkImplicitFunction *cf = nullptr);
   ~AlignedCutter() override;
   int RequestData(vtkInformation *, vtkInformationVector **,
                   vtkInformationVector *) override;
   void AlignedStructuredGridCutter(vtkDataSet *, vtkPolyData *);
-  int AxisNumber;
+  int AxisNumber{0};
 
 private:
   AlignedCutter(const AlignedCutter &) VTK_DELETE_FUNCTION;


### PR DESCRIPTION
Description of work.

This addresses two minor issues in `AlignedCutter` found by cppcheck.

**To test:**

Check cppcheck warnings.

<!-- Instructions for testing. -->

There is no GitHub issue associated with this pull request.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
