### PR TITLE
Add a friendly type name string for OptionalBool

### DIFF
--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -3,6 +3,7 @@
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/IPropertySettings.h"
+#include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/PropertyHistory.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/TimeSeriesProperty.h"
@@ -343,6 +344,8 @@ std::string getUnmangledTypeName(const std::type_info &type) {
     typestrings.emplace(typeid(std::vector<double>).name(), string("dbl list"));
     typestrings.emplace(typeid(std::vector<std::vector<string>>).name(),
                         string("list of str lists"));
+    typestrings.emplace(typeid(OptionalBool).name(),
+                        string("optional boolean"));
 
     // Workspaces
     typestrings.emplace(typeid(boost::shared_ptr<Workspace>).name(),

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -38,26 +38,31 @@ public:
   void testConstructor() {
     // Test that all the base class member variables are correctly assigned to
     TS_ASSERT(!iProp->name().compare("intProp"));
+    TS_ASSERT(!iProp->type().compare("number"));
     TS_ASSERT(!iProp->documentation().compare(""));
     TS_ASSERT(typeid(int) == *iProp->type_info());
     TS_ASSERT(iProp->isDefault());
 
     TS_ASSERT(!dProp->name().compare("doubleProp"));
+    TS_ASSERT(!dProp->type().compare("number"));
     TS_ASSERT(!dProp->documentation().compare(""));
     TS_ASSERT(typeid(double) == *dProp->type_info());
     TS_ASSERT(dProp->isDefault());
 
     TS_ASSERT(!sProp->name().compare("stringProp"));
+    TS_ASSERT(!sProp->type().compare("string"));
     TS_ASSERT(!sProp->documentation().compare(""));
     TS_ASSERT(typeid(std::string) == *sProp->type_info());
     TS_ASSERT(sProp->isDefault());
 
     TS_ASSERT(!lProp->name().compare("int64Prop"));
+    TS_ASSERT(!lProp->type().compare("number"));
     TS_ASSERT(!lProp->documentation().compare(""));
     TS_ASSERT(typeid(int64_t) == *lProp->type_info());
     TS_ASSERT(lProp->isDefault());
 
     TS_ASSERT(!bProp->name().compare("boolProp"));
+    TS_ASSERT(!bProp->type().compare("optional boolean"));
     TS_ASSERT(!bProp->documentation().compare(""));
     TS_ASSERT(typeid(OptionalBool) == *bProp->type_info());
     TS_ASSERT(bProp->isDefault());

--- a/docs/source/release/v3.11.0/framework.rst
+++ b/docs/source/release/v3.11.0/framework.rst
@@ -86,6 +86,7 @@ Bug fixes
 #########
 
 - :ref:`CubicSpline <func-CubicSpline>` is fixed to sort the y-values and x-values correctly.
+- Fix displayed type name for optional boolean properties.
 
 Improved
 ########


### PR DESCRIPTION
Adds an unmanged type name string for `OptionalBool` properties.

**To test:**

- Run `[p.type for p in AlgorithmManager.create('LoadInstrument').getProperties()]` in the IPython interpreter, see that the `OptionalBool` property has a nice, unmangled name
- Build the docs and check the parameter type of the `RewriteSpectraMap` property of the `LoadInstrument` algorithm

Fixes #20488. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
