### PR TITLE
Fix DOSPartial systemtests for python 3

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimulatedDensityOfStates.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimulatedDensityOfStates.py
@@ -6,6 +6,7 @@ import numpy as np
 import re
 import os.path
 import math
+from collections import OrderedDict
 
 from mantid.kernel import *
 from mantid.api import *
@@ -332,7 +333,8 @@ class SimulatedDensityOfStates(PythonAlgorithm):
         @param weights          :: weight data from file
         """
         # Build a dictionary of ions that the user cares about
-        partial_ions = dict()
+        # systemtests check order so use OrderedDict
+        partial_ions = OrderedDict()
 
         calc_ion_index = self.getProperty('CalculateIonIndices').value
 


### PR DESCRIPTION
DOSPartial* systemtests fail on python 3 because it assumes the order of ions. http://builds.mantidproject.org/job/master_systemtests-ubuntu-16.04-python3/189/testReport/

This changes to using an OrderedDict to guarantee the order.

**To test:**
Try `./systemtest -R DOSPart` with python 3. `SystemTests.DOSTest.DOSPartialTest` and `SystemTests.DOSTest.DOSPartialCrossSectionScaleTest` should now pass

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
