### PR TITLE
Get rid of unused arg warnings in gcc7

### DIFF
--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -467,7 +467,7 @@ public:
     mappings.emplace(1, std::set<Mantid::detid_t>{2});
     expt.cacheDetectorGroupings(mappings);
 
-    size_t index = 0;
+    size_t index{0};
     TS_ASSERT_THROWS_NOTHING(index = expt.groupOfDetectorID(1));
     TS_ASSERT_EQUALS(index, 0);
   }

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -467,7 +467,7 @@ public:
     mappings.emplace(1, std::set<Mantid::detid_t>{2});
     expt.cacheDetectorGroupings(mappings);
 
-    size_t index;
+    size_t index = 0;
     TS_ASSERT_THROWS_NOTHING(index = expt.groupOfDetectorID(1));
     TS_ASSERT_EQUALS(index, 0);
   }

--- a/Framework/HistogramData/test/BinEdgesTest.h
+++ b/Framework/HistogramData/test/BinEdgesTest.h
@@ -18,11 +18,6 @@ public:
 
   void test_has_correct_mixins() {
     BinEdges data;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
     TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
         (dynamic_cast<detail::VectorOf<BinEdges, HistogramX> &>(data))));
     TS_ASSERT_THROWS_NOTHING(
@@ -31,9 +26,6 @@ public:
         UNUSED_ARG(dynamic_cast<detail::Offsetable<BinEdges> &>(data)));
     TS_ASSERT_THROWS_NOTHING(
         UNUSED_ARG(dynamic_cast<detail::Scalable<BinEdges> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
   }
 
   void test_default_constructor() {

--- a/Framework/HistogramData/test/BinEdgesTest.h
+++ b/Framework/HistogramData/test/BinEdgesTest.h
@@ -23,12 +23,14 @@ public:
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-value"
 #endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::VectorOf<BinEdges, HistogramX> &>(data))));
     TS_ASSERT_THROWS_NOTHING(
-        (dynamic_cast<detail::VectorOf<BinEdges, HistogramX> &>(data)));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Iterable<BinEdges> &>(data));
+        UNUSED_ARG(dynamic_cast<detail::Iterable<BinEdges> &>(data)));
     TS_ASSERT_THROWS_NOTHING(
-        dynamic_cast<detail::Offsetable<BinEdges> &>(data));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Scalable<BinEdges> &>(data));
+        UNUSED_ARG(dynamic_cast<detail::Offsetable<BinEdges> &>(data)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Scalable<BinEdges> &>(data)));
 #if __clang__
 #pragma clang diagnostic pop
 #endif

