### PR TITLE
Fix Python Ui interface imports

### DIFF
--- a/MantidPlot/test/squish_test_suites/refl_gui_tests/envvars
+++ b/MantidPlot/test/squish_test_suites/refl_gui_tests/envvars
@@ -1,1 +1,2 @@
-LD_LIBRARY_PATH=/opt/mantidnightly/lib/paraview-5.4
+LD_LIBRARY_PATH=/opt/mantidnightly/lib/paraview-5.4:/opt/mantidnightly/plugins/qtplugins/mantid
+QT_API=pyqt

--- a/scripts/Interface/ui/dataprocessorinterface/data_processor_gui.py
+++ b/scripts/Interface/ui/dataprocessorinterface/data_processor_gui.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     canMantidPlot = False
 
-import ui_data_processor_window
+from .ui_data_processor_window import Ui_DataProcessorWindow
 from PyQt4 import QtGui
 from mantid.simpleapi import *
 from mantidqtpython import MantidQt
@@ -63,7 +63,7 @@ class MainPresenter(MantidQt.MantidWidgets.DataProcessorMainPresenter):
         self.gui.add_actions_to_menus(workspace_list)
 
 
-class DataProcessorGui(QtGui.QMainWindow, ui_data_processor_window.Ui_DataProcessorWindow):
+class DataProcessorGui(QtGui.QMainWindow, Ui_DataProcessorWindow):
 
     data_processor_table = None
     main_presenter = None

--- a/scripts/Interface/ui/dataprocessorinterface/data_processor_gui.py
+++ b/scripts/Interface/ui/dataprocessorinterface/data_processor_gui.py
@@ -4,10 +4,10 @@ try:
 except ImportError:
     canMantidPlot = False
 
-from .ui_data_processor_window import Ui_DataProcessorWindow
 from PyQt4 import QtGui
 from mantid.simpleapi import *
 from mantidqtpython import MantidQt
+from ui.reflectometer.ui_data_processor_window import Ui_DataProcessorWindow
 
 canMantidPlot = True
 

--- a/scripts/Interface/ui/poldi/poldi_gui.py
+++ b/scripts/Interface/ui/poldi/poldi_gui.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     canMantidPlot = False
 
-import ui_poldi_window
+from .ui_poldi_window import Ui_PoldiWindow
 from PyQt4 import QtGui
 from mantid.simpleapi import *
 from mantidqtpython import MantidQt
@@ -63,7 +63,7 @@ class MainPresenter(MantidQt.MantidWidgets.DataProcessorMainPresenter):
         self.gui.add_actions_to_menus(workspace_list)
 
 
-class PoldiGui(QtGui.QMainWindow, ui_poldi_window.Ui_PoldiWindow):
+class PoldiGui(QtGui.QMainWindow, Ui_PoldiWindow):
 
     data_processor_table = None
     main_presenter = None

--- a/scripts/Interface/ui/poldi/poldi_gui.py
+++ b/scripts/Interface/ui/poldi/poldi_gui.py
@@ -4,10 +4,11 @@ try:
 except ImportError:
     canMantidPlot = False
 
-from .ui_poldi_window import Ui_PoldiWindow
 from PyQt4 import QtGui
 from mantid.simpleapi import *
 from mantidqtpython import MantidQt
+from ui.poldi.ui_poldi_window import Ui_PoldiWindow
+
 
 canMantidPlot = True
 

--- a/scripts/Interface/ui/reflectometer/refl_choose_col.py
+++ b/scripts/Interface/ui/reflectometer/refl_choose_col.py
@@ -3,7 +3,7 @@
 #so this file provides any extra GUI tweaks not easily doable in the designer
 #for the time being this also includes non-GUI behaviour
 from __future__ import (absolute_import, division, print_function)
-import ui_refl_columns
+from .ui_refl_columns import Ui_chooseColumnsDialog
 from PyQt4 import QtCore, QtGui
 
 try:
@@ -13,7 +13,7 @@ except AttributeError:
         return s
 
 
-class ReflChoose(QtGui.QDialog, ui_refl_columns.Ui_chooseColumnsDialog):
+class ReflChoose(QtGui.QDialog, Ui_chooseColumnsDialog):
 
     visiblestates = {}
 

--- a/scripts/Interface/ui/reflectometer/refl_choose_col.py
+++ b/scripts/Interface/ui/reflectometer/refl_choose_col.py
@@ -3,8 +3,8 @@
 #so this file provides any extra GUI tweaks not easily doable in the designer
 #for the time being this also includes non-GUI behaviour
 from __future__ import (absolute_import, division, print_function)
-from .ui_refl_columns import Ui_chooseColumnsDialog
 from PyQt4 import QtCore, QtGui
+from ui.reflectometer.ui_refl_columns import Ui_chooseColumnsDialog
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -7,10 +7,6 @@ try:
 except ImportError:
     canMantidPlot = False  #
 
-from .ui_refl_window import Ui_windowRefl
-from .refl_save import Ui_SaveWindow
-from .refl_choose_col import ReflChoose
-from. refl_options import ReflOptions
 import csv
 import os
 import re
