### PR TITLE
Fix E999 python 3 flake8 warnings

### DIFF
--- a/tools/DOI/doi.py
+++ b/tools/DOI/doi.py
@@ -56,6 +56,7 @@ USEFUL LINKS:
   http://docs.python.org/2/library/httplib.html#httplib.HTTPS_PORT
 """
 
+from __future__ import (absolute_import, division, print_function)
 import argparse
 import getpass
 import os
@@ -225,7 +226,7 @@ def _http_request(body, method, url, options):
     proc = subprocess.Popen(args,stdout=subprocess.PIPE)
     result = proc.stdout.readlines()
 
-    print "Server Response: " + str(result)
+    print("Server Response: " + str(result))
     return result
 
 
@@ -234,7 +235,7 @@ def delete_doi(base, doi, options):
     remove the DOI from the DataCite servers; it makes its metadata "inactive"
     and points the DOI to a "DOI invalid" page.
     '''
-    print "\nAttempting to delete the meta data for:" + doi
+    print("\nAttempting to delete the meta data for:" + doi)
     result = _http_request(
         body    = '',
         method  = 'DELETE',
@@ -245,7 +246,7 @@ def delete_doi(base, doi, options):
     if not re.match(SUCCESS_RESPONSE, result[0]):
         raise RuntimeError('Deleting metadata unsuccessful.  Quitting.')
 
-    print "\nAttempting to point " + doi + " to invalid page."
+    print("\nAttempting to point " + doi + " to invalid page.")
     result = _http_request(
         body    = 'doi=' + doi + '\n' + 'url=' + INVALID_URL,
         method  = "PUT",
@@ -262,7 +263,7 @@ def create_or_update_metadata(xml_form, base, doi, options):
     Metadata must be created before a doi can be created.  If the metadata
     already exists, then it will simply be updated.
     '''
-    print "\nAttempting to create / update metadata:"
+    print("\nAttempting to create / update metadata:")
     result = _http_request(
         body    = xml_form,
         method  = "PUT",
@@ -279,9 +280,9 @@ def create_or_update_doi(base, doi, destination, options):
     created before this can be successful.  If the doi already exists, then it
     will simply be updated.
     '''
-    print "\nAttempting to create / update the following DOI:"
-    print 'DOI = ' + doi
-    print 'URL = ' + destination
+    print("\nAttempting to create / update the following DOI:")
+    print('DOI = ' + doi)
+    print('URL = ' + destination)
     result = _http_request(
         body    = 'doi=' + doi + '\n' + 'url=' + destination,
         method  = "PUT",
@@ -300,7 +301,7 @@ def check_if_doi_exists(base, doi, destination, options):
     as the given destination), else false.  Throws if the response from the
     server is unrecognised, or if there is no response at all.
     '''
-    print "\nChecking if \"" + base + "doi/" + doi + "\" DOI exists."
+    print("\nChecking if \"" + base + "doi/" + doi + "\" DOI exists.")
     result = _http_request(
         body    = '',
         method  = 'GET',
@@ -309,10 +310,10 @@ def check_if_doi_exists(base, doi, destination, options):
     )
 
     if result[0] == 'DOI not found' or result[0] == INVALID_URL:
-        print "\"" + doi + "\" does not exist"
+        print("\"" + doi + "\" does not exist")
         return False
     elif result[0] == destination:
-        print "DOI found."
+        print("DOI found.")
         return True
     else:
         raise RuntimeError(
@@ -511,7 +512,7 @@ def run(args):
         message = "\nSUCCESS!" + \
                   "\nThe DOI can be %s at \"%s\"." % (method, doi_add) + \
                   "\nThe metadata can be inspected at \"%s\"." % (meta_add)
-    print message
+    print(message)
 
     quit()
 

--- a/tools/DefaultConfigFiles/configToCpp.py
+++ b/tools/DefaultConfigFiles/configToCpp.py
@@ -3,12 +3,13 @@
 
 ## Dan Nixon
 
+from __future__ import (absolute_import, division, print_function)
 import sys
 
 with open(sys.argv[2]) as f:
     for line in f:
         line = line.rstrip('\n')
         if line == "":
-            print sys.argv[1] + " << std::endl;"
+            print(sys.argv[1] + " << std::endl;")
         else:
-            print sys.argv[1] + " << \"" + line + "\" << std::endl;"
+            print(sys.argv[1] + " << \"" + line + "\" << std::endl;")

--- a/tools/Documentation/wiki2rst.py
+++ b/tools/Documentation/wiki2rst.py
@@ -14,8 +14,7 @@ The bulk of the work is done by pandoc, which is expected to be in the PATH. The
     the inline to normal format.
  3. Image links cannot have spaces in the filename in rst.
     The spaces are removed in the downloaded file names, but not the links in the rst files."""
