### PR TITLE
`ConvertSpectrumAxis` option to leave the new axis unordered

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ConvertSpectrumAxis2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConvertSpectrumAxis2.h
@@ -80,10 +80,19 @@ private:
   /// Creates an output workspace.
   API::MatrixWorkspace_sptr
   createOutputWorkspace(API::Progress &progress, const std::string &targetUnit,
-                        API::MatrixWorkspace_sptr &inputWS, size_t nHist);
+                        API::MatrixWorkspace_sptr &inputWS);
 
-  // Map to which the conversion to the unit is stored.
+  /// Map to which the conversion to the unit is stored.
   std::multimap<double, size_t> m_indexMap;
+
+  /// Vector of axis in case ordering is not asked.
+  std::vector<double> m_axis;
+
+  /// Flag whether ordering is needed.
+  bool m_toOrder;
+
+  /// Emplaces to value and the index pair into the map.
+  void emplaceIndexMap(double value, size_t wsIndex);
 
   /// Getting Efixed
   double getEfixed(const size_t detectorIndex,

--- a/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
@@ -260,7 +260,8 @@ MatrixWorkspace_sptr ConvertSpectrumAxis2::createOutputWorkspace(
       outputWorkspace->getSpectrum(currentIndex)
           .copyInfoFrom(inputWS->getSpectrum(it->second));
       ++currentIndex;
-      progress.report("Setting output spectrum #" + std::to_string(currentIndex));
+      progress.report("Setting output spectrum #" +
+                      std::to_string(currentIndex));
     }
   }
 

