### PR TITLE
Fix intermittently failing Abins tests

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsAdvancedParametersTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsAdvancedParametersTest.py
@@ -71,8 +71,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
         AbinsParameters.threads = 1
 
     def tearDown(self):
-        AbinsTestHelpers.remove_output_files(list_of_names=["Abins", "explicit", "default", "total",
-                                                            "squaricn_scale", "benzene_exp", "experimental"])
+        AbinsTestHelpers.remove_output_files(list_of_names=["AbinsAdvanced"])
         mtd.clear()
 
     def test_wrong_fwhm(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
@@ -55,8 +55,8 @@ class AbinsBasicTest(unittest.TestCase):
     _tolerance = 0.0001
 
     def tearDown(self):
-        AbinsTestHelpers.remove_output_files(list_of_names=["Abins", "explicit",  "default", "total",
-                                                            "squaricn_scale", "benzene_exp", "experimental"])
+        AbinsTestHelpers.remove_output_files(list_of_names=["explicit",  "default", "total", "squaricn_sum_Abins",
+                                                            "squaricn_scale", "benzene", "experimental"])
         mtd.clear()
 
     def test_wrong_input(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
@@ -56,7 +56,7 @@ class AbinsBasicTest(unittest.TestCase):
 
     def tearDown(self):
         AbinsTestHelpers.remove_output_files(list_of_names=["explicit",  "default", "total", "squaricn_sum_Abins",
-                                                            "squaricn_scale", "benzene", "experimental"])
+                                                            "squaricn_scale", "benzene_exp", "benzene_Abins", "experimental"])
         mtd.clear()
 
     def test_wrong_input(self):


### PR DESCRIPTION
Some Abins tests are deleting files created by other tests. This reduces the scope of tearDown for some tests and fixes the intermittent test failures.

Examples of test failures:
http://builds.mantidproject.org/job/master_clean-archlinux_python3/402
http://builds.mantidproject.org/view/Pull%20Requests/job/pull_requests-ubuntu/16215

Also reported on the **Mantid Build False Positives** spreadsheet


**To test:**
`ctest -j15 --output-on-failure --repeat-until-fail 10 -R Abins` should not fail now.


*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
