### PR TITLE
Update Documentation for Instrument Access Layers ComponentInfo and DetectorInfo

### DIFF
--- a/docs/source/concepts/ComponentInfo.rst
+++ b/docs/source/concepts/ComponentInfo.rst
@@ -1,0 +1,15 @@
+.. _ComponentInfo:
+
+=============
+ComponentInfo 
+=============
+
+.. contents::
+  :local:
+
+Introduction
+------------
+``ComponentInfo`` provides faster and simpler access to instrument/beamline geometry as required by Mantid :ref:`Algorithms <Algorithm>` than was possible using :ref:`Instrument`. ``ComponentInfo`` and :ref:`DetectorInfo` are designed as full replacements to :ref:`Instrument`. At the time of writing, `ComponentInfo` is incomplete.
+
+Until complete, :ref:`Instrument Access Layers <InstrumentAccessLayers>` proivides the best details on how `ComponentInfo` can be used in it's current state of implementation.
+

--- a/docs/source/concepts/ComponentInfo.rst
+++ b/docs/source/concepts/ComponentInfo.rst
@@ -11,5 +11,5 @@ Introduction
 ------------
 ``ComponentInfo`` provides faster and simpler access to instrument/beamline geometry as required by Mantid :ref:`Algorithms <Algorithm>` than was possible using :ref:`Instrument`. ``ComponentInfo`` and :ref:`DetectorInfo` are designed as full replacements to :ref:`Instrument`. At the time of writing, `ComponentInfo` is incomplete.
 
-Until complete, :ref:`Instrument Access Layers <InstrumentAccessLayers>` proivides the best details on how `ComponentInfo` can be used in it's current state of implementation.
+Until complete, :ref:`Instrument Access Layers <InstrumentAccessLayers>` provides the best details on how `ComponentInfo` can be used in it's current state of implementation.
 

--- a/docs/source/concepts/DetectorInfo.rst
+++ b/docs/source/concepts/DetectorInfo.rst
@@ -9,6 +9,6 @@ DetectorInfo
 
 Introduction
 ------------
-``DetectorInfo`` provides faster and simpler access to instrument/beamline detector geometry and metadata as required by Mantid :ref:`Algorithms <Algorithm>` than was possible using :ref:`Instrument`. ``DetectorInfo`` and :ref:`CompnentInfo` are designed as full replacements to :ref:`Instrument`. At the time of writing, `DetectorInfo` is incomplete.
+``DetectorInfo`` provides faster and simpler access to instrument/beamline detector geometry and metadata as required by Mantid :ref:`Algorithms <Algorithm>` than was possible using :ref:`Instrument`. ``DetectorInfo`` and :ref:`ComponentInfo` are designed as full replacements to :ref:`Instrument`. At the time of writing, `DetectorInfo` is incomplete.
 
 Until complete, :ref:`Instrument Access Layers <InstrumentAccessLayers>` proivides the best details on how `DetectorInfo` can be used in it's current state of implementation.

--- a/docs/source/concepts/DetectorInfo.rst
+++ b/docs/source/concepts/DetectorInfo.rst
@@ -11,4 +11,4 @@ Introduction
 ------------
 ``DetectorInfo`` provides faster and simpler access to instrument/beamline detector geometry and metadata as required by Mantid :ref:`Algorithms <Algorithm>` than was possible using :ref:`Instrument`. ``DetectorInfo`` and :ref:`ComponentInfo` are designed as full replacements to :ref:`Instrument`. At the time of writing, `DetectorInfo` is incomplete.
 
-Until complete, :ref:`Instrument Access Layers <InstrumentAccessLayers>` proivides the best details on how `DetectorInfo` can be used in it's current state of implementation.
+Until complete, :ref:`Instrument Access Layers <InstrumentAccessLayers>` provides the best details on how `DetectorInfo` can be used in it's current state of implementation.

--- a/docs/source/concepts/DetectorInfo.rst
+++ b/docs/source/concepts/DetectorInfo.rst
@@ -1,0 +1,14 @@
+.. _DetectorInfo:
+
+=============
+DetectorInfo
+=============
+
+.. contents::
+  :local:
+
+Introduction
+------------
+``DetectorInfo`` provides faster and simpler access to instrument/beamline detector geometry and metadata as required by Mantid :ref:`Algorithms <Algorithm>` than was possible using :ref:`Instrument`. ``DetectorInfo`` and :ref:`CompnentInfo` are designed as full replacements to :ref:`Instrument`. At the time of writing, `DetectorInfo` is incomplete.
+
+Until complete, :ref:`Instrument Access Layers <InstrumentAccessLayers>` proivides the best details on how `DetectorInfo` can be used in it's current state of implementation.