--- a/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
@@ -67,7 +67,7 @@ void ConvertSpectrumAxis2::init() {
                   "(EMode=Indirect))");
 
   declareProperty("OrderAxis", true, "Whether or not to sort the resulting"
-                                     " spectum axis.");
+                                     " spectrum axis.");
 }
 
 void ConvertSpectrumAxis2::exec() {

--- a/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
+++ b/Framework/Algorithms/src/ConvertSpectrumAxis2.cpp
@@ -1,6 +1,4 @@
 #include "MantidAlgorithms/ConvertSpectrumAxis2.h"
-#include "MantidTypes/SpectrumDefinition.h"
-#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/Run.h"
@@ -8,12 +6,14 @@
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidGeometry/Instrument.h"
-#include "MantidKernel/CompositeValidator.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/BoundedValidator.h"
+#include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitConversion.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidTypes/SpectrumDefinition.h"
 
 #include <cfloat>
 
@@ -65,18 +65,33 @@ void ConvertSpectrumAxis2::init() {
   declareProperty("EFixed", EMPTY_DBL(), mustBePositive,
                   "Value of fixed energy in meV : EI (EMode=Direct) or EF "
                   "(EMode=Indirect))");
+
+  declareProperty("OrderAxis", true, "Whether or not to sort the resulting"
+                                     " spectum axis.");
 }
 
 void ConvertSpectrumAxis2::exec() {
   // Get the input workspace.
   API::MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
   // Assign value to the member variable storing the number of histograms.
-  size_t nHist = inputWS->getNumberHistograms();
+  const size_t nHist = inputWS->getNumberHistograms();
 
   // The unit to convert to.
   const std::string unitTarget = getProperty("Target");
 
-  Progress progress(this, 0.0, 1.0, inputWS->getNumberHistograms());
+  // Whether needs to be ordered
+  m_toOrder = getProperty("OrderAxis");
+
+  size_t nProgress = nHist;
+  if (m_toOrder) {
+    // we will need to loop twice, once to build the indexMap,
+    // once to copy over the spectra and set the output
+    nProgress *= 2;
+  } else {
+    m_axis.reserve(nHist);
+  }
+
+  Progress progress(this, 0.0, 1.0, nProgress);
 
   // Call the functions to convert to the different forms of theta or Q.
   if (unitTarget == "theta" || unitTarget == "Theta" ||
@@ -88,7 +103,7 @@ void ConvertSpectrumAxis2::exec() {
 
   // Create an output workspace and set the property for it.
   MatrixWorkspace_sptr outputWS =
-      createOutputWorkspace(progress, unitTarget, inputWS, nHist);
+      createOutputWorkspace(progress, unitTarget, inputWS);
   setProperty("OutputWorkspace", outputWS);
 }
 
@@ -121,11 +136,11 @@ void ConvertSpectrumAxis2::createThetaMap(API::Progress &progress,
     }
     if (!spectrumInfo.isMonitor(i)) {
       if (signedTheta)
-        m_indexMap.emplace(spectrumInfo.signedTwoTheta(i) * rad2deg, i);
+        emplaceIndexMap(spectrumInfo.signedTwoTheta(i) * rad2deg, i);
       else
-        m_indexMap.emplace(spectrumInfo.twoTheta(i) * rad2deg, i);
+        emplaceIndexMap(spectrumInfo.twoTheta(i) * rad2deg, i);
     } else {
-      m_indexMap.emplace(0.0, i);
+      emplaceIndexMap(0.0, i);
     }
 
     progress.report("Converting to theta...");
@@ -176,13 +191,13 @@ void ConvertSpectrumAxis2::createElasticQMap(
         Kernel::UnitConversion::convertToElasticQ(theta, efixed);
 
     if (targetUnit == "ElasticQ") {
-      m_indexMap.emplace(elasticQInAngstroms, i);
+      emplaceIndexMap(elasticQInAngstroms, i);
     } else if (targetUnit == "ElasticQSquared") {
       // The QSquared value.
       double elasticQSquaredInAngstroms =
           elasticQInAngstroms * elasticQInAngstroms;
 
-      m_indexMap.emplace(elasticQSquaredInAngstroms, i);
+      emplaceIndexMap(elasticQSquaredInAngstroms, i);
     }
 
     progress.report("Converting to Elastic Q...");
@@ -195,22 +210,32 @@ void ConvertSpectrumAxis2::createElasticQMap(
 * @param progress :: Progress indicator
 * @param targetUnit :: Target conversion unit
 * @param inputWS :: Input workspace
-* @param nHist :: Stores the number of histograms
 */
 MatrixWorkspace_sptr ConvertSpectrumAxis2::createOutputWorkspace(
     API::Progress &progress, const std::string &targetUnit,
-    API::MatrixWorkspace_sptr &inputWS, size_t nHist) {
-  // Create the output workspace. Can not re-use the input one because the
-  // spectra are re-ordered.
-  MatrixWorkspace_sptr outputWorkspace = WorkspaceFactory::Instance().create(
-      inputWS, m_indexMap.size(), inputWS->x(0).size(), inputWS->y(0).size());
+    API::MatrixWorkspace_sptr &inputWS) {
 
-  // Now set up a new numeric axis holding the theta values corresponding to
-  // each spectrum.
-  auto const newAxis = new NumericAxis(m_indexMap.size());
+  MatrixWorkspace_sptr outputWorkspace = nullptr;
+  NumericAxis *newAxis = nullptr;
+  size_t size;
+  if (m_toOrder) {
+    // Can not re-use the input one because the spectra are re-ordered.
+    size = m_indexMap.size();
+    outputWorkspace = WorkspaceFactory::Instance().create(
+        inputWS, size, inputWS->x(0).size(), inputWS->y(0).size());
+    std::vector<double> axis;
+    axis.reserve(m_indexMap.size());
+    for (const auto &it : m_indexMap) {
+      axis.emplace_back(it.first);
+    }
+    newAxis = new NumericAxis(std::move(axis));
+  } else {
+    // If there is no reordering we can simply clone.
+    size = m_axis.size();
+    outputWorkspace = inputWS->clone();
+    newAxis = new NumericAxis(m_axis);
+  }
   outputWorkspace->replaceAxis(1, newAxis);
-
-  progress.setNumSteps(nHist + m_indexMap.size());
 
   // Set the units of the axis.
   if (targetUnit == "theta" || targetUnit == "Theta" ||
@@ -222,20 +247,23 @@ MatrixWorkspace_sptr ConvertSpectrumAxis2::createOutputWorkspace(
     newAxis->unit() = UnitFactory::Instance().create("QSquared");
   }
 
-  std::multimap<double, size_t>::const_iterator it;
   size_t currentIndex = 0;
-  for (it = m_indexMap.begin(); it != m_indexMap.end(); ++it) {
-    // Set the axis value.
-    newAxis->setValue(currentIndex, it->first);
-    // Copy over the data.
-    outputWorkspace->setHistogram(currentIndex, inputWS->histogram(it->second));
-    // We can keep the spectrum numbers etc.
-    outputWorkspace->getSpectrum(currentIndex)
-        .copyInfoFrom(inputWS->getSpectrum(it->second));
-    ++currentIndex;
 
-    progress.report("Creating output workspace...");
+  // Note that this is needed only for ordered case
+  if (m_toOrder) {
+    std::multimap<double, size_t>::const_iterator it;
+    for (it = m_indexMap.begin(); it != m_indexMap.end(); ++it) {
+      // Copy over the data.
+      outputWorkspace->setHistogram(currentIndex,
+                                    inputWS->histogram(it->second));
+      // We can keep the spectrum numbers etc.
+      outputWorkspace->getSpectrum(currentIndex)
+          .copyInfoFrom(inputWS->getSpectrum(it->second));
+      ++currentIndex;
+      progress.report("Setting output spectrum #" + std::to_string(currentIndex));
+    }
   }
+
   return outputWorkspace;
 }
 
@@ -277,6 +305,18 @@ double ConvertSpectrumAxis2::getEfixed(
     }
   }
   return efixed;
+}
+
+/** Emplaces inside the ordered or unordered index registry
+* @param value :: value to insert
+* @param wsIndex :: workspace index
+*/
+void ConvertSpectrumAxis2::emplaceIndexMap(double value, size_t wsIndex) {
+  if (m_toOrder) {
+    m_indexMap.emplace(value, wsIndex);
+  } else {
+    m_axis.emplace_back(value);
+  }
 }
 
 } // namespace Algorithms

--- a/docs/source/algorithms/ConvertSpectrumAxis-v2.rst
+++ b/docs/source/algorithms/ConvertSpectrumAxis-v2.rst
@@ -14,8 +14,9 @@ a matrix in MantidPlot) of a Workspace2D from its default of holding the
 spectrum number to the target unit given - theta, elastic Q and elastic
 Q^2.
 
-The spectra will be reordered in increasing order by the new unit and
-duplicates will not be aggregated. Any spectrum for which a detector is
+The spectra will be reordered in increasing order by default, however this can be disbled by `OrderAxis=False`.
+In the case of the latter, spectra will preserve correspondence to the original workspace.
+The new unit and duplicates will not be aggregated. Any spectrum for which a detector is
 not found (i.e. if the instrument definition is incomplete) will not
 appear in the output workspace.
 

--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -45,7 +45,7 @@ Improved
 - :ref:`SimpleShapeMonteCarloAbsorption <algm-SimpleShapeMonteCarloAbsorption>` has been added to simplify sample environment inputs for MonteCarloAbsorption
 - :ref:`SumSpectra <algm-SumSpectra-v1>`: Fixed a bug where a wrong fallback value would be used in case of invalid values being set for min/max worspace index, and improved input validation for those properties.
 - :ref:`LoadBBY <algm-LoadBBY-v1>`: Fixed bug where the logManager did not work with sample_name, sample_aperture and source_aperture. Also added more information regarding the sample and the selected choppers.
-
+- :ref:`ConvertSpectrumAxis <algm-ConvertSpectrumAxis-v2>`: Added an option to disable the sorting of the resulting axis making it useful especially for scanning workspaces. Also reduced the complexity of the operation for the default (ordered axis) case from *Nˆ2* to *N*.
 
 
 Deprecated


### PR DESCRIPTION
This adds a new boolean option (true by default) to the above mentioned algorithm, to be able to switch off the ordering, which is needed for scanning workspaces (see the issue). 

Also, in the default ordered axis case, the performance is improved (complexity from Nˆ2 down to N) by creating the new numeric axis from the whole vector once, instead of inserting each point individually in a loop, where insertion (`NumericAxis::setValue`) triggers another loop over the whole axis. This made it possible to execute the algorithm in finite time over scanning workspaces, that are normally very large.

**To test:**
1) Load the attached detector scan file (`tar -xzvf` first, you might also need to set facility to `ILL`).
[scanfile.zip](https://github.com/mantidproject/mantid/files/1280438/scanfile.zip)
2) Run ConvertSpectrumAxis to convert to`SignedTheta` without ordering.
3) The spectrum axis of the result should be
   
- 0 for spectra 0-570 (monitor)
- -34.24 >> -5.749 for spectra 571 - 1141 (pixel 1) 
- -34.19 >> -5.699 for spectra 1142 - 1712 (pixel 2)


and so on.

<!-- Instructions for testing. -->

Fixes #20375 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.