### PR TITLE
Fix summation in Q for point detectors

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne2.h
@@ -8,6 +8,9 @@ namespace Mantid {
 namespace API {
 class SpectrumInfo;
 }
+namespace Geometry {
+class ReferenceFrame;
+}
 namespace HistogramData {
 class HistogramX;
 class HistogramY;
@@ -88,6 +91,8 @@ private:
   // convert to momentum transfer
   Mantid::API::MatrixWorkspace_sptr
   convertToQ(Mantid::API::MatrixWorkspace_sptr inputWS);
+  // Get the twoTheta width of a given detector
+  double getDetectorTwoThetaRange(const size_t spectrumIdx);
   // Utility function to create name for diagnostic workspaces
   std::string createDebugWorkspaceName(const std::string &inputName);
   // Utility function to output a diagnostic workspace to the ADS
@@ -152,6 +157,7 @@ private:
 
   API::MatrixWorkspace_sptr m_runWS;
   const API::SpectrumInfo *m_spectrumInfo;
+  boost::shared_ptr<const Mantid::Geometry::ReferenceFrame> m_refFrame;
   bool m_convertUnits;          // convert the input workspace to lambda
   bool m_normaliseMonitors;     // normalise by monitors and direct beam
   bool m_normaliseTransmission; // transmission or algorithmic correction

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -4,18 +4,22 @@
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/MandatoryValidator.h"
 #include "MantidKernel/StringTokenizer.h"
 #include "MantidKernel/Unit.h"
 #include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
 
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
+using namespace Mantid::Geometry;
 using namespace Mantid::HistogramData;
 using namespace Mantid::Indexing;
 
@@ -35,27 +39,6 @@ namespace {
 double getDetectorTwoTheta(const SpectrumInfo *spectrumInfo,
                            const size_t spectrumIdx) {
   return spectrumInfo->signedTwoTheta(spectrumIdx);
-}
-
-/** Get the twoTheta angle range for the top/bottom of the detector associated
-* with the given spectrum
-*
-* @param spectrumInfo : the spectrum info
-* @param spectrumIdx : the workspace index of the spectrum
-* @return : the twoTheta angle in radians
-*/
-double getDetectorTwoThetaRange(const SpectrumInfo *spectrumInfo,
-                                const size_t spectrumIdx) {
-  // Assume the range covered by this pixel is the diff between this
-  // pixel's twoTheta and the next/prev pixel)
-  double twoTheta = getDetectorTwoTheta(spectrumInfo, spectrumIdx);
-  double bTwoTheta = 0;
-
-  if (spectrumIdx + 1 < spectrumInfo->size()) {
-    bTwoTheta = getDetectorTwoTheta(spectrumInfo, spectrumIdx + 1) - twoTheta;
-  }
-
-  return bTwoTheta;
 }
 
 /** Get the start/end of the lambda range for the detector associated
@@ -328,6 +311,33 @@ std::string createProcessingCommandsFromDetectorWS(
 
   return result;
 }
+
+/**
+* Get the topbottom extent of a detector for the given axis
+*
+* @param axis [in] : the axis to get the extent for
+* @param top [in] : if true, get the max extent, or min otherwise
+* @return : the max/min extent on the given axis
+*/
+double getBoundingBoxExtent(const BoundingBox &boundingBox,
+  const PointingAlong axis, const bool top) {
+
+  double result = 0.0;
+  switch (axis) {
+  case X:
+    result = top ? boundingBox.xMax() : boundingBox.xMin();
+    break;
+  case Y:
+    result = top ? boundingBox.yMax() : boundingBox.yMin();
+    break;
+  case Z:
+    result = top ? boundingBox.zMax() : boundingBox.zMin();
+    break;
+  default:
+    throw std::runtime_error("Axis is not X/Y/Z"); break;
+  }
+  return result;
+}
 }
 
 // Register the algorithm into the AlgorithmFactory
@@ -434,7 +444,11 @@ void ReflectometryReductionOne2::exec() {
     throw std::invalid_argument(
         "InputWorkspace must have units of TOF or Wavelength");
 
+
+  // Cache the spectrum info and reference frame
   m_spectrumInfo = &m_runWS->spectrumInfo();
+  auto instrument = m_runWS->getInstrument();
+  m_refFrame = instrument->getReferenceFrame();
 
   // Find and cache detector groups and theta0
   findDetectorGroups();
@@ -461,6 +475,43 @@ void ReflectometryReductionOne2::exec() {
 
   setProperty("OutputWorkspaceWavelength", IvsLam);
   setProperty("OutputWorkspace", IvsQ);
+}
+
+/** Get the twoTheta angle range for the top/bottom of the detector associated
+* with the given spectrum
+*
+* @param spectrumIdx : the workspace index of the spectrum
+* @return : the twoTheta range in radians
+*/
+double ReflectometryReductionOne2::getDetectorTwoThetaRange(
+   const size_t spectrumIdx) {
+
+  double bTwoTheta = 0;
+  
+  // Get the sample->detector distance along the beam
+  const V3D detSample = m_spectrumInfo->position(spectrumIdx) -
+    m_spectrumInfo->samplePosition();
+  const double beamOffset = m_refFrame->vecPointingAlongBeam().scalar_prod(detSample);
+  // Get the bounding box for this detector/group
+  BoundingBox boundingBox;
+  auto detector = m_runWS->getDetector(spectrumIdx);
+  detector->getBoundingBox(boundingBox);
+  // Get the top and bottom on the axis pointing up
+  const double top = getBoundingBoxExtent(boundingBox,
+      m_refFrame->pointingUp(), true);
+  const double bottom = getBoundingBoxExtent(boundingBox,
+    m_refFrame->pointingUp(), false);
+  // Calculate the difference in twoTheta between the top and bottom
+  const double twoThetaTop = std::atan(top / beamOffset);
+  const double twoThetaBottom = std::atan(bottom / beamOffset);
+  bTwoTheta = twoThetaTop - twoThetaBottom;
+
+  // We must have non-zero width to project a range
+  if (bTwoTheta < Tolerance) {
+    throw std::runtime_error("Error calculating pixel size.");
+  }
+  
+  return bTwoTheta;
 }
 
 /**
@@ -994,7 +1045,7 @@ void ReflectometryReductionOne2::findIvsLamRange(
   const size_t spIdxMin = detectors.front();
   const double twoThetaMin = getDetectorTwoTheta(m_spectrumInfo, spIdxMin);
   const double bTwoThetaMin =
-      getDetectorTwoThetaRange(m_spectrumInfo, spIdxMin);
+      getDetectorTwoThetaRange(spIdxMin);
   // For bLambda, use the average bin size for this spectrum
   auto xValues = detectorWS->x(spIdxMin);
   double bLambda = (xValues[xValues.size() - 1] - xValues[0]) /
@@ -1005,7 +1056,7 @@ void ReflectometryReductionOne2::findIvsLamRange(
   const size_t spIdxMax = detectors.back();
   const double twoThetaMax = getDetectorTwoTheta(m_spectrumInfo, spIdxMax);
   const double bTwoThetaMax =
-      getDetectorTwoThetaRange(m_spectrumInfo, spIdxMax);
+      getDetectorTwoThetaRange(spIdxMax);
   xValues = detectorWS->x(spIdxMax);
   bLambda = (xValues[xValues.size() - 1] - xValues[0]) /
             static_cast<int>(xValues.size());
@@ -1092,7 +1143,7 @@ ReflectometryReductionOne2::sumInQ(MatrixWorkspace_sptr detectorWS) {
     for (auto spIdx : detectors) {
       // Get the angle of this detector and its size in twoTheta
       const double twoTheta = getDetectorTwoTheta(m_spectrumInfo, spIdx);
-      const double bTwoTheta = getDetectorTwoThetaRange(m_spectrumInfo, spIdx);
+      const double bTwoTheta = getDetectorTwoThetaRange(spIdx);
 
       // Check X length is Y length + 1
       const auto &inputX = detectorWS->x(spIdx);
@@ -1228,11 +1279,18 @@ void ReflectometryReductionOne2::sumInQShareCounts(
     }
     // Add a share of the input counts to this bin based on the proportion of
     // overlap.
-    const double overlapWidth =
-        std::min({bLambda, lambdaMax - binStart, binEnd - lambdaMin});
-    const double fraction = overlapWidth / totalWidth;
-    outputY[outIdx] += inputCounts * fraction;
-    outputE[outIdx] += inputErr * fraction;
+    if (totalWidth > Tolerance) {
+      // Share counts out proportionally based on the overlap of this range
+      const double overlapWidth =
+        std::min({ bLambda, lambdaMax - binStart, binEnd - lambdaMin });
+      const double fraction = overlapWidth / totalWidth;
+      outputY[outIdx] += inputCounts * fraction;
+      outputE[outIdx] += inputErr * fraction;
+    } else {
+      // Projection to a single value. Put all counts in the overlapping output bin.
+      outputY[outIdx] += inputCounts;
+      outputE[outIdx] += inputCounts;
+    }
   }
 }
 

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -911,6 +911,14 @@ void ReflectometryReductionOne2::findDetectorGroups() {
   if (m_detectorGroups.size() == 0) {
     throw std::runtime_error("Invalid processing instructions");
   }
+
+  for (const auto &group : m_detectorGroups) {
+    for (const auto &spIdx : group) {
+      if (spIdx > m_spectrumInfo->size() - 1) {
+        throw std::runtime_error("ProcessingInstructions contains an out-of-range index: " + std::to_string(spIdx));
+      }
+    }
+  }
 }
 
 /**

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -320,7 +320,7 @@ std::string createProcessingCommandsFromDetectorWS(
 * @return : the max/min extent on the given axis
 */
 double getBoundingBoxExtent(const BoundingBox &boundingBox,
-  const PointingAlong axis, const bool top) {
+                            const PointingAlong axis, const bool top) {
 
   double result = 0.0;
   switch (axis) {
@@ -334,7 +334,8 @@ double getBoundingBoxExtent(const BoundingBox &boundingBox,
     result = top ? boundingBox.zMax() : boundingBox.zMin();
     break;
   default:
-    throw std::runtime_error("Axis is not X/Y/Z"); break;
+    throw std::runtime_error("Axis is not X/Y/Z");
+    break;
   }
   return result;
 }
@@ -444,7 +445,6 @@ void ReflectometryReductionOne2::exec() {
     throw std::invalid_argument(
         "InputWorkspace must have units of TOF or Wavelength");
 
-
   // Cache the spectrum info and reference frame
   m_spectrumInfo = &m_runWS->spectrumInfo();
   auto instrument = m_runWS->getInstrument();
@@ -483,24 +483,25 @@ void ReflectometryReductionOne2::exec() {
 * @param spectrumIdx : the workspace index of the spectrum
 * @return : the twoTheta range in radians
 */
-double ReflectometryReductionOne2::getDetectorTwoThetaRange(
-   const size_t spectrumIdx) {
+double
+ReflectometryReductionOne2::getDetectorTwoThetaRange(const size_t spectrumIdx) {
 
   double bTwoTheta = 0;
-  
+
   // Get the sample->detector distance along the beam
-  const V3D detSample = m_spectrumInfo->position(spectrumIdx) -
-    m_spectrumInfo->samplePosition();
-  const double beamOffset = m_refFrame->vecPointingAlongBeam().scalar_prod(detSample);
+  const V3D detSample =
+      m_spectrumInfo->position(spectrumIdx) - m_spectrumInfo->samplePosition();
+  const double beamOffset =
+      m_refFrame->vecPointingAlongBeam().scalar_prod(detSample);
   // Get the bounding box for this detector/group
   BoundingBox boundingBox;
   auto detector = m_runWS->getDetector(spectrumIdx);
   detector->getBoundingBox(boundingBox);
   // Get the top and bottom on the axis pointing up
-  const double top = getBoundingBoxExtent(boundingBox,
-      m_refFrame->pointingUp(), true);
-  const double bottom = getBoundingBoxExtent(boundingBox,
-    m_refFrame->pointingUp(), false);
+  const double top =
+      getBoundingBoxExtent(boundingBox, m_refFrame->pointingUp(), true);
+  const double bottom =
+      getBoundingBoxExtent(boundingBox, m_refFrame->pointingUp(), false);
   // Calculate the difference in twoTheta between the top and bottom
   const double twoThetaTop = std::atan(top / beamOffset);
   const double twoThetaBottom = std::atan(bottom / beamOffset);
@@ -510,7 +511,7 @@ double ReflectometryReductionOne2::getDetectorTwoThetaRange(
   if (bTwoTheta < Tolerance) {
     throw std::runtime_error("Error calculating pixel size.");
   }
-  
+
   return bTwoTheta;
 }
 
@@ -1044,8 +1045,7 @@ void ReflectometryReductionOne2::findIvsLamRange(
 
   const size_t spIdxMin = detectors.front();
   const double twoThetaMin = getDetectorTwoTheta(m_spectrumInfo, spIdxMin);
-  const double bTwoThetaMin =
-      getDetectorTwoThetaRange(spIdxMin);
+  const double bTwoThetaMin = getDetectorTwoThetaRange(spIdxMin);
   // For bLambda, use the average bin size for this spectrum
   auto xValues = detectorWS->x(spIdxMin);
   double bLambda = (xValues[xValues.size() - 1] - xValues[0]) /
@@ -1055,8 +1055,7 @@ void ReflectometryReductionOne2::findIvsLamRange(
 
   const size_t spIdxMax = detectors.back();
   const double twoThetaMax = getDetectorTwoTheta(m_spectrumInfo, spIdxMax);
-  const double bTwoThetaMax =
-      getDetectorTwoThetaRange(spIdxMax);
+  const double bTwoThetaMax = getDetectorTwoThetaRange(spIdxMax);
   xValues = detectorWS->x(spIdxMax);
   bLambda = (xValues[xValues.size() - 1] - xValues[0]) /
             static_cast<int>(xValues.size());
@@ -1282,12 +1281,13 @@ void ReflectometryReductionOne2::sumInQShareCounts(
     if (totalWidth > Tolerance) {
       // Share counts out proportionally based on the overlap of this range
       const double overlapWidth =
-        std::min({ bLambda, lambdaMax - binStart, binEnd - lambdaMin });
+          std::min({bLambda, lambdaMax - binStart, binEnd - lambdaMin});
       const double fraction = overlapWidth / totalWidth;
       outputY[outIdx] += inputCounts * fraction;
       outputE[outIdx] += inputErr * fraction;
     } else {
-      // Projection to a single value. Put all counts in the overlapping output bin.
+      // Projection to a single value. Put all counts in the overlapping output
+      // bin.
       outputY[outIdx] += inputCounts;
       outputE[outIdx] += inputCounts;
     }

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -915,7 +915,9 @@ void ReflectometryReductionOne2::findDetectorGroups() {
   for (const auto &group : m_detectorGroups) {
     for (const auto &spIdx : group) {
       if (spIdx > m_spectrumInfo->size() - 1) {
-        throw std::runtime_error("ProcessingInstructions contains an out-of-range index: " + std::to_string(spIdx));
+        throw std::runtime_error(
+            "ProcessingInstructions contains an out-of-range index: " +
+            std::to_string(spIdx));
       }
     }
   }

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -35,8 +35,7 @@ public:
   ReflectometryReductionOne2Test() {
     FrameworkManager::Instance();
     // A single detector ws
-    m_singleDetectorWS =
-        create2DWorkspaceWithReflectometryInstrument(0);
+    m_singleDetectorWS = create2DWorkspaceWithReflectometryInstrument(0);
     // A multi detector ws
     m_multiDetectorWS =
         create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -447,12 +447,12 @@ public:
     alg.setProperty("ThetaIn", 25.0);
     MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 12);
 
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.927132, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.165740, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.817217, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 2.773699, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 2.828460, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 2.816935, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.934991, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.173599, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 10.825076, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 2.768185, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 2.792649, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 2.787410, 1e-6);
   }
 
   void test_sum_in_q_non_flat_sample() {
@@ -469,12 +469,12 @@ public:
     alg.setProperty("ReductionType", "NonFlatSample");
     MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 10);
 
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.822974, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.061582, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.713059, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 3.140302, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 3.140457, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 3.140644, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.825488, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.064095, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 10.715573, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 3.141858, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 3.141885, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 3.141920, 1e-6);
   }
 
   void test_sum_in_q_direct_beam() {
@@ -492,12 +492,12 @@ public:
     alg.setProperty("ThetaIn", 25.0);
     MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
 
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.913144, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.151752, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.803229, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 0.447237, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 0.454605, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 0.451946, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.920496, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.159104, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 10.810581, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 0.446571, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 0.449843, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 0.448591, 1e-6);
   }
 
   void test_sum_in_q_monitor_normalization() {
@@ -527,12 +527,12 @@ public:
     alg.setProperty("ThetaIn", 25.0);
     MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 13);
 
-    TS_ASSERT_DELTA(outLam->x(0)[0], -0.742692, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[5], 6.321654, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[9], 11.973131, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 5.044175, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[5], 2.118472, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[9], 2.280546, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[0], -0.748671, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[5], 6.315674, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[9], 11.967151, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 5.040302, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[5], 2.193649, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[9], 2.255101, 1e-6);
   }
 
   void test_sum_in_q_transmission_correction_run() {
@@ -546,12 +546,12 @@ public:
     alg.setProperty("ThetaIn", 25.0);
     MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 12);
 
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.927132, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.165740, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.817217, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 0.620714, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 0.899935, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 0.896268, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.934991, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.173599, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 10.825076, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 0.631775, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 0.888541, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 0.886874, 1e-6);
   }
 
   void test_sum_in_q_exponential_correction() {
@@ -567,12 +567,12 @@ public:
     alg.setProperty("C1", 0.1);
     MatrixWorkspace_sptr outLam = runAlgorithmLam(alg, 11);
 
-    TS_ASSERT_DELTA(outLam->x(0)[0], 0.913144, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 5.151752, 1e-6);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 10.803229, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 16.353662, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[3], 24.261270, 1e-6);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 39.844321, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 0.920496, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 5.159104, 1e-6);
+    TS_ASSERT_DELTA(outLam->x(0)[7], 10.810581, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 16.351599, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[3], 23.963539, 1e-6);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 39.756738, 1e-6);
   }
 
   void test_sum_in_q_IvsQ() {
@@ -590,13 +590,13 @@ public:
     MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 11);
 
     // X range in outQ
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.292253, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[3], 0.393656, 1e-6);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.732554, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.292122, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[3], 0.393419, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.731734, 1e-6);
     // Y counts