-from __future__ import print_function
-
+from __future__ import (absolute_import, division, print_function)
 import argparse
 import json
 import os
@@ -87,7 +86,7 @@ class WikiURL(object):
                   "api.php?titles=File:{0}&action=query&prop=imageinfo&iiprop=url&format=json".format(name.replace(" ", "_"))
         try:
             json_str = urllib2.urlopen(apicall_url).read()
-        except urllib2.URLError, err:
+        except urllib2.URLError as err:
             raise RuntimeError("Failed to fetch JSON describing image page: {}".format(str(err)))
         apicall = json.loads(json_str)
         pages = apicall['query']['pages']
@@ -101,7 +100,7 @@ def fetch_wiki_markup(wiki_url):
     try:
         response = urllib2.urlopen(wiki_url.raw())
         return response.read()
-    except urllib2.URLError, err:
+    except urllib2.URLError as err:
         raise RuntimeError("Failed to fetch wiki page: {}".format(str(err)))
 
 # ------------------------------------------------------------------------------
@@ -126,7 +125,7 @@ def run_pandoc(wiki_markup_text):
     args = ["-f", "mediawiki", "-t", "rst", wiki_tmp_file.name]
     try:
         rst_text = execute_process(cmd, args)
-    except Exception, err:
+    except Exception as err:
         raise RuntimeError("Error executing pandoc: '{}'".format(str(err)))
     finally:
         wiki_tmp_file.close()
@@ -276,7 +275,7 @@ def download_image_from_wiki(wiki_url, name, img_dir):
     image_url = wiki_url.fileurl(name)
     try:
         response = urllib2.urlopen(image_url)
-    except urllib2.URLError, err:
+    except urllib2.URLError as err:
         raise RuntimeError("Failed to fetch image data: {}".format(str(err)))
     filename = os.path.join(img_dir, name)
     display_info("Downloading {0} to {1}".format(name, filename))
@@ -360,7 +359,7 @@ def main(argv):
             open(args.output_file, 'w').write(rst_text + "\n")
         else:
             display_info(rst_text)
-    except RuntimeError, exc:
+    except RuntimeError as exc:
         display_info(str(exc))
         return 1
     return 0

--- a/tools/Pylint/fixPylint.py
+++ b/tools/Pylint/fixPylint.py
@@ -1,5 +1,6 @@
 #pylint: disable=invalid-name,anomalous-backslash-in-string
 from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division, print_function)
 import os
 import re
 import argparse
@@ -82,7 +83,7 @@ if __name__=='__main__':
     parser.add_argument('-fix','--fix', default='simple',
                         choices=choices,
                         help='Select things to fix (default: simple). \nSee the choices options below.')
-    parser.add_argument('Filename', type=file, help='The output from "make pylint"')
+    parser.add_argument('Filename', type=argparse.FileType(), help='The output from "make pylint"')
     parser.add_argument('-v','--version', action='version', version='%(prog)s 1.0')
 
     #read pylint.log

--- a/tools/Pylint/run_pylint.py
+++ b/tools/Pylint/run_pylint.py
@@ -4,8 +4,9 @@
 
     Run pylint on selected Python files/directories.
 """
-from __future__ import print_function
 
+
+from __future__ import (absolute_import, division, print_function)
 import logging
 from optparse import OptionParser
 import os.path
@@ -249,7 +250,7 @@ def check_module_imports():
     #pylint: disable=unused-variable
     try:
         import mantid # noqa
-    except ImportError, exc:
+    except ImportError as exc:
         msg = "Unable to import mantid module: '%s'\n"\
               "Try passing the -m option along with the path to the module"\
                 % str(exc)
@@ -299,8 +300,7 @@ def run_checks(relpaths, options):
       bool: Success/failure
     """
     # convert to excludes absolute paths
