### PR TITLE
Use IntegateEPP in ComputeCalibrationCoefVan

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeCalibrationCoefVan.py
@@ -125,50 +125,27 @@ class ComputeCalibrationCoefVan(PythonAlgorithm):
         outws_name = self.getPropertyValue("OutputWorkspace")
         eppws = self.getProperty("EPPTable").value
         nhist = self.vanaws.getNumberHistograms()
-        prog_reporter = Progress(self, start=0.0, end=1.0, nreports=nhist+1)
+        prog_reporter = Progress(self, start=0.8, end=1.0, nreports=3)
 
+
+        integrate = self.createChildAlgorithm("IntegrateEPP", startProgress=0.0, endProgress=0.8, enableLogging=False)
+        integrate.setProperty("InputWorkspace", self.vanaws)
+        integrate.setProperty("OutputWorkspace", "__unused_for_child")
+        integrate.setProperty("EPPWorkspace", eppws)
+        width = 3. * 2. * np.sqrt(2. * np.log(2.))
+        integrate.setProperty("HalfWidthInSigmas", width)
+        integrate.execute()
+        prog_reporter.report("Computing DWFs")
+        outws = integrate.getProperty("OutputWorkspace").value
         # calculate array of Debye-Waller factors
+        prog_reporter.report("Applying DWFs")
         dwf = self.calculate_dwf()
-
-        # for each detector: fit gaussian to get peak_centre and fwhm
-        # sum data in the range [peak_centre - 3*fwhm, peak_centre + 3*fwhm]
-        dataX = self.vanaws.readX(0)
-        coefY = np.zeros(nhist)
-        coefE = np.zeros(nhist)
-        peak_centre = eppws.column('PeakCentre')
-        sigma = eppws.column('Sigma')
-
-        specInfo = self.vanaws.spectrumInfo()
         for idx in range(nhist):