--- a/docs/source/concepts/InstrumentAccessLayers.rst
+++ b/docs/source/concepts/InstrumentAccessLayers.rst
@@ -1,8 +1,8 @@
 .. _InstrumentAccessLayers:
 
-===================================================
-Instrument Access via SpectrumInfo and DetectorInfo
-===================================================
+================================================================
+Instrument Access via SpectrumInfo, DetectorInfo, ComponentInfo
+================================================================
 
 .. contents::
   :local:
@@ -38,7 +38,7 @@ There is also a near-complete implementation of the "real" ``DetectorInfo`` clas
 ``ExperimentInfo`` now also provides a method ``mutableDetectorInfo()`` so that non-const access to the DetectorInfo is possible for purposes of writing detector related information such as positions or rotations. These should be used wherever possible, but note, much like the existing instrument, writes are not guranteed to be thread safe.
 
 ComponentInfo
-____________
+______________
 ``ComponentInfo`` can be obtatined from a call to ``ExperimentInfo::componentInfo()`` (usually this method would be called on ``MatrixWorkspace``). Much like ``DetectorInfo``, the ``ComponentInfo`` yielded from this method call is a wrapper, which contains shape and index information, that cannot yet be moved in to the real ``Beamline::ComponentInfo``. However, replacing existing usage of ``IComponent`` and ``IObjComponent`` wherever possible with ``ComponentInfo`` across the framework will represent a major step forwards.
 
 For writing to the component tree. You can extract a non-const ``ComponentInfo`` via ``ExperimentInfo::mutableComponentInfo``.
@@ -54,7 +54,7 @@ Before starting the refactoring work please take a look at the state of any perf
 Each PR should include the runtime metrics for the algorithms changed, so that improvements can be captured for the release notes.
 
 ComponentInfo
-############
+#############
 
 Basics
 ______
@@ -128,7 +128,7 @@ Below is an example refactoring.
   }
 
 Access to Components and working with Detectors
-___________________
+_______________________________________________
 
 Detector Indices are the same as the corresponding Component Indices. Note that there are no dynamic casts.
 
@@ -175,7 +175,7 @@ Detector Indices are the same as the corresponding Component Indices. Note that 
   }
 
 Mutable ComponentInfo
-____________________
+_____________________
 
 The method ``ExperimentInfo::mutableComponentInfo()`` returns a non-const ``ComponentInfo`` object. This allows the methods below to be used.
 
@@ -190,16 +190,6 @@ ___________
 * If a ``ComponentInfo`` object is required for more than one workspace, include the workspace name in the variable name to avoid confusion.
 * Get the ``ComponentInfo`` object as a const-ref and use ``const auto &componentInfo = ws->componentInfo();``, do not get a non-const reference unless you really do need to modify the object, and ensure that the ``&`` is always included to prevent accidental copies.
 * ``ComponentInfo`` is widely forward declared. Ensure that you import - ``#include "MantidGeometry/Instrument/ComponentInfo.h"``
-
-Complete Examples
-_________________
-
-TODO
-
-Rollout status
---------------
-
-TODO
 
 Dealing with problems
 ---------------------

--- a/docs/source/concepts/InstrumentAccessLayers.rst
+++ b/docs/source/concepts/InstrumentAccessLayers.rst
@@ -85,7 +85,7 @@ The following methods are useful helpers on ``ComponentInfo`` that allow the ext
 
 The ``ComponentInfo`` object is accessed by an index going from 0 to the number of components (including the instrument iteself). **ALL Detector Indexes have a Component Index which is the EXACT same representation**, this is an important point to understand. In other words, a detector with a Detector Index of 5, for the purposes of working with a ``DetectorInfo`` and  will have a Component Index of 5, when working with a ``ComponentInfo``. Explained in yet another way: The first 0 - n components referenced in the ``ComponentInfo`` are detectors, where n is the total number of detectors. This gurantee can be leveraged to provide speedups, as some of the examples will show.  
 