-    excludes = map(lambda path: os.path.join(options.basedir, path),
-                   options.exclude)
+    excludes = [os.path.join(options.basedir, path) for path in options.exclude]
     # Gather targets first
     target_paths = gather_targets(options.basedir, relpaths, excludes)
     logging.debug("Found {} targets".format(len(target_paths)))
@@ -405,7 +405,7 @@ def gather_targets(basedir, relpaths, excludes=[]):
             if path.startswith(exclude_path):
                 return False
         return True
-    return filter(include_target, targets)
+    return list(filter(include_target, targets))
 
 #------------------------------------------------------------------------------
 

--- a/tools/VTKConverter/processISISData.py
+++ b/tools/VTKConverter/processISISData.py
@@ -1,11 +1,12 @@
 #pylint: disable=invalid-name
 #!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
 import os
 import sys
 import VTKConvert
 
 if  len(sys.argv) == 1 :
-    print "Usage: processISISData file-name1 file-name2 ...\n       processISISDATA dir-name"
+    print("Usage: processISISData file-name1 file-name2 ...\n       processISISDATA dir-name")
     exit(1)
 
 names=[]
@@ -20,7 +21,7 @@ prefix=""
 if  is_dir :
     prefix = sys.argv[1].split('/')[0] + "-VTU/"
     if  os.path.isdir(prefix) :
-        print "Directory " + prefix + " already exists, please move\n"
+        print("Directory " + prefix + " already exists, please move\n")
         exit(1)
     else:
         os.mkdir(prefix)

--- a/tools/scripts/ConvertBadAlgmLinks.py
+++ b/tools/scripts/ConvertBadAlgmLinks.py
@@ -1,4 +1,5 @@
 #pylint: disable=invalid-name
+from __future__ import (absolute_import, division, print_function)
 import re
 import glob
 import os
@@ -40,5 +41,5 @@ for filename in files:
             expr = regexs[alg]
             results = grep(expr, lines)
             if results:
-                print filename
-                print results
+                print(filename)
+                print(results)

--- a/tools/scripts/CorrectConceptLinksinAlgPages.py
+++ b/tools/scripts/CorrectConceptLinksinAlgPages.py
@@ -1,4 +1,5 @@
 #pylint: disable=invalid-name
+from __future__ import (absolute_import, division, print_function)
 import os
 import re
 from mantid.api import AlgorithmFactory
