### PR TITLE
DetectorInfo sync scan merge with identical scan intervals

### DIFF
--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -110,7 +110,7 @@ private:
   void initScanIntervals();
   void initIndices();
   std::vector<bool> buildMergeIndices(const DetectorInfo &other) const;
-  void checkIdentitcalIntervals(const DetectorInfo &other, const size_t index1,
+  void checkIdenticalIntervals(const DetectorInfo &other, const size_t index1,
                                 const size_t index2) const;
   bool m_isSyncScan{true};
 

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -110,6 +110,8 @@ private:
   void initScanIntervals();
   void initIndices();
   std::vector<bool> buildMergeIndices(const DetectorInfo &other) const;
+  void checkIdentitcalIntervals(const DetectorInfo &other, const size_t index1,
+                                const size_t index2) const;
   bool m_isSyncScan{true};
 
   Kernel::cow_ptr<std::vector<bool>> m_isMonitor{nullptr};

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -110,8 +110,10 @@ private:
   void initScanIntervals();
   void initIndices();
   std::vector<bool> buildMergeIndices(const DetectorInfo &other) const;
+  std::vector<bool> buildMergeSyncScanIndices(const DetectorInfo &other) const;
+  void checkSizes(const DetectorInfo &other) const;
   void checkIdenticalIntervals(const DetectorInfo &other, const size_t index1,
-                                const size_t index2) const;
+                               const size_t index2) const;
   bool m_isSyncScan{true};
 
   Kernel::cow_ptr<std::vector<bool>> m_isMonitor{nullptr};

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -256,10 +256,8 @@ void DetectorInfo::merge(const DetectorInfo &other) {
       auto &positions = m_positions.access();
       auto &rotations = m_rotations.access();
       m_scanCounts.access()[0]++;
-      scanIntervals.insert(scanIntervals.end(),
-                           other.m_scanIntervals->begin() + timeIndex,
-                           other.m_scanIntervals->begin() + timeIndex + 1);
-      const size_t indexStart = linearIndex({0, timeIndex});
+      scanIntervals.push_back((*other.m_scanIntervals)[timeIndex]);
+      const size_t indexStart = other.linearIndex({0, timeIndex});
       size_t indexEnd = indexStart + size();
       isMasked.insert(isMasked.end(), other.m_isMasked->begin() + indexStart,
                       other.m_isMasked->begin() + indexEnd);
@@ -372,17 +370,17 @@ DetectorInfo::buildMergeIndices(const DetectorInfo &other) const {
 
     for (size_t t1 = 0; t1 < other.m_scanIntervals->size(); ++t1) {
       for (size_t t2 = 0; t2 < m_scanIntervals->size(); ++t2) {
-        if ((*other.m_scanIntervals)[t1] == (*m_scanIntervals)[t2]) {
+        const auto &interval1 = (*other.m_scanIntervals)[t1];
+        const auto &interval2 = (*m_scanIntervals)[t2];
+        if (interval1 == interval2) {
           for (size_t detIndex = 0; detIndex < size(); ++detIndex) {
-            const size_t linearIndex1 = linearIndex({detIndex, t1});
+            const size_t linearIndex1 = other.linearIndex({detIndex, t1});
             const size_t linearIndex2 = linearIndex({detIndex, t2});
-            checkIdentitcalIntervals(other, linearIndex1, linearIndex2);
+            checkIdenticalIntervals(other, linearIndex1, linearIndex2);
           }
           merge[t1] = false;
-        } else if (!(((*other.m_scanIntervals)[t1].second <=
-                      (*m_scanIntervals)[t2].first) ||
-                     ((*other.m_scanIntervals)[t1].first >=
-                      (*m_scanIntervals)[t2].second))) {
+        } else if ((interval1.first < interval2.second) &&
+                   (interval1.second > interval2.first)) {
           failMerge("sync scan intervals overlap but not identical");
         }
       }
@@ -400,7 +398,7 @@ DetectorInfo::buildMergeIndices(const DetectorInfo &other) const {
       const auto linearIndex2 = linearIndex({detIndex, timeIndex});
       const auto &interval2 = (*m_scanIntervals)[linearIndex2];
       if (interval1 == interval2) {
-        checkIdentitcalIntervals(other, linearIndex1, linearIndex2);
+        checkIdenticalIntervals(other, linearIndex1, linearIndex2);
         merge[linearIndex1] = false;
       } else if ((interval1.first < interval2.second) &&
                  (interval1.second > interval2.first)) {
@@ -411,15 +409,15 @@ DetectorInfo::buildMergeIndices(const DetectorInfo &other) const {
   return merge;
 }
 
-void DetectorInfo::checkIdentitcalIntervals(const DetectorInfo &other,
-                                            const size_t linearIndex1,
-                                            const size_t linearIndex2) const {
-  if ((*m_isMasked)[linearIndex2] != (*other.m_isMasked)[linearIndex1])
+void DetectorInfo::checkIdenticalIntervals(const DetectorInfo &other,
+                                           const size_t linearIndexOther,
+                                           const size_t linearIndexThis) const {
+  if ((*m_isMasked)[linearIndexThis] != (*other.m_isMasked)[linearIndexOther])
     failMerge("matching scan interval but mask flags differ");
-  if ((*m_positions)[linearIndex2] != (*other.m_positions)[linearIndex1])
+  if ((*m_positions)[linearIndexThis] != (*other.m_positions)[linearIndexOther])
     failMerge("matching scan interval but positions differ");
-  if ((*m_rotations)[linearIndex2].coeffs() !=
-      (*other.m_rotations)[linearIndex1].coeffs())
+  if ((*m_rotations)[linearIndexThis].coeffs() !=
+      (*other.m_rotations)[linearIndexOther].coeffs())
     failMerge("matching scan interval but rotations differ");
 }
 

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -412,8 +412,8 @@ DetectorInfo::buildMergeIndices(const DetectorInfo &other) const {
 }
 
 void DetectorInfo::checkIdentitcalIntervals(const DetectorInfo &other,
-                                             const size_t linearIndex1,
-                                             const size_t linearIndex2) const {
+                                            const size_t linearIndex1,
+                                            const size_t linearIndex2) const {
   if ((*m_isMasked)[linearIndex2] != (*other.m_isMasked)[linearIndex1])
     failMerge("matching scan interval but mask flags differ");
   if ((*m_positions)[linearIndex2] != (*other.m_positions)[linearIndex1])

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -376,15 +376,7 @@ DetectorInfo::buildMergeIndices(const DetectorInfo &other) const {
           for (size_t detIndex = 0; detIndex < size(); ++detIndex) {
             const size_t linearIndex1 = linearIndex({detIndex, t1});
             const size_t linearIndex2 = linearIndex({detIndex, t2});
-            if ((*m_isMasked)[linearIndex2] !=
-                (*other.m_isMasked)[linearIndex1])
-              failMerge("matching scan interval but mask flags differ");
-            if ((*m_positions)[linearIndex2] !=
-                (*other.m_positions)[linearIndex1])
-              failMerge("matching scan interval but positions differ");
-            if ((*m_rotations)[linearIndex2].coeffs() !=
-                (*other.m_rotations)[linearIndex1].coeffs())
-              failMerge("matching scan interval but rotations differ");
+            checkIdentitcalIntervals(other, linearIndex1, linearIndex2);
           }
           merge[t1] = false;
         } else if (!(((*other.m_scanIntervals)[t1].second <=
@@ -408,13 +400,7 @@ DetectorInfo::buildMergeIndices(const DetectorInfo &other) const {
       const auto linearIndex2 = linearIndex({detIndex, timeIndex});
       const auto &interval2 = (*m_scanIntervals)[linearIndex2];
       if (interval1 == interval2) {
-        if ((*m_isMasked)[linearIndex2] != (*other.m_isMasked)[linearIndex1])
-          failMerge("matching scan interval but mask flags differ");
-        if ((*m_positions)[linearIndex2] != (*other.m_positions)[linearIndex1])
-          failMerge("matching scan interval but positions differ");
-        if ((*m_rotations)[linearIndex2].coeffs() !=
-            (*other.m_rotations)[linearIndex1].coeffs())
-          failMerge("matching scan interval but rotations differ");
+        checkIdentitcalIntervals(other, linearIndex1, linearIndex2);
         merge[linearIndex1] = false;
       } else if ((interval1.first < interval2.second) &&
                  (interval1.second > interval2.first)) {
@@ -423,6 +409,18 @@ DetectorInfo::buildMergeIndices(const DetectorInfo &other) const {
     }
   }
   return merge;
+}
+
+void DetectorInfo::checkIdentitcalIntervals(const DetectorInfo &other,
+                                             const size_t linearIndex1,
+                                             const size_t linearIndex2) const {
+  if ((*m_isMasked)[linearIndex2] != (*other.m_isMasked)[linearIndex1])
+    failMerge("matching scan interval but mask flags differ");
+  if ((*m_positions)[linearIndex2] != (*other.m_positions)[linearIndex1])
+    failMerge("matching scan interval but positions differ");
+  if ((*m_rotations)[linearIndex2].coeffs() !=
+      (*other.m_rotations)[linearIndex1].coeffs())
+    failMerge("matching scan interval but rotations differ");
 }
 
 } // namespace Beamline

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -243,10 +243,10 @@ getIndex(const Kernel::cow_ptr<std::vector<std::pair<size_t, size_t>>> &indices,
  * index in `other` is identical to a corresponding interval in `this`, it is
  * ignored, i.e., no time index is added. */
 void DetectorInfo::merge(const DetectorInfo &other) {
-  const auto &merge = buildMergeIndices(other);
   if (!m_scanCounts)
     initScanCounts();
   if (m_isSyncScan) {
+    const auto &merge = buildMergeSyncScanIndices(other);
     for (size_t timeIndex = 0; timeIndex < other.m_scanIntervals->size();
          ++timeIndex) {
       if (!merge[timeIndex])
@@ -268,6 +268,7 @@ void DetectorInfo::merge(const DetectorInfo &other) {
     }
     return;
   }
+  const auto &merge = buildMergeIndices(other);
   if (!m_indexMap)
     initIndices();
   // Temporary to accumulate scan counts (need original for index offset).
@@ -352,42 +353,10 @@ void DetectorInfo::initIndices() {
   }
 }
 
+// Indices returned here are the list of linear indexes not to merge
 std::vector<bool>
 DetectorInfo::buildMergeIndices(const DetectorInfo &other) const {
-  if (size() != other.size())
-    failMerge("size mismatch");
-  if (!m_scanIntervals || !other.m_scanIntervals)
-    failMerge("scan intervals not defined");
-  if (m_isSyncScan != other.m_isSyncScan)
-    failMerge("both or none of the scans must be synchronous");
-  if (!(m_isMonitor == other.m_isMonitor) &&
-      (*m_isMonitor != *other.m_isMonitor))
-    failMerge("monitor flags mismatch");
-  // TODO If we make masking time-independent we need to check masking here.
-
-  if (m_isSyncScan) {
-    std::vector<bool> merge(other.m_scanIntervals->size(), true);
-
-    for (size_t t1 = 0; t1 < other.m_scanIntervals->size(); ++t1) {
-      for (size_t t2 = 0; t2 < m_scanIntervals->size(); ++t2) {
-        const auto &interval1 = (*other.m_scanIntervals)[t1];
-        const auto &interval2 = (*m_scanIntervals)[t2];
-        if (interval1 == interval2) {
-          for (size_t detIndex = 0; detIndex < size(); ++detIndex) {
-            const size_t linearIndex1 = other.linearIndex({detIndex, t1});
-            const size_t linearIndex2 = linearIndex({detIndex, t2});
-            checkIdenticalIntervals(other, linearIndex1, linearIndex2);
-          }
-          merge[t1] = false;
-        } else if ((interval1.first < interval2.second) &&
-                   (interval1.second > interval2.first)) {
-          failMerge("sync scan intervals overlap but not identical");
-        }
-      }
-    }
-    return merge;
-  }
-
+  checkSizes(other);
   std::vector<bool> merge(other.m_positions->size(), true);
 
   for (size_t linearIndex1 = 0; linearIndex1 < other.m_positions->size();
@@ -407,6 +376,45 @@ DetectorInfo::buildMergeIndices(const DetectorInfo &other) const {
     }
   }
   return merge;
+}
+
+// Indices returned here are the list of time indexes not to merge
+std::vector<bool>
+DetectorInfo::buildMergeSyncScanIndices(const DetectorInfo &other) const {
+  checkSizes(other);
+  std::vector<bool> merge(other.m_scanIntervals->size(), true);
+
+  for (size_t t1 = 0; t1 < other.m_scanIntervals->size(); ++t1) {
+    for (size_t t2 = 0; t2 < m_scanIntervals->size(); ++t2) {
+      const auto &interval1 = (*other.m_scanIntervals)[t1];
+      const auto &interval2 = (*m_scanIntervals)[t2];
+      if (interval1 == interval2) {
+        for (size_t detIndex = 0; detIndex < size(); ++detIndex) {
+          const size_t linearIndex1 = other.linearIndex({detIndex, t1});
+          const size_t linearIndex2 = linearIndex({detIndex, t2});
+          checkIdenticalIntervals(other, linearIndex1, linearIndex2);
+        }
+        merge[t1] = false;
+      } else if ((interval1.first < interval2.second) &&
+                 (interval1.second > interval2.first)) {
+        failMerge("sync scan intervals overlap but not identical");
+      }
+    }
+  }
+  return merge;
+}
+
+void DetectorInfo::checkSizes(const DetectorInfo &other) const {
+  if (size() != other.size())
+    failMerge("size mismatch");
+  if (!m_scanIntervals || !other.m_scanIntervals)
+    failMerge("scan intervals not defined");
+  if (m_isSyncScan != other.m_isSyncScan)
+    failMerge("both or none of the scans must be synchronous");
+  if (!(m_isMonitor == other.m_isMonitor) &&
+      (*m_isMonitor != *other.m_isMonitor))
+    failMerge("monitor flags mismatch");
+  // TODO If we make masking time-independent we need to check masking here.
 }
 
 void DetectorInfo::checkIdenticalIntervals(const DetectorInfo &other,

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -247,19 +247,27 @@ void DetectorInfo::merge(const DetectorInfo &other) {
   if (!m_scanCounts)
     initScanCounts();
   if (m_isSyncScan) {
-    auto &scanIntervals = m_scanIntervals.access();
-    auto &isMasked = m_isMasked.access();
-    auto &positions = m_positions.access();
-    auto &rotations = m_rotations.access();
-    m_scanCounts.access().front() += other.scanCount(0);
-    scanIntervals.insert(scanIntervals.end(), other.m_scanIntervals->begin(),
-                         other.m_scanIntervals->end());
-    isMasked.insert(isMasked.end(), other.m_isMasked->begin(),
-                    other.m_isMasked->end());
-    positions.insert(positions.end(), other.m_positions->begin(),
-                     other.m_positions->end());
-    rotations.insert(rotations.end(), other.m_rotations->begin(),
-                     other.m_rotations->end());
+    for (size_t timeIndex = 0; timeIndex < other.m_scanIntervals->size();
+         ++timeIndex) {
+      if (!merge[timeIndex])
+        continue;
+      auto &scanIntervals = m_scanIntervals.access();
+      auto &isMasked = m_isMasked.access();
+      auto &positions = m_positions.access();
+      auto &rotations = m_rotations.access();
+      m_scanCounts.access()[0]++;
+      scanIntervals.insert(scanIntervals.end(),
+                           other.m_scanIntervals->begin() + timeIndex,
+                           other.m_scanIntervals->begin() + timeIndex + 1);
+      const size_t indexStart = linearIndex({0, timeIndex});
+      size_t indexEnd = indexStart + size();
+      isMasked.insert(isMasked.end(), other.m_isMasked->begin() + indexStart,
+                      other.m_isMasked->begin() + indexEnd);
+      positions.insert(positions.end(), other.m_positions->begin() + indexStart,
+                       other.m_positions->begin() + indexEnd);
+      rotations.insert(rotations.end(), other.m_rotations->begin() + indexStart,
+                       other.m_rotations->begin() + indexEnd);
+    }
     return;
   }
   if (!m_indexMap)
@@ -360,15 +368,34 @@ DetectorInfo::buildMergeIndices(const DetectorInfo &other) const {
   // TODO If we make masking time-independent we need to check masking here.
 
   if (m_isSyncScan) {
-    for (const auto &interval1 : *other.m_scanIntervals) {
-      for (const auto &interval2 : *m_scanIntervals) {
-        if (!((interval1.second <= interval2.first) ||
-              (interval1.first >= interval2.second))) {
-          failMerge("scan intervals overlap in sync scan");
+    std::vector<bool> merge(other.m_scanIntervals->size(), true);
+
+    for (size_t t1 = 0; t1 < other.m_scanIntervals->size(); ++t1) {
+      for (size_t t2 = 0; t2 < m_scanIntervals->size(); ++t2) {
+        if ((*other.m_scanIntervals)[t1] == (*m_scanIntervals)[t2]) {
+          for (size_t detIndex = 0; detIndex < size(); ++detIndex) {
+            const size_t linearIndex1 = linearIndex({detIndex, t1});
+            const size_t linearIndex2 = linearIndex({detIndex, t2});
+            if ((*m_isMasked)[linearIndex2] !=
+                (*other.m_isMasked)[linearIndex1])
+              failMerge("matching scan interval but mask flags differ");
+            if ((*m_positions)[linearIndex2] !=
+                (*other.m_positions)[linearIndex1])
+              failMerge("matching scan interval but positions differ");
+            if ((*m_rotations)[linearIndex2].coeffs() !=
+                (*other.m_rotations)[linearIndex1].coeffs())
+              failMerge("matching scan interval but rotations differ");
+          }
+          merge[t1] = false;
+        } else if (!(((*other.m_scanIntervals)[t1].second <=
+                      (*m_scanIntervals)[t2].first) ||
+                     ((*other.m_scanIntervals)[t1].first >=
+                      (*m_scanIntervals)[t2].second))) {
+          failMerge("sync scan intervals overlap but not identical");
         }
       }
     }
-    return {};
+    return merge;
   }
 
   std::vector<bool> merge(other.m_positions->size(), true);

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -402,14 +402,17 @@ public:
         "Cannot merge DetectorInfo: monitor flags mismatch");
   }
 
+  void test_merge_identical_sync() {
+    DetectorInfo a(PosVec(2), RotVec(2));
+    a.setScanInterval({0, 10});
+    auto b(a);
+    TS_ASSERT_THROWS_NOTHING(b.merge(a));
+  }
+
   void test_merge_fail_overlap_sync() {
     DetectorInfo a(PosVec(2), RotVec(2));
     a.setScanInterval({0, 10});
     auto b(a);
-    TS_ASSERT_THROWS_EQUALS(b.merge(a), const std::runtime_error &e,
-                            std::string(e.what()), "Cannot merge DetectorInfo: "
-                                                   "sync scan intervals "
-                                                   "overlap but not identical");
     b = a;
     b.setScanInterval({-1, 5});
     TS_ASSERT_THROWS_EQUALS(b.merge(a), const std::runtime_error &e,
@@ -428,9 +431,7 @@ public:
                                                    "overlap but not identical");
   }
 
-  void test_merge_identical_interval_failures() {
-    DetectorInfo a(PosVec(1), RotVec(1));
-    a.setScanInterval(0, {0, 1});
+  void do_test_merge_identical_interval_failures(DetectorInfo &a) {
     Eigen::Vector3d pos1(1, 0, 0);
     Eigen::Vector3d pos2(2, 0, 0);
     Eigen::Quaterniond rot1(
@@ -471,12 +472,31 @@ public:
     TS_ASSERT_THROWS_NOTHING(b.merge(a));
   }
 
-  void test_merge_identical_interval() {
+  void test_merge_identical_interval_failures_async() {
+    DetectorInfo a(PosVec(1), RotVec(1));
+    a.setScanInterval(0, {0, 1});
+    do_test_merge_identical_interval_failures(a);
+  }
+
+  void test_merge_identical_interval_failures_sync() {
+    DetectorInfo a(PosVec(1), RotVec(1));
+    a.setScanInterval({0, 1});
+    do_test_merge_identical_interval_failures(a);
+  }
+
+  void test_merge_identical_interval_async() {
     DetectorInfo a(PosVec(1), RotVec(1));
     a.setScanInterval(0, {0, 1});
     const auto b(a);
     TS_ASSERT_THROWS_NOTHING(a.merge(b));
     TS_ASSERT(a.isEquivalent(b));
+  }
+
+  void test_merge_identical_interval_sync() {
+    DetectorInfo a(PosVec(2), RotVec(2));
+    a.setScanInterval({0, 10});
+    auto b(a);
+    TS_ASSERT_THROWS_NOTHING(b.merge(a));
   }
 
   void test_merge_identical_interval_with_monitor() {

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -406,22 +406,26 @@ public:
     DetectorInfo a(PosVec(2), RotVec(2));
     a.setScanInterval({0, 10});
     auto b(a);
-    TS_ASSERT_THROWS_EQUALS(
-        b.merge(a), const std::runtime_error &e, std::string(e.what()),
-        "Cannot merge DetectorInfo: scan intervals overlap in sync scan");
+    TS_ASSERT_THROWS_EQUALS(b.merge(a), const std::runtime_error &e,
+                            std::string(e.what()), "Cannot merge DetectorInfo: "
+                                                   "sync scan intervals "
+                                                   "overlap but not identical");
     b = a;
     b.setScanInterval({-1, 5});
-    TS_ASSERT_THROWS_EQUALS(
-        b.merge(a), const std::runtime_error &e, std::string(e.what()),
-        "Cannot merge DetectorInfo: scan intervals overlap in sync scan");
+    TS_ASSERT_THROWS_EQUALS(b.merge(a), const std::runtime_error &e,
+                            std::string(e.what()), "Cannot merge DetectorInfo: "
+                                                   "sync scan intervals "
+                                                   "overlap but not identical");
     b.setScanInterval({1, 5});
-    TS_ASSERT_THROWS_EQUALS(
-        b.merge(a), const std::runtime_error &e, std::string(e.what()),
-        "Cannot merge DetectorInfo: scan intervals overlap in sync scan");
+    TS_ASSERT_THROWS_EQUALS(b.merge(a), const std::runtime_error &e,
+                            std::string(e.what()), "Cannot merge DetectorInfo: "
+                                                   "sync scan intervals "
+                                                   "overlap but not identical");
     b.setScanInterval({1, 11});
-    TS_ASSERT_THROWS_EQUALS(
-        b.merge(a), const std::runtime_error &e, std::string(e.what()),
-        "Cannot merge DetectorInfo: scan intervals overlap in sync scan");
+    TS_ASSERT_THROWS_EQUALS(b.merge(a), const std::runtime_error &e,
+                            std::string(e.what()), "Cannot merge DetectorInfo: "
+                                                   "sync scan intervals "
+                                                   "overlap but not identical");
   }
 
   void test_merge_identical_interval_failures() {


### PR DESCRIPTION
`DetectorInfo` sync scans should support merging `DetectorInfo` objects with identical scans. In this case the positions, rotations etc. must be identical as for the async case.

**To test:**

Code review, ensure necessary unit tests are in place.

Fixes #20503 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

**Release Notes** 

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
