### PR TITLE
Fix locale issues with Mantid Tables

### DIFF
--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -92,7 +92,7 @@ public:
   }
 
   /// Read in from stream and set the value at the given index
-  virtual void read(const size_t index, std::istream &in) {
+  virtual void read(const size_t index, std::istringstream &in) {
     UNUSED_ARG(index)
     UNUSED_ARG(in)
   }

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
@@ -42,7 +42,7 @@ public:
   void read(size_t index, const std::string &text) override;
 
   /// Sets item from a stream
-  void read(const size_t index, std::istream &in) override;
+  void read(const size_t index, std::istringstream &in) override;
 
   /// Specialized type check
   bool isBool() const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -123,7 +123,7 @@ public:
   /// Read in a string and set the value at the given index
   void read(size_t index, const std::string &text) override;
   /// Read in from stream and set the value at the given index
-  void read(const size_t index, std::istream &in) override;
+  void read(const size_t index, std::istringstream &in) override;
   /// Type check
   bool isBool() const override { return typeid(Type) == typeid(API::Boolean); }
   /// Memory used by the column
@@ -245,6 +245,17 @@ inline void TableColumn<std::string>::read(size_t index,
   m_data[index] = text;
 }
 
+/// Template specialization for strings so they can contain spaces
+template <>
+inline void TableColumn<std::string>::read(size_t index,
+                                           std::istringstream &text) {
+  /* As opposed to other types, assigning strings via a stream does not work if
+   * it contains a whitespace character, so instead the assignment operator is
+   * used.
+   */
+  m_data[index] = text.str();
+}
+
 /// Read in a string and set the value at the given index
 template <typename Type>
 void TableColumn<Type>::read(size_t index, const std::string &text) {
@@ -254,8 +265,10 @@ void TableColumn<Type>::read(size_t index, const std::string &text) {
 
 /// Read in from stream and set the value at the given index
 template <typename Type>
-void TableColumn<Type>::read(size_t index, std::istream &in) {
-  in >> m_data[index];
+void TableColumn<Type>::read(size_t index, std::istringstream &in) {
+  Type t;
+  in >> t;
+  m_data[index] = t;
 }
 
 namespace {

--- a/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
@@ -93,7 +93,7 @@ public:
   }
 
   /// Set item from a stream
-  void read(const size_t index, std::istream &in) override {
+  void read(const size_t index, std::istringstream &in) override {
     std::string s;
     in >> s;
     read(index, s);

--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -5,6 +5,7 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/MultiThreaded.h"
 
+#include <boost/algorithm/string.hpp>
 #include <boost/variant/get.hpp>
 
 using namespace Mantid::Kernel;
@@ -184,7 +185,7 @@ void PeakColumn::read(size_t index, const std::string &text) {
  * @param index :: index of the peak to modify
  * @param in :: input stream
  */
-void PeakColumn::read(const size_t index, std::istream &in) {
+void PeakColumn::read(const size_t index, std::istringstream &in) {
   if (this->getReadOnly() || index >= m_peaks.size())
     return;
 

--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -5,7 +5,6 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/MultiThreaded.h"
 
-#include <boost/algorithm/string.hpp>
 #include <boost/variant/get.hpp>
 
 using namespace Mantid::Kernel;

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -2591,9 +2591,10 @@ void ConfigDialog::apply() {
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
     QList<MdiSubWindow *> windows = app->windowsList();
     foreach (MdiSubWindow *w, windows) {
+      auto oldLocale = w->locale();
       w->setLocale(locale);
       if (auto table = dynamic_cast<Table *>(w))
-        table->updateDecimalSeparators();
+        table->updateDecimalSeparators(oldLocale);
       else if (auto matrix = dynamic_cast<Matrix *>(w))
         matrix->resetView();
     }

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -105,7 +105,7 @@ void MantidTable::fillTable() {
     Mantid::API::Column_sptr c = m_ws->getColumn(static_cast<int>(i));
     QString colName = QString::fromStdString(c->name());
     setColName(i, colName);
-    if (c->type() == "str") {
+    if (c->type() == "str" || c->type() == "V3D") {
       setColumnType(i, ColType::Text);
     }
     // Make columns of ITableWorkspaces read only, if specified
@@ -285,35 +285,37 @@ void MantidTable::cellEdited(int row, int col) {
     return;
   }
 
-  QString oldText = d_table->text(row, col);
-  Mantid::API::Column_sptr c = m_ws->getColumn(col);
+  const int index = row;
+
+  auto oldText = d_table->text(row, col);
+  auto c = m_ws->getColumn(col);
 
   if (c->type() != "str") {
     oldText.remove(QRegExp("\\s"));
   }
 
-  const std::string text = oldText.toStdString();
+  if (c->type() == "str" || c->type() == "V3D") {
+      std::istringstream textStream(oldText.toStdString());
+      c->read(index, textStream);
+  } else {
+      // We must be dealing with numerical data. Since there semms to be no way
+      // convert between QLocale and std::locale, get the number out 
+      // of the Qt locale and put it into default std::locale format.
+      // so we can pass it to the workspace.
+      
+      // First convert locale formatted string to native type
+      QTextStream qstream(&oldText);
+      qstream.setLocale(locale());
+      double number;
+      qstream >> number;
 
-  // Have the column convert the text to a value internally
-  int index = row;
-  std::istringstream textStream(text);
-  const auto localName = locale().name().toStdString();
-  std::locale applicationLocale(localName.c_str());
-  textStream.imbue(applicationLocale);
-  c->read(index, textStream);
-
-  // Set the table view to be the same text after editing.
-  // That way, if the string was stupid, it will be reset to the old value.
-  std::ostringstream s;
-  s.imbue(applicationLocale);
-
-  // Avoid losing precision for numeric data
-  if (c->type() == "double") {
-    s.precision(std::numeric_limits<double>::max_digits10);
+      // Put it back in the stream and let the column deduce the correct
+      // type of the number.
+      std::stringstream textStream;
+      textStream << number;
+      std::istringstream stream(textStream.str());
+      c->read(index, stream);
   }
-  c->print(index, s);
-
-  d_table->setText(row, col, QString::fromStdString(s.str()));
 }
 
 //------------------------------------------------------------------------------------------------

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -295,26 +295,26 @@ void MantidTable::cellEdited(int row, int col) {
   }
 
   if (c->type() == "str" || c->type() == "V3D") {
-      std::istringstream textStream(oldText.toStdString());
-      c->read(index, textStream);
+    std::istringstream textStream(oldText.toStdString());
+    c->read(index, textStream);
   } else {
-      // We must be dealing with numerical data. Since there semms to be no way
-      // convert between QLocale and std::locale, get the number out 
-      // of the Qt locale and put it into default std::locale format.
-      // so we can pass it to the workspace.
-      
-      // First convert locale formatted string to native type
-      QTextStream qstream(&oldText);
-      qstream.setLocale(locale());
-      double number;
-      qstream >> number;
+    // We must be dealing with numerical data. Since there semms to be no way
+    // convert between QLocale and std::locale, get the number out
+    // of the Qt locale and put it into default std::locale format.
+    // so we can pass it to the workspace.
 
-      // Put it back in the stream and let the column deduce the correct
-      // type of the number.
-      std::stringstream textStream;
-      textStream << number;
-      std::istringstream stream(textStream.str());
-      c->read(index, stream);
+    // First convert locale formatted string to native type
+    QTextStream qstream(&oldText);
+    qstream.setLocale(locale());
+    double number;
+    qstream >> number;
+
+    // Put it back in the stream and let the column deduce the correct
+    // type of the number.
+    std::stringstream textStream;
+    textStream << number;
+    std::istringstream stream(textStream.str());
+    c->read(index, stream);
   }
 }
 

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -298,7 +298,7 @@ void MantidTable::cellEdited(int row, int col) {
   int index = row;
   std::istringstream textStream(text);
   const auto localName = locale().name().toStdString();
-  std::locale applicationLocale(localName);
+  std::locale applicationLocale(localName.c_str());
   textStream.imbue(applicationLocale);
   c->read(index, textStream);
 

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -105,6 +105,9 @@ void MantidTable::fillTable() {
     Mantid::API::Column_sptr c = m_ws->getColumn(static_cast<int>(i));
     QString colName = QString::fromStdString(c->name());
     setColName(i, colName);
+    if (c->type() == "str") {
+      setColumnType(i, ColType::Text);
+    }
     // Make columns of ITableWorkspaces read only, if specified
     setReadOnlyColumn(i, c->getReadOnly());
 
@@ -294,14 +297,14 @@ void MantidTable::cellEdited(int row, int col) {
   // Have the column convert the text to a value internally
   int index = row;
   std::istringstream textStream(text);
-  const std::locale systemLocale("");
-  textStream.imbue(systemLocale);
-  c->read(index, textStream.str());
+  const std::locale applicationLocale(locale().name().toStdString());
+  textStream.imbue(applicationLocale);
+  c->read(index, textStream);
 
   // Set the table view to be the same text after editing.
   // That way, if the string was stupid, it will be reset to the old value.
   std::ostringstream s;
-  s.imbue(systemLocale);
+  s.imbue(applicationLocale);
 
   // Avoid losing precision for numeric data
   if (c->type() == "double") {

--- a/MantidPlot/src/Mantid/MantidTable.cpp
+++ b/MantidPlot/src/Mantid/MantidTable.cpp
@@ -297,7 +297,8 @@ void MantidTable::cellEdited(int row, int col) {
   // Have the column convert the text to a value internally
   int index = row;
   std::istringstream textStream(text);
-  const std::locale applicationLocale(locale().name().toStdString());
+  const auto localName = locale().name().toStdString();
+  std::locale applicationLocale(localName);
   textStream.imbue(applicationLocale);
   c->read(index, textStream);
 


### PR DESCRIPTION
PR #20401 Fixed truncation issues with table workspaces but reintroduced issues with locales into Mantid. This PR should hopefully fix both.

**To test:**

Here's script to produce a table workspace. Make sure the "hello world" does not get truncated at the first space or converted to a 0.

Change your locale to something that isn't english and check the data is displayed correctly.

```python
ws = CreateEmptyTableWorkspace()
ws.addColumn("str", "value")
ws.addColumn("double", "v")
ws.addColumn("int", "v2")
ws.addColumn("V3D", "v3")
ws.addColumn("double", "v4")
ws.addRow(["hello world", 1000000.0, 123, V3D(0,1,0), 3.14159])
```

_There is no issue associated with this PR_

**Release Notes** 
*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [x] Do changes function as described? Add comments below that describe the tests performed?
- [x] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
