### PR TITLE
Correct MERLIN monitors spectra

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
+++ b/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
@@ -194,7 +194,6 @@ class ISISLoadFilesMER(stresstesting.MantidStressTest):
         propman.ei_mon1_spec = [ 69634,69635,69636,69637]
         propman.ei_mon2_spec = [ 69638,69639,69640,69641]
 
-
         mon_ws = PropertyManager.sample_run.get_monitors_ws()
         self.assertTrue(mon_ws is not None)
 
@@ -202,7 +201,6 @@ class ISISLoadFilesMER(stresstesting.MantidStressTest):
         self.assertTrue(isinstance(ws,Workspace))
         self.assertEqual(ws.getNumberHistograms(),69632)
         self.assertEqual(mon_ws.getNumberHistograms(),9)
-
 
         propman.sample_run = None # (clean things up)
         propman.load_monitors_with_workspace = True

--- a/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
+++ b/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
@@ -190,6 +190,10 @@ class ISISLoadFilesMER(stresstesting.MantidStressTest):
         propman.sample_run = 6398 # (raw file)
         propman.det_cal_file = 6399
         propman.load_monitors_with_workspace = False
+        propman.mon1_norm_spec =  69633
+        propman.ei_mon1_spec = [ 69634,69635,69636,69637]
+        propman.ei_mon2_spec = [ 69638,69639,69640,69641]
+
 
         mon_ws = PropertyManager.sample_run.get_monitors_ws()
         self.assertTrue(mon_ws is not None)
@@ -199,7 +203,7 @@ class ISISLoadFilesMER(stresstesting.MantidStressTest):
         self.assertEqual(ws.getNumberHistograms(),69632)
         self.assertEqual(mon_ws.getNumberHistograms(),9)
 
-        # test load together
+
         propman.sample_run = None # (clean things up)
         propman.load_monitors_with_workspace = True
         propman.sample_run  = 6398
@@ -309,5 +313,5 @@ class ISISLoadFilesLET(stresstesting.MantidStressTest):
 
 
 if __name__=="__main__":
-    tester = ISISLoadFilesLET()
+    tester = ISISLoadFilesMER()
     tester.runTest()

--- a/instrument/MERLIN_Parameters_2017_02.xml
+++ b/instrument/MERLIN_Parameters_2017_02.xml
@@ -63,7 +63,7 @@
 
 <!-- Monitor used to estimate total current on the sample while normalizing by monitor 1.  -->
 <parameter name="norm-mon1-spec"   >
-  <value val="69633"/>
+  <value val="71681"/>
 </parameter>
 
 <!-- Time interval used for integration to estimate current on the sample 
@@ -80,7 +80,7 @@
 
 <!-- Monitor after chopper used to estimate total current on the sample, if normalization is done on monitor 2  -->
 <parameter name="norm-mon2-spec"  type="int">
-    <value val="69634"/>
+    <value val="71682"/>
 </parameter>
 <!-- Relative energy range (wrt. to the incident energy) in which monitor 2 signal is present and the integration to 
      calculate monitor-2 current occurs   -->
@@ -99,7 +99,7 @@
 
 <!-- -->
 <parameter name="ei-mon1-spec"  type="string">
-  <value val="69634,69635,69636,69637"/>
+  <value val="71682,71683,71684,71685"/>
   <description is="First spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
      Should be spectra with well defined energy peak or monitor's spectra.
@@ -109,7 +109,7 @@
 </parameter>
 <!-- -->
 <parameter name="ei-mon2-spec"  type="string">
-  <value val="69638,69639,69640,69641"/>
+  <value val="71686,71687,71688,71689"/>
   <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
      Should be spectra with well defined energy peak or monitor's spectra.
@@ -137,7 +137,7 @@
 
 <!-- -->
 <parameter name="multirep_tof_specta_list"  type="string">
-    <value val="382,68353"/>
+    <value val="20860,20480"/>
     <description is="List of two spectra corresponding to the detectors which are closest and furthest from the sample.
     These detectors locations are used to identify TOF range, contributing into each energy range
      in multirep mode"/>
@@ -176,7 +176,7 @@
 </parameter>
 
 
-<!--  detector_van_range- integratin in E(mev) for detector(white beam) vanadium data [20,100] -->
+<!--  detector_van_range- integration in E(mev) for detector(white beam) vanadium data [20,100] -->
 <parameter name="wb-integr-min">
   <value val="20"/>
 </parameter>
@@ -189,7 +189,7 @@
 
 
 <!-- integration range for background tests  (in TOF) - composite property 
-  Used in test to reject high backgound (FlatBackground) and in High Background tests integration in Diagnostics
+  Used in test to reject high background (FlatBackground) and in High Background tests integration in Diagnostics
   if diag_background_test_range is not set -->
 <parameter name="bkgd-range-min"> 
   <value val="12000"/>
@@ -351,12 +351,12 @@
 <parameter name="vanadium-mass">
   <value val="7.85"/>
 </parameter>
-<!-- if this value set to true, modo-vanadium run is not analyzed and masks obtained for arbitrary units are used for mono-vanadium -->
+<!-- if this value set to true, modo-vanadium run is not analysed and masks obtained for arbitrary units are used for mono-vanadium -->
 <parameter name="use_sam_msk_on_monovan" type = "bool">
   <value val="False"/>
 </parameter>
 
-<!-- if this value is provided (not None) it is string reperesentation of the number used instead of calculating mono-vanadium based normalization factor 
+<!-- if this value is provided (not None) it is string representation of the number used instead of calculating mono-vanadium based normalization factor 
    one does not need to provide mono-vanadium run if this value is provided as it will be used instead
   -->
 <parameter name="mono_correction_factor" type="string">
@@ -373,8 +373,8 @@
 <!--  ****************************************  Workflow control **************************** -->
 
 <!-- This parameter controls the format of output data written by reducer. 
-    Three values are currently supported, namely .spe, .nxspe, and nexus (mantid workspace) (.nxs)
-     Three possible values for this are defined inin DirectEnergyConversion init routine as recognized by save method 
+    Three values are currently supported, namely .spe, .nxspe, and nexus (Mantid workspace) (.nxs)
+     Three possible values for this are defined in DirectEnergyConversion init routine as recognized by save method 
      If None is there, no internal script saving occurs and one needs to use external save operations -->  
 <parameter name="save_format" type="string">
    <value val="None"/>
@@ -414,13 +414,13 @@
    <value val="False"/>
 </parameter>
 
-<!-- The semicolon separated list of possible log names, containing information on crystl rotation.
-     First found log will be used togethere with motor_offset to identify crystal rotation 
+<!-- The semicolon separated list of possible log names, containing information on crystal rotation.
+     First found log will be used together with motor_offset to identify crystal rotation 
      (psi in Horace) -->
 <parameter name="motor_log_names"  type="string">
    <value val="CCR_ROT;wccr"/>
 </parameter>
-<!-- Initial value used to identify crytsal rotation angle psi=motor_offset+wccr.timeAverageValue()  -->
+<!-- Initial value used to identify crystal rotation angle psi=motor_offset+wccr.timeAverageValue()  -->
 <parameter name="motor_offset">
    <value val="None"/>
 </parameter>


### PR DESCRIPTION
fixes #20462 

New MERLIN hardware have added 4 tubes to MERLIN + new wiring tables modified the list of the spectra and monitors spectra numbers. The changes allow reduction to use the new spectra numbers and necessary for reduction to work. 
Nothing to test here -- new monitor's spectra numbers have been collected from new workspaces recorded on MERLIN so should be correct. 
Just merge to master. 

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):



##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
