### PR TITLE
Allow std::array to be used with ListValidator

### DIFF
--- a/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Framework/Algorithms/src/FindPeaks.cpp
@@ -146,9 +146,7 @@ void FindPeaks::init() {
       "this peak will not be fit.  It is designed for EventWorkspace with "
       "integer counts.");
 
-  std::vector<std::string> costFuncOptions;
-  costFuncOptions.emplace_back("Chi-Square");
-  costFuncOptions.emplace_back("Rwp");
+  std::array<std::string, 2> costFuncOptions = {{"Chi-Square", "Rwp"}};
   declareProperty("CostFunction", "Chi-Square",
                   Kernel::IValidator_sptr(
                       new Kernel::ListValidator<std::string>(costFuncOptions)),

--- a/Framework/Algorithms/src/FitPeak.cpp
+++ b/Framework/Algorithms/src/FitPeak.cpp
@@ -1147,7 +1147,7 @@ void FitPeak::init() {
                   "from proposed value more than "
                   "the given value, fit is treated as failure. ");
 
-  vector<string> costFuncOptions{"Chi-Square", "Rwp"};
+  std::array<string, 2> costFuncOptions{"Chi-Square", "Rwp"};
   declareProperty("CostFunction", "Chi-Square",
                   Kernel::IValidator_sptr(
                       new Kernel::ListValidator<std::string>(costFuncOptions)),

--- a/Framework/Algorithms/src/FitPeak.cpp
+++ b/Framework/Algorithms/src/FitPeak.cpp
@@ -1147,7 +1147,7 @@ void FitPeak::init() {
                   "from proposed value more than "
                   "the given value, fit is treated as failure. ");
 
-  std::array<string, 2> costFuncOptions = { {"Chi-Square", "Rwp"} };
+  std::array<string, 2> costFuncOptions = {{"Chi-Square", "Rwp"}};
   declareProperty("CostFunction", "Chi-Square",
                   Kernel::IValidator_sptr(
                       new Kernel::ListValidator<std::string>(costFuncOptions)),

--- a/Framework/Algorithms/src/FitPeak.cpp
+++ b/Framework/Algorithms/src/FitPeak.cpp
@@ -1147,7 +1147,7 @@ void FitPeak::init() {
                   "from proposed value more than "
                   "the given value, fit is treated as failure. ");
 
-  std::array<string, 2> costFuncOptions{"Chi-Square", "Rwp"};
+  std::array<string, 2> costFuncOptions = { {"Chi-Square", "Rwp"} };
   declareProperty("CostFunction", "Chi-Square",
                   Kernel::IValidator_sptr(
                       new Kernel::ListValidator<std::string>(costFuncOptions)),

--- a/Framework/Algorithms/src/LineProfile.cpp
+++ b/Framework/Algorithms/src/LineProfile.cpp
@@ -306,16 +306,16 @@ void LineProfile::init() {
   declareProperty(PropertyNames::HALF_WIDTH, EMPTY_DBL(),
                   mandatoryPositiveDouble,
                   "Half of the width over which to calcualte the profile.");
-  const std::array<std::string, 2> directions{DirectionChoices::HORIZONTAL,
-                                              DirectionChoices::VERTICAL};
+  const std::array<std::string, 2> directions = {{DirectionChoices::HORIZONTAL,
+												  DirectionChoices::VERTICAL}};
   declareProperty(PropertyNames::DIRECTION, DirectionChoices::HORIZONTAL,
                   boost::make_shared<ListValidator<std::string>>(directions),
                   "Orientation of the profile line.");
   declareProperty(PropertyNames::START, EMPTY_DBL(),
                   "Starting point of the line.");
   declareProperty(PropertyNames::END, EMPTY_DBL(), "End point of the line.");
-  const std::array<std::string, 2> modes{ModeChoices::AVERAGE,
-                                         ModeChoices::SUM};
+  const std::array<std::string, 2> modes = {{ModeChoices::AVERAGE,
+											 ModeChoices::SUM}};
   declareProperty(PropertyNames::MODE, ModeChoices::AVERAGE,
                   boost::make_shared<ListValidator<std::string>>(modes),
                   "How the profile is calculated over the line width.");

--- a/Framework/Algorithms/src/LineProfile.cpp
+++ b/Framework/Algorithms/src/LineProfile.cpp
@@ -306,16 +306,16 @@ void LineProfile::init() {
   declareProperty(PropertyNames::HALF_WIDTH, EMPTY_DBL(),
                   mandatoryPositiveDouble,
                   "Half of the width over which to calcualte the profile.");
-  const std::array<std::string, 2> directions = {{DirectionChoices::HORIZONTAL,
-												  DirectionChoices::VERTICAL}};
+  const std::array<std::string, 2> directions = {
+      {DirectionChoices::HORIZONTAL, DirectionChoices::VERTICAL}};
   declareProperty(PropertyNames::DIRECTION, DirectionChoices::HORIZONTAL,
                   boost::make_shared<ListValidator<std::string>>(directions),
                   "Orientation of the profile line.");
   declareProperty(PropertyNames::START, EMPTY_DBL(),
                   "Starting point of the line.");
   declareProperty(PropertyNames::END, EMPTY_DBL(), "End point of the line.");
-  const std::array<std::string, 2> modes = {{ModeChoices::AVERAGE,
-											 ModeChoices::SUM}};
+  const std::array<std::string, 2> modes = {
+      {ModeChoices::AVERAGE, ModeChoices::SUM}};
   declareProperty(PropertyNames::MODE, ModeChoices::AVERAGE,
                   boost::make_shared<ListValidator<std::string>>(modes),
                   "How the profile is calculated over the line width.");

--- a/Framework/Algorithms/src/LineProfile.cpp
+++ b/Framework/Algorithms/src/LineProfile.cpp
@@ -306,15 +306,16 @@ void LineProfile::init() {
   declareProperty(PropertyNames::HALF_WIDTH, EMPTY_DBL(),
                   mandatoryPositiveDouble,
                   "Half of the width over which to calcualte the profile.");
-  const std::set<std::string> directions{DirectionChoices::HORIZONTAL,
-                                         DirectionChoices::VERTICAL};
+  const std::array<std::string, 2> directions{DirectionChoices::HORIZONTAL,
+                                              DirectionChoices::VERTICAL};
   declareProperty(PropertyNames::DIRECTION, DirectionChoices::HORIZONTAL,
                   boost::make_shared<ListValidator<std::string>>(directions),
                   "Orientation of the profile line.");
   declareProperty(PropertyNames::START, EMPTY_DBL(),
                   "Starting point of the line.");
   declareProperty(PropertyNames::END, EMPTY_DBL(), "End point of the line.");
-  const std::set<std::string> modes{ModeChoices::AVERAGE, ModeChoices::SUM};
+  const std::array<std::string, 2> modes{ModeChoices::AVERAGE, 
+	                                     ModeChoices::SUM};
   declareProperty(PropertyNames::MODE, ModeChoices::AVERAGE,
                   boost::make_shared<ListValidator<std::string>>(modes),
                   "How the profile is calculated over the line width.");

--- a/Framework/Algorithms/src/LineProfile.cpp
+++ b/Framework/Algorithms/src/LineProfile.cpp
@@ -314,8 +314,8 @@ void LineProfile::init() {
   declareProperty(PropertyNames::START, EMPTY_DBL(),
                   "Starting point of the line.");
   declareProperty(PropertyNames::END, EMPTY_DBL(), "End point of the line.");
-  const std::array<std::string, 2> modes{ModeChoices::AVERAGE, 
-	                                     ModeChoices::SUM};
+  const std::array<std::string, 2> modes{ModeChoices::AVERAGE,
+                                         ModeChoices::SUM};
   declareProperty(PropertyNames::MODE, ModeChoices::AVERAGE,
                   boost::make_shared<ListValidator<std::string>>(modes),
                   "How the profile is calculated over the line width.");

--- a/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
+++ b/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
@@ -65,10 +65,9 @@ void IntegratePeaksUsingClusters::init() {
                       "Threshold", 0, compositeValidator, Direction::Input),
                   "Threshold signal above which to consider peaks");
 
-  std::vector<std::string> normalizations(3);
-  normalizations[0] = "NoNormalization";
-  normalizations[1] = "VolumeNormalization";
-  normalizations[2] = "NumEventsNormalization";
+  std::array<std::string, 3> normalizations{ "NoNormalization",
+										     "VolumeNormalization",
+										 	 "NumEventsNormalization" };
 
   declareProperty("Normalization", normalizations[1],
                   Kernel::IValidator_sptr(

--- a/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
+++ b/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
@@ -65,8 +65,8 @@ void IntegratePeaksUsingClusters::init() {
                       "Threshold", 0, compositeValidator, Direction::Input),
                   "Threshold signal above which to consider peaks");
 
-  std::array<std::string, 3> normalizations = { {
-	  "NoNormalization", "VolumeNormalization", "NumEventsNormalization"} };
+  std::array<std::string, 3> normalizations = {
+      {"NoNormalization", "VolumeNormalization", "NumEventsNormalization"}};
 
   declareProperty("Normalization", normalizations[1],
                   Kernel::IValidator_sptr(

--- a/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
+++ b/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
@@ -65,8 +65,8 @@ void IntegratePeaksUsingClusters::init() {
                       "Threshold", 0, compositeValidator, Direction::Input),
                   "Threshold signal above which to consider peaks");
 
-  std::array<std::string, 3> normalizations{
-      "NoNormalization", "VolumeNormalization", "NumEventsNormalization"};
+  std::array<std::string, 3> normalizations = { {
+	  "NoNormalization", "VolumeNormalization", "NumEventsNormalization"} };
 
   declareProperty("Normalization", normalizations[1],
                   Kernel::IValidator_sptr(

--- a/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
+++ b/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
@@ -65,9 +65,8 @@ void IntegratePeaksUsingClusters::init() {
                       "Threshold", 0, compositeValidator, Direction::Input),
                   "Threshold signal above which to consider peaks");
 
-  std::array<std::string, 3> normalizations{ "NoNormalization",
-										     "VolumeNormalization",
-										 	 "NumEventsNormalization" };
+  std::array<std::string, 3> normalizations{
+      "NoNormalization", "VolumeNormalization", "NumEventsNormalization"};
 
   declareProperty("Normalization", normalizations[1],
                   Kernel::IValidator_sptr(

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -137,7 +137,7 @@ void PlotPeakByLogValue::init() {
       "Convolution are output convolved\n"
       "with corresponding resolution");
 
-  std::array<std::string, 2> evaluationTypes{"CentrePoint", "Histogram"};
+  std::array<std::string, 2> evaluationTypes = { {"CentrePoint", "Histogram"} };
   declareProperty(
       "EvaluationType", "CentrePoint",
       Kernel::IValidator_sptr(

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -137,7 +137,7 @@ void PlotPeakByLogValue::init() {
       "Convolution are output convolved\n"
       "with corresponding resolution");
 
-  std::array<std::string, 2> evaluationTypes = { {"CentrePoint", "Histogram"} };
+  std::array<std::string, 2> evaluationTypes = {{"CentrePoint", "Histogram"}};
   declareProperty(
       "EvaluationType", "CentrePoint",
       Kernel::IValidator_sptr(

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -137,7 +137,7 @@ void PlotPeakByLogValue::init() {
       "Convolution are output convolved\n"
       "with corresponding resolution");
 
-  std::vector<std::string> evaluationTypes{"CentrePoint", "Histogram"};
+  std::array<std::string, 2> evaluationTypes{"CentrePoint", "Histogram"};
   declareProperty(
       "EvaluationType", "CentrePoint",
       Kernel::IValidator_sptr(

--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -76,7 +76,7 @@ void IFittingAlgorithm::init() {
   declareProperty("IgnoreInvalidData", false,
                   "Flag to ignore infinities, NaNs and data with zero errors.");
 
-  std::vector<std::string> domainTypes{"Simple", "Sequential", "Parallel"};
+  std::array<std::string, 3> domainTypes{"Simple", "Sequential", "Parallel"};
   declareProperty(
       "DomainType", "Simple",
       Kernel::IValidator_sptr(
@@ -84,7 +84,7 @@ void IFittingAlgorithm::init() {
       "The type of function domain to use: Simple, Sequential, or Parallel.",
       Kernel::Direction::Input);
 
-  std::vector<std::string> evaluationTypes{"CentrePoint", "Histogram"};
+  std::array<std::string, 2> evaluationTypes{"CentrePoint", "Histogram"};
   declareProperty("EvaluationType", "CentrePoint",
                   Kernel::IValidator_sptr(
                       new Kernel::ListValidator<std::string>(evaluationTypes)),

--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -76,8 +76,8 @@ void IFittingAlgorithm::init() {
   declareProperty("IgnoreInvalidData", false,
                   "Flag to ignore infinities, NaNs and data with zero errors.");
 
-  std::array<std::string, 3> domainTypes 
-	  = { {"Simple", "Sequential", "Parallel"} };
+  std::array<std::string, 3> domainTypes = {
+      {"Simple", "Sequential", "Parallel"}};
   declareProperty(
       "DomainType", "Simple",
       Kernel::IValidator_sptr(
@@ -85,7 +85,7 @@ void IFittingAlgorithm::init() {
       "The type of function domain to use: Simple, Sequential, or Parallel.",
       Kernel::Direction::Input);
 
-  std::array<std::string, 2> evaluationTypes = { {"CentrePoint", "Histogram"} };
+  std::array<std::string, 2> evaluationTypes = {{"CentrePoint", "Histogram"}};
   declareProperty("EvaluationType", "CentrePoint",
                   Kernel::IValidator_sptr(
                       new Kernel::ListValidator<std::string>(evaluationTypes)),

--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -76,7 +76,8 @@ void IFittingAlgorithm::init() {
   declareProperty("IgnoreInvalidData", false,
                   "Flag to ignore infinities, NaNs and data with zero errors.");
 
-  std::array<std::string, 3> domainTypes{"Simple", "Sequential", "Parallel"};
+  std::array<std::string, 3> domainTypes 
+	  = { {"Simple", "Sequential", "Parallel"} };
   declareProperty(
       "DomainType", "Simple",
       Kernel::IValidator_sptr(
@@ -84,7 +85,7 @@ void IFittingAlgorithm::init() {
       "The type of function domain to use: Simple, Sequential, or Parallel.",
       Kernel::Direction::Input);
 
-  std::array<std::string, 2> evaluationTypes{"CentrePoint", "Histogram"};
+  std::array<std::string, 2> evaluationTypes = { {"CentrePoint", "Histogram"} };
   declareProperty("EvaluationType", "CentrePoint",
                   Kernel::IValidator_sptr(
                       new Kernel::ListValidator<std::string>(evaluationTypes)),

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveFITS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveFITS.h
@@ -68,7 +68,7 @@ private:
   void writePaddingFITSHeaders(size_t count, std::ofstream &file);
 
   static const size_t g_maxBitDepth;
-  template <std::size_t SIZE> static const std::array<int, SIZE> g_bitDepths;
+  static const std::array<int, 3> g_bitDepths;
   static const size_t g_maxBytesPP;
   // size of header entries in bytes
   static const size_t g_maxLenHdr;

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveFITS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveFITS.h
@@ -68,7 +68,8 @@ private:
   void writePaddingFITSHeaders(size_t count, std::ofstream &file);
 
   static const size_t g_maxBitDepth;
-  static const std::vector<int> g_bitDepths;
+  template<std::size_t SIZE>
+  static const std::array<int, SIZE> g_bitDepths;
   static const size_t g_maxBytesPP;
   // size of header entries in bytes
   static const size_t g_maxLenHdr;

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveFITS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveFITS.h
@@ -68,8 +68,7 @@ private:
   void writePaddingFITSHeaders(size_t count, std::ofstream &file);
 
   static const size_t g_maxBitDepth;
-  template<std::size_t SIZE>
-  static const std::array<int, SIZE> g_bitDepths;
+  template <std::size_t SIZE> static const std::array<int, SIZE> g_bitDepths;
   static const size_t g_maxBytesPP;
   // size of header entries in bytes
   static const size_t g_maxLenHdr;

--- a/Framework/DataHandling/src/CreateChopperModel.cpp
+++ b/Framework/DataHandling/src/CreateChopperModel.cpp
@@ -42,7 +42,7 @@ void CreateChopperModel::init() {
                                                            Direction::InOut),
                   "An workspace to attach the model");
 
-  std::array<std::string, 1> keys = { {"FermiChopperModel"} };
+  std::array<std::string, 1> keys = {{"FermiChopperModel"}};
   declareProperty("ModelType", "",
                   boost::make_shared<ListValidator<std::string>>(keys),
                   "The string identifier for the model", Direction::Input);

--- a/Framework/DataHandling/src/CreateChopperModel.cpp
+++ b/Framework/DataHandling/src/CreateChopperModel.cpp
@@ -42,7 +42,7 @@ void CreateChopperModel::init() {
                                                            Direction::InOut),
                   "An workspace to attach the model");
 
-  std::array<std::string, 1> keys({"FermiChopperModel"});
+  std::array<std::string, 1> keys = { {"FermiChopperModel"} };
   declareProperty("ModelType", "",
                   boost::make_shared<ListValidator<std::string>>(keys),
                   "The string identifier for the model", Direction::Input);

--- a/Framework/DataHandling/src/CreateChopperModel.cpp
+++ b/Framework/DataHandling/src/CreateChopperModel.cpp
@@ -42,7 +42,7 @@ void CreateChopperModel::init() {
                                                            Direction::InOut),
                   "An workspace to attach the model");
 
-  std::array<std::string, 1> keys({ "FermiChopperModel" });
+  std::array<std::string, 1> keys({"FermiChopperModel"});
   declareProperty("ModelType", "",
                   boost::make_shared<ListValidator<std::string>>(keys),
                   "The string identifier for the model", Direction::Input);

--- a/Framework/DataHandling/src/CreateChopperModel.cpp
+++ b/Framework/DataHandling/src/CreateChopperModel.cpp
@@ -42,7 +42,7 @@ void CreateChopperModel::init() {
                                                            Direction::InOut),
                   "An workspace to attach the model");
 
-  std::vector<std::string> keys(1, "FermiChopperModel");
+  std::array<std::string, 1> keys({ "FermiChopperModel" });
   declareProperty("ModelType", "",
                   boost::make_shared<ListValidator<std::string>>(keys),
                   "The string identifier for the model", Direction::Input);

--- a/Framework/DataHandling/src/CreateModeratorModel.cpp
+++ b/Framework/DataHandling/src/CreateModeratorModel.cpp
@@ -40,7 +40,7 @@ void CreateModeratorModel::init() {
                                                            Direction::InOut),
                   "An input workspace.");
 
-  std::array<std::string, 1> keys({"IkedaCarpenterModerator"});
+  std::array<std::string, 1> keys = { {"IkedaCarpenterModerator"} };
   declareProperty("ModelType", "",
                   boost::make_shared<ListValidator<std::string>>(keys),
                   "The string identifier for the model", Direction::Input);

--- a/Framework/DataHandling/src/CreateModeratorModel.cpp
+++ b/Framework/DataHandling/src/CreateModeratorModel.cpp
@@ -40,7 +40,7 @@ void CreateModeratorModel::init() {
                                                            Direction::InOut),
                   "An input workspace.");
 
-  std::array<std::string, 1> keys = { {"IkedaCarpenterModerator"} };
+  std::array<std::string, 1> keys = {{"IkedaCarpenterModerator"}};
   declareProperty("ModelType", "",
                   boost::make_shared<ListValidator<std::string>>(keys),
                   "The string identifier for the model", Direction::Input);

--- a/Framework/DataHandling/src/CreateModeratorModel.cpp
+++ b/Framework/DataHandling/src/CreateModeratorModel.cpp
@@ -40,7 +40,7 @@ void CreateModeratorModel::init() {
                                                            Direction::InOut),
                   "An input workspace.");
 
-  std::vector<std::string> keys(1, "IkedaCarpenterModerator");
+  std::array<std::string, 1> keys({ "IkedaCarpenterModerator" });
   declareProperty("ModelType", "",
                   boost::make_shared<ListValidator<std::string>>(keys),
                   "The string identifier for the model", Direction::Input);

--- a/Framework/DataHandling/src/CreateModeratorModel.cpp
+++ b/Framework/DataHandling/src/CreateModeratorModel.cpp
@@ -40,7 +40,7 @@ void CreateModeratorModel::init() {
                                                            Direction::InOut),
                   "An input workspace.");
 
-  std::array<std::string, 1> keys({ "IkedaCarpenterModerator" });
+  std::array<std::string, 1> keys({"IkedaCarpenterModerator"});
   declareProperty("ModelType", "",
                   boost::make_shared<ListValidator<std::string>>(keys),
                   "The string identifier for the model", Direction::Input);

--- a/Framework/DataHandling/src/LoadAscii.cpp
+++ b/Framework/DataHandling/src/LoadAscii.cpp
@@ -321,10 +321,10 @@ void LoadAscii::init() {
   // For the ListValidator
   std::array<std::string, 5> sepOptions;
   for (size_t i = 0; i < 5; ++i) {
-	  const auto &option = spacers[i][0];
-	  m_separatorIndex.insert(
-		  std::pair<std::string, std::string>(option, spacers[i][1]));
-	  sepOptions[i] = option;
+    const auto &option = spacers[i][0];
+    m_separatorIndex.insert(
+        std::pair<std::string, std::string>(option, spacers[i][1]));
+    sepOptions[i] = option;
   }
 
   declareProperty(

--- a/Framework/DataHandling/src/LoadAscii.cpp
+++ b/Framework/DataHandling/src/LoadAscii.cpp
@@ -319,13 +319,14 @@ void LoadAscii::init() {
                                {"Colon", ":"},
                                {"SemiColon", ";"}};
   // For the ListValidator
-  std::vector<std::string> sepOptions;
+  std::array<std::string, 5> sepOptions;
   for (size_t i = 0; i < 5; ++i) {
-    std::string option = spacers[i][0];
-    m_separatorIndex.insert(
-        std::pair<std::string, std::string>(option, spacers[i][1]));
-    sepOptions.push_back(option);
+	  const auto &option = spacers[i][0];
+	  m_separatorIndex.insert(
+		  std::pair<std::string, std::string>(option, spacers[i][1]));
+	  sepOptions[i] = option;
   }
+
   declareProperty(
       "Separator", "Automatic",
       boost::make_shared<StringListValidator>(sepOptions),

--- a/Framework/DataHandling/src/LoadAscii2.cpp
+++ b/Framework/DataHandling/src/LoadAscii2.cpp
@@ -601,21 +601,25 @@ void LoadAscii2::init() {
                   "filled with the read-in data and stored in the [[Analysis "
                   "Data Service]].");
 
-  std::string spacers[7][2] = {{"Automatic", ",\t:; "},
-                               {"CSV", ","},
-                               {"Tab", "\t"},
-                               {"Space", " "},
-                               {"Colon", ":"},
-                               {"SemiColon", ";"},
-                               {"UserDefined", "UserDefined"}};
+  const int numSpacers = 7;
+  std::string spacers[numSpacers][2] = {{"Automatic", ",\t:; "},
+                                        {"CSV", ","},
+                                        {"Tab", "\t"},
+                                        {"Space", " "},
+                                        {"Colon", ":"},
+                                        {"SemiColon", ";"},
+                                        {"UserDefined", "UserDefined"}};
   // For the ListValidator
-  std::vector<std::string> sepOptions;
-  for (auto &spacer : spacers) {
-    std::string option = spacer[0];
-    m_separatorIndex.insert(
-        std::pair<std::string, std::string>(option, spacer[1]));
-    sepOptions.push_back(option);
+  std::array<std::string, numSpacers> sepOptions;
+  int sepOptionsIndex = 0;
+
+  for (const auto &spacer : spacers) {
+	  const auto &option = spacer[0];
+	  m_separatorIndex.insert(
+		  std::pair<std::string, std::string>(option, spacer[1]));
+	  sepOptions[sepOptionsIndex++] = option;
   }
+
   declareProperty("Separator", "Automatic",
                   boost::make_shared<StringListValidator>(sepOptions),
                   "The separator between data columns in the data file. The "

--- a/Framework/DataHandling/src/LoadAscii2.cpp
+++ b/Framework/DataHandling/src/LoadAscii2.cpp
@@ -614,10 +614,10 @@ void LoadAscii2::init() {
   int sepOptionsIndex = 0;
 
   for (const auto &spacer : spacers) {
-	  const auto &option = spacer[0];
-	  m_separatorIndex.insert(
-		  std::pair<std::string, std::string>(option, spacer[1]));
-	  sepOptions[sepOptionsIndex++] = option;
+    const auto &option = spacer[0];
+    m_separatorIndex.insert(
+        std::pair<std::string, std::string>(option, spacer[1]));
+    sepOptions[sepOptionsIndex++] = option;
   }
 
   declareProperty("Separator", "Automatic",

--- a/Framework/DataHandling/src/LoadVulcanCalFile.cpp
+++ b/Framework/DataHandling/src/LoadVulcanCalFile.cpp
@@ -45,7 +45,7 @@ void LoadVulcanCalFile::init() {
                                                     FileProperty::Load, ".dat"),
                   "Path to the VULCAN offset file. ");
 
-  std::array<std::string, 3> groupoptions{"6Modules", "2Banks", "1Bank"};
+  std::array<std::string, 3> groupoptions = { {"6Modules", "2Banks", "1Bank"} };
 
   declareProperty(
       "Grouping", "6Modules",

--- a/Framework/DataHandling/src/LoadVulcanCalFile.cpp
+++ b/Framework/DataHandling/src/LoadVulcanCalFile.cpp
@@ -26,7 +26,6 @@ using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 
-
 namespace Mantid {
 namespace DataHandling {
 // Register the algorithm into the AlgorithmFactory
@@ -130,7 +129,7 @@ void LoadVulcanCalFile::processInOutProperites() {
   } else if (grouptypestr == "1Bank") {
     m_groupingType = VULCAN_OFFSET_STACK;
   } else {
-	  std::stringstream ess;
+    std::stringstream ess;
     ess << "Group type " << grouptypestr << " is not supported. ";
     throw std::runtime_error(ess.str());
   }
@@ -205,7 +204,7 @@ void LoadVulcanCalFile::processInOutProperites() {
   */
 void LoadVulcanCalFile::setupGroupingWorkspace() {
   // Get the right group option for CreateGroupingWorkspace
-	std::string groupdetby;
+  std::string groupdetby;
   switch (m_groupingType) {
   case VULCAN_OFFSET_BANK:
     groupdetby = "bank";
@@ -271,7 +270,7 @@ void LoadVulcanCalFile::setupMaskWorkspace() {
     boost::algorithm::trim(line);
     if (!line.empty()) {
       // Get the bad pixel's detector ID.  One per line
-		std::stringstream liness(line);
+      std::stringstream liness(line);
       try {
         int pixelid;
         liness >> pixelid;
@@ -305,7 +304,7 @@ void LoadVulcanCalFile::setupMaskWorkspace() {
 /** Generate offset workspace
   */
 void LoadVulcanCalFile::generateOffsetsWorkspace() {
-	std::map<detid_t, double> map_detoffset;
+  std::map<detid_t, double> map_detoffset;
 
   // Read offset file
   readOffsetFile(map_detoffset);
@@ -326,9 +325,9 @@ void LoadVulcanCalFile::generateOffsetsWorkspace() {
 void LoadVulcanCalFile::readOffsetFile(
     std::map<detid_t, double> &map_detoffset) {
   // Read file
-	std::ifstream infile(m_offsetFilename.c_str());
+  std::ifstream infile(m_offsetFilename.c_str());
   if (!infile.is_open()) {
-	  std::stringstream errss;
+    std::stringstream errss;
     errss << "Input offset file " << m_offsetFilename << " cannot be opened.";
     throw std::runtime_error(errss.str());
   }
@@ -377,11 +376,11 @@ void LoadVulcanCalFile::processOffsets(
       // Get bank ID from instrument tree
       const auto &det = spectrumInfo.detector(wsindex);
       Geometry::IComponent_const_sptr parent = det.getParent();
-	  std::string pname = parent->getName();
+      std::string pname = parent->getName();
 
-	  std::vector<std::string> terms;
+      std::vector<std::string> terms;
       boost::split(terms, pname, boost::is_any_of("("));
-	  std::vector<std::string> terms2;
+      std::vector<std::string> terms2;
       boost::split(terms2, terms[0], boost::is_any_of("bank"));
       int bank = std::stoi(terms2.back());
       set_bankID.insert(bank);
@@ -532,7 +531,8 @@ void LoadVulcanCalFile::convertOffsets() {
     // Get effective
     mfiter = m_effLTheta.find(bankid);
     if (mfiter == m_effLTheta.end())
-      throw std::runtime_error("Effective DIFC and 2theta information is missed. ");
+      throw std::runtime_error(
+          "Effective DIFC and 2theta information is missed. ");
 
     double effL = mfiter->second.first;
     double effTheta = mfiter->second.second;

--- a/Framework/DataHandling/src/LoadVulcanCalFile.cpp
+++ b/Framework/DataHandling/src/LoadVulcanCalFile.cpp
@@ -45,7 +45,7 @@ void LoadVulcanCalFile::init() {
                                                     FileProperty::Load, ".dat"),
                   "Path to the VULCAN offset file. ");
 
-  std::array<std::string, 3> groupoptions = { {"6Modules", "2Banks", "1Bank"} };
+  std::array<std::string, 3> groupoptions = {{"6Modules", "2Banks", "1Bank"}};
 
   declareProperty(
       "Grouping", "6Modules",

--- a/Framework/DataHandling/src/LoadVulcanCalFile.cpp
+++ b/Framework/DataHandling/src/LoadVulcanCalFile.cpp
@@ -26,7 +26,6 @@ using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 
-using namespace std;
 
 namespace Mantid {
 namespace DataHandling {
@@ -47,11 +46,11 @@ void LoadVulcanCalFile::init() {
                                                     FileProperty::Load, ".dat"),
                   "Path to the VULCAN offset file. ");
 
-  vector<string> groupoptions{"6Modules", "2Banks", "1Bank"};
+  std::array<std::string, 3> groupoptions{"6Modules", "2Banks", "1Bank"};
 
   declareProperty(
       "Grouping", "6Modules",
-      boost::make_shared<ListValidator<string>>(groupoptions),
+      boost::make_shared<ListValidator<std::string>>(groupoptions),
       "Choices to output group workspace for 1 bank, 2 banks or 6 modules. ");
 
   declareProperty(Kernel::make_unique<FileProperty>("BadPixelFilename", "",
@@ -114,7 +113,7 @@ void LoadVulcanCalFile::processInOutProperites() {
   m_offsetFilename = getPropertyValue("OffsetFilename");
   m_badPixFilename = getPropertyValue("BadPixelFilename");
 
-  string WorkspaceName = getPropertyValue("WorkspaceName");
+  std::string WorkspaceName = getPropertyValue("WorkspaceName");
   if (WorkspaceName.empty())
     throw std::invalid_argument("Must specify WorkspaceName.");
 
@@ -122,7 +121,7 @@ void LoadVulcanCalFile::processInOutProperites() {
   m_instrument = getInstrument();
 
   // Grouping
-  string grouptypestr = getPropertyValue("Grouping");
+  std::string grouptypestr = getPropertyValue("Grouping");
   size_t numeffbanks = 6;
   if (grouptypestr == "6Modules") {
     m_groupingType = VULCAN_OFFSET_BANK;
@@ -131,15 +130,15 @@ void LoadVulcanCalFile::processInOutProperites() {
   } else if (grouptypestr == "1Bank") {
     m_groupingType = VULCAN_OFFSET_STACK;
   } else {
-    stringstream ess;
+	  std::stringstream ess;
     ess << "Group type " << grouptypestr << " is not supported. ";
-    throw runtime_error(ess.str());
+    throw std::runtime_error(ess.str());
   }
 
   // Effective L and 2thetas
-  vector<int> vec_bankids = getProperty("BankIDs");
-  vector<double> vec_difcs = getProperty("EffectiveDIFCs");
-  vector<double> vec_2thetas = getProperty("Effective2Thetas");
+  std::vector<int> vec_bankids = getProperty("BankIDs");
+  std::vector<double> vec_difcs = getProperty("EffectiveDIFCs");
+  std::vector<double> vec_2thetas = getProperty("Effective2Thetas");
   if (vec_bankids.size() != numeffbanks || vec_difcs.size() != numeffbanks ||
       vec_2thetas.size() != numeffbanks) {
     std::stringstream ess;
@@ -147,7 +146,7 @@ void LoadVulcanCalFile::processInOutProperites() {
         << "), EffectiveDIFCs (" << vec_difcs.size()
         << ") and Effective2Thetas (" << vec_2thetas.size() << ") must be "
         << numeffbanks << " in mode '" << grouptypestr << "'! ";
-    throw runtime_error(ess.str());
+    throw std::runtime_error(ess.str());
   }
 
   for (size_t i = 0; i < numeffbanks; ++i) {
@@ -156,7 +155,7 @@ void LoadVulcanCalFile::processInOutProperites() {
     double theta = 0.5 * vec_2thetas[i];
     double effl = difc / (252.777 * 2.0 * sin(theta / 180. * M_PI));
 
-    m_effLTheta.emplace(bankid, make_pair(effl, theta));
+    m_effLTheta.emplace(bankid, std::make_pair(effl, theta));
   }
 
   // Create offset workspace
@@ -206,7 +205,7 @@ void LoadVulcanCalFile::processInOutProperites() {
   */
 void LoadVulcanCalFile::setupGroupingWorkspace() {
   // Get the right group option for CreateGroupingWorkspace
-  string groupdetby;
+	std::string groupdetby;
   switch (m_groupingType) {
   case VULCAN_OFFSET_BANK:
     groupdetby = "bank";
@@ -221,7 +220,7 @@ void LoadVulcanCalFile::setupGroupingWorkspace() {
     break;
 
   default:
-    throw runtime_error("Grouping type is not supported. ");
+    throw std::runtime_error("Grouping type is not supported. ");
     break;
   }
 
@@ -235,7 +234,7 @@ void LoadVulcanCalFile::setupGroupingWorkspace() {
 
   creategroupws->execute();
   if (!creategroupws->isExecuted())
-    throw runtime_error("Unable to create grouping workspace.");
+    throw std::runtime_error("Unable to create grouping workspace.");
 
   m_groupWS = creategroupws->getProperty("OutputWorkspace");
 
@@ -243,7 +242,7 @@ void LoadVulcanCalFile::setupGroupingWorkspace() {
   m_groupWS->setTitle(groupdetby);
 
   // Output
-  string WorkspaceName = getPropertyValue("WorkspaceName");
+  std::string WorkspaceName = getPropertyValue("WorkspaceName");
   declareProperty(Kernel::make_unique<WorkspaceProperty<GroupingWorkspace>>(
                       "OutputGroupingWorkspace", WorkspaceName + "_group",
                       Direction::Output),
@@ -267,12 +266,12 @@ void LoadVulcanCalFile::setupMaskWorkspace() {
     return;
   }
 
-  string line;
+  std::string line;
   while (std::getline(maskss, line)) {
     boost::algorithm::trim(line);
     if (!line.empty()) {
       // Get the bad pixel's detector ID.  One per line
-      stringstream liness(line);
+		std::stringstream liness(line);
       try {
         int pixelid;
         liness >> pixelid;
@@ -306,7 +305,7 @@ void LoadVulcanCalFile::setupMaskWorkspace() {
 /** Generate offset workspace
   */
 void LoadVulcanCalFile::generateOffsetsWorkspace() {
-  map<detid_t, double> map_detoffset;
+	std::map<detid_t, double> map_detoffset;
 
   // Read offset file
   readOffsetFile(map_detoffset);
@@ -327,14 +326,14 @@ void LoadVulcanCalFile::generateOffsetsWorkspace() {
 void LoadVulcanCalFile::readOffsetFile(
     std::map<detid_t, double> &map_detoffset) {
   // Read file
-  ifstream infile(m_offsetFilename.c_str());
+	std::ifstream infile(m_offsetFilename.c_str());
   if (!infile.is_open()) {
-    stringstream errss;
+	  std::stringstream errss;
     errss << "Input offset file " << m_offsetFilename << " cannot be opened.";
-    throw runtime_error(errss.str());
+    throw std::runtime_error(errss.str());
   }
 
-  string line;
+  std::string line;
   while (std::getline(infile, line)) {
     std::istringstream iss(line);
     int pid;
@@ -356,7 +355,7 @@ void LoadVulcanCalFile::processOffsets(
   const auto &spectrumInfo = m_tofOffsetsWS->spectrumInfo();
 
   // Map from Mantid instrument to VULCAN offset
-  map<detid_t, size_t> map_det2index;
+  std::map<detid_t, size_t> map_det2index;
   for (size_t i = 0; i < numspec; ++i) {
     detid_t tmpid = spectrumInfo.detector(i).getID();
 
@@ -366,34 +365,34 @@ void LoadVulcanCalFile::processOffsets(
 
   // Map from VULCAN offset to Mantid instrument: Validate
   std::set<int> set_bankID;
-  map<detid_t, pair<bool, int>>
+  std::map<detid_t, std::pair<bool, int>>
       map_verify; // key: detector ID, value: flag to have a match, bank ID
   for (auto &miter : map_detoffset) {
     detid_t pid = miter.first;
     auto fiter = map_det2index.find(pid);
     if (fiter == map_det2index.end()) {
-      map_verify.emplace(pid, make_pair(false, -1));
+      map_verify.emplace(pid, std::make_pair(false, -1));
     } else {
       size_t wsindex = fiter->second;
       // Get bank ID from instrument tree
       const auto &det = spectrumInfo.detector(wsindex);
       Geometry::IComponent_const_sptr parent = det.getParent();
-      string pname = parent->getName();
+	  std::string pname = parent->getName();
 
-      vector<string> terms;
+	  std::vector<std::string> terms;
       boost::split(terms, pname, boost::is_any_of("("));
-      vector<string> terms2;
+	  std::vector<std::string> terms2;
       boost::split(terms2, terms[0], boost::is_any_of("bank"));
       int bank = std::stoi(terms2.back());
       set_bankID.insert(bank);
 
-      map_verify.emplace(pid, make_pair(true, bank));
+      map_verify.emplace(pid, std::make_pair(true, bank));
     }
   }
 
   // Verify
   static const size_t arr[] = {21, 22, 23, 26, 27, 28};
-  vector<size_t> vec_banks(arr, arr + sizeof(arr) / sizeof(arr[0]));
+  std::vector<size_t> vec_banks(arr, arr + sizeof(arr) / sizeof(arr[0]));
 
   for (auto bankindex : vec_banks) {
     for (size_t j = 0; j < NUMBERDETECTORPERMODULE; ++j) {
@@ -401,21 +400,21 @@ void LoadVulcanCalFile::processOffsets(
           static_cast<detid_t>(bankindex * NUMBERRESERVEDPERMODULE + j);
       auto miter = map_verify.find(detindex);
       if (miter == map_verify.end())
-        throw runtime_error("It cannot happen!");
+        throw std::runtime_error("It cannot happen!");
       bool exist = miter->second.first;
       int tmpbank = miter->second.second;
       if (!exist)
-        throw runtime_error(
+        throw std::runtime_error(
             "Define VULCAN offset pixel is not defined in Mantid.");
       if (tmpbank != static_cast<int>(bankindex))
-        throw runtime_error("Bank ID does not match!");
+        throw std::runtime_error("Bank ID does not match!");
     }
   }
 
   // Get the global correction
   g_log.information() << "Number of bankds to process = " << set_bankID.size()
                       << "\n";
-  map<int, double> map_bankLogCorr;
+  std::map<int, double> map_bankLogCorr;
   for (const auto bankid : set_bankID) {
     // Locate inter bank and inter pack correction (log)
     double globalfactor = 0.;
@@ -430,7 +429,7 @@ void LoadVulcanCalFile::processOffsets(
 
       const auto offsetiter = map_detoffset.find(interbank_detid);
       if (offsetiter == map_detoffset.end())
-        throw runtime_error("It cannot happen!");
+        throw std::runtime_error("It cannot happen!");
       double interbanklogcorr = offsetiter->second;
 
       globalfactor += interbanklogcorr;
@@ -445,7 +444,7 @@ void LoadVulcanCalFile::processOffsets(
           static_cast<detid_t>((bankid + 1) * NUMBERRESERVEDPERMODULE) - 1;
       const auto offsetiter = map_detoffset.find(intermodule_detid);
       if (offsetiter == map_detoffset.end())
-        throw runtime_error("It cannot happen!");
+        throw std::runtime_error("It cannot happen!");
       double intermodulelogcorr = offsetiter->second;
 
       globalfactor += intermodulelogcorr;
@@ -455,19 +454,19 @@ void LoadVulcanCalFile::processOffsets(
   }
 
   // Calcualte the offset for each detector (log now still)
-  map<detid_t, double>::iterator offsetiter;
-  map<int, double>::iterator bankcorriter;
+  std::map<detid_t, double>::iterator offsetiter;
+  std::map<int, double>::iterator bankcorriter;
   for (size_t iws = 0; iws < numspec; ++iws) {
     detid_t detid = spectrumInfo.detector(iws).getID();
     offsetiter = map_detoffset.find(detid);
     if (offsetiter == map_detoffset.end())
-      throw runtime_error("It cannot happen!");
+      throw std::runtime_error("It cannot happen!");
 
     int bankid =
         static_cast<int>(detid) / static_cast<int>(NUMBERRESERVEDPERMODULE);
     bankcorriter = map_bankLogCorr.find(bankid);
     if (bankcorriter == map_bankLogCorr.end())
-      throw runtime_error("It cannot happen!");
+      throw std::runtime_error("It cannot happen!");
 
     double offset = offsetiter->second + bankcorriter->second;
     m_tofOffsetsWS->mutableY(iws)[0] = pow(10., offset);
@@ -481,7 +480,7 @@ void LoadVulcanCalFile::alignEventWorkspace() {
 
   size_t numberOfSpectra = m_eventWS->getNumberHistograms();
   if (numberOfSpectra != m_tofOffsetsWS->getNumberHistograms())
-    throw runtime_error("Number of histograms are different!");
+    throw std::runtime_error("Number of histograms are different!");
 
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int64_t i = 0; i < int64_t(numberOfSpectra); ++i) {
@@ -519,7 +518,7 @@ void LoadVulcanCalFile::convertOffsets() {
   const auto &spectrumInfo = m_tofOffsetsWS->spectrumInfo();
   double l1 = spectrumInfo.l1();
 
-  map<int, pair<double, double>>::iterator mfiter;
+  std::map<int, std::pair<double, double>>::iterator mfiter;
   for (size_t iws = 0; iws < numspec; ++iws) {
     // Get detector's information including bank belonged to and geometry
     // parameters
@@ -533,7 +532,7 @@ void LoadVulcanCalFile::convertOffsets() {
     // Get effective
     mfiter = m_effLTheta.find(bankid);
     if (mfiter == m_effLTheta.end())
-      throw runtime_error("Effective DIFC and 2theta information is missed. ");
+      throw std::runtime_error("Effective DIFC and 2theta information is missed. ");
 
     double effL = mfiter->second.first;
     double effTheta = mfiter->second.second;

--- a/Framework/DataHandling/src/PatchBBY.cpp
+++ b/Framework/DataHandling/src/PatchBBY.cpp
@@ -115,10 +115,7 @@ void PatchBBY::init() {
 
     case TYPE_STR:
       if (std::strcmp(itr->Name, "FrameSource") == 0) {
-        std::vector<std::string> keys;
-        keys.emplace_back("");
-        keys.emplace_back(EXTERNAL);
-        keys.emplace_back(INTERNAL);
+		std::array<std::string, 3> keys = {{"", EXTERNAL, INTERNAL}};
         declareProperty(
             Kernel::make_unique<Kernel::PropertyWithValue<std::string>>(
                 itr->Name, "",

--- a/Framework/DataHandling/src/PatchBBY.cpp
+++ b/Framework/DataHandling/src/PatchBBY.cpp
@@ -115,7 +115,7 @@ void PatchBBY::init() {
 
     case TYPE_STR:
       if (std::strcmp(itr->Name, "FrameSource") == 0) {
-		std::array<std::string, 3> keys = {{"", EXTERNAL, INTERNAL}};
+        std::array<std::string, 3> keys = {{"", EXTERNAL, INTERNAL}};
         declareProperty(
             Kernel::make_unique<Kernel::PropertyWithValue<std::string>>(
                 itr->Name, "",

--- a/Framework/DataHandling/src/SaveFITS.cpp
+++ b/Framework/DataHandling/src/SaveFITS.cpp
@@ -44,8 +44,8 @@ const std::string SaveFITS::g_FITSHdrRefComment2 =
 // extend this if we ever want to support 64 bits pixels
 const size_t SaveFITS::g_maxBitDepth = 32;
 // this has to have int type for the validator and getProperty
-const std::vector<int> SaveFITS::g_bitDepths{8, 16,
-                                             static_cast<int>(g_maxBitDepth)};
+const std::array<int, 3> SaveFITS::g_bitDepths{8, 16,
+                                               static_cast<int>(g_maxBitDepth)};
 const size_t SaveFITS::g_maxBytesPP = g_maxBitDepth / 8;
 
 using Mantid::Kernel::Direction;

--- a/Framework/DataHandling/src/SaveFITS.cpp
+++ b/Framework/DataHandling/src/SaveFITS.cpp
@@ -44,8 +44,8 @@ const std::string SaveFITS::g_FITSHdrRefComment2 =
 // extend this if we ever want to support 64 bits pixels
 const size_t SaveFITS::g_maxBitDepth = 32;
 // this has to have int type for the validator and getProperty
-const std::array<int, 3> SaveFITS::g_bitDepths 
-= { {8, 16, static_cast<int>(g_maxBitDepth)} };
+const std::array<int, 3> SaveFITS::g_bitDepths = {
+    {8, 16, static_cast<int>(g_maxBitDepth)}};
 const size_t SaveFITS::g_maxBytesPP = g_maxBitDepth / 8;
 
 using Mantid::Kernel::Direction;

--- a/Framework/DataHandling/src/SaveFITS.cpp
+++ b/Framework/DataHandling/src/SaveFITS.cpp
@@ -44,8 +44,8 @@ const std::string SaveFITS::g_FITSHdrRefComment2 =
 // extend this if we ever want to support 64 bits pixels
 const size_t SaveFITS::g_maxBitDepth = 32;
 // this has to have int type for the validator and getProperty
-const std::array<int, 3> SaveFITS::g_bitDepths{8, 16,
-                                               static_cast<int>(g_maxBitDepth)};
+const std::array<int, 3> SaveFITS::g_bitDepths 
+= { {8, 16, static_cast<int>(g_maxBitDepth)} };
 const size_t SaveFITS::g_maxBytesPP = g_maxBitDepth / 8;
 
 using Mantid::Kernel::Direction;

--- a/Framework/Kernel/inc/MantidKernel/ListValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/ListValidator.h
@@ -48,40 +48,12 @@ public:
   ListValidator() : TypedValidator<TYPE>(), m_allowMultiSelection(false) {}
 
   /** Constructor
-   *  @param values :: A set of values consisting of the valid values
-   *  @param allowMultiSelection :: True if the list allows multi selection
-   */
-  explicit ListValidator(const std::set<TYPE> &values,
-                         const bool allowMultiSelection = false)
-      : TypedValidator<TYPE>(), m_allowedValues(values.begin(), values.end()),
-        m_allowMultiSelection(allowMultiSelection) {
-    if (m_allowMultiSelection) {
-      throw Kernel::Exception::NotImplementedError(
-          "The List Validator does not support Multi selection yet");
-    }
-  }
-
-  /** Constructor
-   *  @param values :: An unordered set of values consisting of the valid values
-   *  @param allowMultiSelection :: True if the list allows multi selection
-   */
-  explicit ListValidator(const std::unordered_set<TYPE> &values,
-                         const bool allowMultiSelection = false)
-      : TypedValidator<TYPE>(), m_allowedValues(values.begin(), values.end()),
-        m_allowMultiSelection(allowMultiSelection) {
-    if (m_allowMultiSelection) {
-      throw Kernel::Exception::NotImplementedError(
-          "The List Validator does not support Multi selection yet");
-    }
-  }
-
-  /** Constructor
-   *  @param values :: An array of the valid values
+   *  @param values :: An iterable type of the valid values
    *  @param aliases :: Optional aliases for the valid values.
    *  @param allowMultiSelection :: True if the list allows multi selection
    */
-  template <std::size_t SIZE>
-  explicit ListValidator(const std::array<TYPE, SIZE> &values,
+  template <typename T>
+  explicit ListValidator(const T &values,
                          const std::map<std::string, std::string> &aliases =
                              std::map<std::string, std::string>(),
                          const bool allowMultiSelection = false)
@@ -104,33 +76,6 @@ public:
     }
   }
 
-  /** Constructor
-    *  @param values :: A vector of the valid values
-    *  @param aliases :: Optional aliases for the valid values.
-    *  @param allowMultiSelection :: True if the list allows multi selection
-    */
-  explicit ListValidator(const std::vector<TYPE> &values,
-                         const std::map<std::string, std::string> &aliases =
-                             std::map<std::string, std::string>(),
-                         const bool allowMultiSelection = false)
-      : TypedValidator<TYPE>(), m_allowedValues(values.begin(), values.end()),
-        m_aliases(aliases.begin(), aliases.end()),
-        m_allowMultiSelection(allowMultiSelection) {
-    for (auto aliasIt = m_aliases.begin(); aliasIt != m_aliases.end();
-         ++aliasIt) {
-      if (values.end() ==
-          std::find(values.begin(), values.end(),
-                    boost::lexical_cast<TYPE>(aliasIt->second))) {
-        throw std::invalid_argument("Alias " + aliasIt->first +
-                                    " refers to invalid value " +
-                                    aliasIt->second);
-        if (m_allowMultiSelection) {
-          throw Kernel::Exception::NotImplementedError(
-              "The List Validator does not support Multi selection yet");
-        }
-      }
-    }
-  }
   /// Clone the validator
   IValidator_sptr clone() const override {
     return boost::make_shared<ListValidator<TYPE>>(*this);

--- a/Framework/Kernel/inc/MantidKernel/ListValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/ListValidator.h
@@ -79,7 +79,7 @@ public:
    *  @param values :: An array of values containing the valid values
    *  @param allowMultiSelection :: True if the list allows multi selection
    */
-  template<std::size_t SIZE>
+  template <std::size_t SIZE>
   explicit ListValidator(const std::array<TYPE, SIZE> &values,
                          const bool allowMultiSelection = false)
       : TypedValidator<TYPE>(), m_allowedValues(values.begin(), values.end()),

--- a/Framework/Kernel/inc/MantidKernel/ListValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/ListValidator.h
@@ -1,16 +1,16 @@
 #ifndef MANTID_KERNEL_LISTVALIDATOR_H_
 #define MANTID_KERNEL_LISTVALIDATOR_H_
 
-#include "MantidKernel/TypedValidator.h"
 #include "MantidKernel/Exception.h"
+#include "MantidKernel/TypedValidator.h"
 #ifndef Q_MOC_RUN
 #include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
 #endif
-#include <vector>
-#include <set>
 #include <map>
+#include <set>
 #include <unordered_set>
+#include <vector>
 
 namespace Mantid {
 namespace Kernel {
@@ -76,25 +76,39 @@ public:
   }
 
   /** Constructor
-   *  @param values :: An array of values containing the valid values
+   *  @param values :: An array of the valid values
+   *  @param aliases :: Optional aliases for the valid values.
    *  @param allowMultiSelection :: True if the list allows multi selection
    */
   template <std::size_t SIZE>
   explicit ListValidator(const std::array<TYPE, SIZE> &values,
+                         const std::map<std::string, std::string> &aliases =
+                             std::map<std::string, std::string>(),
                          const bool allowMultiSelection = false)
       : TypedValidator<TYPE>(), m_allowedValues(values.begin(), values.end()),
+        m_aliases(aliases.begin(), aliases.end()),
         m_allowMultiSelection(allowMultiSelection) {
-    if (m_allowMultiSelection) {
-      throw Kernel::Exception::NotImplementedError(
-          "The List Validator does not support Multi selection yet");
+    for (auto aliasIt = m_aliases.begin(); aliasIt != m_aliases.end();
+         ++aliasIt) {
+      if (values.end() ==
+          std::find(values.begin(), values.end(),
+                    boost::lexical_cast<TYPE>(aliasIt->second))) {
+        throw std::invalid_argument("Alias " + aliasIt->first +
+                                    " refers to invalid value " +
+                                    aliasIt->second);
+        if (m_allowMultiSelection) {
+          throw Kernel::Exception::NotImplementedError(
+              "The List Validator does not support multi selection yet");
+        }
+      }
     }
   }
 
   /** Constructor
-   *  @param values :: A vector of the valid values
-   *  @param aliases :: Optional aliases for the valid values.
-   *  @param allowMultiSelection :: True if the list allows multi selection
-   */
+    *  @param values :: A vector of the valid values
+    *  @param aliases :: Optional aliases for the valid values.
+    *  @param allowMultiSelection :: True if the list allows multi selection
+    */
   explicit ListValidator(const std::vector<TYPE> &values,
                          const std::map<std::string, std::string> &aliases =
                              std::map<std::string, std::string>(),

--- a/Framework/Kernel/inc/MantidKernel/ListValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/ListValidator.h
@@ -76,6 +76,21 @@ public:
   }
 
   /** Constructor
+   *  @param values :: An array of values containing the valid values
+   *  @param allowMultiSelection :: True if the list allows multi selection
+   */
+  template<std::size_t SIZE>
+  explicit ListValidator(const std::array<TYPE, SIZE> &values,
+                         const bool allowMultiSelection = false)
+      : TypedValidator<TYPE>(), m_allowedValues(values.begin(), values.end()),
+        m_allowMultiSelection(allowMultiSelection) {
+    if (m_allowMultiSelection) {
+      throw Kernel::Exception::NotImplementedError(
+          "The List Validator does not support Multi selection yet");
+    }
+  }
+
+  /** Constructor
    *  @param values :: A vector of the valid values
    *  @param aliases :: Optional aliases for the valid values.
    *  @param allowMultiSelection :: True if the list allows multi selection

--- a/Framework/Kernel/inc/MantidKernel/ListValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/ListValidator.h
@@ -7,7 +7,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
 #endif
-#include <iterator>
 #include <map>
 #include <set>
 #include <unordered_set>
@@ -44,40 +43,6 @@ namespace Kernel {
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 template <typename TYPE> class ListValidator : public TypedValidator<TYPE> {
-private:
-	explicit ListValidator(
-		const std::iterator<std::forward_iterator_tag, TYPE> begin,
-		const std::iterator<std::forward_iterator_tag, TYPE> end,
-		const std::iterator<std::forward_iterator_tag,
-		                    std::pair<std::string, std::string>> aliasesBegin,
-		const std::iterator<std::foward_iterator_tag,
-		                    std::pair<std::string, std::string>> aliasesEnd,
-		const bool allowMultiSelection)
-		: m_aliases(aliasesBegin, aliasesEnd),
-		ListValidator<TYPE>(begin, end, allowMultiSelection) {
-		for (auto aliasIt = m_aliases.begin(); aliasIt != m_aliases.end();
-			++aliasIt) {
-			if (values.end() ==
-				std::find(values.begin(), values.end(),
-					boost::lexical_cast<TYPE>(aliasIt->second))) {
-				throw std::invalid_argument("Alias " + aliasIt->first +
-					" referes to invalid value " + aliasIt->second);
-			}
-		}
-	}
-		                 
-	explicit ListValidator(
-		const std::iterator<std::forward_iterator_tag, TYPE> begin, 
-		const std::iterator<std::forward_iterator_tag, TYPE> end,
-		const bool allowMultiSelection)
-		: TypedValidator<TYPE>(), m_allowedValues(begin, end),
-		m_allowMultiSelection(allowMultiSelection) {
-		if (m_allowMultiSelection) {
-			throw Kernel::Exception::NotImplementedError(
-				"The List Validator does not support multi selection yet");
-		}
-	}
-
 public:
   /// Default constructor. Sets up an empty list of valid values.
   ListValidator() : TypedValidator<TYPE>(), m_allowMultiSelection(false) {}
@@ -87,8 +52,14 @@ public:
    *  @param allowMultiSelection :: True if the list allows multi selection
    */
   explicit ListValidator(const std::set<TYPE> &values,
-	  const bool allowMultiSelection = false)
-	  : ListValidator<TYPE>(values.begin(), values.end(), allowMultiSelection) {}
+                         const bool allowMultiSelection = false)
+      : TypedValidator<TYPE>(), m_allowedValues(values.begin(), values.end()),
+        m_allowMultiSelection(allowMultiSelection) {
+    if (m_allowMultiSelection) {
+      throw Kernel::Exception::NotImplementedError(
+          "The List Validator does not support Multi selection yet");
+    }
+  }
 
   /** Constructor
    *  @param values :: An unordered set of values consisting of the valid values
@@ -96,7 +67,13 @@ public:
    */
   explicit ListValidator(const std::unordered_set<TYPE> &values,
                          const bool allowMultiSelection = false)
-	:  ListValidator<TYPE>(values.begin(), values.end(), allowMultiSelection) {}
+      : TypedValidator<TYPE>(), m_allowedValues(values.begin(), values.end()),
+        m_allowMultiSelection(allowMultiSelection) {
+    if (m_allowMultiSelection) {
+      throw Kernel::Exception::NotImplementedError(
+          "The List Validator does not support Multi selection yet");
+    }
+  }
 
   /** Constructor
    *  @param values :: An array of the valid values
@@ -108,8 +85,24 @@ public:
                          const std::map<std::string, std::string> &aliases =
                              std::map<std::string, std::string>(),
                          const bool allowMultiSelection = false)
-	    : ListValidator<TYPE>(values.begin(), values.end(), aliases.begin(),
-			                  aliases.end(), allowMultiSelection) {}
+      : TypedValidator<TYPE>(), m_allowedValues(values.begin(), values.end()),
+        m_aliases(aliases.begin(), aliases.end()),
+        m_allowMultiSelection(allowMultiSelection) {
+    for (auto aliasIt = m_aliases.begin(); aliasIt != m_aliases.end();
+         ++aliasIt) {
+      if (values.end() ==
+          std::find(values.begin(), values.end(),
+                    boost::lexical_cast<TYPE>(aliasIt->second))) {
+        throw std::invalid_argument("Alias " + aliasIt->first +
+                                    " refers to invalid value " +
+                                    aliasIt->second);
+        if (m_allowMultiSelection) {
+          throw Kernel::Exception::NotImplementedError(
+              "The List Validator does not support multi selection yet");
+        }
+      }
+    }
+  }
 
   /** Constructor
     *  @param values :: A vector of the valid values
@@ -120,14 +113,28 @@ public:
                          const std::map<std::string, std::string> &aliases =
                              std::map<std::string, std::string>(),
                          const bool allowMultiSelection = false)
-	  : ListValidator<TYPE>(values.begin(), values.end(), aliases.begin(),
-		  aliases.end(), allowMultiSelection) {}
-
+      : TypedValidator<TYPE>(), m_allowedValues(values.begin(), values.end()),
+        m_aliases(aliases.begin(), aliases.end()),
+        m_allowMultiSelection(allowMultiSelection) {
+    for (auto aliasIt = m_aliases.begin(); aliasIt != m_aliases.end();
+         ++aliasIt) {
+      if (values.end() ==
+          std::find(values.begin(), values.end(),
+                    boost::lexical_cast<TYPE>(aliasIt->second))) {
+        throw std::invalid_argument("Alias " + aliasIt->first +
+                                    " refers to invalid value " +
+                                    aliasIt->second);
+        if (m_allowMultiSelection) {
+          throw Kernel::Exception::NotImplementedError(
+              "The List Validator does not support Multi selection yet");
+        }
+      }
+    }
+  }
   /// Clone the validator
   IValidator_sptr clone() const override {
     return boost::make_shared<ListValidator<TYPE>>(*this);
   }
-
   /**
    * Returns the set of allowed values currently defined
    * @returns A set of allowed values that this validator will currently allow
@@ -242,7 +249,7 @@ protected:
   /// if the validator should allow multiple selection
   bool m_allowMultiSelection;
 };
-}
+
 /// ListValidator<std::string> is used heavily
 typedef ListValidator<std::string> StringListValidator;
 

--- a/Framework/Kernel/inc/MantidKernel/StartsWithValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/StartsWithValidator.h
@@ -40,6 +40,8 @@ public:
   StartsWithValidator() = default;
   StartsWithValidator(const std::vector<std::string> &values);
   StartsWithValidator(const std::set<std::string> &values);
+  template<std::size_t SIZE>
+  StartsWithValidator(const std::array<std::string, SIZE> &values);
   IValidator_sptr clone() const override;
 
 protected:

--- a/Framework/Kernel/inc/MantidKernel/StartsWithValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/StartsWithValidator.h
@@ -41,15 +41,15 @@ public:
   StartsWithValidator(const std::vector<std::string> &values);
   StartsWithValidator(const std::set<std::string> &values);
   IValidator_sptr clone() const override;
-  
+
   /**
    * Constructor
    * @param values :: An array with the allowed values
    */
-  template<std::size_t SIZE>
+  template <std::size_t SIZE>
   StartsWithValidator(const std::array<std::string, SIZE> &values)
-    : Kernel::StringListValidator(values) {}
-  
+      : Kernel::StringListValidator(values) {}
+
 protected:
   std::string checkValidity(const std::string &value) const override;
 };

--- a/Framework/Kernel/inc/MantidKernel/StartsWithValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/StartsWithValidator.h
@@ -40,10 +40,16 @@ public:
   StartsWithValidator() = default;
   StartsWithValidator(const std::vector<std::string> &values);
   StartsWithValidator(const std::set<std::string> &values);
-  template<std::size_t SIZE>
-  StartsWithValidator(const std::array<std::string, SIZE> &values);
   IValidator_sptr clone() const override;
-
+  
+  /**
+   * Constructor
+   * @param values :: An array with the allowed values
+   */
+  template<std::size_t SIZE>
+  StartsWithValidator(const std::array<std::string, SIZE> &values)
+    : Kernel::StringListValidator(values) {}
+  
 protected:
   std::string checkValidity(const std::string &value) const override;
 };

--- a/Framework/Kernel/src/StartsWithValidator.cpp
+++ b/Framework/Kernel/src/StartsWithValidator.cpp
@@ -18,6 +18,16 @@ StartsWithValidator::StartsWithValidator(const std::vector<std::string> &values)
  */
 StartsWithValidator::StartsWithValidator(const std::set<std::string> &values)
     : Kernel::StringListValidator(values) {}
+
+/**
+ * Constructor
+ * @param values :: An array with the allowed values
+ */
+template<size_t SIZE>
+StartsWithValidator::StartsWithValidator(
+	const std::array<std::string, SIZE> &values)
+	: Kernel::StringListValidator(values) {}
+
 /// Clone the validator
 IValidator_sptr StartsWithValidator::clone() const {
   return boost::make_shared<StartsWithValidator>(*this);

--- a/Framework/Kernel/src/StartsWithValidator.cpp
+++ b/Framework/Kernel/src/StartsWithValidator.cpp
@@ -19,15 +19,6 @@ StartsWithValidator::StartsWithValidator(const std::vector<std::string> &values)
 StartsWithValidator::StartsWithValidator(const std::set<std::string> &values)
     : Kernel::StringListValidator(values) {}
 
-/**
- * Constructor
- * @param values :: An array with the allowed values
- */
-template<size_t SIZE>
-StartsWithValidator::StartsWithValidator(
-	const std::array<std::string, SIZE> &values)
-	: Kernel::StringListValidator(values) {}
-
 /// Clone the validator
 IValidator_sptr StartsWithValidator::clone() const {
   return boost::make_shared<StartsWithValidator>(*this);

--- a/Framework/Kernel/test/ListValidatorTest.h
+++ b/Framework/Kernel/test/ListValidatorTest.h
@@ -20,6 +20,12 @@ public:
     TS_ASSERT_EQUALS(v.allowedValues().size(), 3)
   }
 
+  void testArrayConstructor() {
+	  std::array<int, 3> arr{ 1, 2, 3 };
+	  ListValidator<int> v(arr);
+	  TS_ASSERT_EQUALS(v.allowedValues().size(), 3)
+  }
+
   void testIsValid() {
     StringListValidator v;
     TS_ASSERT_EQUALS(v.isValid(""), "Select a value")

--- a/Framework/Kernel/test/ListValidatorTest.h
+++ b/Framework/Kernel/test/ListValidatorTest.h
@@ -21,9 +21,9 @@ public:
   }
 
   void testArrayConstructor() {
-	  std::array<int, 3> arr{ 1, 2, 3 };
-	  ListValidator<int> v(arr);
-	  TS_ASSERT_EQUALS(v.allowedValues().size(), 3)
+    std::array<int, 3> arr{1, 2, 3};
+    ListValidator<int> v(arr);
+    TS_ASSERT_EQUALS(v.allowedValues().size(), 3)
   }
 
   void testIsValid() {

--- a/Framework/Kernel/test/ListValidatorTest.h
+++ b/Framework/Kernel/test/ListValidatorTest.h
@@ -21,7 +21,7 @@ public:
   }
 
   void testArrayConstructor() {
-    std::array<int, 3> arr{1, 2, 3};
+    std::array<int, 3> arr = {{1, 2, 3}};
     ListValidator<int> v(arr);
     TS_ASSERT_EQUALS(v.allowedValues().size(), 3)
   }

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -643,7 +643,7 @@ public:
 
   void test_string_property_alias() {
     // system("pause");
-    std::vector<std::string> allowedValues{"Hello", "World"};
+    std::array<std::string, 2> allowedValues{"Hello", "World"};
     std::map<std::string, std::string> alias{{"1", "Hello"}, {"0", "World"}};
     auto validator =
         boost::make_shared<ListValidator<std::string>>(allowedValues, alias);

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -643,7 +643,7 @@ public:
 
   void test_string_property_alias() {
     // system("pause");
-	  std::array<std::string, 2> allowedValues = { {"Hello", "World"} };
+    std::array<std::string, 2> allowedValues = {{"Hello", "World"}};
     std::map<std::string, std::string> alias{{"1", "Hello"}, {"0", "World"}};
     auto validator =
         boost::make_shared<ListValidator<std::string>>(allowedValues, alias);

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -643,7 +643,7 @@ public:
 
   void test_string_property_alias() {
     // system("pause");
-	std::array<std::string, 2> allowedValues = { {"Hello", "World"} };
+    std::array<std::string, 2> allowedValues = {{"Hello", "World"}};
     std::map<std::string, std::string> alias{{"1", "Hello"}, {"0", "World"}};
     auto validator =
         boost::make_shared<ListValidator<std::string>>(allowedValues, alias);

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -643,7 +643,7 @@ public:
 
   void test_string_property_alias() {
     // system("pause");
-    std::array<std::string, 2> allowedValues{"Hello", "World"};
+	std::array<std::string, 2> allowedValues = { {"Hello", "World"} };
     std::map<std::string, std::string> alias{{"1", "Hello"}, {"0", "World"}};
     auto validator =
         boost::make_shared<ListValidator<std::string>>(allowedValues, alias);

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -643,7 +643,7 @@ public:
 
   void test_string_property_alias() {
     // system("pause");
-    std::array<std::string, 2> allowedValues = {{"Hello", "World"}};
+    std::array<std::string, 2> allowedValues = {"Hello", "World"};
     std::map<std::string, std::string> alias{{"1", "Hello"}, {"0", "World"}};
     auto validator =
         boost::make_shared<ListValidator<std::string>>(allowedValues, alias);

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -643,7 +643,7 @@ public:
 
   void test_string_property_alias() {
     // system("pause");
-    std::array<std::string, 2> allowedValues = {"Hello", "World"};
+	  std::array<std::string, 2> allowedValues = { {"Hello", "World"} };
     std::map<std::string, std::string> alias{{"1", "Hello"}, {"0", "World"}};
     auto validator =
         boost::make_shared<ListValidator<std::string>>(allowedValues, alias);

--- a/Framework/Kernel/test/StartsWithValidatorTest.h
+++ b/Framework/Kernel/test/StartsWithValidatorTest.h
@@ -21,9 +21,9 @@ public:
   }
 
   void testArrayConstructor() {
-	  std::array<std::string, 3> arr{ "one", "two", "three" };
-	  StartsWithValidator v(arr);
-	  TS_ASSERT_EQUALS(v.allowedValues().size(), 3);
+    std::array<std::string, 3> arr{"one", "two", "three"};
+    StartsWithValidator v(arr);
+    TS_ASSERT_EQUALS(v.allowedValues().size(), 3);
   }
 
   void testIsValid() {

--- a/Framework/Kernel/test/StartsWithValidatorTest.h
+++ b/Framework/Kernel/test/StartsWithValidatorTest.h
@@ -20,6 +20,12 @@ public:
     TS_ASSERT_EQUALS(v.allowedValues().size(), 3)
   }
 
+  void testArrayConstructor() {
+	  std::array<std::string, 3> arr{ "one", "two", "three" };
+	  StartsWithValidator v(arr);
+	  TS_ASSERT_EQUALS(v.allowedValues().size(), 3);
+  }
+
   void testIsValid() {
     StartsWithValidator v;
     TS_ASSERT_EQUALS(v.isValid(""), "Select a value")

--- a/Framework/Kernel/test/StartsWithValidatorTest.h
+++ b/Framework/Kernel/test/StartsWithValidatorTest.h
@@ -21,7 +21,7 @@ public:
   }
 
   void testArrayConstructor() {
-    std::array<std::string, 3> arr{"one", "two", "three"};
+	std::array<std::string, 3> arr = { {"one", "two", "three"} };
     StartsWithValidator v(arr);
     TS_ASSERT_EQUALS(v.allowedValues().size(), 3);
   }

--- a/Framework/Kernel/test/StartsWithValidatorTest.h
+++ b/Framework/Kernel/test/StartsWithValidatorTest.h
@@ -21,7 +21,7 @@ public:
   }
 
   void testArrayConstructor() {
-	std::array<std::string, 3> arr = { {"one", "two", "three"} };
+    std::array<std::string, 3> arr = {{"one", "two", "three"}};
     StartsWithValidator v(arr);
     TS_ASSERT_EQUALS(v.allowedValues().size(), 3);
   }

--- a/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
@@ -50,8 +50,8 @@ void ConvertCWPDMDToSpectra::init() {
                       "OutputWorkspace", "", Direction::Output),
                   "Name of the output workspace for reduced data.");
 
-  std::array<std::string, 3> vecunits{"2theta", "dSpacing",
-                                      "Momentum Transfer (Q)"};
+  std::array<std::string, 3> vecunits = { {"2theta", "dSpacing",
+									       "Momentum Transfer (Q)"} };
   auto unitval = boost::make_shared<ListValidator<std::string>>(vecunits);
   declareProperty("UnitOutput", "2theta", unitval,
                   "Unit of the output workspace.");

--- a/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
@@ -50,8 +50,8 @@ void ConvertCWPDMDToSpectra::init() {
                       "OutputWorkspace", "", Direction::Output),
                   "Name of the output workspace for reduced data.");
 
-  std::array<std::string, 3> vecunits = { {"2theta", "dSpacing",
-									       "Momentum Transfer (Q)"} };
+  std::array<std::string, 3> vecunits = {
+      {"2theta", "dSpacing", "Momentum Transfer (Q)"}};
   auto unitval = boost::make_shared<ListValidator<std::string>>(vecunits);
   declareProperty("UnitOutput", "2theta", unitval,
                   "Unit of the output workspace.");

--- a/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
@@ -50,8 +50,8 @@ void ConvertCWPDMDToSpectra::init() {
                       "OutputWorkspace", "", Direction::Output),
                   "Name of the output workspace for reduced data.");
 
-  std::vector<std::string> vecunits{"2theta", "dSpacing",
-                                    "Momentum Transfer (Q)"};
+  std::array<std::string, 3> vecunits{"2theta", "dSpacing",
+                                      "Momentum Transfer (Q)"};
   auto unitval = boost::make_shared<ListValidator<std::string>>(vecunits);
   declareProperty("UnitOutput", "2theta", unitval,
                   "Unit of the output workspace.");

--- a/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
@@ -98,10 +98,9 @@ void ConvertMDHistoToMatrixWorkspace::init() {
                                                    Direction::Output),
                   "An output Workspace2D.");
 
-  std::vector<std::string> normalizations(3);
-  normalizations[0] = "NoNormalization";
-  normalizations[1] = "VolumeNormalization";
-  normalizations[2] = "NumEventsNormalization";
+  std::array<std::string, 3> normalizations({ "NoNormalization",
+											  "VolumeNormalization",
+											  "NumEventsNormalization" });
 
   declareProperty("Normalization", normalizations[0],
                   Kernel::IValidator_sptr(

--- a/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
@@ -98,8 +98,8 @@ void ConvertMDHistoToMatrixWorkspace::init() {
                                                    Direction::Output),
                   "An output Workspace2D.");
 
-  std::array<std::string, 3> normalizations =
-  { {"NoNormalization", "VolumeNormalization", "NumEventsNormalization"} };
+  std::array<std::string, 3> normalizations = {
+      {"NoNormalization", "VolumeNormalization", "NumEventsNormalization"}};
 
   declareProperty("Normalization", normalizations[0],
                   Kernel::IValidator_sptr(

--- a/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
@@ -98,8 +98,8 @@ void ConvertMDHistoToMatrixWorkspace::init() {
                                                    Direction::Output),
                   "An output Workspace2D.");
 
-  std::array<std::string, 3> normalizations(
-      {"NoNormalization", "VolumeNormalization", "NumEventsNormalization"});
+  std::array<std::string, 3> normalizations =
+  { {"NoNormalization", "VolumeNormalization", "NumEventsNormalization"} };
 
   declareProperty("Normalization", normalizations[0],
                   Kernel::IValidator_sptr(

--- a/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
@@ -98,9 +98,8 @@ void ConvertMDHistoToMatrixWorkspace::init() {
                                                    Direction::Output),
                   "An output Workspace2D.");
 
-  std::array<std::string, 3> normalizations({ "NoNormalization",
-											  "VolumeNormalization",
-											  "NumEventsNormalization" });
+  std::array<std::string, 3> normalizations(
+      {"NoNormalization", "VolumeNormalization", "NumEventsNormalization"});
 
   declareProperty("Normalization", normalizations[0],
                   Kernel::IValidator_sptr(

--- a/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
@@ -49,7 +49,7 @@ void ConvertSpiceDataToRealSpace::init() {
                   "input RunInfoWorkspace.");
 
   /// TODO - Add HB2B as it is implemented in future
-  std::vector<std::string> allowedinstruments{"HB2A"};
+  std::array<std::string, 1> allowedinstruments{"HB2A"};
   auto instrumentvalidator =
       boost::make_shared<ListValidator<std::string>>(allowedinstruments);
   declareProperty("Instrument", "HB2A", instrumentvalidator,

--- a/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
@@ -49,7 +49,7 @@ void ConvertSpiceDataToRealSpace::init() {
                   "input RunInfoWorkspace.");
 
   /// TODO - Add HB2B as it is implemented in future
-  std::array<std::string, 1> allowedinstruments{"HB2A"};
+  std::array<std::string, 1> allowedinstruments = { {"HB2A"} };
   auto instrumentvalidator =
       boost::make_shared<ListValidator<std::string>>(allowedinstruments);
   declareProperty("Instrument", "HB2A", instrumentvalidator,

--- a/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
@@ -49,7 +49,7 @@ void ConvertSpiceDataToRealSpace::init() {
                   "input RunInfoWorkspace.");
 
   /// TODO - Add HB2B as it is implemented in future
-  std::array<std::string, 1> allowedinstruments = { {"HB2A"} };
+  std::array<std::string, 1> allowedinstruments = {{"HB2A"}};
   auto instrumentvalidator =
       boost::make_shared<ListValidator<std::string>>(allowedinstruments);
   declareProperty("Instrument", "HB2A", instrumentvalidator,

--- a/Framework/MDAlgorithms/src/GetSpiceDataRawCountsFromMD.cpp
+++ b/Framework/MDAlgorithms/src/GetSpiceDataRawCountsFromMD.cpp
@@ -40,7 +40,7 @@ void GetSpiceDataRawCountsFromMD::init() {
                                                       Direction::Output),
       "Name of the output MatrixWorkspace containing the raw data required.");
 
-  std::array<std::string, 3> vecmode = { {"Pt.", "Detector", "Sample Log"} };
+  std::array<std::string, 3> vecmode = {{"Pt.", "Detector", "Sample Log"}};
   auto modevalidator = boost::make_shared<ListValidator<std::string>>(vecmode);
   declareProperty(
       "Mode", "Detector", modevalidator,

--- a/Framework/MDAlgorithms/src/GetSpiceDataRawCountsFromMD.cpp
+++ b/Framework/MDAlgorithms/src/GetSpiceDataRawCountsFromMD.cpp
@@ -40,7 +40,7 @@ void GetSpiceDataRawCountsFromMD::init() {
                                                       Direction::Output),
       "Name of the output MatrixWorkspace containing the raw data required.");
 
-  std::vector<std::string> vecmode{"Pt.", "Detector", "Sample Log"};
+  std::array<std::string, 3> vecmode{"Pt.", "Detector", "Sample Log"};
   auto modevalidator = boost::make_shared<ListValidator<std::string>>(vecmode);
   declareProperty(
       "Mode", "Detector", modevalidator,

--- a/Framework/MDAlgorithms/src/GetSpiceDataRawCountsFromMD.cpp
+++ b/Framework/MDAlgorithms/src/GetSpiceDataRawCountsFromMD.cpp
@@ -40,7 +40,7 @@ void GetSpiceDataRawCountsFromMD::init() {
                                                       Direction::Output),
       "Name of the output MatrixWorkspace containing the raw data required.");
 
-  std::array<std::string, 3> vecmode{"Pt.", "Detector", "Sample Log"};
+  std::array<std::string, 3> vecmode = { {"Pt.", "Detector", "Sample Log"} };
   auto modevalidator = boost::make_shared<ListValidator<std::string>>(vecmode);
   declareProperty(
       "Mode", "Detector", modevalidator,

--- a/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -426,7 +426,7 @@ void SmoothMD::init() {
           Direction::Input),
       docBuffer.str());
 
-  std::array<std::string, 1> unitOptions = {"pixels"};
+  std::array<std::string, 1> unitOptions = { {"pixels"} };
 
   std::stringstream docUnits;
   docUnits << "The units that WidthVector has been specified in. Allowed "

--- a/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -50,17 +50,6 @@ typedef std::map<std::string, SmoothFunction> SmoothFunctionMap;
 namespace {
 
 /**
- * @brief functions
- * @return Allowed smoothing functions
- */
-std::vector<std::string> functions() {
-  std::vector<std::string> propOptions;
-  propOptions.push_back("Hat");
-  propOptions.push_back("Gaussian");
-  return propOptions;
-}
-
-/**
  * Maps a function name to a smoothing function
  * @return function map
  */
@@ -414,7 +403,7 @@ void SmoothMD::init() {
       "dimension, or provide a single entry (n-pixels) for all "
       "dimensions. Must be odd integers if Hat function is chosen.");
 
-  const auto allFunctionTypes = functions();
+  const std::array<std::string, 2> allFunctionTypes = {{"Hat", "Gaussian"}};
   const std::string first = allFunctionTypes.front();
 
   std::stringstream docBuffer;

--- a/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -426,7 +426,7 @@ void SmoothMD::init() {
           Direction::Input),
       docBuffer.str());
 
-  std::array<std::string, 1> unitOptions = { {"pixels"} };
+  std::array<std::string, 1> unitOptions = {{"pixels"}};
 
   std::stringstream docUnits;
   docUnits << "The units that WidthVector has been specified in. Allowed "

--- a/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -426,7 +426,7 @@ void SmoothMD::init() {
           Direction::Input),
       docBuffer.str());
 
-  std::vector<std::string> unitOptions = {"pixels"};
+  std::array<std::string, 1> unitOptions = {"pixels"};
 
   std::stringstream docUnits;
   docUnits << "The units that WidthVector has been specified in. Allowed "


### PR DESCRIPTION
Added a constructor to `ListValidator` to accept `std::array`, and changed many occurences of this pattern:
```
std::vector<std::string> options {foo, bar, baz};
boost::make_shared<ListValidator<std::string>>(options)
```
to this pattern:
```
std::array<std::string, 3> options {foo, bar, baz};
boost::make_shared<ListValidator<std::string>>(options)
```

The compiler doesn't have to worry about dynamic allocation, so can allocate memory on the stack, saving some time.

Some minor refactoring also took place, where use `using namespace std` was removed

**To test:**

Code review, and make sure all the unit tests for Framework still pass. In particular, I think all the possible occurences of the first pattern have been replaced, but if you come across any that I've missed then shout

Fixes #20101 

**Release Notes** 
*Does not need to be in the release notes, as the change is internal*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
