### PR TITLE
NumericAxis, refactored out `m_binEdges` and the static `indexOfValue`

### DIFF
--- a/Framework/API/inc/MantidAPI/NumericAxis.h
+++ b/Framework/API/inc/MantidAPI/NumericAxis.h
@@ -44,7 +44,6 @@ class MatrixWorkspace;
 */
 class MANTID_API_DLL NumericAxis : public Axis {
 public:
-
   NumericAxis(const std::size_t &length);
   NumericAxis(const std::vector<double> &centres);
 

--- a/Framework/API/inc/MantidAPI/NumericAxis.h
+++ b/Framework/API/inc/MantidAPI/NumericAxis.h
@@ -44,9 +44,6 @@ class MatrixWorkspace;
 */
 class MANTID_API_DLL NumericAxis : public Axis {
 public:
-  /// Find the index of the value in the given set of edges
-  static size_t indexOfValue(const double value,
-                             const std::vector<double> &edges);
 
   NumericAxis(const std::size_t &length);
   NumericAxis(const std::vector<double> &centres);
@@ -86,10 +83,6 @@ protected:
 private:
   /// Private, undefined copy assignment operator
   const NumericAxis &operator=(const NumericAxis &);
-
-  /// A vector holding the edge values, computed from the distance between
-  /// values
-  std::vector<double> m_edges;
 };
 
 } // namespace API

--- a/Framework/API/src/BinEdgeAxis.cpp
+++ b/Framework/API/src/BinEdgeAxis.cpp
@@ -1,5 +1,6 @@
 #include "MantidAPI/BinEdgeAxis.h"
 #include "MantidKernel/Exception.h"
