### PR TITLE
Fix WorkspaceFactory create when axis size different from parent

### DIFF
--- a/Framework/API/inc/MantidAPI/WorkspaceFactory.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceFactory.h
@@ -79,12 +79,10 @@ public:
                               const size_t &YLength) const;
 
   void initializeFromParent(const MatrixWorkspace &parent,
-                            MatrixWorkspace &child,
-                            const bool differentSize) const;
+                            MatrixWorkspace &child) const;
 
   void initializeFromParentWithoutLogs(const MatrixWorkspace &parent,
-                                       MatrixWorkspace &child,
-                                       const bool differentSize) const;
+                                       MatrixWorkspace &child) const;
 
   /// Create a ITableWorkspace
   boost::shared_ptr<ITableWorkspace>

--- a/Framework/API/test/WorkspaceFactoryTest.h
+++ b/Framework/API/test/WorkspaceFactoryTest.h
@@ -66,8 +66,7 @@ public:
 #endif
   }
 
-  /** Make a parent, have the child be created with the same sizes */
-  void testCreateFromParent() {
+  void testCreateFromParent1D() {
     MatrixWorkspace_sptr ws_child(new Workspace1DTest);
     ws_child->initialize(3, 1, 1);
     ws_child->getSpectrum(0).setSpectrumNo(123);
@@ -113,7 +112,9 @@ public:
     // Monitor workspace
     TSM_ASSERT("The workspace factory should not propagate a monitor workspace",
                !child->monitorWorkspace());
+  }
 
+  void testCreateFromParent2D() {
     MatrixWorkspace_sptr ws2D(new Workspace2DTest);
     ws2D->initialize(3, 1, 1);
     MatrixWorkspace_sptr child2;
@@ -121,9 +122,23 @@ public:
                                  WorkspaceFactory::Instance().create(ws2D));
     TS_ASSERT(child2);
     TS_ASSERT_EQUALS(child2->id(), "Workspace2DTest");
+  }
 
+  void testCreateFromParent2DNumVectorsDiffers() {
+    MatrixWorkspace_sptr ws2D(new Workspace2DTest);
+    ws2D->initialize(3, 1, 1);
+    MatrixWorkspace_sptr child2;
+    TS_ASSERT_THROWS_NOTHING(child2 =
+                                 WorkspaceFactory::Instance().create(ws2D, 5));
+    TS_ASSERT(child2);
+    TS_ASSERT_EQUALS(child2->id(), "Workspace2DTest");
+    TS_ASSERT_EQUALS(child2->getAxis(1)->length(), 5);
+  }
+
+  void testCreateFromParentFailsWhenParentNotInFactory() {
     MatrixWorkspace_sptr nif(new NotInFactory);
     nif->initialize(1, 1, 1);
+    MatrixWorkspace_sptr child;
     TS_ASSERT_THROWS(child = WorkspaceFactory::Instance().create(nif),
                      std::runtime_error);
   }

