### PR TITLE
Fix EnginXCalibrateFullThenCalibrateTest for python 3

### DIFF
--- a/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
+++ b/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
@@ -1,6 +1,7 @@
 #pylint: disable=no-init
 import stresstesting
 from mantid.simpleapi import *
+from six import PY2
 
 
 def rel_err_less_delta(val, ref, epsilon):
@@ -234,7 +235,8 @@ class EnginXCalibrateFullThenCalibrateTest(stresstesting.MantidStressTest):
         for idx in [0, 12, 516, 789, 891, 1112]:
             cell_val = self.peaks_info.cell(idx,1)
             self.assertTrue(isinstance(cell_val, str))
-            self.assertEquals(cell_val[0:11], '{"1": {"A":')
+            if PY2: # This test depends on consistent ordering of a dict which is not guaranteed for python 3
+                self.assertEquals(cell_val[0:11], '{"1": {"A":')
             self.assertEquals(cell_val[-2:], '}}')
 
         self.assertEquals(self.difa, 0)


### PR DESCRIPTION
This currently fails for python 3, see [here](http://builds.mantidproject.org/job/master_systemtests-ubuntu-16.04-python3/201/testReport/SystemTests/EnggCalibrationTest/EnginXCalibrateFullThenCalibrateTest/)

Skip test for Python 3 as test depends on consistent ordering of a dict which is not guaranteed for python 3.

**To test:**
`./systemtest -R EnginXCalibrateFullThenCalibrateTest` should now pass for python 3.

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