+#include "MantidKernel/VectorHelper.h"
 
 namespace Mantid {
 namespace API {
@@ -76,10 +77,9 @@ void BinEdgeAxis::setValue(const std::size_t &index, const double &value) {
  * the value falls into. The maximum value will always be length() - 1
  * @param value A value on the axis
  * @return The index closest to given value
- * @throws std::out_of_range if the value is out of range of the axis
  */
 size_t BinEdgeAxis::indexOfValue(const double value) const {
-  return NumericAxis::indexOfValue(value, m_values);
+  return Mantid::Kernel::VectorHelper::indexOfValueFromEdges(m_values, value);
 }
 
 } // namespace API

--- a/Framework/API/src/SpectraAxis.cpp
+++ b/Framework/API/src/SpectraAxis.cpp
@@ -7,6 +7,7 @@
 #include "MantidKernel/MultiThreaded.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Unit.h"
+#include "MantidKernel/VectorHelper.h"
 
 #include <boost/lexical_cast.hpp>
 
@@ -86,7 +87,6 @@ void SpectraAxis::setValue(const std::size_t &index, const double &value) {
  * @param value A value on the axis. It is treated as a spectrum number and cast
  * to specnum_t on input
  * @return The index closest to given value
- * @throws std::out_of_range if the value is out of range of the axis
  */
 size_t SpectraAxis::indexOfValue(const double value) const {
   if (m_edges.empty()) // lazy-instantiation
@@ -101,7 +101,7 @@ size_t SpectraAxis::indexOfValue(const double value) const {
     m_edges[npts] = this->getValue(npts - 1) +
                     (this->getValue(npts - 1) - m_edges[npts - 1]);
   }
-  return NumericAxis::indexOfValue(value, m_edges);
+  return Mantid::Kernel::VectorHelper::indexOfValueFromEdges(m_edges, value);
 }
 
 /** Returns the spectrum number at the position given (Spectra axis only)

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -40,41 +40,41 @@ namespace Kernel {
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
 namespace VectorHelper {
-int MANTID_KERNEL_DLL
-createAxisFromRebinParams(const std::vector<double> &params,
-                          std::vector<double> &xnew,
-                          const bool resize_xnew = true,
-                          const bool full_bins_only = false);
+int MANTID_KERNEL_DLL createAxisFromRebinParams(
+    const std::vector<double> &params, std::vector<double> &xnew,
+    const bool resize_xnew = true, const bool full_bins_only = false);
 
-void MANTID_KERNEL_DLL
-rebin(const std::vector<double> &xold, const std::vector<double> &yold,
-      const std::vector<double> &eold, const std::vector<double> &xnew,
-      std::vector<double> &ynew, std::vector<double> &enew, bool distribution,
-      bool addition = false);
+void MANTID_KERNEL_DLL rebin(const std::vector<double> &xold,
+                             const std::vector<double> &yold,
+                             const std::vector<double> &eold,
+                             const std::vector<double> &xnew,
+                             std::vector<double> &ynew,
+                             std::vector<double> &enew, bool distribution,
+                             bool addition = false);
 
 // New method to rebin Histogram data, should be faster than previous one
-void MANTID_KERNEL_DLL
-rebinHistogram(const std::vector<double> &xold, const std::vector<double> &yold,
-               const std::vector<double> &eold, const std::vector<double> &xnew,
-               std::vector<double> &ynew, std::vector<double> &enew,
-               bool addition);
+void MANTID_KERNEL_DLL rebinHistogram(const std::vector<double> &xold,
+                                      const std::vector<double> &yold,
+                                      const std::vector<double> &eold,
+                                      const std::vector<double> &xnew,
+                                      std::vector<double> &ynew,
+                                      std::vector<double> &enew, bool addition);
 
 /// Convert an array of bin boundaries to bin center values.
 void MANTID_KERNEL_DLL convertToBinCentre(const std::vector<double> &bin_edges,
                                           std::vector<double> &bin_centres);
 
 /// Convert an array of bin centers to bin boundary values.
-void MANTID_KERNEL_DLL
-convertToBinBoundary(const std::vector<double> &bin_centers,
-                     std::vector<double> &bin_edges);
+void MANTID_KERNEL_DLL convertToBinBoundary(
+    const std::vector<double> &bin_centers, std::vector<double> &bin_edges);
 
 /// Gets the bin of a value from a vector of bin centers
 size_t MANTID_KERNEL_DLL indexOfValueFromCenters(
     const std::vector<double> &bin_centers, const double value);
 
 /// Gets the bin of a value from a vector of bin edges
-size_t MANTID_KERNEL_DLL indexOfValueFromEdges(
-    const std::vector<double> &bin_edges, const double value);
+size_t MANTID_KERNEL_DLL
+indexOfValueFromEdges(const std::vector<double> &bin_edges, const double value);
 
 bool MANTID_KERNEL_DLL isConstantValue(const std::vector<double> &arra);
 

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -40,37 +40,38 @@ namespace Kernel {
     Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
 namespace VectorHelper {
-int MANTID_KERNEL_DLL createAxisFromRebinParams(
-    const std::vector<double> &params, std::vector<double> &xnew,
-    const bool resize_xnew = true, const bool full_bins_only = false);
+int MANTID_KERNEL_DLL
+createAxisFromRebinParams(const std::vector<double> &params,
+                          std::vector<double> &xnew,
+                          const bool resize_xnew = true,
+                          const bool full_bins_only = false);
 
-void MANTID_KERNEL_DLL rebin(const std::vector<double> &xold,
-                             const std::vector<double> &yold,
-                             const std::vector<double> &eold,
-                             const std::vector<double> &xnew,
-                             std::vector<double> &ynew,
-                             std::vector<double> &enew, bool distribution,
-                             bool addition = false);
+void MANTID_KERNEL_DLL
+rebin(const std::vector<double> &xold, const std::vector<double> &yold,
+      const std::vector<double> &eold, const std::vector<double> &xnew,
+      std::vector<double> &ynew, std::vector<double> &enew, bool distribution,
+      bool addition = false);
 
 // New method to rebin Histogram data, should be faster than previous one
-void MANTID_KERNEL_DLL rebinHistogram(const std::vector<double> &xold,
-                                      const std::vector<double> &yold,
-                                      const std::vector<double> &eold,
-                                      const std::vector<double> &xnew,
-                                      std::vector<double> &ynew,
-                                      std::vector<double> &enew, bool addition);
+void MANTID_KERNEL_DLL
+rebinHistogram(const std::vector<double> &xold, const std::vector<double> &yold,
+               const std::vector<double> &eold, const std::vector<double> &xnew,
+               std::vector<double> &ynew, std::vector<double> &enew,
+               bool addition);
 
 /// Convert an array of bin boundaries to bin center values.
 void MANTID_KERNEL_DLL convertToBinCentre(const std::vector<double> &bin_edges,
                                           std::vector<double> &bin_centres);
 
 /// Convert an array of bin centers to bin boundary values.
-void MANTID_KERNEL_DLL convertToBinBoundary(
-    const std::vector<double> &bin_centers, std::vector<double> &bin_edges);
+void MANTID_KERNEL_DLL
+convertToBinBoundary(const std::vector<double> &bin_centers,
+                     std::vector<double> &bin_edges);
 
 /// Gets the bin of a value from a vector of bin centers
-size_t MANTID_KERNEL_DLL indexOfValueFromCenters(
-    const std::vector<double> &bin_centers, const double value);
+size_t MANTID_KERNEL_DLL
+indexOfValueFromCenters(const std::vector<double> &bin_centers,
+                        const double value);
 
 /// Gets the bin of a value from a vector of bin edges
 size_t MANTID_KERNEL_DLL

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -68,6 +68,14 @@ void MANTID_KERNEL_DLL
 convertToBinBoundary(const std::vector<double> &bin_centers,
                      std::vector<double> &bin_edges);
 
+/// Gets the bin of a value from a vector of bin centers
+size_t MANTID_KERNEL_DLL indexOfValueFromCenters(
+    const std::vector<double> &bin_centers, const double value);
+
+/// Gets the bin of a value from a vector of bin edges
+size_t MANTID_KERNEL_DLL indexOfValueFromEdges(
+    const std::vector<double> &bin_edges, const double value);
+
 bool MANTID_KERNEL_DLL isConstantValue(const std::vector<double> &arra);
 
 /**

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -447,7 +447,7 @@ size_t indexOfValueFromCenters(const std::vector<double> &bin_centers,
 
 /** Finds the bin index of a value from the vector of bin edges.
  * Assumes the vector is already sorted ascending.
- * @param bin_centers : vector of bin centers
+ * @param bin_edges : vector of bin centers
  * @param value : input value
  * @return : the bin index of the value
  * @throw std::out_of_range : if vector is empty, contains one element,

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -453,27 +453,25 @@ size_t indexOfValueFromCenters(const std::vector<double> &bin_centers,
  * @throw std::out_of_range : if vector is empty, contains one element,
  *  or value is out of it's range
  */
-
 size_t indexOfValueFromEdges(const std::vector<double> &bin_edges,
-                               const double value) {
+                             const double value) {
   if (bin_edges.empty()) {
     throw std::out_of_range("indexOfValue - vector is empty");
   }
   if (bin_edges.size() == 1) {
-      throw std::out_of_range("indexOfValue - requires at least two bin edges");
+    throw std::out_of_range("indexOfValue - requires at least two bin edges");
   }
   if (value < bin_edges.front()) {
-    throw std::out_of_range(
-        "indexOfValue - value out of range");
+    throw std::out_of_range("indexOfValue - value out of range");
   }
   const auto it = std::lower_bound(bin_edges.begin(), bin_edges.end(), value);
   if (it == bin_edges.end()) {
-    throw std::out_of_range(
-        "indexOfValue - value out of range");
+    throw std::out_of_range("indexOfValue - value out of range");
   }
   // index of closest edge above value is distance of iterator from start
   size_t edgeIndex = std::distance(bin_edges.begin(), it);
-  // if the element n is the first that is >= value, then the value is in (n-1) th bin
+  // if the element n is the first that is >= value, then the value is in (n-1)
+  // th bin
   if (edgeIndex > 0)
     edgeIndex--;
   return edgeIndex;

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -397,6 +397,88 @@ void convertToBinBoundary(const std::vector<double> &bin_centers,
   bin_edges[n] = bin_centers[n - 1] + (bin_centers[n - 1] - bin_edges[n - 1]);
 }
 
+/** Finds the bin index of a value from the vector of bin centers
+ * without converting the whole array to bin edges.
+ * Assumes the vector is already sorted ascending.
+ * @param bin_centers : vector of bin centers
+ * @param value : input value
+ * @return : the bin index of the value
+ * @throw std::out_of_range : if vector is empty or value is out of it's range
+ * (in bin edge representation)
+ */
+
+size_t indexOfValueFromCenters(const std::vector<double> &bin_centers,
+                               const double value) {
+  if (bin_centers.empty()) {
+    throw std::out_of_range("indexOfValue - vector is empty");
+  }
+  if (bin_centers.size() == 1) {
+    // no mean to guess bin size, assuming 1
+    if (value < bin_centers[0] - 0.5 || value > bin_centers[0] + 0.5) {
+      throw std::out_of_range("indexOfValue - value out of range");
+    } else {
+      return 0;
+    }
+  } else {
+    const size_t n = bin_centers.size();
+    const double firstBinLowEdge =
+        bin_centers[0] - 0.5 * (bin_centers[1] - bin_centers[0]);
+    const double lastBinHighEdge =
+        bin_centers[n - 1] + 0.5 * (bin_centers[n - 1] - bin_centers[n - 2]);
+    if (value < firstBinLowEdge || value > lastBinHighEdge) {
+      throw std::out_of_range("indexOfValue - value out of range");
+    } else {
+      const auto it =
+          std::lower_bound(bin_centers.begin(), bin_centers.end(), value);
+      if (it == bin_centers.end()) {
+        return n - 1;
+      }
+      size_t binIndex = std::distance(bin_centers.begin(), it);
+      if (binIndex > 0 &&
+          value <
+              bin_centers[binIndex - 1] +
+                  0.5 * (bin_centers[binIndex] - bin_centers[binIndex - 1])) {
+        binIndex--;
+      }
+      return binIndex;
+    }
+  }
+}
+
+/** Finds the bin index of a value from the vector of bin edges.
+ * Assumes the vector is already sorted ascending.
+ * @param bin_centers : vector of bin centers
+ * @param value : input value
+ * @return : the bin index of the value
+ * @throw std::out_of_range : if vector is empty, contains one element,
+ *  or value is out of it's range
+ */
+
+size_t indexOfValueFromEdges(const std::vector<double> &bin_edges,
+                               const double value) {
+  if (bin_edges.empty()) {
+    throw std::out_of_range("indexOfValue - vector is empty");
+  }
+  if (bin_edges.size() == 1) {
+      throw std::out_of_range("indexOfValue - requires at least two bin edges");
+  }
+  if (value < bin_edges.front()) {
+    throw std::out_of_range(
+        "indexOfValue - value out of range");
+  }
+  const auto it = std::lower_bound(bin_edges.begin(), bin_edges.end(), value);
+  if (it == bin_edges.end()) {
+    throw std::out_of_range(
+        "indexOfValue - value out of range");
+  }
+  // index of closest edge above value is distance of iterator from start
+  size_t edgeIndex = std::distance(bin_edges.begin(), it);
+  // if the element n is the first that is >= value, then the value is in (n-1) th bin
+  if (edgeIndex > 0)
+    edgeIndex--;
+  return edgeIndex;
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Assess if all the values in the vector are equal or if there are some
 * different values

--- a/Framework/Kernel/test/VectorHelperTest.h
+++ b/Framework/Kernel/test/VectorHelperTest.h
@@ -26,6 +26,61 @@ public:
     m_test_bins[4] = 3.2;
   }
 
+  void test_indexOfFromEdges() {
+    std::vector<double> single;
+    TS_ASSERT_THROWS_EQUALS(VectorHelper::indexOfValueFromEdges(single, 7.1),
+                            const std::out_of_range &e, std::string(e.what()),
+                            "indexOfValue - vector is empty");
+    single.push_back(1.7);
+    TS_ASSERT_THROWS_EQUALS(VectorHelper::indexOfValueFromEdges(single, 4.8),
+                            const std::out_of_range &e, std::string(e.what()),
+                            "indexOfValue - requires at least two bin edges");
+
+    TS_ASSERT_THROWS_EQUALS(
+        VectorHelper::indexOfValueFromEdges(m_test_bins, -1.2),
+        const std::out_of_range &e, std::string(e.what()),
+        "indexOfValue - value out of range");
+
+    TS_ASSERT_THROWS_EQUALS(
+        VectorHelper::indexOfValueFromEdges(m_test_bins, 3.3),
+        const std::out_of_range &e, std::string(e.what()),
+        "indexOfValue - value out of range");
+
+    TS_ASSERT_EQUALS(VectorHelper::indexOfValueFromEdges(m_test_bins, 0.55), 1);
+  }
+
+  void test_indexOfFromCenters() {
+    std::vector<double> single;
+    TS_ASSERT_THROWS_EQUALS(VectorHelper::indexOfValueFromCenters(single, 5.9),
+                            const std::out_of_range &e, std::string(e.what()),
+                            "indexOfValue - vector is empty");
+    single.push_back(2.5);
+    TS_ASSERT_THROWS_EQUALS(VectorHelper::indexOfValueFromCenters(single, 6.1),
+                            const std::out_of_range &e, std::string(e.what()),
+                            "indexOfValue - value out of range");
+    TS_ASSERT_THROWS_EQUALS(VectorHelper::indexOfValueFromCenters(single, 1.9),
+                            const std::out_of_range &e, std::string(e.what()),
+                            "indexOfValue - value out of range");
+    TS_ASSERT_EQUALS(VectorHelper::indexOfValueFromCenters(single, 2.25), 0);
+
+    TS_ASSERT_THROWS_EQUALS(
+        VectorHelper::indexOfValueFromCenters(m_test_bins, -1.56),
+        const std::out_of_range &e, std::string(e.what()),
+        "indexOfValue - value out of range");
+
+    TS_ASSERT_THROWS_EQUALS(
+        VectorHelper::indexOfValueFromCenters(m_test_bins, 4.1),
+        const std::out_of_range &e, std::string(e.what()),
+        "indexOfValue - value out of range");
+
+    TS_ASSERT_EQUALS(VectorHelper::indexOfValueFromCenters(m_test_bins, -1.23),
+                     0);
+    TS_ASSERT_EQUALS(VectorHelper::indexOfValueFromCenters(m_test_bins, 3.98),
+                     4);
+    TS_ASSERT_EQUALS(VectorHelper::indexOfValueFromCenters(m_test_bins, 0.8),
+                     2);
+  }
+
   void test_CreateAxisFromRebinParams_Gives_Expected_Number_Bins() {
     std::vector<double> rbParams(3);
     rbParams[0] = 1;


### PR DESCRIPTION
This PR improves the design of `NumericAxis` by removing the bin edges member, and reducing the complexity for `setValue` usages from Nˆ2 to N (see the issue). It will compute the bin edges only if they are explicitly asked. `indexOfValue` will be found directly from bin centres. 
In the contrary, the `SpectrumAxis` and `BinEdgeAxis` override this behaviour to retrieve the lower bound from bin edges. 

The static `NumericAxis::indexOfValue`, previously used by `SpectrumAxis` and `BinEdgeAxis` is removed.

**To test:**
Code review and tests pass.

<!-- Instructions for testing. -->

Fixes #20387 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 
<!--
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