--- a/Framework/HistogramData/test/CountStandardDeviationsTest.h
+++ b/Framework/HistogramData/test/CountStandardDeviationsTest.h
@@ -23,16 +23,9 @@ public:
 
   void test_has_correct_mixins() {
     CountStandardDeviations data;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
-    TS_ASSERT_THROWS_NOTHING((dynamic_cast<detail::StandardDeviationVectorOf<
-        CountStandardDeviations, HistogramE, CountVariances> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::StandardDeviationVectorOf<
+             CountStandardDeviations, HistogramE, CountVariances> &>(data))));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/CountStandardDeviationsTest.h
+++ b/Framework/HistogramData/test/CountStandardDeviationsTest.h
@@ -23,9 +23,9 @@ public:
 
   void test_has_correct_mixins() {
     CountStandardDeviations data;
-    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
-        (dynamic_cast<detail::StandardDeviationVectorOf<
-             CountStandardDeviations, HistogramE, CountVariances> &>(data))));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG((dynamic_cast<detail::StandardDeviationVectorOf<
+            CountStandardDeviations, HistogramE, CountVariances> &>(data))));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/CountVariancesTest.h
+++ b/Framework/HistogramData/test/CountVariancesTest.h
@@ -21,16 +21,9 @@ public:
 
   void test_has_correct_mixins() {
     CountVariances data;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
-    TS_ASSERT_THROWS_NOTHING((dynamic_cast<detail::VarianceVectorOf<
-        CountVariances, HistogramE, CountStandardDeviations> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::VarianceVectorOf<
+             CountVariances, HistogramE, CountStandardDeviations> &>(data))));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/CountVariancesTest.h
+++ b/Framework/HistogramData/test/CountVariancesTest.h
@@ -21,9 +21,8 @@ public:
 
   void test_has_correct_mixins() {
     CountVariances data;
-    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
-        (dynamic_cast<detail::VarianceVectorOf<
-             CountVariances, HistogramE, CountStandardDeviations> &>(data))));
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG((dynamic_cast<detail::VarianceVectorOf<
+        CountVariances, HistogramE, CountStandardDeviations> &>(data))));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/CountsTest.h
+++ b/Framework/HistogramData/test/CountsTest.h
@@ -19,20 +19,16 @@ public:
 
   void test_has_correct_mixins() {
     Counts data;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::VectorOf<Counts, HistogramY> &>(data))));
     TS_ASSERT_THROWS_NOTHING(
-        (dynamic_cast<detail::VectorOf<Counts, HistogramY> &>(data)));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Addable<Counts> &>(data));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Iterable<Counts> &>(data));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Offsetable<Counts> &>(data));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Scalable<Counts> &>(data));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+        UNUSED_ARG(dynamic_cast<detail::Addable<Counts> &>(data)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Iterable<Counts> &>(data)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Offsetable<Counts> &>(data)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Scalable<Counts> &>(data)));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/FrequenciesTest.h
+++ b/Framework/HistogramData/test/FrequenciesTest.h
@@ -19,24 +19,16 @@ public:
 
   void test_has_correct_mixins() {
     Frequencies data;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::VectorOf<Frequencies, HistogramY> &>(data))));
     TS_ASSERT_THROWS_NOTHING(
-        (dynamic_cast<detail::VectorOf<Frequencies, HistogramY> &>(data)));
+        UNUSED_ARG(dynamic_cast<detail::Addable<Frequencies> &>(data)));
     TS_ASSERT_THROWS_NOTHING(
-        dynamic_cast<detail::Addable<Frequencies> &>(data));
+        UNUSED_ARG(dynamic_cast<detail::Iterable<Frequencies> &>(data)));
     TS_ASSERT_THROWS_NOTHING(
-        dynamic_cast<detail::Iterable<Frequencies> &>(data));
+        UNUSED_ARG(dynamic_cast<detail::Offsetable<Frequencies> &>(data)));
     TS_ASSERT_THROWS_NOTHING(
-        dynamic_cast<detail::Offsetable<Frequencies> &>(data));
-    TS_ASSERT_THROWS_NOTHING(
-        dynamic_cast<detail::Scalable<Frequencies> &>(data));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+        UNUSED_ARG(dynamic_cast<detail::Scalable<Frequencies> &>(data)));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/FrequencyStandardDeviationsTest.h
+++ b/Framework/HistogramData/test/FrequencyStandardDeviationsTest.h
@@ -25,16 +25,10 @@ public:
 
   void test_has_correct_mixins() {
     FrequencyStandardDeviations data;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
-    TS_ASSERT_THROWS_NOTHING((dynamic_cast<detail::StandardDeviationVectorOf<
-        FrequencyStandardDeviations, HistogramE, FrequencyVariances> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::StandardDeviationVectorOf<
+             FrequencyStandardDeviations, HistogramE, FrequencyVariances> &>(
+            data))));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/FrequencyStandardDeviationsTest.h
+++ b/Framework/HistogramData/test/FrequencyStandardDeviationsTest.h
@@ -25,9 +25,9 @@ public:
 
   void test_has_correct_mixins() {
     FrequencyStandardDeviations data;
-    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
-        (dynamic_cast<detail::StandardDeviationVectorOf<
-             FrequencyStandardDeviations, HistogramE, FrequencyVariances> &>(
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG((dynamic_cast<detail::StandardDeviationVectorOf<
+            FrequencyStandardDeviations, HistogramE, FrequencyVariances> &>(
             data))));
   }
 

--- a/Framework/HistogramData/test/FrequencyVariancesTest.h
+++ b/Framework/HistogramData/test/FrequencyVariancesTest.h
@@ -23,16 +23,10 @@ public:
 
   void test_has_correct_mixins() {
     FrequencyVariances data;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
-    TS_ASSERT_THROWS_NOTHING((dynamic_cast<detail::VarianceVectorOf<
-        FrequencyVariances, HistogramE, FrequencyStandardDeviations> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::VarianceVectorOf<FrequencyVariances, HistogramE,
+                                               FrequencyStandardDeviations> &>(
+            data))));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/HistogramDxTest.h
+++ b/Framework/HistogramData/test/HistogramDxTest.h
@@ -23,16 +23,8 @@ public:
 
   void test_has_correct_mixins() {
     HistogramDx dx;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
     TS_ASSERT_THROWS_NOTHING(
-        dynamic_cast<detail::FixedLengthVector<HistogramDx> &>(dx));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+        UNUSED_ARG(dynamic_cast<detail::FixedLengthVector<HistogramDx> &>(dx)));
   }
 };
 

