### PR TITLE
Fix ISIS_PowderPolarisTest.CreateVanadiumTest for python 3

### DIFF
--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -6,6 +6,7 @@ from isis_powder.routines import absorb_corrections, common
 from isis_powder.routines.run_details import create_run_details_object, \
                                              CustomFuncForRunDetails, RunDetailsWrappedCommonFuncs
 from isis_powder.polaris_routines import polaris_advanced_config
+from six import PY3
 
 
 def calculate_van_absorb_corrections(ws_to_correct, multiple_scattering, is_vanadium):
@@ -72,7 +73,16 @@ def _read_masking_file(masking_file_path):
     all_banks_masking_list = []
     bank_masking_list = []
     ignore_line_prefixes = (' ', '\n', '\t', '#')  # Matches whitespace or # symbol
-    with open(masking_file_path) as mask_file:
+
+    # Python 3 requires the encoding to be included so an Angstrom
+    # symbol can be read, I'm assuming all file read here are
+    # `latin-1` which may not be true in the future. Python 2 `open`
+    # doesn't have an encoding option
+    if PY3:
+        encoding = {"encoding": "latin-1"}
+    else:
+        encoding = {}
+    with open(masking_file_path, **encoding) as mask_file:
         for line in mask_file:
             if line.startswith(ignore_line_prefixes):
                 # Push back onto new bank


### PR DESCRIPTION
Add required encoding for python 3 `open`. This fixes a failing systemtest `ISIS_PowderPolarisTest.CreateVanadiumTest` when run under python 3, see http://builds.mantidproject.org/job/master_systemtests-ubuntu-16.04-python3/195/testReport/junit/SystemTests/ISIS_PowderPolarisTest/CreateVanadiumTest/. The input file has a Å which is encoded with latin-1 not utf-8. I don't like hard coding the encoding but I don't see a better solution.

**To test:**
`./systemtest -R ISIS_PowderPolarisTest.CreateVanadiumTest` with python 3 should now pass

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
