### PR TITLE
Enable StringContainsValidator to be used in Python

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/StringContainsValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/StringContainsValidator.h
@@ -38,6 +38,7 @@ namespace Kernel {
 class DLLExport StringContainsValidator : public TypedValidator<std::string> {
 public:
   StringContainsValidator();
+  StringContainsValidator(const std::vector<std::string> &);
 
   /// Clone the current state
   IValidator_sptr clone() const override;

--- a/Framework/Kernel/src/StringContainsValidator.cpp
+++ b/Framework/Kernel/src/StringContainsValidator.cpp
@@ -10,6 +10,13 @@ StringContainsValidator::StringContainsValidator() {
   m_requiredStrings = std::vector<std::string>();
 }
 
+/** Constructor with required sub strings
+*/
+StringContainsValidator::StringContainsValidator(
+    const std::vector<std::string> &strings) {
+  m_requiredStrings = strings;
+}
+
 /**
  * @return A clone of the current state of the validator
  */

--- a/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -55,6 +55,7 @@ set ( EXPORT_FILES
   src/Exports/OptionalBool.cpp
   src/Exports/UsageService.cpp
   src/Exports/Atom.cpp
+  src/Exports/StringContainsValidator.cpp
 )
 
 set ( MODULE_DEFINITION ${CMAKE_CURRENT_BINARY_DIR}/kernel.cpp )

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/StringContainsValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/StringContainsValidator.cpp
@@ -12,15 +12,15 @@ namespace Converters = Mantid::PythonInterface::Converters;
 using namespace boost::python;
 
 namespace {
-  StringContainsValidator *createStringContainsValidator() {
-    return new StringContainsValidator();
-  }
-
-StringContainsValidator *createStringContainsValidatorWithStrings(const boost::python::list &values) {
-    return new StringContainsValidator(Converters::PySequenceToVector<std::string>(values)());
-
+StringContainsValidator *createStringContainsValidator() {
+  return new StringContainsValidator();
 }
 
+StringContainsValidator *
+createStringContainsValidatorWithStrings(const boost::python::list &values) {
+  return new StringContainsValidator(
+      Converters::PySequenceToVector<std::string>(values)());
+}
 
 /// Set required strings from a python list
 void setRequiredStrings(StringContainsValidator &self,
@@ -34,9 +34,9 @@ void export_StringContainsValidator() {
       "StringContainsValidator")
       .def("__init__", make_constructor(&createStringContainsValidator,
                                         default_call_policies()))
-      .def("__init__", make_constructor(
-        &createStringContainsValidatorWithStrings, default_call_policies(),
-        ( arg("values") )))                         
+      .def("__init__",
+           make_constructor(&createStringContainsValidatorWithStrings,
+                            default_call_policies(), (arg("values"))))
       .def("setRequiredStrings", &setRequiredStrings, arg("Strings"),
            "Set the list of sub strings that the input must contain");
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/StringContainsValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/StringContainsValidator.cpp
@@ -11,16 +11,15 @@ using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
 namespace {
-  StringContainsValidator *createStringContainsValidator() {
-    return new StringContainsValidator();
-  }
+StringContainsValidator *createStringContainsValidator() {
+  return new StringContainsValidator();
+}
 
 /// Set required strings from a python list
 void setRequiredStrings(StringContainsValidator &self,
-          const boost::python::list &strs) {
-    using namespace Mantid::PythonInterface;
-    self.setRequiredStrings(Converters::PySequenceToVector<std::string>(strs)());
-
+                        const boost::python::list &strs) {
+  using namespace Mantid::PythonInterface;
+  self.setRequiredStrings(Converters::PySequenceToVector<std::string>(strs)());
 }
 }
 
@@ -29,8 +28,6 @@ void export_StringContainsValidator() {
       "StringContainsValidator")
       .def("__init__", make_constructor(&createStringContainsValidator,
                                         default_call_policies()))
-      .def("setRequiredStrings", &setRequiredStrings,
-           arg("Strings"),
+      .def("setRequiredStrings", &setRequiredStrings, arg("Strings"),
            "Set the list of sub strings that the input must contain");
 }
-

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/StringContainsValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/StringContainsValidator.cpp
@@ -8,17 +8,23 @@
 
 using Mantid::Kernel::StringContainsValidator;
 using Mantid::Kernel::IValidator;
+namespace Converters = Mantid::PythonInterface::Converters;
 using namespace boost::python;
 
 namespace {
-StringContainsValidator *createStringContainsValidator() {
-  return new StringContainsValidator();
+  StringContainsValidator *createStringContainsValidator() {
+    return new StringContainsValidator();
+  }
+
+StringContainsValidator *createStringContainsValidatorWithStrings(const boost::python::list &values) {
+    return new StringContainsValidator(Converters::PySequenceToVector<std::string>(values)());
+
 }
+
 
 /// Set required strings from a python list
 void setRequiredStrings(StringContainsValidator &self,
                         const boost::python::list &strs) {
-  using namespace Mantid::PythonInterface;
   self.setRequiredStrings(Converters::PySequenceToVector<std::string>(strs)());
 }
 }
@@ -28,6 +34,9 @@ void export_StringContainsValidator() {
       "StringContainsValidator")
       .def("__init__", make_constructor(&createStringContainsValidator,
                                         default_call_policies()))
+      .def("__init__", make_constructor(
+        &createStringContainsValidatorWithStrings, default_call_policies(),
+        ( arg("values") )))                         
       .def("setRequiredStrings", &setRequiredStrings, arg("Strings"),
            "Set the list of sub strings that the input must contain");
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/StringContainsValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/StringContainsValidator.cpp
@@ -1,17 +1,26 @@
 #include "MantidKernel/StringContainsValidator.h"
+#include "MantidPythonInterface/kernel/Converters/PySequenceToVector.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/default_call_policies.hpp>
 #include <boost/python/make_constructor.hpp>
-#include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/list.hpp>
 
 using Mantid::Kernel::StringContainsValidator;
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
 namespace {
-StringContainsValidator *createStringContainsValidator() {
-  return new StringContainsValidator();
+  StringContainsValidator *createStringContainsValidator() {
+    return new StringContainsValidator();
+  }
+
+/// Set required strings from a python list
+void setRequiredStrings(StringContainsValidator &self,
+          const boost::python::list &strs) {
+    using namespace Mantid::PythonInterface;
+    self.setRequiredStrings(Converters::PySequenceToVector<std::string>(strs)());
+
 }
 }
 
@@ -20,7 +29,8 @@ void export_StringContainsValidator() {
       "StringContainsValidator")
       .def("__init__", make_constructor(&createStringContainsValidator,
                                         default_call_policies()))
-      .def("setRequiredStrings", &StringContainsValidator::setRequiredStrings,
+      .def("setRequiredStrings", &setRequiredStrings,
+           arg("Strings"),
            "Set the list of sub strings that the input must contain");
 }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/StringContainsValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/StringContainsValidator.cpp
@@ -1,0 +1,26 @@
+#include "MantidKernel/StringContainsValidator.h"
+
+#include <boost/python/class.hpp>
+#include <boost/python/default_call_policies.hpp>
+#include <boost/python/make_constructor.hpp>
+#include <boost/python/register_ptr_to_python.hpp>
+
+using Mantid::Kernel::StringContainsValidator;
+using Mantid::Kernel::IValidator;
+using namespace boost::python;
+
+namespace {
+StringContainsValidator *createStringContainsValidator() {
+  return new StringContainsValidator();
+}
+}
+
+void export_StringContainsValidator() {
+  class_<StringContainsValidator, bases<IValidator>, boost::noncopyable>(
+      "StringContainsValidator")
+      .def("__init__", make_constructor(&createStringContainsValidator,
+                                        default_call_policies()))
+      .def("setRequiredStrings", &StringContainsValidator::setRequiredStrings,
+           "Set the list of sub strings that the input must contain");
+}
+

--- a/Framework/PythonInterface/test/python/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/kernel/CMakeLists.txt
@@ -30,6 +30,7 @@ set ( TEST_PY_FILES
   PropertyManagerPropertyTest.py
   PythonPluginsTest.py
   StatisticsTest.py
+  StringContainsValidatorTest.py
   TimeSeriesPropertyTest.py
   QuatTest.py
   UnitConversionTest.py

--- a/Framework/PythonInterface/test/python/mantid/kernel/StringContainsValidatorTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/StringContainsValidatorTest.py
@@ -1,0 +1,81 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+import testhelpers
+
+from mantid.kernel import StringContainsValidator
+from mantid.api import PythonAlgorithm
+
+class StringContainsValidatorTest(unittest.TestCase):
+
+
+    def test_StringContainsValidator_with_empty_required_string(self):
+        """
+            Test that a list validator restricts the values
+            for a property
+        """
+
+        class StringContainsValidatorWithEmptyItem(PythonAlgorithm):
+
+            def PyInit(self):
+                validator = StringContainsValidator()
+                validator.setRequiredStrings([""])
+                self.declareProperty("Input", "", validator)
+
+            def PyExec(self):
+                pass
+
+        alg = StringContainsValidatorWithEmptyItem()
+        alg.initialize()
+        testhelpers.assertRaisesNothing(self, alg.setProperty, "Input", "AnyOldString")
+
+    def test_StringContainsValidator_with_single_required_string(self):
+        """
+            Test that a string-contains validator that requires
+            a single string to be contained in the input string
+        """
+
+        class StringContainsValidatorWithSingleItem(PythonAlgorithm):
+
+            def PyInit(self):
+                validator = StringContainsValidator()
+                validator.setRequiredStrings(["meOw"])
+                self.declareProperty("Input", "", validator)
+
+            def PyExec(self):
+                pass
+
+        alg = StringContainsValidatorWithSingleItem()
+        alg.initialize()
+        self.assertRaises(ValueError, alg.setProperty, "Input", "")
+        self.assertRaises(ValueError, alg.setProperty, "Input", "NotValid")
+        self.assertRaises(ValueError, alg.setProperty, "Input", "Homeowner")
+        testhelpers.assertRaisesNothing(self, alg.setProperty, "Input", "HomeOwner")
+        testhelpers.assertRaisesNothing(self, alg.setProperty, "Input", "cat, meOws")
+        
+    def test_StringContainsValidator_with_multiple_required_strings(self):
+        """
+            Test that a string-contains validator that requires
+            multiple strings to all be contained in the input string
+        """
+
+        class StringContainsValidatorWithMultipleItem(PythonAlgorithm):
+
+            def PyInit(self):
+                validator = StringContainsValidator()
+                validator.setRequiredStrings(["Home","meOw"])
+                self.declareProperty("Input", "", validator)
+
+            def PyExec(self):
+                pass
+
+        alg = StringContainsValidatorWithMultipleItem()
+        alg.initialize()
+        self.assertRaises(ValueError, alg.setProperty, "Input", "NotValid")
+        self.assertRaises(ValueError, alg.setProperty, "Input", "HomeRenter")
+        self.assertRaises(ValueError, alg.setProperty, "Input", "catmeOw")
+        testhelpers.assertRaisesNothing(self, alg.setProperty, "Input", "HomeOwner")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/kernel/StringContainsValidatorTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/StringContainsValidatorTest.py
@@ -75,6 +75,28 @@ class StringContainsValidatorTest(unittest.TestCase):
         self.assertRaises(ValueError, alg.setProperty, "Input", "HomeRenter")
         self.assertRaises(ValueError, alg.setProperty, "Input", "catmeOw")
         testhelpers.assertRaisesNothing(self, alg.setProperty, "Input", "HomeOwner")
+        
+    def test_StringContainsValidator_with_multiple_required_strings_constructor(self):
+        """
+            Test that a string-contains validator made from constructor that 
+            supplies multiple strings required to all be contained in the input string
+        """
+
+        class StringContainsValidatorWithMultipleItem(PythonAlgorithm):
+
+            def PyInit(self):
+                validator = StringContainsValidator(["Home","meOw"])
+                self.declareProperty("Input", "", validator)
+
+            def PyExec(self):
+                pass
+
+        alg = StringContainsValidatorWithMultipleItem()
+        alg.initialize()
+        self.assertRaises(ValueError, alg.setProperty, "Input", "NotValid")
+        self.assertRaises(ValueError, alg.setProperty, "Input", "HomeRenter")
+        self.assertRaises(ValueError, alg.setProperty, "Input", "catmeOw")
+        testhelpers.assertRaisesNothing(self, alg.setProperty, "Input", "HomeOwner")
 
 
 if __name__ == '__main__':

--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -89,6 +89,8 @@ Python
 Python Algorithms
 #################
 
+- Exposed `StringContainsValidator` to python to enable python algorithms to place requirement on input string to contain certain substrings.
+
 Bugfixes
 ########
 


### PR DESCRIPTION
Expose StringContainsValidator to python so it can be used in a python algorithm. This validator checks that the input string contains a certain string or all the strings in a certain list of strings as substrings.

**To test:**

Write a very simple python algorithm that uses this validator on an string property. The unit test may help you with writing this algorithm. Then run it with various values of this string property and check it fails or succeeds as expected.

Fixes #13316 . 

**Release Notes** 
To do.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