--- a/Framework/HistogramData/test/HistogramETest.h
+++ b/Framework/HistogramData/test/HistogramETest.h
@@ -24,18 +24,12 @@ public:
 
   void test_has_correct_mixins() {
     HistogramE e;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
     TS_ASSERT_THROWS_NOTHING(
-        dynamic_cast<detail::FixedLengthVector<HistogramE> &>(e));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Addable<HistogramE> &>(e));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Scalable<HistogramE> &>(e));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+        UNUSED_ARG(dynamic_cast<detail::FixedLengthVector<HistogramE> &>(e)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Addable<HistogramE> &>(e)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Scalable<HistogramE> &>(e)));
   }
 };
 

--- a/Framework/HistogramData/test/HistogramXTest.h
+++ b/Framework/HistogramData/test/HistogramXTest.h
@@ -25,18 +25,12 @@ public:
 
   void test_has_correct_mixins() {
     HistogramX x;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
     TS_ASSERT_THROWS_NOTHING(
-        dynamic_cast<detail::FixedLengthVector<HistogramX> &>(x));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Offsetable<HistogramX> &>(x));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Scalable<HistogramX> &>(x));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+        UNUSED_ARG(dynamic_cast<detail::FixedLengthVector<HistogramX> &>(x)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Offsetable<HistogramX> &>(x)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Scalable<HistogramX> &>(x)));
   }
 };
 

--- a/Framework/HistogramData/test/HistogramYTest.h
+++ b/Framework/HistogramData/test/HistogramYTest.h
@@ -27,21 +27,16 @@ public:
 
   void test_has_correct_mixins() {
     HistogramY y;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
     TS_ASSERT_THROWS_NOTHING(
-        dynamic_cast<detail::FixedLengthVector<HistogramY> &>(y));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Addable<HistogramY> &>(y));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Offsetable<HistogramY> &>(y));
+        UNUSED_ARG(dynamic_cast<detail::FixedLengthVector<HistogramY> &>(y)));
     TS_ASSERT_THROWS_NOTHING(
-        dynamic_cast<detail::Multipliable<HistogramY> &>(y));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Scalable<HistogramY> &>(y));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+        UNUSED_ARG(dynamic_cast<detail::Addable<HistogramY> &>(y)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Offsetable<HistogramY> &>(y)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Multipliable<HistogramY> &>(y)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Scalable<HistogramY> &>(y)));
   }
 };
 

--- a/Framework/HistogramData/test/PointStandardDeviationsTest.h
+++ b/Framework/HistogramData/test/PointStandardDeviationsTest.h
@@ -19,16 +19,9 @@ public:
 
   void test_has_correct_mixins() {
     PointStandardDeviations data;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
-    TS_ASSERT_THROWS_NOTHING((dynamic_cast<detail::StandardDeviationVectorOf<
-        PointStandardDeviations, HistogramDx, PointVariances> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::StandardDeviationVectorOf<
+             PointStandardDeviations, HistogramDx, PointVariances> &>(data))));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/PointStandardDeviationsTest.h
+++ b/Framework/HistogramData/test/PointStandardDeviationsTest.h
@@ -19,9 +19,9 @@ public:
 
   void test_has_correct_mixins() {
     PointStandardDeviations data;
-    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
-        (dynamic_cast<detail::StandardDeviationVectorOf<
-             PointStandardDeviations, HistogramDx, PointVariances> &>(data))));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG((dynamic_cast<detail::StandardDeviationVectorOf<
+            PointStandardDeviations, HistogramDx, PointVariances> &>(data))));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/PointVariancesTest.h
+++ b/Framework/HistogramData/test/PointVariancesTest.h
@@ -18,16 +18,9 @@ public:
 
   void test_has_correct_mixins() {
     PointVariances data;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
-    TS_ASSERT_THROWS_NOTHING((dynamic_cast<detail::VarianceVectorOf<
-        PointVariances, HistogramDx, PointStandardDeviations> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::VarianceVectorOf<
+             PointVariances, HistogramDx, PointStandardDeviations> &>(data))));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/PointVariancesTest.h
+++ b/Framework/HistogramData/test/PointVariancesTest.h
@@ -18,9 +18,8 @@ public:
 
   void test_has_correct_mixins() {
     PointVariances data;
-    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
-        (dynamic_cast<detail::VarianceVectorOf<
-             PointVariances, HistogramDx, PointStandardDeviations> &>(data))));
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG((dynamic_cast<detail::VarianceVectorOf<
+        PointVariances, HistogramDx, PointStandardDeviations> &>(data))));
   }
 
   void test_construct_default() {

--- a/Framework/HistogramData/test/PointsTest.h
+++ b/Framework/HistogramData/test/PointsTest.h
@@ -18,19 +18,14 @@ public:
 
   void test_has_correct_mixins() {
     Points data;
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::VectorOf<Points, HistogramX> &>(data))));
     TS_ASSERT_THROWS_NOTHING(
-        (dynamic_cast<detail::VectorOf<Points, HistogramX> &>(data)));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Iterable<Points> &>(data));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Offsetable<Points> &>(data));
-    TS_ASSERT_THROWS_NOTHING(dynamic_cast<detail::Scalable<Points> &>(data));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+        UNUSED_ARG(dynamic_cast<detail::Iterable<Points> &>(data)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Offsetable<Points> &>(data)));
+    TS_ASSERT_THROWS_NOTHING(
+        UNUSED_ARG(dynamic_cast<detail::Scalable<Points> &>(data)));
   }
 
   void test_construct_default() {

--- a/Framework/Indexing/test/DetectorIDTest.h
+++ b/Framework/Indexing/test/DetectorIDTest.h
@@ -17,16 +17,8 @@ public:
 
   void test_has_correct_mixins() {
     DetectorID data(0);
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
-    TS_ASSERT_THROWS_NOTHING(
-        (dynamic_cast<detail::IndexType<DetectorID, int32_t> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::IndexType<DetectorID, int32_t> &>(data))));
   }
 };
 

