### PR TITLE
Fixed Python API docs for Run

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -199,10 +199,10 @@ void export_Run() {
       //--------------------------- Dictionary
       // access----------------------------
       .def("get", &getWithDefault, (arg("self"), arg("key"), arg("default")),
-           "Returns the value pointed to by the key or "
-           "None if it does not exist")
+           "Returns the value pointed to by the key or the default value given.")
       .def("get", &get, (arg("self"), arg("key")),
-           "Returns the value pointed to by the key or the default value given")
+           "Returns the value pointed to by the key or "
+           "None if it does not exist.")
       .def("keys", &keys, arg("self"),
            "Returns the names of the properties as list")
       .def("__contains__", &Run::hasProperty, (arg("self"), arg("name")))

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -199,7 +199,8 @@ void export_Run() {
       //--------------------------- Dictionary
       // access----------------------------
       .def("get", &getWithDefault, (arg("self"), arg("key"), arg("default")),
-           "Returns the value pointed to by the key or the default value given.")
+           "Returns the value pointed to by the key or the default value "
+           "given.")
       .def("get", &get, (arg("self"), arg("key")),
            "Returns the value pointed to by the key or "
            "None if it does not exist.")


### PR DESCRIPTION
This PR fixes the Python API documentation for `mantid.api.Run.get()` methods. The descriptions of the two call signatures were mixed up.

**To test:**

Build the `docs-html` target and check that the documentation for `Run` is correct.

Fixes #20378.

**Release Notes** 

*This is such an insignificant change that it does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
