### PR TITLE
Float conversion to str differs in precision between python 2 and 3

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -216,7 +216,8 @@ class TransformToIqt(PythonAlgorithm):
         if num_res_hist > 1:
             CheckHistSame(self._sample, 'Sample', self._resolution, 'Resolution')
 
-        rebin_param = str(self._e_min) + ',' + str(self._e_width) + ',' + str(self._e_max)
+        # Float conversion to str differs in precision between python 2 and 3, this gives consistent results
+        rebin_param = '{:.14f},{:.14f},{:.14f}'.format(self._e_min, self._e_width, self._e_max)
         trans_prog.report('Rebinning Workspace')
         Rebin(InputWorkspace=self._sample,
               OutputWorkspace='__sam_data',


### PR DESCRIPTION
This now gives consistent results. This was causing ISISIndirectInelastic systemtests to fail for python3, see http://builds.mantidproject.org/job/master_systemtests-ubuntu-16.04-python3/189/testReport/

The following tests should now pass for python 3

SystemTests.ISISIndirectInelastic.IRISIqtAndIqtFit
SystemTests.ISISIndirectInelastic.IRISIqtAndIqtFitMulti
SystemTests.ISISIndirectInelastic.OSIRISIqtAndIqtFit
SystemTests.ISISIndirectInelastic.OSIRISIqtAndIqtFitMulti

**To test:**
Try `./systemtest -R IRISIqtAndIqtFit` with python 3

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