--- a/Framework/Algorithms/src/CalculateEfficiency.cpp
+++ b/Framework/Algorithms/src/CalculateEfficiency.cpp
@@ -103,7 +103,7 @@ void CalculateEfficiency::exec() {
   rebinnedWS = childAlg->getProperty("OutputWorkspace");
 
   outputWS = WorkspaceFactory::Instance().create(rebinnedWS);
-  WorkspaceFactory::Instance().initializeFromParent(*inputWS, *outputWS, false);
+  WorkspaceFactory::Instance().initializeFromParent(*inputWS, *outputWS);
   for (int i = 0; i < static_cast<int>(rebinnedWS->getNumberHistograms());
        i++) {
     outputWS->setSharedX(i, rebinnedWS->sharedX(i));

--- a/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
+++ b/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
@@ -106,8 +106,7 @@ void FindCenterOfMassPosition2::exec() {
     algo->execute();
 
     inputWS = algo->getProperty("OutputWorkspace");
-    WorkspaceFactory::Instance().initializeFromParent(*inputWSWvl, *inputWS,
-                                                      false);
+    WorkspaceFactory::Instance().initializeFromParent(*inputWSWvl, *inputWS);
   } else {
     // Sum up all the wavelength bins
     IAlgorithm_sptr childAlg = createChildAlgorithm("Integration");

--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -380,7 +380,7 @@ MatrixWorkspace_sptr Integration::getOutputWorkspace(MatrixWorkspace_sptr inWS,
   if (inWS->id() == "RebinnedOutput") {
     MatrixWorkspace_sptr outWS = API::WorkspaceFactory::Instance().create(
         "Workspace2D", maxSpec - minSpec + 1, 2, 1);
-    API::WorkspaceFactory::Instance().initializeFromParent(*inWS, *outWS, true);
+    API::WorkspaceFactory::Instance().initializeFromParent(*inWS, *outWS);
     return outWS;
   } else {
     return API::WorkspaceFactory::Instance().create(inWS, maxSpec - minSpec + 1,

--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -622,7 +622,7 @@ void SmoothNeighbours::execWorkspace2D() {
   setupNewInstrument(outWS);
 
   // Copy geometry over.
-  // API::WorkspaceFactory::Instance().initializeFromParent(inWS, outWS, false);
+  // API::WorkspaceFactory::Instance().initializeFromParent(inWS, outWS);
 
   // Go through all the output workspace
   PARALLEL_FOR_IF(Kernel::threadSafe(*inWS, *outWS))
@@ -689,7 +689,7 @@ void SmoothNeighbours::execWorkspace2D() {
   */
 void SmoothNeighbours::setupNewInstrument(MatrixWorkspace_sptr outws) {
   // Copy geometry over.
-  API::WorkspaceFactory::Instance().initializeFromParent(*inWS, *outws, false);
+  API::WorkspaceFactory::Instance().initializeFromParent(*inWS, *outws);
 
   // Go through all the output workspace
   size_t numberOfSpectra = outws->getNumberHistograms();
@@ -730,7 +730,7 @@ void SmoothNeighbours::spreadPixels(MatrixWorkspace_sptr outws) {
   }
 
   // Copy geometry over.
-  API::WorkspaceFactory::Instance().initializeFromParent(*inWS, *outws2, false);
+  API::WorkspaceFactory::Instance().initializeFromParent(*inWS, *outws2);
   // Go through all the input workspace
   for (int outWIi = 0; outWIi < int(numberOfSpectra); outWIi++) {
     const auto &inSpec = inWS->getSpectrum(outWIi);
@@ -769,7 +769,7 @@ void SmoothNeighbours::execEvent(Mantid::DataObjects::EventWorkspace_sptr ws) {
       API::WorkspaceFactory::Instance().create(
           "EventWorkspace", numberOfSpectra, YLength + 1, YLength));
   // Copy geometry over.
-  API::WorkspaceFactory::Instance().initializeFromParent(*ws, *outWS, false);
+  API::WorkspaceFactory::Instance().initializeFromParent(*ws, *outWS);
   // Ensure thread-safety
   outWS->sortAll(TOF_SORT, nullptr);
 

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -40,7 +40,7 @@ MatrixWorkspace_sptr WorkspaceJoiners::execWS2D(const MatrixWorkspace &ws1,
       "Workspace2D", totalHists, ws1.x(0).size(), ws1.y(0).size());
   // Copy over stuff from first input workspace. This will include the spectrum
   // masking
-  WorkspaceFactory::Instance().initializeFromParent(ws1, *output, true);
+  WorkspaceFactory::Instance().initializeFromParent(ws1, *output);
 
   // Create the X values inside a cow pointer - they will be shared in the
   // output workspace

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -95,8 +95,7 @@ void PeakIntegration::exec() {
   outputW = API::WorkspaceFactory::Instance().create(
       inputW, peaksW->getNumberPeaks(), YLength + 1, YLength);
   // Copy geometry over.
-  API::WorkspaceFactory::Instance().initializeFromParent(*inputW, *outputW,
-                                                         true);
+  API::WorkspaceFactory::Instance().initializeFromParent(*inputW, *outputW);
   size_t Numberwi = inputW->getNumberHistograms();
   int NumberPeaks = peaksW->getNumberPeaks();
   int MinPeaks = 0;

--- a/Framework/DataHandling/src/CompressEvents.cpp
+++ b/Framework/DataHandling/src/CompressEvents.cpp
@@ -61,8 +61,7 @@ void CompressEvents::exec() {
         API::WorkspaceFactory::Instance().create(
             "EventWorkspace", inputWS->getNumberHistograms(), 2, 1));
     // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(*inputWS, *outputWS,
-                                                           false);
+    API::WorkspaceFactory::Instance().initializeFromParent(*inputWS, *outputWS);
     // We DONT copy the data though
     // Loop over the histograms (detector spectra)
     tbb::parallel_for(tbb::blocked_range<size_t>(0, noSpectra),

--- a/Framework/DataHandling/src/EventWorkspaceCollection.cpp
+++ b/Framework/DataHandling/src/EventWorkspaceCollection.cpp
@@ -227,7 +227,7 @@ size_t EventWorkspaceCollection::getNumberEvents() const {
 void EventWorkspaceCollection::resizeTo(const size_t size) {
   for (auto &ws : m_WsVec) {
     auto tmp = createWorkspace<DataObjects::EventWorkspace>(size, 2, 1);
-    WorkspaceFactory::Instance().initializeFromParent(*ws, *tmp, true);
+    WorkspaceFactory::Instance().initializeFromParent(*ws, *tmp);
     ws = std::move(tmp);
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i)
       ws->getSpectrum(i).setSpectrumNo(static_cast<specnum_t>(i + 1));

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -595,7 +595,7 @@ FilterEventsByLogValuePreNexus::setupOutputEventWorkspace() {
   if (!this->m_spectraList.empty())
     nSpec = this->m_spectraList.size();
   auto ws = createWorkspace<EventWorkspace>(nSpec, 2, 1);
-  WorkspaceFactory::Instance().initializeFromParent(*tempworkspace, *ws, true);
+  WorkspaceFactory::Instance().initializeFromParent(*tempworkspace, *ws);
 
   return ws;
 }

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -368,7 +368,7 @@ void GroupDetectors2::execEvent() {
           "EventWorkspace", m_GroupWsInds.size() + numUnGrouped,
           inputWS->x(0).size(), inputWS->blocksize()));
   // Copy geometry over.
-  WorkspaceFactory::Instance().initializeFromParent(*inputWS, *outputWS, true);
+  WorkspaceFactory::Instance().initializeFromParent(*inputWS, *outputWS);
 
   // prepare to move the requested histograms into groups, first estimate how
   // long for progress reporting. +1 in the demonator gets rid of any divide by

--- a/Framework/DataHandling/src/LoadEmptyInstrument.cpp
+++ b/Framework/DataHandling/src/LoadEmptyInstrument.cpp
@@ -126,7 +126,7 @@ void LoadEmptyInstrument::exec() {
     outWS = WorkspaceFactory::Instance().create("EventWorkspace",
                                                 number_spectra, 2, 1);
     // Copy geometry over.
-    WorkspaceFactory::Instance().initializeFromParent(*ws, *outWS, true);
+    WorkspaceFactory::Instance().initializeFromParent(*ws, *outWS);
   } else {
     // Now create the outputworkspace and copy over the instrument object
     outWS = WorkspaceFactory::Instance().create(ws, number_spectra, 2, 1);

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -457,8 +457,7 @@ void LoadEventPreNexus2::createOutputWorkspace(
   if (!this->spectra_list.empty())
     nSpec = this->spectra_list.size();
   auto tmp = createWorkspace<EventWorkspace>(nSpec, 2, 1);
-  WorkspaceFactory::Instance().initializeFromParent(*localWorkspace, *tmp,
-                                                    true);
+  WorkspaceFactory::Instance().initializeFromParent(*localWorkspace, *tmp);
   localWorkspace = std::move(tmp);
 }
 

--- a/Framework/DataObjects/src/EventWorkspaceHelpers.cpp
+++ b/Framework/DataObjects/src/EventWorkspaceHelpers.cpp
@@ -28,7 +28,7 @@ EventWorkspaceHelpers::convertEventTo2D(MatrixWorkspace_sptr inputMatrixW) {
   MatrixWorkspace_sptr outputW;
   outputW = WorkspaceFactory::Instance().create(
       "Workspace2D", inputW->getNumberHistograms(), numBins + 1, numBins);
-  WorkspaceFactory::Instance().initializeFromParent(*inputW, *outputW, false);
+  WorkspaceFactory::Instance().initializeFromParent(*inputW, *outputW);
 
   // Now let's set all the X bins and values
   for (size_t i = 0; i < inputW->getNumberHistograms(); i++) {

--- a/Framework/DataObjects/src/SpecialWorkspace2D.cpp
+++ b/Framework/DataObjects/src/SpecialWorkspace2D.cpp
@@ -56,7 +56,7 @@ SpecialWorkspace2D::SpecialWorkspace2D(Geometry::Instrument_const_sptr inst,
  */
 SpecialWorkspace2D::SpecialWorkspace2D(API::MatrixWorkspace_const_sptr parent) {
   this->initialize(parent->getNumberHistograms(), 1, 1);
-  API::WorkspaceFactory::Instance().initializeFromParent(*parent, *this, false);
+  API::WorkspaceFactory::Instance().initializeFromParent(*parent, *this);
   // Make the mapping, which will be used for speed later.
   detID_to_WI.clear();
   for (size_t wi = 0; wi < m_noVectors; wi++) {

--- a/Framework/DataObjects/src/WorkspaceCreation.cpp
+++ b/Framework/DataObjects/src/WorkspaceCreation.cpp
@@ -42,10 +42,7 @@ template <> std::unique_ptr<API::HistoWorkspace> createConcreteHelper() {
  */
 void initializeFromParent(const API::MatrixWorkspace &parent,
                           API::MatrixWorkspace &ws) {
-  bool differentSize = (parent.x(0).size() != ws.x(0).size()) ||
-                       (parent.y(0).size() != ws.y(0).size());
-  API::WorkspaceFactory::Instance().initializeFromParent(parent, ws,
-                                                         differentSize);
+  API::WorkspaceFactory::Instance().initializeFromParent(parent, ws);
   // For EventWorkspace, `ws.y(0)` put entry 0 in the MRU. However, clients
   // would typically expect an empty MRU and fail to clear it. This dummy call
   // removes the entry from the MRU.
@@ -60,10 +57,7 @@ void initializeFromParent(const API::MatrixWorkspace &parent,
  */
 void initializeFromParentWithoutLogs(const API::MatrixWorkspace &parent,
                                      API::MatrixWorkspace &ws) {
-  bool differentSize = (parent.x(0).size() != ws.x(0).size()) ||
-                       (parent.y(0).size() != ws.y(0).size());
-  API::WorkspaceFactory::Instance().initializeFromParentWithoutLogs(
-      parent, ws, differentSize);
+  API::WorkspaceFactory::Instance().initializeFromParentWithoutLogs(parent, ws);
   // For EventWorkspace, `ws.y(0)` put entry 0 in the MRU. However, clients
   // would typically expect an empty MRU and fail to clear it. This dummy call
   // removes the entry from the MRU.

--- a/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISLiveEventDataListener.cpp
@@ -184,7 +184,7 @@ boost::shared_ptr<API::Workspace> ISISLiveEventDataListener::extractData() {
 
     // Copy geometry over.
     API::WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer[i],
-                                                           *temp, false);
+                                                           *temp);
 
     // Clear out the old logs
     temp->mutableRun().clearTimeSeriesLogs();
@@ -363,8 +363,8 @@ void ISISLiveEventDataListener::initEventBuffer(
                   1));
 
       // Copy geometry over.
-      API::WorkspaceFactory::Instance().initializeFromParent(
-          *m_eventBuffer[0], *m_eventBuffer[i], false);
+      API::WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer[0],
+                                                             *m_eventBuffer[i]);
     }
   }
 }

--- a/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
@@ -499,8 +499,7 @@ DataObjects::EventWorkspace_sptr KafkaEventStreamDecoder::createBufferWorkspace(
       API::WorkspaceFactory::Instance().create(
           "EventWorkspace", parent->getNumberHistograms(), 2, 1));
   // Copy meta data
-  API::WorkspaceFactory::Instance().initializeFromParent(*parent, *buffer,
-                                                         false);
+  API::WorkspaceFactory::Instance().initializeFromParent(*parent, *buffer);
   // Clear out the old logs, except for the most recent entry
   buffer->mutableRun().clearOutdatedTimeSeriesLogValues();
   return buffer;

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -1261,7 +1261,7 @@ void SNSLiveEventDataListener::initWorkspacePart2() {
 
   auto tmp = createWorkspace<DataObjects::EventWorkspace>(
       m_eventBuffer->getInstrument()->getDetectorIDs(true).size(), 2, 1);
-  WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer, *tmp, true);
+  WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer, *tmp);
   if (m_eventBuffer->getNumberHistograms() != tmp->getNumberHistograms()) {
     // need to generate the spectra to detector map
     tmp->rebuildSpectraMapping();
@@ -1300,7 +1300,7 @@ void SNSLiveEventDataListener::initMonitorWorkspace() {
   auto monitorsBuffer = WorkspaceFactory::Instance().create(
       "EventWorkspace", monitors.size(), 1, 1);
   WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer,
-                                                    *monitorsBuffer, true);
+                                                    *monitorsBuffer);
   // Set the id numbers
   for (size_t i = 0; i < monitors.size(); ++i) {
     monitorsBuffer->getSpectrum(i).setDetectorID(monitors[i]);
@@ -1397,8 +1397,7 @@ boost::shared_ptr<Workspace> SNSLiveEventDataListener::extractData() {
           "EventWorkspace", m_eventBuffer->getNumberHistograms(), 2, 1));
 
   // Copy geometry over.
-  API::WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer, *temp,
-                                                         false);
+  API::WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer, *temp);
 
   // Clear out the old logs, except for the most recent entry
   temp->mutableRun().clearOutdatedTimeSeriesLogValues();
@@ -1414,7 +1413,7 @@ boost::shared_ptr<Workspace> SNSLiveEventDataListener::extractData() {
   auto newMonitorBuffer = WorkspaceFactory::Instance().create(
       "EventWorkspace", monitorBuffer->getNumberHistograms(), 1, 1);
   WorkspaceFactory::Instance().initializeFromParent(*monitorBuffer,
-                                                    *newMonitorBuffer, false);
+                                                    *newMonitorBuffer);
   temp->setMonitorWorkspace(newMonitorBuffer);
 
   // Lock the mutex and swap the workspaces

--- a/Framework/LiveData/src/TOPAZLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/TOPAZLiveEventDataListener.cpp
@@ -479,7 +479,7 @@ void TOPAZLiveEventDataListener::initWorkspace() {
 
   auto tmp = createWorkspace<DataObjects::EventWorkspace>(
       m_eventBuffer->getInstrument()->getDetectorIDs(true).size(), 2, 1);
-  WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer, *tmp, true);
+  WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer, *tmp);
   if (m_eventBuffer->getNumberHistograms() != tmp->getNumberHistograms()) {
     // need to generate the spectra to detector map
     tmp->rebuildSpectraMapping();
@@ -506,7 +506,7 @@ void TOPAZLiveEventDataListener::initMonitorWorkspace() {
   auto monitorsBuffer = WorkspaceFactory::Instance().create(
       "EventWorkspace", monitors.size(), 1, 1);
   WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer,
-                                                    *monitorsBuffer, true);
+                                                    *monitorsBuffer);
   // Set the id numbers
   for (size_t i = 0; i < monitors.size(); ++i) {
     monitorsBuffer->getSpectrum(i).setDetectorID(monitors[i]);
@@ -567,8 +567,7 @@ boost::shared_ptr<Workspace> TOPAZLiveEventDataListener::extractData() {
           "EventWorkspace", m_eventBuffer->getNumberHistograms(), 2, 1));
 
   // Copy geometry over.
-  API::WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer, *temp,
-                                                         false);
+  API::WorkspaceFactory::Instance().initializeFromParent(*m_eventBuffer, *temp);
 
   // Clear out the old logs, except for the most recent entry
   temp->mutableRun().clearOutdatedTimeSeriesLogValues();
@@ -587,7 +586,7 @@ boost::shared_ptr<Workspace> TOPAZLiveEventDataListener::extractData() {
   auto newMonitorBuffer = WorkspaceFactory::Instance().create(
       "EventWorkspace", monitorBuffer->getNumberHistograms(), 1, 1);
   WorkspaceFactory::Instance().initializeFromParent(*monitorBuffer,
-                                                    *newMonitorBuffer, false);
+                                                    *newMonitorBuffer);
   temp->setMonitorWorkspace(newMonitorBuffer);
 
   // Lock the mutex and swap the workspaces

--- a/Framework/LiveData/test/TestDataListener.cpp
+++ b/Framework/LiveData/test/TestDataListener.cpp
@@ -102,8 +102,7 @@ void TestDataListener::createEmptyWorkspace() {
   // Add a monitor workspace
   auto monitorWS =
       WorkspaceFactory::Instance().create("EventWorkspace", 1, 2, 1);
-  WorkspaceFactory::Instance().initializeFromParent(*m_buffer, *monitorWS,
-                                                    true);
+  WorkspaceFactory::Instance().initializeFromParent(*m_buffer, *monitorWS);
   monitorWS->dataX(0)[0] = 40000;
   monitorWS->dataX(0)[1] = 60000;
   m_buffer->setMonitorWorkspace(monitorWS);

--- a/Framework/MPIAlgorithms/src/GatherWorkspaces.cpp
+++ b/Framework/MPIAlgorithms/src/GatherWorkspaces.cpp
@@ -262,8 +262,8 @@ void GatherWorkspaces::execEvent() {
         API::WorkspaceFactory::Instance().create("EventWorkspace", sumSpec,
                                                  numBins + hist, numBins));
     // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(
-        *eventW, *outputWorkspace, true);
+    API::WorkspaceFactory::Instance().initializeFromParent(*eventW,
+                                                           *outputWorkspace);
     setProperty("OutputWorkspace", outputWorkspace);
     ExperimentInfo_sptr inWS = inputWorkspace;
     outputWorkspace->copyExperimentInfoFrom(inWS.get());


### PR DESCRIPTION
Corrects detection of differing sized axis so that newly created workspaces always have an axis of sufficient length.

Keeps existing values in `TextAxis` when it is cloned with a different length.

**To test:**

- See script in original ticket
- The `labelledworkspace` should now be able to be opened
- It should have a valid `TextAxis` where the first value is copied from the parent workspace and the remaining values are empty

Fixes #17907.

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
