### PR TITLE
Fix Python 3 MantidPlot build for <= v3.4 

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PythonSystemHeader.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PythonSystemHeader.h
@@ -22,7 +22,6 @@
 #define TO_CSTRING _PyUnicode_AsString
 #define FROM_CSTRING PyUnicode_FromString
 #define CODE_OBJECT(x) x
-#define GET_CURRENT_THREADSTATE _PyThreadState_UncheckedGet()
 #else
 #define INT_CHECK PyInt_Check
 #define TO_LONG PyInt_AsLong
@@ -30,7 +29,6 @@
 #define TO_CSTRING PyString_AsString
 #define FROM_CSTRING PyString_FromString
 #define CODE_OBJECT(x) (PyCodeObject *) x
-#define GET_CURRENT_THREADSTATE _PyThreadState_Current
 #endif
 
 #endif // PYTHONSYSTEMHEADER_H_

--- a/qt/widgets/common/src/PythonThreading.cpp
+++ b/qt/widgets/common/src/PythonThreading.cpp
@@ -31,8 +31,12 @@ void PythonInterpreter::finalize() { Py_Finalize(); }
  * @return True if the current thread holds the GIL, false otherwise
  */
 bool PythonGIL::locked() {
-  PyThreadState *ts = GET_CURRENT_THREADSTATE;
+#if PY_VERSION_HEX < 0x03000000
+  PyThreadState *ts = _PyThreadState_Current;
   return (ts && ts == PyGILState_GetThisThreadState());
+#else
+  return (PyGILState_Check() == 1);
+#endif
 }
 
 /**


### PR DESCRIPTION
Description of work.

In #20464 an internal Python function was used that is only available in versions >= 3.5. This replaces that with a function available in all Python 3 versions.

**To test:**

Code review

*No issue*

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
