### PR TITLE
Re #20369 fixed loop and naming of workspaces

### DIFF
--- a/Framework/DataHandling/src/LoadMcStas.cpp
+++ b/Framework/DataHandling/src/LoadMcStas.cpp
@@ -238,7 +238,8 @@ void LoadMcStas::readEventData(
     double longestTOF(0.0);
 
     const size_t numEventEntries = eventEntries.size();
-    Progress progEntries(this, progressFractionInitial, 1.0, numEventEntries * 2);
+    Progress progEntries(this, progressFractionInitial, 1.0,
+                         numEventEntries * 2);
 
     const std::string &dataName = eventEntry.first;
     const std::string &dataType = eventEntry.second;
@@ -370,13 +371,13 @@ void LoadMcStas::readEventData(
     // ensure that specified name is given to workspace (eventWS) when added to
     // outputGroup
     std::string nameOfGroupWS = getProperty("OutputWorkspace");
-    //Ensure the workspace names are unique, otherwise the workspaces
-    //Overwrite each other in workspaceDataService
-    std::string nameUserSee = std::string("EventWS_")+dataName;
+    // Ensure the workspace names are unique, otherwise the workspaces
+    // Overwrite each other in workspaceDataService
+    std::string nameUserSee = std::string("EventWS_") + dataName;
     std::string extraProperty =
-            "Outputworkspace_dummy_" + std::to_string(m_countNumWorkspaceAdded);
+        "Outputworkspace_dummy_" + std::to_string(m_countNumWorkspaceAdded);
     declareProperty(Kernel::make_unique<WorkspaceProperty<Workspace>>(
-            extraProperty, nameUserSee, Direction::Output));
+        extraProperty, nameUserSee, Direction::Output));
     setProperty(extraProperty, boost::static_pointer_cast<Workspace>(eventWS));
     m_countNumWorkspaceAdded++; // need to increment to ensure extraProperty are
     // unique

