### PR TITLE
Fix LoadEXED for failing python 3 systemtests

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadEXED.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadEXED.py
@@ -7,7 +7,6 @@ from mantid.simpleapi import RotateInstrumentComponent
 import struct
 import numpy as np
 import copy
-import types
 
 
 class LoadEXED(PythonAlgorithm):
@@ -85,9 +84,7 @@ class LoadEXED(PythonAlgorithm):
         for i in range(nrows):
             ws.getSpectrum(i).setDetectorID(det_udet[i])
         #Sample_logs the header values are written into the sample logs
-        log_names=[sl.encode('ascii','ignore') for sl in parms_dict.keys()]
-        log_values=[sl.encode('ascii','ignore') if isinstance(sl,types.UnicodeType) else str(sl) for sl in parms_dict.values()]
-        AddSampleLogMultiple(Workspace=wsn, LogNames=log_names,LogValues=log_values)
+        AddSampleLogMultiple(Workspace=wsn, LogNames=list(parms_dict.keys()), LogValues=list(parms_dict.values()))
         SetGoniometer(Workspace=wsn, Goniometers='Universal')
         if (self.fxml == ""):
             LoadInstrument(Workspace=wsn, InstrumentName = "Exed", RewriteSpectraMap= True)


### PR DESCRIPTION
LoadEXED systemtest currently fails with python3 http://builds.mantidproject.org/job/master_systemtests-ubuntu-16.04-python3/189/testReport/SystemTests/LoadExedTest/LoadExedTest/ this fixes that.

Since #20337 just let the Property Manager manage the unicode conversion.

**To test:**
Try `./systemtest -R LoadExed` with python 3


*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
