### PR TITLE
Fix some python2 flake8 warnings

### DIFF
--- a/scripts/Inelastic/Direct/PropertyManager.py
+++ b/scripts/Inelastic/Direct/PropertyManager.py
@@ -6,6 +6,7 @@ from collections import OrderedDict, Iterable
 from six import iteritems
 from mantid.kernel import funcinspect
 
+
 class PropertyManager(NonIDF_Properties):
     """ Class defines the interface for Direct inelastic reduction with properties
         present in Instrument_Properties.xml file

--- a/scripts/Interface/ui/dataprocessorinterface/data_processor_gui.py
+++ b/scripts/Interface/ui/dataprocessorinterface/data_processor_gui.py
@@ -8,8 +8,6 @@ from PyQt4 import QtGui
 from mantidqtpython import MantidQt
 from ui.reflectometer.ui_data_processor_window import Ui_DataProcessorWindow
 
-from . import ui_data_processor_window
-
 
 canMantidPlot = True
 

--- a/scripts/PyChop/__init__.py
+++ b/scripts/PyChop/__init__.py
@@ -19,7 +19,7 @@ PyChop2.showGUI()
 
 from __future__ import (absolute_import, division, print_function)
 import warnings
-from .PyChop2 import PyChop2
+from .PyChop2 import PyChop2  # noqa: F401
 # If the system doesn't have matplotlib, don't import the GUI.
 try:
     from .PyChopGui import show as showGUI

--- a/scripts/reduction/__init__.py
+++ b/scripts/reduction/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import (absolute_import, division, print_function)
-from reduction.reducer import *
-from reduction.instrument import *
-from reduction.find_data import find_data, find_file
+from reduction.reducer import *  # noqa: F401
+from reduction.instrument import *  # noqa: F401
+from reduction.find_data import find_data, find_file  # noqa: F401

--- a/scripts/reduction_workflow/instruments/sans/hfir_command_interface.py
+++ b/scripts/reduction_workflow/instruments/sans/hfir_command_interface.py
@@ -17,8 +17,9 @@ from mantid.simpleapi import Load
 
 # The following imports allow users to import this file and have all functionality automatically imported
 # Do not remove these imports as it will break user scripts which rely on them
-from reduction_workflow.command_interface import OutputPath, Reduce1D, Reduce, \
-                                                 AppendDataFile, ClearDataFiles  # noqa: F401
+from reduction_workflow.command_interface import OutputPath, Reduce1D, Reduce  # noqa: F401
+from reduction_workflow.command_interface import AppendDataFile, ClearDataFiles  # noqa: F401
+
 
 def BIOSANS():
     Clear()

--- a/scripts/reduction_workflow/instruments/sans/hfir_command_interface.py
+++ b/scripts/reduction_workflow/instruments/sans/hfir_command_interface.py
@@ -17,8 +17,8 @@ from mantid.simpleapi import Load
 
 # The following imports allow users to import this file and have all functionality automatically imported
 # Do not remove these imports as it will break user scripts which rely on them
-from reduction_workflow.command_interface import OutputPath, Reduce1D, Reduce  # noqa: F401
-from reduction_workflow.command_interface import AppendDataFile, ClearDataFiles  # noqa: F401
+from reduction_workflow.command_interface import (OutputPath, Reduce1D, Reduce,  # noqa: F401
+                                                  AppendDataFile, ClearDataFiles)
 
 
 def BIOSANS():


### PR DESCRIPTION
Exactly what it says on the tin.

The limits for [`master_flake8`](http://builds.mantidproject.org/job/master_flake8/), [`pull_requests-flake8`](http://builds.mantidproject.org/job/pull_requests-flake8/), and [`master_flake8_python3`](http://builds.mantidproject.org/job/master_flake8_python3/) should be lowered after this is merged.

**To test:**

This should produce less than 54 flake8 warnings (current value on `master`). Check the build result.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
