### PR TITLE
Fix problem with EQSANS offsets

### DIFF
--- a/Framework/Algorithms/src/Q1DWeighted.cpp
+++ b/Framework/Algorithms/src/Q1DWeighted.cpp
@@ -213,7 +213,7 @@ void Q1DWeighted::exec() {
         // For reference - in the case where we don't use sub-pixels, simply
         // use:
         //     double sinTheta = sin( spectrumInfo.twoTheta(i)/2.0 );
-        V3D pos = spectrumInfo.position(i) - V3D(sub_x, sub_y, 0.0);
+        V3D pos = spectrumInfo.position(i) - V3D(sub_x, sub_y, 0.0) - samplePos;
         double sinTheta = sin(0.5 * pos.angle(beamLine));
         double factor = fmp * sinTheta;
         double q = factor * 2.0 / (XIn[j] + XIn[j + 1]);

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -579,24 +579,43 @@ void EQSANSLoad::exec() {
       throw std::runtime_error("Could not cast (interpret) the property " +
                                dzName + " as a time series property value.");
     sfdd = dp->getStatistics().mean;
-    s2d = sfdd;
 
     // Modify SDD according to the DetectorDistance offset if given
     const double sampleflange_det_offset = getProperty("DetectorOffset");
     if (!isEmpty(sampleflange_det_offset))
       sfdd += sampleflange_det_offset;
 
-    // Modify S2D according to the SampleDistance offset if given
-    // This assumes that a positive offset moves the sample toward the detector
-    const double sampleflange_sample_offset = getProperty("SampleOffset");
-    if (!isEmpty(sampleflange_sample_offset))
-      s2d -= sampleflange_sample_offset;
-
-    // Modify SDD according to SampleDetectorDistanceOffset offset if given
+    // Modify SDD according to SampleDetectorDistanceOffset offset if given.
+    // This is here for backward compatibility.
     const double sample_det_offset =
         getProperty("SampleDetectorDistanceOffset");
     if (!isEmpty(sample_det_offset))
-      s2d += sample_det_offset;
+      sfdd += sample_det_offset;
+    if (!isEmpty(sample_det_offset) && !isEmpty(sampleflange_det_offset))
+      g_log.error()
+          << "Both DetectorOffset and SampleDetectorDistanceOffset "
+             "are set. Only one should be used.\n";
+
+    s2d = sfdd;
+    // Modify S2D according to the SampleDistance offset if given
+    // This assumes that a positive offset moves the sample toward the detector
+    const double sampleflange_sample_offset = getProperty("SampleOffset");
+    if (!isEmpty(sampleflange_sample_offset)) {
+      s2d -= sampleflange_sample_offset;
+
+      // Move the sample to its correct position
+      IAlgorithm_sptr mvAlg =
+          createChildAlgorithm("MoveInstrumentComponent", 0.2, 0.4);
+      mvAlg->setProperty<MatrixWorkspace_sptr>("Workspace", dataWS);
+      mvAlg->setProperty("ComponentName", "sample-position");
+      mvAlg->setProperty("Z", sampleflange_sample_offset / 1000.0);
+      mvAlg->setProperty("RelativePosition", false);
+      mvAlg->executeAsChildAlg();
+      g_log.information() << "Moving sample to " << sampleflange_sample_offset / 1000.0 << " meters\n";
+      m_output_message += "   Sample position: " +
+                          Poco::NumberFormatter::format(sampleflange_sample_offset / 1000.0, 3) + " m\n";
+    }
+
   }
   dataWS->mutableRun().addProperty("sampleflange_detector_distance", sfdd, "mm",
                                    true);

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -832,7 +832,6 @@ void EQSANSLoad::exec() {
                                    getPropertyValue("OutputWorkspace"), true);
   setProperty<MatrixWorkspace_sptr>(
       "OutputWorkspace", boost::dynamic_pointer_cast<MatrixWorkspace>(dataWS));
-  // m_output_message = "Loaded " + fileName + '\n' + m_output_message;
   setPropertyValue("OutputMessage", m_output_message);
 }
 

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -592,9 +592,8 @@ void EQSANSLoad::exec() {
     if (!isEmpty(sample_det_offset))
       sfdd += sample_det_offset;
     if (!isEmpty(sample_det_offset) && !isEmpty(sampleflange_det_offset))
-      g_log.error()
-          << "Both DetectorOffset and SampleDetectorDistanceOffset "
-             "are set. Only one should be used.\n";
+      g_log.error() << "Both DetectorOffset and SampleDetectorDistanceOffset "
+                       "are set. Only one should be used.\n";
 
     s2d = sfdd;
     // Modify S2D according to the SampleDistance offset if given
@@ -611,11 +610,13 @@ void EQSANSLoad::exec() {
       mvAlg->setProperty("Z", sampleflange_sample_offset / 1000.0);
       mvAlg->setProperty("RelativePosition", false);
       mvAlg->executeAsChildAlg();
-      g_log.information() << "Moving sample to " << sampleflange_sample_offset / 1000.0 << " meters\n";
+      g_log.information() << "Moving sample to "
+                          << sampleflange_sample_offset / 1000.0 << " meters\n";
       m_output_message += "   Sample position: " +
-                          Poco::NumberFormatter::format(sampleflange_sample_offset / 1000.0, 3) + " m\n";
+                          Poco::NumberFormatter::format(
+                              sampleflange_sample_offset / 1000.0, 3) +
+                          " m\n";
     }
-
   }
   dataWS->mutableRun().addProperty("sampleflange_detector_distance", sfdd, "mm",
                                    true);

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -590,7 +590,7 @@ void EQSANSLoad::exec() {
     // This assumes that a positive offset moves the sample toward the detector
     const double sampleflange_sample_offset = getProperty("SampleOffset");
     if (!isEmpty(sampleflange_sample_offset))
-      s2d = s2d - sampleflange_sample_offset + sampleflange_det_offset;
+      s2d -= sampleflange_sample_offset;
 
     // Modify SDD according to SampleDetectorDistanceOffset offset if given
     const double sample_det_offset =

--- a/docs/source/release/v3.11.0/sans.rst
+++ b/docs/source/release/v3.11.0/sans.rst
@@ -16,6 +16,9 @@ Bug Fixes
 
 - Displaying the masked workspace in the mask tab now makes sure that the masks are displayed in a grey color.
 
-|
+EQSANS
+------
+
+- Following hardware changes in the instrument, sample and detector offsets were added as parameters of the reduction.
 
 `Full list of changes on github <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+SANS%22>`__

--- a/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
+++ b/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
@@ -125,3 +125,10 @@ def Resolution(sample_aperture_diameter=10.0):
 
 def IndependentBinning(independent_binning=True):
     ReductionSingleton().reduction_properties["IQIndependentBinning"]=independent_binning
+
+def SetDetectorOffset(distance):
+    ReductionSingleton().reduction_properties["DetectorOffset"] = distance
+
+def SetSampleOffset(distance):
+    ReductionSingleton().reduction_properties["SampleOffset"] = distance
+

--- a/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
+++ b/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
@@ -133,4 +133,3 @@ def SetDetectorOffset(distance):
 
 def SetSampleOffset(distance):
     ReductionSingleton().reduction_properties["SampleOffset"] = distance
-

--- a/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
+++ b/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
@@ -126,8 +126,10 @@ def Resolution(sample_aperture_diameter=10.0):
 def IndependentBinning(independent_binning=True):
     ReductionSingleton().reduction_properties["IQIndependentBinning"]=independent_binning
 
+
 def SetDetectorOffset(distance):
     ReductionSingleton().reduction_properties["DetectorOffset"] = distance
+
 
 def SetSampleOffset(distance):
     ReductionSingleton().reduction_properties["SampleOffset"] = distance


### PR DESCRIPTION
There are still minor tweaks to be made to the new EQSANS offsets. The logic should be somewhat simplified so that there is no doubt that the offsets are applied properly. Also, the sample location should be moved according to the sample offset so that the scattering angle is calculated properly.

**To test:**

- Review the code.
- Make sure the tests pass.

There is no Github issue for this PR. All the information is here.

**Release Notes** 
*Does not need to be in the release notes.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