--- a/Framework/DataHandling/src/LoadMcStas.cpp
+++ b/Framework/DataHandling/src/LoadMcStas.cpp
@@ -377,7 +377,7 @@ void LoadMcStas::readEventData(
     std::string nameOfGroupWS = getProperty("OutputWorkspace");
     // Ensure the workspace names are unique, otherwise the workspaces
     // Overwrite each other in workspaceDataService
-    std::string nameUserSee = nameofGroupWS + std::string("_EventWS_") +
+    std::string nameUserSee = nameOfGroupWS + std::string("_EventWS_") +
                               std::to_string(numEventEntriesProcessed);
     ++numEventEntriesProcessed;
     std::string extraProperty =

--- a/Framework/DataHandling/src/LoadMcStas.cpp
+++ b/Framework/DataHandling/src/LoadMcStas.cpp
@@ -208,6 +208,11 @@ void LoadMcStas::readEventData(
   // Finished reading Instrument. Then open new data folder again
   nxFile.openGroup("data", "NXdetector");
 
+  // Number of eventEntries processed, to allow unique naming
+  // of the event workspaces
+  int numEventEntriesProcessed(0);
+  bool isAnyNeutrons = false;
+
   for (const auto &eventEntry : eventEntries) {
     // create and prepare an event workspace ready to receive the mcstas events
     progInitial.report("Set up EventWorkspace");
@@ -232,7 +237,6 @@ void LoadMcStas::readEventData(
     // the one is here for the moment for backward compatibility
     eventWS->rebuildSpectraMapping(true);
 
-    bool isAnyNeutrons = false;
     // to store shortest and longest recorded TOF
     double shortestTOF(0.0);
     double longestTOF(0.0);
@@ -373,7 +377,9 @@ void LoadMcStas::readEventData(
     std::string nameOfGroupWS = getProperty("OutputWorkspace");
     // Ensure the workspace names are unique, otherwise the workspaces
     // Overwrite each other in workspaceDataService
-    std::string nameUserSee = std::string("EventWS_") + dataName;
+    std::string nameUserSee = nameofGroupWS + std::string("_EventWS_") +
+                              std::to_string(numEventEntriesProcessed);
+    ++numEventEntriesProcessed;
     std::string extraProperty =
         "Outputworkspace_dummy_" + std::to_string(m_countNumWorkspaceAdded);
     declareProperty(Kernel::make_unique<WorkspaceProperty<Workspace>>(

--- a/Framework/DataHandling/test/LoadMcStasTest.h
+++ b/Framework/DataHandling/test/LoadMcStasTest.h
@@ -1,4 +1,3 @@
-
 #ifndef LOADMCSTASTEST_H_
 #define LOADMCSTASTEST_H_
 
@@ -65,45 +64,55 @@ public:
     //  test workspace created by LoadMcStas
     WorkspaceGroup_sptr output =
         AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(outputSpace);
-    TS_ASSERT_EQUALS(output->getNumberOfEntries(), 5); // 5 NXdata groups
+    TS_ASSERT_EQUALS(output->getNumberOfEntries(), 6); // 6 NXdata groups
     //
     //
+    // Test both detector outputs
     MatrixWorkspace_sptr outputItem1 =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            "EventData" + postfix);
+            "EventData" + postfix + "_1");
     TS_ASSERT_EQUALS(outputItem1->getNumberHistograms(), 8192);
-    double sum = 0.0;
+    double sum1 = 0.0;
     for (size_t i = 0; i < outputItem1->getNumberHistograms(); i++)
-      sum += outputItem1->y(i)[0];
-    sum *= 1.0e22;
-    TS_ASSERT_DELTA(sum, 107163.7851, 0.0001);
-    //
+      sum1 += outputItem1->y(i)[0];
+    sum1 *= 1.0e22;
+    TS_ASSERT_DELTA(sum1, 636716.8615, 0.001);
     //
     MatrixWorkspace_sptr outputItem2 =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("Edet.dat" +
-                                                                    postfix);
-    TS_ASSERT_EQUALS(outputItem2->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outputItem2->getNPoints(), 1000);
-    //
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            "EventData" + postfix + "_2");
+    TS_ASSERT_EQUALS(outputItem2->getNumberHistograms(), 8192);
+    double sum2 = 0.0;
+    for (size_t i = 0; i < outputItem2->getNumberHistograms(); i++)
+      sum2 += outputItem2->y(i)[0];
+    sum2 *= 1.0e22;
+    TS_ASSERT_DELTA(sum2, 22.4557, 0.0001);
     //
     MatrixWorkspace_sptr outputItem3 =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("PSD.dat" +
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("Edet.dat" +
                                                                     postfix);
-    TS_ASSERT_EQUALS(outputItem3->getNumberHistograms(), 128);
+    TS_ASSERT_EQUALS(outputItem3->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outputItem3->getNPoints(), 1000);
     //
     //
     MatrixWorkspace_sptr outputItem4 =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            "psd2_av.dat" + postfix);
-    TS_ASSERT_EQUALS(outputItem4->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outputItem4->getNPoints(), 100);
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("PSD.dat" +
+                                                                    postfix);
+    TS_ASSERT_EQUALS(outputItem4->getNumberHistograms(), 128);
     //
     //
     MatrixWorkspace_sptr outputItem5 =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("psd2.dat" +
-                                                                    postfix);
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            "psd2_av.dat" + postfix);
     TS_ASSERT_EQUALS(outputItem5->getNumberHistograms(), 1);
     TS_ASSERT_EQUALS(outputItem5->getNPoints(), 100);
+    //
+    //
+    MatrixWorkspace_sptr outputItem6 =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("psd2.dat" +
+                                                                    postfix);
+    TS_ASSERT_EQUALS(outputItem6->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outputItem6->getNPoints(), 100);
   } // testExec()
 
 private:


### PR DESCRIPTION
Fix by @michaeljturner "There were two things wrong: first, the new workspace pointer was created outside a for loop, so each subsequent dataset just overwrote the previous one in memory, so I put that inside the for loop.  Then all the workspaces were given the same name, so they overwrote each other in workspace data service."

Fixes #20369 