-    TS_ASSERT_DELTA(outQ->y(0)[0], 2.891639, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[3], 2.854571, 1e-6);
-    TS_ASSERT_DELTA(outQ->y(0)[7], 2.871364, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[0], 2.852088, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[3], 2.833380, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[7], 2.841288, 1e-6);
   }
 
 private:

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -18,6 +18,7 @@ using namespace WorkspaceCreationHelper;
 
 class ReflectometryReductionOne2Test : public CxxTest::TestSuite {
 private:
+  MatrixWorkspace_sptr m_singleDetectorWS;
   MatrixWorkspace_sptr m_multiDetectorWS;
   MatrixWorkspace_sptr m_transmissionWS;
 
@@ -33,6 +34,9 @@ public:
 
   ReflectometryReductionOne2Test() {
     FrameworkManager::Instance();
+    // A single detector ws
+    m_singleDetectorWS =
+        create2DWorkspaceWithReflectometryInstrument(0);
     // A multi detector ws
     m_multiDetectorWS =
         create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
@@ -597,6 +601,31 @@ public:
     TS_ASSERT_DELTA(outQ->y(0)[0], 2.852088, 1e-6);
     TS_ASSERT_DELTA(outQ->y(0)[3], 2.833380, 1e-6);
     TS_ASSERT_DELTA(outQ->y(0)[7], 2.841288, 1e-6);
+  }
+
+  void test_sum_in_q_IvsQ_point_detector() {
+    // Test IvsQ workspace for a point detector
+    // No monitor normalization
+    // No direct beam normalization
+    // No transmission correction
+    // Processing instructions : 0
+
+    ReflectometryReductionOne2 alg;
+    setupAlgorithm(alg, 1.5, 15.0, "0");
+    alg.setProperty("InputWorkspace", m_singleDetectorWS);
+    alg.setProperty("SummationType", "SumInQ");
+    alg.setProperty("ReductionType", "DivergentBeam");
+    alg.setProperty("ThetaIn", 25.0);
+    MatrixWorkspace_sptr outQ = runAlgorithmQ(alg, 28);
+
+    // X range in outQ
+    TS_ASSERT_DELTA(outQ->x(0)[0], 0.279882, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[3], 0.310524, 1e-6);
+    TS_ASSERT_DELTA(outQ->x(0)[7], 0.363599, 1e-6);
+    // Y counts
+    TS_ASSERT_DELTA(outQ->y(0)[0], 2.900305, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[3], 2.886947, 1e-6);
+    TS_ASSERT_DELTA(outQ->y(0)[7], 2.607359, 1e-6);
   }
 
 private:

--- a/docs/source/release/v3.11.0/reflectometry.rst
+++ b/docs/source/release/v3.11.0/reflectometry.rst
@@ -11,6 +11,7 @@ Algorithms
 - The following bugs have been fixed in the summation in Q functionality in :ref:`algm-ReflectometryReductionOne`:
   - the incorrect angle was being used in the final conversion to Q in the divergent beam case
   - the input was being cropped, causing loss of counts
+  - summation in Q was giving incorrect results for a point detector
 - A new property, ``Diagnostics``, has been added to :ref:`algm-ReflectometryReductionOne` to allow the output of additional interim workspaces for debug purposes.
 
 Reflectometry Reduction Interface


### PR DESCRIPTION
This PR fixes a bug in `ReflectometryReductionOne` where summation in Q was giving incorrect results for point detectors due to an incorrect calculation of the pixel size. Summation is not really applicable for point detectors so we could have disabled it. However, it is easy to implement it and useful for debug/comparison purposes. 

This PR also:
- improves the pixel size calculation, which should make the results more accurate in all cases
- adds a check for division by zero in `sumInQShareCounts`
- adds validation of the `ProcessingInstructions` indices

Fixes #20399

**To test:**

See the instructions in the linked issue.

**Release Notes** 
*Added to the release ntoes*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [x] Are the unit tests small and test the class in isolation?
- [x] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [x] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
