### PR TITLE
New version of SpecularReflectionCalculateTheta

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -280,6 +280,7 @@ set ( SRC_FILES
 	src/SpectrumAlgorithm.cpp
 	src/SpecularReflectionAlgorithm.cpp
 	src/SpecularReflectionCalculateTheta.cpp
+	src/SpecularReflectionCalculateTheta2.cpp
 	src/SpecularReflectionPositionCorrect.cpp
 	src/SpecularReflectionPositionCorrect2.cpp
 	src/SphericalAbsorption.cpp
@@ -603,6 +604,7 @@ set ( INC_FILES
 	inc/MantidAlgorithms/SpectrumAlgorithm.h
 	inc/MantidAlgorithms/SpecularReflectionAlgorithm.h
 	inc/MantidAlgorithms/SpecularReflectionCalculateTheta.h
+	inc/MantidAlgorithms/SpecularReflectionCalculateTheta2.h
 	inc/MantidAlgorithms/SpecularReflectionPositionCorrect.h
 	inc/MantidAlgorithms/SpecularReflectionPositionCorrect2.h
 	inc/MantidAlgorithms/SphericalAbsorption.h
@@ -912,6 +914,7 @@ set ( TEST_FILES
 	SparseInstrumentTest.h
 	SpatialGroupingTest.h
 	SpecularReflectionCalculateThetaTest.h
+	SpecularReflectionCalculateTheta2Test.h
 	SpecularReflectionPositionCorrect2Test.h
 	SpecularReflectionPositionCorrectTest.h
 	SphericalAbsorptionTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionAlgorithm.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionAlgorithm.h
@@ -42,18 +42,21 @@ protected:
 
   /// Get the surface sample component
   Mantid::Geometry::IComponent_const_sptr
-  getSurfaceSampleComponent(Mantid::Geometry::Instrument_const_sptr inst);
+  getSurfaceSampleComponent(Mantid::Geometry::Instrument_const_sptr inst) const;
 
   /// Get the detector component
   Mantid::Geometry::IComponent_const_sptr
   getDetectorComponent(Mantid::API::MatrixWorkspace_sptr workspace,
-                       const bool isPointDetector);
+                       const bool isPointDetector) const;
 
   /// Does the property have a default value.
   bool isPropertyDefault(const std::string &propertyName) const;
 
   /// initialize common properties
   void initCommonProperties();
+
+  /// Calculate the twoTheta angle w.r.t the direct beam
+  double calculateTwoTheta() const;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionCalculateTheta2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionCalculateTheta2.h
@@ -44,7 +44,7 @@ public:
 
   int version() const override;
   const std::string category() const override;
-  
+
 private:
   void init() override;
   void exec() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionCalculateTheta2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionCalculateTheta2.h
@@ -1,0 +1,56 @@
+#ifndef MANTID_ALGORITHMS_SPECULARREFLECTIONCALCULATETHETA2_H_
+#define MANTID_ALGORITHMS_SPECULARREFLECTIONCALCULATETHETA2_H_
+
+#include "MantidKernel/System.h"
+#include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/SpecularReflectionAlgorithm.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+/** SpecularReflectionCorrectTheta : Calculates a theta value based on the
+  specular reflection condition. Version 2.
+
+  Copyright &copy; 2014 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport SpecularReflectionCalculateTheta2
+    : public SpecularReflectionAlgorithm {
+public:
+  const std::string name() const override;
+  /// Summary of algorithms purpose
+  const std::string summary() const override {
+    return "Calculate the specular reflection two theta scattering angle "
+           "(degrees) from the detector and sample locations .";
+  }
+
+  int version() const override;
+  const std::string category() const override;
+  
+private:
+  void init() override;
+  void exec() override;
+};
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /* MANTID_ALGORITHMS_SPECULARREFLECTIONCALCULATETHETA2_H_ */

--- a/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -364,8 +364,8 @@ Mantid::API::MatrixWorkspace_sptr ReflectometryReductionOne::toIvsQ(
   if (!thetaInDeg.is_initialized()) {
     g_log.debug("Calculating final theta.");
 
-    auto correctThetaAlg =
-        this->createChildAlgorithm("SpecularReflectionCalculateTheta");
+    auto correctThetaAlg = this->createChildAlgorithm(
+        "SpecularReflectionCalculateTheta", -1, -1, true, 1);
     correctThetaAlg->initialize();
     correctThetaAlg->setProperty("InputWorkspace", toConvert);
     const std::string analysisMode = this->getProperty("AnalysisMode");

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
@@ -410,10 +410,9 @@ ReflectometryReductionOneAuto2::calculateTheta(const std::string &instructions,
   alg->setProperty("DetectorComponentName", detectorsOfInterest[0]);
   alg->execute();
   const double theta = alg->getProperty("TwoTheta");
-  // First factor 0.5 detector position, which isexpected to be at 2 * theta
-  // Second factor 0.5 comes from SpecularReflectionCalculateTheta, which
-  // outputs 2 * theta
-  return theta * 0.5 * 0.5;
+  // Take a factor of 0.5 of the detector position, which isexpected to be at 2
+  // * theta
+  return theta * 0.5;
 }
 
 /** Set direct beam properties

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
@@ -410,8 +410,8 @@ ReflectometryReductionOneAuto2::calculateTheta(const std::string &instructions,
   alg->setProperty("DetectorComponentName", detectorsOfInterest[0]);
   alg->execute();
   const double theta = alg->getProperty("TwoTheta");
-  // Take a factor of 0.5 of the detector position, which isexpected to be at 2
-  // * theta
+  // Take a factor of 0.5 of the detector position, which is expected to be at
+  // 2 * theta
   return theta * 0.5;
 }
 

--- a/Framework/Algorithms/src/SpecularReflectionAlgorithm.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionAlgorithm.cpp
@@ -116,7 +116,7 @@ void SpecularReflectionAlgorithm::initCommonProperties() {
  */
 Mantid::Geometry::IComponent_const_sptr
 SpecularReflectionAlgorithm::getSurfaceSampleComponent(
-    Mantid::Geometry::Instrument_const_sptr inst) {
+    Mantid::Geometry::Instrument_const_sptr inst) const {
   std::string sampleComponent = "some-surface-holder";
   if (!isPropertyDefault("SampleComponentName")) {
     sampleComponent = this->getPropertyValue("SampleComponentName");
@@ -141,7 +141,7 @@ SpecularReflectionAlgorithm::getSurfaceSampleComponent(
  */
 boost::shared_ptr<const Mantid::Geometry::IComponent>
 SpecularReflectionAlgorithm::getDetectorComponent(
-    MatrixWorkspace_sptr workspace, const bool isPointDetector) {
+    MatrixWorkspace_sptr workspace, const bool isPointDetector) const {
   boost::shared_ptr<const IComponent> searchResult;
   if (!isPropertyDefault("SpectrumNumbersOfDetectors")) {
     const std::vector<int> spectrumNumbers =
@@ -197,6 +197,36 @@ bool SpecularReflectionAlgorithm::isPropertyDefault(
     const std::string &propertyName) const {
   Property *property = this->getProperty(propertyName);
   return property->isDefault();
+}
+
+/**
+ * Calculate the twoTheta angle from the detector and sample locations.
+ * @return: twoTheta
+ */
+double SpecularReflectionAlgorithm::calculateTwoTheta() const {
+  MatrixWorkspace_sptr inWS = this->getProperty("InputWorkspace");
+
+  const std::string analysisMode = this->getProperty("AnalysisMode");
+
+  Instrument_const_sptr instrument = inWS->getInstrument();
+
+  IComponent_const_sptr detector =
+      this->getDetectorComponent(inWS, analysisMode == pointDetectorAnalysis);
+
+  IComponent_const_sptr sample = this->getSurfaceSampleComponent(instrument);
+
+  const V3D detSample = detector->getPos() - sample->getPos();
+
+  boost::shared_ptr<const ReferenceFrame> refFrame =
+      instrument->getReferenceFrame();
+
+  const double upoffset = refFrame->vecPointingUp().scalar_prod(detSample);
+  const double beamoffset =
+      refFrame->vecPointingAlongBeam().scalar_prod(detSample);
+
+  const double twoTheta = std::atan(upoffset / beamoffset) * 180 / M_PI;
+
+  return twoTheta;
 }
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/SpecularReflectionAlgorithm.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionAlgorithm.cpp
@@ -213,9 +213,8 @@ double SpecularReflectionAlgorithm::calculateTwoTheta() const {
   IComponent_const_sptr detector =
       this->getDetectorComponent(inWS, analysisMode == pointDetectorAnalysis);
 
-  IComponent_const_sptr sample = this->getSurfaceSampleComponent(instrument);
-
-  const V3D detSample = detector->getPos() - sample->getPos();
+  const V3D detSample =
+      detector->getPos() - inWS->spectrumInfo().samplePosition();
 
   boost::shared_ptr<const ReferenceFrame> refFrame =
       instrument->getReferenceFrame();
@@ -224,7 +223,7 @@ double SpecularReflectionAlgorithm::calculateTwoTheta() const {
   const double beamoffset =
       refFrame->vecPointingAlongBeam().scalar_prod(detSample);
 
-  const double twoTheta = std::atan(upoffset / beamoffset) * 180 / M_PI;
+  const double twoTheta = std::atan2(upoffset, beamoffset) * 180 / M_PI;
 
   return twoTheta;
 }

--- a/Framework/Algorithms/src/SpecularReflectionAlgorithm.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionAlgorithm.cpp
@@ -213,8 +213,9 @@ double SpecularReflectionAlgorithm::calculateTwoTheta() const {
   IComponent_const_sptr detector =
       this->getDetectorComponent(inWS, analysisMode == pointDetectorAnalysis);
 
-  const V3D detSample =
-      detector->getPos() - inWS->spectrumInfo().samplePosition();
+  IComponent_const_sptr sample = this->getSurfaceSampleComponent(instrument);
+
+  const V3D detSample = detector->getPos() - sample->getPos();
 
   boost::shared_ptr<const ReferenceFrame> refFrame =
       instrument->getReferenceFrame();

--- a/Framework/Algorithms/src/SpecularReflectionCalculateTheta.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionCalculateTheta.cpp
@@ -57,27 +57,11 @@ void SpecularReflectionCalculateTheta::init() {
 /** Execute the algorithm.
  */
 void SpecularReflectionCalculateTheta::exec() {
-  MatrixWorkspace_sptr inWS = this->getProperty("InputWorkspace");
 
-  const std::string analysisMode = this->getProperty("AnalysisMode");
-
-  Instrument_const_sptr instrument = inWS->getInstrument();
-
-  IComponent_const_sptr detector =
-      this->getDetectorComponent(inWS, analysisMode == pointDetectorAnalysis);
-
-  IComponent_const_sptr sample = this->getSurfaceSampleComponent(instrument);
-
-  const V3D detSample = detector->getPos() - sample->getPos();
-
-  boost::shared_ptr<const ReferenceFrame> refFrame =
-      instrument->getReferenceFrame();
-
-  const double upoffset = refFrame->vecPointingUp().scalar_prod(detSample);
-  const double beamoffset =
-      refFrame->vecPointingAlongBeam().scalar_prod(detSample);
-
-  const double twoTheta = 2 * std::atan(upoffset / beamoffset) * 180 / M_PI;
+  // This algorithm expects detectors to actually be at theta rather than
+  // twoTheta (for historical reasons), so we need to multiply by 2 to get the
+  // real twoTheta. v2 of this algorithm works with detectors at twoTheta.
+  const double twoTheta = 2 * calculateTwoTheta();
 
   std::stringstream strstream;
   strstream << "Recalculated two theta as: " << twoTheta;

--- a/Framework/Algorithms/src/SpecularReflectionCalculateTheta2.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionCalculateTheta2.cpp
@@ -60,10 +60,8 @@ void SpecularReflectionCalculateTheta2::exec() {
 
   const double twoTheta = calculateTwoTheta();
 
-  std::stringstream strstream;
-  strstream << "Recalculated two theta as: " << twoTheta;
-
-  this->g_log.information(strstream.str());
+  this->g_log.information("Recalculated two theta as: " +
+                          std::to_string(twoTheta));
 
   this->setProperty("TwoTheta", twoTheta);
 }

--- a/Framework/Algorithms/src/SpecularReflectionCalculateTheta2.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionCalculateTheta2.cpp
@@ -1,0 +1,72 @@
+#include "MantidAlgorithms/SpecularReflectionCalculateTheta2.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/PropertyWithValue.h"
+#include "MantidGeometry/IComponent.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+
+#include <cmath>
+
+using namespace Mantid::Kernel;
+using namespace Mantid::Geometry;
+using namespace Mantid::API;
+
+namespace {
+const std::string multiDetectorAnalysis = "MultiDetectorAnalysis";
+const std::string lineDetectorAnalysis = "LineDetectorAnalysis";
+const std::string pointDetectorAnalysis = "PointDetectorAnalysis";
+}
+
+namespace Mantid {
+namespace Algorithms {
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(SpecularReflectionCalculateTheta2)
+
+//----------------------------------------------------------------------------------------------
+/// Algorithm's name for identification. @see Algorithm::name
+const std::string SpecularReflectionCalculateTheta2::name() const {
+  return "SpecularReflectionCalculateTheta";
+}
+
+/// Algorithm's version for identification. @see Algorithm::version
+int SpecularReflectionCalculateTheta2::version() const { return 2; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string SpecularReflectionCalculateTheta2::category() const {
+  return "Reflectometry";
+}
+
+//----------------------------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void SpecularReflectionCalculateTheta2::init() {
+  declareProperty(
+      make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "",
+                                                      Direction::Input),
+      "An Input workspace to calculate the specular relection theta on.");
+  this->initCommonProperties();
+  declareProperty(make_unique<PropertyWithValue<double>>(
+                      "TwoTheta", Mantid::EMPTY_DBL(), Direction::Output),
+                  "Calculated two theta scattering angle in degrees.");
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void SpecularReflectionCalculateTheta2::exec() {
+
+  const double twoTheta = calculateTwoTheta();
+
+  std::stringstream strstream;
+  strstream << "Recalculated two theta as: " << twoTheta;
+
+  this->g_log.information(strstream.str());
+
+  this->setProperty("TwoTheta", twoTheta);
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/test/SpecularReflectionCalculateTheta2Test.h
+++ b/Framework/Algorithms/test/SpecularReflectionCalculateTheta2Test.h
@@ -1,0 +1,118 @@
+#ifndef MANTID_ALGORITHMS_SPECULARREFLECTIONCORRECTTHETA2TEST_H_
+#define MANTID_ALGORITHMS_SPECULARREFLECTIONCORRECTTHETA2TEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "SpecularReflectionAlgorithmTest.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+#include "MantidAlgorithms/SpecularReflectionCalculateTheta2.h"
+
+using namespace Mantid::Algorithms;
+using namespace Mantid::API;
+
+// clang-format off
+class SpecularReflectionCalculateTheta2Test: public CxxTest::TestSuite,
+    public SpecularReflectionAlgorithmTest
+// clang-format on
+{
+
+private:
+  Mantid::API::IAlgorithm_sptr makeAlgorithm() const {
+    IAlgorithm_sptr alg =
+        boost::make_shared<SpecularReflectionCalculateTheta2>();
+    alg->setRethrows(true);
+    alg->setChild(true);
+    alg->initialize();
+    return alg;
+  }
+
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static SpecularReflectionCalculateTheta2Test *createSuite() {
+    return new SpecularReflectionCalculateTheta2Test();
+  }
+  static void destroySuite(SpecularReflectionCalculateTheta2Test *suite) {
+    delete suite;
+  }
+
+  void test_Init() {
+    SpecularReflectionCalculateTheta2 alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  SpecularReflectionCalculateTheta2Test() {}
+
+  void test_throws_if_SpectrumNumbersOfDetectors_less_than_zero() {
+    IAlgorithm_sptr alg = makeAlgorithm();
+    alg->setProperty(
+        "InputWorkspace",
+        WorkspaceCreationHelper::create1DWorkspaceConstant(1, 1, 1, true));
+
+    SpecularReflectionAlgorithmTest::
+        test_throws_if_SpectrumNumbersOfDetectors_less_than_zero(alg);
+  }
+
+  void test_throws_if_SpectrumNumbersOfDetectors_outside_range() {
+    IAlgorithm_sptr alg = makeAlgorithm();
+    alg->setProperty(
+        "InputWorkspace",
+        WorkspaceCreationHelper::create1DWorkspaceConstant(1, 1, 1, true));
+
+    SpecularReflectionAlgorithmTest::
+        test_throws_if_SpectrumNumbersOfDetectors_outside_range(alg);
+  }
+
+  void test_throws_if_DetectorComponentName_unknown() {
+    IAlgorithm_sptr alg = makeAlgorithm();
+    alg->setProperty(
+        "InputWorkspace",
+        WorkspaceCreationHelper::create2DWorkspaceWithRectangularInstrument(
+            1, 1, 1));
+
+    SpecularReflectionAlgorithmTest::
+        test_throws_if_DetectorComponentName_unknown(alg);
+  }
+
+  void test_correct_point_detector_to_current_position() {
+    auto toConvert = pointDetectorWS;
+    auto referenceFrame = toConvert->getInstrument()->getReferenceFrame();
+    auto moveComponentAlg =
+        AlgorithmManager::Instance().create("MoveInstrumentComponent");
+    moveComponentAlg->initialize();
+    moveComponentAlg->setProperty("Workspace", toConvert);
+    const std::string componentName = "point-detector";
+    moveComponentAlg->setProperty("ComponentName", componentName);
+    moveComponentAlg->setProperty("RelativePosition", true);
+    moveComponentAlg->setProperty(
+        referenceFrame->pointingUpAxis(),
+        0.5); // Give the point detector a starting vertical offset.
+    // Execute the movement.
+    moveComponentAlg->execute();
+
+    VerticalHorizontalOffsetType offsetTuple =
+        determine_vertical_and_horizontal_offsets(
+            toConvert); // Offsets before correction
+    const double sampleToDetectorVerticalOffset = offsetTuple.get<0>();
+    const double sampleToDetectorBeamOffset = offsetTuple.get<1>();
+
+    // Based on the current positions, calculate the current incident theta.
+    const double currentTwoThetaInRad =
+        std::atan(sampleToDetectorVerticalOffset / sampleToDetectorBeamOffset);
+    const double currentTwoThetaInDeg = currentTwoThetaInRad * (180.0 / M_PI);
+
+    IAlgorithm_sptr alg = this->makeAlgorithm();
+    alg->setProperty("InputWorkspace", toConvert);
+    alg->setProperty("DetectorComponentName", "point-detector");
+    alg->setProperty("AnalysisMode", "PointDetectorAnalysis");
+    alg->execute();
+    const double twoThetaCalculated = alg->getProperty("TwoTheta");
+
+    TSM_ASSERT_DELTA("Two theta value should be unchanged", twoThetaCalculated,
+                     currentTwoThetaInDeg, 1e-6);
+  }
+};
+
+#endif /* MANTID_ALGORITHMS_SPECULARREFLECTIONCORRECTTHETA2TEST_H_ */

--- a/Framework/Algorithms/test/SpecularReflectionCalculateTheta2Test.h
+++ b/Framework/Algorithms/test/SpecularReflectionCalculateTheta2Test.h
@@ -14,8 +14,8 @@ using namespace Mantid::API;
 // clang-format off
 class SpecularReflectionCalculateTheta2Test: public CxxTest::TestSuite,
     public SpecularReflectionAlgorithmTest
-// clang-format on
-{
+      // clang-format on
+      {
 
 private:
   Mantid::API::IAlgorithm_sptr makeAlgorithm() const {

--- a/docs/source/algorithms/SpecularReflectionCalculateTheta-v1.rst
+++ b/docs/source/algorithms/SpecularReflectionCalculateTheta-v1.rst
@@ -39,7 +39,7 @@ Usage
    MoveInstrumentComponent(ws, 'some-surface-holder',RelativePosition=False,  X=0, Y= 0, Z=0)
 
    # Calculate the two theta.
-   two_theta = SpecularReflectionCalculateTheta(InputWorkspace=ws, DetectorComponentName='point-detector', AnalysisMode='PointDetectorAnalysis')
+   two_theta = SpecularReflectionCalculateTheta(InputWorkspace=ws, DetectorComponentName='point-detector', AnalysisMode='PointDetectorAnalysis', Version=1)
    print two_theta
    
 Output:

--- a/docs/source/algorithms/SpecularReflectionCalculateTheta-v2.rst
+++ b/docs/source/algorithms/SpecularReflectionCalculateTheta-v2.rst
@@ -14,7 +14,7 @@ to calculate and return a corrected :math:`\theta_{In}`.
 
 .. math:: 
 
-   2\centerdot\theta = tan^{-1}\left(\frac{UpOffset}{BeamOffset}\right)
+   2\theta = \arctan\left(\frac{UpOffset}{BeamOffset}\right)
 
 The calculated :math:`2\theta` value in degrees is returned by the algorithm.
 
@@ -49,7 +49,7 @@ Usage
 
    # Calculate the two theta.
    two_theta = SpecularReflectionCalculateTheta(InputWorkspace=ws, DetectorComponentName='point-detector', AnalysisMode='PointDetectorAnalysis')
-   print two_theta
+   print(two_theta)
    
 Output:
 

--- a/docs/source/algorithms/SpecularReflectionCalculateTheta-v2.rst
+++ b/docs/source/algorithms/SpecularReflectionCalculateTheta-v2.rst
@@ -1,0 +1,62 @@
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+Uses the Specular reflection condition :math:`\theta_{In} \equiv \theta_{Out}`
+to calculate and return a corrected :math:`\theta_{In}`.
+
+.. math:: 
+
+   2\centerdot\theta = tan^{-1}\left(\frac{UpOffset}{BeamOffset}\right)
+
+The calculated :math:`2\theta` value in degrees is returned by the algorithm.
+
+Also see
+:ref:`algm-SpecularReflectionPositionCorrect`
+
+Previous Versions
+-----------------
+
+For version 1 of the algorithm, please see
+`SpecularReflectionCalculateTheta-v1. <SpecularReflectionCalculateTheta-v1.html>`_. Note
+that version 1 worked with detectors at :math:`\theta` rather than
+:math:`2\theta` for historical reasons.
+
+Usage
+-----
+
+**Example - Point detector theta calculation**
+
+.. testcode:: SpecularReflectionCalculateThetaPointDetectorExample
+
+   # Set up an instrument with a 45 degree final two theta angle.
+   import os
+   instrument_def = os.path.join( config.getInstrumentDirectory() , "INTER_Definition.xml")
+   ws = LoadEmptyInstrument(instrument_def)
+   inst = ws.getInstrument()
+   ref_frame = inst.getReferenceFrame()
+   upoffset = ref_frame.vecPointingUp() 
+   det_position = {ref_frame.pointingUpAxis(): 1.0, ref_frame.pointingAlongBeamAxis(): 1.0, ref_frame.pointingHorizontalAxis():0}
+   MoveInstrumentComponent(ws, 'point-detector',RelativePosition=False, **det_position)
+   MoveInstrumentComponent(ws, 'some-surface-holder',RelativePosition=False,  X=0, Y= 0, Z=0)
+
+   # Calculate the two theta.
+   two_theta = SpecularReflectionCalculateTheta(InputWorkspace=ws, DetectorComponentName='point-detector', AnalysisMode='PointDetectorAnalysis')
+   print two_theta
+   
+Output:
+
+.. testoutput:: SpecularReflectionCalculateThetaPointDetectorExample 
+ 
+   45.0
+  
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v3.11.0/reflectometry.rst
+++ b/docs/source/release/v3.11.0/reflectometry.rst
@@ -12,6 +12,7 @@ Algorithms
   - the incorrect angle was being used in the final conversion to Q in the divergent beam case
   - the input was being cropped, causing loss of counts
 - A new property, ``Diagnostics``, has been added to :ref:`algm-ReflectometryReductionOne` to allow the output of additional interim workspaces for debug purposes.
+- A new version of :ref:`algm-SpecularReflectionCalculateTheta` (version 2) has been added which works with detectors at :math:`2\theta`. Version 1 works with detectors at :math:`\theta`.
 
 Reflectometry Reduction Interface
 ---------------------------------


### PR DESCRIPTION
This PR adds version 2 of `SpecularReflectionCalculateTheta`, which works with detectors at `twoTheta` (the correct position) instead of `theta` (where the reflectometry algorithms historically required detectors). See the parent issue #20327 for more context.

Version 2 is identical to version 1 apart from a factor of two difference, so the code has been refactored to do the calculation in the base class.

Fixes #20332.

**To test:**
Run the script in the linked issue.

**Release Notes** 
*Added to the release notes*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