- A ``ComponentID`` for compatiblity with older code, and be extracted from ``ComponentInfo::componentID(componentIndex)``, but such calls should be avoided where possible.
+A ``ComponentID`` for compatiblity with older code, and be extracted from ``ComponentInfo::componentID(componentIndex)``, but such calls should be avoided where possible.
 
 It is also possible to use the method ``componentInfo.indexOf(componentID)`` to get the index for a particular component ID. However, this is a call to a lookup in an unordered map, so is an expensive calculation which should be avoided where possible.
 
@@ -190,6 +190,8 @@ ___________
 * If a ``ComponentInfo`` object is required for more than one workspace, include the workspace name in the variable name to avoid confusion.
 * Get the ``ComponentInfo`` object as a const-ref and use ``const auto &componentInfo = ws->componentInfo();``, do not get a non-const reference unless you really do need to modify the object, and ensure that the ``&`` is always included to prevent accidental copies.
 * ``ComponentInfo`` is widely forward declared. Ensure that you import - ``#include "MantidGeometry/Instrument/ComponentInfo.h"``
+* As explained above, a detector index is the same thing as a component index. No translation necessary. The fact that the first 0-n component indexes are for detectors is a feature that can be leveraged.
+* A bank always has a higher component index than any of its nested components. The root is the highest component index of all. This feature can be leveraged. Consider reverse iterating through component indexes when performing operations that involve higher-level components. 
 
 Dealing with problems
 ---------------------

--- a/docs/source/concepts/InstrumentAccessLayers.rst
+++ b/docs/source/concepts/InstrumentAccessLayers.rst
@@ -10,16 +10,18 @@ Instrument Access via SpectrumInfo and DetectorInfo
 Introduction
 ------------
 
-There are two new layers to access instrument information, ``SpectrumInfo`` and ``DetectorInfo``, that are going to be introduced to Mantid as part of the work towards Instrument 2.0. Eventually these classes will store commonly accessed information about spectra or detectors, namely masking, monitor flags, L1, L2, 2-theta and position, leading to improved performance and cleaner code.
+There are three new layers to access instrument information, ``SpectrumInfo``, ``DetectorInfo``, and ``ComponentInfo`` that are introduced to Mantid as part of the work towards Instrument 2.0. Eventually these classes will store all commonly accessed information about spectra and detectors, namely masking, monitor flags, L1, L2, 2-theta and position. In addition, ``ComponentInfo`` will provide the updated API to tree and shape related operations currently peformed by the instrument. These changes are leading to improved performance and cleaner code.
 
 A spectrum corresponds to (a group of) one or more detectors. Most algorithms work with spectra and thus ``SpectrumInfo`` would be used. Some algorithms work on a lower level (with individual detectors) and thus ``DetectorInfo`` would be used.
+
+The current instrument largely consists of ``Detectors`` and ``Components`` - all detectors are also components. ``DetectorInfo`` and ``ComponentInfo`` are the respective replacements for these. ``ComponentInfo`` introduces a new **component index** for access, and ``DetectorInfo`` introduces a new **detector index**, these will be discussed further below. 
 
 In many cases direct access to ``Instrument`` can be removed by using these layers. This will also help in moving to using indexes for enumeration, and only working with IDs for user-facing input.
 
 Current Status
 ##############
 
-``SpectrumInfo`` and ``DetectorInfo`` are currently implemented as wrapper classes in Mantid. Using the new interfaces everywhere now will help with the eventual rollout of Instrument 2.0. It also provides cleaner code and will help with the rollout of planned indexing changes. It is also necessary to provide the addition of time indexing, required to support scanning instruments.
+``SpectrumInfo``, ``DetectorInfo`` and ``ComponentInfo``  are currently implemented in a compatibility mode, and wrap some of the exiting instrument functionality in Mantid. However, using the new interfaces everywhere now will help with the eventual rollout of Instrument 2.0. It also provides cleaner code and will help with the rollout of planned indexing changes. It is also necessary to provide the addition of time indexing, required to support scanning instruments.
 
 SpectrumInfo
 ____________
@@ -31,7 +33,15 @@ ____________
 
 ``DetectorInfo`` can be obtained from a call to ``ExperimentInfo::detectorInfo()`` (usually this method would be called on ``MatrixWorkspace``). The wrapper class holds a reference to the parametrised instrument for retrieving the relevant information.
 
