### PR TITLE
Fix bug with TableWorkspace plot type & sorting

### DIFF
--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -312,6 +312,12 @@ void MantidTable::cellEdited(int row, int col) {
   d_table->setText(row, col, QString::fromStdString(s.str()));
 }
 
+void MantidTable::setPlotDesignation(Table::PlotDesignation pd,
+                                     bool rightColumns) {
+  Table::setPlotDesignation(pd, rightColumns);
+  setPlotTypeForSelectedColumns(pd);
+}
+
 //------------------------------------------------------------------------------------------------
 /** Call an algorithm in order to delete table rows
  *
@@ -420,6 +426,19 @@ void MantidTable::sortColumns(const QStringList &s, int type, int order,
   } else {
     // Fall-back to the default sorting of the table
     Table::sortColumns(s, type, order, leadCol);
+  }
+}
+
+/** Set the plot type on the workspace for each selected column
+ *
+ * @param plotType :: the plot type to set the selected columns to.
+ */
+void MantidTable::setPlotTypeForSelectedColumns(int plotType) {
+  const QStringList list = selectedColumns();
+  for (int i = 0; i < static_cast<int>(list.count()); i++) {
+    const int col = colIndex(list[i]);
+    const auto column = m_ws->getColumn(col);
+    column->setPlotType(plotType);
   }
 }
 

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -434,9 +434,9 @@ void MantidTable::sortColumns(const QStringList &s, int type, int order,
  * @param plotType :: the plot type to set the selected columns to.
  */
 void MantidTable::setPlotTypeForSelectedColumns(int plotType) {
-  const QStringList list = selectedColumns();
-  for (int i = 0; i < static_cast<int>(list.count()); i++) {
-    const int col = colIndex(list[i]);
+  const auto list = selectedColumns();
+  for (const auto &name : list) {
+    const auto col = colIndex(name);
     const auto column = m_ws->getColumn(col);
     column->setPlotType(plotType);
   }

--- a/MantidPlot/src/Mantid/MantidTable.h
+++ b/MantidPlot/src/Mantid/MantidTable.h
@@ -35,6 +35,8 @@ signals:
 public slots:
   void deleteRows(int startRow, int endRow) override;
   void cellEdited(int, int col) override;
+  void setPlotDesignation(PlotDesignation pd,
+                          bool rightColumns = false) override;
 
 protected slots:
   void closeTable();
@@ -57,6 +59,9 @@ protected:
                    const QString &leadCol = QString()) override;
 
 private:
+  /// Set the plot type on the workspace for each selected column
+  void setPlotTypeForSelectedColumns(int plotType);
+
   /// ITableWorkspace being displayed
   Mantid::API::ITableWorkspace_sptr m_ws;
   /// Name of the TableWorkspace being displayed

--- a/MantidPlot/src/Table.h
+++ b/MantidPlot/src/Table.h
@@ -156,7 +156,8 @@ public slots:
 
   int colPlotDesignation(int col) { return col_plot_type[col]; };
   void setColPlotDesignation(int col, PlotDesignation pd);
-  void setPlotDesignation(PlotDesignation pd, bool rightColumns = false);
+  virtual void setPlotDesignation(PlotDesignation pd,
+                                  bool rightColumns = false);
   QList<int> plotDesignations() { return col_plot_type; };
 
   void setHeader(QStringList header);

--- a/docs/source/release/v3.11.0/ui.rst
+++ b/docs/source/release/v3.11.0/ui.rst
@@ -51,6 +51,7 @@ Custom Interfaces
 Bugs Resolved
 -------------
 - Fixed a bug causing table windows with string values to appear truncated if the string contained a space.
+- Fixed a bug where setting a table column's plot type would not be saved to the workspace correctly.
 
 SliceViewer Improvements
 ------------------------


### PR DESCRIPTION
This fixes a bug where if you set the plot type on a table workspace column via a table view, the workspace is not correctly updated with the plot type.

**To test:**
 - Follow the steps to reproduce the bug in the issue report #19518.
 - Apply the fix, check this is now solved.
 - Code review.

Fixes #19518

**Release Notes** 
[See here](https://github.com/mantidproject/mantid/compare/19518-sort-peaks-ws-column?expand=1#diff-314160101dcfa40a50e85e320e4e750fR54)

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
