### PR TITLE
More robust fix for asynchronous python execution in MantidPlot

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -15064,7 +15064,7 @@ bool ApplicationWindow::runPythonScript(const QString &code, bool async,
   }
   bool success(false);
   if (async) {
-    m_iface_script->recursiveAsyncSetup();
+    const bool locked = m_iface_script->recursiveAsyncSetup();
     auto job = m_iface_script->executeAsync(ScriptCode(code));
     // Start a local event loop to keep processing events
     // while we are running the script. Inspired by the IPython
@@ -15077,7 +15077,7 @@ bool ApplicationWindow::runPythonScript(const QString &code, bool async,
       eventLoop.exec();
       timer.stop();
     }
-    m_iface_script->recursiveAsyncTeardown();
+    m_iface_script->recursiveAsyncTeardown(locked);
     success = job.result();
   } else {
     success = m_iface_script->execute(ScriptCode(code));

--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -457,19 +457,24 @@ void PythonScript::endStdoutRedirect() {
 /**
  * To be called from the main thread before an async call that is
  * recursive. See ApplicationWindow::runPythonScript
+ * @return True if the lock was released by this call, false otherwise
  */
-void PythonScript::recursiveAsyncSetup() {
+bool PythonScript::recursiveAsyncSetup() {
   if (gil().locked()) {
     gil().release();
+    return true;
   }
+  return false;
 }
 
 /**
  * To be called from the main thread immediately after an async call
  * that is recursive. See ApplicationWindow::runPythonScript
+ * @param relock If true then relock the GIL on this thread. This should use the
+ * value returned by recursiveAsyncSetup.
  */
-void PythonScript::recursiveAsyncTeardown() {
-  if (!gil().locked()) {
+void PythonScript::recursiveAsyncTeardown(bool relock) {
+  if (relock) {
     gil().acquire();
   }
 }

--- a/MantidPlot/src/PythonScript.h
+++ b/MantidPlot/src/PythonScript.h
@@ -172,8 +172,8 @@ private:
   // are used for this purpose and are NOT used by the general executeAsync
   // methods where the GILState API functions can cope and there is no
   // recursion.
-  virtual void recursiveAsyncSetup() override;
-  virtual void recursiveAsyncTeardown() override;
+  virtual bool recursiveAsyncSetup() override;
+  virtual void recursiveAsyncTeardown(bool relock) override;
 
   /// Compile the code, returning true if it was successful, false otherwise
   bool compileImpl() override;

--- a/MantidPlot/src/PythonScripting.cpp
+++ b/MantidPlot/src/PythonScripting.cpp
@@ -137,9 +137,8 @@ bool PythonScripting::start() {
 #else
   PyImport_AppendInittab("_qti", &init_qti);
 #endif
-  Py_Initialize();
-  // Assume this is called at startup by the the main thread so no GIL
-  // required...yet
+  PythonInterpreter::initialize();
+  ScopedPythonGIL lock(gil());
 
   // Keep a hold of the globals, math and sys dictionary objects
   PyObject *mainmod = PyImport_AddModule("__main__");
@@ -189,20 +188,6 @@ bool PythonScripting::start() {
   } else {
     d_initialized = false;
   }
-  if (d_initialized) {
-    // We will be using C threads created outside of the Python threading module
-    // so we need the GIL. This creates and acquires the lock for this thread
-    PyEval_InitThreads();
-    // We immediately release the lock and threadstate so that other points in
-    // the code can simply use the PyGILstate_Ensure/PyGILstate_Release()
-    // mechanism (through the ScopedPythonGIL class) and they don't
-    // need to worry about swapping out the threadstate before hand.
-    // It would be better if the ScopedPythonGIL handled this but
-    // PyEval_SaveThread() needs to be called in the thread that spawns the
-    // new C thread meaning that ScopedPythonGIL could no longer
-    // be used as a simple RAII class on the stack from within the new thread.
-    m_mainThreadState = PyEval_SaveThread();
-  }
   return d_initialized;
 }
 
@@ -210,9 +195,12 @@ bool PythonScripting::start() {
  * Shutdown the interpreter
  */
 void PythonScripting::shutdown() {
-  PyEval_RestoreThread(m_mainThreadState);
+  // The scoped lock cannot be used here as after the
+  // finalize call no Python code can execute.
+  PythonGIL gil;
+  gil.acquire();
   Py_XDECREF(m_math);
-  Py_Finalize();
+  PythonInterpreter::finalize();
 }
 
 void PythonScripting::setupPythonPath() {

--- a/MantidPlot/src/Script.h
+++ b/MantidPlot/src/Script.h
@@ -91,8 +91,8 @@ public:
   bool redirectStdOut() const { return m_redirectOutput; }
   void redirectStdOut(bool on) { m_redirectOutput = on; }
 
-  virtual void recursiveAsyncSetup() {}
-  virtual void recursiveAsyncTeardown() {}
+  virtual bool recursiveAsyncSetup() { return false; }
+  virtual void recursiveAsyncTeardown(bool) {}
 
   /// Create a list of keywords for the code completion API
   virtual void generateAutoCompleteList() {}

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PythonSystemHeader.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PythonSystemHeader.h
@@ -22,6 +22,7 @@
 #define TO_CSTRING _PyUnicode_AsString
 #define FROM_CSTRING PyUnicode_FromString
 #define CODE_OBJECT(x) x
+#define GET_CURRENT_THREADSTATE _PyThreadState_UncheckedGet()
 #else
 #define INT_CHECK PyInt_Check
 #define TO_LONG PyInt_AsLong
@@ -29,6 +30,7 @@
 #define TO_CSTRING PyString_AsString
 #define FROM_CSTRING PyString_FromString
 #define CODE_OBJECT(x) (PyCodeObject *) x
+#define GET_CURRENT_THREADSTATE _PyThreadState_Current
 #endif
 
 #endif // PYTHONSYSTEMHEADER_H_

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PythonThreading.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PythonThreading.h
@@ -5,6 +5,15 @@
 #include "MantidQtWidgets/Common/DllOption.h"
 
 //------------------------------------------------------------------------------
+// Python Interpreter
+//------------------------------------------------------------------------------
+class EXPORT_OPT_MANTIDQT_COMMON PythonInterpreter {
+public:
+  static void initialize();
+  static void finalize();
+};
+
+//------------------------------------------------------------------------------
 // PythonGIL
 //------------------------------------------------------------------------------
 /**
@@ -13,18 +22,20 @@
  *
  */
 class EXPORT_OPT_MANTIDQT_COMMON PythonGIL {
+
+public:
+  static bool locked();
+
 public:
   PythonGIL();
+  PythonGIL(const PythonGIL &) = delete;
+  PythonGIL &operator=(const PythonGIL &) = delete;
 
-  inline bool locked() const { return m_acquired; }
   void acquire();
   void release();
 
 private:
-  PythonGIL(const PythonGIL &);
-  /// Current GIL state
   PyGILState_STATE m_state;
-  bool m_acquired;
 };
 
 //------------------------------------------------------------------------------

--- a/qt/widgets/common/src/PythonThreading.cpp
+++ b/qt/widgets/common/src/PythonThreading.cpp
@@ -2,36 +2,55 @@
 // Includes
 //------------------------------------------------------------------------------
 #include "MantidQtWidgets/Common/PythonThreading.h"
-#include <iostream>
 
-#include <QThread>
+namespace {
+PyThreadState *INITIAL_TS = nullptr;
+}
+
+//------------------------------------------------------------------------------
+// PythonInterpreter Public members
+//------------------------------------------------------------------------------
+void PythonInterpreter::initialize() {
+  Py_Initialize();
+  PyEval_InitThreads();
+  // Release GIL
+  INITIAL_TS = PyEval_SaveThread();
+}
+
+// Finalize the Python process. The GIL must be held to
+// call this function but after it completes calling
+// any python functions is undefined behaviour
+void PythonInterpreter::finalize() { Py_Finalize(); }
 
 //------------------------------------------------------------------------------
 // PythonGIL Public members
 //------------------------------------------------------------------------------
 
 /**
+ * Check if the current thread has the lock
+ * @return True if the current thread holds the GIL, false otherwise
+ */
+bool PythonGIL::locked() {
+  PyThreadState *ts = _PyThreadState_Current;
+  return (ts && ts == PyGILState_GetThisThreadState());
+}
+
+/**
  * Leaves the lock unlocked. You are strongly encouraged to use
  * the ScopedInterpreterLock class to control this
  */
-PythonGIL::PythonGIL() : m_state(PyGILState_UNLOCKED), m_acquired(false) {}
+PythonGIL::PythonGIL() : m_state(PyGILState_UNLOCKED) {}
 
 /**
  * Calls PyGILState_Ensure. A call to this must be matched by a call to release
  * on the same thread.
  */
-void PythonGIL::acquire() {
-  m_state = PyGILState_Ensure();
-  m_acquired = true;
-}
+void PythonGIL::acquire() { m_state = PyGILState_Ensure(); }
 
 /**
  * Calls PyGILState_Release
  */
-void PythonGIL::release() {
-  PyGILState_Release(m_state);
-  m_acquired = false;
-}
+void PythonGIL::release() { PyGILState_Release(m_state); }
 
 //------------------------------------------------------------------------------
 // RecursivePythonGIL public members

--- a/qt/widgets/common/src/PythonThreading.cpp
+++ b/qt/widgets/common/src/PythonThreading.cpp
@@ -31,7 +31,7 @@ void PythonInterpreter::finalize() { Py_Finalize(); }
  * @return True if the current thread holds the GIL, false otherwise
  */
 bool PythonGIL::locked() {
-  PyThreadState *ts = _PyThreadState_Current;
+  PyThreadState *ts = GET_CURRENT_THREADSTATE;
   return (ts && ts == PyGILState_GetThisThreadState());
 }
 


### PR DESCRIPTION
Description of work.

Uses an internal Python method to check if the GIL has been
acquired by the current thread rather than relying on our own flag.

This only applies in the situations where an executing python script then calls the `runPythonScript` method itself to call more code. The check for the GIL state was not robust enough to cover all cases before.  

**To test:**

Try an interface:
* Open the Muon Analysis GUI
* Load some muon data (MUSR data is in the doctest data)
* click the Data Analysis tab and mantid would crash before this fix

Try a recursive python script:

* Create a new python file with the following contents:
```python
import mantidplot

for i in range(10):
    mantidplot.runPythonScript("CreateWorkspace(OutputWorkspace='test_{}')".format(i), True)
```
* click View->Manage Custom Menus in MantidPlot
* click add menu and enter a name
* click add script and find the file you just saved
* highlight both the script and menu in the tree and click the `->` arrow to attach the script to the menu.
* go to the new menu and run the script
* before the fix MantidPlot would crash.

Fixes #20437

**Release Notes** 

This was broken during this dev cycle so no need for release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
