### PR TITLE
Change input name in interface

### DIFF
--- a/qt/scientific_interfaces/General/MantidEVWorker.cpp
+++ b/qt/scientific_interfaces/General/MantidEVWorker.cpp
@@ -604,7 +604,7 @@ bool MantidEVWorker::optimizePhiChiOmega(const std::string &peaks_ws_name,
   alg->setProperty("MaxAngularChange", max_change);
   alg->setProperty("MaxIndexingError", 0.20);
   alg->setProperty("MaxHKLPeaks2Use", -1.0);
-  alg->setProperty("MaxSamplePositionChange_meters", 0.05);
+  alg->setProperty("MaxSamplePositionChangeMeters", 0.05);
 
   return alg->execute();
 }


### PR DESCRIPTION
Description of work.

**To test:**
Use SCD Event Data Reduction Interface with TOPAZ_3132.  In 3rd tab check Load Isaw UB and Optimize Phi, Chi and Omega.  Here is script to generate UB matrix file, TOPAZ_3132.mat:

```python
Load(Filename='TOPAZ_3132_event.nxs', OutputWorkspace='TOPAZ_3132_event')
FilterBadPulses(InputWorkspace='TOPAZ_3132_event', OutputWorkspace='TOPAZ_3132_event', LowerCutoff=25)
ConvertToMD(InputWorkspace='TOPAZ_3132_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', LorentzCorrection=True, OutputWorkspace='TOPAZ_3132_md', MinValues='-25,-25,-25', MaxValues='25,25,25', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=13, MinRecursionDepth=7)
FindPeaksMD(InputWorkspace='TOPAZ_3132_md', PeakDistanceThreshold=0.37680000000000002, MaxPeaks=50, DensityThresholdFactor=100, OutputWorkspace='TOPAZ_3132_peaks')
FindUBUsingFFT(PeaksWorkspace='TOPAZ_3132_peaks', MinD=3, MaxD=15, Tolerance=0.12)
IndexPeaks(PeaksWorkspace='TOPAZ_3132_peaks', Tolerance=0.12)
SaveIsawUB(InputWorkspace='TOPAZ_3132_peaks', Filename='TOPAZ_3132.mat')
```


Fixes #20379 

**Release Notes** 

*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
