### PR TITLE
Fix string table values being truncated in table window

### DIFF
--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -296,12 +296,13 @@ void MantidTable::cellEdited(int row, int col) {
   std::istringstream textStream(text);
   const std::locale systemLocale("");
   textStream.imbue(systemLocale);
-  c->read(index, textStream);
+  c->read(index, textStream.str());
 
   // Set the table view to be the same text after editing.
   // That way, if the string was stupid, it will be reset to the old value.
   std::ostringstream s;
   s.imbue(systemLocale);
+
   // Avoid losing precision for numeric data
   if (c->type() == "double") {
     s.precision(std::numeric_limits<double>::max_digits10);

--- a/docs/source/release/v3.11.0/ui.rst
+++ b/docs/source/release/v3.11.0/ui.rst
@@ -50,6 +50,7 @@ Custom Interfaces
 
 Bugs Resolved
 -------------
+- Fixed a bug causing table windows with string values to appear truncated if the string contained a space.
 
 SliceViewer Improvements
 ------------------------


### PR DESCRIPTION
There's a script in the issue which can be used to reproduce the issue and a screenshot of what you should expect to see.

With these changes applied I get:
![screen shot 2017-09-06 at 18 03 32](https://user-images.githubusercontent.com/2487781/30124664-c65839e4-932d-11e7-8484-b56aab21f358.png)



Fixes #20400 

**Release Notes** 

Updated docs/source/release/v3.11.0/ui.rst

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