@@ -25,6 +21,11 @@ from isis_reflectometry.combineMulti import *
 import mantidqtpython
 from mantid.api import Workspace, WorkspaceGroup, CatalogManager, AlgorithmManager
 from mantid import UsageService
+
+from ui.reflectometer.ui_refl_window import Ui_windowRefl
+from ui.reflectometer.refl_save import Ui_SaveWindow
+from ui.reflectometer.refl_choose_col import ReflChoose
+from ui.reflectometer.refl_options import ReflOptions
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
@@ -1307,11 +1308,11 @@ class ReflGui(QtGui.QMainWindow, Ui_windowRefl):
         """
         try:
 
-            dialog_controller = refl_options.ReflOptions(def_method=self.live_method, def_freq=self.live_freq,
-                                                         def_alg_use=self.__alg_use,
-                                                         def_icat_download=self.__icat_download,
-                                                         def_group_tof_workspaces=self.__group_tof_workspaces,
-                                                         def_stitch_right=self.__scale_right)
+            dialog_controller = ReflOptions(def_method=self.live_method, def_freq=self.live_freq,
+                                            def_alg_use=self.__alg_use,
+                                            def_icat_download=self.__icat_download,
+                                            def_group_tof_workspaces=self.__group_tof_workspaces,
+                                            def_stitch_right=self.__scale_right)
             if dialog_controller.exec_():
                 # Fetch the settings back off the controller
                 self.live_freq = dialog_controller.frequency()

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -7,10 +7,10 @@ try:
 except ImportError:
     canMantidPlot = False  #
 
-import ui_refl_window
-import refl_save
-import refl_choose_col
-import refl_options
+from .ui_refl_window import Ui_windowRefl
+from .refl_save import Ui_SaveWindow
+from .refl_choose_col import ReflChoose
+from. refl_options import ReflOptions
 import csv
 import os
 import re
@@ -35,7 +35,7 @@ except AttributeError:
 canMantidPlot = True
 
 
-class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
+class ReflGui(QtGui.QMainWindow, Ui_windowRefl):
     current_instrument = None
     current_table = None
     current_polarisation_method = None
@@ -1294,7 +1294,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
         """
         try:
             Dialog = QtGui.QDialog()
-            u = refl_save.Ui_SaveWindow()
+            u = Ui_SaveWindow()
             u.setupUi(Dialog)
             Dialog.exec_()
         except Exception as ex:
@@ -1343,7 +1343,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
         shows the choose columns dialog for hiding and revealing of columns
         """
         try:
-            dialog = refl_choose_col.ReflChoose(self.shown_cols, self.tableMain)
+            dialog = ReflChoose(self.shown_cols, self.tableMain)
             if dialog.exec_():
                 settings = QtCore.QSettings()
                 settings.beginGroup(self.__column_settings)

--- a/scripts/Interface/ui/reflectometer/refl_gui_run.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui_run.py
@@ -1,13 +1,13 @@
 #pylint: disable=invalid-name
 from __future__ import (absolute_import, division, print_function)
-import refl_gui
+from ui.reflectometer.refl_gui import ReflGui
 from PyQt4 import QtGui
 
 if __name__ == "__main__":
     import sys
     app = QtGui.QApplication(sys.argv)
     MainWindow = QtGui.QMainWindow()
-    ui = refl_gui.ReflGui()
+    ui = ReflGui()
     ui.setupUi(MainWindow)
     MainWindow.show()
     sys.exit(app.exec_())

--- a/scripts/Interface/ui/reflectometer/refl_options.py
+++ b/scripts/Interface/ui/reflectometer/refl_options.py
@@ -1,6 +1,6 @@
 # pylint: disable=invalid-name
 from __future__ import (absolute_import, division, print_function)
-import ui_refl_options_window
+from .ui_refl_options_window import Ui_OptionsDialog
 from PyQt4 import QtCore, QtGui
 
 try:
@@ -10,7 +10,7 @@ except AttributeError:
         return s
 
 
-class ReflOptions(QtGui.QDialog, ui_refl_options_window.Ui_OptionsDialog):
+class ReflOptions(QtGui.QDialog, Ui_OptionsDialog):
     """
     Member variables
     """

--- a/scripts/Interface/ui/reflectometer/refl_options.py
+++ b/scripts/Interface/ui/reflectometer/refl_options.py
@@ -1,7 +1,7 @@
 # pylint: disable=invalid-name
 from __future__ import (absolute_import, division, print_function)
-from .ui_refl_options_window import Ui_OptionsDialog
 from PyQt4 import QtCore, QtGui
+from ui.reflectometer.ui_refl_options_window import Ui_OptionsDialog
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8


### PR DESCRIPTION
Description of work.

Fixes imports in user interfaces that were broken on adding the `from __future__` lines recently.

**To test:**

Try and start the ISIS Reflectometry Old interface. It should start successully.

I have also included a fix for the automated squish tests.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