--- a/Framework/Indexing/test/GlobalSpectrumIndexTest.h
+++ b/Framework/Indexing/test/GlobalSpectrumIndexTest.h
@@ -19,16 +19,8 @@ public:
 
   void test_has_correct_mixins() {
     GlobalSpectrumIndex data(0);
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
-    TS_ASSERT_THROWS_NOTHING(
-        (dynamic_cast<detail::IndexType<GlobalSpectrumIndex, size_t> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG((
+        dynamic_cast<detail::IndexType<GlobalSpectrumIndex, size_t> &>(data))));
   }
 };
 

--- a/Framework/Indexing/test/PartitionIndexTest.h
+++ b/Framework/Indexing/test/PartitionIndexTest.h
@@ -17,16 +17,8 @@ public:
 
   void test_has_correct_mixins() {
     PartitionIndex data(0);
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
-    TS_ASSERT_THROWS_NOTHING(
-        (dynamic_cast<detail::IndexType<PartitionIndex, int> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::IndexType<PartitionIndex, int> &>(data))));
   }
 };
 

--- a/Framework/Indexing/test/SpectrumIndexSetTest.h
+++ b/Framework/Indexing/test/SpectrumIndexSetTest.h
@@ -19,16 +19,8 @@ public:
 
   void test_has_correct_mixins() {
     SpectrumIndexSet data(0);
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
     TS_ASSERT_THROWS_NOTHING(
-        (dynamic_cast<detail::IndexSet<SpectrumIndexSet> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+        UNUSED_ARG((dynamic_cast<detail::IndexSet<SpectrumIndexSet> &>(data))));
   }
 };
 

--- a/Framework/Indexing/test/SpectrumNumberTest.h
+++ b/Framework/Indexing/test/SpectrumNumberTest.h
@@ -17,16 +17,8 @@ public:
 
   void test_has_correct_mixins() {
     SpectrumNumber data(0);
-// AppleClang gives warning if the result is unused.
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-value"
-#endif
-    TS_ASSERT_THROWS_NOTHING(
-        (dynamic_cast<detail::IndexType<SpectrumNumber, int32_t> &>(data)));
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    TS_ASSERT_THROWS_NOTHING(UNUSED_ARG(
+        (dynamic_cast<detail::IndexType<SpectrumNumber, int32_t> &>(data))));
   }
 };
 


### PR DESCRIPTION
Exactly what the summary suggests.

**To test:**

Since you can only see the warnings on gcc7, you'll have to compile there to see any difference. Nominally, just make sure the builds pass.

*There is no associated issue.*

*Does not need to be in the release notes.*

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)?
- [ ] Are the unit tests small and test the class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] Do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