@@ -46,7 +47,7 @@ concepts = ['Algorithm',
 
 
 def outputError(alg, algVersion, description, notes=""):
-    print "%s, %i, %s, %s" % (alg, algVersion, description, notes)
+    print("%s, %i, %s, %s" % (alg, algVersion, description, notes))
 
 
 rstdir = r"C:\Mantid\Code\Mantid\docs\source\algorithms"

--- a/tools/scripts/FindIncompleteAlgRSTPages.py
+++ b/tools/scripts/FindIncompleteAlgRSTPages.py
@@ -1,4 +1,5 @@
 #pylint: disable=invalid-name
+from __future__ import (absolute_import, division, print_function)
 import os
 import re
 import urllib2
@@ -26,7 +27,7 @@ def ticketExists(alg, ticketHash):
 
 
 def outputError(alg, algVersion, description, notes=""):
-    print "%s, %i, %s, %s" % (alg, algVersion, description, notes)
+    print("%s, %i, %s, %s" % (alg, algVersion, description, notes))
 
 
 rstdir = r"C:\Mantid\Code\Mantid\docs\source\algorithms"

--- a/tools/scripts/TestWikiPython.py
+++ b/tools/scripts/TestWikiPython.py
@@ -4,6 +4,7 @@
 # run with -h for command line arguments
 #
 ##########################################################################################
+from __future__ import (absolute_import, division, print_function)
 import os
 import re
 import sys
@@ -22,7 +23,7 @@ def readWebPage(url):
 
 def getTestablePages(url):
     retList = []
-    print "Reading Testable pages from " + url
+    print("Reading Testable pages from " + url)
     output = readWebPage(url)
     jsonObj = json.loads(output)
     for member in jsonObj['query']['categorymembers']:
@@ -44,7 +45,7 @@ def writeTestRst(filepath,mediawikiText,pageName):
     try:
         if filepath is not None:
             sys.stdout = open(filepath, 'w')
-        print ":orphan:\n"
+        print(":orphan:\n")
         findCodeSections(mediawikiText,pageName)
     finally:
         sys.stdout = sys.__stdout__
@@ -91,26 +92,26 @@ def findCodeSections(mediawikiText,pageName):
         testName = pageName + "[" + str(line) + "]"
         #print the test
         if m.group(1) is not None:
-            print ".. Skipping Test ", testName
-            print
+            print(".. Skipping Test ", testName)
+            print()
         else:
             printDirective("testsetup",testName,m.group(3),True)
             printDirective("testcode",testName,m.group(4),False)
             printDirective("testcleanup",testName,m.group(6),True)
             printDirective("testoutput",testName,m.group(8),True, "+ELLIPSIS, +NORMALIZE_WHITESPACE")
-        print
+        print()
 
 
 def printDirective (directive, name, contents, hideIfNone = False,options = None):
     if not(hideIfNone and contents is None):
-        print ".. {}:: {}".format(directive,name)
+        print(".. {}:: {}".format(directive,name))
         if options is not None:
-            print "   :options: {}".format(options)
-        print
+            print("   :options: {}".format(options))
+        print()
         if contents is not None:
             for line in contents.split("\n"):
-                print "   " + line
-        print
+                print("   " + line)
+        print()
 
 
 def coords_of_str_index(string, index):
@@ -155,19 +156,19 @@ outputDir = None
 if args.o is not None:
     ensureDirectoriesExist(args.o)
     if not os.path.isdir(args.o):
-        print "Output directory not found", args.o
-        print "Output will be to stdout"
+        print("Output directory not found", args.o)
+        print("Output will be to stdout")
     else:
         outputDir = args.o
 
 for url in urlList:
     pageName = "mwTest_" + url.replace(" ","_").replace(":","")
-    print "Parsing ", pageName,
+    print("Parsing ", pageName, end=' ')
 
     outputFile = None
     if outputDir is not None:
         outputFile = os.path.join(outputDir, pageName+".rst")
-    print "->", outputFile
+    print("->", outputFile)
 
     #run pandoc and get the output in rst
     mediawikiText = readWebPage(convertURLToRaw(baseUrl + url))

--- a/tools/scripts/extractAlgorithmNames.py
+++ b/tools/scripts/extractAlgorithmNames.py
@@ -1,6 +1,7 @@
 #pylint: disable=invalid-name
 # simply just print out all algorithm names in a directory which can be piped
 # to a file
+from __future__ import (absolute_import, division, print_function)
 import os
 import glob
 
@@ -8,7 +9,7 @@ os.chdir("PythonInterface/plugins/algorithms/WorkflowAlgorithms")
 for filename in glob.glob("*.py"):
     #print file
     if 'PythonAlgorithm' in open(filename).read():
-        print filename
+        print(filename)
 
 
 #os.chdir("LiveData/src")

--- a/tools/scripts/extractAuthorNamesFromGit.py
+++ b/tools/scripts/extractAuthorNamesFromGit.py
@@ -6,6 +6,7 @@
 # was original used in connection with creating usage examples for algorithms
 # and creating an algorithm list for each developer to have a go at
 
+from __future__ import (absolute_import, division, print_function)
 import os
 
 import subprocess
@@ -36,7 +37,7 @@ for line in allAlgs:
         #print author
         fullline = fullline + ", " + author
 
-    print fullline
+    print(fullline)
 
 #line = 'GroupWorkspaces.cpp'
 #fullline = line


### PR DESCRIPTION
This will fix all the E999 reported [here](http://builds.mantidproject.org/view/Static%20Analysis/job/master_flake8_python3/566/warnings6Result/type.2112180/). I also fixed one F821 warning :wink: 


**To test:**
Run python 3 flake8 you should see no E999 warnings.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
