### PR TITLE
Add ZOOM to ISIS SANS GUI

### DIFF
--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -363,6 +363,11 @@
     </livedata>
   </instrument>
 
+  <instrument name="ZOOM">
+    <technique>Small Angle Scattering</technique>
+    <zeropadding size="8"/>
+  </instrument>
+
 </facility>
 
 
@@ -816,11 +821,6 @@
     <livedata>
       <connection name="kafka_event" address="sakura:9092" listener="KafkaEventListener" />
     </livedata>
-  </instrument>
-
-  <instrument name="ZOOM">
-    <technique>Small Angle Scattering</technique>
-    <zeropadding size="8"/>
   </instrument>
 
 </facility>

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -98,7 +98,8 @@ class SANSDataProcessorGui(QtGui.QMainWindow, ui_sans_data_processor_window.Ui_S
         SANSDataProcessorGui.INSTRUMENTS = ",".join([SANSInstrument.to_string(item)
                                                      for item in [SANSInstrument.SANS2D,
                                                                   SANSInstrument.LOQ,
-                                                                  SANSInstrument.LARMOR]])
+                                                                  SANSInstrument.LARMOR,
+                                                                  SANSInstrument.ZOOM]])
         settings = QtCore.QSettings()
         settings.beginGroup(self.__generic_settings)
         instrument_name = settings.value(self.__instrument_name,

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -34,6 +34,8 @@ LOQ_HAB = "Hab"
 
 LARMOR_LAB = "DetectorBench"
 
+ZOOM_LAB = "rear-detector"
+
 DEFAULT_LAB = ISISReductionMode.to_string(ISISReductionMode.LAB)
 DEFAULT_HAB = ISISReductionMode.to_string(ISISReductionMode.HAB)
 MERGED = "Merged"
@@ -47,6 +49,8 @@ def get_reduction_mode_strings_for_gui(instrument=None):
         return [LOQ_LAB, LOQ_HAB, MERGED, ALL]
     elif instrument is SANSInstrument.LARMOR:
         return [LARMOR_LAB]
+    elif instrument is SANSInstrument.ZOOM:
+        return [ZOOM_LAB]
     else:
         return [DEFAULT_LAB, DEFAULT_HAB, MERGED, ALL]
 
@@ -62,6 +66,8 @@ def get_reduction_selection(instrument):
                           ISISReductionMode.HAB: LOQ_HAB})
     elif instrument is SANSInstrument.LARMOR:
         selection = {ISISReductionMode.LAB: LARMOR_LAB}
+    elif instrument is SANSInstrument.ZOOM:
+        selection = {ISISReductionMode.LAB: ZOOM_LAB}
     else:
         selection.update({ISISReductionMode.LAB: DEFAULT_LAB,
                           ISISReductionMode.HAB: DEFAULT_HAB})
@@ -81,7 +87,7 @@ def get_reduction_mode_from_gui_selection(gui_selection):
         return ISISReductionMode.Merged
     elif gui_selection == ALL:
         return ISISReductionMode.All
-    elif gui_selection == SANS2D_LAB or gui_selection == LOQ_LAB or gui_selection == LARMOR_LAB or gui_selection == DEFAULT_LAB:  # noqa
+    elif gui_selection == SANS2D_LAB or gui_selection == LOQ_LAB or gui_selection == LARMOR_LAB or gui_selection == ZOOM_LAB or gui_selection == DEFAULT_LAB:  # noqa
         return ISISReductionMode.LAB
     elif gui_selection == SANS2D_HAB or gui_selection == LOQ_HAB:
         return ISISReductionMode.HAB


### PR DESCRIPTION
For the commissioning which is happening at the moment we need to add ZOOM to the new ISIS SANS GUI.
This PR has the following changes.

1. It adds the ZOOM option to the instruments in the ISIS SANS GUI
2. It adds ZOOM to the ISIS instruments on the First Time Setup UI


**To test:**

1. Click `Help > First Time Setup`
2. Select `ISIS` for the `Default Facility`
3. Ensure that `ZOOM` can be selected from the `Default Instrument` selection
4. Open the ISIS SANS v2 experimental GUI. Ensure that ZOOM can be selected from the instruments.

No release notes required and no issue number


---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
