### PR TITLE
Fix sphinx warnings for deprecated algorithms

### DIFF
--- a/docs/source/release/v3.11.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.11.0/indirect_inelastic.rst
@@ -50,7 +50,7 @@ Improvements
 
 Dropped
 -------
-- :ref:`algm-LoadILLIndirect-v1`, :ref:`algm-IndirectILLReduction`, :ref:`algm-ILLIN16BCalibration` algorithms deprecated since v3.9, are now removed.
+- `LoadILLIndirect-v1 <http://docs.mantidproject.org/v3.10.1/algorithms/LoadILLIndirect-v1.html>`_, `IndirectILLReduction <http://docs.mantidproject.org/v3.10.1/algorithms/IndirectILLReduction-v1.html>`_, `ILLIN16BCalibration <http://docs.mantidproject.org/v3.10.1/algorithms/ILLIN16BCalibration-v1.html>`_ algorithms deprecated since v3.9, are now removed.
 
 
 Bugfixes

--- a/docs/source/release/v3.6.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.6.0/indirect_inelastic.rst
@@ -71,7 +71,7 @@ Data Reduction
 ILL Energy Transfer
 ~~~~~~~~~~~~~~~~~~~
 
--  Changed :ref:`IndirectILLReduction <algm-IndirectILLReduction>` algorithm to support the new format for
+-  Changed `IndirectILLReduction <http://docs.mantidproject.org/v3.6.0/algorithms/IndirectILLReduction-v1.html>`_ algorithm to support the new format for
    raw ``.nxs`` files.
 
 Diffraction

--- a/docs/source/release/v3.9.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.9.0/indirect_inelastic.rst
@@ -26,7 +26,7 @@ Data Reduction
 - New :ref:`IndirectILLEnergyTransfer <algm-IndirectILLEnergyTransfer>` algorithm performs initial data reduction steps for IN16B instrument data at ILL.
 - New :ref:`IndirectILLReductionQENS <algm-IndirectILLReductionQENS>` algorithm performs complete multiple file reduction for Quasi-Elastic Neutron Scattering (QENS) data from IN16B instrument at ILL.
 - New :ref:`IndirectILLReductionFWS <algm-IndirectILLReductionFWS>` algorithm performs complete multiple file reduction for the elastic and inelastic fixed-window scan data from IN16B instrument at ILL.
-- Deprecated :ref:`IndirectILLReduction <algm-IndirectILLReduction>` and :ref:`ILLIN16BCalibration <algm-ILLIN16BCalibration>` algorithms.
+- Deprecated `IndirectILLReduction <http://docs.mantidproject.org/v3.9.0/algorithms/IndirectILLReduction-v1.html>`_ and `ILLIN16BCalibration <http://docs.mantidproject.org/v3.9.0/algorithms/ILLIN16BCalibration-v1.html>`_ algorithms.
 - When plotting *ConvFit* results "Two Lorentzians" will produce plots for both lorentzians
 
 Data Analysis


### PR DESCRIPTION
The [doctests](http://builds.mantidproject.org/job/master_doctests/621/) currently have 6 warnings. This hopefully fixes the sphinx warnings for deprecated algorithms in the release notes.

**To test:**
This PR has no issue associated with it.

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