-            prog_reporter.report("Setting %dth spectrum" % idx)
-            dataY = self.vanaws.readY(idx)
-            if np.max(dataY) == 0 or specInfo.isMasked(idx):
-                coefY[idx] = 0.
-                coefE[idx] = 0.
-            else:
-                dataE = self.vanaws.readE(idx)
-                fwhm = sigma[idx]*2.*np.sqrt(2.*np.log(2.))
-                idxmin = (np.fabs(dataX-peak_centre[idx]+3.*fwhm)).argmin()
-                idxmax = (np.fabs(dataX-peak_centre[idx]-3.*fwhm)).argmin()
-                coefY[idx] = sum(dataY[idxmin:idxmax+1])/dwf[idx]
-                coefE[idx] = np.sqrt(sum(
-                    np.square(dataE[idxmin:idxmax+1])))/dwf[idx]
-
-        # create X array, X data are the same for all detectors, so
-        coefX = np.zeros(nhist)
-        coefX.fill(dataX[0])
-
-        create = self.createChildAlgorithm("CreateWorkspace")
-        create.setPropertyValue('OutputWorkspace', outws_name)
-        create.setProperty('ParentWorkspace', self.vanaws)
-        create.setProperty('DataX', coefX)
-        create.setProperty('DataY', coefY)
-        create.setProperty('DataE', coefE)
-        create.setProperty('NSpec', nhist)
-        create.setProperty('UnitX', 'TOF')
-        create.execute()
-        outws = create.getProperty('OutputWorkspace').value
-
+            ys = outws.dataY(idx)
+            ys /= dwf[idx]
+            es = outws.dataE(idx)
+            es /= dwf[idx]
+        prog_reporter.report("Done")
         self.setProperty("OutputWorkspace", outws)
 
     def get_detID_offset(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ComputeCalibrationCoefVanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ComputeCalibrationCoefVanTest.py
@@ -22,6 +22,10 @@ class ComputeCalibrationCoefVanTest(unittest.TestCase):
         self._table = FindEPP(input_ws, OutputWorkspace="table")
         AddSampleLog(self._input_ws, LogName='wavelength', LogText='4.0',
                      LogType='Number', LogUnit='Angstrom')
+        # These ranges correspond to 6*FWHM of the gaussian above,
+        # the integration ranges of ComputeCalibrationCoefVan.
+        self._lowerBoundRange = slice(28, 73)
+        self._upperBoundRange = slice(27, 74)
 
     def test_output(self):
         outputWorkspaceName = "output_ws"
@@ -52,11 +56,12 @@ class ComputeCalibrationCoefVanTest(unittest.TestCase):
         self.assertTrue(alg_test.isExecuted())
         wsoutput = AnalysisDataService.retrieve(outputWorkspaceName)
 
-        # check whether sum is calculated correctly, for theta=0, dwf=1
-        y_sumMin = np.sum(self._input_ws.readY(0)[28:73])
-        y_sumMax = np.sum(self._input_ws.readY(0)[27:74])
-        e_sumMin = np.sqrt(np.sum(np.square(self._input_ws.readE(0)[28:73])))
-        e_sumMax = np.sqrt(np.sum(np.square(self._input_ws.readE(0)[27:74])))
+        # Check whether the sum is calculated correctly, for theta=0, dwf=1
+        # The result should be somewhere between the full bin sums.
+        y_sumMin = np.sum(self._input_ws.readY(0)[self._lowerBoundRange])
+        y_sumMax = np.sum(self._input_ws.readY(0)[self._upperBoundRange])
+        e_sumMin = np.sqrt(np.sum(np.square(self._input_ws.readE(0)[self._lowerBoundRange])))
+        e_sumMax = np.sqrt(np.sum(np.square(self._input_ws.readE(0)[self._upperBoundRange])))
         self.assertLess(y_sumMin, wsoutput.readY(0)[0])
         self.assertGreater(y_sumMax, wsoutput.readY(0)[0])
         self.assertLess(e_sumMin, wsoutput.readE(0)[0])
@@ -140,10 +145,10 @@ class ComputeCalibrationCoefVanTest(unittest.TestCase):
         else:
             raise RuntimeError("Unsupported temperature supplied to " +
                                "_checkDWF(). Use 0K or 293K only.")
-        y_sumMin = np.sum(self._input_ws.readY(1)[28:73])
-        y_sumMax = np.sum(self._input_ws.readY(1)[27:74])
-        e_sumMin = np.sqrt(np.sum(np.square(self._input_ws.readE(1)[28:73])))
-        e_sumMax = np.sqrt(np.sum(np.square(self._input_ws.readE(1)[27:74])))
+        y_sumMin = np.sum(self._input_ws.readY(1)[self._lowerBoundRange])
+        y_sumMax = np.sum(self._input_ws.readY(1)[self._upperBoundRange])
+        e_sumMin = np.sqrt(np.sum(np.square(self._input_ws.readE(1)[self._lowerBoundRange])))
+        e_sumMax = np.sqrt(np.sum(np.square(self._input_ws.readE(1)[self._upperBoundRange])))
         mvan = 0.001*50.942/N_A
         Bcoef = 3.0*integral*1e+20*hbar*hbar/(2.0*mvan*k*389.0)
         dwf = np.exp(

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ComputeCalibrationCoefVanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ComputeCalibrationCoefVanTest.py
@@ -53,10 +53,14 @@ class ComputeCalibrationCoefVanTest(unittest.TestCase):
         wsoutput = AnalysisDataService.retrieve(outputWorkspaceName)
 
         # check whether sum is calculated correctly, for theta=0, dwf=1
-        y_sum = sum(self._input_ws.readY(0)[27:75])
-        e_sum = np.sqrt(sum(np.square(self._input_ws.readE(0)[27:75])))
-        self.assertAlmostEqual(y_sum, wsoutput.readY(0)[0])
-        self.assertAlmostEqual(e_sum, wsoutput.readE(0)[0])
+        y_sumMin = np.sum(self._input_ws.readY(0)[28:73])
+        y_sumMax = np.sum(self._input_ws.readY(0)[27:74])
+        e_sumMin = np.sqrt(np.sum(np.square(self._input_ws.readE(0)[28:73])))
+        e_sumMax = np.sqrt(np.sum(np.square(self._input_ws.readE(0)[27:74])))
+        self.assertLess(y_sumMin, wsoutput.readY(0)[0])
+        self.assertGreater(y_sumMax, wsoutput.readY(0)[0])
+        self.assertLess(e_sumMin, wsoutput.readE(0)[0])
+        self.assertGreater(e_sumMax, wsoutput.readE(0)[0])
 
         DeleteWorkspace(wsoutput)
 
@@ -136,14 +140,18 @@ class ComputeCalibrationCoefVanTest(unittest.TestCase):
         else:
             raise RuntimeError("Unsupported temperature supplied to " +
                                "_checkDWF(). Use 0K or 293K only.")
-        y_sum = sum(self._input_ws.readY(1)[27:75])
-        e_sum = np.sqrt(sum(np.square(self._input_ws.readE(1)[27:75])))
+        y_sumMin = np.sum(self._input_ws.readY(1)[28:73])
+        y_sumMax = np.sum(self._input_ws.readY(1)[27:74])
+        e_sumMin = np.sqrt(np.sum(np.square(self._input_ws.readE(1)[28:73])))
+        e_sumMax = np.sqrt(np.sum(np.square(self._input_ws.readE(1)[27:74])))
         mvan = 0.001*50.942/N_A
         Bcoef = 3.0*integral*1e+20*hbar*hbar/(2.0*mvan*k*389.0)
         dwf = np.exp(
             -1.0*Bcoef*(4.0*np.pi*np.sin(0.5*np.radians(15.0))/4.0)**2)
-        self.assertAlmostEqual(y_sum/dwf, wsoutput.readY(1)[0])
-        self.assertAlmostEqual(e_sum/dwf, wsoutput.readE(1)[0])
+        self.assertLess(y_sumMin/dwf, wsoutput.readY(1)[0])
+        self.assertGreater(y_sumMax/dwf, wsoutput.readY(1)[0])
+        self.assertLess(e_sumMin/dwf, wsoutput.readE(1)[0])
+        self.assertGreater(e_sumMax/dwf, wsoutput.readE(1)[0])
 
 
 if __name__ == "__main__":

--- a/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
+++ b/docs/source/algorithms/ComputeCalibrationCoefVan-v1.rst
@@ -61,6 +61,8 @@ Restrictions for *EPPTable*:
 Usage
 -----
 
+.. include:: ../usagedata-note.txt
+
 **Example**
 
 .. testcode:: ExComputeCalibrationCoefVan
@@ -82,9 +84,9 @@ Output:
 
 .. testoutput:: ExComputeCalibrationCoefVan
 
-    Spectrum 4 of the output workspace is filled with:  6897.0
+    Spectrum 4 of the output workspace is filled with:  6895.0
     Spectrum 4 of the input workspace is filled with:  1.0
-    Spectrum 4 of the corrected workspace is filled with:  0.00014
+    Spectrum 4 of the corrected workspace is filled with:  0.00015
 
 .. categories::
 

--- a/docs/source/release/v3.11.0/direct_inelastic.rst
+++ b/docs/source/release/v3.11.0/direct_inelastic.rst
@@ -16,10 +16,14 @@ Algorithms
 
 `Full list of changes on GitHub <http://github.com/mantidproject/mantid/pulls?q=is%3Apr+milestone%3A%22Release+3.11%22+is%3Amerged+label%3A%22Component%3A+Direct+Inelastic%22>`_
 
+Improvements
+------------
+
 Algorithms
 ##########
 
 - A bug was fixed in :ref:`DPDFReduction <algm-DPDFReduction>` to comply with the signature of one of the underlying C-functions.
+- :ref:`algm-ComputeCalibrationCoefVan` uses :ref:`algm-IntegrateEPP` as its backend instead of manual summation when integrating the vanadium peak.
 
 Other changes
 #############


### PR DESCRIPTION
[`ComputeCalibrationCoefVan`](http://docs.mantidproject.org/nightly/algorithms/ComputeCalibrationCoefVan-v1.html) was doing manual summation when integrating the reference (vanadium) workspace. This PR changes the algorithm to use [`IntegrateEPP`](http://docs.mantidproject.org/nightly/algorithms/IntegrateEPP-v1.html) instead, thus standardizing the integration method (`IntegrateEPP` uses `Integration`) and improving performance. `IntegrateEPP` also handles the integration limits in a more precise manner than what was done in `ComputeCalibrationCoefVan` before.

**To test:**

Code review. One could run the following script before and after applying these changes to check the `norm_coefs` are roughly the same (they won't be exactly because the different integration range handling).
```python
# The next line needs user intervention.
ws = Load('<mantid_build_directory>/ExternalData/Testing/Data/UnitTest/ILL/IN4/084446.nxs')

epps = FindEPP(ws)

ComputeCalibrationCoefVan(VanadiumWorkspace=ws, OutputWorkspace='norm_coefs', Temperature=1011.0, EPPTable=epps)
```

Close #20472.

**Release Notes** 

*Direct inelastic spectrometry release notes were updated accordingly.*


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