-There is also a partial implementation of the "real" ``DetectorInfo`` class, in the ``Beamline`` namespace. The real class currently stores the masking information for a detector. The wrapper ``DetectorInfo`` class holds a reference to the real class. This does not affect the rollout, where the wrapper class should still be used in all cases.
+There is also a near-complete implementation of the "real" ``DetectorInfo`` class, in the ``Beamline`` namespace. The wrapper ``DetectorInfo`` class (which you get from ``ExperimentInfo::detectorInfo()`` holds a reference to the real class. This does not affect the rollout, where the wrapper class should still be used in all cases.
+
+``ExperimentInfo`` now also provides a method ``mutableDetectorInfo()`` so that non-const access to the DetectorInfo is possible for purposes of writing detector related information such as positions or rotations. These should be used wherever possible, but note, much like the existing instrument, writes are not guranteed to be thread safe.
+
+ComponentInfo
+____________
+``ComponentInfo`` can be obtatined from a call to ``ExperimentInfo::componentInfo()`` (usually this method would be called on ``MatrixWorkspace``). Much like ``DetectorInfo``, the ``ComponentInfo`` yielded from this method call is a wrapper, which contains shape and index information, that cannot yet be moved in to the real ``Beamline::ComponentInfo``. However, replacing existing usage of ``IComponent`` and ``IObjComponent`` wherever possible with ``ComponentInfo`` across the framework will represent a major step forwards.
+
+For writing to the component tree. You can extract a non-const ``ComponentInfo`` via ``ExperimentInfo::mutableComponentInfo``.
 
 Changes for Rollout
 -------------------
@@ -39,123 +49,47 @@ Changes for Rollout
 Performance Tests
 #################
 
-Before starting the refactoring work please take a look at the state of any performance tests that exist for the algorithms. If they exist they should be run to get the "before" timings. If they do not exist please add performance test for any algorithms that are widely used, or might be expected to have a performance increase. See `this performance test <https://github.com/mantidproject/mantid/pull/18189/files#diff-5695221d30495359738f90b83ceb0ba3>`_ added for the ``SpectrumInfo`` rollout for an example of adding such a test.
+Before starting the refactoring work please take a look at the state of any performance tests that exist for the algorithms. If they exist they should be run to get the "before" timings. If they do not exist please add performance test for any algorithms that are widely used, or might be expected to have a performance increase. See `this performance test <https://github.com/mantidproject/mantid/pull/18189/files#diff-5695221d30495359738f90b83ceb0ba3>`_ added for the previous ``SpectrumInfo`` rollout phase for an example of adding such a test.
 
 Each PR should include the runtime metrics for the algorithms changed, so that improvements can be captured for the release notes.
 
-SpectrumInfo
+ComponentInfo
 ############
 
 Basics
 ______
 
-All instances of ``MatrixWorkspace::getDetector()`` should be replaced using calls to the ``SpectrumInfo`` object obtained from ``MatrixWorkspace::spectrumInfo()``. The methods below can then be called on `SpectrumInfo` instead of on the detector.
+The conversion is similar to that for ``DetectorInfo``, which is already largeely complete in the framework. For ``ComponentInfo`` all instances of ``Instrument::getComponentByID(const ComponentID id)`` should be replaced using calls to the ``ComponentInfo`` object obtained from ``MatrixWorkspace::componentInfo()``. The methods below can then be called on ``ComponentInfo`` instead of on the component.
 
-* ``isMonitor(wsIndex)``
-* ``isMasked(wsIndex)``
-* ``l2(wsIndex)``
-* ``twoTheta(wsIndex)``
-* ``signedTwoTheta(wsIndex)``
-* ``position(wsIndex)``
+* ``isDetector(componentIndex)``
+* ``detectorsInSubtree(componentIndex)``
+* ``componentsInSubtree(componentIndex)``
+* ``position(componentIndex)``
+* ``rotation(componentIndex)``
+* ``hasParent(componentIndex)``
+* ``parent(componentIndex)``
+* ``position(componentIndex)``
+* ``solidAngle(componentIndex)``
+* ``scaleFactor(componentIndex)``
+* ``sourcePosition()``
+* ``samplePosition()``
+* ``l1()``
 
-The try/catch pattern for checking if a spectrum has a detector might look something like the following before/after example.
+The following methods are useful helpers on ``ComponentInfo`` that allow the extraction of the **component index** for key components
 
-**Before refactoring**
-
-.. code-block:: c++
-
-  try {
-    Geometry::IDetector_const_sptr det = ws.getDetector(wsIndex);
-    // do stuff
-  catch (Exception::NotFoundError &) {
-    // do exception
-    return false;
-  }
-
-**After - check it has some detectors**
-
-.. code-block:: c++
-
-  #include "MantidAPI/SpectrumInfo.h"
-
-  ...
-
-  const auto &spectrumInfo = ws->spectrumInfo();
-
-  if (spectrumInfo.hasDetectors(wsIndex)) {
-    // do stuff
-  } else {
-    // do exception
-    return false;
-  }
-
-In this case, which is generally more common, the check is for at least one detector. It is also possible to check for the existence of a unique detector, see the alternative after example below.
-
-**After - check for a unique detector**
-
-.. code-block:: c++
-
-  #include "MantidAPI/SpectrumInfo.h"
-
-  ...
-
-  const auto &spectrumInfo = ws->spectrumInfo();
-
-  if (!spectrumInfo.hasUniqueDetector(wsIndex)) {
-    // do exception
-    return false;
-  }
-
-  // do stuff
-
-
-Access to Detectors
-___________________
-
-The ``detector(wsIndex)`` method on ``SpectrumInfo`` returns the parameterised detector or detector group for the workspace. As ``SpectrumInfo`` does not provide access to things like ``Object::solidAngle()``, the ``detector()`` method on ``SpectrumInfo`` can be used to get access to these methods.
-
-Mutable SpectrumInfo
-____________________
-
-The method ``MatrixWorkspace::mutableSpectrumInfo()`` returns a non-const ``SpectrumInfo`` object. Currently the only method that this access is required for is ``SpectrumInfo::setMasked(const size_t index, bool masked)``.
-
-Useful Tips
-___________
-
-* Creation of ``SpectrumInfo`` objects is not cheap. Make sure ``ws.spectrumInfo()`` is called outside of loops that go over all spectra.
-* If a ``SpectrumInfo`` object is required for more than one workspace then include the workspace name in the name of the ``SpectrumInfo`` object, to avoid confusion.
-* Get the ``SpectrumInfo`` object as a const reference and use auto - ``const auto &spectrumInfo = ws->spectrumInfo();``.
-* Do not forget to add the import - ``#include "MantidAPI/SpectrumInfo.h"``.
-
-Complete Examples
-_________________
-
-* `FindCenterOfMassPosition2.cpp <https://github.com/mantidproject/mantid/pull/17394/files#diff-905c244467474fc320eaf3b8c7a9f0dd>`_
-
-* `CreatePSDBleedMask.cpp <https://github.com/mantidproject/mantid/pull/18218/files#diff-f490acf06e76f93898dc7d486c8dfa93>`_
-
-* `HRPDSlabCanAbsorption.cpp <https://github.com/mantidproject/mantid/pull/18464/files#diff-fc151838d9d7cc2e4ea469e98472c791>`_
-
-DetectorInfo
-############
-
-Basics
-______
-
-The conversion is similar to that for ``SpectrumInfo``. For ``DetectorInfo`` all instances of ``Instrument::getDetector()`` should be replaced using calls to the ``DetectorInfo`` object obtained from ``MatrixWorkspace::detectorInfo()``. The methods below can then be called on ``DetectorInfo`` instead of on the detector.
-
-* ``isMonitor(detIndex)``
-* ``isMasked(detIndex)``
-* ``l2(detIndex)``
-* ``twoTheta(detIndex)``
-* ``signedTwoTheta(detIndex)``
-* ``position(detIndex)``
+* ``root()``
+* ``source()``
+* ``sample()``
 
 **Indexing**
 
-The ``DetectorInfo`` object is accessed by an index going from 0 to the number of detectors. A vector of detector IDs can be obtained from a call to ``detectorInfo.detectorIDs()``.
+The ``ComponentInfo`` object is accessed by an index going from 0 to the number of components (including the instrument iteself). **ALL Detector Indexes have a Component Index which is the EXACT same representation**, this is an important point to understand. In other words, a detector with a Detector Index of 5, for the purposes of working with a ``DetectorInfo`` and  will have a Component Index of 5, when working with a ``ComponentInfo``. Explained in yet another way: The first 0 - n components referenced in the ``ComponentInfo`` are detectors, where n is the total number of detectors. This gurantee can be leveraged to provide speedups, as some of the examples will show.  
 
-It is also possible to use the method ``detectorInfo.indexOf(detID)`` to get the index for a particular detector ID. However, this is a call to a lookup in an unordered map, so is an expensive calculation which should be avoided where possible.
+ A ``ComponentID`` for compatiblity with older code, and be extracted from ``ComponentInfo::componentID(componentIndex)``, but such calls should be avoided where possible.
+
+It is also possible to use the method ``componentInfo.indexOf(componentID)`` to get the index for a particular component ID. However, this is a call to a lookup in an unordered map, so is an expensive calculation which should be avoided where possible.
+
+**One should NEVER expose a Component Index or Detector Index through a public facing (python, gui, ...) to an end user**. Detector Index and Component Indexes are internal concepts for fast enumeration. It is however desirable to translate from a ``ComponentIndex`` via ``ComponentInfo::indexOf`` to as early as possible and in such a way to avoid repeated calls to this method, as stated above. Likewise, conversion back to a ``ComponentIndex``, if so required, should be done as infrequently and, as late as possible.
 
 Below is an example refactoring.
 
@@ -167,13 +101,13 @@ Below is an example refactoring.
   if (!instrument)
     throw runtime_error("There is no instrument in input workspace.")
 
-  size_t numdets = instrument->getNumberDetectors();
-  vector<detid_t> detIds = instrument->getDetectorIDs();
-
-  for (size_t i = 0; i < numdets; ++i) {
-    IDetector_const_sptr tmpdetector = instrument->getDetector(detIds[i]);
-    if (tmpdetector->isMasked()) {
-      maskeddetids.push_back(tmpdetid);
+  std::vector<IComponent_const_sptr> children;
+  instrument->getChildren(children, true);
+  std::vector<IComponent_const_sptr>::const_iterator it;
+  for (it = children.begin(); it != children.end(); ++it) {
+    if (const ObjComponent* obj = dynamic_cast<const ObjComponent*>(it->get())) {
+      // Do something with the obj component
+      obj.solidAngle(observer);
     }
   }
 
@@ -181,45 +115,81 @@ Below is an example refactoring.
 
 .. code-block:: c++
 
-  #include "MantidAPI/Detector.h"
+  #include "MantidGeometry/Instrument/ComponentInfo.h"
 
   ...
 
-  const auto &detectorInfo = ws->detectorInfo();
-  if (detectorInfo.size() == 0)
+  const auto &componentInfo = ws->componentInfo();
+  if (componentInfo.size() == 0)
     throw runtime_error("There is no instrument in input workspace.")
 
-  vector<detid_t> detIds = detectorInfo.detectorIDs();
+  for (size_t i = 0; i < componentInfo.size(); ++i) {
+    componentInfo.solidAngle(i, observer);
+  }
 
-  for (size_t i = 0; i < detectorInfo.size(); ++i) {
-    if (detectorInfo.isMasked(i)) {
-      maskedDetIds.push_back(detIds[i]);
+Access to Components and working with Detectors
+___________________
+
+Detector Indices are the same as the corresponding Component Indices. Note that there are no dynamic casts.
+
+**Combining DetectorInfo and ComponentInfo**
+
+.. code-block:: c++
+
+  #include "MantidGeometry/Instrument/ComponentInfo.h"
+  #include "MantidGeometry/Instrument/DetectorInfo.h"
+
+  ...
+
+  const auto &componentInfo = ws->componentInfo();
+  const auto &detectorInfo = ws->componentInfo();
+  if (componentInfo.size() == 0)
+    throw runtime_error("There is no instrument in input workspace.")
+  
+  std::vector<double> solidAnglesForDetectors(detectorInfo.size(), -1.0);
+  for (size_t i = 0; i < componentInfo.size(); ++i) {
+    if(componentInfo.isDetector(i) && !detectorInfo.isMasked(i)) 
+     solidAnglesForDetectors[i] = componentInfo.solidAngle(i, observer);
     }
   }
 
-Access to Detectors
-___________________
+``ComponentInfo`` can give quick access to parent and sub-tree component and detector indices.
 
-As for the ``SpectrumInfo`` object ``DetectorInfo`` can return a parameterised detector for the workspace.
+.. code-block:: c++
 
-Mutable DetectorInfo
+  #include "MantidGeometry/Instrument/ComponentInfo.h"
+  #include "MantidGeometry/Instrument/DetectorInfo.h"
+
+  ...
+
+  const auto &componentInfo = ws->componentInfo();
+  const auto &detectorInfo = ws->componentInfo();
+  if (componentInfo.size() == 0)
+    throw runtime_error("There is no instrument in input workspace.")
+  
+  std::set<size_t> componentsHoldingOnlyDetectors;
+  for (size_t i = 0; i < componentInfo.size(); ++i) {
+    if(componentInfo.componentsInSubtree(i) == componentInfo.detectorsInSubtree(i)) {
+     componentsHoldingOnlyDetectors.insert(i); 
+    }
+  }
+
+Mutable ComponentInfo
 ____________________
 
-The method ``ExperimentInfo::mutableDetectorInfo()`` returns a non-const ``DetectorInfo`` object. This allows the methods below to be used.
+The method ``ExperimentInfo::mutableComponentInfo()`` returns a non-const ``ComponentInfo`` object. This allows the methods below to be used.
 
-* ``setMasked(const size_t index, bool masked);``
-* ``clearMaskFlags();``
 * ``setPosition(const size_t index, const Kernel::V3D &position);``
 * ``setRotation(const size_t index, const Kernel::Quat &rotation);``
-* ``setPosition(const Geometry::IComponent &comp, const Kernel::V3D &pos);``
-* ``setRotation(const Geometry::IComponent &comp, const Kernel::Quat &rot);``
-
-For a complete example of setting the position of a detector see the changes to the algorithm `ApplyCalibration.cpp <https://github.com/mantidproject/mantid/commit/0c75f46e85c2dc39c2b76ea811f161fdfdef938e#diff-a4ccabae0099bfc22b3b87154cd6ee9e>`_.
+* ``setScaleFactor(const size_t index, const Kernel::V3D &scaleFactor);``
 
 Useful Tips
 ___________
 
-See tips for ``SpectrumInfo`` - the same advice applies to using ``DetectorInfo``.
+* Creation of ``ComponentInfo`` is not cheap enough to perform uncessarily inside loops. For non-const access, ``ws.componentInfo()`` should be called outside of loops that enumerate over all components.
+* If a ``ComponentInfo`` object is required for more than one workspace, include the workspace name in the variable name to avoid confusion.
+* Get the ``ComponentInfo`` object as a const-ref and use ``const auto &componentInfo = ws->componentInfo();``, do not get a non-const reference unless you really do need to modify the object, and ensure that the ``&`` is always included to prevent accidental copies.
+* ``ComponentInfo`` is widely forward declared. Ensure that you import - ``#include "MantidGeometry/Instrument/ComponentInfo.h"``
 
 Complete Examples
 _________________
@@ -235,12 +205,12 @@ _________________
 Rollout status
 --------------
 
-See ticket `17743 <https://github.com/mantidproject/mantid/issues/17743>`_ for an overview of the ``SpectrumInfo`` and ``DetectorInfo`` rollout, including completed and algorithms, and remaining algorithms. Please follow the instructions on the ticket for the rollout.
+TODO
 
 Dealing with problems
 ---------------------
 
-Join #instrument-2_0 on Slack if you need help or have questions. Please also feel free to get in touch with Ian Bush, Simon Heybrock or Owen Arnold directly for any questions about the ``SpectrumInfo``, ``DetectorInfo`` and the rollout.
+Join #instrument-2_0 on Slack if you need help or have questions. Please also feel free to get in touch with Owen Arnold, Simon Heybrock or Lamar Moore directly for any questions about the ``ComponentInfo`` rollout.
 
 
 .. categories:: Concepts

--- a/docs/source/concepts/InstrumentAccessLayers.rst
+++ b/docs/source/concepts/InstrumentAccessLayers.rst
@@ -10,7 +10,7 @@ Instrument Access via SpectrumInfo and DetectorInfo
 Introduction
 ------------
 
-There are three new layers to access instrument information, ``SpectrumInfo``, ``DetectorInfo``, and ``ComponentInfo`` that are introduced to Mantid as part of the work towards Instrument 2.0. Eventually these classes will store all commonly accessed information about spectra and detectors, namely masking, monitor flags, L1, L2, 2-theta and position. In addition, ``ComponentInfo`` will provide the updated API to tree and shape related operations currently peformed by the instrument. These changes are leading to improved performance and cleaner code.
+There are three new layers to access instrument information, ``SpectrumInfo``, ``DetectorInfo``, and ``ComponentInfo``, which are introduced to Mantid as part of the work towards Instrument 2.0. Eventually these classes will store all commonly accessed information about spectra and detectors, namely masking, monitor flags, L1, L2, 2-theta and position. In addition, ``ComponentInfo`` will provide the updated API to tree and shape related operations currently peformed by the instrument. These changes are leading to improved performance and cleaner code.
 
 A spectrum corresponds to (a group of) one or more detectors. Most algorithms work with spectra and thus ``SpectrumInfo`` would be used. Some algorithms work on a lower level (with individual detectors) and thus ``DetectorInfo`` would be used.
 
@@ -33,7 +33,7 @@ ____________
 
 ``DetectorInfo`` can be obtained from a call to ``ExperimentInfo::detectorInfo()`` (usually this method would be called on ``MatrixWorkspace``). The wrapper class holds a reference to the parametrised instrument for retrieving the relevant information.
 
-There is also a near-complete implementation of the "real" ``DetectorInfo`` class, in the ``Beamline`` namespace. The wrapper ``DetectorInfo`` class (which you get from ``ExperimentInfo::detectorInfo()`` holds a reference to the real class. This does not affect the rollout, where the wrapper class should still be used in all cases.
+There is also a near-complete implementation of the "real" ``DetectorInfo`` class, in the ``Beamline`` namespace. The wrapper ``DetectorInfo`` class (which you get from ``ExperimentInfo::detectorInfo()``) holds a reference to the real class. This does not affect the rollout, where the wrapper class should still be used in all cases.
 
 ``ExperimentInfo`` now also provides a method ``mutableDetectorInfo()`` so that non-const access to the DetectorInfo is possible for purposes of writing detector related information such as positions or rotations. These should be used wherever possible, but note, much like the existing instrument, writes are not guranteed to be thread safe.
 
@@ -59,7 +59,7 @@ ComponentInfo
 Basics
 ______
 
-The conversion is similar to that for ``DetectorInfo``, which is already largeely complete in the framework. For ``ComponentInfo`` all instances of ``Instrument::getComponentByID(const ComponentID id)`` should be replaced using calls to the ``ComponentInfo`` object obtained from ``MatrixWorkspace::componentInfo()``. The methods below can then be called on ``ComponentInfo`` instead of on the component.
+The conversion is similar to that for ``DetectorInfo``, which is already largely complete in the framework. For ``ComponentInfo`` all instances of ``Instrument::getComponentByID(const ComponentID id)`` should be replaced using calls to the ``ComponentInfo`` object obtained from ``MatrixWorkspace::componentInfo()``. The methods below can then be called on ``ComponentInfo`` instead of on the component.
 
 * ``isDetector(componentIndex)``
 * ``detectorsInSubtree(componentIndex)``
@@ -194,13 +194,7 @@ ___________
 Complete Examples
 _________________
 
-* `FindDetectorsInShape.cpp <https://github.com/mantidproject/mantid/commit/177ad14b25db7c40ee10be513512be9ae7dd0da1#diff-7f367da22c1a837b315b4bca5b2b3e24>`_
-
-* `SmoothNeighbours.cpp <https://github.com/mantidproject/mantid/pull/18295/files#diff-26a49ef923e1bdd77677b962528d1e01>`_
-
-* `ClaerMaskFlag.cpp <https://github.com/mantidproject/mantid/pull/18198/files#diff-7f0f739ba6db714eb6ef64b6125e4620>`_
-
-* `ApplyCalibration.cpp <https://github.com/mantidproject/mantid/commit/0c75f46e85c2dc39c2b76ea811f161fdfdef938e#diff-a4ccabae0099bfc22b3b87154cd6ee9e>`_ - for mutable ``DetectorInfo``
+TODO
 
 Rollout status
 --------------


### PR DESCRIPTION
fixes #20248. This is an update to an active area of development, so is not completed/finalised documentation. It does however, bring the documentation forwards for Instrument 2.0

**Tester**
Coder review and generate and read the documentation.